### PR TITLE
feat(web/listings): unify offer + shop publishing into one "Publish products" picker (#1828)

### DIFF
--- a/apps/web/src/features/listings/components/ShopPublishLauncher.tsx
+++ b/apps/web/src/features/listings/components/ShopPublishLauncher.tsx
@@ -38,6 +38,14 @@ interface ShopPublishLauncherProps {
   onOpenChange: (open: boolean) => void;
   defaultVariantId?: string;
   defaultVariantIds?: string[];
+  /**
+   * Shop connection handed off from the unified "Publish products" picker
+   * (#1828). When set (and it resolves to an eligible shop connection), the
+   * launcher skips its own connection picker and opens that connection's
+   * wizard directly. Falls back to the internal auto-resolve / picker when
+   * unset or not eligible.
+   */
+  preselectedConnectionId?: string;
 }
 
 /** The capability a connection must enable to publish products to it. */
@@ -50,7 +58,9 @@ export const SHOP_PUBLISH_CAPABILITY = 'ProductPublisher';
  */
 export function selectShopPublishConnections(all: ReadonlyArray<Connection>): Connection[] {
   return all
-    .filter((c) => c.status === 'active' && c.enabledCapabilities.includes(SHOP_PUBLISH_CAPABILITY))
+    .filter(
+      (c) => c.status === 'active' && c.enabledCapabilities?.includes(SHOP_PUBLISH_CAPABILITY),
+    )
     .slice()
     .sort((a, b) => a.name.localeCompare(b.name));
 }
@@ -60,6 +70,7 @@ export function ShopPublishLauncher({
   onOpenChange,
   defaultVariantId,
   defaultVariantIds,
+  preselectedConnectionId,
 }: ShopPublishLauncherProps): ReactElement | null {
   const connectionsQuery = useConnectionsQuery();
   const shopConnections = useMemo(
@@ -86,13 +97,21 @@ export function ShopPublishLauncher({
     }
   }, [open]);
 
-  // Auto-skip the picker when there is exactly one eligible connection.
+  // Auto-skip the picker when the unified picker handed off a specific shop
+  // connection (#1828), or when there is exactly one eligible connection.
   useEffect(() => {
     if (!open || pickedConnectionId !== null || submitted !== null) return;
+    if (
+      preselectedConnectionId !== undefined &&
+      shopConnections.some((c) => c.id === preselectedConnectionId)
+    ) {
+      setPickedConnectionId(preselectedConnectionId);
+      return;
+    }
     if (shopConnections.length === 1) {
       setPickedConnectionId(shopConnections[0].id);
     }
-  }, [open, shopConnections, pickedConnectionId, submitted]);
+  }, [open, shopConnections, pickedConnectionId, submitted, preselectedConnectionId]);
 
   const pickedConnection =
     pickedConnectionId !== null

--- a/apps/web/src/features/listings/components/bulk/bulk-config-step.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-config-step.tsx
@@ -28,6 +28,7 @@ import { useWriteAccess } from '../../../../shared/auth/use-permission';
 import { useDemoMode } from '../../../system';
 import { useConnectionsQuery } from '../../../connections';
 import type { Connection } from '../../../connections';
+import { selectPublishDestinations } from '../../lib/publish-destinations';
 import { usePlatform, usePlatforms, type BulkConfigFormValues } from '../../../../shared/plugins';
 import type {
   BulkWizardConfig,
@@ -48,12 +49,12 @@ interface BulkConfigStepProps {
 const DEFAULT_CURRENCY = 'PLN';
 
 function selectOfferManagerConnections(all: readonly Connection[]): Connection[] {
-  return all
-    // OfferCreator (not coarse OfferManager, #1498): a quantity-only
-    // OfferManager (WooCommerce stock write-back) cannot create offers.
-    .filter((c) => c.status === 'active' && c.supportedCapabilities?.includes('OfferCreator'))
-    .slice()
-    .sort((a, b) => a.name.localeCompare(b.name));
+  // Unified publish targets (#1828): offer marketplaces (OfferCreator) OR
+  // online shops (ProductPublisher), capability-driven. A connection without a
+  // per-platform config section (e.g. a shop, until the wizard branch #1829
+  // lands) surfaces the "not configured" warning and cannot Proceed via the
+  // marketplace path - see `sectionComplete` below.
+  return selectPublishDestinations(all).map((d) => d.connection);
 }
 
 function defaultFormValues(initial: Partial<BulkWizardConfig>): BulkConfigFormValues {
@@ -127,7 +128,11 @@ export function BulkConfigStep({
     (/^\d+$/.test(values.flatStockValue.trim()) && Number(values.flatStockValue) >= 1);
 
   const sharedSliceValid = markupValid && flatPriceValid && capValid && flatStockValid;
-  const sectionComplete = section ? section.isComplete(values) : true;
+  // A connection with no per-platform config section cannot be bulk-published
+  // through the marketplace wizard (e.g. a shop destination that slipped in via
+  // direct URL before the wizard branch #1829 lands) - block Proceed rather
+  // than submit a shop connection to the offer bulk-create endpoint.
+  const sectionComplete = section ? section.isComplete(values) : false;
   const canProceed = connectionId !== '' && sharedSliceValid && sectionComplete;
 
   function buildPricingPolicy(): PricingPolicy {

--- a/apps/web/src/features/listings/components/offer-product-picker-modal.test.tsx
+++ b/apps/web/src/features/listings/components/offer-product-picker-modal.test.tsx
@@ -211,28 +211,28 @@ describe('OfferProductPickerModal', () => {
     expect(screen.getByText(/1 offer selected across.*1 product/i)).toBeInTheDocument();
   });
 
-  it('auto-resolves the sole eligible connection (no picker shown)', async () => {
+  it('auto-resolves the sole eligible destination (pre-selected)', async () => {
     renderWithProviders(<OfferProductPickerModal isOpen onClose={vi.fn()} />, {
       apiClient: mocks([conn('conn_a', 'Allegro', 'allegro')]),
     });
     await screen.findByText('Product p1');
-    expect(screen.queryByLabelText(/marketplace connection/i)).not.toBeInTheDocument();
-    // Selecting one product is enough to enable Continue (connection auto-resolved).
+    // The sole destination renders in the rail, already selected.
+    expect(screen.getByRole('radio', { name: /Allegro/ })).toHaveAttribute('aria-checked', 'true');
+    // Selecting one product is enough to enable Continue (destination auto-resolved).
     fireEvent.click(screen.getByLabelText('Select Product p1'));
     expect(screen.getByRole('button', { name: /continue/i })).toBeEnabled();
   });
 
-  it('requires a connection pick when 2+ eligible connections exist', async () => {
+  it('requires a destination pick when 2+ eligible destinations exist', async () => {
     renderWithProviders(<OfferProductPickerModal isOpen onClose={vi.fn()} />, {
       apiClient: mocks([conn('conn_a', 'Allegro', 'allegro'), conn('conn_e', 'Erli', 'erli')]),
     });
     fireEvent.click(await screen.findByLabelText('Select Product p1'));
     // Disabled Continue is wrapped in a tooltip trigger; re-query after the
-    // connection pick since the enabled button is a fresh DOM node.
+    // destination pick since the enabled button is a fresh DOM node.
     expect(screen.getByRole('button', { name: /continue/i })).toBeDisabled();
 
-    const select = screen.getByLabelText<HTMLSelectElement>(/marketplace connection/i);
-    fireEvent.change(select, { target: { value: 'conn_e' } });
+    fireEvent.click(screen.getByRole('radio', { name: /Erli/ }));
     const continueBtn = screen.getByRole('button', { name: /continue/i });
     expect(continueBtn).toBeEnabled();
 
@@ -248,12 +248,12 @@ describe('OfferProductPickerModal', () => {
     expect(screen.getByRole('button', { name: /continue/i })).toBeDisabled();
   });
 
-  it('shows a warning when no eligible connection exists', async () => {
+  it('shows a warning when no eligible destination exists', async () => {
     renderWithProviders(<OfferProductPickerModal isOpen onClose={vi.fn()} />, {
       apiClient: mocks([]),
     });
     expect(
-      await screen.findByText(/no marketplace connections available/i),
+      await screen.findByText(/no publish destinations available/i),
     ).toBeInTheDocument();
   });
 
@@ -265,9 +265,9 @@ describe('OfferProductPickerModal', () => {
       ]),
     });
     await screen.findByText('Product p1');
-    // Exactly one eligible → no picker, read-only "Publishing to" line instead.
-    expect(screen.queryByLabelText(/marketplace connection/i)).not.toBeInTheDocument();
-    expect(screen.getByText(/publishing to:/i)).toBeInTheDocument();
+    // Exactly one eligible → sole destination pre-selected in the rail.
+    expect(screen.getByRole('radio', { name: /eligible/ })).toHaveAttribute('aria-checked', 'true');
+    expect(screen.queryByRole('radio', { name: /noCreator/ })).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByLabelText('Select Product p1'));
     fireEvent.click(screen.getByRole('button', { name: /continue/i }));
@@ -285,9 +285,9 @@ describe('OfferProductPickerModal', () => {
       ]),
     });
     expect(
-      await screen.findByText(/no marketplace connections available/i),
+      await screen.findByText(/no publish destinations available/i),
     ).toBeInTheDocument();
-    expect(screen.queryByLabelText(/marketplace connection/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole('radiogroup', { name: /publish destination/i })).not.toBeInTheDocument();
   });
 
   it('resets selection when the dialog is closed and reopened', async () => {
@@ -438,6 +438,52 @@ describe('OfferProductPickerModal', () => {
       fireEvent.click(screen.getByRole('button', { name: /retry/i }));
       await waitFor(() => expect(getById.mock.calls.length).toBeGreaterThan(before));
     });
+  });
+
+  function shopConn(id: string, name: string): Connection {
+    return {
+      id,
+      name,
+      platformType: 'woocommerce',
+      status: 'active',
+      config: {},
+      credentialsBacked: true,
+      adapterKey: 'woocommerce.restapi.v3',
+      enabledCapabilities: ['ProductPublisher'],
+      supportedCapabilities: ['ProductPublisher'],
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    } as unknown as Connection;
+  }
+
+  it('groups marketplaces and shops, and hands a shop pick to onPublishToShop', async () => {
+    const onPublishToShop = vi.fn();
+    renderWithProviders(
+      <OfferProductPickerModal isOpen onClose={vi.fn()} onPublishToShop={onPublishToShop} />,
+      { apiClient: mocks([conn('conn_a', 'Allegro', 'allegro'), shopConn('conn_w', 'My Shop')]) },
+    );
+    fireEvent.click(await screen.findByLabelText('Select Product p1'));
+    // Both groups render with capability-driven hints.
+    expect(screen.getByText('Marketplaces')).toBeInTheDocument();
+    expect(screen.getByText('Online shops')).toBeInTheDocument();
+
+    // Choosing the shop routes through onPublishToShop, not the wizard URL.
+    fireEvent.click(screen.getByRole('radio', { name: /My Shop/ }));
+    fireEvent.click(screen.getByRole('button', { name: /continue/i }));
+    expect(onPublishToShop).toHaveBeenCalledWith(
+      expect.objectContaining({ connectionId: 'conn_w', productIds: ['p1'] }),
+    );
+    expect(navigateMock).not.toHaveBeenCalled();
+  });
+
+  it('omits shop destinations when no onPublishToShop handler is provided', async () => {
+    renderWithProviders(<OfferProductPickerModal isOpen onClose={vi.fn()} />, {
+      apiClient: mocks([conn('conn_a', 'Allegro', 'allegro'), shopConn('conn_w', 'My Shop')]),
+    });
+    await screen.findByText('Product p1');
+    expect(screen.getByRole('radio', { name: /Allegro/ })).toBeInTheDocument();
+    expect(screen.queryByRole('radio', { name: /My Shop/ })).not.toBeInTheDocument();
+    expect(screen.queryByText('Online shops')).not.toBeInTheDocument();
   });
 
   it('navigates between the product list and review steps (two-step wizard)', async () => {

--- a/apps/web/src/features/listings/components/offer-product-picker-modal.tsx
+++ b/apps/web/src/features/listings/components/offer-product-picker-modal.tsx
@@ -43,7 +43,6 @@
  * @module apps/web/src/features/listings/components
  */
 import {
-  Fragment,
   useCallback,
   useEffect,
   useMemo,
@@ -70,12 +69,8 @@ import { useDebouncedValue } from '../../../shared/hooks/use-debounced-value';
 import { useConnectionsQuery } from '../../connections';
 import { useProductQuery, useProductsQuery } from '../../products';
 import type { Product, ProductVariant } from '../../products';
-import {
-  selectPublishDestinations,
-  PUBLISH_DESTINATION_GROUP_LABEL,
-  PUBLISH_DESTINATION_KIND_HINT,
-  PUBLISH_DESTINATION_KIND_ORDER,
-} from '../lib/publish-destinations';
+import { selectPublishDestinations } from '../lib/publish-destinations';
+import { PublishDestinationRail } from './publish-destination-rail';
 
 /** Max distinct products per batch (mirrors the `/products` BULK_SELECTION_CAP,
  *  kept local per R1 to avoid a `features -> pages` import). */
@@ -968,52 +963,12 @@ export function OfferProductPickerModal({
                     <span className="offer-product-picker__eyebrow" id="publishDestinationLabel">
                       Publish to <span className="offer-product-picker__req">*</span>
                     </span>
-                    <div
-                      role="radiogroup"
-                      aria-labelledby="publishDestinationLabel"
-                      aria-label="Publish destination"
-                      className="offer-product-picker__dests"
-                    >
-                      {PUBLISH_DESTINATION_KIND_ORDER.map((kind) => {
-                        const inKind = eligibleDestinations.filter((d) => d.kind === kind);
-                        if (inKind.length === 0) return null;
-                        return (
-                          <Fragment key={kind}>
-                            <div className="offer-product-picker__dest-group">
-                              {PUBLISH_DESTINATION_GROUP_LABEL[kind]}
-                            </div>
-                            {inKind.map((d) => {
-                              const selected = resolvedConnectionId === d.connection.id;
-                              return (
-                                <button
-                                  key={d.connection.id}
-                                  type="button"
-                                  role="radio"
-                                  aria-checked={selected}
-                                  className={`offer-product-picker__dest${
-                                    selected ? ' offer-product-picker__dest--selected' : ''
-                                  }`}
-                                  onClick={() => setPickedConnectionId(d.connection.id)}
-                                >
-                                  <span className="offer-product-picker__dest-meta">
-                                    <span className="offer-product-picker__dest-name">
-                                      {d.connection.name}
-                                    </span>
-                                    <span className="offer-product-picker__dest-kind">
-                                      {PUBLISH_DESTINATION_KIND_HINT[d.kind]}
-                                    </span>
-                                  </span>
-                                  <span
-                                    className="offer-product-picker__dest-radio"
-                                    aria-hidden="true"
-                                  />
-                                </button>
-                              );
-                            })}
-                          </Fragment>
-                        );
-                      })}
-                    </div>
+                    <PublishDestinationRail
+                      destinations={eligibleDestinations}
+                      selectedConnectionId={resolvedConnectionId}
+                      onSelect={setPickedConnectionId}
+                      labelledBy="publishDestinationLabel"
+                    />
                   </div>
                 )}
 

--- a/apps/web/src/features/listings/components/offer-product-picker-modal.tsx
+++ b/apps/web/src/features/listings/components/offer-product-picker-modal.tsx
@@ -20,24 +20,30 @@
  * Selection persists across pagination and search changes, keyed by product
  * id to `'ALL'` (whole product) or a `Set<variantId>` (explicit subset).
  *
- * Connection resolution happens inside the modal (R1 - the picker never
- * imports from `pages/`): active connections advertising the `OfferCreator`
- * sub-capability are eligible; exactly one auto-resolves, several render a
- * `<Select>`, none renders a warning.
+ * Destination resolution happens inside the modal (R1 - the picker never
+ * imports from `pages/`): active connections that are either an offer
+ * marketplace (`OfferCreator`) or an online shop (`ProductPublisher`) are
+ * eligible (#1828). The right rail groups them by kind (Marketplaces /
+ * Online shops) with a capability-driven hint - never a `platformType`
+ * literal - as a single-select radio list. Exactly one destination
+ * auto-resolves; none renders a warning.
  *
  * Closing via X / Cancel / esc / outside-click is routed through a discard
  * guard: a pending selection opens a `ConfirmDialog` before the modal closes.
  *
- * Continue navigates into the bulk wizard route
- * (`/listings/bulk-create/wizard?productIds=...&variantIds=...&connectionId=...`).
- * Products picked whole contribute no `variantIds` (the wizard then seeds all
- * their variants); products picked at variant granularity contribute their
- * explicit subset. Absent `variantIds` keeps the `/products` entry point
- * byte-identical.
+ * Continue dispatches by destination kind. A **marketplace** destination
+ * navigates into the bulk wizard route
+ * (`/listings/bulk-create/wizard?productIds=...&variantIds=...&connectionId=...`);
+ * products picked whole contribute no `variantIds` (the wizard then seeds all
+ * their variants), products picked at variant granularity contribute their
+ * explicit subset. A **shop** destination hands off to the caller's
+ * `onPublishToShop` (today the retained, hidden `ShopPublishLauncher`, until
+ * the wizard branch #1829 folds the shop path into the same route).
  *
  * @module apps/web/src/features/listings/components
  */
 import {
+  Fragment,
   useCallback,
   useEffect,
   useMemo,
@@ -59,13 +65,17 @@ import {
 } from '../../../shared/ui/dialog';
 import { Input } from '../../../shared/ui/input';
 import { ProductThumbnail } from '../../../shared/ui/product-thumbnail';
-import { Select } from '../../../shared/ui/select';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../../../shared/ui/tooltip';
 import { useDebouncedValue } from '../../../shared/hooks/use-debounced-value';
 import { useConnectionsQuery } from '../../connections';
-import type { Connection } from '../../connections';
 import { useProductQuery, useProductsQuery } from '../../products';
 import type { Product, ProductVariant } from '../../products';
+import {
+  selectPublishDestinations,
+  PUBLISH_DESTINATION_GROUP_LABEL,
+  PUBLISH_DESTINATION_KIND_HINT,
+  PUBLISH_DESTINATION_KIND_ORDER,
+} from '../lib/publish-destinations';
 
 /** Max distinct products per batch (mirrors the `/products` BULK_SELECTION_CAP,
  *  kept local per R1 to avoid a `features -> pages` import). */
@@ -79,21 +89,24 @@ type SelectionEntry = 'ALL' | Set<string>;
 /** Two-step wizard step (meaningful only <=1023px; desktop shows both regions). */
 type PickerStep = 'products' | 'review';
 
+/** Args handed to the caller when a shop destination is chosen (#1828). */
+export interface PublishToShopHandoff {
+  connectionId: string;
+  productIds: string[];
+  /** Best-effort known variant ids (explicit subset picks + loaded whole-product variants). */
+  variantIds: string[];
+}
+
 interface OfferProductPickerModalProps {
   isOpen: boolean;
   onClose: () => void;
-}
-
-/**
- * Marketplace connections eligible for offer creation. Filters by the
- * `OfferCreator` sub-capability (#1498) and active status, sorted by name.
- * Mirrors the retired launcher's `selectMarketplaceConnections`.
- */
-function selectOfferCreatorConnections(all: ReadonlyArray<Connection>): Connection[] {
-  return all
-    .filter((c) => c.status === 'active' && c.supportedCapabilities.includes('OfferCreator'))
-    .slice()
-    .sort((a, b) => a.name.localeCompare(b.name));
+  /**
+   * Invoked instead of the marketplace navigation when the chosen destination
+   * is an online shop (`ProductPublisher`). The listings page routes this to
+   * the retained `ShopPublishLauncher` (#1828). When omitted, shop
+   * destinations are not surfaced.
+   */
+  onPublishToShop?: (handoff: PublishToShopHandoff) => void;
 }
 
 function variantLabel(product: Product, variant: ProductVariant): string {
@@ -317,6 +330,7 @@ interface RailGroup {
 export function OfferProductPickerModal({
   isOpen,
   onClose,
+  onPublishToShop,
 }: OfferProductPickerModalProps): ReactElement | null {
   const navigate = useNavigate();
 
@@ -358,17 +372,24 @@ export function OfferProductPickerModal({
   }, [isOpen]);
 
   const connectionsQuery = useConnectionsQuery();
-  const eligibleConnections = useMemo(
-    () => selectOfferCreatorConnections(connectionsQuery.data ?? []),
-    [connectionsQuery.data],
-  );
+  const eligibleDestinations = useMemo(() => {
+    const all = selectPublishDestinations(connectionsQuery.data ?? []);
+    // Shop destinations are only offered when the caller can dispatch them.
+    return onPublishToShop ? all : all.filter((d) => d.kind === 'marketplace');
+  }, [connectionsQuery.data, onPublishToShop]);
 
-  // Auto-resolve when exactly one eligible connection exists; otherwise the
-  // operator picks from the `<Select>` (or gets a warning when none exist).
+  // Auto-resolve when exactly one eligible destination exists; otherwise the
+  // operator picks one from the grouped rail (or gets a warning when none exist).
   const resolvedConnectionId =
-    eligibleConnections.length === 1
-      ? eligibleConnections[0]!.id
+    eligibleDestinations.length === 1
+      ? eligibleDestinations[0]!.connection.id
       : pickedConnectionId || null;
+
+  const resolvedDestination =
+    resolvedConnectionId !== null
+      ? eligibleDestinations.find((d) => d.connection.id === resolvedConnectionId) ?? null
+      : null;
+  const resolvedKind = resolvedDestination?.kind ?? null;
 
   const productsQuery = useProductsQuery(
     { search: debouncedSearch || undefined },
@@ -562,17 +583,33 @@ export function OfferProductPickerModal({
     if (selection.size === 0 || resolvedConnectionId === null) return;
     const productIds: string[] = [];
     const variantIds: string[] = [];
+    // Best-effort variant ids for the shop handoff: whole-product picks
+    // contribute their loaded variant ids when known (the marketplace route
+    // instead lets the bulk wizard hydrate them from productIds).
+    const shopVariantIds: string[] = [];
     for (const [productId, entry] of selection) {
       productIds.push(productId);
       if (entry instanceof Set) {
-        for (const variantId of entry) variantIds.push(variantId);
+        for (const variantId of entry) {
+          variantIds.push(variantId);
+          shopVariantIds.push(variantId);
+        }
+      } else {
+        for (const v of variantMeta.get(productId) ?? []) shopVariantIds.push(v.id);
       }
     }
+
+    if (resolvedKind === 'shop' && onPublishToShop) {
+      onPublishToShop({ connectionId: resolvedConnectionId, productIds, variantIds: shopVariantIds });
+      onClose();
+      return;
+    }
+
     const params = new URLSearchParams({ productIds: productIds.join(',') });
     if (variantIds.length > 0) params.set('variantIds', variantIds.join(','));
     params.set('connectionId', resolvedConnectionId);
     void navigate(`/listings/bulk-create/wizard?${params.toString()}`);
-  }, [selection, resolvedConnectionId, navigate]);
+  }, [selection, resolvedConnectionId, resolvedKind, onPublishToShop, onClose, variantMeta, navigate]);
 
   // Discard guard: a pending selection intercepts every close path (X, Cancel,
   // esc, outside-click) with a confirm; an empty selection closes directly.
@@ -596,7 +633,8 @@ export function OfferProductPickerModal({
   const pageCount = Math.max(1, Math.ceil(total / PAGE_SIZE));
   const currentPage = Math.floor(offset / PAGE_SIZE) + 1;
   const canContinue = selection.size > 0 && resolvedConnectionId !== null;
-  const selectionSummary = `${itemCount} ${itemCount === 1 ? 'offer' : 'offers'} selected across ${
+  const itemNoun = resolvedKind === 'shop' ? 'product listing' : 'offer';
+  const selectionSummary = `${itemCount} ${itemCount === 1 ? itemNoun : `${itemNoun}s`} selected across ${
     selection.size
   } ${selection.size === 1 ? 'product' : 'products'}`;
 
@@ -636,10 +674,10 @@ export function OfferProductPickerModal({
           </span>
 
           <header className="offer-product-picker__head">
-            <DialogTitle className="offer-product-picker__title">Create offers</DialogTitle>
+            <DialogTitle className="offer-product-picker__title">Publish products</DialogTitle>
             <DialogDescription className="offer-product-picker__sub">
-              Pick whole products or individual variants, mix across products - it all becomes one
-              batch.
+              Pick whole products or individual variants, mix across products, then choose a
+              marketplace or shop to publish to - it all becomes one batch.
             </DialogDescription>
           </header>
 
@@ -753,7 +791,7 @@ export function OfferProductPickerModal({
               {/* Step-1 action bar - visible only on the <=1023px two-step layout. */}
               <div className="offer-product-picker__mstep-next">
                 <span className="offer-product-picker__mstep-count">
-                  <b>{itemCount}</b> {itemCount === 1 ? 'offer' : 'offers'} · {selection.size}{' '}
+                  <b>{itemCount}</b> {itemCount === 1 ? itemNoun : `${itemNoun}s`} · {selection.size}{' '}
                   {selection.size === 1 ? 'product' : 'products'}
                 </span>
                 <Button type="button" onClick={() => setStep('review')}>
@@ -790,7 +828,9 @@ export function OfferProductPickerModal({
               <div className="offer-product-picker__rail-counts">
                 <div>
                   <span className="offer-product-picker__rail-n tabular">{itemCount}</span>
-                  <span className="offer-product-picker__rail-lbl">offers</span>
+                  <span className="offer-product-picker__rail-lbl">
+                    {resolvedKind === 'shop' ? 'listings' : 'offers'}
+                  </span>
                 </div>
                 <div>
                   <span className="offer-product-picker__rail-n tabular">{selection.size}</span>
@@ -901,7 +941,7 @@ export function OfferProductPickerModal({
 
               <div className="offer-product-picker__rail-foot">
                 {connectionsQuery.isLoading ? (
-                  <p className="muted-text">Loading marketplace connections…</p>
+                  <p className="muted-text">Loading destinations…</p>
                 ) : connectionsQuery.error ? (
                   <Alert
                     tone="error"
@@ -918,35 +958,62 @@ export function OfferProductPickerModal({
                   >
                     {connectionsQuery.error.message}
                   </Alert>
-                ) : eligibleConnections.length === 0 ? (
-                  <Alert tone="warning" title="No marketplace connections available">
-                    Add an active connection that supports offer creation before publishing offers.
+                ) : eligibleDestinations.length === 0 ? (
+                  <Alert tone="warning" title="No publish destinations available">
+                    Add an active marketplace (offer creation) or online shop (product publishing)
+                    connection before publishing.
                   </Alert>
                 ) : (
                   <div className="offer-product-picker__rail-conn">
-                    <label className="offer-product-picker__eyebrow" htmlFor="offerConnection">
+                    <span className="offer-product-picker__eyebrow" id="publishDestinationLabel">
                       Publish to <span className="offer-product-picker__req">*</span>
-                    </label>
-                    {eligibleConnections.length > 1 ? (
-                      <Select
-                        id="offerConnection"
-                        value={pickedConnectionId}
-                        onChange={(e) => setPickedConnectionId(e.target.value)}
-                        aria-label="Marketplace connection"
-                      >
-                        <option value="">Choose a connection…</option>
-                        {eligibleConnections.map((c) => (
-                          <option key={c.id} value={c.id}>
-                            {c.name} ({c.platformType})
-                          </option>
-                        ))}
-                      </Select>
-                    ) : (
-                      <p className="muted-text offer-product-picker__resolved-connection">
-                        Publishing to: <strong>{eligibleConnections[0]!.name}</strong> (
-                        {eligibleConnections[0]!.platformType})
-                      </p>
-                    )}
+                    </span>
+                    <div
+                      role="radiogroup"
+                      aria-labelledby="publishDestinationLabel"
+                      aria-label="Publish destination"
+                      className="offer-product-picker__dests"
+                    >
+                      {PUBLISH_DESTINATION_KIND_ORDER.map((kind) => {
+                        const inKind = eligibleDestinations.filter((d) => d.kind === kind);
+                        if (inKind.length === 0) return null;
+                        return (
+                          <Fragment key={kind}>
+                            <div className="offer-product-picker__dest-group">
+                              {PUBLISH_DESTINATION_GROUP_LABEL[kind]}
+                            </div>
+                            {inKind.map((d) => {
+                              const selected = resolvedConnectionId === d.connection.id;
+                              return (
+                                <button
+                                  key={d.connection.id}
+                                  type="button"
+                                  role="radio"
+                                  aria-checked={selected}
+                                  className={`offer-product-picker__dest${
+                                    selected ? ' offer-product-picker__dest--selected' : ''
+                                  }`}
+                                  onClick={() => setPickedConnectionId(d.connection.id)}
+                                >
+                                  <span className="offer-product-picker__dest-meta">
+                                    <span className="offer-product-picker__dest-name">
+                                      {d.connection.name}
+                                    </span>
+                                    <span className="offer-product-picker__dest-kind">
+                                      {PUBLISH_DESTINATION_KIND_HINT[d.kind]}
+                                    </span>
+                                  </span>
+                                  <span
+                                    className="offer-product-picker__dest-radio"
+                                    aria-hidden="true"
+                                  />
+                                </button>
+                              );
+                            })}
+                          </Fragment>
+                        );
+                      })}
+                    </div>
                   </div>
                 )}
 
@@ -975,10 +1042,10 @@ export function OfferProductPickerModal({
                       </TooltipTrigger>
                       <TooltipContent>
                         {selection.size === 0
-                          ? 'Select at least one product, then choose a connection.'
-                          : eligibleConnections.length === 0
-                            ? 'Add an active connection that supports offer creation before publishing.'
-                            : 'Choose a connection to publish to first.'}
+                          ? 'Select at least one product, then choose a destination.'
+                          : eligibleDestinations.length === 0
+                            ? 'Add an active marketplace or shop connection before publishing.'
+                            : 'Choose a destination to publish to first.'}
                       </TooltipContent>
                     </Tooltip>
                   )}

--- a/apps/web/src/features/listings/components/publish-destination-rail.test.tsx
+++ b/apps/web/src/features/listings/components/publish-destination-rail.test.tsx
@@ -1,0 +1,122 @@
+/**
+ * PublishDestinationRail tests (#1828)
+ *
+ * Focus: the WAI-ARIA radiogroup keyboard contract — single tab stop via
+ * roving tabindex, and Arrow / Home / End moving (and selecting) between
+ * grouped destinations.
+ */
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { useState, type ReactElement } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { PublishDestinationRail } from './publish-destination-rail';
+import type { Connection } from '../../connections';
+import type { PublishDestination, PublishDestinationKind } from '../lib/publish-destinations';
+
+function dest(id: string, name: string, kind: PublishDestinationKind): PublishDestination {
+  return {
+    kind,
+    connection: {
+      id,
+      name,
+      platformType: kind === 'shop' ? 'woocommerce' : 'allegro',
+      status: 'active',
+      config: {},
+      credentialsBacked: true,
+      adapterKey: 'x.v1',
+      enabledCapabilities: [],
+      supportedCapabilities: [],
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    } as unknown as Connection,
+  };
+}
+
+// Visual/nav order is marketplaces first, then shops.
+const DESTS: PublishDestination[] = [
+  dest('m1', 'Allegro One', 'marketplace'),
+  dest('m2', 'Allegro Two', 'marketplace'),
+  dest('s1', 'Shop One', 'shop'),
+];
+
+/** Controlled harness so arrow keys visibly move the selection. */
+function Harness({ initial = null }: { initial?: string | null }): ReactElement {
+  const [selected, setSelected] = useState<string | null>(initial);
+  return (
+    <PublishDestinationRail
+      destinations={DESTS}
+      selectedConnectionId={selected}
+      onSelect={setSelected}
+      ariaLabel="Publish destination"
+    />
+  );
+}
+
+describe('PublishDestinationRail', () => {
+  afterEach(cleanup);
+
+  it('groups destinations by kind with capability-driven hints', () => {
+    render(<Harness />);
+    expect(screen.getByText('Marketplaces')).toBeInTheDocument();
+    expect(screen.getByText('Online shops')).toBeInTheDocument();
+    expect(screen.getAllByText('Offer marketplace')).toHaveLength(2);
+    expect(screen.getByText('Online shop')).toBeInTheDocument();
+  });
+
+  it('is a single tab stop: first radio is focusable when nothing is selected', () => {
+    render(<Harness />);
+    const radios = screen.getAllByRole('radio');
+    expect(radios[0]).toHaveAttribute('tabindex', '0');
+    expect(radios[1]).toHaveAttribute('tabindex', '-1');
+    expect(radios[2]).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('moves the single tab stop to the selected radio', () => {
+    render(<Harness initial="m2" />);
+    const radios = screen.getAllByRole('radio');
+    expect(radios[0]).toHaveAttribute('tabindex', '-1');
+    expect(radios[1]).toHaveAttribute('tabindex', '0');
+    expect(screen.getByRole('radio', { name: /Allegro Two/ })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    );
+  });
+
+  it('ArrowDown moves selection to the next destination (across group boundary)', () => {
+    render(<Harness initial="m2" />);
+    fireEvent.keyDown(screen.getByRole('radio', { name: /Allegro Two/ }), { key: 'ArrowDown' });
+    // m2 (index 1) -> s1 (index 2), crossing into the shop group.
+    expect(screen.getByRole('radio', { name: /Shop One/ })).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('ArrowUp wraps from the first to the last destination', () => {
+    render(<Harness initial="m1" />);
+    fireEvent.keyDown(screen.getByRole('radio', { name: /Allegro One/ }), { key: 'ArrowUp' });
+    expect(screen.getByRole('radio', { name: /Shop One/ })).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('Home selects the first and End selects the last destination', () => {
+    render(<Harness initial="m2" />);
+    fireEvent.keyDown(screen.getByRole('radio', { name: /Allegro Two/ }), { key: 'End' });
+    expect(screen.getByRole('radio', { name: /Shop One/ })).toHaveAttribute('aria-checked', 'true');
+    fireEvent.keyDown(screen.getByRole('radio', { name: /Shop One/ }), { key: 'Home' });
+    expect(screen.getByRole('radio', { name: /Allegro One/ })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    );
+  });
+
+  it('clicking a destination selects it', () => {
+    const onSelect = vi.fn();
+    render(
+      <PublishDestinationRail
+        destinations={DESTS}
+        selectedConnectionId={null}
+        onSelect={onSelect}
+        ariaLabel="Publish destination"
+      />,
+    );
+    fireEvent.click(screen.getByRole('radio', { name: /Shop One/ }));
+    expect(onSelect).toHaveBeenCalledWith('s1');
+  });
+});

--- a/apps/web/src/features/listings/components/publish-destination-rail.tsx
+++ b/apps/web/src/features/listings/components/publish-destination-rail.tsx
@@ -1,0 +1,143 @@
+/**
+ * PublishDestinationRail
+ *
+ * Single-select destination picker for the unified publish flow (#1828),
+ * grouped by kind (Marketplaces / Online shops) with a capability-driven hint
+ * (never a `platformType` literal). Shared by the Listings picker
+ * (`OfferProductPickerModal`) and the Products picker
+ * (`MarketplacePickerModal`) so the grouped-radio markup and its keyboard a11y
+ * live in one place.
+ *
+ * Uses the WAI-ARIA radiogroup idiom (`role="radiogroup"` + `role="radio"` /
+ * `aria-checked`): a roving tabindex keeps the whole group a single tab stop,
+ * and Arrow / Home / End move (and select) between destinations - mirroring the
+ * `SegmentedControl` primitive. Selection follows the flattened visual order
+ * (marketplaces first, then shops), which is the order `destinations` already
+ * arrives in from `selectPublishDestinations`.
+ *
+ * @module apps/web/src/features/listings/components
+ */
+import { useRef, type KeyboardEvent, type ReactElement } from 'react';
+
+import {
+  PUBLISH_DESTINATION_GROUP_LABEL,
+  PUBLISH_DESTINATION_KIND_HINT,
+  PUBLISH_DESTINATION_KIND_ORDER,
+  type PublishDestination,
+} from '../lib/publish-destinations';
+
+interface PublishDestinationRailProps {
+  destinations: readonly PublishDestination[];
+  selectedConnectionId: string | null;
+  onSelect: (connectionId: string) => void;
+  /** Accessible name for the group; omit when using `labelledBy` instead. */
+  ariaLabel?: string;
+  /** Id of an external element labelling the group (takes precedence visually). */
+  labelledBy?: string;
+}
+
+export function PublishDestinationRail({
+  destinations,
+  selectedConnectionId,
+  onSelect,
+  ariaLabel,
+  labelledBy,
+}: PublishDestinationRailProps): ReactElement {
+  const optionRefs = useRef<(HTMLButtonElement | null)[]>([]);
+
+  // Flatten to visual/tab order (marketplaces first, then shops), so the
+  // radio index used for roving tabindex + arrow nav matches what the operator
+  // sees. `destinations` already arrives sorted this way; re-project defensively.
+  const ordered: PublishDestination[] = PUBLISH_DESTINATION_KIND_ORDER.flatMap((kind) =>
+    destinations.filter((d) => d.kind === kind),
+  );
+  const hasSelected = ordered.some((d) => d.connection.id === selectedConnectionId);
+
+  const selectAt = (index: number): void => {
+    const next = ordered[index];
+    if (next === undefined) return;
+    onSelect(next.connection.id);
+    optionRefs.current[index]?.focus();
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>, index: number): void => {
+    const count = ordered.length;
+    if (count === 0) return;
+    switch (event.key) {
+      case 'ArrowDown':
+      case 'ArrowRight':
+        event.preventDefault();
+        selectAt((index + 1) % count);
+        break;
+      case 'ArrowUp':
+      case 'ArrowLeft':
+        event.preventDefault();
+        selectAt((index - 1 + count) % count);
+        break;
+      case 'Home':
+        event.preventDefault();
+        selectAt(0);
+        break;
+      case 'End':
+        event.preventDefault();
+        selectAt(count - 1);
+        break;
+      default:
+        break;
+    }
+  };
+
+  let flatIndex = -1;
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label={labelledBy ? undefined : (ariaLabel ?? 'Publish destination')}
+      aria-labelledby={labelledBy}
+      className="publish-dest-rail"
+    >
+      {PUBLISH_DESTINATION_KIND_ORDER.map((kind) => {
+        const inKind = destinations.filter((d) => d.kind === kind);
+        if (inKind.length === 0) return null;
+        return (
+          <div key={kind} className="publish-dest-rail__kind">
+            <div className="publish-dest-rail__group">{PUBLISH_DESTINATION_GROUP_LABEL[kind]}</div>
+            {inKind.map((d) => {
+              flatIndex += 1;
+              const index = flatIndex;
+              const selected = selectedConnectionId === d.connection.id;
+              return (
+                <button
+                  key={d.connection.id}
+                  ref={(el) => {
+                    optionRefs.current[index] = el;
+                  }}
+                  type="button"
+                  role="radio"
+                  aria-checked={selected}
+                  // Roving tabindex: the whole group is one tab stop. The
+                  // selected option is tabbable; with nothing selected the first
+                  // option (index 0) takes the stop so the group is reachable.
+                  tabIndex={selected || (!hasSelected && index === 0) ? 0 : -1}
+                  className={`publish-dest-rail__option${
+                    selected ? ' publish-dest-rail__option--selected' : ''
+                  }`}
+                  onClick={() => onSelect(d.connection.id)}
+                  onKeyDown={(event) => handleKeyDown(event, index)}
+                >
+                  <span className="publish-dest-rail__meta">
+                    <span className="publish-dest-rail__name">{d.connection.name}</span>
+                    <span className="publish-dest-rail__kind-hint">
+                      {PUBLISH_DESTINATION_KIND_HINT[d.kind]}
+                    </span>
+                  </span>
+                  <span className="publish-dest-rail__radio" aria-hidden="true" />
+                </button>
+              );
+            })}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/features/listings/index.ts
+++ b/apps/web/src/features/listings/index.ts
@@ -19,6 +19,7 @@ export type {
   PublishDestination,
   PublishDestinationKind,
 } from './lib/publish-destinations';
+export { PublishDestinationRail } from './components/publish-destination-rail';
 export { ErliBulkConfigSection } from './components/erli/erli-bulk-config-section';
 export { erliBulkConfigIsComplete } from './components/erli/erli-offer-fields.schema';
 export { ErliBulkRowSection } from './components/erli/erli-bulk-row-section';

--- a/apps/web/src/features/listings/index.ts
+++ b/apps/web/src/features/listings/index.ts
@@ -6,6 +6,19 @@
  * create-offer wizard and the listings API request type) import from here.
  */
 export type { CreateOfferRequest } from './api/listings.types';
+export {
+  selectPublishDestinations,
+  publishDestinationKind,
+  PUBLISH_DESTINATION_KIND_HINT,
+  PUBLISH_DESTINATION_GROUP_LABEL,
+  PUBLISH_DESTINATION_KIND_ORDER,
+  MARKETPLACE_PUBLISH_CAPABILITY,
+  SHOP_PUBLISH_CAPABILITY,
+} from './lib/publish-destinations';
+export type {
+  PublishDestination,
+  PublishDestinationKind,
+} from './lib/publish-destinations';
 export { ErliBulkConfigSection } from './components/erli/erli-bulk-config-section';
 export { erliBulkConfigIsComplete } from './components/erli/erli-offer-fields.schema';
 export { ErliBulkRowSection } from './components/erli/erli-bulk-row-section';

--- a/apps/web/src/features/listings/lib/publish-destinations.ts
+++ b/apps/web/src/features/listings/lib/publish-destinations.ts
@@ -1,0 +1,89 @@
+/**
+ * Publish destinations (#1828)
+ *
+ * Capability-driven classification of the connections a product can be
+ * *published* to, spanning both kinds of destination the unified "Publish
+ * products" flow surfaces:
+ *   - **marketplaces** — connections advertising the `OfferCreator`
+ *     sub-capability (offer creation, e.g. Allegro / Erli), and
+ *   - **online shops** — connections that have *enabled* the
+ *     `ProductPublisher` capability (a `ShopProductManagerPort`, ADR-024,
+ *     e.g. WooCommerce), which is config-gated and therefore keyed off
+ *     `enabledCapabilities`, not `supportedCapabilities`.
+ *
+ * The kind is resolved purely from capabilities — never from a
+ * `platformType` literal — so the grouped destination rail and the entry
+ * eligibility filters stay marketplace/shop-agnostic and open to future
+ * plugins.
+ *
+ * @module apps/web/src/features/listings/lib
+ */
+import type { Connection } from '../../connections';
+
+/** The two destination kinds the unified publish rail groups by. */
+export type PublishDestinationKind = 'marketplace' | 'shop';
+
+/** Capability that marks a connection as an offer-creating marketplace. */
+export const MARKETPLACE_PUBLISH_CAPABILITY = 'OfferCreator';
+/** Capability that marks a connection as a product-publishing online shop. */
+export const SHOP_PUBLISH_CAPABILITY = 'ProductPublisher';
+
+/** A publish-eligible connection paired with its resolved kind. */
+export interface PublishDestination {
+  connection: Connection;
+  kind: PublishDestinationKind;
+}
+
+/** Short, capability-driven hint rendered under each destination's name. */
+export const PUBLISH_DESTINATION_KIND_HINT: Record<PublishDestinationKind, string> = {
+  marketplace: 'Offer marketplace',
+  shop: 'Online shop',
+};
+
+/** Group heading for the destination rail, per kind. */
+export const PUBLISH_DESTINATION_GROUP_LABEL: Record<PublishDestinationKind, string> = {
+  marketplace: 'Marketplaces',
+  shop: 'Online shops',
+};
+
+/** Stable rail order: marketplaces first, then shops. */
+export const PUBLISH_DESTINATION_KIND_ORDER: readonly PublishDestinationKind[] = [
+  'marketplace',
+  'shop',
+];
+
+/**
+ * Resolve a connection's publish-destination kind, or `null` when it can be
+ * neither published-as-offer nor published-as-shop-product. Marketplace
+ * (offer creation) wins when a connection somehow advertises both.
+ */
+export function publishDestinationKind(connection: Connection): PublishDestinationKind | null {
+  if (connection.supportedCapabilities?.includes(MARKETPLACE_PUBLISH_CAPABILITY)) {
+    return 'marketplace';
+  }
+  if (connection.enabledCapabilities?.includes(SHOP_PUBLISH_CAPABILITY)) {
+    return 'shop';
+  }
+  return null;
+}
+
+/**
+ * Active connections eligible for the unified publish flow (marketplace OR
+ * shop), each tagged with its kind, sorted by kind (marketplaces first) then
+ * name for a stable rail order.
+ */
+export function selectPublishDestinations(
+  all: readonly Connection[],
+): PublishDestination[] {
+  return all
+    .filter((c) => c.status === 'active')
+    .map((c) => ({ connection: c, kind: publishDestinationKind(c) }))
+    .filter((d): d is PublishDestination => d.kind !== null)
+    .sort((a, b) => {
+      const kindDelta =
+        PUBLISH_DESTINATION_KIND_ORDER.indexOf(a.kind) -
+        PUBLISH_DESTINATION_KIND_ORDER.indexOf(b.kind);
+      if (kindDelta !== 0) return kindDelta;
+      return a.connection.name.localeCompare(b.connection.name);
+    });
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -6680,14 +6680,19 @@ a.kpi-card:focus-visible {
   font-size: 0.8rem;
   margin: 0;
 }
-/* ── Grouped publish-destination rail (#1828) ── */
-.offer-product-picker__dests {
+/* ── Grouped publish-destination rail (#1828) — shared PublishDestinationRail ── */
+.publish-dest-rail {
   display: flex;
   flex-direction: column;
   gap: var(--space-1);
   margin-top: var(--space-2);
 }
-.offer-product-picker__dest-group {
+.publish-dest-rail__kind {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+.publish-dest-rail__group {
   display: flex;
   align-items: center;
   gap: var(--space-2);
@@ -6699,18 +6704,19 @@ a.kpi-card:focus-visible {
   text-transform: uppercase;
   color: var(--text-disabled);
 }
-.offer-product-picker__dest-group::after {
+.publish-dest-rail__group::after {
   content: '';
   flex: 1;
   height: 1px;
   background: var(--border-subtle);
 }
-.offer-product-picker__dest {
+.publish-dest-rail__option {
   display: flex;
   align-items: center;
   gap: var(--space-3);
   width: 100%;
   text-align: left;
+  font: inherit;
   padding: var(--space-2) var(--space-3);
   background: var(--bg-surface);
   border: 1px solid var(--border-default);
@@ -6718,33 +6724,33 @@ a.kpi-card:focus-visible {
   color: var(--text-primary);
   cursor: pointer;
 }
-.offer-product-picker__dest:hover {
+.publish-dest-rail__option:hover {
   background: var(--bg-surface-hover);
 }
-.offer-product-picker__dest--selected {
+.publish-dest-rail__option--selected {
   border-color: var(--accent-primary);
   box-shadow: 0 0 0 1px var(--accent-primary);
   background: var(--accent-primary-soft);
 }
-.offer-product-picker__dest:focus-visible {
+.publish-dest-rail__option:focus-visible {
   outline: none;
   box-shadow: var(--shadow-focus);
 }
-.offer-product-picker__dest-meta {
+.publish-dest-rail__meta {
   display: flex;
   flex-direction: column;
   gap: 1px;
   min-width: 0;
 }
-.offer-product-picker__dest-name {
+.publish-dest-rail__name {
   font-size: 0.8rem;
   font-weight: 500;
 }
-.offer-product-picker__dest-kind {
+.publish-dest-rail__kind-hint {
   font-size: 0.7rem;
   color: var(--text-muted);
 }
-.offer-product-picker__dest-radio {
+.publish-dest-rail__radio {
   margin-left: auto;
   width: 15px;
   height: 15px;
@@ -6753,10 +6759,10 @@ a.kpi-card:focus-visible {
   flex: none;
   position: relative;
 }
-.offer-product-picker__dest--selected .offer-product-picker__dest-radio {
+.publish-dest-rail__option--selected .publish-dest-rail__radio {
   border-color: var(--accent-primary);
 }
-.offer-product-picker__dest--selected .offer-product-picker__dest-radio::after {
+.publish-dest-rail__option--selected .publish-dest-rail__radio::after {
   content: '';
   position: absolute;
   inset: 3px;
@@ -10005,44 +10011,6 @@ input.bulk-dispatch__num--wide {
   color: var(--text-primary);
   font-weight: 600;
   font-size: 0.9rem;
-}
-
-/* Grouped destination rail (#1828): kind heading + radio affordance. */
-.marketplace-picker__group {
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
-  margin: var(--space-2) 0 0;
-  font-family: var(--font-mono);
-  font-size: 0.58rem;
-  font-weight: 600;
-  letter-spacing: var(--tracking-caps);
-  text-transform: uppercase;
-  color: var(--text-disabled);
-}
-.marketplace-picker__group::after {
-  content: '';
-  flex: 1;
-  height: 1px;
-  background: var(--border-subtle);
-}
-.marketplace-picker__radio {
-  width: 16px;
-  height: 16px;
-  border-radius: var(--radius-pill);
-  border: 1.5px solid var(--border-strong);
-  flex: none;
-  position: relative;
-}
-.marketplace-picker__option--picked .marketplace-picker__radio {
-  border-color: var(--accent-primary);
-}
-.marketplace-picker__option--picked .marketplace-picker__radio::after {
-  content: '';
-  position: absolute;
-  inset: 3px;
-  border-radius: var(--radius-pill);
-  background: var(--accent-primary);
 }
 
 @media (prefers-reduced-motion: no-preference) {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -6680,6 +6680,89 @@ a.kpi-card:focus-visible {
   font-size: 0.8rem;
   margin: 0;
 }
+/* ── Grouped publish-destination rail (#1828) ── */
+.offer-product-picker__dests {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  margin-top: var(--space-2);
+}
+.offer-product-picker__dest-group {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin: var(--space-2) 0 var(--space-1);
+  font-family: var(--font-mono);
+  font-size: 0.58rem;
+  font-weight: 600;
+  letter-spacing: var(--tracking-caps);
+  text-transform: uppercase;
+  color: var(--text-disabled);
+}
+.offer-product-picker__dest-group::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--border-subtle);
+}
+.offer-product-picker__dest {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  width: 100%;
+  text-align: left;
+  padding: var(--space-2) var(--space-3);
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  cursor: pointer;
+}
+.offer-product-picker__dest:hover {
+  background: var(--bg-surface-hover);
+}
+.offer-product-picker__dest--selected {
+  border-color: var(--accent-primary);
+  box-shadow: 0 0 0 1px var(--accent-primary);
+  background: var(--accent-primary-soft);
+}
+.offer-product-picker__dest:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
+}
+.offer-product-picker__dest-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+.offer-product-picker__dest-name {
+  font-size: 0.8rem;
+  font-weight: 500;
+}
+.offer-product-picker__dest-kind {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+}
+.offer-product-picker__dest-radio {
+  margin-left: auto;
+  width: 15px;
+  height: 15px;
+  border-radius: var(--radius-pill);
+  border: 1.5px solid var(--border-strong);
+  flex: none;
+  position: relative;
+}
+.offer-product-picker__dest--selected .offer-product-picker__dest-radio {
+  border-color: var(--accent-primary);
+}
+.offer-product-picker__dest--selected .offer-product-picker__dest-radio::after {
+  content: '';
+  position: absolute;
+  inset: 3px;
+  border-radius: var(--radius-pill);
+  background: var(--accent-primary);
+}
 .offer-product-picker__rail-summary {
   font-size: 0.78rem;
   color: var(--text-secondary);
@@ -9922,6 +10005,44 @@ input.bulk-dispatch__num--wide {
   color: var(--text-primary);
   font-weight: 600;
   font-size: 0.9rem;
+}
+
+/* Grouped destination rail (#1828): kind heading + radio affordance. */
+.marketplace-picker__group {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  margin: var(--space-2) 0 0;
+  font-family: var(--font-mono);
+  font-size: 0.58rem;
+  font-weight: 600;
+  letter-spacing: var(--tracking-caps);
+  text-transform: uppercase;
+  color: var(--text-disabled);
+}
+.marketplace-picker__group::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--border-subtle);
+}
+.marketplace-picker__radio {
+  width: 16px;
+  height: 16px;
+  border-radius: var(--radius-pill);
+  border: 1.5px solid var(--border-strong);
+  flex: none;
+  position: relative;
+}
+.marketplace-picker__option--picked .marketplace-picker__radio {
+  border-color: var(--accent-primary);
+}
+.marketplace-picker__option--picked .marketplace-picker__radio::after {
+  content: '';
+  position: absolute;
+  inset: 3px;
+  border-radius: var(--radius-pill);
+  background: var(--accent-primary);
 }
 
 @media (prefers-reduced-motion: no-preference) {

--- a/apps/web/src/pages/listings/listings-list-page.test.tsx
+++ b/apps/web/src/pages/listings/listings-list-page.test.tsx
@@ -120,32 +120,22 @@ describe('ListingsListPage', () => {
     expect(await screen.findByRole('link', { name: 'Manage connections' })).toBeInTheDocument();
   });
 
-  it('should render the Create offer CTA enabled with no pre-filter', async () => {
+  it('renders a single "Publish products" entry (no separate shop CTA) with no pre-filter', async () => {
     const mockApi = createMockApiClient({
       listings: { list: vi.fn().mockResolvedValue(sampleMappings) },
     });
 
     renderWithProviders(<ListingsListPage />, { apiClient: mockApi, sessionAdapter: createAuthenticatedSessionAdapter() });
 
-    const cta = await screen.findByRole('button', { name: /create offer/i });
+    const cta = await screen.findByRole('button', { name: /publish products/i });
     expect(cta).toBeInTheDocument();
     expect(cta).not.toBeDisabled();
-  });
-
-  it('hides the "Publish to shop" CTA when no ProductPublisher connection exists', async () => {
-    // Default connections mock returns a single PrestaShop connection with
-    // no ProductPublisher capability — the CTA must stay hidden.
-    const mockApi = createMockApiClient({
-      listings: { list: vi.fn().mockResolvedValue(sampleMappings) },
-    });
-
-    renderWithProviders(<ListingsListPage />, { apiClient: mockApi });
-
-    await screen.findByText('allegro-offer-999');
+    // The old duplicate CTAs are folded into the single unified entry (#1828).
+    expect(screen.queryByRole('button', { name: /create offer/i })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /publish to shop/i })).not.toBeInTheDocument();
   });
 
-  it('shows the "Publish to shop" CTA when a ProductPublisher connection exists', async () => {
+  it('keeps the single unified entry even when a ProductPublisher (shop) connection exists', async () => {
     const mockApi = createMockApiClient({
       listings: { list: vi.fn().mockResolvedValue(sampleMappings) },
       connections: {
@@ -169,7 +159,8 @@ describe('ListingsListPage', () => {
 
     renderWithProviders(<ListingsListPage />, { apiClient: mockApi, sessionAdapter: createAuthenticatedSessionAdapter() });
 
-    expect(await screen.findByRole('button', { name: /publish to shop/i })).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: /publish products/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /publish to shop/i })).not.toBeInTheDocument();
   });
 
   describe('demo read-only viewer (#1663)', () => {
@@ -207,13 +198,11 @@ describe('ListingsListPage', () => {
       });
     }
 
-    it('shows both Create offer and Publish to shop enabled instead of hiding them', async () => {
+    it('shows the unified "Publish products" entry enabled instead of hiding it', async () => {
       renderWithProviders(<ListingsListPage />, { apiClient: demoApiClient(), ...viewerSession });
 
-      const createOffer = await screen.findByRole('button', { name: /create offer/i });
-      expect(createOffer).not.toBeDisabled();
-      const publishToShop = screen.getByRole('button', { name: /publish to shop/i });
-      expect(publishToShop).not.toBeDisabled();
+      const publish = await screen.findByRole('button', { name: /publish products/i });
+      expect(publish).not.toBeDisabled();
     });
 
     it('keeps the existing hide-when-missing behaviour for an unauthorized non-demo viewer', async () => {
@@ -241,8 +230,7 @@ describe('ListingsListPage', () => {
       renderWithProviders(<ListingsListPage />, { apiClient: mockApi, ...viewerSession });
 
       await screen.findByText('allegro-offer-999');
-      expect(screen.queryByRole('button', { name: /create offer/i })).not.toBeInTheDocument();
-      expect(screen.queryByRole('button', { name: /publish to shop/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /publish products/i })).not.toBeInTheDocument();
     });
   });
 });

--- a/apps/web/src/pages/listings/listings-list-page.tsx
+++ b/apps/web/src/pages/listings/listings-list-page.tsx
@@ -11,11 +11,7 @@ import { TimeDisplay } from '../../shared/ui/time-display';
 import { useDebouncedValue } from '../../shared/hooks/use-debounced-value';
 import { useListingsQuery } from '../../features/listings/hooks/use-listings-query';
 import { OfferProductPickerModal } from '../../features/listings/components/offer-product-picker-modal';
-import {
-  ShopPublishLauncher,
-  selectShopPublishConnections,
-} from '../../features/listings/components/ShopPublishLauncher';
-import { useConnectionsQuery } from '../../features/connections';
+import { ShopPublishLauncher } from '../../features/listings/components/ShopPublishLauncher';
 import { useWriteAccess } from '../../shared/auth/use-permission';
 import { useDemoMode } from '../../features/system';
 import type {
@@ -143,17 +139,21 @@ export function ListingsListPage(): ReactElement {
   const hasPrev = offset > 0;
   const hasNext = offset + PAGE_SIZE < total;
 
-  const connectionsQuery = useConnectionsQuery();
-  const shopPublishConnections = selectShopPublishConnections(connectionsQuery.data ?? []);
-  const canPublishToShop = shopPublishConnections.length > 0;
   const demoMode = useDemoMode();
-  // "Create offer" and "Publish to shop" both open a wizard first — visible
+  // The unified "Publish products" entry opens a picker first — visible
   // (enabled) for a demo viewer per the useWriteAccess + ReadOnlyLock pattern
-  // (#1615/#1613); the wizards themselves gate their own final submit (#1663).
+  // (#1615/#1613); the downstream wizard gates its own final submit (#1663).
   const write = useWriteAccess('listings:write', demoMode);
 
   const [isWizardOpen, setIsWizardOpen] = useState(false);
+  // Shop destinations chosen in the unified picker hand off to the retained
+  // ShopPublishLauncher (kept wired but hidden — no standalone CTA — until the
+  // wizard branch #1829 folds the shop path into the bulk-create route).
   const [isShopPublishOpen, setIsShopPublishOpen] = useState(false);
+  const [shopHandoff, setShopHandoff] = useState<{
+    connectionId: string;
+    variantIds: string[];
+  } | null>(null);
 
   return (
     <PageLayout
@@ -162,14 +162,7 @@ export function ListingsListPage(): ReactElement {
       description="Offer mapping workbench — browse offer-to-variant identifier mappings across platforms."
       actions={
         write.visible ? (
-          <>
-            <Button onClick={() => setIsWizardOpen(true)}>Create offer</Button>
-            {canPublishToShop ? (
-              <Button tone="secondary" onClick={() => setIsShopPublishOpen(true)}>
-                Publish to shop
-              </Button>
-            ) : null}
-          </>
+          <Button onClick={() => setIsWizardOpen(true)}>Publish products</Button>
         ) : null
       }
     >
@@ -281,9 +274,21 @@ export function ListingsListPage(): ReactElement {
       <OfferProductPickerModal
         isOpen={isWizardOpen}
         onClose={() => setIsWizardOpen(false)}
+        onPublishToShop={(handoff) => {
+          setShopHandoff({ connectionId: handoff.connectionId, variantIds: handoff.variantIds });
+          setIsShopPublishOpen(true);
+        }}
       />
 
-      <ShopPublishLauncher open={isShopPublishOpen} onOpenChange={setIsShopPublishOpen} />
+      <ShopPublishLauncher
+        open={isShopPublishOpen}
+        onOpenChange={(open) => {
+          setIsShopPublishOpen(open);
+          if (!open) setShopHandoff(null);
+        }}
+        preselectedConnectionId={shopHandoff?.connectionId}
+        defaultVariantIds={shopHandoff?.variantIds}
+      />
     </PageLayout>
   );
 }

--- a/apps/web/src/pages/products/marketplace-picker-modal.test.tsx
+++ b/apps/web/src/pages/products/marketplace-picker-modal.test.tsx
@@ -1,11 +1,12 @@
 /**
- * MarketplacePickerModal tests (#1096)
+ * MarketplacePickerModal tests (#1096, grouped for #1828)
  */
 import { screen, fireEvent, cleanup } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../test/test-utils';
 import { MarketplacePickerModal } from './marketplace-picker-modal';
 import type { Connection } from '../../features/connections';
+import type { PublishDestination, PublishDestinationKind } from '../../features/listings';
 
 function conn(id: string, platformType: string, name: string): Connection {
   return {
@@ -23,17 +24,29 @@ function conn(id: string, platformType: string, name: string): Connection {
   };
 }
 
+function dest(
+  id: string,
+  platformType: string,
+  name: string,
+  kind: PublishDestinationKind,
+): PublishDestination {
+  return { connection: conn(id, platformType, name), kind };
+}
+
 describe('MarketplacePickerModal', () => {
   afterEach(cleanup);
 
-  it('lists each OfferManager connection and continues with the chosen one', () => {
+  it('lists each destination and continues with the chosen one', () => {
     const onContinue = vi.fn();
     renderWithProviders(
       <MarketplacePickerModal
         open
         onOpenChange={vi.fn()}
         productCount={6}
-        connections={[conn('c1', 'allegro', 'My Allegro'), conn('c2', 'erli', 'My Erli')]}
+        destinations={[
+          dest('c1', 'allegro', 'My Allegro', 'marketplace'),
+          dest('c2', 'erli', 'My Erli', 'marketplace'),
+        ]}
         onContinue={onContinue}
       />,
     );
@@ -41,7 +54,7 @@ describe('MarketplacePickerModal', () => {
     expect(screen.getByText('My Allegro')).toBeInTheDocument();
     expect(screen.getByText('My Erli')).toBeInTheDocument();
 
-    // Continue is disabled until a marketplace is picked.
+    // Continue is disabled until a destination is picked.
     const continueBtn = screen.getByRole('button', { name: /continue/i });
     expect(continueBtn).toBeDisabled();
 
@@ -50,5 +63,25 @@ describe('MarketplacePickerModal', () => {
     fireEvent.click(continueBtn);
 
     expect(onContinue).toHaveBeenCalledWith('c2');
+  });
+
+  it('groups marketplaces and online shops with capability-driven hints', () => {
+    renderWithProviders(
+      <MarketplacePickerModal
+        open
+        onOpenChange={vi.fn()}
+        productCount={2}
+        destinations={[
+          dest('c1', 'allegro', 'My Allegro', 'marketplace'),
+          dest('c3', 'woocommerce', 'My Shop', 'shop'),
+        ]}
+        onContinue={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText('Marketplaces')).toBeInTheDocument();
+    expect(screen.getByText('Online shops')).toBeInTheDocument();
+    expect(screen.getByText('Offer marketplace')).toBeInTheDocument();
+    expect(screen.getByText('Online shop')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/products/marketplace-picker-modal.tsx
+++ b/apps/web/src/pages/products/marketplace-picker-modal.tsx
@@ -3,16 +3,13 @@
  *
  * Capability-gated publish-destination picker shown from the Products page
  * when 2+ eligible connections exist (#1096, widened for the unified publish
- * flow in #1828). Lists each destination grouped by kind (Marketplaces /
- * Online shops) with a capability-driven hint - never a `platformType`
- * literal; choosing one continues with that connection preselected.
- *
- * Selection is single-select and capability-based. Display names come from
- * the connection record; the kind hint comes from `publishDestinationKind`.
+ * flow in #1828). Renders the shared `PublishDestinationRail` (grouped by kind
+ * with a capability-driven hint, keyboard-navigable single-select); choosing
+ * one continues with that connection preselected.
  *
  * @module pages/products
  */
-import { Fragment, useEffect, useState, type ReactElement } from 'react';
+import { useEffect, useState, type ReactElement } from 'react';
 
 import { Button } from '../../shared/ui';
 import {
@@ -21,12 +18,7 @@ import {
   DialogDescription,
   DialogTitle,
 } from '../../shared/ui/dialog';
-import {
-  PUBLISH_DESTINATION_GROUP_LABEL,
-  PUBLISH_DESTINATION_KIND_HINT,
-  PUBLISH_DESTINATION_KIND_ORDER,
-  type PublishDestination,
-} from '../../features/listings';
+import { PublishDestinationRail, type PublishDestination } from '../../features/listings';
 
 interface MarketplacePickerModalProps {
   open: boolean;
@@ -60,40 +52,12 @@ export function MarketplacePickerModal({
           them to.
         </DialogDescription>
 
-        <div role="radiogroup" aria-label="Publish destination" className="marketplace-picker">
-          {PUBLISH_DESTINATION_KIND_ORDER.map((kind) => {
-            const inKind = destinations.filter((d) => d.kind === kind);
-            if (inKind.length === 0) return null;
-            return (
-              <Fragment key={kind}>
-                <div className="marketplace-picker__group">
-                  {PUBLISH_DESTINATION_GROUP_LABEL[kind]}
-                </div>
-                {inKind.map((d) => {
-                  const isPicked = picked === d.connection.id;
-                  return (
-                    <button
-                      key={d.connection.id}
-                      type="button"
-                      role="radio"
-                      aria-checked={isPicked}
-                      className={`marketplace-picker__option${isPicked ? ' marketplace-picker__option--picked' : ''}`}
-                      onClick={() => setPicked(d.connection.id)}
-                    >
-                      <span className="marketplace-picker__meta">
-                        <span className="marketplace-picker__name">{d.connection.name}</span>
-                        <span className="mono-text muted-text">
-                          {PUBLISH_DESTINATION_KIND_HINT[d.kind]}
-                        </span>
-                      </span>
-                      <span className="marketplace-picker__radio" aria-hidden="true" />
-                    </button>
-                  );
-                })}
-              </Fragment>
-            );
-          })}
-        </div>
+        <PublishDestinationRail
+          destinations={destinations}
+          selectedConnectionId={picked || null}
+          onSelect={setPicked}
+          ariaLabel="Publish destination"
+        />
 
         <div className="wizard-actions">
           <div className="wizard-actions__group">

--- a/apps/web/src/pages/products/marketplace-picker-modal.tsx
+++ b/apps/web/src/pages/products/marketplace-picker-modal.tsx
@@ -1,33 +1,38 @@
 /**
  * MarketplacePickerModal
  *
- * Capability-gated marketplace picker shown from the Products page when 2+
- * `OfferManager` connections exist (#1096). Lists each eligible connection
- * (name + platform + adapterKey + `OfferManager` badge); choosing one
- * continues to the bulk wizard with that connection preselected.
+ * Capability-gated publish-destination picker shown from the Products page
+ * when 2+ eligible connections exist (#1096, widened for the unified publish
+ * flow in #1828). Lists each destination grouped by kind (Marketplaces /
+ * Online shops) with a capability-driven hint - never a `platformType`
+ * literal; choosing one continues with that connection preselected.
  *
- * Selection is capability-based — there is no literal `platformType ===` here.
- * Display names resolve through `usePlatforms()`.
+ * Selection is single-select and capability-based. Display names come from
+ * the connection record; the kind hint comes from `publishDestinationKind`.
  *
  * @module pages/products
  */
-import { useEffect, useState, type ReactElement } from 'react';
+import { Fragment, useEffect, useState, type ReactElement } from 'react';
 
-import { Button, StatusBadge } from '../../shared/ui';
+import { Button } from '../../shared/ui';
 import {
   Dialog,
   DialogContent,
   DialogDescription,
   DialogTitle,
 } from '../../shared/ui/dialog';
-import { usePlatforms } from '../../shared/plugins';
-import type { Connection } from '../../features/connections';
+import {
+  PUBLISH_DESTINATION_GROUP_LABEL,
+  PUBLISH_DESTINATION_KIND_HINT,
+  PUBLISH_DESTINATION_KIND_ORDER,
+  type PublishDestination,
+} from '../../features/listings';
 
 interface MarketplacePickerModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   productCount: number;
-  connections: readonly Connection[];
+  destinations: readonly PublishDestination[];
   onContinue: (connectionId: string) => void;
 }
 
@@ -35,10 +40,9 @@ export function MarketplacePickerModal({
   open,
   onOpenChange,
   productCount,
-  connections,
+  destinations,
   onContinue,
 }: MarketplacePickerModalProps): ReactElement {
-  const platforms = usePlatforms();
   const [picked, setPicked] = useState<string>('');
 
   // Reset the draft pick every time the modal closes.
@@ -49,38 +53,44 @@ export function MarketplacePickerModal({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
-        <DialogTitle>Where should these list?</DialogTitle>
+        <DialogTitle>Where should these publish?</DialogTitle>
         <DialogDescription>
-          Creating offers for <strong>{productCount.toLocaleString()}</strong>{' '}
-          {productCount === 1 ? 'product' : 'products'}. Pick the marketplace connection to create
-          them on.
+          Publishing <strong>{productCount.toLocaleString()}</strong>{' '}
+          {productCount === 1 ? 'product' : 'products'}. Pick the marketplace or shop to publish
+          them to.
         </DialogDescription>
 
-        <div role="radiogroup" aria-label="Marketplace connection" className="marketplace-picker">
-          {connections.map((c) => {
-            const displayName =
-              platforms.find((p) => p.platformType === c.platformType)?.displayName ??
-              c.platformType;
-            const isPicked = picked === c.id;
+        <div role="radiogroup" aria-label="Publish destination" className="marketplace-picker">
+          {PUBLISH_DESTINATION_KIND_ORDER.map((kind) => {
+            const inKind = destinations.filter((d) => d.kind === kind);
+            if (inKind.length === 0) return null;
             return (
-              <button
-                key={c.id}
-                type="button"
-                role="radio"
-                aria-checked={isPicked}
-                className={`marketplace-picker__option${isPicked ? ' marketplace-picker__option--picked' : ''}`}
-                onClick={() => setPicked(c.id)}
-              >
-                <span className="marketplace-picker__meta">
-                  <span className="marketplace-picker__name">{c.name}</span>
-                  <span className="mono-text muted-text">
-                    {c.adapterKey ?? c.platformType} · {displayName}
-                  </span>
-                </span>
-                <StatusBadge tone="info" compact>
-                  OfferManager
-                </StatusBadge>
-              </button>
+              <Fragment key={kind}>
+                <div className="marketplace-picker__group">
+                  {PUBLISH_DESTINATION_GROUP_LABEL[kind]}
+                </div>
+                {inKind.map((d) => {
+                  const isPicked = picked === d.connection.id;
+                  return (
+                    <button
+                      key={d.connection.id}
+                      type="button"
+                      role="radio"
+                      aria-checked={isPicked}
+                      className={`marketplace-picker__option${isPicked ? ' marketplace-picker__option--picked' : ''}`}
+                      onClick={() => setPicked(d.connection.id)}
+                    >
+                      <span className="marketplace-picker__meta">
+                        <span className="marketplace-picker__name">{d.connection.name}</span>
+                        <span className="mono-text muted-text">
+                          {PUBLISH_DESTINATION_KIND_HINT[d.kind]}
+                        </span>
+                      </span>
+                      <span className="marketplace-picker__radio" aria-hidden="true" />
+                    </button>
+                  );
+                })}
+              </Fragment>
             );
           })}
         </div>

--- a/apps/web/src/pages/products/product-detail-page.tsx
+++ b/apps/web/src/pages/products/product-detail-page.tsx
@@ -333,7 +333,12 @@ export function ProductDetailPage(): ReactElement {
         open={pickerOpen}
         onOpenChange={setPickerOpen}
         productCount={1}
-        connections={offerCreatorConnections}
+        // Single-product offer creation stays marketplace-only here; shop
+        // publishing from the product detail page is #1830 (shop edit mode).
+        destinations={offerCreatorConnections.map((c) => ({
+          connection: c,
+          kind: 'marketplace' as const,
+        }))}
         onContinue={(connectionId) => {
           setPickerOpen(false);
           goToWizard(connectionId);

--- a/apps/web/src/pages/products/products-list-page.test.tsx
+++ b/apps/web/src/pages/products/products-list-page.test.tsx
@@ -599,7 +599,7 @@ describe('ProductsListPage', () => {
     await user.click(screen.getByRole('checkbox', { name: 'Select Test Product' }));
 
     expect(
-      screen.getByRole('button', { name: 'Create Allegro offers (1)' }),
+      screen.getByRole('button', { name: 'Publish to Allegro (1)' }),
     ).toBeInTheDocument();
     expect(screen.getByRole('region', { name: '1 product selected' })).toBeInTheDocument();
   });
@@ -623,7 +623,7 @@ describe('ProductsListPage', () => {
     await user.click(headerCheckbox);
 
     expect(
-      screen.getByRole('button', { name: 'Create Allegro offers (2)' }),
+      screen.getByRole('button', { name: 'Publish to Allegro (2)' }),
     ).toBeInTheDocument();
 
     // After selecting all, header checkbox should be "Unselect all visible"
@@ -649,7 +649,7 @@ describe('ProductsListPage', () => {
     await screen.findByText('Test Product');
     await user.click(screen.getByRole('checkbox', { name: 'Select Test Product' }));
     expect(
-      screen.getByRole('button', { name: 'Create Allegro offers (1)' }),
+      screen.getByRole('button', { name: 'Publish to Allegro (1)' }),
     ).toBeInTheDocument();
 
     await user.click(screen.getByRole('button', { name: 'Clear' }));
@@ -673,7 +673,7 @@ describe('ProductsListPage', () => {
     await user.click(screen.getByRole('checkbox', { name: 'Select Test Product' }));
     await user.click(screen.getByRole('checkbox', { name: 'Select Another Product' }));
 
-    const cta = screen.getByRole('button', { name: 'Create Allegro offers (2)' });
+    const cta = screen.getByRole('button', { name: 'Publish to Allegro (2)' });
     await user.click(cta);
 
     expect(navigateMock).toHaveBeenCalledTimes(1);
@@ -704,7 +704,7 @@ describe('ProductsListPage', () => {
     await screen.findByText('Test Product');
     // Only the first product has a gap (1 of 2 variants listed on Allegro);
     // the second is fully covered (1/1), so exactly one row CTA renders.
-    const ctas = await screen.findAllByRole('button', { name: '+ Create offers' });
+    const ctas = await screen.findAllByRole('button', { name: '+ Publish' });
     expect(ctas).toHaveLength(1);
     await user.click(ctas[0]);
 
@@ -726,7 +726,7 @@ describe('ProductsListPage', () => {
 
     await screen.findByText('Test Product');
     expect(
-      screen.queryByRole('button', { name: '+ Create offers' }),
+      screen.queryByRole('button', { name: '+ Publish' }),
     ).not.toBeInTheDocument();
   });
 
@@ -746,7 +746,7 @@ describe('ProductsListPage', () => {
 
     // The bar still shows (Clear) but the create CTA is absent.
     expect(screen.getByRole('button', { name: 'Clear' })).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /Create .*offers/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Publish/ })).not.toBeInTheDocument();
   });
 
   it('opens the marketplace picker with 2+ OfferManager connections', async () => {
@@ -772,11 +772,11 @@ describe('ProductsListPage', () => {
     await user.click(screen.getByRole('checkbox', { name: 'Select Test Product' }));
 
     // Generic label (no single marketplace name) with 2+ connections.
-    const cta = await screen.findByRole('button', { name: 'Create offers (1)' });
+    const cta = await screen.findByRole('button', { name: 'Publish products (1)' });
     await user.click(cta);
 
     // The picker modal appears; no navigation yet.
-    expect(await screen.findByText('Where should these list?')).toBeInTheDocument();
+    expect(await screen.findByText('Where should these publish?')).toBeInTheDocument();
     expect(navigateMock).not.toHaveBeenCalled();
   });
 
@@ -796,7 +796,7 @@ describe('ProductsListPage', () => {
     await user.click(screen.getByRole('checkbox', { name: 'Select Test Product' }));
 
     expect(screen.getByRole('button', { name: 'Clear' })).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /Create .*offers/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Publish/ })).not.toBeInTheDocument();
   });
 
   it('renders the create-offers CTA (enabled) for a demo read-only viewer', async () => {
@@ -815,7 +815,7 @@ describe('ProductsListPage', () => {
     await user.click(screen.getByRole('checkbox', { name: 'Select Test Product' }));
 
     expect(
-      await screen.findByRole('button', { name: 'Create Allegro offers (1)' }),
+      await screen.findByRole('button', { name: 'Publish to Allegro (1)' }),
     ).toBeEnabled();
   });
 });

--- a/apps/web/src/pages/products/products-list-page.tsx
+++ b/apps/web/src/pages/products/products-list-page.tsx
@@ -55,6 +55,8 @@ import {
 } from '../../features/products/api/products.types';
 import { useConnectionsQuery } from '../../features/connections';
 import type { Connection } from '../../features/connections';
+import { selectPublishDestinations } from '../../features/listings';
+import { ShopPublishLauncher } from '../../features/listings/components/ShopPublishLauncher';
 import {
   deriveStockStatus,
   STOCK_STATUS_BADGE_TONE,
@@ -206,6 +208,14 @@ export function ProductsListPage(): ReactElement {
   // Set when the per-row "+ Create offers" CTA opened the picker for a single
   // product (instead of the bulk selection).
   const [pendingProductId, setPendingProductId] = useState<string | null>(null);
+  // Shop destinations chosen from the publish CTAs hand off to the retained
+  // ShopPublishLauncher (kept wired but hidden — no standalone CTA — until the
+  // wizard branch #1829 folds the shop path into the bulk-create route).
+  // TODO(#1829/#1830): thread the product + variant context into the shop
+  // wizard so the per-row CTA prefills like the marketplace route does; today
+  // the launcher opens its own product picker for the chosen shop connection.
+  const [isShopPublishOpen, setIsShopPublishOpen] = useState(false);
+  const [shopHandoffConnectionId, setShopHandoffConnectionId] = useState<string | null>(null);
 
   // Capability-gated create-offers action (#1096): select target connections by
   // the `OfferManager` capability — never a literal platformType. Display names
@@ -233,6 +243,20 @@ export function ProductsListPage(): ReactElement {
     [offerManagerConnections],
   );
   const gapsCsv = offerCreatorIds.join(',');
+
+  // Unified publish targets (#1828): offer marketplaces (OfferCreator) OR
+  // online shops (ProductPublisher), capability-driven. Drives the publish
+  // CTAs + picker; the offer-coverage surfaces (gaps KPI, "Unlisted on" chips,
+  // coverage pills, per-row gap detection) stay keyed to the marketplace
+  // `offerManagerConnections` subset above, since coverage is offer-based.
+  const publishDestinations = useMemo(
+    () => selectPublishDestinations(connectionsQuery.data ?? []),
+    [connectionsQuery.data],
+  );
+  const hasShopDestination = useMemo(
+    () => publishDestinations.some((d) => d.kind === 'shop'),
+    [publishDestinations],
+  );
 
   // Source select lists ALL active connections (any capability); the cockpit
   // source axis is about provenance, not offer creation.
@@ -464,34 +488,50 @@ export function ProductsListPage(): ReactElement {
     [navigate],
   );
 
-  // Capability-aware bulk launch: 1 connection → straight to wizard
-  // (preselected); 2+ → marketplace-picker modal. (0 hides the action.)
+  // Dispatch a resolved destination by kind (#1828): a marketplace goes to the
+  // bulk-create wizard; a shop hands off to the retained ShopPublishLauncher.
+  const dispatchPublish = useCallback(
+    (productIds: readonly string[], connectionId: string) => {
+      const destination = publishDestinations.find((d) => d.connection.id === connectionId);
+      if (!destination) return;
+      if (destination.kind === 'shop') {
+        setShopHandoffConnectionId(connectionId);
+        setIsShopPublishOpen(true);
+        return;
+      }
+      goToWizard(productIds, connectionId);
+    },
+    [publishDestinations, goToWizard],
+  );
+
+  // Capability-aware bulk launch: 1 destination → dispatch straight;
+  // 2+ → grouped destination picker. (0 hides the action.)
   const handleCreateOffers = useCallback(() => {
-    if (offerManagerConnections.length === 1) {
-      goToWizard(Array.from(selectedIds), offerManagerConnections[0]!.id);
-    } else if (offerManagerConnections.length > 1) {
+    if (publishDestinations.length === 1) {
+      dispatchPublish(Array.from(selectedIds), publishDestinations[0]!.connection.id);
+    } else if (publishDestinations.length > 1) {
       setPendingProductId(null);
       setPickerOpen(true);
     }
-  }, [offerManagerConnections, goToWizard, selectedIds]);
+  }, [publishDestinations, dispatchPublish, selectedIds]);
 
   // Per-row "+ Create offers" CTA — same launch, single product preselected.
   const handleCreateOffersForProduct = useCallback(
     (productId: string) => {
-      if (offerManagerConnections.length === 1) {
-        goToWizard([productId], offerManagerConnections[0]!.id);
-      } else if (offerManagerConnections.length > 1) {
+      if (publishDestinations.length === 1) {
+        dispatchPublish([productId], publishDestinations[0]!.connection.id);
+      } else if (publishDestinations.length > 1) {
         setPendingProductId(productId);
         setPickerOpen(true);
       }
     },
-    [offerManagerConnections, goToWizard],
+    [publishDestinations, dispatchPublish],
   );
 
   const soleConnectionName =
-    offerManagerConnections.length === 1
-      ? (platforms.find((p) => p.platformType === offerManagerConnections[0]!.platformType)
-          ?.displayName ?? offerManagerConnections[0]!.platformType)
+    publishDestinations.length === 1
+      ? (platforms.find((p) => p.platformType === publishDestinations[0]!.connection.platformType)
+          ?.displayName ?? publishDestinations[0]!.connection.platformType)
       : null;
 
   const atCap = selectedIds.size >= BULK_SELECTION_CAP;
@@ -650,7 +690,7 @@ export function ProductsListPage(): ReactElement {
         cell: (product) => (
           <span className="products-cell-stack">
             {renderCoveragePills(product)}
-            {write.visible && hasListingGap(product) ? (
+            {write.visible && (hasListingGap(product) || hasShopDestination) ? (
               <Button
                 tone="ghost"
                 className="button--sm products-row-cta"
@@ -658,7 +698,7 @@ export function ProductsListPage(): ReactElement {
                   handleCreateOffersForProduct(product.id);
                 }}
               >
-                + Create offers
+                + Publish
               </Button>
             ) : null}
           </span>
@@ -710,6 +750,7 @@ export function ProductsListPage(): ReactElement {
       platformLabel,
       write.visible,
       hasListingGap,
+      hasShopDestination,
       handleCreateOffersForProduct,
     ],
   );
@@ -1070,12 +1111,12 @@ export function ProductsListPage(): ReactElement {
                     <Button tone="ghost" className="button--sm" onClick={clearSelection}>
                       Clear
                     </Button>
-                    {/* Capability-gated (#1096): hidden with 0 OfferManager connections. */}
-                    {offerManagerConnections.length > 0 && write.visible ? (
+                    {/* Capability-gated (#1096/#1828): hidden with 0 publish destinations. */}
+                    {publishDestinations.length > 0 && write.visible ? (
                       <Button tone="primary" onClick={handleCreateOffers}>
                         {soleConnectionName
-                          ? `Create ${soleConnectionName} offers (${selectedIds.size.toLocaleString()})`
-                          : `Create offers (${selectedIds.size.toLocaleString()})`}
+                          ? `Publish to ${soleConnectionName} (${selectedIds.size.toLocaleString()})`
+                          : `Publish products (${selectedIds.size.toLocaleString()})`}
                       </Button>
                     ) : null}
                   </>
@@ -1204,13 +1245,22 @@ export function ProductsListPage(): ReactElement {
               if (!open) setPendingProductId(null);
             }}
             productCount={pendingProductId ? 1 : selectedIds.size}
-            connections={offerManagerConnections}
+            destinations={publishDestinations}
             onContinue={(connectionId) => {
               setPickerOpen(false);
               const ids = pendingProductId ? [pendingProductId] : Array.from(selectedIds);
               setPendingProductId(null);
-              goToWizard(ids, connectionId);
+              dispatchPublish(ids, connectionId);
             }}
+          />
+
+          <ShopPublishLauncher
+            open={isShopPublishOpen}
+            onOpenChange={(open) => {
+              setIsShopPublishOpen(open);
+              if (!open) setShopHandoffConnectionId(null);
+            }}
+            preselectedConnectionId={shopHandoffConnectionId ?? undefined}
           />
         </>
       )}

--- a/docs/frontend-architecture.md
+++ b/docs/frontend-architecture.md
@@ -420,7 +420,11 @@ to {name}"** CTA share the same flow.
   neither.
 - **The destination rail groups by kind** (Marketplaces / Online shops) with a
   capability-driven hint (`PUBLISH_DESTINATION_KIND_HINT`), single-select. A sole
-  eligible destination auto-resolves.
+  eligible destination auto-resolves. Both pickers render the shared
+  `PublishDestinationRail` (`features/listings/components`), which owns the
+  WAI-ARIA radiogroup keyboard contract - a single tab stop via roving
+  `tabindex` plus Arrow / Home / End to move-and-select (mirroring the
+  `SegmentedControl` primitive) - so the markup and its a11y live in one place.
 - **Continue dispatches by kind.** A marketplace navigates to the bulk-create
   wizard route (`/listings/bulk-create/wizard?productIds=…&variantIds=…&connectionId=…`,
   destination-agnostic). A shop hands off to the retained `ShopPublishLauncher`

--- a/docs/frontend-architecture.md
+++ b/docs/frontend-architecture.md
@@ -403,6 +403,35 @@ Naming conventions:
 - route modules: `*.route.tsx`
 - tests: `*.test.tsx`
 
+### Unified publish flow (#1828)
+
+Publishing a product to a channel is a **single operator intent** with one entry
+point. The Listings page exposes one **"Publish products"** action (the former
+separate "Create offer" + "Publish to shop" CTAs are folded together); the
+Products page per-row **"+ Publish"** CTA and bulk **"Publish products / Publish
+to {name}"** CTA share the same flow.
+
+- **Eligibility is capability-driven, never `platformType`.** `selectPublishDestinations`
+  (`features/listings/lib/publish-destinations.ts`, re-exported from the
+  `features/listings` barrel) classifies every active connection as a
+  `'marketplace'` (advertises the `OfferCreator` sub-capability, via
+  `supportedCapabilities`) or a `'shop'` (has **enabled** `ProductPublisher`,
+  via `enabledCapabilities`). It returns `null` for connections that are
+  neither.
+- **The destination rail groups by kind** (Marketplaces / Online shops) with a
+  capability-driven hint (`PUBLISH_DESTINATION_KIND_HINT`), single-select. A sole
+  eligible destination auto-resolves.
+- **Continue dispatches by kind.** A marketplace navigates to the bulk-create
+  wizard route (`/listings/bulk-create/wizard?productIds=…&variantIds=…&connectionId=…`,
+  destination-agnostic). A shop hands off to the retained `ShopPublishLauncher`
+  (its `preselectedConnectionId` prop skips the launcher's own picker). The
+  launcher is kept wired but has no standalone CTA.
+- **Deferred to #1829 / #1830.** Folding the shop path into the bulk-create
+  wizard route (so shop and marketplace share one wizard + dispatch) is #1829;
+  shop edit mode is #1830. Until #1829 lands, `ShopPublishLauncher` is the shop
+  wizard, and the marketplace `BulkConfigStep` blocks Proceed for any connection
+  without a per-platform config section (e.g. a shop reached by direct URL).
+
 ### UI Library Policy
 
 No **styled** external UI library (no shadcn/ui, MUI, Mantine, Chakra, Ant Design). Visual opinions are ours — every pixel is vanilla CSS against the tokens in `apps/web/src/index.css`.


### PR DESCRIPTION
## What & why

Part of epic #1838. OpenLinker had two parallel entries for the same operator
intent - publishing a product to a channel: the marketplace offer-creation
picker (gated on `OfferCreator`) and a separate `ShopPublishLauncher`
"Publish to shop" CTA (gated on `ProductPublisher`). This folds them into a
**single "Publish products" entry** with one destination rail grouped by kind,
so operators see marketplaces and shops in one capability-driven, single-select
list.

### Changes

- **`selectPublishDestinations`** (`apps/web/src/features/listings/lib/publish-destinations.ts`,
  re-exported from the `features/listings` barrel) - classifies each active
  connection as `'marketplace'` (`OfferCreator`, via `supportedCapabilities`) or
  `'shop'` (`ProductPublisher`, via `enabledCapabilities`). Capability-driven,
  never `platformType`. Ships the group labels + kind hints.
- **`OfferProductPickerModal`** (Listings picker) - widened eligibility to
  marketplace + shop; the rail is now a grouped single-select radio list
  (Marketplaces / Online shops) with a capability hint; title -> "Publish
  products". Continue dispatches by kind: marketplace -> bulk-create wizard route
  (unchanged); shop -> new `onPublishToShop` handoff.
- **Listings page** - one "Publish products" CTA replaces the "Create offer" +
  "Publish to shop" pair.
- **Products page** - per-row **"+ Publish"** CTA + bulk CTA + `MarketplacePickerModal`
  widened to surface shop destinations (grouped rail). Offer-coverage surfaces
  (gaps KPI, "Unlisted on" chips, coverage pills, `hasListingGap`) stay keyed to
  the marketplace subset, since coverage is offer-based; the CTA also surfaces
  when a shop destination exists.
- **`BulkConfigStep`** - connection eligibility widened to the union; Proceed is
  now blocked for a connection with no per-platform config section (guards a shop
  connection reaching the marketplace wizard via direct URL before #1829).

### ShopPublishLauncher disposition

**Retained, not removed - kept wired but hidden** (no standalone CTA). It is the
shop wizard the unified picker hands off to (new `preselectedConnectionId` prop).
Fully removing it now would strand shop publishing, because folding the shop path
into the bulk-create wizard route is **#1829** (wizard branch + dispatch) and
shop edit mode is **#1830**. TODOs referencing #1829/#1830 mark the handoff seams
(picker + products page).

## How to test

1. Listings page: with a marketplace connection only -> single "Publish products"
   entry; picker rail shows the marketplace under "Marketplaces", Continue goes to
   the bulk-create wizard.
2. Add a WooCommerce connection with `ProductPublisher` enabled -> it appears
   under "Online shops" in the same rail; picking it + Continue opens the
   (retained) shop publish wizard preselected to that connection.
3. Products page: the per-row "+ Publish" CTA and bulk "Publish products" CTA open
   the same grouped picker; a sole shop destination routes straight to the shop
   wizard.
4. `pnpm --filter @openlinker/web test` (touched suites), `type-check`, `lint`.

## Docs

- `docs/frontend-architecture.md` -> added a "Unified publish flow (#1828)"
  subsection (single entry, capability-gated grouped destination rail, dispatch
  by kind, #1829/#1830 deferral).
- No backend/central capability docs changed - FE-only, no port/capability change.

Closes #1828
