### PR TITLE
fix(api/integration-tests): disable four core scheduler tasks in the harness

### DIFF
--- a/apps/api/test/integration/setup.ts
+++ b/apps/api/test/integration/setup.ts
@@ -145,6 +145,10 @@ const harness = createIntegrationTestHarness({
     OL_ERLI_ORDERS_POLL_SCHEDULER_ENABLED: 'false',
     OL_INVENTORY_SYNC_ENABLED: 'false',
     OL_PRODUCT_SYNC_ENABLED: 'false',
+    OL_PICKUP_POINT_REFRESH_ENABLED: 'false',
+    OL_REGULATORY_RECONCILE_ENABLED: 'false',
+    OL_OFFLINE_RESUBMIT_ENABLED: 'false',
+    OL_PENDING_RECOVERY_ENABLED: 'false',
 
     // Integration tests seed users explicitly via loginAsAdmin / seedUser
     // helpers. Letting BootstrapAdminService also insert a default `admin`


### PR DESCRIPTION
## Summary

The integration-test harness (`apps/api/test/integration/setup.ts`) explicitly disables every scheduler it knows about — 13 flags covering Allegro, PrestaShop, WooCommerce, Erli, InPost, DPD, inventory sync and product sync. Four core scheduler tasks registered in `apps/api/src/sync/application/services/scheduler.service.ts` were never added to that list:

| `taskId` | env var | default cron | default enabled |
|---|---|---|---|
| `pickup-point-refresh` | `OL_PICKUP_POINT_REFRESH_ENABLED` | `0 3 * * *` | on |
| `regulatory-status-reconcile` | `OL_REGULATORY_RECONCILE_ENABLED` | `*/30 * * * *` | on |
| `pending-recovery` | `OL_PENDING_RECOVERY_ENABLED` | `*/20 * * * *` | on |
| `offline-resubmit` | `OL_OFFLINE_RESUBMIT_ENABLED` | — | off (`defaultEnabled: false`, #1585 B1) |

The three that default **on** register cron jobs inside the test Nest application. Those timers keep the Node event loop alive past suite teardown, so a job firing after Jest has torn the suite down surfaces as `Cannot log after tests are done` — a nondeterministic CI integration-test failure reported against whichever suite happens to be finishing.

This sets all four to `'false'`, alongside the schedulers already disabled in the same block. `OL_OFFLINE_RESUBMIT_ENABLED` already defaults to `false` in the scheduler; listing it explicitly is deliberate belt-and-braces so a future flip of that default cannot silently reintroduce the same class of failure in the harness.

Production defaults are unchanged — this is a harness gap, not a scheduler defect. No production source file is touched.

Split out of #1884 at review request so this fix isn't reverted alongside the unrelated analytics-consent feature. Supersedes #1887 (same one-file change; recreated on an issue-numbered branch per the `/work` convention).

## Test plan

- [x] `pnpm test:integration` — completes with no `Cannot log after tests are done` warnings
- [x] `pnpm lint` — passes (0 errors)
- [x] `pnpm type-check` — passes (0 errors)

Closes #1888

🤖 Generated with [Claude Code](https://claude.com/claude-code)
