### PR TITLE
feat(demo): disclose marketing-UTM tracking on /login and /register

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -281,6 +281,15 @@ module.exports = {
       },
     },
     {
+      // Marketing-landing capture (#1900) posts directly to PostHog's own
+      // ingestion host, not our API — it must bypass the app's authenticated
+      // API client entirely and is exempt from the no-restricted-globals rule.
+      files: ['apps/web/src/features/demo/lib/capture-marketing-landing.ts'],
+      rules: {
+        'no-restricted-globals': 'off',
+      },
+    },
+    {
       files: ['apps/web/src/pages/**/*.{ts,tsx}'],
       rules: {
         'no-restricted-imports': [

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -281,9 +281,10 @@ module.exports = {
       },
     },
     {
-      // Marketing-landing capture (#1900) posts directly to PostHog's own
-      // ingestion host, not our API — it must bypass the app's authenticated
-      // API client entirely and is exempt from the no-restricted-globals rule.
+      // The captureMarketingLanding marketing-landing capture posts directly
+      // to PostHog's own ingestion host, not our API — it must bypass the
+      // app's authenticated API client entirely and is exempt from the
+      // no-restricted-globals rule.
       files: ['apps/web/src/features/demo/lib/capture-marketing-landing.ts'],
       rules: {
         'no-restricted-globals': 'off',

--- a/apps/web/src/app/layouts/authenticated-app-layout.test.tsx
+++ b/apps/web/src/app/layouts/authenticated-app-layout.test.tsx
@@ -1,6 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { render, screen } from '@testing-library/react';
-import { RouterProvider, createMemoryRouter } from 'react-router-dom';
+import { RouterProvider, createMemoryRouter, useLocation } from 'react-router-dom';
 import { describe, expect, it } from 'vitest';
 import { AuthenticatedAppLayout } from './authenticated-app-layout';
 import { ApiClientProvider } from '../api/api-client-provider';
@@ -10,10 +10,7 @@ import { ThemeProvider } from '../../shared/theme/theme-provider';
 import { LocaleProvider } from '../../shared/i18n';
 import { ToastProvider } from '../../shared/ui/toast-provider';
 import { createNoopSessionAdapter } from '../../shared/auth/noop-session-adapter';
-import {
-  createAuthenticatedSessionAdapter,
-  createMockApiClient,
-} from '../../test/test-utils';
+import { createAuthenticatedSessionAdapter, createMockApiClient } from '../../test/test-utils';
 import type { RouteCrumbHandle } from '../nav-registry.types';
 
 function TestChild(): React.ReactElement {
@@ -24,11 +21,19 @@ function LoginSentinel(): React.ReactElement {
   return <div>Login page</div>;
 }
 
+function SearchEchoLoginSentinel(): React.ReactElement {
+  const location = useLocation();
+  return <div>Login page search: {location.search}</div>;
+}
+
 const indexCrumb: RouteCrumbHandle = {
   crumb: { group: 'Operations', title: 'Dashboard' },
 };
 
-function renderLayout(sessionAdapter?: SessionAdapter): void {
+function renderLayout(
+  sessionAdapter?: SessionAdapter,
+  options?: { initialEntry?: string; loginElement?: React.ReactElement }
+): void {
   const adapter = sessionAdapter ?? createNoopSessionAdapter();
   const router = createMemoryRouter(
     [
@@ -37,9 +42,9 @@ function renderLayout(sessionAdapter?: SessionAdapter): void {
         element: <AuthenticatedAppLayout />,
         children: [{ index: true, handle: indexCrumb, element: <TestChild /> }],
       },
-      { path: '/login', element: <LoginSentinel /> },
+      { path: '/login', element: options?.loginElement ?? <LoginSentinel /> },
     ],
-    { initialEntries: ['/'] },
+    { initialEntries: [options?.initialEntry ?? '/'] }
   );
   const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
 
@@ -56,7 +61,7 @@ function renderLayout(sessionAdapter?: SessionAdapter): void {
           </ToastProvider>
         </SessionProvider>
       </LocaleProvider>
-    </ThemeProvider>,
+    </ThemeProvider>
   );
 }
 
@@ -71,5 +76,18 @@ describe('AuthenticatedAppLayout', () => {
     renderLayout(createAuthenticatedSessionAdapter());
 
     expect(await screen.findByText('Authenticated content')).toBeInTheDocument();
+  });
+
+  it('should preserve the query string when redirecting an anonymous session to /login', async () => {
+    renderLayout(undefined, {
+      initialEntry: '/?utm_source=email&utm_campaign=demo_invite_2026_07',
+      loginElement: <SearchEchoLoginSentinel />,
+    });
+
+    expect(
+      await screen.findByText(
+        'Login page search: ?utm_source=email&utm_campaign=demo_invite_2026_07'
+      )
+    ).toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/layouts/authenticated-app-layout.tsx
+++ b/apps/web/src/app/layouts/authenticated-app-layout.tsx
@@ -1,5 +1,5 @@
 import type { ReactElement } from 'react';
-import { Navigate, Outlet } from 'react-router-dom';
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
 import { useSession } from '../../shared/auth/use-session';
 import { LoadingState } from '../../shared/ui/feedback-state';
 import { AppShell } from '../app-shell';
@@ -7,6 +7,7 @@ import { PageLayout } from '../../shared/ui/page-layout';
 
 export function AuthenticatedAppLayout(): ReactElement {
   const { isReady, session } = useSession();
+  const location = useLocation();
 
   if (!isReady) {
     return (
@@ -26,7 +27,10 @@ export function AuthenticatedAppLayout(): ReactElement {
   }
 
   if (session.status === 'anonymous') {
-    return <Navigate to="/login" replace />;
+    // Preserve the query string (e.g. utm_* campaign params from a marketing
+    // redirect landing on the app root) so it survives onto /login instead of
+    // being silently dropped by the redirect.
+    return <Navigate to={{ pathname: '/login', search: location.search }} replace />;
   }
 
   return (

--- a/apps/web/src/app/layouts/guest-layout.test.tsx
+++ b/apps/web/src/app/layouts/guest-layout.test.tsx
@@ -1,8 +1,12 @@
 import { screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { Route, Routes } from 'react-router-dom';
 import { GuestLayout } from './guest-layout';
-import { createAuthenticatedSessionAdapter, renderWithProviders } from '../../test/test-utils';
+import {
+  createAuthenticatedSessionAdapter,
+  createMockApiClient,
+  renderWithProviders,
+} from '../../test/test-utils';
 
 function TestChild(): React.ReactElement {
   return <div>Guest content</div>;
@@ -12,7 +16,10 @@ function DashboardSentinel(): React.ReactElement {
   return <div>Dashboard page</div>;
 }
 
-function renderLayout(sessionAdapter?: ReturnType<typeof createAuthenticatedSessionAdapter>): void {
+function renderLayout(
+  sessionAdapter?: ReturnType<typeof createAuthenticatedSessionAdapter>,
+  options?: { apiClient?: ReturnType<typeof createMockApiClient>; route?: string }
+): void {
   renderWithProviders(
     <Routes>
       <Route path="/login" element={<GuestLayout />}>
@@ -20,7 +27,7 @@ function renderLayout(sessionAdapter?: ReturnType<typeof createAuthenticatedSess
       </Route>
       <Route path="/" element={<DashboardSentinel />} />
     </Routes>,
-    { route: '/login', sessionAdapter },
+    { route: options?.route ?? '/login', sessionAdapter, apiClient: options?.apiClient }
   );
 }
 
@@ -36,5 +43,67 @@ describe('GuestLayout', () => {
     renderLayout(createAuthenticatedSessionAdapter());
 
     expect(await screen.findByText('Dashboard page')).toBeInTheDocument();
+  });
+
+  describe('marketing UTM capture (#1900)', () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+      window.sessionStorage.clear();
+    });
+
+    it('should capture the landing when demo mode, posthog, and a utm param are all present', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+      vi.stubGlobal('fetch', fetchMock);
+      const apiClient = createMockApiClient({
+        system: {
+          getConfig: vi.fn().mockResolvedValue({
+            demoMode: true,
+            demoIntegrations: {
+              posthog: {
+                key: 'phc_abc',
+                host: 'https://eu.i.posthog.com',
+                autocapture: true,
+                sessionRecording: true,
+              },
+            },
+          }),
+        },
+      });
+
+      renderLayout(undefined, {
+        apiClient,
+        route: '/login?utm_source=email&utm_campaign=demo_invite_2026_07',
+      });
+
+      await screen.findByText('Guest content');
+      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+      const [url] = fetchMock.mock.calls[0] as [string];
+      expect(url).toBe('https://eu.i.posthog.com/capture/');
+    });
+
+    it('should not capture when the URL carries no utm params', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+      vi.stubGlobal('fetch', fetchMock);
+      const apiClient = createMockApiClient({
+        system: {
+          getConfig: vi.fn().mockResolvedValue({
+            demoMode: true,
+            demoIntegrations: {
+              posthog: {
+                key: 'phc_abc',
+                host: 'https://eu.i.posthog.com',
+                autocapture: true,
+                sessionRecording: true,
+              },
+            },
+          }),
+        },
+      });
+
+      renderLayout(undefined, { apiClient, route: '/login' });
+
+      await screen.findByText('Guest content');
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/web/src/app/layouts/guest-layout.test.tsx
+++ b/apps/web/src/app/layouts/guest-layout.test.tsx
@@ -25,6 +25,12 @@ function renderLayout(
       <Route path="/login" element={<GuestLayout />}>
         <Route index element={<TestChild />} />
       </Route>
+      <Route path="/register" element={<GuestLayout />}>
+        <Route index element={<TestChild />} />
+      </Route>
+      <Route path="/forgot-password" element={<GuestLayout />}>
+        <Route index element={<TestChild />} />
+      </Route>
       <Route path="/" element={<DashboardSentinel />} />
     </Routes>,
     { route: options?.route ?? '/login', sessionAdapter, apiClient: options?.apiClient }
@@ -45,7 +51,7 @@ describe('GuestLayout', () => {
     expect(await screen.findByText('Dashboard page')).toBeInTheDocument();
   });
 
-  describe('marketing UTM capture (#1900)', () => {
+  describe('marketing UTM capture (captureMarketingLanding)', () => {
     afterEach(() => {
       vi.unstubAllGlobals();
       window.sessionStorage.clear();
@@ -103,6 +109,62 @@ describe('GuestLayout', () => {
       renderLayout(undefined, { apiClient, route: '/login' });
 
       await screen.findByText('Guest content');
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('should not capture on /forgot-password even when a utm param is present', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+      vi.stubGlobal('fetch', fetchMock);
+      const apiClient = createMockApiClient({
+        system: {
+          getConfig: vi.fn().mockResolvedValue({
+            demoMode: true,
+            demoIntegrations: {
+              posthog: {
+                key: 'phc_abc',
+                host: 'https://eu.i.posthog.com',
+                autocapture: true,
+                sessionRecording: true,
+              },
+            },
+          }),
+        },
+      });
+
+      renderLayout(undefined, {
+        apiClient,
+        route: '/forgot-password?utm_source=email&utm_campaign=demo_invite_2026_07',
+      });
+
+      await screen.findByText('Guest content');
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('should not capture when the session is already authenticated even with a utm param present', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+      vi.stubGlobal('fetch', fetchMock);
+      const apiClient = createMockApiClient({
+        system: {
+          getConfig: vi.fn().mockResolvedValue({
+            demoMode: true,
+            demoIntegrations: {
+              posthog: {
+                key: 'phc_abc',
+                host: 'https://eu.i.posthog.com',
+                autocapture: true,
+                sessionRecording: true,
+              },
+            },
+          }),
+        },
+      });
+
+      renderLayout(createAuthenticatedSessionAdapter(), {
+        apiClient,
+        route: '/login?utm_source=email&utm_campaign=demo_invite_2026_07',
+      });
+
+      await screen.findByText('Dashboard page');
       expect(fetchMock).not.toHaveBeenCalled();
     });
   });

--- a/apps/web/src/app/layouts/guest-layout.tsx
+++ b/apps/web/src/app/layouts/guest-layout.tsx
@@ -1,26 +1,41 @@
 import type { ReactElement } from 'react';
 import { useEffect } from 'react';
-import { Navigate, Outlet } from 'react-router-dom';
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
 import { useSession } from '../../shared/auth/use-session';
 import { LoadingState } from '../../shared/ui/feedback-state';
 import { useSystemConfigQuery } from '../../features/system';
 import { captureMarketingLanding } from '../../features/demo';
 
+const MARKETING_CAPTURE_PATHS = ['/login', '/register'];
+
 export function GuestLayout(): ReactElement {
   const { isReady, session } = useSession();
   const systemConfigQuery = useSystemConfigQuery();
+  const location = useLocation();
 
-  // Marketing UTM capture (#1900) — the single mount point for every guest
-  // route (login, register, forgot/reset password), so it fires on whichever
-  // one a visitor actually lands on. Deliberately NOT gated on session
-  // readiness: it never reads session state and must fire even if the
-  // visitor never signs in this tab.
+  // Marketing UTM capture — mounted here (rather than per-page) so it fires
+  // regardless of which of /login or /register a visitor actually lands on,
+  // but deliberately scoped to only those two paths: that's where
+  // `MarketingTrackingFootnote` discloses it, and `/forgot-password`,
+  // `/reset-password/:token`, and `/confirm-email/:token` are excluded on
+  // purpose — the latter two carry a single-use sensitive token as a path
+  // segment, and `captureMarketingLanding` sends the full `window.location`
+  // (including path) to PostHog, which would otherwise leak the token.
+  // Also skipped once the session is authenticated, so a visitor who is
+  // already signed in and about to be redirected away from /login never
+  // gets captured.
   useEffect(() => {
     if (!systemConfigQuery.isSuccess) {
       return;
     }
+    if (session.status === 'authenticated') {
+      return;
+    }
+    if (!MARKETING_CAPTURE_PATHS.includes(location.pathname)) {
+      return;
+    }
     captureMarketingLanding(systemConfigQuery.data);
-  }, [systemConfigQuery.isSuccess, systemConfigQuery.data]);
+  }, [systemConfigQuery.isSuccess, systemConfigQuery.data, session.status, location.pathname]);
 
   if (!isReady) {
     return (

--- a/apps/web/src/app/layouts/guest-layout.tsx
+++ b/apps/web/src/app/layouts/guest-layout.tsx
@@ -1,10 +1,26 @@
 import type { ReactElement } from 'react';
+import { useEffect } from 'react';
 import { Navigate, Outlet } from 'react-router-dom';
 import { useSession } from '../../shared/auth/use-session';
 import { LoadingState } from '../../shared/ui/feedback-state';
+import { useSystemConfigQuery } from '../../features/system';
+import { captureMarketingLanding } from '../../features/demo';
 
 export function GuestLayout(): ReactElement {
   const { isReady, session } = useSession();
+  const systemConfigQuery = useSystemConfigQuery();
+
+  // Marketing UTM capture (#1900) — the single mount point for every guest
+  // route (login, register, forgot/reset password), so it fires on whichever
+  // one a visitor actually lands on. Deliberately NOT gated on session
+  // readiness: it never reads session state and must fire even if the
+  // visitor never signs in this tab.
+  useEffect(() => {
+    if (!systemConfigQuery.isSuccess) {
+      return;
+    }
+    captureMarketingLanding(systemConfigQuery.data);
+  }, [systemConfigQuery.isSuccess, systemConfigQuery.data]);
 
   if (!isReady) {
     return (

--- a/apps/web/src/features/auth/components/LoginForm.test.tsx
+++ b/apps/web/src/features/auth/components/LoginForm.test.tsx
@@ -118,7 +118,25 @@ describe('LoginForm', () => {
       const view = renderWithProviders(<LoginForm demoMode={false} />);
       const container = within(view.container);
 
-      expect(container.queryByRole('link', { name: /create a free demo account/i })).not.toBeInTheDocument();
+      expect(
+        container.queryByRole('link', { name: /create a free demo account/i })
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('tracking footnote', () => {
+    it('should show the footnote when showTrackingFootnote is true', () => {
+      const view = renderWithProviders(<LoginForm showTrackingFootnote />);
+      const container = within(view.container);
+
+      expect(container.getByText(/logged for analytics/i)).toBeInTheDocument();
+    });
+
+    it('should not show the footnote when showTrackingFootnote is false', () => {
+      const view = renderWithProviders(<LoginForm showTrackingFootnote={false} />);
+      const container = within(view.container);
+
+      expect(container.queryByText(/logged for analytics/i)).not.toBeInTheDocument();
     });
   });
 });

--- a/apps/web/src/features/auth/components/LoginForm.tsx
+++ b/apps/web/src/features/auth/components/LoginForm.tsx
@@ -9,6 +9,7 @@ import { Button } from '../../../shared/ui/button';
 import { FormErrorSummary } from '../../../shared/ui/form-error-summary';
 import { FormField } from '../../../shared/ui/form-field';
 import { Input } from '../../../shared/ui/input';
+import { MarketingTrackingFootnote } from '../../demo';
 
 const DEFAULT_VALUES: LoginFormValues = {
   username: '',
@@ -17,9 +18,13 @@ const DEFAULT_VALUES: LoginFormValues = {
 
 interface LoginFormProps {
   demoMode?: boolean;
+  showTrackingFootnote?: boolean;
 }
 
-export function LoginForm({ demoMode = false }: LoginFormProps): ReactElement {
+export function LoginForm({
+  demoMode = false,
+  showTrackingFootnote = false,
+}: LoginFormProps): ReactElement {
   const login = useLogin();
   const form = useForm<LoginFormValues>({
     defaultValues: DEFAULT_VALUES,
@@ -27,7 +32,7 @@ export function LoginForm({ demoMode = false }: LoginFormProps): ReactElement {
   });
 
   const validationMessages = Object.values(form.formState.errors).flatMap((error) =>
-    error?.message ? [String(error.message)] : [],
+    error?.message ? [String(error.message)] : []
   );
 
   const onSubmit = form.handleSubmit(async (values) => {
@@ -96,6 +101,8 @@ export function LoginForm({ demoMode = false }: LoginFormProps): ReactElement {
           </Link>
         </>
       ) : null}
+
+      {showTrackingFootnote ? <MarketingTrackingFootnote /> : null}
     </form>
   );
 }

--- a/apps/web/src/features/demo/components/marketing-tracking-footnote.tsx
+++ b/apps/web/src/features/demo/components/marketing-tracking-footnote.tsx
@@ -1,0 +1,19 @@
+/**
+ * Marketing Tracking Footnote
+ *
+ * Near-invisible fine-print disclosure rendered on /login and /register when
+ * the page load is actually trackable by `captureMarketingLanding` (#1900) —
+ * i.e. the visitor arrived via a marketing link carrying a UTM param. Never
+ * echoes the raw UTM/campaign value back to the visitor.
+ *
+ * @module features/demo/components
+ */
+import type { ReactElement } from 'react';
+
+export function MarketingTrackingFootnote(): ReactElement {
+  return (
+    <p className="guest-form__tracking-footnote">
+      This visit is being logged for analytics. No personal profile is created from this.
+    </p>
+  );
+}

--- a/apps/web/src/features/demo/components/marketing-tracking-footnote.tsx
+++ b/apps/web/src/features/demo/components/marketing-tracking-footnote.tsx
@@ -2,8 +2,8 @@
  * Marketing Tracking Footnote
  *
  * Near-invisible fine-print disclosure rendered on /login and /register when
- * the page load is actually trackable by `captureMarketingLanding` (#1900) —
- * i.e. the visitor arrived via a marketing link carrying a UTM param. Never
+ * the page load is actually trackable by `captureMarketingLanding` — i.e.
+ * the visitor arrived via a marketing link carrying a UTM param. Never
  * echoes the raw UTM/campaign value back to the visitor.
  *
  * @module features/demo/components

--- a/apps/web/src/features/demo/demo.types.ts
+++ b/apps/web/src/features/demo/demo.types.ts
@@ -20,8 +20,9 @@ export const DemoAnalyticsConsentValues = ['accepted', 'declined'] as const;
 export type DemoAnalyticsConsent = (typeof DemoAnalyticsConsentValues)[number];
 
 /**
- * Per-tab de-dup flag for the consent-independent marketing-UTM capture
- * (#1900). Session-scoped (not localStorage) — a fresh tab re-evaluates the
- * landing URL, but repeated renders within the same tab don't re-fire.
+ * Per-tab de-dup flag for the consent-independent `captureMarketingLanding`
+ * marketing-UTM capture. Session-scoped (not localStorage) — a fresh tab
+ * re-evaluates the landing URL, but repeated renders within the same tab
+ * don't re-fire.
  */
 export const MARKETING_LANDING_CAPTURED_STORAGE_KEY = 'openlinker.marketingLandingCaptured';

--- a/apps/web/src/features/demo/demo.types.ts
+++ b/apps/web/src/features/demo/demo.types.ts
@@ -18,3 +18,10 @@ export const DEMO_ANALYTICS_CONSENT_CHANGE_EVENT = 'openlinker:demo-analytics-co
 
 export const DemoAnalyticsConsentValues = ['accepted', 'declined'] as const;
 export type DemoAnalyticsConsent = (typeof DemoAnalyticsConsentValues)[number];
+
+/**
+ * Per-tab de-dup flag for the consent-independent marketing-UTM capture
+ * (#1900). Session-scoped (not localStorage) — a fresh tab re-evaluates the
+ * landing URL, but repeated renders within the same tab don't re-fire.
+ */
+export const MARKETING_LANDING_CAPTURED_STORAGE_KEY = 'openlinker.marketingLandingCaptured';

--- a/apps/web/src/features/demo/index.ts
+++ b/apps/web/src/features/demo/index.ts
@@ -8,6 +8,11 @@ export {
   setDemoAnalyticsConsent,
   subscribeToDemoAnalyticsConsent,
 } from './lib/demo-analytics-consent';
+export {
+  captureMarketingLanding,
+  isMarketingLandingTrackable,
+} from './lib/capture-marketing-landing';
 export { AnalyticsConsentTile } from './components/analytics-consent-tile';
+export { MarketingTrackingFootnote } from './components/marketing-tracking-footnote';
 export { DEMO_ANALYTICS_CONSENT_STORAGE_KEY } from './demo.types';
 export type { DemoAnalyticsConsent } from './demo.types';

--- a/apps/web/src/features/demo/lib/capture-marketing-landing.test.ts
+++ b/apps/web/src/features/demo/lib/capture-marketing-landing.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SystemConfig } from '../../system';
+import {
+  captureMarketingLanding,
+  hasMarketingUtmParams,
+  isMarketingLandingTrackable,
+} from './capture-marketing-landing';
+
+const configuredPosthog: SystemConfig = {
+  demoMode: true,
+  demoIntegrations: {
+    posthog: {
+      key: 'phc_abc',
+      host: 'https://eu.i.posthog.com',
+      autocapture: true,
+      sessionRecording: true,
+    },
+  },
+};
+
+function setLocation(search: string): void {
+  Object.defineProperty(window, 'location', {
+    value: new URL(`https://app.demo.openlinker.io/${search}`),
+    writable: true,
+  });
+}
+
+describe('hasMarketingUtmParams', () => {
+  it('should return true when the search string carries a utm param', () => {
+    expect(hasMarketingUtmParams('?utm_campaign=demo_invite_2026_07')).toBe(true);
+  });
+
+  it('should return false when the search string carries no utm param', () => {
+    expect(hasMarketingUtmParams('?ref=whatever')).toBe(false);
+  });
+
+  it('should return false for an empty search string', () => {
+    expect(hasMarketingUtmParams('')).toBe(false);
+  });
+});
+
+describe('isMarketingLandingTrackable', () => {
+  it('should return true when demo mode, posthog key, and a utm param are all present', () => {
+    expect(isMarketingLandingTrackable(configuredPosthog, '?utm_source=email')).toBe(true);
+  });
+
+  it('should return false when demo mode is off', () => {
+    expect(
+      isMarketingLandingTrackable({ ...configuredPosthog, demoMode: false }, '?utm_source=email')
+    ).toBe(false);
+  });
+
+  it('should return false when no posthog key is configured', () => {
+    expect(isMarketingLandingTrackable({ demoMode: true }, '?utm_source=email')).toBe(false);
+  });
+
+  it('should return false when config is undefined', () => {
+    expect(isMarketingLandingTrackable(undefined, '?utm_source=email')).toBe(false);
+  });
+
+  it('should return false when the URL carries no utm params', () => {
+    expect(isMarketingLandingTrackable(configuredPosthog, '?ref=whatever')).toBe(false);
+  });
+});
+
+describe('captureMarketingLanding', () => {
+  const originalLocation = window.location;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+    window.sessionStorage.clear();
+    setLocation('?utm_source=email&utm_medium=email&utm_campaign=demo_invite_2026_07');
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    Object.defineProperty(window, 'location', { value: originalLocation, writable: true });
+  });
+
+  it('should not capture when demoMode is false', () => {
+    captureMarketingLanding({ ...configuredPosthog, demoMode: false });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('should not capture when no posthog key is configured', () => {
+    captureMarketingLanding({ demoMode: true });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('should not capture when config is undefined', () => {
+    captureMarketingLanding(undefined);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('should not capture when the URL carries no utm params', () => {
+    setLocation('?ref=whatever');
+    captureMarketingLanding(configuredPosthog);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('should POST a de-identified event to the resolved capture host when utm params are present', () => {
+    captureMarketingLanding(configuredPosthog);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://eu.i.posthog.com/capture/');
+    expect(init.keepalive).toBe(true);
+
+    const body = JSON.parse(init.body as string) as {
+      api_key: string;
+      event: string;
+      distinct_id: string;
+      properties: Record<string, unknown>;
+    };
+    expect(body.api_key).toBe('phc_abc');
+    expect(body.event).toBe('demo_marketing_landing');
+    expect(body.distinct_id).toEqual(expect.any(String));
+    expect(body.properties).toMatchObject({
+      utm_source: 'email',
+      utm_medium: 'email',
+      utm_campaign: 'demo_invite_2026_07',
+      $process_person_profile: false,
+    });
+  });
+
+  it('should only capture once per tab', () => {
+    captureMarketingLanding(configuredPosthog);
+    captureMarketingLanding(configuredPosthog);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should still capture when sessionStorage.getItem throws (private browsing)', () => {
+    const getItemSpy = vi
+      .spyOn(window.sessionStorage.__proto__ as Storage, 'getItem')
+      .mockImplementation(() => {
+        throw new DOMException('blocked');
+      });
+
+    captureMarketingLanding(configuredPosthog);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    getItemSpy.mockRestore();
+  });
+
+  it('should not throw when sessionStorage.setItem throws (private browsing)', () => {
+    const setItemSpy = vi
+      .spyOn(window.sessionStorage.__proto__ as Storage, 'setItem')
+      .mockImplementation(() => {
+        throw new DOMException('blocked');
+      });
+
+    expect(() => captureMarketingLanding(configuredPosthog)).not.toThrow();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    setItemSpy.mockRestore();
+  });
+});

--- a/apps/web/src/features/demo/lib/capture-marketing-landing.test.ts
+++ b/apps/web/src/features/demo/lib/capture-marketing-landing.test.ts
@@ -61,6 +61,22 @@ describe('isMarketingLandingTrackable', () => {
   it('should return false when the URL carries no utm params', () => {
     expect(isMarketingLandingTrackable(configuredPosthog, '?ref=whatever')).toBe(false);
   });
+
+  it('should return false once the tab has already captured a landing', () => {
+    const originalLocation = window.location;
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+    window.sessionStorage.clear();
+    setLocation('?utm_source=email');
+
+    captureMarketingLanding(configuredPosthog);
+
+    expect(isMarketingLandingTrackable(configuredPosthog, '?utm_source=email')).toBe(false);
+
+    window.sessionStorage.clear();
+    vi.unstubAllGlobals();
+    Object.defineProperty(window, 'location', { value: originalLocation, writable: true });
+  });
 });
 
 describe('captureMarketingLanding', () => {

--- a/apps/web/src/features/demo/lib/capture-marketing-landing.ts
+++ b/apps/web/src/features/demo/lib/capture-marketing-landing.ts
@@ -4,9 +4,10 @@
  * Fire-and-forget UTM/campaign attribution for a visitor's FIRST landing hit
  * on a demo instance — independent of the analytics-consent gate that guards
  * `initDemoIntegrations` (session recording + full posthog-js SDK). That gate
- * exists because session recording plays back page content (ADR-032, #1301's
- * explicitly-rejected "skip consent" alternative); this capture carries none
- * of that weight, so it is not subject to the same gate:
+ * exists because session recording plays back page content, which is far
+ * more privacy-sensitive than a single de-identified attribution event; this
+ * capture carries none of that weight, so it is not subject to the same
+ * gate:
  *
  * - never loads `posthog-js` — a single `fetch` to PostHog's REST capture
  *   endpoint, so autocapture/session-recording code never reaches the page
@@ -63,15 +64,21 @@ function resolvePosthogCaptureConfig(
 
 /**
  * Whether a page load would actually trigger `captureMarketingLanding` —
- * i.e. demo mode is on, PostHog is configured, and the URL carries a UTM
- * param. Consumed by the /login and /register footnote so it never claims a
- * capture happened when the underlying config can't actually send one.
+ * i.e. demo mode is on, PostHog is configured, the URL carries a UTM param,
+ * and this tab hasn't already captured a landing. Consumed by the /login and
+ * /register footnote so it never claims a capture happened (or will happen)
+ * when the underlying capture would actually no-op — e.g. a same-tab reload
+ * or back-navigation after the tab's one-per-tab capture already fired.
  */
 export function isMarketingLandingTrackable(
   config: SystemConfig | undefined,
   search: string
 ): boolean {
-  return Boolean(resolvePosthogCaptureConfig(config)?.key) && hasMarketingUtmParams(search);
+  return (
+    Boolean(resolvePosthogCaptureConfig(config)?.key) &&
+    hasMarketingUtmParams(search) &&
+    !alreadyCapturedThisTab()
+  );
 }
 
 function alreadyCapturedThisTab(): boolean {

--- a/apps/web/src/features/demo/lib/capture-marketing-landing.ts
+++ b/apps/web/src/features/demo/lib/capture-marketing-landing.ts
@@ -1,0 +1,132 @@
+/**
+ * Capture Marketing Landing
+ *
+ * Fire-and-forget UTM/campaign attribution for a visitor's FIRST landing hit
+ * on a demo instance — independent of the analytics-consent gate that guards
+ * `initDemoIntegrations` (session recording + full posthog-js SDK). That gate
+ * exists because session recording plays back page content (ADR-032, #1301's
+ * explicitly-rejected "skip consent" alternative); this capture carries none
+ * of that weight, so it is not subject to the same gate:
+ *
+ * - never loads `posthog-js` — a single `fetch` to PostHog's REST capture
+ *   endpoint, so autocapture/session-recording code never reaches the page
+ * - never persists a person profile (`$process_person_profile: false`) or a
+ *   durable distinct_id — a fresh random id per landing, kept only in
+ *   `sessionStorage` for this tab's de-dup, never written to a durable
+ *   PostHog cookie
+ * - fires only when the URL actually carries a `utm_*` param — a plain visit
+ *   with no campaign context emits nothing
+ *
+ * This is deliberately narrower than "track all anonymous traffic" — it
+ * exists to answer one question (which campaign drove this visit), not to
+ * build a pre-consent behavioral profile.
+ *
+ * @module features/demo/lib
+ */
+import type { PosthogDemoIntegration, SystemConfig } from '../../system';
+import { MARKETING_LANDING_CAPTURED_STORAGE_KEY } from '../demo.types';
+
+const UTM_PARAM_NAMES = [
+  'utm_source',
+  'utm_medium',
+  'utm_campaign',
+  'utm_term',
+  'utm_content',
+] as const;
+
+function readUtmParams(search: string): Record<string, string> | null {
+  const params = new URLSearchParams(search);
+  const utmProps: Record<string, string> = {};
+  for (const name of UTM_PARAM_NAMES) {
+    const value = params.get(name);
+    if (value) {
+      utmProps[name] = value;
+    }
+  }
+  return Object.keys(utmProps).length > 0 ? utmProps : null;
+}
+
+/**
+ * Pure presence check, reused by both the capture side-effect below and the
+ * campaign-tracking disclosure footnote (#1892) so the two never drift on
+ * what counts as "arrived via a marketing link".
+ */
+export function hasMarketingUtmParams(search: string): boolean {
+  return readUtmParams(search) !== null;
+}
+
+function resolvePosthogCaptureConfig(
+  config: SystemConfig | undefined
+): PosthogDemoIntegration | undefined {
+  return config?.demoMode ? config.demoIntegrations?.posthog : undefined;
+}
+
+/**
+ * Whether a page load would actually trigger `captureMarketingLanding` —
+ * i.e. demo mode is on, PostHog is configured, and the URL carries a UTM
+ * param. Consumed by the /login and /register footnote so it never claims a
+ * capture happened when the underlying config can't actually send one.
+ */
+export function isMarketingLandingTrackable(
+  config: SystemConfig | undefined,
+  search: string
+): boolean {
+  return Boolean(resolvePosthogCaptureConfig(config)?.key) && hasMarketingUtmParams(search);
+}
+
+function alreadyCapturedThisTab(): boolean {
+  try {
+    return window.sessionStorage.getItem(MARKETING_LANDING_CAPTURED_STORAGE_KEY) === '1';
+  } catch {
+    // Storage unavailable (private browsing) — proceed rather than silently
+    // drop every landing capture for that visitor.
+    return false;
+  }
+}
+
+function markCapturedThisTab(): void {
+  try {
+    window.sessionStorage.setItem(MARKETING_LANDING_CAPTURED_STORAGE_KEY, '1');
+  } catch {
+    // Best-effort de-dup only; a missed write just risks one duplicate event.
+  }
+}
+
+export function captureMarketingLanding(config: SystemConfig | undefined): void {
+  const posthogConfig = resolvePosthogCaptureConfig(config);
+  if (!posthogConfig?.key) {
+    return;
+  }
+
+  if (alreadyCapturedThisTab()) {
+    return;
+  }
+
+  const utmProps = readUtmParams(window.location.search);
+  if (!utmProps) {
+    return;
+  }
+
+  markCapturedThisTab();
+
+  const body = JSON.stringify({
+    api_key: posthogConfig.key,
+    event: 'demo_marketing_landing',
+    distinct_id: crypto.randomUUID(),
+    properties: {
+      ...utmProps,
+      $current_url: window.location.href,
+      $referrer: document.referrer || undefined,
+      $process_person_profile: false,
+    },
+  });
+
+  void fetch(`${posthogConfig.host}/capture/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body,
+    keepalive: true,
+  }).catch(() => {
+    // Best-effort — marketing attribution must never affect the app boot path.
+  });
+}

--- a/apps/web/src/features/users/components/register-form.test.tsx
+++ b/apps/web/src/features/users/components/register-form.test.tsx
@@ -76,9 +76,7 @@ describe('RegisterForm', () => {
   it('should show a dedicated message when registration fails with a 409 (#1625)', async () => {
     const mockApi = createMockApiClient({
       auth: {
-        register: vi
-          .fn()
-          .mockRejectedValue(new ApiError('Email already registered', 409, null)),
+        register: vi.fn().mockRejectedValue(new ApiError('Email already registered', 409, null)),
       },
     });
     renderWithProviders(<RegisterForm />, { apiClient: mockApi });
@@ -146,7 +144,7 @@ describe('RegisterForm', () => {
 
       await screen.findByText(/check your email to confirm your account/i);
       expect(registerFn).toHaveBeenCalledWith(
-        expect.objectContaining({ username: 'demo_user', analyticsConsent: false }),
+        expect.objectContaining({ username: 'demo_user', analyticsConsent: false })
       );
     });
 
@@ -160,14 +158,12 @@ describe('RegisterForm', () => {
       await userEvent.type(screen.getByLabelText('Password'), 'password123');
       await userEvent.type(screen.getByLabelText('Confirm password'), 'password123');
       await userEvent.click(
-        screen.getByRole('checkbox', { name: /share anonymous usage analytics/i }),
+        screen.getByRole('checkbox', { name: /share anonymous usage analytics/i })
       );
       await userEvent.click(screen.getByRole('button', { name: /start exploring/i }));
 
       await screen.findByText(/check your email to confirm your account/i);
-      expect(registerFn).toHaveBeenCalledWith(
-        expect.objectContaining({ analyticsConsent: true }),
-      );
+      expect(registerFn).toHaveBeenCalledWith(expect.objectContaining({ analyticsConsent: true }));
     });
 
     it('should show demo success copy after registration in demo mode', async () => {
@@ -182,7 +178,23 @@ describe('RegisterForm', () => {
       await userEvent.type(screen.getByLabelText('Confirm password'), 'password123');
       await userEvent.click(screen.getByRole('button', { name: /start exploring/i }));
 
-      expect(await screen.findByText(/check your email to confirm your account/i)).toBeInTheDocument();
+      expect(
+        await screen.findByText(/check your email to confirm your account/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('tracking footnote', () => {
+    it('should show the footnote when showTrackingFootnote is true', () => {
+      renderWithProviders(<RegisterForm showTrackingFootnote />);
+
+      expect(screen.getByText(/logged for analytics/i)).toBeInTheDocument();
+    });
+
+    it('should not show the footnote when showTrackingFootnote is false', () => {
+      renderWithProviders(<RegisterForm showTrackingFootnote={false} />);
+
+      expect(screen.queryByText(/logged for analytics/i)).not.toBeInTheDocument();
     });
   });
 });

--- a/apps/web/src/features/users/components/register-form.tsx
+++ b/apps/web/src/features/users/components/register-form.tsx
@@ -21,12 +21,17 @@ import { Button } from '../../../shared/ui/button';
 import { FormErrorSummary } from '../../../shared/ui/form-error-summary';
 import { FormField } from '../../../shared/ui/form-field';
 import { Input } from '../../../shared/ui/input';
+import { MarketingTrackingFootnote } from '../../demo';
 
 interface RegisterFormProps {
   demoMode?: boolean;
+  showTrackingFootnote?: boolean;
 }
 
-export function RegisterForm({ demoMode = false }: RegisterFormProps): ReactElement {
+export function RegisterForm({
+  demoMode = false,
+  showTrackingFootnote = false,
+}: RegisterFormProps): ReactElement {
   const register = useRegisterMutation();
   const [submitted, setSubmitted] = useState(false);
 
@@ -97,11 +102,13 @@ export function RegisterForm({ demoMode = false }: RegisterFormProps): ReactElem
 
       {demoMode ? (
         <div className="guest-form__demo-callout">
-          <span className="guest-form__demo-callout-icon" aria-hidden="true">⚡</span>
+          <span className="guest-form__demo-callout-icon" aria-hidden="true">
+            ⚡
+          </span>
           <div>
             <strong>Demo mode active</strong> — no approval needed. Your account is set to
-            read-only. We'll email you a confirmation link; click it to activate your account
-            before signing in.
+            read-only. We'll email you a confirmation link; click it to activate your account before
+            signing in.
           </div>
         </div>
       ) : null}
@@ -156,24 +163,22 @@ export function RegisterForm({ demoMode = false }: RegisterFormProps): ReactElem
                 false claim on the signup path (#1882). */}
             <span className="guest-form__consent-hint">
               Optional. Helps us improve OpenLinker. Includes session recording — passwords are
-              never recorded, but other text you type and view may be. Off unless you tick this;
-              you can change it anytime on Settings.
+              never recorded, but other text you type and view may be. Off unless you tick this; you
+              can change it anytime on Settings.
             </span>
           </span>
         </label>
       ) : null}
 
       <Button type="submit" tone="primary" disabled={register.isPending}>
-        {register.isPending
-          ? 'Submitting…'
-          : demoMode
-            ? 'Start exploring →'
-            : 'Request access'}
+        {register.isPending ? 'Submitting…' : demoMode ? 'Start exploring →' : 'Request access'}
       </Button>
 
       <p className="guest-form__footer-link">
         Already have an account? <Link to="/login">Sign in</Link>
       </p>
+
+      {showTrackingFootnote ? <MarketingTrackingFootnote /> : null}
     </form>
   );
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -13808,6 +13808,19 @@ textarea.bulk-editor__input { resize: vertical; min-height: 66px; font-family: i
   color: var(--text-secondary);
 }
 
+/* ── Marketing-tracking disclosure footnote (#1892) ──
+   Deliberately the least visually prominent thing on the card: no box, no
+   icon, no eyebrow label — a single line of fine print reading as boilerplate
+   footer text, not a feature. */
+.guest-form__tracking-footnote {
+  margin: var(--space-3) 0 0;
+  padding-top: var(--space-2);
+  font-size: 10.5px;
+  line-height: 1.5;
+  color: var(--text-muted);
+  text-align: center;
+}
+
 /* ── Product detail (#1304) ── */
 
 .product-detail-hero {

--- a/apps/web/src/pages/auth/LoginPage.tsx
+++ b/apps/web/src/pages/auth/LoginPage.tsx
@@ -1,10 +1,14 @@
 import type { ReactElement } from 'react';
+import { useLocation } from 'react-router-dom';
 import { LoginForm } from '../../features/auth/components/LoginForm';
 import { useSystemConfigQuery } from '../../features/system';
+import { isMarketingLandingTrackable } from '../../features/demo';
 
 export function LoginPage(): ReactElement {
   const systemConfigQuery = useSystemConfigQuery();
+  const location = useLocation();
   const demoMode = systemConfigQuery.data?.demoMode ?? false;
+  const showTrackingFootnote = isMarketingLandingTrackable(systemConfigQuery.data, location.search);
 
   return (
     <section className="guest-page">
@@ -12,7 +16,7 @@ export function LoginPage(): ReactElement {
       <p className="guest-page__description">
         Enter your credentials to access the operator workspace.
       </p>
-      <LoginForm demoMode={demoMode} />
+      <LoginForm demoMode={demoMode} showTrackingFootnote={showTrackingFootnote} />
     </section>
   );
 }

--- a/apps/web/src/pages/auth/RegisterPage.tsx
+++ b/apps/web/src/pages/auth/RegisterPage.tsx
@@ -9,24 +9,26 @@
  * @module pages/auth
  */
 import type { ReactElement } from 'react';
+import { useLocation } from 'react-router-dom';
 import { RegisterForm } from '../../features/users';
 import { useSystemConfigQuery } from '../../features/system';
+import { isMarketingLandingTrackable } from '../../features/demo';
 
 export function RegisterPage(): ReactElement {
   const systemConfigQuery = useSystemConfigQuery();
+  const location = useLocation();
   const demoMode = systemConfigQuery.data?.demoMode ?? false;
+  const showTrackingFootnote = isMarketingLandingTrackable(systemConfigQuery.data, location.search);
 
   return (
     <section className="guest-page">
-      <h1 className="guest-page__title">
-        {demoMode ? 'Create a demo account' : 'Request access'}
-      </h1>
+      <h1 className="guest-page__title">{demoMode ? 'Create a demo account' : 'Request access'}</h1>
       <p className="guest-page__description">
         {demoMode
           ? "No approval needed — we'll email you a confirmation link to activate your account."
           : 'Submit your details. An admin will review and approve your account.'}
       </p>
-      <RegisterForm demoMode={demoMode} />
+      <RegisterForm demoMode={demoMode} showTrackingFootnote={showTrackingFootnote} />
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- Adds `captureMarketingLanding` (#1900) — a fire-and-forget, consent-independent PostHog event fired once per tab when a demo visitor lands on `/login` or `/register` carrying a `utm_*` campaign param. Never loads `posthog-js`, never persists a durable id or person profile.
- Adds a near-invisible fine-print footnote (#1892) on `/login` and `/register` disclosing that the analytics event fired — shown only when it actually does, never echoes the raw campaign value.
- Fixes `AuthenticatedAppLayout` dropping the query string on the anonymous → `/login` redirect, which would have silently broken this feature for campaign traffic landing on the app root (`/?utm_source=...`) instead of `/login` directly.

## Test plan
- [x] `pnpm lint` / `pnpm type-check` / `pnpm test` all clean (2594/2594 passing)
- [x] `check-design-tokens.mjs` passes (no new CSS custom properties introduced)
- [x] Verified live on the `ol-demo-fresh` stack: `/login?utm_source=email&utm_campaign=demo_invite_2026_07` and `/register` with the same params show the footnote; `/login` with no params does not
- [x] New/updated unit tests cover: UTM-presence + trackability predicates, the capture side-effect (incl. private-browsing storage failures), the redirect search-preservation fix, and footnote visibility on both forms

## Related
- Companion follow-up filed separately (not blocking this PR): `openlinker-website#37` proposes disclosing this same demo-app tracking on the marketing site's `/legal` page — a legal-copy change that needs product-owner sign-off before it ships, so it's tracked independently.

Closes #1892