### PR TITLE
fix(listings): extend products cockpit coverage pills to shop destinations

### DIFF
--- a/apps/api/src/products/http/products.controller.spec.ts
+++ b/apps/api/src/products/http/products.controller.spec.ts
@@ -17,6 +17,8 @@ import { INVENTORY_QUERY_SERVICE_TOKEN } from '@openlinker/core/inventory';
 import type { IInventoryQueryService } from '@openlinker/core/inventory';
 import { OFFER_MAPPINGS_SERVICE_TOKEN } from '@openlinker/core/listings';
 import type { IOfferMappingsService } from '@openlinker/core/listings';
+import { SHOP_PRODUCT_MAPPINGS_SERVICE_TOKEN } from '@openlinker/core/listings';
+import type { IShopProductMappingsService } from '@openlinker/core/listings';
 
 function makeProduct(overrides: Partial<Product> = {}): Product {
   return {
@@ -80,6 +82,12 @@ function createMockOfferMappings(): jest.Mocked<IOfferMappingsService> {
   };
 }
 
+function createMockShopProductMappings(): jest.Mocked<IShopProductMappingsService> {
+  return {
+    countListedVariantsByProducts: jest.fn(),
+  };
+}
+
 function createMockIdentifierMapping(): jest.Mocked<IdentifierMappingPort> {
   return {
     getOrCreateInternalId: jest.fn(),
@@ -99,12 +107,14 @@ describe('ProductsController', () => {
   let identifierMapping: jest.Mocked<IdentifierMappingPort>;
   let inventoryQuery: jest.Mocked<IInventoryQueryService>;
   let offerMappings: jest.Mocked<IOfferMappingsService>;
+  let shopProductMappings: jest.Mocked<IShopProductMappingsService>;
 
   beforeEach(async () => {
     const mockProductsService = createMockProductsService();
     const mockIdentifierMapping = createMockIdentifierMapping();
     const mockInventoryQuery = createMockInventoryQuery();
     const mockOfferMappings = createMockOfferMappings();
+    const mockShopProductMappings = createMockShopProductMappings();
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [ProductsController],
@@ -113,6 +123,7 @@ describe('ProductsController', () => {
         { provide: IDENTIFIER_MAPPING_SERVICE_TOKEN, useValue: mockIdentifierMapping },
         { provide: INVENTORY_QUERY_SERVICE_TOKEN, useValue: mockInventoryQuery },
         { provide: OFFER_MAPPINGS_SERVICE_TOKEN, useValue: mockOfferMappings },
+        { provide: SHOP_PRODUCT_MAPPINGS_SERVICE_TOKEN, useValue: mockShopProductMappings },
       ],
     }).compile();
 
@@ -121,6 +132,7 @@ describe('ProductsController', () => {
     identifierMapping = module.get(IDENTIFIER_MAPPING_SERVICE_TOKEN);
     inventoryQuery = module.get(INVENTORY_QUERY_SERVICE_TOKEN);
     offerMappings = module.get(OFFER_MAPPINGS_SERVICE_TOKEN);
+    shopProductMappings = module.get(SHOP_PRODUCT_MAPPINGS_SERVICE_TOKEN);
 
     jest.clearAllMocks();
 
@@ -129,6 +141,7 @@ describe('ProductsController', () => {
     // override where they assert enrichment mapping.
     inventoryQuery.getProductStockAggregates.mockResolvedValue([]);
     offerMappings.countListedVariantsByProducts.mockResolvedValue([]);
+    shopProductMappings.countListedVariantsByProducts.mockResolvedValue([]);
     productsService.getVariantCountsByProductIds.mockResolvedValue(new Map());
     identifierMapping.getExternalIds.mockResolvedValue([]);
   });
@@ -263,6 +276,14 @@ describe('ProductsController', () => {
           listedVariants: 2,
         },
       ]);
+      shopProductMappings.countListedVariantsByProducts.mockResolvedValue([
+        {
+          productId: 'ol_product_1',
+          connectionId: 'conn-woo-1',
+          platformType: 'woocommerce',
+          listedVariants: 1,
+        },
+      ]);
       productsService.getVariantCountsByProductIds.mockResolvedValue(
         new Map([['ol_product_1', 3]])
       );
@@ -279,6 +300,9 @@ describe('ProductsController', () => {
 
       expect(inventoryQuery.getProductStockAggregates).toHaveBeenCalledWith(['ol_product_1']);
       expect(offerMappings.countListedVariantsByProducts).toHaveBeenCalledWith(['ol_product_1']);
+      expect(shopProductMappings.countListedVariantsByProducts).toHaveBeenCalledWith([
+        'ol_product_1',
+      ]);
       expect(productsService.getVariantCountsByProductIds).toHaveBeenCalledWith(['ol_product_1']);
       expect(identifierMapping.getExternalIds).toHaveBeenCalledWith('Product', 'ol_product_1');
 
@@ -287,8 +311,11 @@ describe('ProductsController', () => {
       expect(item.totalReserved).toBe(3);
       expect(item.stockUpdatedAt).toBe('2026-05-01T12:00:00.000Z');
       expect(item.variantCount).toBe(3);
+      // Offer (marketplace) and ShopProduct (shop) coverage rows merge into
+      // the same per-product list (#1838 follow-up fix).
       expect(item.listingsCoverage).toEqual([
         { connectionId: 'conn-1', platformType: 'allegro', listedVariants: 2 },
+        { connectionId: 'conn-woo-1', platformType: 'woocommerce', listedVariants: 1 },
       ]);
       expect(item.externalIds).toEqual([
         { externalId: '42', platformType: 'prestashop', connectionId: 'conn-src' },
@@ -317,6 +344,7 @@ describe('ProductsController', () => {
       expect(result.items).toEqual([]);
       expect(inventoryQuery.getProductStockAggregates).not.toHaveBeenCalled();
       expect(offerMappings.countListedVariantsByProducts).not.toHaveBeenCalled();
+      expect(shopProductMappings.countListedVariantsByProducts).not.toHaveBeenCalled();
       expect(productsService.getVariantCountsByProductIds).not.toHaveBeenCalled();
       expect(identifierMapping.getExternalIds).not.toHaveBeenCalled();
     });

--- a/apps/api/src/products/http/products.controller.ts
+++ b/apps/api/src/products/http/products.controller.ts
@@ -27,7 +27,12 @@ import { IDENTIFIER_MAPPING_SERVICE_TOKEN, CORE_ENTITY_TYPE } from '@openlinker/
 import type { Product, ProductVariant, ProductListSort } from '@openlinker/core/products';
 import { IdentifierMappingPort } from '@openlinker/core/identifier-mapping';
 import { IInventoryQueryService, INVENTORY_QUERY_SERVICE_TOKEN } from '@openlinker/core/inventory';
-import { IOfferMappingsService, OFFER_MAPPINGS_SERVICE_TOKEN } from '@openlinker/core/listings';
+import {
+  IOfferMappingsService,
+  OFFER_MAPPINGS_SERVICE_TOKEN,
+  IShopProductMappingsService,
+  SHOP_PRODUCT_MAPPINGS_SERVICE_TOKEN,
+} from '@openlinker/core/listings';
 import type { ProductListingsCoverage } from '@openlinker/core/listings';
 import { Logger } from '@openlinker/shared/logging';
 import { ListProductsQueryDto } from './dto/list-products-query.dto';
@@ -91,7 +96,9 @@ export class ProductsController {
     @Inject(INVENTORY_QUERY_SERVICE_TOKEN)
     private readonly inventoryQuery: IInventoryQueryService,
     @Inject(OFFER_MAPPINGS_SERVICE_TOKEN)
-    private readonly offerMappings: IOfferMappingsService
+    private readonly offerMappings: IOfferMappingsService,
+    @Inject(SHOP_PRODUCT_MAPPINGS_SERVICE_TOKEN)
+    private readonly shopProductMappings: IShopProductMappingsService
   ) {}
 
   @Get()
@@ -127,16 +134,21 @@ export class ProductsController {
     // ids (identifier mapping), all in parallel.
     if (items.length > 0) {
       const ids = items.map((p) => p.id);
-      const [aggregates, coverage, variantCounts, externalIdLists] = await Promise.all([
-        this.inventoryQuery.getProductStockAggregates(ids),
-        this.offerMappings.countListedVariantsByProducts(ids),
-        this.productsService.getVariantCountsByProductIds(ids),
-        Promise.all(ids.map((id) => this.identifierMapping.getExternalIds(CORE_ENTITY_TYPE.Product, id))),
-      ]);
+      const [aggregates, offerCoverage, shopCoverage, variantCounts, externalIdLists] =
+        await Promise.all([
+          this.inventoryQuery.getProductStockAggregates(ids),
+          this.offerMappings.countListedVariantsByProducts(ids),
+          // Shop-destination coverage (#1838 follow-up fix): a product published
+          // to a WooCommerce connection previously showed no coverage indication
+          // because only Offer mappings fed this pipeline.
+          this.shopProductMappings.countListedVariantsByProducts(ids),
+          this.productsService.getVariantCountsByProductIds(ids),
+          Promise.all(ids.map((id) => this.identifierMapping.getExternalIds(CORE_ENTITY_TYPE.Product, id))),
+        ]);
 
       const aggregateByProduct = new Map(aggregates.map((a) => [a.productId, a]));
       const coverageByProduct = new Map<string, ProductListingsCoverageDto[]>();
-      for (const row of coverage) {
+      for (const row of [...offerCoverage, ...shopCoverage]) {
         const list = coverageByProduct.get(row.productId) ?? [];
         list.push(this.toCoverageDto(row));
         coverageByProduct.set(row.productId, list);

--- a/apps/web/src/pages/products/listings-coverage-pills.tsx
+++ b/apps/web/src/pages/products/listings-coverage-pills.tsx
@@ -2,10 +2,12 @@
  * Listings Coverage Pills
  *
  * Per-connection listings coverage for the products cockpit (#1720). Renders
- * one pill per ACTIVE OfferCreator connection - strictly connection-driven:
- * coverage rows for connections the operator no longer has (or that lack the
- * OfferCreator capability) are ignored, and a connection with no coverage row
- * renders as a 0/{variantCount} "none" pill. Visual states:
+ * one pill per ACTIVE publish-destination connection - strictly
+ * connection-driven: coverage rows for connections the operator no longer has
+ * are ignored, and a connection with no coverage row renders as a
+ * 0/{variantCount} "none" pill. The `connections` prop is capability-agnostic
+ * here (marketplace OfferCreator or shop ProductPublisher, #1838 follow-up
+ * fix); the caller decides which connections qualify. Visual states:
  * - full:    listed >= variantCount and variantCount > 0 (success)
  * - partial: 0 < listed < variantCount (warning)
  * - none:    listed = 0 or variantCount = 0 (muted)
@@ -20,7 +22,7 @@ import { usePlatforms } from '../../shared/plugins';
 export interface ListingsCoveragePillsProps {
   coverage: ProductListingsCoverage[] | undefined;
   variantCount: number;
-  /** Active OfferCreator connections - the pill set is derived from these. */
+  /** Active publish-destination connections - the pill set is derived from these. */
   connections: readonly Connection[];
 }
 

--- a/apps/web/src/pages/products/products-list-page.test.tsx
+++ b/apps/web/src/pages/products/products-list-page.test.tsx
@@ -219,6 +219,50 @@ describe('ProductsListPage', () => {
     expect(pills[1]).toHaveClass('coverage-pill--full');
   });
 
+  it('renders a coverage pill for a ShopProduct (WooCommerce) connection too (#1838 follow-up fix)', async () => {
+    // Coverage pills previously stayed keyed to the marketplace OfferCreator
+    // subset, so a product published to a shop connection (ShopProduct
+    // mapping, ProductPublisher capability) showed no coverage indication at
+    // all - this is the regression test for that fix.
+    const wooConnection = {
+      id: 'conn_woo',
+      name: 'My WooCommerce',
+      status: 'active',
+      platformType: 'woocommerce',
+      supportedCapabilities: ['OfferManager', 'ProductPublisher'],
+      enabledCapabilities: ['ProductPublisher'],
+    } as const;
+    const products: PaginatedProducts = {
+      items: [
+        {
+          ...sampleProducts.items[0]!,
+          listingsCoverage: [
+            { connectionId: 'conn_woo', platformType: 'woocommerce', listedVariants: 2 },
+          ],
+        },
+      ],
+      total: 1,
+      limit: 20,
+      offset: 0,
+    };
+    const mockApi = createMockApiClient({
+      products: { list: vi.fn().mockResolvedValue(products) },
+      connections: { list: vi.fn().mockResolvedValue([wooConnection]) },
+    });
+
+    const { container } = renderWithProviders(<ProductsListPage />, { apiClient: mockApi });
+
+    await screen.findByText('Test Product');
+    await waitFor(() => {
+      expect(container.querySelectorAll('.coverage-pill').length).toBeGreaterThan(0);
+    });
+    const pills = Array.from(container.querySelectorAll('.coverage-pill'));
+    expect(pills).toHaveLength(1);
+    expect(pills[0]).toHaveAttribute('data-channel', 'woocommerce');
+    // 2 of 2 variants listed → full.
+    expect(pills[0]).toHaveClass('coverage-pill--full');
+  });
+
   it('should show muted price with hover explanation when currency is absent', async () => {
     const mockApi = createMockApiClient({
       products: {

--- a/apps/web/src/pages/products/products-list-page.tsx
+++ b/apps/web/src/pages/products/products-list-page.tsx
@@ -237,15 +237,26 @@ export function ProductsListPage(): ReactElement {
 
   // Unified publish targets (#1828): offer marketplaces (OfferCreator) OR
   // online shops (ProductPublisher), capability-driven. Drives the publish
-  // CTAs + picker; the offer-coverage surfaces (gaps KPI, "Unlisted on" chips,
-  // coverage pills, per-row gap detection) stay keyed to the marketplace
-  // `offerManagerConnections` subset above, since coverage is offer-based.
+  // CTAs + picker. The gaps KPI / "Unlisted on" chips / per-row gap detection
+  // stay keyed to the marketplace `offerManagerConnections` subset above -
+  // "gap" is a narrower, offer-specific concept. The coverage PILLS, however,
+  // answer "is this published anywhere" and must include shop destinations
+  // too (#1838 follow-up fix - a product published to a WooCommerce
+  // connection previously rendered no pill at all).
   const publishDestinations = useMemo(
     () => selectPublishDestinations(connectionsQuery.data ?? []),
     [connectionsQuery.data],
   );
   const hasShopDestination = useMemo(
     () => publishDestinations.some((d) => d.kind === 'shop'),
+    [publishDestinations],
+  );
+  // Coverage-pill connection set (#1838 follow-up fix): every active publish
+  // destination (marketplace OR shop) - the same union `publishDestinations`
+  // already resolves, since a connection carries at most one listing-mapping
+  // kind (#1837) so it can never double-count here either.
+  const coveragePillConnections = useMemo(
+    () => publishDestinations.map((d) => d.connection),
     [publishDestinations],
   );
 
@@ -594,10 +605,10 @@ export function ProductsListPage(): ReactElement {
       <ListingsCoveragePills
         coverage={product.listingsCoverage}
         variantCount={product.variantCount ?? 0}
-        connections={offerManagerConnections}
+        connections={coveragePillConnections}
       />
     ),
-    [offerManagerConnections],
+    [coveragePillConnections],
   );
 
   const columns: DataTableColumn<Product>[] = useMemo(

--- a/libs/core/src/listings/application/services/__tests__/published-variants.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/published-variants.service.spec.ts
@@ -19,6 +19,7 @@ describe('PublishedVariantsService', () => {
     };
     shopRepo = {
       countByConnectionAndVariants: jest.fn(),
+      countListedVariantsByProducts: jest.fn(),
     };
     service = new PublishedVariantsService(offerRepo, shopRepo);
   });

--- a/libs/core/src/listings/application/services/__tests__/shop-product-mappings.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/shop-product-mappings.service.spec.ts
@@ -1,0 +1,65 @@
+/**
+ * Shop Product Mappings Service Tests
+ *
+ * Mirrors OfferMappingsService's countListedVariantsByProducts coverage
+ * (#1838 follow-up fix) - the empty-input short-circuit, the passthrough
+ * forwarding semantics, and the 200-id cap.
+ *
+ * @module libs/core/src/listings/application/services/__tests__
+ */
+import { ShopProductMappingsService } from '../shop-product-mappings.service';
+import type { ShopProductMappingRepositoryPort } from '../../../domain/ports/shop-product-mapping-repository.port';
+
+function buildRepoMock(): jest.Mocked<ShopProductMappingRepositoryPort> {
+  return {
+    countByConnectionAndVariants: jest.fn(),
+    countListedVariantsByProducts: jest.fn(),
+  };
+}
+
+describe('ShopProductMappingsService', () => {
+  describe('countListedVariantsByProducts', () => {
+    it('should return [] without hitting the repository when productIds is empty', async () => {
+      const repo = buildRepoMock();
+      const service = new ShopProductMappingsService(repo);
+
+      const result = await service.countListedVariantsByProducts([]);
+
+      expect(result).toEqual([]);
+      expect(repo.countListedVariantsByProducts).not.toHaveBeenCalled();
+    });
+
+    it('should forward productIds to the repository and return its rows verbatim', async () => {
+      const repo = buildRepoMock();
+      const rows = [
+        {
+          productId: 'ol_product_1',
+          connectionId: 'conn-woo-1',
+          platformType: 'woocommerce',
+          listedVariants: 1,
+        },
+      ];
+      repo.countListedVariantsByProducts.mockResolvedValue(rows);
+      const service = new ShopProductMappingsService(repo);
+
+      const result = await service.countListedVariantsByProducts(['ol_product_1', 'ol_product_2']);
+
+      expect(repo.countListedVariantsByProducts).toHaveBeenCalledWith([
+        'ol_product_1',
+        'ol_product_2',
+      ]);
+      expect(result).toBe(rows);
+    });
+
+    it('should reject input exceeding the 200-id cap without hitting the repository', async () => {
+      const repo = buildRepoMock();
+      const service = new ShopProductMappingsService(repo);
+      const oversize = Array.from({ length: 201 }, (_, i) => `ol_product_${String(i)}`);
+
+      await expect(service.countListedVariantsByProducts(oversize)).rejects.toThrow(
+        /at most 200 productIds/
+      );
+      expect(repo.countListedVariantsByProducts).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/libs/core/src/listings/application/services/shop-product-mappings.service.interface.ts
+++ b/libs/core/src/listings/application/services/shop-product-mappings.service.interface.ts
@@ -1,0 +1,25 @@
+/**
+ * Shop Product Mappings Service Interface
+ *
+ * Cross-context read seam over `ShopProductMappingRepositoryPort` - the
+ * shop-side sibling of `IOfferMappingsService` (#718). Exposes the
+ * per-product coverage read the products cockpit needs so callers never
+ * value-import the repository port directly.
+ *
+ * @module libs/core/src/listings/application/services
+ */
+import type { ProductListingsCoverage } from '../../domain/types/offer-mapping.types';
+
+export interface IShopProductMappingsService {
+  /**
+   * Count DISTINCT listed variants per (product, connection) for the given
+   * product IDs, scoped to `entityType = 'ShopProduct'` (#1838 follow-up
+   * fix - a product published to a shop connection previously reported zero
+   * coverage on the products cockpit because only offer mappings were read).
+   * Pairs with zero listed variants are omitted. Empty input returns [] without
+   * hitting the database; input is capped at 200 IDs per call.
+   */
+  countListedVariantsByProducts(
+    productIds: readonly string[]
+  ): Promise<readonly ProductListingsCoverage[]>;
+}

--- a/libs/core/src/listings/application/services/shop-product-mappings.service.ts
+++ b/libs/core/src/listings/application/services/shop-product-mappings.service.ts
@@ -1,0 +1,42 @@
+/**
+ * Shop Product Mappings Service
+ *
+ * Thin pass-through over `ShopProductMappingRepositoryPort` - the shop-side
+ * sibling of `OfferMappingsService` (#718). Created for the #1838 follow-up
+ * fix that closes the products cockpit coverage gap: a product published to
+ * a shop (WooCommerce) connection previously showed no listings-coverage
+ * indication because only `entityType = 'Offer'` mappings fed the coverage
+ * pipeline.
+ *
+ * @module libs/core/src/listings/application/services
+ * @implements {IShopProductMappingsService}
+ */
+import { Inject, Injectable } from '@nestjs/common';
+import { ShopProductMappingRepositoryPort } from '../../domain/ports/shop-product-mapping-repository.port';
+import type { ProductListingsCoverage } from '../../domain/types/offer-mapping.types';
+import { SHOP_PRODUCT_MAPPING_REPOSITORY_TOKEN } from '../../listings.tokens';
+import type { IShopProductMappingsService } from './shop-product-mappings.service.interface';
+
+// Mirrors OfferMappingsService.MAX_COVERAGE_PRODUCT_IDS - keeps the grouped
+// identifier_mappings query page-scoped.
+const MAX_COVERAGE_PRODUCT_IDS = 200;
+
+@Injectable()
+export class ShopProductMappingsService implements IShopProductMappingsService {
+  constructor(
+    @Inject(SHOP_PRODUCT_MAPPING_REPOSITORY_TOKEN)
+    private readonly repository: ShopProductMappingRepositoryPort
+  ) {}
+
+  async countListedVariantsByProducts(
+    productIds: readonly string[]
+  ): Promise<readonly ProductListingsCoverage[]> {
+    if (productIds.length === 0) return [];
+    if (productIds.length > MAX_COVERAGE_PRODUCT_IDS) {
+      throw new Error(
+        `countListedVariantsByProducts accepts at most ${String(MAX_COVERAGE_PRODUCT_IDS)} productIds per call (got ${String(productIds.length)})`
+      );
+    }
+    return this.repository.countListedVariantsByProducts(productIds);
+  }
+}

--- a/libs/core/src/listings/domain/ports/shop-product-mapping-repository.port.ts
+++ b/libs/core/src/listings/domain/ports/shop-product-mapping-repository.port.ts
@@ -11,6 +11,7 @@
  *
  * @module libs/core/src/listings/domain/ports
  */
+import type { ProductListingsCoverage } from '../types/offer-mapping.types';
 
 export interface ShopProductMappingRepositoryPort {
   /**
@@ -23,4 +24,15 @@ export interface ShopProductMappingRepositoryPort {
     connectionId: string,
     internalIds: ReadonlyArray<string>
   ): Promise<Map<string, number>>;
+
+  /**
+   * Count DISTINCT listed variants per (product, connection) for the given
+   * product IDs, scoped to `entityType = 'ShopProduct'`. The shop-side
+   * sibling of `OfferMappingRepositoryPort.countListedVariantsByProducts`
+   * (#1720) - closes the gap where a product published to a shop connection
+   * (#1042) reported zero coverage on the products cockpit.
+   */
+  countListedVariantsByProducts(
+    productIds: readonly string[]
+  ): Promise<readonly ProductListingsCoverage[]>;
 }

--- a/libs/core/src/listings/index.ts
+++ b/libs/core/src/listings/index.ts
@@ -65,6 +65,7 @@ export type { IOfferMappingsService } from './application/services/offer-mapping
 export type { OfferMappingRepositoryPort } from './domain/ports/offer-mapping-repository.port';
 export type { ShopProductMappingRepositoryPort } from './domain/ports/shop-product-mapping-repository.port';
 export type { IPublishedVariantsService } from './application/services/published-variants.service.interface';
+export type { IShopProductMappingsService } from './application/services/shop-product-mappings.service.interface';
 export type {
   OfferMappingFilters,
   OfferMappingPagination,

--- a/libs/core/src/listings/infrastructure/persistence/repositories/shop-product-mapping.repository.spec.ts
+++ b/libs/core/src/listings/infrastructure/persistence/repositories/shop-product-mapping.repository.spec.ts
@@ -1,0 +1,126 @@
+/**
+ * Shop Product Mapping Repository — Unit Tests
+ *
+ * Mirrors offer-mapping.repository.spec.ts's countListedVariantsByProducts
+ * coverage (#1838 follow-up fix), scoped to `entityType = 'ShopProduct'`.
+ *
+ * @module libs/core/src/listings/infrastructure/persistence/repositories
+ */
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import type { Repository } from 'typeorm';
+
+import { IdentifierMappingOrmEntity } from '@openlinker/core/identifier-mapping/orm-entities';
+
+import { ShopProductMappingRepository } from './shop-product-mapping.repository';
+
+describe('ShopProductMappingRepository', () => {
+  let repository: ShopProductMappingRepository;
+  let ormRepository: jest.Mocked<Repository<IdentifierMappingOrmEntity>>;
+
+  beforeEach(async () => {
+    const mockOrmRepo = {
+      createQueryBuilder: jest.fn(),
+    } as unknown as jest.Mocked<Repository<IdentifierMappingOrmEntity>>;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ShopProductMappingRepository,
+        {
+          provide: getRepositoryToken(IdentifierMappingOrmEntity),
+          useValue: mockOrmRepo,
+        },
+      ],
+    }).compile();
+
+    repository = module.get<ShopProductMappingRepository>(ShopProductMappingRepository);
+    ormRepository = module.get(getRepositoryToken(IdentifierMappingOrmEntity));
+  });
+
+  describe('countListedVariantsByProducts', () => {
+    type CoverageQb = {
+      select: jest.Mock;
+      addSelect: jest.Mock;
+      innerJoin: jest.Mock;
+      where: jest.Mock;
+      andWhere: jest.Mock;
+      groupBy: jest.Mock;
+      addGroupBy: jest.Mock;
+      getRawMany: jest.Mock;
+    };
+
+    function buildCoverageQb(
+      rows: Array<{
+        productId: string;
+        connectionId: string;
+        platformType: string;
+        listedVariants: string;
+      }>
+    ): CoverageQb {
+      const qb: CoverageQb = {
+        select: jest.fn(),
+        addSelect: jest.fn(),
+        innerJoin: jest.fn(),
+        where: jest.fn(),
+        andWhere: jest.fn(),
+        groupBy: jest.fn(),
+        addGroupBy: jest.fn(),
+        getRawMany: jest.fn().mockResolvedValue(rows),
+      };
+      qb.select.mockReturnValue(qb);
+      qb.addSelect.mockReturnValue(qb);
+      qb.innerJoin.mockReturnValue(qb);
+      qb.where.mockReturnValue(qb);
+      qb.andWhere.mockReturnValue(qb);
+      qb.groupBy.mockReturnValue(qb);
+      qb.addGroupBy.mockReturnValue(qb);
+      return qb;
+    }
+
+    it('should return [] on empty input without touching the query builder', async () => {
+      const result = await repository.countListedVariantsByProducts([]);
+
+      expect(result).toEqual([]);
+      expect(ormRepository.createQueryBuilder).not.toHaveBeenCalled();
+    });
+
+    it('should scope to ShopProduct mappings, join product_variants by table name, and cast counts to numbers', async () => {
+      const qb = buildCoverageQb([
+        {
+          productId: 'ol_product_1',
+          connectionId: 'conn-woo-1',
+          platformType: 'woocommerce',
+          listedVariants: '1',
+        },
+      ]);
+      (ormRepository.createQueryBuilder as jest.Mock).mockReturnValue(qb);
+
+      const result = await repository.countListedVariantsByProducts([
+        'ol_product_1',
+        'ol_product_2',
+      ]);
+
+      expect(qb.innerJoin).toHaveBeenCalledWith(
+        'product_variants',
+        'pv',
+        'pv."id" = mapping."internalId"'
+      );
+      expect(qb.where).toHaveBeenCalledWith('mapping.entityType = :entityType', {
+        entityType: 'ShopProduct',
+      });
+      expect(qb.andWhere).toHaveBeenCalledWith('pv."productId" IN (:...productIds)', {
+        productIds: ['ol_product_1', 'ol_product_2'],
+      });
+      expect(qb.groupBy).toHaveBeenCalledWith('pv."productId"');
+      expect(result).toEqual([
+        {
+          productId: 'ol_product_1',
+          connectionId: 'conn-woo-1',
+          platformType: 'woocommerce',
+          listedVariants: 1,
+        },
+      ]);
+    });
+  });
+});

--- a/libs/core/src/listings/infrastructure/persistence/repositories/shop-product-mapping.repository.ts
+++ b/libs/core/src/listings/infrastructure/persistence/repositories/shop-product-mapping.repository.ts
@@ -16,6 +16,7 @@ import type { CoreEntityType } from '@openlinker/core/identifier-mapping';
 import { CORE_ENTITY_TYPE } from '@openlinker/core/identifier-mapping';
 import { IdentifierMappingOrmEntity } from '@openlinker/core/identifier-mapping/orm-entities';
 import type { ShopProductMappingRepositoryPort } from '../../../domain/ports/shop-product-mapping-repository.port';
+import type { ProductListingsCoverage } from '../../../domain/types/offer-mapping.types';
 
 const SHOP_PRODUCT_ENTITY_TYPE: CoreEntityType = CORE_ENTITY_TYPE.ShopProduct;
 
@@ -48,5 +49,43 @@ export class ShopProductMappingRepository implements ShopProductMappingRepositor
       if (count > 0) result.set(row.internalId, count);
     }
     return result;
+  }
+
+  async countListedVariantsByProducts(
+    productIds: readonly string[]
+  ): Promise<readonly ProductListingsCoverage[]> {
+    if (productIds.length === 0) return [];
+
+    const rows = await this.repository
+      .createQueryBuilder('mapping')
+      .select('pv."productId"', 'productId')
+      .addSelect('mapping.connectionId', 'connectionId')
+      .addSelect('mapping.platformType', 'platformType')
+      .addSelect('COUNT(DISTINCT mapping.internalId)', 'listedVariants')
+      // Read-model reporting join onto the products-context table by name -
+      // no cross-context ORM-entity import, so the import contract stays
+      // intact (#1720; columns are camelCase and must be double-quoted in
+      // raw fragments). Mirrors OfferMappingRepository.countListedVariantsByProducts.
+      .innerJoin('product_variants', 'pv', 'pv."id" = mapping."internalId"')
+      .where('mapping.entityType = :entityType', { entityType: SHOP_PRODUCT_ENTITY_TYPE })
+      .andWhere('pv."productId" IN (:...productIds)', { productIds: [...productIds] })
+      .groupBy('pv."productId"')
+      .addGroupBy('mapping.connectionId')
+      .addGroupBy('mapping.platformType')
+      .getRawMany<{
+        productId: string;
+        connectionId: string;
+        platformType: string;
+        listedVariants: string;
+      }>();
+
+    // COUNT(DISTINCT) comes back as bigint (string) through TypeORM's
+    // raw-query path - explicit Number() cast surfaces the right shape.
+    return rows.map((row) => ({
+      productId: row.productId,
+      connectionId: row.connectionId,
+      platformType: row.platformType,
+      listedVariants: Number(row.listedVariants),
+    }));
   }
 }

--- a/libs/core/src/listings/listings.module.ts
+++ b/libs/core/src/listings/listings.module.ts
@@ -23,6 +23,7 @@ import { AttributeProjectionService } from './application/services/attribute-pro
 import { OfferMappingRepository } from './infrastructure/persistence/repositories/offer-mapping.repository';
 import { ShopProductMappingRepository } from './infrastructure/persistence/repositories/shop-product-mapping.repository';
 import { PublishedVariantsService } from './application/services/published-variants.service';
+import { ShopProductMappingsService } from './application/services/shop-product-mappings.service';
 import { OfferCreationRecordOrmEntity } from './infrastructure/persistence/entities/offer-creation-record.orm-entity';
 import { OfferCreationRecordRepository } from './infrastructure/persistence/repositories/offer-creation-record.repository';
 import { BulkListingBatchOrmEntity } from './infrastructure/persistence/entities/bulk-listing-batch.orm-entity';
@@ -97,6 +98,7 @@ import {
   SHOP_ATTRIBUTE_READ_SERVICE_TOKEN,
   SHOP_PRODUCT_MAPPING_REPOSITORY_TOKEN,
   PUBLISHED_VARIANTS_SERVICE_TOKEN,
+  SHOP_PRODUCT_MAPPINGS_SERVICE_TOKEN,
 } from './listings.tokens';
 
 // Re-export tokens for convenience
@@ -138,6 +140,7 @@ export {
   SHOP_ATTRIBUTE_READ_SERVICE_TOKEN,
   SHOP_PRODUCT_MAPPING_REPOSITORY_TOKEN,
   PUBLISHED_VARIANTS_SERVICE_TOKEN,
+  SHOP_PRODUCT_MAPPINGS_SERVICE_TOKEN,
 } from './listings.tokens';
 
 @Module({
@@ -205,6 +208,7 @@ export {
     OfferStockRestoreService,
     ShopProductMappingRepository,
     PublishedVariantsService,
+    ShopProductMappingsService,
     {
       provide: OFFER_LINKING_SERVICE_TOKEN,
       useExisting: OfferLinkingService,
@@ -216,6 +220,10 @@ export {
     {
       provide: PUBLISHED_VARIANTS_SERVICE_TOKEN,
       useExisting: PublishedVariantsService,
+    },
+    {
+      provide: SHOP_PRODUCT_MAPPINGS_SERVICE_TOKEN,
+      useExisting: ShopProductMappingsService,
     },
     {
       provide: OFFER_MAPPING_SYNC_SERVICE_TOKEN,
@@ -390,6 +398,7 @@ export {
     SHOP_ATTRIBUTE_READ_SERVICE_TOKEN,
     SHOP_PRODUCT_MAPPING_REPOSITORY_TOKEN,
     PUBLISHED_VARIANTS_SERVICE_TOKEN,
+    SHOP_PRODUCT_MAPPINGS_SERVICE_TOKEN,
   ],
 })
 export class ListingsModule {}

--- a/libs/core/src/listings/listings.tokens.ts
+++ b/libs/core/src/listings/listings.tokens.ts
@@ -58,3 +58,6 @@ export const SHOP_ATTRIBUTE_READ_SERVICE_TOKEN = Symbol('IShopAttributeReadServi
 // Destination-aware duplicate guard (#1837)
 export const SHOP_PRODUCT_MAPPING_REPOSITORY_TOKEN = Symbol('ShopProductMappingRepositoryPort');
 export const PUBLISHED_VARIANTS_SERVICE_TOKEN = Symbol('IPublishedVariantsService');
+
+// Shop-side products cockpit coverage pills (#1838 follow-up fix)
+export const SHOP_PRODUCT_MAPPINGS_SERVICE_TOKEN = Symbol('IShopProductMappingsService');


### PR DESCRIPTION
## Summary

Fixes a real bug found via live testing on the demo: after successfully publishing a product to a WooCommerce (shop) connection, the `/products` page's LISTINGS column showed zero indication that it's published anywhere — just a generic "+ PUBLISH" CTA, as if nothing had happened. Verified via direct DB query and the `POST /v1/listings/published-variants` endpoint that the publish itself was correct and the mapping existed; the bug was entirely in the coverage-reporting pipeline.

## Root cause

`ListingsCoveragePills` (`apps/web/src/pages/products/listings-coverage-pills.tsx`) renders one pill per connection passed to it, but `products-list-page.tsx` only ever passed `offerManagerConnections` — connections with the `OfferCreator` capability (marketplace-only: Allegro/Erli). This predates epic #1838's unification of the marketplace + shop publish flows and was never revisited when shop publishing was added.

The backend mirrored the same gap: `ProductsController` only called `OfferMappingsService.countListedVariantsByProducts`, which reads `identifier_mappings` scoped to `entityType = 'Offer'`. There was no equivalent read for `entityType = 'ShopProduct'` in the coverage pipeline (a `ShopProductMappingRepositoryPort.countByConnectionAndVariants` existed for the #1837 duplicate guard, but not the per-product grouped-count shape coverage needs).

## Fix

- Added `countListedVariantsByProducts` to `ShopProductMappingRepositoryPort`, mirroring `OfferMappingRepositoryPort`'s method and query shape exactly (same `product_variants` join, same groupBy, same bigint-cast handling).
- New `ShopProductMappingsService` / `IShopProductMappingsService` thin pass-through (mirrors `OfferMappingsService`), wired via a new `SHOP_PRODUCT_MAPPINGS_SERVICE_TOKEN` Symbol token in `listings.tokens.ts` and the `ListingsModule` providers/exports.
- `ProductsController` now fetches offer coverage and shop coverage in parallel and merges both into the same per-product `coverageByProduct` map.
- Frontend: `products-list-page.tsx` now builds the coverage-pill connection set from `selectPublishDestinations` (the same marketplace+shop union already used for the unified publish CTA) instead of the marketplace-only `offerManagerConnections`. The gaps KPI and "Unlisted on" chips intentionally stay marketplace-only — that's a narrower, offer-specific concept and out of scope for this fix.

## Test plan

- [x] `pnpm --filter @openlinker/core build` — clean
- [x] `pnpm --filter @openlinker/api type-check` — clean
- [x] `pnpm --filter @openlinker/web type-check` — clean
- [x] `pnpm check:invariants` — clean (86 core services checked, all implement an interface; cross-context imports conform)
- [x] Verified the new repository query shape directly against the live demo Postgres database — the existing ShopProduct mapping row (WooCommerce connection, a real published product) resolves correctly.
- Local Jest/Vitest run skipped per standing project guidance (too heavy for this machine). Pre-commit hooks were skipped explicitly (`--no-verify`, with the user's approval) after lint/type-check/invariants were already run manually clean; the smart-test step's only failure was a confirmed pre-existing, unrelated test (`offer-product-picker-modal.test.tsx`, aria-hidden chip dot) already surfaced independently by PR #1876.

Closes part of epic #1838.