### PR TITLE
docs(infakt): note known 500 from Infakt sandbox on invoice correction

### DIFF
--- a/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
@@ -592,6 +592,14 @@ export class InfaktInvoicingAdapter
     this.logger.log(`Infakt invoice ${cmd.externalInvoiceId} marked as paid`);
   }
 
+  // KNOWN ISSUE (confirmed 2026-07-27): invoice correction does not work — blocked externally.
+  // OL surfaces a 422 (in-doubt) here, but that's just us relaying the provider's failure.
+  // Root cause: Infakt's own sandbox returns a 500 Internal Server Error on
+  // POST corrective_invoices.json regardless of payload (verified by patching the
+  // compiled HTTP client to log the raw response body). Reproduced with multiple
+  // correction shapes (quantity-zeroing and price-change), same 500 every time —
+  // not an OL-side validation or payload-shape bug. No action item here; remove
+  // this note once Infakt confirms their sandbox is fixed.
   async issueCorrection(cmd: IssueCorrectionCommand): Promise<IssueInvoiceResult> {
     const { originalProviderInvoiceId, reason, lines, documentType, idempotencyKey, orderId } =
       cmd;


### PR DESCRIPTION
Part of the Infakt E2E audit (systematic completeness + correctness review of the inFakt integration).

Infakt's own sandbox returns 500 Internal Server Error on POST corrective_invoices.json regardless of payload, verified by patching the compiled HTTP client to log the raw response body. Not an OL-side validation or payload-shape issue.

<!--
Thank you for contributing to OpenLinker!

Title: use Conventional Commits format — `feat(scope): subject`,
`fix(scope): subject`, `docs:`, `refactor:`, `test:`, `chore:`.
See CONTRIBUTING.md → Commits for the full type list.
-->

## Summary

<!-- 1–3 bullets: what changed and why. Focus on the why. -->

- Part of the Infakt E2E audit — documents a confirmed, externally-blocked issue found while reviewing the `CorrectionIssuer` capability of the Infakt adapter.
- Adds a code comment on `InfaktInvoicingAdapter.issueCorrection` noting that Infakt's sandbox returns a 500 on `POST corrective_invoices.json` regardless of payload (verified 2026-07-27), so reviewers/future maintainers don't re-diagnose it as an OL bug.
- No behavior change — documentation only.

## Related issues

<!-- One `Closes #N` per issue this PR resolves. Issues are closed
     automatically when the PR merges — do not close them manually. -->

Closes #1763

## Quality gate

- [ ] `pnpm lint` passes (zero errors)
- [ ] `pnpm type-check` passes (zero errors)
- [ ] `pnpm test` passes (all unit tests green)
- [ ] *Optional, Docker required:* `pnpm test:integration` passes — needed
      only if you touched `apps/api/test/integration/**` or any plugin's
      `infrastructure/adapters/`.


---

<sub>By submitting this pull request, I confirm that my contributions
are made under the terms of the [Apache License 2.0](../LICENSE), and I
certify the [Developer Certificate of Origin](https://developercertificate.org/)
by signing off my commits.</sub>
