### PR TITLE
fix(api/integration-tests): disable missing core scheduler tasks

### DIFF
--- a/apps/api/test/integration/setup.ts
+++ b/apps/api/test/integration/setup.ts
@@ -145,6 +145,10 @@ const harness = createIntegrationTestHarness({
     OL_ERLI_ORDERS_POLL_SCHEDULER_ENABLED: 'false',
     OL_INVENTORY_SYNC_ENABLED: 'false',
     OL_PRODUCT_SYNC_ENABLED: 'false',
+    OL_PICKUP_POINT_REFRESH_ENABLED: 'false',
+    OL_REGULATORY_RECONCILE_ENABLED: 'false',
+    OL_OFFLINE_RESUBMIT_ENABLED: 'false',
+    OL_PENDING_RECOVERY_ENABLED: 'false',
 
     // Integration tests seed users explicitly via loginAsAdmin / seedUser
     // helpers. Letting BootstrapAdminService also insert a default `admin`


### PR DESCRIPTION
## Summary

Split out of #1884 at review request — this harness fix is unrelated to the analytics consent toggle and should not be reverted along with it.

Four scheduler tasks (`OL_PICKUP_POINT_REFRESH_ENABLED`, `OL_REGULATORY_RECONCILE_ENABLED`, `OL_OFFLINE_RESUBMIT_ENABLED`, `OL_PENDING_RECOVERY_ENABLED`) run by default in the integration-test harness. Their cron jobs keep the Node event loop alive past teardown, so Jest reports `Cannot log after tests are done` when a job fires after a suite finishes.

Disables all four in `apps/api/test/integration/setup.ts`, matching the other schedulers already disabled there.

## Test plan

- [ ] `pnpm test:integration` — no post-teardown logging warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)