### PR TITLE
fix(listings): reset button height/shadow on publish destination rail

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -6711,6 +6711,10 @@ a.kpi-card:focus-visible {
   background: var(--border-subtle);
 }
 .publish-dest-rail__option {
+  /* height + box-shadow reset - the global `button, .button {}` base (fixed
+     2rem height, accent box-shadow) otherwise survives and collapses this
+     two-line (name + kind-hint) option so its content overflows the padded
+     box. Mirrors the .variant-card__header reset (#1720). */
   display: flex;
   align-items: center;
   gap: var(--space-3);
@@ -6718,10 +6722,12 @@ a.kpi-card:focus-visible {
   box-sizing: border-box;
   text-align: left;
   font: inherit;
+  height: auto;
   padding: var(--space-4) var(--space-4);
   background: var(--bg-surface);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
+  box-shadow: none;
   color: var(--text-primary);
   cursor: pointer;
 }


### PR DESCRIPTION
## Summary

The "Configure batch" step of the bulk shop-publish wizard rendered the selected destination option (`PublishDestinationRail`) with almost no vertical breathing room between its text content and its own border, even though `.publish-dest-rail__option` sets `padding: var(--space-4) var(--space-4)` (16px).

## Root cause (confirmed via live browser inspection)

The padding was correctly applied, but it never had room to matter: the global `button, .button {}` base rule in `index.css` sets a fixed `height: 2rem` (32px) and an accent `box-shadow`, and `.publish-dest-rail__option` never overrode either property. Since the option renders two lines of content (connection name + kind hint) inside 16px top/bottom padding, it needs ~70px of height, but the inherited `height: 2rem` (34px border-box, with `box-sizing: border-box`) capped it far below that.

Live `getComputedStyle` inspection on the running demo confirmed it exactly:
- Before the fix: `height: 34px`, `padding-top/bottom: 16px`, and the name/hint text measured **-1.5px** from the button's own border edges (i.e. overflowing past the border on both sides, not just touching it).
- Unselected options have the same base rule and are equally affected; they additionally leaked the global button's default `box-shadow` (a drop shadow), since `.publish-dest-rail__option` never set `box-shadow` at all.

This is the same class of regression already fixed once for `.variant-card__header` (#1720, see the comment left in that rule) — a button-based component whose own class never resets the global button's fixed height, so multi-line content overflows the box.

## Fix

Add `height: auto` and `box-shadow: none` to `.publish-dest-rail__option` in `apps/web/src/index.css`, mirroring the existing `.variant-card__header` reset.

## Verification

Reproduced live against the local demo stack (`http://localhost:8090`, bulk shop-publish wizard reached via Listings → "Publish products" → select a product → Review), rebuilt the `web` container, and re-inspected:
- `height` now resolves to `auto` (~71px, fits both lines)
- name/hint gap from the border is a consistent ~17px on both selected and unselected states
- `box-shadow` on the unselected state is now `none` (no more stray drop shadow)

`pnpm --filter @openlinker/web type-check` passes with zero errors. Lint was run manually (zero errors, pre-existing warnings only). The repo-wide `smart-test` pre-commit step was skipped per standing project guidance (local Jest/Vitest runs are too heavy for this machine); it surfaced one pre-existing failure in `offer-product-picker-modal.test.tsx` asserting on `.bulk-chip__dot` aria-hidden behaviour, unrelated to this change (different component/class, no markup touched here).

## Test plan

- [x] Live-verified in the running demo: selected + unselected destination rail options both show correct vertical spacing
- [x] `pnpm --filter @openlinker/web type-check` passes
- [ ] CI: full test suite (not run locally per project guidance)