### PR TITLE
fix(web/demo): mask passwords only in PostHog session recordings (#1877)

### DIFF
--- a/apps/web/src/features/demo/lib/init-demo-integrations.test.ts
+++ b/apps/web/src/features/demo/lib/init-demo-integrations.test.ts
@@ -60,7 +60,7 @@ describe('initDemoIntegrations', () => {
     expect(posthogInit).not.toHaveBeenCalled();
   });
 
-  it('should init with masking options and the resolved autocapture/sessionRecording when all gates pass', async () => {
+  it('should init with password-only masking and the resolved autocapture/sessionRecording when all gates pass', async () => {
     getDemoAnalyticsConsent.mockReturnValue('accepted');
     await initDemoIntegrations(configuredPosthog);
     expect(posthogInit).toHaveBeenCalledWith('phc_abc', {
@@ -69,10 +69,22 @@ describe('initDemoIntegrations', () => {
       autocapture: true,
       capture_pageview: true,
       session_recording: {
-        maskAllInputs: true,
-        maskTextSelector: '*',
+        maskAllInputs: false,
+        maskInputOptions: { password: true },
       },
     });
+  });
+
+  it('should not mask rendered page text or non-password inputs (#1877)', async () => {
+    getDemoAnalyticsConsent.mockReturnValue('accepted');
+    await initDemoIntegrations(configuredPosthog);
+    const [, options] = posthogInit.mock.calls[0] as [string, Record<string, unknown>];
+    const sessionRecording = options.session_recording as Record<string, unknown>;
+    // A regression here means replays go back to being unwatchable.
+    expect(sessionRecording).not.toHaveProperty('maskTextSelector');
+    expect(sessionRecording.maskAllInputs).toBe(false);
+    // ...but the one guarantee that remains must hold.
+    expect(sessionRecording.maskInputOptions).toEqual({ password: true });
   });
 
   it('should omit session_recording entirely when the resolved config disables it', async () => {

--- a/apps/web/src/features/demo/lib/init-demo-integrations.ts
+++ b/apps/web/src/features/demo/lib/init-demo-integrations.ts
@@ -8,13 +8,20 @@
  *
  * `autocapture` and whether session recording is enabled at all (#1685) are
  * now read from the resolved config rather than hardcoded — an admin
- * toggles them via the PostHog settings dialog on `/settings`. Masking
- * WITHIN session recording stays unconditional regardless of that toggle
- * (`maskTextSelector: '*'` masks every rendered text node), not opt-in by
- * selector: demo mode must only ever run against synthetic seed data (see
- * docs/one-command-demo-setup-guide.md), but rrweb records every rendered
- * DOM text node by default, so an operator who points a demo instance at
- * real data would otherwise ship buyer PII to PostHog cloud.
+ * toggles them via the PostHog settings dialog on `/settings`.
+ *
+ * Masking within session recording is narrowed to PASSWORDS ONLY (#1877).
+ * Page text and ordinary input values (search boxes, filters, form fields)
+ * are recorded verbatim — a replay that masks everything shows the layout
+ * and none of the content, which defeats the point of recording a demo.
+ *
+ * CONSEQUENCE — READ BEFORE WIDENING THE DEMO DATASET: the previous
+ * blanket mask (`maskTextSelector: '*'`) doubled as a backstop against an
+ * operator pointing a demo instance at a live store. That backstop is gone.
+ * The requirement that demo mode runs ONLY against synthetic seed data (see
+ * docs/one-command-demo-setup-guide.md) is now load-bearing, not belt-and-
+ * braces: with real data behind it, rrweb would ship buyer names, addresses,
+ * and tax IDs (KSeF / invoicing surfaces) to PostHog cloud verbatim.
  */
 import type { PostHog } from 'posthog-js';
 import type { SystemConfig } from '../../system';
@@ -41,8 +48,11 @@ export async function initDemoIntegrations(config: SystemConfig | undefined): Pr
     capture_pageview: true,
     session_recording: posthogConfig.sessionRecording
       ? {
-          maskAllInputs: true,
-          maskTextSelector: '*',
+          // Passwords only (#1877). `password` is stated explicitly rather
+          // than left to rrweb's implicit default so the one guarantee this
+          // config still makes is visible in the source.
+          maskAllInputs: false,
+          maskInputOptions: { password: true },
         }
       : undefined,
   });

--- a/docs/one-command-demo-setup-guide.md
+++ b/docs/one-command-demo-setup-guide.md
@@ -120,13 +120,22 @@ in the demo banner.
 | `OL_POSTHOG_KEY` | PostHog project API key (publishable, write-only ingestion key — never a personal/private key). Unset by default. |
 | `OL_POSTHOG_HOST` | PostHog ingestion host. Defaults to `https://eu.posthog.com` when `OL_POSTHOG_KEY` is set. |
 
-**Only run session recording against synthetic seed data.** Recording masks
-all form inputs and all rendered text (`maskAllInputs` + a mask-everything
-text selector), but a demo instance pointed at real shop data would still
-expose non-text signal (order IDs in URLs, image content, layout) to
-PostHog cloud. Session recording is intended for the seeded demo dataset
-only — never enable `OL_POSTHOG_KEY` on an instance connected to a live
-PrestaShop/Allegro/Erli store with real customer data.
+**Only run session recording against synthetic seed data. This is a hard
+requirement, not a precaution.** Recording masks **passwords only** (#1877)
+— every other input value and all rendered page text is captured verbatim,
+because a replay that masks everything shows layout and no content, which
+makes the recording useless.
+
+So a demo instance pointed at real shop data ships real buyer PII to
+PostHog cloud: customer names and addresses on the orders and customers
+surfaces, and tax IDs on the KSeF / invoicing surfaces — plus the non-text
+signal that was always exposed (order IDs in URLs, product image content,
+layout).
+
+Never set `OL_POSTHOG_KEY` on an instance connected to a live
+PrestaShop / Allegro / Erli / WooCommerce store with real customer data.
+If you need recordings against a realistic dataset, seed it synthetically
+rather than relaxing this rule.
 
 A visitor who accepted the consent prompt can revoke it at any time from
 the demo banner ("Disable" next to "Analytics on").


### PR DESCRIPTION
Closes #1877

## What & why

Demo-mode session replays were unwatchable — every rendered text node was replaced with asterisks, so a replay showed the layout and none of the content.

Cause was `maskTextSelector: '*'` in `init-demo-integrations.ts`: that selector matches *every* element, so rrweb masks the text content of the entire DOM. `maskAllInputs: true` alongside it masked every input value, not just sensitive ones.

Both knobs are narrowed to passwords only:

```diff
 session_recording: posthogConfig.sessionRecording
   ? {
-      maskAllInputs: true,
-      maskTextSelector: '*',
+      maskAllInputs: false,
+      maskInputOptions: { password: true },
     }
   : undefined,
```

`maskTextSelector` is dropped entirely (PostHog's default masks no text). `password: true` is stated explicitly rather than left to rrweb's implicit default, so the one guarantee this config still makes is visible in the source rather than inherited.

## The trade-off this accepts

The blanket mask also served as a backstop against an operator pointing a demo instance at a live store — that rationale was written into the file header. **That backstop is gone.**

The "demo mode runs only against synthetic seed data" rule therefore moves from belt-and-braces to load-bearing. With real data behind it, rrweb now ships buyer names and addresses (orders / customers surfaces) and tax IDs (KSeF / invoicing surfaces) to PostHog cloud verbatim.

This is stated plainly in two places so it isn't rediscovered the hard way, and so nobody reinstates the blanket mask without knowing why it went:
- the `init-demo-integrations.ts` header, under a `CONSEQUENCE — READ BEFORE WIDENING THE DEMO DATASET` heading;
- `docs/one-command-demo-setup-guide.md`, where the old paragraph claimed the masking made real data merely inadvisable rather than unsafe.

No backend change — `sessionRecording` remains the existing admin on/off toggle; only the masking options within it change.

## Test plan

- [x] `init-demo-integrations.test.ts` — existing assertion updated; **new regression test** asserts `maskTextSelector` is absent and `maskAllInputs === false` (a revert makes replays unwatchable again) *and* that `maskInputOptions` still equals `{ password: true }` (the remaining guarantee).
- [x] `pnpm --filter @openlinker/web type-check` — clean (confirms `maskInputOptions` is on the `posthog-js` type).
- [x] `eslint` on both changed source files — clean.
- [x] Full `apps/web` suite — 264 files / 2387 tests passed.

## Manual verification worth doing before relying on this

Bring up a demo stack with `OL_POSTHOG_KEY` set, accept the consent prompt, log in, and confirm in the PostHog replay that: the login password field is masked, and the products/orders lists are legible.

## Note on the in-flight demo-events stack

PRs #1823 / #1827 / #1839 touch this same file (#1839 wraps the `posthog.init` block in `try/finally` for the init-race buffer). This change is small and adjacent to that edit, but expect a trivial conflict on whichever lands second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)