### PR TITLE
feat(woocommerce): map remaining product fields + fix dropped SEO title/description (#1832, #1833)

### DIFF
--- a/apps/api/src/listings/http/bulk-shop-publish.controller.ts
+++ b/apps/api/src/listings/http/bulk-shop-publish.controller.ts
@@ -81,6 +81,7 @@ export class BulkShopPublishController {
         })),
         status: dto.status,
         ...(dto.content !== undefined && { content: dto.content }),
+        ...(dto.commerce !== undefined && { commerce: dto.commerce }),
       });
       return { batchId, items };
     } catch (error) {

--- a/apps/api/src/listings/http/dto/publish-product.dto.spec.ts
+++ b/apps/api/src/listings/http/dto/publish-product.dto.spec.ts
@@ -1,0 +1,72 @@
+/**
+ * Publish-Product DTO validation tests (#1832) — focused on the neutral
+ * `commerce` block's cross-field sale-window rules.
+ */
+import 'reflect-metadata';
+import { plainToInstance } from 'class-transformer';
+import { validate } from 'class-validator';
+
+import { PublishCommerceDto } from './publish-product.dto';
+
+async function errorsFor(commerce: Record<string, unknown>): Promise<string[]> {
+  const dto = plainToInstance(PublishCommerceDto, commerce);
+  const errors = await validate(dto, { whitelist: true });
+  const collect = (es: typeof errors): string[] =>
+    es.flatMap((e) => [
+      ...Object.keys(e.constraints ?? {}),
+      ...(e.children ? collect(e.children) : []),
+    ]);
+  return collect(errors);
+}
+
+describe('PublishCommerceDto (#1832)', () => {
+  it('accepts an empty commerce block', async () => {
+    expect(await errorsFor({})).toEqual([]);
+  });
+
+  it('accepts a sale price with a valid window', async () => {
+    expect(
+      await errorsFor({
+        salePrice: { amount: 9.99, currency: 'PLN' },
+        saleStartsAt: '2026-08-01T00:00:00Z',
+        saleEndsAt: '2026-08-31T23:59:59Z',
+      }),
+    ).toEqual([]);
+  });
+
+  it('accepts a sale price with no window', async () => {
+    expect(await errorsFor({ salePrice: { amount: 9.99, currency: 'PLN' } })).toEqual([]);
+  });
+
+  it('rejects a sale window without a sale price', async () => {
+    const errs = await errorsFor({ saleStartsAt: '2026-08-01T00:00:00Z' });
+    expect(errs).toContain('isDefined');
+  });
+
+  it('rejects a sale end that is not after the start', async () => {
+    const errs = await errorsFor({
+      salePrice: { amount: 9.99, currency: 'PLN' },
+      saleStartsAt: '2026-08-31T00:00:00Z',
+      saleEndsAt: '2026-08-01T00:00:00Z',
+    });
+    expect(errs).toContain('isAfter');
+  });
+
+  it('rejects a non-ISO sale date', async () => {
+    const errs = await errorsFor({
+      salePrice: { amount: 9.99, currency: 'PLN' },
+      saleStartsAt: 'not-a-date',
+    });
+    expect(errs).toContain('isIso8601');
+  });
+
+  it('rejects an unknown tax status', async () => {
+    const errs = await errorsFor({ taxStatus: 'bogus' });
+    expect(errs).toContain('isIn');
+  });
+
+  it('rejects a negative dimension', async () => {
+    const errs = await errorsFor({ dimensions: { length: -1 } });
+    expect(errs).toContain('min');
+  });
+});

--- a/apps/api/src/listings/http/dto/publish-product.dto.ts
+++ b/apps/api/src/listings/http/dto/publish-product.dto.ts
@@ -14,6 +14,7 @@ import {
   ArrayNotEmpty,
   IsArray,
   IsIn,
+  IsISO8601,
   IsInt,
   IsNotEmpty,
   IsNumber,
@@ -30,7 +31,12 @@ import {
 import { Type } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
-import { PublishProductStatusValues, type PublishProductStatus } from '@openlinker/core/listings';
+import {
+  PublishProductStatusValues,
+  PublishTaxStatusValues,
+  type PublishProductStatus,
+  type PublishTaxStatus,
+} from '@openlinker/core/listings';
 
 const VARIANT_ID_PATTERN = /^ol_variant_[a-f0-9]+$/;
 const VARIANT_ID_MESSAGE = 'must be an OpenLinker internal variant id (ol_variant_{hex})';
@@ -64,6 +70,26 @@ export class PublishContentDto {
 
   @ApiPropertyOptional({
     nullable: true,
+    description: 'Short/excerpt description. `null` ⇒ no override.',
+  })
+  @IsOptional()
+  @IsString()
+  shortDescription?: string | null;
+
+  @ApiPropertyOptional({
+    nullable: true,
+    isArray: true,
+    type: String,
+    description: 'Marketing tags. `null` ⇒ no override.',
+  })
+  @IsOptional()
+  @ValidateIf((_o, v) => v !== null)
+  @IsArray()
+  @IsString({ each: true })
+  tags?: string[] | null;
+
+  @ApiPropertyOptional({
+    nullable: true,
     isArray: true,
     type: String,
     description: 'Image URLs in display order. `null` ⇒ no override.',
@@ -73,6 +99,71 @@ export class PublishContentDto {
   @IsArray()
   @IsUrl({}, { each: true, message: 'imageUrls must be an array of valid URLs' })
   imageUrls?: string[] | null;
+}
+
+export class PublishDimensionsDto {
+  @ApiPropertyOptional({ example: 12.5, minimum: 0, description: 'Length. Omitted ⇒ unset.' })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  length?: number;
+
+  @ApiPropertyOptional({ example: 8, minimum: 0, description: 'Width. Omitted ⇒ unset.' })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  width?: number;
+
+  @ApiPropertyOptional({ example: 3, minimum: 0, description: 'Height. Omitted ⇒ unset.' })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  height?: number;
+}
+
+export class PublishCommerceDto {
+  @ApiPropertyOptional({
+    type: PublishPriceDto,
+    description: 'Discounted sale price. Omitted ⇒ no sale price set.',
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => PublishPriceDto)
+  salePrice?: PublishPriceDto;
+
+  @ApiPropertyOptional({
+    description: 'ISO 8601 datetime the sale price becomes active.',
+    example: '2026-08-01T00:00:00Z',
+  })
+  @IsOptional()
+  @IsISO8601()
+  saleStartsAt?: string;
+
+  @ApiPropertyOptional({
+    description: 'ISO 8601 datetime the sale price expires.',
+    example: '2026-08-31T23:59:59Z',
+  })
+  @IsOptional()
+  @IsISO8601()
+  saleEndsAt?: string;
+
+  @ApiPropertyOptional({ type: PublishDimensionsDto, description: 'Physical dimensions.' })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => PublishDimensionsDto)
+  dimensions?: PublishDimensionsDto;
+
+  @ApiPropertyOptional({
+    description: 'Tax class slug (shop-defined, e.g. "reduced-rate"). Omitted ⇒ shop default.',
+  })
+  @IsOptional()
+  @IsString()
+  taxClass?: string;
+
+  @ApiPropertyOptional({ enum: PublishTaxStatusValues, description: 'Tax treatment.' })
+  @IsOptional()
+  @IsIn(PublishTaxStatusValues)
+  taxStatus?: PublishTaxStatus;
 }
 
 export class PublishProductRequestDto {
@@ -108,6 +199,15 @@ export class PublishProductRequestDto {
   @ValidateNested()
   @Type(() => PublishContentDto)
   content?: PublishContentDto;
+
+  @ApiPropertyOptional({
+    type: PublishCommerceDto,
+    description: 'Operator-supplied commerce fields (sale price, dimensions, tax).',
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => PublishCommerceDto)
+  commerce?: PublishCommerceDto;
 }
 
 export class BulkPublishItemDto {
@@ -162,4 +262,13 @@ export class BulkPublishProductRequestDto {
   @ValidateNested()
   @Type(() => PublishContentDto)
   content?: PublishContentDto;
+
+  @ApiPropertyOptional({
+    type: PublishCommerceDto,
+    description: 'Shared commerce fields (sale price, dimensions, tax) applied to every child.',
+  })
+  @IsOptional()
+  @ValidateNested()
+  @Type(() => PublishCommerceDto)
+  commerce?: PublishCommerceDto;
 }

--- a/apps/api/src/listings/http/dto/publish-product.dto.ts
+++ b/apps/api/src/listings/http/dto/publish-product.dto.ts
@@ -13,6 +13,7 @@ import {
   ArrayMaxSize,
   ArrayNotEmpty,
   IsArray,
+  IsDefined,
   IsIn,
   IsISO8601,
   IsInt,
@@ -25,11 +26,45 @@ import {
   Matches,
   MaxLength,
   Min,
+  registerDecorator,
   ValidateIf,
   ValidateNested,
+  type ValidationArguments,
+  type ValidationOptions,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+/**
+ * Property validator: the decorated ISO-8601 datetime must be strictly after the
+ * sibling datetime named by `property`. Passes when either side is absent
+ * (presence is enforced separately) or unparseable (format is `@IsISO8601`'s job).
+ */
+function IsAfter(property: string, validationOptions?: ValidationOptions) {
+  return function (object: object, propertyName: string): void {
+    registerDecorator({
+      name: 'isAfter',
+      target: object.constructor,
+      propertyName,
+      constraints: [property],
+      options: validationOptions,
+      validator: {
+        validate(value: unknown, args: ValidationArguments): boolean {
+          const [relatedProperty] = args.constraints as [string];
+          const related = (args.object as Record<string, unknown>)[relatedProperty];
+          if (typeof value !== 'string' || typeof related !== 'string') return true;
+          const end = Date.parse(value);
+          const start = Date.parse(related);
+          if (Number.isNaN(end) || Number.isNaN(start)) return true;
+          return end > start;
+        },
+        defaultMessage(args: ValidationArguments): string {
+          return `${args.property} must be after ${args.constraints[0]}`;
+        },
+      },
+    });
+  };
+}
 
 import {
   PublishProductStatusValues,
@@ -124,15 +159,21 @@ export class PublishDimensionsDto {
 export class PublishCommerceDto {
   @ApiPropertyOptional({
     type: PublishPriceDto,
-    description: 'Discounted sale price. Omitted ⇒ no sale price set.',
+    description:
+      'Discounted sale price. Required when a sale window (saleStartsAt/saleEndsAt) is supplied; omitted ⇒ no sale price set.',
   })
-  @IsOptional()
+  // Validated when a sale price OR a sale window is supplied; `@IsDefined` then
+  // enforces that a window can't be scheduled without a price to discount to.
+  @ValidateIf((o: PublishCommerceDto) => o.saleStartsAt != null || o.saleEndsAt != null || o.salePrice != null)
+  @IsDefined({
+    message: 'salePrice is required when a sale window (saleStartsAt/saleEndsAt) is supplied',
+  })
   @ValidateNested()
   @Type(() => PublishPriceDto)
   salePrice?: PublishPriceDto;
 
   @ApiPropertyOptional({
-    description: 'ISO 8601 datetime the sale price becomes active.',
+    description: 'ISO 8601 datetime the sale price becomes active (UTC).',
     example: '2026-08-01T00:00:00Z',
   })
   @IsOptional()
@@ -140,11 +181,12 @@ export class PublishCommerceDto {
   saleStartsAt?: string;
 
   @ApiPropertyOptional({
-    description: 'ISO 8601 datetime the sale price expires.',
+    description: 'ISO 8601 datetime the sale price expires (UTC). Must be after saleStartsAt.',
     example: '2026-08-31T23:59:59Z',
   })
   @IsOptional()
   @IsISO8601()
+  @IsAfter('saleStartsAt', { message: 'saleEndsAt must be after saleStartsAt' })
   saleEndsAt?: string;
 
   @ApiPropertyOptional({ type: PublishDimensionsDto, description: 'Physical dimensions.' })

--- a/apps/api/src/listings/http/shop-publish.controller.ts
+++ b/apps/api/src/listings/http/shop-publish.controller.ts
@@ -73,6 +73,7 @@ export class ShopPublishController {
       stock: dto.stock,
       ...(dto.price !== undefined && { price: dto.price }),
       ...(dto.content !== undefined && { content: dto.content }),
+      ...(dto.commerce !== undefined && { commerce: dto.commerce }),
       ...(idempotencyKey !== undefined && { idempotencyKey }),
     });
     return { jobId, listingCreationRecordId: listingCreationRecord.id };

--- a/apps/worker/src/sync/handlers/shop-product-publish.handler.ts
+++ b/apps/worker/src/sync/handlers/shop-product-publish.handler.ts
@@ -67,6 +67,7 @@ export class ShopProductPublishHandler implements SyncJobHandler {
         status: payload.status,
         price: payload.price,
         content: payload.content,
+        commerce: payload.commerce,
         idempotencyKey: payload.idempotencyKey,
         listingCreationRecordId: payload.listingCreationRecordId,
       });
@@ -146,6 +147,7 @@ export class ShopProductPublishHandler implements SyncJobHandler {
       price: payload.price,
       destinationCategoryIds: payload.destinationCategoryIds,
       content: payload.content,
+      commerce: payload.commerce,
       parameters: payload.parameters,
       idempotencyKey: payload.idempotencyKey,
     };

--- a/libs/core/src/listings/application/services/__tests__/product-publish-builder.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/product-publish-builder.service.spec.ts
@@ -167,6 +167,24 @@ describe('ProductPublishBuilderService', () => {
     expect(command).not.toHaveProperty('weight');
   });
 
+  it('should thread operator shortDescription and tags through content', async () => {
+    const command = await service.buildPublishProductCommand({
+      ...baseInput,
+      content: { shortDescription: 'Short blurb', tags: ['sale', 'new'] },
+    });
+
+    expect(command.content).toEqual(
+      expect.objectContaining({ shortDescription: 'Short blurb', tags: ['sale', 'new'] }),
+    );
+  });
+
+  it('should omit shortDescription and tags from content when not supplied', async () => {
+    const command = await service.buildPublishProductCommand(baseInput);
+
+    expect(command.content).not.toHaveProperty('shortDescription');
+    expect(command.content).not.toHaveProperty('tags');
+  });
+
   it('should pass operator commerce fields through to the command', async () => {
     const commerce = {
       salePrice: { amount: 9.99, currency: 'PLN' },

--- a/libs/core/src/listings/application/services/__tests__/product-publish-builder.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/product-publish-builder.service.spec.ts
@@ -119,6 +119,65 @@ describe('ProductPublishBuilderService', () => {
     expect(command.sku).toBe('SKU-123');
   });
 
+  it('should derive barcode (gtin then ean) and weight from the master variant', async () => {
+    products.getVariant.mockResolvedValue({
+      id: VARIANT,
+      productId: 'prod-1',
+      attributes: {},
+      ean: '1111111111116',
+      gtin: '5901234123457',
+      sku: null,
+      weight: 2.5,
+    });
+
+    const command = await service.buildPublishProductCommand(baseInput);
+
+    expect(command.barcode).toBe('5901234123457'); // gtin wins over ean
+    expect(command.weight).toBe(2.5);
+  });
+
+  it('should fall back to the ean and the product weight when the variant lacks them', async () => {
+    products.getVariant.mockResolvedValue({
+      id: VARIANT,
+      productId: 'prod-1',
+      attributes: {},
+      ean: '1111111111116',
+      gtin: null,
+      sku: null,
+    });
+    productMaster.getProduct.mockResolvedValue({
+      name: 'Widget',
+      description: 'A widget',
+      images: ['http://img'],
+      price: 12.5,
+      currency: 'PLN',
+      weight: 3,
+    });
+
+    const command = await service.buildPublishProductCommand(baseInput);
+
+    expect(command.barcode).toBe('1111111111116');
+    expect(command.weight).toBe(3);
+  });
+
+  it('should omit barcode and weight when neither variant nor product provide them', async () => {
+    const command = await service.buildPublishProductCommand(baseInput);
+
+    expect(command).not.toHaveProperty('barcode');
+    expect(command).not.toHaveProperty('weight');
+  });
+
+  it('should pass operator commerce fields through to the command', async () => {
+    const commerce = {
+      salePrice: { amount: 9.99, currency: 'PLN' },
+      taxStatus: 'taxable' as const,
+    };
+
+    const command = await service.buildPublishProductCommand({ ...baseInput, commerce });
+
+    expect(command.commerce).toEqual(commerce);
+  });
+
   it('should publish uncategorised when the shop adapter is not a CategoryProvisioner', async () => {
     delete shopAdapter.provisionCategory; // not a provisioner
 

--- a/libs/core/src/listings/application/services/bulk-shop-publish-submit.service.ts
+++ b/libs/core/src/listings/application/services/bulk-shop-publish-submit.service.ts
@@ -75,6 +75,7 @@ export class BulkShopPublishSubmitService implements IBulkShopPublishSubmitServi
       sharedConfig: {
         status: input.status,
         ...(input.content !== undefined && { content: input.content }),
+        ...(input.commerce !== undefined && { commerce: input.commerce }),
       },
     });
 
@@ -91,6 +92,7 @@ export class BulkShopPublishSubmitService implements IBulkShopPublishSubmitServi
           bulkBatchId: batch.id,
           ...(item.price !== undefined && { price: item.price }),
           ...(input.content !== undefined && { content: input.content }),
+          ...(input.commerce !== undefined && { commerce: input.commerce }),
         });
         items.push({
           internalVariantId: item.internalVariantId,

--- a/libs/core/src/listings/application/services/product-publish-builder.service.ts
+++ b/libs/core/src/listings/application/services/product-publish-builder.service.ts
@@ -105,6 +105,11 @@ export class ProductPublishBuilderService implements IProductPublishBuilderServi
 
     const content = this.buildContent(input.content, product);
 
+    // Master-derived barcode/weight: prefer the variant's own value, fall back
+    // to the product's. Empty/absent ⇒ omitted (never sent as blank/zero).
+    const barcode = variant.gtin ?? variant.ean ?? undefined;
+    const weight = variant.weight ?? product.weight;
+
     const command: PublishProductCommand = {
       internalVariantId: input.internalVariantId,
       connectionId: input.connectionId,
@@ -117,7 +122,10 @@ export class ProductPublishBuilderService implements IProductPublishBuilderServi
       // shop can key on (reconciliation, inventory-by-SKU). Omitted when the
       // variant has no SKU, matching the spread-omit convention below.
       ...(variant.sku ? { sku: variant.sku } : {}),
+      ...(barcode ? { barcode } : {}),
+      ...(weight != null ? { weight } : {}),
       ...(content ? { content } : {}),
+      ...(input.commerce ? { commerce: input.commerce } : {}),
       ...(parameters.length > 0 ? { parameters } : {}),
       ...(input.idempotencyKey ? { idempotencyKey: input.idempotencyKey } : {}),
     };

--- a/libs/core/src/listings/application/services/product-publish-builder.service.ts
+++ b/libs/core/src/listings/application/services/product-publish-builder.service.ts
@@ -254,6 +254,12 @@ export class ProductPublishBuilderService implements IProductPublishBuilderServi
     if (title != null) content.title = title;
     if (description != null) content.description = description;
     if (imageUrls != null) content.imageUrls = imageUrls;
+    // Operator-only, no master fallback: the master product carries no
+    // short-description / tags fields. Threaded here so the builder-owned
+    // content object actually reaches the adapter (both single + bulk flow
+    // through this method).
+    if (overrides?.shortDescription != null) content.shortDescription = overrides.shortDescription;
+    if (overrides?.tags != null) content.tags = overrides.tags;
     if (overrides?.seo != null) content.seo = overrides.seo;
 
     return Object.keys(content).length > 0 ? content : undefined;

--- a/libs/core/src/listings/application/services/product-publish-enqueue.service.ts
+++ b/libs/core/src/listings/application/services/product-publish-enqueue.service.ts
@@ -84,6 +84,7 @@ export class ProductPublishEnqueueService implements IProductPublishEnqueueServi
             listingCreationRecordId: record.id,
             ...(input.price !== undefined && { price: input.price }),
             ...(input.content !== undefined && { content: input.content }),
+            ...(input.commerce !== undefined && { commerce: input.commerce }),
             ...(input.idempotencyKey !== undefined && { idempotencyKey: input.idempotencyKey }),
           } satisfies ShopProductPublishPayloadV2)
         : ({
@@ -94,6 +95,7 @@ export class ProductPublishEnqueueService implements IProductPublishEnqueueServi
             listingCreationRecordId: record.id,
             ...(input.price !== undefined && { price: input.price }),
             ...(input.content !== undefined && { content: input.content }),
+            ...(input.commerce !== undefined && { commerce: input.commerce }),
             ...(input.idempotencyKey !== undefined && { idempotencyKey: input.idempotencyKey }),
           } satisfies ShopProductPublishPayloadV1);
 

--- a/libs/core/src/listings/application/services/product-publish-execution.service.ts
+++ b/libs/core/src/listings/application/services/product-publish-execution.service.ts
@@ -102,6 +102,7 @@ export class ProductPublishExecutionService implements IProductPublishExecutionS
         status: input.status,
         price: input.price,
         content: input.content,
+        commerce: input.commerce,
         idempotencyKey: input.idempotencyKey,
       });
     } catch (error) {

--- a/libs/core/src/listings/application/types/bulk-shop-publish-submit.types.ts
+++ b/libs/core/src/listings/application/types/bulk-shop-publish-submit.types.ts
@@ -12,6 +12,7 @@
 import type { BulkListingBatch } from '../../domain/entities/bulk-listing-batch.entity';
 import type { ListingCreationRecord } from '../../domain/entities/listing-creation-record.entity';
 import type {
+  PublishProductCommerce,
   PublishProductContent,
   PublishProductStatus,
 } from '../../domain/types/product-publish.types';
@@ -40,6 +41,8 @@ export interface BulkShopPublishSubmitInput {
   status: PublishProductStatus;
   /** Optional shared content overrides applied to every child. */
   content?: PublishProductContent;
+  /** Optional shared commerce fields (sale price, dimensions, tax) applied to every child. */
+  commerce?: PublishProductCommerce;
 }
 
 export interface BulkShopPublishItem {

--- a/libs/core/src/listings/application/types/product-publish-builder.types.ts
+++ b/libs/core/src/listings/application/types/product-publish-builder.types.ts
@@ -11,7 +11,11 @@
  * @module libs/core/src/listings/application/types
  */
 
-import type { PublishProductContent, PublishProductStatus } from '@openlinker/core/listings';
+import type {
+  PublishProductCommerce,
+  PublishProductContent,
+  PublishProductStatus,
+} from '@openlinker/core/listings';
 
 export interface BuildPublishProductCommandInput {
   /** OL internal variant id being published. */
@@ -29,6 +33,8 @@ export interface BuildPublishProductCommandInput {
   price?: { amount: number; currency: string };
   /** Optional owned-record content overrides; missing fields fall back to the master product. */
   content?: PublishProductContent;
+  /** Optional operator-supplied commerce fields (sale price, dimensions, tax). */
+  commerce?: PublishProductCommerce;
   /** Optional idempotency key forwarded to the produced command. */
   idempotencyKey?: string;
 }

--- a/libs/core/src/listings/application/types/product-publish-enqueue.types.ts
+++ b/libs/core/src/listings/application/types/product-publish-enqueue.types.ts
@@ -10,6 +10,7 @@
  */
 
 import type {
+  PublishProductCommerce,
   PublishProductContent,
   PublishProductStatus,
 } from '../../domain/types/product-publish.types';
@@ -28,6 +29,8 @@ export interface EnqueueProductPublishInput {
   price?: { amount: number; currency: string };
   /** Optional owned-record content overrides (title, description, images, SEO). */
   content?: PublishProductContent;
+  /** Optional operator-supplied commerce fields (sale price, dimensions, tax). */
+  commerce?: PublishProductCommerce;
   /** Optional idempotency key; defaults to `shop-publish:{recordId}` (single) / a batch-scoped key (bulk). */
   idempotencyKey?: string;
   /**

--- a/libs/core/src/listings/application/types/product-publish-execution.types.ts
+++ b/libs/core/src/listings/application/types/product-publish-execution.types.ts
@@ -7,7 +7,11 @@
  * @module libs/core/src/listings/application/types
  */
 
-import type { PublishProductContent, PublishProductStatus } from '@openlinker/core/listings';
+import type {
+  PublishProductCommerce,
+  PublishProductContent,
+  PublishProductStatus,
+} from '@openlinker/core/listings';
 import type { JobOutcome } from '@openlinker/core/sync';
 
 import type { ListingCreationRecord } from '../../domain/entities/listing-creation-record.entity';
@@ -25,6 +29,8 @@ export interface ExecutePublishProductInput {
   price?: { amount: number; currency: string };
   /** Optional owned-record content overrides. */
   content?: PublishProductContent;
+  /** Optional operator-supplied commerce fields (sale price, dimensions, tax). */
+  commerce?: PublishProductCommerce;
   /** Optional idempotency key threaded to the adapter. */
   idempotencyKey?: string;
   /**

--- a/libs/core/src/listings/domain/types/product-publish.types.ts
+++ b/libs/core/src/listings/domain/types/product-publish.types.ts
@@ -34,6 +34,14 @@ export const PublishProductStatusValues = ['draft', 'published'] as const;
 export type PublishProductStatus = (typeof PublishProductStatusValues)[number];
 
 /**
+ * Neutral tax-treatment values for a shop product. Mirrors the common shop
+ * vocabulary (taxable / shipping-only / not-taxed); adapters map it to their
+ * platform field (WooCommerce `tax_status`).
+ */
+export const PublishTaxStatusValues = ['taxable', 'shipping', 'none'] as const;
+export type PublishTaxStatus = (typeof PublishTaxStatusValues)[number];
+
+/**
  * Owned-record content fields. Extracted as a named type (not inline on the
  * command) so the `shop.product.publish` job payload can reference the same
  * shape without indexed-access coupling.
@@ -47,6 +55,10 @@ export interface PublishProductContent {
   title?: string;
   /** Product description (HTML or rich text). `null`/`undefined` → no override. */
   description?: string | null;
+  /** Short/excerpt description. `null`/`undefined` → no override. */
+  shortDescription?: string | null;
+  /** Marketing tags for the storefront product. `null`/`undefined` → no override. */
+  tags?: string[] | null;
   /** Image URLs in display order. `null`/`undefined` → no override. */
   imageUrls?: string[] | null;
   /** SEO metadata for the storefront product page. */
@@ -55,6 +67,31 @@ export interface PublishProductContent {
     description?: string | null;
     slug?: string;
   };
+}
+
+/**
+ * Operator-supplied commerce/physical product fields beyond the core
+ * name/price/stock. Shop-neutral: WooCommerce, Shopify, … adapters map the keys
+ * they support and ignore the rest. Every field is optional; an absent field is
+ * left unset on the shop (never sent as empty/zero).
+ */
+export interface PublishProductCommerce {
+  /**
+   * Discounted sale price. Currency should match the shop/connection locale
+   * (shops typically apply the store currency, so adapters may use only the
+   * amount). Absent ⇒ no sale price is set.
+   */
+  salePrice?: { amount: number; currency: string };
+  /** ISO 8601 datetime the sale price becomes active. Absent ⇒ immediate/unset. */
+  saleStartsAt?: string;
+  /** ISO 8601 datetime the sale price expires. Absent ⇒ open-ended/unset. */
+  saleEndsAt?: string;
+  /** Physical dimensions. Each axis optional; an absent axis is left unset. */
+  dimensions?: { length?: number; width?: number; height?: number };
+  /** Tax class slug (shop-defined, e.g. WooCommerce "reduced-rate"). Absent ⇒ shop default. */
+  taxClass?: string;
+  /** Whether/how the product is taxed. Absent ⇒ shop default. */
+  taxStatus?: PublishTaxStatus;
 }
 
 /**
@@ -90,6 +127,23 @@ export interface PublishProductCommand {
   status: PublishProductStatus;
   /** Owned-record content fields (title, description, images, SEO). */
   content?: PublishProductContent;
+  /**
+   * Product barcode (GTIN/EAN). Master-derived by the builder from the variant
+   * (`ProductVariant.gtin` ?? `ProductVariant.ean`). Absent ⇒ the variant has no
+   * barcode and the field is left unset on the shop.
+   */
+  barcode?: string;
+  /**
+   * Physical weight in the shop's configured weight unit. Master-derived by the
+   * builder (`ProductVariant.weight` ?? `Product.weight`). Absent ⇒ left unset.
+   */
+  weight?: number;
+  /**
+   * Operator-supplied commerce/physical fields (sale price + schedule,
+   * dimensions, tax class/status). Shop-neutral; adapters map the keys they
+   * support. Absent ⇒ no operator overrides for these fields.
+   */
+  commerce?: PublishProductCommerce;
   /**
    * Neutral, section-tagged projected/operator category parameters (#1072,
    * ADR-024 §Flow). Produced by core (attribute projection on the ADR-023

--- a/libs/core/src/listings/index.ts
+++ b/libs/core/src/listings/index.ts
@@ -312,10 +312,12 @@ export { isCategoryProvisioner } from './domain/ports/capabilities/category-prov
 // names the owner taxonomy whose category/parameter ids it reuses verbatim.
 export type { TaxonomyBorrower } from './domain/ports/capabilities/taxonomy-borrower.capability';
 export { isTaxonomyBorrower } from './domain/ports/capabilities/taxonomy-borrower.capability';
-export { PublishProductStatusValues } from './domain/types/product-publish.types';
+export { PublishProductStatusValues, PublishTaxStatusValues } from './domain/types/product-publish.types';
 export type {
   PublishProductStatus,
+  PublishTaxStatus,
   PublishProductContent,
+  PublishProductCommerce,
   PublishProductCommand,
   PublishProductResult,
 } from './domain/types/product-publish.types';

--- a/libs/core/src/sync/domain/types/shop-job-payloads.types.ts
+++ b/libs/core/src/sync/domain/types/shop-job-payloads.types.ts
@@ -13,6 +13,7 @@
 import type {
   PublishProductStatus,
   PublishProductContent,
+  PublishProductCommerce,
   OfferParameter,
 } from '@openlinker/core/listings';
 
@@ -44,6 +45,8 @@ export interface ShopProductPublishPayloadV1 {
   destinationCategoryIds?: string[];
   /** Optional owned-record content overrides (title, description, images, SEO). */
   content?: PublishProductContent;
+  /** Optional operator-supplied commerce fields (sale price, dimensions, tax). */
+  commerce?: PublishProductCommerce;
   /**
    * Neutral, section-tagged projected category parameters (#1072) — the same
    * `OfferParameter` channel the offer payload uses. Mirrors

--- a/libs/integrations/woocommerce/README.md
+++ b/libs/integrations/woocommerce/README.md
@@ -48,6 +48,50 @@ Generate at **WooCommerce → Settings → Advanced → REST API**.
 | `inventory` | Object (optional) | Inventory tuning: `unmanagedStockQuantity` (integer >= 0, default 1000) - the quantity reported for in-stock products with stock management disabled |
 | `orders` | Object (optional) | Order-ingestion tuning: `initialSyncFrom` (parseable date string, e.g. `"2024-01-01"`) - the earliest order date picked up by the first sync |
 
+## Product publish field mapping
+
+`ProductPublisher.publishProduct` maps the neutral `PublishProductCommand` onto the
+WooCommerce `products` resource. Each field is sent only when a value is present;
+an absent master/operator value **omits** the WooCommerce key (never sends an
+empty string or zero), so an upsert never clears a field the operator did not touch.
+
+| Neutral field | Source | WooCommerce field |
+|---|---|---|
+| `sku` | master variant | `sku` |
+| `barcode` (GTIN/EAN) | master variant (`gtin` ?? `ean`) | `global_unique_id` (WooCommerce 9.2+) |
+| `weight` | master variant (`weight`) ?? product | `weight` (string) |
+| `price` | operator override ?? master | `regular_price` |
+| `stock` | operator | `stock_quantity` (+ `manage_stock: true`) |
+| `status` | operator | `status` (`publish` / `draft`) |
+| `content.title` | operator ?? master | `name` |
+| `content.description` | operator ?? master | `description` |
+| `content.shortDescription` | operator | `short_description` |
+| `content.tags` | operator | `tags` (`[{ name }]`, created on demand) |
+| `content.imageUrls` | operator ?? master | `images` |
+| `content.seo.slug` | operator | `slug` |
+| `content.seo.title` / `content.seo.description` | operator | `meta_data` (see SEO below) |
+| `commerce.salePrice.amount` | operator | `sale_price` (store currency applies; amount only) |
+| `commerce.saleStartsAt` / `saleEndsAt` | operator | `date_on_sale_from` / `date_on_sale_to` |
+| `commerce.dimensions` | operator | `dimensions.{length,width,height}` (strings) |
+| `commerce.taxClass` | operator | `tax_class` |
+| `commerce.taxStatus` | operator | `tax_status` (`taxable` / `shipping` / `none`) |
+| `destinationCategoryIds` | resolved upstream | `categories` |
+| `parameters` | projected attributes | `attributes` (custom, per-product) |
+
+### SEO title & description
+
+Core WooCommerce has **no native product SEO title/description field** — those are
+owned by whichever SEO plugin the store runs, stored as post meta. The adapter
+therefore maps `content.seo.title` / `content.seo.description` to `meta_data`,
+writing the keys for **both** dominant plugins so whichever is active picks them up:
+
+- **Yoast SEO**: `_yoast_wpseo_title`, `_yoast_wpseo_metadesc`
+- **Rank Math**: `rank_math_title`, `rank_math_description`
+
+If neither plugin is installed, the rows are inert post meta (no effect). This
+replaces the previous behaviour where `seo.title` / `seo.description` were accepted
+and silently discarded (only `seo.slug` mapped, to the native `slug`).
+
 ## Documentation
 
 - [docs/setup-guide.md](./docs/setup-guide.md) — setup guide

--- a/libs/integrations/woocommerce/README.md
+++ b/libs/integrations/woocommerce/README.md
@@ -71,7 +71,7 @@ empty string or zero), so an upsert never clears a field the operator did not to
 | `content.seo.slug` | operator | `slug` |
 | `content.seo.title` / `content.seo.description` | operator | `meta_data` (see SEO below) |
 | `commerce.salePrice.amount` | operator | `sale_price` (store currency applies; amount only) |
-| `commerce.saleStartsAt` / `saleEndsAt` | operator | `date_on_sale_from` / `date_on_sale_to` |
+| `commerce.saleStartsAt` / `saleEndsAt` | operator (UTC ISO-8601) | `date_on_sale_from_gmt` / `date_on_sale_to_gmt` (UTC; the site-local `date_on_sale_from`/`_to` are deliberately not used so the store timezone can't shift the window) |
 | `commerce.dimensions` | operator | `dimensions.{length,width,height}` (strings) |
 | `commerce.taxClass` | operator | `tax_class` |
 | `commerce.taxStatus` | operator | `tax_status` (`taxable` / `shipping` / `none`) |

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/product-publisher/__tests__/woocommerce-product-publisher.adapter.spec.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/product-publisher/__tests__/woocommerce-product-publisher.adapter.spec.ts
@@ -133,6 +133,107 @@ describe('WooCommerceProductPublisherAdapter', () => {
       expect(body.tax_class).toBe('reduced-rate'); // un-modeled knob passes through
     });
 
+    it('should map barcode, weight, short_description and tags when present', async () => {
+      http.post.mockResolvedValue({ id: 20, status: 'publish' });
+
+      await adapter.publishProduct(
+        baseCommand({
+          barcode: '5901234123457',
+          weight: 1.25,
+          content: {
+            title: 'Widget',
+            shortDescription: 'Short blurb',
+            tags: ['sale', 'new'],
+          },
+        }),
+      );
+
+      const body = http.post.mock.calls[0][1] as Record<string, unknown>;
+      expect(body).toMatchObject({
+        global_unique_id: '5901234123457',
+        weight: '1.25',
+        short_description: 'Short blurb',
+        tags: [{ name: 'sale' }, { name: 'new' }],
+      });
+    });
+
+    it('should map the commerce block (sale price + schedule, dimensions, tax)', async () => {
+      http.post.mockResolvedValue({ id: 21, status: 'publish' });
+
+      await adapter.publishProduct(
+        baseCommand({
+          commerce: {
+            salePrice: { amount: 14.5, currency: 'PLN' },
+            saleStartsAt: '2026-08-01T00:00:00Z',
+            saleEndsAt: '2026-08-31T23:59:59Z',
+            dimensions: { length: 10, width: 5, height: 2 },
+            taxClass: 'reduced-rate',
+            taxStatus: 'taxable',
+          },
+        }),
+      );
+
+      const body = http.post.mock.calls[0][1] as Record<string, unknown>;
+      expect(body).toMatchObject({
+        sale_price: '14.5',
+        date_on_sale_from: '2026-08-01T00:00:00Z',
+        date_on_sale_to: '2026-08-31T23:59:59Z',
+        dimensions: { length: '10', width: '5', height: '2' },
+        tax_class: 'reduced-rate',
+        tax_status: 'taxable',
+      });
+    });
+
+    it('should omit new fields when the command does not carry them', async () => {
+      http.post.mockResolvedValue({ id: 22, status: 'publish' });
+
+      await adapter.publishProduct(baseCommand());
+
+      const body = http.post.mock.calls[0][1];
+      expect(body).not.toHaveProperty('global_unique_id');
+      expect(body).not.toHaveProperty('weight');
+      expect(body).not.toHaveProperty('short_description');
+      expect(body).not.toHaveProperty('tags');
+      expect(body).not.toHaveProperty('sale_price');
+      expect(body).not.toHaveProperty('dimensions');
+      expect(body).not.toHaveProperty('tax_class');
+      expect(body).not.toHaveProperty('tax_status');
+      expect(body).not.toHaveProperty('meta_data');
+    });
+
+    it('should map SEO title/description to Yoast + RankMath meta_data (#1833)', async () => {
+      http.post.mockResolvedValue({ id: 23, status: 'publish' });
+
+      await adapter.publishProduct(
+        baseCommand({
+          content: {
+            title: 'Widget',
+            seo: { title: 'SEO Title', description: 'SEO Desc', slug: 'widget' },
+          },
+        }),
+      );
+
+      const body = http.post.mock.calls[0][1] as Record<string, unknown>;
+      expect(body.slug).toBe('widget');
+      expect(body.meta_data).toEqual([
+        { key: '_yoast_wpseo_title', value: 'SEO Title' },
+        { key: 'rank_math_title', value: 'SEO Title' },
+        { key: '_yoast_wpseo_metadesc', value: 'SEO Desc' },
+        { key: 'rank_math_description', value: 'SEO Desc' },
+      ]);
+    });
+
+    it('should not emit meta_data when only the SEO slug is supplied', async () => {
+      http.post.mockResolvedValue({ id: 24, status: 'publish' });
+
+      await adapter.publishProduct(
+        baseCommand({ content: { title: 'Widget', seo: { slug: 'widget' } } }),
+      );
+
+      const body = http.post.mock.calls[0][1];
+      expect(body).not.toHaveProperty('meta_data');
+    });
+
     it('should map a 4xx rejection to ProductPublishRejectedException', async () => {
       http.post.mockRejectedValue(
         new WooCommerceHttpResponseException(400, 'Invalid price', 'product_invalid_price'),

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/product-publisher/__tests__/woocommerce-product-publisher.adapter.spec.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/product-publisher/__tests__/woocommerce-product-publisher.adapter.spec.ts
@@ -176,12 +176,25 @@ describe('WooCommerceProductPublisherAdapter', () => {
       const body = http.post.mock.calls[0][1] as Record<string, unknown>;
       expect(body).toMatchObject({
         sale_price: '14.5',
-        date_on_sale_from: '2026-08-01T00:00:00Z',
-        date_on_sale_to: '2026-08-31T23:59:59Z',
+        // UTC input is written to the `_gmt` fields, not the site-local ones.
+        date_on_sale_from_gmt: '2026-08-01T00:00:00Z',
+        date_on_sale_to_gmt: '2026-08-31T23:59:59Z',
         dimensions: { length: '10', width: '5', height: '2' },
         tax_class: 'reduced-rate',
         tax_status: 'taxable',
       });
+      expect(body).not.toHaveProperty('date_on_sale_from');
+      expect(body).not.toHaveProperty('date_on_sale_to');
+    });
+
+    it('should omit an empty tags array so upsert does not clear existing WC tags', async () => {
+      http.put.mockResolvedValue({ id: 30, status: 'publish' });
+
+      await adapter.publishProduct(
+        baseCommand({ externalProductId: '30', content: { title: 'Widget', tags: [] } }),
+      );
+
+      expect(http.put.mock.calls[0][1]).not.toHaveProperty('tags');
     });
 
     it('should omit new fields when the command does not carry them', async () => {

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/product-publisher/woocommerce-product-publish.types.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/product-publisher/woocommerce-product-publish.types.ts
@@ -23,17 +23,43 @@ export interface WooCommerceProductPublishRequest {
   name?: string;
   /** Product SKU / reference. Maps the neutral `PublishProductCommand.sku`. */
   sku?: string;
+  /** Native GTIN/EAN barcode field (WooCommerce 9.2+). Maps `PublishProductCommand.barcode`. */
+  global_unique_id?: string;
   type?: 'simple';
   status?: WooCommerceProductStatus;
   regular_price?: string;
+  /** Discounted price (amount only; WooCommerce applies the store currency). */
+  sale_price?: string;
+  /** ISO 8601 datetime the sale price becomes active. */
+  date_on_sale_from?: string;
+  /** ISO 8601 datetime the sale price expires. */
+  date_on_sale_to?: string;
   description?: string;
+  /** Short/excerpt description. Maps `PublishProductContent.shortDescription`. */
+  short_description?: string;
   manage_stock?: boolean;
   stock_quantity?: number;
+  /** Product weight in the store's configured weight unit (WooCommerce expects a string). */
+  weight?: string;
+  /** Product dimensions; each axis a string in the store's configured dimension unit. */
+  dimensions?: { length?: string; width?: string; height?: string };
+  /** Tax class slug (empty string = "Standard"). */
+  tax_class?: string;
+  /** Tax treatment. */
+  tax_status?: 'taxable' | 'shipping' | 'none';
   slug?: string;
   categories?: Array<{ id: number }>;
+  /** Product tags (created on demand by name). Maps `PublishProductContent.tags`. */
+  tags?: Array<{ name: string }>;
   images?: Array<{ src: string }>;
   /** Per-product custom attributes (preferred over global-attribute-on-variation in v1). */
   attributes?: Array<{ name: string; options: string[]; visible: boolean }>;
+  /**
+   * Arbitrary post-meta rows. Used to carry SEO title/description for the common
+   * SEO plugins (Yoast / RankMath), which read product SEO from post meta rather
+   * than a native WooCommerce field.
+   */
+  meta_data?: Array<{ key: string; value: string }>;
   [key: string]: unknown;
 }
 

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/product-publisher/woocommerce-product-publish.types.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/product-publisher/woocommerce-product-publish.types.ts
@@ -30,10 +30,14 @@ export interface WooCommerceProductPublishRequest {
   regular_price?: string;
   /** Discounted price (amount only; WooCommerce applies the store currency). */
   sale_price?: string;
-  /** ISO 8601 datetime the sale price becomes active. */
-  date_on_sale_from?: string;
-  /** ISO 8601 datetime the sale price expires. */
-  date_on_sale_to?: string;
+  /**
+   * UTC/GMT datetime the sale price becomes active. The `_gmt` variant (not the
+   * site-local `date_on_sale_from`) is used so the neutral UTC input is honoured
+   * regardless of the store's timezone.
+   */
+  date_on_sale_from_gmt?: string;
+  /** UTC/GMT datetime the sale price expires (see `date_on_sale_from_gmt`). */
+  date_on_sale_to_gmt?: string;
   description?: string;
   /** Short/excerpt description. Maps `PublishProductContent.shortDescription`. */
   short_description?: string;

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/product-publisher/woocommerce-product-publisher.adapter.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/product-publisher/woocommerce-product-publisher.adapter.ts
@@ -134,7 +134,12 @@ export class WooCommerceProductPublisherAdapter
     if (content?.title != null) typed.name = content.title;
     if (content?.description != null) typed.description = content.description;
     if (content?.shortDescription != null) typed.short_description = content.shortDescription;
-    if (content?.tags != null) typed.tags = content.tags.map((name) => ({ name }));
+    // Omit an empty tags array: sending `tags: []` on upsert would CLEAR the WC
+    // product's existing tags, violating the "never clear an untouched field"
+    // contract. An explicit non-empty list still replaces the set.
+    if (content?.tags != null && content.tags.length > 0) {
+      typed.tags = content.tags.map((name) => ({ name }));
+    }
     if (content?.imageUrls != null) typed.images = content.imageUrls.map((src) => ({ src }));
     if (content?.seo?.slug != null) typed.slug = content.seo.slug;
     if (cmd.destinationCategoryIds.length > 0) {
@@ -170,8 +175,10 @@ export class WooCommerceProductPublisherAdapter
     if (!commerce) return;
 
     if (commerce.salePrice != null) typed.sale_price = String(commerce.salePrice.amount);
-    if (commerce.saleStartsAt != null) typed.date_on_sale_from = commerce.saleStartsAt;
-    if (commerce.saleEndsAt != null) typed.date_on_sale_to = commerce.saleEndsAt;
+    // Neutral sale window is UTC (ISO 8601); write the `_gmt` fields so WC does
+    // not reinterpret the value as site-local and shift the window.
+    if (commerce.saleStartsAt != null) typed.date_on_sale_from_gmt = commerce.saleStartsAt;
+    if (commerce.saleEndsAt != null) typed.date_on_sale_to_gmt = commerce.saleEndsAt;
     if (commerce.taxClass != null) typed.tax_class = commerce.taxClass;
     if (commerce.taxStatus != null) typed.tax_status = commerce.taxStatus;
 

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/product-publisher/woocommerce-product-publisher.adapter.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/product-publisher/woocommerce-product-publisher.adapter.ts
@@ -24,6 +24,7 @@ import {
   type ProvisionCategoryCommand,
   type ProvisionCategoryResult,
   type PublishProductCommand,
+  type PublishProductContent,
   type PublishProductResult,
   type PublishProductStatus,
   type ShopProductManagerPort,
@@ -41,6 +42,13 @@ import type {
 const PRODUCTS_PATH = '/wp-json/wc/v3/products';
 const CATEGORIES_PATH = '/wp-json/wc/v3/products/categories';
 const DEFAULT_ADAPTER_KEY = 'woocommerce.restapi.v3';
+
+// Core WooCommerce has no native SEO title/description field — those live in
+// post meta owned by whichever SEO plugin the store runs. We write the meta keys
+// for both dominant plugins (Yoast, RankMath); the inactive plugin's rows are
+// inert post meta, so emitting both is safe and covers the common installs.
+const SEO_TITLE_META_KEYS = ['_yoast_wpseo_title', 'rank_math_title'] as const;
+const SEO_DESCRIPTION_META_KEYS = ['_yoast_wpseo_metadesc', 'rank_math_description'] as const;
 
 export class WooCommerceProductPublisherAdapter
   implements ShopProductManagerPort, CategoryProvisioner
@@ -121,8 +129,12 @@ export class WooCommerceProductPublisherAdapter
     // the builder's spread-omit and avoiding an empty `sku` clearing the WC
     // product's SKU on upsert.
     if (cmd.sku) typed.sku = cmd.sku;
+    if (cmd.barcode) typed.global_unique_id = cmd.barcode;
+    if (cmd.weight != null) typed.weight = String(cmd.weight);
     if (content?.title != null) typed.name = content.title;
     if (content?.description != null) typed.description = content.description;
+    if (content?.shortDescription != null) typed.short_description = content.shortDescription;
+    if (content?.tags != null) typed.tags = content.tags.map((name) => ({ name }));
     if (content?.imageUrls != null) typed.images = content.imageUrls.map((src) => ({ src }));
     if (content?.seo?.slug != null) typed.slug = content.seo.slug;
     if (cmd.destinationCategoryIds.length > 0) {
@@ -139,7 +151,56 @@ export class WooCommerceProductPublisherAdapter
       }));
     }
 
+    this.applyCommerce(typed, cmd);
+
+    // SEO title/description have no native WooCommerce product field — route them
+    // to the SEO-plugin post-meta keys so they aren't silently dropped (#1833).
+    const metaData = this.buildSeoMetaData(content?.seo);
+    if (metaData.length > 0) typed.meta_data = metaData;
+
     return { ...(cmd.platformParams ?? {}), ...typed };
+  }
+
+  /** Map the neutral `commerce` block (sale price + schedule, dimensions, tax). */
+  private applyCommerce(
+    typed: WooCommerceProductPublishRequest,
+    cmd: PublishProductCommand,
+  ): void {
+    const commerce = cmd.commerce;
+    if (!commerce) return;
+
+    if (commerce.salePrice != null) typed.sale_price = String(commerce.salePrice.amount);
+    if (commerce.saleStartsAt != null) typed.date_on_sale_from = commerce.saleStartsAt;
+    if (commerce.saleEndsAt != null) typed.date_on_sale_to = commerce.saleEndsAt;
+    if (commerce.taxClass != null) typed.tax_class = commerce.taxClass;
+    if (commerce.taxStatus != null) typed.tax_status = commerce.taxStatus;
+
+    if (commerce.dimensions != null) {
+      const { length, width, height } = commerce.dimensions;
+      const dimensions: { length?: string; width?: string; height?: string } = {};
+      if (length != null) dimensions.length = String(length);
+      if (width != null) dimensions.width = String(width);
+      if (height != null) dimensions.height = String(height);
+      if (Object.keys(dimensions).length > 0) typed.dimensions = dimensions;
+    }
+  }
+
+  /**
+   * Build SEO post-meta rows for the common SEO plugins. Emits both Yoast and
+   * RankMath keys for each supplied value so whichever plugin the store runs
+   * picks it up; an absent value emits no rows for that field.
+   */
+  private buildSeoMetaData(
+    seo: PublishProductContent['seo'],
+  ): Array<{ key: string; value: string }> {
+    const rows: Array<{ key: string; value: string }> = [];
+    if (seo?.title != null) {
+      for (const key of SEO_TITLE_META_KEYS) rows.push({ key, value: seo.title });
+    }
+    if (seo?.description != null) {
+      for (const key of SEO_DESCRIPTION_META_KEYS) rows.push({ key, value: seo.description });
+    }
+    return rows;
   }
 
   private async findCategory(


### PR DESCRIPTION
Part of #1838 (epic: Unify publish flow + WooCommerce field completeness). Combines two adapter-focused sub-issues that touch the same publisher.

## What & why

### #1832 - map remaining WooCommerce product fields
`WooCommerceProductPublisherAdapter.buildProductBody` only sent name/description/price/stock/status/sku/slug/categories/attributes/images. This maps the remaining commonly-needed fields, preferring typed neutral command fields over the opaque `platformParams` bag:

- `global_unique_id` (GTIN/EAN) - master-derived from `ProductVariant.gtin ?? ean`
- `weight` - master-derived from `variant.weight ?? product.weight`
- `sale_price` (+ `date_on_sale_from`/`date_on_sale_to`), `short_description`, `tags`, `dimensions`, `tax_class`/`tax_status` - operator-editable via the publish DTO

New neutral typed fields: `PublishProductCommand.barcode` / `.weight` / `.commerce` and `PublishProductContent.shortDescription` / `.tags`. Threaded end-to-end (DTO -> enqueue input -> `shop.product.publish` job payload -> execution -> builder -> adapter) for both single and bulk publish. Absent values **omit** the WooCommerce key (never empty/zero), so an upsert never clears an untouched field.

### #1833 - stop dropping SEO title/description
`content.seo.title` / `content.seo.description` were accepted end-to-end but the adapter mapped only `seo.slug`, silently discarding them. Core WooCommerce has no native product SEO title/description field, so they now map to `meta_data` for both dominant SEO plugins (Yoast `_yoast_wpseo_*`, Rank Math `rank_math_*`). Documented in the package README.

## How to test
- `pnpm --filter @openlinker/integrations-woocommerce test` (adapter: new-field mapping, commerce block, omit-when-absent, SEO meta_data)
- `pnpm --filter @openlinker/core test -- product-publish` (builder: barcode/weight derivation + precedence, commerce passthrough)
- `pnpm --filter @openlinker/worker test -- shop-product-publish`, `pnpm --filter @openlinker/api test -- publish`
- Gate: `pnpm lint` (incl. `check:invariants` - CORE<->Integration boundary clean), `pnpm type-check` - all green.

## Docs
- `libs/integrations/woocommerce/README.md` -> added a "Product publish field mapping" table + an "SEO title & description" subsection documenting the Yoast/Rank Math `meta_data` routing.
- `docs/architecture-overview.md` -> None (the neutral `PublishProductCommand` gained optional fields but no Listings-section behavior change worth calling out centrally).

Closes #1832
Closes #1833

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCm7D2MsPDBwBEL5AiPJAK
