### PR TITLE
feat(orders): delivery chip - four outcomes + rider (list & detail)

### DIFF
--- a/apps/web/src/features/orders/api/orders.types.ts
+++ b/apps/web/src/features/orders/api/orders.types.ts
@@ -66,6 +66,52 @@ export type FulfillmentRollupStateValue = (typeof FulfillmentRollupStateValues)[
 export const SlaStateValues = ['none', 'on_track', 'at_risk', 'overdue'] as const;
 export type SlaStateValue = (typeof SlaStateValues)[number];
 
+// ── Mapping-aware delivery (epic #1776) ─────────────────────────────────────
+// Hand-mirrored from the BE order response DTOs (`OrderDeliveryResolutionDto`
+// #1791, `OrderDeliveryRiderDto` #1792) and the `@openlinker/core/mappings`
+// unions, per the FE-001 contract strategy — keep in sync with the backend.
+
+// How fulfillment routing resolved for the order's delivery method (#1791):
+// `rule` = a configured routing rule matched; `default` = the omp_fulfilled
+// fallback (shop-fulfilled). The rider only fires on a `default` resolution.
+export const FulfillmentRoutingSourceValues = ['rule', 'default'] as const;
+export type FulfillmentRoutingSource = (typeof FulfillmentRoutingSourceValues)[number];
+
+// Where the fulfilling connection sits (#1791). Mirrors the `mappings` feature's
+// `FulfillmentProcessorKind`; re-declared here so `orders` stays decoupled.
+export const FulfillmentProcessorKindValues = [
+  'omp_fulfilled',
+  'ol_managed_carrier',
+  'source_brokered',
+] as const;
+export type FulfillmentProcessorKind = (typeof FulfillmentProcessorKindValues)[number];
+
+/** Read-only projection of how fulfillment routing resolved for an order (#1791). */
+export interface OrderDeliveryResolution {
+  source: FulfillmentRoutingSource;
+  processorKind: FulfillmentProcessorKind;
+  processorConnectionId: string | null;
+}
+
+// Actionable delivery hint on a `default`-resolved order (#1792): `unmapped`
+// (a supported carrier is connected → Add mapping), `not-connected` (OL supports
+// the carrier but none is connected → Connect), `none` (show nothing).
+export const DeliveryRiderValues = ['unmapped', 'not-connected', 'none'] as const;
+export type DeliveryRiderValue = (typeof DeliveryRiderValues)[number];
+
+/** Heuristic-matched candidate carrier for an actionable rider (#1792). */
+export interface DeliveryRiderCandidateCarrier {
+  platformType: string;
+  displayName: string;
+}
+
+/** Delivery rider projection (#1792) — present alongside a `default` resolution. */
+export interface OrderDeliveryRider {
+  rider: DeliveryRiderValue;
+  /** Present only for the actionable riders (`unmapped` / `not-connected`). */
+  candidateCarrier?: DeliveryRiderCandidateCarrier;
+}
+
 export interface OrderRecord {
   internalOrderId: string;
   customerId: string | null;
@@ -105,6 +151,20 @@ export interface OrderRecord {
    * `dispatchByAt`. Optional for graceful degradation.
    */
   slaState?: SlaStateValue;
+  /**
+   * How fulfillment routing resolved for this order's delivery method (#1791).
+   * Optional — older/absent payloads degrade to a snapshot-only chip.
+   */
+  deliveryResolution?: OrderDeliveryResolution;
+  /**
+   * Actionable delivery hint on a defaulted order (#1792). Present only
+   * alongside a `default` resolution; `rider: 'none'` renders nothing.
+   */
+  deliveryRider?: OrderDeliveryRider;
+  /** Source delivery-method id (#1791) — the #1794 Add-mapping deep-link target. */
+  sourceDeliveryMethodId?: string | null;
+  /** Source delivery-method label (#1791). */
+  sourceDeliveryMethodName?: string | null;
 }
 
 // Result ordering for the orders list (#927, extended #944). Mirrors

--- a/apps/web/src/features/orders/components/delivery-chip.test.tsx
+++ b/apps/web/src/features/orders/components/delivery-chip.test.tsx
@@ -1,0 +1,128 @@
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { renderWithProviders } from '../../../test/test-utils';
+import type { OrderDeliveryRider } from '../api/orders.types';
+import {
+  DeliveryChip,
+  DeliveryOutcomeChip,
+  DeliveryRiderBanner,
+  DeliveryRiderChip,
+} from './delivery-chip';
+
+describe('DeliveryOutcomeChip', () => {
+  it('should render the "Resolved" label for the resolved outcome', () => {
+    renderWithProviders(<DeliveryOutcomeChip outcome="resolved" />);
+    expect(screen.getByText('Resolved')).toBeInTheDocument();
+  });
+
+  it('should render the "Awaiting label" label for the awaiting-label outcome', () => {
+    renderWithProviders(<DeliveryOutcomeChip outcome="awaiting-label" />);
+    expect(screen.getByText('Awaiting label')).toBeInTheDocument();
+  });
+
+  it('should render the "Shop-fulfilled" label for the shop-fulfilled outcome', () => {
+    renderWithProviders(<DeliveryOutcomeChip outcome="shop-fulfilled" />);
+    expect(screen.getByText('Shop-fulfilled')).toBeInTheDocument();
+  });
+
+  it('should render the "No method" label with the dashed modifier for the no-method outcome', () => {
+    const { container } = renderWithProviders(<DeliveryOutcomeChip outcome="no-method" />);
+    expect(screen.getByText('No method')).toBeInTheDocument();
+    expect(container.querySelector('.delivery-outcome-chip--dashed')).not.toBeNull();
+  });
+});
+
+describe('DeliveryRiderChip', () => {
+  it('should render the "Unmapped" rider', () => {
+    renderWithProviders(<DeliveryRiderChip rider={{ rider: 'unmapped' }} />);
+    expect(screen.getByText('Unmapped')).toBeInTheDocument();
+  });
+
+  it('should render the "Not connected" rider with the accent modifier', () => {
+    const { container } = renderWithProviders(
+      <DeliveryRiderChip rider={{ rider: 'not-connected' }} />,
+    );
+    expect(screen.getByText('Not connected')).toBeInTheDocument();
+    expect(container.querySelector('.delivery-rider-chip--not-connected')).not.toBeNull();
+  });
+
+  it('should render nothing for the "none" rider', () => {
+    renderWithProviders(<DeliveryRiderChip rider={{ rider: 'none' }} />);
+    expect(screen.queryByText('Unmapped')).not.toBeInTheDocument();
+    expect(screen.queryByText('Not connected')).not.toBeInTheDocument();
+  });
+});
+
+describe('DeliveryChip', () => {
+  it('should stack the outcome chip and the actionable rider chip', () => {
+    const rider: OrderDeliveryRider = {
+      rider: 'unmapped',
+      candidateCarrier: { platformType: 'inpost', displayName: 'InPost' },
+    };
+    renderWithProviders(<DeliveryChip outcome="shop-fulfilled" rider={rider} />);
+    expect(screen.getByText('Shop-fulfilled')).toBeInTheDocument();
+    expect(screen.getByText('Unmapped')).toBeInTheDocument();
+  });
+
+  it('should render only the outcome chip when the rider is "none"', () => {
+    renderWithProviders(<DeliveryChip outcome="shop-fulfilled" rider={{ rider: 'none' }} />);
+    expect(screen.getByText('Shop-fulfilled')).toBeInTheDocument();
+    expect(screen.queryByText('Unmapped')).not.toBeInTheDocument();
+    expect(screen.queryByText('Not connected')).not.toBeInTheDocument();
+  });
+
+  it('should render only the outcome chip when no rider is supplied', () => {
+    renderWithProviders(<DeliveryChip outcome="resolved" />);
+    expect(screen.getByText('Resolved')).toBeInTheDocument();
+    expect(screen.queryByText('Unmapped')).not.toBeInTheDocument();
+  });
+});
+
+describe('DeliveryRiderBanner', () => {
+  it('should render the unmapped explanation naming the candidate carrier + an "Add mapping" slot button', () => {
+    renderWithProviders(
+      <DeliveryRiderBanner
+        rider={{ rider: 'unmapped', candidateCarrier: { platformType: 'inpost', displayName: 'InPost' } }}
+      />,
+    );
+    expect(screen.getByText(/isn't mapped to a carrier/i)).toBeInTheDocument();
+    expect(screen.getByText(/InPost/)).toBeInTheDocument();
+    const button = screen.getByRole('button', { name: 'Add mapping' });
+    // Slot only — navigation is #1794, so the button is non-functional here.
+    expect(button).toBeDisabled();
+  });
+
+  it('should render the not-connected explanation + a "Connect {carrier}" slot button', () => {
+    renderWithProviders(
+      <DeliveryRiderBanner
+        rider={{ rider: 'not-connected', candidateCarrier: { platformType: 'dpd', displayName: 'DPD' } }}
+      />,
+    );
+    expect(screen.getByText(/no DPD connection is set up/i)).toBeInTheDocument();
+    const button = screen.getByRole('button', { name: 'Connect DPD' });
+    expect(button).toBeDisabled();
+  });
+
+  it('should prefer a caller-supplied action slot over the placeholder button', () => {
+    renderWithProviders(
+      <DeliveryRiderBanner
+        rider={{ rider: 'unmapped', candidateCarrier: { platformType: 'inpost', displayName: 'InPost' } }}
+        actionSlot={<a href="/mappings">Go map it</a>}
+      />,
+    );
+    expect(screen.getByRole('link', { name: 'Go map it' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Add mapping' })).not.toBeInTheDocument();
+  });
+
+  it('should render nothing for the "none" rider', () => {
+    renderWithProviders(<DeliveryRiderBanner rider={{ rider: 'none' }} />);
+    expect(screen.queryByRole('note')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('should fall back to "a carrier" when no candidate carrier is present', () => {
+    renderWithProviders(<DeliveryRiderBanner rider={{ rider: 'unmapped' }} />);
+    expect(screen.getByText(/map it to a carrier/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/orders/components/delivery-chip.tsx
+++ b/apps/web/src/features/orders/components/delivery-chip.tsx
@@ -16,9 +16,10 @@
  *
  * Colours reuse the design tokens via `StatusBadge`: green (`success`) =
  * resolved, blue (`info`) = awaiting-label, grey (`neutral`, dashed) = no
- * method / shop-fulfilled, amber (`warning`) = unmapped, signal-orange
- * (`--accent-primary`, via a className override) = not-connected. Colour is
- * never the only signal — every chip carries its text label + tone dot.
+ * method / shop-fulfilled, amber (`warning`) = unmapped, semantic conflict
+ * orange (`--status-conflict`, via a className override — distinct from the
+ * brand accent) = not-connected. Colour is never the only signal — every
+ * chip carries its text label + tone dot.
  *
  * @module apps/web/src/features/orders/components
  */

--- a/apps/web/src/features/orders/components/delivery-chip.tsx
+++ b/apps/web/src/features/orders/components/delivery-chip.tsx
@@ -1,0 +1,192 @@
+/**
+ * Delivery Chip
+ *
+ * Mapping-aware delivery presentation for the orders list + order detail
+ * (#1793, epic #1776). Renders one of four physical outcomes and, on a
+ * `default`-resolved shop-fulfilled order, an actionable rider stacked on top
+ * (never replacing the outcome):
+ *
+ * - `DeliveryChip` — the outcome pill plus, in list mode, the compact rider
+ *   pill beneath it (outcome + rider stacked).
+ * - `DeliveryOutcomeChip` — the outcome pill alone (order-detail Carrier row).
+ * - `DeliveryRiderChip` — the compact rider pill (list).
+ * - `DeliveryRiderBanner` — the order-detail inline banner: explanation text +
+ *   a fix-it button SLOT. The button's navigation is wired later (#1794); here
+ *   it is a non-functional placeholder, or a caller-supplied `actionSlot`.
+ *
+ * Colours reuse the design tokens via `StatusBadge`: green (`success`) =
+ * resolved, blue (`info`) = awaiting-label, grey (`neutral`, dashed) = no
+ * method / shop-fulfilled, amber (`warning`) = unmapped, signal-orange
+ * (`--accent-primary`, via a className override) = not-connected. Colour is
+ * never the only signal — every chip carries its text label + tone dot.
+ *
+ * @module apps/web/src/features/orders/components
+ */
+import type { ReactElement, ReactNode } from 'react';
+
+import { StatusBadge, type StatusBadgeTone } from '../../../shared/ui/status-badge';
+import type { OrderDeliveryRider } from '../api/orders.types';
+import type { DeliveryOutcome } from '../lib/delivery-outcome';
+
+const OUTCOME_LABEL: Record<DeliveryOutcome, string> = {
+  resolved: 'Resolved',
+  'awaiting-label': 'Awaiting label',
+  'shop-fulfilled': 'Shop-fulfilled',
+  'no-method': 'No method',
+};
+
+const OUTCOME_TONE: Record<DeliveryOutcome, StatusBadgeTone> = {
+  resolved: 'success',
+  'awaiting-label': 'info',
+  'shop-fulfilled': 'neutral',
+  'no-method': 'neutral',
+};
+
+type ActionableRider = 'unmapped' | 'not-connected';
+
+const RIDER_LABEL: Record<ActionableRider, string> = {
+  unmapped: 'Unmapped',
+  'not-connected': 'Not connected',
+};
+
+/** An actionable rider is one that renders a chip/banner (`unmapped` / `not-connected`). */
+function isActionableRider(
+  rider: OrderDeliveryRider | null | undefined,
+): rider is OrderDeliveryRider & { rider: ActionableRider } {
+  return !!rider && (rider.rider === 'unmapped' || rider.rider === 'not-connected');
+}
+
+function cx(...classes: (string | false | undefined)[]): string {
+  return classes.filter(Boolean).join(' ');
+}
+
+interface DeliveryOutcomeChipProps {
+  outcome: DeliveryOutcome;
+  className?: string;
+}
+
+export function DeliveryOutcomeChip({
+  outcome,
+  className = '',
+}: DeliveryOutcomeChipProps): ReactElement {
+  return (
+    <StatusBadge
+      tone={OUTCOME_TONE[outcome]}
+      withDot
+      compact
+      className={cx(
+        'delivery-outcome-chip',
+        outcome === 'no-method' && 'delivery-outcome-chip--dashed',
+        className,
+      )}
+    >
+      {OUTCOME_LABEL[outcome]}
+    </StatusBadge>
+  );
+}
+
+interface DeliveryRiderChipProps {
+  rider: OrderDeliveryRider;
+  className?: string;
+}
+
+export function DeliveryRiderChip({
+  rider,
+  className = '',
+}: DeliveryRiderChipProps): ReactElement | null {
+  if (!isActionableRider(rider)) {
+    return null;
+  }
+  return (
+    <StatusBadge
+      tone="warning"
+      withDot
+      compact
+      className={cx(
+        'delivery-rider-chip',
+        rider.rider === 'not-connected' && 'delivery-rider-chip--not-connected',
+        className,
+      )}
+    >
+      {RIDER_LABEL[rider.rider]}
+    </StatusBadge>
+  );
+}
+
+interface DeliveryChipProps {
+  outcome: DeliveryOutcome;
+  /** Rider stacked beneath the outcome (list surface). `none`/absent renders nothing. */
+  rider?: OrderDeliveryRider | null;
+  className?: string;
+}
+
+export function DeliveryChip({
+  outcome,
+  rider,
+  className = '',
+}: DeliveryChipProps): ReactElement {
+  return (
+    <span className={cx('delivery-chip', className)}>
+      <DeliveryOutcomeChip outcome={outcome} />
+      {isActionableRider(rider) ? <DeliveryRiderChip rider={rider} /> : null}
+    </span>
+  );
+}
+
+const RIDER_BANNER_TEXT: Record<ActionableRider, (carrier: string) => string> = {
+  unmapped: (carrier) =>
+    `This delivery method isn't mapped to a carrier. Map it to ${carrier} so OpenLinker generates the label.`,
+  'not-connected': (carrier) =>
+    `OpenLinker supports ${carrier}, but no ${carrier} connection is set up. Connect one to fulfil this delivery.`,
+};
+
+const RIDER_ACTION_LABEL: Record<ActionableRider, (carrier: string) => string> = {
+  unmapped: () => 'Add mapping',
+  'not-connected': (carrier) => `Connect ${carrier}`,
+};
+
+interface DeliveryRiderBannerProps {
+  rider: OrderDeliveryRider;
+  /**
+   * Fix-it action. The navigation is wired in #1794 — when omitted, a
+   * non-functional placeholder button renders in its place (a slot).
+   */
+  actionSlot?: ReactNode;
+  className?: string;
+}
+
+export function DeliveryRiderBanner({
+  rider,
+  actionSlot,
+  className = '',
+}: DeliveryRiderBannerProps): ReactElement | null {
+  if (!isActionableRider(rider)) {
+    return null;
+  }
+  const carrier = rider.candidateCarrier?.displayName ?? 'a carrier';
+  return (
+    <div
+      className={cx(
+        'delivery-rider-banner',
+        rider.rider === 'not-connected' && 'delivery-rider-banner--not-connected',
+        className,
+      )}
+      role="note"
+    >
+      <p className="delivery-rider-banner__text">{RIDER_BANNER_TEXT[rider.rider](carrier)}</p>
+      <div className="delivery-rider-banner__action">
+        {actionSlot ?? (
+          <button
+            type="button"
+            className="delivery-rider-banner__button"
+            disabled
+            aria-disabled="true"
+            title="Coming soon (#1794)"
+          >
+            {RIDER_ACTION_LABEL[rider.rider](carrier)}
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/orders/components/order-delivery-panel.test.tsx
+++ b/apps/web/src/features/orders/components/order-delivery-panel.test.tsx
@@ -102,11 +102,49 @@ describe('OrderDeliveryPanel', () => {
       expect(screen.getByText('Paczkomat')).toBeInTheDocument();
     });
 
+    it('should fall back to the pickup-point name when no method or fallback resolves (#1793)', () => {
+      renderWithProviders(
+        <OrderDeliveryPanel pickupPoint={{ id: 'OLS06A', name: 'Paczkomat OLS06A' }} />,
+      );
+      expect(screen.getByText('Method')).toBeInTheDocument();
+      expect(screen.getByText('Paczkomat OLS06A')).toBeInTheDocument();
+    });
+
     it('should render "-" for Method when neither snapshot nor fallback resolves', () => {
       renderWithProviders(<OrderDeliveryPanel carrier="InPost" />);
       expect(screen.getByText('Method')).toBeInTheDocument();
       // Only the Method value falls back to "-"; Carrier shows InPost.
       expect(screen.getByText('-')).toBeInTheDocument();
+    });
+  });
+
+  describe('mapping-aware delivery outcome + rider (#1793)', () => {
+    it('should render the delivery outcome chip in the Carrier row', () => {
+      renderWithProviders(<OrderDeliveryPanel carrier="InPost" deliveryOutcome="resolved" />);
+      expect(screen.getByText('InPost')).toBeInTheDocument();
+      expect(screen.getByText('Resolved')).toBeInTheDocument();
+    });
+
+    it('should render the rider banner with a fix-it slot when a rider is actionable', () => {
+      renderWithProviders(
+        <OrderDeliveryPanel
+          deliveryOutcome="shop-fulfilled"
+          deliveryRider={{
+            rider: 'unmapped',
+            candidateCarrier: { platformType: 'inpost', displayName: 'InPost' },
+          }}
+        />,
+      );
+      expect(screen.getByText('Shop-fulfilled')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Add mapping' })).toBeDisabled();
+    });
+
+    it('should not render a rider banner when the rider is "none"', () => {
+      renderWithProviders(
+        <OrderDeliveryPanel deliveryOutcome="shop-fulfilled" deliveryRider={{ rider: 'none' }} />,
+      );
+      expect(screen.getByText('Shop-fulfilled')).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /Add mapping|Connect/ })).not.toBeInTheDocument();
     });
   });
 });

--- a/apps/web/src/features/orders/components/order-delivery-panel.tsx
+++ b/apps/web/src/features/orders/components/order-delivery-panel.tsx
@@ -33,6 +33,9 @@ import type {
   ParsedOrderPickupPoint,
   ParsedOrderShipping,
 } from '../api/order-snapshot.schema';
+import type { OrderDeliveryRider } from '../api/orders.types';
+import type { DeliveryOutcome } from '../lib/delivery-outcome';
+import { DeliveryOutcomeChip, DeliveryRiderBanner } from './delivery-chip';
 
 interface OrderDeliveryPanelProps {
   shippingAddress?: ParsedAddress;
@@ -51,9 +54,22 @@ interface OrderDeliveryPanelProps {
    * Method row when the snapshot carried no `shipping.methodName`/`methodId`.
    * Callers derive it from the booked shipment (carrier / mapped method) so a
    * source order with no delivery line still shows a method. The Method row
-   * chain is `shipping.methodName ?? shipping.methodId ?? methodFallback ?? '-'`.
+   * chain is `shipping.methodName ?? shipping.methodId ?? methodFallback ??
+   * pickupPoint.name ?? '-'`.
    */
   methodFallback?: string | null;
+  /**
+   * Physical delivery outcome (#1793) rendered as a chip in the Carrier row.
+   * Derived by the caller from `deliveryResolution` + shipment state via
+   * `deriveDeliveryOutcome`. Absent → no chip (older/degraded payloads).
+   */
+  deliveryOutcome?: DeliveryOutcome;
+  /**
+   * Actionable delivery rider (#1793/#1792). When actionable
+   * (`unmapped` / `not-connected`) an inline banner + fix-it button SLOT
+   * renders beneath the delivery fields; navigation is wired in #1794.
+   */
+  deliveryRider?: OrderDeliveryRider | null;
 }
 
 function addressLines(address: ParsedAddress): ReactElement {
@@ -94,6 +110,8 @@ export function OrderDeliveryPanel({
   sourcePlatformType,
   carrier,
   methodFallback,
+  deliveryOutcome,
+  deliveryRider,
 }: OrderDeliveryPanelProps): ReactElement {
   // Resolved unconditionally (never inside a branch) — see #893.
   const sourcePlatform = usePlatform(sourcePlatformType ?? undefined);
@@ -105,11 +123,13 @@ export function OrderDeliveryPanel({
   // Always rendered (#1776) — the delivery-method label is a core "where it's
   // going" fact, so it must not blank out when the source order carried no
   // shipping line. Precedence: source method name → source method id →
-  // caller-supplied fallback (shipment-derived carrier/method) → "-".
+  // caller-supplied fallback (shipment-derived carrier/method) → pickup-point
+  // name (#1793) → "-".
   items.push({
     id: 'method',
     label: 'Method',
-    value: shipping?.methodName ?? shipping?.methodId ?? methodFallback ?? '-',
+    value:
+      shipping?.methodName ?? shipping?.methodId ?? methodFallback ?? pickupPoint?.name ?? '-',
   });
   // Always rendered (unlike the fields above) — "-" fallback per #1617 so the
   // operator can tell "no carrier resolved" apart from "field doesn't exist".
@@ -117,8 +137,20 @@ export function OrderDeliveryPanel({
   // source order carried no delivery method (so the Method row above is absent —
   // e.g. Erli/WooCommerce orders with no shipping line), the booked shipment's
   // carrier still surfaces here, so the panel always answers "how is this
-  // shipping?" without duplicating a Method row.
-  items.push({ id: 'carrier', label: 'Carrier', value: carrier ?? '-' });
+  // shipping?" without duplicating a Method row. The mapping-aware outcome chip
+  // (#1793) sits alongside the carrier name when the caller derived one.
+  items.push({
+    id: 'carrier',
+    label: 'Carrier',
+    value: deliveryOutcome ? (
+      <span className="order-delivery__carrier">
+        <span>{carrier ?? '-'}</span>
+        <DeliveryOutcomeChip outcome={deliveryOutcome} />
+      </span>
+    ) : (
+      (carrier ?? '-')
+    ),
+  });
 
   const pickupCaption =
     sourcePlatform?.pickupPointResolvesAsync === true
@@ -139,6 +171,7 @@ export function OrderDeliveryPanel({
       <h3 className="detail-section__title">Delivery</h3>
       <div className="order-delivery__card">
         <KeyValueList items={items} />
+        {deliveryRider ? <DeliveryRiderBanner rider={deliveryRider} /> : null}
         {pickupPoint ? (
           <div className="order-delivery__pickup">
             <div className="order-delivery__pickup-code mono-text">

--- a/apps/web/src/features/orders/lib/delivery-outcome.test.ts
+++ b/apps/web/src/features/orders/lib/delivery-outcome.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+
+import { deriveDeliveryOutcome } from './delivery-outcome';
+
+describe('deriveDeliveryOutcome', () => {
+  it('should be "resolved" for a carrier-driven order with a booked label', () => {
+    expect(
+      deriveDeliveryOutcome({
+        processorKind: 'ol_managed_carrier',
+        hasMethod: true,
+        isFulfilled: true,
+      }),
+    ).toBe('resolved');
+  });
+
+  it('should be "awaiting-label" for a carrier-driven order without a label yet', () => {
+    expect(
+      deriveDeliveryOutcome({
+        processorKind: 'source_brokered',
+        hasMethod: true,
+        isFulfilled: false,
+      }),
+    ).toBe('awaiting-label');
+  });
+
+  it('should stay carrier-driven (never no-method) even when hasMethod is false', () => {
+    expect(
+      deriveDeliveryOutcome({
+        processorKind: 'ol_managed_carrier',
+        hasMethod: false,
+        isFulfilled: false,
+      }),
+    ).toBe('awaiting-label');
+  });
+
+  it('should be "shop-fulfilled" for the omp_fulfilled default with a method', () => {
+    expect(
+      deriveDeliveryOutcome({ processorKind: 'omp_fulfilled', hasMethod: true, isFulfilled: false }),
+    ).toBe('shop-fulfilled');
+  });
+
+  it('should be "no-method" for the omp_fulfilled default with no method', () => {
+    expect(
+      deriveDeliveryOutcome({
+        processorKind: 'omp_fulfilled',
+        hasMethod: false,
+        isFulfilled: false,
+      }),
+    ).toBe('no-method');
+  });
+
+  it('should treat an absent processorKind (older payload) as the shop default', () => {
+    expect(deriveDeliveryOutcome({ hasMethod: true, isFulfilled: false })).toBe('shop-fulfilled');
+    expect(deriveDeliveryOutcome({ hasMethod: false, isFulfilled: false })).toBe('no-method');
+  });
+});

--- a/apps/web/src/features/orders/lib/delivery-outcome.ts
+++ b/apps/web/src/features/orders/lib/delivery-outcome.ts
@@ -1,0 +1,51 @@
+/**
+ * Delivery Outcome Derivation
+ *
+ * Pure, framework-free view-model helper that maps the BE-computed delivery
+ * routing (#1791 `deliveryResolution.processorKind`) plus the caller's local
+ * signals (does a method exist, is a label booked) onto one of four physical
+ * delivery outcomes rendered by the delivery chip (#1793, epic #1776).
+ *
+ * This is presentation mapping only — it consumes the routing outcome the
+ * backend already resolved and never re-derives routing rules the client can't
+ * see (AC: "no re-deriving routing on the client").
+ *
+ * @module apps/web/src/features/orders/lib
+ */
+import type { FulfillmentProcessorKind } from '../api/orders.types';
+
+export const DeliveryOutcomeValues = [
+  'resolved',
+  'awaiting-label',
+  'shop-fulfilled',
+  'no-method',
+] as const;
+export type DeliveryOutcome = (typeof DeliveryOutcomeValues)[number];
+
+export interface DeliveryOutcomeInput {
+  /** #1791 routing kind. Absent on older payloads → treated as the shop default. */
+  processorKind?: FulfillmentProcessorKind;
+  /** Whether the order carries any delivery method (name / id / shipment / pickup). */
+  hasMethod: boolean;
+  /** Whether a label/tracking exists (booked shipment, or a dispatched/delivered rollup). */
+  isFulfilled: boolean;
+}
+
+/**
+ * Map routing + local signals to a physical outcome:
+ * - carrier-driven (`ol_managed_carrier` / `source_brokered`) → `resolved`
+ *   once a label exists, else `awaiting-label` (a routed order is never
+ *   `no-method`);
+ * - otherwise (`omp_fulfilled` / unknown): `shop-fulfilled` when a method
+ *   exists, else `no-method`.
+ */
+export function deriveDeliveryOutcome({
+  processorKind,
+  hasMethod,
+  isFulfilled,
+}: DeliveryOutcomeInput): DeliveryOutcome {
+  if (processorKind === 'ol_managed_carrier' || processorKind === 'source_brokered') {
+    return isFulfilled ? 'resolved' : 'awaiting-label';
+  }
+  return hasMethod ? 'shop-fulfilled' : 'no-method';
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2383,10 +2383,11 @@ textarea,
  * Mapping-aware delivery: the outcome pill + (on a defaulted order) an
  * actionable rider stacked beneath it. Outcomes reuse StatusBadge tones
  * (success / info / neutral); the "no method" outcome adds a dashed border,
- * the "not connected" rider overrides the amber warning tone to the
- * signal-orange accent so amber (unmapped) and orange (not-connected) read
- * as distinct hues. Colour is never the only signal — each chip keeps its
- * text label + tone dot. */
+ * the "not connected" rider overrides the amber warning tone to the semantic
+ * `conflict` tone (a distinct "needs attention, not error" orange, kept
+ * distinct from the brand accent per the #1793 AC) so amber (unmapped) and
+ * orange (not-connected) read as distinct hues. Colour is never the only
+ * signal — each chip keeps its text label + tone dot. */
 .delivery-chip {
   display: inline-flex;
   flex-direction: column;
@@ -2399,9 +2400,9 @@ textarea,
 }
 
 .status-badge.delivery-rider-chip--not-connected {
-  border-color: var(--accent-primary-border);
-  background: var(--accent-primary-soft);
-  color: var(--accent-primary);
+  border-color: var(--status-conflict-border);
+  background: var(--status-conflict-soft);
+  color: var(--status-conflict-strong);
 }
 
 .delivery-rider-banner {
@@ -2420,10 +2421,10 @@ textarea,
 }
 
 .delivery-rider-banner--not-connected {
-  border-color: var(--accent-primary-border);
-  border-left-color: var(--accent-primary);
-  background: var(--accent-primary-soft);
-  color: var(--accent-primary);
+  border-color: var(--status-conflict-border);
+  border-left-color: var(--status-conflict);
+  background: var(--status-conflict-soft);
+  color: var(--status-conflict-strong);
 }
 
 .delivery-rider-banner__text {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2379,6 +2379,85 @@ textarea,
   }
 }
 
+/* ── Delivery chip (#1793) ─────────────────────────────────────────────
+ * Mapping-aware delivery: the outcome pill + (on a defaulted order) an
+ * actionable rider stacked beneath it. Outcomes reuse StatusBadge tones
+ * (success / info / neutral); the "no method" outcome adds a dashed border,
+ * the "not connected" rider overrides the amber warning tone to the
+ * signal-orange accent so amber (unmapped) and orange (not-connected) read
+ * as distinct hues. Colour is never the only signal — each chip keeps its
+ * text label + tone dot. */
+.delivery-chip {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-1);
+}
+
+.status-badge.delivery-outcome-chip--dashed {
+  border-style: dashed;
+}
+
+.status-badge.delivery-rider-chip--not-connected {
+  border-color: var(--accent-primary-border);
+  background: var(--accent-primary-soft);
+  color: var(--accent-primary);
+}
+
+.delivery-rider-banner {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  margin-top: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--status-warning-border);
+  border-left-width: 3px;
+  border-radius: var(--radius-sm);
+  background: var(--status-warning-soft);
+  color: var(--status-warning-fg);
+}
+
+.delivery-rider-banner--not-connected {
+  border-color: var(--accent-primary-border);
+  border-left-color: var(--accent-primary);
+  background: var(--accent-primary-soft);
+  color: var(--accent-primary);
+}
+
+.delivery-rider-banner__text {
+  margin: 0;
+  font-size: 0.8125rem;
+  line-height: 1.4;
+  flex: 1 1 16rem;
+}
+
+.delivery-rider-banner__button {
+  flex-shrink: 0;
+  padding: var(--space-1) var(--space-3);
+  font: inherit;
+  font-size: 0.8125rem;
+  font-weight: 500;
+  color: var(--text-primary);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.delivery-rider-banner__button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.order-delivery__carrier {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
 .state-card {
   border: 1px solid var(--border-default);
   border-radius: 0.5rem;

--- a/apps/web/src/pages/orders/order-detail-page.tsx
+++ b/apps/web/src/pages/orders/order-detail-page.tsx
@@ -42,6 +42,7 @@ import { OrderHealthSummary } from '../../features/orders/components/order-healt
 import { OrderPricingPanel } from '../../features/orders/components/order-pricing-panel';
 import { OrderDeliveryPanel } from '../../features/orders/components/order-delivery-panel';
 import { deriveFulfillment } from '../../features/orders/lib/order-health';
+import { deriveDeliveryOutcome } from '../../features/orders/lib/delivery-outcome';
 import { parseOrderSnapshot } from '../../features/orders/api/order-snapshot.schema';
 
 const RAW_SNAPSHOT_ANCHOR_ID = 'order-raw-snapshot';
@@ -176,6 +177,22 @@ export function OrderDetailPage(): ReactElement {
   const methodFallback =
     getCarrierDisplayName(activeShipment?.carrier ?? null) ??
     (activeShipment ? SHIPPING_METHOD_LABEL[activeShipment.shippingMethod] : null);
+  // Mapping-aware delivery outcome (#1793): map the BE-computed routing kind +
+  // whether a shipment (label/tracking) is booked onto a physical outcome. A
+  // booked `activeShipment` means the carrier-driven path has a label
+  // (resolved); its absence reads as awaiting-label. `hasMethod` gates the
+  // shop-fulfilled vs no-method distinction on the default path.
+  const deliveryHasMethod = Boolean(
+    snapshot.shipping?.methodName ??
+      snapshot.shipping?.methodId ??
+      methodFallback ??
+      snapshot.pickupPoint?.name,
+  );
+  const deliveryOutcome = deriveDeliveryOutcome({
+    processorKind: order.deliveryResolution?.processorKind,
+    hasMethod: deliveryHasMethod,
+    isFulfilled: Boolean(activeShipment),
+  });
   const sourcePlatformType =
     connections.find((c) => c.id === order.sourceConnectionId)?.platformType ?? null;
 
@@ -337,6 +354,8 @@ export function OrderDetailPage(): ReactElement {
             sourcePlatformType={sourcePlatformType}
             carrier={carrier}
             methodFallback={methodFallback}
+            deliveryOutcome={deliveryOutcome}
+            deliveryRider={order.deliveryRider}
           />
           {/* Anchor wrappers (#1713) for the orders-list deep-link CTAs
               (`/orders/{id}#shipment`, `/orders/{id}#invoicing`). Page-level

--- a/apps/web/src/pages/orders/orders-list-page.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.tsx
@@ -709,12 +709,16 @@ export function OrdersListPage(): ReactElement {
             parsed.pickupPoint?.name ??
             null;
           // Mapping-aware delivery chip (#1793): outcome + rider stacked. The
-          // list can't fetch shipments, so `fulfillmentState` (dispatched /
-          // delivered) stands in for "label exists"; the rider comes straight
-          // off the order response (BE-gated to `default` resolutions).
+          // rider comes straight off the order response (BE-gated to `default`
+          // resolutions).
           const deliveryOutcome = deriveDeliveryOutcome({
             processorKind: order.deliveryResolution?.processorKind,
-            hasMethod: carrier != null,
+            // Use the typed #1792 source-method fields (not the snapshot carrier
+            // proxy) so the list agrees with the detail for methodId-only orders.
+            hasMethod: Boolean(order.sourceDeliveryMethodId ?? order.sourceDeliveryMethodName),
+            // Snapshot-only divergence (documented, not silent): the list uses
+            // the rollup `fulfillmentState` because it can't fetch per-row
+            // shipments, whereas the detail uses booked-shipment presence.
             isFulfilled:
               order.fulfillmentState === 'dispatched' || order.fulfillmentState === 'delivered',
           });
@@ -1246,11 +1250,16 @@ export function OrdersListPage(): ReactElement {
                   parsed.shipping?.methodId ??
                   parsed.pickupPoint?.name ??
                   null;
-                // Mapping-aware delivery chip (#1793) — same snapshot-only
-                // derivation as the desktop cell.
+                // Mapping-aware delivery chip (#1793) — same derivation as the
+                // desktop cell.
                 const deliveryOutcome = deriveDeliveryOutcome({
                   processorKind: order.deliveryResolution?.processorKind,
-                  hasMethod: carrier != null,
+                  // Typed #1792 source-method fields, to match the detail (see desktop cell).
+                  hasMethod: Boolean(
+                    order.sourceDeliveryMethodId ?? order.sourceDeliveryMethodName,
+                  ),
+                  // Snapshot-only divergence (documented): list uses the rollup
+                  // fulfillmentState; detail uses booked-shipment presence.
                   isFulfilled:
                     order.fulfillmentState === 'dispatched' ||
                     order.fulfillmentState === 'delivered',

--- a/apps/web/src/pages/orders/orders-list-page.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.tsx
@@ -54,6 +54,8 @@ import { useDemoMode } from '../../features/system';
 import { parseOrderSnapshot } from '../../features/orders/api/order-snapshot.schema';
 import { deriveOrderHealth, slaBadge, fulfillmentBadge } from '../../features/orders/lib/order-health';
 import { itemsSummary, paymentBadge, invoiceBadge } from '../../features/orders/lib/order-row';
+import { deriveDeliveryOutcome } from '../../features/orders/lib/delivery-outcome';
+import { DeliveryChip } from '../../features/orders/components/delivery-chip';
 import { capSelectionPerSource, sourcesAtCap } from '../../features/orders/lib/dispatch-input';
 import { BulkDispatchDialog } from '../../features/orders/components/bulk-dispatch-dialog';
 import { OrderRowDetail } from '../../features/orders/components/order-row-detail';
@@ -706,6 +708,16 @@ export function OrdersListPage(): ReactElement {
             parsed.shipping?.methodId ??
             parsed.pickupPoint?.name ??
             null;
+          // Mapping-aware delivery chip (#1793): outcome + rider stacked. The
+          // list can't fetch shipments, so `fulfillmentState` (dispatched /
+          // delivered) stands in for "label exists"; the rider comes straight
+          // off the order response (BE-gated to `default` resolutions).
+          const deliveryOutcome = deriveDeliveryOutcome({
+            processorKind: order.deliveryResolution?.processorKind,
+            hasMethod: carrier != null,
+            isFulfilled:
+              order.fulfillmentState === 'dispatched' || order.fulfillmentState === 'delivered',
+          });
           // Offer "Generate label" ONLY when fulfillment is EXPLICITLY not-shipped
           // and the order isn't cancelled (#1713). An undefined fulfillmentState
           // (genuinely unknown) or a cancelled order shows the passive fulfillment
@@ -747,6 +759,7 @@ export function OrdersListPage(): ReactElement {
                   {view.remaining}
                 </StatusBadge>
               ) : null}
+              <DeliveryChip outcome={deliveryOutcome} rider={order.deliveryRider} />
               {carrier ? (
                 <span className="text-muted orders-cell-sub orders-carrier" title={carrier}>
                   {carrier}
@@ -1233,6 +1246,15 @@ export function OrdersListPage(): ReactElement {
                   parsed.shipping?.methodId ??
                   parsed.pickupPoint?.name ??
                   null;
+                // Mapping-aware delivery chip (#1793) — same snapshot-only
+                // derivation as the desktop cell.
+                const deliveryOutcome = deriveDeliveryOutcome({
+                  processorKind: order.deliveryResolution?.processorKind,
+                  hasMethod: carrier != null,
+                  isFulfilled:
+                    order.fulfillmentState === 'dispatched' ||
+                    order.fulfillmentState === 'delivered',
+                });
                 const inv = parsed.invoice ? invoiceBadge(parsed.invoice) : null;
                 const fulfillment = fulfillmentBadge(order.fulfillmentState);
                 // Offer "Generate label" ONLY when explicitly not-shipped and not
@@ -1316,6 +1338,10 @@ export function OrdersListPage(): ReactElement {
                               <StatusBadge tone={fulfillment.tone} withDot compact>
                                 {fulfillment.label}
                               </StatusBadge>
+                              <DeliveryChip
+                                outcome={deliveryOutcome}
+                                rider={order.deliveryRider}
+                              />
                               {carrier ? (
                                 <span className="text-muted orders-cell-sub">{carrier}</span>
                               ) : null}


### PR DESCRIPTION
## What & why

Part of epic #1776, references #1793. Presentation layer for mapping-aware delivery on the orders list and order detail. It consumes the resolution (#1791) and rider (#1792) fields already on the order response - the client never re-derives routing.

## The model

One physical **outcome** per order, plus (on a `default`-resolved order) a **rider** stacked on top, never replacing it:

- **Outcomes**: Resolved (green), Awaiting label (blue), Shop-fulfilled (grey), No method (grey, dashed border).
- **Riders**: Unmapped (amber) and Not connected (signal-orange) - two distinct hues so a defaulted order reads at a glance. Each chip pairs colour with a text label + tone dot (colour is never the only signal).

## Changes

- New `DeliveryChip` / `DeliveryOutcomeChip` / `DeliveryRiderChip` / `DeliveryRiderBanner` in `features/orders/components/delivery-chip.tsx`, built on the existing `StatusBadge` primitive. Pure `deriveDeliveryOutcome` helper in `lib/delivery-outcome.ts` maps the BE routing kind + local shipment state onto the four outcomes (list uses `fulfillmentState`; detail uses the booked shipment).
- **Order detail** (`order-delivery-panel.tsx`): outcome chip in the Carrier row; when a rider is present, an inline banner with the explanation + a fix-it **button SLOT**. Method row now also falls back to `pickupPoint.name` (`name -> id -> shipment -> pickup -> '-'`).
- **Orders list** (`orders-list-page.tsx`, desktop cell + mobile summary): outcome chip + rider chip stacked; method label stays snapshot-only (no per-row shipment fetch).
- Extended the FE `OrderRecord` type with `deliveryResolution` / `deliveryRider` / `sourceDeliveryMethodId` / `sourceDeliveryMethodName` (hand-mirrored from the BE DTOs).

## Buttons are slots

The rider-banner fix-it buttons are non-functional placeholders here (disabled, "Coming soon (#1794)"); their navigation (Add mapping / Connect) is wired in **#1794**. The banner also accepts an `actionSlot` so #1794 can inject the real link without touching this component.

## Colour mapping

Artifact colours map to existing repo tokens via `StatusBadge` tones: success/info/neutral for outcomes, `--status-warning` (amber) for Unmapped, `--accent-primary` (signal-orange) for Not connected. No new CSS vars were added - the design-token drift check passes clean.

## Tests

New `delivery-chip.test.tsx` and `delivery-outcome.test.ts` cover every outcome + rider state, the banner slot behaviour, and the derivation matrix; `order-delivery-panel.test.tsx` gains the pickup-name fallback + outcome-chip + rider-banner cases.

## Gate (scoped to web)

- `type-check`: pass
- vitest (delivery-chip, delivery-outcome, order-delivery-panel, orders-list-page, order-detail-page): pass
- eslint: 0 errors
- design-token drift check: pass