### PR TITLE
fix(listings): clear stale variation id on WC parent-cascade recovery

### DIFF
--- a/libs/core/src/listings/application/services/__tests__/product-publish-execution.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/product-publish-execution.service.spec.ts
@@ -514,7 +514,12 @@ describe('ProductPublishExecutionService', () => {
         expect(result.outcome).toBe('ok');
       });
 
-      it('should recover the PARENT mapping (not the variant mapping) when the parent upsert 404s and an existing variant mapping is present', async () => {
+      it('should recover BOTH the parent and the variant mapping when the parent upsert 404s and an existing variant mapping is present (WC cascade-delete, #1838 fix)', async () => {
+        // Deleting a WooCommerce `type:'variable'` parent cascade-deletes its
+        // child variations, so a stale-parent recovery must also treat this
+        // sibling's own (existing) variation id as dead — not just the
+        // parent's id — and must NOT retry the variation upsert against the
+        // old (now-nonexistent-under-the-fresh-parent) variation id.
         identifierMapping.getExternalIds.mockImplementation(
           (entityType: string, internalId: string) => {
             if (internalId === GROUP_ID) {
@@ -528,46 +533,50 @@ describe('ProductPublishExecutionService', () => {
           },
         );
         const NEW_PARENT_EXT = 'wc-parent-99';
+        const NEW_VARIATION_EXT = 'wc-variation-99';
         adapter.publishProduct
           .mockRejectedValueOnce(
             new ProductPublishTargetNotFoundException('woocommerce.restapi.v3', PARENT_EXT),
           )
           .mockResolvedValueOnce({
-            externalProductId: VARIATION_EXT,
+            externalProductId: NEW_VARIATION_EXT,
             status: 'published',
             externalParentProductId: NEW_PARENT_EXT,
           });
 
         const result = await service.executePublish(input);
 
-        // Only the PARENT mapping is deleted — the variant's own mapping is untouched.
+        // Both the stale parent mapping AND the now-equally-stale variant
+        // mapping are deleted — the parent's cascade-delete took the
+        // variation with it.
         expect(identifierMapping.deleteMapping).toHaveBeenCalledWith('ShopProduct', PARENT_EXT, CONN);
-        expect(identifierMapping.deleteMapping).not.toHaveBeenCalledWith(
+        expect(identifierMapping.deleteMapping).toHaveBeenCalledWith(
           'ShopProduct',
           VARIATION_EXT,
           CONN,
         );
         expect(adapter.publishProduct).toHaveBeenCalledTimes(2);
+        // The retried command is a CREATE on BOTH axes: no stale variation id
+        // is retried against the freshly-created (zero-variation) parent.
         expect(adapter.publishProduct).toHaveBeenNthCalledWith(
           2,
           expect.objectContaining({
-            externalProductId: VARIATION_EXT,
+            externalProductId: null,
             variantGroup: expect.objectContaining({ externalParentProductId: null }),
           }),
         );
-        // Fresh parent mapping written; the variant's own mapping already
-        // existed and is not re-created.
+        // Fresh mappings written for BOTH the new variation and the new parent.
+        expect(identifierMapping.createMapping).toHaveBeenCalledWith(
+          'ShopProduct',
+          NEW_VARIATION_EXT,
+          CONN,
+          VARIANT,
+        );
         expect(identifierMapping.createMapping).toHaveBeenCalledWith(
           'ShopProduct',
           NEW_PARENT_EXT,
           CONN,
           GROUP_ID,
-        );
-        expect(identifierMapping.createMapping).not.toHaveBeenCalledWith(
-          'ShopProduct',
-          expect.anything(),
-          CONN,
-          VARIANT,
         );
         expect(result.outcome).toBe('ok');
       });

--- a/libs/core/src/listings/application/services/product-publish-execution.service.ts
+++ b/libs/core/src/listings/application/services/product-publish-execution.service.ts
@@ -214,9 +214,17 @@ export class ProductPublishExecutionService implements IProductPublishExecutionS
               adapter,
               command,
               input,
-              existingParentExternalProductId
+              existingParentExternalProductId,
+              existingExternalProductId
             );
             parentMappingNeedsCreate = true;
+            // A WooCommerce `type:'variable'` parent CASCADE-DELETES its child
+            // variations when it's deleted shop-side — the stale-parent recovery
+            // above therefore also invalidates this sibling's own variation id
+            // (if it had one), not just the parent id. Force the variant's own
+            // mapping to be (re)written too, mirroring
+            // `recreateAfterStaleUpsertTarget`'s posture.
+            mappingNeedsCreate = true;
           } catch (recoveryError) {
             if (recoveryError instanceof ProductPublishRejectedException) {
               return this.recordRejection(record.id, input.connectionId, recoveryError);
@@ -361,25 +369,47 @@ export class ProductPublishExecutionService implements IProductPublishExecutionS
    * {@link recreateAfterStaleUpsertTarget}, which recovers the variant/variation's
    * OWN stale mapping — the two are mutually exclusive per invocation because
    * only one id can be the one that actually 404'd.
+   *
+   * A deleted WooCommerce `type:'variable'` parent CASCADE-DELETES its child
+   * variations, so if this variant already had its own mapping
+   * (`existingVariantExternalProductId`), that variation id is dead too — not
+   * just the parent's. The retried command therefore ALSO clears
+   * `externalProductId` (forcing the adapter's variation upsert to CREATE
+   * instead of PUT against a variation id that no longer exists under the
+   * freshly-created parent), and the dead variant mapping is deleted alongside
+   * the parent's so both are cleanly re-created by the caller.
    */
   private async recreateAfterStaleParentTarget(
     adapter: ShopProductManagerPort,
     command: PublishProductCommand,
     input: ExecutePublishProductInput,
-    staleParentExternalProductId: string
+    staleParentExternalProductId: string,
+    existingVariantExternalProductId: string | null
   ): Promise<PublishProductResult> {
     this.logger.warn(
       `Stale ShopProduct PARENT mapping detected; grouped-parent upsert target missing shop-side. ` +
         `Deleting parent mapping and re-creating. connectionId=${input.connectionId} ` +
-        `internalVariantId=${input.internalVariantId} staleParentExternalProductId=${staleParentExternalProductId}`
+        `internalVariantId=${input.internalVariantId} staleParentExternalProductId=${staleParentExternalProductId} ` +
+        `existingVariantExternalProductId=${existingVariantExternalProductId ?? '<none>'}`
     );
     await this.identifierMapping.deleteMapping(
       CORE_ENTITY_TYPE.ShopProduct,
       staleParentExternalProductId,
       input.connectionId
     );
+    if (existingVariantExternalProductId) {
+      // The parent's cascade-delete took this variant's own variation with it —
+      // its mapping is equally stale and must not survive to be reused as an
+      // upsert target against the fresh parent (which has zero variations).
+      await this.identifierMapping.deleteMapping(
+        CORE_ENTITY_TYPE.ShopProduct,
+        existingVariantExternalProductId,
+        input.connectionId
+      );
+    }
     const retriedCommand: PublishProductCommand = {
       ...command,
+      externalProductId: null,
       variantGroup: command.variantGroup
         ? { ...command.variantGroup, externalParentProductId: null }
         : command.variantGroup,


### PR DESCRIPTION
## Summary

Fixes a BLOCKING bug in `ProductPublishExecutionService.recreateAfterStaleParentTarget` (the grouped-parent stale-mapping 404 recovery path added by #1836) that orphans empty WooCommerce `type:'variable'` products on retry.

**The bug**: when the shared parent's `ShopProduct` mapping is stale (the parent was deleted shop-side and the parent upsert 404s), the recovery path only cleared `command.variantGroup.externalParentProductId`. It left `command.externalProductId` (this sibling's own existing variation id) untouched. In real WooCommerce, deleting a `type:'variable'` parent **cascade-deletes its child variations** - so whenever this recovery fired for a variant that already had its own mapping, the variation id was equally dead. The retried command still carried the stale variation id, so the adapter's `upsertVariation` PUT `/products/{brand-new-parentId}/variations/{old-stale-variationId}` against a freshly created parent with zero variations - guaranteed to 404 again.

That second `ProductPublishTargetNotFoundException` was not caught (the surrounding `catch` only special-cases `ProductPublishRejectedException`), so it propagated raw. Consequences: an orphaned "variable" product with zero variations leaks into WooCommerce on every retry, and even if the variation PUT had somehow succeeded, `mappingNeedsCreate` was never forced `true` in this branch, so the variant's own mapping would never get rewritten to the new variation id.

## Fix

- `recreateAfterStaleParentTarget` now also accepts the variant's existing `externalProductId` (if any), deletes that mapping alongside the parent's (both are dead after a WC cascade-delete), and clears `externalProductId: null` on the retried command so the adapter's variation upsert is forced to CREATE instead of retrying a dead id.
- The caller now also sets `mappingNeedsCreate = true` alongside `parentMappingNeedsCreate = true` after a successful parent-stale recovery, so the freshly-created variation's new id is persisted to the variant's own `ShopProduct` mapping - mirroring the existing `recreateAfterStaleUpsertTarget` posture.
- Fixed the masking unit test ("should recover the PARENT mapping...") which mocked the adapter as an opaque resolve reusing the same stale `externalProductId` on retry and asserted the variant mapping was left untouched - both assumptions were wrong under the real adapter's two-phase parent/variation logic. It now asserts the retried command carries `externalProductId: null`, that both stale mappings are deleted, and that both fresh mappings get persisted.

## Test plan

- [x] `pnpm --filter @openlinker/core build`
- [x] `pnpm type-check` (full monorepo)
- [x] `pnpm --filter @openlinker/core test -- product-publish-execution` (20/20 passing, including the fixed test and the pre-existing "no existing variant mapping" sibling case which was already correct)
- [x] `pnpm check:invariants`
- [x] `pnpm --filter @openlinker/core lint` (0 errors, pre-existing warnings only, none in touched files)

The fixed test exercises the exact scenario described in the bug report - a parent-stale 404 recovery WITH an existing variant mapping present - and asserts `externalProductId: null` on the retried command plus deletion of both stale mappings, so it would have caught the original bug (previously it asserted the opposite: the stale id retried and the variant mapping untouched).

Closes part of epic #1838 (WooCommerce native variable-product publishing hardening).