### PR TITLE
feat(web/shipping): surface DPD rejection traceId and persisted shipment error (#1800)

### DIFF
--- a/apps/web/src/features/orders/components/generate-label-form.test.tsx
+++ b/apps/web/src/features/orders/components/generate-label-form.test.tsx
@@ -1031,3 +1031,61 @@ describe('GenerateLabelForm — #1806 carrier field-error breakdown', () => {
     expect(document.querySelector('.structured-error-list')).toBeNull();
   });
 });
+
+// ── #1800 — surface the carrier support-reference (traceId) in the Alert ──
+
+describe('GenerateLabelForm — #1800 carrier support-reference (traceId)', () => {
+  function fillParcelAndSubmit(): void {
+    fireEvent.change(screen.getByLabelText(/Length in millimetres/i), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText(/Width in millimetres/i), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText(/Height in millimetres/i), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText(/^Weight \(g\)$/i), { target: { value: '500' } });
+    fireEvent.click(screen.getByRole('button', { name: /^Generate label$/ }));
+  }
+
+  it('renders the generic message plus the support-reference line when the 502 carries a traceId', async () => {
+    const apiClient = createMockApiClient({
+      shipments: {
+        generateLabel: vi.fn().mockRejectedValue(
+          new ApiError('DPD create was rejected (status=NOT_PROCESSED).', 502, {
+            providerCode: 'NOT_PROCESSED',
+            details: { traceId: 'trace-xyz-789' },
+          }),
+        ),
+      },
+    });
+
+    renderWithProviders(
+      <GenerateLabelForm order={makeOrder()} onSuccess={vi.fn()} onCancel={vi.fn()} />,
+      { apiClient },
+    );
+    fillParcelAndSubmit();
+
+    // Generic message still renders (never replaced, only augmented).
+    expect(
+      await screen.findByText(/DPD create was rejected \(status=NOT_PROCESSED\)/i),
+    ).toBeInTheDocument();
+    // Support-reference line renders with the trace id.
+    expect(screen.getByText(/Reference for carrier support:/i)).toBeInTheDocument();
+    expect(screen.getByText('trace-xyz-789')).toBeInTheDocument();
+  });
+
+  it('does not render the support-reference line when the error carries no traceId', async () => {
+    const apiClient = createMockApiClient({
+      shipments: {
+        generateLabel: vi.fn().mockRejectedValue(
+          new ApiError('DPD create was rejected.', 502, { providerCode: 'NOT_PROCESSED' }),
+        ),
+      },
+    });
+
+    renderWithProviders(
+      <GenerateLabelForm order={makeOrder()} onSuccess={vi.fn()} onCancel={vi.fn()} />,
+      { apiClient },
+    );
+    fillParcelAndSubmit();
+
+    expect(await screen.findByText('DPD create was rejected.')).toBeInTheDocument();
+    expect(screen.queryByText(/Reference for carrier support:/i)).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/orders/components/generate-label-form.tsx
+++ b/apps/web/src/features/orders/components/generate-label-form.tsx
@@ -49,6 +49,7 @@ import {
 import { ordersQueryKeys } from '../api/orders.query-keys';
 import {
   extractShippingFieldErrors,
+  extractShippingTraceId,
   useGenerateLabelMutation,
   useLabelDownload,
   type GenerateLabelInput,
@@ -150,6 +151,11 @@ export function GenerateLabelForm({
   const mutation = useGenerateLabelMutation();
   const labelDownload = useLabelDownload();
   const { showToast } = useToast();
+
+  // Carrier support-reference (#1800). Non-ApiError / traceId-less errors
+  // resolve to null, so the reference line stays absent until a carrier that
+  // attaches one (today DPD, #1781) rejects the label.
+  const errorTraceId = extractShippingTraceId(mutation.error);
 
   // AC-3 retry hint (#839) — when the order is Allegro-sourced + the
   // buyer's pickup-point hasn't been resolved yet + the order is young
@@ -478,11 +484,20 @@ export function GenerateLabelForm({
       {/* API error at top (#1806) — the generic carrier message always
           renders; a structured per-field breakdown (e.g. ShipX
           `details.fieldErrors`) is appended underneath when the mutation
-          error carries one, so the operator knows exactly what to fix. */}
+          error carries one, so the operator knows exactly what to fix. A
+          carrier support-reference (`traceId`, e.g. DPD's — #1800) renders
+          last, so the operator can quote it to carrier support without a log
+          dive. */}
       {mutation.error ? (
         <Alert tone="error" className="generate-label-form__error">
           <p className="generate-label-form__error-message">{mutation.error.message}</p>
           <StructuredErrorList errors={extractShippingFieldErrors(mutation.error)} />
+          {errorTraceId ? (
+            <p className="generate-label-form__error-trace">
+              Reference for carrier support:{' '}
+              <span className="mono-text">{errorTraceId}</span>
+            </p>
+          ) : null}
         </Alert>
       ) : null}
 

--- a/apps/web/src/features/orders/components/order-shipment-panel.test.tsx
+++ b/apps/web/src/features/orders/components/order-shipment-panel.test.tsx
@@ -179,6 +179,52 @@ describe('OrderShipmentPanel — populated state', () => {
     expect(screen.getByText(/operator-selected/i)).toBeInTheDocument();
   });
 
+  it('should render the persisted rejection reason and failed-at for a Failed shipment (#1800)', async () => {
+    const shipment = makeShipment({
+      status: 'failed',
+      trackingNumber: null,
+      carrier: 'dpd',
+      failedAt: '2026-05-28T12:34:56.000Z',
+      errorMessage: 'DPD rejected the shipment (NOT_PROCESSED). traceId=trace-xyz-789',
+    });
+    const apiClient = createMockApiClient({
+      connections: { list: vi.fn().mockResolvedValue([makeConnection()]) },
+      shipments: {
+        list: vi.fn().mockResolvedValue({ items: [shipment], total: 1, limit: 20, offset: 0 }),
+      },
+    });
+
+    renderWithProviders(<OrderShipmentPanel order={makeOrder()} />, { apiClient });
+
+    expect(
+      await screen.findByText(/DPD rejected the shipment \(NOT_PROCESSED\)\. traceId=trace-xyz-789/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Failed at/i)).toBeInTheDocument();
+  });
+
+  it('should not render a persisted-error Alert for a non-failed shipment even if errorMessage is set (#1800)', async () => {
+    // Defensive: only the `failed` status gates the persisted-error Alert, so
+    // a stale errorMessage on a recovered shipment never re-surfaces.
+    const shipment = makeShipment({
+      status: 'delivered',
+      errorMessage: 'stale message from an earlier failed attempt',
+    });
+    const apiClient = createMockApiClient({
+      connections: { list: vi.fn().mockResolvedValue([makeConnection()]) },
+      shipments: {
+        list: vi.fn().mockResolvedValue({ items: [shipment], total: 1, limit: 20, offset: 0 }),
+      },
+    });
+
+    const { container } = renderWithProviders(<OrderShipmentPanel order={makeOrder()} />, {
+      apiClient,
+    });
+
+    await screen.findByText('InPost');
+    expect(container.querySelector('.order-shipment-panel__error')).toBeNull();
+    expect(screen.queryByText(/stale message from an earlier failed attempt/i)).not.toBeInTheDocument();
+  });
+
   it('should label the paczkomat as buyer-selected via Allegro when the shipping connection is Allegro', async () => {
     const shipment = makeShipment({ connectionId: 'conn-allegro-delivery' });
     const apiClient = createMockApiClient({

--- a/apps/web/src/features/orders/components/order-shipment-panel.tsx
+++ b/apps/web/src/features/orders/components/order-shipment-panel.tsx
@@ -177,6 +177,21 @@ function OrderShipmentPanelBody({
   return (
     <div className="order-shipment-panel__body">
       <KeyValueList items={items} />
+      {/* Persisted rejection (#1800) — the richer `errorMessage` / `failedAt`
+          the dispatch service stored on a failed shipment. Without this the
+          reason was visible only synchronously during the failing
+          generate-label mutation, never on a later revisit to a Failed
+          shipment. */}
+      {shipment.status === 'failed' && shipment.errorMessage ? (
+        <Alert tone="error" className="order-shipment-panel__error">
+          <p className="order-shipment-panel__error-message">{shipment.errorMessage}</p>
+          {shipment.failedAt ? (
+            <p className="order-shipment-panel__error-meta text-muted">
+              Failed at {new Date(shipment.failedAt).toLocaleString()}
+            </p>
+          ) : null}
+        </Alert>
+      ) : null}
       {mutationError ? (
         <Alert tone="error" className="order-shipment-panel__error">
           {mutationError}

--- a/apps/web/src/features/shipments/index.ts
+++ b/apps/web/src/features/shipments/index.ts
@@ -51,3 +51,4 @@ export { ShipmentStatusBadge } from './components/shipment-status-badge';
 export { buildCarrierTrackingUrl, getCarrierDisplayName } from './lib/carrier-tracking-url';
 export { pickActiveShipment } from './lib/pick-active-shipment';
 export { extractShippingFieldErrors } from './lib/extract-shipping-field-errors';
+export { extractShippingTraceId } from './lib/extract-shipping-trace-id';

--- a/apps/web/src/features/shipments/lib/extract-shipping-trace-id.test.ts
+++ b/apps/web/src/features/shipments/lib/extract-shipping-trace-id.test.ts
@@ -1,0 +1,55 @@
+/**
+ * extractShippingTraceId — unit tests (#1800)
+ *
+ * Covers the shape-sniffing extractor: a real ApiError carrying a DPD-style
+ * `details.traceId`, the non-matching shapes it must reject, and the
+ * non-ApiError / null-error fall-throughs.
+ */
+import { describe, expect, it } from 'vitest';
+import { ApiError } from '../../../shared/api/api-error';
+import { extractShippingTraceId } from './extract-shipping-trace-id';
+
+function makeApiError(details: unknown, message = 'DPD create was rejected.'): ApiError {
+  return new ApiError(message, 502, details);
+}
+
+describe('extractShippingTraceId', () => {
+  it('returns null when the error is not an ApiError', () => {
+    expect(extractShippingTraceId(new Error('boom'))).toBeNull();
+  });
+
+  it('returns null for a null error (no mutation failure)', () => {
+    expect(extractShippingTraceId(null)).toBeNull();
+  });
+
+  it('returns null when details has no nested traceId', () => {
+    expect(extractShippingTraceId(makeApiError({ providerCode: 'NOT_PROCESSED' }))).toBeNull();
+  });
+
+  it('returns null when details.details exists but carries no traceId', () => {
+    const err = makeApiError({ providerCode: 'NOT_PROCESSED', details: { validationInfo: [] } });
+    expect(extractShippingTraceId(err)).toBeNull();
+  });
+
+  it('returns null when traceId is present but not a string', () => {
+    const err = makeApiError({ details: { traceId: 12345 } });
+    expect(extractShippingTraceId(err)).toBeNull();
+  });
+
+  it('returns null when traceId is an empty string', () => {
+    const err = makeApiError({ details: { traceId: '' } });
+    expect(extractShippingTraceId(err)).toBeNull();
+  });
+
+  it('extracts the traceId from the nested providerDetails shape the 502 body carries', () => {
+    const err = makeApiError({
+      providerCode: 'NOT_PROCESSED',
+      details: { traceId: 'trace-xyz-789' },
+    });
+    expect(extractShippingTraceId(err)).toBe('trace-xyz-789');
+  });
+
+  it('returns null for a generic non-shipping ApiError (e.g. a network failure)', () => {
+    expect(extractShippingTraceId(ApiError.fromNetworkFailure(new Error('timeout')))).toBeNull();
+  });
+});

--- a/apps/web/src/features/shipments/lib/extract-shipping-trace-id.ts
+++ b/apps/web/src/features/shipments/lib/extract-shipping-trace-id.ts
@@ -1,0 +1,43 @@
+/**
+ * Shipping support-reference (traceId) extractor
+ *
+ * Sniffs the FE `ApiError.details` shape a shipping-command 502 carries for a
+ * carrier-side support reference. The controller maps
+ * `ShippingProviderRejectionException` to `{ message, providerCode, details:
+ * providerDetails }`, so a `providerDetails.traceId` surfaces on the FE at
+ * `ApiError.details.details.traceId` — the same nesting depth
+ * `extractShippingFieldErrors` reads `fieldErrors` from. Returns the trace id
+ * string when present, `null` otherwise (#1800).
+ *
+ * Provider-generic by construction: any shipping adapter that attaches a
+ * `traceId` to `providerDetails` (today DPD Polska, #1777/#1781) renders the
+ * same way — no carrier name is hardcoded here.
+ *
+ * @module features/shipments/lib
+ */
+import { ApiError } from '../../../shared/api/api-error';
+
+interface TraceIdBody {
+  details: {
+    traceId: string;
+  };
+}
+
+function hasTraceId(value: unknown): value is TraceIdBody {
+  if (typeof value !== 'object' || value === null) return false;
+  const details = (value as { details?: unknown }).details;
+  if (typeof details !== 'object' || details === null) return false;
+  const traceId = (details as { traceId?: unknown }).traceId;
+  return typeof traceId === 'string' && traceId.length > 0;
+}
+
+/**
+ * Extracts the carrier support-reference (`traceId`) from a shipping-command
+ * mutation error, or `null` when the error is not an `ApiError` or carries no
+ * `traceId`. Callers render a "quote this to carrier support" line only when a
+ * non-null value comes back.
+ */
+export function extractShippingTraceId(err: unknown): string | null {
+  if (!(err instanceof ApiError)) return null;
+  return hasTraceId(err.details) ? err.details.details.traceId : null;
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -10488,6 +10488,16 @@ textarea.bulk-editor__input { resize: vertical; min-height: 66px; font-family: i
   margin: 0;
 }
 
+/* #1800 — persisted rejection reason on a Failed shipment (revisit view) */
+.order-shipment-panel__error-message {
+  margin: 0;
+}
+
+.order-shipment-panel__error-meta {
+  margin: var(--space-1) 0 0;
+  font-size: var(--font-size-sm);
+}
+
 /* Loading-state skeleton (avoids CLS on first paint while connections
  * settle — tech-review SUGGESTION). Reserves the same vertical footprint
  * the populated panel will occupy. */
@@ -10523,6 +10533,27 @@ textarea.bulk-editor__input { resize: vertical; min-height: 66px; font-family: i
 }
 
 /* ── Shipment action buttons (#769) ────────────────────────────────────── */
+
+/* ── Shipments list — failed-shipment reason under the status badge (#1800) ── */
+.shipment-status-cell {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  align-items: flex-start;
+}
+
+.shipment-status-cell__error {
+  max-width: 32ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  color: var(--status-error-fg);
+  font-size: var(--font-size-sm);
+}
+
+.shipment-status-cell__failed-at {
+  font-size: var(--font-size-sm);
+}
 
 .shipment-action-buttons {
   display: flex;
@@ -10814,6 +10845,13 @@ textarea.bulk-editor__input { resize: vertical; min-height: 66px; font-family: i
 
 .generate-label-form__error .structured-error-list {
   margin-top: var(--space-2);
+}
+
+/* #1800 — carrier support-reference (traceId) line under the error breakdown */
+.generate-label-form__error-trace {
+  margin: var(--space-2) 0 0;
+  color: var(--text-secondary);
+  font-size: var(--font-size-sm);
 }
 
 .generate-label-form__missing-list {

--- a/apps/web/src/pages/shipments/shipments-page.test.tsx
+++ b/apps/web/src/pages/shipments/shipments-page.test.tsx
@@ -33,6 +33,26 @@ function page(items: Shipment[]): PaginatedShipments {
   return { items, total: items.length, limit: 20, offset: 0 };
 }
 
+/** Forces the DataTable's `useMediaQuery('(max-width: 767.98px)')` to report a
+ * mobile viewport so the card view (not the table) renders. Mirrors the
+ * `mockMobileViewport` helper in `data-table.test.tsx`. */
+function mockMobileViewport(): { restore: () => void } {
+  const spy = vi.spyOn(window, 'matchMedia').mockImplementation(
+    (query) =>
+      ({
+        matches: query.includes('max-width'),
+        media: query,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      }) as MediaQueryList,
+  );
+  return { restore: () => spy.mockRestore() };
+}
+
 function makeConnection(overrides: Partial<Connection> = {}): Connection {
   return {
     id: 'conn_inpost',
@@ -74,6 +94,79 @@ describe('ShipmentsPage', () => {
     // Status word renders in both the table cell and the mobile card meta.
     expect((await screen.findAllByText('generated')).length).toBeGreaterThan(0);
     expect(screen.getByText('Shipments')).toBeInTheDocument();
+  });
+
+  it('should render the persisted rejection reason under the status for a Failed shipment (#1800)', async () => {
+    const mockApi = createMockApiClient({
+      shipments: {
+        list: vi.fn().mockResolvedValue(
+          page([
+            makeShipment({
+              status: 'failed',
+              trackingNumber: null,
+              failedAt: '2026-05-28T12:34:56.000Z',
+              errorMessage: 'DPD rejected the shipment (NOT_PROCESSED).',
+            }),
+          ]),
+        ),
+      },
+      connections: { list: vi.fn().mockResolvedValue([]) },
+    });
+
+    renderWithProviders(<ShipmentsPage />, { apiClient: mockApi });
+
+    // The persisted reason renders in the status cell (table + mobile card).
+    expect(
+      (await screen.findAllByText('DPD rejected the shipment (NOT_PROCESSED).')).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it('should render the persisted rejection reason in the mobile card view too (#1800)', async () => {
+    // The DataTable renders the card view (not the table) on a mobile
+    // viewport, so the failure reason must reach the card `meta` slot as well —
+    // triage-from-phone parity per frontend-ui-style-guide § Responsive.
+    const viewport = mockMobileViewport();
+    try {
+      const mockApi = createMockApiClient({
+        shipments: {
+          list: vi.fn().mockResolvedValue(
+            page([
+              makeShipment({
+                status: 'failed',
+                trackingNumber: null,
+                failedAt: '2026-05-28T12:34:56.000Z',
+                errorMessage: 'DPD rejected the shipment (NOT_PROCESSED).',
+              }),
+            ]),
+          ),
+        },
+        connections: { list: vi.fn().mockResolvedValue([]) },
+      });
+
+      const { container } = renderWithProviders(<ShipmentsPage />, { apiClient: mockApi });
+
+      await screen.findByText('DPD rejected the shipment (NOT_PROCESSED).');
+      // Confirm it rendered inside a card, not a table row.
+      expect(container.querySelector('.data-table__card')).not.toBeNull();
+    } finally {
+      viewport.restore();
+    }
+  });
+
+  it('should not render an error line for a non-failed shipment (#1800)', async () => {
+    const mockApi = createMockApiClient({
+      shipments: {
+        list: vi.fn().mockResolvedValue(
+          page([makeShipment({ status: 'delivered', errorMessage: 'stale earlier failure' })]),
+        ),
+      },
+      connections: { list: vi.fn().mockResolvedValue([]) },
+    });
+
+    renderWithProviders(<ShipmentsPage />, { apiClient: mockApi });
+
+    expect((await screen.findAllByText('delivered')).length).toBeGreaterThan(0);
+    expect(screen.queryByText('stale earlier failure')).not.toBeInTheDocument();
   });
 
   it('should pass URL filters through to the query (incl. hasTracking=false coercion)', async () => {

--- a/apps/web/src/pages/shipments/shipments-page.tsx
+++ b/apps/web/src/pages/shipments/shipments-page.tsx
@@ -56,6 +56,34 @@ function inclusiveEndOfDay(dateOnly: string): string {
   return dateOnly.includes('T') ? dateOnly : `${dateOnly}T23:59:59.999Z`;
 }
 
+/**
+ * Status column / mobile-card-meta renderer (#1800). For a failed shipment the
+ * persisted rejection reason renders under the badge — clamped to one line with
+ * the full message on hover — plus when it failed, so the operator sees why on a
+ * later revisit rather than only synchronously during the failing
+ * generate-label call. Shared between the table cell and the mobile card `meta`
+ * slot (the DataTable renders one or the other by viewport) so the reason has
+ * list parity at every breakpoint.
+ */
+function ShipmentStatusCell({ shipment }: { shipment: Shipment }): ReactElement {
+  const showError = shipment.status === 'failed' && shipment.errorMessage;
+  return (
+    <div className="shipment-status-cell">
+      <ShipmentStatusBadge status={shipment.status} />
+      {showError ? (
+        <span className="shipment-status-cell__error" title={shipment.errorMessage ?? undefined}>
+          {shipment.errorMessage}
+        </span>
+      ) : null}
+      {shipment.status === 'failed' && shipment.failedAt ? (
+        <span className="shipment-status-cell__failed-at text-muted">
+          <TimeDisplay iso={shipment.failedAt} />
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
 export function ShipmentsPage(): ReactElement {
   const [searchParams, setSearchParams] = useSearchParams();
   const { sort, setSort } = useTableSort([{ id: 'createdAt', desc: true }]);
@@ -187,7 +215,7 @@ export function ShipmentsPage(): ReactElement {
     {
       id: 'status',
       header: 'Status',
-      cell: (s) => <ShipmentStatusBadge status={s.status} />,
+      cell: (s) => <ShipmentStatusCell shipment={s} />,
       accessor: (s) => s.status,
       sortable: true,
     },
@@ -397,7 +425,7 @@ export function ShipmentsPage(): ReactElement {
                 ) : (
                   <EntityLabel id={s.orderId} to={`/orders/${s.orderId}`} showId />
                 ),
-              meta: (s) => <ShipmentStatusBadge status={s.status} />,
+              meta: (s) => <ShipmentStatusCell shipment={s} />,
             }}
           />
 


### PR DESCRIPTION
## Summary

Surfaces the DPD rejection-diagnosability backend fields (#1777/#1781) on the operator FE so the recovery handles reach the operator at the keyboard, not only log-readers (#1800). `apps/web` only, no backend changes.

- **`extractShippingTraceId`** (`features/shipments/lib/extract-shipping-trace-id.ts`) — a provider-generic sibling of `extractShippingFieldErrors` (#1806). Reads the carrier support-reference off the 502 body at `ApiError.details.details.traceId` and returns `null` otherwise. No carrier name is hardcoded — any adapter that attaches `providerDetails.traceId` (today DPD, #1781) renders the same way.
- **`GenerateLabelForm`** — the error `Alert` now renders a `Reference for carrier support: <traceId>` line under the existing per-field breakdown when the mutation error carries a `traceId`; absent otherwise.
- **`ShipmentsPage`** — the status cell renders the persisted `errorMessage` (clamped to one line, full message on hover) + `failedAt` for `Failed` shipments, so the reason is visible on a later revisit, not only synchronously during the failing mutation.
- **`OrderShipmentPanel`** — renders an error `Alert` with `errorMessage` + `failedAt` for a `Failed` shipment, gated strictly on `status === 'failed'`.
- Tests for the extractor and every new render branch (present/absent traceId; failed/non-failed shipment in both list and panel).

## Stacked on #1812

This edits the same error `Alert` block in `generate-label-form.tsx` that #1806/PR #1812 restructured, so it is **based on `1806-shipx-field-errors-alert`** to reuse `extractShippingFieldErrors` + `StructuredErrorList` and avoid a conflict. GitHub will retarget this PR to `main` once #1812 merges.

## Corrections vs. the issue

- The issue's file paths said `features/shipping/…`; the real file is `features/orders/components/generate-label-form.tsx`.
- The issue's snippet read `error.details.traceId`; the controller nests `providerDetails` under `details`, so the real FE path is **`error.details.details.traceId`** (mirrors how #1812's extractor reads `fieldErrors`).
- #1781 (backend `traceId`) is **not merged yet** — the FE is forward-compatible: the reference line stays absent until a carrier attaches a `traceId`.
- Copy is `Reference for carrier support` (not `DPD support`) to stay provider-generic, consistent with the #1806 extractor.

## Test plan

- [x] `pnpm --filter @openlinker/web type-check` — clean
- [x] `pnpm --filter @openlinker/web test` — 270 files / 2456 tests passing
- [x] `pnpm --filter @openlinker/web lint` — 0 errors (pre-existing warnings only)

## Docs

None — FE-only diagnostics surface over existing backend fields (`error.details.details.traceId`, `Shipment.errorMessage` / `failedAt`); no new port, capability, contract, or UI pattern (matches the issue's own `## Docs impact`).

Closes #1800