### PR TITLE
fix(invoicing): thread buyer e-mail to Infakt so send-by-email stops 422ing

### DIFF
--- a/apps/api/test/integration/invoicing/invoice-record-repository.int-spec.ts
+++ b/apps/api/test/integration/invoicing/invoice-record-repository.int-spec.ts
@@ -132,6 +132,7 @@ describe('invoice_records persistence (integration)', () => {
         taxId: { scheme: 'pl-nip', value: '1234567890' },
         address: { line1: 'ul. X 1', line2: null, city: 'Poznań', postalCode: '60-001', countryIso2: 'PL' },
         type: 'company',
+        email: null,
       },
       currency: 'PLN',
       lines: [{ name: 'Widget', quantity: 2, unitPriceGross: 100, taxRate: '23' }],

--- a/apps/worker/src/sync/handlers/__tests__/invoicing-issue.handler.spec.ts
+++ b/apps/worker/src/sync/handlers/__tests__/invoicing-issue.handler.spec.ts
@@ -112,6 +112,43 @@ describe('InvoicingIssueHandler', () => {
     });
   });
 
+  describe('buyer.email (#1797)', () => {
+    it('reconstructs BuyerProfile.email from payload.buyer.email', async () => {
+      await handler.execute(
+        makeJob(
+          makePayload({
+            buyer: { ...makePayload().buyer, email: 'buyer@example.com' },
+          }),
+        ),
+      );
+      const cmd = invoiceService.issueInvoice.mock.calls[0][0];
+      expect(cmd.buyer.email).toBe('buyer@example.com');
+    });
+
+    it('normalizes a missing buyer.email (pre-#1797 payload shape) to null', async () => {
+      const payload = makePayload();
+      // Simulate a job persisted before this field existed: no `email` key at all.
+      delete (payload.buyer as { email?: string | null }).email;
+
+      const result = await handler.execute(makeJob(payload));
+
+      expect(result).toEqual({ outcome: 'ok' });
+      expect(invoiceService.issueInvoice.mock.calls[0][0].buyer.email).toBeNull();
+    });
+
+    it('a present-but-non-string, non-null buyer.email ⇒ business_failure (F5)', async () => {
+      const result = await handler.execute(
+        makeJob(
+          makePayload({
+            buyer: { ...makePayload().buyer, email: 42 as unknown as string },
+          }),
+        ),
+      );
+      expect(result).toEqual({ outcome: 'business_failure' });
+      expect(invoiceService.issueInvoice).not.toHaveBeenCalled();
+    });
+  });
+
   describe('deep payload validation ⇒ business_failure (F5)', () => {
     const cases: Array<[string, unknown]> = [
       ['wrong schemaVersion', makePayload({ schemaVersion: 2 as unknown as 1 })],

--- a/apps/worker/src/sync/handlers/__tests__/invoicing-issue.handler.spec.ts
+++ b/apps/worker/src/sync/handlers/__tests__/invoicing-issue.handler.spec.ts
@@ -135,18 +135,6 @@ describe('InvoicingIssueHandler', () => {
       expect(result).toEqual({ outcome: 'ok' });
       expect(invoiceService.issueInvoice.mock.calls[0][0].buyer.email).toBeNull();
     });
-
-    it('a present-but-non-string, non-null buyer.email ⇒ business_failure (F5)', async () => {
-      const result = await handler.execute(
-        makeJob(
-          makePayload({
-            buyer: { ...makePayload().buyer, email: 42 as unknown as string },
-          }),
-        ),
-      );
-      expect(result).toEqual({ outcome: 'business_failure' });
-      expect(invoiceService.issueInvoice).not.toHaveBeenCalled();
-    });
   });
 
   describe('deep payload validation ⇒ business_failure (F5)', () => {
@@ -169,6 +157,9 @@ describe('InvoicingIssueHandler', () => {
       })],
       ['half-populated taxId', makePayload({
         buyer: { ...makePayload().buyer, taxId: { scheme: 'pl-nip', value: '' } },
+      })],
+      ['present but non-string, non-null buyer.email (#1797)', makePayload({
+        buyer: { ...makePayload().buyer, email: 42 as unknown as string },
       })],
       ['missing connectionId', makePayload({ connectionId: '' })],
       ['present but empty saleDate', makePayload({ saleDate: '' })],

--- a/apps/worker/src/sync/handlers/invoicing-issue.handler.ts
+++ b/apps/worker/src/sync/handlers/invoicing-issue.handler.ts
@@ -157,6 +157,16 @@ export class InvoicingIssueHandler implements SyncJobHandler {
       if (!isNonEmptyString(buyer.taxId.scheme)) return fail('buyer.taxId.scheme');
       if (!isNonEmptyString(buyer.taxId.value)) return fail('buyer.taxId.value');
     }
+    // Optional additive field (#1797): a payload persisted before this field
+    // existed has `buyer.email === undefined` — that's valid. Only reject a
+    // present-but-wrong-shaped value.
+    if (
+      buyer.email !== undefined &&
+      buyer.email !== null &&
+      typeof buyer.email !== 'string'
+    ) {
+      return fail('buyer.email');
+    }
 
     return p as InvoicingIssuePayloadV1;
   }
@@ -168,11 +178,14 @@ export class InvoicingIssueHandler implements SyncJobHandler {
    */
   private toCommand(payload: InvoicingIssuePayloadV1): IssueInvoiceCommand {
     // #12: rebuild the BuyerProfile class from the PLAIN payload buyer.
+    // #1797: `buyer.email` is `undefined` on a payload persisted before this
+    // field existed — normalize to `null` rather than requiring the key.
     const buyer = new BuyerProfile(
       payload.buyer.name,
       payload.buyer.taxId,
       payload.buyer.address,
       payload.buyer.type,
+      payload.buyer.email ?? null,
     );
 
     const command: IssueInvoiceCommand = {

--- a/apps/worker/src/sync/handlers/invoicing-issue.handler.ts
+++ b/apps/worker/src/sync/handlers/invoicing-issue.handler.ts
@@ -102,7 +102,8 @@ export class InvoicingIssueHandler implements SyncJobHandler {
    *    finite number `> 0` and `unitPriceGross` a finite number `>= 0`;
    *  - `buyer.type ∈ BuyerTypeValues`; `buyer.name` non-empty; `buyer.address`
    *    present with required string fields; `buyer.taxId` `null` OR
-   *    `{ scheme, value }` with both non-empty.
+   *    `{ scheme, value }` with both non-empty; `buyer.email` (#1797) absent
+   *    (pre-existing payload), `null`, OR a `string` — never any other type.
    *
    * PII: on violation logs ONLY the failed field name(s) + `orderId` /
    * `connectionId` / `schemaVersion` — NEVER `payload` / `buyer` / `lines`.

--- a/docs/plans/analysis/ANALYSIS-1797-invoicing-buyer-email.md
+++ b/docs/plans/analysis/ANALYSIS-1797-invoicing-buyer-email.md
@@ -1,0 +1,76 @@
+# Pre-Implementation Analysis: implementation-plan-1797-invoicing-buyer-email.md
+
+**Issue**: #1797
+**Plan**: `docs/plans/implementation-plan-1797-invoicing-buyer-email.md`
+**Verdict**: **READY**
+
+---
+
+## Reuse Findings
+
+| Plan artifact | Classification | File / evidence |
+|---|---|---|
+| `BuyerProfile.email` field | NEW (confirmed absent) | `libs/core/src/invoicing/domain/entities/buyer-profile.entity.ts` — constructor is `(name, taxId, address, type)`, no 5th param today. |
+| `order.customerEmail` source field | ALREADY EXISTS → reuse | `libs/core/src/orders/domain/types/order.types.ts:96` (`Order.customerEmail?: string`, populated since #948). Plan correctly reuses it, adds no new field here. |
+| `InvocingIssueBuyerV1.email` | NEW (confirmed absent) | `libs/core/src/sync/domain/types/invoicing-job-payloads.types.ts` — current shape is `{ name, taxId, address, type }`. |
+| Additive-payload-field precedent | ALREADY EXISTS → pattern to follow | Same file, `saleDate` field + its doc comment establish the exact "optional additive field, no schemaVersion bump" convention the plan proposes reusing. |
+| `AutoIssueTriggerService` buyer-flatten site | ALREADY EXISTS → extend | `libs/core/src/invoicing/application/services/auto-issue-trigger.service.ts:266-271`. |
+| `InvoicingIssueHandler.toCommand` reconstruction site | ALREADY EXISTS → extend | `apps/worker/src/sync/handlers/invoicing-issue.handler.ts:169-176`. |
+| `InfaktInvoicingAdapter.upsertCustomer` payload site | ALREADY EXISTS → extend | `libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts:364-373`; `nip: nip ?? undefined` is the exact drop-key-when-null precedent the plan proposes mirroring for `email`. |
+| `InfaktClient.email` (provider response shape) | ALREADY EXISTS (unused on write) | `libs/integrations/infakt/src/domain/types/infakt.types.ts:107` — confirms Infakt's own API already models this field; nothing new needed on the read/response-type side. |
+
+No port, service, DI token, or ORM entity is being reinvented. This is a pure additive-field extension across 4 already-identified files plus their tests — no new abstraction is proposed, matching the plan's own "No new components required" claim.
+
+## Backward-Compatibility Findings
+
+### Constructor call-site blast radius (broader than the plan's file list — verified safe)
+
+A repo-wide grep for `new BuyerProfile(` surfaces **16 call sites**, not just the ~5 the plan explicitly names as touched:
+
+```
+libs/core/src/sync/domain/types/invoicing-job-payloads.types.ts        (doc comment only, not a call)
+libs/core/src/invoicing/application/services/invoice.service.spec.ts
+libs/core/src/invoicing/application/mappers/order-to-issue-invoice-command.mapper.ts   ← plan touches
+libs/core/src/invoicing/domain/entities/buyer-profile.entity.spec.ts   ← plan touches
+libs/integrations/infakt/scripts/poc-sandbox-test.ts                  ← plan touches (Phase 5)
+libs/integrations/infakt/src/application/__tests__/infakt-adapter.factory.spec.ts
+libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-invoicing.adapter.spec.ts   ← plan touches
+libs/integrations/subiekt/src/infrastructure/adapters/__tests__/subiekt-invoicing.adapter.spec.ts
+libs/integrations/subiekt/src/infrastructure/mappers/__tests__/subiekt-document-type.mapper.spec.ts
+libs/integrations/subiekt/src/infrastructure/mappers/__tests__/subiekt-buyer.mapper.spec.ts
+libs/integrations/ksef/src/infrastructure/fa3/domain/fa3-builder-input.mapper.spec.ts
+libs/integrations/ksef/src/infrastructure/adapters/__tests__/ksef-invoicing.adapter.spec.ts
+apps/worker/src/sync/handlers/invoicing-issue.handler.ts               ← plan touches
+apps/api/test/integration/invoicing/invoice-record-repository.int-spec.ts
+apps/api/src/invoicing/http/invoicing.controller.ts                   (correction-snapshot rebuild — explicitly out of scope per plan §2)
+apps/api/src/invoicing/http/invoicing.controller.spec.ts
+```
+
+**Severity: none (Warning-level check, cleared).** Every one of the untouched call sites passes exactly 4 positional arguments (`name, taxId, address, type`). The plan's design decision — add `email` as a **5th, defaulted** (`= null`) constructor parameter — means all 11 untouched call sites (Subiekt's two test files, KSeF's two test files, `invoice.service.spec.ts`, the factory spec, the two integration/controller specs not in scope) keep compiling with zero changes required. This was the plan's explicit assumption (§5, "Assumptions") and it is confirmed correct against the live tree, not just asserted.
+
+One nuance not spelled out in the plan: **Subiekt and KSeF both already construct `BuyerProfile` in their own adapter tests** (`subiekt-invoicing.adapter.spec.ts`, `subiekt-buyer.mapper.spec.ts`, `ksef-invoicing.adapter.spec.ts`, `fa3-builder-input.mapper.spec.ts`). This reinforces the plan's own §3 justification (the field belongs in CORE, not Infakt-only) — Subiekt and KSeF both already receive a `BuyerProfile` and would see `.email` for free once this ships, with zero action required on their side today.
+
+### Contract-surface checklist
+
+| Surface | Check | Result |
+|---|---|---|
+| Top-level barrel `@openlinker/core/invoicing` | `BuyerProfile` already exported; no export removed/renamed, only the class's shape gains an optional field. | Clear |
+| Port method signatures (`InvoicingPort.upsertCustomer`, `InvoiceEmailSender.sendByEmail`) | Neither signature changes — only the *data* flowing through `UpsertCustomerCommand.buyer` gains a field. | Clear |
+| DTO shapes (`SendInvoiceEmailRequestDto`, `SendInvoiceEmailResponseDto`) | Untouched by this plan — confirmed no DTO file is in the plan's file list. | Clear |
+| Symbol tokens (`*.tokens.ts`) | None touched — no new/renamed DI binding. | Clear |
+| ORM schema / migration | No `*.orm-entity.ts` touched; `email` lives only in an in-memory domain object and inside the existing untyped jsonb sync-job payload column. Plan explicitly calls this out (§2, §6 Implementation Details) — confirmed correct, no migration required. | Clear |
+| `check:invariants` (`check-cross-context-imports`, `check-service-interfaces`) | No new cross-context import — `email` stays inside `invoicing`/`sync` (already-adjacent core contexts) and the Infakt adapter (already depends on `@openlinker/core/invoicing`). No new/changed service `implements` clause. | Clear |
+| `InvocingIssuePayloadV1` schema-version discipline | Plan proposes an additive field, no `schemaVersion` bump, explicitly modeled on the file's own `saleDate` precedent (verified present in the live file). Correct application of the existing convention. | Clear |
+
+No Critical or Warning items found.
+
+## Open Questions
+
+- The plan itself already flags one open question (§5): whether the Infakt "existing client found by NIP" branch should `PUT`-backfill an e-mail onto a pre-existing e-mail-less client. Confirmed still open, correctly deferred to implementation-time sandbox testing, and correctly excluded from the acceptance criteria. No action needed before implementation starts.
+- None of this gate's own research surfaces a new open question — the plan's file-level scope, defaulted-constructor-parameter design, and additive-payload-field approach are all confirmed safe against the live tree.
+
+---
+
+**Post-gate correction (found during implementation)**: this gate did not check for a handler spec under a `__tests__/` subdirectory convention — `apps/worker/src/sync/handlers/__tests__/invoicing-issue.handler.spec.ts` already existed (191 lines) even though a sibling-flat check (`apps/worker/src/sync/handlers/invoicing-issue.handler.spec.ts`, no `__tests__/`) correctly reported nothing there. The plan's Phase 3 step 8 originally said to *create* the spec; it was corrected to *extend* the existing one instead, avoiding a duplicate test file. No other artifact in this analysis was affected by this gap — every other reuse/backward-compat finding above still holds.
+
+**Summary**: The plan is READY. Every artifact it proposes extending (the `BuyerProfile` constructor, the mapper, the async job payload + its flatten/reconstruction sites, and the Infakt adapter's `clients.json` payload) exists exactly where the plan says, and no new port/service/token/ORM entity is being reinvented. A repo-wide search for every `new BuyerProfile(...)` call site turned up 16 locations rather than the ~5 the plan names explicitly, including two other adapters (Subiekt, KSeF) that already construct this entity in their own tests — but because the plan adds `email` as a 5th, defaulted constructor parameter, all untouched call sites keep compiling with no required changes, and Subiekt/KSeF gain the field for free without any action. No Critical or Warning contract-surface breaks were found; the plan's own additive-payload-field and no-migration-needed claims both check out against the live schema files. Implementation may proceed as written.

--- a/docs/plans/implementation-plan-1797-invoicing-buyer-email.md
+++ b/docs/plans/implementation-plan-1797-invoicing-buyer-email.md
@@ -1,0 +1,312 @@
+# Implementation Plan: Carry Buyer E-mail Into the Invoicing Domain (Fix Infakt "Send by Email" 422)
+
+**Date**: 2026-07-23
+**Status**: Draft
+**Estimated Effort**: 4–6 hours
+**Issue**: [#1797](https://github.com/openlinker-project/openlinker/issues/1797)
+
+---
+
+## 1. Task Summary
+
+**Objective**: Thread the buyer's e-mail address — already present on `Order.customerEmail` — through the invoicing domain (`BuyerProfile`) and into `InfaktInvoicingAdapter.upsertCustomer()`'s `clients.json` payload, so Infakt clients are created *with* an e-mail and `POST /invoices/:invoiceId/send-email` stops 422ing.
+
+**Context**: Every invoice issued through Infakt today creates a client with no e-mail on file, because `BuyerProfile` (the shared neutral buyer shape used by every invoicing provider adapter, per ADR-026) has no `email` field at all. Confirmed empirically (see issue #1797): a throwaway repro test showed the real `clients.json` POST body omits `email` entirely. Infakt then rejects `deliver_via_email.json` with `422 — "adres e-mail Klienta jest nieznany"` (client's e-mail unknown), so the "Send by email" button is broken for 100% of Infakt invoices.
+
+**Classification**: CORE (domain entity + application mapper + sync job payload contract) + Integration (Infakt adapter).
+
+---
+
+## 2. Scope & Non-Goals
+
+### In Scope
+- Add an optional `email: string | null` field to `BuyerProfile` (domain entity).
+- Populate it from `Order.customerEmail` in the order→invoice command mapper (covers all **synchronous** issuance paths: manual issue, bulk-issue, retry, correction's original-invoice reissue — all call the mapper directly).
+- Carry it through the **asynchronous auto-issue path**: `AutoIssueTriggerService` flattens `IssueInvoiceCommand.buyer` into a plain, jsonb-serializable sync-job payload (`InvoicingIssueBuyerV1`), and `InvoicingIssueHandler` (worker) reconstructs `BuyerProfile` from that plain shape before calling `issueInvoice`. Both the flatten and the reconstruction need the new field or it silently drops on this path only.
+- Send `email` in `InfaktInvoicingAdapter.upsertCustomer()`'s `clients.json` payload on client **creation**.
+- Add/extend unit tests for every touched file.
+- Extend `libs/integrations/infakt/scripts/poc-sandbox-test.ts` to exercise `sendByEmail` against the real sandbox (currently uncovered by the POC script — the only real-API check available for this feature).
+
+### Out of Scope
+- Updating the existing-client-found-by-NIP branch (`upsertCustomer` lines 352-358) to `PUT`-backfill an e-mail onto a pre-existing e-mail-less Infakt client. This is a separate, smaller follow-up — verify against the sandbox first; not required to fix the reported bug (new clients created going forward will have the e-mail).
+- `IssuedSnapshotBuyer` / `buildSnapshotFromRecord` (`apps/api/src/invoicing/http/invoicing.controller.ts:1160-1176`) and `IssuedDocumentBuyer` — these rebuild a `BuyerProfile` only for `IssueCorrectionCommand.originalDocument`, which never calls `upsertCustomer` or `sendByEmail`. Traced and confirmed not on the affected path; left untouched.
+- `Subiekt`'s `upsertCustomer()` (`libs/integrations/subiekt/...`) — also takes a `BuyerProfile` and could benefit from `email` later, but Subiekt has no reported bug and is not part of this issue. The new field is available to it for free; wiring it in is a follow-up if Subiekt ever needs e-mail delivery.
+- Any UI change — the "Send by email" button and its request already exist and are correct; only the payload the *client-creation* call sends is wrong.
+- A database migration — no schema change; `email` lives only in-memory (mapper output) and in a jsonb sync-job payload column that already stores arbitrary buyer fields.
+
+### Constraints
+- `BuyerProfile` is a plain domain entity per [ADR-011](../architecture/adrs/011-domain-entity-behavior.md) — anemic, readonly constructor fields only, no added behavior.
+- Must not break any of the 5 existing `new BuyerProfile(...)` call sites (mapper, worker handler, controller correction-snapshot rebuild, POC script, and the two test spec helper functions) — the new field must be **optional / defaulted** so untouched call sites keep compiling.
+- `InvoicingIssuePayloadV1` is a versioned, schema-pinned contract (`schemaVersion: 1`) already amended once additively (`saleDate`, per its own doc comment: "Optional additive field - no schemaVersion bump"). The new `email` field on `InvocingIssueBuyerV1` follows the same precedent — no version bump.
+- No PII policy change — `Order.customerEmail` is already an existing, sanctioned field (#948); this only threads it one layer further into an already-PII-carrying payload (the same job payload's doc comment already flags `buyer`/`lines` as containing real PII that must never be logged).
+
+---
+
+## 3. Architecture Mapping
+
+**Target Layer**: Domain (`libs/core/src/invoicing/domain/entities/`), Application (`libs/core/src/invoicing/application/mappers/`, `libs/core/src/invoicing/application/services/`), Shared sync-contract types (`libs/core/src/sync/domain/types/`), Infrastructure/Adapter (`libs/integrations/infakt/src/infrastructure/adapters/`).
+
+**Capabilities Involved**:
+- `InvoicingPort.upsertCustomer` (base port method, unchanged signature — only the Infakt adapter's payload construction changes).
+- `InvoiceEmailSender.sendByEmail` (unchanged — this issue fixes the *upstream* cause of its 422, not the method itself).
+
+**Existing Services Reused**:
+- `order-to-issue-invoice-command.mapper.ts::toIssueInvoiceCommand` / `buildBuyerProfile` — extended, not replaced.
+- `AutoIssueTriggerService` — extended (one more field in the flatten).
+- `InvoicingIssueHandler` (worker) — extended (one more field in the reconstruction).
+- `InfaktInvoicingAdapter.upsertCustomer` — extended (one more key in the `clients.json` payload).
+
+**New Components Required**: None. This is a field-level extension to four existing files plus their tests — no new entities, ports, services, or adapters.
+
+**Core vs Integration Justification**: The `email` field belongs on `BuyerProfile` in **CORE**, not as an Infakt-only workaround, because `BuyerProfile` is the shared neutral buyer shape every invoicing provider adapter receives (ADR-026, country-agnostic design) — any other provider adapter implementing e-mail delivery would need the identical seam. Only the *payload-building* change (what JSON key to send, when) is Infakt-specific and belongs in the Infakt adapter. This mirrors the existing precedent of `taxId: TaxIdentifier | null` — a neutral, optional field on `BuyerProfile` that individual adapters choose whether/how to use.
+
+**Reference**: [Architecture Overview - Hexagonal Architecture Structure](../architecture-overview.md#hexagonal-architecture-structure), [Architecture Overview §14 Invoicing](../architecture-overview.md#14-invoicing).
+
+---
+
+## 4. External / Domain Research
+
+### External System (Infakt)
+- **Endpoint affected**: `POST clients.json` (client creation) — confirmed via `InfaktClient` response type (`libs/integrations/infakt/src/domain/types/infakt.types.ts:102-112`) that Infakt's client resource already models `email: string | null`; the provider API supports it, OL just never sends it.
+- **Endpoint whose failure this fixes**: `POST invoices/{uuid}/deliver_via_email.json` — requires a stored client e-mail, no recipient-override parameter (adapter doc comment, `infakt-invoicing.adapter.ts:792-802`).
+- **No rate-limit or retry changes** — this is a payload-completeness fix, not a transport concern.
+- **Verification channel**: `libs/integrations/infakt/scripts/poc-sandbox-test.ts` run against `https://api.sandbox-infakt.pl/api/v3` with `INFAKT_SANDBOX_API_KEY`. Currently exercises upsertCustomer → issueInvoice → getInvoice → getClearanceStatus → sendToKsef, but not `sendByEmail` — this plan extends it.
+
+### Internal Patterns
+- **Similar precedent**: `BuyerProfile.taxId: TaxIdentifier | null` — an optional, scheme-tagged, nullable field already on the entity, with the exact same "caller doesn't have to supply it" shape the plan proposes for `email`. `email` follows the identical pattern.
+- **Reusable components**: No new abstractions — `order.customerEmail` (already exists, #948), the mapper, the worker handler, and the adapter's existing payload-building code are all reused verbatim, just extended by one field each.
+- **Existing additive-payload precedent**: `saleDate` on `InvoicingIssuePayloadV1` — added without a `schemaVersion` bump, with an inline comment explaining why. The `email` addition to `InvocingIssueBuyerV1` follows this exact precedent.
+
+---
+
+## 5. Questions & Assumptions
+
+### Open Questions
+- Should the Infakt "found existing client by NIP" branch (`upsertCustomer`, lines 352-358) `PUT`-backfill an e-mail onto a client that already exists in Infakt without one? Left open — resolve empirically against the sandbox during implementation; **not** required by the acceptance criteria below (out of scope, see §2).
+
+### Assumptions
+- `email` is **optional and nullable** on `BuyerProfile` — an order with no captured buyer e-mail (source platform didn't expose one) must continue to issue invoices successfully; only `sendByEmail` for that invoice keeps 422ing with the same clear provider-supplied reason, which is correct, expected behavior, not a regression to fix.
+- The `email` field is added as the **5th, defaulted constructor parameter** (`email: string | null = null`) on `BuyerProfile`, not inserted earlier in the parameter list — this keeps every existing 4-argument call site (worker handler, POC script, both spec files, controller correction-snapshot rebuild) compiling unchanged, and only the mapper and the async-path flatten/reconstruction need to actually pass a 5th argument.
+- No PII/GDPR policy change needed — `Order.customerEmail` is an existing, already-sanctioned field (#948); this only threads an existing value one layer further into an already-PII-carrying payload.
+- No ADR is required for this change (see [ADR README §When to write an ADR](../architecture/adrs/README.md)) — it's a routine additive field on an existing entity following an established pattern (`taxId`), with no rejected alternative design, no cross-package contract break, and no multi-context coordination beyond the four files touched. Assessed and explicitly declined.
+
+### Documentation Gaps
+- None found — ADR-026 (country-agnostic invoicing) and the existing `BuyerProfile`/`taxId` precedent give clear guidance for how to add this field.
+
+---
+
+## 6. Proposed Implementation Plan
+
+### Phase 1: Domain — `BuyerProfile.email`
+
+**Goal**: Give the neutral buyer shape a seam for an e-mail address.
+
+**Steps**:
+1. **Add `email` field to `BuyerProfile`**
+   - **File**: `libs/core/src/invoicing/domain/entities/buyer-profile.entity.ts`
+   - **Action**: Add a 5th constructor parameter `public readonly email: string | null = null` after `type`. Update the file's header comment if it documents the constructor shape.
+   - **Acceptance**: `new BuyerProfile('Jan', null, address, 'private')` still compiles (email defaults to `null`); `new BuyerProfile('Jan', null, address, 'private', 'jan@example.com')` sets `email`.
+   - **Dependencies**: None.
+
+2. **Extend `BuyerProfile` unit tests**
+   - **File**: `libs/core/src/invoicing/domain/entities/buyer-profile.entity.spec.ts`
+   - **Action**: Add a test asserting `email` defaults to `null` when omitted, and a test asserting the 5th argument is assigned verbatim when passed.
+   - **Acceptance**: `pnpm --filter @openlinker/core test buyer-profile.entity.spec.ts` passes.
+   - **Dependencies**: Step 1.
+
+### Phase 2: Application — synchronous issuance path (mapper)
+
+**Goal**: Every synchronous `toIssueInvoiceCommand` call (manual issue, bulk-issue, retry, correction reissue) picks up the order's buyer e-mail automatically.
+
+**Steps**:
+3. **Pass `order.customerEmail` into `BuyerProfile` in the mapper**
+   - **File**: `libs/core/src/invoicing/application/mappers/order-to-issue-invoice-command.mapper.ts`
+   - **Action**: In `buildBuyerProfile` (currently lines 139-151), change the return to `new BuyerProfile(name, buyerTaxId, address, type, order.customerEmail ?? null)`.
+   - **Acceptance**: An `Order` with `customerEmail: 'buyer@example.com'` produces a `BuyerProfile` whose `.email === 'buyer@example.com'`; an `Order` with no `customerEmail` produces `.email === null` (no throw — `InvalidBuyerProfileError` still fires only for the existing missing-address/name cases).
+   - **Dependencies**: Phase 1.
+
+4. **Extend the mapper's unit tests**
+   - **File**: `libs/core/src/invoicing/application/mappers/order-to-issue-invoice-command.mapper.spec.ts`
+   - **Action**: Add a test asserting `order.customerEmail` flows into `command.buyer.email`; add a test asserting an order with no `customerEmail` yields `command.buyer.email === null` without throwing.
+   - **Acceptance**: `pnpm --filter @openlinker/core test order-to-issue-invoice-command.mapper.spec.ts` passes.
+   - **Dependencies**: Step 3.
+
+### Phase 3: Application/Sync — asynchronous auto-issue path
+
+**Goal**: The queued/async auto-issue path (`AutoIssueTriggerService` → sync job → `InvoicingIssueHandler`) doesn't silently drop the e-mail during the jsonb round-trip.
+
+**Steps**:
+5. **Add `email` to the plain, serializable buyer shape**
+   - **File**: `libs/core/src/sync/domain/types/invoicing-job-payloads.types.ts`
+   - **Action**: Add `email: string | null;` to `InvoicingIssueBuyerV1`. Follow the file's own additive-field precedent (see the `saleDate` comment) — no `schemaVersion` bump; add a one-line comment noting it's additive and a v1 consumer written before this field existed already tolerates an extra jsonb key.
+   - **Acceptance**: Type-checks; no existing payload-shape test breaks.
+   - **Dependencies**: Phase 1 (uses `BuyerProfile.email`'s type).
+
+6. **Flatten `email` into the job payload**
+   - **File**: `libs/core/src/invoicing/application/services/auto-issue-trigger.service.ts`
+   - **Action**: In the payload-composing block (currently lines 266-271), add `email: command.buyer.email` to the flattened `buyer` object.
+   - **Acceptance**: The composed `InvoicingIssuePayloadV1.buyer.email` matches `command.buyer.email` for an order with a captured customer e-mail.
+   - **Dependencies**: Step 5, Phase 2 (step 3 — `command.buyer` already carries `email` by the time this runs, since `AutoIssueTriggerService` also calls `toIssueInvoiceCommand`).
+
+7. **Reconstruct `email` in the worker handler**
+   - **File**: `apps/worker/src/sync/handlers/invoicing-issue.handler.ts`
+   - **Action**: In `toCommand` (currently lines 169-176), pass `payload.buyer.email` as the 5th argument to `new BuyerProfile(...)`. Also check the deep-validation block (the `fail('buyer.taxId.value')`-style guards, around lines ~150-160) — add a lenient check that `payload.buyer.email` is `string | null` if present, matching the existing per-field validation style, WITHOUT requiring it (backward-compatible with any already-queued v1 jobs from before this field existed, which won't have the key at all — `payload.buyer.email` will be `undefined` there; normalize `undefined` to `null` when reconstructing).
+   - **Acceptance**: A validated `InvocingIssuePayloadV1` with `buyer.email` set reconstructs a `BuyerProfile` whose `.email` matches; a payload from before this field existed (no `email` key) reconstructs `.email === null` without failing validation.
+   - **Dependencies**: Step 5.
+
+8. **Extend worker-handler and auto-issue-trigger unit tests**
+   - **Files**:
+     - `apps/worker/src/sync/handlers/__tests__/invoicing-issue.handler.spec.ts` — **exists** (correction: an earlier pass of this plan mis-checked the sibling-flat convention and missed this handler's own `__tests__/` subdirectory; verified present with 191 lines of existing coverage). Extend it, following its own `makePayload(overrides)` helper pattern.
+     - `libs/core/src/invoicing/application/services/auto-issue-trigger.service.spec.ts` — **exists** (verified); extend it.
+   - **Action**: Assert the round-trip: a command with `buyer.email` set survives flatten → (simulated jsonb round-trip, e.g. `JSON.parse(JSON.stringify(payload))`) → reconstruct, ending with the same `email` value. Assert a pre-existing-field-shape payload (no `email` key) reconstructs to `email: null`.
+   - **Acceptance**: Both spec files pass.
+   - **Dependencies**: Steps 6, 7.
+
+### Phase 4: Infrastructure — Infakt adapter payload
+
+**Goal**: `upsertCustomer()` actually sends the e-mail to Infakt on client creation.
+
+**Steps**:
+9. **Include `email` in the `clients.json` create payload**
+   - **File**: `libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts`
+   - **Action**: In `upsertCustomer` (currently lines 364-373), add `email: buyer.email ?? undefined` to the `payload.client` object (matching the existing `nip: nip ?? undefined` pattern already in the same object literal — `undefined` keys are dropped by `JSON.stringify`, so a `null` `email` produces the same "field omitted" wire shape Infakt already tolerates today).
+   - **Acceptance**: Confirmed via unit test (below) that the `client` object includes `email: 'buyer@example.com'` when the buyer has one, and omits the key when the buyer's `email` is `null`.
+   - **Dependencies**: Phase 1.
+
+10. **Extend `infakt-invoicing.adapter.spec.ts`'s `upsertCustomer` tests**
+    - **File**: `libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-invoicing.adapter.spec.ts`
+    - **Action**: Add a case to the existing `describe('upsertCustomer', ...)` block: build a `buyer` with an `email` set (extend the local `buyer()` test helper to accept an `email` override, defaulting to `null` to keep existing calls unchanged) and assert the `POST clients.json` body's `client.email` equals it. Add a second case with `email: null` and assert the `client` object has no `email` key (`expect(Object.keys(createCall.body.client)).not.toContain('email')` — this is the exact repro assertion used to confirm the bug in issue #1797, now flipped to prove the fix).
+    - **Acceptance**: `pnpm --filter @openlinker/integrations-infakt test infakt-invoicing.adapter.spec.ts` passes.
+    - **Dependencies**: Step 9.
+
+### Phase 5: Real-provider verification (sandbox)
+
+**Goal**: Prove the fix end-to-end against the actual Infakt API, not just mocks — this path has zero real-API coverage today.
+
+**Steps**:
+11. **Extend the sandbox POC script to exercise `sendByEmail`**
+    - **File**: `libs/integrations/infakt/scripts/poc-sandbox-test.ts`
+    - **Action**: Add an `email` to the script's `testBuyer` (currently lines 66-71, no 5th arg). After the existing `issueInvoice` step, add a call to `adapter.sendByEmail({ externalInvoiceId: <issued uuid>, locale: undefined, sendCopy: undefined })` and log the result. Use a real, disposable test-inbox address the operator controls (never a fabricated third-party address) — document this requirement in a comment next to the new call.
+    - **Acceptance**: Manual run instructions documented in the script's header comment (or immediately above the new call) so a future maintainer can re-run it.
+    - **Dependencies**: Phase 4.
+12. **Manual verification run** (not automatable in CI — requires `INFAKT_SANDBOX_API_KEY`)
+    - **Action**: Run `INFAKT_SANDBOX_API_KEY=<key> pnpm --filter @openlinker/integrations-infakt poc:sandbox` locally. Confirm: (a) the created sandbox client has the e-mail set (inspect the Infakt sandbox dashboard or the script's logged response), (b) `sendByEmail` returns `{ delivered: true, recipient: null }` instead of throwing a 422.
+    - **Acceptance**: Documented as done in the PR description with the observed script output (redacted of any real secret/API key).
+    - **Dependencies**: Step 11.
+
+---
+
+## Implementation Details
+
+**New Components**: None — every change is an additive field or payload-key extension to existing files.
+
+**Configuration Changes**: None.
+
+**Database Migrations**: None — no ORM entity changes; `email` lives in-memory (mapper/adapter) and inside the existing jsonb `invoicing.issue` sync-job payload column, which already stores arbitrary buyer fields with no per-field schema.
+
+**Events**: None emitted or consumed by this change.
+
+**Error Handling**: No new exception types. `InvalidBuyerProfileError` (thrown by the mapper for missing name/address) is unaffected — an order missing only `customerEmail` must not throw; it should simply carry `email: null`.
+
+**Reference**: [Engineering Standards - Project Structure](../engineering-standards.md#project-structure), [Engineering Standards - Type Definitions in Separate Files](../engineering-standards.md#type-definitions-in-separate-files) (the new field lives directly on `BuyerProfile`/`InvoicingIssueBuyerV1`, matching how `taxId` already does — no separate `*.types.ts` extraction needed for a single primitive field on an existing type).
+
+---
+
+## 7. Alternatives Considered
+
+### Alternative 1: Fix only inside `InfaktInvoicingAdapter`, deriving e-mail from somewhere adapter-local
+- **Description**: Have the Infakt adapter itself look up the buyer's e-mail some other way (e.g. from `IdentifierMappingService` context, or a side-channel lookup) instead of extending `BuyerProfile`.
+- **Why Rejected**: There is no other channel — the e-mail only exists on `Order.customerEmail`, which the adapter never sees (it only receives `IssueInvoiceCommand`/`BuyerProfile`). Inventing an adapter-side lookup would duplicate or bypass the mapper's already-correct order→command composition, and would leave every *other* invoicing provider (Subiekt, future ones) without the same fix.
+- **Trade-offs**: Marginally larger diff (4 files instead of 1) but the correct architectural placement per ADR-026's shared-neutral-model design; the extra files are one-line-per-file additions.
+
+### Alternative 2: Bump `InvoicingIssuePayloadV1` to `schemaVersion: 2`
+- **Description**: Treat the new `buyer.email` field as a breaking schema change requiring a version bump and handler branching for v1 vs v2 payloads.
+- **Why Rejected**: The file's own doc comment already establishes the additive-field precedent (`saleDate`) — a v1 consumer that doesn't know about `email` still works correctly by treating it as absent/`null`. A version bump is reserved for genuinely breaking changes (field removal/retyping), not an optional new key.
+- **Trade-offs**: None meaningful — the additive path is strictly simpler and follows established convention.
+
+---
+
+## 8. Validation & Risks
+
+### Architecture Compliance
+- ✅ `BuyerProfile` stays anemic (readonly constructor field only, no new behavior) — complies with [ADR-011](../architecture/adrs/011-domain-entity-behavior.md).
+- ✅ No CORE ↔ Integration boundary violation — `email` is a neutral field on a CORE entity; the Infakt adapter only reads it and shapes its own wire payload.
+- **Reference**: [Architecture Overview](../architecture-overview.md).
+
+### Naming Conventions
+- ✅ `email: string | null` matches the existing `taxId: TaxIdentifier | null` nullable-optional convention on the same entity.
+- **Reference**: [Engineering Standards - Naming Conventions](../engineering-standards.md#naming-conventions).
+
+### Existing Patterns
+- ✅ Additive-field-on-versioned-payload pattern already established by `saleDate` on `InvoicingIssuePayloadV1` — followed verbatim for `email` on `InvocingIssueBuyerV1`.
+- ✅ `undefined`-drops-the-JSON-key pattern already used for `nip: nip ?? undefined` in the same Infakt payload object — followed verbatim for `email ?? undefined`.
+
+### Risks
+- **Silent field-drop on the async path if Phase 3 is skipped**: if only Phases 1/2/4 ship, the *synchronous* issuance paths (manual issue, bulk-issue, retry, correction reissue) get the fix, but the *auto-issue* (async, queued) path would keep silently dropping `email` at the jsonb flatten step, reproducing the exact same bug for a subset of invoices with no obvious symptom difference. Mitigation: Phase 3 is not optional — it's the primary way most production invoices are likely issued (via `AutoIssueTriggerService`, not manual `POST /invoices`).
+- **Already-queued jobs from before this change**: any `invoicing.issue` sync job already sitting in the queue (persisted with the old `InvocingIssueBuyerV1` shape, no `email` key) must not fail worker-side deep validation when picked up post-deploy. Mitigation: step 7 explicitly handles `payload.buyer.email === undefined` by normalizing to `null`, not by requiring the key.
+
+### Edge Cases
+- **Order with no captured `customerEmail`** (source platform didn't expose one): invoice issuance must still succeed; `email` on `BuyerProfile` is `null`; `sendByEmail` for that invoice keeps failing with Infakt's own clear 422 reason — expected, not a regression.
+- **Buyer e-mail changes between order placement and a later retry/correction**: out of scope — `Order.customerEmail` is read at command-composition time exactly as every other buyer field already is; no new staleness risk beyond what already exists for name/address.
+
+### Backward Compatibility
+- ✅ No breaking changes. `BuyerProfile`'s new constructor parameter is defaulted; every existing call site (worker handler pre-fix, POC script, both spec helpers, controller correction-snapshot rebuild) keeps compiling without modification (except where this plan explicitly extends them). `InvocingIssueBuyerV1`'s new field is additive per the file's own established convention.
+
+---
+
+## 9. Testing Strategy & Acceptance Criteria
+
+### Unit Tests
+- `buyer-profile.entity.spec.ts` — `email` defaults to `null`; `email` is assigned when passed. **File**: `libs/core/src/invoicing/domain/entities/buyer-profile.entity.spec.ts`.
+- `order-to-issue-invoice-command.mapper.spec.ts` — `order.customerEmail` flows into `command.buyer.email`; missing `customerEmail` yields `null` without throwing. **File**: `libs/core/src/invoicing/application/mappers/order-to-issue-invoice-command.mapper.spec.ts`.
+- `auto-issue-trigger.service.spec.ts` (exists — extend) — flattened payload's `buyer.email` matches the command's. **File**: `libs/core/src/invoicing/application/services/auto-issue-trigger.service.spec.ts`.
+- `invoicing-issue.handler.spec.ts` (exists — extend) — reconstructed `BuyerProfile.email` matches the payload's; a payload missing the `email` key (pre-fix shape) reconstructs to `null`. **File**: `apps/worker/src/sync/handlers/__tests__/invoicing-issue.handler.spec.ts`.
+- `infakt-invoicing.adapter.spec.ts` — `clients.json` POST body includes `email` when set, omits the key when `null` (the flipped repro assertion from issue #1797). **File**: `libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-invoicing.adapter.spec.ts`.
+
+### Integration Tests
+- None required — this is pure application/domain logic plus one adapter payload shape; no new HTTP endpoint, DB schema, or cross-service orchestration is introduced. The existing `POST /invoices/:invoiceId/send-email` controller endpoint and its behavior are unchanged.
+
+### Mocking Strategy
+- Adapter test continues to use `FakeInfaktHttpClient` (existing pattern) — no real HTTP calls in unit tests.
+- Real-provider verification happens exclusively via the Phase 5 sandbox script, run manually (not part of `pnpm test` or CI).
+
+### Acceptance Criteria
+- [ ] `BuyerProfile` has an `email: string | null` field (defaulted to `null`), populated from `order.customerEmail` via the mapper.
+- [ ] The async auto-issue path (`AutoIssueTriggerService` → job payload → `InvoicingIssueHandler`) preserves `email` through the jsonb round-trip.
+- [ ] `InfaktInvoicingAdapter.upsertCustomer()` includes `email` in the `clients.json` payload when the buyer has one, and omits the key when the buyer has none.
+- [ ] Manual verification against the real Infakt sandbox (extended `poc-sandbox-test.ts`, `INFAKT_SANDBOX_API_KEY`): a newly-created Infakt client has the e-mail set, and `sendByEmail` returns `{ delivered: true }` instead of a 422.
+- [ ] Regression check: an order with no `customerEmail` still issues an invoice successfully (no new exception); `sendByEmail` for that invoice fails with the same clear Infakt-provided reason, not a crash.
+- [ ] All new/extended unit tests listed above pass (`pnpm test`).
+- [ ] `pnpm lint` and `pnpm type-check` pass with zero errors.
+- [ ] No CORE ↔ Integration boundary violations introduced.
+
+**Reference**: [Testing Guide](../testing-guide.md).
+
+---
+
+## 10. Alignment Checklist
+
+- [x] Follows hexagonal architecture
+- [x] Respects CORE vs Integration boundaries
+- [x] Uses existing patterns (no unnecessary abstractions) — mirrors `taxId` on `BuyerProfile` and `saleDate` on `InvoicingIssuePayloadV1`
+- [x] Idempotency considered — no change to idempotency keys or dedup logic; e-mail is a passive payload field
+- [ ] Event-driven patterns used where applicable — N/A, no events involved
+- [ ] Rate limits & retries addressed — N/A, no new external calls or retry logic
+- [x] Error handling comprehensive — missing `customerEmail` is a valid, non-throwing state
+- [x] Testing strategy complete
+- [x] Naming conventions followed
+- [x] File structure matches standards — no new files, only extensions to existing ones
+- [x] Plan is execution-ready
+- [x] Plan is saved as markdown file
+
+---
+
+## Related Documentation
+
+- [Architecture Overview](../architecture-overview.md)
+- [Architecture Overview §14 Invoicing](../architecture-overview.md#14-invoicing)
+- [ADR-026: Country-agnostic invoicing domain](../architecture/adrs/026-country-agnostic-invoicing-domain.md)
+- [ADR-011: Domain entity behavior](../architecture/adrs/011-domain-entity-behavior.md)
+- [Engineering Standards](../engineering-standards.md)
+- [Testing Guide](../testing-guide.md)
+- [Issue #1797](https://github.com/openlinker-project/openlinker/issues/1797)

--- a/libs/core/src/invoicing/application/mappers/order-to-issue-invoice-command.mapper.spec.ts
+++ b/libs/core/src/invoicing/application/mappers/order-to-issue-invoice-command.mapper.spec.ts
@@ -73,6 +73,21 @@ describe('toIssueInvoiceCommand', () => {
     expect(cmd.buyer.name).toBe('Jan Kowalski');
   });
 
+  it('carries order.customerEmail into buyer.email (#1797)', () => {
+    const cmd = toIssueInvoiceCommand({
+      order: makeOrder({ customerEmail: 'buyer@example.com' }),
+      connectionId: 'conn-1',
+    });
+
+    expect(cmd.buyer.email).toBe('buyer@example.com');
+  });
+
+  it('buyer.email is null when the order has no customerEmail (#1797)', () => {
+    const cmd = toIssueInvoiceCommand({ order: makeOrder(), connectionId: 'conn-1' });
+
+    expect(cmd.buyer.email).toBeNull();
+  });
+
   it('multi-line: items -> lines, currency from totals.currency, name fallback to sku then productId', () => {
     const order = makeOrder({
       totals: { subtotal: 0, tax: 0, shipping: 0, total: 0, currency: 'EUR', taxTreatment: 'inclusive' },

--- a/libs/core/src/invoicing/application/mappers/order-to-issue-invoice-command.mapper.ts
+++ b/libs/core/src/invoicing/application/mappers/order-to-issue-invoice-command.mapper.ts
@@ -148,7 +148,10 @@ function buildBuyerProfile(order: Order, buyerTaxId: TaxIdentifier | null): Buye
   const name = deriveBuyerName(order, source);
   const address = toBuyerAddress(source);
 
-  return new BuyerProfile(name, buyerTaxId, address, type);
+  // #1797: thread the order's buyer e-mail (already captured from the
+  // source platform, #948) into the invoicing domain so providers that
+  // support InvoiceEmailSender can actually deliver to a known address.
+  return new BuyerProfile(name, buyerTaxId, address, type, order.customerEmail ?? null);
 }
 
 /**

--- a/libs/core/src/invoicing/application/services/auto-issue-trigger.service.spec.ts
+++ b/libs/core/src/invoicing/application/services/auto-issue-trigger.service.spec.ts
@@ -220,6 +220,25 @@ describe('AutoIssueTriggerService', () => {
       expect((buyer as { isCompany?: unknown }).isCompany).toBeUndefined();
     });
 
+    it('payload buyer carries order.customerEmail (#1797)', async () => {
+      connectionPort.list.mockResolvedValue([makeConnection('auto-on-paid')]);
+      await service.onOrderTransition(
+        makeOrder({ paymentStatus: 'paid', customerEmail: 'buyer@example.com' }),
+        'src-1',
+      );
+      const buyer = (syncJobs.schedule.mock.calls[0][0].payload as { buyer: { email?: string | null } })
+        .buyer;
+      expect(buyer.email).toBe('buyer@example.com');
+    });
+
+    it('payload buyer.email is null when the order has no customerEmail (#1797)', async () => {
+      connectionPort.list.mockResolvedValue([makeConnection('auto-on-paid')]);
+      await service.onOrderTransition(makeOrder({ paymentStatus: 'paid' }), 'src-1');
+      const buyer = (syncJobs.schedule.mock.calls[0][0].payload as { buyer: { email?: string | null } })
+        .buyer;
+      expect(buyer.email).toBeNull();
+    });
+
     it('no buyerTaxId ⇒ buyer type "private" (B2C-only MVP)', async () => {
       connectionPort.list.mockResolvedValue([makeConnection('auto-on-paid')]);
       await service.onOrderTransition(makeOrder({ paymentStatus: 'paid' }), 'src-1');

--- a/libs/core/src/invoicing/application/services/auto-issue-trigger.service.ts
+++ b/libs/core/src/invoicing/application/services/auto-issue-trigger.service.ts
@@ -268,6 +268,7 @@ export class AutoIssueTriggerService implements IAutoIssueTriggerService {
         taxId: command.buyer.taxId,
         address: command.buyer.address,
         type: command.buyer.type,
+        email: command.buyer.email,
       },
       sourceConnectionId,
       trigger: triggerModel,

--- a/libs/core/src/invoicing/domain/entities/buyer-profile.entity.spec.ts
+++ b/libs/core/src/invoicing/domain/entities/buyer-profile.entity.spec.ts
@@ -31,4 +31,16 @@ describe('BuyerProfile', () => {
     const buyer = new BuyerProfile('Acme', { scheme: 'eu-vat', value: 'PL1234567890' }, address, 'company');
     expect(buyer.taxId).toEqual({ scheme: 'eu-vat', value: 'PL1234567890' });
   });
+
+  describe('email', () => {
+    it('defaults to null when omitted (#1797)', () => {
+      const buyer = new BuyerProfile('Jan Kowalski', null, address, 'private');
+      expect(buyer.email).toBeNull();
+    });
+
+    it('is assigned verbatim when provided (#1797)', () => {
+      const buyer = new BuyerProfile('Jan Kowalski', null, address, 'private', 'jan@example.com');
+      expect(buyer.email).toBe('jan@example.com');
+    });
+  });
 });

--- a/libs/core/src/invoicing/domain/entities/buyer-profile.entity.ts
+++ b/libs/core/src/invoicing/domain/entities/buyer-profile.entity.ts
@@ -18,6 +18,13 @@ export class BuyerProfile {
     public readonly taxId: TaxIdentifier | null,
     public readonly address: BuyerAddress,
     public readonly type: BuyerType,
+    /**
+     * Buyer e-mail, when known (#1797). `null` when the order's source didn't
+     * expose one — issuance must still succeed; only e-mail delivery
+     * (`InvoiceEmailSender.sendByEmail`) needs it. Defaulted so every
+     * pre-existing 4-argument call site keeps compiling unchanged.
+     */
+    public readonly email: string | null = null,
   ) {}
 
   /** Pure derivation: a business buyer (B2B). No I/O, no mutation. */

--- a/libs/core/src/invoicing/domain/types/invoicing.types.ts
+++ b/libs/core/src/invoicing/domain/types/invoicing.types.ts
@@ -301,6 +301,16 @@ export interface IssuedSnapshotBuyer {
   taxId: TaxIdentifier | null;
   address: BuyerAddress;
   type: BuyerType;
+  /**
+   * Buyer e-mail, or `null` when unknown (#1797). `InvoiceService` persists
+   * `IssuedLineSnapshot.buyer` verbatim from the issue command's `BuyerProfile`
+   * (no field-by-field recomputation), so this field round-trips through jsonb
+   * for free once `BuyerProfile` carries it — declared here so the type stays
+   * honest about what's actually persisted. Not read back into a real send
+   * flow: the correction path that rebuilds a `BuyerProfile` from this shape
+   * never calls `sendByEmail`.
+   */
+  email: string | null;
 }
 
 /**

--- a/libs/core/src/orders/domain/order-from-ready-snapshot.spec.ts
+++ b/libs/core/src/orders/domain/order-from-ready-snapshot.spec.ts
@@ -120,6 +120,18 @@ describe('orderFromReadySnapshot', () => {
     expect(order.placedAt?.toISOString()).toBe('2026-06-19T14:30:00.000Z');
   });
 
+  it('rehydrates customerEmail from the snapshot when present (#1797)', () => {
+    const order = orderFromReadySnapshot(
+      makeRecord({ ...READY_SNAPSHOT, customerEmail: 'buyer@example.com' }),
+    );
+    expect(order.customerEmail).toBe('buyer@example.com');
+  });
+
+  it('leaves customerEmail undefined when the snapshot has none (#1797)', () => {
+    const order = orderFromReadySnapshot(makeRecord(READY_SNAPSHOT));
+    expect(order.customerEmail).toBeUndefined();
+  });
+
   it('falls back to shipping address when billing is absent', () => {
     const { billingAddress: _omit, ...rest } = READY_SNAPSHOT;
     void _omit;

--- a/libs/core/src/orders/domain/order-from-ready-snapshot.ts
+++ b/libs/core/src/orders/domain/order-from-ready-snapshot.ts
@@ -72,6 +72,14 @@ export function orderFromReadySnapshot(record: OrderRecord): Order {
   if (typeof snapshot.customerId === 'string') {
     order.customerId = snapshot.customerId;
   }
+  // #1797: without this, a manually re-issued/bulk-issued/corrected invoice
+  // (every path that goes through `rehydrateOrder` → `orderFromReadySnapshot`)
+  // silently drops the buyer's e-mail even though the snapshot has it, so
+  // `BuyerProfile.email` ends up `null` and `sendByEmail` 422s regardless of
+  // the mapper fix.
+  if (typeof snapshot.customerEmail === 'string') {
+    order.customerEmail = snapshot.customerEmail;
+  }
   if (billingAddress) {
     order.billingAddress = billingAddress;
   }

--- a/libs/core/src/sync/domain/types/invoicing-job-payloads.types.ts
+++ b/libs/core/src/sync/domain/types/invoicing-job-payloads.types.ts
@@ -35,6 +35,13 @@ export interface InvoicingIssueBuyerV1 {
   taxId: TaxIdentifier | null;
   address: BuyerAddress;
   type: BuyerType;
+  /**
+   * Buyer e-mail, or `null` when unknown (#1797). Optional additive field (no
+   * `schemaVersion` bump) — a handler reading a payload persisted before this
+   * field existed sees `undefined` and must normalize it to `null`, not require
+   * the key.
+   */
+  email?: string | null;
 }
 
 /**

--- a/libs/integrations/infakt/scripts/poc-sandbox-test.ts
+++ b/libs/integrations/infakt/scripts/poc-sandbox-test.ts
@@ -4,6 +4,7 @@
  * Runs a full E2E verification against the Infakt sandbox API:
  *   1. upsertCustomer — find or create a test buyer by NIP
  *   2. issueInvoice   — create a VAT invoice
+ *   2b. sendByEmail   — trigger Infakt to e-mail the issued invoice (#1797)
  *   3. getInvoice     — read back the created invoice by UUID
  *   4. getClearanceStatus — read ksef_data (before KSeF submit)
  *   5. sendToKsef     — trigger KSeF submission
@@ -16,6 +17,12 @@
  *   INFAKT_BASE_URL   — defaults to https://api.sandbox-infakt.pl/api/v3
  *   POC_POLL_MAX_MS   — max poll time in ms (default 180000 = 3 min)
  *   POC_POLL_INTERVAL_MS — poll interval (default 10000 = 10 s)
+ *   POC_TEST_BUYER_EMAIL — a real, disposable test-inbox address YOU control
+ *     (#1797). Never a fabricated or third-party address — step 2b actually
+ *     asks Infakt to send a real e-mail to it. Defaults to a
+ *     `noreply@example.com` placeholder, which is enough to prove the
+ *     `clients.json` payload carries `email` and to unblock `deliver_via_email`
+ *     past the "client e-mail unknown" 422, but won't confirm real delivery.
  *
  * Verified live 2026-06-30: full draft→KSeF clearance in ~90 s on sandbox.
  *
@@ -37,6 +44,7 @@ const BASE_URL =
   process.env['INFAKT_BASE_URL'] ?? 'https://api.sandbox-infakt.pl/api/v3';
 const POLL_MAX_MS = parseInt(process.env['POC_POLL_MAX_MS'] ?? '180000', 10);
 const POLL_INTERVAL_MS = parseInt(process.env['POC_POLL_INTERVAL_MS'] ?? '10000', 10);
+const TEST_BUYER_EMAIL = process.env['POC_TEST_BUYER_EMAIL'] ?? 'noreply@example.com';
 
 const CONNECTION_ID = 'poc-sandbox-connection';
 
@@ -68,6 +76,7 @@ const testBuyer = new BuyerProfile(
   { scheme: 'pl-nip', value: '5252659437' },
   { line1: 'ul. Testowa 1', line2: null, city: 'Warszawa', postalCode: '00-001', countryIso2: 'PL' },
   'company',
+  TEST_BUYER_EMAIL,
 );
 
 // ---- helpers ----------------------------------------------------------------
@@ -183,6 +192,18 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
+  // Step 2b — sendByEmail (#1797: confirms the client-creation payload
+  // actually carries `email`, so Infakt's deliver_via_email no longer 422s
+  // with "adres e-mail Klienta jest nieznany").
+  console.log('\nSTEP 2b — sendByEmail');
+  try {
+    const result = await adapter.sendByEmail({ externalInvoiceId: invoiceUuid });
+    ok('invoice emailed', `delivered=${result.delivered} recipient=${result.recipient ?? 'null'}`);
+  } catch (err) {
+    fail('sendByEmail failed', err);
+    // Non-fatal — continue; a failure here is the exact regression #1797 fixes.
+  }
+
   // Step 3 — getInvoice by UUID
   console.log('\nSTEP 3 — getInvoice (read back by UUID)');
   try {
@@ -231,7 +252,7 @@ async function main(): Promise<void> {
     fail('sendToKsef failed', err);
     console.log('  → skipping KSeF poll (KSeF may not be configured on this account)');
     console.log('\n=== POC DONE (no KSeF) ===');
-    console.log('issueInvoice + getInvoice + getClearanceStatus: CONFIRMED ✅');
+    console.log('issueInvoice + sendByEmail + getInvoice + getClearanceStatus: CONFIRMED ✅');
     return;
   }
 
@@ -248,7 +269,9 @@ async function main(): Promise<void> {
   console.log('');
   console.log('=== POC COMPLETE ✅ ===');
   console.log('All steps confirmed:');
-  console.log('  upsertCustomer → issueInvoice → getInvoice → getClearanceStatus → sendToKsef → cleared');
+  console.log(
+    '  upsertCustomer → issueInvoice → sendByEmail → getInvoice → getClearanceStatus → sendToKsef → cleared',
+  );
 }
 
 main().catch((err: unknown) => {

--- a/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-invoicing.adapter.spec.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-invoicing.adapter.spec.ts
@@ -31,7 +31,7 @@ function fakeLogger(): jest.Mocked<LoggerPort> {
   return { log: jest.fn(), debug: jest.fn(), warn: jest.fn(), error: jest.fn() };
 }
 
-function buyer(overrides: Partial<{ nip: string | null }> = {}): BuyerProfile {
+function buyer(overrides: Partial<{ nip: string | null; email: string | null }> = {}): BuyerProfile {
   return new BuyerProfile(
     'Acme Sp. z o.o.',
     overrides.nip === undefined || overrides.nip === null
@@ -45,6 +45,7 @@ function buyer(overrides: Partial<{ nip: string | null }> = {}): BuyerProfile {
       countryIso2: 'PL',
     },
     overrides.nip ? 'company' : 'private',
+    overrides.email ?? null,
   );
 }
 
@@ -190,6 +191,67 @@ describe('InfaktInvoicingAdapter', () => {
       expect(createCall?.body).toMatchObject({
         client: expect.objectContaining({ company_name: 'Acme Sp. z o.o.', postal_code: '00-001' }),
       });
+    });
+
+    it('includes the buyer email in the create payload when known (#1797)', async () => {
+      http.seed<InfaktListResponse<InfaktClient>>('GET', 'clients.json', {
+        items: [],
+        pagination: { current_page: 1, items_on_page: 0, limit: 10, total_items: 0, total_pages: 1 },
+      });
+      const created: InfaktClient = {
+        id: 4,
+        uuid: 'client-with-email',
+        company_name: 'Acme',
+        nip: '1234567890',
+        email: 'buyer@example.com',
+        city: 'Warszawa',
+        street: 'Testowa 1',
+        postal_code: '00-001',
+        country: 'PL',
+      };
+      http.seed('POST', 'clients.json', created);
+
+      await adapter.upsertCustomer({
+        connectionId: 'conn-1',
+        buyer: buyer({ nip: '1234567890', email: 'buyer@example.com' }),
+      });
+
+      const createCall = http.calls.find((c) => c.method === 'POST' && c.path === 'clients.json');
+      const body = createCall?.body as { client: Record<string, unknown> };
+      expect(body.client.email).toBe('buyer@example.com');
+    });
+
+    it('omits the email key from the create payload when the buyer has none (#1797)', async () => {
+      http.seed<InfaktListResponse<InfaktClient>>('GET', 'clients.json', {
+        items: [],
+        pagination: { current_page: 1, items_on_page: 0, limit: 10, total_items: 0, total_pages: 1 },
+      });
+      const created: InfaktClient = {
+        id: 5,
+        uuid: 'client-no-email',
+        company_name: 'Acme',
+        nip: '1234567890',
+        email: null,
+        city: 'Warszawa',
+        street: 'Testowa 1',
+        postal_code: '00-001',
+        country: 'PL',
+      };
+      http.seed('POST', 'clients.json', created);
+
+      await adapter.upsertCustomer({
+        connectionId: 'conn-1',
+        buyer: buyer({ nip: '1234567890' }),
+      });
+
+      const createCall = http.calls.find((c) => c.method === 'POST' && c.path === 'clients.json');
+      const body = createCall?.body as { client: Record<string, unknown> };
+      // `undefined` (not absent) at this layer — the fake HTTP client captures
+      // the raw pre-serialization object; `JSON.stringify` (the real transport,
+      // `InfaktHttpClient.post`) is what actually drops an `undefined` key from
+      // the wire payload, mirroring the pre-existing `nip: nip ?? undefined`
+      // behavior in the same object literal.
+      expect(body.client.email).toBeUndefined();
     });
 
     it('should create a new client without a NIP lookup when the buyer has no tax id', async () => {

--- a/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
@@ -361,7 +361,7 @@ export class InfaktInvoicingAdapter
     // (2026-07-01): the API wants `company_name` / `postal_code`, not the
     // `name` / `post_code` this previously sent — the latter is silently
     // rejected/ignored, so first-time client creation always 422'd.
-    // #1797: without `email`, Infakt creates the client with no address on
+    // #1797: without `email`, Infakt creates the client with no email on
     // file, so a later `deliver_via_email.json` call 422s ("adres e-mail
     // Klienta jest nieznany") — confirmed live against the sandbox.
     const payload = {
@@ -804,6 +804,10 @@ export class InfaktInvoicingAdapter
    * override — inFakt always uses the client's stored email, so the response
    * `recipient` is always null (inFakt doesn't echo it back). A provider
    * rejection propagates as-is (the controller maps it to a 502).
+   *
+   * `deliver_via_email.json` replies `202 Accepted` with an empty body (it's
+   * a fire-and-forget async trigger, #1797) — `postForEffect` tolerates that,
+   * unlike the generic `post<T>()` used elsewhere in this adapter.
    */
   async sendByEmail(cmd: SendInvoiceByEmailCommand): Promise<SendInvoiceByEmailResult> {
     const locale = toInfaktEmailLocale(cmd.locale);
@@ -812,7 +816,7 @@ export class InfaktInvoicingAdapter
       ...(locale ? { locale } : {}),
       ...(cmd.sendCopy !== undefined ? { send_copy: cmd.sendCopy } : {}),
     };
-    await this.http.post(
+    await this.http.postForEffect(
       `invoices/${encodeURIComponent(cmd.externalInvoiceId)}/deliver_via_email.json`,
       payload,
     );

--- a/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
@@ -361,10 +361,14 @@ export class InfaktInvoicingAdapter
     // (2026-07-01): the API wants `company_name` / `postal_code`, not the
     // `name` / `post_code` this previously sent — the latter is silently
     // rejected/ignored, so first-time client creation always 422'd.
+    // #1797: without `email`, Infakt creates the client with no address on
+    // file, so a later `deliver_via_email.json` call 422s ("adres e-mail
+    // Klienta jest nieznany") — confirmed live against the sandbox.
     const payload = {
       client: {
         company_name: buyer.name,
         nip: nip ?? undefined,
+        email: buyer.email ?? undefined,
         city: buyer.address.city,
         street: buyer.address.line1,
         postal_code: buyer.address.postalCode,

--- a/libs/integrations/infakt/src/infrastructure/http/__tests__/infakt-http-client.spec.ts
+++ b/libs/integrations/infakt/src/infrastructure/http/__tests__/infakt-http-client.spec.ts
@@ -175,6 +175,23 @@ describe('InfaktHttpClient', () => {
     });
   });
 
+  describe('empty-body success responses (#1797)', () => {
+    it('does not throw on a 202 Accepted with an empty body (e.g. deliver_via_email.json)', async () => {
+      fetchMock.mockResolvedValue(fakeResponse(202, ''));
+      await expect(client.post('invoices/x/deliver_via_email.json', {})).resolves.toBeUndefined();
+    });
+
+    it('does not throw on a 204 No Content with a whitespace-only body', async () => {
+      fetchMock.mockResolvedValue(fakeResponse(204, '   '));
+      await expect(client.get('some/path.json')).resolves.toBeUndefined();
+    });
+
+    it('still throws on a non-JSON body when the status is a 2xx WITH content', async () => {
+      fetchMock.mockResolvedValue(fakeResponse(200, '<html>not json</html>'));
+      await expect(client.get('some/path.json')).rejects.toBeInstanceOf(InfaktApiError);
+    });
+  });
+
   describe('error handling', () => {
     it('should throw InfaktApiError on a non-2xx JSON response', async () => {
       fetchMock.mockResolvedValue(fakeResponse(422, '{"error":"invalid nip"}'));

--- a/libs/integrations/infakt/src/infrastructure/http/__tests__/infakt-http-client.spec.ts
+++ b/libs/integrations/infakt/src/infrastructure/http/__tests__/infakt-http-client.spec.ts
@@ -175,20 +175,45 @@ describe('InfaktHttpClient', () => {
     });
   });
 
-  describe('empty-body success responses (#1797)', () => {
-    it('does not throw on a 202 Accepted with an empty body (e.g. deliver_via_email.json)', async () => {
+  describe('get/post/put still require a JSON body on success', () => {
+    it('throws on a 2xx with an empty body (T stays honestly non-undefined)', async () => {
       fetchMock.mockResolvedValue(fakeResponse(202, ''));
-      await expect(client.post('invoices/x/deliver_via_email.json', {})).resolves.toBeUndefined();
+      await expect(client.post('some/path.json', {})).rejects.toBeInstanceOf(InfaktApiError);
     });
 
-    it('does not throw on a 204 No Content with a whitespace-only body', async () => {
-      fetchMock.mockResolvedValue(fakeResponse(204, '   '));
-      await expect(client.get('some/path.json')).resolves.toBeUndefined();
-    });
-
-    it('still throws on a non-JSON body when the status is a 2xx WITH content', async () => {
+    it('throws on a non-JSON body when the status is a 2xx WITH content', async () => {
       fetchMock.mockResolvedValue(fakeResponse(200, '<html>not json</html>'));
       await expect(client.get('some/path.json')).rejects.toBeInstanceOf(InfaktApiError);
+    });
+  });
+
+  describe('postForEffect (#1797)', () => {
+    it('resolves on a 202 Accepted with an empty body (e.g. deliver_via_email.json)', async () => {
+      fetchMock.mockResolvedValue(fakeResponse(202, ''));
+      await expect(
+        client.postForEffect('invoices/x/deliver_via_email.json', {}),
+      ).resolves.toBeUndefined();
+    });
+
+    it('resolves on a 2xx with a non-empty, even non-JSON body (body is ignored on success)', async () => {
+      fetchMock.mockResolvedValue(fakeResponse(200, '<html>ok</html>'));
+      await expect(client.postForEffect('some/path.json', {})).resolves.toBeUndefined();
+    });
+
+    it('throws InfaktApiError on a non-2xx JSON response', async () => {
+      fetchMock.mockResolvedValue(fakeResponse(422, '{"error":"invalid"}'));
+      await expect(client.postForEffect('some/path.json', {})).rejects.toMatchObject({
+        statusCode: 422,
+        responseBody: { error: 'invalid' },
+      });
+    });
+
+    it('throws InfaktApiError carrying the raw text when the error body is not JSON', async () => {
+      fetchMock.mockResolvedValue(fakeResponse(502, '<html>Bad Gateway</html>'));
+      await expect(client.postForEffect('some/path.json', {})).rejects.toMatchObject({
+        statusCode: 502,
+        responseBody: '<html>Bad Gateway</html>',
+      });
     });
   });
 

--- a/libs/integrations/infakt/src/infrastructure/http/infakt-http-client.interface.ts
+++ b/libs/integrations/infakt/src/infrastructure/http/infakt-http-client.interface.ts
@@ -22,6 +22,14 @@ export interface IInfaktHttpClient {
   get<T>(path: string, query?: Record<string, string>): Promise<T>;
   post<T>(path: string, body: unknown): Promise<T>;
   put<T>(path: string, body: unknown): Promise<T>;
+  /**
+   * POST that triggers a provider-side effect with no meaningful response body
+   * to deserialize (#1797) — e.g. a fire-and-forget async trigger like
+   * `deliver_via_email.json`, which replies `202 Accepted` with an empty body.
+   * Resolves on any 2xx regardless of body shape/emptiness; still throws
+   * `InfaktApiError` on a non-2xx response.
+   */
+  postForEffect(path: string, body: unknown): Promise<void>;
   /** Fetch a binary response (e.g. a PDF) rather than parsing JSON. */
   getBinary(path: string, query?: Record<string, string>): Promise<InfaktBinaryResponse>;
 }

--- a/libs/integrations/infakt/src/infrastructure/http/infakt-http-client.ts
+++ b/libs/integrations/infakt/src/infrastructure/http/infakt-http-client.ts
@@ -63,6 +63,43 @@ export class InfaktHttpClient implements IInfaktHttpClient {
     return this.parse<T>(res, 'PUT', path);
   }
 
+  /**
+   * POST that triggers a provider-side effect with no meaningful response
+   * body to deserialize (#1797) — e.g. `deliver_via_email.json`, a
+   * fire-and-forget async trigger that replies `202 Accepted` with an empty
+   * body. Unlike `post<T>()`, this never attempts to JSON-parse a successful
+   * response (whatever shape/emptiness it has), so `IInfaktHttpClient`'s
+   * typed `get`/`post`/`put` keep their honest `Promise<T>` (never
+   * `undefined`) contract for endpoints that really do return content. A
+   * non-2xx response still throws `InfaktApiError` with the same shape
+   * `parse()` produces (JSON body when parseable, else the raw text).
+   */
+  async postForEffect(path: string, body: unknown): Promise<void> {
+    const url = this.buildUrl(path);
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { ...this.headers(), 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (res.ok) {
+      return;
+    }
+    const text = await res.text();
+    let parsedBody: unknown = text;
+    try {
+      parsedBody = JSON.parse(text);
+    } catch {
+      // Keep the raw text — Infakt error bodies aren't guaranteed JSON.
+    }
+    // Don't log the response body — see the same note in `parse()`.
+    this.logger.warn(`Infakt API POST ${path} → ${res.status}`);
+    throw new InfaktApiError(
+      `Infakt API POST ${path} failed with status ${res.status}`,
+      res.status,
+      parsedBody,
+    );
+  }
+
   async getBinary(path: string, query?: Record<string, string>): Promise<InfaktBinaryResponse> {
     const url = this.buildUrl(path, query);
     const res = await fetch(url, { headers: this.headers() });
@@ -122,16 +159,6 @@ export class InfaktHttpClient implements IInfaktHttpClient {
 
   private async parse<T>(res: Response, method: string, path: string): Promise<T> {
     const text = await res.text();
-
-    // A successful response with an empty body (e.g. `deliver_via_email.json`
-    // replies `202 Accepted` with nothing to echo back — it's a fire-and-forget
-    // async job on Infakt's side, #1797) is valid and must not be treated as a
-    // parse failure. Only a 2xx status qualifies; an empty error body still
-    // falls through to the non-JSON branch below.
-    if (res.ok && text.trim().length === 0) {
-      return undefined as T;
-    }
-
     let json: unknown;
     try {
       json = JSON.parse(text);

--- a/libs/integrations/infakt/src/infrastructure/http/infakt-http-client.ts
+++ b/libs/integrations/infakt/src/infrastructure/http/infakt-http-client.ts
@@ -122,6 +122,16 @@ export class InfaktHttpClient implements IInfaktHttpClient {
 
   private async parse<T>(res: Response, method: string, path: string): Promise<T> {
     const text = await res.text();
+
+    // A successful response with an empty body (e.g. `deliver_via_email.json`
+    // replies `202 Accepted` with nothing to echo back — it's a fire-and-forget
+    // async job on Infakt's side, #1797) is valid and must not be treated as a
+    // parse failure. Only a 2xx status qualifies; an empty error body still
+    // falls through to the non-JSON branch below.
+    if (res.ok && text.trim().length === 0) {
+      return undefined as T;
+    }
+
     let json: unknown;
     try {
       json = JSON.parse(text);

--- a/libs/integrations/infakt/src/testing/fake-infakt-http-client.ts
+++ b/libs/integrations/infakt/src/testing/fake-infakt-http-client.ts
@@ -68,6 +68,12 @@ export class FakeInfaktHttpClient implements IInfaktHttpClient {
     return this.resolve<T>('PUT', path);
   }
 
+  /** Like `post`, but resolves to `void` regardless of the seeded value (#1797). */
+  async postForEffect(path: string, body?: unknown): Promise<void> {
+    this.calls.push({ method: 'POST', path, body });
+    await this.resolve<unknown>('POST', path);
+  }
+
   getBinary(path: string, query?: Record<string, string>): Promise<InfaktBinaryResponse> {
     this.calls.push({ method: 'GET_BINARY', path, query });
     return this.resolve<InfaktBinaryResponse>('GET_BINARY', path);


### PR DESCRIPTION
## Summary

- `BuyerProfile` never carried a buyer e-mail, even though `Order.customerEmail` already had it (#948) — every Infakt client was created with no e-mail on file, so `POST invoices/{uuid}/deliver_via_email.json` always 422'd with "adres e-mail Klienta jest nieznany" (client's e-mail unknown). Confirmed empirically via a throwaway repro before writing any fix.
- Threads the e-mail end-to-end: `BuyerProfile.email` (new, optional, defaulted — no breaking change to any of the 16 existing constructor call sites) → `order-to-issue-invoice-command.mapper.ts` reads `order.customerEmail` → the async auto-issue job payload (`InvocingIssueBuyerV1.email`, additive field, no schemaVersion bump) + worker-handler reconstruction preserve it through the jsonb round-trip → `InfaktInvoicingAdapter.upsertCustomer` sends it in the `clients.json` create payload.
- **Found while verifying live against the demo stack**: `orderFromReadySnapshot` (used by the manual/UI issue-invoice paths — `POST /invoices`, bulk-issue, retry, correction reissue) rehydrates `Order` from the persisted `orderSnapshot` jsonb field-by-field and never read `customerEmail`, so it silently dropped the e-mail on that path only even after the mapper fix. Fixed with the same additive pattern.
- **Found while re-testing after the above fix**: Infakt's `deliver_via_email.json` replies `202 Accepted` with an **empty body** (it's a fire-and-forget async trigger) — `InfaktHttpClient.parse()` unconditionally tried `JSON.parse()` on every response and threw on the empty string even though the status was a success.
  - Fixed by adding a dedicated `IInfaktHttpClient.postForEffect(path, body): Promise<void>`, used only by `sendByEmail`, which never attempts to parse a 2xx body (empty or otherwise). `get/post/put<T>` are untouched and keep their original strict behavior (a 2xx with no/non-JSON body still throws `InfaktApiError`, as before) — an earlier version of this fix loosened the shared `parse<T>()` instead, which a follow-up tech review correctly flagged as silently breaking the `Promise<T>` (never `undefined`) contract for every typed call; this version has no such regression.
- Deliberately **not** touched: `invoicing.controller.ts`'s `buildSnapshotFromRecord` (the correction-snapshot `BuyerProfile` rebuild) — traced and confirmed it never calls `upsertCustomer`/`sendByEmail`, so it's inert either way (see issue comment for the full trace).

## Test plan

- [x] Unit tests added/extended for every touched file (`BuyerProfile`, the mapper, `auto-issue-trigger.service`, the worker handler, `orderFromReadySnapshot`, `InfaktInvoicingAdapter.upsertCustomer`, `InfaktHttpClient` incl. the new `postForEffect`) — all pass (180/180 in `@openlinker/integrations-infakt`, 22/22 in the worker handler spec).
- [x] Verified live against the demo stack (real Infakt sandbox connection): confirmed the client-creation payload now carries `email`, and `sendByEmail` on a freshly-issued invoice returns success instead of 422.
- [ ] `pnpm lint` / `pnpm type-check` / full `pnpm test` — run locally during development on the touched packages; re-run in CI on this PR (commits were pushed with `--no-verify`, skipping the local pre-commit hook, at the user's explicit request).

Closes #1797
