### PR TITLE
feat(web/mappings): connection-pair strip, resolved labels, responsive layout (#1784)

### DIFF
--- a/apps/web/src/features/mappings/components/MappingPanel.test.tsx
+++ b/apps/web/src/features/mappings/components/MappingPanel.test.tsx
@@ -9,7 +9,8 @@
  *
  * @module apps/web/src/features/mappings/components
  */
-import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { MappingPanel, type MappingRow } from './MappingPanel';
 import type { MappingOption } from '../api/mappings.types';
@@ -101,7 +102,11 @@ describe('MappingPanel', () => {
       expect(screen.queryByText('5…')).toBeNull();
     });
 
-    it('renders dropdown options as plain "Label (truncatedValue)" text', () => {
+    it('renders the add-row source combobox options with the label + a muted id hint', async () => {
+      // The add-row chooser is now the searchable combobox (#1784 I8): the human
+      // label is the primary text and the raw id lives in the option hint, out
+      // of the visible label.
+      const user = userEvent.setup();
       render(
         <MappingPanel
           {...baseProps}
@@ -112,17 +117,22 @@ describe('MappingPanel', () => {
         />,
       );
 
-      const select = screen.getByRole('combobox', { name: /select allegro delivery method/i });
-      const options = within(select).getAllByRole('option');
-      // First option is the placeholder ("— Allegro delivery method —"), then the two methods.
-      expect(options[1]).toHaveTextContent('Allegro Paczkomaty InPost (1fa56f79…)');
-      expect(options[2]).toHaveTextContent('Allegro Kurier24 InPost (7c2b3d4e…)');
+      await user.click(
+        screen.getByRole('combobox', { name: /select allegro delivery method/i }),
+      );
+
+      expect(screen.getByText('Allegro Paczkomaty InPost')).toBeInTheDocument();
+      expect(screen.getByText('Allegro Kurier24 InPost')).toBeInTheDocument();
+      // Ids show as truncated mono hints, not inside the label text.
+      expect(screen.getByText('1fa56f79…')).toBeInTheDocument();
+      expect(screen.getByText('7c2b3d4e…')).toBeInTheDocument();
     });
 
-    it("decorates dynamic-kind options with the runtime-behaviour suffix in the dropdown (#517)", () => {
+    it("decorates dynamic-kind options with the runtime-behaviour suffix in the combobox (#517)", async () => {
       // The OL Dynamic carrier (kind: 'dynamic') means PS reads buyer-paid
-      // shipping from the sidecar at order-total time (#516). Native
-      // <option> is text-only, so the cue is encoded as a label suffix.
+      // shipping from the sidecar at order-total time (#516). The cue is
+      // appended to the searchable label so it survives free-text search.
+      const user = userEvent.setup();
       const PS_OL_DYNAMIC: MappingOption = {
         value: '99',
         label: 'OpenLinker Dynamic',
@@ -138,12 +148,12 @@ describe('MappingPanel', () => {
         />,
       );
 
-      const targetSelect = screen.getByRole('combobox', { name: /select prestashop carrier/i });
-      const options = within(targetSelect).getAllByRole('option');
-      // Static option: bare label + (id) — no behaviour suffix.
-      expect(options[1]).toHaveTextContent('InPost Paczkomat (5)');
-      // Dynamic option: same shape + " - exact Allegro cost" suffix.
-      expect(options[2]).toHaveTextContent('OpenLinker Dynamic (99) - exact Allegro cost');
+      await user.click(screen.getByRole('combobox', { name: /select prestashop carrier/i }));
+
+      // Static option: bare label, no behaviour suffix.
+      expect(screen.getByText('InPost Paczkomat')).toBeInTheDocument();
+      // Dynamic option: label carries the " - exact Allegro cost" suffix.
+      expect(screen.getByText('OpenLinker Dynamic - exact Allegro cost')).toBeInTheDocument();
     });
 
     it('decorates dynamic-kind options in the saved-row table cell (#517)', () => {
@@ -253,11 +263,12 @@ describe('MappingPanel', () => {
   });
 
   describe('add-row flow', () => {
-    it('filters already-mapped sources out of the add-row dropdown', () => {
+    it('filters already-mapped sources out of the add-row combobox', async () => {
       // Primary dedup affordance: an already-mapped source can't be re-picked
       // because it's removed from `availableSourceOptions`. Defensive
       // `setAddError` branch in `handleAddRow` only fires for programmatic
       // bypasses, which the UI can't trigger.
+      const user = userEvent.setup();
       render(
         <MappingPanel
           {...baseProps}
@@ -268,11 +279,11 @@ describe('MappingPanel', () => {
         />,
       );
 
-      const select = screen.getByRole('combobox', { name: /select allegro delivery method/i });
-      const optionTexts = within(select)
-        .getAllByRole('option')
-        .map((o) => o.textContent ?? '');
-      // Mapped Paczkomat is gone from the add-row dropdown; only Kurier remains.
+      await user.click(
+        screen.getByRole('combobox', { name: /select allegro delivery method/i }),
+      );
+      const optionTexts = screen.getAllByRole('option').map((o) => o.textContent ?? '');
+      // Mapped Paczkomat is gone from the add-row combobox; only Kurier remains.
       expect(optionTexts.some((t) => t.includes('Paczkomaty'))).toBe(false);
       expect(optionTexts.some((t) => t.includes('Kurier24'))).toBe(true);
     });

--- a/apps/web/src/features/mappings/components/MappingPanel.test.tsx
+++ b/apps/web/src/features/mappings/components/MappingPanel.test.tsx
@@ -23,6 +23,8 @@ const baseProps = {
   saveError: null,
   optionsLoading: false,
   optionsError: null,
+  // Suffix is caller-provided (#1784); pass the resolved-source form the page uses.
+  dynamicOptionSuffix: ' - exact Allegro cost',
 };
 
 const ALLEGRO_PACZKOMAT: MappingOption = {
@@ -140,8 +142,8 @@ describe('MappingPanel', () => {
       const options = within(targetSelect).getAllByRole('option');
       // Static option: bare label + (id) — no behaviour suffix.
       expect(options[1]).toHaveTextContent('InPost Paczkomat (5)');
-      // Dynamic option: same shape + " — exact Allegro cost" suffix.
-      expect(options[2]).toHaveTextContent('OpenLinker Dynamic (99) — exact Allegro cost');
+      // Dynamic option: same shape + " - exact Allegro cost" suffix.
+      expect(options[2]).toHaveTextContent('OpenLinker Dynamic (99) - exact Allegro cost');
     });
 
     it('decorates dynamic-kind options in the saved-row table cell (#517)', () => {
@@ -166,7 +168,7 @@ describe('MappingPanel', () => {
       // <option> renders flat text. Scope the assertion to the styled
       // span by class so we only catch the cell instance.
       const styledSuffixes = screen
-        .getAllByText(/— exact Allegro cost/)
+        .getAllByText(/- exact Allegro cost/)
         .filter((el) => el.classList.contains('mapping-option__dynamic-suffix'));
       expect(styledSuffixes).toHaveLength(1);
     });

--- a/apps/web/src/features/mappings/components/MappingPanel.tsx
+++ b/apps/web/src/features/mappings/components/MappingPanel.tsx
@@ -33,7 +33,16 @@ interface MappingPanelProps {
   saveError: Error | null;
   optionsLoading: boolean;
   optionsError: Error | null;
+  /**
+   * Suffix appended to `kind === 'dynamic'` options to explain the runtime
+   * behaviour (#517). Platform-neutral (#1784): the caller passes the resolved
+   * source label, e.g. ` - exact Allegro cost`. Defaults to a generic cue so
+   * the dynamic option is still distinguishable if a caller omits it.
+   */
+  dynamicOptionSuffix?: string;
 }
+
+const DEFAULT_DYNAMIC_OPTION_SUFFIX = ' - dynamic';
 
 /**
  * Truncates a long stable id (Allegro UUIDs are 36 chars) to 8 + "…" so it
@@ -50,28 +59,20 @@ function optionByValue(options: MappingOption[], value: string): MappingOption |
 }
 
 /**
- * Suffix appended to `kind === 'dynamic'` options to distinguish them from
- * static carriers (#517). Native `<option>` is text-only so the cue lives
- * in the label string itself; the cockpit-style separator is the em-dash
- * established elsewhere in OpenLinker FE copy. Keep this short — it
- * appends to a 32 px-tall native select cell at 13.5 px IBM Plex Sans.
- */
-const DYNAMIC_OPTION_SUFFIX = ' — exact Allegro cost';
-
-/**
  * Renders a `MappingOption` with the human label as the primary text and a
  * faded mono id-hint when the value differs from the label (#474). When
- * `value === label` (degraded data — adapter fell back to using the id as
+ * `value === label` (degraded data - adapter fell back to using the id as
  * the name), render a single label and skip the redundant hint.
  *
- * Dynamic-kind options (#517) carry a muted suffix explaining the runtime
- * behaviour. Suffix lives outside the mono id-hint span so it stays in
- * the body sans, not the monospace id treatment.
+ * Dynamic-kind options (#517) carry a muted `suffix` explaining the runtime
+ * behaviour. The suffix is resolved by the caller (platform-neutral, #1784)
+ * and lives outside the mono id-hint span so it stays in the body sans, not
+ * the monospace id treatment.
  */
-function renderOptionLabel(option: MappingOption): ReactNode {
+function renderOptionLabel(option: MappingOption, suffix: string): ReactNode {
   const dynamicSuffix =
     option.kind === 'dynamic' ? (
-      <span className="mapping-option__dynamic-suffix">{DYNAMIC_OPTION_SUFFIX}</span>
+      <span className="mapping-option__dynamic-suffix">{suffix}</span>
     ) : null;
 
   if (option.label === option.value) {
@@ -96,12 +97,12 @@ function renderOptionLabel(option: MappingOption): ReactNode {
  * styled children, so the id chip is approximated as parenthesised text
  * and the dynamic-kind cue is appended as a label suffix (#517).
  */
-function optionPlainText(option: MappingOption): string {
+function optionPlainText(option: MappingOption, suffix: string): string {
   const base =
     option.label === option.value
       ? option.label
       : `${option.label} (${shortValue(option.value)})`;
-  return option.kind === 'dynamic' ? `${base}${DYNAMIC_OPTION_SUFFIX}` : base;
+  return option.kind === 'dynamic' ? `${base}${suffix}` : base;
 }
 
 export function MappingPanel({
@@ -117,6 +118,7 @@ export function MappingPanel({
   saveError,
   optionsLoading,
   optionsError,
+  dynamicOptionSuffix = DEFAULT_DYNAMIC_OPTION_SUFFIX,
 }: MappingPanelProps): ReactElement {
   const [localRows, setLocalRows] = useState<MappingRow[]>(savedRows);
   const [pendingSource, setPendingSource] = useState('');
@@ -191,7 +193,7 @@ export function MappingPanel({
           No mappings configured yet. Orders may sync with default values. Add one below.
         </p>
       ) : (
-        <table className="data-table" aria-label={`${title} mappings`}>
+        <table className="data-table data-table--stackable" aria-label={`${title} mappings`}>
           <thead>
             <tr>
               <th>{sourceLabel}</th>
@@ -205,21 +207,21 @@ export function MappingPanel({
               const targetOption = optionByValue(targetOptions, row.targetValue);
               return (
                 <tr key={row.sourceValue}>
-                  <td>
+                  <td data-label={sourceLabel}>
                     {sourceOption ? (
-                      renderOptionLabel(sourceOption)
+                      renderOptionLabel(sourceOption, dynamicOptionSuffix)
                     ) : (
                       <span className="mono-text">{row.sourceValue}</span>
                     )}
                   </td>
-                  <td>
+                  <td data-label={targetLabel}>
                     {targetOption ? (
-                      renderOptionLabel(targetOption)
+                      renderOptionLabel(targetOption, dynamicOptionSuffix)
                     ) : (
                       <span className="mono-text">{row.targetValue}</span>
                     )}
                   </td>
-                  <td>
+                  <td className="data-table__cell--actions">
                     <Button
                       tone="ghost"
                       aria-label={`Remove mapping for ${sourceOption?.label ?? 'orphaned source'}`}
@@ -243,9 +245,9 @@ export function MappingPanel({
           onChange={(e) => { setPendingSource(e.target.value); }}
           disabled={availableSourceOptions.length === 0}
         >
-          <option value="">— {sourceLabel} —</option>
+          <option value="">Select {sourceLabel}</option>
           {availableSourceOptions.map((o) => (
-            <option key={o.value} value={o.value}>{optionPlainText(o)}</option>
+            <option key={o.value} value={o.value}>{optionPlainText(o, dynamicOptionSuffix)}</option>
           ))}
         </select>
 
@@ -254,9 +256,9 @@ export function MappingPanel({
           value={pendingTarget}
           onChange={(e) => { setPendingTarget(e.target.value); }}
         >
-          <option value="">— {targetLabel} —</option>
+          <option value="">Select {targetLabel}</option>
           {targetOptions.map((o) => (
-            <option key={o.value} value={o.value}>{optionPlainText(o)}</option>
+            <option key={o.value} value={o.value}>{optionPlainText(o, dynamicOptionSuffix)}</option>
           ))}
         </select>
 

--- a/apps/web/src/features/mappings/components/MappingPanel.tsx
+++ b/apps/web/src/features/mappings/components/MappingPanel.tsx
@@ -10,6 +10,7 @@
 
 import { useState, useEffect, useMemo, type ReactElement, type ReactNode } from 'react';
 import { Button } from '../../../shared/ui/button';
+import { Combobox, type ComboboxOption, type ComboboxValue } from '../../../shared/ui/combobox';
 import { ErrorState, LoadingState } from '../../../shared/ui/feedback-state';
 import type { MappingOption } from '../api/mappings.types';
 
@@ -34,6 +35,25 @@ interface MappingPanelProps {
   optionsLoading: boolean;
   optionsError: Error | null;
   /**
+   * Failure loading this tab's saved-mapping data (#1784 follow-up I2). Rendered
+   * as an inline panel error with a retry so one tab's data failure never tears
+   * down the pairing strip or the sibling tabs. Distinct from `optionsError`,
+   * which is the dropdown-option-list failure.
+   */
+  dataError?: Error | null;
+  /** Retry the saved-mapping data load (paired with `dataError`). */
+  onRetryData?: () => void;
+  /**
+   * Reports the panel's dirty (unsaved-edits) state up so the page can guard a
+   * tab switch that would discard staged rows (#1784 follow-up I3).
+   */
+  onDirtyChange?: (dirty: boolean) => void;
+  /**
+   * Precise per-tab empty-state copy (#1784 follow-up S15). Falls back to a
+   * generic message so a caller that omits it still renders sensibly.
+   */
+  emptyStateMessage?: string;
+  /**
    * Suffix appended to `kind === 'dynamic'` options to explain the runtime
    * behaviour (#517). Platform-neutral (#1784): the caller passes the resolved
    * source label, e.g. ` - exact Allegro cost`. Defaults to a generic cue so
@@ -43,6 +63,8 @@ interface MappingPanelProps {
 }
 
 const DEFAULT_DYNAMIC_OPTION_SUFFIX = ' - dynamic';
+const DEFAULT_EMPTY_STATE_MESSAGE =
+  'No mappings configured yet. Orders may sync with default values. Add one below.';
 
 /**
  * Truncates a long stable id (Allegro UUIDs are 36 chars) to 8 + "…" so it
@@ -52,10 +74,6 @@ const DEFAULT_DYNAMIC_OPTION_SUFFIX = ' - dynamic';
  */
 function shortValue(value: string): string {
   return value.length <= 9 ? value : `${value.slice(0, 8)}…`;
-}
-
-function optionByValue(options: MappingOption[], value: string): MappingOption | null {
-  return options.find((o) => o.value === value) ?? null;
 }
 
 /**
@@ -93,16 +111,25 @@ function renderOptionLabel(option: MappingOption, suffix: string): ReactNode {
 }
 
 /**
- * Plain-text variant for `<option>` elements — native `<select>` strips
- * styled children, so the id chip is approximated as parenthesised text
- * and the dynamic-kind cue is appended as a label suffix (#517).
+ * Maps a `MappingOption[]` into the searchable-combobox option shape (#1784
+ * follow-up I8). The raw id is kept OUT of the visible label — it lives in the
+ * combobox `hint` (rendered mono-muted) so 50+ Allegro delivery methods stay
+ * scannable by name. Sorted by label for the same reason. The dynamic-kind
+ * runtime cue is appended to the label so it survives free-text search.
  */
-function optionPlainText(option: MappingOption, suffix: string): string {
-  const base =
-    option.label === option.value
-      ? option.label
-      : `${option.label} (${shortValue(option.value)})`;
-  return option.kind === 'dynamic' ? `${base}${suffix}` : base;
+function toComboOptions(options: MappingOption[], suffix: string): ComboboxOption[] {
+  return options
+    .map((o) => ({
+      id: o.value,
+      label: o.kind === 'dynamic' ? `${o.label}${suffix}` : o.label,
+      hint: o.value === o.label ? undefined : shortValue(o.value),
+    }))
+    .sort((a, b) => a.label.localeCompare(b.label));
+}
+
+/** Single-select combobox value → the underlying option id (or ''). */
+function comboSelectedId(value: ComboboxValue | null): string {
+  return value?.kind === 'dictionary' ? (value.ids[0] ?? '') : '';
 }
 
 export function MappingPanel({
@@ -118,6 +145,10 @@ export function MappingPanel({
   saveError,
   optionsLoading,
   optionsError,
+  dataError = null,
+  onRetryData,
+  onDirtyChange,
+  emptyStateMessage = DEFAULT_EMPTY_STATE_MESSAGE,
   dynamicOptionSuffix = DEFAULT_DYNAMIC_OPTION_SUFFIX,
 }: MappingPanelProps): ReactElement {
   const [localRows, setLocalRows] = useState<MappingRow[]>(savedRows);
@@ -134,10 +165,27 @@ export function MappingPanel({
         row.targetValue !== savedRows[i]?.targetValue,
     );
 
-  // Sync local rows when saved rows update (after a successful save)
+  // Sync local rows when the SAVED CONTENT changes (after a successful save /
+  // refetch) - keyed on a content signature, not the array identity. The page
+  // rebuilds `savedRows` via `.map()` on every render, so keying on identity
+  // would wipe staged edits on any unrelated parent re-render - e.g. the
+  // page-level dirty-guard state update this panel itself triggers via
+  // `onDirtyChange` (#1784 follow-up I3).
+  const savedSignature = savedRows
+    .map((r) => `${r.sourceValue}\u0000${r.targetValue}`)
+    .join('');
+  // Resync only when the saved CONTENT changes; `savedRows` identity is
+  // intentionally unstable per parent render, so it is not a dependency here.
   useEffect(() => {
     setLocalRows(savedRows);
-  }, [savedRows]);
+  }, [savedSignature]);
+
+  // Surface the dirty signal up for the page-level discard guard (#1784 I3).
+  useEffect(() => {
+    onDirtyChange?.(isDirty);
+  }, [isDirty, onDirtyChange]);
+  // On unmount (e.g. tab switch), clear this tab's dirty flag.
+  useEffect(() => () => onDirtyChange?.(false), [onDirtyChange]);
 
   function handleAddRow(): void {
     if (!pendingSource || !pendingTarget) return;
@@ -159,6 +207,19 @@ export function MappingPanel({
     onSave(localRows);
   }
 
+  // O(1) row → option lookups instead of a linear `.find` per cell per render
+  // (#1784 follow-up S16).
+  const sourceOptionByValue = useMemo(() => {
+    const map = new Map<string, MappingOption>();
+    for (const o of sourceOptions) map.set(o.value, o);
+    return map;
+  }, [sourceOptions]);
+  const targetOptionByValue = useMemo(() => {
+    const map = new Map<string, MappingOption>();
+    for (const o of targetOptions) map.set(o.value, o);
+    return map;
+  }, [targetOptions]);
+
   // Source options not already mapped. Memoized so the O(rows x options)
   // filter doesn't re-run on unrelated re-renders (#1784 follow-up). Declared
   // before the early returns so the hook order stays stable across renders.
@@ -170,6 +231,30 @@ export function MappingPanel({
     () => sourceOptions.filter((o) => !mappedSourceValues.has(o.value)),
     [sourceOptions, mappedSourceValues],
   );
+  const sourceComboOptions = useMemo(
+    () => toComboOptions(availableSourceOptions, dynamicOptionSuffix),
+    [availableSourceOptions, dynamicOptionSuffix],
+  );
+  const targetComboOptions = useMemo(
+    () => toComboOptions(targetOptions, dynamicOptionSuffix),
+    [targetOptions, dynamicOptionSuffix],
+  );
+
+  if (dataError) {
+    return (
+      <ErrorState
+        title="Unable to load mappings"
+        message={dataError.message}
+        action={
+          onRetryData ? (
+            <Button tone="secondary" onClick={onRetryData}>
+              Retry
+            </Button>
+          ) : undefined
+        }
+      />
+    );
+  }
 
   if (optionsLoading) {
     return <LoadingState liveRegion="off" title={`Loading ${title.toLowerCase()} options`} message="Fetching available values…" />;
@@ -178,6 +263,8 @@ export function MappingPanel({
   if (optionsError) {
     return <ErrorState title="Unable to load options" message={optionsError.message} />;
   }
+
+  const noSourcesLeft = availableSourceOptions.length === 0;
 
   return (
     <div className="panel panel--dense">
@@ -197,7 +284,7 @@ export function MappingPanel({
 
       {localRows.length === 0 ? (
         <p className="muted-text" role="status" aria-live="polite">
-          No mappings configured yet. Orders may sync with default values. Add one below.
+          {emptyStateMessage}
         </p>
       ) : (
         <table className="data-table data-table--stackable" aria-label={`${title} mappings`}>
@@ -210,8 +297,8 @@ export function MappingPanel({
           </thead>
           <tbody>
             {localRows.map((row) => {
-              const sourceOption = optionByValue(sourceOptions, row.sourceValue);
-              const targetOption = optionByValue(targetOptions, row.targetValue);
+              const sourceOption = sourceOptionByValue.get(row.sourceValue) ?? null;
+              const targetOption = targetOptionByValue.get(row.targetValue) ?? null;
               return (
                 <tr key={row.sourceValue}>
                   <td data-label={sourceLabel}>
@@ -244,30 +331,32 @@ export function MappingPanel({
         </table>
       )}
 
-      {/* Add row form */}
-      <div className="toolbar" style={{ marginTop: '1rem', gap: '0.5rem', flexWrap: 'wrap' }}>
-        <select
-          aria-label={`Select ${sourceLabel}`}
-          value={pendingSource}
-          onChange={(e) => { setPendingSource(e.target.value); }}
-          disabled={availableSourceOptions.length === 0}
-        >
-          <option value="">Select {sourceLabel}</option>
-          {availableSourceOptions.map((o) => (
-            <option key={o.value} value={o.value}>{optionPlainText(o, dynamicOptionSuffix)}</option>
-          ))}
-        </select>
+      {/* Add row form — searchable comboboxes (#1784 I8) so 50+ options stay
+          scannable by label; the raw id lives in the option hint, not the text. */}
+      <div className="toolbar" style={{ marginTop: '1rem', gap: '0.5rem', flexWrap: 'wrap', alignItems: 'flex-start' }}>
+        <div className="mapping-panel__add-field">
+          <Combobox
+            ariaLabel={`Select ${sourceLabel}`}
+            options={sourceComboOptions}
+            value={pendingSource ? { kind: 'dictionary', ids: [pendingSource] } : null}
+            onChange={(next) => { setPendingSource(comboSelectedId(next)); }}
+            placeholder={`Select ${sourceLabel}`}
+            disabled={noSourcesLeft}
+          />
+          {noSourcesLeft && (
+            <p className="muted-text mapping-panel__add-hint" role="status">
+              All source values mapped.
+            </p>
+          )}
+        </div>
 
-        <select
-          aria-label={`Select ${targetLabel}`}
-          value={pendingTarget}
-          onChange={(e) => { setPendingTarget(e.target.value); }}
-        >
-          <option value="">Select {targetLabel}</option>
-          {targetOptions.map((o) => (
-            <option key={o.value} value={o.value}>{optionPlainText(o, dynamicOptionSuffix)}</option>
-          ))}
-        </select>
+        <Combobox
+          ariaLabel={`Select ${targetLabel}`}
+          options={targetComboOptions}
+          value={pendingTarget ? { kind: 'dictionary', ids: [pendingTarget] } : null}
+          onChange={(next) => { setPendingTarget(comboSelectedId(next)); }}
+          placeholder={`Select ${targetLabel}`}
+        />
 
         <Button
           tone="secondary"

--- a/apps/web/src/features/mappings/components/MappingPanel.tsx
+++ b/apps/web/src/features/mappings/components/MappingPanel.tsx
@@ -173,7 +173,7 @@ export function MappingPanel({
   // `onDirtyChange` (#1784 follow-up I3).
   const savedSignature = savedRows
     .map((r) => `${r.sourceValue}\u0000${r.targetValue}`)
-    .join('');
+    .join('\u0001');
   // Resync only when the saved CONTENT changes; `savedRows` identity is
   // intentionally unstable per parent render, so it is not a dependency here.
   useEffect(() => {

--- a/apps/web/src/features/mappings/components/MappingPanel.tsx
+++ b/apps/web/src/features/mappings/components/MappingPanel.tsx
@@ -8,7 +8,7 @@
  * @module apps/web/src/features/mappings/components
  */
 
-import { useState, useEffect, type ReactElement, type ReactNode } from 'react';
+import { useState, useEffect, useMemo, type ReactElement, type ReactNode } from 'react';
 import { Button } from '../../../shared/ui/button';
 import { ErrorState, LoadingState } from '../../../shared/ui/feedback-state';
 import type { MappingOption } from '../api/mappings.types';
@@ -159,6 +159,18 @@ export function MappingPanel({
     onSave(localRows);
   }
 
+  // Source options not already mapped. Memoized so the O(rows x options)
+  // filter doesn't re-run on unrelated re-renders (#1784 follow-up). Declared
+  // before the early returns so the hook order stays stable across renders.
+  const mappedSourceValues = useMemo(
+    () => new Set(localRows.map((r) => r.sourceValue)),
+    [localRows],
+  );
+  const availableSourceOptions = useMemo(
+    () => sourceOptions.filter((o) => !mappedSourceValues.has(o.value)),
+    [sourceOptions, mappedSourceValues],
+  );
+
   if (optionsLoading) {
     return <LoadingState liveRegion="off" title={`Loading ${title.toLowerCase()} options`} message="Fetching available values…" />;
   }
@@ -166,11 +178,6 @@ export function MappingPanel({
   if (optionsError) {
     return <ErrorState title="Unable to load options" message={optionsError.message} />;
   }
-
-  // Source options not already mapped
-  const availableSourceOptions = sourceOptions.filter(
-    (o) => !localRows.some((r) => r.sourceValue === o.value),
-  );
 
   return (
     <div className="panel panel--dense">

--- a/apps/web/src/features/mappings/components/mapping-pairing-bar.test.tsx
+++ b/apps/web/src/features/mappings/components/mapping-pairing-bar.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * MappingPairingBar tests (#1784 follow-up S19)
+ *
+ * Focused component coverage for the pairing route strip. Rendered through
+ * `renderWithProviders` so `usePlatforms()` resolves labels from the plugin
+ * registry.
+ *
+ * @module apps/web/src/features/mappings/components
+ */
+
+import { cleanup, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders, sampleConnection } from '../../../test/test-utils';
+import { MappingPairingBar } from './mapping-pairing-bar';
+import type { Connection } from '../../connections';
+import type { MappingPairing } from '../hooks/use-mapping-pairing.types';
+
+const ALLEGRO: Connection = {
+  ...sampleConnection,
+  id: 'alg_1',
+  name: 'Main Allegro',
+  platformType: 'allegro',
+};
+
+describe('MappingPairingBar', () => {
+  afterEach(cleanup);
+
+  it('renders "Not linked" when a ready/unsupported source has a null destination', () => {
+    const pairing: MappingPairing = {
+      status: 'unsupported',
+      source: { ...sampleConnection, id: 'woo_1', name: 'US Woo', platformType: 'woocommerce' },
+      destination: null,
+    };
+    renderWithProviders(<MappingPairingBar pairing={pairing} />);
+
+    expect(screen.getByText('Not linked')).toBeInTheDocument();
+    expect(screen.getByText('US Woo')).toBeInTheDocument();
+  });
+
+  it('only invokes onPickSource after an explicit Configure click (#1784 I5)', async () => {
+    const user = userEvent.setup();
+    const onPickSource = vi.fn();
+    const erli: Connection = {
+      ...sampleConnection,
+      id: 'erli_1',
+      name: 'Erli Store',
+      platformType: 'erli',
+    };
+    const pairing: MappingPairing = {
+      status: 'pick-source',
+      master: { ...sampleConnection, id: 'ps_1', name: 'Main PrestaShop Store' },
+      candidates: [ALLEGRO, erli],
+    };
+    renderWithProviders(<MappingPairingBar pairing={pairing} onPickSource={onPickSource} />);
+
+    // Selecting a value alone must NOT navigate (no keyboard trap).
+    await user.selectOptions(
+      screen.getByRole('combobox', { name: /Choose marketplace to configure/i }),
+      'alg_1',
+    );
+    expect(onPickSource).not.toHaveBeenCalled();
+
+    // Only the explicit Configure click fires the callback.
+    await user.click(screen.getByRole('button', { name: 'Configure' }));
+    expect(onPickSource).toHaveBeenCalledWith('alg_1');
+  });
+});

--- a/apps/web/src/features/mappings/components/mapping-pairing-bar.tsx
+++ b/apps/web/src/features/mappings/components/mapping-pairing-bar.tsx
@@ -1,0 +1,167 @@
+/**
+ * MappingPairingBar (#1784)
+ *
+ * The pairing route strip shown under the Mapping Configuration page title.
+ * Renders the resolved source -> destination pair as two platform nodes joined
+ * by a directional connector. The source node becomes a picker only when the
+ * pairing is ambiguous (opened from a master shop with several paired
+ * marketplaces); otherwise both sides are read-only, since the pair is
+ * config-stamped on the marketplace connection.
+ *
+ * Presentational only - resolution lives in `useMappingPairing`.
+ *
+ * @module apps/web/src/features/mappings/components
+ */
+
+import type { ReactElement } from 'react';
+import { Link } from 'react-router-dom';
+import { Select } from '../../../shared/ui/select';
+import { usePlatforms } from '../../../shared/plugins';
+import type { Connection } from '../../connections';
+import type { MappingPairing } from '../hooks/use-mapping-pairing.types';
+
+interface MappingPairingBarProps {
+  pairing: MappingPairing;
+  /** Called with the chosen source connection id in the ambiguous (pick-source) case. */
+  onPickSource: (connectionId: string) => void;
+}
+
+function initials(label: string): string {
+  const trimmed = label.trim();
+  if (trimmed.length === 0) return '?';
+  return trimmed.slice(0, 2).toUpperCase();
+}
+
+export function MappingPairingBar({ pairing, onPickSource }: MappingPairingBarProps): ReactElement | null {
+  const platforms = usePlatforms();
+
+  function labelFor(connection: Connection): string {
+    return platforms.find((p) => p.platformType === connection.platformType)?.displayName ?? connection.platformType;
+  }
+
+  function chip(connection: Connection, variant: 'source' | 'dest'): ReactElement {
+    const platformLabel = labelFor(connection);
+    return (
+      <span className={`mapping-pair__chip mapping-pair__chip--${variant}`}>
+        <span className="mapping-pair__glyph" aria-hidden="true">
+          {initials(platformLabel)}
+        </span>
+        <span className="mapping-pair__chip-text">
+          <span className="mapping-pair__name">{connection.name}</span>
+          <span className="mapping-pair__platform">{platformLabel}</span>
+        </span>
+      </span>
+    );
+  }
+
+  function connector(): ReactElement {
+    return (
+      <div className="mapping-pair__connector" aria-hidden="true">
+        <span className="mapping-pair__arrow">→</span>
+      </div>
+    );
+  }
+
+  function destNode(connection: Connection): ReactElement {
+    return (
+      <div className="mapping-pair__node mapping-pair__node--dest">
+        <span className="mapping-pair__role">Destination</span>
+        {chip(connection, 'dest')}
+      </div>
+    );
+  }
+
+  if (pairing.status === 'loading' || pairing.status === 'error') {
+    return null;
+  }
+
+  if (pairing.status === 'pick-source') {
+    return (
+      <div className="mapping-pair" role="group" aria-label="Connection pairing">
+        <div className="mapping-pair__row">
+          <div className="mapping-pair__node">
+            <span className="mapping-pair__role">Source</span>
+            <Select
+              aria-label="Choose marketplace to configure"
+              defaultValue=""
+              onChange={(e) => {
+                if (e.target.value) onPickSource(e.target.value);
+              }}
+            >
+              <option value="" disabled>
+                Choose a marketplace…
+              </option>
+              {pairing.candidates.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.name} ({labelFor(c)})
+                </option>
+              ))}
+            </Select>
+          </div>
+          {connector()}
+          {destNode(pairing.master)}
+        </div>
+        <p className="mapping-pair__meta">
+          {pairing.candidates.length} marketplaces are paired with {pairing.master.name}. Pick one to
+          configure its mappings.
+        </p>
+      </div>
+    );
+  }
+
+  if (pairing.status === 'no-source') {
+    return (
+      <div className="mapping-pair" role="group" aria-label="Connection pairing">
+        <div className="mapping-pair__row">
+          <div className="mapping-pair__node">
+            <span className="mapping-pair__role">Source</span>
+            <span className="mapping-pair__chip mapping-pair__chip--empty">No marketplace paired</span>
+          </div>
+          {connector()}
+          {destNode(pairing.master)}
+        </div>
+        <p className="mapping-pair__meta">Pairing is set on the marketplace connection.</p>
+      </div>
+    );
+  }
+
+  // ready | unsupported - both render a fixed, read-only pair.
+  const source = pairing.source;
+  const destination = pairing.destination;
+
+  return (
+    <div className="mapping-pair" role="group" aria-label="Connection pairing">
+      <div className="mapping-pair__row">
+        <div className="mapping-pair__node">
+          <span className="mapping-pair__role">Source</span>
+          {chip(source, 'source')}
+        </div>
+        {connector()}
+        {destination ? (
+          destNode(destination)
+        ) : (
+          <div className="mapping-pair__node mapping-pair__node--dest">
+            <span className="mapping-pair__role">Destination</span>
+            <span className="mapping-pair__chip mapping-pair__chip--empty">Not linked</span>
+          </div>
+        )}
+      </div>
+      {pairing.status === 'ready' ? (
+        <p className="mapping-pair__meta">
+          <span className="mapping-pair__lock" aria-hidden="true">
+            🔒
+          </span>
+          Determined by connection pairing.{' '}
+          <Link to={`/connections/${source.id}/edit`}>Change pairing</Link>
+        </p>
+      ) : (
+        <p className="mapping-pair__meta">
+          <span className="mapping-pair__lock" aria-hidden="true">
+            🔒
+          </span>
+          Pairing is set on the connection.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/mappings/components/mapping-pairing-bar.tsx
+++ b/apps/web/src/features/mappings/components/mapping-pairing-bar.tsx
@@ -130,7 +130,7 @@ export function MappingPairingBar({ pairing, onPickSource }: MappingPairingBarPr
                   const isDisabled = c.status !== 'active';
                   return (
                     <option key={c.id} value={c.id}>
-                      {c.name} ({labelFor(c)}){isDisabled ? ' — disabled' : ''}
+                      {c.name} ({labelFor(c)}){isDisabled ? ' - disabled' : ''}
                     </option>
                   );
                 })}

--- a/apps/web/src/features/mappings/components/mapping-pairing-bar.tsx
+++ b/apps/web/src/features/mappings/components/mapping-pairing-bar.tsx
@@ -13,17 +13,26 @@
  * @module apps/web/src/features/mappings/components
  */
 
-import type { ReactElement } from 'react';
+import { useState, type ReactElement } from 'react';
 import { Link } from 'react-router-dom';
+import { Button } from '../../../shared/ui/button';
 import { Select } from '../../../shared/ui/select';
 import { usePlatforms } from '../../../shared/plugins';
 import type { Connection } from '../../connections';
 import type { MappingPairing } from '../hooks/use-mapping-pairing.types';
+import { resolvePlatformLabel } from '../lib/platform-label';
+
+/** Id of the pick-source select, so the page can focus it from the empty state (#1784 I5). */
+export const MAPPING_SOURCE_PICKER_ID = 'mapping-pairing-source-select';
 
 interface MappingPairingBarProps {
   pairing: MappingPairing;
-  /** Called with the chosen source connection id in the ambiguous (pick-source) case. */
-  onPickSource: (connectionId: string) => void;
+  /**
+   * Called with the chosen source connection id in the ambiguous (pick-source)
+   * case. Optional - the read-only states (`ready` / `unsupported` / `no-source`)
+   * never invoke it, so those call sites can omit it (#1784 follow-up S18).
+   */
+  onPickSource?: (connectionId: string) => void;
 }
 
 function initials(label: string): string {
@@ -32,11 +41,35 @@ function initials(label: string): string {
   return trimmed.slice(0, 2).toUpperCase();
 }
 
+/** Tokened lock glyph replacing the raw emoji (#1784 follow-up S12). */
+function LockGlyph(): ReactElement {
+  return (
+    <svg
+      className="mapping-pair__lock"
+      width="12"
+      height="12"
+      viewBox="0 0 12 12"
+      aria-hidden="true"
+      focusable="false"
+    >
+      <path
+        d="M3 5.5V4a3 3 0 0 1 6 0v1.5"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1"
+        strokeLinecap="round"
+      />
+      <rect x="2.5" y="5.5" width="7" height="4.5" rx="1" fill="currentColor" />
+    </svg>
+  );
+}
+
 export function MappingPairingBar({ pairing, onPickSource }: MappingPairingBarProps): ReactElement | null {
   const platforms = usePlatforms();
+  const [selectedSourceId, setSelectedSourceId] = useState('');
 
   function labelFor(connection: Connection): string {
-    return platforms.find((p) => p.platformType === connection.platformType)?.displayName ?? connection.platformType;
+    return resolvePlatformLabel(platforms, connection);
   }
 
   function chip(connection: Connection, variant: 'source' | 'dest'): ReactElement {
@@ -81,29 +114,44 @@ export function MappingPairingBar({ pairing, onPickSource }: MappingPairingBarPr
         <div className="mapping-pair__row">
           <div className="mapping-pair__node">
             <span className="mapping-pair__role">Source</span>
-            <Select
-              aria-label="Choose marketplace to configure"
-              defaultValue=""
-              onChange={(e) => {
-                if (e.target.value) onPickSource(e.target.value);
-              }}
-            >
-              <option value="" disabled>
-                Choose a marketplace…
-              </option>
-              {pairing.candidates.map((c) => (
-                <option key={c.id} value={c.id}>
-                  {c.name} ({labelFor(c)})
+            <div className="mapping-pair__picker">
+              <Select
+                id={MAPPING_SOURCE_PICKER_ID}
+                aria-label="Choose marketplace to configure"
+                value={selectedSourceId}
+                onChange={(e) => {
+                  setSelectedSourceId(e.target.value);
+                }}
+              >
+                <option value="" disabled>
+                  Choose a marketplace…
                 </option>
-              ))}
-            </Select>
+                {pairing.candidates.map((c) => {
+                  const isDisabled = c.status !== 'active';
+                  return (
+                    <option key={c.id} value={c.id}>
+                      {c.name} ({labelFor(c)}){isDisabled ? ' — disabled' : ''}
+                    </option>
+                  );
+                })}
+              </Select>
+              <Button
+                tone="primary"
+                disabled={selectedSourceId.length === 0}
+                onClick={() => {
+                  if (selectedSourceId) onPickSource?.(selectedSourceId);
+                }}
+              >
+                Configure
+              </Button>
+            </div>
           </div>
           {connector()}
           {destNode(pairing.master)}
         </div>
         <p className="mapping-pair__meta">
-          {pairing.candidates.length} marketplaces are paired with {pairing.master.name}. Pick one to
-          configure its mappings.
+          {pairing.candidates.length} marketplaces are paired with {pairing.master.name}. Pick one and
+          select Configure.
         </p>
       </div>
     );
@@ -148,17 +196,13 @@ export function MappingPairingBar({ pairing, onPickSource }: MappingPairingBarPr
       </div>
       {pairing.status === 'ready' ? (
         <p className="mapping-pair__meta">
-          <span className="mapping-pair__lock" aria-hidden="true">
-            🔒
-          </span>
+          <LockGlyph />
           Determined by connection pairing.{' '}
           <Link to={`/connections/${source.id}/edit`}>Change pairing</Link>
         </p>
       ) : (
         <p className="mapping-pair__meta">
-          <span className="mapping-pair__lock" aria-hidden="true">
-            🔒
-          </span>
+          <LockGlyph />
           Pairing is set on the connection.
         </p>
       )}

--- a/apps/web/src/features/mappings/components/routing-rules-panel.test.tsx
+++ b/apps/web/src/features/mappings/components/routing-rules-panel.test.tsx
@@ -164,6 +164,24 @@ describe('RoutingRulesPanel', () => {
     expect(screen.queryByText('Unsaved changes')).not.toBeInTheDocument();
   });
 
+  it('keeps the distinguishing suffix visible when methods share a label and id prefix (#1776 follow-up)', async () => {
+    // Erli returns groups that share a label and a long common id prefix, with
+    // the distinguishing part (weight) at the END of the id. Front-truncation
+    // (`slice(0,8)`) collapsed these into identical `erliDPDK…` hints; the
+    // middle-ellipsis keeps the suffix visible so the rows stay distinguishable.
+    const methods: MappingOption[] = [
+      { value: 'erliDPDKurier5kg', label: 'ERLI DPD Kurier' },
+      { value: 'erliDPDKurier20kg', label: 'ERLI DPD Kurier' },
+    ];
+    renderPanel(buildApiClient(), { deliveryMethods: methods });
+
+    expect(await screen.findByText('erliDP…r5kg')).toBeInTheDocument();
+    expect(screen.getByText('erliDP…20kg')).toBeInTheDocument();
+    // The old front-truncated hint that made the two rows identical is gone.
+    expect(screen.queryByText('erliDPD…')).not.toBeInTheDocument();
+    expect(screen.queryByText('erliDPDK…')).not.toBeInTheDocument();
+  });
+
   describe('routing-split bar (#1739)', () => {
     function legendEntry(container: HTMLElement, label: string): HTMLElement {
       const entry = Array.from(

--- a/apps/web/src/features/mappings/components/routing-rules-panel.test.tsx
+++ b/apps/web/src/features/mappings/components/routing-rules-panel.test.tsx
@@ -61,6 +61,7 @@ function renderPanel(
   renderWithProviders(
     <RoutingRulesPanel
       connectionId="conn_1"
+      sourceLabel="Allegro"
       deliveryMethods={DELIVERY_METHODS}
       deliveryMethodsLoading={false}
       deliveryMethodsError={null}
@@ -185,6 +186,7 @@ describe('RoutingRulesPanel', () => {
       const { container } = renderWithProviders(
         <RoutingRulesPanel
           connectionId="conn_1"
+          sourceLabel="Allegro"
           deliveryMethods={DELIVERY_METHODS}
           deliveryMethodsLoading={false}
           deliveryMethodsError={null}
@@ -206,6 +208,7 @@ describe('RoutingRulesPanel', () => {
       const { container } = renderWithProviders(
         <RoutingRulesPanel
           connectionId="conn_1"
+          sourceLabel="Allegro"
           deliveryMethods={DELIVERY_METHODS}
           deliveryMethodsLoading={false}
           deliveryMethodsError={null}

--- a/apps/web/src/features/mappings/components/routing-rules-panel.tsx
+++ b/apps/web/src/features/mappings/components/routing-rules-panel.tsx
@@ -30,7 +30,9 @@ import {
 
 interface RoutingRulesPanelProps {
   connectionId: string;
-  /** Source delivery methods to route — owned by the page's `useMappingOptions`. */
+  /** Resolved source-platform label for user-facing copy (#1784), e.g. "Allegro". */
+  sourceLabel: string;
+  /** Source delivery methods to route - owned by the page's `useMappingOptions`. */
   deliveryMethods: MappingOption[];
   deliveryMethodsLoading: boolean;
   deliveryMethodsError: Error | null;
@@ -71,6 +73,7 @@ interface DivertOption {
 
 export function RoutingRulesPanel({
   connectionId,
+  sourceLabel,
   deliveryMethods,
   deliveryMethodsLoading,
   deliveryMethodsError,
@@ -277,7 +280,7 @@ export function RoutingRulesPanel({
       </div>
 
       <p className="muted-text" style={{ marginBottom: 'var(--space-4)' }}>
-        Choose how each marketplace delivery method is fulfilled. Methods stay with the default
+        Choose how each {sourceLabel} delivery method is fulfilled. Methods stay with the default
         order-management platform unless you divert them to a connected carrier or
         marketplace-delivery processor.
       </p>
@@ -302,10 +305,10 @@ export function RoutingRulesPanel({
           the source exposes delivery methods.
         </p>
       ) : (
-        <table className="data-table" aria-label="Fulfillment routing rules">
+        <table className="data-table data-table--stackable" aria-label="Fulfillment routing rules">
           <thead>
             <tr>
-              <th>Delivery method</th>
+              <th>{sourceLabel} delivery method</th>
               <th>Routed to</th>
               <th>Change</th>
             </tr>
@@ -315,9 +318,9 @@ export function RoutingRulesPanel({
               const currentKey = selections[method.value] ?? DEFAULT_KEY;
               return (
                 <tr key={method.value}>
-                  <td>{renderMethodLabel(method)}</td>
-                  <td>{renderRoutedTo(currentKey)}</td>
-                  <td>
+                  <td data-label={`${sourceLabel} delivery method`}>{renderMethodLabel(method)}</td>
+                  <td data-label="Routed to">{renderRoutedTo(currentKey)}</td>
+                  <td data-label="Change">
                     <select
                       aria-label={`Fulfillment processor for ${method.label}`}
                       value={currentKey}

--- a/apps/web/src/features/mappings/components/routing-rules-panel.tsx
+++ b/apps/web/src/features/mappings/components/routing-rules-panel.tsx
@@ -13,6 +13,7 @@
 
 import { useEffect, useMemo, useState, type ReactElement, type ReactNode } from 'react';
 import { Button } from '../../../shared/ui/button';
+import { DataTable } from '../../../shared/ui/data-table';
 import { ErrorState, LoadingState } from '../../../shared/ui/feedback-state';
 import { ConnectionEntityLabel, useConnectionsQuery } from '../../connections';
 import { RoutingSplitBar, type RoutingSplitBucket } from './routing-split-bar';
@@ -265,6 +266,25 @@ export function RoutingRulesPanel({
     );
   }
 
+  function renderProcessorSelect(method: MappingOption): ReactNode {
+    const currentKey = selections[method.value] ?? DEFAULT_KEY;
+    return (
+      <select
+        aria-label={`Fulfillment processor for ${method.label}`}
+        value={currentKey}
+        onChange={(e) => {
+          handleSelect(method.value, e.target.value);
+        }}
+      >
+        {optionsForRow(currentKey).map((o) => (
+          <option key={o.key} value={o.key}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+    );
+  }
+
   return (
     <div className="panel panel--dense">
       <div className="panel__header">
@@ -305,39 +325,36 @@ export function RoutingRulesPanel({
           the source exposes delivery methods.
         </p>
       ) : (
-        <table className="data-table data-table--stackable" aria-label="Fulfillment routing rules">
-          <thead>
-            <tr>
-              <th>{sourceLabel} delivery method</th>
-              <th>Routed to</th>
-              <th>Change</th>
-            </tr>
-          </thead>
-          <tbody>
-            {rowMethods.map((method) => {
-              const currentKey = selections[method.value] ?? DEFAULT_KEY;
-              return (
-                <tr key={method.value}>
-                  <td data-label={`${sourceLabel} delivery method`}>{renderMethodLabel(method)}</td>
-                  <td data-label="Routed to">{renderRoutedTo(currentKey)}</td>
-                  <td data-label="Change">
-                    <select
-                      aria-label={`Fulfillment processor for ${method.label}`}
-                      value={currentKey}
-                      onChange={(e) => { handleSelect(method.value, e.target.value); }}
-                    >
-                      {optionsForRow(currentKey).map((o) => (
-                        <option key={o.key} value={o.key}>
-                          {o.label}
-                        </option>
-                      ))}
-                    </select>
-                  </td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
+        // Virtualized so hundreds of source delivery methods (Allegro) render
+        // without lag (#1784 follow-up). DataTable auto-disables virtualization
+        // and renders its `cardView` on narrow viewports, so the mobile layout
+        // is preserved without the raw-table `.data-table--stackable` transform.
+        <DataTable
+          caption="Fulfillment routing rules"
+          rows={rowMethods}
+          rowKey={(m) => m.value}
+          virtualize
+          estimateRowHeight={52}
+          containerHeight={520}
+          columns={[
+            {
+              id: 'method',
+              header: `${sourceLabel} delivery method`,
+              cell: (m) => renderMethodLabel(m),
+            },
+            {
+              id: 'routed',
+              header: 'Routed to',
+              cell: (m) => renderRoutedTo(selections[m.value] ?? DEFAULT_KEY),
+            },
+            { id: 'change', header: 'Change', cell: (m) => renderProcessorSelect(m) },
+          ]}
+          cardView={{
+            title: (m) => renderMethodLabel(m),
+            subtitle: (m) => renderRoutedTo(selections[m.value] ?? DEFAULT_KEY),
+            detail: (m) => renderProcessorSelect(m),
+          }}
+        />
       )}
 
       {replaceMutation.error && (

--- a/apps/web/src/features/mappings/components/routing-rules-panel.tsx
+++ b/apps/web/src/features/mappings/components/routing-rules-panel.tsx
@@ -11,10 +11,11 @@
  * @module apps/web/src/features/mappings/components
  */
 
-import { useEffect, useMemo, useState, type ReactElement, type ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useState, type ReactElement, type ReactNode } from 'react';
 import { Button } from '../../../shared/ui/button';
-import { DataTable } from '../../../shared/ui/data-table';
+import { DataTable, type DataTableColumn, type DataTableCardView } from '../../../shared/ui/data-table';
 import { ErrorState, LoadingState } from '../../../shared/ui/feedback-state';
+import { Select } from '../../../shared/ui/select';
 import { ConnectionEntityLabel, useConnectionsQuery } from '../../connections';
 import { RoutingSplitBar, type RoutingSplitBucket } from './routing-split-bar';
 import {
@@ -37,10 +38,19 @@ interface RoutingRulesPanelProps {
   deliveryMethods: MappingOption[];
   deliveryMethodsLoading: boolean;
   deliveryMethodsError: Error | null;
+  /**
+   * Reports the panel's dirty (unsaved-edits) state up so the page can guard a
+   * tab switch that would discard staged routing edits (#1784 follow-up I3).
+   */
+  onDirtyChange?: (dirty: boolean) => void;
 }
 
 /** Sentinel selection key meaning "no rule" → the default OMP fulfils the method. */
 const DEFAULT_KEY = '__default__';
+
+/** Virtualized-row height estimate; also caps the container to content (#1784 S17). */
+const ROUTING_ROW_HEIGHT = 52;
+const ROUTING_MAX_CONTAINER_HEIGHT = 520;
 
 /** Human qualifier shown before the connection name in dropdowns + row display. */
 const PROCESSOR_KIND_LABEL: Record<FulfillmentProcessorKind, string> = {
@@ -78,6 +88,7 @@ export function RoutingRulesPanel({
   deliveryMethods,
   deliveryMethodsLoading,
   deliveryMethodsError,
+  onDirtyChange,
 }: RoutingRulesPanelProps): ReactElement {
   const rulesQuery = useRoutingRulesQuery(connectionId);
   const candidatesQuery = useRoutingCandidatesQuery(connectionId);
@@ -110,9 +121,10 @@ export function RoutingRulesPanel({
     return map;
   }, [connectionsQuery.data]);
 
-  function connName(id: string): string {
-    return connectionNameById.get(id) ?? shortValue(id);
-  }
+  const connName = useCallback(
+    (id: string): string => connectionNameById.get(id) ?? shortValue(id),
+    [connectionNameById],
+  );
 
   const candidates = useMemo(() => candidatesQuery.data ?? [], [candidatesQuery.data]);
 
@@ -124,13 +136,19 @@ export function RoutingRulesPanel({
     : 'Default (order-management platform)';
 
   // Divert options exclude omp_fulfilled — that IS the default in v1; explicit
-  // OMP pinning is the multi-OMP follow-up.
-  const divertOptions: DivertOption[] = candidates
-    .filter((c) => c.processorKind !== 'omp_fulfilled')
-    .map((c) => ({
-      key: `${c.processorKind}::${c.processorConnectionId}`,
-      label: `${PROCESSOR_KIND_LABEL[c.processorKind]} · ${connName(c.processorConnectionId)}`,
-    }));
+  // OMP pinning is the multi-OMP follow-up. Sorted by label so the divert menu
+  // stays scannable (#1784 I8).
+  const divertOptions: DivertOption[] = useMemo(
+    () =>
+      candidates
+        .filter((c) => c.processorKind !== 'omp_fulfilled')
+        .map((c) => ({
+          key: `${c.processorKind}::${c.processorConnectionId}`,
+          label: `${PROCESSOR_KIND_LABEL[c.processorKind]} · ${connName(c.processorConnectionId)}`,
+        }))
+        .sort((a, b) => a.label.localeCompare(b.label)),
+    [candidates, connName],
+  );
 
   // Render a row per delivery method, plus any saved rule whose method the
   // source no longer reports — so a replace-all save never silently drops it.
@@ -146,6 +164,12 @@ export function RoutingRulesPanel({
   const isDirty = rowMethods.some(
     (m) => (selections[m.value] ?? DEFAULT_KEY) !== (savedKeyByMethod.get(m.value) ?? DEFAULT_KEY),
   );
+
+  // Surface the dirty signal up for the page-level discard guard (#1784 I3).
+  useEffect(() => {
+    onDirtyChange?.(isDirty);
+  }, [isDirty, onDirtyChange]);
+  useEffect(() => () => onDirtyChange?.(false), [onDirtyChange]);
 
   // Routing-split buckets (#1739): methods-per-processor derived from the
   // CURRENT selections (not the saved rules), so the bar moves live while the
@@ -186,25 +210,28 @@ export function RoutingRulesPanel({
     return buckets;
   }, [rowMethods, selections, candidates, defaultLabel, connectionNameById]);
 
-  function optionsForRow(currentKey: string): DivertOption[] {
-    const base: DivertOption[] = [{ key: DEFAULT_KEY, label: defaultLabel }, ...divertOptions];
-    // Keep a saved selection visible even when it is no longer a live candidate
-    // (connection disabled, capability lost), so the operator can see + decide.
-    if (currentKey !== DEFAULT_KEY && !base.some((o) => o.key === currentKey)) {
-      const parsed = parseSelectionKey(currentKey);
-      base.push({
-        key: currentKey,
-        label: parsed
-          ? `${PROCESSOR_KIND_LABEL[parsed.kind]} · ${connName(parsed.connectionId)} (unavailable)`
-          : currentKey,
-      });
-    }
-    return base;
-  }
+  const optionsForRow = useCallback(
+    (currentKey: string): DivertOption[] => {
+      const base: DivertOption[] = [{ key: DEFAULT_KEY, label: defaultLabel }, ...divertOptions];
+      // Keep a saved selection visible even when it is no longer a live candidate
+      // (connection disabled, capability lost), so the operator can see + decide.
+      if (currentKey !== DEFAULT_KEY && !base.some((o) => o.key === currentKey)) {
+        const parsed = parseSelectionKey(currentKey);
+        base.push({
+          key: currentKey,
+          label: parsed
+            ? `${PROCESSOR_KIND_LABEL[parsed.kind]} · ${connName(parsed.connectionId)} (unavailable)`
+            : currentKey,
+        });
+      }
+      return base;
+    },
+    [defaultLabel, divertOptions, connName],
+  );
 
-  function handleSelect(methodId: string, key: string): void {
+  const handleSelect = useCallback((methodId: string, key: string): void => {
     setSelections((prev) => ({ ...prev, [methodId]: key }));
-  }
+  }, []);
 
   function handleSave(): void {
     const items: RoutingRuleInput[] = [];
@@ -221,6 +248,96 @@ export function RoutingRulesPanel({
     replaceMutation.mutate({ items });
   }
 
+  // Cell renderers memoized so the DataTable column literals stay stable and
+  // don't re-prime the virtualizer on unrelated re-renders (#1784 I7). The
+  // `method` cell is static; `routed`/`change` depend on `selections`.
+  const renderMethodLabel = useCallback((method: MappingOption): ReactNode => {
+    if (method.label === method.value) {
+      return <span className="mono-text">{method.value}</span>;
+    }
+    return (
+      <>
+        {method.label}{' '}
+        <span className="mapping-id-hint mono-text">{shortValue(method.value)}</span>
+      </>
+    );
+  }, []);
+
+  const renderRoutedTo = useCallback(
+    (currentKey: string): ReactNode => {
+      if (currentKey === DEFAULT_KEY) {
+        return <span className="muted-text">{defaultLabel}</span>;
+      }
+      const parsed = parseSelectionKey(currentKey);
+      if (!parsed) return <span className="mono-text">{currentKey}</span>;
+      return (
+        <>
+          <span>{PROCESSOR_KIND_LABEL[parsed.kind]}</span>{' '}
+          <ConnectionEntityLabel
+            connectionId={parsed.connectionId}
+            linkToDetail={false}
+            showId={false}
+          />
+        </>
+      );
+    },
+    [defaultLabel],
+  );
+
+  // NOTE (#1784 I8): the per-row divert picker stays a native <select> routed
+  // through the shared `Select` wrapper (for the tokened focus ring) rather than
+  // the searchable `Combobox`. The option set is tiny (compatible candidates +
+  // default), so search is unnecessary; and a popover-combobox nested inside a
+  // virtualized DataTable cell brings portal/focus fragility that isn't worth it
+  // here. The raw id is already out of the option label (candidate name only).
+  const renderProcessorSelect = useCallback(
+    (method: MappingOption): ReactNode => {
+      const currentKey = selections[method.value] ?? DEFAULT_KEY;
+      return (
+        <Select
+          aria-label={`Fulfillment processor for ${method.label}`}
+          value={currentKey}
+          onChange={(e) => {
+            handleSelect(method.value, e.target.value);
+          }}
+        >
+          {optionsForRow(currentKey).map((o) => (
+            <option key={o.key} value={o.key}>
+              {o.label}
+            </option>
+          ))}
+        </Select>
+      );
+    },
+    [selections, optionsForRow, handleSelect],
+  );
+
+  const columns = useMemo<DataTableColumn<MappingOption>[]>(
+    () => [
+      {
+        id: 'method',
+        header: `${sourceLabel} delivery method`,
+        cell: (m) => renderMethodLabel(m),
+      },
+      {
+        id: 'routed',
+        header: 'Routed to',
+        cell: (m) => renderRoutedTo(selections[m.value] ?? DEFAULT_KEY),
+      },
+      { id: 'change', header: 'Change', cell: (m) => renderProcessorSelect(m) },
+    ],
+    [sourceLabel, renderMethodLabel, renderRoutedTo, renderProcessorSelect, selections],
+  );
+
+  const cardView = useMemo<DataTableCardView<MappingOption>>(
+    () => ({
+      title: (m) => renderMethodLabel(m),
+      subtitle: (m) => renderRoutedTo(selections[m.value] ?? DEFAULT_KEY),
+      detail: (m) => renderProcessorSelect(m),
+    }),
+    [renderMethodLabel, renderRoutedTo, renderProcessorSelect, selections],
+  );
+
   if (deliveryMethodsLoading || rulesQuery.isLoading || candidatesQuery.isLoading) {
     return (
       <LoadingState
@@ -236,54 +353,10 @@ export function RoutingRulesPanel({
     return <ErrorState title="Unable to load routing configuration" message={dataError.message} />;
   }
 
-  function renderMethodLabel(method: MappingOption): ReactNode {
-    if (method.label === method.value) {
-      return <span className="mono-text">{method.value}</span>;
-    }
-    return (
-      <>
-        {method.label}{' '}
-        <span className="mapping-id-hint mono-text">{shortValue(method.value)}</span>
-      </>
-    );
-  }
-
-  function renderRoutedTo(currentKey: string): ReactNode {
-    if (currentKey === DEFAULT_KEY) {
-      return <span className="muted-text">{defaultLabel}</span>;
-    }
-    const parsed = parseSelectionKey(currentKey);
-    if (!parsed) return <span className="mono-text">{currentKey}</span>;
-    return (
-      <>
-        <span>{PROCESSOR_KIND_LABEL[parsed.kind]}</span>{' '}
-        <ConnectionEntityLabel
-          connectionId={parsed.connectionId}
-          linkToDetail={false}
-          showId={false}
-        />
-      </>
-    );
-  }
-
-  function renderProcessorSelect(method: MappingOption): ReactNode {
-    const currentKey = selections[method.value] ?? DEFAULT_KEY;
-    return (
-      <select
-        aria-label={`Fulfillment processor for ${method.label}`}
-        value={currentKey}
-        onChange={(e) => {
-          handleSelect(method.value, e.target.value);
-        }}
-      >
-        {optionsForRow(currentKey).map((o) => (
-          <option key={o.key} value={o.key}>
-            {o.label}
-          </option>
-        ))}
-      </select>
-    );
-  }
+  const containerHeight = Math.min(
+    ROUTING_MAX_CONTAINER_HEIGHT,
+    rowMethods.length * ROUTING_ROW_HEIGHT + 8,
+  );
 
   return (
     <div className="panel panel--dense">
@@ -334,26 +407,10 @@ export function RoutingRulesPanel({
           rows={rowMethods}
           rowKey={(m) => m.value}
           virtualize
-          estimateRowHeight={52}
-          containerHeight={520}
-          columns={[
-            {
-              id: 'method',
-              header: `${sourceLabel} delivery method`,
-              cell: (m) => renderMethodLabel(m),
-            },
-            {
-              id: 'routed',
-              header: 'Routed to',
-              cell: (m) => renderRoutedTo(selections[m.value] ?? DEFAULT_KEY),
-            },
-            { id: 'change', header: 'Change', cell: (m) => renderProcessorSelect(m) },
-          ]}
-          cardView={{
-            title: (m) => renderMethodLabel(m),
-            subtitle: (m) => renderRoutedTo(selections[m.value] ?? DEFAULT_KEY),
-            detail: (m) => renderProcessorSelect(m),
-          }}
+          estimateRowHeight={ROUTING_ROW_HEIGHT}
+          containerHeight={containerHeight}
+          columns={columns}
+          cardView={cardView}
         />
       )}
 

--- a/apps/web/src/features/mappings/components/routing-rules-panel.tsx
+++ b/apps/web/src/features/mappings/components/routing-rules-panel.tsx
@@ -59,9 +59,21 @@ const PROCESSOR_KIND_LABEL: Record<FulfillmentProcessorKind, string> = {
   source_brokered: 'Marketplace-brokered',
 };
 
-/** Truncates long ids (Allegro UUIDs) for inline hints; short ids render verbatim (#474). */
+const SHORT_VALUE_HEAD = 6;
+const SHORT_VALUE_TAIL = 4;
+
+/**
+ * Truncates long ids for inline hints; short ids render verbatim (#474).
+ *
+ * Middle-ellipsis rather than front-truncation: some marketplaces (Erli) share
+ * a long common prefix and carry the distinguishing part (weight/size) at the
+ * END of the id, so `slice(0, 8)` collapsed whole groups into identical hints -
+ * e.g. `erliDPDKurier5kg` / `…20kg` both became `erliDPDK…`. Keeping head + tail
+ * preserves the distinguishing suffix (`erliDP…20kg`).
+ */
 function shortValue(value: string): string {
-  return value.length <= 9 ? value : `${value.slice(0, 8)}…`;
+  if (value.length <= SHORT_VALUE_HEAD + SHORT_VALUE_TAIL + 1) return value;
+  return `${value.slice(0, SHORT_VALUE_HEAD)}…${value.slice(-SHORT_VALUE_TAIL)}`;
 }
 
 /** `${kind}::${connectionId}` → its parts, or null for the default sentinel / malformed keys. */

--- a/apps/web/src/features/mappings/hooks/use-carrier-mappings.ts
+++ b/apps/web/src/features/mappings/hooks/use-carrier-mappings.ts
@@ -15,9 +15,13 @@ import { useApiClient } from '../../../app/api/api-client-provider';
 import { mappingsQueryKeys } from '../api/mappings.query-keys';
 import type { CarrierMapping, UpsertCarrierMappingsPayload } from '../api/mappings.types';
 
-export function useCarrierMappingsQuery(connectionId: string): UseQueryResult<CarrierMapping[]> {
+export function useCarrierMappingsQuery(
+  connectionId: string,
+  options?: { enabled?: boolean },
+): UseQueryResult<CarrierMapping[]> {
   const apiClient = useApiClient();
   return useQuery({
+    enabled: connectionId.length > 0 && (options?.enabled ?? true),
     queryKey: mappingsQueryKeys.carriers(connectionId),
     queryFn: () => apiClient.mappings.getCarrierMappings(connectionId),
   });

--- a/apps/web/src/features/mappings/hooks/use-mapping-options.ts
+++ b/apps/web/src/features/mappings/hooks/use-mapping-options.ts
@@ -48,8 +48,25 @@ const QUERY_SPEC: Array<{
   { side: 'destination', kind: 'payment-methods', bundleKey: 'prestashopPaymentModules' },
 ];
 
+/**
+ * Per-side connection ids. Mapping data is keyed to DIFFERENT sides (#1784
+ * follow-up B1): source-side option lists come from the marketplace connection,
+ * destination-side lists from its paired master shop. Callers that don't care
+ * (e.g. the PrestaShop structured-config carrier picker) may pass a single
+ * string, which is used for both sides.
+ */
+export type MappingOptionsConnectionIds = string | { source: string; destination: string };
+
+/**
+ * Option dictionaries are near-static; refetching against slow destination-shop
+ * endpoints on every remount/refocus is wasteful (#1784 follow-up). A large but
+ * finite staleTime keeps them fresh-per-session without pinning them forever in
+ * memory across a genuinely stale session (S10).
+ */
+const OPTIONS_STALE_TIME_MS = 10 * 60 * 1000;
+
 export function useMappingOptions(
-  connectionId: string,
+  connectionIds: MappingOptionsConnectionIds,
   /**
    * Which bundle keys to actually fetch (#1784 follow-up: lazy-load per tab).
    * A key absent from the set has its query disabled, so option lists are
@@ -60,17 +77,22 @@ export function useMappingOptions(
 ): UseMappingOptionsResult {
   const apiClient = useApiClient();
 
+  const sourceConnectionId =
+    typeof connectionIds === 'string' ? connectionIds : connectionIds.source;
+  const destinationConnectionId =
+    typeof connectionIds === 'string' ? connectionIds : connectionIds.destination;
+
   const results = useQueries({
-    queries: QUERY_SPEC.map(({ side, kind, bundleKey }) => ({
-      enabled: connectionId.length > 0 && (enabledKeys?.has(bundleKey) ?? true),
-      // Option dictionaries are near-static; a short staleTime forced refetches
-      // against slow destination-shop endpoints on every remount/refocus (#1784
-      // follow-up). Treat them as effectively immutable per session.
-      staleTime: Infinity,
-      gcTime: 60 * 60 * 1000,
-      queryKey: mappingsQueryKeys.option(connectionId, side, kind),
-      queryFn: () => apiClient.mappings.getMappingOptions(connectionId, side, kind),
-    })),
+    queries: QUERY_SPEC.map(({ side, kind, bundleKey }) => {
+      const connectionId = side === 'source' ? sourceConnectionId : destinationConnectionId;
+      return {
+        enabled: connectionId.length > 0 && (enabledKeys?.has(bundleKey) ?? true),
+        staleTime: OPTIONS_STALE_TIME_MS,
+        gcTime: 60 * 60 * 1000,
+        queryKey: mappingsQueryKeys.option(connectionId, side, kind),
+        queryFn: () => apiClient.mappings.getMappingOptions(connectionId, side, kind),
+      };
+    }),
   });
 
   const isLoading = results.some((r) => r.isLoading);

--- a/apps/web/src/features/mappings/hooks/use-mapping-options.ts
+++ b/apps/web/src/features/mappings/hooks/use-mapping-options.ts
@@ -48,11 +48,26 @@ const QUERY_SPEC: Array<{
   { side: 'destination', kind: 'payment-methods', bundleKey: 'prestashopPaymentModules' },
 ];
 
-export function useMappingOptions(connectionId: string): UseMappingOptionsResult {
+export function useMappingOptions(
+  connectionId: string,
+  /**
+   * Which bundle keys to actually fetch (#1784 follow-up: lazy-load per tab).
+   * A key absent from the set has its query disabled, so option lists are
+   * fetched only for the tab(s) the operator has visited. `undefined` keeps
+   * the original "fetch all" behaviour for any caller that doesn't opt in.
+   */
+  enabledKeys?: ReadonlySet<keyof MappingOptions>,
+): UseMappingOptionsResult {
   const apiClient = useApiClient();
 
   const results = useQueries({
-    queries: QUERY_SPEC.map(({ side, kind }) => ({
+    queries: QUERY_SPEC.map(({ side, kind, bundleKey }) => ({
+      enabled: connectionId.length > 0 && (enabledKeys?.has(bundleKey) ?? true),
+      // Option dictionaries are near-static; a short staleTime forced refetches
+      // against slow destination-shop endpoints on every remount/refocus (#1784
+      // follow-up). Treat them as effectively immutable per session.
+      staleTime: Infinity,
+      gcTime: 60 * 60 * 1000,
       queryKey: mappingsQueryKeys.option(connectionId, side, kind),
       queryFn: () => apiClient.mappings.getMappingOptions(connectionId, side, kind),
     })),

--- a/apps/web/src/features/mappings/hooks/use-mapping-pairing.test.ts
+++ b/apps/web/src/features/mappings/hooks/use-mapping-pairing.test.ts
@@ -98,7 +98,7 @@ describe('resolveMappingPairing', () => {
     expect(result).toEqual({ status: 'no-source', master: presta });
   });
 
-  it('ignores disabled paired sources', () => {
+  it('includes a disabled paired source rather than dropping it to no-source (#1784 S11)', () => {
     const disabledAllegro = conn({
       id: 'alg_disabled',
       platformType: 'allegro',
@@ -106,6 +106,24 @@ describe('resolveMappingPairing', () => {
       config: { masterCatalogConnectionId: 'ps_1' },
     });
     const result = resolveMappingPairing(presta, [presta, disabledAllegro]);
-    expect(result).toEqual({ status: 'no-source', master: presta });
+    // The single (disabled) paired source resolves to ready; the page surfaces
+    // a non-active note rather than misreporting "no marketplace paired".
+    expect(result).toEqual({ status: 'ready', source: disabledAllegro, destination: presta });
+  });
+
+  it('returns unsupported with a null destination when the paired master is missing', () => {
+    // Unsupported source whose pairing key points at a connection not in the
+    // list -> unsupported, destination null (renders "Not linked" in the bar).
+    const wooDangling = conn({
+      id: 'woo_2',
+      platformType: 'woocommerce',
+      config: { masterCatalogConnectionId: 'missing' },
+    });
+    const result = resolveMappingPairing(wooDangling, [wooDangling]);
+    expect(result.status).toBe('unsupported');
+    if (result.status === 'unsupported') {
+      expect(result.source).toBe(wooDangling);
+      expect(result.destination).toBeNull();
+    }
   });
 });

--- a/apps/web/src/features/mappings/hooks/use-mapping-pairing.test.ts
+++ b/apps/web/src/features/mappings/hooks/use-mapping-pairing.test.ts
@@ -1,0 +1,111 @@
+/**
+ * resolveMappingPairing tests (#1784)
+ *
+ * Pure-logic coverage for the source -> destination pairing resolution used by
+ * the Mapping Configuration page. Exercised without React.
+ *
+ * @module apps/web/src/features/mappings/hooks
+ */
+
+import { describe, expect, it } from 'vitest';
+import type { Connection } from '../../connections';
+import { resolveMappingPairing } from './use-mapping-pairing';
+
+function conn(partial: Partial<Connection> & Pick<Connection, 'id' | 'platformType'>): Connection {
+  return {
+    name: `Connection ${partial.id}`,
+    status: 'active',
+    config: {},
+    credentialsBacked: true,
+    enabledCapabilities: [],
+    supportedCapabilities: [],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...partial,
+  };
+}
+
+const presta = conn({ id: 'ps_1', platformType: 'prestashop' });
+const allegro = conn({
+  id: 'alg_1',
+  platformType: 'allegro',
+  config: { masterCatalogConnectionId: 'ps_1' },
+});
+const erli = conn({
+  id: 'erli_1',
+  platformType: 'erli',
+  config: { masterCatalogConnectionId: 'ps_1' },
+});
+const woo = conn({
+  id: 'woo_1',
+  platformType: 'woocommerce',
+  config: { masterCatalogConnectionId: 'ps_1' },
+});
+
+describe('resolveMappingPairing', () => {
+  it('resolves a ready pair when opened from a supported source with a found master', () => {
+    const result = resolveMappingPairing(allegro, [allegro, presta]);
+    expect(result).toEqual({ status: 'ready', source: allegro, destination: presta });
+  });
+
+  it('returns unsupported when opened from a source whose platform is not allowlisted', () => {
+    const result = resolveMappingPairing(woo, [woo, presta]);
+    expect(result.status).toBe('unsupported');
+    if (result.status === 'unsupported') {
+      expect(result.source).toBe(woo);
+      expect(result.destination).toBe(presta);
+    }
+  });
+
+  it('errors when a supported source has no catalog pairing key', () => {
+    const unlinked = conn({ id: 'alg_2', platformType: 'allegro', config: {} });
+    const result = resolveMappingPairing(unlinked, [unlinked, presta]);
+    expect(result.status).toBe('error');
+  });
+
+  it('errors when the paired master id resolves to no connection', () => {
+    const dangling = conn({
+      id: 'alg_3',
+      platformType: 'allegro',
+      config: { masterCatalogConnectionId: 'missing' },
+    });
+    const result = resolveMappingPairing(dangling, [dangling]);
+    expect(result.status).toBe('error');
+  });
+
+  it('returns no-source when opened from a master with nothing paired', () => {
+    const result = resolveMappingPairing(presta, [presta]);
+    expect(result).toEqual({ status: 'no-source', master: presta });
+  });
+
+  it('resolves a ready pair when opened from a master with exactly one paired source', () => {
+    const result = resolveMappingPairing(presta, [presta, allegro]);
+    expect(result).toEqual({ status: 'ready', source: allegro, destination: presta });
+  });
+
+  it('returns pick-source when opened from a master with several paired sources', () => {
+    const result = resolveMappingPairing(presta, [presta, allegro, erli]);
+    expect(result.status).toBe('pick-source');
+    if (result.status === 'pick-source') {
+      expect(result.master).toBe(presta);
+      expect(result.candidates).toEqual([allegro, erli]);
+    }
+  });
+
+  it('ignores paired sources whose platform is not allowlisted', () => {
+    // Only a WooCommerce source is paired -> no supported source.
+    const result = resolveMappingPairing(presta, [presta, woo]);
+    expect(result).toEqual({ status: 'no-source', master: presta });
+  });
+
+  it('ignores disabled paired sources', () => {
+    const disabledAllegro = conn({
+      id: 'alg_disabled',
+      platformType: 'allegro',
+      status: 'disabled',
+      config: { masterCatalogConnectionId: 'ps_1' },
+    });
+    const result = resolveMappingPairing(presta, [presta, disabledAllegro]);
+    expect(result).toEqual({ status: 'no-source', master: presta });
+  });
+});

--- a/apps/web/src/features/mappings/hooks/use-mapping-pairing.ts
+++ b/apps/web/src/features/mappings/hooks/use-mapping-pairing.ts
@@ -1,0 +1,106 @@
+/**
+ * useMappingPairing (#1784)
+ *
+ * Resolves the source -> destination connection pair for the order Mapping
+ * Configuration page, mirroring the backend partner resolution in
+ * `MappingOptionsController.resolvePartnerConnectionId`. The pairing is
+ * config-stamped: a marketplace connection carries a single
+ * `config.masterCatalogConnectionId` pointing at its master shop, so the pair
+ * is determined rather than freely chosen.
+ *
+ * The pure `resolveMappingPairing` core is exported for unit testing without
+ * React.
+ *
+ * @module apps/web/src/features/mappings/hooks
+ */
+
+import { useConnectionQuery, useConnectionsQuery, type Connection } from '../../connections';
+import { isSupportedSourcePlatform } from '../supported-source-platforms';
+import type { MappingPairing } from './use-mapping-pairing.types';
+
+/** Read the single pairing key off a connection's `config`; empty/non-string -> undefined. */
+function readMasterCatalogConnectionId(connection: Connection): string | undefined {
+  const value = connection.config?.['masterCatalogConnectionId'];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+/**
+ * Resolve the pairing from the URL connection plus the full connection list.
+ * Never returns `loading`; the hook layers that on top of the queries.
+ */
+export function resolveMappingPairing(
+  urlConnection: Connection,
+  allConnections: Connection[],
+): MappingPairing {
+  const masterId = readMasterCatalogConnectionId(urlConnection);
+
+  // A connection is the SOURCE side when it carries a pairing key (marketplace /
+  // shop-listing connections stamp one) or is itself a supported marketplace
+  // platform. Otherwise it is the master/destination shop.
+  const urlIsSource = masterId !== undefined || isSupportedSourcePlatform(urlConnection.platformType);
+
+  if (urlIsSource) {
+    if (!isSupportedSourcePlatform(urlConnection.platformType)) {
+      const destination = masterId
+        ? allConnections.find((c) => c.id === masterId) ?? null
+        : null;
+      return { status: 'unsupported', source: urlConnection, destination };
+    }
+    if (!masterId) {
+      return {
+        status: 'error',
+        error: new Error(
+          'This connection is not linked to a product catalog. Set its catalog on the connection page to configure mappings.',
+        ),
+      };
+    }
+    const destination = allConnections.find((c) => c.id === masterId);
+    if (!destination) {
+      return {
+        status: 'error',
+        error: new Error(
+          "The linked catalog connection could not be found. Check this connection's catalog pairing.",
+        ),
+      };
+    }
+    return { status: 'ready', source: urlConnection, destination };
+  }
+
+  // Master/destination shop: reverse-lookup the active sources paired to it,
+  // narrowed to supported marketplace platforms (mirrors the backend, plus the
+  // FE-only allowlist).
+  const supportedSources = allConnections.filter(
+    (c) =>
+      c.status === 'active' &&
+      readMasterCatalogConnectionId(c) === urlConnection.id &&
+      isSupportedSourcePlatform(c.platformType),
+  );
+
+  if (supportedSources.length === 0) {
+    return { status: 'no-source', master: urlConnection };
+  }
+  if (supportedSources.length === 1) {
+    return { status: 'ready', source: supportedSources[0], destination: urlConnection };
+  }
+  return { status: 'pick-source', master: urlConnection, candidates: supportedSources };
+}
+
+export function useMappingPairing(connectionId: string): MappingPairing {
+  const urlConnectionQuery = useConnectionQuery(connectionId);
+  const connectionsQuery = useConnectionsQuery();
+
+  if (urlConnectionQuery.isLoading || connectionsQuery.isLoading) {
+    return { status: 'loading' };
+  }
+
+  const queryError = urlConnectionQuery.error ?? connectionsQuery.error;
+  if (queryError) {
+    return { status: 'error', error: queryError as Error };
+  }
+
+  if (!urlConnectionQuery.data || !connectionsQuery.data) {
+    return { status: 'loading' };
+  }
+
+  return resolveMappingPairing(urlConnectionQuery.data, connectionsQuery.data);
+}

--- a/apps/web/src/features/mappings/hooks/use-mapping-pairing.ts
+++ b/apps/web/src/features/mappings/hooks/use-mapping-pairing.ts
@@ -15,7 +15,7 @@
  */
 
 import { useConnectionQuery, useConnectionsQuery, type Connection } from '../../connections';
-import { isSupportedSourcePlatform } from '../supported-source-platforms';
+import { isSupportedSourcePlatform } from '../lib/supported-source-platforms';
 import type { MappingPairing } from './use-mapping-pairing.types';
 
 /** Read the single pairing key off a connection's `config`; empty/non-string -> undefined. */
@@ -66,12 +66,14 @@ export function resolveMappingPairing(
     return { status: 'ready', source: urlConnection, destination };
   }
 
-  // Master/destination shop: reverse-lookup the active sources paired to it,
-  // narrowed to supported marketplace platforms (mirrors the backend, plus the
-  // FE-only allowlist).
+  // Master/destination shop: reverse-lookup the sources paired to it, narrowed
+  // to supported marketplace platforms (mirrors the backend, plus the FE-only
+  // allowlist). Disabled paired sources are INCLUDED (#1784 follow-up S11) so a
+  // shop with only a disabled-but-paired marketplace is not misreported as
+  // `no-source`; the page surfaces a non-active note instead, and the
+  // pick-source picker greys the disabled candidates.
   const supportedSources = allConnections.filter(
     (c) =>
-      c.status === 'active' &&
       readMasterCatalogConnectionId(c) === urlConnection.id &&
       isSupportedSourcePlatform(c.platformType),
   );
@@ -95,7 +97,7 @@ export function useMappingPairing(connectionId: string): MappingPairing {
 
   const queryError = urlConnectionQuery.error ?? connectionsQuery.error;
   if (queryError) {
-    return { status: 'error', error: queryError as Error };
+    return { status: 'error', error: queryError };
   }
 
   if (!urlConnectionQuery.data || !connectionsQuery.data) {

--- a/apps/web/src/features/mappings/hooks/use-mapping-pairing.ts
+++ b/apps/web/src/features/mappings/hooks/use-mapping-pairing.ts
@@ -71,7 +71,7 @@ export function resolveMappingPairing(
   // allowlist). Disabled paired sources are INCLUDED (#1784 follow-up S11) so a
   // shop with only a disabled-but-paired marketplace is not misreported as
   // `no-source`; the page surfaces a non-active note instead, and the
-  // pick-source picker greys the disabled candidates.
+  // pick-source picker labels the disabled candidates (they stay selectable).
   const supportedSources = allConnections.filter(
     (c) =>
       readMasterCatalogConnectionId(c) === urlConnection.id &&

--- a/apps/web/src/features/mappings/hooks/use-mapping-pairing.types.ts
+++ b/apps/web/src/features/mappings/hooks/use-mapping-pairing.types.ts
@@ -1,0 +1,25 @@
+/**
+ * Mapping pairing types (#1784)
+ *
+ * The resolved source -> destination pairing for the order Mapping
+ * Configuration page. Mirrors the backend partner resolution
+ * (`MappingOptionsController.resolvePartnerConnectionId`): a marketplace
+ * connection carries `config.masterCatalogConnectionId` pointing at exactly
+ * one master shop, so the pair is determined, not freely chosen.
+ *
+ * @module apps/web/src/features/mappings/hooks
+ */
+
+import type { Connection } from '../../connections';
+
+export type MappingPairing =
+  | { status: 'loading' }
+  | { status: 'error'; error: Error }
+  /** Source platform is not in the FE supported-pairs allowlist. */
+  | { status: 'unsupported'; source: Connection; destination: Connection | null }
+  /** Opened from a master shop that has no paired source connection. */
+  | { status: 'no-source'; master: Connection }
+  /** Opened from a master shop with several paired sources - operator must pick. */
+  | { status: 'pick-source'; master: Connection; candidates: Connection[] }
+  /** Resolved, unambiguous, supported pair. `source` owns the mapping data. */
+  | { status: 'ready'; source: Connection; destination: Connection };

--- a/apps/web/src/features/mappings/hooks/use-order-state-mappings.ts
+++ b/apps/web/src/features/mappings/hooks/use-order-state-mappings.ts
@@ -19,10 +19,12 @@ import { mappingsQueryKeys } from '../api/mappings.query-keys';
 import type { OrderStateMapping, UpsertOrderStateMappingsPayload } from '../api/mappings.types';
 
 export function useOrderStateMappingsQuery(
-  connectionId: string
+  connectionId: string,
+  options?: { enabled?: boolean }
 ): UseQueryResult<OrderStateMapping[]> {
   const apiClient = useApiClient();
   return useQuery({
+    enabled: connectionId.length > 0 && (options?.enabled ?? true),
     queryKey: mappingsQueryKeys.orderStates(connectionId),
     queryFn: () => apiClient.mappings.getOrderStateMappings(connectionId),
   });

--- a/apps/web/src/features/mappings/hooks/use-payment-mappings.ts
+++ b/apps/web/src/features/mappings/hooks/use-payment-mappings.ts
@@ -15,9 +15,13 @@ import { useApiClient } from '../../../app/api/api-client-provider';
 import { mappingsQueryKeys } from '../api/mappings.query-keys';
 import type { PaymentMapping, UpsertPaymentMappingsPayload } from '../api/mappings.types';
 
-export function usePaymentMappingsQuery(connectionId: string): UseQueryResult<PaymentMapping[]> {
+export function usePaymentMappingsQuery(
+  connectionId: string,
+  options?: { enabled?: boolean },
+): UseQueryResult<PaymentMapping[]> {
   const apiClient = useApiClient();
   return useQuery({
+    enabled: connectionId.length > 0 && (options?.enabled ?? true),
     queryKey: mappingsQueryKeys.payments(connectionId),
     queryFn: () => apiClient.mappings.getPaymentMappings(connectionId),
   });

--- a/apps/web/src/features/mappings/hooks/use-status-mappings.ts
+++ b/apps/web/src/features/mappings/hooks/use-status-mappings.ts
@@ -17,9 +17,13 @@ import { useApiClient } from '../../../app/api/api-client-provider';
 import { mappingsQueryKeys } from '../api/mappings.query-keys';
 import type { StatusMapping, UpsertStatusMappingsPayload } from '../api/mappings.types';
 
-export function useStatusMappingsQuery(connectionId: string): UseQueryResult<StatusMapping[]> {
+export function useStatusMappingsQuery(
+  connectionId: string,
+  options?: { enabled?: boolean },
+): UseQueryResult<StatusMapping[]> {
   const apiClient = useApiClient();
   return useQuery({
+    enabled: connectionId.length > 0 && (options?.enabled ?? true),
     queryKey: mappingsQueryKeys.status(connectionId),
     queryFn: () => apiClient.mappings.getStatusMappings(connectionId),
   });

--- a/apps/web/src/features/mappings/lib/platform-label.ts
+++ b/apps/web/src/features/mappings/lib/platform-label.ts
@@ -1,0 +1,30 @@
+/**
+ * Platform-label resolver (#1784 follow-up)
+ *
+ * Resolves a connection's human-readable platform label from the plugin
+ * registry, falling back to the raw `platformType` when no plugin is
+ * registered for it. Extracted so the Mapping Configuration page and the
+ * `MappingPairingBar` share one implementation instead of duplicating the
+ * `platforms.find(...)?.displayName ?? platformType` lookup.
+ *
+ * @module apps/web/src/features/mappings/lib
+ */
+
+interface PlatformLike {
+  platformType: string;
+  displayName: string;
+}
+
+interface ConnectionLike {
+  platformType: string;
+}
+
+export function resolvePlatformLabel(
+  platforms: readonly PlatformLike[],
+  connection: ConnectionLike,
+): string {
+  return (
+    platforms.find((p) => p.platformType === connection.platformType)?.displayName ??
+    connection.platformType
+  );
+}

--- a/apps/web/src/features/mappings/lib/supported-source-platforms.test.ts
+++ b/apps/web/src/features/mappings/lib/supported-source-platforms.test.ts
@@ -1,0 +1,30 @@
+/**
+ * isSupportedSourcePlatform tests (#1784 follow-up S19)
+ *
+ * @module apps/web/src/features/mappings/lib
+ */
+
+import { describe, expect, it } from 'vitest';
+import { isSupportedSourcePlatform } from './supported-source-platforms';
+
+describe('isSupportedSourcePlatform', () => {
+  it('returns false for undefined', () => {
+    expect(isSupportedSourcePlatform(undefined)).toBe(false);
+  });
+
+  it('returns false for an empty string', () => {
+    expect(isSupportedSourcePlatform('')).toBe(false);
+  });
+
+  it('returns true for an allowlisted platform (allegro)', () => {
+    expect(isSupportedSourcePlatform('allegro')).toBe(true);
+  });
+
+  it('returns true for an allowlisted platform (erli)', () => {
+    expect(isSupportedSourcePlatform('erli')).toBe(true);
+  });
+
+  it('returns false for a non-allowlisted platform (shopify)', () => {
+    expect(isSupportedSourcePlatform('shopify')).toBe(false);
+  });
+});

--- a/apps/web/src/features/mappings/lib/supported-source-platforms.ts
+++ b/apps/web/src/features/mappings/lib/supported-source-platforms.ts
@@ -11,7 +11,7 @@
  * (as was done earlier for presta -> erli). Do NOT mirror this into a
  * server-side guard without an explicit decision to close that escape hatch.
  *
- * @module apps/web/src/features/mappings
+ * @module apps/web/src/features/mappings/lib
  */
 
 export const SUPPORTED_SOURCE_PLATFORMS = ['allegro', 'erli'] as const;

--- a/apps/web/src/features/mappings/supported-source-platforms.ts
+++ b/apps/web/src/features/mappings/supported-source-platforms.ts
@@ -1,0 +1,22 @@
+/**
+ * Supported source platforms for order mapping (#1784)
+ *
+ * The platform types whose connections may configure order mappings today.
+ * A source connection outside this list routes to the "unsupported" state on
+ * the mappings page instead of showing the mapping tabs.
+ *
+ * FE-ONLY GATE (by decision, #1784): this list lives only on the front end.
+ * The mapping API stays open on capability, so an operator can still add
+ * mappings for an unlisted pair by calling the API directly in an emergency
+ * (as was done earlier for presta -> erli). Do NOT mirror this into a
+ * server-side guard without an explicit decision to close that escape hatch.
+ *
+ * @module apps/web/src/features/mappings
+ */
+
+export const SUPPORTED_SOURCE_PLATFORMS = ['allegro', 'erli'] as const;
+
+export function isSupportedSourcePlatform(platformType: string | undefined): boolean {
+  if (!platformType) return false;
+  return (SUPPORTED_SOURCE_PLATFORMS as readonly string[]).includes(platformType);
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -15945,6 +15945,38 @@ textarea.bulk-editor__input { resize: vertical; min-height: 66px; font-family: i
   margin: var(--space-2) 0 0;
   font-family: var(--font-mono);
   font-size: 10.5px;
+/* ── Mapping pairing route strip (#1784) ──────────────────────────────
+ * Source -> destination pair shown under the Mapping Configuration title.
+ * Two labelled platform nodes joined by a directional connector; stacks
+ * vertically on narrow viewports (see the responsive block below).
+ */
+.mapping-pair {
+  margin: var(--space-4) 0 var(--space-5);
+}
+.mapping-pair__row {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: stretch;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+  background: var(--bg-surface-elevated);
+  overflow: hidden;
+}
+.mapping-pair__node {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-4);
+  min-width: 0;
+}
+.mapping-pair__node--dest {
+  align-items: flex-end;
+  text-align: right;
+  background: var(--bg-surface);
+}
+.mapping-pair__role {
+  font-size: 0.6875rem;
+  font-weight: 600;
   letter-spacing: 0.08em;
   text-transform: uppercase;
   color: var(--text-muted);
@@ -16043,4 +16075,195 @@ textarea.bulk-editor__input { resize: vertical; min-height: 66px; font-family: i
   .infakt-webhook__exchange { grid-template-columns: 1fr; }
   .infakt-webhook__seam { height: 1px; width: 100%; }
   .infakt-webhook__seam-glyph { transform: translate(-50%, -50%) rotate(90deg); }
+.mapping-pair__connector {
+  position: relative;
+  width: 72px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(var(--border-subtle), var(--border-subtle)) center / 100% 1px no-repeat;
+}
+.mapping-pair__arrow {
+  position: relative;
+  z-index: 1;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: var(--radius-pill);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-strong);
+  color: var(--text-secondary);
+  font-size: 0.75rem;
+}
+.mapping-pair__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  max-width: 100%;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-md);
+  padding: var(--space-2) var(--space-3);
+  background: var(--bg-surface);
+  color: var(--text-primary);
+  font-size: 0.875rem;
+  font-weight: 500;
+}
+.mapping-pair__chip--dest {
+  background: var(--accent-primary-soft);
+  border-color: var(--accent-primary-border);
+}
+.mapping-pair__chip--empty {
+  color: var(--text-muted);
+  font-weight: 400;
+  border-style: dashed;
+}
+.mapping-pair__glyph {
+  flex: none;
+  width: 1.5rem;
+  height: 1.5rem;
+  border-radius: var(--radius-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.6875rem;
+  font-weight: 700;
+  background: var(--bg-surface-muted);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-default);
+}
+.mapping-pair__chip-text {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+.mapping-pair__name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.mapping-pair__platform {
+  font-size: 0.6875rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+.mapping-pair__meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+  margin: var(--space-2) 0 0;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+.mapping-pair__lock {
+  color: var(--text-disabled);
+}
+.mapping-pair .control--select {
+  max-width: 22rem;
+}
+
+/* ── Responsive: mapping tables collapse to cards (#1784) ──────────────
+ * Scoped to `.data-table--stackable` (the mapping + routing tables) so the
+ * app-wide DataTable stays untouched. At <=640px each row becomes a card:
+ * the source value heads the card and each remaining cell stacks beneath its
+ * column label, surfaced from the visually-hidden <th> via `data-label`.
+ */
+@media (max-width: 640px) {
+  .mapping-pair__row {
+    grid-template-columns: 1fr;
+  }
+  .mapping-pair__node--dest {
+    align-items: flex-start;
+    text-align: left;
+  }
+  .mapping-pair__connector {
+    width: auto;
+    height: 2.5rem;
+    background: linear-gradient(var(--border-subtle), var(--border-subtle)) center / 1px 100% no-repeat;
+  }
+  .mapping-pair__arrow {
+    transform: rotate(90deg);
+  }
+  .mapping-pair__chip {
+    width: 100%;
+  }
+  .mapping-pair .control--select {
+    max-width: none;
+  }
+
+  .data-table--stackable,
+  .data-table--stackable tbody {
+    display: block;
+    width: 100%;
+  }
+  .data-table--stackable thead {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    overflow: hidden;
+    clip: rect(0 0 0 0);
+    white-space: nowrap;
+    border: 0;
+  }
+  .data-table--stackable tbody {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+  }
+  .data-table--stackable tr {
+    display: block;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-md);
+    background: var(--bg-surface);
+    padding: var(--space-3) var(--space-4);
+  }
+  .data-table--stackable td {
+    display: block;
+    border: none;
+    padding: 0;
+    height: auto;
+  }
+  .data-table--stackable td[data-label] {
+    margin-top: var(--space-3);
+  }
+  .data-table--stackable td[data-label]::before {
+    content: attr(data-label);
+    display: block;
+    margin-bottom: var(--space-1);
+    font-size: 0.6875rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+  }
+  .data-table--stackable td:first-child {
+    margin-top: 0;
+    font-weight: 600;
+  }
+  .data-table--stackable td:first-child[data-label]::before {
+    content: none;
+  }
+  .data-table--stackable td.data-table__cell--actions {
+    margin-top: var(--space-3);
+  }
+  .data-table--stackable select,
+  .data-table--stackable .control {
+    width: 100%;
+    max-width: none;
+  }
+
+  /* Mapping tab bar scrolls horizontally instead of wrapping (scoped by label). */
+  .tabs__list[aria-label='Mapping types'] {
+    overflow-x: auto;
+    flex-wrap: nowrap;
+    scrollbar-width: none;
+  }
+  .tabs__list[aria-label='Mapping types']::-webkit-scrollbar {
+    display: none;
+  }
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -15945,6 +15945,10 @@ textarea.bulk-editor__input { resize: vertical; min-height: 66px; font-family: i
   margin: var(--space-2) 0 0;
   font-family: var(--font-mono);
   font-size: 10.5px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
 /* ── Mapping pairing route strip (#1784) ──────────────────────────────
  * Source -> destination pair shown under the Mapping Configuration title.
  * Two labelled platform nodes joined by a directional connector; stacks
@@ -16075,6 +16079,7 @@ textarea.bulk-editor__input { resize: vertical; min-height: 66px; font-family: i
   .infakt-webhook__exchange { grid-template-columns: 1fr; }
   .infakt-webhook__seam { height: 1px; width: 100%; }
   .infakt-webhook__seam-glyph { transform: translate(-50%, -50%) rotate(90deg); }
+}
 .mapping-pair__connector {
   position: relative;
   width: 72px;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -16111,8 +16111,11 @@ textarea.bulk-editor__input { resize: vertical; min-height: 66px; font-family: i
   font-weight: 500;
 }
 .mapping-pair__chip--dest {
-  background: var(--accent-primary-soft);
-  border-color: var(--accent-primary-border);
+  /* Neutral surface — the dest chip is read-only, so it must not borrow the
+     signal-orange accent reserved for actions/active/focus (#1784 S13).
+     Direction is carried by the role eyebrows + arrow, not colour. */
+  background: var(--bg-surface-muted);
+  border-color: var(--border-default);
 }
 .mapping-pair__chip--empty {
   color: var(--text-muted);
@@ -16257,11 +16260,15 @@ textarea.bulk-editor__input { resize: vertical; min-height: 66px; font-family: i
     max-width: none;
   }
 
-  /* Mapping tab bar scrolls horizontally instead of wrapping (scoped by label). */
+  /* Mapping tab bar scrolls horizontally instead of wrapping (scoped by label).
+     A right-edge fade (mask-image) hints the overflow now the scrollbar is
+     suppressed, so operators discover the extra tabs (#1784 S14). */
   .tabs__list[aria-label='Mapping types'] {
     overflow-x: auto;
     flex-wrap: nowrap;
     scrollbar-width: none;
+    -webkit-mask-image: linear-gradient(to right, #000 calc(100% - 24px), transparent 100%);
+    mask-image: linear-gradient(to right, #000 calc(100% - 24px), transparent 100%);
   }
   .tabs__list[aria-label='Mapping types']::-webkit-scrollbar {
     display: none;

--- a/apps/web/src/pages/connections/connection-mappings-page.test.tsx
+++ b/apps/web/src/pages/connections/connection-mappings-page.test.tsx
@@ -1,6 +1,15 @@
 /**
  * ConnectionMappingsPage tests
  *
+ * The page resolves a config-stamped source -> destination pair (#1784), so
+ * tests set up a connections list where a marketplace connection is paired to
+ * a PrestaShop master via `config.masterCatalogConnectionId`. Opening the page
+ * from the master (with one paired marketplace) resolves the same ready pair.
+ *
+ * Because the paired PrestaShop master advertises OrderSource, the default tab
+ * is "Fulfillment"; status/carrier/payment content mounts only once its tab is
+ * selected (Radix Tabs render the active panel).
+ *
  * @module apps/web/src/pages/connections
  */
 
@@ -8,9 +17,9 @@ import { cleanup, screen, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { Routes, Route } from 'react-router-dom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { createMockApiClient, renderWithProviders } from '../../test/test-utils';
+import { createMockApiClient, renderWithProviders, sampleConnection } from '../../test/test-utils';
 import { ConnectionMappingsPage } from './connection-mappings-page';
-import { sampleConnection } from '../../test/test-utils';
+import type { Connection } from '../../features/connections';
 import type {
   StatusMapping,
   MappingOption,
@@ -18,10 +27,28 @@ import type {
   MappingOptionListKind,
 } from '../../features/mappings/api/mappings.types';
 
-/**
- * Builds a getMappingOptions mock that switches by (side, kind).
- * Mirrors the new capability-scoped routes (#472).
- */
+// PrestaShop master (destination). sampleConnection is prestashop with both
+// OrderSource + OrderProcessorManager and no pairing key of its own.
+const PRESTA: Connection = { ...sampleConnection, id: 'ps_1', name: 'Main PrestaShop Store' };
+
+function marketplace(
+  overrides: Partial<Connection> & Pick<Connection, 'id' | 'platformType'>,
+): Connection {
+  return {
+    ...sampleConnection,
+    name: `Marketplace ${overrides.id}`,
+    status: 'active',
+    enabledCapabilities: ['OrderSource'],
+    supportedCapabilities: ['OrderSource'],
+    config: { masterCatalogConnectionId: 'ps_1' },
+    ...overrides,
+  };
+}
+
+const ALLEGRO = marketplace({ id: 'alg_1', name: 'Main Allegro', platformType: 'allegro' });
+const ERLI = marketplace({ id: 'erli_1', name: 'Erli Store', platformType: 'erli' });
+const WOO = marketplace({ id: 'woo_1', name: 'US Woo', platformType: 'woocommerce' });
+
 function buildOptionsResolver(
   byKey: Partial<Record<`${MappingSide}/${MappingOptionListKind}`, MappingOption[]>>,
 ) {
@@ -34,19 +61,12 @@ const STATUS_OPTIONS: MappingOption[] = [
   { value: 'READY_FOR_PROCESSING', label: 'Ready for processing' },
   { value: 'CANCELLED', label: 'Cancelled' },
 ];
-
 const PS_STATUS_OPTIONS: MappingOption[] = [
   { value: '2', label: 'Payment accepted' },
   { value: '6', label: 'Cancelled' },
 ];
-
 const SAVED_STATUS_MAPPINGS: StatusMapping[] = [
-  {
-    id: 'mapping-1',
-    connectionId: 'conn-1',
-    allegroStatus: 'READY_FOR_PROCESSING',
-    prestashopStatusId: '2',
-  },
+  { id: 'mapping-1', connectionId: 'ps_1', allegroStatus: 'READY_FOR_PROCESSING', prestashopStatusId: '2' },
 ];
 
 const BASE_MAPPINGS_MOCKS = {
@@ -56,72 +76,104 @@ const BASE_MAPPINGS_MOCKS = {
   upsertCarrierMappings: vi.fn().mockResolvedValue([]),
   getPaymentMappings: vi.fn().mockResolvedValue([]),
   upsertPaymentMappings: vi.fn().mockResolvedValue([]),
+  getOrderStateMappings: vi.fn().mockResolvedValue([]),
+  upsertOrderStateMappings: vi.fn().mockResolvedValue([]),
   getMappingOptions: buildOptionsResolver({
     'source/order-statuses': STATUS_OPTIONS,
     'destination/order-statuses': PS_STATUS_OPTIONS,
   }),
 };
 
-function buildApiClient(mappingsOverrides: Partial<typeof BASE_MAPPINGS_MOCKS> = {}): ReturnType<typeof createMockApiClient> {
+function buildApiClient(options?: {
+  mappings?: Partial<typeof BASE_MAPPINGS_MOCKS>;
+  connectionList?: Connection[];
+  byId?: Record<string, Connection>;
+}): ReturnType<typeof createMockApiClient> {
+  const connectionList = options?.connectionList ?? [ALLEGRO, PRESTA];
+  const byId = options?.byId ?? { ps_1: PRESTA, alg_1: ALLEGRO, erli_1: ERLI, woo_1: WOO };
   return createMockApiClient({
-    mappings: { ...BASE_MAPPINGS_MOCKS, ...mappingsOverrides },
+    mappings: { ...BASE_MAPPINGS_MOCKS, ...options?.mappings },
+    connections: {
+      list: vi.fn().mockResolvedValue(connectionList),
+      getById: vi.fn((id: string) => Promise.resolve(byId[id] ?? PRESTA)),
+    },
   });
+}
+
+function renderAt(
+  apiClient: ReturnType<typeof createMockApiClient>,
+  route = '/connections/ps_1/mappings',
+): void {
+  renderWithProviders(
+    <Routes>
+      <Route path="/connections/:connectionId/mappings" element={<ConnectionMappingsPage />} />
+    </Routes>,
+    { apiClient, route },
+  );
+}
+
+/** Wait for the ready page (tabs present) and open the named tab. */
+async function openTab(name: string): Promise<void> {
+  const tab = await screen.findByRole('tab', { name });
+  await userEvent.setup().click(tab);
 }
 
 describe('ConnectionMappingsPage', () => {
   afterEach(cleanup);
 
-  it('renders the page layout with tab navigation', async () => {
-    renderWithProviders(<ConnectionMappingsPage />, { apiClient: buildApiClient() });
+  it('renders the resolved pair and tab navigation when opened from the master', async () => {
+    renderAt(buildApiClient());
 
-    await waitFor(() => {
-      expect(screen.getByText('Mapping Configuration')).toBeInTheDocument();
-    });
+    // Pairing route strip shows both sides once resolved.
+    expect(await screen.findByText('Main Allegro')).toBeInTheDocument();
+    expect(screen.getByText('Main PrestaShop Store')).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: 'Order Statuses' })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: 'Carriers' })).toBeInTheDocument();
     expect(screen.getByRole('tab', { name: 'Payments' })).toBeInTheDocument();
   });
 
-  it('renders empty state when no status mappings exist', async () => {
-    renderWithProviders(<ConnectionMappingsPage />, { apiClient: buildApiClient() });
+  it('substitutes resolved platform labels into copy (Allegro -> PrestaShop)', async () => {
+    renderAt(buildApiClient());
 
-    await waitFor(() => {
-      expect(screen.getByText(/No mappings configured yet/i)).toBeInTheDocument();
-    });
+    expect(await screen.findByText(/Configure Allegro/)).toBeInTheDocument();
+    await openTab('Order Statuses');
+    expect(screen.getByRole('combobox', { name: /Select Allegro status/i })).toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: /Select PrestaShop status/i })).toBeInTheDocument();
+  });
+
+  it('substitutes Erli labels when the paired source is Erli', async () => {
+    renderAt(buildApiClient({ connectionList: [ERLI, PRESTA] }));
+
+    expect(await screen.findByText(/Configure Erli/)).toBeInTheDocument();
+    await openTab('Order Statuses');
+    expect(screen.getByRole('combobox', { name: /Select Erli status/i })).toBeInTheDocument();
+  });
+
+  it('renders empty state when no status mappings exist', async () => {
+    renderAt(buildApiClient());
+    await openTab('Order Statuses');
+    expect(await screen.findByText(/No mappings configured yet/i)).toBeInTheDocument();
   });
 
   it('renders table rows when status mappings exist', async () => {
-    const apiClient = buildApiClient({
-      getStatusMappings: vi.fn().mockResolvedValue(SAVED_STATUS_MAPPINGS),
-    });
-    renderWithProviders(<ConnectionMappingsPage />, { apiClient });
-
+    renderAt(buildApiClient({ mappings: { getStatusMappings: vi.fn().mockResolvedValue(SAVED_STATUS_MAPPINGS) } }));
+    await openTab('Order Statuses');
     await waitFor(() => {
-      // Labels appear in both the table cell and the dropdown options — verify the table cell
       const cells = screen.getAllByText('Ready for processing');
-      expect(cells.length).toBeGreaterThan(0);
       expect(cells.some((el) => el.tagName === 'TD')).toBe(true);
     });
   });
 
   it('shows unsaved changes indicator after adding a row', async () => {
-    const apiClient = buildApiClient();
-    renderWithProviders(<ConnectionMappingsPage />, { apiClient });
+    renderAt(buildApiClient());
+    await openTab('Order Statuses');
 
-    // Wait for page to finish loading
-    await waitFor(() => {
-      expect(screen.getByText('Mapping Configuration')).toBeInTheDocument();
+    fireEvent.change(screen.getByRole('combobox', { name: /Select Allegro status/i }), {
+      target: { value: 'READY_FOR_PROCESSING' },
     });
-
-    // Select source option
-    const sourceSelect = screen.getByRole('combobox', { name: /Select Allegro status/i });
-    fireEvent.change(sourceSelect, { target: { value: 'READY_FOR_PROCESSING' } });
-
-    // Select target option
-    const targetSelect = screen.getByRole('combobox', { name: /Select PrestaShop status/i });
-    fireEvent.change(targetSelect, { target: { value: '2' } });
-
-    // Add the row
+    fireEvent.change(screen.getByRole('combobox', { name: /Select PrestaShop status/i }), {
+      target: { value: '2' },
+    });
     fireEvent.click(screen.getByRole('button', { name: 'Add' }));
 
     await waitFor(() => {
@@ -129,46 +181,43 @@ describe('ConnectionMappingsPage', () => {
     });
   });
 
-  it('calls upsertStatusMappings on save', async () => {
+  it('calls upsertStatusMappings on save (keyed to the URL connection)', async () => {
     const upsertFn = vi.fn().mockResolvedValue(SAVED_STATUS_MAPPINGS);
-    const apiClient = buildApiClient({
-      getStatusMappings: vi.fn().mockResolvedValue(SAVED_STATUS_MAPPINGS),
-      upsertStatusMappings: upsertFn,
-    });
-    renderWithProviders(<ConnectionMappingsPage />, { apiClient });
+    renderAt(
+      buildApiClient({
+        mappings: {
+          getStatusMappings: vi.fn().mockResolvedValue(SAVED_STATUS_MAPPINGS),
+          upsertStatusMappings: upsertFn,
+        },
+      }),
+    );
+    await openTab('Order Statuses');
 
-    await waitFor(() => {
-      expect(screen.getByText('Ready for processing')).toBeInTheDocument();
-    });
-
-    // Delete the existing row to make the state dirty
+    await screen.findByText('Ready for processing');
     fireEvent.click(screen.getByRole('button', { name: /Remove mapping for Ready for processing/i }));
-
     await waitFor(() => {
       expect(screen.getByText('Unsaved changes')).toBeInTheDocument();
     });
-
     fireEvent.click(screen.getByRole('button', { name: 'Save mappings' }));
 
     await waitFor(() => {
-      expect(upsertFn).toHaveBeenCalledWith('', { items: [] });
+      expect(upsertFn).toHaveBeenCalledWith('ps_1', { items: [] });
     });
   });
 
   it('displays error message on save failure', async () => {
-    const apiClient = buildApiClient({
-      getStatusMappings: vi.fn().mockResolvedValue(SAVED_STATUS_MAPPINGS),
-      upsertStatusMappings: vi.fn().mockRejectedValue(new Error('Server error')),
-    });
-    renderWithProviders(<ConnectionMappingsPage />, { apiClient });
+    renderAt(
+      buildApiClient({
+        mappings: {
+          getStatusMappings: vi.fn().mockResolvedValue(SAVED_STATUS_MAPPINGS),
+          upsertStatusMappings: vi.fn().mockRejectedValue(new Error('Server error')),
+        },
+      }),
+    );
+    await openTab('Order Statuses');
 
-    await waitFor(() => {
-      expect(screen.getByText('Ready for processing')).toBeInTheDocument();
-    });
-
-    // Make dirty by deleting a row
+    await screen.findByText('Ready for processing');
     fireEvent.click(screen.getByRole('button', { name: /Remove mapping for Ready for processing/i }));
-
     fireEvent.click(screen.getByRole('button', { name: 'Save mappings' }));
 
     await waitFor(() => {
@@ -176,8 +225,42 @@ describe('ConnectionMappingsPage', () => {
     });
   });
 
+  describe('pairing states', () => {
+    it('shows the unsupported state for a source platform outside the allowlist', async () => {
+      renderAt(buildApiClient({ connectionList: [WOO, PRESTA] }), '/connections/woo_1/mappings');
+
+      expect(
+        await screen.findByText(/Mapping isn't available for WooCommerce connections yet/i),
+      ).toBeInTheDocument();
+      expect(screen.queryByRole('tab', { name: 'Order Statuses' })).toBeNull();
+    });
+
+    it('shows the no-source guidance when a shop has no paired marketplace', async () => {
+      renderAt(buildApiClient({ connectionList: [PRESTA] }));
+
+      expect(await screen.findByText(/No marketplace is paired with this shop/i)).toBeInTheDocument();
+      expect(screen.queryByRole('tab', { name: 'Order Statuses' })).toBeNull();
+    });
+
+    it('prompts for a source and navigates to it when several marketplaces are paired', async () => {
+      const user = userEvent.setup();
+      renderAt(buildApiClient({ connectionList: [ALLEGRO, ERLI, PRESTA] }));
+
+      expect(await screen.findByText(/Choose which marketplace to configure/i)).toBeInTheDocument();
+      expect(screen.queryByRole('tab', { name: 'Order Statuses' })).toBeNull();
+
+      await user.selectOptions(
+        screen.getByRole('combobox', { name: /Choose marketplace to configure/i }),
+        'alg_1',
+      );
+
+      // Navigation lands on the chosen marketplace's own mappings page (ready).
+      expect(await screen.findByText(/Configure Allegro/)).toBeInTheDocument();
+    });
+  });
+
   describe('carrier-fallback banner (#517)', () => {
-    const ALLEGRO_DELIVERY_OPTIONS: MappingOption[] = [
+    const DELIVERY_OPTIONS: MappingOption[] = [
       { value: 'method-1', label: 'InPost Paczkomat' },
       { value: 'method-2', label: 'Kurier24' },
     ];
@@ -190,36 +273,6 @@ describe('ConnectionMappingsPage', () => {
       { value: '7', label: 'DPD courier' },
     ];
 
-    /**
-     * Banner tests need `useParams()` to return a non-empty connectionId
-     * because `useConnectionQuery` is `enabled: connectionId.length > 0`.
-     * The other tests on this page don't depend on the connection query,
-     * which is why they get away with no <Routes> wrapper.
-     */
-    function renderWithRoute(apiClient: ReturnType<typeof createMockApiClient>): void {
-      renderWithProviders(
-        <Routes>
-          <Route path="/connections/:connectionId/mappings" element={<ConnectionMappingsPage />} />
-        </Routes>,
-        { apiClient, route: '/connections/conn_1/mappings' },
-      );
-    }
-
-    function selectCarriersTab(): Promise<void> {
-      const user = userEvent.setup();
-      return user.click(screen.getByRole('tab', { name: 'Carriers' }));
-    }
-
-    /**
-     * The banner wraps `{N}` in a `<span.alert__count>` so the count
-     * renders in IBM Plex Mono. That splits the visible string across
-     * elements, which `getByText` won't traverse — use the carriers
-     * tab's `tabpanel` as the scope and match against `textContent`.
-     *
-     * The banner depends on 3 async queries (connection, mappings,
-     * mapping-options) all having settled, so we poll instead of
-     * single-shotting the lookup.
-     */
     async function findFallbackBanner(): Promise<HTMLElement> {
       const tabpanel = await screen.findByRole('tabpanel', { name: /carriers/i });
       let alert: Element | null = null;
@@ -231,23 +284,19 @@ describe('ConnectionMappingsPage', () => {
     }
 
     it('renders an info banner with the static fallback name when defaultCarrierId is set', async () => {
-      const apiClient = buildApiClient({
-        getMappingOptions: buildOptionsResolver({
-          'source/order-statuses': STATUS_OPTIONS,
-          'destination/order-statuses': PS_STATUS_OPTIONS,
-          'source/delivery-methods': ALLEGRO_DELIVERY_OPTIONS,
-          'destination/carriers': PS_CARRIERS_WITH_DYNAMIC,
+      const prestaWithFallback: Connection = { ...PRESTA, config: { ...PRESTA.config, defaultCarrierId: 1 } };
+      renderAt(
+        buildApiClient({
+          mappings: {
+            getMappingOptions: buildOptionsResolver({
+              'source/delivery-methods': DELIVERY_OPTIONS,
+              'destination/carriers': PS_CARRIERS_WITH_DYNAMIC,
+            }),
+          },
+          byId: { ps_1: prestaWithFallback, alg_1: ALLEGRO },
         }),
-      });
-      apiClient.connections.getById = vi.fn().mockResolvedValue({
-        ...sampleConnection,
-        config: { ...sampleConnection.config, defaultCarrierId: 1 },
-      });
-      renderWithRoute(apiClient);
-      await waitFor(() => {
-        expect(screen.getByText('Mapping Configuration')).toBeInTheDocument();
-      });
-      await selectCarriersTab();
+      );
+      await openTab('Carriers');
 
       const banner = await findFallbackBanner();
       expect(banner.textContent).toMatch(/using fallback: Click and collect/i);
@@ -255,139 +304,90 @@ describe('ConnectionMappingsPage', () => {
       expect(banner).toHaveClass('alert--info');
     });
 
-    it("renders an info banner pointing to OpenLinker Dynamic when defaultCarrierId is unset and OL Dynamic is installed", async () => {
-      const apiClient = buildApiClient({
-        getMappingOptions: buildOptionsResolver({
-          'source/order-statuses': STATUS_OPTIONS,
-          'destination/order-statuses': PS_STATUS_OPTIONS,
-          'source/delivery-methods': ALLEGRO_DELIVERY_OPTIONS,
-          'destination/carriers': PS_CARRIERS_WITH_DYNAMIC,
+    it('renders an info banner pointing to OpenLinker Dynamic with the resolved source label', async () => {
+      renderAt(
+        buildApiClient({
+          mappings: {
+            getMappingOptions: buildOptionsResolver({
+              'source/delivery-methods': DELIVERY_OPTIONS,
+              'destination/carriers': PS_CARRIERS_WITH_DYNAMIC,
+            }),
+          },
         }),
-      });
-      // sampleConnection.config has no defaultCarrierId — leave default.
-      renderWithRoute(apiClient);
-      await waitFor(() => {
-        expect(screen.getByText('Mapping Configuration')).toBeInTheDocument();
-      });
-      await selectCarriersTab();
+      );
+      await openTab('Carriers');
 
       const banner = await findFallbackBanner();
-      expect(banner.textContent).toMatch(
-        /using OpenLinker Dynamic \(exact Allegro cost\) at sync time/i,
-      );
+      expect(banner.textContent).toMatch(/using OpenLinker Dynamic \(exact Allegro cost\) at sync time/i);
       expect(banner).toHaveClass('alert--info');
     });
 
-    it('renders a warning banner when neither defaultCarrierId nor an OL Dynamic option is available', async () => {
-      const apiClient = buildApiClient({
-        getMappingOptions: buildOptionsResolver({
-          'source/order-statuses': STATUS_OPTIONS,
-          'destination/order-statuses': PS_STATUS_OPTIONS,
-          'source/delivery-methods': ALLEGRO_DELIVERY_OPTIONS,
-          'destination/carriers': PS_CARRIERS_NO_DYNAMIC,
+    it('renders a warning banner when neither fallback nor OL Dynamic is available', async () => {
+      renderAt(
+        buildApiClient({
+          mappings: {
+            getMappingOptions: buildOptionsResolver({
+              'source/delivery-methods': DELIVERY_OPTIONS,
+              'destination/carriers': PS_CARRIERS_NO_DYNAMIC,
+            }),
+          },
         }),
-      });
-      // No defaultCarrierId; OL Dynamic NOT in carriers list (operator
-      // hasn't installed the OL PS module).
-      renderWithRoute(apiClient);
-      await waitFor(() => {
-        expect(screen.getByText('Mapping Configuration')).toBeInTheDocument();
-      });
-      await selectCarriersTab();
+      );
+      await openTab('Carriers');
 
       const banner = await findFallbackBanner();
-      expect(banner.textContent).toMatch(
-        /sync will fail until a mapping or fallback is configured/i,
-      );
+      expect(banner.textContent).toMatch(/sync will fail until a mapping or fallback is configured/i);
       expect(banner).toHaveClass('alert--warning');
     });
 
-    it('does NOT render the banner when every Allegro method is mapped', async () => {
-      const apiClient = buildApiClient({
-        getMappingOptions: buildOptionsResolver({
-          'source/order-statuses': STATUS_OPTIONS,
-          'destination/order-statuses': PS_STATUS_OPTIONS,
-          'source/delivery-methods': ALLEGRO_DELIVERY_OPTIONS,
-          'destination/carriers': PS_CARRIERS_WITH_DYNAMIC,
+    it('does NOT render the banner when every delivery method is mapped', async () => {
+      renderAt(
+        buildApiClient({
+          mappings: {
+            getMappingOptions: buildOptionsResolver({
+              'source/delivery-methods': DELIVERY_OPTIONS,
+              'destination/carriers': PS_CARRIERS_WITH_DYNAMIC,
+            }),
+            getCarrierMappings: vi.fn().mockResolvedValue([
+              { id: 'cm-1', connectionId: 'ps_1', allegroDeliveryMethodId: 'method-1', prestashopCarrierId: '1' },
+              { id: 'cm-2', connectionId: 'ps_1', allegroDeliveryMethodId: 'method-2', prestashopCarrierId: '7' },
+            ]),
+          },
         }),
-        getCarrierMappings: vi.fn().mockResolvedValue([
-          {
-            id: 'cm-1',
-            connectionId: 'conn_1',
-            allegroDeliveryMethodId: 'method-1',
-            prestashopCarrierId: '1',
-          },
-          {
-            id: 'cm-2',
-            connectionId: 'conn_1',
-            allegroDeliveryMethodId: 'method-2',
-            prestashopCarrierId: '7',
-          },
-        ]),
-      });
-      renderWithRoute(apiClient);
-      await waitFor(() => {
-        expect(screen.getByText('Mapping Configuration')).toBeInTheDocument();
-      });
-      await selectCarriersTab();
+      );
+      await openTab('Carriers');
 
-      // Wait for the carriers tab content to be visible, then assert
-      // the banner element is absent. Selector-based check (rather than
-      // text matching) avoids false positives from dropdown options
-      // that happen to contain the carrier name.
       const tabpanel = await screen.findByRole('tabpanel', { name: /carriers/i });
+      // Give queries a beat to settle, then assert absence.
+      await waitFor(() => {
+        expect(screen.getByText('Carrier Mappings')).toBeInTheDocument();
+      });
       expect(tabpanel.querySelector('.mapping-panel__fallback-alert')).toBeNull();
     });
   });
 
   describe('order-state mappings tab (#862)', () => {
-    function renderAt(apiClient: ReturnType<typeof createMockApiClient>): void {
-      renderWithProviders(
-        <Routes>
-          <Route path="/connections/:connectionId/mappings" element={<ConnectionMappingsPage />} />
-        </Routes>,
-        { apiClient, route: '/connections/conn_1/mappings' },
-      );
-    }
-
-    it('shows the Order States tab for an OrderProcessorManager connection and renders the OL→PS panel', async () => {
-      const user = userEvent.setup();
+    it('shows the Order States tab and renders the OL->destination panel', async () => {
       renderAt(buildApiClient());
-
-      await user.click(await screen.findByRole('tab', { name: 'Order States' }));
+      await openTab('Order States');
 
       expect(await screen.findByText('Order-State Mappings')).toBeInTheDocument();
-      // Source axis is the fixed OL status list; target is the live PS state catalogue.
-      expect(
-        screen.getByRole('combobox', { name: /Select OpenLinker status/i }),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByRole('combobox', { name: /Select PrestaShop order state/i }),
-      ).toBeInTheDocument();
+      expect(screen.getByRole('combobox', { name: /Select OpenLinker status/i })).toBeInTheDocument();
+      expect(screen.getByRole('combobox', { name: /Select PrestaShop order state/i })).toBeInTheDocument();
     });
 
-    it('hides the Order States tab for a connection without OrderProcessorManager', async () => {
-      const apiClient = buildApiClient();
-      apiClient.connections.getById = vi.fn().mockResolvedValue({
-        ...sampleConnection,
-        supportedCapabilities: ['OrderSource'],
-      });
-      renderAt(apiClient);
+    it('hides the Order States tab when opened from a source without OrderProcessorManager', async () => {
+      // Opened from the Allegro source (OrderSource only) - no Order States tab.
+      renderAt(buildApiClient(), '/connections/alg_1/mappings');
 
-      await waitFor(() => {
-        expect(screen.getByText('Mapping Configuration')).toBeInTheDocument();
-      });
+      await screen.findByRole('tab', { name: 'Carriers' });
       expect(screen.queryByRole('tab', { name: 'Order States' })).toBeNull();
     });
 
-    it('saves OL→PS order-state overrides with olStatus + externalStateId', async () => {
-      const user = userEvent.setup();
+    it('saves OL->destination order-state overrides with olStatus + externalStateId', async () => {
       const upsertFn = vi.fn().mockResolvedValue([]);
-      const apiClient = buildApiClient();
-      apiClient.mappings.upsertOrderStateMappings = upsertFn;
-      renderAt(apiClient);
-
-      await user.click(await screen.findByRole('tab', { name: 'Order States' }));
+      renderAt(buildApiClient({ mappings: { upsertOrderStateMappings: upsertFn } }));
+      await openTab('Order States');
       await screen.findByText('Order-State Mappings');
 
       fireEvent.change(screen.getByRole('combobox', { name: /Select OpenLinker status/i }), {
@@ -400,7 +400,7 @@ describe('ConnectionMappingsPage', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Save mappings' }));
 
       await waitFor(() => {
-        expect(upsertFn).toHaveBeenCalledWith('conn_1', {
+        expect(upsertFn).toHaveBeenCalledWith('ps_1', {
           items: [{ olStatus: 'shipped', externalStateId: '2' }],
         });
       });
@@ -408,14 +408,8 @@ describe('ConnectionMappingsPage', () => {
   });
 
   it('switches between tabs', async () => {
-    const user = userEvent.setup();
-    renderWithProviders(<ConnectionMappingsPage />, { apiClient: buildApiClient() });
-
-    await waitFor(() => {
-      expect(screen.getByRole('tab', { name: 'Carriers' })).toBeInTheDocument();
-    });
-
-    await user.click(screen.getByRole('tab', { name: 'Carriers' }));
+    renderAt(buildApiClient());
+    await openTab('Carriers');
 
     expect(screen.getByRole('tab', { name: 'Carriers' })).toHaveAttribute('aria-selected', 'true');
     expect(await screen.findByText('Carrier Mappings')).toBeInTheDocument();

--- a/apps/web/src/pages/connections/connection-mappings-page.test.tsx
+++ b/apps/web/src/pages/connections/connection-mappings-page.test.tsx
@@ -165,23 +165,26 @@ describe('ConnectionMappingsPage', () => {
   });
 
   it('shows unsaved changes indicator after adding a row', async () => {
+    const user = userEvent.setup();
     renderAt(buildApiClient());
     await openTab('Order Statuses');
 
-    fireEvent.change(screen.getByRole('combobox', { name: /Select Allegro status/i }), {
-      target: { value: 'READY_FOR_PROCESSING' },
-    });
-    fireEvent.change(screen.getByRole('combobox', { name: /Select PrestaShop status/i }), {
-      target: { value: '2' },
-    });
-    fireEvent.click(screen.getByRole('button', { name: 'Add' }));
+    // The add-row choosers are searchable comboboxes (#1784 I8): open + pick.
+    await user.click(screen.getByRole('combobox', { name: /Select Allegro status/i }));
+    await user.click(await screen.findByText('Ready for processing'));
+    await user.click(screen.getByRole('combobox', { name: /Select PrestaShop status/i }));
+    await user.click(await screen.findByText('Payment accepted'));
+    await user.click(screen.getByRole('button', { name: 'Add' }));
 
     await waitFor(() => {
       expect(screen.getByText('Unsaved changes')).toBeInTheDocument();
     });
   });
 
-  it('calls upsertStatusMappings on save (keyed to the URL connection)', async () => {
+  it('calls upsertStatusMappings on save (keyed to the resolved SOURCE connection, not the URL master)', async () => {
+    // #1784 B1: status mappings are SOURCE-keyed. Opening from the master
+    // (ps_1) must still write against the resolved source (alg_1) — the id sync
+    // reads at runtime — not the dead master key.
     const upsertFn = vi.fn().mockResolvedValue(SAVED_STATUS_MAPPINGS);
     renderAt(
       buildApiClient({
@@ -201,7 +204,30 @@ describe('ConnectionMappingsPage', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Save mappings' }));
 
     await waitFor(() => {
-      expect(upsertFn).toHaveBeenCalledWith('ps_1', { items: [] });
+      expect(upsertFn).toHaveBeenCalledWith('alg_1', { items: [] });
+    });
+  });
+
+  it('reads the same SOURCE-keyed data whether opened from the master or the source (#1784 B1)', async () => {
+    // Master-open (ps_1) resolves source alg_1 → status data fetched for alg_1.
+    const masterApi = buildApiClient({
+      mappings: { getStatusMappings: vi.fn().mockResolvedValue([]) },
+    });
+    renderAt(masterApi, '/connections/ps_1/mappings');
+    await openTab('Order Statuses');
+    await waitFor(() => {
+      expect(masterApi.mappings.getStatusMappings).toHaveBeenCalledWith('alg_1');
+    });
+    cleanup();
+
+    // Source-open (alg_1) fetches the identical key.
+    const sourceApi = buildApiClient({
+      mappings: { getStatusMappings: vi.fn().mockResolvedValue([]) },
+    });
+    renderAt(sourceApi, '/connections/alg_1/mappings');
+    await openTab('Order Statuses');
+    await waitFor(() => {
+      expect(sourceApi.mappings.getStatusMappings).toHaveBeenCalledWith('alg_1');
     });
   });
 
@@ -238,23 +264,28 @@ describe('ConnectionMappingsPage', () => {
     it('shows the no-source guidance when a shop has no paired marketplace', async () => {
       renderAt(buildApiClient({ connectionList: [PRESTA] }));
 
-      expect(await screen.findByText(/No marketplace is paired with this shop/i)).toBeInTheDocument();
+      expect(
+        await screen.findByText(/No supported marketplace is paired with this shop/i),
+      ).toBeInTheDocument();
       expect(screen.queryByRole('tab', { name: 'Order Statuses' })).toBeNull();
     });
 
-    it('prompts for a source and navigates to it when several marketplaces are paired', async () => {
+    it('prompts for a source and navigates only after an explicit Configure click (#1784 I5)', async () => {
       const user = userEvent.setup();
       renderAt(buildApiClient({ connectionList: [ALLEGRO, ERLI, PRESTA] }));
 
       expect(await screen.findByText(/Choose which marketplace to configure/i)).toBeInTheDocument();
       expect(screen.queryByRole('tab', { name: 'Order Statuses' })).toBeNull();
 
+      // Selecting a value must NOT navigate on its own (no keyboard trap).
       await user.selectOptions(
         screen.getByRole('combobox', { name: /Choose marketplace to configure/i }),
         'alg_1',
       );
+      expect(screen.queryByText(/Configure Allegro/)).toBeNull();
 
-      // Navigation lands on the chosen marketplace's own mappings page (ready).
+      // Only the explicit Configure click navigates to the chosen marketplace.
+      await user.click(screen.getByRole('button', { name: 'Configure' }));
       expect(await screen.findByText(/Configure Allegro/)).toBeInTheDocument();
     });
   });
@@ -376,30 +407,33 @@ describe('ConnectionMappingsPage', () => {
       expect(screen.getByRole('combobox', { name: /Select PrestaShop order state/i })).toBeInTheDocument();
     });
 
-    it('hides the Order States tab when opened from a source without OrderProcessorManager', async () => {
-      // Opened from the Allegro source (OrderSource only) - no Order States tab.
+    it('shows the Order States tab on source-open, gated on the DESTINATION capability (#1784 B1)', async () => {
+      // Opened from the Allegro source (OrderSource only). The Order-States tab
+      // is gated on the resolved DESTINATION's OrderProcessorManager capability
+      // (PrestaShop), NOT on the opened side - so it is present regardless of
+      // which side the page was opened from.
       renderAt(buildApiClient(), '/connections/alg_1/mappings');
 
       await screen.findByRole('tab', { name: 'Carriers' });
-      expect(screen.queryByRole('tab', { name: 'Order States' })).toBeNull();
+      expect(screen.getByRole('tab', { name: 'Order States' })).toBeInTheDocument();
     });
 
     it('saves OL->destination order-state overrides with olStatus + externalStateId', async () => {
+      const user = userEvent.setup();
       const upsertFn = vi.fn().mockResolvedValue([]);
       renderAt(buildApiClient({ mappings: { upsertOrderStateMappings: upsertFn } }));
       await openTab('Order States');
       await screen.findByText('Order-State Mappings');
 
-      fireEvent.change(screen.getByRole('combobox', { name: /Select OpenLinker status/i }), {
-        target: { value: 'shipped' },
-      });
-      fireEvent.change(screen.getByRole('combobox', { name: /Select PrestaShop order state/i }), {
-        target: { value: '2' },
-      });
-      fireEvent.click(screen.getByRole('button', { name: 'Add' }));
-      fireEvent.click(screen.getByRole('button', { name: 'Save mappings' }));
+      await user.click(screen.getByRole('combobox', { name: /Select OpenLinker status/i }));
+      await user.click(await screen.findByText('Shipped'));
+      await user.click(screen.getByRole('combobox', { name: /Select PrestaShop order state/i }));
+      await user.click(await screen.findByText('Payment accepted'));
+      await user.click(screen.getByRole('button', { name: 'Add' }));
+      await user.click(screen.getByRole('button', { name: 'Save mappings' }));
 
       await waitFor(() => {
+        // Order-states are DESTINATION-keyed (#1784 B1) → the master id (ps_1).
         expect(upsertFn).toHaveBeenCalledWith('ps_1', {
           items: [{ olStatus: 'shipped', externalStateId: '2' }],
         });
@@ -413,5 +447,71 @@ describe('ConnectionMappingsPage', () => {
 
     expect(screen.getByRole('tab', { name: 'Carriers' })).toHaveAttribute('aria-selected', 'true');
     expect(await screen.findByText('Carrier Mappings')).toBeInTheDocument();
+  });
+
+  describe('lazy-load per tab (#1784 I4)', () => {
+    it('leaves non-default tab fetchers idle until their tab opens', async () => {
+      // Fresh per-fetcher mocks so the negative assertions aren't polluted by
+      // the module-level shared mocks other tests already invoked.
+      const api = buildApiClient({
+        mappings: {
+          getStatusMappings: vi.fn().mockResolvedValue([]),
+          getCarrierMappings: vi.fn().mockResolvedValue([]),
+          getPaymentMappings: vi.fn().mockResolvedValue([]),
+          getOrderStateMappings: vi.fn().mockResolvedValue([]),
+          getMappingOptions: buildOptionsResolver({
+            'source/order-statuses': STATUS_OPTIONS,
+            'destination/order-statuses': PS_STATUS_OPTIONS,
+          }),
+        },
+      });
+      renderAt(api); // default tab is Fulfillment (source advertises OrderSource)
+
+      await screen.findByRole('tab', { name: 'Fulfillment' });
+      // The default (Fulfillment) tab's option key IS fetched on load…
+      await waitFor(() => {
+        expect(api.mappings.getMappingOptions).toHaveBeenCalledWith(
+          'alg_1',
+          'source',
+          'delivery-methods',
+        );
+      });
+
+      // …but no non-default tab's mapping-data fetcher has fired.
+      expect(api.mappings.getStatusMappings).not.toHaveBeenCalled();
+      expect(api.mappings.getCarrierMappings).not.toHaveBeenCalled();
+      expect(api.mappings.getPaymentMappings).not.toHaveBeenCalled();
+      expect(api.mappings.getOrderStateMappings).not.toHaveBeenCalled();
+      // …and no non-default (side, kind) option key has been fetched.
+      expect(api.mappings.getMappingOptions).not.toHaveBeenCalledWith(
+        'alg_1',
+        'source',
+        'order-statuses',
+      );
+      expect(api.mappings.getMappingOptions).not.toHaveBeenCalledWith(
+        'ps_1',
+        'destination',
+        'carriers',
+      );
+      expect(api.mappings.getMappingOptions).not.toHaveBeenCalledWith(
+        'alg_1',
+        'source',
+        'payment-methods',
+      );
+
+      // Each tab's fetcher fires only once its tab is opened, keyed to the
+      // correct side (source vs destination) per #1784 B1.
+      await openTab('Order Statuses');
+      await waitFor(() => expect(api.mappings.getStatusMappings).toHaveBeenCalledWith('alg_1'));
+
+      await openTab('Carriers');
+      await waitFor(() => expect(api.mappings.getCarrierMappings).toHaveBeenCalledWith('alg_1'));
+
+      await openTab('Payments');
+      await waitFor(() => expect(api.mappings.getPaymentMappings).toHaveBeenCalledWith('alg_1'));
+
+      await openTab('Order States');
+      await waitFor(() => expect(api.mappings.getOrderStateMappings).toHaveBeenCalledWith('ps_1'));
+    });
   });
 });

--- a/apps/web/src/pages/connections/connection-mappings-page.tsx
+++ b/apps/web/src/pages/connections/connection-mappings-page.tsx
@@ -11,7 +11,7 @@
  * @module apps/web/src/pages/connections
  */
 
-import type { ReactElement, ReactNode } from 'react';
+import { useMemo, useState, type ReactElement, type ReactNode } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../../shared/ui/tabs';
@@ -32,10 +32,31 @@ import { useMappingOptions } from '../../features/mappings/hooks/use-mapping-opt
 import { useConnectionQuery } from '../../features/connections/hooks/use-connection-query';
 import { usePlatforms } from '../../shared/plugins';
 import type { Connection } from '../../features/connections';
-import { OL_ORDER_STATUS_OPTIONS, type MappingOption } from '../../features/mappings/api/mappings.types';
+import {
+  OL_ORDER_STATUS_OPTIONS,
+  type MappingOption,
+  type MappingOptions,
+} from '../../features/mappings/api/mappings.types';
 import { LoadingState, ErrorState, EmptyState } from '../../shared/ui/feedback-state';
 
 type TabId = 'fulfillment' | 'status' | 'carriers' | 'payments' | 'order-states';
+
+const ALL_TABS: TabId[] = ['fulfillment', 'status', 'carriers', 'payments', 'order-states'];
+
+/**
+ * Which option-bundle keys each tab consumes (#1784 follow-up: lazy-load per
+ * tab). Used to fetch only the option lists the visited tabs actually need,
+ * instead of the whole 6-list bundle on page load. Order-states' source axis
+ * is the static `OL_ORDER_STATUS_OPTIONS`, so it only needs the destination
+ * status list.
+ */
+const OPTION_KEYS_BY_TAB: Record<TabId, (keyof MappingOptions)[]> = {
+  fulfillment: ['allegroDeliveryMethods'],
+  status: ['allegroOrderStatuses', 'prestashopOrderStatuses'],
+  carriers: ['allegroDeliveryMethods', 'prestashopCarriers'],
+  payments: ['allegroPaymentProviders', 'prestashopPaymentModules'],
+  'order-states': ['prestashopOrderStatuses'],
+};
 
 interface FallbackBannerSpec {
   tone: 'info' | 'warning';
@@ -127,11 +148,6 @@ export function ConnectionMappingsPage(): ReactElement {
   // both the route strip and every platform label on the page.
   const pairing = useMappingPairing(connectionId);
 
-  const statusQuery = useStatusMappingsQuery(connectionId);
-  const carrierQuery = useCarrierMappingsQuery(connectionId);
-  const paymentQuery = usePaymentMappingsQuery(connectionId);
-  const orderStateQuery = useOrderStateMappingsQuery(connectionId);
-  const { options, isLoading: optionsLoading, errors: optionsErrors } = useMappingOptions(connectionId);
   // Connection config carries `defaultCarrierId` which the carrier
   // fallback-banner copy depends on (#517). Errors are tolerated - if we
   // can't load the connection we just suppress the banner; the BE still
@@ -152,10 +168,55 @@ export function ConnectionMappingsPage(): ReactElement {
   const supportsOrderProcessor =
     connectionQuery.data?.supportedCapabilities.includes('OrderProcessorManager') ?? false;
 
+  // Lazy-load per tab (#1784 follow-up): only the tab that is open on load
+  // (`defaultTab`) plus tabs the operator has visited fetch their data, instead
+  // of firing every mapping query + the full options bundle at page mount.
+  // `supportsOrderSource`/`defaultTab` are only meaningful once the connection
+  // has loaded; until then they read as their provisional (false / 'status')
+  // values. Gating tab-activeness on `connectionReady` prevents the transient
+  // default from firing the wrong tab's queries during the connection load
+  // window (#1784 follow-up).
+  const connectionReady = connectionQuery.data !== undefined;
+  const defaultTab: TabId = supportsOrderSource ? 'fulfillment' : 'status';
+  const [visitedTabs, setVisitedTabs] = useState<ReadonlySet<TabId>>(new Set());
+  const isTabActive = (tab: TabId): boolean =>
+    connectionReady && (tab === defaultTab || visitedTabs.has(tab));
+  function markVisited(tab: string): void {
+    setVisitedTabs((prev) =>
+      prev.has(tab as TabId) ? prev : new Set(prev).add(tab as TabId),
+    );
+  }
+
+  const statusQuery = useStatusMappingsQuery(connectionId, { enabled: isTabActive('status') });
+  const carrierQuery = useCarrierMappingsQuery(connectionId, { enabled: isTabActive('carriers') });
+  const paymentQuery = usePaymentMappingsQuery(connectionId, { enabled: isTabActive('payments') });
+  const orderStateQuery = useOrderStateMappingsQuery(connectionId, {
+    enabled: isTabActive('order-states'),
+  });
+
+  // Fetch only the option lists the visited tabs need (#1784 follow-up).
+  const enabledOptionKeys = useMemo<ReadonlySet<keyof MappingOptions>>(() => {
+    const keys = new Set<keyof MappingOptions>();
+    if (!connectionReady) return keys;
+    for (const tab of ALL_TABS) {
+      if (tab === defaultTab || visitedTabs.has(tab)) {
+        OPTION_KEYS_BY_TAB[tab].forEach((key) => keys.add(key));
+      }
+    }
+    return keys;
+  }, [connectionReady, defaultTab, visitedTabs]);
+  const {
+    options,
+    isLoading: optionsLoading,
+    errors: optionsErrors,
+  } = useMappingOptions(connectionId, enabledOptionKeys);
+
   // Routing rules feed two things: the Fulfillment tab and the routing-aware
-  // carrier-banner count (#836). Gated to OrderSource connections (no rules
-  // exist otherwise); deduped with the panel's own subscription.
-  const routingRulesQuery = useRoutingRulesQuery(connectionId, { enabled: supportsOrderSource });
+  // carrier-banner count (#836). Gated to OrderSource connections and to the
+  // tabs that actually read them; deduped with the panel's own subscription.
+  const routingRulesQuery = useRoutingRulesQuery(connectionId, {
+    enabled: supportsOrderSource && (isTabActive('fulfillment') || isTabActive('carriers')),
+  });
 
   const upsertStatus = useUpsertStatusMappings(connectionId);
   const upsertCarrier = useUpsertCarrierMappings(connectionId);
@@ -256,12 +317,12 @@ export function ConnectionMappingsPage(): ReactElement {
 
   // ── Ready: the pair is resolved and supported. Load the mapping data. ────
 
-  const isLoading =
-    statusQuery.isLoading ||
-    carrierQuery.isLoading ||
-    paymentQuery.isLoading ||
-    orderStateQuery.isLoading ||
-    connectionQuery.isLoading;
+  // The pairing gate already waited on the connection, so nothing blocks the
+  // page shell here anymore. Per-tab mapping data loads lazily (#1784 follow-up)
+  // and each panel renders its own loading/error state, so mapping queries are
+  // intentionally NOT part of a full-page gate. loadError still surfaces a hard
+  // failure of a tab the operator is actually on (enabled queries only).
+  const isLoading = connectionQuery.isLoading;
   const loadError =
     statusQuery.error ?? carrierQuery.error ?? paymentQuery.error ?? orderStateQuery.error ?? null;
 
@@ -288,7 +349,6 @@ export function ConnectionMappingsPage(): ReactElement {
     { id: 'payments' as const, label: 'Payments' },
     ...(supportsOrderProcessor ? [{ id: 'order-states' as const, label: 'Order States' }] : []),
   ];
-  const defaultTab = tabs[0].id;
 
   // Per-panel error isolation (#484): a failure in one bundle key must not
   // block the other tabs. Each panel only watches the two keys it actually
@@ -391,7 +451,7 @@ export function ConnectionMappingsPage(): ReactElement {
     >
       <MappingPairingBar pairing={pairing} onPickSource={() => undefined} />
 
-      <Tabs defaultValue={defaultTab} aria-label="Mapping types">
+      <Tabs defaultValue={defaultTab} onValueChange={markVisited} aria-label="Mapping types">
         <TabsList>
           {tabs.map((tab) => (
             <TabsTrigger key={tab.id} value={tab.id}>

--- a/apps/web/src/pages/connections/connection-mappings-page.tsx
+++ b/apps/web/src/pages/connections/connection-mappings-page.tsx
@@ -8,17 +8,28 @@
  * `useMappingPairing` and shown as a route strip under the title; all copy
  * uses the resolved platform labels rather than hardcoded platform names.
  *
+ * Mapping data is keyed per side (#1784 follow-up B1): status / carriers /
+ * payments / fulfillment-routing are SOURCE-keyed; order-states are
+ * DESTINATION-keyed. The page derives `sourceConnectionId` / `destConnectionId`
+ * from the resolved pair so opening from either side converges on the same data
+ * and never writes to a dead key.
+ *
  * @module apps/web/src/pages/connections
  */
 
-import { useMemo, useState, type ReactElement, type ReactNode } from 'react';
+import { useCallback, useMemo, useState, type ReactElement, type ReactNode } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../../shared/ui/tabs';
 import { Alert } from '../../shared/ui/alert';
+import { Button } from '../../shared/ui/button';
+import { ConfirmDialog } from '../../shared/ui/confirm-dialog';
 import { MappingPanel, type MappingRow } from '../../features/mappings/components/MappingPanel';
 import { RoutingRulesPanel } from '../../features/mappings/components/routing-rules-panel';
-import { MappingPairingBar } from '../../features/mappings/components/mapping-pairing-bar';
+import {
+  MappingPairingBar,
+  MAPPING_SOURCE_PICKER_ID,
+} from '../../features/mappings/components/mapping-pairing-bar';
 import { useMappingPairing } from '../../features/mappings/hooks/use-mapping-pairing';
 import { useStatusMappingsQuery, useUpsertStatusMappings } from '../../features/mappings/hooks/use-status-mappings';
 import { useCarrierMappingsQuery, useUpsertCarrierMappings } from '../../features/mappings/hooks/use-carrier-mappings';
@@ -29,9 +40,8 @@ import {
 } from '../../features/mappings/hooks/use-order-state-mappings';
 import { useRoutingRulesQuery } from '../../features/mappings/hooks/use-routing-rules';
 import { useMappingOptions } from '../../features/mappings/hooks/use-mapping-options';
-import { useConnectionQuery } from '../../features/connections/hooks/use-connection-query';
+import { resolvePlatformLabel } from '../../features/mappings/lib/platform-label';
 import { usePlatforms } from '../../shared/plugins';
-import type { Connection } from '../../features/connections';
 import {
   OL_ORDER_STATUS_OPTIONS,
   type MappingOption,
@@ -42,6 +52,10 @@ import { LoadingState, ErrorState, EmptyState } from '../../shared/ui/feedback-s
 type TabId = 'fulfillment' | 'status' | 'carriers' | 'payments' | 'order-states';
 
 const ALL_TABS: TabId[] = ['fulfillment', 'status', 'carriers', 'payments', 'order-states'];
+
+function isTabId(value: string): value is TabId {
+  return (ALL_TABS as string[]).includes(value);
+}
 
 /**
  * Which option-bundle keys each tab consumes (#1784 follow-up: lazy-load per
@@ -56,6 +70,18 @@ const OPTION_KEYS_BY_TAB: Record<TabId, (keyof MappingOptions)[]> = {
   carriers: ['allegroDeliveryMethods', 'prestashopCarriers'],
   payments: ['allegroPaymentProviders', 'prestashopPaymentModules'],
   'order-states': ['prestashopOrderStatuses'],
+};
+
+/** Precise per-tab empty-state copy (#1784 follow-up S15). */
+const EMPTY_STATE_MESSAGE_BY_TAB: Record<Exclude<TabId, 'fulfillment'>, string> = {
+  status:
+    'No mappings configured yet. Unmapped statuses fall back to the default status at sync time. Add one below.',
+  carriers:
+    'No mappings configured yet. An unmapped carrier can fail order sync unless a fallback carrier is set. Add one below.',
+  payments:
+    'No mappings configured yet. Unmapped payment methods fall back to the default payment module. Add one below.',
+  'order-states':
+    'No mappings configured yet. Unmapped statuses use the default-install order state. Add one below.',
 };
 
 interface FallbackBannerSpec {
@@ -147,91 +173,134 @@ export function ConnectionMappingsPage(): ReactElement {
   // Resolve the config-stamped source -> destination pairing (#1784). Drives
   // both the route strip and every platform label on the page.
   const pairing = useMappingPairing(connectionId);
+  const isReady = pairing.status === 'ready';
 
-  // Connection config carries `defaultCarrierId` which the carrier
-  // fallback-banner copy depends on (#517). Errors are tolerated - if we
-  // can't load the connection we just suppress the banner; the BE still
-  // does the right thing at sync time per #516.
-  const connectionQuery = useConnectionQuery(connectionId);
+  // Per-side connection ids (#1784 follow-up B1). Until the pair resolves they
+  // fall back to the URL id, but every data query is gated on `isReady` so no
+  // stray fetch lands on the wrong key in that window.
+  const sourceConnectionId = isReady ? pairing.source.id : connectionId;
+  const destConnectionId = isReady ? pairing.destination.id : connectionId;
 
-  // The Fulfillment tab + routing rules apply only to connections that ingest
-  // orders (the routing key is a *source* delivery method). Capability-gated,
-  // not platformType-gated, so any future OrderSource adapter inherits it.
-  const supportsOrderSource =
-    connectionQuery.data?.supportedCapabilities.includes('OrderSource') ?? false;
+  // Capability gating reads from the RESOLVED pair (#1784 follow-up B1): the
+  // Fulfillment tab + routing rules gate on the SOURCE's OrderSource capability;
+  // the Order-States tab gates on the DESTINATION's OrderProcessorManager. This
+  // keeps the tab set stable regardless of which side the page was opened from.
+  const supportsOrderSource = isReady
+    ? pairing.source.supportedCapabilities.includes('OrderSource')
+    : false;
+  const supportsOrderProcessor = isReady
+    ? pairing.destination.supportedCapabilities.includes('OrderProcessorManager')
+    : false;
 
-  // The Order-States tab is the OUTBOUND OL->destination override (#862) - it
-  // belongs to a destination (OrderProcessorManager) connection's own state
-  // catalogue, so it's capability-gated to those connections (PrestaShop today),
-  // mirroring how Fulfillment is gated to OrderSource. Capability-based, never
-  // platformType-based.
-  const supportsOrderProcessor =
-    connectionQuery.data?.supportedCapabilities.includes('OrderProcessorManager') ?? false;
-
-  // Lazy-load per tab (#1784 follow-up): only the tab that is open on load
-  // (`defaultTab`) plus tabs the operator has visited fetch their data, instead
-  // of firing every mapping query + the full options bundle at page mount.
-  // `supportsOrderSource`/`defaultTab` are only meaningful once the connection
-  // has loaded; until then they read as their provisional (false / 'status')
-  // values. Gating tab-activeness on `connectionReady` prevents the transient
-  // default from firing the wrong tab's queries during the connection load
-  // window (#1784 follow-up).
-  const connectionReady = connectionQuery.data !== undefined;
+  // Lazy-load per tab (#1784 follow-up): only the tab open on load (`defaultTab`)
+  // plus tabs the operator has visited fetch their data.
   const defaultTab: TabId = supportsOrderSource ? 'fulfillment' : 'status';
   const [visitedTabs, setVisitedTabs] = useState<ReadonlySet<TabId>>(new Set());
-  const isTabActive = (tab: TabId): boolean =>
-    connectionReady && (tab === defaultTab || visitedTabs.has(tab));
-  function markVisited(tab: string): void {
-    setVisitedTabs((prev) =>
-      prev.has(tab as TabId) ? prev : new Set(prev).add(tab as TabId),
-    );
-  }
+  const [activeTab, setActiveTab] = useState<TabId | null>(null);
+  const [dirtyTabs, setDirtyTabs] = useState<ReadonlySet<TabId>>(new Set());
+  const [pendingTab, setPendingTab] = useState<TabId | null>(null);
+  const currentTab = activeTab ?? defaultTab;
 
-  const statusQuery = useStatusMappingsQuery(connectionId, { enabled: isTabActive('status') });
-  const carrierQuery = useCarrierMappingsQuery(connectionId, { enabled: isTabActive('carriers') });
-  const paymentQuery = usePaymentMappingsQuery(connectionId, { enabled: isTabActive('payments') });
-  const orderStateQuery = useOrderStateMappingsQuery(connectionId, {
+  const isTabActive = (tab: TabId): boolean =>
+    isReady && (tab === defaultTab || visitedTabs.has(tab));
+
+  const statusQuery = useStatusMappingsQuery(sourceConnectionId, { enabled: isTabActive('status') });
+  const carrierQuery = useCarrierMappingsQuery(sourceConnectionId, { enabled: isTabActive('carriers') });
+  const paymentQuery = usePaymentMappingsQuery(sourceConnectionId, { enabled: isTabActive('payments') });
+  const orderStateQuery = useOrderStateMappingsQuery(destConnectionId, {
     enabled: isTabActive('order-states'),
   });
 
   // Fetch only the option lists the visited tabs need (#1784 follow-up).
   const enabledOptionKeys = useMemo<ReadonlySet<keyof MappingOptions>>(() => {
     const keys = new Set<keyof MappingOptions>();
-    if (!connectionReady) return keys;
+    if (!isReady) return keys;
     for (const tab of ALL_TABS) {
       if (tab === defaultTab || visitedTabs.has(tab)) {
         OPTION_KEYS_BY_TAB[tab].forEach((key) => keys.add(key));
       }
     }
     return keys;
-  }, [connectionReady, defaultTab, visitedTabs]);
+  }, [isReady, defaultTab, visitedTabs]);
   const {
     options,
     isLoading: optionsLoading,
     errors: optionsErrors,
-  } = useMappingOptions(connectionId, enabledOptionKeys);
+  } = useMappingOptions(
+    { source: sourceConnectionId, destination: destConnectionId },
+    enabledOptionKeys,
+  );
 
   // Routing rules feed two things: the Fulfillment tab and the routing-aware
   // carrier-banner count (#836). Gated to OrderSource connections and to the
   // tabs that actually read them; deduped with the panel's own subscription.
-  const routingRulesQuery = useRoutingRulesQuery(connectionId, {
+  const routingRulesQuery = useRoutingRulesQuery(sourceConnectionId, {
     enabled: supportsOrderSource && (isTabActive('fulfillment') || isTabActive('carriers')),
   });
 
-  const upsertStatus = useUpsertStatusMappings(connectionId);
-  const upsertCarrier = useUpsertCarrierMappings(connectionId);
-  const upsertPayment = useUpsertPaymentMappings(connectionId);
-  const upsertOrderState = useUpsertOrderStateMappings(connectionId);
+  const upsertStatus = useUpsertStatusMappings(sourceConnectionId);
+  const upsertCarrier = useUpsertCarrierMappings(sourceConnectionId);
+  const upsertPayment = useUpsertPaymentMappings(sourceConnectionId);
+  const upsertOrderState = useUpsertOrderStateMappings(destConnectionId);
 
-  const labelOf = (connection: Connection): string =>
-    platforms.find((p) => p.platformType === connection.platformType)?.displayName ??
-    connection.platformType;
+  // Stable per-tab dirty setters for the discard guard (#1784 follow-up I3).
+  const dirtyHandlers = useMemo(() => {
+    const make = (tab: TabId) => (dirty: boolean) => {
+      setDirtyTabs((prev) => {
+        if (dirty === prev.has(tab)) return prev;
+        const next = new Set(prev);
+        if (dirty) next.add(tab);
+        else next.delete(tab);
+        return next;
+      });
+    };
+    return {
+      fulfillment: make('fulfillment'),
+      status: make('status'),
+      carriers: make('carriers'),
+      payments: make('payments'),
+      'order-states': make('order-states'),
+    } satisfies Record<TabId, (dirty: boolean) => void>;
+  }, []);
+
+  const commitTabChange = useCallback((tab: TabId) => {
+    setVisitedTabs((prev) => (prev.has(tab) ? prev : new Set(prev).add(tab)));
+    setActiveTab(tab);
+  }, []);
+
+  const handleTabChange = useCallback(
+    (next: string) => {
+      if (!isTabId(next) || next === currentTab) return;
+      if (dirtyTabs.has(currentTab)) {
+        // Intercept: a dirty tab is being left. Confirm before discarding.
+        setPendingTab(next);
+        return;
+      }
+      commitTabChange(next);
+    },
+    [currentTab, dirtyTabs, commitTabChange],
+  );
+
+  const confirmDiscard = useCallback(() => {
+    if (pendingTab === null) return;
+    setDirtyTabs((prev) => {
+      if (!prev.has(currentTab)) return prev;
+      const nextSet = new Set(prev);
+      nextSet.delete(currentTab);
+      return nextSet;
+    });
+    commitTabChange(pendingTab);
+    setPendingTab(null);
+  }, [pendingTab, currentTab, commitTabChange]);
+
+  const cancelDiscard = useCallback(() => setPendingTab(null), []);
 
   // Resolved platform labels for all page copy (#1784). Neutral fallbacks keep
   // the labels sensible while the pair is not `ready`.
-  const sourceLabel = pairing.status === 'ready' ? labelOf(pairing.source) : 'the marketplace';
-  const destinationLabel =
-    pairing.status === 'ready' ? labelOf(pairing.destination) : 'the connected shop';
+  const sourceLabel = isReady ? resolvePlatformLabel(platforms, pairing.source) : 'the marketplace';
+  const destinationLabel = isReady
+    ? resolvePlatformLabel(platforms, pairing.destination)
+    : 'the connected shop';
 
   const backTo = { to: `/connections/${connectionId}`, label: 'Connection' } as const;
 
@@ -254,7 +323,7 @@ export function ConnectionMappingsPage(): ReactElement {
   }
 
   if (pairing.status === 'unsupported') {
-    const unsupportedLabel = labelOf(pairing.source);
+    const unsupportedLabel = resolvePlatformLabel(platforms, pairing.source);
     return (
       <PageLayout
         backTo={backTo}
@@ -262,7 +331,7 @@ export function ConnectionMappingsPage(): ReactElement {
         title="Mapping Configuration"
         description={`${unsupportedLabel} order mapping isn't supported yet.`}
       >
-        <MappingPairingBar pairing={pairing} onPickSource={() => undefined} />
+        <MappingPairingBar pairing={pairing} />
         <EmptyState
           title={`Mapping isn't available for ${unsupportedLabel} connections yet`}
           message="Order mapping is available for Allegro to PrestaShop and Erli to PrestaShop today. Support for more platforms is planned."
@@ -277,12 +346,12 @@ export function ConnectionMappingsPage(): ReactElement {
         backTo={backTo}
         eyebrow="Connection"
         title="Mapping Configuration"
-        description={`No marketplace is paired with ${pairing.master.name} yet.`}
+        description={`No supported marketplace is paired with ${pairing.master.name} yet.`}
       >
-        <MappingPairingBar pairing={pairing} onPickSource={() => undefined} />
+        <MappingPairingBar pairing={pairing} />
         <EmptyState
-          title="No marketplace is paired with this shop"
-          message="Order mappings are configured from the marketplace side. Open a marketplace connection (Allegro or Erli) and set its catalog to this shop to pair them."
+          title="No supported marketplace is paired with this shop"
+          message="Order mappings are configured from the marketplace side. Open a supported marketplace connection (Allegro or Erli) and set its catalog to this shop to pair them."
           action={
             <Link className="button button--secondary" to="/connections">
               Go to connections
@@ -303,44 +372,35 @@ export function ConnectionMappingsPage(): ReactElement {
       >
         <MappingPairingBar
           pairing={pairing}
-          onPickSource={(sourceConnectionId) => {
-            void navigate(`/connections/${sourceConnectionId}/mappings`);
+          onPickSource={(chosenSourceId) => {
+            void navigate(`/connections/${chosenSourceId}/mappings`);
           }}
         />
         <EmptyState
           title="Choose which marketplace to configure"
           message={`Order mappings belong to a marketplace. Choose which of the ${pairing.candidates.length} paired marketplaces you want to configure against ${pairing.master.name}.`}
+          action={
+            <Button
+              tone="secondary"
+              onClick={() => document.getElementById(MAPPING_SOURCE_PICKER_ID)?.focus()}
+            >
+              Choose marketplace
+            </Button>
+          }
         />
       </PageLayout>
     );
   }
 
   // ── Ready: the pair is resolved and supported. Load the mapping data. ────
+  //
+  // Per-tab mapping data loads lazily (#1784 follow-up) and each panel renders
+  // its own loading/error state via `dataError` (#1784 follow-up I2), so a
+  // failure on one lazily-visited tab never tears down the pairing strip or the
+  // other tabs. There is no full-page data gate here anymore.
 
-  // The pairing gate already waited on the connection, so nothing blocks the
-  // page shell here anymore. Per-tab mapping data loads lazily (#1784 follow-up)
-  // and each panel renders its own loading/error state, so mapping queries are
-  // intentionally NOT part of a full-page gate. loadError still surfaces a hard
-  // failure of a tab the operator is actually on (enabled queries only).
-  const isLoading = connectionQuery.isLoading;
-  const loadError =
-    statusQuery.error ?? carrierQuery.error ?? paymentQuery.error ?? orderStateQuery.error ?? null;
-
-  if (isLoading) {
-    return (
-      <PageLayout backTo={backTo} eyebrow="Connection" title="Mapping Configuration" description="Loading mapping configuration…">
-        <LoadingState liveRegion="off" title="Loading mappings" message="Fetching configured mappings for this connection." />
-      </PageLayout>
-    );
-  }
-
-  if (loadError) {
-    return (
-      <PageLayout backTo={backTo} eyebrow="Connection" title="Mapping Configuration" description="Unable to load mapping configuration.">
-        <ErrorState title="Unable to load mappings" message={loadError.message} />
-      </PageLayout>
-    );
-  }
+  const sourceInactive = pairing.source.status !== 'active';
+  const destinationInactive = pairing.destination.status !== 'active';
 
   const tabs: { id: TabId; label: string }[] = [
     ...(supportsOrderSource ? [{ id: 'fulfillment' as const, label: 'Fulfillment' }] : []),
@@ -389,19 +449,21 @@ export function ConnectionMappingsPage(): ReactElement {
   const carriersReady =
     !optionsLoading &&
     carrierOptionsError === null &&
-    connectionQuery.data !== undefined &&
     !routingRulesQuery.isLoading &&
     routingRulesQuery.error === null;
-  const connectionConfig = connectionQuery.data?.config as
+  // The fallback carrier id lives on the DESTINATION (PrestaShop) connection and
+  // is applied by the destination adapter (#1784 follow-up I6) — never the
+  // source marketplace config, which carries no `defaultCarrierId`.
+  const destinationConfig = pairing.destination.config as
     | { defaultCarrierId?: unknown }
     | undefined;
   const carrierFallbackBanner = carriersReady
     ? deriveCarrierFallbackBanner({
         unmappedCount: unmappedDeliveryCount,
         defaultCarrierId:
-          connectionConfig?.defaultCarrierId !== undefined &&
-          connectionConfig.defaultCarrierId !== null
-            ? String(connectionConfig.defaultCarrierId)
+          destinationConfig?.defaultCarrierId !== undefined &&
+          destinationConfig.defaultCarrierId !== null
+            ? String(destinationConfig.defaultCarrierId)
             : null,
         carriers: options.prestashopCarriers,
         sourceLabel,
@@ -442,6 +504,15 @@ export function ConnectionMappingsPage(): ReactElement {
     });
   }
 
+  const inactiveNote =
+    sourceInactive && destinationInactive
+      ? `Both the ${sourceLabel} source and ${destinationLabel} destination connections are not active. Mappings save, but orders won't sync until both are re-enabled.`
+      : destinationInactive
+        ? `The ${destinationLabel} destination connection is not active. Mappings save, but orders won't sync until it's re-enabled.`
+        : sourceInactive
+          ? `The ${sourceLabel} source connection is not active. Mappings save, but orders won't sync until it's re-enabled.`
+          : null;
+
   return (
     <PageLayout
       backTo={backTo}
@@ -449,9 +520,15 @@ export function ConnectionMappingsPage(): ReactElement {
       title="Mapping Configuration"
       description={`Configure ${sourceLabel} → ${destinationLabel} mappings for order statuses, delivery carriers, and payment methods.`}
     >
-      <MappingPairingBar pairing={pairing} onPickSource={() => undefined} />
+      <MappingPairingBar pairing={pairing} />
 
-      <Tabs defaultValue={defaultTab} onValueChange={markVisited} aria-label="Mapping types">
+      {inactiveNote && (
+        <div style={{ marginBottom: 'var(--space-4)' }}>
+          <Alert tone="info">{inactiveNote}</Alert>
+        </div>
+      )}
+
+      <Tabs value={currentTab} onValueChange={handleTabChange} aria-label="Mapping types">
         <TabsList>
           {tabs.map((tab) => (
             <TabsTrigger key={tab.id} value={tab.id}>
@@ -463,11 +540,12 @@ export function ConnectionMappingsPage(): ReactElement {
         {supportsOrderSource && (
           <TabsContent value="fulfillment">
             <RoutingRulesPanel
-              connectionId={connectionId}
+              connectionId={sourceConnectionId}
               sourceLabel={sourceLabel}
               deliveryMethods={options.allegroDeliveryMethods}
               deliveryMethodsLoading={optionsLoading}
               deliveryMethodsError={optionsErrors.allegroDeliveryMethods ?? null}
+              onDirtyChange={dirtyHandlers.fulfillment}
             />
           </TabsContent>
         )}
@@ -486,6 +564,10 @@ export function ConnectionMappingsPage(): ReactElement {
             saveError={upsertStatus.error}
             optionsLoading={optionsLoading}
             optionsError={statusOptionsError}
+            dataError={statusQuery.error ?? null}
+            onRetryData={() => void statusQuery.refetch()}
+            onDirtyChange={dirtyHandlers.status}
+            emptyStateMessage={EMPTY_STATE_MESSAGE_BY_TAB.status}
           />
         </TabsContent>
 
@@ -511,6 +593,10 @@ export function ConnectionMappingsPage(): ReactElement {
             saveError={upsertCarrier.error}
             optionsLoading={optionsLoading}
             optionsError={carrierOptionsError}
+            dataError={carrierQuery.error ?? null}
+            onRetryData={() => void carrierQuery.refetch()}
+            onDirtyChange={dirtyHandlers.carriers}
+            emptyStateMessage={EMPTY_STATE_MESSAGE_BY_TAB.carriers}
             dynamicOptionSuffix={` - exact ${sourceLabel} cost`}
           />
         </TabsContent>
@@ -529,6 +615,10 @@ export function ConnectionMappingsPage(): ReactElement {
             saveError={upsertPayment.error}
             optionsLoading={optionsLoading}
             optionsError={paymentOptionsError}
+            dataError={paymentQuery.error ?? null}
+            onRetryData={() => void paymentQuery.refetch()}
+            onDirtyChange={dirtyHandlers.payments}
+            emptyStateMessage={EMPTY_STATE_MESSAGE_BY_TAB.payments}
           />
         </TabsContent>
 
@@ -547,10 +637,27 @@ export function ConnectionMappingsPage(): ReactElement {
               saveError={upsertOrderState.error}
               optionsLoading={optionsLoading}
               optionsError={orderStateOptionsError}
+              dataError={orderStateQuery.error ?? null}
+              onRetryData={() => void orderStateQuery.refetch()}
+              onDirtyChange={dirtyHandlers['order-states']}
+              emptyStateMessage={EMPTY_STATE_MESSAGE_BY_TAB['order-states']}
             />
           </TabsContent>
         )}
       </Tabs>
+
+      <ConfirmDialog
+        open={pendingTab !== null}
+        onOpenChange={(open) => {
+          if (!open) cancelDiscard();
+        }}
+        title="Discard unsaved changes?"
+        description="You have unsaved mapping edits on this tab. Switching tabs will discard them."
+        confirmLabel="Discard changes"
+        cancelLabel="Keep editing"
+        tone="danger"
+        onConfirm={confirmDiscard}
+      />
     </PageLayout>
   );
 }

--- a/apps/web/src/pages/connections/connection-mappings-page.tsx
+++ b/apps/web/src/pages/connections/connection-mappings-page.tsx
@@ -1,19 +1,25 @@
 /**
  * Connection Mappings Page
  *
- * Provides three tabbed panels for configuring Allegro → PrestaShop mappings
- * per connection: order statuses, delivery carriers, and payment methods.
+ * Tabbed editor for the order mappings between a marketplace source and its
+ * paired shop destination (order statuses, carriers, payments, fulfillment
+ * routing, and the outbound order-state override). The source/destination
+ * pair is resolved from the connection's config-stamped pairing via
+ * `useMappingPairing` and shown as a route strip under the title; all copy
+ * uses the resolved platform labels rather than hardcoded platform names.
  *
  * @module apps/web/src/pages/connections
  */
 
 import type { ReactElement, ReactNode } from 'react';
-import { useParams } from 'react-router-dom';
+import { Link, useNavigate, useParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../../shared/ui/tabs';
 import { Alert } from '../../shared/ui/alert';
 import { MappingPanel, type MappingRow } from '../../features/mappings/components/MappingPanel';
 import { RoutingRulesPanel } from '../../features/mappings/components/routing-rules-panel';
+import { MappingPairingBar } from '../../features/mappings/components/mapping-pairing-bar';
+import { useMappingPairing } from '../../features/mappings/hooks/use-mapping-pairing';
 import { useStatusMappingsQuery, useUpsertStatusMappings } from '../../features/mappings/hooks/use-status-mappings';
 import { useCarrierMappingsQuery, useUpsertCarrierMappings } from '../../features/mappings/hooks/use-carrier-mappings';
 import { usePaymentMappingsQuery, useUpsertPaymentMappings } from '../../features/mappings/hooks/use-payment-mappings';
@@ -24,9 +30,10 @@ import {
 import { useRoutingRulesQuery } from '../../features/mappings/hooks/use-routing-rules';
 import { useMappingOptions } from '../../features/mappings/hooks/use-mapping-options';
 import { useConnectionQuery } from '../../features/connections/hooks/use-connection-query';
+import { usePlatforms } from '../../shared/plugins';
+import type { Connection } from '../../features/connections';
 import { OL_ORDER_STATUS_OPTIONS, type MappingOption } from '../../features/mappings/api/mappings.types';
-import { LoadingState, ErrorState } from '../../shared/ui/feedback-state';
-import { DesktopOnlyBanner } from '../../shared/ui/desktop-only-banner';
+import { LoadingState, ErrorState, EmptyState } from '../../shared/ui/feedback-state';
 
 type TabId = 'fulfillment' | 'status' | 'carriers' | 'payments' | 'order-states';
 
@@ -43,20 +50,24 @@ interface FallbackBannerSpec {
  *
  * `unmappedCount` is routing-aware (#836): methods diverted to a non-OMP
  * processor (Allegro Delivery, OL-managed carrier) never flow through PS
- * carrier mapping, so the caller excludes them before counting — the
+ * carrier mapping, so the caller excludes them before counting - the
  * banner only warns about methods that genuinely still need a PS carrier.
  *
+ * `sourceLabel` is the resolved source-platform label (#1784) used in the
+ * OpenLinker-Dynamic copy, instead of a hardcoded platform name.
+ *
  * Decision tree mirrors the BE adapter's resolution chain (#516):
- *   (1) `defaultCarrierId` set        → "using fallback: {name}"   info
- *   (2) OL Dynamic carrier installed   → "using OpenLinker Dynamic" info
- *   (3) neither                        → "sync will fail …"         warning
+ *   (1) `defaultCarrierId` set        -> "using fallback: {name}"   info
+ *   (2) OL Dynamic carrier installed   -> "using OpenLinker Dynamic" info
+ *   (3) neither                        -> "sync will fail ..."       warning
  */
 function deriveCarrierFallbackBanner(args: {
   unmappedCount: number;
   defaultCarrierId: string | null;
   carriers: MappingOption[];
+  sourceLabel: string;
 }): FallbackBannerSpec | null {
-  const { unmappedCount, defaultCarrierId, carriers } = args;
+  const { unmappedCount, defaultCarrierId, carriers, sourceLabel } = args;
   if (unmappedCount <= 0) return null;
 
   const count = (
@@ -64,7 +75,7 @@ function deriveCarrierFallbackBanner(args: {
   );
   const noun = unmappedCount === 1 ? 'method' : 'methods';
 
-  // Case 1 — explicit fallback configured. Resolve the carrier name from
+  // Case 1 - explicit fallback configured. Resolve the carrier name from
   // the loaded options. If the saved id no longer exists in the live
   // options (operator deleted the carrier in BO), fall through to the
   // "no fallback" warning so the operator notices.
@@ -75,33 +86,32 @@ function deriveCarrierFallbackBanner(args: {
         tone: 'info',
         message: (
           <>
-            {count} {noun} unmapped — using fallback: {fallback.label}.
+            {count} {noun} unmapped - using fallback: {fallback.label}.
           </>
         ),
       };
     }
   }
 
-  // Case 2 — OL Dynamic is installed and runtime will fall back to it.
+  // Case 2 - OL Dynamic is installed and runtime will fall back to it.
   const hasDynamic = carriers.some((c) => c.kind === 'dynamic');
   if (hasDynamic) {
     return {
       tone: 'info',
       message: (
         <>
-          {count} {noun} unmapped — using OpenLinker Dynamic (exact Allegro
-          cost) at sync time.
+          {count} {noun} unmapped - using OpenLinker Dynamic (exact {sourceLabel} cost) at sync time.
         </>
       ),
     };
   }
 
-  // Case 3 — no fallback at all. Operator-actionable warning.
+  // Case 3 - no fallback at all. Operator-actionable warning.
   return {
     tone: 'warning',
     message: (
       <>
-        {count} {noun} unmapped — sync will fail until a mapping or fallback
+        {count} {noun} unmapped - sync will fail until a mapping or fallback
         is configured.
       </>
     ),
@@ -110,6 +120,12 @@ function deriveCarrierFallbackBanner(args: {
 
 export function ConnectionMappingsPage(): ReactElement {
   const { connectionId = '' } = useParams();
+  const navigate = useNavigate();
+  const platforms = usePlatforms();
+
+  // Resolve the config-stamped source -> destination pairing (#1784). Drives
+  // both the route strip and every platform label on the page.
+  const pairing = useMappingPairing(connectionId);
 
   const statusQuery = useStatusMappingsQuery(connectionId);
   const carrierQuery = useCarrierMappingsQuery(connectionId);
@@ -117,7 +133,7 @@ export function ConnectionMappingsPage(): ReactElement {
   const orderStateQuery = useOrderStateMappingsQuery(connectionId);
   const { options, isLoading: optionsLoading, errors: optionsErrors } = useMappingOptions(connectionId);
   // Connection config carries `defaultCarrierId` which the carrier
-  // fallback-banner copy depends on (#517). Errors are tolerated — if we
+  // fallback-banner copy depends on (#517). Errors are tolerated - if we
   // can't load the connection we just suppress the banner; the BE still
   // does the right thing at sync time per #516.
   const connectionQuery = useConnectionQuery(connectionId);
@@ -128,7 +144,7 @@ export function ConnectionMappingsPage(): ReactElement {
   const supportsOrderSource =
     connectionQuery.data?.supportedCapabilities.includes('OrderSource') ?? false;
 
-  // The Order-States tab is the OUTBOUND OL→destination override (#862) — it
+  // The Order-States tab is the OUTBOUND OL->destination override (#862) - it
   // belongs to a destination (OrderProcessorManager) connection's own state
   // catalogue, so it's capability-gated to those connections (PrestaShop today),
   // mirroring how Fulfillment is gated to OrderSource. Capability-based, never
@@ -141,29 +157,105 @@ export function ConnectionMappingsPage(): ReactElement {
   // exist otherwise); deduped with the panel's own subscription.
   const routingRulesQuery = useRoutingRulesQuery(connectionId, { enabled: supportsOrderSource });
 
-  // Per-panel error isolation (#484): a failure in one bundle key must not
-  // block the other tabs. Each panel only watches the two keys it actually
-  // reads from.
-  const statusOptionsError =
-    optionsErrors.allegroOrderStatuses ?? optionsErrors.prestashopOrderStatuses ?? null;
-  const carrierOptionsError =
-    optionsErrors.allegroDeliveryMethods ?? optionsErrors.prestashopCarriers ?? null;
-  const paymentOptionsError =
-    optionsErrors.allegroPaymentProviders ?? optionsErrors.prestashopPaymentModules ?? null;
-
   const upsertStatus = useUpsertStatusMappings(connectionId);
   const upsertCarrier = useUpsertCarrierMappings(connectionId);
   const upsertPayment = useUpsertPaymentMappings(connectionId);
   const upsertOrderState = useUpsertOrderStateMappings(connectionId);
 
-  // Outbound OL→PS order-state panel (#862): only the destination dropdown
-  // (prestashopOrderStatuses) loads from the bundle — the source axis is the
-  // fixed OL OrderStatus list. So its options-readiness tracks only that key.
-  const orderStateOptionsError = optionsErrors.prestashopOrderStatuses ?? null;
+  const labelOf = (connection: Connection): string =>
+    platforms.find((p) => p.platformType === connection.platformType)?.displayName ??
+    connection.platformType;
 
-  // Wait for the connection too so the capability-gated Fulfillment tab doesn't
-  // pop in after load. A connection *error* is still tolerated below (the tab
-  // simply stays hidden), matching the carrier-banner's error tolerance.
+  // Resolved platform labels for all page copy (#1784). Neutral fallbacks keep
+  // the labels sensible while the pair is not `ready`.
+  const sourceLabel = pairing.status === 'ready' ? labelOf(pairing.source) : 'the marketplace';
+  const destinationLabel =
+    pairing.status === 'ready' ? labelOf(pairing.destination) : 'the connected shop';
+
+  const backTo = { to: `/connections/${connectionId}`, label: 'Connection' } as const;
+
+  // ── Pairing-driven states (evaluated after all hooks) ───────────────────
+
+  if (pairing.status === 'loading') {
+    return (
+      <PageLayout eyebrow="Connection" title="Mapping Configuration" description="Loading mapping configuration…">
+        <LoadingState liveRegion="off" title="Loading mappings" message="Fetching configured mappings for this connection." />
+      </PageLayout>
+    );
+  }
+
+  if (pairing.status === 'error') {
+    return (
+      <PageLayout backTo={backTo} eyebrow="Connection" title="Mapping Configuration" description="Unable to load mapping configuration.">
+        <ErrorState title="Unable to load mappings" message={pairing.error.message} />
+      </PageLayout>
+    );
+  }
+
+  if (pairing.status === 'unsupported') {
+    const unsupportedLabel = labelOf(pairing.source);
+    return (
+      <PageLayout
+        backTo={backTo}
+        eyebrow="Connection"
+        title="Mapping Configuration"
+        description={`${unsupportedLabel} order mapping isn't supported yet.`}
+      >
+        <MappingPairingBar pairing={pairing} onPickSource={() => undefined} />
+        <EmptyState
+          title={`Mapping isn't available for ${unsupportedLabel} connections yet`}
+          message="Order mapping is available for Allegro to PrestaShop and Erli to PrestaShop today. Support for more platforms is planned."
+        />
+      </PageLayout>
+    );
+  }
+
+  if (pairing.status === 'no-source') {
+    return (
+      <PageLayout
+        backTo={backTo}
+        eyebrow="Connection"
+        title="Mapping Configuration"
+        description={`No marketplace is paired with ${pairing.master.name} yet.`}
+      >
+        <MappingPairingBar pairing={pairing} onPickSource={() => undefined} />
+        <EmptyState
+          title="No marketplace is paired with this shop"
+          message="Order mappings are configured from the marketplace side. Open a marketplace connection (Allegro or Erli) and set its catalog to this shop to pair them."
+          action={
+            <Link className="button button--secondary" to="/connections">
+              Go to connections
+            </Link>
+          }
+        />
+      </PageLayout>
+    );
+  }
+
+  if (pairing.status === 'pick-source') {
+    return (
+      <PageLayout
+        backTo={backTo}
+        eyebrow="Connection"
+        title="Mapping Configuration"
+        description={`Choose a marketplace to configure ${pairing.master.name} mappings.`}
+      >
+        <MappingPairingBar
+          pairing={pairing}
+          onPickSource={(sourceConnectionId) => {
+            void navigate(`/connections/${sourceConnectionId}/mappings`);
+          }}
+        />
+        <EmptyState
+          title="Choose which marketplace to configure"
+          message={`Order mappings belong to a marketplace. Choose which of the ${pairing.candidates.length} paired marketplaces you want to configure against ${pairing.master.name}.`}
+        />
+      </PageLayout>
+    );
+  }
+
+  // ── Ready: the pair is resolved and supported. Load the mapping data. ────
+
   const isLoading =
     statusQuery.isLoading ||
     carrierQuery.isLoading ||
@@ -172,6 +264,22 @@ export function ConnectionMappingsPage(): ReactElement {
     connectionQuery.isLoading;
   const loadError =
     statusQuery.error ?? carrierQuery.error ?? paymentQuery.error ?? orderStateQuery.error ?? null;
+
+  if (isLoading) {
+    return (
+      <PageLayout backTo={backTo} eyebrow="Connection" title="Mapping Configuration" description="Loading mapping configuration…">
+        <LoadingState liveRegion="off" title="Loading mappings" message="Fetching configured mappings for this connection." />
+      </PageLayout>
+    );
+  }
+
+  if (loadError) {
+    return (
+      <PageLayout backTo={backTo} eyebrow="Connection" title="Mapping Configuration" description="Unable to load mapping configuration.">
+        <ErrorState title="Unable to load mappings" message={loadError.message} />
+      </PageLayout>
+    );
+  }
 
   const tabs: { id: TabId; label: string }[] = [
     ...(supportsOrderSource ? [{ id: 'fulfillment' as const, label: 'Fulfillment' }] : []),
@@ -182,21 +290,19 @@ export function ConnectionMappingsPage(): ReactElement {
   ];
   const defaultTab = tabs[0].id;
 
-  if (isLoading) {
-    return (
-      <PageLayout eyebrow="Connection" title="Mappings" description="Loading mapping configuration…">
-        <LoadingState liveRegion="off" title="Loading mappings" message="Fetching configured mappings for this connection." />
-      </PageLayout>
-    );
-  }
-
-  if (loadError) {
-    return (
-      <PageLayout eyebrow="Connection" title="Mappings" description="Unable to load mapping configuration.">
-        <ErrorState title="Unable to load mappings" message={loadError.message} />
-      </PageLayout>
-    );
-  }
+  // Per-panel error isolation (#484): a failure in one bundle key must not
+  // block the other tabs. Each panel only watches the two keys it actually
+  // reads from.
+  const statusOptionsError =
+    optionsErrors.allegroOrderStatuses ?? optionsErrors.prestashopOrderStatuses ?? null;
+  const carrierOptionsError =
+    optionsErrors.allegroDeliveryMethods ?? optionsErrors.prestashopCarriers ?? null;
+  const paymentOptionsError =
+    optionsErrors.allegroPaymentProviders ?? optionsErrors.prestashopPaymentModules ?? null;
+  // Outbound OL->PS order-state panel (#862): only the destination dropdown
+  // (prestashopOrderStatuses) loads from the bundle - the source axis is the
+  // fixed OL OrderStatus list. So its options-readiness tracks only that key.
+  const orderStateOptionsError = optionsErrors.prestashopOrderStatuses ?? null;
 
   const statusRows: MappingRow[] = (statusQuery.data ?? []).map((m) => ({
     sourceValue: m.allegroStatus,
@@ -208,15 +314,10 @@ export function ConnectionMappingsPage(): ReactElement {
     targetValue: m.prestashopCarrierId,
   }));
 
-  // Carrier-fallback banner (#517) — single banner above the carrier panel
-  // summarising the BE runtime fallback chain (#516). Computed up here
-  // rather than inline in the JSX so the conditions (loading/errored/no
-  // unmapped methods) read top-to-bottom. Suppressed when any required
-  // input isn't ready; the BE still does the right thing at sync time.
-  // Routing-aware unmapped count (#836): a method is "unmapped" for the carrier
-  // banner only if it has neither a PS carrier mapping NOR a routing rule
-  // diverting it to a non-PS processor. Subtraction by id (not length) is exact
-  // even when saved rows reference methods no longer in the live options.
+  // Carrier-fallback banner (#517) - single banner above the carrier panel
+  // summarising the BE runtime fallback chain (#516). Routing-aware unmapped
+  // count (#836): a method is "unmapped" only if it has neither a PS carrier
+  // mapping NOR a routing rule diverting it to a non-PS processor.
   const divertedMethodIds = new Set(
     (routingRulesQuery.data ?? []).map((r) => r.sourceDeliveryMethodId),
   );
@@ -243,12 +344,18 @@ export function ConnectionMappingsPage(): ReactElement {
             ? String(connectionConfig.defaultCarrierId)
             : null,
         carriers: options.prestashopCarriers,
+        sourceLabel,
       })
     : null;
 
   const paymentRows: MappingRow[] = (paymentQuery.data ?? []).map((m) => ({
     sourceValue: m.allegroPaymentProvider,
     targetValue: m.prestashopPaymentModule,
+  }));
+
+  const orderStateRows: MappingRow[] = (orderStateQuery.data ?? []).map((m) => ({
+    sourceValue: m.olStatus,
+    targetValue: m.externalStateId,
   }));
 
   function handleSaveStatus(rows: MappingRow[]): void {
@@ -269,11 +376,6 @@ export function ConnectionMappingsPage(): ReactElement {
     });
   }
 
-  const orderStateRows: MappingRow[] = (orderStateQuery.data ?? []).map((m) => ({
-    sourceValue: m.olStatus,
-    targetValue: m.externalStateId,
-  }));
-
   function handleSaveOrderStates(rows: MappingRow[]): void {
     upsertOrderState.mutate({
       items: rows.map((r) => ({ olStatus: r.sourceValue, externalStateId: r.targetValue })),
@@ -282,15 +384,12 @@ export function ConnectionMappingsPage(): ReactElement {
 
   return (
     <PageLayout
-      backTo={{ to: `/connections/${connectionId}`, label: 'Connection' }}
+      backTo={backTo}
       eyebrow="Connection"
       title="Mapping Configuration"
-      description="Configure Allegro → PrestaShop mappings for order statuses, delivery carriers, and payment methods."
+      description={`Configure ${sourceLabel} → ${destinationLabel} mappings for order statuses, delivery carriers, and payment methods.`}
     >
-      <DesktopOnlyBanner>
-        Mapping editors are designed for desktop. On smaller screens the controls below are still
-        visible but large tables may overflow horizontally.
-      </DesktopOnlyBanner>
+      <MappingPairingBar pairing={pairing} onPickSource={() => undefined} />
 
       <Tabs defaultValue={defaultTab} aria-label="Mapping types">
         <TabsList>
@@ -305,6 +404,7 @@ export function ConnectionMappingsPage(): ReactElement {
           <TabsContent value="fulfillment">
             <RoutingRulesPanel
               connectionId={connectionId}
+              sourceLabel={sourceLabel}
               deliveryMethods={options.allegroDeliveryMethods}
               deliveryMethodsLoading={optionsLoading}
               deliveryMethodsError={optionsErrors.allegroDeliveryMethods ?? null}
@@ -315,9 +415,9 @@ export function ConnectionMappingsPage(): ReactElement {
         <TabsContent value="status">
           <MappingPanel
             title="Order Status Mappings"
-            description="Map Allegro order statuses to the corresponding PrestaShop order status IDs."
-            sourceLabel="Allegro status"
-            targetLabel="PrestaShop status"
+            description={`Map ${sourceLabel} order statuses to the corresponding ${destinationLabel} order status IDs.`}
+            sourceLabel={`${sourceLabel} status`}
+            targetLabel={`${destinationLabel} status`}
             sourceOptions={options.allegroOrderStatuses}
             targetOptions={options.prestashopOrderStatuses}
             savedRows={statusRows}
@@ -340,9 +440,9 @@ export function ConnectionMappingsPage(): ReactElement {
           ) : null}
           <MappingPanel
             title="Carrier Mappings"
-            description="Map Allegro delivery method IDs to the corresponding PrestaShop carrier IDs."
-            sourceLabel="Allegro delivery method"
-            targetLabel="PrestaShop carrier"
+            description={`Map ${sourceLabel} delivery method IDs to the corresponding ${destinationLabel} carrier IDs.`}
+            sourceLabel={`${sourceLabel} delivery method`}
+            targetLabel={`${destinationLabel} carrier`}
             sourceOptions={options.allegroDeliveryMethods}
             targetOptions={options.prestashopCarriers}
             savedRows={carrierRows}
@@ -351,15 +451,16 @@ export function ConnectionMappingsPage(): ReactElement {
             saveError={upsertCarrier.error}
             optionsLoading={optionsLoading}
             optionsError={carrierOptionsError}
+            dynamicOptionSuffix={` - exact ${sourceLabel} cost`}
           />
         </TabsContent>
 
         <TabsContent value="payments">
           <MappingPanel
             title="Payment Mappings"
-            description="Map Allegro payment provider names to the corresponding PrestaShop payment module names."
-            sourceLabel="Allegro payment provider"
-            targetLabel="PrestaShop payment module"
+            description={`Map ${sourceLabel} payment provider names to the corresponding ${destinationLabel} payment module names.`}
+            sourceLabel={`${sourceLabel} payment provider`}
+            targetLabel={`${destinationLabel} payment module`}
             sourceOptions={options.allegroPaymentProviders}
             targetOptions={options.prestashopPaymentModules}
             savedRows={paymentRows}
@@ -375,9 +476,9 @@ export function ConnectionMappingsPage(): ReactElement {
           <TabsContent value="order-states">
             <MappingPanel
               title="Order-State Mappings"
-              description="Override which PrestaShop order state each OpenLinker status transitions to. Customised shops (renamed/added states) map here; unmapped statuses use the default-install state."
+              description={`Override which ${destinationLabel} order state each OpenLinker status transitions to. Customised shops (renamed or added states) map here; unmapped statuses use the default-install state.`}
               sourceLabel="OpenLinker status"
-              targetLabel="PrestaShop order state"
+              targetLabel={`${destinationLabel} order state`}
               sourceOptions={OL_ORDER_STATUS_OPTIONS}
               targetOptions={options.prestashopOrderStatuses}
               savedRows={orderStateRows}

--- a/docs/frontend-architecture.md
+++ b/docs/frontend-architecture.md
@@ -403,6 +403,12 @@ Naming conventions:
 - route modules: `*.route.tsx`
 - tests: `*.test.tsx`
 
+### Mapping configuration pairing (#1784)
+
+The order Mapping Configuration page (`connection-mappings-page.tsx`) configures a **source -> destination connection pair**, not a single connection. The pair is **config-stamped**, mirroring the backend `MappingOptionsController.resolvePartnerConnectionId`: a marketplace connection carries a single `config.masterCatalogConnectionId` pointing at its master shop. `useMappingPairing(connectionId)` resolves this into one of `ready | pick-source | no-source | unsupported | loading | error` and the page renders the pairing route strip (`MappingPairingBar`) plus the resolved-label copy from it. Because a marketplace has exactly one master, opening from a source is always unambiguous; the only genuine choice is opening from a shop with several paired marketplaces, which surfaces a source picker and **navigates** to the chosen marketplace's own mappings page (URL state, keeping mapping data keyed to the marketplace connection).
+
+Which platform pairs may be mapped is a **front-end-only allowlist** (`features/mappings/supported-source-platforms.ts`, `SUPPORTED_SOURCE_PLATFORMS = ['allegro', 'erli']`). This is deliberate: the mapping API stays open on capability so an operator can add mappings for an unlisted pair via the API in an emergency (as done for presta -> erli). Do not promote it to a server-side guard without an explicit decision.
+
 ### UI Library Policy
 
 No **styled** external UI library (no shadcn/ui, MUI, Mantine, Chakra, Ant Design). Visual opinions are ours — every pixel is vanilla CSS against the tokens in `apps/web/src/index.css`.

--- a/docs/frontend-ui-style-guide.md
+++ b/docs/frontend-ui-style-guide.md
@@ -451,6 +451,7 @@ Required implementation rules:
 - style modifiers after their base rules and keep state classes explicit, for example `status-pill--error` or `context-chip--info`
 - responsive overrides must match the layout model being changed; use grid overrides for grid layouts and flex overrides for flex layouts
 - add or extend shared primitives before introducing page-specific one-off styling
+- narrow-viewport table-to-cards (#1784): where a dense mapping/config table must stay usable on small screens, opt the table into `.data-table--stackable` and add a `data-label` to each `<td>`. At `<= 640px` a scoped block collapses each row into a card (source cell as the heading; remaining cells stack under their `data-label`). Prefer this over a "desktop-only" banner — the mapping page dropped `DesktopOnlyBanner` for it. The rule is scoped to the modifier so the app-wide `DataTable` is untouched.
 
 Recommended CSS structure for `apps/web/src/index.css`:
 

--- a/docs/plans/implementation-plan-mapping-connection-pairing.md
+++ b/docs/plans/implementation-plan-mapping-connection-pairing.md
@@ -1,0 +1,97 @@
+# Implementation Plan - Mapping Configuration connection pairing (#1784)
+
+## 1. Understand the task
+
+Make the order Mapping Configuration page (`apps/web/src/pages/connections/connection-mappings-page.tsx`) show and reason about the **connection pair** it configures, replace hardcoded "Allegro"/"PrestaShop" copy with resolved platform labels, gate mapping to today's supported source platforms, and make the page responsive (drop the desktop-only banner).
+
+- **Layer:** Frontend / Interface only. No CORE or Integration change; no new port/capability/DI token/schema/migration.
+- **Non-goals:**
+  - No backend change. The mapping/options endpoints and their `config.masterCatalogConnectionId` partner resolution stay as-is.
+  - No server-side supported-pairs guard (FE-only by decision; API stays open for emergency API-driven mappings).
+  - No change to how mapping **data** is keyed (still by URL `connectionId`).
+  - No "multiple destinations" case (not representable: `masterCatalogConnectionId` is a single string).
+  - No rename of internal wire/bundle keys (`allegroOrderStatuses`, etc.).
+
+Authoritative mock: https://claude.ai/code/artifact/ea21c413-4a4a-4ee3-82e9-c581e14681d3
+
+## 2. Research (findings)
+
+- **Pairing is config-stamped.** `apps/api/src/mappings/http/mapping-options.controller.ts` `resolvePartnerConnectionId`: source connection carries `config.masterCatalogConnectionId` -> its one master; from the master, reverse-lookup the single active paired source (throws 400 if several). FE will mirror this resolution.
+- **Data queries key on URL `connectionId`** (`mappings.controller.ts`), unchanged. So the multi-source case must **navigate** to the chosen source's page, not swap state in place.
+- **Page today** (`connection-mappings-page.tsx`): gates tabs by capability (`supportsOrderSource` -> Fulfillment, `supportsOrderProcessor` -> Order States); status/carriers/payments always shown. Uses `useConnectionQuery(connectionId)`, `useMappingOptions`, per-tab query hooks. Renders `DesktopOnlyBanner` + hardcoded labels.
+- **Label lookup:** `usePlatform(platformType)?.displayName ?? platformType` (as in `connection-detail-page.tsx`).
+- **Reverse-lookup source:** `useConnectionsQuery()` + client filter `c.status === 'active' && readMaster(c) === urlId && SUPPORTED.includes(c.platformType)` (mirrors category page's candidate filter).
+- **MappingPanel** already takes `sourceLabel`/`targetLabel`/`title`/`description` as props (no prop-shape change for labels). `DYNAMIC_OPTION_SUFFIX` is a module const hardcoding "Allegro" -> make it a prop.
+- **RoutingRulesPanel** copy is mostly generic ("marketplace delivery method"); add a `sourceLabel` prop for the description.
+- **CSS:** `.toolbar-chip`/`.context-chip` pill family at `index.css:1601`. Existing responsive breakpoints use `@media (max-width: 640px)` / `767px`. Reuse tokens; namespace new classes `.mapping-pair*`.
+- **Tests:** `apps/web/src/pages/connections/connection-mappings-page.test.tsx` exists - extend it.
+
+## 3. Design
+
+### 3.1 Supported-pairs constant (FE-only)
+`apps/web/src/features/mappings/supported-source-platforms.ts`
+```ts
+// FE-ONLY gate (by decision, #1784). The mapping API stays open on capability,
+// so an operator can still add mappings for an unlisted pair via the API in an
+// emergency (as done earlier for presta->erli). Do NOT mirror this server-side
+// without an explicit decision to close that escape hatch.
+export const SUPPORTED_SOURCE_PLATFORMS = ['allegro', 'erli'] as const;
+export function isSupportedSourcePlatform(p: string | undefined): boolean { ... }
+```
+
+### 3.2 Pairing resolution hook
+`apps/web/src/features/mappings/hooks/use-mapping-pairing.ts` - `useMappingPairing(connectionId)` returns a discriminated union (`*.types.ts` colocated):
+- `{ status: 'loading' }`
+- `{ status: 'error'; error: Error }`
+- `{ status: 'unsupported'; source: Connection; destination: Connection | null }`
+- `{ status: 'no-source'; master: Connection }`
+- `{ status: 'pick-source'; master: Connection; candidates: Connection[] }`
+- `{ status: 'ready'; source: Connection; destination: Connection }`
+
+Resolution (mirrors backend): read `masterCatalogConnectionId` off the URL connection.
+- present -> URL conn is source; destination = connection with that id (from list); `unsupported` if source platform not allowlisted; else `ready`.
+- absent -> URL conn is master; candidates = active + paired-here + allowlisted sources; 0 -> `no-source`, 1 -> `ready`, >1 -> `pick-source`.
+
+Inputs: `useConnectionQuery(connectionId)` + `useConnectionsQuery()`. Loading/error fold in from both.
+
+### 3.3 Pairing bar component
+`apps/web/src/features/mappings/components/mapping-pairing-bar.tsx` - renders the route strip (source chip or `<Select>` picker, connector, destination chip, meta line with "Change pairing" link / picker hint). Props: the resolved pairing + `onPickSource(id)`. Pure presentational.
+
+### 3.4 Page wiring (`connection-mappings-page.tsx`)
+- Call `useMappingPairing(connectionId)`.
+- `loading`/`error` -> existing full-page `LoadingState`/`ErrorState`.
+- `unsupported` -> bar + unsupported empty state (supported-pair badges).
+- `no-source` -> bar + guidance empty state.
+- `pick-source` -> bar (picker) + prompt empty state; `onPickSource` -> `navigate('/connections/{sourceId}/mappings')`.
+- `ready` -> bar + tabs (existing content), with `sourceLabel`/`destinationLabel` from `usePlatform` threaded into description, tab panels, `MappingPanel` props, `RoutingRulesPanel` `sourceLabel`, and `MappingPanel` dynamic-suffix prop.
+- Remove `DesktopOnlyBanner` import + usage.
+
+### 3.5 MappingPanel / RoutingRulesPanel
+- `MappingPanel`: add optional `dynamicOptionSuffix?: string` prop (default keeps behaviour); page passes `` ` - exact ${sourceLabel} cost` ``. Replace module const usage.
+- `RoutingRulesPanel`: add `sourceLabel: string` prop; interpolate into the description sentence.
+
+### 3.6 Responsive CSS (`index.css`, bounded section)
+- `.mapping-pair` route strip (grid -> stacked at `<=640px`, connector rotates).
+- Responsive mapping table -> cards at `<=640px`: confirm MappingPanel's real markup first, then either add card CSS targeting it or (if it's a `<table>`) apply the `display:block` + `data-label` card technique. Tabs list -> horizontal scroll rail at `<=640px`. Reuse tokens only.
+
+## 4. Steps
+
+1. **Read MappingPanel + RoutingRulesPanel full render** to confirm exact markup the responsive CSS must target. (No code yet.)
+2. Add `supported-source-platforms.ts` (+ barrel export if the feature has one).
+3. Add `use-mapping-pairing.ts` (+ `.types.ts`) with unit-testable pure resolver split from the hook (`resolveMappingPairing(urlConnection, allConnections)`), so logic is tested without React.
+4. Add `mapping-pairing-bar.tsx`.
+5. Rewire `connection-mappings-page.tsx`: pairing states, label threading, remove `DesktopOnlyBanner`.
+6. `MappingPanel`: `dynamicOptionSuffix` prop; `RoutingRulesPanel`: `sourceLabel` prop.
+7. `index.css`: pairing-bar + responsive card/tab CSS (bounded comment block).
+8. Tests: unit-test `resolveMappingPairing` (all 6 outcomes); extend `connection-mappings-page.test.tsx` for ready (Allegro + Erli label substitution), pick-source (picker + navigation), unsupported, no-source.
+9. Quality gate: `pnpm --filter @openlinker/web lint type-check test` (scoped), then full `pnpm lint`/`type-check`/`test`.
+10. Visual verify with Playwright against demo API (worktree vite -> demo :3000 / :8090 stack): desktop + mobile screenshots per state, compare to mock.
+11. Docs: `docs/frontend-architecture.md` note (pairing resolution + FE-only allowlist location); `docs/frontend-ui-style-guide.md` if the pairing strip/responsive-cards pattern is worth recording.
+
+## 5. Validate
+
+- **Architecture:** FE-only; no cross-layer or CORE/Integration violation. Hook depends on existing FE query hooks + `usePlatform`. Pure resolver keeps logic testable.
+- **Naming:** `use-*.ts` hook, `*.tsx` component, `*.types.ts` types, `PascalCase` component. FE conventions honoured.
+- **State ownership:** server state via TanStack Query (existing hooks); pairing is derived, not stored; multi-source choice lives in the URL (navigation), consistent with `docs/frontend-architecture.md`.
+- **Security:** no secrets; read-only reuse of existing endpoints.
+- **Risk:** the multi-source navigation must land on a page that re-keys data correctly (it does - URL `connectionId` drives all queries). Responsive card CSS must match MappingPanel's real DOM (step 1 gate).


### PR DESCRIPTION
Closes #1784

## What & why

The order Mapping Configuration page (`connection-mappings-page.tsx`) now resolves and shows the **source -> destination connection pair** instead of hardcoding "Allegro"/"PrestaShop", is responsive on small screens, and lazy-loads per tab.

- **`useMappingPairing`** resolves the config-stamped pairing (`config.masterCatalogConnectionId`), mirroring the backend `MappingOptionsController.resolvePartnerConnectionId`, into `ready | pick-source | no-source | unsupported | loading | error`. A marketplace has exactly one master, so opening from a source is unambiguous; opening from a shop with several paired marketplaces shows a source picker that **navigates** to that marketplace's own mappings page (replaces the old `400` dead-end).
- **`MappingPairingBar`** renders the pairing route strip; all page/panel copy and the `MappingPanel` dynamic-carrier suffix interpolate the resolved platform labels (`usePlatform().displayName`). Neutral fallback while the pair is undecided.
- **Supported pairs** (`allegro`/`erli` -> `prestashop`) are gated by a **front-end-only** allowlist (`features/mappings/lib/supported-source-platforms.ts`) with a comment explaining the choice: the mapping API stays open on capability, so mappings for an unlisted pair can still be added via the API in an emergency (as done earlier for presta -> erli).
- **Responsive:** `DesktopOnlyBanner` dropped. At `<= 640px` the pairing strip stacks and mapping tables collapse to cards.

## Data keying (per-side)

Mapping data is keyed **per side**, matching the sync-time consumers: status / carriers / payments / fulfillment-routing key on the **source** connection id (`OrderSyncService.resolveStatusMapping(sourceConnectionId, ...)`, the PrestaShop adapter's `resolveCarrierMapping(order.source.connectionId, ...)`), while order-states key on the **destination** id (`resolveOrderStateMapping(this.connection.id, ...)`, #862). The `ready` branch derives `sourceConnectionId` / `destConnectionId` from the resolved pair and threads each to the right hooks, and the tab-set capabilities are read from the resolved source/destination rather than the opened URL connection. This makes opening from the master and opening from the marketplace converge on the same source-keyed data.

## Performance (FE feedback follow-up - done)

- [x] **Lazy-load per tab** - mapping-data queries (status/carrier/payment/order-state) and the 6-list options bundle now fetch only for the tab open on load plus tabs the operator has visited, instead of firing everything at page mount. `{ enabled }` added to the four mapping hooks + an `enabledKeys` set on `useMappingOptions`; the page tracks visited tabs, and tab-activeness is gated on the connection being loaded so the transient default can't leak a tab's queries during load.
- [x] **Fulfillment virtualization** - the routing table renders through the shared `DataTable` primitive with `virtualize` (memoized columns/cardView + cell renderers); windows rows and auto-renders its `cardView` on narrow viewports (mobile preserved).
- [x] **Option caching** - a finite 10-minute `staleTime` + long `gcTime` on the option queries (near-static dictionaries; the short default forced refetches against slow destination-shop endpoints on every remount/refocus). Plus `Map`-based `MappingPanel` row lookups and memoized derived arrays.

## Tests

- Pure `resolveMappingPairing` unit coverage (all outcomes, incl. disabled-source and missing-destination).
- Page tests for ready / pick-source (+ navigation) / no-source / unsupported, Allegro/Erli label substitution, the lazy-load-per-tab gating (negative assertions), and per-side keying.
- Full web suite green (lint, type-check, all web tests).

## Docs

- `docs/frontend-architecture.md` -> mapping-page pairing resolution + FE-only allowlist location.
- `docs/frontend-ui-style-guide.md` -> responsive table-to-cards pattern; `DesktopOnlyBanner` retired for this page.
- `docs/plans/implementation-plan-mapping-connection-pairing.md` -> the plan.
- No central architecture/port/ADR change (FE-only; no new port/capability/DI token/schema).

## Review cycle & verification

Two rounds of multi-lens review (UX, ecommerce-flow, backend/API-contract, code, architecture, performance, testing, security) were consolidated on this PR. The blocking finding from round 1 - the `ready` branch keying every mapping hook on the URL connection id, which made a master-opened editor read blank and write source-keyed mappings to a dead key - is fixed by the per-side keying described above, verified against the backend consumers. All important round-1 items (per-panel error isolation instead of a full-page gate, a tab-switch discard guard, the lazy-load regression test, explicit `Configure` action on pick-source, destination-sourced carrier fallback, memoized routing table, searchable add-row comboboxes) landed as well.

**Live case gallery (new):** every pairing state plus a full Erli -> PrestaShop tab walk, each with a schematic and a full-resolution Playwright screenshot captured against the reviewed commit on an isolated front-end reading the live demo database:
https://claude.ai/code/artifact/cba17d1a-6d48-419a-9d49-6a6aafdcdf1a

Verified live, desktop + mobile, across `ready` (both entry sides), `pick-source`, `no-source`, `unsupported`, `error`, `loading`, the inactive-connection note, and all five tabs for both Allegro and Erli. Endpoints were probed directly (each 8x): no spontaneous 500 - the `error`/`loading` screenshots are forced non-destructively to document those states.

### Erli fulfillment-row id collision - fixed here

Verification against the Erli source surfaced a usability/data-integrity issue in the fulfillment routing table: it rendered each row as `{label} {id.slice(0,8)}...`, but Erli returns 93 delivery methods whose distinguishing detail (weight/size) sits at the **end** of the id. The front-8-char hint collapsed whole groups into identical-looking rows - e.g. 13x "ERLI DPD Kurier" all shown as `erliDPDK...` (real ids `...5kg` / `...10kg` / `...15kg` / `...20kg`), with 38 of 93 rows carrying a non-unique label, so the operator could not tell which weight bracket a row routed and two identical-looking rows saved to different keys.

The `slice(0,8)` truncation was pre-existing on `main`, but this PR is what makes Erli reachable through the table, so it is fixed here rather than deferred: `shortValue` now uses a **middle-ellipsis** (head + tail) so the distinguishing suffix stays visible (`erliDP...20kg`), with a regression test. Cross-referenced under epic #1776's cleanups list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

