### PR TITLE
fix(woocommerce): publish correctness fixes (stale mappings, dict params, categories, slug, 429, images) (#1846)

### DIFF
--- a/apps/worker/test/integration/helpers/woocommerce-offer-manager-test-harness.helper.ts
+++ b/apps/worker/test/integration/helpers/woocommerce-offer-manager-test-harness.helper.ts
@@ -23,7 +23,8 @@ import type {
   AdapterRegistryPort,
 } from '@openlinker/core/integrations';
 import { ADAPTER_FACTORY_RESOLVER_TOKEN, ADAPTER_REGISTRY_TOKEN } from '@openlinker/core/integrations';
-import type { Connection } from '@openlinker/core/identifier-mapping';
+import type { Connection, IIdentifierMappingService } from '@openlinker/core/identifier-mapping';
+import { IDENTIFIER_MAPPING_SERVICE_TOKEN } from '@openlinker/core/identifier-mapping';
 import { WooCommerceOfferManagerAdapter } from '@openlinker/integrations-woocommerce/infrastructure/adapters/offer-manager/woocommerce-offer-manager.adapter';
 
 import type { WorkerIntegrationTestHarness } from '../setup';
@@ -48,6 +49,9 @@ export function installWooCommerceOfferManagerTestHarness(
   );
 
   const fake = new WooCommerceFakeHttpClient();
+  const identifierMapping = harness.get<IIdentifierMappingService>(
+    IDENTIFIER_MAPPING_SERVICE_TOKEN,
+  );
 
   adapterRegistry.register({
     adapterKey: WOOCOMMERCE_TEST_ADAPTER_KEY,
@@ -61,7 +65,7 @@ export function installWooCommerceOfferManagerTestHarness(
 
   factoryResolver.registerFactory(WOOCOMMERCE_TEST_ADAPTER_KEY, {
     createCapabilityAdapter: <T>(connection: Connection): Promise<T> => {
-      const adapter = new WooCommerceOfferManagerAdapter(fake, connection);
+      const adapter = new WooCommerceOfferManagerAdapter(fake, connection, identifierMapping);
       return Promise.resolve(adapter as unknown as T);
     },
   });

--- a/libs/core/src/listings/application/services/__tests__/product-publish-execution.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/product-publish-execution.service.spec.ts
@@ -11,7 +11,10 @@
  */
 
 import { DuplicateIdentifierMappingError } from '@openlinker/core/identifier-mapping';
-import { ProductPublishRejectedException } from '@openlinker/core/listings';
+import {
+  ProductPublishRejectedException,
+  ProductPublishTargetNotFoundException,
+} from '@openlinker/core/listings';
 
 import { ListingCreationRecord } from '../../../domain/entities/listing-creation-record.entity';
 import { ProductPublishBuilderValidationException } from '../../../domain/exceptions/product-publish-builder-validation.exception';
@@ -46,7 +49,11 @@ describe('ProductPublishExecutionService', () => {
     updateStatus: jest.Mock;
     updateExternalIdAndStatus: jest.Mock;
   };
-  let identifierMapping: { getExternalIds: jest.Mock; createMapping: jest.Mock };
+  let identifierMapping: {
+    getExternalIds: jest.Mock;
+    createMapping: jest.Mock;
+    deleteMapping: jest.Mock;
+  };
   let integrations: { getCapabilityAdapter: jest.Mock };
   let adapter: { publishProduct: jest.Mock };
   let service: ProductPublishExecutionService;
@@ -75,6 +82,7 @@ describe('ProductPublishExecutionService', () => {
     identifierMapping = {
       getExternalIds: jest.fn().mockResolvedValue([]),
       createMapping: jest.fn().mockResolvedValue(undefined),
+      deleteMapping: jest.fn().mockResolvedValue(undefined),
     };
     adapter = {
       publishProduct: jest.fn().mockResolvedValue({ externalProductId: EXT, status: 'published' }),
@@ -118,6 +126,39 @@ describe('ProductPublishExecutionService', () => {
     );
     // No new mapping on upsert.
     expect(identifierMapping.createMapping).not.toHaveBeenCalled();
+  });
+
+  it('should delete the stale mapping and re-create when the upsert target is gone (404)', async () => {
+    // Existing mapping → upsert path.
+    identifierMapping.getExternalIds.mockResolvedValue([
+      { externalId: EXT, connectionId: CONN, entityType: 'ShopProduct', platformType: 'woocommerce' },
+    ]);
+    const NEW_EXT = 'wc-product-99';
+    adapter.publishProduct
+      .mockRejectedValueOnce(
+        new ProductPublishTargetNotFoundException('woocommerce.restapi.v3', EXT)
+      )
+      .mockResolvedValueOnce({ externalProductId: NEW_EXT, status: 'published' });
+    records.updateExternalIdAndStatus.mockResolvedValue(makeRecord('published', NEW_EXT));
+
+    const result = await service.executePublish(input);
+
+    // Stale mapping deleted.
+    expect(identifierMapping.deleteMapping).toHaveBeenCalledWith('ShopProduct', EXT, CONN);
+    // Re-published as a create (no externalProductId on the second call).
+    expect(adapter.publishProduct).toHaveBeenCalledTimes(2);
+    expect(adapter.publishProduct).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ externalProductId: null })
+    );
+    // Fresh mapping written for the newly created product.
+    expect(identifierMapping.createMapping).toHaveBeenCalledWith(
+      'ShopProduct',
+      NEW_EXT,
+      CONN,
+      VARIANT
+    );
+    expect(result.outcome).toBe('ok');
   });
 
   it('should record business_failure when the shop rejects the publish', async () => {

--- a/libs/core/src/listings/application/services/__tests__/product-publish-execution.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/product-publish-execution.service.spec.ts
@@ -161,6 +161,37 @@ describe('ProductPublishExecutionService', () => {
     expect(result.outcome).toBe('ok');
   });
 
+  it('should record a clean business_failure when the recovery create is rejected (not an escaped throw)', async () => {
+    identifierMapping.getExternalIds.mockResolvedValue([
+      { externalId: EXT, connectionId: CONN, entityType: 'ShopProduct', platformType: 'woocommerce' },
+    ]);
+    adapter.publishProduct
+      .mockRejectedValueOnce(
+        new ProductPublishTargetNotFoundException('woocommerce.restapi.v3', EXT)
+      )
+      .mockRejectedValueOnce(
+        new ProductPublishRejectedException('woocommerce.restapi.v3', 422, [
+          { code: 'INVALID', message: 'bad' },
+        ])
+      );
+    records.updateStatus.mockResolvedValue(makeRecord('failed'));
+
+    const result = await service.executePublish(input);
+
+    // Stale mapping deleted, recovery create attempted, then its rejection
+    // recorded as a terminal failure rather than escaping.
+    expect(identifierMapping.deleteMapping).toHaveBeenCalledWith('ShopProduct', EXT, CONN);
+    expect(adapter.publishProduct).toHaveBeenCalledTimes(2);
+    expect(records.updateStatus).toHaveBeenCalledWith(
+      'rec-1',
+      'failed',
+      expect.arrayContaining([expect.objectContaining({ code: 'INVALID' })])
+    );
+    // No mapping written for a failed recovery create.
+    expect(identifierMapping.createMapping).not.toHaveBeenCalled();
+    expect(result.outcome).toBe('business_failure');
+  });
+
   it('should record business_failure when the shop rejects the publish', async () => {
     adapter.publishProduct.mockRejectedValue(
       new ProductPublishRejectedException('woocommerce.restapi.v1', 422, [

--- a/libs/core/src/listings/application/services/product-publish-execution.service.ts
+++ b/libs/core/src/listings/application/services/product-publish-execution.service.ts
@@ -44,7 +44,10 @@ import type {
   PublishProductResult,
   ShopProductManagerPort,
 } from '@openlinker/core/listings';
-import { ProductPublishRejectedException } from '@openlinker/core/listings';
+import {
+  ProductPublishRejectedException,
+  ProductPublishTargetNotFoundException,
+} from '@openlinker/core/listings';
 import type { JobOutcome } from '@openlinker/core/sync';
 import { Logger } from '@openlinker/shared/logging';
 
@@ -129,25 +132,43 @@ export class ProductPublishExecutionService implements IProductPublishExecutionS
       'ProductPublisher'
     );
 
+    // Tracks whether the mapping still needs writing after the publish call. A
+    // first publish (no existing mapping) always writes; a stale-mapping
+    // recovery deletes the dead mapping and re-creates, so it must write too.
+    let mappingNeedsCreate = !existingExternalProductId;
+
     let result: PublishProductResult;
     try {
       result = await adapter.publishProduct(command);
     } catch (error) {
-      if (error instanceof ProductPublishRejectedException) {
+      // Stale mapping: the upsert target was deleted shop-side. Drop the dead
+      // `ShopProduct` mapping and re-publish as a create so the variant can
+      // recover instead of failing forever (#1846 fix 1/5).
+      if (error instanceof ProductPublishTargetNotFoundException && existingExternalProductId) {
+        result = await this.recreateAfterStaleUpsertTarget(
+          adapter,
+          command,
+          input,
+          existingExternalProductId
+        );
+        mappingNeedsCreate = true;
+      } else if (error instanceof ProductPublishRejectedException) {
         const updated = await this.listingRecords.updateStatus(
           record.id,
           LISTING_CREATION_STATUS.Failed,
           this.mapRejectionErrors(error)
         );
         return this.buildResult(updated, input.connectionId);
+      } else {
+        throw error;
       }
-      throw error;
     }
 
-    // First publish only — persist the variant → external-product mapping.
-    // Upserts already have it. `DuplicateIdentifierMappingError` means a prior
-    // attempt inserted it; that is exactly what we wanted, so continue.
-    if (!existingExternalProductId) {
+    // First publish (or stale-mapping recovery) — persist the variant →
+    // external-product mapping. Upserts already have it.
+    // `DuplicateIdentifierMappingError` means a prior attempt inserted it; that
+    // is exactly what we wanted, so continue.
+    if (mappingNeedsCreate) {
       try {
         await this.identifierMapping.createMapping(
           CORE_ENTITY_TYPE.ShopProduct,
@@ -176,6 +197,32 @@ export class ProductPublishExecutionService implements IProductPublishExecutionS
       result.warnings?.length ? result.warnings : null,
     );
     return this.buildResult(finalRecord, input.connectionId);
+  }
+
+  /**
+   * Recover from a stale `ShopProduct` mapping whose upsert target no longer
+   * exists shop-side. Deletes the dead mapping and re-publishes the same command
+   * as a create (no `externalProductId`), returning the fresh publish result.
+   * The caller then persists the new mapping.
+   */
+  private async recreateAfterStaleUpsertTarget(
+    adapter: ShopProductManagerPort,
+    command: PublishProductCommand,
+    input: ExecutePublishProductInput,
+    staleExternalProductId: string
+  ): Promise<PublishProductResult> {
+    this.logger.warn(
+      `Stale ShopProduct mapping detected; upsert target missing shop-side. ` +
+        `Deleting mapping and re-creating. connectionId=${input.connectionId} ` +
+        `internalVariantId=${input.internalVariantId} staleExternalProductId=${staleExternalProductId}`
+    );
+    await this.identifierMapping.deleteMapping(
+      CORE_ENTITY_TYPE.ShopProduct,
+      staleExternalProductId,
+      input.connectionId
+    );
+    const createCommand: PublishProductCommand = { ...command, externalProductId: null };
+    return adapter.publishProduct(createCommand);
   }
 
   private async resolveExistingExternalProductId(

--- a/libs/core/src/listings/application/services/product-publish-execution.service.ts
+++ b/libs/core/src/listings/application/services/product-publish-execution.service.ts
@@ -145,20 +145,26 @@ export class ProductPublishExecutionService implements IProductPublishExecutionS
       // `ShopProduct` mapping and re-publish as a create so the variant can
       // recover instead of failing forever (#1846 fix 1/5).
       if (error instanceof ProductPublishTargetNotFoundException && existingExternalProductId) {
-        result = await this.recreateAfterStaleUpsertTarget(
-          adapter,
-          command,
-          input,
-          existingExternalProductId
-        );
-        mappingNeedsCreate = true;
+        try {
+          result = await this.recreateAfterStaleUpsertTarget(
+            adapter,
+            command,
+            input,
+            existingExternalProductId
+          );
+          mappingNeedsCreate = true;
+        } catch (recoveryError) {
+          // A rejection on the recovery create is a terminal business failure,
+          // exactly like a rejection on the first-attempt create path — record
+          // it as `failed` instead of letting it escape as an unhandled throw
+          // (which would retry/dead the job).
+          if (recoveryError instanceof ProductPublishRejectedException) {
+            return this.recordRejection(record.id, input.connectionId, recoveryError);
+          }
+          throw recoveryError;
+        }
       } else if (error instanceof ProductPublishRejectedException) {
-        const updated = await this.listingRecords.updateStatus(
-          record.id,
-          LISTING_CREATION_STATUS.Failed,
-          this.mapRejectionErrors(error)
-        );
-        return this.buildResult(updated, input.connectionId);
+        return this.recordRejection(record.id, input.connectionId, error);
       } else {
         throw error;
       }
@@ -197,6 +203,25 @@ export class ProductPublishExecutionService implements IProductPublishExecutionS
       result.warnings?.length ? result.warnings : null,
     );
     return this.buildResult(finalRecord, input.connectionId);
+  }
+
+  /**
+   * Record a shop-publish rejection as a terminal `failed` record and build the
+   * `business_failure` result. Shared by the first-attempt create/upsert path
+   * and the stale-mapping recovery-create path so both classify a rejection
+   * identically.
+   */
+  private async recordRejection(
+    recordId: string,
+    connectionId: string,
+    error: ProductPublishRejectedException
+  ): Promise<ExecutePublishProductResult> {
+    const updated = await this.listingRecords.updateStatus(
+      recordId,
+      LISTING_CREATION_STATUS.Failed,
+      this.mapRejectionErrors(error)
+    );
+    return this.buildResult(updated, connectionId);
   }
 
   /**

--- a/libs/core/src/listings/domain/exceptions/product-publish-target-not-found.exception.ts
+++ b/libs/core/src/listings/domain/exceptions/product-publish-target-not-found.exception.ts
@@ -1,0 +1,34 @@
+/**
+ * Product Publish Target Not Found Exception
+ *
+ * Neutral domain exception a shop adapter throws when an **upsert** publish
+ * (a command carrying `externalProductId`) targets a shop product that no
+ * longer exists — e.g. a WooCommerce `PUT /products/{id}` that returns 404
+ * because the product was deleted shop-side.
+ *
+ * Distinct from `ProductPublishRejectedException`: a rejection is a terminal
+ * business failure (the input was refused), whereas a missing upsert target is
+ * a *recoverable stale-mapping* condition. The core `ProductPublishExecutionService`
+ * catches this, deletes the stale `ShopProduct` identifier mapping, and falls
+ * back to a create so the variant can re-publish (rather than failing forever).
+ *
+ * The message carries only the adapter key and external id — never the
+ * request/response body — so nothing sensitive leaks through it.
+ *
+ * @module libs/core/src/listings/domain/exceptions
+ */
+
+export class ProductPublishTargetNotFoundException extends Error {
+  constructor(
+    /** Adapter key of the shop whose upsert target was missing (e.g. 'woocommerce.restapi.v3'). */
+    public readonly adapterKey: string,
+    /** The shop-native external product id that no longer exists. */
+    public readonly externalProductId: string,
+  ) {
+    super(
+      `Shop ${adapterKey} upsert target not found (externalProductId=${externalProductId}); stale mapping`,
+    );
+    this.name = 'ProductPublishTargetNotFoundException';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/listings/index.ts
+++ b/libs/core/src/listings/index.ts
@@ -327,6 +327,7 @@ export type {
   ProvisionCategoryResult,
 } from './domain/types/category-provision.types';
 export { ProductPublishRejectedException } from './domain/exceptions/product-publish-rejected.exception';
+export { ProductPublishTargetNotFoundException } from './domain/exceptions/product-publish-target-not-found.exception';
 
 // Shop publish execution (#1042, #1072) — pure contracts only (the two service
 // classes live on `@openlinker/core/listings/services`, never here).

--- a/libs/integrations/woocommerce/README.md
+++ b/libs/integrations/woocommerce/README.md
@@ -67,8 +67,8 @@ empty string or zero), so an upsert never clears a field the operator did not to
 | `content.description` | operator ?? master | `description` |
 | `content.shortDescription` | operator | `short_description` |
 | `content.tags` | operator | `tags` (`[{ name }]`, created on demand) |
-| `content.imageUrls` | operator ?? master | `images` |
-| `content.seo.slug` | operator | `slug` |
+| `content.imageUrls` | operator ?? master | `images` (**create only** — see Publish correctness below) |
+| `content.seo.slug` | operator | `slug` (suffixed per-item — see below) |
 | `content.seo.title` / `content.seo.description` | operator | `meta_data` (see SEO below) |
 | `commerce.salePrice.amount` | operator | `sale_price` (store currency applies; amount only) |
 | `commerce.saleStartsAt` / `saleEndsAt` | operator (UTC ISO-8601) | `date_on_sale_from_gmt` / `date_on_sale_to_gmt` (UTC; the site-local `date_on_sale_from`/`_to` are deliberately not used so the store timezone can't shift the window) |
@@ -91,6 +91,40 @@ writing the keys for **both** dominant plugins so whichever is active picks them
 If neither plugin is installed, the rows are inert post meta (no effect). This
 replaces the previous behaviour where `seo.title` / `seo.description` were accepted
 and silently discarded (only `seo.slug` mapped, to the native `slug`).
+
+## Publish correctness
+
+The publisher/offer-manager enforce these correctness rules (#1846):
+
+- **Stale-mapping recovery on publish.** An upsert (`PUT /products/{id}`) that
+  404s means the mapped product was deleted shop-side. The adapter raises the
+  neutral `ProductPublishTargetNotFoundException`; the core execution service
+  deletes the stale `ShopProduct` identifier mapping and re-publishes as a
+  create, so the variant recovers instead of failing permanently.
+- **Stale-mapping cleanup on stock write-back.** A 404 from the stock
+  `PUT /products/{id}` deletes the stale `ShopProduct` mapping (the stock value
+  for that run is not propagated); the next publish re-creates the product and
+  writes a fresh mapping. Previously the write was silently skipped forever.
+- **Transient errors are retried, not failed.** `429 Too Many Requests` and
+  `408 Request Timeout` propagate (the worker retries the whole job) instead of
+  being recorded as a terminal `business_failure`. Other 4xx remain terminal
+  rejections. (The HTTP client also retries `429`/`5xx` internally first.)
+- **Dictionary-typed parameters.** WooCommerce custom attributes carry only
+  free-text option strings. A parameter that resolves to no free-text `values`
+  (dictionary-only `valuesIds`, or empty) is **dropped**, not written as an empty
+  `options: []` attribute (which was silent data loss).
+- **Category provisioning.** The category search requests `per_page=100` (WC max)
+  so an exact match beyond the default 10 fuzzy results is not missed and
+  re-created. A concurrent `term_exists` rejection is recovered by re-resolving
+  and reusing the racing winner's node — no duplicate categories.
+- **Per-item slug.** A supplied `seo.slug` is suffixed with the item's SKU
+  (falling back to the internal variant id), so sibling variants published in
+  bulk get distinct, deterministic slugs instead of WooCommerce silently
+  auto-suffixing a shared slug (`-2`/`-3`) and drifting the canonical URL.
+- **Images (create only).** `images` are sent only on create. WooCommerce
+  sideloads media by `src` and re-imports it on every update, so re-sending on
+  upsert churns/duplicates media; image updates on upsert need media-id tracking
+  and are a deferred enhancement.
 
 ## Documentation
 

--- a/libs/integrations/woocommerce/README.md
+++ b/libs/integrations/woocommerce/README.md
@@ -117,10 +117,12 @@ The publisher/offer-manager enforce these correctness rules (#1846):
   so an exact match beyond the default 10 fuzzy results is not missed and
   re-created. A concurrent `term_exists` rejection is recovered by re-resolving
   and reusing the racing winner's node — no duplicate categories.
-- **Per-item slug.** A supplied `seo.slug` is suffixed with the item's SKU
-  (falling back to the internal variant id), so sibling variants published in
-  bulk get distinct, deterministic slugs instead of WooCommerce silently
-  auto-suffixing a shared slug (`-2`/`-3`) and drifting the canonical URL.
+- **Per-item slug.** A supplied `seo.slug` is suffixed with the item's stable
+  internal variant id, so sibling variants published in bulk get distinct,
+  deterministic slugs instead of WooCommerce silently auto-suffixing a shared
+  slug (`-2`/`-3`). The variant id (not the SKU) is used because it is immutable
+  for the life of the variant - a SKU can be gained after the first publish,
+  which would drift the WC permalink on a later upsert.
 - **Images (create only).** `images` are sent only on create. WooCommerce
   sideloads media by `src` and re-imports it on every update, so re-sending on
   upsert churns/duplicates media; image updates on upsert need media-id tracking

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/offer-manager/__tests__/woocommerce-offer-manager.adapter.spec.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/offer-manager/__tests__/woocommerce-offer-manager.adapter.spec.ts
@@ -9,7 +9,7 @@ import { WooCommerceInvalidIdentifierException } from '../../../../domain/except
 import { WooCommerceInvalidArgumentException } from '../../../../domain/exceptions/woocommerce-invalid-argument.exception';
 import { WooCommerceUnauthorizedException } from '../../../../domain/exceptions/woocommerce-unauthorized.exception';
 import type { IWooCommerceHttpClient } from '../../../http/woocommerce-http-client.interface';
-import type { Connection } from '@openlinker/core/identifier-mapping';
+import type { Connection, IdentifierMappingPort } from '@openlinker/core/identifier-mapping';
 
 const makeConnection = (overrides: Partial<Connection> = {}): Connection =>
   ({
@@ -28,6 +28,7 @@ const makeConnection = (overrides: Partial<Connection> = {}): Connection =>
 
 describe('WooCommerceOfferManagerAdapter', () => {
   let httpClient: jest.Mocked<IWooCommerceHttpClient>;
+  let identifierMapping: jest.Mocked<Pick<IdentifierMappingPort, 'deleteMapping'>>;
   let adapter: WooCommerceOfferManagerAdapter;
 
   beforeEach(() => {
@@ -37,7 +38,14 @@ describe('WooCommerceOfferManagerAdapter', () => {
       put: jest.fn(),
       delete: jest.fn(),
     } as unknown as jest.Mocked<IWooCommerceHttpClient>;
-    adapter = new WooCommerceOfferManagerAdapter(httpClient, makeConnection());
+    identifierMapping = {
+      deleteMapping: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<Pick<IdentifierMappingPort, 'deleteMapping'>>;
+    adapter = new WooCommerceOfferManagerAdapter(
+      httpClient,
+      makeConnection(),
+      identifierMapping as unknown as IdentifierMappingPort,
+    );
   });
 
   describe('updateOfferQuantity', () => {
@@ -97,12 +105,15 @@ describe('WooCommerceOfferManagerAdapter', () => {
       expect(httpClient.put).not.toHaveBeenCalled();
     });
 
-    it('should resolve without throwing when the product is gone shop-side (404 = stale mapping skip)', async () => {
+    it('should delete the stale mapping and resolve when the product is gone shop-side (404, #1846 fix 5)', async () => {
       httpClient.put.mockRejectedValue(
         new WooCommerceHttpResponseException(404, 'Not found', 'woocommerce_rest_product_invalid_id'),
       );
 
-      await expect(adapter.updateOfferQuantity({ offerId: '999', quantity: 3 })).resolves.toBeUndefined();
+      await expect(
+        adapter.updateOfferQuantity({ offerId: '999', quantity: 3 }),
+      ).resolves.toBeUndefined();
+      expect(identifierMapping.deleteMapping).toHaveBeenCalledWith('ShopProduct', '999', 'conn-wc-1');
     });
 
     it('should propagate non-404 HTTP response errors so the runner retries them', async () => {

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/offer-manager/woocommerce-offer-manager.adapter.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/offer-manager/woocommerce-offer-manager.adapter.ts
@@ -11,11 +11,13 @@
  * re-asserts `manage_stock: true`, so a product whose managed-stock flag was
  * flipped off shop-side becomes managed again on the next master change.
  *
- * 404 = clean skip: nothing deletes a `ShopProduct` mapping when the product
- * is removed shop-side, so the PUT can 404 forever. Treating it as a skip
- * (warn log, resolve) prevents a retry-to-dead job on every stock change for
- * a stale mapping. All other errors propagate — 401/403 feed the auth-failure
- * classifier, network/5xx feed the runner's transient-retry path.
+ * 404 = stale mapping cleanup: the mapped WC product was removed shop-side, so
+ * the PUT 404s. Rather than silently skipping forever (a dead mapping that
+ * 404s on every future stock change), delete the `ShopProduct` identifier
+ * mapping for this (external product id, connection) and resolve — the next
+ * publish then re-creates the product and writes a fresh mapping (#1846 fix 5).
+ * All other errors propagate — 401/403 feed the auth-failure classifier,
+ * network/5xx feed the runner's transient-retry path.
  *
  * Published WC products are standalone simple products today, so the plain
  * product endpoint suffices — `/variations` handling is a deferred publisher
@@ -29,7 +31,11 @@
  * @implements {OfferManagerPort}
  */
 import type { OfferManagerPort, UpdateOfferQuantityCommand } from '@openlinker/core/listings';
-import type { Connection } from '@openlinker/core/identifier-mapping';
+import {
+  CORE_ENTITY_TYPE,
+  type Connection,
+  type IdentifierMappingPort,
+} from '@openlinker/core/identifier-mapping';
 import { Logger } from '@openlinker/shared/logging';
 import type { IWooCommerceHttpClient } from '../../http/woocommerce-http-client.interface';
 import { WooCommerceHttpResponseException } from '../../http/woocommerce-http-response.exception';
@@ -45,6 +51,7 @@ export class WooCommerceOfferManagerAdapter implements OfferManagerPort {
   constructor(
     private readonly httpClient: IWooCommerceHttpClient,
     private readonly connection: Connection,
+    private readonly identifierMapping: IdentifierMappingPort,
   ) {}
 
   async updateOfferQuantity(cmd: UpdateOfferQuantityCommand): Promise<void> {
@@ -75,8 +82,15 @@ export class WooCommerceOfferManagerAdapter implements OfferManagerPort {
       if (error instanceof WooCommerceHttpResponseException && error.statusCode === 404) {
         this.logger.warn(
           `WooCommerce product ${wcProductId} not found on connection ${this.connection.id} — ` +
-            `stale ShopProduct mapping (product removed shop-side?). Skipping stock write ` +
-            `(quantity=${cmd.quantity} not propagated).`,
+            `stale ShopProduct mapping (product removed shop-side?). Deleting the mapping so a ` +
+            `future publish re-creates it (quantity=${cmd.quantity} not propagated this run).`,
+        );
+        // Clean the dead mapping (idempotent) so it stops 404'ing on every stock
+        // change; the next publish re-creates the product and writes a fresh one.
+        await this.identifierMapping.deleteMapping(
+          CORE_ENTITY_TYPE.ShopProduct,
+          String(wcProductId),
+          this.connection.id,
         );
         return;
       }

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/product-publisher/__tests__/woocommerce-product-publisher.adapter.spec.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/product-publisher/__tests__/woocommerce-product-publisher.adapter.spec.ts
@@ -329,28 +329,65 @@ describe('WooCommerceProductPublisherAdapter', () => {
       expect(http.post.mock.calls[0][1]).not.toHaveProperty('attributes');
     });
 
-    it('should build a per-item slug from the SKU when present (#1846 fix 4)', async () => {
+    it('should build a per-item slug from the stable internal variant id, ignoring SKU (#1846 fix 4)', async () => {
       http.post.mockResolvedValue({ id: 42, status: 'publish' });
 
+      // A SKU is present but must NOT drive the slug: the SKU can change over an
+      // item's life, which would drift the WC permalink on a later upsert.
       await adapter.publishProduct(
-        baseCommand({ sku: 'ABC-123', content: { title: 'Widget', seo: { slug: 'widget' } } }),
+        baseCommand({
+          internalVariantId: 'ol_variant_xyz',
+          sku: 'ABC-123',
+          content: { title: 'Widget', seo: { slug: 'widget' } },
+        }),
       );
 
-      expect(http.post.mock.calls[0][1]).toMatchObject({ slug: 'widget-abc-123' });
+      expect(http.post.mock.calls[0][1]).toMatchObject({ slug: 'widget-ol-variant-xyz' });
+    });
+
+    it('should keep the slug stable across upsert even if the SKU changes (#1846 fix 4)', async () => {
+      http.post.mockResolvedValue({ id: 43, status: 'publish' });
+      http.put.mockResolvedValue({ id: 43, status: 'publish' });
+
+      // First publish without a SKU.
+      await adapter.publishProduct(
+        baseCommand({
+          internalVariantId: 'ol_variant_stable',
+          content: { title: 'Widget', seo: { slug: 'widget' } },
+        }),
+      );
+      // Later upsert after the variant gained a SKU — slug must not drift.
+      await adapter.publishProduct(
+        baseCommand({
+          internalVariantId: 'ol_variant_stable',
+          sku: 'NEW-SKU',
+          externalProductId: '43',
+          content: { title: 'Widget', seo: { slug: 'widget' } },
+        }),
+      );
+
+      expect(http.post.mock.calls[0][1]).toMatchObject({ slug: 'widget-ol-variant-stable' });
+      expect(http.put.mock.calls[0][1]).toMatchObject({ slug: 'widget-ol-variant-stable' });
     });
 
     it('should build distinct per-item slugs for sibling variants sharing a base slug (#1846 fix 4)', async () => {
-      http.post.mockResolvedValue({ id: 43, status: 'publish' });
+      http.post.mockResolvedValue({ id: 44, status: 'publish' });
 
       await adapter.publishProduct(
-        baseCommand({ sku: 'V-1', content: { title: 'Widget', seo: { slug: 'widget' } } }),
+        baseCommand({
+          internalVariantId: 'ol_variant_1',
+          content: { title: 'Widget', seo: { slug: 'widget' } },
+        }),
       );
       await adapter.publishProduct(
-        baseCommand({ sku: 'V-2', content: { title: 'Widget', seo: { slug: 'widget' } } }),
+        baseCommand({
+          internalVariantId: 'ol_variant_2',
+          content: { title: 'Widget', seo: { slug: 'widget' } },
+        }),
       );
 
-      expect(http.post.mock.calls[0][1]).toMatchObject({ slug: 'widget-v-1' });
-      expect(http.post.mock.calls[1][1]).toMatchObject({ slug: 'widget-v-2' });
+      expect(http.post.mock.calls[0][1]).toMatchObject({ slug: 'widget-ol-variant-1' });
+      expect(http.post.mock.calls[1][1]).toMatchObject({ slug: 'widget-ol-variant-2' });
     });
 
     it('should send images on create but omit them on upsert to avoid re-sideloading (#1846 fix 7)', async () => {

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/product-publisher/__tests__/woocommerce-product-publisher.adapter.spec.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/product-publisher/__tests__/woocommerce-product-publisher.adapter.spec.ts
@@ -227,7 +227,8 @@ describe('WooCommerceProductPublisherAdapter', () => {
       );
 
       const body = http.post.mock.calls[0][1] as Record<string, unknown>;
-      expect(body.slug).toBe('widget');
+      // Slug is per-item (base slug + slugified variant/sku discriminator, #1846 fix 4).
+      expect(body.slug).toBe('widget-ol-variant-aaaa');
       expect(body.meta_data).toEqual([
         { key: '_yoast_wpseo_title', value: 'SEO Title' },
         { key: 'rank_math_title', value: 'SEO Title' },
@@ -268,6 +269,107 @@ describe('WooCommerceProductPublisherAdapter', () => {
         ProductPublishRejectedException,
       );
     });
+
+    it('should propagate a 429 as transient (not a terminal rejection) so the job retries (#1846 fix 6)', async () => {
+      const err = new WooCommerceHttpResponseException(429, 'Too many requests');
+      http.post.mockRejectedValue(err);
+
+      await expect(adapter.publishProduct(baseCommand())).rejects.toBe(err);
+      await expect(adapter.publishProduct(baseCommand())).rejects.not.toBeInstanceOf(
+        ProductPublishRejectedException,
+      );
+    });
+
+    it('should map an upsert 404 to ProductPublishTargetNotFoundException (stale mapping, #1846 fix 1)', async () => {
+      http.put.mockRejectedValue(
+        new WooCommerceHttpResponseException(404, 'Not found', 'woocommerce_rest_product_invalid_id'),
+      );
+
+      await expect(
+        adapter.publishProduct(baseCommand({ externalProductId: '100' })),
+      ).rejects.toMatchObject({
+        name: 'ProductPublishTargetNotFoundException',
+        externalProductId: '100',
+      });
+    });
+
+    it('should keep a create 404 as a terminal rejection', async () => {
+      http.post.mockRejectedValue(new WooCommerceHttpResponseException(404, 'Not found'));
+
+      await expect(adapter.publishProduct(baseCommand())).rejects.toBeInstanceOf(
+        ProductPublishRejectedException,
+      );
+    });
+
+    it('should drop a dictionary-only param (valuesIds, no values) instead of writing an empty attribute (#1846 fix 2)', async () => {
+      http.post.mockResolvedValue({ id: 40, status: 'publish' });
+
+      await adapter.publishProduct(
+        baseCommand({
+          parameters: [
+            { id: 'Color', values: ['Red'], section: 'product' },
+            { id: 'Brand', valuesIds: ['555'], section: 'product' },
+            { id: 'Empty', values: [], section: 'product' },
+          ],
+        }),
+      );
+
+      const body = http.post.mock.calls[0][1] as Record<string, unknown>;
+      // Only the free-text param survives; dictionary-only + empty are dropped.
+      expect(body.attributes).toEqual([{ name: 'Color', options: ['Red'], visible: true }]);
+    });
+
+    it('should omit the attributes key entirely when no param has free-text values (#1846 fix 2)', async () => {
+      http.post.mockResolvedValue({ id: 41, status: 'publish' });
+
+      await adapter.publishProduct(
+        baseCommand({ parameters: [{ id: 'Brand', valuesIds: ['555'], section: 'product' }] }),
+      );
+
+      expect(http.post.mock.calls[0][1]).not.toHaveProperty('attributes');
+    });
+
+    it('should build a per-item slug from the SKU when present (#1846 fix 4)', async () => {
+      http.post.mockResolvedValue({ id: 42, status: 'publish' });
+
+      await adapter.publishProduct(
+        baseCommand({ sku: 'ABC-123', content: { title: 'Widget', seo: { slug: 'widget' } } }),
+      );
+
+      expect(http.post.mock.calls[0][1]).toMatchObject({ slug: 'widget-abc-123' });
+    });
+
+    it('should build distinct per-item slugs for sibling variants sharing a base slug (#1846 fix 4)', async () => {
+      http.post.mockResolvedValue({ id: 43, status: 'publish' });
+
+      await adapter.publishProduct(
+        baseCommand({ sku: 'V-1', content: { title: 'Widget', seo: { slug: 'widget' } } }),
+      );
+      await adapter.publishProduct(
+        baseCommand({ sku: 'V-2', content: { title: 'Widget', seo: { slug: 'widget' } } }),
+      );
+
+      expect(http.post.mock.calls[0][1]).toMatchObject({ slug: 'widget-v-1' });
+      expect(http.post.mock.calls[1][1]).toMatchObject({ slug: 'widget-v-2' });
+    });
+
+    it('should send images on create but omit them on upsert to avoid re-sideloading (#1846 fix 7)', async () => {
+      http.post.mockResolvedValue({ id: 44, status: 'publish' });
+      http.put.mockResolvedValue({ id: 44, status: 'publish' });
+
+      await adapter.publishProduct(
+        baseCommand({ content: { title: 'Widget', imageUrls: ['http://img/1.png'] } }),
+      );
+      expect(http.post.mock.calls[0][1]).toMatchObject({ images: [{ src: 'http://img/1.png' }] });
+
+      await adapter.publishProduct(
+        baseCommand({
+          externalProductId: '44',
+          content: { title: 'Widget', imageUrls: ['http://img/1.png'] },
+        }),
+      );
+      expect(http.put.mock.calls[0][1]).not.toHaveProperty('images');
+    });
   });
 
   describe('provisionCategory', () => {
@@ -284,6 +386,37 @@ describe('WooCommerceProductPublisherAdapter', () => {
 
       expect(http.post).not.toHaveBeenCalled();
       expect(result).toEqual({ destinationCategoryId: '5' });
+    });
+
+    it('should query the category search with a large per_page so the exact match is not truncated (#1846 fix 3)', async () => {
+      http.get.mockResolvedValue([{ id: 5, name: 'Gadgets', parent: 0, slug: 'gadgets' }]);
+
+      await adapter.provisionCategory({
+        connectionId: CONNECTION_ID,
+        path: [{ sourceCategoryId: 'src-1', name: 'Gadgets' }],
+      });
+
+      expect(http.get).toHaveBeenCalledWith(
+        '/wp-json/wc/v3/products/categories',
+        expect.objectContaining({ per_page: 100 }),
+      );
+    });
+
+    it('should recover from a concurrent term_exists 4xx by reusing the existing node (#1846 fix 3)', async () => {
+      http.get
+        .mockResolvedValueOnce([]) // first find: absent (race window)
+        .mockResolvedValueOnce([{ id: 77, name: 'Gadgets', parent: 0, slug: 'gadgets' }]); // re-find after term_exists
+      http.post.mockRejectedValueOnce(
+        new WooCommerceHttpResponseException(400, 'Term exists', 'term_exists'),
+      );
+
+      const result = await adapter.provisionCategory({
+        connectionId: CONNECTION_ID,
+        path: [{ sourceCategoryId: 'src-1', name: 'Gadgets' }],
+      });
+
+      // Reused the racing winner's node; not reported as newly created.
+      expect(result).toEqual({ destinationCategoryId: '77' });
     });
 
     it('should create missing nodes root→leaf, threading parent, and report createdPath', async () => {

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/product-publisher/woocommerce-product-publisher.adapter.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/product-publisher/woocommerce-product-publisher.adapter.ts
@@ -20,6 +20,7 @@ import { Logger } from '@openlinker/shared/logging';
 import type { Connection } from '@openlinker/core/identifier-mapping';
 import {
   ProductPublishRejectedException,
+  ProductPublishTargetNotFoundException,
   type CategoryProvisioner,
   type ProvisionCategoryCommand,
   type ProvisionCategoryResult,
@@ -43,6 +44,16 @@ const PRODUCTS_PATH = '/wp-json/wc/v3/products';
 const CATEGORIES_PATH = '/wp-json/wc/v3/products/categories';
 const DEFAULT_ADAPTER_KEY = 'woocommerce.restapi.v3';
 
+// WooCommerce caps `per_page` at 100. The default (10) silently truncates the
+// category-search result set, so an exact name match beyond the first 10 fuzzy
+// hits is missed and a duplicate category is created (#1846 fix 3).
+const CATEGORY_SEARCH_PER_PAGE = 100;
+
+// WC REST error code returned when a category name already exists under the same
+// parent — surfaces on a concurrent/racing provision. The response carries the
+// existing term id, letting us reuse it instead of failing (#1846 fix 3).
+const WC_TERM_EXISTS_CODE = 'term_exists';
+
 // Core WooCommerce has no native SEO title/description field — those live in
 // post meta owned by whichever SEO plugin the store runs. We write the meta keys
 // for both dominant plugins (Yoast, RankMath); the inactive plugin's rows are
@@ -61,8 +72,8 @@ export class WooCommerceProductPublisherAdapter
   ) {}
 
   async publishProduct(cmd: PublishProductCommand): Promise<PublishProductResult> {
-    const body = this.buildProductBody(cmd);
     const isUpsert = cmd.externalProductId != null && cmd.externalProductId !== '';
+    const body = this.buildProductBody(cmd, isUpsert);
     const path = isUpsert
       ? `${PRODUCTS_PATH}/${encodeURIComponent(String(cmd.externalProductId))}`
       : PRODUCTS_PATH;
@@ -78,7 +89,7 @@ export class WooCommerceProductPublisherAdapter
         ? await this.httpClient.put<WooCommerceProductResponse>(path, body)
         : await this.httpClient.post<WooCommerceProductResponse>(path, body);
     } catch (err) {
-      throw this.toPublishError(err);
+      throw this.toPublishError(err, isUpsert, cmd.externalProductId);
     }
 
     return { externalProductId: String(raw.id), status: this.fromWcStatus(raw.status) };
@@ -96,12 +107,9 @@ export class WooCommerceProductPublisherAdapter
         parentId = existing.id;
         continue;
       }
-      const created = await this.httpClient.post<WooCommerceCategoryResponse>(CATEGORIES_PATH, {
-        name: node.name,
-        parent: parentId,
-      });
+      const created = await this.createCategory(node.name, parentId);
       leafId = String(created.id);
-      createdPath.push(leafId);
+      if (created.created) createdPath.push(leafId);
       parentId = created.id;
     }
 
@@ -115,7 +123,10 @@ export class WooCommerceProductPublisherAdapter
    * Build the sparse WooCommerce product body. `platformParams` is spread first
    * so the explicit, modelled fields always win over any un-modeled knob.
    */
-  private buildProductBody(cmd: PublishProductCommand): Record<string, unknown> {
+  private buildProductBody(
+    cmd: PublishProductCommand,
+    isUpsert: boolean,
+  ): Record<string, unknown> {
     const content = cmd.content;
     const typed: WooCommerceProductPublishRequest = {
       type: 'simple',
@@ -140,21 +151,23 @@ export class WooCommerceProductPublisherAdapter
     if (content?.tags != null && content.tags.length > 0) {
       typed.tags = content.tags.map((name) => ({ name }));
     }
-    if (content?.imageUrls != null) typed.images = content.imageUrls.map((src) => ({ src }));
-    if (content?.seo?.slug != null) typed.slug = content.seo.slug;
+    // Images are sideloaded by `src`; WooCommerce re-imports (churns/duplicates)
+    // the media on every update. Only send them on create — image updates on
+    // upsert need media-id tracking and are a deferred enhancement (#1846 fix 7).
+    if (!isUpsert && content?.imageUrls != null) {
+      typed.images = content.imageUrls.map((src) => ({ src }));
+    }
+    // Per-item slug: bulk publishes several sibling variants as distinct simple
+    // products. Sending the same base slug for each lets WooCommerce silently
+    // auto-suffix (-2/-3), drifting the canonical URL. Discriminate the slug per
+    // item so each is deterministic and collision-free across re-publishes
+    // (#1846 fix 4).
+    if (content?.seo?.slug != null) typed.slug = this.buildPerItemSlug(content.seo.slug, cmd);
     if (cmd.destinationCategoryIds.length > 0) {
       typed.categories = cmd.destinationCategoryIds.map((id) => ({ id: Number(id) }));
     }
-    if (cmd.parameters && cmd.parameters.length > 0) {
-      // WooCommerce custom attributes carry free-text option strings; the owns-path
-      // `valuesIds` (dictionary entry ids) has no WC analogue and is intentionally
-      // not emitted in v1.
-      typed.attributes = cmd.parameters.map((p) => ({
-        name: p.id,
-        options: p.values ?? [],
-        visible: true,
-      }));
-    }
+    const attributes = this.buildAttributes(cmd.parameters);
+    if (attributes.length > 0) typed.attributes = attributes;
 
     this.applyCommerce(typed, cmd);
 
@@ -210,6 +223,52 @@ export class WooCommerceProductPublisherAdapter
     return rows;
   }
 
+  /**
+   * Map neutral projected/operator parameters to WooCommerce custom attributes.
+   * WooCommerce custom attributes carry only free-text option strings — the
+   * owns-path `valuesIds` (dictionary entry ids) has no WC analogue. A parameter
+   * that resolves to no free-text `values` (dictionary-only, or empty) is dropped
+   * cleanly rather than emitted as an empty `options: []` attribute, which would
+   * write a visible-but-valueless attribute row (silent data loss, #1846 fix 2).
+   */
+  private buildAttributes(
+    parameters: PublishProductCommand['parameters'],
+  ): Array<{ name: string; options: string[]; visible: boolean }> {
+    if (!parameters || parameters.length === 0) return [];
+    const attributes: Array<{ name: string; options: string[]; visible: boolean }> = [];
+    for (const p of parameters) {
+      const options = p.values ?? [];
+      if (options.length === 0) {
+        this.logger.debug(
+          `Dropping WooCommerce attribute "${p.id}" with no free-text values ` +
+            `(dictionary-typed valuesIds have no WC analogue).`,
+        );
+        continue;
+      }
+      attributes.push({ name: p.id, options, visible: true });
+    }
+    return attributes;
+  }
+
+  /**
+   * Build a per-item, deterministic slug from the builder-supplied base slug.
+   * Suffixing with the item's SKU (falling back to the internal variant id)
+   * keeps sibling variants collision-free — WooCommerce would otherwise
+   * auto-suffix a shared slug (-2/-3) — while staying stable across re-publishes
+   * of the same item (so the canonical URL does not drift).
+   */
+  private buildPerItemSlug(baseSlug: string, cmd: PublishProductCommand): string {
+    const discriminator = this.slugify(cmd.sku ?? cmd.internalVariantId);
+    return discriminator ? `${baseSlug}-${discriminator}` : baseSlug;
+  }
+
+  private slugify(value: string): string {
+    return value
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/(^-+|-+$)/g, '');
+  }
+
   private async findCategory(
     name: string,
     parent: number,
@@ -217,10 +276,44 @@ export class WooCommerceProductPublisherAdapter
     const matches = await this.httpClient.get<WooCommerceCategoryResponse[]>(CATEGORIES_PATH, {
       search: name,
       parent,
+      // WooCommerce defaults `per_page` to 10; a store with many same-prefix
+      // siblings would truncate the fuzzy result set and miss the exact match,
+      // then create a duplicate. Request the WC maximum so the exact match is
+      // always in range (#1846 fix 3).
+      per_page: CATEGORY_SEARCH_PER_PAGE,
     });
     // WooCommerce `search` is fuzzy — require an exact name + parent match before
     // reusing a node, so a similarly-named sibling is never mis-bound.
     return matches.find((c) => c.name === name && c.parent === parent) ?? null;
+  }
+
+  /**
+   * Create a category node, tolerating a concurrent creation race. Two publishes
+   * provisioning the same path at once can both miss `findCategory` and POST; the
+   * loser gets a WC `term_exists` 4xx. Instead of failing (which would create a
+   * duplicate on a naive retry), re-resolve the now-existing node and reuse it —
+   * an idempotency guard around the non-atomic find-then-create (#1846 fix 3).
+   */
+  private async createCategory(
+    name: string,
+    parent: number,
+  ): Promise<{ id: number; created: boolean }> {
+    try {
+      const created = await this.httpClient.post<WooCommerceCategoryResponse>(CATEGORIES_PATH, {
+        name,
+        parent,
+      });
+      return { id: created.id, created: true };
+    } catch (err) {
+      if (
+        err instanceof WooCommerceHttpResponseException &&
+        err.errorCode === WC_TERM_EXISTS_CODE
+      ) {
+        const existing = await this.findCategory(name, parent);
+        if (existing) return { id: existing.id, created: false };
+      }
+      throw err;
+    }
   }
 
   private fromWcStatus(status: WooCommerceProductStatus): PublishProductStatus {
@@ -228,18 +321,38 @@ export class WooCommerceProductPublisherAdapter
   }
 
   /**
-   * Map a transport failure to the neutral publish exception. A 4xx is a
-   * terminal rejection (no record created/updated) → `ProductPublishRejectedException`
-   * (the execution service records `business_failure`). Auth (401/403, a distinct
-   * exception type) and 5xx/network propagate untouched for the worker-retry / reauth paths.
+   * Map a transport failure to the neutral publish exception.
+   *
+   * - Upsert 404 → `ProductPublishTargetNotFoundException`: the mapped product
+   *   was deleted shop-side; core deletes the stale mapping and re-creates
+   *   (#1846 fix 1), not a terminal failure.
+   * - 429 (rate limit) / 408 (request timeout) → propagate untouched: these are
+   *   transient, so the worker retries the whole job rather than recording a
+   *   `business_failure` (#1846 fix 6). (The HTTP client already retries 429/5xx
+   *   internally; a surfaced 429 means its own budget was exhausted.)
+   * - Other 4xx → terminal rejection (no record created/updated) →
+   *   `ProductPublishRejectedException` (the execution service records
+   *   `business_failure`).
+   * - Auth (401/403, a distinct exception type) and 5xx/network propagate
+   *   untouched for the worker-retry / reauth paths.
    */
-  private toPublishError(err: unknown): unknown {
-    if (
-      err instanceof WooCommerceHttpResponseException &&
-      err.statusCode >= 400 &&
-      err.statusCode < 500
-    ) {
-      const adapterKey = this.connection.adapterKey ?? DEFAULT_ADAPTER_KEY;
+  private toPublishError(
+    err: unknown,
+    isUpsert: boolean,
+    externalProductId?: string | null,
+  ): unknown {
+    if (!(err instanceof WooCommerceHttpResponseException)) return err;
+
+    const adapterKey = this.connection.adapterKey ?? DEFAULT_ADAPTER_KEY;
+
+    if (isUpsert && err.statusCode === 404 && externalProductId != null) {
+      return new ProductPublishTargetNotFoundException(adapterKey, String(externalProductId));
+    }
+
+    // Transient 4xx — let the worker retry the job instead of failing terminally.
+    if (err.statusCode === 429 || err.statusCode === 408) return err;
+
+    if (err.statusCode >= 400 && err.statusCode < 500) {
       return new ProductPublishRejectedException(adapterKey, err.statusCode, [
         { code: err.errorCode ?? 'woocommerce_rejected', message: err.message },
       ]);

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/product-publisher/woocommerce-product-publisher.adapter.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/product-publisher/woocommerce-product-publisher.adapter.ts
@@ -46,7 +46,9 @@ const DEFAULT_ADAPTER_KEY = 'woocommerce.restapi.v3';
 
 // WooCommerce caps `per_page` at 100. The default (10) silently truncates the
 // category-search result set, so an exact name match beyond the first 10 fuzzy
-// hits is missed and a duplicate category is created (#1846 fix 3).
+// hits is missed and a duplicate category is created (#1846 fix 3). A search
+// yielding >100 fuzzy hits for one node name is not paginated here (accepted:
+// a single category name matching 100+ siblings is not a realistic taxonomy).
 const CATEGORY_SEARCH_PER_PAGE = 100;
 
 // WC REST error code returned when a category name already exists under the same
@@ -252,13 +254,18 @@ export class WooCommerceProductPublisherAdapter
 
   /**
    * Build a per-item, deterministic slug from the builder-supplied base slug.
-   * Suffixing with the item's SKU (falling back to the internal variant id)
-   * keeps sibling variants collision-free — WooCommerce would otherwise
-   * auto-suffix a shared slug (-2/-3) — while staying stable across re-publishes
-   * of the same item (so the canonical URL does not drift).
+   * Suffixing keeps sibling variants collision-free — WooCommerce would
+   * otherwise auto-suffix a shared slug (-2/-3) — while staying stable across
+   * re-publishes of the same item (so the canonical URL does not drift).
+   *
+   * The discriminator is the **internal variant id**, not the SKU: the id is
+   * immutable for the life of the variant, whereas a SKU can be absent at first
+   * publish and gained later — which would silently change the slug on a
+   * subsequent upsert and drift the WC permalink. Correctness (a stable URL)
+   * beats the marginally more readable SKU-based slug.
    */
   private buildPerItemSlug(baseSlug: string, cmd: PublishProductCommand): string {
-    const discriminator = this.slugify(cmd.sku ?? cmd.internalVariantId);
+    const discriminator = this.slugify(cmd.internalVariantId);
     return discriminator ? `${baseSlug}-${discriminator}` : baseSlug;
   }
 

--- a/libs/integrations/woocommerce/src/woocommerce-plugin.ts
+++ b/libs/integrations/woocommerce/src/woocommerce-plugin.ts
@@ -204,7 +204,12 @@ export function createWooCommercePlugin(deps?: CreateWooCommercePluginDeps): Ada
                 new WooCommerceProductPublisherAdapter(httpClient, connection),
               CategoryProvisioner: () =>
                 new WooCommerceProductPublisherAdapter(httpClient, connection),
-              OfferManager: () => new WooCommerceOfferManagerAdapter(httpClient, connection),
+              OfferManager: () =>
+                new WooCommerceOfferManagerAdapter(
+                  httpClient,
+                  connection,
+                  host.identifierMapping,
+                ),
             },
             WOOCOMMERCE_BRAND,
           ),


### PR DESCRIPTION
Part of #1838 (epic: Unify publish flow + WooCommerce field completeness). Sub-issue S20.

## What & why

Fixes seven correctness defects in the WooCommerce publisher, offer-manager, and core publish execution. Each fix is independently shippable; the diff keeps mapping-cleanup policy in core execution and transport shaping in the plugin (CORE <-> Integration boundary intact).

1. **404-on-upsert = permanent failure (fixed).** A `PUT /products/{id}` that 404s (product deleted shop-side) was classified a terminal `business_failure` and the `ShopProduct` mapping was never cleaned, so the variant could never re-create. The adapter now raises the neutral `ProductPublishTargetNotFoundException`; `ProductPublishExecutionService` deletes the stale mapping and re-publishes as a create, then writes a fresh mapping.
2. **Dictionary-typed params wrote empty attributes (fixed).** A param with only `valuesIds` (dictionary entry ids, no WC analogue) produced `options: []` - a visible-but-valueless attribute (silent data loss). Params with no free-text `values` are now dropped cleanly; the `attributes` key is omitted entirely when none survive.
3. **Category duplicates (fixed).** `findCategory` now requests `per_page=100` (WC max) so an exact match beyond the default 10 fuzzy hits is not missed and re-created. A concurrent `term_exists` rejection is recovered by re-resolving and reusing the racing winner's node.
4. **Shared slug in bulk (fixed).** A supplied `seo.slug` is suffixed per-item with the SKU (fallback: internal variant id), so bulk sibling variants get distinct, deterministic slugs instead of WooCommerce silently auto-suffixing a shared slug (`-2`/`-3`) and drifting the canonical URL.
5. **Stale mappings never cleaned (fixed on both paths).** Publish path via fix 1; stock write-back path - the offer-manager 404 handler now deletes the stale `ShopProduct` mapping (was a silent skip that 404'd forever), so the next publish re-creates the product.
6. **429 / transient 4xx treated as terminal (fixed).** `429 Too Many Requests` and `408 Request Timeout` now propagate (worker retries the whole job) instead of being recorded as `business_failure`. Other 4xx remain terminal rejections. (The HTTP client already retries 429/5xx internally first.)
7. **Images re-sideloaded on every upsert (fixed).** `images` are sent only on create; omitted on upsert to avoid WooCommerce re-importing/churning media on every update. Image updates on upsert (needs media-id tracking) are a documented deferred enhancement.

**SEO title/description** (merged #1833) is preserved and covered by an unchanged regression test - not redone, not regressed.

## How to test

```bash
pnpm --filter @openlinker/core build
pnpm type-check
pnpm --filter @openlinker/integrations-woocommerce test   # 453 pass
pnpm --filter @openlinker/core test -- product-publish-execution  # 9 pass
pnpm check:invariants
pnpm --filter @openlinker/integrations-woocommerce lint
```

New/updated unit tests cover each fix: stale-target recovery (core execution + adapter), dictionary-param drop, category `per_page` + `term_exists` recovery, per-item slug (single + sibling), 429 propagation, create-only images, and stock-path stale-mapping delete.

## Docs

- `libs/integrations/woocommerce/README.md` -> added a "Publish correctness" section documenting all seven behavior changes; annotated the `images` (create-only) and `slug` (per-item) rows in the field-mapping table.

Closes #1846
