### PR TITLE
feat(listings): capability-branch publish wizard + submit dispatch by destination (#1829)

### DIFF
--- a/apps/web/src/features/listings/components/bulk/bulk-config-step.test.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-config-step.test.tsx
@@ -128,6 +128,60 @@ describe('BulkConfigStep', () => {
     expect(screen.getByRole('button', { name: /Proceed/ })).toBeDisabled();
   }, 15000);
 
+  describe('shop destination branch (#1829)', () => {
+    function makeShopClient() {
+      const shop = {
+        id: 'conn-shop',
+        name: 'My Shop',
+        status: 'active',
+        platformType: 'woocommerce',
+        supportedCapabilities: ['ProductPublisher'],
+        enabledCapabilities: ['ProductPublisher'],
+      } as unknown as Connection;
+      return createMockApiClient({
+        connections: { list: vi.fn().mockResolvedValue([shop]) },
+      });
+    }
+
+    it('lets a shop connection Proceed without a per-platform section and emits config', async () => {
+      const onProceed = vi.fn<(c: BulkWizardConfig) => void>();
+      renderWithProviders(
+        <BulkConfigStep initial={{}} onProceed={onProceed} onCancel={() => undefined} />,
+        { apiClient: makeShopClient(), sessionAdapter: createAuthenticatedSessionAdapter() },
+      );
+
+      // Shop callout replaces the marketplace per-platform section.
+      await screen.findByText(/Publishing to an online shop/i);
+
+      await clickProceed();
+
+      expect(onProceed).toHaveBeenCalledTimes(1);
+      expect(onProceed.mock.calls[0][0]).toMatchObject({
+        connectionId: 'conn-shop',
+        platformParams: {},
+        pricingPolicy: { mode: 'use-master' },
+        stockPolicy: { mode: 'use-master' },
+      });
+    }, 15000);
+
+    it('reports the auto-selected connection up via onConnectionChange', async () => {
+      const onConnectionChange = vi.fn<(id: string) => void>();
+      renderWithProviders(
+        <BulkConfigStep
+          initial={{}}
+          onProceed={vi.fn()}
+          onCancel={() => undefined}
+          onConnectionChange={onConnectionChange}
+        />,
+        { apiClient: makeShopClient(), sessionAdapter: createAuthenticatedSessionAdapter() },
+      );
+
+      await waitFor(() => {
+        expect(onConnectionChange).toHaveBeenCalledWith('conn-shop');
+      });
+    }, 15000);
+  });
+
   describe('AI-generation toggle permission gating (listings:write, useWriteAccess + ReadOnlyLock, #1668)', () => {
     it('hides the toggle entirely for a genuinely unauthorized non-demo session (viewer)', async () => {
       renderWithProviders(

--- a/apps/web/src/features/listings/components/bulk/bulk-config-step.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-config-step.tsx
@@ -28,7 +28,7 @@ import { useWriteAccess } from '../../../../shared/auth/use-permission';
 import { useDemoMode } from '../../../system';
 import { useConnectionsQuery } from '../../../connections';
 import type { Connection } from '../../../connections';
-import { selectPublishDestinations } from '../../lib/publish-destinations';
+import { publishDestinationKind, selectPublishDestinations } from '../../lib/publish-destinations';
 import { usePlatform, usePlatforms, type BulkConfigFormValues } from '../../../../shared/plugins';
 import type {
   BulkWizardConfig,
@@ -44,16 +44,22 @@ interface BulkConfigStepProps {
   preselectedConnectionId?: string;
   onProceed: (config: BulkWizardConfig) => void;
   onCancel: () => void;
+  /**
+   * Reports the live-selected connection id up so the wizard can branch its
+   * step model by the destination's capability (#1829) - a `ProductPublisher`
+   * shop runs Config -> Review, an `OfferCreator` marketplace keeps
+   * Config -> Resolve -> Review. Fires on auto-select and manual change.
+   */
+  onConnectionChange?: (connectionId: string) => void;
 }
 
 const DEFAULT_CURRENCY = 'PLN';
 
-function selectOfferManagerConnections(all: readonly Connection[]): Connection[] {
+function selectPublishConnections(all: readonly Connection[]): Connection[] {
   // Unified publish targets (#1828): offer marketplaces (OfferCreator) OR
-  // online shops (ProductPublisher), capability-driven. A connection without a
-  // per-platform config section (e.g. a shop, until the wizard branch #1829
-  // lands) surfaces the "not configured" warning and cannot Proceed via the
-  // marketplace path - see `sectionComplete` below.
+  // online shops (ProductPublisher), capability-driven. Marketplaces render a
+  // per-platform config section and gate Proceed on it; shops (#1829) skip the
+  // section and the Resolve step entirely - see `isShop` / `canProceed` below.
   return selectPublishDestinations(all).map((d) => d.connection);
 }
 
@@ -80,11 +86,12 @@ export function BulkConfigStep({
   preselectedConnectionId,
   onProceed,
   onCancel,
+  onConnectionChange,
 }: BulkConfigStepProps): ReactElement {
   const connectionsQuery = useConnectionsQuery();
   const platforms = usePlatforms();
-  const offerManagerConnections = useMemo(
-    () => selectOfferManagerConnections(connectionsQuery.data ?? []),
+  const publishConnections = useMemo(
+    () => selectPublishConnections(connectionsQuery.data ?? []),
     [connectionsQuery.data],
   );
 
@@ -97,16 +104,26 @@ export function BulkConfigStep({
     initial.connectionId ?? preselectedConnectionId ?? '',
   );
 
-  // Auto-select the sole OfferManager connection (honors explicit preselect first).
+  // Auto-select the sole publish connection (honors explicit preselect first).
   useEffect(() => {
-    if (connectionId === '' && offerManagerConnections.length === 1) {
-      setConnectionId(offerManagerConnections[0]!.id);
+    if (connectionId === '' && publishConnections.length === 1) {
+      setConnectionId(publishConnections[0]!.id);
     }
-  }, [offerManagerConnections, connectionId]);
+  }, [publishConnections, connectionId]);
 
-  const connection = offerManagerConnections.find((c) => c.id === connectionId) ?? null;
+  // Report the live selection up so the wizard can branch its step model by the
+  // destination's capability (#1829).
+  useEffect(() => {
+    if (connectionId !== '') onConnectionChange?.(connectionId);
+  }, [connectionId, onConnectionChange]);
+
+  const connection = publishConnections.find((c) => c.id === connectionId) ?? null;
+  // Capability-driven destination kind - never a platformType literal (#1829).
+  const isShop = connection ? publishDestinationKind(connection) === 'shop' : false;
   const platform = usePlatform(connection?.platformType);
-  const section = platform?.bulkOfferConfigSection;
+  // Shops carry no per-platform offer-config section (category/attributes/images
+  // are resolved from the master product at publish time).
+  const section = isShop ? undefined : platform?.bulkOfferConfigSection;
 
   const values = form.watch();
   const demoMode = useDemoMode();
@@ -128,11 +145,9 @@ export function BulkConfigStep({
     (/^\d+$/.test(values.flatStockValue.trim()) && Number(values.flatStockValue) >= 1);
 
   const sharedSliceValid = markupValid && flatPriceValid && capValid && flatStockValid;
-  // A connection with no per-platform config section cannot be bulk-published
-  // through the marketplace wizard (e.g. a shop destination that slipped in via
-  // direct URL before the wizard branch #1829 lands) - block Proceed rather
-  // than submit a shop connection to the offer bulk-create endpoint.
-  const sectionComplete = section ? section.isComplete(values) : false;
+  // Marketplaces must complete their per-platform config section before
+  // Proceed; shops have no section (#1829) so the shared slice alone gates.
+  const sectionComplete = isShop ? true : section ? section.isComplete(values) : false;
   const canProceed = connectionId !== '' && sharedSliceValid && sectionComplete;
 
   function buildPricingPolicy(): PricingPolicy {
@@ -167,10 +182,10 @@ export function BulkConfigStep({
   if (connectionsQuery.isLoading) {
     return <Alert tone="info">Loading connections…</Alert>;
   }
-  if (offerManagerConnections.length === 0) {
+  if (publishConnections.length === 0) {
     return (
       <Alert tone="error">
-        No active connections with offer-creation capability found. Add one from{' '}
+        No active publish destinations found. Add a marketplace or online-shop connection from{' '}
         <a href="/connections">Connections</a>.
       </Alert>
     );
@@ -194,13 +209,13 @@ export function BulkConfigStep({
         </p>
       </header>
 
-      {offerManagerConnections.length > 1 ? (
-        <FormField name="bulk-config-connection" label="Marketplace connection">
+      {publishConnections.length > 1 ? (
+        <FormField name="bulk-config-connection" label="Destination connection">
           <Select value={connectionId} onChange={(e) => setConnectionId(e.target.value)}>
             <option value="" disabled>
               Select a connection…
             </option>
-            {offerManagerConnections.map((c) => {
+            {publishConnections.map((c) => {
               const label = platforms.find((p) => p.platformType === c.platformType)?.displayName;
               return (
                 <option key={c.id} value={c.id}>
@@ -213,12 +228,22 @@ export function BulkConfigStep({
         </FormField>
       ) : (
         <Alert tone="info">
-          Publishing as <strong>{offerManagerConnections[0]?.name}</strong>.
+          Publishing as <strong>{publishConnections[0]?.name}</strong>.
         </Alert>
       )}
 
+      {/* Shops resolve category, attributes & images from the master product at
+          publish time (#1829) - no per-platform section to configure. */}
+      {connection && isShop ? (
+        <div className="shop-publish-callout">
+          Publishing to an online shop. Category placement, attributes &amp; images are resolved
+          from the master product at publish time - only visibility, price, and stock policy below
+          apply.
+        </div>
+      ) : null}
+
       {/* Per-platform config section (Allegro: delivery policy + currency; Erli: dispatch time). */}
-      {connection ? (
+      {connection && !isShop ? (
         section ? (
           <Suspense fallback={<Alert tone="info">Loading marketplace options…</Alert>}>
             <section.component connection={connection} form={form} />

--- a/apps/web/src/features/listings/components/bulk/bulk-shop-review-step.test.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-shop-review-step.test.tsx
@@ -7,9 +7,17 @@
  * variants dropped, and a null resolved price omitted (shop builder falls back
  * to master server-side).
  */
-import { describe, expect, it } from 'vitest';
-import { buildBulkShopPublishItems } from './bulk-shop-review-step';
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { renderWithProviders, createMockApiClient } from '../../../../test/test-utils';
+import {
+  BulkShopReviewStep,
+  buildBulkShopPublishItems,
+  type ShopPublishVisibility,
+} from './bulk-shop-review-step';
 import type { BulkVariantRow, BulkWizardConfig, BulkWizardRow } from './bulk-wizard.types';
+import type { BulkShopPublishItemRequest } from '../../api/listings.types';
+import type { Connection } from '../../../connections';
 import type { Product, ProductVariant } from '../../../products';
 
 function makeVariantRow(id: string, over: Partial<BulkVariantRow> = {}): BulkVariantRow {
@@ -112,5 +120,106 @@ describe('buildBulkShopPublishItems', () => {
     const rows = [makeRow('prod_1', [makeVariantRow('v1')])];
     const items = buildBulkShopPublishItems(rows, config(), new Map());
     expect(items[0].stock).toBe(0);
+  });
+});
+
+const shopConnection = {
+  id: 'conn_shop',
+  name: 'My Shop',
+  status: 'active',
+  platformType: 'woocommerce',
+  supportedCapabilities: ['ProductPublisher'],
+  enabledCapabilities: ['ProductPublisher'],
+} as unknown as Connection;
+
+function renderStep(
+  rows: BulkWizardRow[],
+  cfg: BulkWizardConfig,
+  handlers: {
+    onPublish?: (items: BulkShopPublishItemRequest[], status: ShopPublishVisibility) => void;
+    onSetVariantIncluded?: (p: string, v: string, i: boolean) => void;
+    onBack?: () => void;
+  } = {},
+  availability: { productVariantId: string; totalAvailable: number }[] = [],
+): void {
+  const apiClient = createMockApiClient({
+    inventory: {
+      availability: vi.fn().mockResolvedValue({ items: availability }),
+    },
+  });
+  renderWithProviders(
+    <BulkShopReviewStep
+      rows={rows}
+      connection={shopConnection}
+      config={cfg}
+      demoReadOnly={false}
+      isSubmitting={false}
+      errorMessage={null}
+      onSetVariantIncluded={handlers.onSetVariantIncluded ?? ((): void => undefined)}
+      onBack={handlers.onBack ?? ((): void => undefined)}
+      onPublish={handlers.onPublish ?? ((): void => undefined)}
+    />,
+    { apiClient },
+  );
+}
+
+describe('BulkShopReviewStep (render)', () => {
+  it('renders one row per included variant and displays the resolved stock + price it will submit', async () => {
+    const rows = [makeRow('prod_1', [makeVariantRow('v1'), makeVariantRow('v2', { included: false })])];
+    // use-master stock (availability 7) + flat price 99 -> review must show both.
+    renderStep(
+      rows,
+      config({ pricingPolicy: { mode: 'flat', amount: 99 } }),
+      {},
+      [{ productVariantId: 'v1', totalAvailable: 7 }],
+    );
+
+    // Only the included variant renders a row.
+    expect(await screen.findByLabelText('Remove P - v1')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Remove P - v2')).not.toBeInTheDocument();
+
+    // Displayed stock == resolved availability; price == flat policy value.
+    await waitFor(() => {
+      expect(screen.getByText('7')).toBeInTheDocument();
+    });
+    expect(screen.getByText('99 PLN')).toBeInTheDocument();
+  });
+
+  it('publishes the resolved items with the chosen visibility', async () => {
+    const onPublish = vi.fn();
+    const rows = [makeRow('prod_1', [makeVariantRow('v1')])];
+    renderStep(
+      rows,
+      config({ pricingPolicy: { mode: 'flat', amount: 99 } }),
+      { onPublish },
+      [{ productVariantId: 'v1', totalAvailable: 7 }],
+    );
+
+    // Flip visibility to Draft, then publish.
+    fireEvent.click(await screen.findByRole('button', { name: 'Draft' }));
+    await waitFor(() => {
+      expect(screen.getByText('7')).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Publish 1 listing/ }));
+
+    expect(onPublish).toHaveBeenCalledWith(
+      [{ internalVariantId: 'v1', stock: 7, price: { amount: 99, currency: 'PLN' } }],
+      'draft',
+    );
+  });
+
+  it('excludes a variant via its remove button', async () => {
+    const onSetVariantIncluded = vi.fn();
+    const rows = [makeRow('prod_1', [makeVariantRow('v1')])];
+    renderStep(rows, config(), { onSetVariantIncluded });
+
+    fireEvent.click(await screen.findByLabelText('Remove P - v1'));
+    expect(onSetVariantIncluded).toHaveBeenCalledWith('prod_1', 'v1', false);
+  });
+
+  it('shows the empty-state alert when no variants are included', () => {
+    const rows = [makeRow('prod_1', [makeVariantRow('v1', { included: false })])];
+    renderStep(rows, config());
+    expect(screen.getByText(/No variants are included/i)).toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/listings/components/bulk/bulk-shop-review-step.test.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-shop-review-step.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * BulkShopReviewStep pure-helper tests (#1829)
+ *
+ * Pins `buildBulkShopPublishItems`: one `bulk-shop-publish` item per INCLUDED
+ * variant, stock resolved from master availability + the batch stock policy,
+ * price from the variant master price + the batch pricing policy, excluded
+ * variants dropped, and a null resolved price omitted (shop builder falls back
+ * to master server-side).
+ */
+import { describe, expect, it } from 'vitest';
+import { buildBulkShopPublishItems } from './bulk-shop-review-step';
+import type { BulkVariantRow, BulkWizardConfig, BulkWizardRow } from './bulk-wizard.types';
+import type { Product, ProductVariant } from '../../../products';
+
+function makeVariantRow(id: string, over: Partial<BulkVariantRow> = {}): BulkVariantRow {
+  const variant = { id, productId: 'prod_1', sku: id } as unknown as ProductVariant;
+  return {
+    variantId: id,
+    variant,
+    ean: null,
+    distinguishingAttributes: null,
+    masterStock: null,
+    masterPrice: 39,
+    masterCurrency: 'PLN',
+    included: true,
+    blockers: [],
+    resolvedCategoryId: null,
+    resolvedProductCardId: null,
+    resolutionMethod: null,
+    categoryCandidates: [],
+    override: {},
+    ...over,
+  };
+}
+
+function makeRow(productId: string, variants: BulkVariantRow[]): BulkWizardRow {
+  return {
+    productId,
+    product: { id: productId, name: 'P', currency: 'PLN' } as unknown as Product,
+    primaryVariant: variants[0]?.variant ?? null,
+    variants,
+    blockers: [],
+    resolvedCategoryId: null,
+    resolvedProductCardId: null,
+    resolutionMethod: null,
+    masterPrice: null,
+    masterStock: null,
+    masterCurrency: null,
+    categoryCandidates: [],
+    override: {},
+  };
+}
+
+function config(over: Partial<BulkWizardConfig> = {}): BulkWizardConfig {
+  return {
+    connectionId: 'conn_shop',
+    platformParams: {},
+    currency: 'PLN',
+    pricingPolicy: { mode: 'use-master' },
+    stockPolicy: { mode: 'use-master' },
+    publishImmediately: true,
+    generateDescription: false,
+    ...over,
+  };
+}
+
+describe('buildBulkShopPublishItems', () => {
+  it('emits one item per included variant with master-derived price + availability stock', () => {
+    const rows = [makeRow('prod_1', [makeVariantRow('v1'), makeVariantRow('v2')])];
+    const items = buildBulkShopPublishItems(
+      rows,
+      config(),
+      new Map([
+        ['v1', 7],
+        ['v2', 3],
+      ]),
+    );
+    expect(items).toEqual([
+      { internalVariantId: 'v1', stock: 7, price: { amount: 39, currency: 'PLN' } },
+      { internalVariantId: 'v2', stock: 3, price: { amount: 39, currency: 'PLN' } },
+    ]);
+  });
+
+  it('drops excluded variants', () => {
+    const rows = [
+      makeRow('prod_1', [makeVariantRow('v1'), makeVariantRow('v2', { included: false })]),
+    ];
+    const items = buildBulkShopPublishItems(rows, config(), new Map([['v1', 5]]));
+    expect(items.map((i) => i.internalVariantId)).toEqual(['v1']);
+  });
+
+  it('applies flat stock + flat price policies', () => {
+    const rows = [makeRow('prod_1', [makeVariantRow('v1')])];
+    const items = buildBulkShopPublishItems(
+      rows,
+      config({ stockPolicy: { mode: 'flat', value: 10 }, pricingPolicy: { mode: 'flat', amount: 99 } }),
+      new Map(),
+    );
+    expect(items).toEqual([
+      { internalVariantId: 'v1', stock: 10, price: { amount: 99, currency: 'PLN' } },
+    ]);
+  });
+
+  it('omits price when master price is missing under use-master pricing', () => {
+    const rows = [makeRow('prod_1', [makeVariantRow('v1', { masterPrice: null })])];
+    const items = buildBulkShopPublishItems(rows, config(), new Map([['v1', 4]]));
+    expect(items).toEqual([{ internalVariantId: 'v1', stock: 4 }]);
+    expect(items[0]).not.toHaveProperty('price');
+  });
+
+  it('sends 0 stock when no availability is known under use-master stock', () => {
+    const rows = [makeRow('prod_1', [makeVariantRow('v1')])];
+    const items = buildBulkShopPublishItems(rows, config(), new Map());
+    expect(items[0].stock).toBe(0);
+  });
+});

--- a/apps/web/src/features/listings/components/bulk/bulk-shop-review-step.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-shop-review-step.tsx
@@ -1,0 +1,242 @@
+/**
+ * Bulk wizard Shop Review step (#1829)
+ *
+ * The `ProductPublisher` (online shop) branch of the bulk wizard. Shops have no
+ * marketplace category/EAN resolution, so the wizard skips the Resolve step and
+ * lands here straight from Config. This step reviews the included variants of
+ * the seeded rows, computes each one's stock (from master availability + the
+ * batch stock policy) and price (from the variant master price + the batch
+ * pricing policy), lets the operator flip visibility (draft / published) and
+ * exclude variants, then submits one `bulk-shop-publish` item per included
+ * variant.
+ *
+ * Per-item stock/price *editing* is intentionally out of scope here - the
+ * current `bulk-shop-publish` endpoint takes computed values, and #1831
+ * enriches the per-item payload + editing surface.
+ *
+ * @module apps/web/src/features/listings/components/bulk
+ */
+import { useMemo, useState, type ReactElement } from 'react';
+
+import { Alert, Button } from '../../../../shared/ui';
+import { ReadOnlyLock } from '../../../../shared/ui/read-only-lock';
+import { DEMO_READ_ONLY_ACTION_MESSAGE } from '../../../../shared/config/demo-mode';
+import { useInventoryAvailabilityBatchQuery } from '../../../inventory';
+import type { Connection } from '../../../connections';
+import type { BulkShopPublishItemRequest } from '../../api/listings.types';
+import { computeResolvedPrice, computeResolvedStock } from './bulk-policy';
+import type { BulkVariantRow, BulkWizardConfig, BulkWizardRow } from './bulk-wizard.types';
+
+/** Visibility the batch publishes with; mirrors the shop publish status set. */
+export type ShopPublishVisibility = 'draft' | 'published';
+
+interface BulkShopReviewStepProps {
+  rows: BulkWizardRow[];
+  connection: Connection | null;
+  config: BulkWizardConfig;
+  demoReadOnly: boolean;
+  isSubmitting: boolean;
+  errorMessage: string | null;
+  onSetVariantIncluded: (productId: string, variantId: string, included: boolean) => void;
+  onBack: () => void;
+  onPublish: (items: BulkShopPublishItemRequest[], status: ShopPublishVisibility) => void;
+}
+
+/** A flattened included variant paired with its owning product for display. */
+interface ShopReviewLine {
+  productId: string;
+  productName: string;
+  variantId: string;
+  variantLabel: string;
+  masterPrice: number | null;
+}
+
+function variantDisplayLabel(variant: BulkVariantRow): string {
+  const attrs = variant.distinguishingAttributes
+    ? Object.values(variant.distinguishingAttributes).join(' · ')
+    : '';
+  return attrs || variant.variant.sku || variant.variantId;
+}
+
+/**
+ * Build one `bulk-shop-publish` item per included variant. Stock resolves from
+ * master availability + the batch stock policy; price from the variant master
+ * price + the batch pricing policy. A null resolved price is omitted (the shop
+ * builder falls back to master at publish time); a null resolved stock sends 0.
+ */
+export function buildBulkShopPublishItems(
+  rows: BulkWizardRow[],
+  config: BulkWizardConfig,
+  masterStockByVariantId: ReadonlyMap<string, number>,
+): BulkShopPublishItemRequest[] {
+  const items: BulkShopPublishItemRequest[] = [];
+  for (const row of rows) {
+    for (const variant of row.variants) {
+      if (!variant.included) continue;
+      const masterStock = masterStockByVariantId.get(variant.variantId) ?? variant.masterStock;
+      const stock = computeResolvedStock(config.stockPolicy, masterStock, variant.override);
+      const price = computeResolvedPrice(config.pricingPolicy, variant.masterPrice, variant.override);
+      items.push({
+        internalVariantId: variant.variantId,
+        stock: stock.value ?? 0,
+        ...(price.value !== null
+          ? { price: { amount: price.value, currency: config.currency } }
+          : {}),
+      });
+    }
+  }
+  return items;
+}
+
+export function BulkShopReviewStep({
+  rows,
+  connection,
+  config,
+  demoReadOnly,
+  isSubmitting,
+  errorMessage,
+  onSetVariantIncluded,
+  onBack,
+  onPublish,
+}: BulkShopReviewStepProps): ReactElement {
+  const [status, setStatus] = useState<ShopPublishVisibility>(
+    config.publishImmediately ? 'published' : 'draft',
+  );
+
+  const includedVariantIds = useMemo(() => {
+    const ids: string[] = [];
+    for (const row of rows) {
+      for (const variant of row.variants) {
+        if (variant.included) ids.push(variant.variantId);
+      }
+    }
+    return ids;
+  }, [rows]);
+
+  const availabilityQuery = useInventoryAvailabilityBatchQuery(includedVariantIds, {
+    enabled: includedVariantIds.length > 0,
+  });
+  const masterStockByVariantId = useMemo(
+    () =>
+      new Map(
+        (availabilityQuery.data?.items ?? []).map((i) => [i.productVariantId, i.totalAvailable]),
+      ),
+    [availabilityQuery.data],
+  );
+
+  const lines = useMemo<ShopReviewLine[]>(() => {
+    const out: ShopReviewLine[] = [];
+    for (const row of rows) {
+      for (const variant of row.variants) {
+        if (!variant.included) continue;
+        out.push({
+          productId: row.productId,
+          productName: row.product?.name ?? row.productId,
+          variantId: variant.variantId,
+          variantLabel: variantDisplayLabel(variant),
+          masterPrice: variant.masterPrice,
+        });
+      }
+    }
+    return out;
+  }, [rows]);
+
+  const handlePublish = (): void => {
+    const items = buildBulkShopPublishItems(rows, config, masterStockByVariantId);
+    if (items.length === 0) return;
+    onPublish(items, status);
+  };
+
+  return (
+    <div className="bulk-shop-review">
+      {errorMessage ? <Alert tone="error">{errorMessage}</Alert> : null}
+
+      <header>
+        <h2
+          style={{ margin: 0, fontSize: 17, fontWeight: 600, letterSpacing: 'var(--tracking-tight)' }}
+        >
+          Review shop listings
+        </h2>
+        <p style={{ margin: '4px 0 0', color: 'var(--text-secondary)', fontSize: 13 }}>
+          Publishing {lines.length} {lines.length === 1 ? 'product listing' : 'product listings'} to{' '}
+          <strong>{connection?.name ?? 'the selected shop'}</strong>. Stock and price come from each
+          product's master values and the batch policy.
+        </p>
+      </header>
+
+      <div className="form-field">
+        <span className="form-field__label">Visibility</span>
+        <div className="segmented" role="group" aria-label="Visibility">
+          <button
+            type="button"
+            className={
+              status === 'draft' ? 'segmented__opt segmented__opt--active' : 'segmented__opt'
+            }
+            aria-pressed={status === 'draft'}
+            onClick={() => setStatus('draft')}
+          >
+            <span className="segmented__dot segmented__dot--draft" aria-hidden="true" />
+            Draft
+          </button>
+          <button
+            type="button"
+            className={
+              status === 'published' ? 'segmented__opt segmented__opt--active' : 'segmented__opt'
+            }
+            aria-pressed={status === 'published'}
+            onClick={() => setStatus('published')}
+          >
+            <span className="segmented__dot segmented__dot--pub" aria-hidden="true" />
+            Published
+          </button>
+        </div>
+      </div>
+
+      {lines.length === 0 ? (
+        <Alert tone="warning">
+          No variants are included. Re-include at least one variant to publish.
+        </Alert>
+      ) : (
+        <ul className="bulk-shop-review__list">
+          {lines.map((line) => (
+            <li key={line.variantId} className="bulk-shop-review__row">
+              <div className="bulk-shop-review__row-main">
+                <b>{line.productName}</b>
+                <small className="mono-text muted-text">{line.variantLabel}</small>
+              </div>
+              <span className="mono-text tabular">
+                {line.masterPrice !== null ? `${line.masterPrice} ${config.currency}` : 'from master'}
+              </span>
+              <button
+                type="button"
+                className="bulk-shop-review__remove"
+                aria-label={`Remove ${line.productName} - ${line.variantLabel}`}
+                onClick={() => onSetVariantIncluded(line.productId, line.variantId, false)}
+              >
+                ×
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <footer className="bulk-wizard__footer">
+        <Button tone="ghost" onClick={onBack}>
+          ← Back
+        </Button>
+        <div className="bulk-wizard__footer-spacer" />
+        <ReadOnlyLock active={demoReadOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
+          <Button
+            tone="primary"
+            disabled={isSubmitting || demoReadOnly || lines.length === 0}
+            onClick={handlePublish}
+          >
+            {isSubmitting
+              ? 'Publishing…'
+              : `Publish ${lines.length} ${lines.length === 1 ? 'listing' : 'listings'}`}
+          </Button>
+        </ReadOnlyLock>
+      </footer>
+    </div>
+  );
+}

--- a/apps/web/src/features/listings/components/bulk/bulk-shop-review-step.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-shop-review-step.tsx
@@ -42,13 +42,18 @@ interface BulkShopReviewStepProps {
   onPublish: (items: BulkShopPublishItemRequest[], status: ShopPublishVisibility) => void;
 }
 
-/** A flattened included variant paired with its owning product for display. */
+/** A flattened included variant paired with its owning product for display.
+ *  The displayed `stock` / `price` are the SAME policy-resolved values the
+ *  submit sends (see `buildBulkShopPublishItems`), so review == publish. */
 interface ShopReviewLine {
   productId: string;
   productName: string;
   variantId: string;
   variantLabel: string;
-  masterPrice: number | null;
+  /** Policy-resolved published quantity; null when unresolved (shown as 0). */
+  stock: number | null;
+  /** Policy-resolved price; null when it falls back to master server-side. */
+  price: number | null;
 }
 
 function variantDisplayLabel(variant: BulkVariantRow): string {
@@ -129,17 +134,23 @@ export function BulkShopReviewStep({
     for (const row of rows) {
       for (const variant of row.variants) {
         if (!variant.included) continue;
+        // Resolve exactly as the payload does so what the operator reviews
+        // equals what is submitted (review == publish).
+        const masterStock = masterStockByVariantId.get(variant.variantId) ?? variant.masterStock;
+        const stock = computeResolvedStock(config.stockPolicy, masterStock, variant.override);
+        const price = computeResolvedPrice(config.pricingPolicy, variant.masterPrice, variant.override);
         out.push({
           productId: row.productId,
           productName: row.product?.name ?? row.productId,
           variantId: variant.variantId,
           variantLabel: variantDisplayLabel(variant),
-          masterPrice: variant.masterPrice,
+          stock: stock.value,
+          price: price.value,
         });
       }
     }
     return out;
-  }, [rows]);
+  }, [rows, config.stockPolicy, config.pricingPolicy, masterStockByVariantId]);
 
   const handlePublish = (): void => {
     const items = buildBulkShopPublishItems(rows, config, masterStockByVariantId);
@@ -204,8 +215,13 @@ export function BulkShopReviewStep({
                 <b>{line.productName}</b>
                 <small className="mono-text muted-text">{line.variantLabel}</small>
               </div>
-              <span className="mono-text tabular">
-                {line.masterPrice !== null ? `${line.masterPrice} ${config.currency}` : 'from master'}
+              <span className="bulk-shop-review__cell mono-text tabular" aria-label="Stock">
+                <span className="bulk-shop-review__cell-label">stock</span>
+                {line.stock ?? 0}
+              </span>
+              <span className="bulk-shop-review__cell mono-text tabular" aria-label="Price">
+                <span className="bulk-shop-review__cell-label">price</span>
+                {line.price !== null ? `${line.price} ${config.currency}` : 'from master'}
               </span>
               <button
                 type="button"

--- a/apps/web/src/features/listings/components/bulk/bulk-wizard.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-wizard.tsx
@@ -15,22 +15,30 @@
  */
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Alert, PageLayout, SetupStepper } from '../../../../shared/ui';
+import { Alert, Button, PageLayout, SetupStepper } from '../../../../shared/ui';
 import { useToast } from '../../../../shared/ui/toast-provider';
 import { usePlatforms, type OfferRowValidationInput } from '../../../../shared/plugins';
 import { useWriteAccess } from '../../../../shared/auth/use-permission';
 import { useDemoMode } from '../../../system';
 import { useConnectionsQuery } from '../../../connections';
 import { useBulkSubmitMutation } from '../../hooks/use-bulk-submit-mutation';
+import { useBulkShopPublishMutation } from '../../hooks/use-bulk-shop-publish-mutation';
 import { useBulkRequiredProductParams } from '../../hooks/use-bulk-required-product-params';
+import { publishDestinationKind } from '../../lib/publish-destinations';
 import type {
   BulkOfferCreateRequest,
   BulkPerProductOverride,
 } from '../../api/bulk-listings.types';
+import type { BulkShopPublishItemRequest } from '../../api/listings.types';
 import type { Product, ProductVariant } from '../../../products';
 import { BulkConfigStep } from './bulk-config-step';
 import { BulkResolveStep, type BulkResolveOutcome } from './bulk-resolve-step';
 import { BulkReviewStep } from './bulk-review-step';
+import {
+  BulkShopReviewStep,
+  type ShopPublishVisibility,
+} from './bulk-shop-review-step';
+import { ShopPublishTracker } from '../ShopPublishTracker';
 import { BulkConfirmModal } from './bulk-confirm-modal';
 import {
   computeResolvedPrice,
@@ -76,6 +84,13 @@ const WIZARD_STEPS: { id: BulkWizardStep; label: string }[] = [
   { id: 'confirm', label: 'Confirm' },
 ];
 
+// Shops (#1829) skip the marketplace Resolve step (no category/EAN matching)
+// and publish straight from Review: Config -> Review.
+const SHOP_WIZARD_STEPS: { id: BulkWizardStep; label: string }[] = [
+  { id: 'config', label: 'Config' },
+  { id: 'review', label: 'Review' },
+];
+
 /** Stable empty list so a param-schema opt-out platform keeps a constant deps identity. */
 const EMPTY_CATEGORY_IDS: readonly string[] = [];
 
@@ -88,6 +103,7 @@ export function BulkWizard({
   const navigate = useNavigate();
   const { showToast } = useToast();
   const mutation = useBulkSubmitMutation();
+  const shopMutation = useBulkShopPublishMutation();
   const platforms = usePlatforms();
   const connectionsQuery = useConnectionsQuery();
 
@@ -100,6 +116,24 @@ export function BulkWizard({
   const [config, setConfig] = useState<BulkWizardConfig | null>(null);
   const [rows, setRows] = useState<BulkWizardRow[]>(() => seedRows(products, preSelectedVariantIds));
   const [confirmOpen, setConfirmOpen] = useState(false);
+  // Live-selected connection id (before config is committed) so the stepper +
+  // flow can branch by destination capability from the start (#1829). Seeded
+  // from the picker/URL preselect; updated by the Config step's selector.
+  const [liveConnectionId, setLiveConnectionId] = useState<string>(
+    preselectedConnectionId ?? '',
+  );
+  // Set once a shop batch submits, to swap the body for the publish tracker.
+  const [shopBatchId, setShopBatchId] = useState<string | null>(null);
+
+  // Capability-driven destination kind - never a platformType literal (#1829).
+  // Resolves from the committed config once known, else the live selection.
+  const activeConnectionId = config?.connectionId ?? liveConnectionId;
+  const activeConnection = useMemo(
+    () => (connectionsQuery.data ?? []).find((c) => c.id === activeConnectionId) ?? null,
+    [connectionsQuery.data, activeConnectionId],
+  );
+  const isShop = activeConnection ? publishDestinationKind(activeConnection) === 'shop' : false;
+  const wizardSteps = isShop ? SHOP_WIZARD_STEPS : WIZARD_STEPS;
 
   // Sync row state when the products list changes (dedup by product id so a
   // product surfaced twice yields one row / one fan-out, mirroring the BE seen
@@ -167,7 +201,8 @@ export function BulkWizard({
   // blockers whenever a category's schema resolves. Gated to Review so only
   // rows with resolved master data recompute.
   useEffect(() => {
-    if (!config || step !== 'review') return;
+    // Marketplace-only: shops carry no category/param blockers (#1829).
+    if (!config || step !== 'review' || isShop) return;
     setRows((prev) => {
       let changed = false;
       const next = prev.map((row) => {
@@ -196,10 +231,21 @@ export function BulkWizard({
     });
   }, [config, step, requiredByCategory, platformValidate, destinationResolvesCategoryAtSubmit]);
 
-  const handleConfigProceed = useCallback((next: BulkWizardConfig) => {
-    setConfig(next);
-    setStep('resolve');
-  }, []);
+  const handleConfigProceed = useCallback(
+    (next: BulkWizardConfig) => {
+      setConfig(next);
+      // Shops skip Resolve (no category/EAN matching) and go straight to
+      // Review; marketplaces resolve categories first (#1829). Derived from
+      // the committed connection so a switch in Config is honoured.
+      const nextConnection = (connectionsQuery.data ?? []).find(
+        (c) => c.id === next.connectionId,
+      );
+      const nextIsShop =
+        nextConnection !== undefined && publishDestinationKind(nextConnection) === 'shop';
+      setStep(nextIsShop ? 'review' : 'resolve');
+    },
+    [connectionsQuery.data],
+  );
 
   const handleResolveComplete = useCallback((outcomes: BulkResolveOutcome[]) => {
     setRows((prev) => mergeResolveOutcomes(prev, outcomes));
@@ -390,21 +436,53 @@ export function BulkWizard({
     [config, rows, mutation, navigate, showToast, canGenerateDescription],
   );
 
+  // Shop branch submit (#1829): POST /listings/bulk-shop-publish, one item per
+  // included variant. On success the body swaps to the publish tracker.
+  const handleShopPublish = useCallback(
+    async (items: BulkShopPublishItemRequest[], status: ShopPublishVisibility) => {
+      if (!config || items.length === 0) return;
+      try {
+        const result = await shopMutation.mutateAsync({
+          request: { connectionId: config.connectionId, items, status },
+        });
+        showToast({
+          tone: 'success',
+          title: 'Bulk publish started',
+          description: `${items.length.toLocaleString()} product ${items.length === 1 ? 'listing' : 'listings'} queued.`,
+        });
+        setShopBatchId(result.batchId);
+      } catch {
+        // Surfaced via shopMutation.error in the review step.
+      }
+    },
+    [config, shopMutation, showToast],
+  );
+
   const counts = useMemo(() => countBatch(rows), [rows]);
   const marketplaceName = batchPlatform?.displayName ?? 'marketplace';
+
+  const currentStepIndex = Math.max(
+    0,
+    wizardSteps.findIndex((s) => s.id === step),
+  );
+  const stepperCurrent = shopBatchId !== null ? wizardSteps.length : currentStepIndex;
 
   return (
     <PageLayout
       eyebrow="Operations · Listings"
-      title="Bulk marketplace offer creation"
-      description={`Creating offers for ${rows.length} ${rows.length === 1 ? 'product' : 'products'} · ${counts.totalVariants} variants.`}
+      title={isShop ? 'Bulk shop product publishing' : 'Bulk marketplace offer creation'}
+      description={
+        isShop
+          ? `Publishing ${rows.length} ${rows.length === 1 ? 'product' : 'products'} · ${counts.totalVariants} variants to a shop.`
+          : `Creating offers for ${rows.length} ${rows.length === 1 ? 'product' : 'products'} · ${counts.totalVariants} variants.`
+      }
     >
       <div className="bulk-wizard">
         <div className="bulk-wizard__stepper">
           <SetupStepper
-            steps={WIZARD_STEPS.map((s) => s.label)}
-            currentStep={stepOrder(step)}
-            completedSteps={new Set(Array.from({ length: stepOrder(step) }, (_, i) => i))}
+            steps={wizardSteps.map((s) => s.label)}
+            currentStep={stepperCurrent}
+            completedSteps={new Set(Array.from({ length: stepperCurrent }, (_, i) => i))}
           />
         </div>
 
@@ -415,51 +493,77 @@ export function BulkWizard({
           </Alert>
         ) : null}
 
-        <div className={step === 'resolve' ? '' : 'bulk-wizard__body'}>
-          {step === 'config' && (
-            <BulkConfigStep
-              initial={config ?? {}}
-              preselectedConnectionId={preselectedConnectionId}
-              onProceed={handleConfigProceed}
-              onCancel={() => { void navigate(-1); }}
-            />
-          )}
-          {step === 'resolve' && config && (
-            <BulkResolveStep
-              rows={rows}
-              connectionId={config.connectionId}
-              pricingPolicy={config.pricingPolicy}
-              stockPolicy={config.stockPolicy}
-              currency={config.currency}
-              platformValidate={platformValidate}
-              destinationResolvesCategoryAtSubmit={destinationResolvesCategoryAtSubmit}
-              onComplete={handleResolveComplete}
-            />
-          )}
-          {step === 'review' && config && (
-            <BulkReviewStep
-              rows={rows}
-              connection={batchConnection}
-              config={config}
-              paramsResolving={paramsResolving}
-              platformBlockerChips={platformBlockerChips}
-              canBrowseCategories={destinationBrowsesCategories}
-              batchDeliveryPriceList={
-                typeof config.platformParams.deliveryPriceList === 'string'
-                  ? config.platformParams.deliveryPriceList
-                  : ''
-              }
-              demoReadOnly={write.demoReadOnly}
-              onSetVariantIncluded={setVariantIncluded}
-              onSetProductIncluded={setProductIncluded}
-              onSaveEditor={handleSaveEditor}
-              onApproveAll={() => { setConfirmOpen(true); }}
-              onBack={() => { setStep('config'); }}
-            />
-          )}
-        </div>
+        {shopBatchId !== null && config ? (
+          <div className="bulk-wizard__body">
+            <ShopPublishTracker connectionId={config.connectionId} batchId={shopBatchId} />
+            <div className="bulk-wizard__footer">
+              <div className="bulk-wizard__footer-spacer" />
+              <Button tone="primary" onClick={() => { void navigate('/listings'); }}>
+                Done
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <div className={step === 'resolve' ? '' : 'bulk-wizard__body'}>
+            {step === 'config' && (
+              <BulkConfigStep
+                initial={config ?? {}}
+                preselectedConnectionId={preselectedConnectionId}
+                onConnectionChange={setLiveConnectionId}
+                onProceed={handleConfigProceed}
+                onCancel={() => { void navigate(-1); }}
+              />
+            )}
+            {step === 'resolve' && config && !isShop && (
+              <BulkResolveStep
+                rows={rows}
+                connectionId={config.connectionId}
+                pricingPolicy={config.pricingPolicy}
+                stockPolicy={config.stockPolicy}
+                currency={config.currency}
+                platformValidate={platformValidate}
+                destinationResolvesCategoryAtSubmit={destinationResolvesCategoryAtSubmit}
+                onComplete={handleResolveComplete}
+              />
+            )}
+            {step === 'review' && config && isShop && (
+              <BulkShopReviewStep
+                rows={rows}
+                connection={activeConnection}
+                config={config}
+                demoReadOnly={write.demoReadOnly}
+                isSubmitting={shopMutation.isPending}
+                errorMessage={shopMutation.error ? shopMutation.error.message : null}
+                onSetVariantIncluded={setVariantIncluded}
+                onBack={() => { setStep('config'); }}
+                onPublish={(items, status) => { void handleShopPublish(items, status); }}
+              />
+            )}
+            {step === 'review' && config && !isShop && (
+              <BulkReviewStep
+                rows={rows}
+                connection={batchConnection}
+                config={config}
+                paramsResolving={paramsResolving}
+                platformBlockerChips={platformBlockerChips}
+                canBrowseCategories={destinationBrowsesCategories}
+                batchDeliveryPriceList={
+                  typeof config.platformParams.deliveryPriceList === 'string'
+                    ? config.platformParams.deliveryPriceList
+                    : ''
+                }
+                demoReadOnly={write.demoReadOnly}
+                onSetVariantIncluded={setVariantIncluded}
+                onSetProductIncluded={setProductIncluded}
+                onSaveEditor={handleSaveEditor}
+                onApproveAll={() => { setConfirmOpen(true); }}
+                onBack={() => { setStep('config'); }}
+              />
+            )}
+          </div>
+        )}
 
-        {config ? (
+        {config && !isShop ? (
           <BulkConfirmModal
             open={confirmOpen}
             onOpenChange={setConfirmOpen}
@@ -481,10 +585,6 @@ export function BulkWizard({
       </div>
     </PageLayout>
   );
-}
-
-function stepOrder(step: BulkWizardStep): number {
-  return WIZARD_STEPS.findIndex((s) => s.id === step);
 }
 
 /** Order-sensitive blocker-list equality. */

--- a/apps/web/src/features/listings/components/bulk/bulk-wizard.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-wizard.tsx
@@ -229,7 +229,7 @@ export function BulkWizard({
       });
       return changed ? next : prev;
     });
-  }, [config, step, requiredByCategory, platformValidate, destinationResolvesCategoryAtSubmit]);
+  }, [config, step, isShop, requiredByCategory, platformValidate, destinationResolvesCategoryAtSubmit]);
 
   const handleConfigProceed = useCallback(
     (next: BulkWizardConfig) => {

--- a/apps/web/src/features/listings/components/offer-product-picker-modal.test.tsx
+++ b/apps/web/src/features/listings/components/offer-product-picker-modal.test.tsx
@@ -456,34 +456,32 @@ describe('OfferProductPickerModal', () => {
     } as unknown as Connection;
   }
 
-  it('groups marketplaces and shops, and hands a shop pick to onPublishToShop', async () => {
-    const onPublishToShop = vi.fn();
-    renderWithProviders(
-      <OfferProductPickerModal isOpen onClose={vi.fn()} onPublishToShop={onPublishToShop} />,
-      { apiClient: mocks([conn('conn_a', 'Allegro', 'allegro'), shopConn('conn_w', 'My Shop')]) },
-    );
+  it('groups marketplaces and shops, and routes a shop pick to the bulk wizard (#1829)', async () => {
+    renderWithProviders(<OfferProductPickerModal isOpen onClose={vi.fn()} />, {
+      apiClient: mocks([conn('conn_a', 'Allegro', 'allegro'), shopConn('conn_w', 'My Shop')]),
+    });
     fireEvent.click(await screen.findByLabelText('Select Product p1'));
     // Both groups render with capability-driven hints.
     expect(screen.getByText('Marketplaces')).toBeInTheDocument();
     expect(screen.getByText('Online shops')).toBeInTheDocument();
 
-    // Choosing the shop routes through onPublishToShop, not the wizard URL.
+    // Choosing the shop navigates to the SAME bulk wizard route as a
+    // marketplace - the wizard branches by capability (#1829).
     fireEvent.click(screen.getByRole('radio', { name: /My Shop/ }));
     fireEvent.click(screen.getByRole('button', { name: /continue/i }));
-    expect(onPublishToShop).toHaveBeenCalledWith(
-      expect.objectContaining({ connectionId: 'conn_w', productIds: ['p1'] }),
-    );
-    expect(navigateMock).not.toHaveBeenCalled();
+    const qs = continueUrlParams();
+    expect(qs.get('productIds')).toBe('p1');
+    expect(qs.get('connectionId')).toBe('conn_w');
   });
 
-  it('omits shop destinations when no onPublishToShop handler is provided', async () => {
+  it('always surfaces shop destinations alongside marketplaces (#1829)', async () => {
     renderWithProviders(<OfferProductPickerModal isOpen onClose={vi.fn()} />, {
       apiClient: mocks([conn('conn_a', 'Allegro', 'allegro'), shopConn('conn_w', 'My Shop')]),
     });
     await screen.findByText('Product p1');
     expect(screen.getByRole('radio', { name: /Allegro/ })).toBeInTheDocument();
-    expect(screen.queryByRole('radio', { name: /My Shop/ })).not.toBeInTheDocument();
-    expect(screen.queryByText('Online shops')).not.toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /My Shop/ })).toBeInTheDocument();
+    expect(screen.getByText('Online shops')).toBeInTheDocument();
   });
 
   it('navigates between the product list and review steps (two-step wizard)', async () => {

--- a/apps/web/src/features/listings/components/offer-product-picker-modal.tsx
+++ b/apps/web/src/features/listings/components/offer-product-picker-modal.tsx
@@ -31,14 +31,13 @@
  * Closing via X / Cancel / esc / outside-click is routed through a discard
  * guard: a pending selection opens a `ConfirmDialog` before the modal closes.
  *
- * Continue dispatches by destination kind. A **marketplace** destination
- * navigates into the bulk wizard route
- * (`/listings/bulk-create/wizard?productIds=...&variantIds=...&connectionId=...`);
- * products picked whole contribute no `variantIds` (the wizard then seeds all
- * their variants), products picked at variant granularity contribute their
- * explicit subset. A **shop** destination hands off to the caller's
- * `onPublishToShop` (today the retained, hidden `ShopPublishLauncher`, until
- * the wizard branch #1829 folds the shop path into the same route).
+ * Continue navigates into the bulk wizard route for BOTH destination kinds
+ * (`/listings/bulk-create/wizard?productIds=...&variantIds=...&connectionId=...`,
+ * #1829): the wizard branches on the destination's capability - a marketplace
+ * (`OfferCreator`) runs Config -> Resolve -> Review, a shop (`ProductPublisher`)
+ * runs Config -> Review. Products picked whole contribute no `variantIds` (the
+ * wizard then seeds all their variants), products picked at variant granularity
+ * contribute their explicit subset.
  *
  * @module apps/web/src/features/listings/components
  */
@@ -84,24 +83,9 @@ type SelectionEntry = 'ALL' | Set<string>;
 /** Two-step wizard step (meaningful only <=1023px; desktop shows both regions). */
 type PickerStep = 'products' | 'review';
 
-/** Args handed to the caller when a shop destination is chosen (#1828). */
-export interface PublishToShopHandoff {
-  connectionId: string;
-  productIds: string[];
-  /** Best-effort known variant ids (explicit subset picks + loaded whole-product variants). */
-  variantIds: string[];
-}
-
 interface OfferProductPickerModalProps {
   isOpen: boolean;
   onClose: () => void;
-  /**
-   * Invoked instead of the marketplace navigation when the chosen destination
-   * is an online shop (`ProductPublisher`). The listings page routes this to
-   * the retained `ShopPublishLauncher` (#1828). When omitted, shop
-   * destinations are not surfaced.
-   */
-  onPublishToShop?: (handoff: PublishToShopHandoff) => void;
 }
 
 function variantLabel(product: Product, variant: ProductVariant): string {
@@ -325,7 +309,6 @@ interface RailGroup {
 export function OfferProductPickerModal({
   isOpen,
   onClose,
-  onPublishToShop,
 }: OfferProductPickerModalProps): ReactElement | null {
   const navigate = useNavigate();
 
@@ -367,11 +350,12 @@ export function OfferProductPickerModal({
   }, [isOpen]);
 
   const connectionsQuery = useConnectionsQuery();
-  const eligibleDestinations = useMemo(() => {
-    const all = selectPublishDestinations(connectionsQuery.data ?? []);
-    // Shop destinations are only offered when the caller can dispatch them.
-    return onPublishToShop ? all : all.filter((d) => d.kind === 'marketplace');
-  }, [connectionsQuery.data, onPublishToShop]);
+  // Both destination kinds are eligible - Continue routes each into the bulk
+  // wizard, which branches by capability (#1829).
+  const eligibleDestinations = useMemo(
+    () => selectPublishDestinations(connectionsQuery.data ?? []),
+    [connectionsQuery.data],
+  );
 
   // Auto-resolve when exactly one eligible destination exists; otherwise the
   // operator picks one from the grouped rail (or gets a warning when none exist).
@@ -577,34 +561,22 @@ export function OfferProductPickerModal({
   const handleContinue = useCallback(() => {
     if (selection.size === 0 || resolvedConnectionId === null) return;
     const productIds: string[] = [];
+    // Explicit variant-subset picks contribute their ids; whole-product picks
+    // contribute none, so the wizard seeds all their variants (#1829 - same
+    // semantics for marketplace and shop destinations).
     const variantIds: string[] = [];
-    // Best-effort variant ids for the shop handoff: whole-product picks
-    // contribute their loaded variant ids when known (the marketplace route
-    // instead lets the bulk wizard hydrate them from productIds).
-    const shopVariantIds: string[] = [];
     for (const [productId, entry] of selection) {
       productIds.push(productId);
       if (entry instanceof Set) {
-        for (const variantId of entry) {
-          variantIds.push(variantId);
-          shopVariantIds.push(variantId);
-        }
-      } else {
-        for (const v of variantMeta.get(productId) ?? []) shopVariantIds.push(v.id);
+        for (const variantId of entry) variantIds.push(variantId);
       }
-    }
-
-    if (resolvedKind === 'shop' && onPublishToShop) {
-      onPublishToShop({ connectionId: resolvedConnectionId, productIds, variantIds: shopVariantIds });
-      onClose();
-      return;
     }
 
     const params = new URLSearchParams({ productIds: productIds.join(',') });
     if (variantIds.length > 0) params.set('variantIds', variantIds.join(','));
     params.set('connectionId', resolvedConnectionId);
     void navigate(`/listings/bulk-create/wizard?${params.toString()}`);
-  }, [selection, resolvedConnectionId, resolvedKind, onPublishToShop, onClose, variantMeta, navigate]);
+  }, [selection, resolvedConnectionId, navigate]);
 
   // Discard guard: a pending selection intercepts every close path (X, Cancel,
   // esc, outside-click) with a confirm; an empty selection closes directly.

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -9698,6 +9698,61 @@ input.bulk-dispatch__num--wide {
   flex: 1;
 }
 
+/* ── Bulk shop-publish review step (#1829) ──────────────────────────── */
+.bulk-shop-review {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.bulk-shop-review__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+}
+
+.bulk-shop-review__row {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.bulk-shop-review__row:last-child {
+  border-bottom: none;
+}
+
+.bulk-shop-review__row-main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.bulk-shop-review__row-main small {
+  color: var(--text-muted);
+}
+
+.bulk-shop-review__remove {
+  border: none;
+  background: none;
+  cursor: pointer;
+  color: var(--text-muted);
+  font-size: 18px;
+  line-height: 1;
+  padding: 0 var(--space-1);
+}
+
+.bulk-shop-review__remove:hover {
+  color: var(--text-primary);
+}
+
 /* Edit modal — AI button row */
 .bulk-edit__desc-row {
   display: flex;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -9739,6 +9739,21 @@ input.bulk-dispatch__num--wide {
   color: var(--text-muted);
 }
 
+.bulk-shop-review__cell {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-end;
+  min-width: 72px;
+  font-size: 13px;
+}
+
+.bulk-shop-review__cell-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: var(--tracking-wide);
+  color: var(--text-muted);
+}
+
 .bulk-shop-review__remove {
   border: none;
   background: none;

--- a/apps/web/src/pages/listings/listings-list-page.tsx
+++ b/apps/web/src/pages/listings/listings-list-page.tsx
@@ -11,7 +11,6 @@ import { TimeDisplay } from '../../shared/ui/time-display';
 import { useDebouncedValue } from '../../shared/hooks/use-debounced-value';
 import { useListingsQuery } from '../../features/listings/hooks/use-listings-query';
 import { OfferProductPickerModal } from '../../features/listings/components/offer-product-picker-modal';
-import { ShopPublishLauncher } from '../../features/listings/components/ShopPublishLauncher';
 import { useWriteAccess } from '../../shared/auth/use-permission';
 import { useDemoMode } from '../../features/system';
 import type {
@@ -146,14 +145,6 @@ export function ListingsListPage(): ReactElement {
   const write = useWriteAccess('listings:write', demoMode);
 
   const [isWizardOpen, setIsWizardOpen] = useState(false);
-  // Shop destinations chosen in the unified picker hand off to the retained
-  // ShopPublishLauncher (kept wired but hidden — no standalone CTA — until the
-  // wizard branch #1829 folds the shop path into the bulk-create route).
-  const [isShopPublishOpen, setIsShopPublishOpen] = useState(false);
-  const [shopHandoff, setShopHandoff] = useState<{
-    connectionId: string;
-    variantIds: string[];
-  } | null>(null);
 
   return (
     <PageLayout
@@ -274,20 +265,6 @@ export function ListingsListPage(): ReactElement {
       <OfferProductPickerModal
         isOpen={isWizardOpen}
         onClose={() => setIsWizardOpen(false)}
-        onPublishToShop={(handoff) => {
-          setShopHandoff({ connectionId: handoff.connectionId, variantIds: handoff.variantIds });
-          setIsShopPublishOpen(true);
-        }}
-      />
-
-      <ShopPublishLauncher
-        open={isShopPublishOpen}
-        onOpenChange={(open) => {
-          setIsShopPublishOpen(open);
-          if (!open) setShopHandoff(null);
-        }}
-        preselectedConnectionId={shopHandoff?.connectionId}
-        defaultVariantIds={shopHandoff?.variantIds}
       />
     </PageLayout>
   );

--- a/apps/web/src/pages/products/products-list-page.tsx
+++ b/apps/web/src/pages/products/products-list-page.tsx
@@ -56,7 +56,6 @@ import {
 import { useConnectionsQuery } from '../../features/connections';
 import type { Connection } from '../../features/connections';
 import { selectPublishDestinations } from '../../features/listings';
-import { ShopPublishLauncher } from '../../features/listings/components/ShopPublishLauncher';
 import {
   deriveStockStatus,
   STOCK_STATUS_BADGE_TONE,
@@ -208,14 +207,6 @@ export function ProductsListPage(): ReactElement {
   // Set when the per-row "+ Create offers" CTA opened the picker for a single
   // product (instead of the bulk selection).
   const [pendingProductId, setPendingProductId] = useState<string | null>(null);
-  // Shop destinations chosen from the publish CTAs hand off to the retained
-  // ShopPublishLauncher (kept wired but hidden — no standalone CTA — until the
-  // wizard branch #1829 folds the shop path into the bulk-create route).
-  // TODO(#1829/#1830): thread the product + variant context into the shop
-  // wizard so the per-row CTA prefills like the marketplace route does; today
-  // the launcher opens its own product picker for the chosen shop connection.
-  const [isShopPublishOpen, setIsShopPublishOpen] = useState(false);
-  const [shopHandoffConnectionId, setShopHandoffConnectionId] = useState<string | null>(null);
 
   // Capability-gated create-offers action (#1096): select target connections by
   // the `OfferManager` capability — never a literal platformType. Display names
@@ -488,17 +479,14 @@ export function ProductsListPage(): ReactElement {
     [navigate],
   );
 
-  // Dispatch a resolved destination by kind (#1828): a marketplace goes to the
-  // bulk-create wizard; a shop hands off to the retained ShopPublishLauncher.
+  // Dispatch a resolved destination to the bulk wizard (#1829): both a
+  // marketplace and a shop route into the same bulk-create wizard, which
+  // branches its steps + submit by the destination's capability. Product
+  // context is preserved end-to-end (no re-pick).
   const dispatchPublish = useCallback(
     (productIds: readonly string[], connectionId: string) => {
       const destination = publishDestinations.find((d) => d.connection.id === connectionId);
       if (!destination) return;
-      if (destination.kind === 'shop') {
-        setShopHandoffConnectionId(connectionId);
-        setIsShopPublishOpen(true);
-        return;
-      }
       goToWizard(productIds, connectionId);
     },
     [publishDestinations, goToWizard],
@@ -1252,15 +1240,6 @@ export function ProductsListPage(): ReactElement {
               setPendingProductId(null);
               dispatchPublish(ids, connectionId);
             }}
-          />
-
-          <ShopPublishLauncher
-            open={isShopPublishOpen}
-            onOpenChange={(open) => {
-              setIsShopPublishOpen(open);
-              if (!open) setShopHandoffConnectionId(null);
-            }}
-            preselectedConnectionId={shopHandoffConnectionId ?? undefined}
           />
         </>
       )}

--- a/docs/frontend-architecture.md
+++ b/docs/frontend-architecture.md
@@ -425,16 +425,33 @@ to {name}"** CTA share the same flow.
   WAI-ARIA radiogroup keyboard contract - a single tab stop via roving
   `tabindex` plus Arrow / Home / End to move-and-select (mirroring the
   `SegmentedControl` primitive) - so the markup and its a11y live in one place.
-- **Continue dispatches by kind.** A marketplace navigates to the bulk-create
-  wizard route (`/listings/bulk-create/wizard?productIds=…&variantIds=…&connectionId=…`,
-  destination-agnostic). A shop hands off to the retained `ShopPublishLauncher`
-  (its `preselectedConnectionId` prop skips the launcher's own picker). The
-  launcher is kept wired but has no standalone CTA.
-- **Deferred to #1829 / #1830.** Folding the shop path into the bulk-create
-  wizard route (so shop and marketplace share one wizard + dispatch) is #1829;
-  shop edit mode is #1830. Until #1829 lands, `ShopPublishLauncher` is the shop
-  wizard, and the marketplace `BulkConfigStep` blocks Proceed for any connection
-  without a per-platform config section (e.g. a shop reached by direct URL).
+- **Continue dispatches to one route for both kinds (#1829).** Marketplace AND
+  shop both navigate to the bulk-create wizard route
+  (`/listings/bulk-create/wizard?productIds=…&variantIds=…&connectionId=…`,
+  destination-agnostic). Product + variant context is carried through the URL
+  identically - a whole-product pick contributes no `variantIds` (the wizard
+  seeds all variants), a variant-subset pick contributes its explicit ids.
+
+**Capability-branched bulk wizard (#1829).** `BulkWizard`
+(`features/listings/components/bulk/bulk-wizard.tsx`) resolves the destination's
+kind from the selected connection via `publishDestinationKind` (capability, never
+`platformType`) and branches its step model + submit:
+
+| Destination | Capability | Steps | Config section | Submit |
+|---|---|---|---|---|
+| Marketplace | `OfferCreator` | Config → Resolve → Review → Confirm | per-platform `bulkOfferConfigSection` (Allegro/Erli) | `useBulkSubmitMutation` → `POST /listings/bulk-create` |
+| Online shop | `ProductPublisher` | Config → Review | shared visibility + pricing/stock policy (no category/EAN resolve) | `useBulkShopPublishMutation` → `POST /listings/bulk-shop-publish` |
+
+  `BulkConfigStep` reports the live-selected connection up via `onConnectionChange`
+  so the stepper branches before Proceed; it skips the per-platform section (and
+  its Proceed gate) for shops. `BulkShopReviewStep` reviews the included variants,
+  computes each one's stock (master availability + the batch stock policy) and
+  price (variant master price + the batch pricing policy), and submits one item
+  per included variant; on success it swaps to `ShopPublishTracker`.
+- **`ShopPublishLauncher` disposition.** The launcher is no longer wired to any
+  publish CTA - the unified picker + wizard cover the create path end-to-end. It
+  and the WooCommerce single-publish wizard are retained (unreferenced by the
+  pages) for the shop **edit** mode still owned by #1830.
 
 ### UI Library Policy
 


### PR DESCRIPTION
## What & why

S2 of epic #1838. The bulk publish wizard was hardcoded to the marketplace flow (always Config -> Resolve -> Review, always `POST /listings/bulk-create`). Shops have no marketplace category/EAN resolution and a different submit endpoint. This makes the wizard adapt to the chosen destination's **capability**.

- **`BulkWizard`** resolves the destination kind via `publishDestinationKind` (capability, never `platformType`) and branches:
  - `ProductPublisher` (shop): **Config -> Review** (Resolve skipped), submit via `useBulkShopPublishMutation` (`POST /listings/bulk-shop-publish`).
  - `OfferCreator` (marketplace): **Config -> Resolve -> Review** unchanged, submit via `useBulkSubmitMutation` (`POST /listings/bulk-create`).
- **`BulkConfigStep`** branches: shops skip the per-platform section and its Proceed gate (shared visibility + pricing/stock policy still apply); it reports the live-selected connection up via a new `onConnectionChange` so the stepper branches before Proceed.
- **New `BulkShopReviewStep`** reviews the included variants, computes each one's stock (master availability + batch stock policy) and price (variant master price + batch pricing policy), submits one item per included variant, and swaps to `ShopPublishTracker` on success. Per-item editing is deferred to #1831 (as the issue notes the current endpoint is sufficient).

### S1-review follow-up folded in (shop context carryover)
The unified picker and both Products-page publish CTAs now navigate a shop destination to the **same** bulk-create route as a marketplace, carrying product + all-variants context through the URL (whole-product picks seed all variants) - no more re-pick. Removed the `ShopPublishLauncher` double-selection detour from `listings-list-page` and `products-list-page`.

### ShopPublishLauncher disposition
`ShopPublishLauncher` + the WooCommerce single-publish wizard are **retained but unwired** from any publish CTA. Fully retiring them would strip the single-publish + tracker machinery that the shop **edit** experience (#1830) builds on, so they are kept for that sibling issue. Noted here per the task's escape hatch.

## How to test
1. Products or Listings page -> "Publish products".
2. Pick a **shop** (`ProductPublisher`) destination + some products/variants -> Continue. Wizard runs **Config -> Review**, Review lists the included variants with computed price, Publish submits to `bulk-shop-publish` and shows the tracker.
3. Pick a **marketplace** destination -> Continue. Wizard runs **Config -> Resolve -> Review -> Confirm** exactly as before.
4. `pnpm --filter @openlinker/web test` (touched suites: bulk wizard/config/shop-review, picker, list pages) - all green; `pnpm --filter @openlinker/web type-check` clean.

## Docs
- `docs/frontend-architecture.md` -> Unified publish flow section: documented the capability-branched wizard step model + submit dispatch table, the single-route dispatch for both kinds, and the `ShopPublishLauncher` disposition.
- Central backend docs: None - both submit services already exist; no backend change.

Closes #1829