### PR TITLE
fix(listings): wire initialProductMeta into the products-page picker call

### DIFF
--- a/apps/web/src/pages/products/products-list-page.tsx
+++ b/apps/web/src/pages/products/products-list-page.tsx
@@ -1233,6 +1233,11 @@ export function ProductsListPage(): ReactElement {
               setPendingProductId(null);
             }}
             initialProductIds={pendingProductId ? [pendingProductId] : Array.from(selectedIds)}
+            initialProductMeta={
+              pendingProductId
+                ? items.filter((p) => p.id === pendingProductId)
+                : items.filter((p) => selectedIds.has(p.id))
+            }
           />
         </>
       )}


### PR DESCRIPTION
Wave-2 review finding (confirmed by 2 independent reviewers): the picker's initialProductMeta prop existed to avoid a flash-of-unnamed-product on the rail for preselected items, but the only caller never passed it. products-list-page.tsx already has the Product objects in its own query data - just filters them down to the preselected ids. Type-check clean.