### PR TITLE
fix(listings): resolve whole-epic UI/UX review seams for unified publish

### DIFF
--- a/apps/web/src/features/listings/components/already-listed-chip.tsx
+++ b/apps/web/src/features/listings/components/already-listed-chip.tsx
@@ -1,0 +1,29 @@
+/**
+ * AlreadyListedChip
+ *
+ * Soft "already on {destination}" chip (#1837) - informational, never
+ * blocking. Shared by the bulk review steps (marketplace + shop) and the
+ * offer/product picker modal so the markup and its a11y treatment (the
+ * decorative dot is `aria-hidden`) live in one place instead of four
+ * hand-rolled copies that could drift.
+ *
+ * @module apps/web/src/features/listings/components
+ */
+import type { ReactElement } from 'react';
+
+interface AlreadyListedChipProps {
+  /** Destination connection name, e.g. "My Allegro" / "My Shop". */
+  destinationName: string;
+  /** Tooltip/title text. Callers keep their own copy - marketplace vs shop
+   *  wording is intentionally different (duplicate offer vs upsert). */
+  title: string;
+}
+
+export function AlreadyListedChip({ destinationName, title }: AlreadyListedChipProps): ReactElement {
+  return (
+    <span className="bulk-chip bulk-chip--neutral" title={title}>
+      <span className="bulk-chip__dot" aria-hidden="true" />
+      already on {destinationName}
+    </span>
+  );
+}

--- a/apps/web/src/features/listings/components/bulk/bulk-config-step.test.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-config-step.test.tsx
@@ -128,6 +128,33 @@ describe('BulkConfigStep', () => {
     expect(screen.getByRole('button', { name: /Proceed/ })).toBeDisabled();
   }, 15000);
 
+  describe('marketplace with no registered bulkOfferConfigSection (#1838 fix - fallback regression)', () => {
+    function makeUnknownMarketplaceClient() {
+      const unknownMarketplace = {
+        id: 'conn-unknown',
+        name: 'My Unknown Marketplace',
+        status: 'active',
+        platformType: 'some-future-marketplace',
+        supportedCapabilities: ['OfferManager', 'OfferCreator'],
+      } as unknown as Connection;
+      return createMockApiClient({
+        connections: { list: vi.fn().mockResolvedValue([unknownMarketplace]) },
+      });
+    }
+
+    it('does not permanently block Proceed when the platform has no registered config section', async () => {
+      renderWithProviders(
+        <BulkConfigStep initial={{}} onProceed={vi.fn()} onCancel={() => undefined} />,
+        { apiClient: makeUnknownMarketplaceClient(), sessionAdapter: createAuthenticatedSessionAdapter() },
+      );
+
+      await screen.findByText(/isn't configured for this marketplace yet/i);
+      await waitFor(() => {
+        expect(screen.getByRole('button', { name: /Proceed/ })).toBeEnabled();
+      });
+    });
+  });
+
   describe('shop destination branch (#1829)', () => {
     function makeShopClient() {
       const shop = {
@@ -180,6 +207,66 @@ describe('BulkConfigStep', () => {
         expect(onConnectionChange).toHaveBeenCalledWith('conn-shop');
       });
     }, 15000);
+  });
+
+  describe('destination rail (#1838 - shared PublishDestinationRail, not a plain Select)', () => {
+    function makeMultiConnectionClient() {
+      const marketplace = {
+        id: 'conn-1',
+        name: 'My Allegro',
+        status: 'active',
+        platformType: 'allegro',
+        supportedCapabilities: ['OfferManager', 'OfferCreator'],
+      } as unknown as Connection;
+      const shop = {
+        id: 'conn-shop',
+        name: 'My Shop',
+        status: 'active',
+        platformType: 'woocommerce',
+        supportedCapabilities: ['ProductPublisher'],
+        enabledCapabilities: ['ProductPublisher'],
+      } as unknown as Connection;
+      return createMockApiClient({
+        connections: { list: vi.fn().mockResolvedValue([marketplace, shop]) },
+        listings: {
+          getSellerPolicies: vi.fn().mockResolvedValue({
+            deliveryPolicies: [{ id: 'dp1', name: 'Courier 24h' }],
+          }),
+        },
+      });
+    }
+
+    it('renders the grouped destination rail instead of a plain select', async () => {
+      renderWithProviders(
+        <BulkConfigStep initial={{}} onProceed={vi.fn()} onCancel={() => undefined} />,
+        { apiClient: makeMultiConnectionClient(), sessionAdapter: createAuthenticatedSessionAdapter() },
+      );
+
+      expect(await screen.findByRole('radiogroup')).toBeInTheDocument();
+      expect(screen.getByText('Marketplaces')).toBeInTheDocument();
+      expect(screen.getByText('Online shops')).toBeInTheDocument();
+      expect(screen.getByRole('radio', { name: /My Allegro/ })).toBeInTheDocument();
+      expect(screen.getByRole('radio', { name: /My Shop/ })).toBeInTheDocument();
+    });
+
+    it('fires onConnectionChange when a destination is selected via the rail', async () => {
+      const onConnectionChange = vi.fn<(id: string) => void>();
+      renderWithProviders(
+        <BulkConfigStep
+          initial={{}}
+          onProceed={vi.fn()}
+          onCancel={() => undefined}
+          onConnectionChange={onConnectionChange}
+        />,
+        { apiClient: makeMultiConnectionClient(), sessionAdapter: createAuthenticatedSessionAdapter() },
+      );
+
+      fireEvent.click(await screen.findByRole('radio', { name: /My Shop/ }));
+
+      await waitFor(() => {
+        expect(onConnectionChange).toHaveBeenCalledWith('conn-shop');
+      });
+    });
   });
 
   describe('AI-generation toggle permission gating (listings:write, useWriteAccess + ReadOnlyLock, #1668)', () => {

--- a/apps/web/src/features/listings/components/bulk/bulk-config-step.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-config-step.tsx
@@ -20,16 +20,20 @@
 import { Suspense, useEffect, useMemo, useState, type ReactElement } from 'react';
 import { useForm } from 'react-hook-form';
 
-import { Alert, Button, FormField, Input, Select } from '../../../../shared/ui';
+import { Alert, Button, FormField, Input } from '../../../../shared/ui';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../../../../shared/ui/tooltip';
 import { ReadOnlyLock } from '../../../../shared/ui/read-only-lock';
 import { DEMO_READ_ONLY_ACTION_MESSAGE } from '../../../../shared/config/demo-mode';
 import { useWriteAccess } from '../../../../shared/auth/use-permission';
 import { useDemoMode } from '../../../system';
 import { useConnectionsQuery } from '../../../connections';
-import type { Connection } from '../../../connections';
-import { publishDestinationKind, selectPublishDestinations } from '../../lib/publish-destinations';
-import { usePlatform, usePlatforms, type BulkConfigFormValues } from '../../../../shared/plugins';
+import { PublishDestinationRail } from '../publish-destination-rail';
+import {
+  publishDestinationKind,
+  selectPublishDestinations,
+  type PublishDestination,
+} from '../../lib/publish-destinations';
+import { usePlatform, type BulkConfigFormValues } from '../../../../shared/plugins';
 import type {
   BulkWizardConfig,
   PricingPolicy,
@@ -54,14 +58,6 @@ interface BulkConfigStepProps {
 }
 
 const DEFAULT_CURRENCY = 'PLN';
-
-function selectPublishConnections(all: readonly Connection[]): Connection[] {
-  // Unified publish targets (#1828): offer marketplaces (OfferCreator) OR
-  // online shops (ProductPublisher), capability-driven. Marketplaces render a
-  // per-platform config section and gate Proceed on it; shops (#1829) skip the
-  // section and the Resolve step entirely - see `isShop` / `canProceed` below.
-  return selectPublishDestinations(all).map((d) => d.connection);
-}
 
 function defaultFormValues(initial: Partial<BulkWizardConfig>): BulkConfigFormValues {
   return {
@@ -89,11 +85,15 @@ export function BulkConfigStep({
   onConnectionChange,
 }: BulkConfigStepProps): ReactElement {
   const connectionsQuery = useConnectionsQuery();
-  const platforms = usePlatforms();
-  const publishConnections = useMemo(
-    () => selectPublishConnections(connectionsQuery.data ?? []),
+  // Unified publish targets (#1828): offer marketplaces (OfferCreator) OR
+  // online shops (ProductPublisher), capability-driven. Marketplaces render a
+  // per-platform config section and gate Proceed on it; shops (#1829) skip the
+  // section and the Resolve step entirely - see `isShop` / `canProceed` below.
+  const destinations: PublishDestination[] = useMemo(
+    () => selectPublishDestinations(connectionsQuery.data ?? []),
     [connectionsQuery.data],
   );
+  const publishConnections = useMemo(() => destinations.map((d) => d.connection), [destinations]);
 
   const form = useForm<BulkConfigFormValues>({
     defaultValues: defaultFormValues(initial),
@@ -147,7 +147,12 @@ export function BulkConfigStep({
   const sharedSliceValid = markupValid && flatPriceValid && capValid && flatStockValid;
   // Marketplaces must complete their per-platform config section before
   // Proceed; shops have no section (#1829) so the shared slice alone gates.
-  const sectionComplete = isShop ? true : section ? section.isComplete(values) : false;
+  // A marketplace with no registered `bulkOfferConfigSection` (today
+  // impossible - Allegro and Erli both register one) must NOT permanently
+  // block Proceed with no explanation - pre-epic behavior was `: true`
+  // (nothing to complete = nothing blocking), matching #1096's original
+  // fallback before the unified-publish rework inverted it.
+  const sectionComplete = isShop ? true : section ? section.isComplete(values) : true;
   const canProceed = connectionId !== '' && sharedSliceValid && sectionComplete;
 
   function buildPricingPolicy(): PricingPolicy {
@@ -210,22 +215,21 @@ export function BulkConfigStep({
       </header>
 
       {publishConnections.length > 1 ? (
-        <FormField name="bulk-config-connection" label="Destination connection">
-          <Select value={connectionId} onChange={(e) => setConnectionId(e.target.value)}>
-            <option value="" disabled>
-              Select a connection…
-            </option>
-            {publishConnections.map((c) => {
-              const label = platforms.find((p) => p.platformType === c.platformType)?.displayName;
-              return (
-                <option key={c.id} value={c.id}>
-                  {c.name}
-                  {label ? ` (${label})` : ` (${c.platformType})`}
-                </option>
-              );
-            })}
-          </Select>
-        </FormField>
+        // Same grouped, keyboard-accessible rail the picker modals use
+        // (`OfferProductPickerModal` / `MarketplacePickerModal`) - the operator
+        // sees one consistent destination-picking pattern across the whole
+        // publish flow instead of a plain `<Select>` here.
+        <div className="form-field">
+          <label id="bulk-config-connection-label" className="form-field__label">
+            Destination connection
+          </label>
+          <PublishDestinationRail
+            destinations={destinations}
+            selectedConnectionId={connectionId || null}
+            onSelect={setConnectionId}
+            labelledBy="bulk-config-connection-label"
+          />
+        </div>
       ) : (
         <Alert tone="info">
           Publishing as <strong>{publishConnections[0]?.name}</strong>.

--- a/apps/web/src/features/listings/components/bulk/bulk-review-step.test.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-review-step.test.tsx
@@ -169,4 +169,17 @@ describe('BulkReviewStep', () => {
     fireEvent.click(screen.getByRole('button', { name: /Zoom image of Doniczka Terra/ }));
     expect(screen.getByRole('button', { name: 'Close image' })).toBeInTheDocument();
   });
+
+  it('renders the "already on {destination}" chip with an aria-hidden decorative dot (#1838)', () => {
+    renderWithProviders(
+      <BulkReviewStep
+        rows={[makeRow('prod_1', [variantRow('v1')])]}
+        {...baseProps()}
+        alreadyListedVariantIds={new Set(['v1'])}
+      />,
+    );
+    const chip = screen.getByText(/already on Test Marketplace/);
+    const dot = chip.parentElement?.querySelector('.bulk-chip__dot');
+    expect(dot).toHaveAttribute('aria-hidden', 'true');
+  });
 });

--- a/apps/web/src/features/listings/components/bulk/bulk-review-step.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-review-step.tsx
@@ -34,6 +34,7 @@ import type {
 } from './bulk-wizard.types';
 import { BulkEditModal } from './bulk-edit-modal';
 import { BulkImageLightbox } from './bulk-image-lightbox';
+import { AlreadyListedChip } from '../already-listed-chip';
 import {
   FALLBACK_CHIP,
   NEUTRAL_BLOCKER_CHIPS,
@@ -577,7 +578,7 @@ function ProductRow({
             <>
               <AggregateChips ready={agg.ready} attn={agg.attn} off={agg.off} />
               {anyAlreadyListed ? (
-                <AlreadyListedChip destinationName={destinationName} />
+                <AlreadyListedChip destinationName={destinationName} title={`already on ${destinationName}`} />
               ) : null}
             </>
           )}
@@ -741,7 +742,7 @@ function VariantChips({
 }): ReactElement {
   // The "already on {destination}" chip is a SOFT warning shown alongside the
   // readiness/blocker chips - it never marks the variant not-ready (#1837).
-  const dupChip = alreadyListed ? <AlreadyListedChip destinationName={destinationName} /> : null;
+  const dupChip = alreadyListed ? <AlreadyListedChip destinationName={destinationName} title={`already on ${destinationName}`} /> : null;
   if (!variant.included) {
     return (
       <>
@@ -773,19 +774,6 @@ function VariantChips({
       })}
       {dupChip}
     </>
-  );
-}
-
-/** Soft "already on {destination}" chip (#1837) - informational, never blocking. */
-function AlreadyListedChip({ destinationName }: { destinationName: string }): ReactElement {
-  return (
-    <span
-      className="bulk-chip bulk-chip--neutral"
-      title={`already on ${destinationName}`}
-    >
-      <span className="bulk-chip__dot" aria-hidden="true" />
-      already on {destinationName}
-    </span>
   );
 }
 

--- a/apps/web/src/features/listings/components/bulk/bulk-shop-review-step.test.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-shop-review-step.test.tsx
@@ -328,3 +328,110 @@ describe('BulkShopReviewStep (render)', () => {
     expect(screen.getByLabelText('Title')).toBeInTheDocument();
   });
 });
+
+describe('BulkShopReviewStep already-listed chip (#1838)', () => {
+  it('renders the "already on {destination}" chip with an aria-hidden decorative dot', async () => {
+    const rows = [makeRow('prod_1', [makeVariantRow('v1')])];
+    const apiClient = createMockApiClient({
+      inventory: { availability: vi.fn().mockResolvedValue({ items: [{ productVariantId: 'v1', totalAvailable: 7 }] }) },
+    });
+    renderWithProviders(
+      <BulkShopReviewStep
+        rows={rows}
+        connection={shopConnection}
+        config={config()}
+        demoReadOnly={false}
+        isSubmitting={false}
+        errorMessage={null}
+        alreadyListedVariantIds={new Set(['v1'])}
+        destinationName="Test Shop"
+        onSetVariantIncluded={(): void => undefined}
+        onBack={(): void => undefined}
+        onPublish={(): void => undefined}
+        onSaveEditor={(): void => undefined}
+      />,
+      { apiClient },
+    );
+
+    const chip = await screen.findByText(/already on Test Shop/);
+    const dot = chip.parentElement?.querySelector('.bulk-chip__dot');
+    expect(dot).toHaveAttribute('aria-hidden', 'true');
+  });
+});
+
+describe('BulkShopReviewStep grouping/filter/expand (#1838 whole-epic review)', () => {
+  function multiVariantRows(): BulkWizardRow[] {
+    return [makeRow('prod_1', [makeVariantRow('v1'), makeVariantRow('v2')])];
+  }
+
+  it('groups a multi-variant product behind a collapsed expand toggle', async () => {
+    renderStep(multiVariantRows(), config(), {}, [
+      { productVariantId: 'v1', totalAvailable: 7 },
+      { productVariantId: 'v2', totalAvailable: 3 },
+    ]);
+
+    await screen.findByText('2 variants');
+    // Collapsed by default - no per-variant remove buttons rendered yet.
+    expect(screen.queryByLabelText(/Remove P - /)).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Expand P variants/ }),
+    ).toBeInTheDocument();
+  });
+
+  it('expands a group to reveal its per-variant rows', async () => {
+    renderStep(multiVariantRows(), config(), {}, [
+      { productVariantId: 'v1', totalAvailable: 7 },
+      { productVariantId: 'v2', totalAvailable: 3 },
+    ]);
+
+    const toggle = await screen.findByRole('button', { name: /Expand P variants/ });
+    fireEvent.click(toggle);
+
+    expect(await screen.findByLabelText('Remove P - v1')).toBeInTheDocument();
+    expect(screen.getByLabelText('Remove P - v2')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Collapse P variants/ })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: /Collapse P variants/ }));
+    expect(screen.queryByLabelText('Remove P - v1')).not.toBeInTheDocument();
+  });
+
+  it('narrows the visible set via the filter box', async () => {
+    const rows = [
+      makeRow('prod_1', [makeVariantRow('v1')]),
+      { ...makeRow('prod_2', [makeVariantRow('v2')]), product: { id: 'prod_2', name: 'Other', currency: 'PLN' } as never },
+    ];
+    renderStep(rows, config(), {}, [
+      { productVariantId: 'v1', totalAvailable: 7 },
+      { productVariantId: 'v2', totalAvailable: 5 },
+    ]);
+
+    expect(await screen.findByText('P')).toBeInTheDocument();
+    expect(screen.getByText('Other')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Filter products by name or SKU'), {
+      target: { value: 'Other' },
+    });
+
+    expect(screen.queryByText('P')).not.toBeInTheDocument();
+    expect(screen.getByText('Other')).toBeInTheDocument();
+  });
+
+  it('shows only flagged rows (out of stock) when "Only flagged" is checked', async () => {
+    const rows = [
+      makeRow('prod_1', [makeVariantRow('v1')]),
+      { ...makeRow('prod_2', [makeVariantRow('v2')]), product: { id: 'prod_2', name: 'Other', currency: 'PLN' } as never },
+    ];
+    renderStep(rows, config(), {}, [
+      { productVariantId: 'v1', totalAvailable: 0 },
+      { productVariantId: 'v2', totalAvailable: 5 },
+    ]);
+
+    expect(await screen.findByText('P')).toBeInTheDocument();
+    expect(screen.getByText('Other')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Only flagged' }));
+
+    expect(screen.getByText('P')).toBeInTheDocument();
+    expect(screen.queryByText('Other')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/listings/components/bulk/bulk-shop-review-step.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-shop-review-step.tsx
@@ -15,11 +15,17 @@
  * overrides it saves round-trip through each item's `content` /
  * `destinationCategoryIds` / `parameters` (backed by the #1831 transport).
  *
+ * Structural parity with the marketplace `BulkReviewStep` (#1838 whole-epic
+ * review): rows group by product with expand/collapse for a multi-variant
+ * product, plus a filter box and an "only flagged" toggle (flagged = out of
+ * stock OR already-listed) - a large multi-variant batch would otherwise
+ * render every variant as a flat, repetitive `<li>`.
+ *
  * @module apps/web/src/features/listings/components/bulk
  */
 import { useEffect, useMemo, useState, type ReactElement } from 'react';
 
-import { Alert, Button } from '../../../../shared/ui';
+import { Alert, Button, Input } from '../../../../shared/ui';
 import { ReadOnlyLock } from '../../../../shared/ui/read-only-lock';
 import { DEMO_READ_ONLY_ACTION_MESSAGE } from '../../../../shared/config/demo-mode';
 import { useInventoryAvailabilityBatchQuery } from '../../../inventory';
@@ -35,6 +41,7 @@ import {
   effectiveStockPolicy,
 } from './bulk-policy';
 import { BulkEditModal } from './bulk-edit-modal';
+import { AlreadyListedChip } from '../already-listed-chip';
 import type { BulkVariantRow, BulkWizardConfig, BulkWizardRow } from './bulk-wizard.types';
 
 /** Visibility the batch publishes with; mirrors the shop publish status set. */
@@ -82,6 +89,34 @@ interface ShopReviewLine {
   stock: number | null;
   /** Policy-resolved price; null when it falls back to master server-side. */
   price: number | null;
+}
+
+/** Product-grouped lines (#1838) - a product with 2+ INCLUDED lines to review
+ *  renders as an expand/collapse group; one (or zero) included line renders
+ *  flat with no caret, mirroring the marketplace `BulkReviewStep`
+ *  isSimple/isMulti split (a group is only worth collapsing when there's more
+ *  than one row underneath it). */
+interface ShopReviewGroup {
+  productId: string;
+  productName: string;
+  isMulti: boolean;
+  lines: ShopReviewLine[];
+}
+
+function groupReviewLines(lines: ShopReviewLine[]): ShopReviewGroup[] {
+  const groups = new Map<string, ShopReviewGroup>();
+  for (const line of lines) {
+    let group = groups.get(line.productId);
+    if (!group) {
+      group = { productId: line.productId, productName: line.productName, isMulti: false, lines: [] };
+      groups.set(line.productId, group);
+    }
+    group.lines.push(line);
+  }
+  for (const group of groups.values()) {
+    group.isMulti = group.lines.length > 1;
+  }
+  return Array.from(groups.values());
 }
 
 function variantDisplayLabel(variant: BulkVariantRow): string {
@@ -268,6 +303,51 @@ export function BulkShopReviewStep({
     setAcknowledgeOutOfStock(false);
   }, [outOfStockVariantIds.size]);
 
+  // Flagged = out of stock OR already listed on the destination (#1838) -
+  // drives the "only flagged" toggle, mirroring the marketplace review step.
+  const flaggedVariantIds = useMemo(() => {
+    const flagged = new Set<string>();
+    for (const line of lines) {
+      if (outOfStockVariantIds.has(line.variantId) || alreadyListedVariantIds.has(line.variantId)) {
+        flagged.add(line.variantId);
+      }
+    }
+    return flagged;
+  }, [lines, outOfStockVariantIds, alreadyListedVariantIds]);
+
+  // Product-grouped rows with expand/collapse + filter/"only flagged" (#1838
+  // whole-epic review) - structural parity with the marketplace review step.
+  const [filter, setFilter] = useState('');
+  const [onlyFlagged, setOnlyFlagged] = useState(false);
+  const [expanded, setExpanded] = useState<Set<string>>(() => new Set());
+
+  function toggleExpand(productId: string): void {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(productId)) next.delete(productId);
+      else next.add(productId);
+      return next;
+    });
+  }
+
+  const groups = useMemo(() => groupReviewLines(lines), [lines]);
+  const filteredGroups = useMemo(() => {
+    const needle = filter.trim().toLowerCase();
+    return groups.filter((group) => {
+      if (needle !== '') {
+        const nameMatch = group.productName.toLowerCase().includes(needle);
+        const skuMatch = group.lines.some((line) =>
+          line.variantLabel.toLowerCase().includes(needle)
+        );
+        if (!nameMatch && !skuMatch) return false;
+      }
+      if (onlyFlagged) {
+        return group.lines.some((line) => flaggedVariantIds.has(line.variantId));
+      }
+      return true;
+    });
+  }, [groups, filter, onlyFlagged, flaggedVariantIds]);
+
   const handlePublish = (): void => {
     if (needsSellabilityAck) return;
     const items = buildBulkShopPublishItems(rows, config, masterStockByVariantId);
@@ -296,6 +376,35 @@ export function BulkShopReviewStep({
           product's master values and the batch policy.
         </p>
       </header>
+
+      {lines.length > 0 ? (
+        <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-2)' }}>
+          <Input
+            type="search"
+            placeholder="Filter products..."
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            className="bulk-review__filter"
+            aria-label="Filter products by name or SKU"
+          />
+          <label
+            style={{
+              display: 'inline-flex',
+              alignItems: 'center',
+              gap: 6,
+              fontSize: 12,
+              color: 'var(--text-secondary)',
+            }}
+          >
+            <input
+              type="checkbox"
+              checked={onlyFlagged}
+              onChange={(e) => setOnlyFlagged(e.target.checked)}
+            />
+            Only flagged
+          </label>
+        </div>
+      ) : null}
 
       <div className="form-field">
         <span className="form-field__label">Visibility</span>
@@ -358,62 +467,94 @@ export function BulkShopReviewStep({
               </label>
             </Alert>
           ) : null}
-          <ul className="bulk-shop-review__list">
-            {lines.map((line) => (
-              <li key={line.variantId} className="bulk-shop-review__row">
-                <div className="bulk-shop-review__row-main">
-                  <b>{line.productName}</b>
-                  <small className="mono-text muted-text">{line.variantLabel}</small>
-                  {alreadyListedVariantIds.has(line.variantId) ? (
-                    <span
-                      className="bulk-chip bulk-chip--neutral"
-                      title={`already on ${destinationName} - publishing updates it`}
-                    >
-                      <span className="bulk-chip__dot" />
-                      already on {destinationName}
-                    </span>
-                  ) : null}
-                  {outOfStockVariantIds.has(line.variantId) ? (
-                    <span
-                      className="bulk-chip bulk-chip--warning"
-                      title="Out of stock - will publish but cannot be purchased until restocked"
-                    >
-                      <span className="bulk-chip__dot" />
-                      out of stock
-                    </span>
-                  ) : null}
-                </div>
-                <span className="bulk-shop-review__cell mono-text tabular" aria-label="Stock">
-                  <span className="bulk-shop-review__cell-label">stock</span>
-                  {line.stock ?? 0}
-                </span>
-                <span className="bulk-shop-review__cell mono-text tabular" aria-label="Price">
-                  <span className="bulk-shop-review__cell-label">price</span>
-                  {line.price !== null ? `${line.price} ${config.currency}` : 'from master'}
-                </span>
-                {isShopDestination ? (
-                  <Button
-                    tone="ghost"
-                    className="button--xs bulk-shop-review__edit"
-                    aria-label={`Edit ${line.productName}`}
-                    onClick={() =>
-                      setEditing({ productId: line.productId, focusVariantId: line.variantId })
-                    }
-                  >
-                    Edit
-                  </Button>
-                ) : null}
-                <button
-                  type="button"
-                  className="bulk-shop-review__remove"
-                  aria-label={`Remove ${line.productName} - ${line.variantLabel}`}
-                  onClick={() => onSetVariantIncluded(line.productId, line.variantId, false)}
-                >
-                  ×
-                </button>
-              </li>
-            ))}
-          </ul>
+          {filteredGroups.length === 0 ? (
+            <Alert tone="info">No products match the current filter.</Alert>
+          ) : (
+            <ul className="bulk-shop-review__list">
+              {filteredGroups.map((group) =>
+                !group.isMulti ? (
+                  group.lines.map((line) => (
+                    <ShopReviewLineRow
+                      key={line.variantId}
+                      line={line}
+                      currency={config.currency}
+                      alreadyListed={alreadyListedVariantIds.has(line.variantId)}
+                      destinationName={destinationName}
+                      outOfStock={outOfStockVariantIds.has(line.variantId)}
+                      showEdit={isShopDestination}
+                      onEdit={() =>
+                        setEditing({ productId: line.productId, focusVariantId: line.variantId })
+                      }
+                      onRemove={() => onSetVariantIncluded(line.productId, line.variantId, false)}
+                    />
+                  ))
+                ) : (
+                  <li key={group.productId} className="bulk-shop-review__group">
+                    <div className="bulk-shop-review__row bulk-shop-review__group-head">
+                      <button
+                        type="button"
+                        className="bulk-review__toggle"
+                        aria-expanded={expanded.has(group.productId)}
+                        aria-label={`${expanded.has(group.productId) ? 'Collapse' : 'Expand'} ${
+                          group.productName
+                        } variants`}
+                        onClick={() => toggleExpand(group.productId)}
+                      >
+                        <span className="bulk-review__caret" aria-hidden="true">
+                          &#9656;
+                        </span>
+                      </button>
+                      <div className="bulk-shop-review__row-main">
+                        <b>{group.productName}</b>
+                        <small className="mono-text muted-text">
+                          {group.lines.length} variants
+                        </small>
+                        {group.lines.some((l) => alreadyListedVariantIds.has(l.variantId)) ? (
+                          <AlreadyListedChip
+                            destinationName={destinationName}
+                            title={`already on ${destinationName} - publishing updates it`}
+                          />
+                        ) : null}
+                        {group.lines.some((l) => outOfStockVariantIds.has(l.variantId)) ? (
+                          <span
+                            className="bulk-chip bulk-chip--warning"
+                            title="Out of stock - will publish but cannot be purchased until restocked"
+                          >
+                            <span className="bulk-chip__dot" aria-hidden="true" />
+                            out of stock
+                          </span>
+                        ) : null}
+                      </div>
+                    </div>
+                    {expanded.has(group.productId) ? (
+                      <ul className="bulk-shop-review__vrows">
+                        {group.lines.map((line) => (
+                          <ShopReviewLineRow
+                            key={line.variantId}
+                            line={line}
+                            currency={config.currency}
+                            alreadyListed={alreadyListedVariantIds.has(line.variantId)}
+                            destinationName={destinationName}
+                            outOfStock={outOfStockVariantIds.has(line.variantId)}
+                            showEdit={isShopDestination}
+                            onEdit={() =>
+                              setEditing({
+                                productId: line.productId,
+                                focusVariantId: line.variantId,
+                              })
+                            }
+                            onRemove={() =>
+                              onSetVariantIncluded(line.productId, line.variantId, false)
+                            }
+                          />
+                        ))}
+                      </ul>
+                    ) : null}
+                  </li>
+                )
+              )}
+            </ul>
+          )}
         </>
       )}
 
@@ -457,5 +598,79 @@ export function BulkShopReviewStep({
         />
       ) : null}
     </div>
+  );
+}
+
+interface ShopReviewLineRowProps {
+  line: ShopReviewLine;
+  currency: string;
+  alreadyListed: boolean;
+  destinationName: string;
+  outOfStock: boolean;
+  showEdit: boolean;
+  onEdit: () => void;
+  onRemove: () => void;
+}
+
+/** One variant line - flat under a single-variant product, or nested inside
+ *  an expanded multi-variant group (#1838). */
+function ShopReviewLineRow({
+  line,
+  currency,
+  alreadyListed,
+  destinationName,
+  outOfStock,
+  showEdit,
+  onEdit,
+  onRemove,
+}: ShopReviewLineRowProps): ReactElement {
+  return (
+    <li className="bulk-shop-review__row">
+      <div className="bulk-shop-review__row-main">
+        <b>{line.productName}</b>
+        <small className="mono-text muted-text">{line.variantLabel}</small>
+        {alreadyListed ? (
+          <AlreadyListedChip
+            destinationName={destinationName}
+            title={`already on ${destinationName} - publishing updates it`}
+          />
+        ) : null}
+        {outOfStock ? (
+          <span
+            className="bulk-chip bulk-chip--warning"
+            title="Out of stock - will publish but cannot be purchased until restocked"
+          >
+            <span className="bulk-chip__dot" aria-hidden="true" />
+            out of stock
+          </span>
+        ) : null}
+      </div>
+      <span className="bulk-shop-review__cell mono-text tabular" aria-label="Stock">
+        <span className="bulk-shop-review__cell-label">stock</span>
+        {line.stock ?? 0}
+      </span>
+      <span className="bulk-shop-review__cell mono-text tabular" aria-label="Price">
+        <span className="bulk-shop-review__cell-label">price</span>
+        {line.price !== null ? `${line.price} ${currency}` : 'from master'}
+      </span>
+      {showEdit ? (
+        <Button
+          tone="ghost"
+          className="button--xs bulk-shop-review__edit"
+          aria-label={`Edit ${line.productName}`}
+          onClick={onEdit}
+        >
+          Edit
+        </Button>
+      ) : null}
+      <button
+        type="button"
+        className="bulk-shop-review__remove"
+        aria-label={`Remove ${line.productName} - ${line.variantLabel}`}
+        onClick={onRemove}
+      >
+        ×
+      </button>
+    </li>
   );
 }

--- a/apps/web/src/features/listings/components/offer-product-picker-modal.test.tsx
+++ b/apps/web/src/features/listings/components/offer-product-picker-modal.test.tsx
@@ -379,6 +379,25 @@ describe('OfferProductPickerModal', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
+  it('renders the "already on {destination}" chip with an aria-hidden decorative dot (#1838)', async () => {
+    const coveredP1: Product = {
+      ...P1,
+      listingsCoverage: [{ connectionId: 'conn_a', platformType: 'allegro', listedVariants: 2 }],
+    };
+    const apiClient = createMockApiClient({
+      connections: { list: vi.fn().mockResolvedValue([conn('conn_a', 'Allegro', 'allegro')]) },
+      products: {
+        list: vi.fn().mockResolvedValue({ items: [coveredP1], total: 1, limit: 20, offset: 0 }),
+        getById: vi.fn().mockResolvedValue(coveredP1),
+      },
+    });
+    renderWithProviders(<OfferProductPickerModal isOpen onClose={vi.fn()} />, { apiClient });
+
+    const chip = await screen.findByText(/already on Allegro/);
+    const dot = chip.parentElement?.querySelector('.bulk-chip__dot');
+    expect(dot).toHaveAttribute('aria-hidden', 'true');
+  });
+
   describe('query error + retry branches', () => {
     const oneProductPage = (): PaginatedProductsShape => ({
       items: [P1],

--- a/apps/web/src/features/listings/components/offer-product-picker-modal.tsx
+++ b/apps/web/src/features/listings/components/offer-product-picker-modal.tsx
@@ -72,6 +72,7 @@ import { selectPublishDestinations } from '../lib/publish-destinations';
 import { usePublishedVariantsQuery } from '../hooks/use-published-variants-query';
 import { DuplicateGuardModal } from './duplicate-guard-modal';
 import { PublishDestinationRail } from './publish-destination-rail';
+import { AlreadyListedChip } from './already-listed-chip';
 
 /** Max distinct products per batch (mirrors the `/products` BULK_SELECTION_CAP,
  *  kept local per R1 to avoid a `features -> pages` import). */
@@ -126,9 +127,9 @@ interface PickerProductRowProps {
   isExpanded: boolean;
   entry: SelectionEntry | undefined;
   capBlocked: boolean;
-  /** "already on {destination}" label when this product is already published
-   *  to the resolved destination (#1837); null when not / no destination. */
-  alreadyOnLabel: string | null;
+  /** Destination name when this product is already published there (#1837);
+   *  null when not / no destination. Renders the shared `AlreadyListedChip`. */
+  alreadyOnDestinationName: string | null;
   onToggleExpand: () => void;
   onSelectAll: () => void;
   onClear: () => void;
@@ -141,7 +142,7 @@ function PickerProductRow({
   isExpanded,
   entry,
   capBlocked,
-  alreadyOnLabel,
+  alreadyOnDestinationName,
   onToggleExpand,
   onSelectAll,
   onClear,
@@ -230,11 +231,11 @@ function PickerProductRow({
               {variantCount} {variantCount === 1 ? 'variant' : 'variants'}
             </span>
           ) : null}
-          {alreadyOnLabel ? (
-            <span className="bulk-chip bulk-chip--neutral" title={alreadyOnLabel}>
-              <span className="bulk-chip__dot" />
-              {alreadyOnLabel}
-            </span>
+          {alreadyOnDestinationName ? (
+            <AlreadyListedChip
+              destinationName={alreadyOnDestinationName}
+              title={`already on ${alreadyOnDestinationName}`}
+            />
           ) : null}
           <span className="offer-product-picker__chev" aria-hidden="true">
 
@@ -804,10 +805,8 @@ export function OfferProductPickerModal({
                         isExpanded={expanded.has(product.id)}
                         entry={selection.get(product.id)}
                         capBlocked={capReached && !selection.has(product.id)}
-                        alreadyOnLabel={
-                          productAlreadyOnList(product) && destinationName
-                            ? `already on ${destinationName}`
-                            : null
+                        alreadyOnDestinationName={
+                          productAlreadyOnList(product) && destinationName ? destinationName : null
                         }
                         onToggleExpand={() => toggleExpand(product.id)}
                         onSelectAll={() => selectAllProduct(product.id, product.variantCount)}
@@ -965,13 +964,10 @@ export function OfferProductPickerModal({
                             </span>
                           )}
                           {group.alreadyOnDestination && destinationName ? (
-                            <span
-                              className="bulk-chip bulk-chip--neutral"
+                            <AlreadyListedChip
+                              destinationName={destinationName}
                               title={`already on ${destinationName}`}
-                            >
-                              <span className="bulk-chip__dot" />
-                              already on {destinationName}
-                            </span>
+                            />
                           ) : null}
                           <button
                             type="button"

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -9768,6 +9768,32 @@ input.bulk-dispatch__num--wide {
   color: var(--text-primary);
 }
 
+/* Product-grouped expand/collapse (#1838 - parity with .bulk-review__prow) */
+.bulk-shop-review__group {
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.bulk-shop-review__group:last-child {
+  border-bottom: none;
+}
+
+.bulk-shop-review__group-head {
+  border-bottom: none;
+  gap: var(--space-2);
+}
+
+.bulk-shop-review__vrows {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.bulk-shop-review__vrows .bulk-shop-review__row {
+  padding-left: calc(var(--space-3) + 24px);
+}
+
 /* Edit modal — AI button row */
 .bulk-edit__desc-row {
   display: flex;


### PR DESCRIPTION
Fixes 3 IMPORTANT seam issues + 1 latent logic bug found by an independent whole-epic UI/UX review of epic #1838 (unify offer-create + shop-publish into one capability-driven flow).

## Fixes

1. **Config-step destination picker parity** - `bulk-config-step.tsx` now uses the shared `PublishDestinationRail` (grouped Marketplaces/Online shops, keyboard-accessible radiogroup) instead of a plain native `<select>`, matching the picker modals (`offer-product-picker-modal.tsx`, `marketplace-picker-modal.tsx`) one screen earlier. `onConnectionChange` up-report behavior preserved.
2. **Shop review step grouping/navigation** - `bulk-shop-review-step.tsx` now groups variant rows by product with expand/collapse, a filter/search box, and an "only flagged" toggle (flagged = out-of-stock OR already-listed), for structural parity with the marketplace `bulk-review-step.tsx`. The existing out-of-stock banner, "already on {destination}" chip, and publish-anyway acknowledgement checkbox (#1837/#1842) are unchanged.
3. **De-duplicated "already on {destination}" chip** - extracted the existing `AlreadyListedChip` (from `bulk-review-step.tsx`) into a shared `apps/web/src/features/listings/components/already-listed-chip.tsx` and reused it at all 4 call sites (`bulk-review-step.tsx`, `bulk-shop-review-step.tsx`, `offer-product-picker-modal.tsx` x2), fixing a missing `aria-hidden` on the decorative dot at 3 of the 4 sites.
4. **Section-completeness fallback inversion (latent bug)** - `bulk-config-step.tsx`'s `sectionComplete` fallback was `: false` instead of the pre-epic `: true`, meaning a future marketplace platform with no registered `bulkOfferConfigSection` would permanently block Proceed with no explanation. Restored to `: true`.

## Test plan

- [x] `pnpm --filter @openlinker/web type-check` - passes
- [x] `pnpm --filter @openlinker/web exec eslint` on all changed files - 0 errors (pre-existing style warnings only)
- [x] `pnpm --filter @openlinker/web test` - full suite green (2450/2450)
- [x] New/updated tests: grouped rail render + selection (bulk-config-step), grouping/expand/filter/only-flagged (bulk-shop-review-step), aria-hidden dot at all 4 chip sites, no-registered-section Proceed-not-blocked (bulk-config-step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)