### PR TITLE
fix(listings): picker item-count fallback + rail padding

### DIFF
--- a/apps/web/src/features/listings/components/offer-product-picker-modal.tsx
+++ b/apps/web/src/features/listings/components/offer-product-picker-modal.tsx
@@ -517,15 +517,16 @@ export function OfferProductPickerModal({
   }, []);
 
   // Item total across products: an explicit set counts its size; a whole
-  // product counts its known variant count, else 1.
+  // product counts its known variant count (loaded count, else the list
+  // query's own variantCount, else 1 for a genuinely-unknown product).
   const itemCount = useMemo(() => {
     let sum = 0;
     for (const [productId, entry] of selection) {
       if (entry instanceof Set) sum += entry.size;
-      else sum += variantCounts.get(productId) ?? 1;
+      else sum += variantCounts.get(productId) ?? productMeta.get(productId)?.variantCount ?? 1;
     }
     return sum;
-  }, [selection, variantCounts]);
+  }, [selection, variantCounts, productMeta]);
 
   // Per-product rail rows, derived from the selection + accumulated metadata.
   const railGroups = useMemo<RailGroup[]>(() => {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -6715,9 +6715,10 @@ a.kpi-card:focus-visible {
   align-items: center;
   gap: var(--space-3);
   width: 100%;
+  box-sizing: border-box;
   text-align: left;
   font: inherit;
-  padding: var(--space-3) var(--space-4);
+  padding: var(--space-4) var(--space-4);
   background: var(--bg-surface);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);


### PR DESCRIPTION
Fixes two live-testing findings: whole-product itemCount undercounted to 1 for preselected-but-unexpanded products (falls back through variantCount now), and the destination rail's padding was still cramped in a narrower host context. Type-check clean.