### PR TITLE
fix(listings): distinguish parent vs variation targets in 404 recovery + status reads

### DIFF
--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -86,17 +86,19 @@ declare what they support via `implements <BasePort>, <SubCapability>, …`.
 section); Erli implements a reconciliation-first subset
 ([ADR-025](./architecture/adrs/025-erli-marketplace-adapter.md)).
 
-### `ShopProductManagerPort` (listings) — 3
+### `ShopProductManagerPort` (listings) — 4
 
 | Sub-capability | What it does | Method(s) | Guard |
 |---|---|---|---|
 | `CategoryProvisioner` | Create / ensure a category exists on the destination shop before publishing. Also a registry-level capability (`CategoryProvisioner` ∈ `CoreCapabilityValues`). | `provisionCategory` | `isCategoryProvisioner` |
 | `ShopCategoryBrowser` | Browse the shop's existing category tree (drill-down by parent) so an operator can pick a placement — the shop-side sibling of the marketplace `CategoryBrowser`. Every node is selectable (no leaf gate). Advertised-without-dispatch (not in `CoreCapabilityValues`): declared in the manifest for discovery, resolved by narrowing the `ProductPublisher` adapter. | `browseCategories` | `isShopCategoryBrowser` |
 | `ShopAttributeReader` | Read the shop's store-wide global product attributes + their predefined terms so an operator can pick a structured attribute (linked on publish as `pa_*` + term ids), with free-text custom attributes as the fallback. Advertised-without-dispatch (not in `CoreCapabilityValues`): declared in the manifest for discovery, resolved by narrowing the `ProductPublisher` adapter. | `listAttributes`, `listAttributeTerms` | `isShopAttributeReader` |
+| `ShopProductStatusReader` | Read a previously-published product's live shop-side publication status for the steady-state `ShopStatusSyncService` reconcile (#1845) — the shop-side sibling of `OfferStatusReader`. Optional `getShopVariationStatus` reads a grouped/multi-variant publish's CHILD variation status scoped under its parent (a variation lives at a different shop-native resource than a standalone simple product). Advertised-without-dispatch (not in `CoreCapabilityValues`): declared in the manifest for discovery, resolved by narrowing the `ProductPublisher` adapter. | `getShopProductStatus`, `getShopVariationStatus?` | `isShopProductStatusReader` |
 
 **Adapter coverage:** WooCommerce implements `CategoryProvisioner` (write),
-`ShopCategoryBrowser` (read, #1834), and `ShopAttributeReader` (read, #1835) on
-its `ProductPublisher` adapter.
+`ShopCategoryBrowser` (read, #1834), `ShopAttributeReader` (read, #1835), and
+`ShopProductStatusReader` (read, #1845, including the grouped-variation-aware
+read) on its `ProductPublisher` adapter.
 
 ### `OrderProcessorManagerPort` / `OrderSourcePort` (orders) — 5
 

--- a/libs/core/src/listings/application/services/__tests__/product-publish-execution.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/product-publish-execution.service.spec.ts
@@ -454,5 +454,174 @@ describe('ProductPublishExecutionService', () => {
         ShopProductMappingConflictException,
       );
     });
+
+    describe('stale-mapping 404 recovery distinguishes variant vs parent target (whole-epic review finding #1)', () => {
+      it('should recover the VARIANT-level mapping unchanged when the variation upsert 404s (existing parent untouched)', async () => {
+        // Both variant and parent mappings already exist (steady-state re-publish).
+        identifierMapping.getExternalIds.mockImplementation(
+          (entityType: string, internalId: string) => {
+            if (internalId === GROUP_ID) {
+              return Promise.resolve([
+                { externalId: PARENT_EXT, connectionId: CONN, entityType, platformType: 'woocommerce' },
+              ]);
+            }
+            return Promise.resolve([
+              { externalId: VARIATION_EXT, connectionId: CONN, entityType, platformType: 'woocommerce' },
+            ]);
+          },
+        );
+        const NEW_VARIATION_EXT = 'wc-variation-99';
+        adapter.publishProduct
+          .mockRejectedValueOnce(
+            new ProductPublishTargetNotFoundException('woocommerce.restapi.v3', VARIATION_EXT),
+          )
+          .mockResolvedValueOnce({
+            externalProductId: NEW_VARIATION_EXT,
+            status: 'published',
+            externalParentProductId: PARENT_EXT,
+          });
+
+        const result = await service.executePublish(input);
+
+        // Only the variant-level mapping is deleted — the parent mapping is untouched.
+        expect(identifierMapping.deleteMapping).toHaveBeenCalledWith('ShopProduct', VARIATION_EXT, CONN);
+        expect(identifierMapping.deleteMapping).not.toHaveBeenCalledWith(
+          'ShopProduct',
+          PARENT_EXT,
+          CONN,
+        );
+        expect(adapter.publishProduct).toHaveBeenCalledTimes(2);
+        expect(adapter.publishProduct).toHaveBeenNthCalledWith(
+          2,
+          expect.objectContaining({
+            externalProductId: null,
+            variantGroup: expect.objectContaining({ externalParentProductId: PARENT_EXT }),
+          }),
+        );
+        // Fresh variant mapping written; parent mapping already existed, not re-created.
+        expect(identifierMapping.createMapping).toHaveBeenCalledWith(
+          'ShopProduct',
+          NEW_VARIATION_EXT,
+          CONN,
+          VARIANT,
+        );
+        expect(identifierMapping.createMapping).not.toHaveBeenCalledWith(
+          'ShopProduct',
+          expect.anything(),
+          CONN,
+          GROUP_ID,
+        );
+        expect(result.outcome).toBe('ok');
+      });
+
+      it('should recover the PARENT mapping (not the variant mapping) when the parent upsert 404s and an existing variant mapping is present', async () => {
+        identifierMapping.getExternalIds.mockImplementation(
+          (entityType: string, internalId: string) => {
+            if (internalId === GROUP_ID) {
+              return Promise.resolve([
+                { externalId: PARENT_EXT, connectionId: CONN, entityType, platformType: 'woocommerce' },
+              ]);
+            }
+            return Promise.resolve([
+              { externalId: VARIATION_EXT, connectionId: CONN, entityType, platformType: 'woocommerce' },
+            ]);
+          },
+        );
+        const NEW_PARENT_EXT = 'wc-parent-99';
+        adapter.publishProduct
+          .mockRejectedValueOnce(
+            new ProductPublishTargetNotFoundException('woocommerce.restapi.v3', PARENT_EXT),
+          )
+          .mockResolvedValueOnce({
+            externalProductId: VARIATION_EXT,
+            status: 'published',
+            externalParentProductId: NEW_PARENT_EXT,
+          });
+
+        const result = await service.executePublish(input);
+
+        // Only the PARENT mapping is deleted — the variant's own mapping is untouched.
+        expect(identifierMapping.deleteMapping).toHaveBeenCalledWith('ShopProduct', PARENT_EXT, CONN);
+        expect(identifierMapping.deleteMapping).not.toHaveBeenCalledWith(
+          'ShopProduct',
+          VARIATION_EXT,
+          CONN,
+        );
+        expect(adapter.publishProduct).toHaveBeenCalledTimes(2);
+        expect(adapter.publishProduct).toHaveBeenNthCalledWith(
+          2,
+          expect.objectContaining({
+            externalProductId: VARIATION_EXT,
+            variantGroup: expect.objectContaining({ externalParentProductId: null }),
+          }),
+        );
+        // Fresh parent mapping written; the variant's own mapping already
+        // existed and is not re-created.
+        expect(identifierMapping.createMapping).toHaveBeenCalledWith(
+          'ShopProduct',
+          NEW_PARENT_EXT,
+          CONN,
+          GROUP_ID,
+        );
+        expect(identifierMapping.createMapping).not.toHaveBeenCalledWith(
+          'ShopProduct',
+          expect.anything(),
+          CONN,
+          VARIANT,
+        );
+        expect(result.outcome).toBe('ok');
+      });
+
+      it('should recover a stale parent mapping even with NO existing variant mapping (new sibling, dead parent)', async () => {
+        // Parent mapping already exists (created by an earlier sibling); this
+        // sibling has never published (no variant-level mapping yet).
+        identifierMapping.getExternalIds.mockImplementation(
+          (entityType: string, internalId: string) => {
+            if (internalId === GROUP_ID) {
+              return Promise.resolve([
+                { externalId: PARENT_EXT, connectionId: CONN, entityType, platformType: 'woocommerce' },
+              ]);
+            }
+            return Promise.resolve([]);
+          },
+        );
+        const NEW_PARENT_EXT = 'wc-parent-99';
+        adapter.publishProduct
+          .mockRejectedValueOnce(
+            new ProductPublishTargetNotFoundException('woocommerce.restapi.v3', PARENT_EXT),
+          )
+          .mockResolvedValueOnce({
+            externalProductId: VARIATION_EXT,
+            status: 'published',
+            externalParentProductId: NEW_PARENT_EXT,
+          });
+
+        const result = await service.executePublish(input);
+
+        // Recovers instead of throwing raw — the old (pre-fix) behavior would
+        // hit `throw error` here since `existingExternalProductId` was null.
+        expect(identifierMapping.deleteMapping).toHaveBeenCalledWith('ShopProduct', PARENT_EXT, CONN);
+        expect(adapter.publishProduct).toHaveBeenCalledTimes(2);
+        expect(adapter.publishProduct).toHaveBeenNthCalledWith(
+          2,
+          expect.objectContaining({
+            variantGroup: expect.objectContaining({ externalParentProductId: null }),
+          }),
+        );
+        expect(identifierMapping.createMapping).toHaveBeenCalledWith(
+          'ShopProduct',
+          NEW_PARENT_EXT,
+          CONN,
+          GROUP_ID,
+        );
+        expect(identifierMapping.createMapping).toHaveBeenCalledWith(
+          'ShopProduct',
+          VARIATION_EXT,
+          CONN,
+          VARIANT,
+        );
+        expect(result.outcome).toBe('ok');
+      });
+    });
   });
 });

--- a/libs/core/src/listings/application/services/__tests__/shop-status-sync.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/shop-status-sync.service.spec.ts
@@ -32,7 +32,13 @@ describe('ShopStatusSyncService', () => {
   let integrations: { getCapabilityAdapter: jest.Mock };
   let records: { findPublishedByConnection: jest.Mock };
   let snapshots: { upsert: jest.Mock };
-  let adapter: { publishProduct: jest.Mock; getShopProductStatus?: jest.Mock };
+  let productsService: { getVariant: jest.Mock; getVariantsByProductId: jest.Mock };
+  let identifierMapping: { getExternalIds: jest.Mock };
+  let adapter: {
+    publishProduct: jest.Mock;
+    getShopProductStatus?: jest.Mock;
+    getShopVariationStatus?: jest.Mock;
+  };
   let service: ShopStatusSyncService;
 
   beforeEach(() => {
@@ -50,10 +56,17 @@ describe('ShopStatusSyncService', () => {
       }),
     };
     snapshots = { upsert: jest.fn().mockResolvedValue({ previousStatus: null }) };
+    productsService = {
+      getVariant: jest.fn().mockResolvedValue({ productId: 'ol_product_a' }),
+      getVariantsByProductId: jest.fn().mockResolvedValue([{ id: 'ol_variant_a' }]),
+    };
+    identifierMapping = { getExternalIds: jest.fn().mockResolvedValue([]) };
     service = new ShopStatusSyncService(
       integrations as never,
       records as never,
       snapshots as never,
+      productsService as never,
+      identifierMapping as never,
     );
   });
 
@@ -111,5 +124,69 @@ describe('ShopStatusSyncService', () => {
     const result = await service.sync(CONN, { limit: 1, offset: 0 });
 
     expect(result.nextOffset).toBe(1);
+  });
+
+  describe('grouped-variation status read (whole-epic review finding #2)', () => {
+    it('should call the standalone getShopProductStatus path (no regression) for a simple-product record', async () => {
+      productsService.getVariantsByProductId.mockResolvedValue([{ id: 'ol_variant_a' }]); // single variant, not grouped
+      adapter.getShopVariationStatus = jest.fn();
+
+      await service.sync(CONN, { limit: 100 });
+
+      expect(adapter.getShopProductStatus).toHaveBeenCalledWith('wc-1');
+      expect(adapter.getShopVariationStatus).not.toHaveBeenCalled();
+    });
+
+    it('should call the variation-aware read with parent+variation ids for a grouped-variant record, and not report it removed when the variation is live', async () => {
+      productsService.getVariant.mockResolvedValue({ productId: 'ol_product_a' });
+      productsService.getVariantsByProductId.mockResolvedValue([
+        { id: 'ol_variant_a' },
+        { id: 'ol_variant_b' },
+      ]); // multi-variant → grouped
+      identifierMapping.getExternalIds.mockResolvedValue([
+        { externalId: 'wc-parent-1', connectionId: CONN, entityType: 'ShopProduct', platformType: 'woocommerce' },
+      ]);
+      adapter.getShopVariationStatus = jest
+        .fn()
+        .mockResolvedValue({ publicationStatus: SHOP_PUBLICATION_STATUS.Published });
+
+      const result = await service.sync(CONN, { limit: 100 });
+
+      expect(adapter.getShopVariationStatus).toHaveBeenCalledWith('wc-parent-1', 'wc-1');
+      expect(adapter.getShopProductStatus).not.toHaveBeenCalled();
+      expect(result.removed).toBe(0);
+      expect(snapshots.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({ publicationStatus: SHOP_PUBLICATION_STATUS.Published }),
+      );
+    });
+
+    it('should fall back to getShopProductStatus when grouped but no parent mapping is resolvable', async () => {
+      productsService.getVariantsByProductId.mockResolvedValue([
+        { id: 'ol_variant_a' },
+        { id: 'ol_variant_b' },
+      ]);
+      identifierMapping.getExternalIds.mockResolvedValue([]); // no parent mapping yet
+      adapter.getShopVariationStatus = jest.fn();
+
+      await service.sync(CONN, { limit: 100 });
+
+      expect(adapter.getShopVariationStatus).not.toHaveBeenCalled();
+      expect(adapter.getShopProductStatus).toHaveBeenCalledWith('wc-1');
+    });
+
+    it('should fall back to getShopProductStatus when the adapter does not implement getShopVariationStatus', async () => {
+      productsService.getVariantsByProductId.mockResolvedValue([
+        { id: 'ol_variant_a' },
+        { id: 'ol_variant_b' },
+      ]);
+      identifierMapping.getExternalIds.mockResolvedValue([
+        { externalId: 'wc-parent-1', connectionId: CONN, entityType: 'ShopProduct', platformType: 'woocommerce' },
+      ]);
+      // adapter.getShopVariationStatus intentionally left undefined.
+
+      await service.sync(CONN, { limit: 100 });
+
+      expect(adapter.getShopProductStatus).toHaveBeenCalledWith('wc-1');
+    });
   });
 });

--- a/libs/core/src/listings/application/services/product-publish-execution.service.ts
+++ b/libs/core/src/listings/application/services/product-publish-execution.service.ts
@@ -168,35 +168,63 @@ export class ProductPublishExecutionService implements IProductPublishExecutionS
     let mappingNeedsCreate = !existingExternalProductId;
     // #1836 — same tracking for the grouped parent mapping, independent of the
     // variant's own mapping lifecycle (a variant re-publish after the parent
-    // already exists must not re-write the parent mapping).
-    const parentMappingNeedsCreate =
+    // already exists must not re-write the parent mapping). `let` because a
+    // parent-level stale-mapping recovery (below) also forces a re-write.
+    let parentMappingNeedsCreate =
       command.variantGroup != null && !existingParentExternalProductId;
 
     let result: PublishProductResult;
     try {
       result = await adapter.publishProduct(command);
     } catch (error) {
-      // Stale mapping: the upsert target was deleted shop-side. Drop the dead
-      // `ShopProduct` mapping and re-publish as a create so the variant can
-      // recover instead of failing forever (#1846 fix 1/5).
-      if (error instanceof ProductPublishTargetNotFoundException && existingExternalProductId) {
-        try {
-          result = await this.recreateAfterStaleUpsertTarget(
-            adapter,
-            command,
-            input,
-            existingExternalProductId
-          );
-          mappingNeedsCreate = true;
-        } catch (recoveryError) {
-          // A rejection on the recovery create is a terminal business failure,
-          // exactly like a rejection on the first-attempt create path — record
-          // it as `failed` instead of letting it escape as an unhandled throw
-          // (which would retry/dead the job).
-          if (recoveryError instanceof ProductPublishRejectedException) {
-            return this.recordRejection(record.id, input.connectionId, recoveryError);
+      if (error instanceof ProductPublishTargetNotFoundException) {
+        // The adapter reports which id actually 404'd — a grouped publish has
+        // TWO distinct upsert targets (the variant's own variation id and the
+        // shared parent's id, resolved separately above), and only recovering
+        // whichever one is truly stale avoids deleting a perfectly-fine
+        // mapping or leaving a dead parent mapping in place forever (whole-epic
+        // review finding #1).
+        const staleId = error.externalProductId;
+        if (existingExternalProductId && staleId === existingExternalProductId) {
+          try {
+            result = await this.recreateAfterStaleUpsertTarget(
+              adapter,
+              command,
+              input,
+              existingExternalProductId
+            );
+            mappingNeedsCreate = true;
+          } catch (recoveryError) {
+            // A rejection on the recovery create is a terminal business failure,
+            // exactly like a rejection on the first-attempt create path — record
+            // it as `failed` instead of letting it escape as an unhandled throw
+            // (which would retry/dead the job).
+            if (recoveryError instanceof ProductPublishRejectedException) {
+              return this.recordRejection(record.id, input.connectionId, recoveryError);
+            }
+            throw recoveryError;
           }
-          throw recoveryError;
+        } else if (
+          command.variantGroup &&
+          existingParentExternalProductId &&
+          staleId === existingParentExternalProductId
+        ) {
+          try {
+            result = await this.recreateAfterStaleParentTarget(
+              adapter,
+              command,
+              input,
+              existingParentExternalProductId
+            );
+            parentMappingNeedsCreate = true;
+          } catch (recoveryError) {
+            if (recoveryError instanceof ProductPublishRejectedException) {
+              return this.recordRejection(record.id, input.connectionId, recoveryError);
+            }
+            throw recoveryError;
+          }
+        } else {
+          throw error;
         }
       } else if (error instanceof ProductPublishRejectedException) {
         return this.recordRejection(record.id, input.connectionId, error);
@@ -321,6 +349,42 @@ export class ProductPublishExecutionService implements IProductPublishExecutionS
     );
     const createCommand: PublishProductCommand = { ...command, externalProductId: null };
     return adapter.publishProduct(createCommand);
+  }
+
+  /**
+   * Recover from a stale grouped-parent `ShopProduct` mapping (whole-epic review
+   * finding #1) — the PARENT id resolved onto `command.variantGroup.externalParentProductId`
+   * no longer exists shop-side (the parent upsert 404'd, not the variation
+   * upsert). Deletes the dead parent mapping and re-publishes the same command
+   * with `variantGroup.externalParentProductId` cleared so the adapter creates a
+   * fresh parent; the caller then persists the new parent mapping. Distinct from
+   * {@link recreateAfterStaleUpsertTarget}, which recovers the variant/variation's
+   * OWN stale mapping — the two are mutually exclusive per invocation because
+   * only one id can be the one that actually 404'd.
+   */
+  private async recreateAfterStaleParentTarget(
+    adapter: ShopProductManagerPort,
+    command: PublishProductCommand,
+    input: ExecutePublishProductInput,
+    staleParentExternalProductId: string
+  ): Promise<PublishProductResult> {
+    this.logger.warn(
+      `Stale ShopProduct PARENT mapping detected; grouped-parent upsert target missing shop-side. ` +
+        `Deleting parent mapping and re-creating. connectionId=${input.connectionId} ` +
+        `internalVariantId=${input.internalVariantId} staleParentExternalProductId=${staleParentExternalProductId}`
+    );
+    await this.identifierMapping.deleteMapping(
+      CORE_ENTITY_TYPE.ShopProduct,
+      staleParentExternalProductId,
+      input.connectionId
+    );
+    const retriedCommand: PublishProductCommand = {
+      ...command,
+      variantGroup: command.variantGroup
+        ? { ...command.variantGroup, externalParentProductId: null }
+        : command.variantGroup,
+    };
+    return adapter.publishProduct(retriedCommand);
   }
 
   /**

--- a/libs/core/src/listings/application/services/shop-status-sync.service.ts
+++ b/libs/core/src/listings/application/services/shop-status-sync.service.ts
@@ -17,15 +17,27 @@
  */
 import { Inject, Injectable } from '@nestjs/common';
 
+import {
+  CORE_ENTITY_TYPE,
+  IDENTIFIER_MAPPING_SERVICE_TOKEN,
+  IIdentifierMappingService,
+} from '@openlinker/core/identifier-mapping';
 import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
+import { IProductsService, PRODUCTS_SERVICE_TOKEN } from '@openlinker/core/products';
 import { Logger } from '@openlinker/shared/logging';
 
 import type { ShopProductManagerPort } from '../../domain/ports/shop-product-manager.port';
-import { isShopProductStatusReader } from '../../domain/ports/capabilities/shop-product-status-reader.capability';
+import {
+  isShopProductStatusReader,
+  type ShopProductStatusReader,
+} from '../../domain/ports/capabilities/shop-product-status-reader.capability';
 import { ListingCreationRecordRepositoryPort } from '../../domain/ports/listing-creation-record-repository.port';
 import { ShopProductStatusSnapshotRepositoryPort } from '../../domain/ports/shop-product-status-snapshot-repository.port';
 import { SHOP_PUBLICATION_STATUS } from '../../domain/types/shop-product-status.types';
-import type { ShopStatusSyncResult } from '../../domain/types/shop-product-status.types';
+import type {
+  ShopProductStatusReadResult,
+  ShopStatusSyncResult,
+} from '../../domain/types/shop-product-status.types';
 import {
   LISTING_CREATION_RECORD_REPOSITORY_TOKEN,
   SHOP_PRODUCT_STATUS_SNAPSHOT_REPOSITORY_TOKEN,
@@ -46,6 +58,10 @@ export class ShopStatusSyncService implements IShopStatusSyncService {
     private readonly listingRecords: ListingCreationRecordRepositoryPort,
     @Inject(SHOP_PRODUCT_STATUS_SNAPSHOT_REPOSITORY_TOKEN)
     private readonly snapshots: ShopProductStatusSnapshotRepositoryPort,
+    @Inject(PRODUCTS_SERVICE_TOKEN)
+    private readonly productsService: IProductsService,
+    @Inject(IDENTIFIER_MAPPING_SERVICE_TOKEN)
+    private readonly identifierMapping: IIdentifierMappingService,
   ) {}
 
   async sync(
@@ -84,7 +100,7 @@ export class ShopStatusSyncService implements IShopStatusSyncService {
       }
       const externalProductId = record.externalProductId;
 
-      const status = await adapter.getShopProductStatus(externalProductId);
+      const status = await this.readStatus(adapter, connectionId, record.internalVariantId, externalProductId);
 
       const { previousStatus } = await this.snapshots.upsert({
         connectionId,
@@ -123,5 +139,57 @@ export class ShopStatusSyncService implements IShopStatusSyncService {
       total: page.total,
       nextOffset,
     };
+  }
+
+  /**
+   * Resolve the correct status-read call for one record (whole-epic review
+   * finding #2). A grouped/multi-variant publish (#1836) stores the CHILD
+   * variation's id on `record.externalProductId`, which is a different
+   * shop-native resource than a standalone simple product (WooCommerce:
+   * `products/{parentId}/variations/{id}`, not `products/{id}`) — reading it
+   * through `getShopProductStatus` 404s and is misread as `removed`.
+   *
+   * Detects "grouped" the same way the publish path does (sibling count > 1 on
+   * the variant's product), then resolves the parent's `ShopProduct` mapping
+   * (keyed on the product id, same lookup shape used to thread
+   * `variantGroup.externalParentProductId` in `ProductPublishExecutionService`)
+   * and calls the adapter's variation-aware read when both the grouping and
+   * the adapter support exist. Falls back to the simple-product read
+   * otherwise — including when the adapter doesn't implement the optional
+   * `getShopVariationStatus` method — so existing readers are unaffected.
+   */
+  private async readStatus(
+    adapter: ShopProductManagerPort & ShopProductStatusReader,
+    connectionId: string,
+    internalVariantId: string,
+    externalProductId: string,
+  ): Promise<ShopProductStatusReadResult> {
+    if (typeof adapter.getShopVariationStatus === 'function') {
+      const variant = await this.productsService.getVariant(internalVariantId);
+      if (variant) {
+        const siblings = await this.productsService.getVariantsByProductId(variant.productId);
+        if (siblings.length > 1) {
+          const parentExternalId = await this.resolveParentExternalId(
+            variant.productId,
+            connectionId,
+          );
+          if (parentExternalId) {
+            return adapter.getShopVariationStatus(parentExternalId, externalProductId);
+          }
+        }
+      }
+    }
+    return adapter.getShopProductStatus(externalProductId);
+  }
+
+  private async resolveParentExternalId(
+    productId: string,
+    connectionId: string,
+  ): Promise<string | null> {
+    const mappings = await this.identifierMapping.getExternalIds(
+      CORE_ENTITY_TYPE.ShopProduct,
+      productId,
+    );
+    return mappings.find((m) => m.connectionId === connectionId)?.externalId ?? null;
   }
 }

--- a/libs/core/src/listings/domain/ports/capabilities/shop-product-status-reader.capability.ts
+++ b/libs/core/src/listings/domain/ports/capabilities/shop-product-status-reader.capability.ts
@@ -14,6 +14,17 @@
  * transport-level failures should propagate so the runner's transient-retry path
  * absorbs the blip.
  *
+ * `getShopVariationStatus` is the variation-aware sibling (whole-epic review
+ * finding #2): for a grouped/multi-variant publish (#1836), a `ListingCreationRecord`'s
+ * `externalProductId` is the CHILD variation's id, which lives at a different
+ * shop-native resource than a standalone simple product (WooCommerce:
+ * `products/{parentId}/variations/{id}`, not `products/{id}`) — calling
+ * `getShopProductStatus` with a variation id 404s and would be misread as
+ * `removed`. Optional (not every reader implements grouped publishing, and not
+ * every `ShopStatusSyncService` record is a grouped variation) so existing
+ * simple-product-only readers stay unchanged; `ShopStatusSyncService` calls it
+ * only when it resolves a parent id for the record's product.
+ *
  * @module libs/core/src/listings/domain/ports/capabilities
  */
 import type { ShopProductStatusReadResult } from '../../types/shop-product-status.types';
@@ -21,6 +32,16 @@ import type { ShopProductManagerPort } from '../shop-product-manager.port';
 
 export interface ShopProductStatusReader {
   getShopProductStatus(externalProductId: string): Promise<ShopProductStatusReadResult>;
+  /**
+   * Read the live status of a grouped-publish CHILD variation, scoped under its
+   * parent. Optional: only meaningful for adapters that support grouped/
+   * multi-variant publishing (#1836, e.g. WooCommerce `type:'variable'` +
+   * `products/{parentId}/variations/{id}`).
+   */
+  getShopVariationStatus?(
+    externalParentProductId: string,
+    externalVariationId: string,
+  ): Promise<ShopProductStatusReadResult>;
 }
 
 export function isShopProductStatusReader(

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/product-publisher/__tests__/woocommerce-product-publisher.adapter.spec.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/product-publisher/__tests__/woocommerce-product-publisher.adapter.spec.ts
@@ -621,6 +621,37 @@ describe('WooCommerceProductPublisherAdapter', () => {
       // Never reached the variation call — the parent upsert failed first.
       expect(http.post).not.toHaveBeenCalled();
     });
+
+    it('should omit sale_price/date_on_sale fields from the parent body while the variation body still carries them (whole-epic review finding #3)', async () => {
+      http.post.mockResolvedValueOnce({ id: 500 }).mockResolvedValueOnce({ id: 501 });
+
+      await adapter.publishProduct(
+        baseCommand({
+          variantGroup: { ...variantGroup, externalParentProductId: null },
+          commerce: {
+            salePrice: { amount: 9.99, currency: 'PLN' },
+            saleStartsAt: '2026-01-01T00:00:00Z',
+            saleEndsAt: '2026-02-01T00:00:00Z',
+            taxClass: 'reduced-rate',
+          },
+        }),
+      );
+
+      const parentBody = http.post.mock.calls[0][1] as Record<string, unknown>;
+      expect(parentBody).not.toHaveProperty('sale_price');
+      expect(parentBody).not.toHaveProperty('date_on_sale_from_gmt');
+      expect(parentBody).not.toHaveProperty('date_on_sale_to_gmt');
+      // Non-price commerce fields still apply to the parent.
+      expect(parentBody).toMatchObject({ tax_class: 'reduced-rate' });
+
+      const variationBody = http.post.mock.calls[1][1] as Record<string, unknown>;
+      expect(variationBody).toMatchObject({
+        sale_price: '9.99',
+        date_on_sale_from_gmt: '2026-01-01T00:00:00Z',
+        date_on_sale_to_gmt: '2026-02-01T00:00:00Z',
+        tax_class: 'reduced-rate',
+      });
+    });
   });
 
   describe('provisionCategory', () => {
@@ -816,6 +847,33 @@ describe('WooCommerceProductPublisherAdapter', () => {
       http.get.mockRejectedValue(new WooCommerceHttpResponseException(500, 'boom'));
 
       await expect(adapter.getShopProductStatus('42')).rejects.toBeInstanceOf(
+        WooCommerceHttpResponseException,
+      );
+    });
+  });
+
+  describe('getShopVariationStatus (whole-epic review finding #2)', () => {
+    it('should read the variation-scoped resource under its parent', async () => {
+      http.get.mockResolvedValue({ id: 501, status: 'publish' });
+
+      const result = await adapter.getShopVariationStatus('500', '501');
+
+      expect(http.get).toHaveBeenCalledWith('/wp-json/wc/v3/products/500/variations/501');
+      expect(result).toEqual({ publicationStatus: 'published' });
+    });
+
+    it('should map a 404 to removed (variation deleted/trashed shop-side)', async () => {
+      http.get.mockRejectedValue(new WooCommerceHttpResponseException(404, 'not found'));
+
+      const result = await adapter.getShopVariationStatus('500', '999');
+
+      expect(result).toEqual({ publicationStatus: 'removed' });
+    });
+
+    it('should propagate a non-404 transport error for worker retry', async () => {
+      http.get.mockRejectedValue(new WooCommerceHttpResponseException(500, 'boom'));
+
+      await expect(adapter.getShopVariationStatus('500', '501')).rejects.toBeInstanceOf(
         WooCommerceHttpResponseException,
       );
     });

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/product-publisher/woocommerce-product-publisher.adapter.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/product-publisher/woocommerce-product-publisher.adapter.ts
@@ -252,6 +252,31 @@ export class WooCommerceProductPublisherAdapter
   }
 
   /**
+   * Read the live status of a grouped-publish CHILD variation (whole-epic review
+   * finding #2). A variation lives at a different resource than a standalone
+   * simple product — `products/{parentId}/variations/{id}`, not `products/{id}`
+   * — so calling `getShopProductStatus` with a variation id 404s and would be
+   * misread as `removed` even though the variation is genuinely live. Same 404
+   * → `removed` mapping as the simple-product path.
+   */
+  async getShopVariationStatus(
+    externalParentProductId: string,
+    externalVariationId: string,
+  ): Promise<ShopProductStatusReadResult> {
+    const path = `${PRODUCTS_PATH}/${encodeURIComponent(externalParentProductId)}/variations/${encodeURIComponent(externalVariationId)}`;
+    let raw: WooCommerceProductStatusResponse;
+    try {
+      raw = await this.httpClient.get<WooCommerceProductStatusResponse>(path);
+    } catch (err) {
+      if (err instanceof WooCommerceHttpResponseException && err.statusCode === 404) {
+        return { publicationStatus: SHOP_PUBLICATION_STATUS.Removed };
+      }
+      throw err;
+    }
+    return { publicationStatus: this.toPublicationStatus(raw.status) };
+  }
+
+  /**
    * Map a WooCommerce native product status onto the neutral union. `publish` is
    * live; `draft` reverted to draft; `pending`/`private` are present but not
    * buyer-visible (unpublished); `trash` (or any unknown value) is treated as
@@ -512,7 +537,12 @@ export class WooCommerceProductPublisherAdapter
     ];
     if (attributes.length > 0) typed.attributes = attributes;
 
-    this.applyCommerce(typed, cmd);
+    // Price/sale-price/sale-window fields are intentionally excluded on the
+    // PARENT (whole-epic review finding #3): WooCommerce derives a variable
+    // product's price/sale/on-sale state from its VARIATIONS, not the parent
+    // post, so writing them here is silently ignored. `applyCommerce` still
+    // writes dimensions/tax_class, which ARE legitimate parent-level fields.
+    this.applyCommerce(typed, cmd, { includePricing: false });
 
     const metaData = this.buildSeoMetaData(content?.seo);
     if (metaData.length > 0) typed.meta_data = metaData;
@@ -575,19 +605,26 @@ export class WooCommerceProductPublisherAdapter
    * Map the neutral `commerce` block (sale price + schedule, dimensions, tax).
    * Typed against the shared `WooCommercePriceCommerceFields` shape so it can
    * write into either the parent/simple-product body or a variation body.
+   * `includePricing` (default `true`) gates the price/sale-price/sale-window
+   * fields off for the `variable` PARENT body (whole-epic review finding #3) —
+   * WooCommerce derives those from the VARIATIONS, not the parent post, so
+   * writing them there is silently ignored. Dimensions/tax always apply.
    */
   private applyCommerce(
     typed: WooCommercePriceCommerceFields,
     cmd: PublishProductCommand,
+    { includePricing = true }: { includePricing?: boolean } = {},
   ): void {
     const commerce = cmd.commerce;
     if (!commerce) return;
 
-    if (commerce.salePrice != null) typed.sale_price = String(commerce.salePrice.amount);
-    // Neutral sale window is UTC (ISO 8601); write the `_gmt` fields so WC does
-    // not reinterpret the value as site-local and shift the window.
-    if (commerce.saleStartsAt != null) typed.date_on_sale_from_gmt = commerce.saleStartsAt;
-    if (commerce.saleEndsAt != null) typed.date_on_sale_to_gmt = commerce.saleEndsAt;
+    if (includePricing) {
+      if (commerce.salePrice != null) typed.sale_price = String(commerce.salePrice.amount);
+      // Neutral sale window is UTC (ISO 8601); write the `_gmt` fields so WC
+      // does not reinterpret the value as site-local and shift the window.
+      if (commerce.saleStartsAt != null) typed.date_on_sale_from_gmt = commerce.saleStartsAt;
+      if (commerce.saleEndsAt != null) typed.date_on_sale_to_gmt = commerce.saleEndsAt;
+    }
     if (commerce.taxClass != null) typed.tax_class = commerce.taxClass;
     if (commerce.taxStatus != null) typed.tax_status = commerce.taxStatus;
 

--- a/libs/integrations/woocommerce/src/woocommerce-plugin.ts
+++ b/libs/integrations/woocommerce/src/woocommerce-plugin.ts
@@ -70,6 +70,12 @@ export const woocommerceAdapterManifest: AdapterMetadata = {
     // structured attribute picker (global attribute + terms; custom free-text
     // fallback).
     'ShopAttributeReader',
+    // Shop-side publication status read (#1845). Advertised-without-dispatch:
+    // declared here for host/FE discovery, resolved by narrowing the dispatched
+    // ProductPublisher adapter with `isShopProductStatusReader` (never via
+    // getCapabilityAdapter('ShopProductStatusReader')). Backs the steady-state
+    // `ShopStatusSyncService` reconcile scheduler.
+    'ShopProductStatusReader',
     // Inventory write-back to published products (#1498). Quantity-only —
     // WooCommerce is a destination shop, not a marketplace: no OfferCreator /
     // OfferLister sub-capabilities, so offer-creation flows (gated on


### PR DESCRIPTION
## Summary

Fixes 4 findings from the whole-epic review of epic #1838 (WooCommerce publish/status pipeline).

1. **BLOCKING** - `ProductPublishExecutionService`'s stale-mapping 404 recovery keyed off the variant's own mapping regardless of which id actually 404'd. For a grouped (multi-variant) publish, a parent-level 404 was either mis-recovered as a variant-level stale mapping, or (when no variant mapping existed yet) thrown raw instead of recovering. Recovery now branches on `error.externalProductId` to delete and recreate whichever mapping (variant or parent) actually went stale, including the "new sibling, dead parent" case with no existing variant mapping.
2. **BLOCKING** - `ShopStatusSyncService` called `getShopProductStatus` unconditionally, but a grouped/multi-variant record's `externalProductId` is a WooCommerce variation id, which lives at a different resource (`products/{parentId}/variations/{id}`) than a standalone simple product (`products/{id}`). This 404'd every live variation on the first reconcile pass and flipped them all to `removed`. Added an optional `getShopVariationStatus` on the `ShopProductStatusReader` capability and grouped-aware detection (sibling count + resolved parent mapping) in the sync loop, falling back to the simple-product read when not applicable.
3. **IMPORTANT** - WooCommerce's `variable` parent body wrote `sale_price`/`date_on_sale_*` fields that WC silently ignores on a variable parent (derived from variations instead). Excluded price/sale-window fields from the parent body specifically, keeping dimensions/tax_class (legitimate parent-level fields).
4. **IMPORTANT** - Documented the `ShopProductStatusReader` sub-capability in `docs/capabilities.md` and declared it in the WooCommerce plugin manifest (`supportedCapabilities`) for host-side discovery.

## Test plan

- [x] `pnpm --filter @openlinker/core build` - clean
- [x] `pnpm --filter @openlinker/integrations-woocommerce build` - clean
- [x] `pnpm --filter @openlinker/core test` - 1901/1901 passed
- [x] `pnpm --filter @openlinker/integrations-woocommerce test` - 488/488 passed
- [x] `pnpm type-check` (full workspace) - clean
- [x] `pnpm lint` incl. `check:invariants` - clean (0 errors)
- [x] New unit tests cover: variant-level 404 unchanged, parent-level 404 with existing variant mapping, parent-level 404 with no existing variant mapping, grouped-variation status read (live/removed/no-parent-mapping/adapter-without-method fallback), parent body excludes sale fields while variation body keeps them