### PR TITLE
fix(listings): make selected destination-rail hover visible in dark mode

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -6739,6 +6739,17 @@ a.kpi-card:focus-visible {
   box-shadow: 0 0 0 1px var(--accent-primary);
   background: var(--accent-primary-soft);
 }
+/* `--selected`'s own background always wins the cascade over the plain
+   :hover rule above (same specificity, declared later), so hovering an
+   already-selected option showed no feedback at all. A relative
+   filter (not a new token) keeps this correct in both themes without
+   depending on --accent-primary-soft / --bg-surface-hover happening to
+   differ enough in lightness - in dark mode they sit at the identical
+   OKLCH lightness (28%), which made the effect invisible there while
+   still reading fine in light mode (96% vs 93%, near white). */
+.publish-dest-rail__option--selected:hover {
+  filter: brightness(0.93);
+}
 .publish-dest-rail__option:focus-visible {
   outline: none;
   box-shadow: var(--shadow-focus);


### PR DESCRIPTION
## Summary

Follow-up to #1876 (padding fix on the same component). Found via live testing: hovering an already-selected `PublishDestinationRail` option (e.g. "Demo WooCommerce" in the "Configure batch" step) showed no visual hover feedback at all in dark mode, though light mode looked fine.

## Root cause

`.publish-dest-rail__option--selected` sets `background: var(--accent-primary-soft)`, which always wins the CSS cascade over the plain `.publish-dest-rail__option:hover` rule (same specificity, declared later in the stylesheet) — so the hover rule's background swap never actually applies to a selected+hovered element, in either theme.

This was invisible specifically in **dark mode** because `--accent-primary-soft` and `--bg-surface-hover` sit at the **identical OKLCH lightness (28%)** there, differing only in hue/chroma — a shift too subtle to read as "hovering." In light mode the same two tokens differ enough near white (96% vs 93%) that the overall look still read as correct, which is why this only surfaced in dark mode.

## Fix

Add `.publish-dest-rail__option--selected:hover { filter: brightness(0.93); }` — a relative adjustment rather than a new token pair, so it stays visually correct in both themes regardless of the exact lightness relationship between `--accent-primary-soft` and `--bg-surface-hover`.

## Test plan

- [x] `pnpm --filter @openlinker/web type-check` — clean
- [x] Verified live in the demo: the deployed CSS bundle contains `.publish-dest-rail__option--selected:hover{filter:brightness(.93)}`
- Local Jest/Vitest run and pre-commit hooks skipped per standing project guidance (too heavy for this machine); this is a CSS-only change with no logic under test.

Closes part of epic #1838.