### PR TITLE
feat(listings): field-complete shop variant scope panel (attribute overrides)

### DIFF
--- a/apps/web/src/features/listings/components/bulk/bulk-edit-modal.shop.test.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-edit-modal.shop.test.tsx
@@ -12,7 +12,7 @@
  * stubbed so the test isolates the editor's own logic.
  */
 import { describe, expect, it, vi } from 'vitest';
-import { fireEvent, screen } from '@testing-library/react';
+import { fireEvent, screen, within } from '@testing-library/react';
 import { renderWithProviders } from '../../../../test/test-utils';
 import { BulkEditModal, mergeShopParameter } from './bulk-edit-modal';
 import type { BulkVariantRow, BulkWizardRow } from './bulk-wizard.types';
@@ -141,6 +141,21 @@ function renderShopEditor(
   );
 }
 
+/**
+ * Selects a variant's rail entry and returns its panel container. The base
+ * scope form stays mounted (just `hidden`) while a variant is active, so any
+ * unscoped query (e.g. the "Attribute" picker's select, present in both
+ * forms) would otherwise match twice - scoping to the panel's own subtree
+ * keeps every assertion unambiguous.
+ */
+function openVariantPanel(label: RegExp | string): HTMLElement {
+  fireEvent.click(screen.getByRole('radio', { name: label }));
+  const heading = screen.getByRole('heading', { name: /^Variant ·/ });
+  const panel = heading.closest('.bulk-editor__form');
+  if (!panel) throw new Error('variant panel container not found');
+  return panel as HTMLElement;
+}
+
 describe('mergeShopParameter', () => {
   it('appends a distinct-id parameter', () => {
     const existing: OfferParameter[] = [{ id: 'pa_color', values: ['Red'], section: 'product' }];
@@ -265,5 +280,99 @@ describe('BulkEditModal (shop mode)', () => {
       Record<string, BulkPerProductOverride>,
     ];
     expect(perVariantOverrides.v1.overrides?.description).toBe('Only for M');
+  });
+
+  it('renders provenance badges + reset affordances in the variant panel, matching the marketplace panel (#1838)', () => {
+    const row = makeRow([makeVariant('v1', { Size: 'M' }), makeVariant('v2', { Size: 'L' })]);
+    renderShopEditor(row, vi.fn());
+
+    const panel = openVariantPanel(/Size: M|M$/);
+
+    // Description, Attributes, and Price all start inherited - muted styling,
+    // no reset control yet (three "inherited" badges: description/attributes/price).
+    const description = within(panel).getByLabelText(/Description for/);
+    expect(description).toHaveClass('bulk-editor__input--inherited');
+    expect(within(panel).queryByText(/reset to base/)).not.toBeInTheDocument();
+    expect(within(panel).getAllByText('inherited').length).toBeGreaterThanOrEqual(3);
+
+    // Stock is always master-provenance, never overridable (parity with the
+    // marketplace variant panel's read-only master stock field).
+    const stock = within(panel).getByDisplayValue('5');
+    expect(stock).toHaveAttribute('readonly');
+    expect(within(panel).getByText('from master')).toBeInTheDocument();
+
+    // Overriding description flips the badge + input styling and surfaces reset.
+    fireEvent.change(description, { target: { value: 'Only for M' } });
+    expect(description).toHaveClass('bulk-editor__input--overridden');
+    const resetButton = within(panel).getByText(/reset to base/);
+    expect(resetButton).toBeInTheDocument();
+
+    fireEvent.click(resetButton);
+    expect(description).toHaveClass('bulk-editor__input--inherited');
+    expect(within(panel).queryByText(/reset to base/)).not.toBeInTheDocument();
+  });
+
+  it('emits a per-variant attribute override on top of the base list (#1838)', () => {
+    const onSave = vi.fn();
+    const row = makeRow([makeVariant('v1', { Size: 'M' }), makeVariant('v2', { Size: 'L' })]);
+    renderShopEditor(row, onSave);
+
+    // Add a base-level attribute first (single picker instance while on the
+    // shared-base scope), then switch to the variant to add its own.
+    fireEvent.change(screen.getByLabelText('Attribute'), { target: { value: 'pa_color' } });
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Red' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Add attribute' }));
+
+    const panel = openVariantPanel(/Size: M|M$/);
+    // Inherited effective list surfaces the base pick even before overriding.
+    expect(within(panel).getByText('pa_color: Red')).toBeInTheDocument();
+
+    fireEvent.change(within(panel).getByLabelText('Attribute'), { target: { value: 'pa_color' } });
+    fireEvent.click(within(panel).getByRole('checkbox', { name: 'Blue' }));
+    fireEvent.click(within(panel).getByRole('button', { name: 'Add attribute' }));
+
+    expect(within(panel).getByText('overridden')).toBeInTheDocument();
+    expect(within(panel).getByText(/reset to base/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save all' }));
+
+    const [, baseOverride, perVariantOverrides] = onSave.mock.calls[0] as [
+      string,
+      BulkPerProductOverride,
+      Record<string, BulkPerProductOverride>,
+    ];
+    expect(baseOverride.overrides?.parameters).toEqual([
+      { id: 'pa_color', values: ['Red'], valuesIds: ['t1'], section: 'product' },
+    ]);
+    expect(perVariantOverrides.v1.overrides?.parameters).toEqual([
+      { id: 'pa_color', values: ['Red', 'Blue'], valuesIds: ['t1', 't2'], section: 'product' },
+    ]);
+    // The other variant never diverged - no override recorded for it.
+    expect(perVariantOverrides.v2).toBeUndefined();
+  });
+
+  it('reverts a per-variant attribute override to inherited via the reset control (#1838)', () => {
+    const onSave = vi.fn();
+    const row = makeRow([makeVariant('v1', { Size: 'M' }), makeVariant('v2', { Size: 'L' })]);
+    renderShopEditor(row, onSave);
+
+    const panel = openVariantPanel(/Size: M|M$/);
+    fireEvent.change(within(panel).getByLabelText('Attribute'), { target: { value: 'pa_color' } });
+    fireEvent.click(within(panel).getByRole('checkbox', { name: 'Red' }));
+    fireEvent.click(within(panel).getByRole('button', { name: 'Add attribute' }));
+    expect(within(panel).getByText('overridden')).toBeInTheDocument();
+
+    fireEvent.click(within(panel).getByText(/reset to base/));
+    expect(within(panel).queryByText('overridden')).not.toBeInTheDocument();
+    expect(within(panel).queryByText('pa_color: Red')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save all' }));
+
+    const [, , perVariantOverrides] = onSave.mock.calls[0] as [
+      string,
+      BulkPerProductOverride,
+      Record<string, BulkPerProductOverride>,
+    ];
+    expect(perVariantOverrides.v1).toBeUndefined();
   });
 });

--- a/apps/web/src/features/listings/components/bulk/bulk-edit-modal.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-edit-modal.tsx
@@ -2521,10 +2521,17 @@ function shopParameterLabel(parameter: OfferParameter): string {
   return values === '' ? parameter.id : `${parameter.id}: ${values}`;
 }
 
-/** Per-variant shop overrides (#1830). Absent key ⇒ inherited from base. */
+/**
+ * Per-variant shop overrides (#1830). Absent key ⇒ inherited from base.
+ * `parameters` mirrors the base scope's whole-array-replace attribute model
+ * (#1835, `mergeShopParameter`) rather than a per-param diff map - the shop
+ * attribute picker adds/removes whole `OfferParameter` entries, not
+ * per-field values like the marketplace category-parameters form.
+ */
 interface ShopVariantEdit {
   description?: string;
   price?: string;
+  parameters?: OfferParameter[];
 }
 
 function initShopVariantEdit(variant: BulkVariantRow): ShopVariantEdit {
@@ -2532,6 +2539,7 @@ function initShopVariantEdit(variant: BulkVariantRow): ShopVariantEdit {
   return {
     description: typeof o.description === 'string' ? o.description : undefined,
     price: variant.override.price !== undefined ? String(variant.override.price.amount) : undefined,
+    parameters: Array.isArray(o.parameters) ? o.parameters : undefined,
   };
 }
 
@@ -2667,6 +2675,31 @@ function BulkShopEditModalForm({
     setParameters((prev) => prev.filter((p) => p.id !== id));
   }, []);
 
+  // Per-variant attribute overrides (field-completeness parity with the
+  // marketplace variant panel's category-parameter overrides). Absent
+  // `edit.parameters` ⇒ inherits the live base list; any add/remove pins an
+  // explicit array for that variant.
+  const addVariantAttribute = useCallback(
+    (variantId: string, parameter: OfferParameter): void => {
+      setVariantEdits((prev) => {
+        const current = prev[variantId];
+        const effective = current.parameters ?? parameters;
+        return { ...prev, [variantId]: { ...current, parameters: mergeShopParameter(effective, parameter) } };
+      });
+    },
+    [parameters],
+  );
+  const removeVariantAttribute = useCallback(
+    (variantId: string, id: string): void => {
+      setVariantEdits((prev) => {
+        const current = prev[variantId];
+        const effective = current.parameters ?? parameters;
+        return { ...prev, [variantId]: { ...current, parameters: effective.filter((p) => p.id !== id) } };
+      });
+    },
+    [parameters],
+  );
+
   const scopeList = useMemo(() => {
     if (!isMultiVariant) return [{ id: 'simple', label: 'Product fields' }];
     return [
@@ -2748,6 +2781,7 @@ function BulkShopEditModalForm({
         const edit = variantEdits[variant.variantId];
         const variantOverrides: BulkOfferOverrides = {};
         if (edit.description !== undefined) variantOverrides.description = edit.description;
+        if (edit.parameters !== undefined) variantOverrides.parameters = edit.parameters;
         const override: BulkPerProductOverride = {
           ...(edit.price !== undefined && edit.price.trim() !== ''
             ? { price: { amount: Number(edit.price.replace(',', '.')), currency } }
@@ -2918,6 +2952,11 @@ function BulkShopEditModalForm({
                         included={included[v.variantId]}
                         baseDescription={description}
                         basePriceValue={shopInheritedPrice(pricingPolicy, v.masterPrice)}
+                        canPickShopAttributes={canPickShopAttributes}
+                        connectionId={connectionId}
+                        baseParameters={parameters}
+                        onAddAttribute={(parameter) => addVariantAttribute(v.variantId, parameter)}
+                        onRemoveAttribute={(id) => removeVariantAttribute(v.variantId, id)}
                         onPatch={(patch) => patchVariant(v.variantId, patch)}
                         onIncludedChange={(next) =>
                           setIncluded((prev) => ({ ...prev, [v.variantId]: next }))
@@ -3332,6 +3371,13 @@ interface ShopVariantScopeFormProps {
   included: boolean;
   baseDescription: string;
   basePriceValue: string;
+  /** Gates the Attributes block (ShopAttributeReader capability, #1835). */
+  canPickShopAttributes: boolean;
+  connectionId: string;
+  /** Live base-scope attribute list this variant inherits when un-overridden. */
+  baseParameters: OfferParameter[];
+  onAddAttribute: (parameter: OfferParameter) => void;
+  onRemoveAttribute: (id: string) => void;
   onPatch: (patch: Partial<ShopVariantEdit>) => void;
   onIncludedChange: (next: boolean) => void;
 }
@@ -3343,10 +3389,17 @@ function ShopVariantScopeForm({
   included,
   baseDescription,
   basePriceValue,
+  canPickShopAttributes,
+  connectionId,
+  baseParameters,
+  onAddAttribute,
+  onRemoveAttribute,
   onPatch,
   onIncludedChange,
 }: ShopVariantScopeFormProps): ReactElement {
   const label = distinguishingLabel(variant, index);
+  const effectiveParameters = edit.parameters ?? baseParameters;
+  const parametersOverridden = edit.parameters !== undefined;
   const formClasses = [
     'bulk-editor__form',
     'bulk-editor__form--acc-open',
@@ -3396,6 +3449,42 @@ function ShopVariantScopeForm({
           onChange={(e) => onPatch({ description: e.target.value === baseDescription ? undefined : e.target.value })}
         />
       </div>
+
+      {canPickShopAttributes ? (
+        <div className="bulk-editor__field">
+          <label>
+            Attributes {parametersOverridden ? <ProvBadge kind="override" /> : <ProvBadge kind="inherit" />}
+            {parametersOverridden ? (
+              <button type="button" className="bulk-editor__reset" onClick={() => onPatch({ parameters: undefined })}>
+                ↺ reset to base
+              </button>
+            ) : null}
+          </label>
+          {effectiveParameters.length > 0 ? (
+            <ul className="shop-attr-picker__added" role="list">
+              {effectiveParameters.map((p) => (
+                <li key={p.id} className="shop-attr-picker__added-item">
+                  <span className="shop-attr-picker__added-label">{shopParameterLabel(p)}</span>
+                  <button
+                    type="button"
+                    className="bulk-editor__img-x"
+                    aria-label={`Remove attribute ${p.id} for ${label}`}
+                    onClick={() => onRemoveAttribute(p.id)}
+                  >
+                    ×
+                  </button>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+          <ShopAttributePicker connectionId={connectionId} onAdd={onAddAttribute} />
+          <div className="hint" style={{ color: 'var(--text-muted)', fontSize: 12 }}>
+            {parametersOverridden
+              ? 'Custom attribute set for this variant.'
+              : 'Inherits the base attributes - add or remove to override for this variant.'}
+          </div>
+        </div>
+      ) : null}
 
       <div className="bulk-editor__row2">
         <div className="bulk-editor__field">


### PR DESCRIPTION
Live-testing follow-up: the shop variant panel already had provenance badges/reset-to-inherit/inherited-overridden styling (landed in an earlier epic commit). The one real gap vs the design spec was per-variant attribute overrides - added, mirroring the marketplace panel's category-parameter override pattern. +3 tests, gate green (157/157 in bulk/).