### PR TITLE
fix(listings): remove stale duplicate-guard test from offer picker

### DIFF
--- a/apps/web/src/features/listings/components/offer-product-picker-modal.test.tsx
+++ b/apps/web/src/features/listings/components/offer-product-picker-modal.test.tsx
@@ -379,25 +379,6 @@ describe('OfferProductPickerModal', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it('renders the "already on {destination}" chip with an aria-hidden decorative dot (#1838)', async () => {
-    const coveredP1: Product = {
-      ...P1,
-      listingsCoverage: [{ connectionId: 'conn_a', platformType: 'allegro', listedVariants: 2 }],
-    };
-    const apiClient = createMockApiClient({
-      connections: { list: vi.fn().mockResolvedValue([conn('conn_a', 'Allegro', 'allegro')]) },
-      products: {
-        list: vi.fn().mockResolvedValue({ items: [coveredP1], total: 1, limit: 20, offset: 0 }),
-        getById: vi.fn().mockResolvedValue(coveredP1),
-      },
-    });
-    renderWithProviders(<OfferProductPickerModal isOpen onClose={vi.fn()} />, { apiClient });
-
-    const chip = await screen.findByText(/already on Allegro/);
-    const dot = chip.parentElement?.querySelector('.bulk-chip__dot');
-    expect(dot).toHaveAttribute('aria-hidden', 'true');
-  });
-
   describe('query error + retry branches', () => {
     const oneProductPage = (): PaginatedProductsShape => ({
       items: [P1],


### PR DESCRIPTION
## Summary

Fixes the CI failure blocking PR #1870 — `offer-product-picker-modal.test.tsx > OfferProductPickerModal > renders the "already on {destination}" chip with an aria-hidden decorative dot (#1838)` was failing with `Unable to find an element with the text: /already on Allegro/`.

## Root cause (traced through history, not a guess)

- PR #1864 wired the shared `AlreadyListedChip` + `usePublishedVariantsQuery` duplicate-guard check into `OfferProductPickerModal` and added this test.
- PR #1866 (unifying the `/products` and `/listings` publish entry points) then **deliberately removed** that entire best-effort early-picker duplicate check — `usePublishedVariantsQuery`, `DuplicateGuardModal`, `AlreadyListedChip`, `productAlreadyOnList`, `destinationName` — all gone from `offer-product-picker-modal.tsx`.

This removal was **correct, not a regression**: the wizard's Review step already re-checks every selected variant authoritatively (`DuplicateGuardModal` in `bulk-wizard.tsx`, `AlreadyListedChip` used in both `bulk-review-step.tsx` and `bulk-shop-review-step.tsx`, the latter with 3 call sites). The picker-level check was explicitly documented as "best-effort... the wizard Review re-checks every variant authoritatively" before its removal — so dropping the early, incomplete check in favor of the single authoritative one at Review is sound design consolidation.

The now-orphaned test asserting the removed picker-level behavior was left behind by #1866 and has been silently red ever since (masked because it wasn't run against this exact file in isolation until CI caught it on #1870).

## Fix

Delete the stale test. No production code changes — the duplicate-guard feature itself is fully intact at the Review step.

## Test plan

- [x] `pnpm --filter @openlinker/web type-check` — clean
- [x] Single-file `vitest run` on `offer-product-picker-modal.test.tsx` — 24/24 remaining tests pass (3.46s)
- Full local suite not run per standing project guidance (too heavy for this machine) — this is a pure test-deletion, no logic changed.

Closes part of epic #1838.