### PR TITLE
feat(listings): pricing-resolution seam for markup/margin + rounding formulas

### DIFF
--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -529,7 +529,7 @@ Each is an independent interface + co-located `is{Capability}(adapter)` type gua
 
 ### Future Capability Ports
 
-- **PricingAuthorityPort**: Manages pricing rules and catalog pricing
+- **PricingAuthorityPort**: Manages pricing rules and catalog pricing. A capability-port-shaped `PricingAuthorityPort` is still future work, but its underlying **pricing-resolution seam** already exists (#1843): `readPricingRule` / `applyPricingRule` (`libs/core/src/identifier-mapping/domain/types/pricing-rule.types.ts`) are pure, marketplace-neutral helpers — mirroring the `stockSafetyBuffer` config-coercion precedent (#1844) — that resolve a destination price from the master catalog price via a per-connection `Connection.config.pricingRule` (`{ type: 'passthrough' | 'markup' | 'margin', percent?, rounding?: 'none' | 'nearestWhole' | 'endingIn99' }`, JSONB — no schema/migration change). `markup` is cost-plus (`price = base * (1 + percent/100)`); `margin` solves for the price whose margin over the base equals `percent` (`price = base / (1 - percent/100)`, guarded for `percent >= 100`). Both `OfferBuilderService` and `ProductPublishBuilderService` call it as the sole source of `command.price` whenever no explicit per-item `input.price` is supplied (an explicit price always wins and is never re-priced) — replacing the prior raw `product.price` passthrough. A connection with no configured rule is untouched (byte-identical to the pre-#1843 passthrough). No FE control exists yet for editing `config.pricingRule` (same posture as `stockSafetyBuffer` today) — a follow-up.
 - **ShippingProviderManagerPort**: Orchestrates shipping and tracking
 - **PaymentProcessorPort**: Handles payment processing
 

--- a/libs/core/src/identifier-mapping/domain/types/__tests__/pricing-rule.types.spec.ts
+++ b/libs/core/src/identifier-mapping/domain/types/__tests__/pricing-rule.types.spec.ts
@@ -1,0 +1,105 @@
+/**
+ * Pricing Rule helper tests (#1843)
+ *
+ * @module libs/core/src/identifier-mapping/domain/types/__tests__
+ */
+import { applyPricingRule, readPricingRule } from '../pricing-rule.types';
+
+describe('pricing-rule', () => {
+  describe('readPricingRule', () => {
+    it('should return null when config is null or undefined', () => {
+      expect(readPricingRule(null)).toBeNull();
+      expect(readPricingRule(undefined)).toBeNull();
+    });
+
+    it('should return null when the key is absent (backward compatible passthrough)', () => {
+      expect(readPricingRule({})).toBeNull();
+      expect(readPricingRule({ masterCatalogConnectionId: 'c1' })).toBeNull();
+    });
+
+    it('should return null for a non-object or unrecognized type', () => {
+      expect(readPricingRule({ pricingRule: 'markup' as unknown as never })).toBeNull();
+      expect(readPricingRule({ pricingRule: { type: 'bogus' } as unknown as never })).toBeNull();
+    });
+
+    it('should read a valid markup rule', () => {
+      expect(readPricingRule({ pricingRule: { type: 'markup', percent: 20 } })).toEqual({
+        type: 'markup',
+        percent: 20,
+        rounding: 'none',
+      });
+    });
+
+    it('should read a valid margin rule with rounding', () => {
+      expect(
+        readPricingRule({ pricingRule: { type: 'margin', percent: 30, rounding: 'endingIn99' } })
+      ).toEqual({ type: 'margin', percent: 30, rounding: 'endingIn99' });
+    });
+
+    it('should coerce a non-numeric/non-finite percent to 0', () => {
+      expect(
+        readPricingRule({
+          pricingRule: { type: 'markup', percent: '20' as unknown as number },
+        })
+      ).toEqual({
+        type: 'markup',
+        percent: 0,
+        rounding: 'none',
+      });
+      expect(readPricingRule({ pricingRule: { type: 'markup', percent: Number.NaN } })).toEqual({
+        type: 'markup',
+        percent: 0,
+        rounding: 'none',
+      });
+    });
+
+    it('should coerce an unrecognized rounding mode to none', () => {
+      expect(
+        readPricingRule({
+          pricingRule: { type: 'passthrough', rounding: 'bogus' as unknown as 'none' },
+        })
+      ).toEqual({ type: 'passthrough', percent: 0, rounding: 'none' });
+    });
+  });
+
+  describe('applyPricingRule', () => {
+    it('should return the base price completely unchanged when no rule is configured', () => {
+      expect(applyPricingRule(49.999, null)).toBe(49.999);
+    });
+
+    it('should apply a passthrough rule with default (none) rounding as 2dp cleanup', () => {
+      expect(applyPricingRule(49.999, { type: 'passthrough' })).toBe(50);
+    });
+
+    it('should apply a markup percentage on top of the base price', () => {
+      expect(applyPricingRule(100, { type: 'markup', percent: 20 })).toBe(120);
+      expect(applyPricingRule(100, { type: 'markup', percent: -10 })).toBe(90);
+    });
+
+    it('should apply a margin percentage solving for price over the base cost', () => {
+      // margin 20% => price = 100 / 0.8 = 125
+      expect(applyPricingRule(100, { type: 'margin', percent: 20 })).toBe(125);
+    });
+
+    it('should degrade a margin >= 100% to the base price (undefined formula guard)', () => {
+      expect(applyPricingRule(100, { type: 'margin', percent: 100 })).toBe(100);
+      expect(applyPricingRule(100, { type: 'margin', percent: 150 })).toBe(100);
+    });
+
+    it('should round to the nearest whole unit when rounding=nearestWhole', () => {
+      expect(
+        applyPricingRule(100, { type: 'markup', percent: 12.3, rounding: 'nearestWhole' })
+      ).toBe(112);
+    });
+
+    it('should round up to the next whole unit minus a cent when rounding=endingIn99', () => {
+      expect(applyPricingRule(19.3, { type: 'passthrough', rounding: 'endingIn99' })).toBe(19.99);
+      expect(applyPricingRule(20, { type: 'passthrough', rounding: 'endingIn99' })).toBe(19.99);
+      expect(applyPricingRule(19.99, { type: 'passthrough', rounding: 'endingIn99' })).toBe(19.99);
+    });
+
+    it('should never return a negative price', () => {
+      expect(applyPricingRule(0.001, { type: 'passthrough', rounding: 'endingIn99' })).toBeGreaterThanOrEqual(0);
+    });
+  });
+});

--- a/libs/core/src/identifier-mapping/domain/types/connection.types.ts
+++ b/libs/core/src/identifier-mapping/domain/types/connection.types.ts
@@ -7,6 +7,8 @@
  *
  * @module libs/core/src/identifier-mapping/domain/types
  */
+import type { PricingRule } from './pricing-rule.types';
+
 /**
  * Platform type identifier (e.g., 'prestashop', 'allegro', 'shopify')
  */
@@ -73,6 +75,14 @@ export interface ConnectionConfig {
    * (`stock-safety-buffer.types.ts`).
    */
   stockSafetyBuffer?: number;
+  /**
+   * Per-connection pricing-resolution rule (#1843). Markup/margin formula +
+   * rounding applied when a destination's price is derived from the master
+   * catalog price (no explicit per-item price override). A missing value
+   * preserves the pre-#1843 raw passthrough. Read via `readPricingRule` and
+   * applied via `applyPricingRule` (`pricing-rule.types.ts`).
+   */
+  pricingRule?: PricingRule;
   [key: string]: unknown;
 }
 

--- a/libs/core/src/identifier-mapping/domain/types/pricing-rule.types.ts
+++ b/libs/core/src/identifier-mapping/domain/types/pricing-rule.types.ts
@@ -1,0 +1,138 @@
+/**
+ * Pricing Rule
+ *
+ * Per-connection pricing-resolution seam (#1843) — the pluggable markup/margin
+ * + rounding formula applied when a destination's `price` is derived from the
+ * master catalog price rather than an explicit per-item override. Today's
+ * builders (`OfferBuilderService`, `ProductPublishBuilderService`) treat
+ * `product.price` as a raw passthrough; this is the seam that replaces it.
+ *
+ * The rule is read from the connection's `config.pricingRule` (JSONB) and
+ * defaults to `null` (passthrough), which preserves the pre-#1843 behaviour —
+ * the master price flows through unchanged. Pure helpers (no I/O), mirroring
+ * the `stock-safety-buffer.types.ts` config-coercion precedent (#1844).
+ *
+ * Precedence is owned by the callers: an explicit per-item `input.price`
+ * always wins over the connection's pricing rule — the rule only fires when
+ * the builder falls back to the master catalog price.
+ *
+ * @module libs/core/src/identifier-mapping/domain/types
+ */
+import type { ConnectionConfig } from './connection.types';
+
+/**
+ * Pricing formula kinds.
+ *
+ * - `passthrough`: use the master price unchanged (optionally still rounded).
+ * - `markup`: apply `percent` on top of the master price (cost-plus): `price = base * (1 + percent/100)`.
+ * - `margin`: solve for the price whose margin over the master price equals
+ *   `percent`: `price = base / (1 - percent/100)`. Guarded against `percent >= 100`
+ *   (undefined/negative denominator) by falling back to the base price.
+ */
+export const PricingRuleTypeValues = ['passthrough', 'markup', 'margin'] as const;
+export type PricingRuleType = (typeof PricingRuleTypeValues)[number];
+
+/**
+ * Rounding applied after the formula.
+ *
+ * - `none` (default): round to 2 decimal places only (float-precision cleanup).
+ * - `nearestWhole`: round to the nearest whole unit.
+ * - `endingIn99`: psychological/charm pricing — round up to the next whole unit
+ *   and subtract one cent (e.g. 19.30 → 19.99; 20.00 → 19.99).
+ */
+export const PriceRoundingModeValues = ['none', 'nearestWhole', 'endingIn99'] as const;
+export type PriceRoundingMode = (typeof PriceRoundingModeValues)[number];
+
+/**
+ * A per-connection pricing rule. `percent` is required for `markup` / `margin`
+ * (ignored for `passthrough`); a missing/invalid `percent` coerces to `0`
+ * (no-op formula) rather than throwing — config is operator-editable JSONB and
+ * must degrade gracefully.
+ */
+export interface PricingRule {
+  type: PricingRuleType;
+  percent?: number;
+  rounding?: PriceRoundingMode;
+}
+
+/** Config key holding the per-connection pricing rule on `Connection.config`. */
+export const PRICING_RULE_CONFIG_KEY = 'pricingRule';
+
+/**
+ * Read the per-connection pricing rule from a connection config.
+ *
+ * Returns `null` when the key is absent, not an object, or carries an
+ * unrecognized `type` — the caller then treats it as pure passthrough
+ * (identical to the pre-#1843 behaviour). A recognized rule with a
+ * non-numeric/non-finite `percent` coerces `percent` to `0`; an unrecognized
+ * `rounding` coerces to `'none'`.
+ */
+export function readPricingRule(config: ConnectionConfig | null | undefined): PricingRule | null {
+  if (!config) {
+    return null;
+  }
+  const raw = config[PRICING_RULE_CONFIG_KEY];
+  if (raw == null || typeof raw !== 'object' || Array.isArray(raw)) {
+    return null;
+  }
+  const candidate = raw as unknown as Record<string, unknown>;
+  const type = candidate['type'];
+  if (!isPricingRuleType(type)) {
+    return null;
+  }
+  const rawPercent = candidate['percent'];
+  const percent = typeof rawPercent === 'number' && Number.isFinite(rawPercent) ? rawPercent : 0;
+  const rawRounding = candidate['rounding'];
+  const rounding = isPriceRoundingMode(rawRounding) ? rawRounding : 'none';
+  return { type, percent, rounding };
+}
+
+function isPricingRuleType(value: unknown): value is PricingRuleType {
+  return typeof value === 'string' && (PricingRuleTypeValues as readonly string[]).includes(value);
+}
+
+function isPriceRoundingMode(value: unknown): value is PriceRoundingMode {
+  return typeof value === 'string' && (PriceRoundingModeValues as readonly string[]).includes(value);
+}
+
+/**
+ * Apply a pricing rule to a base (master catalog) price, returning the
+ * resolved destination price. `rule === null` (no configured rule) returns
+ * `basePrice` completely unchanged — no rounding, no float cleanup — so a
+ * connection with no `pricingRule` is byte-identical to the pre-#1843
+ * passthrough. Once a rule is configured (even `type: 'passthrough'`),
+ * rounding applies.
+ */
+export function applyPricingRule(basePrice: number, rule: PricingRule | null): number {
+  if (!rule) {
+    return basePrice;
+  }
+  const percent = rule.percent ?? 0;
+  let resolved = basePrice;
+  if (rule.type === 'markup') {
+    resolved = basePrice * (1 + percent / 100);
+  } else if (rule.type === 'margin') {
+    // percent >= 100 makes the denominator <= 0 (undefined margin formula);
+    // degrade to the base price rather than producing Infinity/a negative price.
+    resolved = percent >= 100 ? basePrice : basePrice / (1 - percent / 100);
+  }
+  return applyRounding(resolved, rule.rounding ?? 'none');
+}
+
+function applyRounding(value: number, mode: PriceRoundingMode): number {
+  switch (mode) {
+    case 'nearestWhole':
+      return Math.round(value);
+    case 'endingIn99': {
+      const roundedUp = Math.max(0, Math.ceil(value));
+      return round2dp(roundedUp - 0.01);
+    }
+    case 'none':
+    default:
+      return round2dp(value);
+  }
+}
+
+function round2dp(value: number): number {
+  return Math.max(0, Math.round((value + Number.EPSILON) * 100) / 100);
+}

--- a/libs/core/src/identifier-mapping/index.ts
+++ b/libs/core/src/identifier-mapping/index.ts
@@ -14,6 +14,7 @@ export * from './domain/ports/connection.port';
 export * from './domain/types/identifier-mapping.types';
 export * from './domain/types/connection.types';
 export * from './domain/types/stock-safety-buffer.types';
+export * from './domain/types/pricing-rule.types';
 export * from './domain/exceptions/duplicate-identifier-mapping.error';
 export * from './domain/exceptions/mapping-already-exists.error';
 export { ConnectionNotFoundException } from './domain/exceptions/connection-not-found.exception';

--- a/libs/core/src/listings/application/services/__tests__/offer-builder.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/offer-builder.service.spec.ts
@@ -180,6 +180,51 @@ describe('OfferBuilderService', () => {
       expect(floored.stock).toBe(0);
     });
 
+    it('resolves the master price unchanged when no pricing rule is configured (#1843)', async () => {
+      const result = await service.buildCreateOfferCommand({
+        internalVariantId: VARIANT_ID,
+        connectionId: MARKETPLACE_CONN_ID,
+        stock: 1,
+      });
+      expect(result.price).toEqual({ amount: 49.99, currency: 'PLN' });
+    });
+
+    it('applies the connection pricing rule to the master price (#1843)', async () => {
+      connectionPort.get.mockResolvedValue({
+        ...defaultConnection,
+        config: {
+          masterCatalogConnectionId: MASTER_CONN_ID,
+          pricingRule: { type: 'markup', percent: 20 },
+        },
+      } as Connection);
+
+      const result = await service.buildCreateOfferCommand({
+        internalVariantId: VARIANT_ID,
+        connectionId: MARKETPLACE_CONN_ID,
+        stock: 1,
+      });
+      // 49.99 * 1.2 = 59.988 -> rounds to 59.99
+      expect(result.price).toEqual({ amount: 59.99, currency: 'PLN' });
+    });
+
+    it('does not apply the pricing rule when an explicit input.price is supplied (#1843)', async () => {
+      connectionPort.get.mockResolvedValue({
+        ...defaultConnection,
+        config: {
+          masterCatalogConnectionId: MASTER_CONN_ID,
+          pricingRule: { type: 'markup', percent: 50 },
+        },
+      } as Connection);
+
+      const result = await service.buildCreateOfferCommand({
+        internalVariantId: VARIANT_ID,
+        connectionId: MARKETPLACE_CONN_ID,
+        stock: 1,
+        price: { amount: 10, currency: 'PLN' },
+      });
+      expect(result.price).toEqual({ amount: 10, currency: 'PLN' });
+    });
+
     it('lifts overrides.productCardId to the top-level command (#808)', async () => {
       const result = await service.buildCreateOfferCommand({
         internalVariantId: VARIANT_ID,

--- a/libs/core/src/listings/application/services/__tests__/product-publish-builder.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/product-publish-builder.service.spec.ts
@@ -127,6 +127,30 @@ describe('ProductPublishBuilderService', () => {
     expect(floored.stock).toBe(0);
   });
 
+  it('should apply the connection pricing rule to the master price (#1843)', async () => {
+    connectionPort.get.mockResolvedValue({
+      config: { masterCatalogConnectionId: MASTER, pricingRule: { type: 'margin', percent: 20 } },
+    });
+
+    const command = await service.buildPublishProductCommand(baseInput);
+
+    // margin 20% => price = 12.5 / 0.8 = 15.625 -> rounds to 15.63
+    expect(command.price).toEqual({ amount: 15.63, currency: 'PLN' });
+  });
+
+  it('should not apply the pricing rule when an explicit input.price is supplied (#1843)', async () => {
+    connectionPort.get.mockResolvedValue({
+      config: { masterCatalogConnectionId: MASTER, pricingRule: { type: 'markup', percent: 100 } },
+    });
+
+    const command = await service.buildPublishProductCommand({
+      ...baseInput,
+      price: { amount: 9.99, currency: 'PLN' },
+    });
+
+    expect(command.price).toEqual({ amount: 9.99, currency: 'PLN' });
+  });
+
   it('should thread the variant SKU into the command when the variant has one', async () => {
     products.getVariant.mockResolvedValue({
       id: VARIANT,

--- a/libs/core/src/listings/application/services/offer-builder.service.ts
+++ b/libs/core/src/listings/application/services/offer-builder.service.ts
@@ -36,8 +36,10 @@ import { Logger } from '@openlinker/shared/logging';
 import {
   CONNECTION_PORT_TOKEN,
   ConnectionPort,
+  applyPricingRule,
   applyStockSafetyBuffer,
   isPresentButInvalidStockSafetyBuffer,
+  readPricingRule,
   readStockSafetyBuffer,
 } from '@openlinker/core/identifier-mapping';
 import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
@@ -156,7 +158,7 @@ export class OfferBuilderService implements IOfferBuilderService {
       });
     }
 
-    const price = this.resolvePrice(input, product, issues);
+    const price = this.resolvePrice(input, product, connection.config, issues);
 
     // Gate 1 — category / price. Throw before projection: projection needs a
     // resolved category, and surfacing all field problems at once is the
@@ -440,9 +442,19 @@ export class OfferBuilderService implements IOfferBuilderService {
     }
   }
 
+  /**
+   * Resolve `command.price`. An explicit `input.price` always wins (per-item
+   * operator/UI-resolved price, e.g. the bulk wizard's client-side pricing
+   * policy) and is used verbatim — no rule applies to it. Otherwise falls back
+   * to the master catalog price, run through the connection's pricing-resolution
+   * rule (#1843, `pricing-rule.types.ts`) — markup/margin formula + rounding.
+   * A connection with no configured rule is untouched (`applyPricingRule`
+   * returns the master price unchanged), preserving the pre-#1843 passthrough.
+   */
   private resolvePrice(
     input: BuildCreateOfferCommandInput,
     product: { price: number | null; currency: string | null },
+    connectionConfig: Parameters<typeof readPricingRule>[0],
     issues: OfferBuilderValidationIssue[]
   ): { amount: number; currency: string } | null {
     if (input.price) {
@@ -478,7 +490,16 @@ export class OfferBuilderService implements IOfferBuilderService {
       });
       return null;
     }
-    return { amount, currency };
+    const resolvedAmount = applyPricingRule(amount, readPricingRule(connectionConfig));
+    if (resolvedAmount <= 0) {
+      issues.push({
+        field: 'price.amount',
+        code: 'NON_POSITIVE',
+        message: `Resolved price (${resolvedAmount}) from the connection's pricing rule is not a positive value; provide input.price explicitly or adjust the pricing rule`,
+      });
+      return null;
+    }
+    return { amount: resolvedAmount, currency };
   }
 
   private readMasterCatalogConnectionId(

--- a/libs/core/src/listings/application/services/product-publish-builder.service.ts
+++ b/libs/core/src/listings/application/services/product-publish-builder.service.ts
@@ -29,8 +29,10 @@ import { Logger } from '@openlinker/shared/logging';
 import {
   CONNECTION_PORT_TOKEN,
   ConnectionPort,
+  applyPricingRule,
   applyStockSafetyBuffer,
   isPresentButInvalidStockSafetyBuffer,
+  readPricingRule,
   readStockSafetyBuffer,
 } from '@openlinker/core/identifier-mapping';
 import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
@@ -100,7 +102,7 @@ export class ProductPublishBuilderService implements IProductPublishBuilderServi
     );
     const product = await productMaster.getProduct(variant.productId);
 
-    const price = this.resolvePrice(input, product, issues);
+    const price = this.resolvePrice(input, product, connection.config, issues);
     if (issues.length > 0) {
       throw new ProductPublishBuilderValidationException(issues);
     }
@@ -338,9 +340,19 @@ export class ProductPublishBuilderService implements IProductPublishBuilderServi
     return Object.keys(content).length > 0 ? content : undefined;
   }
 
+  /**
+   * Resolve `command.price`. An explicit `input.price` always wins (per-item
+   * operator/UI-resolved price) and is used verbatim — no rule applies to it.
+   * Otherwise falls back to the master catalog price, run through the
+   * connection's pricing-resolution rule (#1843, `pricing-rule.types.ts`) —
+   * markup/margin formula + rounding. A connection with no configured rule is
+   * untouched (`applyPricingRule` returns the master price unchanged),
+   * preserving the pre-#1843 passthrough.
+   */
   private resolvePrice(
     input: BuildPublishProductCommandInput,
     product: { price: number | null; currency: string | null },
+    connectionConfig: Parameters<typeof readPricingRule>[0],
     issues: ProductPublishBuilderValidationIssue[]
   ): { amount: number; currency: string } | null {
     if (input.price) {
@@ -374,7 +386,16 @@ export class ProductPublishBuilderService implements IProductPublishBuilderServi
       });
       return null;
     }
-    return { amount, currency };
+    const resolvedAmount = applyPricingRule(amount, readPricingRule(connectionConfig));
+    if (resolvedAmount <= 0) {
+      issues.push({
+        field: 'price.amount',
+        code: 'NON_POSITIVE',
+        message: `Resolved price (${resolvedAmount}) from the connection's pricing rule is not a positive value; provide input.price explicitly or adjust the pricing rule`,
+      });
+      return null;
+    }
+    return { amount: resolvedAmount, currency };
   }
 
   private readMasterCatalogConnectionId(


### PR DESCRIPTION
## What

Introduces a pure, marketplace-neutral **pricing-resolution seam** (#1843) that replaces the raw master-price passthrough in both publish builders (`OfferBuilderService`, `ProductPublishBuilderService`).

- `readPricingRule` / `applyPricingRule` (`libs/core/src/identifier-mapping/domain/types/pricing-rule.types.ts`) resolve a destination price from the master catalog price via a new per-connection `Connection.config.pricingRule` (JSONB — no migration): `{ type: 'passthrough' | 'markup' | 'margin', percent?, rounding?: 'none' | 'nearestWhole' | 'endingIn99' }`.
  - `markup` is cost-plus: `price = base * (1 + percent/100)`.
  - `margin` solves for the price whose margin over the base equals `percent`: `price = base / (1 - percent/100)`, guarded against `percent >= 100` (degrades to the base price rather than a negative/`Infinity` result).
  - `rounding: 'endingIn99'` implements the ".99" psychological-pricing rounding the issue calls out.
  - Mirrors the `stockSafetyBuffer` config-coercion precedent (#1844) exactly — same file layout, same "coerce defensively, never throw" posture.
- Both builders now call the seam as the **sole source of `command.price`** whenever no explicit per-item `input.price` is supplied — an explicit price always wins and is never re-priced. A connection with no configured rule is untouched (`applyPricingRule` returns the base price completely unchanged), so this is fully backward-compatible with every existing caller.
- `docs/architecture-overview.md` — documents the seam under the `PricingAuthorityPort` future-capability entry.

## Why not duplicated with #1832

#1832 (already merged) added `PublishProductCommerce.salePrice` (+ `saleStartsAt`/`saleEndsAt`) — the discounted **sale price** passthrough, mapped by the WooCommerce adapter to `sale_price` + `date_on_sale_from/to_gmt`. That is untouched here.

This PR adds a different, upstream layer: how the **regular price** itself is derived from the master catalog price via a markup/margin formula + rounding, when the caller doesn't supply an explicit price. The two are complementary — the sale price sits on top of whatever regular price this seam resolves.

## Scope decisions

- **FE**: no control ships yet for editing `config.pricingRule` — same posture as `stockSafetyBuffer` today (no FE surface either). The existing FE bulk-wizard `PricingPolicy` (`use-master` / `markup` / `flat`, per-batch, client-computed) is a *different* mechanism that resolves an explicit `override.price` before submit — it already bypasses this seam by design (an explicit input price always wins). Extending/reconciling the two is a natural follow-up but out of scope for an MVP-appropriate CORE seam; documented as a follow-up in `architecture-overview.md`.
- Kept the rule shape flat and closed (3 types, 3 rounding modes) per the issue's "do not over-build" guidance. A full `PricingAuthorityPort` capability is still future work.

## How to test

```bash
pnpm --filter @openlinker/core build
pnpm --filter @openlinker/core exec tsc -b --force
cd libs/core && node_modules/.bin/jest pricing-rule offer-builder product-publish-builder
```

All 87 tests pass (18 new: 12 pure-helper tests + 6 builder-integration tests across the two builders).

## Docs

- `docs/architecture-overview.md` — expanded the `PricingAuthorityPort` future-capability-port entry to document the shipped pricing-resolution seam, its config shape, and the "no FE control yet" follow-up note.
- No ADR: this is a config-coercion helper mirroring an existing precedent (#1844), not a new cross-context architectural pattern.

Closes #1843