### PR TITLE
feat(listings): shop mode in the two-pane bulk edit modal (#1830)

### DIFF
--- a/apps/web/src/features/listings/api/bulk-listings.types.ts
+++ b/apps/web/src/features/listings/api/bulk-listings.types.ts
@@ -56,6 +56,14 @@ export interface BulkOfferOverrides {
   /** Operator-picked neutral category parameters (#1071). */
   parameters?: OfferParameter[];
   platformParams?: Record<string, unknown>;
+  /**
+   * Per-product destination *shop* category ids (#1830). FE-only carrier used by
+   * the shop edit modal; the shop review threads it onto the bulk shop-publish
+   * transport's per-item `destinationCategoryIds` (present, including empty ⇒
+   * skips server-side provisioning). Distinct from the marketplace `categoryId`;
+   * the marketplace offer path ignores it.
+   */
+  destinationCategoryIds?: string[];
 }
 
 export interface BulkSharedConfig {

--- a/apps/web/src/features/listings/api/listings.types.ts
+++ b/apps/web/src/features/listings/api/listings.types.ts
@@ -364,6 +364,23 @@ export interface BulkShopPublishItemRequest {
   internalVariantId: string;
   stock: number;
   price?: ShopPublishPrice;
+  /**
+   * Per-item content override (#1830); wins over the batch-shared `content`.
+   * Omitted ⇒ batch-shared content (or the master product) applies.
+   */
+  content?: ShopPublishContent;
+  /**
+   * Per-item destination category ids (#1830). Present (including an empty
+   * array ⇒ uncategorised) skips server-side category provisioning; omitted ⇒
+   * the builder provisions as before.
+   */
+  destinationCategoryIds?: string[];
+  /**
+   * Per-item neutral category parameters / attributes (#1830). Present
+   * (including empty) skips server-side attribute projection; omitted ⇒ the
+   * builder projects as before.
+   */
+  parameters?: OfferParameter[];
 }
 
 export interface BulkShopPublishRequest {

--- a/apps/web/src/features/listings/components/bulk/bulk-edit-modal.shop.test.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-edit-modal.shop.test.tsx
@@ -1,0 +1,269 @@
+/**
+ * BulkEditModal shop-mode tests (#1830)
+ *
+ * The shared two-pane editor rendered for a `ProductPublisher` (shop) destination:
+ * the shop field set (title / description / price / stock / attributes /
+ * visibility, category in the crumb bar), flat-vs-two-pane by variant shape, the
+ * shop save payload (content / destinationCategoryIds / parameters on the base
+ * override), per-variant description/price overrides, and the same-global-id
+ * attribute de-duplication (`mergeShopParameter`).
+ *
+ * The shop category/attribute query hooks and the AI suggestion dialog are
+ * stubbed so the test isolates the editor's own logic.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, screen } from '@testing-library/react';
+import { renderWithProviders } from '../../../../test/test-utils';
+import { BulkEditModal, mergeShopParameter } from './bulk-edit-modal';
+import type { BulkVariantRow, BulkWizardRow } from './bulk-wizard.types';
+import type { OfferParameter } from '../../api/listings.types';
+import type { BulkPerProductOverride } from '../../api/bulk-listings.types';
+import type { Connection } from '../../../connections';
+import type { Product, ProductVariant } from '../../../products';
+
+vi.mock('../../../content', () => ({ SuggestionDialog: () => null }));
+vi.mock('../../hooks/use-shop-attributes-query', () => ({
+  useShopAttributesQuery: () => ({
+    data: [{ id: 'pa_color', name: 'Color', slug: 'color' }],
+    isLoading: false,
+    error: null,
+  }),
+}));
+vi.mock('../../hooks/use-shop-attribute-terms-query', () => ({
+  useShopAttributeTermsQuery: () => ({
+    data: [
+      { id: 't1', name: 'Red', slug: 'red' },
+      { id: 't2', name: 'Blue', slug: 'blue' },
+    ],
+    isLoading: false,
+    error: null,
+  }),
+}));
+
+const shopConnection: Connection = {
+  id: 'conn_shop',
+  name: 'My Shop',
+  platformType: 'woocommerce',
+  status: 'active',
+  config: {},
+  credentialsBacked: true,
+  enabledCapabilities: ['ProductPublisher'],
+  supportedCapabilities: ['ProductPublisher', 'ShopCategoryBrowser', 'ShopAttributeReader'],
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+function makeVariant(id: string, attributes?: Record<string, string>): ProductVariant {
+  return {
+    id,
+    productId: 'prod_1',
+    sku: `SKU-${id}`,
+    attributes: attributes ?? null,
+    ean: null,
+    gtin: null,
+    price: 12,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+function makeVariantRow(variant: ProductVariant): BulkVariantRow {
+  return {
+    variantId: variant.id,
+    variant,
+    ean: null,
+    distinguishingAttributes: variant.attributes,
+    masterStock: 5,
+    masterPrice: 12,
+    masterCurrency: 'PLN',
+    included: true,
+    blockers: [],
+    resolvedCategoryId: null,
+    resolvedProductCardId: null,
+    resolutionMethod: null,
+    categoryCandidates: [],
+    override: {},
+  };
+}
+
+function makeRow(variants: ProductVariant[]): BulkWizardRow {
+  const product: Product = {
+    id: 'prod_1',
+    name: 'Widget',
+    sku: 'SKU',
+    price: 12,
+    currency: 'PLN',
+    description: 'Master description',
+    images: [],
+    variants,
+  } as unknown as Product;
+  return {
+    productId: 'prod_1',
+    product,
+    primaryVariant: variants[0],
+    variants: variants.map(makeVariantRow),
+    blockers: [],
+    resolvedCategoryId: null,
+    resolvedProductCardId: null,
+    resolutionMethod: null,
+    masterPrice: 12,
+    masterStock: 5,
+    masterCurrency: 'PLN',
+    categoryCandidates: [],
+    override: {},
+  };
+}
+
+function renderShopEditor(
+  row: BulkWizardRow,
+  onSave: (
+    productId: string,
+    baseOverride: BulkPerProductOverride,
+    perVariantOverrides: Record<string, BulkPerProductOverride>,
+    included: Record<string, boolean>,
+    editFormValues: Record<string, unknown>,
+  ) => void,
+): void {
+  renderWithProviders(
+    <BulkEditModal
+      open
+      onOpenChange={() => undefined}
+      row={row}
+      connection={shopConnection}
+      destinationKind="shop"
+      canBrowseCategories={false}
+      canBrowseShopCategories
+      canPickShopAttributes
+      currency="PLN"
+      defaults={{ publishImmediately: true }}
+      onSave={onSave}
+    />,
+  );
+}
+
+describe('mergeShopParameter', () => {
+  it('appends a distinct-id parameter', () => {
+    const existing: OfferParameter[] = [{ id: 'pa_color', values: ['Red'], section: 'product' }];
+    const next = mergeShopParameter(existing, { id: 'pa_size', values: ['M'], section: 'product' });
+    expect(next).toHaveLength(2);
+  });
+
+  it('unions term values + ids when the same global-attribute id repeats', () => {
+    const existing: OfferParameter[] = [
+      { id: 'pa_color', values: ['Red'], valuesIds: ['t1'], section: 'product' },
+    ];
+    const merged = mergeShopParameter(existing, {
+      id: 'pa_color',
+      values: ['Blue'],
+      valuesIds: ['t2'],
+      section: 'product',
+    });
+    expect(merged).toHaveLength(1);
+    expect(merged[0]).toEqual({
+      id: 'pa_color',
+      values: ['Red', 'Blue'],
+      valuesIds: ['t1', 't2'],
+      section: 'product',
+    });
+  });
+
+  it('does not duplicate an already-present term id', () => {
+    const existing: OfferParameter[] = [
+      { id: 'pa_color', values: ['Red'], valuesIds: ['t1'], section: 'product' },
+    ];
+    const merged = mergeShopParameter(existing, {
+      id: 'pa_color',
+      values: ['Red'],
+      valuesIds: ['t1'],
+      section: 'product',
+    });
+    expect(merged[0].valuesIds).toEqual(['t1']);
+  });
+
+  it('unions custom (no-id) attribute values', () => {
+    const existing: OfferParameter[] = [{ id: 'Material', values: ['Cotton'], section: 'product' }];
+    const merged = mergeShopParameter(existing, {
+      id: 'Material',
+      values: ['Wool'],
+      section: 'product',
+    });
+    expect(merged[0].values).toEqual(['Cotton', 'Wool']);
+  });
+});
+
+describe('BulkEditModal (shop mode)', () => {
+  it('renders a flat shop editor (no rail) for a simple product with shop-only sections', () => {
+    renderShopEditor(makeRow([makeVariant('v1')]), vi.fn());
+
+    expect(screen.getByRole('heading', { name: 'Product fields' })).toBeInTheDocument();
+    expect(screen.getByLabelText('Title')).toBeInTheDocument();
+    expect(screen.getByLabelText('Stock')).toBeInTheDocument();
+    // Category lives in the crumb bar, not a mid-form field.
+    expect(screen.getByRole('button', { name: 'Change category' })).toBeInTheDocument();
+    // No variant rail for a simple product, and no marketplace EAN self-link.
+    expect(screen.queryByRole('radiogroup', { name: 'Variant scope selector' })).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('EAN (GTIN)')).not.toBeInTheDocument();
+  });
+
+  it('renders the two-pane rail for a multi-variant product', () => {
+    const row = makeRow([makeVariant('v1', { Size: 'M' }), makeVariant('v2', { Size: 'L' })]);
+    renderShopEditor(row, vi.fn());
+    expect(screen.getByRole('radiogroup', { name: 'Variant scope selector' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /Shared base/ })).toBeInTheDocument();
+  });
+
+  it('saves shop content + price + stock on the base override for a simple product', () => {
+    const onSave = vi.fn();
+    renderShopEditor(makeRow([makeVariant('v1')]), onSave);
+
+    fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'New title' } });
+    fireEvent.change(screen.getByLabelText('Price'), { target: { value: '49.90' } });
+    fireEvent.change(screen.getByLabelText('Stock'), { target: { value: '8' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save all' }));
+
+    expect(onSave).toHaveBeenCalledTimes(1);
+    const [productId, baseOverride] = onSave.mock.calls[0];
+    expect(productId).toBe('prod_1');
+    expect(baseOverride.overrides.title).toBe('New title');
+    expect(baseOverride.price).toEqual({ amount: 49.9, currency: 'PLN' });
+    expect(baseOverride.stock).toBe(8);
+  });
+
+  it('de-duplicates two adds of the same global attribute id into one parameter (#1830)', () => {
+    const onSave = vi.fn();
+    renderShopEditor(makeRow([makeVariant('v1')]), onSave);
+
+    // Pick the global attribute, then add Red and Blue as two separate adds.
+    fireEvent.change(screen.getByLabelText('Attribute'), { target: { value: 'pa_color' } });
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Red' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Add attribute' }));
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Blue' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Add attribute' }));
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save all' }));
+
+    const [, baseOverride] = onSave.mock.calls[0];
+    expect(baseOverride.overrides.parameters).toEqual([
+      { id: 'pa_color', values: ['Red', 'Blue'], valuesIds: ['t1', 't2'], section: 'product' },
+    ]);
+  });
+
+  it('emits a per-variant description override in the two-pane editor (#1830)', () => {
+    const onSave = vi.fn();
+    const row = makeRow([makeVariant('v1', { Size: 'M' }), makeVariant('v2', { Size: 'L' })]);
+    renderShopEditor(row, onSave);
+
+    // Focus the first variant scope, override its description.
+    fireEvent.click(screen.getByRole('radio', { name: /Size: M|M$/ }));
+    const descriptions = screen.getAllByLabelText(/Description for/);
+    fireEvent.change(descriptions[0], { target: { value: 'Only for M' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save all' }));
+
+    const [, , perVariantOverrides] = onSave.mock.calls[0] as [
+      string,
+      BulkPerProductOverride,
+      Record<string, BulkPerProductOverride>,
+    ];
+    expect(perVariantOverrides.v1.overrides?.description).toBe('Only for M');
+  });
+});

--- a/apps/web/src/features/listings/components/bulk/bulk-edit-modal.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-edit-modal.tsx
@@ -1,5 +1,21 @@
 /**
- * Bulk Edit Modal - per-variant two-pane editor (#1741)
+ * Bulk Edit Modal - per-variant two-pane editor (#1741 marketplace, #1830 shop)
+ *
+ * One editor serves both destination kinds. The two-pane shell (rail = Base +
+ * per-variant scopes, base->variant inherit/override, flat form for a simple
+ * product) is shared; the field set is chosen by capability, never platformType:
+ *
+ * - **marketplace** (`OfferCreator` destinations, #1741) - category-parameter
+ *   schema, EAN self-link, product-card link, Allegro grouping params, per-plugin
+ *   platform sections. Rendered by `BulkEditModalForm`.
+ * - **shop** (`ProductPublisher` destinations, #1830) - category placement in the
+ *   top crumb bar (via `ShopCategoryPickerModal`, gated on `ShopCategoryBrowser`),
+ *   structured attributes (via `ShopAttributePicker`, gated on `ShopAttributeReader`),
+ *   content (title/description/images), and price/stock. No category-parameter
+ *   schema and no EAN self-link. Rendered by `BulkShopEditModalForm`.
+ *
+ * `BulkEditModal` dispatches to the right form by `destinationKind`; the discard
+ * guard + dialog wrapper are shared.
  *
  * Edits one product's SHARED BASE override plus per-VARIANT overrides with
  * inherit/override semantics. Multi-variant products render a two-pane editor
@@ -64,6 +80,8 @@ import {
   toComboboxValue,
 } from '../category-parameters-step';
 import { BulkCategoryChooseModal } from './bulk-category-choose-modal';
+import { ShopCategoryPickerModal } from './shop-category-picker-modal';
+import { ShopAttributePicker } from './shop-attribute-picker';
 import { BulkImageLightbox } from './bulk-image-lightbox';
 import { blockerLabel, isVariantScopeFixable } from './bulk-blockers';
 import { ErliDeliveryPriceListOverrideField } from '../erli/erli-delivery-price-list-override-field';
@@ -228,6 +246,23 @@ interface BulkEditModalProps {
   /** Variant id to open focused on (from a Review-step blocker chip). */
   focusVariantId?: string;
   /**
+   * Which field set to render (#1830). `'marketplace'` (default) keeps the
+   * legacy offer editor; `'shop'` renders the `ProductPublisher` editor
+   * (category crumb + attributes + content + price/stock, no offer schema).
+   * Resolved by the caller from the connection's capability, never platformType.
+   */
+  destinationKind?: 'marketplace' | 'shop';
+  /**
+   * Shop destinations only (#1830). Whether the connection advertises the
+   * `ShopCategoryBrowser` sub-capability - gates the top category picker.
+   */
+  canBrowseShopCategories?: boolean;
+  /**
+   * Shop destinations only (#1830). Whether the connection advertises the
+   * `ShopAttributeReader` sub-capability - gates the global-attribute picker.
+   */
+  canPickShopAttributes?: boolean;
+  /**
    * Demo read-only viewer (#1704). Disables every field edit + image add/remove
    * and locks "Save all" behind a read-only tooltip, matching the Config +
    * Confirm gating - nothing persists to wizard state.
@@ -248,6 +283,9 @@ export function BulkEditModal({
   batchDeliveryPriceList,
   onSave,
   focusVariantId,
+  destinationKind = 'marketplace',
+  canBrowseShopCategories = false,
+  canPickShopAttributes = false,
   demoReadOnly = false,
 }: BulkEditModalProps): ReactElement | null {
   const [dirty, setDirty] = useState(false);
@@ -290,24 +328,45 @@ export function BulkEditModal({
             }
           }}
         >
-          <BulkEditModalForm
-            row={row}
-            connection={connection}
-            canBrowseCategories={canBrowseCategories}
-            currency={currency}
-            defaults={defaults}
-            batchPricingPolicy={pricingPolicy}
-            batchStockPolicy={stockPolicy}
-            batchDeliveryPriceList={batchDeliveryPriceList ?? ''}
-            focusVariantId={focusVariantId}
-            demoReadOnly={demoReadOnly}
-            onDirtyChange={setDirty}
-            onRequestClose={requestClose}
-            onSave={onSave}
-            onClose={() => {
-              onOpenChange(false);
-            }}
-          />
+          {destinationKind === 'shop' ? (
+            <BulkShopEditModalForm
+              row={row}
+              connection={connection}
+              canBrowseShopCategories={canBrowseShopCategories}
+              canPickShopAttributes={canPickShopAttributes}
+              currency={currency}
+              defaults={defaults}
+              batchPricingPolicy={pricingPolicy}
+              batchStockPolicy={stockPolicy}
+              focusVariantId={focusVariantId}
+              demoReadOnly={demoReadOnly}
+              onDirtyChange={setDirty}
+              onRequestClose={requestClose}
+              onSave={onSave}
+              onClose={() => {
+                onOpenChange(false);
+              }}
+            />
+          ) : (
+            <BulkEditModalForm
+              row={row}
+              connection={connection}
+              canBrowseCategories={canBrowseCategories}
+              currency={currency}
+              defaults={defaults}
+              batchPricingPolicy={pricingPolicy}
+              batchStockPolicy={stockPolicy}
+              batchDeliveryPriceList={batchDeliveryPriceList ?? ''}
+              focusVariantId={focusVariantId}
+              demoReadOnly={demoReadOnly}
+              onDirtyChange={setDirty}
+              onRequestClose={requestClose}
+              onSave={onSave}
+              onClose={() => {
+                onOpenChange(false);
+              }}
+            />
+          )}
         </DialogContent>
       </Dialog>
 
@@ -2418,4 +2477,951 @@ function applyEditsToRow(
       };
     }),
   };
+}
+
+// ── Shop editor (#1830) ──────────────────────────────────────────────────────
+
+/**
+ * Merge a shop attribute into an accumulator, de-duplicating by global-attribute
+ * id (#1830 carry-over). The `ShopAttributePicker` can emit two params with the
+ * SAME id (e.g. Color=Red then Color=Blue); WooCommerce must not receive two
+ * `attributes[]` entries for one id, so we UNION the term values (and their
+ * aligned ids) instead of appending a duplicate. Custom attributes (no
+ * `valuesIds`) union by value string. Last write wins for `section`.
+ */
+export function mergeShopParameter(
+  existing: readonly OfferParameter[],
+  incoming: OfferParameter,
+): OfferParameter[] {
+  const index = existing.findIndex((p) => p.id === incoming.id);
+  if (index === -1) return [...existing, incoming];
+  const current = existing[index];
+  let merged: OfferParameter;
+  if (current.valuesIds && incoming.valuesIds) {
+    const seen = new Set(current.valuesIds);
+    const values = [...(current.values ?? [])];
+    const valuesIds = [...current.valuesIds];
+    incoming.valuesIds.forEach((vid, i) => {
+      if (seen.has(vid)) return;
+      seen.add(vid);
+      valuesIds.push(vid);
+      values.push(incoming.values?.[i] ?? vid);
+    });
+    merged = { ...current, values, valuesIds, section: incoming.section };
+  } else {
+    const values = Array.from(new Set([...(current.values ?? []), ...(incoming.values ?? [])]));
+    merged = { ...current, values, section: incoming.section };
+  }
+  return existing.map((p, i) => (i === index ? merged : p));
+}
+
+/** Human label for one collected shop attribute (id + its chosen values). */
+function shopParameterLabel(parameter: OfferParameter): string {
+  const values = (parameter.values ?? []).join(', ');
+  return values === '' ? parameter.id : `${parameter.id}: ${values}`;
+}
+
+/** Per-variant shop overrides (#1830). Absent key ⇒ inherited from base. */
+interface ShopVariantEdit {
+  description?: string;
+  price?: string;
+}
+
+function initShopVariantEdit(variant: BulkVariantRow): ShopVariantEdit {
+  const o = variant.override.overrides ?? {};
+  return {
+    description: typeof o.description === 'string' ? o.description : undefined,
+    price: variant.override.price !== undefined ? String(variant.override.price.amount) : undefined,
+  };
+}
+
+/** Read a previously-stashed shop category breadcrumb from the FE-only edit stash. */
+function readStashedShopPath(editFormValues: Record<string, unknown> | undefined): string[] | null {
+  const shop = editFormValues?.shop;
+  if (shop && typeof shop === 'object' && 'categoryPathNames' in shop) {
+    const p = (shop as { categoryPathNames?: unknown }).categoryPathNames;
+    if (Array.isArray(p) && p.every((x): x is string => typeof x === 'string')) return p;
+  }
+  return null;
+}
+
+/** Concrete price a shop variant inherits when un-overridden (policy-resolved). */
+function shopInheritedPrice(pricingPolicy: PricingPolicy, masterPrice: number | null): string {
+  const resolved = computeResolvedPrice(pricingPolicy, masterPrice, {});
+  return resolved.value !== null ? resolved.value.toFixed(2) : '';
+}
+
+interface BulkShopEditModalFormProps {
+  row: BulkWizardRow;
+  connection: Connection;
+  canBrowseShopCategories: boolean;
+  canPickShopAttributes: boolean;
+  currency: string;
+  defaults: { publishImmediately: boolean };
+  batchPricingPolicy: PricingPolicy;
+  batchStockPolicy: StockPolicy;
+  focusVariantId?: string;
+  demoReadOnly: boolean;
+  onDirtyChange: (dirty: boolean) => void;
+  onRequestClose: () => void;
+  onSave: BulkEditModalProps['onSave'];
+  onClose: () => void;
+}
+
+function BulkShopEditModalForm({
+  row,
+  connection,
+  canBrowseShopCategories,
+  canPickShopAttributes,
+  currency,
+  defaults,
+  batchPricingPolicy,
+  batchStockPolicy,
+  focusVariantId,
+  demoReadOnly,
+  onDirtyChange,
+  onRequestClose,
+  onSave,
+  onClose,
+}: BulkShopEditModalFormProps): ReactElement {
+  const connectionId = connection.id;
+  const isMultiVariant = row.variants.length > 1;
+  const masterImages = useMemo(
+    () => (row.product?.images ?? []).filter((u): u is string => typeof u === 'string' && u.trim() !== ''),
+    [row.product?.images],
+  );
+  const baseOverrides = row.override.overrides ?? {};
+
+  const [scope, setScope] = useState<string>(
+    () => (isMultiVariant && focusVariantId ? focusVariantId : isMultiVariant ? 'base' : 'simple'),
+  );
+
+  const [title, setTitle] = useState<string>(() => baseOverrides.title ?? row.product?.name ?? '');
+  const [titleTouched, setTitleTouched] = useState(false);
+  const [description, setDescription] = useState<string>(() =>
+    typeof baseOverrides.description === 'string' ? baseOverrides.description : row.product?.description ?? '',
+  );
+  const [categoryId, setCategoryId] = useState<string>(() => baseOverrides.destinationCategoryIds?.[0] ?? '');
+  const [categoryPathNames, setCategoryPathNames] = useState<string[] | null>(() =>
+    readStashedShopPath(row.editFormValues),
+  );
+  const [baseImageUrls, setBaseImageUrls] = useState<string[] | undefined>(() =>
+    Array.isArray(baseOverrides.imageUrls) ? baseOverrides.imageUrls : undefined,
+  );
+  const [parameters, setParameters] = useState<OfferParameter[]>(() =>
+    Array.isArray(baseOverrides.parameters) ? baseOverrides.parameters : [],
+  );
+  const [priceAmount, setPriceAmount] = useState<string>(() =>
+    row.override.price !== undefined ? String(row.override.price.amount) : '',
+  );
+  const [stock, setStock] = useState<number>(() => row.override.stock ?? row.masterStock ?? 0);
+  const [pricingPolicy, setPricingPolicy] = useState<PricingPolicy>(
+    () => row.override.pricingPolicy ?? batchPricingPolicy,
+  );
+  const [stockPolicy, setStockPolicy] = useState<StockPolicy>(
+    () => row.override.stockPolicy ?? batchStockPolicy,
+  );
+
+  const [variantEdits, setVariantEdits] = useState<Record<string, ShopVariantEdit>>(() => {
+    const map: Record<string, ShopVariantEdit> = {};
+    for (const v of row.variants) map[v.variantId] = initShopVariantEdit(v);
+    return map;
+  });
+  const [included, setIncluded] = useState<Record<string, boolean>>(() => {
+    const map: Record<string, boolean> = {};
+    for (const v of row.variants) map[v.variantId] = v.included;
+    return map;
+  });
+
+  const [catModalOpen, setCatModalOpen] = useState(false);
+  const [zoomSrc, setZoomSrc] = useState<string | null>(null);
+
+  // ── Dirty tracking (vs the on-open snapshot) ──
+  const snapshotRef = useRef<string | null>(null);
+  const liveState = JSON.stringify({
+    title,
+    description,
+    categoryId,
+    baseImageUrls,
+    parameters,
+    priceAmount,
+    stock,
+    pricingPolicy,
+    stockPolicy,
+    variantEdits,
+    included,
+  });
+  if (snapshotRef.current === null) snapshotRef.current = liveState;
+  useEffect(() => {
+    onDirtyChange(liveState !== snapshotRef.current);
+  }, [liveState, onDirtyChange]);
+
+  const patchVariant = useCallback((variantId: string, patch: Partial<ShopVariantEdit>): void => {
+    setVariantEdits((prev) => ({ ...prev, [variantId]: { ...prev[variantId], ...patch } }));
+  }, []);
+
+  const addAttribute = useCallback((parameter: OfferParameter): void => {
+    setParameters((prev) => mergeShopParameter(prev, parameter));
+  }, []);
+  const removeAttribute = useCallback((id: string): void => {
+    setParameters((prev) => prev.filter((p) => p.id !== id));
+  }, []);
+
+  const scopeList = useMemo(() => {
+    if (!isMultiVariant) return [{ id: 'simple', label: 'Product fields' }];
+    return [
+      { id: 'base', label: 'Shared base' },
+      ...row.variants.map((v, i) => ({ id: v.variantId, label: distinguishingLabel(v, i) })),
+    ];
+  }, [isMultiVariant, row.variants]);
+
+  const scopeStatus = useCallback(
+    (id: string): ScopeStatusKind => {
+      if (id === 'base' || id === 'simple') return 'base';
+      return included[id] ? 'ok' : 'off';
+    },
+    [included],
+  );
+
+  const onRailKeyDown = (event: KeyboardEvent<HTMLElement>): void => {
+    if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') return;
+    event.preventDefault();
+    const idx = scopeList.findIndex((s) => s.id === scope);
+    const nextIdx =
+      event.key === 'ArrowDown' ? Math.min(scopeList.length - 1, idx + 1) : Math.max(0, idx - 1);
+    const nextId = scopeList[nextIdx].id;
+    setScope(nextId);
+    event.currentTarget.querySelector<HTMLElement>(`[data-scope="${nextId}"]`)?.focus();
+  };
+
+  const crumbContent =
+    categoryPathNames && categoryPathNames.length > 0 ? (
+      categoryPathNames.map((name, i) => (
+        <Fragment key={`${name}-${i}`}>
+          {i > 0 ? <span className="sep"> › </span> : null}
+          {i === categoryPathNames.length - 1 ? <b>{name}</b> : name}
+        </Fragment>
+      ))
+    ) : categoryId ? (
+      <span className="mono-text">{categoryId}</span>
+    ) : (
+      <span className="bulk-editor__cat-missing">Not set</span>
+    );
+
+  const applyCategory = (nextId: string, pathNames: string[]): void => {
+    setCategoryId(nextId);
+    setCategoryPathNames(pathNames);
+  };
+
+  const handleSaveAll = (): void => {
+    if (title.trim() === '') {
+      setTitleTouched(true);
+      setScope(isMultiVariant ? 'base' : 'simple');
+      return;
+    }
+
+    const overrides: BulkOfferOverrides = {
+      title: title.trim(),
+      description: description.trim() === '' ? null : description.trim(),
+      ...(baseImageUrls !== undefined ? { imageUrls: baseImageUrls } : {}),
+      ...(parameters.length > 0 ? { parameters } : {}),
+      ...(categoryId.trim() !== '' ? { destinationCategoryIds: [categoryId.trim()] } : {}),
+    };
+
+    const pricingDiverges = isMultiVariant && !pricingPolicyEquals(pricingPolicy, batchPricingPolicy);
+    const stockDiverges = isMultiVariant && !stockPolicyEquals(stockPolicy, batchStockPolicy);
+    const baseAmount = priceAmount.trim();
+    const baseOverride: BulkPerProductOverride = {
+      publishImmediately: defaults.publishImmediately,
+      ...(!isMultiVariant && baseAmount !== ''
+        ? { price: { amount: Number(baseAmount.replace(',', '.')), currency } }
+        : {}),
+      ...(!isMultiVariant ? { stock: Number(stock) } : {}),
+      ...(pricingDiverges ? { pricingPolicy } : {}),
+      ...(stockDiverges ? { stockPolicy } : {}),
+      overrides,
+    };
+
+    const perVariantOverrides: Record<string, BulkPerProductOverride> = {};
+    if (isMultiVariant) {
+      for (const variant of row.variants) {
+        const edit = variantEdits[variant.variantId];
+        const variantOverrides: BulkOfferOverrides = {};
+        if (edit.description !== undefined) variantOverrides.description = edit.description;
+        const override: BulkPerProductOverride = {
+          ...(edit.price !== undefined && edit.price.trim() !== ''
+            ? { price: { amount: Number(edit.price.replace(',', '.')), currency } }
+            : {}),
+          ...(Object.keys(variantOverrides).length > 0 ? { overrides: variantOverrides } : {}),
+        };
+        if (Object.keys(override).length > 0) perVariantOverrides[variant.variantId] = override;
+      }
+    }
+
+    const editFormValues: Record<string, unknown> = {
+      shop: { title, description, categoryId, categoryPathNames, baseImageUrls, parameters, priceAmount, stock },
+    };
+
+    onSave(row.productId, baseOverride, perVariantOverrides, { ...included }, editFormValues);
+    onClose();
+  };
+
+  const productTypeLabel = isMultiVariant
+    ? `${row.variants.length} variants`
+    : 'Simple product · no variants';
+  const visibilityLabel = defaults.publishImmediately ? 'Published' : 'Draft';
+
+  return (
+    <>
+      <div className="bulk-editor__head">
+        <DialogTitle className="bulk-editor__title">
+          Edit product <span>- {row.product?.name ?? row.productId}</span>
+        </DialogTitle>
+        <Button
+          tone="ghost"
+          type="button"
+          className="button--icon"
+          aria-label="Close editor"
+          onClick={onRequestClose}
+        >
+          ×
+        </Button>
+      </div>
+      <DialogDescription className="sr-only">
+        Edit the shared base product and per-variant overrides for this shop listing.
+      </DialogDescription>
+
+      {canBrowseShopCategories ? (
+        <div className="bulk-editor__cat-chip">
+          <Button
+            tone="ghost"
+            type="button"
+            className="bulk-editor__cat-change"
+            onClick={() => setCatModalOpen(true)}
+          >
+            change ↱
+          </Button>
+          <span className="eyebrow">Category</span>
+          <button
+            type="button"
+            className="bulk-editor__cat-crumb crumb"
+            onClick={() => setCatModalOpen(true)}
+            aria-label="Change category"
+          >
+            {crumbContent}
+          </button>
+        </div>
+      ) : null}
+
+      <div className="bulk-editor__ptype">{productTypeLabel}</div>
+
+      <div className={['bulk-editor__body', isMultiVariant ? '' : 'bulk-editor__body--simple'].filter(Boolean).join(' ')}>
+        {isMultiVariant ? (
+          <nav
+            className="bulk-editor__rail"
+            role="radiogroup"
+            aria-label="Variant scope selector"
+            onKeyDown={onRailKeyDown}
+          >
+            <div className="eyebrow bulk-editor__rail-eyebrow">Scope</div>
+            <RailItem
+              id="base"
+              label="Shared base"
+              status="base"
+              active={scope === 'base'}
+              excluded={false}
+              onSelect={setScope}
+            />
+            <div className="bulk-editor__rail-sep" />
+            <div className="eyebrow bulk-editor__rail-eyebrow">Variants</div>
+            {row.variants.map((v, i) => (
+              <RailItem
+                key={v.variantId}
+                id={v.variantId}
+                label={distinguishingLabel(v, i)}
+                status={scopeStatus(v.variantId)}
+                active={scope === v.variantId}
+                excluded={!included[v.variantId]}
+                onSelect={setScope}
+              />
+            ))}
+          </nav>
+        ) : null}
+
+        <div className="bulk-editor__scopes">
+          <fieldset
+            disabled={demoReadOnly}
+            style={{ border: 0, margin: 0, padding: 0, minWidth: 0, display: 'contents' }}
+          >
+            {isMultiVariant ? (
+              <AccordionHead
+                id="base"
+                label="Shared base"
+                status="base"
+                active={scope === 'base'}
+                onSelect={setScope}
+              />
+            ) : null}
+            <ShopBaseScopeForm
+              mode={isMultiVariant ? 'base' : 'simple'}
+              active={scope === (isMultiVariant ? 'base' : 'simple')}
+              connectionId={connectionId}
+              channel={connection.platformType}
+              productId={row.product?.id ?? ''}
+              canPickShopAttributes={canPickShopAttributes}
+              currency={currency}
+              visibilityLabel={visibilityLabel}
+              title={title}
+              titleError={titleTouched && title.trim() === ''}
+              onTitleChange={(next) => {
+                setTitle(next);
+                if (next.trim() !== '') setTitleTouched(false);
+              }}
+              description={description}
+              onDescriptionChange={setDescription}
+              masterImages={masterImages}
+              baseImageUrls={baseImageUrls}
+              onBaseImageUrlsChange={setBaseImageUrls}
+              onZoom={setZoomSrc}
+              parameters={parameters}
+              onAddAttribute={addAttribute}
+              onRemoveAttribute={removeAttribute}
+              priceAmount={priceAmount}
+              onPriceAmountChange={setPriceAmount}
+              stock={stock}
+              onStockChange={setStock}
+              pricingPolicy={pricingPolicy}
+              onPricingPolicyChange={setPricingPolicy}
+              stockPolicy={stockPolicy}
+              onStockPolicyChange={setStockPolicy}
+              simpleIncluded={included[row.variants[0].variantId]}
+              onSimpleIncludedChange={(next) =>
+                setIncluded((prev) => ({ ...prev, [row.variants[0].variantId]: next }))
+              }
+            />
+
+            {isMultiVariant
+              ? row.variants.map((v, i) => (
+                  <Fragment key={v.variantId}>
+                    <AccordionHead
+                      id={v.variantId}
+                      label={distinguishingLabel(v, i)}
+                      status={scopeStatus(v.variantId)}
+                      active={scope === v.variantId}
+                      onSelect={setScope}
+                    />
+                    {scope === v.variantId ? (
+                      <ShopVariantScopeForm
+                        variant={v}
+                        index={i}
+                        edit={variantEdits[v.variantId]}
+                        included={included[v.variantId]}
+                        baseDescription={description}
+                        basePriceValue={shopInheritedPrice(pricingPolicy, v.masterPrice)}
+                        onPatch={(patch) => patchVariant(v.variantId, patch)}
+                        onIncludedChange={(next) =>
+                          setIncluded((prev) => ({ ...prev, [v.variantId]: next }))
+                        }
+                      />
+                    ) : null}
+                  </Fragment>
+                ))
+              : null}
+          </fieldset>
+        </div>
+      </div>
+
+      <div className="bulk-editor__foot">
+        <span className="grow">
+          {isMultiVariant
+            ? scope === 'base'
+              ? 'Editing shared base - changes cascade to every variant that has not overridden the field.'
+              : 'Editing one variant - only overridden fields diverge from the base.'
+            : 'Simple product - no variants. These fields apply to the single listing.'}
+        </span>
+        <Button tone="ghost" type="button" onClick={onRequestClose}>
+          Cancel
+        </Button>
+        <ReadOnlyLock active={demoReadOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
+          <Button tone="primary" type="button" disabled={demoReadOnly} onClick={handleSaveAll}>
+            Save all
+          </Button>
+        </ReadOnlyLock>
+      </div>
+
+      {canBrowseShopCategories ? (
+        <ShopCategoryPickerModal
+          open={catModalOpen}
+          onOpenChange={setCatModalOpen}
+          connectionId={connectionId}
+          productName={row.product?.name ?? row.productId}
+          selectedId={categoryId || null}
+          onSelect={applyCategory}
+        />
+      ) : null}
+
+      {zoomSrc ? (
+        <BulkImageLightbox
+          src={zoomSrc}
+          name={row.product?.name ?? 'Product image'}
+          onClose={() => setZoomSrc(null)}
+        />
+      ) : null}
+    </>
+  );
+}
+
+// ── Shop base / simple scope form ────────────────────────────────────────────
+
+interface ShopBaseScopeFormProps {
+  mode: 'base' | 'simple';
+  active: boolean;
+  connectionId: string;
+  channel: string;
+  productId: string;
+  canPickShopAttributes: boolean;
+  currency: string;
+  visibilityLabel: string;
+  title: string;
+  titleError: boolean;
+  onTitleChange: (next: string) => void;
+  description: string;
+  onDescriptionChange: (next: string) => void;
+  masterImages: string[];
+  baseImageUrls: string[] | undefined;
+  onBaseImageUrlsChange: (next: string[] | undefined) => void;
+  onZoom: (src: string) => void;
+  parameters: OfferParameter[];
+  onAddAttribute: (parameter: OfferParameter) => void;
+  onRemoveAttribute: (id: string) => void;
+  priceAmount: string;
+  onPriceAmountChange: (next: string) => void;
+  stock: number;
+  onStockChange: (next: number) => void;
+  pricingPolicy: PricingPolicy;
+  onPricingPolicyChange: (next: PricingPolicy) => void;
+  stockPolicy: StockPolicy;
+  onStockPolicyChange: (next: StockPolicy) => void;
+  simpleIncluded: boolean;
+  onSimpleIncludedChange: (next: boolean) => void;
+}
+
+function ShopBaseScopeForm({
+  mode,
+  active,
+  connectionId,
+  channel,
+  productId,
+  canPickShopAttributes,
+  currency,
+  visibilityLabel,
+  title,
+  titleError,
+  onTitleChange,
+  description,
+  onDescriptionChange,
+  masterImages,
+  baseImageUrls,
+  onBaseImageUrlsChange,
+  onZoom,
+  parameters,
+  onAddAttribute,
+  onRemoveAttribute,
+  priceAmount,
+  onPriceAmountChange,
+  stock,
+  onStockChange,
+  pricingPolicy,
+  onPricingPolicyChange,
+  stockPolicy,
+  onStockPolicyChange,
+  simpleIncluded,
+  onSimpleIncludedChange,
+}: ShopBaseScopeFormProps): ReactElement {
+  const [addingImage, setAddingImage] = useState(false);
+  const [newImageUrl, setNewImageUrl] = useState('');
+  const effectiveImages = baseImageUrls ?? masterImages;
+  const imagesOverridden = baseImageUrls !== undefined;
+  const classes = ['bulk-editor__form', active ? 'bulk-editor__form--acc-open' : ''].filter(Boolean).join(' ');
+
+  return (
+    <div className={classes} hidden={!active} data-form={mode}>
+      <div className="bulk-editor__scope-head">
+        <h4>{mode === 'simple' ? 'Product fields' : 'Shared base'}</h4>
+        <div className="grow" />
+        {mode === 'simple' ? (
+          <label className="checkbox-row" style={{ display: 'inline-flex', alignItems: 'center', gap: 'var(--space-2)' }}>
+            <input
+              type="checkbox"
+              checked={simpleIncluded}
+              onChange={(e) => onSimpleIncludedChange(e.target.checked)}
+            />
+            <span>Include in this batch</span>
+          </label>
+        ) : (
+          <ProvBadge kind="defaults" />
+        )}
+      </div>
+
+      <FormField
+        name="shop-edit-title"
+        label="Title"
+        description="The product name shown in the shop."
+        error={titleError ? 'Title is required' : undefined}
+      >
+        <Input
+          value={title}
+          onChange={(e) => onTitleChange(e.target.value)}
+          className="bulk-editor__input"
+          aria-invalid={titleError}
+          aria-label="Title"
+        />
+      </FormField>
+
+      <div className="bulk-editor__field">
+        <label>
+          Description
+          {productId !== '' ? (
+            <span style={{ marginLeft: 'auto' }}>
+              <SuggestionDialog
+                productId={productId}
+                channel={channel}
+                onApply={(suggestion) => onDescriptionChange(suggestion)}
+              />
+            </span>
+          ) : null}
+        </label>
+        <Textarea
+          value={description}
+          onChange={(e) => onDescriptionChange(e.target.value)}
+          className="bulk-editor__input"
+          rows={6}
+          aria-label="Description"
+        />
+        <div className="hint" style={{ color: 'var(--text-muted)', fontSize: 12 }}>
+          Plain text. Shared by every variant unless a variant overrides it.
+        </div>
+      </div>
+
+      {mode === 'simple' ? (
+        <div className="bulk-editor__row2">
+          <div className="bulk-editor__field">
+            <label>Price ({currency})</label>
+            <Input
+              value={priceAmount}
+              onChange={(e) => onPriceAmountChange(e.target.value)}
+              className="bulk-editor__input"
+              inputMode="decimal"
+              placeholder="79.00"
+              aria-label="Price"
+            />
+            <div className="hint" style={{ color: 'var(--text-muted)', fontSize: 12 }}>
+              Leave blank to publish at the master price.
+            </div>
+          </div>
+          <div className="bulk-editor__field">
+            <label>Stock</label>
+            <Input
+              type="number"
+              min={0}
+              value={stock}
+              onChange={(e) => onStockChange(Number(e.target.value))}
+              className="bulk-editor__input"
+              aria-label="Stock"
+            />
+          </div>
+        </div>
+      ) : (
+        <>
+          <div className="bulk-editor__row2">
+            <FormField
+              name="shop-edit-pricing-policy"
+              label="Price policy"
+              description="Per-product override of the batch pricing policy."
+            >
+              <select
+                className="bulk-editor__input"
+                aria-label="Price policy"
+                value={pricingPolicy.mode}
+                onChange={(e) =>
+                  onPricingPolicyChange(nextPricingPolicy(e.target.value as PricingPolicyMode, pricingPolicy))
+                }
+              >
+                <option value="use-master">Use master price</option>
+                <option value="markup">Markup on master price</option>
+                <option value="flat">Flat price for all variants</option>
+              </select>
+            </FormField>
+            <FormField
+              name="shop-edit-stock-policy"
+              label="Stock policy"
+              description="Per-product override of the batch stock policy."
+            >
+              <select
+                className="bulk-editor__input"
+                aria-label="Stock policy"
+                value={stockPolicy.mode}
+                onChange={(e) =>
+                  onStockPolicyChange(nextStockPolicy(e.target.value as StockPolicyMode, stockPolicy))
+                }
+              >
+                <option value="use-master">Use master stock</option>
+                <option value="cap">Cap master stock</option>
+                <option value="flat">Flat stock for all variants</option>
+              </select>
+            </FormField>
+          </div>
+
+          {pricingPolicy.mode !== 'use-master' ? (
+            <FormField
+              name="shop-edit-pricing-param"
+              label={pricingPolicy.mode === 'markup' ? 'Markup %' : `Flat price (${currency})`}
+            >
+              <Input
+                className="bulk-editor__input"
+                inputMode="decimal"
+                value={pricingParamValue(pricingPolicy)}
+                aria-label={pricingPolicy.mode === 'markup' ? 'Markup percent' : 'Flat price'}
+                onChange={(e) => onPricingPolicyChange(withPricingParam(pricingPolicy, e.target.value))}
+              />
+            </FormField>
+          ) : null}
+
+          {stockPolicy.mode !== 'use-master' ? (
+            <FormField name="shop-edit-stock-param" label={stockPolicy.mode === 'cap' ? 'Cap at' : 'Stock'}>
+              <Input
+                type="number"
+                min={1}
+                className="bulk-editor__input"
+                value={stockParamValue(stockPolicy)}
+                aria-label={stockPolicy.mode === 'cap' ? 'Cap at' : 'Flat stock'}
+                onChange={(e) => onStockPolicyChange(withStockParam(stockPolicy, e.target.value))}
+              />
+            </FormField>
+          ) : null}
+        </>
+      )}
+
+      <div className="bulk-editor__field">
+        <label>
+          Images {imagesOverridden ? <ProvBadge kind="override" /> : <ProvBadge kind="master" />}
+          {imagesOverridden ? (
+            <button
+              type="button"
+              className="bulk-editor__reset"
+              onClick={() => onBaseImageUrlsChange(undefined)}
+            >
+              ↺ reset to master
+            </button>
+          ) : null}
+        </label>
+        <div className="bulk-editor__img-strip bulk-editor__img-strip--editable">
+          {effectiveImages.map((url, i) => (
+            <span className="bulk-editor__img-thumb" key={`${url}-${i}`}>
+              <ThumbZoomButton url={url} onZoom={onZoom} />
+              <button
+                type="button"
+                className="bulk-editor__img-x"
+                aria-label="Remove image"
+                onClick={() => {
+                  const base = baseImageUrls ?? masterImages;
+                  onBaseImageUrlsChange(base.filter((_, idx) => idx !== i));
+                }}
+              >
+                ×
+              </button>
+            </span>
+          ))}
+          {!addingImage ? (
+            <button
+              type="button"
+              className="bulk-editor__img-add"
+              aria-label="Add image"
+              onClick={() => setAddingImage(true)}
+            >
+              ＋
+            </button>
+          ) : null}
+        </div>
+        {addingImage ? (
+          <div className="bulk-editor__img-add-row">
+            <Input
+              className="bulk-editor__input"
+              value={newImageUrl}
+              onChange={(e) => setNewImageUrl(e.target.value)}
+              placeholder="https://example.com/image.jpg"
+              aria-label="New image URL"
+            />
+            <Button
+              tone="primary"
+              type="button"
+              className="button--sm"
+              onClick={() => {
+                const url = newImageUrl.trim();
+                if (url === '') return;
+                const base = baseImageUrls ?? masterImages;
+                onBaseImageUrlsChange([...base, url]);
+                setNewImageUrl('');
+                setAddingImage(false);
+              }}
+            >
+              Add
+            </Button>
+            <Button
+              tone="ghost"
+              type="button"
+              className="button--sm"
+              onClick={() => {
+                setNewImageUrl('');
+                setAddingImage(false);
+              }}
+            >
+              Cancel
+            </Button>
+          </div>
+        ) : null}
+        <div className="hint" style={{ color: 'var(--text-muted)', margin: '5px 0 0' }}>
+          {effectiveImages.length === 0 ? 'No images yet - add an image URL to include one. ' : ''}
+          Shared image set for every variant. Add or remove to override the master set.
+        </div>
+      </div>
+
+      {canPickShopAttributes ? (
+        <div className="bulk-editor__platform-slot">
+          <div className="bulk-editor__slot-tag">
+            <span className="eyebrow">Attributes</span>
+          </div>
+          {parameters.length > 0 ? (
+            <ul className="shop-attr-picker__added" role="list">
+              {parameters.map((p) => (
+                <li key={p.id} className="shop-attr-picker__added-item">
+                  <span className="shop-attr-picker__added-label">{shopParameterLabel(p)}</span>
+                  <button
+                    type="button"
+                    className="bulk-editor__img-x"
+                    aria-label={`Remove attribute ${p.id}`}
+                    onClick={() => onRemoveAttribute(p.id)}
+                  >
+                    ×
+                  </button>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+          <ShopAttributePicker connectionId={connectionId} onAdd={onAddAttribute} />
+        </div>
+      ) : null}
+
+      <div className="bulk-editor__field">
+        <label>Visibility</label>
+        <Input className="bulk-editor__input" value={visibilityLabel} readOnly aria-readonly="true" />
+        <div className="hint" style={{ color: 'var(--text-muted)', fontSize: 12 }}>
+          Draft or published is chosen for the whole batch on the Review step.
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Shop variant scope form ──────────────────────────────────────────────────
+
+interface ShopVariantScopeFormProps {
+  variant: BulkVariantRow;
+  index: number;
+  edit: ShopVariantEdit;
+  included: boolean;
+  baseDescription: string;
+  basePriceValue: string;
+  onPatch: (patch: Partial<ShopVariantEdit>) => void;
+  onIncludedChange: (next: boolean) => void;
+}
+
+function ShopVariantScopeForm({
+  variant,
+  index,
+  edit,
+  included,
+  baseDescription,
+  basePriceValue,
+  onPatch,
+  onIncludedChange,
+}: ShopVariantScopeFormProps): ReactElement {
+  const label = distinguishingLabel(variant, index);
+  const formClasses = [
+    'bulk-editor__form',
+    'bulk-editor__form--acc-open',
+    included ? '' : 'bulk-editor__form--excluded',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <div className={formClasses} data-form={variant.variantId}>
+      <div className="bulk-editor__scope-head">
+        <h4>Variant · {label}</h4>
+        <div className="grow" />
+        <label className="checkbox-row" style={{ display: 'inline-flex', alignItems: 'center', gap: 'var(--space-2)' }}>
+          <input type="checkbox" checked={included} onChange={(e) => onIncludedChange(e.target.checked)} />
+          <span>Include in this batch</span>
+        </label>
+      </div>
+
+      {!included ? (
+        <div className="bulk-editor__excl-note">
+          This variant is excluded - it will not be published. Switch it back on to include it.
+        </div>
+      ) : null}
+
+      <div className="eyebrow" style={{ marginBottom: 'var(--space-3)' }}>
+        Per-variant
+      </div>
+
+      <div className="bulk-editor__field">
+        <label>
+          Description {edit.description !== undefined ? <ProvBadge kind="override" /> : <ProvBadge kind="inherit" />}
+          {edit.description !== undefined ? (
+            <button type="button" className="bulk-editor__reset" onClick={() => onPatch({ description: undefined })}>
+              ↺ reset to base
+            </button>
+          ) : null}
+        </label>
+        <Textarea
+          className={[
+            'bulk-editor__input',
+            edit.description !== undefined ? 'bulk-editor__input--overridden' : 'bulk-editor__input--inherited',
+          ].join(' ')}
+          rows={4}
+          value={edit.description !== undefined ? edit.description : baseDescription}
+          aria-label={`Description for ${label}`}
+          onChange={(e) => onPatch({ description: e.target.value === baseDescription ? undefined : e.target.value })}
+        />
+      </div>
+
+      <div className="bulk-editor__row2">
+        <div className="bulk-editor__field">
+          <label>
+            Stock <ProvBadge kind="master" />
+          </label>
+          <Input
+            className="bulk-editor__input bulk-editor__input--inherited"
+            value={variant.masterStock ?? 0}
+            readOnly
+            aria-readonly="true"
+          />
+          <div className="hint" style={{ color: 'var(--text-muted)', fontSize: 12 }}>
+            Authoritative from master inventory.
+          </div>
+        </div>
+
+        <InheritableTextField
+          label="Price"
+          overridden={edit.price !== undefined}
+          value={edit.price ?? ''}
+          baseValue={basePriceValue}
+          ariaLabel={`Price for ${label}`}
+          onChange={(next) => onPatch({ price: next })}
+        />
+      </div>
+    </div>
+  );
 }

--- a/apps/web/src/features/listings/components/bulk/bulk-shop-review-step.test.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-shop-review-step.test.tsx
@@ -10,6 +10,9 @@
 import { describe, expect, it, vi } from 'vitest';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { renderWithProviders, createMockApiClient } from '../../../../test/test-utils';
+
+// Isolate the shop editor render from the AI suggestion dialog (#1830).
+vi.mock('../../../content', () => ({ SuggestionDialog: () => null }));
 import {
   BulkShopReviewStep,
   buildBulkShopPublishItems,
@@ -121,6 +124,55 @@ describe('buildBulkShopPublishItems', () => {
     const items = buildBulkShopPublishItems(rows, config(), new Map());
     expect(items[0].stock).toBe(0);
   });
+
+  it('threads per-product content, destination categories, and parameters onto each item (#1830)', () => {
+    const row = makeRow('prod_1', [makeVariantRow('v1')]);
+    row.override = {
+      overrides: {
+        title: 'Custom title',
+        description: 'Base description',
+        imageUrls: ['https://img/1.jpg'],
+        destinationCategoryIds: ['cat_42'],
+        parameters: [{ id: 'pa_color', values: ['Red'], valuesIds: ['t1'], section: 'product' }],
+      },
+    };
+    const items = buildBulkShopPublishItems([row], config(), new Map([['v1', 5]]));
+    expect(items[0]).toMatchObject({
+      internalVariantId: 'v1',
+      content: {
+        title: 'Custom title',
+        description: 'Base description',
+        imageUrls: ['https://img/1.jpg'],
+      },
+      destinationCategoryIds: ['cat_42'],
+      parameters: [{ id: 'pa_color', values: ['Red'], valuesIds: ['t1'], section: 'product' }],
+    });
+  });
+
+  it('lets a per-variant description override win over the base content (#1830)', () => {
+    const v1 = makeVariantRow('v1', {
+      override: { overrides: { description: 'Variant-specific copy' } },
+    });
+    const row = makeRow('prod_1', [v1]);
+    row.override = { overrides: { description: 'Base description' } };
+    const items = buildBulkShopPublishItems([row], config(), new Map([['v1', 5]]));
+    expect(items[0].content?.description).toBe('Variant-specific copy');
+  });
+
+  it('preserves a defined-but-empty destinationCategoryIds (uncategorised) (#1830)', () => {
+    const row = makeRow('prod_1', [makeVariantRow('v1')]);
+    row.override = { overrides: { destinationCategoryIds: [] } };
+    const items = buildBulkShopPublishItems([row], config(), new Map([['v1', 5]]));
+    expect(items[0].destinationCategoryIds).toEqual([]);
+  });
+
+  it('omits content/category/parameters for a passthrough item with no overrides (#1830)', () => {
+    const rows = [makeRow('prod_1', [makeVariantRow('v1')])];
+    const items = buildBulkShopPublishItems(rows, config(), new Map([['v1', 5]]));
+    expect(items[0]).not.toHaveProperty('content');
+    expect(items[0]).not.toHaveProperty('destinationCategoryIds');
+    expect(items[0]).not.toHaveProperty('parameters');
+  });
 });
 
 const shopConnection = {
@@ -139,6 +191,7 @@ function renderStep(
     onPublish?: (items: BulkShopPublishItemRequest[], status: ShopPublishVisibility) => void;
     onSetVariantIncluded?: (p: string, v: string, i: boolean) => void;
     onBack?: () => void;
+    onSaveEditor?: () => void;
   } = {},
   availability: { productVariantId: string; totalAvailable: number }[] = [],
 ): void {
@@ -158,6 +211,7 @@ function renderStep(
       onSetVariantIncluded={handlers.onSetVariantIncluded ?? ((): void => undefined)}
       onBack={handlers.onBack ?? ((): void => undefined)}
       onPublish={handlers.onPublish ?? ((): void => undefined)}
+      onSaveEditor={handlers.onSaveEditor ?? ((): void => undefined)}
     />,
     { apiClient },
   );
@@ -221,5 +275,15 @@ describe('BulkShopReviewStep (render)', () => {
     const rows = [makeRow('prod_1', [makeVariantRow('v1', { included: false })])];
     renderStep(rows, config());
     expect(screen.getByText(/No variants are included/i)).toBeInTheDocument();
+  });
+
+  it('opens the shop editor from a row Edit button (#1830)', async () => {
+    const rows = [makeRow('prod_1', [makeVariantRow('v1')])];
+    renderStep(rows, config(), {}, [{ productVariantId: 'v1', totalAvailable: 7 }]);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Edit P' }));
+    // The shop editor mounts its title field (a shop-only "Product fields" scope).
+    expect(await screen.findByRole('heading', { name: 'Product fields' })).toBeInTheDocument();
+    expect(screen.getByLabelText('Title')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/listings/components/bulk/bulk-shop-review-step.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-shop-review-step.tsx
@@ -10,9 +10,10 @@
  * exclude variants, then submits one `bulk-shop-publish` item per included
  * variant.
  *
- * Per-item stock/price *editing* is intentionally out of scope here - the
- * current `bulk-shop-publish` endpoint takes computed values, and #1831
- * enriches the per-item payload + editing surface.
+ * Per-product content / category / attribute editing lands via the shared
+ * two-pane editor (#1830, shop mode) opened from each row's Edit button; the
+ * overrides it saves round-trip through each item's `content` /
+ * `destinationCategoryIds` / `parameters` (backed by the #1831 transport).
  *
  * @module apps/web/src/features/listings/components/bulk
  */
@@ -22,9 +23,20 @@ import { Alert, Button } from '../../../../shared/ui';
 import { ReadOnlyLock } from '../../../../shared/ui/read-only-lock';
 import { DEMO_READ_ONLY_ACTION_MESSAGE } from '../../../../shared/config/demo-mode';
 import { useInventoryAvailabilityBatchQuery } from '../../../inventory';
+import { publishDestinationKind } from '../../lib/publish-destinations';
 import type { Connection } from '../../../connections';
-import type { BulkShopPublishItemRequest } from '../../api/listings.types';
-import { computeResolvedPrice, computeResolvedStock } from './bulk-policy';
+import type {
+  BulkShopPublishItemRequest,
+  ShopPublishContent,
+} from '../../api/listings.types';
+import type { BulkPerProductOverride } from '../../api/bulk-listings.types';
+import {
+  computeResolvedPrice,
+  computeResolvedStock,
+  effectivePricingPolicy,
+  effectiveStockPolicy,
+} from './bulk-policy';
+import { BulkEditModal } from './bulk-edit-modal';
 import type { BulkVariantRow, BulkWizardConfig, BulkWizardRow } from './bulk-wizard.types';
 
 /** Visibility the batch publishes with; mirrors the shop publish status set. */
@@ -40,6 +52,19 @@ interface BulkShopReviewStepProps {
   onSetVariantIncluded: (productId: string, variantId: string, included: boolean) => void;
   onBack: () => void;
   onPublish: (items: BulkShopPublishItemRequest[], status: ShopPublishVisibility) => void;
+  /**
+   * Commit a per-product edit session from the shop editor (#1830). Same
+   * signature as the marketplace review's editor save; the wizard stores the
+   * overrides on the row + per-variant map, which `buildBulkShopPublishItems`
+   * threads onto each item's content / category / attribute payload.
+   */
+  onSaveEditor: (
+    productId: string,
+    baseOverride: BulkPerProductOverride,
+    perVariantOverrides: Record<string, BulkPerProductOverride>,
+    includedByVariantId: Record<string, boolean>,
+    editFormValues: Record<string, unknown>,
+  ) => void;
 }
 
 /** A flattened included variant paired with its owning product for display.
@@ -64,10 +89,41 @@ function variantDisplayLabel(variant: BulkVariantRow): string {
 }
 
 /**
+ * Effective per-item content override (#1830). Title / images are base-only
+ * (parent-scoped); description falls back base -> variant with the variant
+ * winning. Returns `undefined` when the operator supplied no content override,
+ * so the item omits `content` and the builder keeps its master/batch fallback.
+ */
+function effectiveShopContent(
+  row: BulkWizardRow,
+  variant: BulkVariantRow,
+): ShopPublishContent | undefined {
+  const base = row.override.overrides ?? {};
+  const variantOverrides = variant.override.overrides ?? {};
+  const content: ShopPublishContent = {};
+  if (typeof base.title === 'string' && base.title !== '') content.title = base.title;
+  const description =
+    typeof variantOverrides.description === 'string'
+      ? variantOverrides.description
+      : typeof base.description === 'string'
+        ? base.description
+        : undefined;
+  if (description !== undefined) content.description = description;
+  if (Array.isArray(base.imageUrls)) content.imageUrls = base.imageUrls;
+  return Object.keys(content).length > 0 ? content : undefined;
+}
+
+/**
  * Build one `bulk-shop-publish` item per included variant. Stock resolves from
- * master availability + the batch stock policy; price from the variant master
- * price + the batch pricing policy. A null resolved price is omitted (the shop
- * builder falls back to master at publish time); a null resolved stock sends 0.
+ * master availability + the row-effective stock policy; price from the variant
+ * master price + the row-effective pricing policy (a per-product policy override
+ * from the editor wins over the batch, #1741). A null resolved price is omitted
+ * (the shop builder falls back to master at publish time); a null resolved stock
+ * sends 0. Per-product content / destination category / attribute overrides from
+ * the shop editor (#1830) thread onto the item so they beat the server-side
+ * defaults (#1831 transport). Category / parameters are base-only (product
+ * scoped); a defined-but-empty value is preserved (it means "uncategorised" /
+ * "no attributes", which the builder honours by skipping provisioning).
  */
 export function buildBulkShopPublishItems(
   rows: BulkWizardRow[],
@@ -76,17 +132,26 @@ export function buildBulkShopPublishItems(
 ): BulkShopPublishItemRequest[] {
   const items: BulkShopPublishItemRequest[] = [];
   for (const row of rows) {
+    const rowPricingPolicy = effectivePricingPolicy(row.override, config.pricingPolicy);
+    const rowStockPolicy = effectiveStockPolicy(row.override, config.stockPolicy);
+    const base = row.override.overrides ?? {};
     for (const variant of row.variants) {
       if (!variant.included) continue;
       const masterStock = masterStockByVariantId.get(variant.variantId) ?? variant.masterStock;
-      const stock = computeResolvedStock(config.stockPolicy, masterStock, variant.override);
-      const price = computeResolvedPrice(config.pricingPolicy, variant.masterPrice, variant.override);
+      const stock = computeResolvedStock(rowStockPolicy, masterStock, variant.override);
+      const price = computeResolvedPrice(rowPricingPolicy, variant.masterPrice, variant.override);
+      const content = effectiveShopContent(row, variant);
       items.push({
         internalVariantId: variant.variantId,
         stock: stock.value ?? 0,
         ...(price.value !== null
           ? { price: { amount: price.value, currency: config.currency } }
           : {}),
+        ...(content ? { content } : {}),
+        ...(base.destinationCategoryIds !== undefined
+          ? { destinationCategoryIds: base.destinationCategoryIds }
+          : {}),
+        ...(base.parameters !== undefined ? { parameters: base.parameters } : {}),
       });
     }
   }
@@ -103,9 +168,28 @@ export function BulkShopReviewStep({
   onSetVariantIncluded,
   onBack,
   onPublish,
+  onSaveEditor,
 }: BulkShopReviewStepProps): ReactElement {
   const [status, setStatus] = useState<ShopPublishVisibility>(
     config.publishImmediately ? 'published' : 'draft',
+  );
+  // Per-product edit session (#1830) - product id + the variant to focus.
+  const [editing, setEditing] = useState<{ productId: string; focusVariantId?: string } | null>(
+    null,
+  );
+
+  // Capability-gated shop editor sub-sections - never a platformType literal.
+  const canBrowseShopCategories =
+    connection?.supportedCapabilities?.includes('ShopCategoryBrowser') ?? false;
+  const canPickShopAttributes =
+    connection?.supportedCapabilities?.includes('ShopAttributeReader') ?? false;
+  // Guard: only mount the editor for a genuine shop destination (#1830).
+  const isShopDestination =
+    connection !== null && publishDestinationKind(connection) === 'shop';
+
+  const editingRow = useMemo(
+    () => (editing ? rows.find((r) => r.productId === editing.productId) ?? null : null),
+    [editing, rows],
   );
 
   const includedVariantIds = useMemo(() => {
@@ -223,6 +307,16 @@ export function BulkShopReviewStep({
                 <span className="bulk-shop-review__cell-label">price</span>
                 {line.price !== null ? `${line.price} ${config.currency}` : 'from master'}
               </span>
+              {isShopDestination ? (
+                <Button
+                  tone="ghost"
+                  className="button--xs bulk-shop-review__edit"
+                  aria-label={`Edit ${line.productName}`}
+                  onClick={() => setEditing({ productId: line.productId, focusVariantId: line.variantId })}
+                >
+                  Edit
+                </Button>
+              ) : null}
               <button
                 type="button"
                 className="bulk-shop-review__remove"
@@ -253,6 +347,28 @@ export function BulkShopReviewStep({
           </Button>
         </ReadOnlyLock>
       </footer>
+
+      {editingRow && connection && isShopDestination ? (
+        <BulkEditModal
+          open={editing !== null}
+          onOpenChange={(open) => {
+            if (!open) setEditing(null);
+          }}
+          row={editingRow}
+          connection={connection}
+          destinationKind="shop"
+          canBrowseCategories={false}
+          canBrowseShopCategories={canBrowseShopCategories}
+          canPickShopAttributes={canPickShopAttributes}
+          currency={config.currency}
+          defaults={{ publishImmediately: config.publishImmediately }}
+          pricingPolicy={config.pricingPolicy}
+          stockPolicy={config.stockPolicy}
+          focusVariantId={editing?.focusVariantId}
+          demoReadOnly={demoReadOnly}
+          onSave={onSaveEditor}
+        />
+      ) : null}
     </div>
   );
 }

--- a/apps/web/src/features/listings/components/bulk/bulk-wizard.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-wizard.tsx
@@ -535,6 +535,7 @@ export function BulkWizard({
                 isSubmitting={shopMutation.isPending}
                 errorMessage={shopMutation.error ? shopMutation.error.message : null}
                 onSetVariantIncluded={setVariantIncluded}
+                onSaveEditor={handleSaveEditor}
                 onBack={() => { setStep('config'); }}
                 onPublish={(items, status) => { void handleShopPublish(items, status); }}
               />

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -11110,6 +11110,30 @@ textarea.bulk-editor__input { resize: vertical; min-height: 66px; font-family: i
 .shop-attr-picker__empty { padding: var(--space-3); color: var(--text-muted); font-size: 12.5px; }
 .shop-attr-picker__foot { display: flex; justify-content: flex-end; }
 
+/* ── Shop editor: collected attributes list (#1830) ── */
+.shop-attr-picker__added {
+  list-style: none;
+  margin: 0 0 var(--space-2);
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+.shop-attr-picker__added-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  background: var(--bg-surface-muted);
+  font-size: 12.5px;
+}
+.shop-attr-picker__added-label { flex: 1; min-width: 0; word-break: break-word; }
+
+/* ── Shop review: per-product edit affordance (#1830) ── */
+.bulk-shop-review__edit { flex: none; }
+
 /* ── Per-product progress rollup (#1741) ── */
 .bulk-progress__list { display: flex; flex-direction: column; gap: var(--space-2); }
 .bulk-progress__row {

--- a/docs/frontend-architecture.md
+++ b/docs/frontend-architecture.md
@@ -451,7 +451,42 @@ kind from the selected connection via `publishDestinationKind` (capability, neve
 - **`ShopPublishLauncher` disposition.** The launcher is no longer wired to any
   publish CTA - the unified picker + wizard cover the create path end-to-end. It
   and the WooCommerce single-publish wizard are retained (unreferenced by the
-  pages) for the shop **edit** mode still owned by #1830.
+  pages).
+
+**Two-axis edit modal: destination kind × variant shape (#1830).** `BulkEditModal`
+(`features/listings/components/bulk/bulk-edit-modal.tsx`) is one component that
+serves both destination kinds via a `destinationKind: 'marketplace' | 'shop'`
+prop, resolved by the caller from `publishDestinationKind(connection)` (capability,
+never `platformType`) - never inferred inside the modal itself. Both branches
+share the same shell: the two-pane layout (rail = Base + per-variant scopes with
+inherit/override semantics) for a multi-variant product, a flat form with no rail
+for a simple/single-variant product, and the discard-guard dialog wrapper.
+
+- **Marketplace branch** (`BulkEditModalForm`, unchanged since #1741): category
+  tree + parameter schema, EAN self-link, product-card link, grouping-determining
+  params locked to base, per-plugin platform sections.
+- **Shop branch** (`BulkShopEditModalForm`, #1830): category placement lives in
+  the top crumb bar (mounts `ShopCategoryPickerModal`, gated on the connection's
+  `ShopCategoryBrowser` sub-capability) rather than a mid-form field; structured
+  attributes are collected via `ShopAttributePicker` (gated on `ShopAttributeReader`);
+  content (title/description/images), visibility, and price/stock round out the
+  base scope. No category-parameter schema, no EAN self-link - a shop product has
+  neither. The variant scope keeps the marketplace precedent of no standalone
+  "distinguishing" field (the scope heading already names the variant) and makes
+  every override-eligible base field (description, price) overridable per variant;
+  parent-only fields (title, category, images, attributes) stay base-only, mirroring
+  which fields are genuinely shared across a shop's simple-product siblings.
+  Per-product content/category/parameter overrides are carried on
+  `BulkOfferOverrides` (`destinationCategoryIds` addition, #1830) and threaded by
+  `buildBulkShopPublishItems` (`bulk-shop-review-step.tsx`) onto each item's
+  `content` / `destinationCategoryIds` / `parameters` - the FE consumer of the
+  #1831 per-item transport. Two adds of the same global-attribute id from
+  `ShopAttributePicker` (e.g. Color=Red then Color=Blue) are merged by
+  `mergeShopParameter` (union term values/ids, last-wins on `section`) rather
+  than appended as duplicate `parameters` entries, so WooCommerce never receives
+  two `attributes[]` rows for one attribute id. The AI-description toggle for
+  shops is a separate follow-up (#1840) - the shop editor's `SuggestionDialog`
+  wiring exists but no shop-specific toggle is added here.
 
 ### UI Library Policy
 

--- a/docs/frontend-ui-style-guide.md
+++ b/docs/frontend-ui-style-guide.md
@@ -773,6 +773,26 @@ Used for:
 - field mappings
 - shipping mappings
 
+### Two-Axis Bulk Editor (#1741 / #1830)
+
+The bulk publish edit modal (`BulkEditModal`) is organized along two independent
+axes rather than one flow per destination:
+
+- **Variant shape** - a multi-variant product renders the two-pane layout (left
+  rail of scopes: Shared base + one per variant, right pane = the active scope's
+  form, inherit/override provenance badges); a simple/single-variant product
+  collapses to a flat form with no rail.
+- **Destination kind** - a marketplace destination (`OfferCreator`) shows the
+  offer field set (category tree + parameter schema, EAN self-link); a shop
+  destination (`ProductPublisher`, #1830) shows the shop field set (category in
+  the top crumb bar, structured attributes, content, visibility, price/stock).
+
+Both axes reuse the same shell chrome (rail, accordion heads, provenance badges,
+discard-guard dialog) - only the field set inside a scope changes with the
+destination kind. A destination's sub-capabilities (`ShopCategoryBrowser`,
+`ShopAttributeReader`, `CategoryBrowser`, …) gate which sections render; never
+branch on `platformType`.
+
 ## Accessibility
 
 The operations cockpit must remain accessible even when dense.


### PR DESCRIPTION
## Summary

Adds shop mode to the two-pane bulk edit modal (`BulkEditModal`, #1741) so one component serves both marketplace (`OfferCreator`) and shop (`ProductPublisher`) destinations.

- `BulkEditModal` dispatches to `BulkShopEditModalForm` vs the existing `BulkEditModalForm` via a `destinationKind: 'marketplace' | 'shop'` prop, resolved by the caller (`BulkShopReviewStep`) from `publishDestinationKind(connection)` - capability-driven, never `platformType`.
- Shop sections: category placement in the top crumb bar (mounts `ShopCategoryPickerModal`, gated on the `ShopCategoryBrowser` sub-capability), structured attributes (`ShopAttributePicker`, gated on `ShopAttributeReader`), content (title/description/images), visibility, and price/stock policy. No category-parameter schema, no EAN self-link - marketplace-only sections are simply absent from the shop branch.
- Same two-pane shell reused: multi-variant products render the rail (Shared base + one scope per variant, inherit/override provenance badges); a simple/single-variant product renders a flat form with no rail. The variant scope carries no standalone "distinguishing" field (the scope heading already names it, matching the marketplace precedent); description and price are overridable per variant, while title/category/images/attributes stay base-only (genuinely shared, parent-scoped fields).
- `mergeShopParameter` de-duplicates same-global-attribute-id adds from `ShopAttributePicker` (e.g. Color=Red then Color=Blue as two separate adds) into one `OfferParameter` with unioned `values`/`valuesIds`, so WooCommerce never receives two `attributes[]` entries for one attribute id.
- `BulkShopReviewStep` gains a per-row **Edit** button that opens the shop editor. `buildBulkShopPublishItems` now threads the saved per-product `content` / `destinationCategoryIds` / `parameters` onto each item, consuming the #1831 per-item shop-publish transport end to end (`BulkShopPublishItemRequest` extended with these three optional fields). A per-variant description override wins over the base content for that variant's item.
- Row-effective pricing/stock policy (a per-product override wins over the batch default) is now honored in the shop review too, matching the #1741 marketplace precedent - previously the shop review only ever used the batch-wide policy.

The AI-description toggle for shops is a separate in-flight issue (#1840) and is intentionally not built here.

## How to test

- `pnpm --filter @openlinker/web test -- bulk-edit-modal.shop bulk-shop-review-step bulk-edit-modal.test bulk-wizard.test`
- Manually: open the bulk wizard against a WooCommerce connection, pick a multi-variant product, verify the rail renders, edit the shared base (title/description/price policy/stock policy/category via crumb/attributes), edit one variant's description/price override, save, and confirm the Review step shows the resolved values; then publish and check the request payload carries `content` / `destinationCategoryIds` / `parameters` on the item.

## Docs

- `docs/frontend-architecture.md` - documents the two-axis (destination kind × variant shape) dispatch in `BulkEditModal`, the shop branch's sections, capability gates, and the `mergeShopParameter` dedup rule; updates the stale `ShopPublishLauncher` disposition note that pointed at #1830 as still-owed.
- `docs/frontend-ui-style-guide.md` - adds a "Two-Axis Bulk Editor (#1741 / #1830)" pattern entry describing the variant-shape × destination-kind layout rule.

Closes #1830