### PR TITLE
fix(web/shipping): wrap the failed-shipment reason on mobile cards + lock the parity (#1800)

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -11086,6 +11086,23 @@ textarea.bulk-editor__input { resize: vertical; min-height: 66px; font-family: i
   color: var(--text-muted);
 }
 
+/* #1800 — mobile card view. The dense desktop table row keeps the reason on
+   one truncated line (density budget) with the full text on native `title`
+   hover; a card has vertical room and no hover on touch, so let the reason
+   wrap to full text there — otherwise triage-from-phone can only read a
+   clamped fragment. `overflow-wrap: anywhere` keeps a long unbroken token
+   (e.g. a traceId embedded in the message) from overflowing the card. */
+.data-table__card .shipment-status-cell__error {
+  max-width: 100%;
+}
+
+.data-table__card .shipment-status-cell__error-message {
+  white-space: normal;
+  overflow: visible;
+  text-overflow: clip;
+  overflow-wrap: anywhere;
+}
+
 /* Loading-state skeleton (avoids CLS on first paint while connections
  * settle — tech-review SUGGESTION). Reserves the same vertical footprint
  * the populated panel will occupy. */

--- a/apps/web/src/pages/shipments/shipments-page.test.tsx
+++ b/apps/web/src/pages/shipments/shipments-page.test.tsx
@@ -1,6 +1,7 @@
-import { cleanup, screen } from '@testing-library/react';
+import { cleanup, screen, within } from '@testing-library/react';
 import { afterEach, describe, it, expect, vi } from 'vitest';
 import { renderWithProviders, createMockApiClient } from '../../test/test-utils';
+import { mockMobileViewport } from '../../test/viewport';
 import { ShipmentsPage } from './shipments-page';
 import type { PaginatedShipments, Shipment } from '../../features/shipments/api/shipments.types';
 import type { Connection } from '../../features/connections/api/connections.types';
@@ -320,6 +321,42 @@ describe('ShipmentsPage — failed-shipment hint (#1800)', () => {
     expect(
       (await screen.findAllByText(/sender postal code not serviceable/i)).length,
     ).toBeGreaterThan(0);
+  });
+
+  it('should render the persisted rejection reason in the mobile card view too', async () => {
+    // `ShipmentStatusCell` is shared between the table cell and the mobile card
+    // `meta` slot, and the DataTable renders one OR the other by viewport — so
+    // this locks the card-view path (which the desktop-only assertion above
+    // never exercises), keeping triage-from-phone parity (frontend-ui-style-guide
+    // § Responsive) from silently regressing.
+    const viewport = mockMobileViewport();
+    try {
+      const failed = makeShipment({
+        id: 'ol_shipment_failed_mobile',
+        status: 'failed',
+        errorMessage: 'DPD rejected: sender postal code not serviceable',
+        failedAt: '2026-05-20T12:00:00.000Z',
+        trackingNumber: null,
+      });
+      const mockApi = createMockApiClient({
+        shipments: { list: vi.fn().mockResolvedValue(page([failed])) },
+        connections: { list: vi.fn().mockResolvedValue([]) },
+      });
+
+      const { container } = renderWithProviders(<ShipmentsPage />, { apiClient: mockApi });
+
+      await screen.findByText(/sender postal code not serviceable/i);
+      // Assert the reason rendered *inside* a card (not merely somewhere on the
+      // page) — in mobile mode the table isn't rendered, so scoping to the card
+      // pins the card-view path specifically.
+      const card = container.querySelector('.data-table__card');
+      expect(card).not.toBeNull();
+      expect(
+        within(card as HTMLElement).getByText(/sender postal code not serviceable/i),
+      ).toBeInTheDocument();
+    } finally {
+      viewport.restore();
+    }
   });
 
   it('should not render an error hint for a non-failed shipment', async () => {

--- a/apps/web/src/shared/ui/data-table.test.tsx
+++ b/apps/web/src/shared/ui/data-table.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { DataTable } from './data-table';
+import { mockMobileViewport } from '../../test/viewport';
 
 interface TestRow {
   createdAt: string;
@@ -19,22 +20,6 @@ function renderWithRouter(ui: React.ReactElement): ReturnType<typeof render> {
   return render(<MemoryRouter>{ui}</MemoryRouter>);
 }
 
-function mockMobileViewport(): { restore: () => void } {
-  const spy = vi.spyOn(window, 'matchMedia').mockImplementation(
-    (query) =>
-      ({
-        matches: query.includes('max-width'),
-        media: query,
-        onchange: null,
-        addEventListener: () => {},
-        removeEventListener: () => {},
-        addListener: () => {},
-        removeListener: () => {},
-        dispatchEvent: () => false,
-      }) as MediaQueryList,
-  );
-  return { restore: () => spy.mockRestore() };
-}
 
 describe('DataTable', () => {
   afterEach(cleanup);

--- a/apps/web/src/test/viewport.ts
+++ b/apps/web/src/test/viewport.ts
@@ -1,0 +1,35 @@
+/**
+ * Viewport test helpers
+ *
+ * Lightweight, provider-free helpers for driving responsive behaviour in
+ * component tests. Kept out of `test-utils.tsx` on purpose so low-level
+ * primitive specs (e.g. `shared/ui/data-table.test.tsx`) can force a viewport
+ * without dragging the full app provider/plugin harness into their module
+ * graph.
+ *
+ * @module test
+ */
+import { vi } from 'vitest';
+
+/**
+ * Forces `window.matchMedia` to report a mobile viewport so the DataTable's
+ * `useMediaQuery('(max-width: 767.98px)')` returns true and the card view (not
+ * the table) renders. Returns a `restore()` — call it in a `finally` so the
+ * spy never leaks into sibling tests.
+ */
+export function mockMobileViewport(): { restore: () => void } {
+  const spy = vi.spyOn(window, 'matchMedia').mockImplementation(
+    (query) =>
+      ({
+        matches: query.includes('max-width'),
+        media: query,
+        onchange: null,
+        addEventListener: () => {},
+        removeEventListener: () => {},
+        addListener: () => {},
+        removeListener: () => {},
+        dispatchEvent: () => false,
+      }) as MediaQueryList,
+  );
+  return { restore: () => spy.mockRestore() };
+}


### PR DESCRIPTION
## Summary

Grew out of the closed duplicate #1820 (which reimplemented #1800 in parallel with the merged #1821). Two things:

1. **Production UX fix.** The #1800 status cell (`ShipmentStatusCell`, shared between the desktop table cell and the DataTable mobile card `meta` slot) rendered the persisted rejection reason as one truncated line (`white-space: nowrap` + ellipsis + `max-width: 32ch`) with the full text only on native `title` hover. That undercuts triage-from-phone (`frontend-ui-style-guide § Responsive`): touch has no hover, so on the mobile card the operator saw only a clamped fragment and had to open the order to read why it failed. The card has vertical room, so its reason now **wraps to full text** (`overflow-wrap: anywhere` prevents a long unbroken token from overflowing). The dense desktop table row keeps the one-line truncation + `title` (density budget; consistent with the codebase's existing truncated-cell convention).

2. **Regression test.** A mobile-viewport test (forces `useMediaQuery` via a `matchMedia` mock) asserts the reason renders inside `.data-table__card`, so the card path can't silently regress. jsdom can't assert CSS wrapping, so the test locks the reason's *presence* on the card; the CSS fix makes it *readable*.

Plus a small test-infra tidy: the `matchMedia` mobile-viewport mock is extracted into a provider-free `test/viewport.ts#mockMobileViewport` (kept out of the heavier `test-utils.tsx` so the `shared/ui` DataTable spec doesn't pull the app provider/plugin harness into its graph); `data-table.test.tsx`'s local copy is migrated to it.

## Follow-ups

List-triage recovery action (inline/bulk retry from a failed row) + carrier-message role visibility are tracked in #1826.

## Test plan

- [x] `pnpm --filter @openlinker/web type-check` — clean
- [x] `pnpm --filter @openlinker/web test` — green (mobile-card test included)
- [x] `pnpm --filter @openlinker/web lint` — 0 errors (design-token drift clean; no new tokens)

## Docs

None — a responsive CSS fix to an existing surface + test hardening; no new port, capability, contract, token, or UI pattern.

Relates to #1800. Based on `1806-shipx-field-errors-alert` (where the #1800 code lives); GitHub will retarget to `main` once that stack merges.