### PR TITLE
fix(listings): add missing @Roles to checkPublishedVariants endpoint

### DIFF
--- a/apps/api/src/listings/http/listings.controller.ts
+++ b/apps/api/src/listings/http/listings.controller.ts
@@ -146,6 +146,7 @@ export class ListingsController {
     private readonly publishedVariants: IPublishedVariantsService
   ) {}
 
+  @Roles('admin', 'operator', 'viewer')
   @Post('published-variants')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({


### PR DESCRIPTION
## Summary

Fixes the remaining CI failure blocking PR #1870 — the write-guard coverage invariant test (`src/auth/write-guard-coverage.spec.ts`, #1124 / #1126 / #1357) failed with `ListingsController.checkPublishedVariants (HTTP method POST) is missing @Roles`.

## Root cause

`checkPublishedVariants` (`POST /listings/published-variants`, added by #1837 as the destination-aware duplicate-guard lookup) never got a `@Roles` decorator — its own `@ApiResponse({ status: 403, ... })` docstring already documented a 403 for insufficient permissions, but the actual decorator enforcing it was missing.

## Fix

Add `@Roles('admin', 'operator', 'viewer')`, matching the sibling read-only POST lookup endpoints on the same controller (`categories/resolve`, `categories/resolve-batch`, `products/find-by-barcode`) — this endpoint is the same shape: a POST that only reads/checks state, never mutates.

## Test plan

- [x] `pnpm --filter @openlinker/api type-check` — clean
- [x] `npx jest src/auth/write-guard-coverage.spec.ts` — 22/22 pass, including the previously-failing `ListingsController` case
- Full local suite not run per standing project guidance (too heavy for this machine) — single-file scoped run targets exactly the failing invariant.

Closes part of epic #1838.