### PR TITLE
refactor(web/shipping): render DPD traceId via shared CopyableId primitive

### DIFF
--- a/apps/web/src/features/orders/components/generate-label-form.test.tsx
+++ b/apps/web/src/features/orders/components/generate-label-form.test.tsx
@@ -1066,9 +1066,10 @@ describe('GenerateLabelForm — #1800 carrier support reference', () => {
 
     expect(await screen.findByText(/DPD could not process the shipment/i)).toBeInTheDocument();
     expect(screen.getByText(/Reference for carrier support/i)).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', { name: 'Copy support reference trace-xyz-789' }),
-    ).toBeInTheDocument();
+    // The trace id is rendered via the shared CopyableId primitive (aria-label
+    // `Copy <id>`), which also displays the id verbatim.
+    expect(screen.getByRole('button', { name: 'Copy trace-xyz-789' })).toBeInTheDocument();
+    expect(screen.getByText('trace-xyz-789')).toBeInTheDocument();
   });
 
   it('should not render the support-reference line when the mutation error carries no traceId', async () => {

--- a/apps/web/src/features/orders/components/generate-label-form.tsx
+++ b/apps/web/src/features/orders/components/generate-label-form.tsx
@@ -30,6 +30,7 @@ import { useConnectionsQuery } from '../../connections';
 import { usePlatform } from '../../../shared/plugins';
 import { Alert } from '../../../shared/ui/alert';
 import { Button } from '../../../shared/ui/button';
+import { CopyableId } from '../../../shared/ui/copyable-id';
 import { FieldError } from '../../../shared/ui/field-error';
 import { FormErrorSummary } from '../../../shared/ui/form-error-summary';
 import { FormField } from '../../../shared/ui/form-field';
@@ -801,35 +802,17 @@ function collectValidationMessages(
 
 /**
  * Carrier support reference (#1800). Renders the carrier-assigned `traceId`
- * (e.g. DPD's, surfaced on an undiagnosable `NOT_PROCESSED` rejection) with a
- * click-to-copy affordance so the operator can quote it to carrier support.
- * Renders nothing when the error carries no trace id, so the caller can pass
- * `extractShippingTraceId(...)` unconditionally.
+ * (e.g. DPD's, surfaced on an undiagnosable `NOT_PROCESSED` rejection) via the
+ * shared `CopyableId` primitive so the operator can copy it and quote it to
+ * carrier support. Renders nothing when the error carries no trace id, so the
+ * caller can pass `extractShippingTraceId(...)` unconditionally.
  */
 function ShippingTraceReference({ traceId }: { traceId: string | null }): ReactElement | null {
-  const [copied, setCopied] = useState(false);
-
   if (traceId === null) return null;
-
-  const handleCopy = (): void => {
-    void navigator.clipboard?.writeText(traceId).then(() => {
-      setCopied(true);
-      window.setTimeout(() => setCopied(false), 1500);
-    });
-  };
 
   return (
     <p className="generate-label-form__error-trace">
-      Reference for carrier support:{' '}
-      <button
-        type="button"
-        className="generate-label-form__error-trace-id mono-text"
-        onClick={handleCopy}
-        aria-label={copied ? `Copied ${traceId}` : `Copy support reference ${traceId}`}
-      >
-        {traceId}
-        {copied ? <span className="generate-label-form__error-trace-copied">copied</span> : null}
-      </button>
+      Reference for carrier support: <CopyableId id={traceId} />
     </p>
   );
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -10856,36 +10856,17 @@ textarea.bulk-editor__input { resize: vertical; min-height: 66px; font-family: i
   margin-top: var(--space-2);
 }
 
-/* #1800 — carrier support reference (traceId) under the error breakdown */
+/* #1800 — carrier support reference (traceId) under the error breakdown.
+   The mono id + copy affordance come from the shared CopyableId primitive;
+   this rule only spaces + tones the wrapping line. */
 .generate-label-form__error-trace {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-1);
   margin: var(--space-2) 0 0;
   font-size: 0.8125rem;
   color: var(--text-secondary);
-}
-
-.generate-label-form__error-trace-id {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-1);
-  padding: 0 var(--space-1);
-  border: 1px solid var(--border-subtle);
-  border-radius: var(--radius-sm);
-  background: var(--bg-surface-muted);
-  color: var(--text-primary);
-  cursor: pointer;
-  overflow-wrap: anywhere;
-}
-
-.generate-label-form__error-trace-id:focus-visible {
-  box-shadow: var(--shadow-focus);
-  outline: none;
-}
-
-.generate-label-form__error-trace-copied {
-  font-size: 0.6875rem;
-  text-transform: uppercase;
-  letter-spacing: var(--tracking-caps);
-  color: var(--text-muted);
 }
 
 .generate-label-form__missing-list {


### PR DESCRIPTION
## Summary

Follow-up to #1800 (merged as PR #1821 into this branch). The carrier support-reference line added there hand-rolled its own copy button + `clipboard`/`copied` state; this swaps it for the shared **`CopyableId`** primitive (`shared/ui/copyable-id.tsx`), which every other id-copy site already uses (`EntityLabel`, `order-detail-header`, inFakt/InPost panels, …).

Why:
- **Removes duplication** of the copy-to-clipboard pattern.
- **Fixes a missing `setTimeout` cleanup** — the hand-rolled version set `copied` state on a bare `window.setTimeout` with no unmount cleanup, so if the error Alert unmounted within the 1.5 s reset window (mutation reset / form collapse) it would `setState` after unmount. `CopyableId` clears its timer in a `useEffect` cleanup.
- **Drops now-dead CSS** (`.generate-label-form__error-trace-id`, `.generate-label-form__error-trace-copied`), keeping only the wrapping-line rule.

Behaviour is unchanged: the traceId still renders (copyable) only when the mutation error carries one. This surfaced during self-review of #1821; the fix landed just after that PR was merged, hence the separate follow-up.

## Test plan

- [x] `pnpm --filter @openlinker/web type-check` — clean
- [x] `pnpm --filter @openlinker/web test src/features/orders/components/generate-label-form.test.tsx` — 36 passing (the #1800 block now asserts CopyableId's `Copy <id>` affordance)
- [x] `scripts/check-design-tokens.mjs` — OK

## Docs

None — internal FE refactor swapping a hand-rolled affordance for an existing shared primitive; no port, capability, contract, or pattern change.

Relates to #1800