### PR TITLE
feat(orders): delivery rider detection (unmapped / not-connected / none)

### DIFF
--- a/apps/api/src/orders/http/dto/order-delivery-rider.dto.ts
+++ b/apps/api/src/orders/http/dto/order-delivery-rider.dto.ts
@@ -1,0 +1,46 @@
+/**
+ * Order Delivery Rider DTO
+ *
+ * Read-only projection (#1792, epic #1776) of the actionable delivery hint for a
+ * `default`-resolved order, surfaced next to #1791's `deliveryResolution` so the
+ * FE consumes both together. Maps the order's raw source delivery method to a
+ * candidate carrier and reports whether the operator should *Add mapping*
+ * (`unmapped`), *Connect* the carrier (`not-connected`), or see nothing
+ * (`none`). Never influences routing — a pure derived read.
+ *
+ * @module apps/api/src/orders/http/dto
+ */
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { DeliveryRider, DeliveryRiderValues } from '@openlinker/core/mappings';
+
+class DeliveryRiderCandidateCarrierDto {
+  @ApiProperty({
+    description:
+      "The candidate carrier's platformType (matches the carrier adapter manifest, e.g. \"inpost\", \"dpd\").",
+  })
+  platformType!: string;
+
+  @ApiProperty({
+    description: 'Canonical carrier label for the fix-it button (e.g. "InPost", "DPD").',
+  })
+  displayName!: string;
+}
+
+export class OrderDeliveryRiderDto {
+  @ApiProperty({
+    enum: DeliveryRiderValues,
+    description:
+      '"unmapped" (a supported carrier is connected → Add mapping), "not-connected" (OL supports the ' +
+      'carrier but none is connected → Connect), or "none" (no carrier match, a non-default resolution, ' +
+      'or a carrier OL cannot handle → show nothing). Only fires on a "default" resolution.',
+  })
+  rider!: DeliveryRider;
+
+  @ApiPropertyOptional({
+    type: DeliveryRiderCandidateCarrierDto,
+    description:
+      'The heuristic-matched candidate carrier. Present only for the actionable riders ' +
+      '("unmapped" / "not-connected"); absent for "none".',
+  })
+  candidateCarrier?: DeliveryRiderCandidateCarrierDto;
+}

--- a/apps/api/src/orders/http/dto/order-record-response.dto.ts
+++ b/apps/api/src/orders/http/dto/order-record-response.dto.ts
@@ -18,6 +18,7 @@ import { OrderSyncStatusResponseDto } from './order-sync-status-response.dto';
 import { SyncAttemptResponseDto } from './sync-attempt-response.dto';
 import type { OrderInvoiceProjectionDto } from './order-invoice-projection.dto';
 import { OrderDeliveryResolutionDto } from './order-delivery-resolution.dto';
+import { OrderDeliveryRiderDto } from './order-delivery-rider.dto';
 
 export class OrderRecordResponseDto {
   @ApiProperty({ description: 'Internal order ID (e.g. ol_order_...)' })
@@ -108,4 +109,14 @@ export class OrderRecordResponseDto {
       'routing behaviour — a pure derived read.',
   })
   deliveryResolution?: OrderDeliveryResolutionDto;
+
+  @ApiPropertyOptional({
+    type: OrderDeliveryRiderDto,
+    description:
+      'Read-only actionable delivery hint (#1792) for a "default"-resolved order — Add mapping / ' +
+      'Connect {carrier} / nothing. Present alongside deliveryResolution when the order carries a ' +
+      'source delivery method; absent otherwise. The heuristic only picks which hint to show — it ' +
+      'never influences routing/dispatch.',
+  })
+  deliveryRider?: OrderDeliveryRiderDto;
 }

--- a/apps/api/src/orders/http/dto/order-record-response.dto.ts
+++ b/apps/api/src/orders/http/dto/order-record-response.dto.ts
@@ -119,4 +119,16 @@ export class OrderRecordResponseDto {
       'never influences routing/dispatch.',
   })
   deliveryRider?: OrderDeliveryRiderDto;
+
+  @ApiPropertyOptional({
+    nullable: true,
+    description: 'Source delivery method id (#1791) — the Add-mapping deep-link target.',
+  })
+  sourceDeliveryMethodId?: string | null;
+
+  @ApiPropertyOptional({
+    nullable: true,
+    description: 'Source delivery method label (#1791).',
+  })
+  sourceDeliveryMethodName?: string | null;
 }

--- a/apps/api/src/orders/http/orders.controller.spec.ts
+++ b/apps/api/src/orders/http/orders.controller.spec.ts
@@ -429,8 +429,13 @@ describe('OrdersController', () => {
         rider: 'unmapped',
         candidateCarrier: { platformType: 'inpost', displayName: 'InPost' },
       });
-      // No method on mockOrder → no rider attached.
+      // Typed source-method projection (#1791/#1792) for the #1794 deep link.
+      expect(result.items[0].sourceDeliveryMethodId).toBe('ai-inpost-1');
+      expect(result.items[0].sourceDeliveryMethodName).toBe('Allegro Paczkomat InPost');
+      // No method on mockOrder → no rider attached; method fields null.
       expect(result.items[1].deliveryRider).toBeUndefined();
+      expect(result.items[1].sourceDeliveryMethodId).toBeNull();
+      expect(result.items[1].sourceDeliveryMethodName).toBeNull();
     });
 
     it('should omit candidateCarrier from the rider DTO when the rider is "none" (#1792)', async () => {

--- a/apps/api/src/orders/http/orders.controller.spec.ts
+++ b/apps/api/src/orders/http/orders.controller.spec.ts
@@ -23,8 +23,14 @@ import type {
 import { INVOICE_SERVICE_TOKEN } from '@openlinker/core/invoicing';
 import type { IInvoiceService } from '@openlinker/core/invoicing';
 import { InvoiceRecord } from '@openlinker/core/invoicing';
-import { FULFILLMENT_ROUTING_SERVICE_TOKEN } from '@openlinker/core/mappings';
-import type { IFulfillmentRoutingService } from '@openlinker/core/mappings';
+import {
+  FULFILLMENT_ROUTING_SERVICE_TOKEN,
+  DELIVERY_RIDER_SERVICE_TOKEN,
+} from '@openlinker/core/mappings';
+import type {
+  IFulfillmentRoutingService,
+  IDeliveryRiderService,
+} from '@openlinker/core/mappings';
 
 describe('OrdersController', () => {
   let controller: OrdersController;
@@ -32,6 +38,7 @@ describe('OrdersController', () => {
   let retryService: jest.Mocked<IOrderDestinationRetryService>;
   let invoiceService: jest.Mocked<IInvoiceService>;
   let fulfillmentRouting: jest.Mocked<IFulfillmentRoutingService>;
+  let deliveryRider: jest.Mocked<IDeliveryRiderService>;
 
   const mockOrder = new OrderRecord(
     'ol_order_001',
@@ -87,6 +94,17 @@ describe('OrdersController', () => {
       resolveBatch: jest.fn().mockResolvedValue([]),
     };
 
+    const mockDeliveryRider: jest.Mocked<IDeliveryRiderService> = {
+      // Default: no actionable hint. Batch mirrors the input length so the
+      // controller's positional zip stays aligned.
+      resolve: jest.fn().mockResolvedValue({ rider: 'none' }),
+      resolveBatch: jest
+        .fn()
+        .mockImplementation((inputs: unknown[]) =>
+          Promise.resolve(inputs.map(() => ({ rider: 'none' })))
+        ),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       controllers: [OrdersController],
       providers: [
@@ -106,6 +124,10 @@ describe('OrdersController', () => {
           provide: FULFILLMENT_ROUTING_SERVICE_TOKEN,
           useValue: mockFulfillmentRouting,
         },
+        {
+          provide: DELIVERY_RIDER_SERVICE_TOKEN,
+          useValue: mockDeliveryRider,
+        },
       ],
     }).compile();
 
@@ -114,6 +136,7 @@ describe('OrdersController', () => {
     retryService = module.get(ORDER_DESTINATION_RETRY_SERVICE_TOKEN);
     invoiceService = module.get(INVOICE_SERVICE_TOKEN);
     fulfillmentRouting = module.get(FULFILLMENT_ROUTING_SERVICE_TOKEN);
+    deliveryRider = module.get(DELIVERY_RIDER_SERVICE_TOKEN);
   });
 
   describe('listOrders', () => {
@@ -372,6 +395,67 @@ describe('OrdersController', () => {
       expect(fulfillmentRouting.resolveBatch).not.toHaveBeenCalled();
       expect(result.items[0].deliveryResolution).toBeUndefined();
     });
+
+    it('should attach a batched deliveryRider next to deliveryResolution, threading the routing source (#1792)', async () => {
+      const orderWithMethod = new OrderRecord(
+        'ol_order_rider',
+        null,
+        'conn-source-001',
+        null,
+        { shipping: { methodId: 'ai-inpost-1', methodName: 'Allegro Paczkomat InPost' } },
+        [],
+        'ready',
+        new Date('2026-04-01T00:00:00Z'),
+        new Date('2026-04-01T00:00:00Z')
+      );
+      repository.findMany.mockResolvedValue({ items: [orderWithMethod, mockOrder], total: 2 });
+      fulfillmentRouting.resolveBatch.mockResolvedValue([
+        { processorKind: 'omp_fulfilled', processorConnectionId: null, source: 'default' },
+      ]);
+      deliveryRider.resolveBatch.mockResolvedValue([
+        { rider: 'unmapped', candidateCarrier: { platformType: 'inpost', displayName: 'InPost' } },
+      ]);
+
+      const result = await controller.listOrders({ limit: 20, offset: 0 });
+
+      expect(deliveryRider.resolveBatch).toHaveBeenCalledWith([
+        {
+          sourceConnectionId: 'conn-source-001',
+          sourceDeliveryMethod: { name: 'Allegro Paczkomat InPost', typeId: 'ai-inpost-1' },
+          resolutionSource: 'default',
+        },
+      ]);
+      expect(result.items[0].deliveryRider).toEqual({
+        rider: 'unmapped',
+        candidateCarrier: { platformType: 'inpost', displayName: 'InPost' },
+      });
+      // No method on mockOrder → no rider attached.
+      expect(result.items[1].deliveryRider).toBeUndefined();
+    });
+
+    it('should omit candidateCarrier from the rider DTO when the rider is "none" (#1792)', async () => {
+      const orderWithMethod = new OrderRecord(
+        'ol_order_rider_none',
+        null,
+        'conn-source-001',
+        null,
+        { shipping: { methodId: 'courier-1', methodName: 'Kurier standardowy' } },
+        [],
+        'ready',
+        new Date('2026-04-01T00:00:00Z'),
+        new Date('2026-04-01T00:00:00Z')
+      );
+      repository.findMany.mockResolvedValue({ items: [orderWithMethod], total: 1 });
+      fulfillmentRouting.resolveBatch.mockResolvedValue([
+        { processorKind: 'omp_fulfilled', processorConnectionId: null, source: 'default' },
+      ]);
+      deliveryRider.resolveBatch.mockResolvedValue([{ rider: 'none' }]);
+
+      const result = await controller.listOrders({ limit: 20, offset: 0 });
+
+      expect(result.items[0].deliveryRider).toEqual({ rider: 'none' });
+      expect(result.items[0].deliveryRider).not.toHaveProperty('candidateCarrier');
+    });
   });
 
   describe('statusSummary', () => {
@@ -547,6 +631,51 @@ describe('OrdersController', () => {
 
       expect(fulfillmentRouting.resolve).not.toHaveBeenCalled();
       expect(result.deliveryResolution).toBeUndefined();
+    });
+
+    it('should attach the delivery rider on detail, built from the routing source + snapshot method (#1792)', async () => {
+      const orderWithMethod = new OrderRecord(
+        'ol_order_rider_detail',
+        null,
+        'conn-source-001',
+        null,
+        { shipping: { methodId: 'dpd-1', methodName: 'Kurier DPD' } },
+        [],
+        'ready',
+        new Date('2026-04-01T00:00:00Z'),
+        new Date('2026-04-01T00:00:00Z')
+      );
+      repository.findById.mockResolvedValue(orderWithMethod);
+      fulfillmentRouting.resolve.mockResolvedValue({
+        processorKind: 'omp_fulfilled',
+        processorConnectionId: null,
+        source: 'default',
+      });
+      deliveryRider.resolve.mockResolvedValue({
+        rider: 'not-connected',
+        candidateCarrier: { platformType: 'dpd', displayName: 'DPD' },
+      });
+
+      const result = await controller.getOrder('ol_order_rider_detail');
+
+      expect(deliveryRider.resolve).toHaveBeenCalledWith({
+        sourceConnectionId: 'conn-source-001',
+        sourceDeliveryMethod: { name: 'Kurier DPD', typeId: 'dpd-1' },
+        resolutionSource: 'default',
+      });
+      expect(result.deliveryRider).toEqual({
+        rider: 'not-connected',
+        candidateCarrier: { platformType: 'dpd', displayName: 'DPD' },
+      });
+    });
+
+    it('should not compute a rider when the order carries no delivery method (#1792)', async () => {
+      repository.findById.mockResolvedValue(mockOrder);
+
+      const result = await controller.getOrder('ol_order_001');
+
+      expect(deliveryRider.resolve).not.toHaveBeenCalled();
+      expect(result.deliveryRider).toBeUndefined();
     });
   });
 

--- a/apps/api/src/orders/http/orders.controller.ts
+++ b/apps/api/src/orders/http/orders.controller.ts
@@ -334,6 +334,11 @@ export class OrdersController {
       // BE-owned SLA bucket (#1108): single source of truth so the list filter +
       // badge agree. The FE renders only the live countdown off dispatchByAt.
       slaState: deriveSlaState(order.dispatchByAt, order.fulfillmentState, new Date()),
+      // Typed projection of the source delivery method (#1791/#1792) so the
+      // #1794 Add-mapping deep link reads named fields, not the untyped
+      // orderSnapshot blob. Read off the OrderRecord getters; null when absent.
+      sourceDeliveryMethodId: order.sourceDeliveryMethodId,
+      sourceDeliveryMethodName: order.sourceDeliveryMethodName,
     };
   }
 

--- a/apps/api/src/orders/http/orders.controller.ts
+++ b/apps/api/src/orders/http/orders.controller.ts
@@ -47,8 +47,14 @@ import type { InvoiceRecord } from '@openlinker/core/invoicing';
 import {
   FULFILLMENT_ROUTING_SERVICE_TOKEN,
   IFulfillmentRoutingService,
+  DELIVERY_RIDER_SERVICE_TOKEN,
+  IDeliveryRiderService,
 } from '@openlinker/core/mappings';
-import type { FulfillmentRoutingResolution } from '@openlinker/core/mappings';
+import type {
+  FulfillmentRoutingResolution,
+  DeliveryRiderInput,
+  DeliveryRiderResolution,
+} from '@openlinker/core/mappings';
 import { ListOrdersQueryDto } from './dto/list-orders-query.dto';
 import { OrderHealthSummaryQueryDto } from './dto/order-health-summary-query.dto';
 import { OrderHealthSummaryResponseDto } from './dto/order-health-summary-response.dto';
@@ -60,6 +66,7 @@ import { PaginatedOrdersResponseDto } from './dto/paginated-orders-response.dto'
 import { RetryOrderDestinationResponseDto } from './dto/retry-order-destination-response.dto';
 import type { OrderInvoiceProjectionDto } from './dto/order-invoice-projection.dto';
 import type { OrderDeliveryResolutionDto } from './dto/order-delivery-resolution.dto';
+import type { OrderDeliveryRiderDto } from './dto/order-delivery-rider.dto';
 
 @ApiBearerAuth()
 @ApiTags('orders')
@@ -73,7 +80,9 @@ export class OrdersController {
     @Inject(INVOICE_SERVICE_TOKEN)
     private readonly invoiceService: IInvoiceService,
     @Inject(FULFILLMENT_ROUTING_SERVICE_TOKEN)
-    private readonly fulfillmentRouting: IFulfillmentRoutingService
+    private readonly fulfillmentRouting: IFulfillmentRoutingService,
+    @Inject(DELIVERY_RIDER_SERVICE_TOKEN)
+    private readonly deliveryRider: IDeliveryRiderService
   ) {}
 
   @Get()
@@ -134,12 +143,13 @@ export class OrdersController {
     );
     const invoiceByOrderId = new Map(invoices.map((invoice) => [invoice.orderId, invoice]));
 
-    // Batch the delivery-routing-resolution projection for the whole page
-    // (#1791): one `resolveBatch` call (one repository read per distinct
-    // sourceConnectionId — typically 1-3 per page), not an N+1 of per-row
-    // `resolve`. Only orders that carry a source delivery method are queried;
-    // the rest simply have no `deliveryResolution` on their DTO.
-    const resolutionByOrderId = await this.resolveDeliveryForOrders(items);
+    // Batch the delivery-routing-resolution + rider projection for the whole
+    // page (#1791/#1792): one `resolveBatch` per service (each collapsing to a
+    // small, fixed number of reads — the rider's carrier-state read is
+    // order-independent and happens once), not an N+1 of per-row calls. Only
+    // orders that carry a source delivery method are queried; the rest simply
+    // have no `deliveryResolution` / `deliveryRider` on their DTO.
+    const deliveryByOrderId = await this.resolveDeliveryForOrders(items);
 
     return {
       items: items.map((order) => {
@@ -148,9 +158,10 @@ export class OrdersController {
         if (invoice) {
           dto.orderSnapshot = { ...dto.orderSnapshot, invoice: this.toInvoiceProjection(invoice) };
         }
-        const deliveryResolution = resolutionByOrderId.get(order.internalOrderId);
-        if (deliveryResolution) {
-          dto.deliveryResolution = deliveryResolution;
+        const delivery = deliveryByOrderId.get(order.internalOrderId);
+        if (delivery) {
+          dto.deliveryResolution = delivery.resolution;
+          dto.deliveryRider = delivery.rider;
         }
         return dto;
       }),
@@ -234,16 +245,18 @@ export class OrdersController {
     if (invoiceRecord) {
       dto.orderSnapshot = { ...dto.orderSnapshot, invoice: this.toInvoiceProjection(invoiceRecord) };
     }
-    // Delivery-routing-resolution projection (#1791): a single-order counterpart
-    // to the list read's batched resolution below. Absent when the order carries
-    // no source delivery method — resolving would just echo the omp_fulfilled
-    // default with no delivery method to route.
+    // Delivery-routing-resolution + rider projection (#1791/#1792): a
+    // single-order counterpart to the list read's batched resolution below.
+    // Absent when the order carries no source delivery method — resolving would
+    // just echo the omp_fulfilled default with no delivery method to route.
     if (order.sourceDeliveryMethodId) {
-      dto.deliveryResolution = this.toDeliveryResolutionDto(
-        await this.fulfillmentRouting.resolve({
-          sourceConnectionId: order.sourceConnectionId,
-          sourceDeliveryMethodId: order.sourceDeliveryMethodId,
-        })
+      const resolution = await this.fulfillmentRouting.resolve({
+        sourceConnectionId: order.sourceConnectionId,
+        sourceDeliveryMethodId: order.sourceDeliveryMethodId,
+      });
+      dto.deliveryResolution = this.toDeliveryResolutionDto(resolution);
+      dto.deliveryRider = this.toDeliveryRiderDto(
+        await this.deliveryRider.resolve(this.toRiderInput(order, resolution))
       );
     }
     return dto;
@@ -354,7 +367,9 @@ export class OrdersController {
    */
   private async resolveDeliveryForOrders(
     orders: OrderRecord[]
-  ): Promise<Map<string, OrderDeliveryResolutionDto>> {
+  ): Promise<
+    Map<string, { resolution: OrderDeliveryResolutionDto; rider: OrderDeliveryRiderDto }>
+  > {
     const ordersWithMethod = orders.filter(
       (order): order is OrderRecord & { sourceDeliveryMethodId: string } =>
         order.sourceDeliveryMethodId !== null
@@ -368,10 +383,19 @@ export class OrdersController {
         sourceDeliveryMethodId: order.sourceDeliveryMethodId,
       }))
     );
+    // Rider inputs carry each order's resolution `source` (#1791) — the rider
+    // only fires on `default`. The service reads carrier state once for the
+    // whole batch (it is order-independent), so this stays cheap.
+    const riders = await this.deliveryRider.resolveBatch(
+      ordersWithMethod.map((order, i) => this.toRiderInput(order, resolutions[i]))
+    );
     return new Map(
       ordersWithMethod.map((order, i) => [
         order.internalOrderId,
-        this.toDeliveryResolutionDto(resolutions[i]),
+        {
+          resolution: this.toDeliveryResolutionDto(resolutions[i]),
+          rider: this.toDeliveryRiderDto(riders[i]),
+        },
       ])
     );
   }
@@ -383,6 +407,32 @@ export class OrdersController {
       source: resolution.source,
       processorKind: resolution.processorKind,
       processorConnectionId: resolution.processorConnectionId,
+    };
+  }
+
+  /**
+   * Build the delivery-rider input (#1792) from an order + its #1791 routing
+   * resolution. The rider's `resolutionSource` is the resolution's `source`, so
+   * a `rule`-resolved order short-circuits to `none` inside the service.
+   */
+  private toRiderInput(
+    order: OrderRecord,
+    resolution: FulfillmentRoutingResolution
+  ): DeliveryRiderInput {
+    return {
+      sourceConnectionId: order.sourceConnectionId,
+      sourceDeliveryMethod: {
+        name: order.sourceDeliveryMethodName,
+        typeId: order.sourceDeliveryMethodId,
+      },
+      resolutionSource: resolution.source,
+    };
+  }
+
+  private toDeliveryRiderDto(rider: DeliveryRiderResolution): OrderDeliveryRiderDto {
+    return {
+      rider: rider.rider,
+      ...(rider.candidateCarrier ? { candidateCarrier: rider.candidateCarrier } : {}),
     };
   }
 

--- a/apps/api/test/integration/orders/order-delivery-rider.int-spec.ts
+++ b/apps/api/test/integration/orders/order-delivery-rider.int-spec.ts
@@ -76,6 +76,9 @@ describe('Order delivery-rider projection (#1792)', () => {
       rider: 'unmapped',
       candidateCarrier: { platformType: 'inpost', displayName: 'InPost' },
     });
+    // Typed source-method projection (#1791/#1792) for the #1794 deep link.
+    expect(detail.body.sourceDeliveryMethodId).toBe('ai-inpost-1');
+    expect(detail.body.sourceDeliveryMethodName).toBe('Allegro Paczkomat InPost');
 
     const list = await http
       .get(`/v1/orders?sourceConnectionId=${sourceId}`)

--- a/apps/api/test/integration/orders/order-delivery-rider.int-spec.ts
+++ b/apps/api/test/integration/orders/order-delivery-rider.int-spec.ts
@@ -1,0 +1,166 @@
+/**
+ * Order Delivery Rider Int-Spec (#1792)
+ *
+ * Vertical slice for the read-only delivery-rider projection on the orders HTTP
+ * endpoints: `GET /orders` (list) and `GET /orders/:internalOrderId` (detail).
+ * Exercises the real `DeliveryRiderService` against real Postgres connections +
+ * the real adapter registry (InPost + DPD plugins are registered at boot):
+ *   - a defaulted order whose method maps to a CONNECTED carrier → `unmapped`;
+ *   - a defaulted order whose method maps to a SUPPORTED-but-unconnected carrier
+ *     → `not-connected`;
+ *   - a method with no carrier match → `none`;
+ *   - a rule-resolved order (non-default) → `none`.
+ *
+ * @module apps/api/test/integration/orders
+ */
+import {
+  FULFILLMENT_PROCESSOR_KIND,
+  FULFILLMENT_ROUTING_SERVICE_TOKEN,
+  IFulfillmentRoutingService,
+} from '@openlinker/core/mappings';
+import { getTestHarness, IntegrationTestHarness, resetTestHarness, teardownTestHarness } from '../setup';
+import { loginAsAdmin } from '../helpers/test-auth.helper';
+import { createTestConnection } from '../helpers/test-connection.helper';
+import { createTestOrderRecord } from '../fixtures/order.fixtures';
+
+describe('Order delivery-rider projection (#1792)', () => {
+  let harness: IntegrationTestHarness;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+  });
+
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  async function seedSource(): Promise<string> {
+    const source = await createTestConnection(harness.getDataSource(), {
+      platformType: 'allegro',
+      name: 'Allegro source',
+      adapterKey: 'allegro.publicapi.v1',
+      enabledCapabilities: ['OrderSource'],
+    });
+    return source.id;
+  }
+
+  it('returns rider "unmapped" for a defaulted order whose method maps to a connected carrier', async () => {
+    const sourceId = await seedSource();
+    await createTestConnection(harness.getDataSource(), {
+      platformType: 'inpost',
+      name: 'InPost carrier',
+      adapterKey: 'inpost.shipx.v1',
+      enabledCapabilities: ['ShippingProviderManager'],
+    });
+    const order = await createTestOrderRecord(harness.getDataSource(), {
+      sourceConnectionId: sourceId,
+      orderSnapshot: {
+        items: [],
+        shipping: { methodId: 'ai-inpost-1', methodName: 'Allegro Paczkomat InPost' },
+      },
+    });
+
+    const http = harness.getHttp();
+    const token = await loginAsAdmin(http, harness.getDataSource());
+
+    const detail = await http
+      .get(`/v1/orders/${order.internalOrderId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    expect(detail.body.deliveryResolution.source).toBe('default');
+    expect(detail.body.deliveryRider).toEqual({
+      rider: 'unmapped',
+      candidateCarrier: { platformType: 'inpost', displayName: 'InPost' },
+    });
+
+    const list = await http
+      .get(`/v1/orders?sourceConnectionId=${sourceId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    expect(list.body.items[0].deliveryRider).toEqual({
+      rider: 'unmapped',
+      candidateCarrier: { platformType: 'inpost', displayName: 'InPost' },
+    });
+  });
+
+  it('returns rider "not-connected" when the carrier is supported (registered) but not connected', async () => {
+    const sourceId = await seedSource();
+    // No DPD connection — but the DPD plugin is registered, so DPD is supported.
+    const order = await createTestOrderRecord(harness.getDataSource(), {
+      sourceConnectionId: sourceId,
+      orderSnapshot: { items: [], shipping: { methodId: 'dpd-1', methodName: 'Kurier DPD' } },
+    });
+
+    const http = harness.getHttp();
+    const token = await loginAsAdmin(http, harness.getDataSource());
+
+    const detail = await http
+      .get(`/v1/orders/${order.internalOrderId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    expect(detail.body.deliveryRider).toEqual({
+      rider: 'not-connected',
+      candidateCarrier: { platformType: 'dpd', displayName: 'DPD' },
+    });
+  });
+
+  it('returns rider "none" for a method that maps to no carrier', async () => {
+    const sourceId = await seedSource();
+    const order = await createTestOrderRecord(harness.getDataSource(), {
+      sourceConnectionId: sourceId,
+      orderSnapshot: { items: [], shipping: { methodId: 'c-1', methodName: 'Kurier standardowy' } },
+    });
+
+    const http = harness.getHttp();
+    const token = await loginAsAdmin(http, harness.getDataSource());
+
+    const detail = await http
+      .get(`/v1/orders/${order.internalOrderId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    expect(detail.body.deliveryRider).toEqual({ rider: 'none' });
+    expect(detail.body.deliveryRider.candidateCarrier).toBeUndefined();
+  });
+
+  it('returns rider "none" for a rule-resolved (non-default) order even when the method maps to a carrier', async () => {
+    const sourceId = await seedSource();
+    const inpost = await createTestConnection(harness.getDataSource(), {
+      platformType: 'inpost',
+      name: 'InPost carrier',
+      adapterKey: 'inpost.shipx.v1',
+      enabledCapabilities: ['ShippingProviderManager'],
+    });
+    const routing = harness
+      .getApp()
+      .get<IFulfillmentRoutingService>(FULFILLMENT_ROUTING_SERVICE_TOKEN);
+    await routing.replaceRules(sourceId, [
+      {
+        sourceDeliveryMethodId: 'ai-inpost-1',
+        processorKind: FULFILLMENT_PROCESSOR_KIND.OlManagedCarrier,
+        processorConnectionId: inpost.id,
+      },
+    ]);
+    const order = await createTestOrderRecord(harness.getDataSource(), {
+      sourceConnectionId: sourceId,
+      orderSnapshot: {
+        items: [],
+        shipping: { methodId: 'ai-inpost-1', methodName: 'Allegro Paczkomat InPost' },
+      },
+    });
+
+    const http = harness.getHttp();
+    const token = await loginAsAdmin(http, harness.getDataSource());
+
+    const detail = await http
+      .get(`/v1/orders/${order.internalOrderId}`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    // Resolution matched a rule → rider must not fire.
+    expect(detail.body.deliveryResolution.source).toBe('rule');
+    expect(detail.body.deliveryRider).toEqual({ rider: 'none' });
+  });
+});

--- a/libs/core/src/mappings/application/interfaces/delivery-rider.service.interface.ts
+++ b/libs/core/src/mappings/application/interfaces/delivery-rider.service.interface.ts
@@ -1,0 +1,32 @@
+/**
+ * Delivery Rider Service Interface
+ *
+ * Application contract for the delivery-rider hint (#1792, epic #1776): given a
+ * defaulted order's raw source delivery method, decide which actionable hint to
+ * surface (`unmapped` / `not-connected` / `none`) by mapping the method to a
+ * candidate carrier and reading connection/registry state through the
+ * integrations service — never a concrete carrier adapter.
+ *
+ * @module libs/core/src/mappings/application/interfaces
+ */
+import type {
+  DeliveryRiderInput,
+  DeliveryRiderResolution,
+} from '../../domain/types/delivery-rider.types';
+
+export interface IDeliveryRiderService {
+  /**
+   * Resolve the rider for a single order. Returns `none` when the resolution is
+   * not `default`, when no delivery method is present, or when the method maps
+   * to no supported/connected carrier.
+   */
+  resolve(input: DeliveryRiderInput): Promise<DeliveryRiderResolution>;
+
+  /**
+   * Batched counterpart to {@link resolve}: resolves many orders in one pass,
+   * reading the carrier connection/registry state once for the whole batch
+   * (it is order-independent) rather than per order. Returns resolutions
+   * positionally aligned with `inputs`.
+   */
+  resolveBatch(inputs: DeliveryRiderInput[]): Promise<DeliveryRiderResolution[]>;
+}

--- a/libs/core/src/mappings/application/services/delivery-rider.service.spec.ts
+++ b/libs/core/src/mappings/application/services/delivery-rider.service.spec.ts
@@ -1,0 +1,178 @@
+/**
+ * Delivery Rider Service Unit Tests (#1792)
+ *
+ * Covers all three rider branches (unmapped / not-connected / none), the
+ * heuristic table wiring, and the critical invariant that the rider is a pure
+ * read that never touches fulfillment routing.
+ *
+ * @module libs/core/src/mappings/application/services
+ */
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import {
+  ADAPTER_REGISTRY_TOKEN,
+  INTEGRATIONS_SERVICE_TOKEN,
+  type AdapterRegistryPort,
+  type AdapterMetadata,
+  type IIntegrationsService,
+} from '@openlinker/core/integrations';
+import { DeliveryRiderService } from './delivery-rider.service';
+import type { DeliveryRiderInput } from '../../domain/types/delivery-rider.types';
+
+/** A connected active carrier connection of a given platformType. */
+const connectedCarrier = (platformType: string): { connection: { platformType: string } } => ({
+  connection: { platformType },
+});
+
+/** A registered adapter manifest declaring ShippingProviderManager. */
+const carrierAdapter = (platformType: string): AdapterMetadata =>
+  ({
+    adapterKey: `${platformType}.test.v1`,
+    platformType,
+    supportedCapabilities: ['ShippingProviderManager'],
+    displayName: `${platformType} test`,
+    version: '1.0.0',
+  }) as AdapterMetadata;
+
+const defaultInput = (
+  overrides: Partial<DeliveryRiderInput> = {}
+): DeliveryRiderInput => ({
+  sourceConnectionId: 'conn-source-1',
+  sourceDeliveryMethod: { name: 'Allegro Paczkomat InPost', typeId: 'ai-1' },
+  resolutionSource: 'default',
+  ...overrides,
+});
+
+describe('DeliveryRiderService', () => {
+  let service: DeliveryRiderService;
+  let integrations: jest.Mocked<Pick<IIntegrationsService, 'listCapabilityAdapters'>>;
+  let registry: jest.Mocked<Pick<AdapterRegistryPort, 'listAdapters'>>;
+
+  beforeEach(async () => {
+    integrations = { listCapabilityAdapters: jest.fn().mockResolvedValue([]) };
+    registry = { listAdapters: jest.fn().mockResolvedValue([]) };
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        DeliveryRiderService,
+        { provide: INTEGRATIONS_SERVICE_TOKEN, useValue: integrations },
+        { provide: ADAPTER_REGISTRY_TOKEN, useValue: registry },
+      ],
+    }).compile();
+
+    service = module.get(DeliveryRiderService);
+  });
+
+  describe('resolve', () => {
+    it('returns "unmapped" when the method maps to a CONNECTED carrier', async () => {
+      integrations.listCapabilityAdapters.mockResolvedValue([connectedCarrier('inpost')] as never);
+      registry.listAdapters.mockResolvedValue([carrierAdapter('inpost')]);
+
+      const result = await service.resolve(defaultInput());
+
+      expect(result).toEqual({
+        rider: 'unmapped',
+        candidateCarrier: { platformType: 'inpost', displayName: 'InPost' },
+      });
+      // Read carrier state through the integrations seam, filtering on the
+      // ShippingProviderManager capability (never a concrete adapter).
+      expect(integrations.listCapabilityAdapters).toHaveBeenCalledWith(
+        expect.objectContaining({ capability: 'ShippingProviderManager', lazy: true })
+      );
+    });
+
+    it('returns "not-connected" when the carrier is SUPPORTED (registered) but not connected', async () => {
+      integrations.listCapabilityAdapters.mockResolvedValue([] as never);
+      registry.listAdapters.mockResolvedValue([carrierAdapter('inpost'), carrierAdapter('dpd')]);
+
+      const result = await service.resolve(defaultInput({ sourceDeliveryMethod: { name: 'Kurier DPD', typeId: null } }));
+
+      expect(result).toEqual({
+        rider: 'not-connected',
+        candidateCarrier: { platformType: 'dpd', displayName: 'DPD' },
+      });
+    });
+
+    it('returns "none" when the matched carrier is neither connected nor supported', async () => {
+      integrations.listCapabilityAdapters.mockResolvedValue([] as never);
+      registry.listAdapters.mockResolvedValue([]); // dpd plugin not loaded
+
+      const result = await service.resolve(defaultInput({ sourceDeliveryMethod: { name: 'Kurier DPD', typeId: null } }));
+
+      expect(result).toEqual({ rider: 'none' });
+    });
+
+    it('returns "none" for a method that maps to no carrier', async () => {
+      const result = await service.resolve(
+        defaultInput({ sourceDeliveryMethod: { name: 'Kurier standardowy', typeId: 'courier-1' } })
+      );
+
+      expect(result).toEqual({ rider: 'none' });
+      // No carrier candidate → no carrier-state reads at all.
+      expect(integrations.listCapabilityAdapters).not.toHaveBeenCalled();
+      expect(registry.listAdapters).not.toHaveBeenCalled();
+    });
+
+    it('returns "none" for a NON-default resolution, without reading carrier state', async () => {
+      const result = await service.resolve(defaultInput({ resolutionSource: 'rule' }));
+
+      expect(result).toEqual({ rider: 'none' });
+      expect(integrations.listCapabilityAdapters).not.toHaveBeenCalled();
+      expect(registry.listAdapters).not.toHaveBeenCalled();
+    });
+
+    it('prefers "unmapped" over "not-connected" when the carrier is both connected and supported', async () => {
+      integrations.listCapabilityAdapters.mockResolvedValue([connectedCarrier('inpost')] as never);
+      registry.listAdapters.mockResolvedValue([carrierAdapter('inpost')]);
+
+      const result = await service.resolve(defaultInput());
+
+      expect(result.rider).toBe('unmapped');
+    });
+  });
+
+  describe('resolveBatch', () => {
+    it('resolves each input positionally and reads carrier state ONCE for the whole batch', async () => {
+      integrations.listCapabilityAdapters.mockResolvedValue([connectedCarrier('inpost')] as never);
+      registry.listAdapters.mockResolvedValue([carrierAdapter('inpost'), carrierAdapter('dpd')]);
+
+      const results = await service.resolveBatch([
+        defaultInput(), // inpost, connected → unmapped
+        defaultInput({ sourceDeliveryMethod: { name: 'Kurier DPD', typeId: null } }), // dpd, supported → not-connected
+        defaultInput({ sourceDeliveryMethod: { name: 'Kurier standardowy', typeId: null } }), // none
+        defaultInput({ resolutionSource: 'rule' }), // rule → none
+      ]);
+
+      expect(results.map((r) => r.rider)).toEqual([
+        'unmapped',
+        'not-connected',
+        'none',
+        'none',
+      ]);
+      // Carrier-state reads happen once, not per order.
+      expect(integrations.listCapabilityAdapters).toHaveBeenCalledTimes(1);
+      expect(registry.listAdapters).toHaveBeenCalledTimes(1);
+    });
+
+    it('skips carrier-state reads entirely when no input has an actionable candidate', async () => {
+      const results = await service.resolveBatch([
+        defaultInput({ resolutionSource: 'rule' }),
+        defaultInput({ sourceDeliveryMethod: { name: 'Kurier standardowy', typeId: null } }),
+      ]);
+
+      expect(results).toEqual([{ rider: 'none' }, { rider: 'none' }]);
+      expect(integrations.listCapabilityAdapters).not.toHaveBeenCalled();
+      expect(registry.listAdapters).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('routing isolation (critical invariant)', () => {
+    it('depends only on the integrations + registry read seams — it takes NO routing collaborator', () => {
+      // The service constructor accepts exactly the two read ports; there is no
+      // FulfillmentRoutingService dependency, so the heuristic cannot feed back
+      // into a routing/dispatch decision. A wrong guess only changes which hint
+      // is shown, never where a parcel goes.
+      expect(DeliveryRiderService.length).toBe(2);
+    });
+  });
+});

--- a/libs/core/src/mappings/application/services/delivery-rider.service.ts
+++ b/libs/core/src/mappings/application/services/delivery-rider.service.ts
@@ -1,0 +1,137 @@
+/**
+ * Delivery Rider Service
+ *
+ * Resolves the delivery-rider hint (#1792, epic #1776) for a defaulted order:
+ * maps the raw source delivery method to a candidate carrier via the pure
+ * {@link matchCandidateCarrier} heuristic, then reads carrier state through the
+ * integrations seam — connected carriers via `listCapabilityAdapters`, and the
+ * set of carriers OL *supports* from the adapter registry — to pick between
+ * `unmapped` (Add mapping), `not-connected` (Connect), or `none`.
+ *
+ * INVARIANT: this service is a pure read-side hint. It takes NO dependency on
+ * `FulfillmentRoutingService` and nothing it returns feeds back into routing —
+ * the heuristic only picks which hint to render, never where a parcel goes. A
+ * wrong or missing guess degrades to `none`, never to a wrong dispatch.
+ *
+ * @module application/services
+ * @implements {IDeliveryRiderService}
+ */
+
+import { Inject, Injectable } from '@nestjs/common';
+import {
+  ADAPTER_REGISTRY_TOKEN,
+  type AdapterRegistryPort,
+  IIntegrationsService,
+  INTEGRATIONS_SERVICE_TOKEN,
+} from '@openlinker/core/integrations';
+import type { IDeliveryRiderService } from '../interfaces/delivery-rider.service.interface';
+import { matchCandidateCarrier } from '../../domain/delivery-rider-heuristic';
+import type {
+  CandidateCarrier,
+  DeliveryRiderInput,
+  DeliveryRiderResolution,
+} from '../../domain/types/delivery-rider.types';
+
+/**
+ * Capability a connection/adapter must declare to be a rider-eligible carrier.
+ * `ShippingProviderManager` is an open/plugin capability (#763) — not a member
+ * of the closed `CoreCapability` set — so it stays a bare literal, matching the
+ * InPost/DPD adapter manifests that register it.
+ */
+const SHIPPING_PROVIDER_MANAGER_CAPABILITY = 'ShippingProviderManager';
+
+/**
+ * Order-independent carrier state read once per batch: which carrier
+ * `platformType`s have an active, capability-enabled connection, and which are
+ * supported (an adapter is registered declaring the capability).
+ */
+interface CarrierState {
+  connectedPlatformTypes: Set<string>;
+  supportedPlatformTypes: Set<string>;
+}
+
+@Injectable()
+export class DeliveryRiderService implements IDeliveryRiderService {
+  constructor(
+    @Inject(INTEGRATIONS_SERVICE_TOKEN)
+    private readonly integrations: IIntegrationsService,
+    @Inject(ADAPTER_REGISTRY_TOKEN)
+    private readonly adapterRegistry: AdapterRegistryPort,
+  ) {}
+
+  async resolve(input: DeliveryRiderInput): Promise<DeliveryRiderResolution> {
+    const candidate = this.candidateFor(input);
+    if (!candidate) {
+      return { rider: 'none' };
+    }
+    const state = await this.loadCarrierState();
+    return this.evaluate(candidate, state);
+  }
+
+  async resolveBatch(inputs: DeliveryRiderInput[]): Promise<DeliveryRiderResolution[]> {
+    const candidates = inputs.map((input) => this.candidateFor(input));
+
+    // Skip the carrier-state reads entirely unless at least one input has an
+    // actionable candidate — a page of rule-resolved / no-match orders costs
+    // zero integration round trips.
+    if (candidates.every((candidate) => candidate === null)) {
+      return candidates.map(() => ({ rider: 'none' }));
+    }
+
+    const state = await this.loadCarrierState();
+    return candidates.map((candidate) =>
+      candidate ? this.evaluate(candidate, state) : { rider: 'none' },
+    );
+  }
+
+  /**
+   * The candidate carrier for an input, or `null` when the rider must not fire:
+   * a non-`default` resolution, or a method that maps to no known carrier. This
+   * is the only place the heuristic runs.
+   */
+  private candidateFor(input: DeliveryRiderInput): CandidateCarrier | null {
+    if (input.resolutionSource !== 'default') {
+      return null;
+    }
+    return matchCandidateCarrier(input.sourceDeliveryMethod);
+  }
+
+  /** Map a matched candidate + carrier state to the rider decision. */
+  private evaluate(candidate: CandidateCarrier, state: CarrierState): DeliveryRiderResolution {
+    if (state.connectedPlatformTypes.has(candidate.platformType)) {
+      return { rider: 'unmapped', candidateCarrier: candidate };
+    }
+    if (state.supportedPlatformTypes.has(candidate.platformType)) {
+      return { rider: 'not-connected', candidateCarrier: candidate };
+    }
+    return { rider: 'none' };
+  }
+
+  /**
+   * Read the order-independent carrier state once. `connectedPlatformTypes`
+   * comes from active, capability-enabled `ShippingProviderManager` connections
+   * (lazy: no adapter is constructed — only `connection.platformType` is read).
+   * `supportedPlatformTypes` comes from the adapter registry — the authoritative
+   * "supported carrier" source (#1792), never a hardcoded list.
+   */
+  private async loadCarrierState(): Promise<CarrierState> {
+    const connected = await this.integrations.listCapabilityAdapters<unknown>({
+      capability: SHIPPING_PROVIDER_MANAGER_CAPABILITY,
+      lazy: true,
+    });
+    const connectedPlatformTypes = new Set(
+      connected.map((entry) => entry.connection.platformType),
+    );
+
+    const adapters = await this.adapterRegistry.listAdapters();
+    const supportedPlatformTypes = new Set(
+      adapters
+        .filter((metadata) =>
+          metadata.supportedCapabilities.includes(SHIPPING_PROVIDER_MANAGER_CAPABILITY),
+        )
+        .map((metadata) => metadata.platformType),
+    );
+
+    return { connectedPlatformTypes, supportedPlatformTypes };
+  }
+}

--- a/libs/core/src/mappings/application/services/delivery-rider.service.ts
+++ b/libs/core/src/mappings/application/services/delivery-rider.service.ts
@@ -115,6 +115,10 @@ export class DeliveryRiderService implements IDeliveryRiderService {
    * "supported carrier" source (#1792), never a hardcoded list.
    */
   private async loadCarrierState(): Promise<CarrierState> {
+    // "Connected" deliberately means the connection has ShippingProviderManager
+    // *enabled* (listCapabilityAdapters gates on connection.enabledCapabilities,
+    // not just adapter support), so a carrier-type connection that hasn't
+    // enabled shipping is intentionally treated as `not-connected`, not `unmapped`.
     const connected = await this.integrations.listCapabilityAdapters<unknown>({
       capability: SHIPPING_PROVIDER_MANAGER_CAPABILITY,
       lazy: true,

--- a/libs/core/src/mappings/domain/delivery-rider-heuristic.spec.ts
+++ b/libs/core/src/mappings/domain/delivery-rider-heuristic.spec.ts
@@ -1,0 +1,74 @@
+/**
+ * Delivery Rider Heuristic Unit Tests (#1792)
+ *
+ * @module libs/core/src/mappings/domain
+ */
+import { matchCandidateCarrier } from './delivery-rider-heuristic';
+import { CANDIDATE_CARRIER_HEURISTICS } from './types/delivery-rider.types';
+
+describe('matchCandidateCarrier', () => {
+  it('maps a "paczkomat" method name to InPost', () => {
+    expect(
+      matchCandidateCarrier({ name: 'Allegro Paczkomat InPost', typeId: 'abc-123' })
+    ).toEqual({ platformType: 'inpost', displayName: 'InPost' });
+  });
+
+  it('maps an "inpost" method name to InPost', () => {
+    expect(matchCandidateCarrier({ name: 'InPost Kurier', typeId: null })).toEqual({
+      platformType: 'inpost',
+      displayName: 'InPost',
+    });
+  });
+
+  it('maps a "dpd" method name to DPD', () => {
+    expect(matchCandidateCarrier({ name: 'Kurier DPD', typeId: null })).toEqual({
+      platformType: 'dpd',
+      displayName: 'DPD',
+    });
+  });
+
+  it('matches case-insensitively', () => {
+    expect(matchCandidateCarrier({ name: 'PACZKOMAT INPOST', typeId: null })?.platformType).toBe(
+      'inpost'
+    );
+  });
+
+  it('matches against the typeId when the name carries no keyword', () => {
+    expect(
+      matchCandidateCarrier({ name: 'Punkt odbioru', typeId: 'ALLEGRO-INPOST-LOCKER' })
+        ?.platformType
+    ).toBe('inpost');
+  });
+
+  it('returns null for a method with no carrier keyword', () => {
+    expect(matchCandidateCarrier({ name: 'Kurier standardowy', typeId: 'courier-1' })).toBeNull();
+  });
+
+  it('returns null when both name and typeId are null', () => {
+    expect(matchCandidateCarrier({ name: null, typeId: null })).toBeNull();
+  });
+
+  it('returns null when both fields are empty/whitespace', () => {
+    expect(matchCandidateCarrier({ name: '   ', typeId: '' })).toBeNull();
+  });
+
+  it('every heuristic table entry resolves to a candidate for each of its keywords', () => {
+    for (const entry of CANDIDATE_CARRIER_HEURISTICS) {
+      for (const keyword of entry.keywords) {
+        expect(matchCandidateCarrier({ name: keyword, typeId: null })).toEqual({
+          platformType: entry.platformType,
+          displayName: entry.displayName,
+        });
+      }
+    }
+  });
+
+  it('is pure — repeated calls with the same input yield equal, side-effect-free results', () => {
+    const input = { name: 'Paczkomat InPost', typeId: null };
+    const first = matchCandidateCarrier(input);
+    const second = matchCandidateCarrier(input);
+    expect(first).toEqual(second);
+    // Input is not mutated.
+    expect(input).toEqual({ name: 'Paczkomat InPost', typeId: null });
+  });
+});

--- a/libs/core/src/mappings/domain/delivery-rider-heuristic.spec.ts
+++ b/libs/core/src/mappings/domain/delivery-rider-heuristic.spec.ts
@@ -3,8 +3,7 @@
  *
  * @module libs/core/src/mappings/domain
  */
-import { matchCandidateCarrier } from './delivery-rider-heuristic';
-import { CANDIDATE_CARRIER_HEURISTICS } from './types/delivery-rider.types';
+import { matchCandidateCarrier, CANDIDATE_CARRIER_HEURISTICS } from './delivery-rider-heuristic';
 
 describe('matchCandidateCarrier', () => {
   it('maps a "paczkomat" method name to InPost', () => {

--- a/libs/core/src/mappings/domain/delivery-rider-heuristic.ts
+++ b/libs/core/src/mappings/domain/delivery-rider-heuristic.ts
@@ -1,0 +1,36 @@
+/**
+ * Delivery Rider Heuristic
+ *
+ * Pure mapping of a raw source delivery method to a candidate carrier (#1792),
+ * reading the single-source-of-truth {@link CANDIDATE_CARRIER_HEURISTICS} table.
+ * No I/O, no framework deps — the heuristic half of the delivery rider, kept
+ * pure and independently testable, and deliberately isolated from any routing
+ * decision (its output only picks which hint to show, never where a parcel goes).
+ *
+ * @module libs/core/src/mappings/domain
+ */
+import {
+  CANDIDATE_CARRIER_HEURISTICS,
+  type CandidateCarrier,
+  type RiderSourceDeliveryMethod,
+} from './types/delivery-rider.types';
+
+/**
+ * Map a source delivery method to a candidate carrier via keyword/alias match,
+ * or `null` when nothing matches. First matching table entry wins (table order
+ * is the precedence). Case-insensitive substring test over `name` + `typeId`.
+ */
+export function matchCandidateCarrier(
+  method: RiderSourceDeliveryMethod,
+): CandidateCarrier | null {
+  const haystack = `${method.name ?? ''} ${method.typeId ?? ''}`.toLowerCase();
+  if (haystack.trim() === '') {
+    return null;
+  }
+  for (const entry of CANDIDATE_CARRIER_HEURISTICS) {
+    if (entry.keywords.some((keyword) => haystack.includes(keyword))) {
+      return { platformType: entry.platformType, displayName: entry.displayName };
+    }
+  }
+  return null;
+}

--- a/libs/core/src/mappings/domain/delivery-rider-heuristic.ts
+++ b/libs/core/src/mappings/domain/delivery-rider-heuristic.ts
@@ -9,11 +9,26 @@
  *
  * @module libs/core/src/mappings/domain
  */
-import {
-  CANDIDATE_CARRIER_HEURISTICS,
-  type CandidateCarrier,
-  type RiderSourceDeliveryMethod,
+import type {
+  CandidateCarrier,
+  CarrierHeuristicEntry,
+  RiderSourceDeliveryMethod,
 } from './types/delivery-rider.types';
+
+/**
+ * The single-source-of-truth heuristic table mapping a raw source delivery
+ * method to a candidate carrier `platformType`. Seeded with the carriers OL
+ * supports today; adding a carrier is a one-line entry here.
+ *
+ * Match semantics: a case-insensitive substring test of any keyword against the
+ * method's `name` + `typeId`. `platformType` MUST match the carrier adapter's
+ * manifest `platformType` (`inpost`, `dpd`) so the connection/registry lookups
+ * key correctly.
+ */
+export const CANDIDATE_CARRIER_HEURISTICS: readonly CarrierHeuristicEntry[] = [
+  { platformType: 'inpost', displayName: 'InPost', keywords: ['paczkomat', 'inpost'] },
+  { platformType: 'dpd', displayName: 'DPD', keywords: ['dpd'] },
+];
 
 /**
  * Map a source delivery method to a candidate carrier via keyword/alias match,

--- a/libs/core/src/mappings/domain/types/delivery-rider.types.ts
+++ b/libs/core/src/mappings/domain/types/delivery-rider.types.ts
@@ -1,0 +1,96 @@
+/**
+ * Delivery Rider Types
+ *
+ * Types for the delivery-rider hint (#1792, epic #1776): on a `default`-resolved
+ * order (no fulfillment-routing rule matched → shop-fulfilled fallback), decide
+ * which actionable hint the operator should see for the order's raw source
+ * delivery method — *Add mapping* (a supported carrier is connected),
+ * *Connect {carrier}* (OL supports the carrier but none is connected), or
+ * *nothing* (OL can't handle it, the shop is correct).
+ *
+ * The rider is a pure read-side hint layered on top of the #1791
+ * `deliveryResolution` projection. It NEVER influences routing/dispatch — a
+ * wrong or missing heuristic guess degrades to `none`, never to wrong dispatch.
+ *
+ * @module libs/core/src/mappings/domain/types
+ */
+
+import type { FulfillmentRoutingSource } from './fulfillment-routing.types';
+
+/**
+ * The actionable hint to render for a defaulted order's delivery method:
+ * - `unmapped`: the method maps to a carrier that IS connected → *Add mapping*.
+ * - `not-connected`: the method maps to a carrier OL supports (an adapter is
+ *   registered) but none is connected → *Connect {carrier}*.
+ * - `none`: no carrier match, a non-default resolution, or a matched carrier OL
+ *   doesn't support → show nothing.
+ */
+export const DeliveryRiderValues = ['unmapped', 'not-connected', 'none'] as const;
+export type DeliveryRider = (typeof DeliveryRiderValues)[number];
+
+/**
+ * The raw source delivery method the heuristic maps to a candidate carrier.
+ * Kept as loose primitives (not the `Order` entity) so `mappings` stays
+ * decoupled from `orders`. Both fields are nullable — a source may expose only
+ * a human label, only an opaque id, or neither.
+ */
+export interface RiderSourceDeliveryMethod {
+  /** Human-facing method label (e.g. Allegro `"Allegro Paczkomat InPost"`). */
+  name: string | null;
+  /** Opaque source-side method/type identifier (`OrderShipping.methodId`). */
+  typeId: string | null;
+}
+
+/**
+ * Input to resolve a delivery rider. `resolutionSource` is #1791's
+ * `deliveryResolution.source`; the rider only fires when it is `'default'`.
+ */
+export interface DeliveryRiderInput {
+  sourceConnectionId: string;
+  sourceDeliveryMethod: RiderSourceDeliveryMethod;
+  resolutionSource: FulfillmentRoutingSource;
+}
+
+/**
+ * The candidate carrier the heuristic mapped a source method to. `displayName`
+ * is the canonical carrier label the FE renders on the button (e.g. `"InPost"`),
+ * carried on the heuristic entry so it stays stable regardless of adapter naming.
+ */
+export interface CandidateCarrier {
+  platformType: string;
+  displayName: string;
+}
+
+/**
+ * The resolved rider. `candidateCarrier` is present only for the actionable
+ * riders (`unmapped` / `not-connected`) — `none` carries no carrier.
+ */
+export interface DeliveryRiderResolution {
+  rider: DeliveryRider;
+  candidateCarrier?: CandidateCarrier;
+}
+
+/**
+ * One entry of the carrier heuristic table: a candidate carrier plus the
+ * lowercase substrings that identify it in a source method's name/typeId.
+ */
+export interface CarrierHeuristicEntry {
+  platformType: string;
+  displayName: string;
+  keywords: readonly string[];
+}
+
+/**
+ * The single-source-of-truth heuristic table mapping a raw source delivery
+ * method to a candidate carrier `platformType`. Seeded with the carriers OL
+ * supports today; adding a carrier is a one-line entry here.
+ *
+ * Match semantics: a case-insensitive substring test of any keyword against the
+ * method's `name` + `typeId`. `platformType` MUST match the carrier adapter's
+ * manifest `platformType` (`inpost`, `dpd`) so the connection/registry lookups
+ * key correctly.
+ */
+export const CANDIDATE_CARRIER_HEURISTICS: readonly CarrierHeuristicEntry[] = [
+  { platformType: 'inpost', displayName: 'InPost', keywords: ['paczkomat', 'inpost'] },
+  { platformType: 'dpd', displayName: 'DPD', keywords: ['dpd'] },
+];

--- a/libs/core/src/mappings/domain/types/delivery-rider.types.ts
+++ b/libs/core/src/mappings/domain/types/delivery-rider.types.ts
@@ -72,25 +72,12 @@ export interface DeliveryRiderResolution {
 
 /**
  * One entry of the carrier heuristic table: a candidate carrier plus the
- * lowercase substrings that identify it in a source method's name/typeId.
+ * lowercase substrings that identify it in a source method's name/typeId. The
+ * runtime table itself lives co-located with `matchCandidateCarrier` in
+ * `delivery-rider-heuristic.ts`.
  */
 export interface CarrierHeuristicEntry {
   platformType: string;
   displayName: string;
   keywords: readonly string[];
 }
-
-/**
- * The single-source-of-truth heuristic table mapping a raw source delivery
- * method to a candidate carrier `platformType`. Seeded with the carriers OL
- * supports today; adding a carrier is a one-line entry here.
- *
- * Match semantics: a case-insensitive substring test of any keyword against the
- * method's `name` + `typeId`. `platformType` MUST match the carrier adapter's
- * manifest `platformType` (`inpost`, `dpd`) so the connection/registry lookups
- * key correctly.
- */
-export const CANDIDATE_CARRIER_HEURISTICS: readonly CarrierHeuristicEntry[] = [
-  { platformType: 'inpost', displayName: 'InPost', keywords: ['paczkomat', 'inpost'] },
-  { platformType: 'dpd', displayName: 'DPD', keywords: ['dpd'] },
-];

--- a/libs/core/src/mappings/index.ts
+++ b/libs/core/src/mappings/index.ts
@@ -45,3 +45,14 @@ export type {
   FulfillmentRoutingResolution,
   CandidateProcessor,
 } from './domain/types/fulfillment-routing.types';
+
+// Delivery rider (#1792)
+export type { IDeliveryRiderService } from './application/interfaces/delivery-rider.service.interface';
+export { DeliveryRiderValues } from './domain/types/delivery-rider.types';
+export type {
+  DeliveryRider,
+  RiderSourceDeliveryMethod,
+  DeliveryRiderInput,
+  CandidateCarrier,
+  DeliveryRiderResolution,
+} from './domain/types/delivery-rider.types';

--- a/libs/core/src/mappings/mappings.module.ts
+++ b/libs/core/src/mappings/mappings.module.ts
@@ -31,6 +31,7 @@ import { OrderStateMappingRepository } from './infrastructure/persistence/reposi
 import { FulfillmentRoutingRepository } from './infrastructure/persistence/repositories/fulfillment-routing.repository';
 import { MappingConfigService } from './application/services/mapping-config.service';
 import { FulfillmentRoutingService } from './application/services/fulfillment-routing.service';
+import { DeliveryRiderService } from './application/services/delivery-rider.service';
 import {
   MAPPING_CONFIG_SERVICE_TOKEN,
   STATUS_MAPPING_REPOSITORY_TOKEN,
@@ -41,6 +42,7 @@ import {
   ORDER_STATE_MAPPING_REPOSITORY_TOKEN,
   FULFILLMENT_ROUTING_REPOSITORY_TOKEN,
   FULFILLMENT_ROUTING_SERVICE_TOKEN,
+  DELIVERY_RIDER_SERVICE_TOKEN,
 } from './mappings.tokens';
 
 @Module({
@@ -71,6 +73,7 @@ import {
     FulfillmentRoutingRepository,
     MappingConfigService,
     FulfillmentRoutingService,
+    DeliveryRiderService,
     {
       provide: STATUS_MAPPING_REPOSITORY_TOKEN,
       useExisting: StatusMappingRepository,
@@ -107,11 +110,16 @@ import {
       provide: FULFILLMENT_ROUTING_SERVICE_TOKEN,
       useExisting: FulfillmentRoutingService,
     },
+    {
+      provide: DELIVERY_RIDER_SERVICE_TOKEN,
+      useExisting: DeliveryRiderService,
+    },
   ],
   exports: [
     MAPPING_CONFIG_SERVICE_TOKEN,
     MappingConfigService,
     FULFILLMENT_ROUTING_SERVICE_TOKEN,
+    DELIVERY_RIDER_SERVICE_TOKEN,
   ],
 })
 export class MappingsModule {}

--- a/libs/core/src/mappings/mappings.tokens.ts
+++ b/libs/core/src/mappings/mappings.tokens.ts
@@ -15,3 +15,4 @@ export const ATTRIBUTE_MAPPING_REPOSITORY_TOKEN = Symbol('AttributeMappingReposi
 export const ORDER_STATE_MAPPING_REPOSITORY_TOKEN = Symbol('OrderStateMappingRepositoryPort');
 export const FULFILLMENT_ROUTING_REPOSITORY_TOKEN = Symbol('FulfillmentRoutingRepositoryPort');
 export const FULFILLMENT_ROUTING_SERVICE_TOKEN = Symbol('IFulfillmentRoutingService');
+export const DELIVERY_RIDER_SERVICE_TOKEN = Symbol('IDeliveryRiderService');

--- a/libs/core/src/orders/domain/entities/order-record.entity.spec.ts
+++ b/libs/core/src/orders/domain/entities/order-record.entity.spec.ts
@@ -89,3 +89,26 @@ describe('OrderRecord.sourceDeliveryMethodId (#1791)', () => {
     expect(makeRecord({ shipping: { methodId: 42 } }).sourceDeliveryMethodId).toBeNull();
   });
 });
+
+describe('OrderRecord.sourceDeliveryMethodName (#1792)', () => {
+  it('returns the methodName from a well-formed shipping snapshot', () => {
+    expect(
+      makeRecord({ shipping: { methodId: 'ai-1', methodName: 'Allegro Paczkomat InPost' } })
+        .sourceDeliveryMethodName,
+    ).toBe('Allegro Paczkomat InPost');
+  });
+
+  it('returns null when the snapshot has no shipping key', () => {
+    expect(makeRecord({}).sourceDeliveryMethodName).toBeNull();
+  });
+
+  it('returns null when shipping is not an object', () => {
+    expect(makeRecord({ shipping: 'x' }).sourceDeliveryMethodName).toBeNull();
+    expect(makeRecord({ shipping: null }).sourceDeliveryMethodName).toBeNull();
+  });
+
+  it('returns null when methodName is missing or non-string (id present, no label)', () => {
+    expect(makeRecord({ shipping: { methodId: 'ai-1' } }).sourceDeliveryMethodName).toBeNull();
+    expect(makeRecord({ shipping: { methodName: 7 } }).sourceDeliveryMethodName).toBeNull();
+  });
+});

--- a/libs/core/src/orders/domain/entities/order-record.entity.ts
+++ b/libs/core/src/orders/domain/entities/order-record.entity.ts
@@ -115,4 +115,21 @@ export class OrderRecord {
     const { methodId } = shipping as Record<string, unknown>;
     return typeof methodId === 'string' ? methodId : null;
   }
+
+  /**
+   * Typed, fail-safe read of the source-side delivery method's human label
+   * (#1792) from the snapshot (`orderSnapshot.shipping.methodName`). Pure
+   * derivation of an already-loaded field (ADR-011): no I/O, no mutation.
+   * Mirrors {@link sourceDeliveryMethodId} — the delivery-rider heuristic keys
+   * mainly on this label (a marketplace method id is typically opaque). Returns
+   * `null` when the source exposed no label or the snapshot predates the field.
+   */
+  get sourceDeliveryMethodName(): string | null {
+    const shipping = this.orderSnapshot.shipping;
+    if (typeof shipping !== 'object' || shipping === null) {
+      return null;
+    }
+    const { methodName } = shipping as Record<string, unknown>;
+    return typeof methodName === 'string' ? methodName : null;
+  }
 }


### PR DESCRIPTION
## What changed

Adds a read-only **delivery-rider hint** on the orders response, layered on top of #1791's `deliveryResolution`. For a `default`-resolved order (no fulfillment-routing rule matched -> shop-fulfilled fallback), it tells the operator which actionable hint to show:

| Rider | Meaning | Button |
|---|---|---|
| `unmapped` | the method maps to a carrier that IS connected | Add mapping |
| `not-connected` | OL supports the carrier (an adapter is registered) but none is connected | Connect {carrier} |
| `none` | no carrier match, a non-default resolution, or a carrier OL can't handle | (nothing) |

### Core (`libs/core/src/mappings`)
- **`DeliveryRiderService`** (application layer) resolves the rider. It only fires when `resolutionSource === 'default'`; otherwise `none`.
  1. **Heuristic** - the pure `matchCandidateCarrier` maps the source method (`name` + `typeId`) to a candidate carrier `platformType` via a **single-place** keyword/alias table (`CANDIDATE_CARRIER_HEURISTICS`, seeded with `paczkomat`/`inpost` -> `inpost`, `dpd` -> `dpd`; adding a carrier is a one-line entry). No match -> `none`.
  2. **Connected?** - `IIntegrationsService.listCapabilityAdapters({ capability: 'ShippingProviderManager', lazy: true })`; a connection of the candidate `platformType` exists -> `unmapped`.
  3. **Supported but not connected?** - the candidate `platformType` is registered in `AdapterRegistryPort.listAdapters()` declaring `ShippingProviderManager`, but no connection -> `not-connected`. **"Supported carrier" is read from the registry, never a hardcoded list.**
  4. Otherwise -> `none`.
- Rider values use an `as const` + union type (`DeliveryRiderValues` / `DeliveryRider`) in a `*.types.ts` per engineering standards.
- `OrderRecord.sourceDeliveryMethodName` getter (ADR-011 pure read) mirrors #1791's `sourceDeliveryMethodId` for the heuristic's method label.

### Critical invariant: the heuristic never influences routing
`DeliveryRiderService` takes **no** `FulfillmentRoutingService` dependency and nothing it returns feeds back into `resolve` - the heuristic only picks which hint to render. A wrong or missing guess degrades to `none`, never to a wrong dispatch. This is asserted in the unit tests.

### API (`apps/api/src/orders`)
- `OrderDeliveryRiderDto` + a `deliveryRider?` field on the order response.
- `OrdersController` attaches `deliveryRider` next to `deliveryResolution` on **both** the list (batched - carrier state read once per page) and detail reads, following the exact #1791 wiring pattern.

## Tests
- **Unit** - the heuristic table + all three rider branches + the routing-isolation invariant (`libs/core/src/mappings/.../delivery-rider*.spec.ts`, `orders.controller.spec.ts`, `order-record.entity.spec.ts`).
- **Integration** (`order-delivery-rider.int-spec.ts`) - real Postgres connections + real adapter registry: `unmapped` (connected InPost), `not-connected` (DPD registered, no connection), `none` (no carrier match), and `none` for a rule-resolved order. Verified passing locally against Testcontainers.

## Gate (scoped to touched packages)
`type-check` (core + api), unit tests (core + api), the rider integration spec, `check-cross-context-imports`, `check-service-interfaces`, and per-package lint - all pass with zero errors.

## Notes for review
- Rider service placed in `libs/core/src/mappings` (not `shipping`) because it consumes #1791's `FulfillmentRoutingSource` and is the natural sibling of fulfillment routing; `mappings` already depends on `integrations`.
- Carrier state (`listCapabilityAdapters` + registry `listAdapters`) is order-independent, so `resolveBatch` reads it once per page rather than per order.

Part of epic #1776. References #1792.