### PR TITLE
feat(web/shipping): surface carrier traceId and persisted shipment error on the operator UI

### DIFF
--- a/apps/web/src/features/orders/components/generate-label-form.test.tsx
+++ b/apps/web/src/features/orders/components/generate-label-form.test.tsx
@@ -1031,3 +1031,60 @@ describe('GenerateLabelForm — #1806 carrier field-error breakdown', () => {
     expect(document.querySelector('.structured-error-list')).toBeNull();
   });
 });
+
+// ── #1800 — surface carrier support reference (traceId) in the error Alert ──
+
+describe('GenerateLabelForm — #1800 carrier support reference', () => {
+  function fillParcelAndSubmit(): void {
+    fireEvent.change(screen.getByLabelText(/Length in millimetres/i), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText(/Width in millimetres/i), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText(/Height in millimetres/i), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText(/^Weight \(g\)$/i), { target: { value: '500' } });
+    fireEvent.click(screen.getByRole('button', { name: /^Generate label$/ }));
+  }
+
+  it('should render a copyable carrier support reference when the 502 nests a traceId on providerDetails', async () => {
+    const apiClient = createMockApiClient({
+      shipments: {
+        generateLabel: vi.fn().mockRejectedValue(
+          // Real DPD envelope: traceId merged into providerDetails →
+          // controller wraps it as `{ message, providerCode, details }`, so on
+          // the FE it lands at ApiError.details.details.traceId.
+          new ApiError('DPD could not process the shipment.', 502, {
+            providerCode: 'NOT_PROCESSED',
+            details: { errorCode: null, info: 'rejected', traceId: 'trace-xyz-789' },
+          }),
+        ),
+      },
+    });
+
+    renderWithProviders(
+      <GenerateLabelForm order={makeOrder()} onSuccess={vi.fn()} onCancel={vi.fn()} />,
+      { apiClient },
+    );
+    fillParcelAndSubmit();
+
+    expect(await screen.findByText(/DPD could not process the shipment/i)).toBeInTheDocument();
+    expect(screen.getByText(/Reference for carrier support/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Copy support reference trace-xyz-789' }),
+    ).toBeInTheDocument();
+  });
+
+  it('should not render the support-reference line when the mutation error carries no traceId', async () => {
+    const apiClient = createMockApiClient({
+      shipments: {
+        generateLabel: vi.fn().mockRejectedValue(new ApiError('Carrier is unreachable', 502, null)),
+      },
+    });
+
+    renderWithProviders(
+      <GenerateLabelForm order={makeOrder()} onSuccess={vi.fn()} onCancel={vi.fn()} />,
+      { apiClient },
+    );
+    fillParcelAndSubmit();
+
+    expect(await screen.findByText('Carrier is unreachable')).toBeInTheDocument();
+    expect(screen.queryByText(/Reference for carrier support/i)).toBeNull();
+  });
+});

--- a/apps/web/src/features/orders/components/generate-label-form.tsx
+++ b/apps/web/src/features/orders/components/generate-label-form.tsx
@@ -49,6 +49,7 @@ import {
 import { ordersQueryKeys } from '../api/orders.query-keys';
 import {
   extractShippingFieldErrors,
+  extractShippingTraceId,
   useGenerateLabelMutation,
   useLabelDownload,
   type GenerateLabelInput,
@@ -478,11 +479,15 @@ export function GenerateLabelForm({
       {/* API error at top (#1806) — the generic carrier message always
           renders; a structured per-field breakdown (e.g. ShipX
           `details.fieldErrors`) is appended underneath when the mutation
-          error carries one, so the operator knows exactly what to fix. */}
+          error carries one, so the operator knows exactly what to fix.
+          A carrier support reference (`traceId`, e.g. DPD's undiagnosable
+          `NOT_PROCESSED`, #1800) renders last when present, so the operator
+          can quote it to carrier support without a log dive. */}
       {mutation.error ? (
         <Alert tone="error" className="generate-label-form__error">
           <p className="generate-label-form__error-message">{mutation.error.message}</p>
           <StructuredErrorList errors={extractShippingFieldErrors(mutation.error)} />
+          <ShippingTraceReference traceId={extractShippingTraceId(mutation.error)} />
         </Alert>
       ) : null}
 
@@ -792,4 +797,39 @@ function collectValidationMessages(
     if (typeof message === 'string') messages.push(message);
   }
   return messages;
+}
+
+/**
+ * Carrier support reference (#1800). Renders the carrier-assigned `traceId`
+ * (e.g. DPD's, surfaced on an undiagnosable `NOT_PROCESSED` rejection) with a
+ * click-to-copy affordance so the operator can quote it to carrier support.
+ * Renders nothing when the error carries no trace id, so the caller can pass
+ * `extractShippingTraceId(...)` unconditionally.
+ */
+function ShippingTraceReference({ traceId }: { traceId: string | null }): ReactElement | null {
+  const [copied, setCopied] = useState(false);
+
+  if (traceId === null) return null;
+
+  const handleCopy = (): void => {
+    void navigator.clipboard?.writeText(traceId).then(() => {
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1500);
+    });
+  };
+
+  return (
+    <p className="generate-label-form__error-trace">
+      Reference for carrier support:{' '}
+      <button
+        type="button"
+        className="generate-label-form__error-trace-id mono-text"
+        onClick={handleCopy}
+        aria-label={copied ? `Copied ${traceId}` : `Copy support reference ${traceId}`}
+      >
+        {traceId}
+        {copied ? <span className="generate-label-form__error-trace-copied">copied</span> : null}
+      </button>
+    </p>
+  );
 }

--- a/apps/web/src/features/orders/components/order-shipment-panel.test.tsx
+++ b/apps/web/src/features/orders/components/order-shipment-panel.test.tsx
@@ -402,3 +402,53 @@ describe('OrderShipmentPanel — action button matrix (§3.4)', () => {
     vi.restoreAllMocks();
   });
 });
+
+describe('OrderShipmentPanel — persisted rejection (#1800)', () => {
+  it('should render the persisted errorMessage and failedAt for a failed shipment', async () => {
+    const shipment = makeShipment({
+      status: 'failed',
+      errorMessage: 'DPD rejected the shipment: sender postal code is not serviceable.',
+      failedAt: '2026-05-28T12:30:00.000Z',
+      trackingNumber: null,
+      carrier: 'dpd',
+    });
+    const apiClient = createMockApiClient({
+      connections: { list: vi.fn().mockResolvedValue([makeConnection()]) },
+      shipments: {
+        list: vi.fn().mockResolvedValue({ items: [shipment], total: 1, limit: 20, offset: 0 }),
+      },
+    });
+
+    renderWithProviders(<OrderShipmentPanel order={makeOrder()} />, { apiClient });
+
+    expect(
+      await screen.findByText(/sender postal code is not serviceable/i),
+    ).toBeInTheDocument();
+    // failedAt renders as a relative/absolute time — the "Failed" label anchors it.
+    expect(screen.getByText(/^Failed/)).toBeInTheDocument();
+  });
+
+  it('should not render a persisted-error Alert for a non-failed shipment carrying a stale errorMessage', async () => {
+    // A shipment that failed once then recovered keeps its old errorMessage;
+    // gating on status === 'failed' prevents surfacing it as a current error.
+    const shipment = makeShipment({
+      status: 'dispatched',
+      errorMessage: 'previous transient error',
+      failedAt: '2026-05-28T12:30:00.000Z',
+    });
+    const apiClient = createMockApiClient({
+      connections: { list: vi.fn().mockResolvedValue([makeConnection()]) },
+      shipments: {
+        list: vi.fn().mockResolvedValue({ items: [shipment], total: 1, limit: 20, offset: 0 }),
+      },
+    });
+
+    const { container } = renderWithProviders(<OrderShipmentPanel order={makeOrder()} />, {
+      apiClient,
+    });
+
+    await screen.findByText('Shipment');
+    expect(screen.queryByText('previous transient error')).toBeNull();
+    expect(container.querySelector('.order-shipment-panel__error')).toBeNull();
+  });
+});

--- a/apps/web/src/features/orders/components/order-shipment-panel.tsx
+++ b/apps/web/src/features/orders/components/order-shipment-panel.tsx
@@ -25,6 +25,7 @@ import { LoadingState, ErrorState, EmptyState } from '../../../shared/ui/feedbac
 import { KeyValueList, type KeyValueItem } from '../../../shared/ui/key-value-list';
 import { StatusBadge } from '../../../shared/ui/status-badge';
 import { Button } from '../../../shared/ui/button';
+import { TimeDisplay } from '../../../shared/ui/time-display';
 
 import type { OrderRecord } from '../api/orders.types';
 import { parseOrderSnapshot, type PaymentStatus } from '../api/order-snapshot.schema';
@@ -177,6 +178,20 @@ function OrderShipmentPanelBody({
   return (
     <div className="order-shipment-panel__body">
       <KeyValueList items={items} />
+      {/* Persisted rejection (#1800) — the richer `errorMessage` / `failedAt`
+          the dispatch service stores on a failed shipment is otherwise only
+          visible synchronously during the failing mutation; render it here so
+          an operator revisiting a `failed` shipment still sees why. */}
+      {shipment.status === 'failed' && shipment.errorMessage ? (
+        <Alert tone="error" className="order-shipment-panel__error">
+          <p className="order-shipment-panel__error-message">{shipment.errorMessage}</p>
+          {shipment.failedAt ? (
+            <p className="order-shipment-panel__error-meta">
+              Failed <TimeDisplay iso={shipment.failedAt} />
+            </p>
+          ) : null}
+        </Alert>
+      ) : null}
       {mutationError ? (
         <Alert tone="error" className="order-shipment-panel__error">
           {mutationError}

--- a/apps/web/src/features/shipments/index.ts
+++ b/apps/web/src/features/shipments/index.ts
@@ -51,3 +51,4 @@ export { ShipmentStatusBadge } from './components/shipment-status-badge';
 export { buildCarrierTrackingUrl, getCarrierDisplayName } from './lib/carrier-tracking-url';
 export { pickActiveShipment } from './lib/pick-active-shipment';
 export { extractShippingFieldErrors } from './lib/extract-shipping-field-errors';
+export { extractShippingTraceId } from './lib/extract-shipping-trace-id';

--- a/apps/web/src/features/shipments/lib/extract-shipping-trace-id.test.ts
+++ b/apps/web/src/features/shipments/lib/extract-shipping-trace-id.test.ts
@@ -1,0 +1,63 @@
+/**
+ * extractShippingTraceId — unit tests (#1800)
+ *
+ * Covers the trace-id sniffer: the real nested ApiError envelope DPD produces
+ * (`details.details.traceId`), the non-matching shapes it must reject, and the
+ * empty/whitespace guard.
+ */
+import { describe, expect, it } from 'vitest';
+import { ApiError } from '../../../shared/api/api-error';
+import { extractShippingTraceId } from './extract-shipping-trace-id';
+
+function makeApiError(details: unknown, message = 'There are some validation errors.'): ApiError {
+  return new ApiError(message, 502, details);
+}
+
+describe('extractShippingTraceId', () => {
+  it('returns null when the error is not an ApiError', () => {
+    expect(extractShippingTraceId(new Error('boom'))).toBeNull();
+  });
+
+  it('returns null when details is not an object', () => {
+    expect(extractShippingTraceId(makeApiError('a string body'))).toBeNull();
+  });
+
+  it('returns null when the 502 body has no nested details object', () => {
+    expect(extractShippingTraceId(makeApiError({ message: 'boom', providerCode: 'x' }))).toBeNull();
+  });
+
+  it('returns null when nested details carries no traceId', () => {
+    const err = makeApiError({
+      providerCode: 'NOT_PROCESSED',
+      details: { errorCode: null, info: 'rejected' },
+    });
+    expect(extractShippingTraceId(err)).toBeNull();
+  });
+
+  it('returns null when traceId is present but not a string', () => {
+    const err = makeApiError({ providerCode: 'x', details: { traceId: 123 } });
+    expect(extractShippingTraceId(err)).toBeNull();
+  });
+
+  it('returns null when traceId is an empty / whitespace-only string', () => {
+    expect(extractShippingTraceId(makeApiError({ details: { traceId: '' } }))).toBeNull();
+    expect(extractShippingTraceId(makeApiError({ details: { traceId: '   ' } }))).toBeNull();
+  });
+
+  it('extracts the traceId from the real DPD nested rejection envelope', () => {
+    const err = makeApiError({
+      providerCode: 'NOT_PROCESSED',
+      details: { errorCode: null, info: 'rejected', traceId: 'trace-xyz-789' },
+    });
+    expect(extractShippingTraceId(err)).toBe('trace-xyz-789');
+  });
+
+  it('trims surrounding whitespace on the extracted traceId', () => {
+    const err = makeApiError({ details: { traceId: '  trace-abc-123  ' } });
+    expect(extractShippingTraceId(err)).toBe('trace-abc-123');
+  });
+
+  it('returns null for a generic non-shipping ApiError (e.g. a network failure)', () => {
+    expect(extractShippingTraceId(ApiError.fromNetworkFailure(new Error('timeout')))).toBeNull();
+  });
+});

--- a/apps/web/src/features/shipments/lib/extract-shipping-trace-id.ts
+++ b/apps/web/src/features/shipments/lib/extract-shipping-trace-id.ts
@@ -1,0 +1,39 @@
+/**
+ * Shipping trace-id extractor
+ *
+ * Sniffs the FE `ApiError.details` shape a shipping-command 502 carries for a
+ * carrier-assigned support reference. `shipment.controller.ts` maps
+ * `ShippingProviderRejectionException` to `{ message, providerCode, details:
+ * providerDetails }`, so any `traceId` an adapter merges into
+ * `providerDetails` (DPD does this for undiagnosable `NOT_PROCESSED`
+ * rejections, #1777) lands at `ApiError.details.details.traceId` — the same
+ * nested `details.details.*` envelope `extractShippingFieldErrors` reads.
+ * Returns the trimmed trace id when present, `null` otherwise so callers
+ * render nothing.
+ *
+ * Provider-generic by construction: it reads whatever `traceId` the 502 body
+ * carries — no carrier name is hardcoded here. Any shipping adapter that
+ * merges a `traceId` into `providerDetails` surfaces the same way (#1800).
+ *
+ * @module features/shipments/lib
+ */
+import { ApiError } from '../../../shared/api/api-error';
+
+/**
+ * Extracts a carrier-assigned support reference (`traceId`) from a
+ * shipping-command mutation error. Returns `null` unless the error is an
+ * `ApiError` whose nested `details.details.traceId` is a non-empty string.
+ */
+export function extractShippingTraceId(err: unknown): string | null {
+  if (!(err instanceof ApiError)) return null;
+  if (typeof err.details !== 'object' || err.details === null) return null;
+
+  const inner = (err.details as { details?: unknown }).details;
+  if (typeof inner !== 'object' || inner === null) return null;
+
+  const traceId = (inner as { traceId?: unknown }).traceId;
+  if (typeof traceId !== 'string') return null;
+
+  const trimmed = traceId.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -10488,6 +10488,46 @@ textarea.bulk-editor__input { resize: vertical; min-height: 66px; font-family: i
   margin: 0;
 }
 
+/* #1800 — persisted rejection message + failedAt on a revisited failed shipment */
+.order-shipment-panel__error-message {
+  margin: 0;
+  overflow-wrap: anywhere;
+}
+
+.order-shipment-panel__error-meta {
+  margin: var(--space-1) 0 0;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+/* ── Shipments list — failed-rejection hint in the status cell (#1800) ── */
+.shipment-status-cell {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  align-items: flex-start;
+}
+
+.shipment-status-cell__error {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  max-width: 32ch;
+}
+
+.shipment-status-cell__error-message {
+  font-size: 0.75rem;
+  color: var(--status-error-fg);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.shipment-status-cell__error-time {
+  font-size: 0.6875rem;
+  color: var(--text-muted);
+}
+
 /* Loading-state skeleton (avoids CLS on first paint while connections
  * settle — tech-review SUGGESTION). Reserves the same vertical footprint
  * the populated panel will occupy. */
@@ -10814,6 +10854,38 @@ textarea.bulk-editor__input { resize: vertical; min-height: 66px; font-family: i
 
 .generate-label-form__error .structured-error-list {
   margin-top: var(--space-2);
+}
+
+/* #1800 — carrier support reference (traceId) under the error breakdown */
+.generate-label-form__error-trace {
+  margin: var(--space-2) 0 0;
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+}
+
+.generate-label-form__error-trace-id {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: 0 var(--space-1);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--bg-surface-muted);
+  color: var(--text-primary);
+  cursor: pointer;
+  overflow-wrap: anywhere;
+}
+
+.generate-label-form__error-trace-id:focus-visible {
+  box-shadow: var(--shadow-focus);
+  outline: none;
+}
+
+.generate-label-form__error-trace-copied {
+  font-size: 0.6875rem;
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-caps);
+  color: var(--text-muted);
 }
 
 .generate-label-form__missing-list {

--- a/apps/web/src/pages/shipments/shipments-page.test.tsx
+++ b/apps/web/src/pages/shipments/shipments-page.test.tsx
@@ -297,3 +297,42 @@ describe('ShipmentsPage', () => {
     expect(filters).toMatchObject({ hasProviderShipmentId: true });
   });
 });
+
+describe('ShipmentsPage — failed-shipment hint (#1800)', () => {
+  afterEach(cleanup);
+
+  it('should render the persisted errorMessage for a failed shipment', async () => {
+    const failed = makeShipment({
+      id: 'ol_shipment_failed',
+      status: 'failed',
+      errorMessage: 'DPD rejected: sender postal code not serviceable',
+      failedAt: '2026-05-20T12:00:00.000Z',
+      trackingNumber: null,
+    });
+    const mockApi = createMockApiClient({
+      shipments: { list: vi.fn().mockResolvedValue(page([failed])) },
+      connections: { list: vi.fn().mockResolvedValue([]) },
+    });
+
+    renderWithProviders(<ShipmentsPage />, { apiClient: mockApi });
+
+    // The message renders in the status cell (table + mobile card => >=1).
+    expect(
+      (await screen.findAllByText(/sender postal code not serviceable/i)).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it('should not render an error hint for a non-failed shipment', async () => {
+    const mockApi = createMockApiClient({
+      shipments: {
+        list: vi.fn().mockResolvedValue(page([makeShipment({ status: 'delivered', errorMessage: null })])),
+      },
+      connections: { list: vi.fn().mockResolvedValue([]) },
+    });
+
+    const { container } = renderWithProviders(<ShipmentsPage />, { apiClient: mockApi });
+
+    expect((await screen.findAllByText('delivered')).length).toBeGreaterThan(0);
+    expect(container.querySelector('.shipment-status-cell__error')).toBeNull();
+  });
+});

--- a/apps/web/src/pages/shipments/shipments-page.tsx
+++ b/apps/web/src/pages/shipments/shipments-page.tsx
@@ -56,6 +56,34 @@ function inclusiveEndOfDay(dateOnly: string): string {
   return dateOnly.includes('T') ? dateOnly : `${dateOnly}T23:59:59.999Z`;
 }
 
+/**
+ * Status cell (#1800). The status badge, plus — for a `failed` shipment that
+ * persisted a rejection — a compact one-line `errorMessage` (full text on
+ * hover) and the `failedAt` time, so an operator scanning the list sees which
+ * shipments failed and why without opening each order. Non-failed rows render
+ * the badge alone.
+ */
+function ShipmentStatusCell({ shipment }: { shipment: Shipment }): ReactElement {
+  const showError = shipment.status === 'failed' && Boolean(shipment.errorMessage);
+  return (
+    <div className="shipment-status-cell">
+      <ShipmentStatusBadge status={shipment.status} />
+      {showError ? (
+        <span className="shipment-status-cell__error">
+          <span className="shipment-status-cell__error-message" title={shipment.errorMessage ?? undefined}>
+            {shipment.errorMessage}
+          </span>
+          {shipment.failedAt ? (
+            <span className="shipment-status-cell__error-time">
+              <TimeDisplay iso={shipment.failedAt} />
+            </span>
+          ) : null}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
 export function ShipmentsPage(): ReactElement {
   const [searchParams, setSearchParams] = useSearchParams();
   const { sort, setSort } = useTableSort([{ id: 'createdAt', desc: true }]);
@@ -187,7 +215,7 @@ export function ShipmentsPage(): ReactElement {
     {
       id: 'status',
       header: 'Status',
-      cell: (s) => <ShipmentStatusBadge status={s.status} />,
+      cell: (s) => <ShipmentStatusCell shipment={s} />,
       accessor: (s) => s.status,
       sortable: true,
     },
@@ -397,7 +425,7 @@ export function ShipmentsPage(): ReactElement {
                 ) : (
                   <EntityLabel id={s.orderId} to={`/orders/${s.orderId}`} showId />
                 ),
-              meta: (s) => <ShipmentStatusBadge status={s.status} />,
+              meta: (s) => <ShipmentStatusCell shipment={s} />,
             }}
           />
 


### PR DESCRIPTION
## Summary

Surfaces two diagnosability handles the backend already captures but the operator never saw on the shipping UI (`apps/web` only, no backend change):

1. **Generate-label error Alert renders a carrier support reference (`traceId`).** New provider-generic `extractShippingTraceId` (`features/shipments/lib/`) reads the `traceId` a carrier adapter merges into `providerDetails` for an otherwise-undiagnosable rejection (DPD's `NOT_PROCESSED`, #1777). It sits in the same nested `ApiError.details.details.*` envelope as #1806's `extractShippingFieldErrors`, so the new `ShippingTraceReference` line renders below the existing per-field breakdown with a click-to-copy affordance. No carrier name is hardcoded.
2. **Persisted `errorMessage` / `failedAt` on a revisited failure.** The `/shipments` list status cell and the order-detail shipment panel now render the stored `errorMessage` + `failedAt` for `failed` shipments (gated on `status === 'failed'` so a recovered shipment's stale message never shows). Previously these were visible only synchronously during the failing mutation.

Narrow-viewport wrapping (AC #3): the error copy renders as block `<p>` inside `.alert__description` (`p { margin: 0 }`, normal word-wrap), and long single-token values get `overflow-wrap: anywhere` — the #1778 sender-postcode hint paragraph wraps rather than overflowing.

## Corrections to the issue body

Three inaccuracies in #1800 were found and corrected while implementing:

- **PR #1781 is NOT merged** (issue says "already merged") — it is still OPEN and is what defines `traceId`. This PR's `traceId` render is written defensively (renders nothing until the field arrives), so it is forward-compatible; it only becomes live once #1781 merges.
- **The traceId path is nested.** The issue's snippet reads `error.details.traceId`; the backend merges `traceId` into `providerDetails`, and the controller wraps that as `{ message, providerCode, details: providerDetails }`, so on the FE it lands at `error.details.details.traceId`.
- **File paths.** The issue lists `features/shipping/...`; the real file is `apps/web/src/features/orders/components/generate-label-form.tsx`.

## Stacking

Based on `1806-shipx-field-errors-alert` (PR #1812), **not** `main`, because both PRs edit the same generate-label error Alert block; stacking avoids the conflict and reuses `StructuredErrorList` + the `extract-shipping-field-errors` precedent. Rebase onto `main` once #1812 lands.

## Test plan

- [x] `pnpm --filter @openlinker/web type-check` — clean
- [x] `pnpm --filter @openlinker/web lint` — 0 errors (pre-existing warnings only)
- [x] Touched-suite run — 81 passing, including:
  - `extract-shipping-trace-id.test.ts` — nested-envelope extraction, non-ApiError / missing / non-string / empty-string rejection, trim
  - `generate-label-form.test.tsx` (#1800 block) — copyable reference when `traceId` present; no reference line when absent
  - `order-shipment-panel.test.tsx` (#1800 block) — renders errorMessage/failedAt for `failed`; hides a stale message on a non-failed shipment
  - `shipments-page.test.tsx` (#1800 block) — failed-row hint renders; non-failed row has no hint
- [x] `scripts/check-design-tokens.mjs` — OK (no new tokens; only existing vars used)

## Docs

None — FE-only change that surfaces existing backend fields (`traceId` on `providerDetails` per #1777/#1781; `Shipment.errorMessage` / `failedAt` already on the FE shipment types). No new port, capability, cross-context edge, wire contract, or UI pattern (reuses `StructuredErrorList` and the #1806 extractor precedent).

## Dependencies

- Functionally depends on **#1781** (backend `traceId` enrichment, OPEN) for the trace reference to become non-empty in production. FE is forward-compatible in the meantime.
- Stacked on **#1812** (OPEN).

Closes #1800