### PR TITLE
feat(auth): self-service analytics consent toggle on /settings

### DIFF
--- a/apps/api/src/auth/auth.controller.spec.ts
+++ b/apps/api/src/auth/auth.controller.spec.ts
@@ -38,6 +38,8 @@ import { REGISTRATION_SERVICE_TOKEN } from './registration.service.interface';
 import type { IEmailConfirmationService } from './email-confirmation.service.interface';
 import { EMAIL_CONFIRMATION_SERVICE_TOKEN } from './email-confirmation.service.interface';
 import { PATH_METADATA } from '@nestjs/common/constants';
+import { IS_PUBLIC_KEY } from './decorators/public.decorator';
+import { ROLES_KEY } from './decorators/roles.decorator';
 import { API_VERSION_LABEL } from '../app-info/app-info.types';
 import { REFRESH_COOKIE_NAME, REFRESH_COOKIE_PATH } from './auth.cookies';
 
@@ -67,6 +69,7 @@ describe('AuthController', () => {
       validateUser: jest.fn(),
       login: jest.fn(),
       getMe: jest.fn(),
+      updateAnalyticsConsent: jest.fn(),
     };
     const mockPasswordResetService: jest.Mocked<IPasswordResetService> = {
       requestReset: jest.fn(),
@@ -425,6 +428,62 @@ describe('AuthController', () => {
       expect(result.role).toBe('admin');
       expect(result.permissions).toBeDefined();
       expect(result.permissions.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('PATCH /auth/me/analytics-consent (#1882)', () => {
+    const makeViewer = (analyticsConsent: boolean): User =>
+      new User(
+        'viewer-uuid-1',
+        'demo_user',
+        'demo@example.com',
+        '$2a$10$hash',
+        'viewer',
+        'active',
+        new Date(),
+        new Date(),
+        analyticsConsent
+      );
+
+    it('should persist the requested consent and answer with the refreshed user', async () => {
+      const updated = makeViewer(true);
+      authService.updateAnalyticsConsent.mockResolvedValue(updated);
+
+      const result = await controller.updateAnalyticsConsent(
+        { id: updated.id, username: updated.username, role: 'viewer' },
+        { analyticsConsent: true }
+      );
+
+      expect(authService.updateAnalyticsConsent).toHaveBeenCalledWith(updated.id, true);
+      expect(result.analyticsConsent).toBe(true);
+      expect(result.id).toBe(updated.id);
+    });
+
+    it('should pass a withdrawal (false) through unchanged', async () => {
+      const updated = makeViewer(false);
+      authService.updateAnalyticsConsent.mockResolvedValue(updated);
+
+      const result = await controller.updateAnalyticsConsent(
+        { id: updated.id, username: updated.username, role: 'viewer' },
+        { analyticsConsent: false }
+      );
+
+      expect(authService.updateAnalyticsConsent).toHaveBeenCalledWith(updated.id, false);
+      expect(result.analyticsConsent).toBe(false);
+    });
+
+    it('should carry no @Roles metadata so a viewer can change their own preference', () => {
+      const handler = AuthController.prototype.updateAnalyticsConsent;
+      const roles = Reflect.getMetadata(ROLES_KEY, handler) as unknown[] | undefined;
+
+      expect(roles).toBeUndefined();
+    });
+
+    it('should not be @Public — the handler needs an authenticated caller', () => {
+      const handler = AuthController.prototype.updateAnalyticsConsent;
+      const isPublic = Reflect.getMetadata(IS_PUBLIC_KEY, handler) as boolean | undefined;
+
+      expect(isPublic).toBeUndefined();
     });
   });
 });

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -3,8 +3,9 @@
  *
  * HTTP REST API endpoints for authentication. Provides login, current-user,
  * refresh, logout, and password reset endpoints. Login, refresh, logout,
- * and password-reset endpoints are public; /auth/me requires a valid JWT
- * bearer token (enforced by global guard).
+ * and password-reset endpoints are public; /auth/me and the self-service
+ * /auth/me/analytics-consent preference update require a valid JWT bearer
+ * token (enforced by global guard).
  *
  * The refresh / logout endpoints are public from the JWT auth standpoint
  * (no bearer required) but gated by CsrfGuard so cookie credentials
@@ -23,6 +24,7 @@ import {
   HttpException,
   HttpStatus,
   Inject,
+  Patch,
   Post,
   Req,
   Res,
@@ -57,6 +59,7 @@ import { OkResponseDto } from './dto/ok-response.dto';
 import { RegisterDto } from './dto/register.dto';
 import { ConfirmEmailDto } from './dto/confirm-email.dto';
 import { ResendConfirmationDto } from './dto/resend-confirmation.dto';
+import { UpdateAnalyticsConsentDto } from './dto/update-analytics-consent.dto';
 import { AuthenticatedUser } from './auth.types';
 import {
   IPasswordResetService,
@@ -299,6 +302,24 @@ export class AuthController {
   async getMe(@CurrentUser() user: AuthenticatedUser): Promise<UserResponseDto> {
     const fullUser = await this.authService.getMe(user.id);
     return UserResponseDto.fromDomain(fullUser);
+  }
+
+  // Deliberately carries no @Roles: this is a self-service preference on the
+  // caller's OWN account, so every authenticated role — viewer included, which
+  // is what a demo signup gets — must be able to change it (#1882).
+  @Patch('me/analytics-consent')
+  @HttpCode(HttpStatus.OK)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: "Update the current user's demo analytics consent" })
+  @ApiResponse({ status: 200, description: 'Updated current user', type: UserResponseDto })
+  @ApiResponse({ status: 400, description: 'Validation error (analyticsConsent is not a boolean)' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async updateAnalyticsConsent(
+    @CurrentUser() user: AuthenticatedUser,
+    @Body() dto: UpdateAnalyticsConsentDto,
+  ): Promise<UserResponseDto> {
+    const updated = await this.authService.updateAnalyticsConsent(user.id, dto.analyticsConsent);
+    return UserResponseDto.fromDomain(updated);
   }
 
   @Public()

--- a/apps/api/src/auth/auth.service.interface.ts
+++ b/apps/api/src/auth/auth.service.interface.ts
@@ -14,4 +14,10 @@ export interface IAuthService {
   validateUser(username: string, password: string): Promise<User | null>;
   login(user: User): LoginResponseDto;
   getMe(userId: string): Promise<User>;
+  /**
+   * Persists the caller's own analytics opt-in and returns the refreshed user
+   * so the controller can answer with the authoritative post-update state
+   * rather than echoing the request body (#1882).
+   */
+  updateAnalyticsConsent(userId: string, analyticsConsent: boolean): Promise<User>;
 }

--- a/apps/api/src/auth/auth.service.spec.ts
+++ b/apps/api/src/auth/auth.service.spec.ts
@@ -38,6 +38,7 @@ describe('AuthService', () => {
       findByEmail: jest.fn().mockResolvedValue(null),
       findById: jest.fn(),
       save: jest.fn(),
+      updateAnalyticsConsent: jest.fn(),
     } as unknown as jest.Mocked<UserRepositoryPort>;
 
     const mockJwtService = {
@@ -181,6 +182,52 @@ describe('AuthService', () => {
       userRepository.findById.mockResolvedValue(null);
 
       await expect(service.getMe('ghost-id')).rejects.toThrow(UnauthorizedException);
+    });
+  });
+
+  describe('updateAnalyticsConsent (#1882)', () => {
+    const makeConsentUser = (analyticsConsent: boolean): User =>
+      new User(
+        'user-uuid-123',
+        'demo_user',
+        'demo@example.com',
+        '$2a$10$hash',
+        'viewer',
+        'active',
+        new Date(),
+        new Date(),
+        analyticsConsent
+      );
+
+    it('should persist the new consent and return the re-read user', async () => {
+      userRepository.findById
+        .mockResolvedValueOnce(makeConsentUser(false))
+        .mockResolvedValueOnce(makeConsentUser(true));
+
+      const result = await service.updateAnalyticsConsent('user-uuid-123', true);
+
+      expect(userRepository.updateAnalyticsConsent).toHaveBeenCalledWith('user-uuid-123', true);
+      expect(result.analyticsConsent).toBe(true);
+    });
+
+    it('should return the persisted value rather than echoing the request', async () => {
+      // Repository re-read is authoritative: if it reports false, so do we.
+      userRepository.findById
+        .mockResolvedValueOnce(makeConsentUser(false))
+        .mockResolvedValueOnce(makeConsentUser(false));
+
+      const result = await service.updateAnalyticsConsent('user-uuid-123', true);
+
+      expect(result.analyticsConsent).toBe(false);
+    });
+
+    it('should throw UnauthorizedException and not write when the user no longer exists', async () => {
+      userRepository.findById.mockResolvedValue(null);
+
+      await expect(service.updateAnalyticsConsent('ghost-id', true)).rejects.toThrow(
+        UnauthorizedException
+      );
+      expect(userRepository.updateAnalyticsConsent).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/auth/auth.service.ts
+++ b/apps/api/src/auth/auth.service.ts
@@ -78,4 +78,12 @@ export class AuthService implements IAuthService {
     }
     return user;
   }
+
+  async updateAnalyticsConsent(userId: string, analyticsConsent: boolean): Promise<User> {
+    // getMe first so a deleted-but-still-bearing-a-valid-JWT caller gets a 401
+    // instead of a silent no-op UPDATE reported back as success.
+    await this.getMe(userId);
+    await this.userRepository.updateAnalyticsConsent(userId, analyticsConsent);
+    return this.getMe(userId);
+  }
 }

--- a/apps/api/src/auth/bootstrap-admin.service.spec.ts
+++ b/apps/api/src/auth/bootstrap-admin.service.spec.ts
@@ -38,6 +38,7 @@ const makeRepo = (): jest.Mocked<UserRepositoryPort> => ({
   deleteById: jest.fn(),
   deactivateAdminAtomically: jest.fn(),
   updateAdminRoleAtomically: jest.fn(),
+  updateAnalyticsConsent: jest.fn(),
   deleteAdminAtomically: jest.fn(),
   findStaleViewerAccounts: jest.fn(),
 });

--- a/apps/api/src/auth/demo-account-cleanup.service.spec.ts
+++ b/apps/api/src/auth/demo-account-cleanup.service.spec.ts
@@ -33,6 +33,7 @@ const makeRepo = (): jest.Mocked<UserRepositoryPort> => ({
   deleteById: jest.fn(),
   deactivateAdminAtomically: jest.fn(),
   updateAdminRoleAtomically: jest.fn(),
+  updateAnalyticsConsent: jest.fn(),
   deleteAdminAtomically: jest.fn(),
   findStaleViewerAccounts: jest.fn(),
 });

--- a/apps/api/src/auth/dto/update-analytics-consent.dto.ts
+++ b/apps/api/src/auth/dto/update-analytics-consent.dto.ts
@@ -1,0 +1,13 @@
+/**
+ * Update Analytics Consent DTO
+ *
+ * Represents a request to update the user's analytics consent preference.
+ *
+ * @module interfaces/http/dto
+ */
+import { IsBoolean } from 'class-validator';
+
+export class UpdateAnalyticsConsentDto {
+  @IsBoolean()
+  analyticsConsent!: boolean;
+}

--- a/apps/api/src/auth/email-confirmation.service.spec.ts
+++ b/apps/api/src/auth/email-confirmation.service.spec.ts
@@ -71,6 +71,7 @@ const makeUserRepo = (): jest.Mocked<UserRepositoryPort> => ({
   updateRole: jest.fn(),
   approveUser: jest.fn(),
   deleteById: jest.fn(),
+  updateAnalyticsConsent: jest.fn(),
   findStaleViewerAccounts: jest.fn(),
   save: jest.fn(),
   deactivateAdminAtomically: jest.fn(),

--- a/apps/api/src/auth/password-reset-round-trip.spec.ts
+++ b/apps/api/src/auth/password-reset-round-trip.spec.ts
@@ -85,6 +85,7 @@ describe('Password reset - delivery + reset round trip', () => {
       deleteById: jest.fn(),
       deactivateAdminAtomically: jest.fn(),
       updateAdminRoleAtomically: jest.fn(),
+      updateAnalyticsConsent: jest.fn(),
       deleteAdminAtomically: jest.fn(),
       findStaleViewerAccounts: jest.fn(),
     };

--- a/apps/api/src/auth/password-reset.service.spec.ts
+++ b/apps/api/src/auth/password-reset.service.spec.ts
@@ -34,6 +34,7 @@ function makeMocks() {
     deleteById: jest.fn(),
     deactivateAdminAtomically: jest.fn(),
     updateAdminRoleAtomically: jest.fn(),
+    updateAnalyticsConsent: jest.fn(),
     deleteAdminAtomically: jest.fn(),
     findStaleViewerAccounts: jest.fn(),
   };

--- a/apps/api/src/auth/registration.service.spec.ts
+++ b/apps/api/src/auth/registration.service.spec.ts
@@ -48,6 +48,7 @@ const makeRepo = (): jest.Mocked<UserRepositoryPort> => ({
   deleteById: jest.fn(),
   deactivateAdminAtomically: jest.fn(),
   updateAdminRoleAtomically: jest.fn(),
+  updateAnalyticsConsent: jest.fn(),
   deleteAdminAtomically: jest.fn(),
   findStaleViewerAccounts: jest.fn(),
 });

--- a/apps/api/src/users/user-management.service.spec.ts
+++ b/apps/api/src/users/user-management.service.spec.ts
@@ -36,6 +36,7 @@ const makeRepo = (): jest.Mocked<UserRepositoryPort> => ({
   deleteById: jest.fn(),
   deactivateAdminAtomically: jest.fn(),
   updateAdminRoleAtomically: jest.fn(),
+  updateAnalyticsConsent: jest.fn(),
   deleteAdminAtomically: jest.fn(),
   findStaleViewerAccounts: jest.fn(),
 });

--- a/apps/api/test/integration/auth-analytics-consent.int-spec.ts
+++ b/apps/api/test/integration/auth-analytics-consent.int-spec.ts
@@ -1,0 +1,152 @@
+/**
+ * Analytics Consent Integration Test
+ *
+ * Vertical slice for the self-service consent toggle (#1882):
+ * PATCH /auth/me/analytics-consent → users.analytics_consent → GET /auth/me.
+ *
+ * The role dimension is the point of this suite: a demo signup is a `viewer`,
+ * and viewers are denied every other write in the API. This endpoint must be
+ * the documented exception, so a viewer path is asserted explicitly.
+ *
+ * @module apps/api/test/integration
+ */
+import { DataSource } from 'typeorm';
+import {
+  getTestHarness,
+  IntegrationTestHarness,
+  resetTestHarness,
+  teardownTestHarness,
+} from './setup';
+import { loginAsAdmin, loginAsViewer } from './helpers/test-auth.helper';
+
+async function readConsent(dataSource: DataSource, username: string): Promise<boolean> {
+  const rows = await dataSource.query<{ analytics_consent: boolean }[]>(
+    `SELECT analytics_consent FROM users WHERE username = $1`,
+    [username],
+  );
+  return rows[0].analytics_consent;
+}
+
+describe('Analytics Consent Integration (#1882)', () => {
+  let harness: IntegrationTestHarness;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+  });
+
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  it('should let a viewer grant consent on their own account', async () => {
+    const http = harness.getHttp();
+    const dataSource = harness.getDataSource();
+    const token = await loginAsViewer(http, dataSource, 'demo_viewer');
+
+    const response = await http
+      .patch('/v1/auth/me/analytics-consent')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ analyticsConsent: true })
+      .expect(200);
+
+    expect(response.body.analyticsConsent).toBe(true);
+    expect(response.body.username).toBe('demo_viewer');
+    expect(response.body.passwordHash).toBeUndefined();
+    expect(await readConsent(dataSource, 'demo_viewer')).toBe(true);
+  });
+
+  it('should let a viewer withdraw consent again', async () => {
+    const http = harness.getHttp();
+    const dataSource = harness.getDataSource();
+    const token = await loginAsViewer(http, dataSource, 'demo_viewer');
+
+    await http
+      .patch('/v1/auth/me/analytics-consent')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ analyticsConsent: true })
+      .expect(200);
+
+    await http
+      .patch('/v1/auth/me/analytics-consent')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ analyticsConsent: false })
+      .expect(200);
+
+    expect(await readConsent(dataSource, 'demo_viewer')).toBe(false);
+  });
+
+  it('should surface the new value on a subsequent GET /auth/me', async () => {
+    const http = harness.getHttp();
+    const dataSource = harness.getDataSource();
+    const token = await loginAsViewer(http, dataSource, 'demo_viewer');
+
+    await http
+      .patch('/v1/auth/me/analytics-consent')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ analyticsConsent: true })
+      .expect(200);
+
+    const me = await http
+      .get('/v1/auth/me')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    expect(me.body.analyticsConsent).toBe(true);
+  });
+
+  it('should work for an admin as well — the preference is not role-scoped', async () => {
+    const http = harness.getHttp();
+    const dataSource = harness.getDataSource();
+    const token = await loginAsAdmin(http, dataSource, 'consent_admin');
+
+    await http
+      .patch('/v1/auth/me/analytics-consent')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ analyticsConsent: true })
+      .expect(200);
+
+    expect(await readConsent(dataSource, 'consent_admin')).toBe(true);
+  });
+
+  it('should only touch the caller — another account keeps its own value', async () => {
+    const http = harness.getHttp();
+    const dataSource = harness.getDataSource();
+    const token = await loginAsViewer(http, dataSource, 'demo_viewer');
+    await loginAsViewer(http, dataSource, 'other_viewer');
+
+    await http
+      .patch('/v1/auth/me/analytics-consent')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ analyticsConsent: true })
+      .expect(200);
+
+    expect(await readConsent(dataSource, 'other_viewer')).toBe(false);
+  });
+
+  it('should return 400 when analyticsConsent is not a boolean', async () => {
+    const http = harness.getHttp();
+    const dataSource = harness.getDataSource();
+    const token = await loginAsViewer(http, dataSource, 'demo_viewer');
+
+    await http
+      .patch('/v1/auth/me/analytics-consent')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ analyticsConsent: 'yes' })
+      .expect(400);
+
+    expect(await readConsent(dataSource, 'demo_viewer')).toBe(false);
+  });
+
+  it('should return 401 when no token is provided', async () => {
+    const http = harness.getHttp();
+
+    await http
+      .patch('/v1/auth/me/analytics-consent')
+      .send({ analyticsConsent: true })
+      .expect(401);
+  });
+});

--- a/apps/web/src/app/app-shell.test.tsx
+++ b/apps/web/src/app/app-shell.test.tsx
@@ -33,6 +33,10 @@ import {
   createAuthenticatedSessionAdapter,
   createMockApiClient,
 } from '../test/test-utils';
+import {
+  setDemoAnalyticsConsent,
+  DEMO_ANALYTICS_CONSENT_STORAGE_KEY,
+} from '../features/demo';
 
 interface RenderShellOptions {
   apiClient?: ApiClient;
@@ -116,7 +120,10 @@ function getDrawer(): HTMLDialogElement {
 }
 
 describe('AppShell', () => {
-  afterEach(cleanup);
+  afterEach(() => {
+    cleanup();
+    window.localStorage.clear();
+  });
 
   it('renders the three live nav groups plus a disabled Planned footer', () => {
     renderShell({ pathname: '/' });
@@ -243,6 +250,69 @@ describe('AppShell', () => {
     const primary = screen.getByRole('navigation', { name: 'Primary' });
     await within(primary).findByText('Prompt templates');
     expect(screen.queryByRole('note', { name: 'Demo mode notice' })).toBeNull();
+  });
+
+  it('drops the banner "Analytics on" state when consent is withdrawn elsewhere (#1882)', async () => {
+    const viewerAdapter = createAuthenticatedSessionAdapter({
+      id: 'u2',
+      username: 'viewer',
+      email: 'viewer@example.com',
+      role: 'viewer',
+      permissions: [],
+      analyticsConsent: true,
+    });
+    const demoApiClient = createMockApiClient({
+      system: {
+        getConfig: vi.fn().mockResolvedValue({
+          demoMode: true,
+          demoIntegrations: { posthog: { key: 'phc_abc', host: 'https://eu.posthog.com' } },
+        }),
+      },
+    });
+    renderShell({ pathname: '/', apiClient: demoApiClient, sessionAdapter: viewerAdapter });
+
+    // Seeded from the account: consent granted → banner reports analytics on.
+    expect(await screen.findByText('Analytics on.')).toBeInTheDocument();
+
+    // The /settings toggle writes localStorage in this same tab; without the
+    // subscription the banner would keep claiming "on" until a reload.
+    act(() => {
+      setDemoAnalyticsConsent('declined');
+    });
+
+    await waitFor(() => expect(screen.queryByText('Analytics on.')).not.toBeInTheDocument());
+  });
+
+  it('picks up a consent change made in another tab (#1882)', async () => {
+    const viewerAdapter = createAuthenticatedSessionAdapter({
+      id: 'u2',
+      username: 'viewer',
+      email: 'viewer@example.com',
+      role: 'viewer',
+      permissions: [],
+      analyticsConsent: false,
+    });
+    const demoApiClient = createMockApiClient({
+      system: {
+        getConfig: vi.fn().mockResolvedValue({
+          demoMode: true,
+          demoIntegrations: { posthog: { key: 'phc_abc', host: 'https://eu.posthog.com' } },
+        }),
+      },
+    });
+    renderShell({ pathname: '/', apiClient: demoApiClient, sessionAdapter: viewerAdapter });
+
+    expect(await screen.findByRole('note', { name: 'Demo mode notice' })).toBeInTheDocument();
+    expect(screen.queryByText('Analytics on.')).not.toBeInTheDocument();
+
+    act(() => {
+      window.localStorage.setItem(DEMO_ANALYTICS_CONSENT_STORAGE_KEY, 'accepted');
+      window.dispatchEvent(
+        new StorageEvent('storage', { key: DEMO_ANALYTICS_CONSENT_STORAGE_KEY }),
+      );
+    });
+
+    expect(await screen.findByText('Analytics on.')).toBeInTheDocument();
   });
 
   it('uses "Connections" as the nav label (not "Integrations")', () => {

--- a/apps/web/src/app/app-shell.tsx
+++ b/apps/web/src/app/app-shell.tsx
@@ -50,6 +50,7 @@ import {
   getDemoAnalyticsConsent,
   initDemoIntegrations,
   setDemoAnalyticsConsent,
+  subscribeToDemoAnalyticsConsent,
   type DemoAnalyticsConsent,
 } from '../features/demo';
 
@@ -294,6 +295,12 @@ export function AppShell({ children }: PropsWithChildren): ReactElement {
     // would otherwise show while analytics stays off (fail-safe, consistent).
     setAnalyticsConsent(persisted ? seeded : 'declined');
   }, [isReady, session, analyticsConsent]);
+
+  // Keep the banner in step with consent changed elsewhere (#1882): the
+  // /settings toggle writes localStorage in THIS tab (custom event) and any
+  // other open tab sees the native `storage` event. Without this the banner
+  // would keep claiming "analytics on" until a reload.
+  useEffect(() => subscribeToDemoAnalyticsConsent(setAnalyticsConsent), []);
 
   // Demo-only analytics (#1301) — attempt init once the config query has
   // settled and once consent resolves to 'accepted'. The loader's own guards

--- a/apps/web/src/features/auth/api/auth.api.ts
+++ b/apps/web/src/features/auth/api/auth.api.ts
@@ -3,9 +3,11 @@ import type {
   ForgotPasswordRequest,
   LoginRequest,
   LoginResponse,
+  MeResponse,
   OkResponse,
   RegisterRequest,
   ResetPasswordRequest,
+  UpdateAnalyticsConsentRequest,
 } from './auth.types';
 
 interface ApiRequest {
@@ -18,6 +20,7 @@ export interface AuthApi {
   forgotPassword: (input: ForgotPasswordRequest) => Promise<OkResponse>;
   resetPassword: (input: ResetPasswordRequest) => Promise<OkResponse>;
   confirmEmail: (input: ConfirmEmailRequest) => Promise<OkResponse>;
+  updateAnalyticsConsent: (input: UpdateAnalyticsConsentRequest) => Promise<MeResponse>;
 }
 
 export function createAuthApi(request: ApiRequest): AuthApi {
@@ -49,6 +52,12 @@ export function createAuthApi(request: ApiRequest): AuthApi {
     confirmEmail(input): Promise<OkResponse> {
       return request<OkResponse>('/auth/confirm-email', {
         method: 'POST',
+        body: JSON.stringify(input),
+      });
+    },
+    updateAnalyticsConsent(input): Promise<MeResponse> {
+      return request<MeResponse>('/auth/me/analytics-consent', {
+        method: 'PATCH',
         body: JSON.stringify(input),
       });
     },

--- a/apps/web/src/features/auth/api/auth.types.ts
+++ b/apps/web/src/features/auth/api/auth.types.ts
@@ -28,6 +28,10 @@ export interface ConfirmEmailRequest {
   token: string;
 }
 
+export interface UpdateAnalyticsConsentRequest {
+  analyticsConsent: boolean;
+}
+
 export interface OkResponse {
   ok: true;
 }

--- a/apps/web/src/features/auth/hooks/use-update-analytics-consent-mutation.test.tsx
+++ b/apps/web/src/features/auth/hooks/use-update-analytics-consent-mutation.test.tsx
@@ -1,0 +1,110 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { ReactElement, ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ApiClientProvider } from '../../../app/api/api-client-provider';
+import { SessionProvider } from '../../../shared/auth/session-provider';
+import type { SessionAdapter } from '../../../shared/auth/session-adapter';
+import type { Session } from '../../../shared/auth/session.types';
+import type { ApiClient } from '../../../app/api/api-client';
+import { createMockApiClient } from '../../../test/test-utils';
+import { useUpdateAnalyticsConsentMutation } from './use-update-analytics-consent-mutation';
+
+const authenticated = (analyticsConsent: boolean): Session => ({
+  status: 'authenticated',
+  accessToken: 'test-jwt-token',
+  user: {
+    id: 'user_2',
+    username: 'demo_user',
+    email: 'demo@example.com',
+    role: 'viewer',
+    permissions: [],
+    analyticsConsent,
+  },
+});
+
+/**
+ * Adapter that flips its reported consent after the first re-read, so a test
+ * can tell "the hook refreshed the session" apart from "the hook assumed".
+ */
+function createCountingAdapter(): { adapter: SessionAdapter; getSessionCalls: () => number } {
+  let calls = 0;
+  return {
+    getSessionCalls: () => calls,
+    adapter: {
+      async getSession(): Promise<Session> {
+        calls += 1;
+        return authenticated(calls > 1);
+      },
+      async getAccessToken(): Promise<string> {
+        return 'test-jwt-token';
+      },
+      async persistSession(): Promise<void> {},
+      async clearSession(): Promise<void> {},
+    },
+  };
+}
+
+function wrapper(
+  apiClient: ApiClient,
+  adapter: SessionAdapter,
+): (props: { children: ReactNode }) => ReactElement {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }): ReactElement {
+    return (
+      <SessionProvider adapter={adapter}>
+        <ApiClientProvider client={apiClient}>
+          <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+        </ApiClientProvider>
+      </SessionProvider>
+    );
+  };
+}
+
+describe('useUpdateAnalyticsConsentMutation (#1882)', () => {
+  it('should call the consent endpoint with the requested value', async () => {
+    const updateAnalyticsConsent = vi.fn().mockResolvedValue(authenticated(true).user);
+    const apiClient = createMockApiClient({ auth: { updateAnalyticsConsent } });
+    const { adapter } = createCountingAdapter();
+
+    const { result } = renderHook(() => useUpdateAnalyticsConsentMutation(), {
+      wrapper: wrapper(apiClient, adapter),
+    });
+
+    await result.current.mutateAsync({ analyticsConsent: true });
+
+    expect(updateAnalyticsConsent).toHaveBeenCalledWith({ analyticsConsent: true });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+  });
+
+  it('should re-read the session so the JWT-backed consent is not assumed', async () => {
+    const apiClient = createMockApiClient({
+      auth: { updateAnalyticsConsent: vi.fn().mockResolvedValue(authenticated(true).user) },
+    });
+    const { adapter, getSessionCalls } = createCountingAdapter();
+
+    const { result } = renderHook(() => useUpdateAnalyticsConsentMutation(), {
+      wrapper: wrapper(apiClient, adapter),
+    });
+
+    await waitFor(() => expect(getSessionCalls()).toBe(1));
+    await result.current.mutateAsync({ analyticsConsent: true });
+
+    await waitFor(() => expect(getSessionCalls()).toBeGreaterThan(1));
+  });
+
+  it('should surface the failure to the caller when the endpoint rejects', async () => {
+    const apiClient = createMockApiClient({
+      auth: { updateAnalyticsConsent: vi.fn().mockRejectedValue(new Error('boom')) },
+    });
+    const { adapter } = createCountingAdapter();
+
+    const { result } = renderHook(() => useUpdateAnalyticsConsentMutation(), {
+      wrapper: wrapper(apiClient, adapter),
+    });
+
+    await expect(result.current.mutateAsync({ analyticsConsent: true })).rejects.toThrow('boom');
+  });
+});

--- a/apps/web/src/features/auth/hooks/use-update-analytics-consent-mutation.ts
+++ b/apps/web/src/features/auth/hooks/use-update-analytics-consent-mutation.ts
@@ -1,0 +1,29 @@
+/**
+ * useUpdateAnalyticsConsentMutation Hook
+ *
+ * Provides a mutation for updating the user's analytics consent preference.
+ * On success, refreshes the session to update the JWT with the new consent value.
+ *
+ * @module features/auth/hooks
+ */
+import { useMutation, type UseMutationResult } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { useSession } from '../../../shared/auth/use-session';
+import type { MeResponse, UpdateAnalyticsConsentRequest } from '../api/auth.types';
+
+export function useUpdateAnalyticsConsentMutation(): UseMutationResult<
+  MeResponse,
+  Error,
+  UpdateAnalyticsConsentRequest
+> {
+  const apiClient = useApiClient();
+  const { refreshSession } = useSession();
+
+  return useMutation({
+    mutationFn: async (input: UpdateAnalyticsConsentRequest) => {
+      const response = await apiClient.auth.updateAnalyticsConsent(input);
+      await refreshSession();
+      return response;
+    },
+  });
+}

--- a/apps/web/src/features/demo/components/analytics-consent-tile.test.tsx
+++ b/apps/web/src/features/demo/components/analytics-consent-tile.test.tsx
@@ -6,6 +6,7 @@ import {
   createMockApiClient,
   findToastDescription,
   renderWithProviders,
+  stubUnavailableLocalStorage,
 } from '../../../test/test-utils';
 import { DEMO_ANALYTICS_CONSENT_STORAGE_KEY } from '../demo.types';
 import { AnalyticsConsentTile } from './analytics-consent-tile';
@@ -29,13 +30,20 @@ const viewer = {
 const demoConfig = { demoMode: true };
 
 describe('AnalyticsConsentTile (#1882)', () => {
+  let restoreLocalStorage: (() => void) | null = null;
+
   beforeEach(() => {
     enableDemoAnalytics.mockClear();
     disableDemoAnalytics.mockClear();
     window.localStorage.clear();
   });
 
-  afterEach(cleanup);
+  afterEach(() => {
+    cleanup();
+    restoreLocalStorage?.();
+    restoreLocalStorage = null;
+    vi.restoreAllMocks();
+  });
 
   it('should render nothing when the deployment is not in demo mode', async () => {
     const apiClient = createMockApiClient({
@@ -150,6 +158,33 @@ describe('AnalyticsConsentTile (#1882)', () => {
     expect(window.localStorage.getItem(DEMO_ANALYTICS_CONSENT_STORAGE_KEY)).toBe('declined');
     expect(disableDemoAnalytics).toHaveBeenCalledTimes(1);
     expect(enableDemoAnalytics).not.toHaveBeenCalled();
+  });
+
+  it('should warn instead of claiming a clean save when the localStorage mirror fails', async () => {
+    restoreLocalStorage = stubUnavailableLocalStorage();
+    const updateAnalyticsConsent = vi.fn().mockResolvedValue({ ...viewer, analyticsConsent: true });
+    const apiClient = createMockApiClient({
+      system: { getConfig: vi.fn().mockResolvedValue(demoConfig) },
+      auth: { updateAnalyticsConsent },
+    });
+
+    renderWithProviders(<AnalyticsConsentTile />, {
+      apiClient,
+      sessionAdapter: createAuthenticatedSessionAdapter(viewer),
+    });
+
+    await userEvent.click(await screen.findByRole('checkbox'));
+
+    await waitFor(() =>
+      expect(updateAnalyticsConsent).toHaveBeenCalledWith({ analyticsConsent: true }),
+    );
+    expect(
+      await findToastDescription(
+        'This browser blocks local storage, so you may be asked again on the next page load.',
+      ),
+    ).toBeInTheDocument();
+    // The DB write still happened, so the live opt-in must still take effect.
+    expect(enableDemoAnalytics).toHaveBeenCalledTimes(1);
   });
 
   it('should surface an error toast and leave PostHog + storage untouched when the call fails', async () => {

--- a/apps/web/src/features/demo/components/analytics-consent-tile.test.tsx
+++ b/apps/web/src/features/demo/components/analytics-consent-tile.test.tsx
@@ -1,0 +1,175 @@
+import { cleanup, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createAuthenticatedSessionAdapter,
+  createMockApiClient,
+  findToastDescription,
+  renderWithProviders,
+} from '../../../test/test-utils';
+import { DEMO_ANALYTICS_CONSENT_STORAGE_KEY } from '../demo.types';
+import { AnalyticsConsentTile } from './analytics-consent-tile';
+
+const enableDemoAnalytics = vi.fn();
+const disableDemoAnalytics = vi.fn();
+vi.mock('../lib/init-demo-integrations', () => ({
+  enableDemoAnalytics: (): void => enableDemoAnalytics(),
+  disableDemoAnalytics: (): void => disableDemoAnalytics(),
+}));
+
+const viewer = {
+  id: 'user_2',
+  username: 'demo_user',
+  email: 'demo@example.com',
+  role: 'viewer' as const,
+  permissions: [],
+  analyticsConsent: false,
+};
+
+const demoConfig = { demoMode: true };
+
+describe('AnalyticsConsentTile (#1882)', () => {
+  beforeEach(() => {
+    enableDemoAnalytics.mockClear();
+    disableDemoAnalytics.mockClear();
+    window.localStorage.clear();
+  });
+
+  afterEach(cleanup);
+
+  it('should render nothing when the deployment is not in demo mode', async () => {
+    const apiClient = createMockApiClient({
+      system: { getConfig: vi.fn().mockResolvedValue({ demoMode: false }) },
+    });
+
+    renderWithProviders(<AnalyticsConsentTile />, {
+      apiClient,
+      sessionAdapter: createAuthenticatedSessionAdapter(viewer),
+    });
+
+    await waitFor(() => expect(apiClient.system.getConfig).toHaveBeenCalled());
+    expect(screen.queryByRole('heading', { name: 'Analytics' })).not.toBeInTheDocument();
+  });
+
+  it('should render nothing for an anonymous visitor even in demo mode', async () => {
+    const apiClient = createMockApiClient({
+      system: { getConfig: vi.fn().mockResolvedValue(demoConfig) },
+    });
+
+    renderWithProviders(<AnalyticsConsentTile />, { apiClient });
+
+    await waitFor(() => expect(apiClient.system.getConfig).toHaveBeenCalled());
+    expect(screen.queryByRole('heading', { name: 'Analytics' })).not.toBeInTheDocument();
+  });
+
+  it('should render the toggle in demo mode for an authenticated user', async () => {
+    const apiClient = createMockApiClient({
+      system: { getConfig: vi.fn().mockResolvedValue(demoConfig) },
+    });
+
+    renderWithProviders(<AnalyticsConsentTile />, {
+      apiClient,
+      sessionAdapter: createAuthenticatedSessionAdapter(viewer),
+    });
+
+    expect(await screen.findByRole('heading', { name: 'Analytics' })).toBeInTheDocument();
+    expect(await screen.findByRole('checkbox')).not.toBeChecked();
+  });
+
+  it('should reflect a session that already granted consent', async () => {
+    const apiClient = createMockApiClient({
+      system: { getConfig: vi.fn().mockResolvedValue(demoConfig) },
+    });
+
+    renderWithProviders(<AnalyticsConsentTile />, {
+      apiClient,
+      sessionAdapter: createAuthenticatedSessionAdapter({ ...viewer, analyticsConsent: true }),
+    });
+
+    expect(await screen.findByRole('checkbox')).toBeChecked();
+  });
+
+  it('should not claim that all inputs are masked — only passwords are (#1878)', async () => {
+    const apiClient = createMockApiClient({
+      system: { getConfig: vi.fn().mockResolvedValue(demoConfig) },
+    });
+
+    renderWithProviders(<AnalyticsConsentTile />, {
+      apiClient,
+      sessionAdapter: createAuthenticatedSessionAdapter(viewer),
+    });
+
+    expect(await screen.findByText(/Passwords are never recorded/)).toBeInTheDocument();
+    expect(screen.queryByText(/all inputs masked/i)).not.toBeInTheDocument();
+  });
+
+  it('should persist consent, mirror it to localStorage, and opt PostHog back in', async () => {
+    const updateAnalyticsConsent = vi
+      .fn()
+      .mockResolvedValue({ ...viewer, analyticsConsent: true });
+    const apiClient = createMockApiClient({
+      system: { getConfig: vi.fn().mockResolvedValue(demoConfig) },
+      auth: { updateAnalyticsConsent },
+    });
+
+    renderWithProviders(<AnalyticsConsentTile />, {
+      apiClient,
+      sessionAdapter: createAuthenticatedSessionAdapter(viewer),
+    });
+
+    await userEvent.click(await screen.findByRole('checkbox'));
+
+    await waitFor(() =>
+      expect(updateAnalyticsConsent).toHaveBeenCalledWith({ analyticsConsent: true }),
+    );
+    expect(window.localStorage.getItem(DEMO_ANALYTICS_CONSENT_STORAGE_KEY)).toBe('accepted');
+    expect(enableDemoAnalytics).toHaveBeenCalledTimes(1);
+    expect(disableDemoAnalytics).not.toHaveBeenCalled();
+    expect(await findToastDescription('Analytics sharing enabled.')).toBeInTheDocument();
+  });
+
+  it('should opt PostHog out immediately when consent is withdrawn', async () => {
+    const updateAnalyticsConsent = vi
+      .fn()
+      .mockResolvedValue({ ...viewer, analyticsConsent: false });
+    const apiClient = createMockApiClient({
+      system: { getConfig: vi.fn().mockResolvedValue(demoConfig) },
+      auth: { updateAnalyticsConsent },
+    });
+
+    renderWithProviders(<AnalyticsConsentTile />, {
+      apiClient,
+      sessionAdapter: createAuthenticatedSessionAdapter({ ...viewer, analyticsConsent: true }),
+    });
+
+    await userEvent.click(await screen.findByRole('checkbox'));
+
+    await waitFor(() =>
+      expect(updateAnalyticsConsent).toHaveBeenCalledWith({ analyticsConsent: false }),
+    );
+    expect(window.localStorage.getItem(DEMO_ANALYTICS_CONSENT_STORAGE_KEY)).toBe('declined');
+    expect(disableDemoAnalytics).toHaveBeenCalledTimes(1);
+    expect(enableDemoAnalytics).not.toHaveBeenCalled();
+  });
+
+  it('should surface an error toast and leave PostHog + storage untouched when the call fails', async () => {
+    const apiClient = createMockApiClient({
+      system: { getConfig: vi.fn().mockResolvedValue(demoConfig) },
+      auth: { updateAnalyticsConsent: vi.fn().mockRejectedValue(new Error('boom')) },
+    });
+
+    renderWithProviders(<AnalyticsConsentTile />, {
+      apiClient,
+      sessionAdapter: createAuthenticatedSessionAdapter(viewer),
+    });
+
+    await userEvent.click(await screen.findByRole('checkbox'));
+
+    expect(
+      await findToastDescription('Could not update your analytics preference.'),
+    ).toBeInTheDocument();
+    expect(window.localStorage.getItem(DEMO_ANALYTICS_CONSENT_STORAGE_KEY)).toBeNull();
+    expect(enableDemoAnalytics).not.toHaveBeenCalled();
+    expect(disableDemoAnalytics).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/features/demo/components/analytics-consent-tile.tsx
+++ b/apps/web/src/features/demo/components/analytics-consent-tile.tsx
@@ -33,11 +33,23 @@ export function AnalyticsConsentTile(): ReactElement | null {
     try {
       await mutation.mutateAsync({ analyticsConsent: next });
       const demoConsent: DemoAnalyticsConsent = next ? 'accepted' : 'declined';
-      setDemoAnalyticsConsent(demoConsent);
+      const mirrored = setDemoAnalyticsConsent(demoConsent);
       if (next) {
         enableDemoAnalytics();
       } else {
         disableDemoAnalytics();
+      }
+      if (!mirrored) {
+        // The DB write succeeded, but the pre-auth boot path reads localStorage
+        // — so the next page load would show the opposite state. Say so rather
+        // than reporting an unqualified "Saved" (#1884).
+        showToast({
+          tone: 'warning',
+          title: 'Saved to your account',
+          description:
+            'This browser blocks local storage, so you may be asked again on the next page load.',
+        });
+        return;
       }
       showToast({
         tone: 'success',

--- a/apps/web/src/features/demo/components/analytics-consent-tile.tsx
+++ b/apps/web/src/features/demo/components/analytics-consent-tile.tsx
@@ -1,0 +1,75 @@
+/**
+ * Analytics Consent Tile Component
+ *
+ * Self-service UI for users to toggle analytics consent in demo mode.
+ * Calls the backend endpoint, updates localStorage, and toggles PostHog.
+ *
+ * @module features/demo/components
+ */
+import type { ReactElement } from 'react';
+import { useSession } from '../../../shared/auth/use-session';
+import { useDemoMode } from '../../../features/system/hooks/use-demo-mode';
+import { useToast } from '../../../shared/ui/toast-provider';
+import { useUpdateAnalyticsConsentMutation } from '../../auth/hooks/use-update-analytics-consent-mutation';
+import { disableDemoAnalytics, enableDemoAnalytics } from '../lib/init-demo-integrations';
+import { setDemoAnalyticsConsent } from '../lib/demo-analytics-consent';
+import type { DemoAnalyticsConsent } from '../demo.types';
+
+export function AnalyticsConsentTile(): ReactElement | null {
+  const { isReady, session } = useSession();
+  const demoMode = useDemoMode();
+  const mutation = useUpdateAnalyticsConsentMutation();
+  const { showToast } = useToast();
+
+  if (!demoMode || !isReady || session.status !== 'authenticated') {
+    return null;
+  }
+
+  const consent = session.user?.analyticsConsent ?? false;
+
+  const handleToggle = async (next: boolean): Promise<void> => {
+    try {
+      await mutation.mutateAsync({ analyticsConsent: next });
+      const demoConsent: DemoAnalyticsConsent = next ? 'accepted' : 'declined';
+      setDemoAnalyticsConsent(demoConsent);
+      if (next) {
+        enableDemoAnalytics();
+      } else {
+        disableDemoAnalytics();
+      }
+      showToast({
+        tone: 'success',
+        title: 'Saved',
+        description: next ? 'Analytics sharing enabled.' : 'Analytics sharing disabled.',
+      });
+    } catch {
+      showToast({ tone: 'error', description: 'Could not update your analytics preference.' });
+    }
+  };
+
+  return (
+    <article className="panel panel--dense">
+      <div className="panel__header">
+        <div>
+          <p className="eyebrow">Privacy</p>
+          <h3 className="section-title">Analytics</h3>
+        </div>
+      </div>
+
+      <label className="guest-form__consent">
+        <input
+          type="checkbox"
+          checked={consent}
+          disabled={mutation.isPending}
+          onChange={(event) => void handleToggle(event.target.checked)}
+        />
+        <span className="guest-form__consent-text">
+          <strong>Share anonymous usage analytics</strong>
+          <span className="guest-form__consent-hint">
+            Includes session recording with all inputs masked. Change this anytime.
+          </span>
+        </span>
+      </label>
+    </article>
+  );
+}

--- a/apps/web/src/features/demo/components/analytics-consent-tile.tsx
+++ b/apps/web/src/features/demo/components/analytics-consent-tile.tsx
@@ -2,13 +2,15 @@
  * Analytics Consent Tile Component
  *
  * Self-service UI for users to toggle analytics consent in demo mode.
- * Calls the backend endpoint, updates localStorage, and toggles PostHog.
+ * Calls the backend endpoint (authoritative, cross-device), mirrors the result
+ * into localStorage (what the pre-auth boot path reads), and opts PostHog
+ * in/out live so the change takes effect without a reload.
  *
  * @module features/demo/components
  */
 import type { ReactElement } from 'react';
 import { useSession } from '../../../shared/auth/use-session';
-import { useDemoMode } from '../../../features/system/hooks/use-demo-mode';
+import { useDemoMode } from '../../system/hooks/use-demo-mode';
 import { useToast } from '../../../shared/ui/toast-provider';
 import { useUpdateAnalyticsConsentMutation } from '../../auth/hooks/use-update-analytics-consent-mutation';
 import { disableDemoAnalytics, enableDemoAnalytics } from '../lib/init-demo-integrations';
@@ -54,6 +56,7 @@ export function AnalyticsConsentTile(): ReactElement | null {
           <p className="eyebrow">Privacy</p>
           <h3 className="section-title">Analytics</h3>
         </div>
+        <span className="panel__meta">Demo only</span>
       </div>
 
       <label className="guest-form__consent">
@@ -65,8 +68,12 @@ export function AnalyticsConsentTile(): ReactElement | null {
         />
         <span className="guest-form__consent-text">
           <strong>Share anonymous usage analytics</strong>
+          {/* Copy must track the real masking config in
+              init-demo-integrations.ts — #1878 narrowed masking to passwords
+              only, so "all inputs masked" is no longer true (#1882). */}
           <span className="guest-form__consent-hint">
-            Includes session recording with all inputs masked. Change this anytime.
+            Includes session recording. Passwords are never recorded; other text you type and view
+            may be. Change this anytime.
           </span>
         </span>
       </label>

--- a/apps/web/src/features/demo/demo.types.ts
+++ b/apps/web/src/features/demo/demo.types.ts
@@ -8,5 +8,13 @@
 
 export const DEMO_ANALYTICS_CONSENT_STORAGE_KEY = 'openlinker.demoAnalyticsConsent';
 
+/**
+ * Same-tab change notification for the consent key (#1882). The native
+ * `storage` event only fires in OTHER tabs, so the settings toggle and the
+ * AppShell demo banner — both mounted in the same document — would otherwise
+ * disagree until reload.
+ */
+export const DEMO_ANALYTICS_CONSENT_CHANGE_EVENT = 'openlinker:demo-analytics-consent-change';
+
 export const DemoAnalyticsConsentValues = ['accepted', 'declined'] as const;
 export type DemoAnalyticsConsent = (typeof DemoAnalyticsConsentValues)[number];

--- a/apps/web/src/features/demo/index.ts
+++ b/apps/web/src/features/demo/index.ts
@@ -1,3 +1,13 @@
-export { disableDemoAnalytics, initDemoIntegrations } from './lib/init-demo-integrations';
-export { getDemoAnalyticsConsent, setDemoAnalyticsConsent } from './lib/demo-analytics-consent';
+export {
+  disableDemoAnalytics,
+  enableDemoAnalytics,
+  initDemoIntegrations,
+} from './lib/init-demo-integrations';
+export {
+  getDemoAnalyticsConsent,
+  setDemoAnalyticsConsent,
+  subscribeToDemoAnalyticsConsent,
+} from './lib/demo-analytics-consent';
+export { AnalyticsConsentTile } from './components/analytics-consent-tile';
+export { DEMO_ANALYTICS_CONSENT_STORAGE_KEY } from './demo.types';
 export type { DemoAnalyticsConsent } from './demo.types';

--- a/apps/web/src/features/demo/lib/demo-analytics-consent.test.ts
+++ b/apps/web/src/features/demo/lib/demo-analytics-consent.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { stubUnavailableLocalStorage } from '../../../test/test-utils';
 import { DEMO_ANALYTICS_CONSENT_STORAGE_KEY } from '../demo.types';
 import {
   getDemoAnalyticsConsent,
@@ -32,18 +33,23 @@ describe('demo-analytics-consent', () => {
   });
 
   it('should not throw and should return null when localStorage.getItem throws', () => {
-    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
-      throw new Error('storage disabled');
-    });
-    expect(() => getDemoAnalyticsConsent()).not.toThrow();
-    expect(getDemoAnalyticsConsent()).toBeNull();
+    const restore = stubUnavailableLocalStorage();
+    try {
+      expect(() => getDemoAnalyticsConsent()).not.toThrow();
+      expect(getDemoAnalyticsConsent()).toBeNull();
+    } finally {
+      restore();
+    }
   });
 
-  it('should not throw when localStorage.setItem throws', () => {
-    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
-      throw new Error('storage disabled');
-    });
-    expect(() => setDemoAnalyticsConsent('accepted')).not.toThrow();
+  it('should not throw and should report failure when localStorage.setItem throws', () => {
+    const restore = stubUnavailableLocalStorage();
+    try {
+      expect(() => setDemoAnalyticsConsent('accepted')).not.toThrow();
+      expect(setDemoAnalyticsConsent('accepted')).toBe(false);
+    } finally {
+      restore();
+    }
   });
 });
 
@@ -112,14 +118,16 @@ describe('subscribeToDemoAnalyticsConsent (#1882)', () => {
   });
 
   it('should not notify when the write failed (storage unavailable)', () => {
-    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
-      throw new Error('storage disabled');
-    });
+    const restore = stubUnavailableLocalStorage();
     const listener = vi.fn();
     const unsubscribe = subscribeToDemoAnalyticsConsent(listener);
 
-    expect(setDemoAnalyticsConsent('accepted')).toBe(false);
-    expect(listener).not.toHaveBeenCalled();
-    unsubscribe();
+    try {
+      expect(setDemoAnalyticsConsent('accepted')).toBe(false);
+      expect(listener).not.toHaveBeenCalled();
+    } finally {
+      unsubscribe();
+      restore();
+    }
   });
 });

--- a/apps/web/src/features/demo/lib/demo-analytics-consent.test.ts
+++ b/apps/web/src/features/demo/lib/demo-analytics-consent.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { DEMO_ANALYTICS_CONSENT_STORAGE_KEY } from '../demo.types';
-import { getDemoAnalyticsConsent, setDemoAnalyticsConsent } from './demo-analytics-consent';
+import {
+  getDemoAnalyticsConsent,
+  setDemoAnalyticsConsent,
+  subscribeToDemoAnalyticsConsent,
+} from './demo-analytics-consent';
 
 describe('demo-analytics-consent', () => {
   afterEach(() => {
@@ -40,5 +44,82 @@ describe('demo-analytics-consent', () => {
       throw new Error('storage disabled');
     });
     expect(() => setDemoAnalyticsConsent('accepted')).not.toThrow();
+  });
+});
+
+describe('subscribeToDemoAnalyticsConsent (#1882)', () => {
+  afterEach(() => {
+    window.localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('should notify same-tab listeners when consent is written', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeToDemoAnalyticsConsent(listener);
+
+    setDemoAnalyticsConsent('accepted');
+
+    expect(listener).toHaveBeenCalledWith('accepted');
+    unsubscribe();
+  });
+
+  it('should notify on a cross-tab storage event for our key', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeToDemoAnalyticsConsent(listener);
+
+    // Simulate another tab: write directly, then fire the native event the
+    // browser would emit here (jsdom does not dispatch it for us).
+    window.localStorage.setItem(DEMO_ANALYTICS_CONSENT_STORAGE_KEY, 'declined');
+    window.dispatchEvent(
+      new StorageEvent('storage', { key: DEMO_ANALYTICS_CONSENT_STORAGE_KEY }),
+    );
+
+    expect(listener).toHaveBeenCalledWith('declined');
+    unsubscribe();
+  });
+
+  it('should ignore storage events for unrelated keys', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeToDemoAnalyticsConsent(listener);
+
+    window.dispatchEvent(new StorageEvent('storage', { key: 'openlinker.theme' }));
+
+    expect(listener).not.toHaveBeenCalled();
+    unsubscribe();
+  });
+
+  it('should treat a whole-store clear (key === null) as a change', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeToDemoAnalyticsConsent(listener);
+
+    window.dispatchEvent(new StorageEvent('storage', { key: null }));
+
+    expect(listener).toHaveBeenCalledWith(null);
+    unsubscribe();
+  });
+
+  it('should stop notifying after unsubscribe', () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeToDemoAnalyticsConsent(listener);
+    unsubscribe();
+
+    setDemoAnalyticsConsent('accepted');
+    window.dispatchEvent(
+      new StorageEvent('storage', { key: DEMO_ANALYTICS_CONSENT_STORAGE_KEY }),
+    );
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('should not notify when the write failed (storage unavailable)', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('storage disabled');
+    });
+    const listener = vi.fn();
+    const unsubscribe = subscribeToDemoAnalyticsConsent(listener);
+
+    expect(setDemoAnalyticsConsent('accepted')).toBe(false);
+    expect(listener).not.toHaveBeenCalled();
+    unsubscribe();
   });
 });

--- a/apps/web/src/features/demo/lib/demo-analytics-consent.ts
+++ b/apps/web/src/features/demo/lib/demo-analytics-consent.ts
@@ -7,6 +7,7 @@
  * visitor is re-prompted rather than silently enabling recording.
  */
 import {
+  DEMO_ANALYTICS_CONSENT_CHANGE_EVENT,
   DEMO_ANALYTICS_CONSENT_STORAGE_KEY,
   DemoAnalyticsConsentValues,
   type DemoAnalyticsConsent,
@@ -34,14 +35,47 @@ export function getDemoAnalyticsConsent(): DemoAnalyticsConsent | null {
  * consent-gated loader (`initDemoIntegrations`, which re-reads localStorage)
  * will actually see — otherwise "accepted" could be shown while analytics
  * silently stays off.
+ *
+ * A successful write also dispatches DEMO_ANALYTICS_CONSENT_CHANGE_EVENT so
+ * same-tab listeners (the AppShell demo banner) re-read immediately; other
+ * tabs pick the change up through the native `storage` event.
  */
 export function setDemoAnalyticsConsent(value: DemoAnalyticsConsent): boolean {
   try {
     window.localStorage.setItem(DEMO_ANALYTICS_CONSENT_STORAGE_KEY, value);
-    return true;
   } catch {
     // localStorage may be disabled — the visitor will simply be re-prompted
     // next time; no functional impact beyond that.
     return false;
   }
+  window.dispatchEvent(
+    new CustomEvent<DemoAnalyticsConsent>(DEMO_ANALYTICS_CONSENT_CHANGE_EVENT, { detail: value }),
+  );
+  return true;
+}
+
+/**
+ * Subscribes to consent changes from anywhere in the app: the same-tab custom
+ * event above, plus the native cross-tab `storage` event scoped to our key.
+ * Returns an unsubscribe function for `useEffect` cleanup.
+ */
+export function subscribeToDemoAnalyticsConsent(
+  listener: (value: DemoAnalyticsConsent | null) => void,
+): () => void {
+  const handleLocalChange = (): void => listener(getDemoAnalyticsConsent());
+  const handleStorage = (event: StorageEvent): void => {
+    // `key === null` is a whole-store clear(), which also drops our value.
+    if (event.key !== null && event.key !== DEMO_ANALYTICS_CONSENT_STORAGE_KEY) {
+      return;
+    }
+    listener(getDemoAnalyticsConsent());
+  };
+
+  window.addEventListener(DEMO_ANALYTICS_CONSENT_CHANGE_EVENT, handleLocalChange);
+  window.addEventListener('storage', handleStorage);
+
+  return () => {
+    window.removeEventListener(DEMO_ANALYTICS_CONSENT_CHANGE_EVENT, handleLocalChange);
+    window.removeEventListener('storage', handleStorage);
+  };
 }

--- a/apps/web/src/features/demo/lib/init-demo-integrations.test.ts
+++ b/apps/web/src/features/demo/lib/init-demo-integrations.test.ts
@@ -1,11 +1,20 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { SystemConfig } from '../../system';
-import { disableDemoAnalytics, initDemoIntegrations } from './init-demo-integrations';
+import {
+  disableDemoAnalytics,
+  enableDemoAnalytics,
+  initDemoIntegrations,
+} from './init-demo-integrations';
 
 const posthogInit = vi.fn();
 const posthogOptOut = vi.fn();
+const posthogOptIn = vi.fn();
 vi.mock('posthog-js', () => ({
-  default: { init: posthogInit, opt_out_capturing: posthogOptOut },
+  default: {
+    init: posthogInit,
+    opt_out_capturing: posthogOptOut,
+    opt_in_capturing: posthogOptIn,
+  },
 }));
 
 const getDemoAnalyticsConsent = vi.fn();
@@ -121,5 +130,30 @@ describe('disableDemoAnalytics', () => {
     disableDemoAnalytics();
 
     expect(posthogOptOut).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('enableDemoAnalytics (#1882)', () => {
+  beforeEach(() => {
+    posthogInit.mockClear();
+    posthogOptIn.mockClear();
+    getDemoAnalyticsConsent.mockReset();
+  });
+
+  it('should opt the visitor back in without a reload after PostHog was initialized', async () => {
+    getDemoAnalyticsConsent.mockReturnValue('accepted');
+    await initDemoIntegrations(configuredPosthog);
+
+    enableDemoAnalytics();
+
+    expect(posthogOptIn).toHaveBeenCalledTimes(1);
+  });
+
+  it('should be a no-op when PostHog was never initialized', async () => {
+    vi.resetModules();
+    const fresh = await import('./init-demo-integrations');
+
+    expect(() => fresh.enableDemoAnalytics()).not.toThrow();
+    expect(posthogOptIn).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/features/demo/lib/init-demo-integrations.ts
+++ b/apps/web/src/features/demo/lib/init-demo-integrations.ts
@@ -66,3 +66,11 @@ export async function initDemoIntegrations(config: SystemConfig | undefined): Pr
 export function disableDemoAnalytics(): void {
   posthogInstance?.opt_out_capturing();
 }
+
+/**
+ * Opts the current visitor back in to PostHog capture without a page reload.
+ * A no-op when PostHog was never initialized.
+ */
+export function enableDemoAnalytics(): void {
+  posthogInstance?.opt_in_capturing();
+}

--- a/apps/web/src/features/users/components/register-form.tsx
+++ b/apps/web/src/features/users/components/register-form.tsx
@@ -150,9 +150,14 @@ export function RegisterForm({ demoMode = false }: RegisterFormProps): ReactElem
           <input type="checkbox" {...form.register('analyticsConsent')} />
           <span className="guest-form__consent-text">
             <strong>Share anonymous usage analytics</strong>
+            {/* Keep in step with the masking config in
+                features/demo/lib/init-demo-integrations.ts — #1878 narrowed it
+                to passwords only, so the old "all inputs masked" wording was a
+                false claim on the signup path (#1882). */}
             <span className="guest-form__consent-hint">
-              Optional. Helps us improve OpenLinker. Includes session recording with all inputs
-              masked. Off unless you tick this; you can change it anytime after signing in.
+              Optional. Helps us improve OpenLinker. Includes session recording — passwords are
+              never recorded, but other text you type and view may be. Off unless you tick this;
+              you can change it anytime on Settings.
             </span>
           </span>
         </label>

--- a/apps/web/src/pages/settings/settings-page.test.tsx
+++ b/apps/web/src/pages/settings/settings-page.test.tsx
@@ -1,6 +1,10 @@
-import { cleanup, screen } from '@testing-library/react';
-import { afterEach, describe, expect, it } from 'vitest';
-import { createAuthenticatedSessionAdapter, renderWithProviders } from '../../test/test-utils';
+import { cleanup, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  createAuthenticatedSessionAdapter,
+  createMockApiClient,
+  renderWithProviders,
+} from '../../test/test-utils';
 import { SettingsPage } from './settings-page';
 
 describe('SettingsPage', () => {
@@ -109,5 +113,33 @@ describe('SettingsPage', () => {
     expect(await screen.findByText('viewer@example.com')).toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: 'PostHog' })).not.toBeInTheDocument();
     expect(screen.queryByText('PostHog', { selector: '.toolbar-chip' })).not.toBeInTheDocument();
+  });
+
+  it('shows the analytics consent tile in demo mode (#1882)', async () => {
+    renderWithProviders(<SettingsPage />, {
+      apiClient: createMockApiClient({
+        system: { getConfig: vi.fn().mockResolvedValue({ demoMode: true }) },
+      }),
+      sessionAdapter: createAuthenticatedSessionAdapter(),
+    });
+
+    expect(await screen.findByRole('heading', { name: 'Analytics' })).toBeInTheDocument();
+    expect(screen.getByText('Privacy', { selector: '.toolbar-chip' })).toBeInTheDocument();
+    expect(screen.getByRole('checkbox')).toBeInTheDocument();
+  });
+
+  it('never renders the analytics consent tile outside demo mode', async () => {
+    const apiClient = createMockApiClient({
+      system: { getConfig: vi.fn().mockResolvedValue({ demoMode: false }) },
+    });
+
+    renderWithProviders(<SettingsPage />, {
+      apiClient,
+      sessionAdapter: createAuthenticatedSessionAdapter(),
+    });
+
+    await waitFor(() => expect(apiClient.system.getConfig).toHaveBeenCalled());
+    expect(screen.queryByRole('heading', { name: 'Analytics' })).not.toBeInTheDocument();
+    expect(screen.queryByText('Privacy', { selector: '.toolbar-chip' })).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/settings/settings-page.tsx
+++ b/apps/web/src/pages/settings/settings-page.tsx
@@ -1,6 +1,8 @@
 import type { ReactElement } from 'react';
 import { env } from '../../shared/config/env';
 import { useSession } from '../../shared/auth/use-session';
+import { AnalyticsConsentTile } from '../../features/demo';
+import { useDemoMode } from '../../features/system';
 import { MailerSettingsTile } from '../../features/mailer-settings/components/mailer-settings-tile';
 import { PosthogSettingsTile } from '../../features/posthog-settings/components/posthog-settings-tile';
 import { PageLayout } from '../../shared/ui/page-layout';
@@ -8,6 +10,7 @@ import { PageLayout } from '../../shared/ui/page-layout';
 export function SettingsPage(): ReactElement {
   const { isReady, session } = useSession();
   const isAdmin = isReady && session.status === 'authenticated' && session.user?.role === 'admin';
+  const demoMode = useDemoMode();
 
   return (
     <PageLayout
@@ -18,6 +21,7 @@ export function SettingsPage(): ReactElement {
         <div className="toolbar__group">
           <span className="toolbar-chip">Environment</span>
           <span className="toolbar-chip">Account</span>
+          {demoMode ? <span className="toolbar-chip">Privacy</span> : null}
           {isAdmin ? <span className="toolbar-chip">Mailer</span> : null}
           {isAdmin ? <span className="toolbar-chip">PostHog</span> : null}
           <span className="toolbar-chip">Upcoming</span>
@@ -83,6 +87,9 @@ export function SettingsPage(): ReactElement {
             </dl>
           )}
         </article>
+
+        {/* ── Analytics consent (demo mode only, self-service) ─────── */}
+        <AnalyticsConsentTile />
 
         {/* ── Mailer (admin-only) ──────────────────────────────────── */}
         {isAdmin ? <MailerSettingsTile /> : null}

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -607,6 +607,40 @@ export function getToastDescription(text: string | RegExp): HTMLElement {
   return screen.getByText(text, { selector: '.toast__description' });
 }
 
+/**
+ * Replaces `window.localStorage` with one that throws on every access, to
+ * exercise the private-browsing / blocked-storage branches. Returns a restore
+ * function — call it in `afterEach`.
+ *
+ * Why not `vi.spyOn(...)`: jsdom's `localStorage` is a Proxy whose set trap
+ * writes *stored items*, so both `Storage.prototype` and instance spies are
+ * order-dependent — they stop intercepting once another test in the same file
+ * restores mocks, silently turning "should not throw" assertions vacuous
+ * (#1884). Swapping the whole object out is deterministic.
+ */
+export function stubUnavailableLocalStorage(): () => void {
+  const original = window.localStorage;
+  const unavailable = (): never => {
+    throw new Error('storage disabled');
+  };
+
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: {
+      clear: unavailable,
+      getItem: unavailable,
+      key: unavailable,
+      length: 0,
+      removeItem: unavailable,
+      setItem: unavailable,
+    },
+  });
+
+  return () => {
+    Object.defineProperty(window, 'localStorage', { configurable: true, value: original });
+  };
+}
+
 export function renderWithProviders(
   ui: ReactElement,
   options: RenderWithProvidersOptions = {},

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -117,6 +117,7 @@ export function createMockApiClient(
       forgotPassword: vi.fn().mockResolvedValue({ ok: true }),
       resetPassword: vi.fn().mockResolvedValue({ ok: true }),
       confirmEmail: vi.fn().mockResolvedValue({ ok: true }),
+      updateAnalyticsConsent: vi.fn().mockResolvedValue({ ...DEFAULT_TEST_USER }),
       ...overrides.auth,
     } as ApiClient['auth'],
     connections: {

--- a/libs/core/src/users/domain/ports/user-repository.port.ts
+++ b/libs/core/src/users/domain/ports/user-repository.port.ts
@@ -24,6 +24,12 @@ export interface UserRepositoryPort {
   updatePasswordHash(userId: string, passwordHash: string): Promise<void>;
   updateStatus(userId: string, status: UserStatus): Promise<void>;
   updateRole(userId: string, role: UserRole): Promise<void>;
+  /**
+   * Self-service update of the account's demo-analytics opt-in (#1882).
+   * Separate from `save` because it is the one user-owned field a viewer may
+   * change on their own account after registration.
+   */
+  updateAnalyticsConsent(userId: string, analyticsConsent: boolean): Promise<void>;
   approveUser(userId: string, role: UserRole): Promise<void>;
   deleteById(userId: string): Promise<void>;
 

--- a/libs/core/src/users/infrastructure/persistence/repositories/user.repository.spec.ts
+++ b/libs/core/src/users/infrastructure/persistence/repositories/user.repository.spec.ts
@@ -1,8 +1,9 @@
 /**
  * User Repository — Unit Tests
  *
- * Verifies email normalization (#1625) and the Postgres unique-violation →
- * domain-exception conversion path in UserRepository.save.
+ * Verifies email normalization (#1625), the Postgres unique-violation →
+ * domain-exception conversion path in UserRepository.save, and the
+ * self-service analytics-consent update (#1882).
  *
  * @module libs/core/src/users/infrastructure/persistence/repositories
  */
@@ -40,6 +41,7 @@ describe('UserRepository', () => {
       findOne: jest.fn(),
       create: jest.fn((entityLike: Partial<UserOrmEntity>) => entityLike as UserOrmEntity),
       save: jest.fn(),
+      update: jest.fn(),
     } as unknown as jest.Mocked<Repository<UserOrmEntity>>;
 
     const module: TestingModule = await Test.createTestingModule({
@@ -171,6 +173,26 @@ describe('UserRepository', () => {
           status: 'pending',
         })
       ).rejects.toBe(error);
+    });
+  });
+
+  describe('updateAnalyticsConsent (#1882)', () => {
+    it('should update only the analytics_consent column for the given user', async () => {
+      await repository.updateAnalyticsConsent('user-uuid', true);
+
+      expect(ormRepository.update).toHaveBeenCalledWith(
+        { id: 'user-uuid' },
+        { analyticsConsent: true }
+      );
+    });
+
+    it('should persist a withdrawal (false) rather than skipping the falsy value', async () => {
+      await repository.updateAnalyticsConsent('user-uuid', false);
+
+      expect(ormRepository.update).toHaveBeenCalledWith(
+        { id: 'user-uuid' },
+        { analyticsConsent: false }
+      );
     });
   });
 });

--- a/libs/core/src/users/infrastructure/persistence/repositories/user.repository.ts
+++ b/libs/core/src/users/infrastructure/persistence/repositories/user.repository.ts
@@ -75,6 +75,10 @@ export class UserRepository implements UserRepositoryPort {
     await this.ormRepository.update({ id: userId }, { role });
   }
 
+  async updateAnalyticsConsent(userId: string, analyticsConsent: boolean): Promise<void> {
+    await this.ormRepository.update({ id: userId }, { analyticsConsent });
+  }
+
   async approveUser(userId: string, role: UserRole): Promise<void> {
     await this.ormRepository.update({ id: userId }, { role, status: 'active' });
   }


### PR DESCRIPTION
## Summary

Enable authenticated users to change their demo analytics consent preference without a page reload, persisting the choice to both the database (authoritative, cross-device) and localStorage (what the pre-auth boot path reads).

**Backend**
- `PATCH /auth/me/analytics-consent` — self-service, authenticated, deliberately **no `@Roles`** (a demo signup is a `viewer`, and this is a preference on the caller's own account).
- `AuthService.updateAnalyticsConsent` re-reads the user after the write and returns the persisted state; a deleted-but-still-bearing-a-JWT caller gets 401 without a silent no-op UPDATE.
- `UserRepositoryPort.updateAnalyticsConsent` + TypeORM implementation.

**Frontend**
- `AnalyticsConsentTile` is now rendered on `/settings` (demo mode only, authenticated only), with a `Privacy` toolbar chip.
- `useUpdateAnalyticsConsentMutation` calls the endpoint and `await refreshSession()`s so the JWT-backed value is re-read, not assumed.
- `enableDemoAnalytics()` / `disableDemoAnalytics()` opt PostHog in/out live — no reload.
- Cross-tab **and** same-tab sync: `setDemoAnalyticsConsent` dispatches a `CustomEvent`; `subscribeToDemoAnalyticsConsent` also listens for the native `storage` event. The AppShell demo banner tracks the `/settings` toggle immediately.

**Privacy copy**
- The tile and the registration form no longer claim "all inputs masked" — #1878 narrowed session-recording masking to passwords only. Both now read: *passwords are never recorded; other text you type and view may be.*

## Test plan

- [x] `pnpm type-check` passes
- [x] `pnpm lint` passes (0 errors)
- [x] Controller: persists both values, returns the refreshed user, carries no `@Roles`, is not `@Public`
- [x] Service: writes then re-reads; 401 + no write for a vanished user
- [x] Repository: updates only `analytics_consent`, including the `false` withdrawal
- [x] Integration (`auth-analytics-consent.int-spec.ts`): viewer grant/withdraw, admin, caller isolation, 400 on non-boolean, 401 unauthenticated
- [x] Mutation hook: calls the endpoint, refreshes the session, propagates failures
- [x] Tile: demo-mode-only + authenticated-only rendering, both toggle directions, PostHog opt-in/out, localStorage mirror, error toast, no stale masking claim
- [x] Consent sync lib: same-tab event, cross-tab `storage`, unrelated-key filtering, unsubscribe, no notify on failed write
- [x] AppShell: banner drops/gains "Analytics on." on a consent change from elsewhere
- [x] Settings page: tile mounted in demo mode, absent outside it

The unrelated integration-harness scheduler fix that was bundled here has been split out into #1889 (tracked as #1888).

Closes #1882

