### PR TITLE
feat(orders): fix-it deep links (Add mapping / Connect)

### DIFF
--- a/apps/web/src/features/mappings/components/MappingPanel.test.tsx
+++ b/apps/web/src/features/mappings/components/MappingPanel.test.tsx
@@ -320,6 +320,12 @@ describe('MappingPanel', () => {
       ).toBeInTheDocument();
       const select = screen.getByRole('combobox', { name: /select allegro delivery method/i });
       expect(select).toHaveValue(ALLEGRO_PACZKOMAT.value);
+
+      // savedRows is empty here — the pre-existing "no mappings configured
+      // yet" empty state and the deep-link focus hint are both role="status"
+      // and would otherwise announce together. Only the focus hint may render.
+      expect(screen.getAllByRole('status')).toHaveLength(1);
+      expect(screen.queryByText(/No mappings configured yet/)).not.toBeInTheDocument();
     });
 
     it('does not pre-select or show the hint when focusSourceValue is already mapped', () => {

--- a/apps/web/src/features/mappings/components/MappingPanel.test.tsx
+++ b/apps/web/src/features/mappings/components/MappingPanel.test.tsx
@@ -300,4 +300,64 @@ describe('MappingPanel', () => {
       expect(onSave).toHaveBeenCalledWith([]);
     });
   });
+
+  describe('deep-link pre-focus (#1794)', () => {
+    it('pre-selects an unmapped, known focusSourceValue and shows the hint', () => {
+      render(
+        <MappingPanel
+          {...baseProps}
+          sourceOptions={[ALLEGRO_PACZKOMAT, ALLEGRO_KURIER]}
+          targetOptions={[PS_INPOST]}
+          savedRows={[]}
+          onSave={vi.fn()}
+          focusSourceValue={ALLEGRO_PACZKOMAT.value}
+          focusSourceName="Allegro Paczkomaty InPost"
+        />,
+      );
+
+      expect(
+        screen.getByText((_, element) => element?.textContent === 'Map Allegro Paczkomaty InPost to a prestashop carrier below.'),
+      ).toBeInTheDocument();
+      const select = screen.getByRole('combobox', { name: /select allegro delivery method/i });
+      expect(select).toHaveValue(ALLEGRO_PACZKOMAT.value);
+    });
+
+    it('does not pre-select or show the hint when focusSourceValue is already mapped', () => {
+      render(
+        <MappingPanel
+          {...baseProps}
+          sourceOptions={[ALLEGRO_PACZKOMAT]}
+          targetOptions={[PS_INPOST]}
+          savedRows={[{ sourceValue: ALLEGRO_PACZKOMAT.value, targetValue: PS_INPOST.value }]}
+          onSave={vi.fn()}
+          focusSourceValue={ALLEGRO_PACZKOMAT.value}
+          focusSourceName="Allegro Paczkomaty InPost"
+        />,
+      );
+
+      expect(screen.queryByRole('status')).not.toBeInTheDocument();
+      const select = screen.getByRole('combobox', { name: /select allegro delivery method/i });
+      expect(select).toHaveValue('');
+    });
+
+    it('does not pre-select or show the hint when focusSourceValue is absent from sourceOptions', () => {
+      render(
+        <MappingPanel
+          {...baseProps}
+          sourceOptions={[ALLEGRO_KURIER]}
+          targetOptions={[PS_INPOST]}
+          savedRows={[]}
+          onSave={vi.fn()}
+          focusSourceValue="unknown-method-id"
+          focusSourceName="Unknown method"
+        />,
+      );
+
+      // Scoped to the deep-link hint specifically — the panel's pre-existing
+      // "no mappings configured yet" empty state also renders role="status".
+      expect(screen.queryByText(/Unknown method/)).not.toBeInTheDocument();
+      const select = screen.getByRole('combobox', { name: /select allegro delivery method/i });
+      expect(select).toHaveValue('');
+    });
+  });
 });

--- a/apps/web/src/features/mappings/components/MappingPanel.tsx
+++ b/apps/web/src/features/mappings/components/MappingPanel.tsx
@@ -8,7 +8,7 @@
  * @module apps/web/src/features/mappings/components
  */
 
-import { useState, useEffect, type ReactElement, type ReactNode } from 'react';
+import { useState, useEffect, useRef, type ReactElement, type ReactNode } from 'react';
 import { Button } from '../../../shared/ui/button';
 import { ErrorState, LoadingState } from '../../../shared/ui/feedback-state';
 import type { MappingOption } from '../api/mappings.types';
@@ -33,6 +33,15 @@ interface MappingPanelProps {
   saveError: Error | null;
   optionsLoading: boolean;
   optionsError: Error | null;
+  /**
+   * Deep-link pre-focus (#1794): a source value to pre-select in the add-row
+   * form and scroll/highlight, so an operator arriving from the order-detail
+   * "Add mapping" fix-it link lands on the exact unmapped method. Ignored when
+   * the value is already mapped or absent from the loaded source options.
+   */
+  focusSourceValue?: string | null;
+  /** Human label for `focusSourceValue`, used in the pre-focus hint copy. */
+  focusSourceName?: string | null;
 }
 
 /**
@@ -117,11 +126,15 @@ export function MappingPanel({
   saveError,
   optionsLoading,
   optionsError,
+  focusSourceValue,
+  focusSourceName,
 }: MappingPanelProps): ReactElement {
   const [localRows, setLocalRows] = useState<MappingRow[]>(savedRows);
   const [pendingSource, setPendingSource] = useState('');
   const [pendingTarget, setPendingTarget] = useState('');
   const [addError, setAddError] = useState<string | null>(null);
+  const [focusApplied, setFocusApplied] = useState(false);
+  const sourceSelectRef = useRef<HTMLSelectElement>(null);
 
   // Track dirty state by comparing local rows to saved rows
   const isDirty =
@@ -136,6 +149,23 @@ export function MappingPanel({
   useEffect(() => {
     setLocalRows(savedRows);
   }, [savedRows]);
+
+  // Deep-link pre-focus (#1794): once options have loaded, pre-select the
+  // requested source value in the add-row form and scroll/focus it. Runs at
+  // most once, and no-ops when the method is already mapped or unknown.
+  useEffect(() => {
+    if (focusApplied || !focusSourceValue || optionsLoading || optionsError) return;
+    setFocusApplied(true);
+    const inSource = sourceOptions.some((o) => o.value === focusSourceValue);
+    const alreadyMapped = savedRows.some((r) => r.sourceValue === focusSourceValue);
+    if (!inSource || alreadyMapped) return;
+    setPendingSource(focusSourceValue);
+    const el = sourceSelectRef.current;
+    if (el) {
+      el.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      el.focus();
+    }
+  }, [focusApplied, focusSourceValue, optionsLoading, optionsError, sourceOptions, savedRows]);
 
   function handleAddRow(): void {
     if (!pendingSource || !pendingTarget) return;
@@ -169,6 +199,15 @@ export function MappingPanel({
   const availableSourceOptions = sourceOptions.filter(
     (o) => !localRows.some((r) => r.sourceValue === o.value),
   );
+
+  // Deep-link pre-focus target (#1794) is "actionable" only while it remains an
+  // unmapped, known source value — drives the hint copy + select highlight.
+  const focusActionable = Boolean(
+    focusSourceValue &&
+      sourceOptions.some((o) => o.value === focusSourceValue) &&
+      !localRows.some((r) => r.sourceValue === focusSourceValue),
+  );
+  const focusLabel = focusSourceName ?? focusSourceValue ?? '';
 
   return (
     <div className="panel panel--dense">
@@ -235,10 +274,19 @@ export function MappingPanel({
         </table>
       )}
 
+      {/* Deep-link pre-focus hint (#1794) */}
+      {focusActionable && (
+        <p className="mapping-panel__focus-hint" role="status" aria-live="polite">
+          Map <strong>{focusLabel}</strong> to a {targetLabel.toLowerCase()} below.
+        </p>
+      )}
+
       {/* Add row form */}
       <div className="toolbar" style={{ marginTop: '1rem', gap: '0.5rem', flexWrap: 'wrap' }}>
         <select
+          ref={sourceSelectRef}
           aria-label={`Select ${sourceLabel}`}
+          className={focusActionable ? 'mapping-panel__source-select--focus' : undefined}
           value={pendingSource}
           onChange={(e) => { setPendingSource(e.target.value); }}
           disabled={availableSourceOptions.length === 0}

--- a/apps/web/src/features/mappings/components/MappingPanel.tsx
+++ b/apps/web/src/features/mappings/components/MappingPanel.tsx
@@ -225,11 +225,14 @@ export function MappingPanel({
 
       <p className="muted-text" style={{ marginBottom: '1rem' }}>{description}</p>
 
-      {localRows.length === 0 ? (
+      {/* Suppressed while the deep-link focus hint (#1794) is showing below —
+          otherwise two role="status" live regions would announce together
+          for a connection with zero carrier mappings and an unmapped method. */}
+      {localRows.length === 0 && !focusActionable ? (
         <p className="muted-text" role="status" aria-live="polite">
           No mappings configured yet. Orders may sync with default values. Add one below.
         </p>
-      ) : (
+      ) : localRows.length === 0 ? null : (
         <table className="data-table" aria-label={`${title} mappings`}>
           <thead>
             <tr>

--- a/apps/web/src/features/mappings/index.ts
+++ b/apps/web/src/features/mappings/index.ts
@@ -13,3 +13,11 @@ export { useMappingOptions } from './hooks/use-mapping-options';
 // Consumed by the orders generate-label flow to predict the routed carrier
 // (#1569 — scope the COD currency to the carrier a delivery method routes to).
 export { useRoutingRulesQuery } from './hooks/use-routing-rules';
+// Delivery-mapping fix-it deep link (#1794) — built by the orders delivery
+// rider, parsed by the connection-mappings page.
+export {
+  DELIVERY_MAPPING_DEEP_LINK_PARAMS,
+  DELIVERY_MAPPING_TAB,
+  buildDeliveryMappingLink,
+  type DeliveryMappingLinkInput,
+} from './lib/delivery-mapping-deep-link';

--- a/apps/web/src/features/mappings/lib/delivery-mapping-deep-link.ts
+++ b/apps/web/src/features/mappings/lib/delivery-mapping-deep-link.ts
@@ -1,0 +1,52 @@
+/**
+ * Delivery-mapping deep-link contract (#1794)
+ *
+ * Shared contract for the "Add mapping" fix-it deep link that the order-detail
+ * delivery rider (#1793) points at. The orders feature builds the link; the
+ * connection-mappings page parses these params to pre-select the Delivery
+ * (carriers) tab and pre-focus the unmapped source delivery method.
+ *
+ * Centralised here so the producer (orders) and consumer (connections page)
+ * can't drift on param names or the target tab id.
+ *
+ * @module apps/web/src/features/mappings/lib
+ */
+
+/** Query-param keys carried by the Add-mapping deep link. */
+export const DELIVERY_MAPPING_DEEP_LINK_PARAMS = {
+  /** Which mappings tab to open. */
+  tab: 'tab',
+  /** Source delivery-method id to pre-focus. */
+  method: 'method',
+  /** Human label for the pre-focused method (fallback copy when options lag). */
+  methodName: 'methodName',
+} as const;
+
+/** The mappings tab that owns source-delivery-method → carrier rows. */
+export const DELIVERY_MAPPING_TAB = 'carriers';
+
+export interface DeliveryMappingLinkInput {
+  connectionId: string;
+  sourceDeliveryMethodId?: string | null;
+  sourceDeliveryMethodName?: string | null;
+}
+
+/**
+ * Build the deep link to a connection's Delivery (carriers) mapping tab,
+ * carrying the unmapped source method so the page can pre-focus it.
+ */
+export function buildDeliveryMappingLink({
+  connectionId,
+  sourceDeliveryMethodId,
+  sourceDeliveryMethodName,
+}: DeliveryMappingLinkInput): string {
+  const params = new URLSearchParams();
+  params.set(DELIVERY_MAPPING_DEEP_LINK_PARAMS.tab, DELIVERY_MAPPING_TAB);
+  if (sourceDeliveryMethodId) {
+    params.set(DELIVERY_MAPPING_DEEP_LINK_PARAMS.method, sourceDeliveryMethodId);
+  }
+  if (sourceDeliveryMethodName) {
+    params.set(DELIVERY_MAPPING_DEEP_LINK_PARAMS.methodName, sourceDeliveryMethodName);
+  }
+  return `/connections/${encodeURIComponent(connectionId)}/mappings?${params.toString()}`;
+}

--- a/apps/web/src/features/orders/components/delivery-rider-action.test.tsx
+++ b/apps/web/src/features/orders/components/delivery-rider-action.test.tsx
@@ -1,0 +1,63 @@
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { renderWithProviders } from '../../../test/test-utils';
+import { DeliveryRiderAction } from './delivery-rider-action';
+import type { OrderDeliveryRider } from '../api/orders.types';
+
+const UNMAPPED_RIDER: OrderDeliveryRider = {
+  rider: 'unmapped',
+  candidateCarrier: { platformType: 'inpost', displayName: 'InPost' },
+};
+
+const NOT_CONNECTED_RIDER: OrderDeliveryRider = {
+  rider: 'not-connected',
+  candidateCarrier: { platformType: 'inpost', displayName: 'InPost' },
+};
+
+describe('DeliveryRiderAction (#1794)', () => {
+  it('should link an unmapped rider to the source connection Delivery mapping tab with the method pre-filtered', () => {
+    renderWithProviders(
+      <DeliveryRiderAction
+        rider={UNMAPPED_RIDER}
+        sourceConnectionId="conn-abc"
+        sourceDeliveryMethodId="method-xyz"
+        sourceDeliveryMethodName="InPost Paczkomat"
+      />,
+    );
+
+    const link = screen.getByRole('link', { name: 'Add mapping' });
+    const href = link.getAttribute('href') ?? '';
+    expect(href).toContain('/connections/conn-abc/mappings');
+    expect(href).toContain('tab=carriers');
+    expect(href).toContain('method=method-xyz');
+    expect(href).toContain('methodName=');
+  });
+
+  it('should link a not-connected rider to the candidate carrier guided setup wizard', () => {
+    renderWithProviders(
+      <DeliveryRiderAction rider={NOT_CONNECTED_RIDER} sourceConnectionId="conn-abc" />,
+    );
+
+    const link = screen.getByRole('link', { name: 'Connect InPost' });
+    expect(link.getAttribute('href')).toBe('/connections/new/inpost');
+  });
+
+  it('should fall back to the platform picker when the candidate carrier ships no setup wizard', () => {
+    renderWithProviders(
+      <DeliveryRiderAction
+        rider={{ rider: 'not-connected', candidateCarrier: { platformType: 'unknown-carrier', displayName: 'Unknown' } }}
+        sourceConnectionId="conn-abc"
+      />,
+    );
+
+    const link = screen.getByRole('link', { name: 'Connect Unknown' });
+    expect(link.getAttribute('href')).toBe('/connections/new');
+  });
+
+  it('should render nothing for a non-actionable rider', () => {
+    const { container } = renderWithProviders(
+      <DeliveryRiderAction rider={{ rider: 'none' }} sourceConnectionId="conn-abc" />,
+    );
+    expect(container.querySelector('a')).toBeNull();
+  });
+});

--- a/apps/web/src/features/orders/components/delivery-rider-action.tsx
+++ b/apps/web/src/features/orders/components/delivery-rider-action.tsx
@@ -1,0 +1,67 @@
+/**
+ * Delivery Rider Action
+ *
+ * Fix-it deep-link buttons for the order-detail delivery rider (#1794, epic
+ * #1776). Rendered into the `actionSlot` of #1793's `DeliveryRiderBanner`,
+ * replacing the disabled "Coming soon" placeholder with a real navigation:
+ *
+ * - `unmapped` → **Add mapping**: the source connection's Delivery (carriers)
+ *   mapping tab, pre-focused on the unmapped source method.
+ * - `not-connected` → **Connect {carrier}**: the candidate carrier's guided
+ *   new-connection wizard (or the platform picker when it ships no wizard).
+ *
+ * @module apps/web/src/features/orders/components
+ */
+import type { ReactElement } from 'react';
+import { Link } from 'react-router-dom';
+
+import { usePlatform } from '../../../shared/plugins';
+import { buildDeliveryMappingLink } from '../../mappings';
+import type { OrderDeliveryRider } from '../api/orders.types';
+
+interface DeliveryRiderActionProps {
+  rider: OrderDeliveryRider;
+  /** Source connection whose Delivery mapping tab the Add-mapping link targets. */
+  sourceConnectionId: string;
+  /** Unmapped source delivery-method id (Add-mapping pre-focus target). */
+  sourceDeliveryMethodId?: string | null;
+  /** Source delivery-method label (fallback pre-focus copy). */
+  sourceDeliveryMethodName?: string | null;
+}
+
+export function DeliveryRiderAction({
+  rider,
+  sourceConnectionId,
+  sourceDeliveryMethodId,
+  sourceDeliveryMethodName,
+}: DeliveryRiderActionProps): ReactElement | null {
+  const candidate = rider.candidateCarrier;
+  // Resolved unconditionally (never inside a branch) so hook order stays stable.
+  // The candidate carrier's guided setup wizard; falls back to the platform
+  // picker when the plugin ships no setup card.
+  const connectTarget = usePlatform(candidate?.platformType)?.setupCard?.to ?? '/connections/new';
+
+  if (rider.rider === 'unmapped') {
+    const to = buildDeliveryMappingLink({
+      connectionId: sourceConnectionId,
+      sourceDeliveryMethodId,
+      sourceDeliveryMethodName,
+    });
+    return (
+      <Link to={to} className="delivery-rider-banner__button">
+        Add mapping
+      </Link>
+    );
+  }
+
+  if (rider.rider === 'not-connected') {
+    const label = candidate ? `Connect ${candidate.displayName}` : 'Connect';
+    return (
+      <Link to={connectTarget} className="delivery-rider-banner__button">
+        {label}
+      </Link>
+    );
+  }
+
+  return null;
+}

--- a/apps/web/src/features/orders/components/order-delivery-panel.test.tsx
+++ b/apps/web/src/features/orders/components/order-delivery-panel.test.tsx
@@ -147,4 +147,39 @@ describe('OrderDeliveryPanel', () => {
       expect(screen.queryByRole('button', { name: /Add mapping|Connect/ })).not.toBeInTheDocument();
     });
   });
+
+  describe('fix-it deep-link wiring (#1794)', () => {
+    it('should render the real Add-mapping deep link when sourceConnectionId is provided', () => {
+      renderWithProviders(
+        <OrderDeliveryPanel
+          deliveryOutcome="shop-fulfilled"
+          deliveryRider={{
+            rider: 'unmapped',
+            candidateCarrier: { platformType: 'inpost', displayName: 'InPost' },
+          }}
+          sourceConnectionId="conn-abc"
+          sourceDeliveryMethodId="method-xyz"
+          sourceDeliveryMethodName="InPost Paczkomat"
+        />,
+      );
+      const link = screen.getByRole('link', { name: 'Add mapping' });
+      expect(link.getAttribute('href')).toContain('/connections/conn-abc/mappings');
+      expect(link.getAttribute('href')).toContain('method=method-xyz');
+      expect(screen.queryByRole('button', { name: 'Add mapping' })).not.toBeInTheDocument();
+    });
+
+    it('should fall back to the disabled placeholder when sourceConnectionId is absent', () => {
+      renderWithProviders(
+        <OrderDeliveryPanel
+          deliveryOutcome="shop-fulfilled"
+          deliveryRider={{
+            rider: 'unmapped',
+            candidateCarrier: { platformType: 'inpost', displayName: 'InPost' },
+          }}
+        />,
+      );
+      expect(screen.getByRole('button', { name: 'Add mapping' })).toBeDisabled();
+      expect(screen.queryByRole('link', { name: 'Add mapping' })).not.toBeInTheDocument();
+    });
+  });
 });

--- a/apps/web/src/features/orders/components/order-delivery-panel.tsx
+++ b/apps/web/src/features/orders/components/order-delivery-panel.tsx
@@ -36,6 +36,7 @@ import type {
 import type { OrderDeliveryRider } from '../api/orders.types';
 import type { DeliveryOutcome } from '../lib/delivery-outcome';
 import { DeliveryOutcomeChip, DeliveryRiderBanner } from './delivery-chip';
+import { DeliveryRiderAction } from './delivery-rider-action';
 
 interface OrderDeliveryPanelProps {
   shippingAddress?: ParsedAddress;
@@ -66,10 +67,19 @@ interface OrderDeliveryPanelProps {
   deliveryOutcome?: DeliveryOutcome;
   /**
    * Actionable delivery rider (#1793/#1792). When actionable
-   * (`unmapped` / `not-connected`) an inline banner + fix-it button SLOT
-   * renders beneath the delivery fields; navigation is wired in #1794.
+   * (`unmapped` / `not-connected`) an inline banner + fix-it deep-link button
+   * (#1794) renders beneath the delivery fields.
    */
   deliveryRider?: OrderDeliveryRider | null;
+  /**
+   * Source connection id (#1794) — the Add-mapping deep-link target. When
+   * absent the rider banner falls back to its disabled placeholder button.
+   */
+  sourceConnectionId?: string | null;
+  /** Unmapped source delivery-method id (#1791) — Add-mapping pre-focus target. */
+  sourceDeliveryMethodId?: string | null;
+  /** Source delivery-method label (#1791) — Add-mapping pre-focus copy. */
+  sourceDeliveryMethodName?: string | null;
 }
 
 function addressLines(address: ParsedAddress): ReactElement {
@@ -112,6 +122,9 @@ export function OrderDeliveryPanel({
   methodFallback,
   deliveryOutcome,
   deliveryRider,
+  sourceConnectionId,
+  sourceDeliveryMethodId,
+  sourceDeliveryMethodName,
 }: OrderDeliveryPanelProps): ReactElement {
   // Resolved unconditionally (never inside a branch) — see #893.
   const sourcePlatform = usePlatform(sourcePlatformType ?? undefined);
@@ -171,7 +184,21 @@ export function OrderDeliveryPanel({
       <h3 className="detail-section__title">Delivery</h3>
       <div className="order-delivery__card">
         <KeyValueList items={items} />
-        {deliveryRider ? <DeliveryRiderBanner rider={deliveryRider} /> : null}
+        {deliveryRider ? (
+          <DeliveryRiderBanner
+            rider={deliveryRider}
+            actionSlot={
+              sourceConnectionId ? (
+                <DeliveryRiderAction
+                  rider={deliveryRider}
+                  sourceConnectionId={sourceConnectionId}
+                  sourceDeliveryMethodId={sourceDeliveryMethodId}
+                  sourceDeliveryMethodName={sourceDeliveryMethodName}
+                />
+              ) : undefined
+            }
+          />
+        ) : null}
         {pickupPoint ? (
           <div className="order-delivery__pickup">
             <div className="order-delivery__pickup-code mono-text">

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2452,6 +2452,36 @@ textarea,
   cursor: not-allowed;
 }
 
+/* Fix-it deep-link buttons render as links (#1794) — reset anchor styling so
+   they read as buttons, matching the disabled placeholder they replace. */
+a.delivery-rider-banner__button {
+  display: inline-flex;
+  align-items: center;
+  text-decoration: none;
+}
+
+a.delivery-rider-banner__button:hover {
+  border-color: var(--accent-primary);
+  color: var(--accent-primary);
+}
+
+a.delivery-rider-banner__button:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
+}
+
+/* Deep-link pre-focus on the mappings add-row (#1794). */
+.mapping-panel__focus-hint {
+  margin: var(--space-3) 0 0;
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+}
+
+.mapping-panel__source-select--focus {
+  border-color: var(--accent-primary);
+  box-shadow: var(--shadow-focus);
+}
+
 .order-delivery__carrier {
   display: inline-flex;
   align-items: center;

--- a/apps/web/src/pages/connections/connection-mappings-page.test.tsx
+++ b/apps/web/src/pages/connections/connection-mappings-page.test.tsx
@@ -407,6 +407,76 @@ describe('ConnectionMappingsPage', () => {
     });
   });
 
+  describe('fix-it deep link (#1794)', () => {
+    const ALLEGRO_DELIVERY_OPTIONS: MappingOption[] = [
+      { value: 'method-1', label: 'InPost Paczkomat' },
+      { value: 'method-2', label: 'Kurier24' },
+    ];
+    const PS_CARRIERS: MappingOption[] = [{ value: '1', label: 'Click and collect' }];
+
+    function renderAtDeepLink(apiClient: ReturnType<typeof createMockApiClient>): void {
+      renderWithProviders(
+        <Routes>
+          <Route path="/connections/:connectionId/mappings" element={<ConnectionMappingsPage />} />
+        </Routes>,
+        {
+          apiClient,
+          route: '/connections/conn_1/mappings?tab=carriers&method=method-1&methodName=InPost%20Paczkomat',
+        },
+      );
+    }
+
+    it('opens the Carriers tab and pre-focuses the unmapped source method when the target route carries ?tab=carriers&method=', async () => {
+      const apiClient = buildApiClient({
+        getMappingOptions: buildOptionsResolver({
+          'source/order-statuses': STATUS_OPTIONS,
+          'destination/order-statuses': PS_STATUS_OPTIONS,
+          'source/delivery-methods': ALLEGRO_DELIVERY_OPTIONS,
+          'destination/carriers': PS_CARRIERS,
+        }),
+      });
+      renderAtDeepLink(apiClient);
+
+      // The Carriers tab is selected on initial render — not the default first tab.
+      const carriersTab = await screen.findByRole('tab', { name: 'Carriers' });
+      await waitFor(() => {
+        expect(carriersTab).toHaveAttribute('aria-selected', 'true');
+      });
+      expect(await screen.findByText('Carrier Mappings')).toBeInTheDocument();
+
+      // The unmapped source method carried via ?method= is pre-selected in the add-row dropdown.
+      await waitFor(() => {
+        const select = screen.getByRole('combobox', { name: /select allegro delivery method/i });
+        expect(select).toHaveValue('method-1');
+      });
+      expect(
+        screen.getByText((_, element) => element?.textContent === 'Map InPost Paczkomat to a prestashop carrier below.'),
+      ).toBeInTheDocument();
+    });
+
+    it('falls back to the first available tab when ?tab= names a tab unavailable on this connection', async () => {
+      const apiClient = buildApiClient();
+      apiClient.connections.getById = vi.fn().mockResolvedValue({
+        ...sampleConnection,
+        supportedCapabilities: ['OrderSource'],
+      });
+      renderWithProviders(
+        <Routes>
+          <Route path="/connections/:connectionId/mappings" element={<ConnectionMappingsPage />} />
+        </Routes>,
+        { apiClient, route: '/connections/conn_1/mappings?tab=order-states' },
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('Mapping Configuration')).toBeInTheDocument();
+      });
+      // With OrderSource capability the Fulfillment tab is tabs[0] — the true
+      // first available tab this connection falls back to.
+      const fulfillmentTab = screen.getByRole('tab', { name: 'Fulfillment' });
+      expect(fulfillmentTab).toHaveAttribute('aria-selected', 'true');
+    });
+  });
+
   it('switches between tabs', async () => {
     const user = userEvent.setup();
     renderWithProviders(<ConnectionMappingsPage />, { apiClient: buildApiClient() });

--- a/apps/web/src/pages/connections/connection-mappings-page.tsx
+++ b/apps/web/src/pages/connections/connection-mappings-page.tsx
@@ -8,7 +8,7 @@
  */
 
 import type { ReactElement, ReactNode } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useSearchParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '../../shared/ui/tabs';
 import { Alert } from '../../shared/ui/alert';
@@ -27,6 +27,7 @@ import { useConnectionQuery } from '../../features/connections/hooks/use-connect
 import { OL_ORDER_STATUS_OPTIONS, type MappingOption } from '../../features/mappings/api/mappings.types';
 import { LoadingState, ErrorState } from '../../shared/ui/feedback-state';
 import { DesktopOnlyBanner } from '../../shared/ui/desktop-only-banner';
+import { DELIVERY_MAPPING_DEEP_LINK_PARAMS } from '../../features/mappings';
 
 type TabId = 'fulfillment' | 'status' | 'carriers' | 'payments' | 'order-states';
 
@@ -111,6 +112,14 @@ function deriveCarrierFallbackBanner(args: {
 export function ConnectionMappingsPage(): ReactElement {
   const { connectionId = '' } = useParams();
 
+  // Fix-it deep link (#1794): the order-detail "Add mapping" rider links here
+  // with `?tab=carriers&method=<id>&methodName=<name>` so we open the Delivery
+  // (carriers) tab and pre-focus the unmapped source method.
+  const [searchParams] = useSearchParams();
+  const requestedTab = searchParams.get(DELIVERY_MAPPING_DEEP_LINK_PARAMS.tab);
+  const focusMethodId = searchParams.get(DELIVERY_MAPPING_DEEP_LINK_PARAMS.method);
+  const focusMethodName = searchParams.get(DELIVERY_MAPPING_DEEP_LINK_PARAMS.methodName);
+
   const statusQuery = useStatusMappingsQuery(connectionId);
   const carrierQuery = useCarrierMappingsQuery(connectionId);
   const paymentQuery = usePaymentMappingsQuery(connectionId);
@@ -180,7 +189,12 @@ export function ConnectionMappingsPage(): ReactElement {
     { id: 'payments' as const, label: 'Payments' },
     ...(supportsOrderProcessor ? [{ id: 'order-states' as const, label: 'Order States' }] : []),
   ];
-  const defaultTab = tabs[0].id;
+  // Honour the deep-link tab request (#1794) only when it names a tab that is
+  // actually available for this connection; otherwise fall back to the first.
+  const initialTab =
+    requestedTab && tabs.some((t) => t.id === requestedTab)
+      ? (requestedTab as TabId)
+      : tabs[0].id;
 
   if (isLoading) {
     return (
@@ -292,7 +306,7 @@ export function ConnectionMappingsPage(): ReactElement {
         visible but large tables may overflow horizontally.
       </DesktopOnlyBanner>
 
-      <Tabs defaultValue={defaultTab} aria-label="Mapping types">
+      <Tabs defaultValue={initialTab} aria-label="Mapping types">
         <TabsList>
           {tabs.map((tab) => (
             <TabsTrigger key={tab.id} value={tab.id}>
@@ -351,6 +365,8 @@ export function ConnectionMappingsPage(): ReactElement {
             saveError={upsertCarrier.error}
             optionsLoading={optionsLoading}
             optionsError={carrierOptionsError}
+            focusSourceValue={focusMethodId}
+            focusSourceName={focusMethodName}
           />
         </TabsContent>
 

--- a/apps/web/src/pages/orders/order-detail-page.tsx
+++ b/apps/web/src/pages/orders/order-detail-page.tsx
@@ -356,6 +356,9 @@ export function OrderDetailPage(): ReactElement {
             methodFallback={methodFallback}
             deliveryOutcome={deliveryOutcome}
             deliveryRider={order.deliveryRider}
+            sourceConnectionId={order.sourceConnectionId}
+            sourceDeliveryMethodId={order.sourceDeliveryMethodId}
+            sourceDeliveryMethodName={order.sourceDeliveryMethodName}
           />
           {/* Anchor wrappers (#1713) for the orders-list deep-link CTAs
               (`/orders/{id}#shipment`, `/orders/{id}#invoicing`). Page-level


### PR DESCRIPTION
## Summary

Wires the two fix-it deep links on the order-detail delivery rider banner (#1793), replacing the disabled "Coming soon" placeholder with real navigation:

- **`unmapped` rider -> "Add mapping"**: links to the source connection's mappings page at `/connections/{id}/mappings?tab=carriers&method=<sourceDeliveryMethodId>&methodName=<name>`. The mappings page reads these query params to pre-select the Carriers (Delivery) tab and pre-focus the unmapped source method in `MappingPanel` - the add-row source select is pre-populated and scrolled/focused, with a "Map X to a carrier below" hint. Pre-focus is a no-op when the method is already mapped or not found among the loaded source options (stale/mismatched link), so it degrades gracefully.
- **`not-connected` rider -> "Connect {carrier}"**: links to the candidate carrier's guided setup-card route (`usePlatform(candidate.platformType)?.setupCard?.to`), falling back to `/connections/new` when the plugin ships no dedicated setup wizard.

The deep-link query-param contract (`tab`/`method`/`methodName`, plus the `buildDeliveryMappingLink` builder) lives in `apps/web/src/features/mappings/lib/delivery-mapping-deep-link.ts` and is re-exported from the `mappings` feature barrel, so the producer (orders) and consumer (connections page) share one source of truth for param names and the target tab id.

New component: `DeliveryRiderAction` (`apps/web/src/features/orders/components/delivery-rider-action.tsx`), rendered into the `actionSlot` of `DeliveryRiderBanner` (#1793) only when a `sourceConnectionId` is available on the order; otherwise the existing disabled placeholder still renders.

This is the fourth and final sub-issue in the epic #1776 chain (#1791 -> #1792 -> #1793 -> #1794). Part of epic #1776.


## Areas worth a closer look

- **Mappings-page pre-filter query-param mechanism**: `ConnectionMappingsPage` now reads `?tab=`/`?method=`/`?methodName=` via `useSearchParams` to set the `Tabs` initial value and pass `focusSourceValue`/`focusSourceName` into `MappingPanel`. The requested tab is only honored if it's actually present in that connection's capability-gated tab list (falls back to `tabs[0]` otherwise) - this touches a shared page consumed by every mapping type (status/carriers/payments/order-states), not just the orders flow.
- **New-connection platform pre-selection fallback**: `usePlatform(candidate?.platformType)?.setupCard?.to ?? '/connections/new'` in `DeliveryRiderAction` reaches into the plugin registry from the orders feature to resolve a carrier's guided setup route, falling back to the generic new-connection page when a plugin has no `setupCard`.

## Test plan

- [x] `pnpm --filter @openlinker/web type-check` - zero errors
- [x] Affected specs pass: `delivery-rider-action.test.tsx`, `order-delivery-panel.test.tsx`, `MappingPanel.test.tsx`, `connection-mappings-page.test.tsx` (53/53 tests)
- [x] `pnpm --filter @openlinker/web lint` - zero errors (pre-existing warnings only, unrelated to this change)
- [x] `node scripts/check-design-tokens.mjs` - OK, no new/undeclared tokens (feature reuses `--accent-primary`, `--shadow-focus`, `--space-3`, `--text-secondary`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)