### PR TITLE
refactor(web/listings): split OfferProductPickerModal into row/rail sub-components

### DIFF
--- a/apps/web/src/features/listings/components/offer-product-picker-modal.tsx
+++ b/apps/web/src/features/listings/components/offer-product-picker-modal.tsx
@@ -39,6 +39,13 @@
  * wizard then seeds all their variants), products picked at variant granularity
  * contribute their explicit subset.
  *
+ * Split (#1819) into this orchestrator + `offer-product-picker-row.tsx` (the
+ * per-product / per-variant list rows) + `offer-product-picker-rail.tsx` (the
+ * selection review rail) + pure derivation helpers in
+ * `../lib/offer-product-picker-selectors.ts` and
+ * `../lib/publish-destinations.ts`. This file owns all state, queries, and
+ * callbacks; the two sub-components are presentational.
+ *
  * @module apps/web/src/features/listings/components
  */
 import {
@@ -53,7 +60,6 @@ import { useNavigate } from 'react-router-dom';
 
 import { Alert } from '../../../shared/ui/alert';
 import { Button } from '../../../shared/ui/button';
-import { CheckboxCell } from '../../../shared/ui/checkbox-cell';
 import { ConfirmDialog } from '../../../shared/ui/confirm-dialog';
 import {
   Dialog,
@@ -62,26 +68,26 @@ import {
   DialogTitle,
 } from '../../../shared/ui/dialog';
 import { Input } from '../../../shared/ui/input';
-import { ProductThumbnail } from '../../../shared/ui/product-thumbnail';
-import { Tooltip, TooltipContent, TooltipTrigger } from '../../../shared/ui/tooltip';
 import { useDebouncedValue } from '../../../shared/hooks/use-debounced-value';
 import { useConnectionsQuery } from '../../connections';
-import { useProductQuery, useProductsQuery } from '../../products';
+import { useProductsQuery } from '../../products';
 import type { Product, ProductVariant } from '../../products';
-import { selectPublishDestinations } from '../lib/publish-destinations';
-import { PublishDestinationRail } from './publish-destination-rail';
+import {
+  computeItemCount,
+  computeNeedEanCount,
+  computeRailGroups,
+} from '../lib/offer-product-picker-selectors';
+import { resolvePublishDestination, selectPublishDestinations } from '../lib/publish-destinations';
+import { OfferProductPickerRail } from './offer-product-picker-rail';
+import { OfferProductPickerRow } from './offer-product-picker-row';
+import {
+  OFFER_PICKER_PRODUCT_CAP,
+  type PickerStep,
+  type SelectionEntry,
+} from './offer-product-picker.types';
 
-/** Max distinct products per batch (mirrors the `/products` BULK_SELECTION_CAP,
- *  kept local per R1 to avoid a `features -> pages` import). */
-const OFFER_PICKER_PRODUCT_CAP = 100;
 const PAGE_SIZE = 20;
 const SEARCH_DEBOUNCE_MS = 300;
-
-/** Per-product selection: whole product, or an explicit variant subset. */
-type SelectionEntry = 'ALL' | Set<string>;
-
-/** Two-step wizard step (meaningful only <=1023px; desktop shows both regions). */
-type PickerStep = 'products' | 'review';
 
 interface OfferProductPickerModalProps {
   isOpen: boolean;
@@ -95,224 +101,6 @@ interface OfferProductPickerModalProps {
   initialProductIds?: readonly string[];
   /** Product objects for `initialProductIds`, so the rail can render names/images immediately without waiting on this picker's own paginated query to reach them. */
   initialProductMeta?: readonly Product[];
-}
-
-function variantLabel(product: Product, variant: ProductVariant): string {
-  const attrs = variant.attributes ? Object.values(variant.attributes).join(' · ') : '';
-  if (attrs) return `${product.name} - ${attrs}`;
-  if (variant.sku) return `${product.name} - ${variant.sku}`;
-  return product.name;
-}
-
-/** Short, product-name-free label for the rail review (attrs, else SKU, else id). */
-function variantShortLabel(variant: ProductVariant): string {
-  const attrs = variant.attributes ? Object.values(variant.attributes).join(' · ') : '';
-  return attrs || variant.sku || variant.id;
-}
-
-/** Whether a variant carries a barcode (EAN or GTIN). */
-function variantHasBarcode(variant: ProductVariant): boolean {
-  return (variant.ean ?? variant.gtin ?? '').trim() !== '';
-}
-
-function firstImage(images: string[] | null | undefined): string | null {
-  return images && images.length > 0 ? images[0] : null;
-}
-
-/**
- * One product row. Lazily loads its variants when expanded (passing an empty
- * id keeps `useProductQuery` disabled until then). Computes its own tri-state
- * and reports its loaded variants up so the parent can total items across
- * products and render the selection rail even after paging away.
- */
-interface PickerProductRowProps {
-  product: Product;
-  isExpanded: boolean;
-  entry: SelectionEntry | undefined;
-  capBlocked: boolean;
-  onToggleExpand: () => void;
-  onSelectAll: () => void;
-  onClear: () => void;
-  onToggleVariant: (variantId: string, loadedVariantIds: string[]) => void;
-  onVariantsLoaded: (variants: ProductVariant[]) => void;
-}
-
-function PickerProductRow({
-  product,
-  isExpanded,
-  entry,
-  capBlocked,
-  onToggleExpand,
-  onSelectAll,
-  onClear,
-  onToggleVariant,
-  onVariantsLoaded,
-}: PickerProductRowProps): ReactElement {
-  const detailQuery = useProductQuery(isExpanded ? product.id : '');
-  const loadedVariants = useMemo(
-    () => detailQuery.data?.variants ?? [],
-    [detailQuery.data],
-  );
-  const loadedVariantIds = useMemo(() => loadedVariants.map((v) => v.id), [loadedVariants]);
-
-  // Report loaded variants up for the item-count total + rail review.
-  useEffect(() => {
-    if (isExpanded && detailQuery.data) {
-      onVariantsLoaded(loadedVariants);
-    }
-  }, [isExpanded, detailQuery.data, loadedVariants, onVariantsLoaded]);
-
-  const selectedVariantIds = entry instanceof Set ? entry : null;
-  const allLoadedSelected =
-    loadedVariantIds.length > 0 &&
-    selectedVariantIds !== null &&
-    loadedVariantIds.every((id) => selectedVariantIds.has(id));
-
-  const checkboxState: 'all' | 'some' | 'none' =
-    entry === 'ALL' || allLoadedSelected
-      ? 'all'
-      : selectedVariantIds !== null && selectedVariantIds.size > 0
-        ? 'some'
-        : 'none';
-
-  const handleToggleProduct = (): void => {
-    if (checkboxState === 'all') onClear();
-    else onSelectAll();
-  };
-
-  const variantCount = product.variantCount;
-  const isSimple = typeof variantCount === 'number' && variantCount <= 1;
-  const rowClasses = [
-    'offer-product-picker__prow',
-    isExpanded ? 'offer-product-picker__prow--open' : '',
-    isSimple ? 'offer-product-picker__prow--simple' : '',
-  ]
-    .filter(Boolean)
-    .join(' ');
-
-  return (
-    <li className={rowClasses}>
-      <div className="offer-product-picker__prow-main">
-        {/* Full 44px hit area for whole-product selection so it matches the
-            variant rows' tap target on mobile (a bare checkbox is ~16px). The
-            wrapping label toggles the nested checkbox natively. */}
-        <label className="offer-product-picker__prow-check">
-          <CheckboxCell
-            state={checkboxState}
-            onToggle={handleToggleProduct}
-            disabled={capBlocked}
-            ariaLabel={`Select ${product.name}`}
-            tooltip={
-              capBlocked
-                ? `Maximum ${OFFER_PICKER_PRODUCT_CAP} products per batch reached`
-                : undefined
-            }
-          />
-        </label>
-        <button
-          type="button"
-          className="offer-product-picker__prow-toggle"
-          onClick={onToggleExpand}
-          aria-expanded={isExpanded}
-          aria-label={`${isExpanded ? 'Collapse' : 'Expand'} ${product.name}`}
-        >
-          <ProductThumbnail name={product.name} src={firstImage(product.images)} size="md" />
-          <span className="offer-product-picker__pname">
-            <b>{product.name}</b>
-            <small className="mono-text">{product.sku ?? '—'}</small>
-          </span>
-          {typeof variantCount === 'number' ? (
-            <span
-              className={`offer-product-picker__vcount${
-                isSimple ? ' offer-product-picker__vcount--simple' : ''
-              }`}
-            >
-              {variantCount} {variantCount === 1 ? 'variant' : 'variants'}
-            </span>
-          ) : null}
-          <span className="offer-product-picker__chev" aria-hidden="true">
-            ▸
-          </span>
-        </button>
-      </div>
-
-      {isExpanded ? (
-        <ul className="offer-product-picker__vrows">
-          {detailQuery.isLoading ? (
-            <li className="muted-text">Loading variants…</li>
-          ) : detailQuery.error ? (
-            <li>
-              <Alert
-                tone="error"
-                title="Unable to load variants"
-                action={
-                  <Button
-                    tone="secondary"
-                    type="button"
-                    onClick={() => void detailQuery.refetch()}
-                  >
-                    Retry
-                  </Button>
-                }
-              >
-                {detailQuery.error.message}
-              </Alert>
-            </li>
-          ) : loadedVariants.length === 0 ? (
-            <li className="muted-text">No variants on this product.</li>
-          ) : (
-            loadedVariants.map((variant) => {
-              const picked = entry === 'ALL' || (selectedVariantIds?.has(variant.id) ?? false);
-              const hasBarcode = variantHasBarcode(variant);
-              return (
-                <li key={variant.id}>
-                  <label
-                    className={`offer-product-picker__vrow${picked ? ' offer-product-picker__vrow--picked' : ''}`}
-                  >
-                    <input
-                      type="checkbox"
-                      checked={picked}
-                      disabled={capBlocked}
-                      onChange={() => onToggleVariant(variant.id, loadedVariantIds)}
-                    />
-                    <ProductThumbnail
-                      name={variantShortLabel(variant)}
-                      src={null}
-                      size="sm"
-                    />
-                    <span className="offer-product-picker__vname">
-                      <b>{variantLabel(detailQuery.data ?? product, variant)}</b>
-                      <small className={`mono-text${hasBarcode ? '' : ' offer-product-picker__vname-bad'}`}>
-                        SKU {variant.sku ?? '—'} · {hasBarcode ? `EAN ${variant.ean ?? variant.gtin ?? '—'}` : 'no EAN'}
-                      </small>
-                    </span>
-                  </label>
-                </li>
-              );
-            })
-          )}
-        </ul>
-      ) : null}
-    </li>
-  );
-}
-
-/** Derived per-product row for the selection rail. */
-interface RailGroup {
-  productId: string;
-  name: string;
-  imageSrc: string | null;
-  whole: boolean;
-  totalVariants: number;
-  /**
-   * Barcode readiness for a whole-product pick, derived from loaded variant
-   * metadata; `null` for a subset pick (which shows per-variant chips instead).
-   * `loaded: false` means the product's variants have not been fetched yet, so
-   * the chip must read "not checked" rather than a confident "ready".
-   */
-  wholeEan: { loaded: boolean; needCount: number } | null;
-  /** Selected variants for a subset pick; `null` for a whole-product pick. */
-  selected: { id: string; label: string; hasBarcode: boolean }[] | null;
 }
 
 export function OfferProductPickerModal({
@@ -391,16 +179,10 @@ export function OfferProductPickerModal({
 
   // Auto-resolve when exactly one eligible destination exists; otherwise the
   // operator picks one from the grouped rail (or gets a warning when none exist).
-  const resolvedConnectionId =
-    eligibleDestinations.length === 1
-      ? eligibleDestinations[0]!.connection.id
-      : pickedConnectionId || null;
-
-  const resolvedDestination =
-    resolvedConnectionId !== null
-      ? eligibleDestinations.find((d) => d.connection.id === resolvedConnectionId) ?? null
-      : null;
-  const resolvedKind = resolvedDestination?.kind ?? null;
+  const { resolvedConnectionId, resolvedKind } = resolvePublishDestination(
+    eligibleDestinations,
+    pickedConnectionId,
+  );
 
   const productsQuery = useProductsQuery(
     { search: debouncedSearch || undefined },
@@ -516,80 +298,40 @@ export function OfferProductPickerModal({
     setSelection(new Map());
   }, []);
 
+  // Remove a single selected variant from the rail; looks up this product's
+  // loaded variant ids so `toggleVariant` can materialize an 'ALL' entry
+  // before removing, same as toggling from the product row.
+  const removeVariant = useCallback(
+    (productId: string, variantId: string) => {
+      toggleVariant(
+        productId,
+        variantId,
+        (variantMeta.get(productId) ?? []).map((v) => v.id),
+      );
+    },
+    [toggleVariant, variantMeta],
+  );
+
   // Item total across products: an explicit set counts its size; a whole
   // product counts its known variant count (loaded count, else the list
   // query's own variantCount, else 1 for a genuinely-unknown product).
-  const itemCount = useMemo(() => {
-    let sum = 0;
-    for (const [productId, entry] of selection) {
-      if (entry instanceof Set) sum += entry.size;
-      else sum += variantCounts.get(productId) ?? productMeta.get(productId)?.variantCount ?? 1;
-    }
-    return sum;
-  }, [selection, variantCounts, productMeta]);
+  const itemCount = useMemo(
+    () => computeItemCount(selection, variantCounts, productMeta),
+    [selection, variantCounts, productMeta],
+  );
 
   // Per-product rail rows, derived from the selection + accumulated metadata.
-  const railGroups = useMemo<RailGroup[]>(() => {
-    const groups: RailGroup[] = [];
-    for (const [productId, entry] of selection) {
-      const meta = productMeta.get(productId);
-      const variants = variantMeta.get(productId) ?? meta?.variants ?? [];
-      const totalVariants =
-        variantCounts.get(productId) ?? meta?.variantCount ?? (variants.length || 1);
-      if (entry === 'ALL') {
-        const loadedVariants = variantMeta.get(productId);
-        const wholeEan = loadedVariants
-          ? {
-              loaded: true,
-              needCount: loadedVariants.filter((v) => !variantHasBarcode(v)).length,
-            }
-          : { loaded: false, needCount: 0 };
-        groups.push({
-          productId,
-          name: meta?.name ?? productId,
-          imageSrc: firstImage(meta?.images),
-          whole: true,
-          totalVariants,
-          wholeEan,
-          selected: null,
-        });
-        continue;
-      }
-      const selected = [...entry].map((variantId) => {
-        const variant = variants.find((v) => v.id === variantId);
-        return {
-          id: variantId,
-          label: variant ? variantShortLabel(variant) : variantId,
-          hasBarcode: variant ? variantHasBarcode(variant) : true,
-        };
-      });
-      groups.push({
-        productId,
-        name: meta?.name ?? productId,
-        imageSrc: firstImage(meta?.images),
-        whole: false,
-        totalVariants,
-        wholeEan: null,
-        selected,
-      });
-    }
-    return groups;
-  }, [selection, productMeta, variantMeta, variantCounts]);
+  const railGroups = useMemo(
+    () => computeRailGroups(selection, productMeta, variantMeta, variantCounts),
+    [selection, productMeta, variantMeta, variantCounts],
+  );
 
   // Selected variants (across groups) whose barcode is missing, best-effort
   // from loaded metadata. Whole-product picks contribute their known variants.
-  const needEanCount = useMemo(() => {
-    let sum = 0;
-    for (const group of railGroups) {
-      if (group.selected === null) {
-        const variants = variantMeta.get(group.productId) ?? [];
-        sum += variants.filter((v) => !variantHasBarcode(v)).length;
-      } else {
-        sum += group.selected.filter((s) => !s.hasBarcode).length;
-      }
-    }
-    return sum;
-  }, [railGroups, variantMeta]);
+  const needEanCount = useMemo(
+    () => computeNeedEanCount(railGroups, variantMeta),
+    [railGroups, variantMeta],
+  );
 
   const handleContinue = useCallback(() => {
     if (selection.size === 0 || resolvedConnectionId === null) return;
@@ -729,7 +471,7 @@ export function OfferProductPickerModal({
                 ) : (
                   <ul className="offer-product-picker__prows">
                     {products.map((product) => (
-                      <PickerProductRow
+                      <OfferProductPickerRow
                         key={product.id}
                         product={product}
                         isExpanded={expanded.has(product.id)}
@@ -800,218 +542,28 @@ export function OfferProductPickerModal({
               </div>
             </section>
 
-            <aside className="offer-product-picker__rail" aria-label="Selection">
-              <div className="offer-product-picker__rail-head">
-                <button
-                  ref={railBackRef}
-                  type="button"
-                  className="offer-product-picker__rail-back"
-                  aria-label="Back to products"
-                  onClick={() => setStep('products')}
-                >
-                  ‹
-                </button>
-                <div className="offer-product-picker__rail-titlebar">
-                  <span className="offer-product-picker__rail-title">In this batch</span>
-                  <Button
-                    tone="ghost"
-                    type="button"
-                    className="button--sm"
-                    disabled={selection.size === 0}
-                    onClick={clearSelection}
-                  >
-                    Clear all
-                  </Button>
-                </div>
-              </div>
-
-              <div className="offer-product-picker__rail-counts">
-                <div>
-                  <span className="offer-product-picker__rail-n tabular">{itemCount}</span>
-                  <span className="offer-product-picker__rail-lbl">
-                    {resolvedKind === 'shop' ? 'listings' : 'offers'}
-                  </span>
-                </div>
-                <div>
-                  <span className="offer-product-picker__rail-n tabular">{selection.size}</span>
-                  <span className="offer-product-picker__rail-lbl">products</span>
-                </div>
-                <div>
-                  <span className="offer-product-picker__rail-n offer-product-picker__rail-n--warn tabular">
-                    {needEanCount}
-                  </span>
-                  <span className="offer-product-picker__rail-lbl">need EAN</span>
-                </div>
-              </div>
-
-              <div className="offer-product-picker__rail-body">
-                {railGroups.length === 0 ? (
-                  <p className="offer-product-picker__rail-empty">
-                    Nothing selected yet. Tick products or variants on the left.
-                  </p>
-                ) : (
-                  railGroups.map((group) => {
-                    const isPartial =
-                      group.selected !== null && group.selected.length < group.totalVariants;
-                    return (
-                      <div className="offer-product-picker__selgrp" key={group.productId}>
-                        <div className="offer-product-picker__selgrp-head">
-                          <ProductThumbnail
-                            name={group.name}
-                            src={group.imageSrc}
-                            size="sm"
-                          />
-                          <b>{group.name}</b>
-                          {group.whole ? (
-                            group.wholeEan && !group.wholeEan.loaded ? (
-                              <span className="bulk-chip bulk-chip--neutral">
-                                <span className="bulk-chip__dot" />
-                                not checked
-                              </span>
-                            ) : group.wholeEan && group.wholeEan.needCount > 0 ? (
-                              <span className="bulk-chip bulk-chip--warning">
-                                <span className="bulk-chip__dot" />
-                                {group.wholeEan.needCount} need EAN
-                              </span>
-                            ) : (
-                              <span className="bulk-chip bulk-chip--success">
-                                <span className="bulk-chip__dot" />
-                                ready
-                              </span>
-                            )
-                          ) : isPartial ? (
-                            <span className="bulk-chip bulk-chip--warning">
-                              <span className="bulk-chip__dot" />
-                              {group.selected!.length} of {group.totalVariants}
-                            </span>
-                          ) : (
-                            <span className="bulk-chip bulk-chip--success">
-                              <span className="bulk-chip__dot" />
-                              ready
-                            </span>
-                          )}
-                          <button
-                            type="button"
-                            className="offer-product-picker__rm"
-                            aria-label={`Remove ${group.name}`}
-                            onClick={() => clearProduct(group.productId)}
-                          >
-                            ×
-                          </button>
-                        </div>
-                        {group.whole ? (
-                          <div className="offer-product-picker__seltag offer-product-picker__seltag--muted">
-                            <span className="offer-product-picker__seltag-dot" />
-                            Whole product · {group.totalVariants}{' '}
-                            {group.totalVariants === 1 ? 'variant' : 'variants'}
-                          </div>
-                        ) : (
-                          group.selected!.map((variant) => (
-                            <div className="offer-product-picker__seltag" key={variant.id}>
-                              <span className="offer-product-picker__seltag-dot" />
-                              {variant.label}
-                              {variant.hasBarcode ? null : (
-                                <span className="bulk-chip bulk-chip--warning">
-                                  <span className="bulk-chip__dot" />
-                                  no EAN
-                                </span>
-                              )}
-                              <button
-                                type="button"
-                                className="offer-product-picker__rm offer-product-picker__rm--tag"
-                                aria-label={`Remove ${variant.label}`}
-                                onClick={() =>
-                                  toggleVariant(
-                                    group.productId,
-                                    variant.id,
-                                    (variantMeta.get(group.productId) ?? []).map((v) => v.id),
-                                  )
-                                }
-                              >
-                                ×
-                              </button>
-                            </div>
-                          ))
-                        )}
-                      </div>
-                    );
-                  })
-                )}
-              </div>
-
-              <div className="offer-product-picker__rail-foot">
-                {connectionsQuery.isLoading ? (
-                  <p className="muted-text">Loading destinations…</p>
-                ) : connectionsQuery.error ? (
-                  <Alert
-                    tone="error"
-                    title="Unable to load connections"
-                    action={
-                      <Button
-                        tone="secondary"
-                        type="button"
-                        onClick={() => void connectionsQuery.refetch()}
-                      >
-                        Retry
-                      </Button>
-                    }
-                  >
-                    {connectionsQuery.error.message}
-                  </Alert>
-                ) : eligibleDestinations.length === 0 ? (
-                  <Alert tone="warning" title="No publish destinations available">
-                    Add an active marketplace (offer creation) or online shop (product publishing)
-                    connection before publishing.
-                  </Alert>
-                ) : (
-                  <div className="offer-product-picker__rail-conn">
-                    <span className="offer-product-picker__eyebrow" id="publishDestinationLabel">
-                      Publish to <span className="offer-product-picker__req">*</span>
-                    </span>
-                    <PublishDestinationRail
-                      destinations={eligibleDestinations}
-                      selectedConnectionId={resolvedConnectionId}
-                      onSelect={setPickedConnectionId}
-                      labelledBy="publishDestinationLabel"
-                    />
-                  </div>
-                )}
-
-                <p className="offer-product-picker__rail-summary" aria-live="polite">
-                  {selectionSummary}
-                </p>
-
-                <div className="offer-product-picker__rail-actions">
-                  <Button tone="ghost" type="button" onClick={requestClose}>
-                    Cancel
-                  </Button>
-                  {canContinue ? (
-                    <Button type="button" onClick={handleContinue}>
-                      Continue →
-                    </Button>
-                  ) : (
-                    // Disabled buttons swallow hover, so the span is the tooltip
-                    // trigger and the button inside opts out of pointer events.
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <span className="offer-product-picker__continue-wrap" tabIndex={0}>
-                          <Button type="button" disabled>
-                            Continue →
-                          </Button>
-                        </span>
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        {selection.size === 0
-                          ? 'Select at least one product, then choose a destination.'
-                          : eligibleDestinations.length === 0
-                            ? 'Add an active marketplace or shop connection before publishing.'
-                            : 'Choose a destination to publish to first.'}
-                      </TooltipContent>
-                    </Tooltip>
-                  )}
-                </div>
-              </div>
-            </aside>
+            <OfferProductPickerRail
+              railBackRef={railBackRef}
+              onBack={() => setStep('products')}
+              railGroups={railGroups}
+              itemCount={itemCount}
+              needEanCount={needEanCount}
+              selectionSize={selection.size}
+              onClearSelection={clearSelection}
+              onRemoveProduct={clearProduct}
+              onRemoveVariant={removeVariant}
+              connectionsLoading={connectionsQuery.isLoading}
+              connectionsError={connectionsQuery.error}
+              onRetryConnections={() => void connectionsQuery.refetch()}
+              eligibleDestinations={eligibleDestinations}
+              resolvedConnectionId={resolvedConnectionId}
+              resolvedKind={resolvedKind}
+              onSelectConnection={setPickedConnectionId}
+              canContinue={canContinue}
+              onContinue={handleContinue}
+              onCancel={requestClose}
+              selectionSummary={selectionSummary}
+            />
           </div>
         </DialogContent>
       </Dialog>

--- a/apps/web/src/features/listings/components/offer-product-picker-rail.tsx
+++ b/apps/web/src/features/listings/components/offer-product-picker-rail.tsx
@@ -1,0 +1,267 @@
+/**
+ * OfferProductPickerRail
+ *
+ * The right-hand (desktop) / step-2 (mobile) review rail of
+ * `OfferProductPickerModal` (#1819 extraction, unchanged behaviour): "In this
+ * batch" counts, per-product selection groups with status chips + remove
+ * actions, the destination picker (`PublishDestinationRail`), and the
+ * Cancel / Continue actions.
+ *
+ * @module apps/web/src/features/listings/components
+ */
+import type { ReactElement, RefObject } from 'react';
+
+import { Alert } from '../../../shared/ui/alert';
+import { Button } from '../../../shared/ui/button';
+import { ProductThumbnail } from '../../../shared/ui/product-thumbnail';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../../../shared/ui/tooltip';
+import type { PublishDestination, PublishDestinationKind } from '../lib/publish-destinations';
+import { PublishDestinationRail } from './publish-destination-rail';
+import type { RailGroup } from './offer-product-picker.types';
+
+interface OfferProductPickerRailProps {
+  railBackRef: RefObject<HTMLButtonElement | null>;
+  onBack: () => void;
+  railGroups: RailGroup[];
+  itemCount: number;
+  needEanCount: number;
+  selectionSize: number;
+  onClearSelection: () => void;
+  onRemoveProduct: (productId: string) => void;
+  onRemoveVariant: (productId: string, variantId: string) => void;
+  connectionsLoading: boolean;
+  connectionsError: Error | null;
+  onRetryConnections: () => void;
+  eligibleDestinations: PublishDestination[];
+  resolvedConnectionId: string | null;
+  resolvedKind: PublishDestinationKind | null;
+  onSelectConnection: (connectionId: string) => void;
+  canContinue: boolean;
+  onContinue: () => void;
+  onCancel: () => void;
+  selectionSummary: string;
+}
+
+export function OfferProductPickerRail({
+  railBackRef,
+  onBack,
+  railGroups,
+  itemCount,
+  needEanCount,
+  selectionSize,
+  onClearSelection,
+  onRemoveProduct,
+  onRemoveVariant,
+  connectionsLoading,
+  connectionsError,
+  onRetryConnections,
+  eligibleDestinations,
+  resolvedConnectionId,
+  resolvedKind,
+  onSelectConnection,
+  canContinue,
+  onContinue,
+  onCancel,
+  selectionSummary,
+}: OfferProductPickerRailProps): ReactElement {
+  return (
+    <aside className="offer-product-picker__rail" aria-label="Selection">
+      <div className="offer-product-picker__rail-head">
+        <button
+          ref={railBackRef}
+          type="button"
+          className="offer-product-picker__rail-back"
+          aria-label="Back to products"
+          onClick={onBack}
+        >
+          ‹
+        </button>
+        <div className="offer-product-picker__rail-titlebar">
+          <span className="offer-product-picker__rail-title">In this batch</span>
+          <Button
+            tone="ghost"
+            type="button"
+            className="button--sm"
+            disabled={selectionSize === 0}
+            onClick={onClearSelection}
+          >
+            Clear all
+          </Button>
+        </div>
+      </div>
+
+      <div className="offer-product-picker__rail-counts">
+        <div>
+          <span className="offer-product-picker__rail-n tabular">{itemCount}</span>
+          <span className="offer-product-picker__rail-lbl">
+            {resolvedKind === 'shop' ? 'listings' : 'offers'}
+          </span>
+        </div>
+        <div>
+          <span className="offer-product-picker__rail-n tabular">{selectionSize}</span>
+          <span className="offer-product-picker__rail-lbl">products</span>
+        </div>
+        <div>
+          <span className="offer-product-picker__rail-n offer-product-picker__rail-n--warn tabular">
+            {needEanCount}
+          </span>
+          <span className="offer-product-picker__rail-lbl">need EAN</span>
+        </div>
+      </div>
+
+      <div className="offer-product-picker__rail-body">
+        {railGroups.length === 0 ? (
+          <p className="offer-product-picker__rail-empty">
+            Nothing selected yet. Tick products or variants on the left.
+          </p>
+        ) : (
+          railGroups.map((group) => {
+            const isPartial =
+              group.selected !== null && group.selected.length < group.totalVariants;
+            return (
+              <div className="offer-product-picker__selgrp" key={group.productId}>
+                <div className="offer-product-picker__selgrp-head">
+                  <ProductThumbnail name={group.name} src={group.imageSrc} size="sm" />
+                  <b>{group.name}</b>
+                  {group.whole ? (
+                    group.wholeEan && !group.wholeEan.loaded ? (
+                      <span className="bulk-chip bulk-chip--neutral">
+                        <span className="bulk-chip__dot" />
+                        not checked
+                      </span>
+                    ) : group.wholeEan && group.wholeEan.needCount > 0 ? (
+                      <span className="bulk-chip bulk-chip--warning">
+                        <span className="bulk-chip__dot" />
+                        {group.wholeEan.needCount} need EAN
+                      </span>
+                    ) : (
+                      <span className="bulk-chip bulk-chip--success">
+                        <span className="bulk-chip__dot" />
+                        ready
+                      </span>
+                    )
+                  ) : isPartial ? (
+                    <span className="bulk-chip bulk-chip--warning">
+                      <span className="bulk-chip__dot" />
+                      {group.selected!.length} of {group.totalVariants}
+                    </span>
+                  ) : (
+                    <span className="bulk-chip bulk-chip--success">
+                      <span className="bulk-chip__dot" />
+                      ready
+                    </span>
+                  )}
+                  <button
+                    type="button"
+                    className="offer-product-picker__rm"
+                    aria-label={`Remove ${group.name}`}
+                    onClick={() => onRemoveProduct(group.productId)}
+                  >
+                    ×
+                  </button>
+                </div>
+                {group.whole ? (
+                  <div className="offer-product-picker__seltag offer-product-picker__seltag--muted">
+                    <span className="offer-product-picker__seltag-dot" />
+                    Whole product · {group.totalVariants}{' '}
+                    {group.totalVariants === 1 ? 'variant' : 'variants'}
+                  </div>
+                ) : (
+                  group.selected!.map((variant) => (
+                    <div className="offer-product-picker__seltag" key={variant.id}>
+                      <span className="offer-product-picker__seltag-dot" />
+                      {variant.label}
+                      {variant.hasBarcode ? null : (
+                        <span className="bulk-chip bulk-chip--warning">
+                          <span className="bulk-chip__dot" />
+                          no EAN
+                        </span>
+                      )}
+                      <button
+                        type="button"
+                        className="offer-product-picker__rm offer-product-picker__rm--tag"
+                        aria-label={`Remove ${variant.label}`}
+                        onClick={() => onRemoveVariant(group.productId, variant.id)}
+                      >
+                        ×
+                      </button>
+                    </div>
+                  ))
+                )}
+              </div>
+            );
+          })
+        )}
+      </div>
+
+      <div className="offer-product-picker__rail-foot">
+        {connectionsLoading ? (
+          <p className="muted-text">Loading destinations…</p>
+        ) : connectionsError ? (
+          <Alert
+            tone="error"
+            title="Unable to load connections"
+            action={
+              <Button tone="secondary" type="button" onClick={onRetryConnections}>
+                Retry
+              </Button>
+            }
+          >
+            {connectionsError.message}
+          </Alert>
+        ) : eligibleDestinations.length === 0 ? (
+          <Alert tone="warning" title="No publish destinations available">
+            Add an active marketplace (offer creation) or online shop (product publishing)
+            connection before publishing.
+          </Alert>
+        ) : (
+          <div className="offer-product-picker__rail-conn">
+            <span className="offer-product-picker__eyebrow" id="publishDestinationLabel">
+              Publish to <span className="offer-product-picker__req">*</span>
+            </span>
+            <PublishDestinationRail
+              destinations={eligibleDestinations}
+              selectedConnectionId={resolvedConnectionId}
+              onSelect={onSelectConnection}
+              labelledBy="publishDestinationLabel"
+            />
+          </div>
+        )}
+
+        <p className="offer-product-picker__rail-summary" aria-live="polite">
+          {selectionSummary}
+        </p>
+
+        <div className="offer-product-picker__rail-actions">
+          <Button tone="ghost" type="button" onClick={onCancel}>
+            Cancel
+          </Button>
+          {canContinue ? (
+            <Button type="button" onClick={onContinue}>
+              Continue →
+            </Button>
+          ) : (
+            // Disabled buttons swallow hover, so the span is the tooltip
+            // trigger and the button inside opts out of pointer events.
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="offer-product-picker__continue-wrap" tabIndex={0}>
+                  <Button type="button" disabled>
+                    Continue →
+                  </Button>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>
+                {selectionSize === 0
+                  ? 'Select at least one product, then choose a destination.'
+                  : eligibleDestinations.length === 0
+                    ? 'Add an active marketplace or shop connection before publishing.'
+                    : 'Choose a destination to publish to first.'}
+              </TooltipContent>
+            </Tooltip>
+          )}
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/apps/web/src/features/listings/components/offer-product-picker-row.tsx
+++ b/apps/web/src/features/listings/components/offer-product-picker-row.tsx
@@ -1,0 +1,198 @@
+/**
+ * OfferProductPickerRow
+ *
+ * One product row of `OfferProductPickerModal` (#1819 extraction, unchanged
+ * behaviour). Lazily loads its variants when expanded (passing an empty id
+ * keeps `useProductQuery` disabled until then). Computes its own tri-state
+ * and reports its loaded variants up so the parent can total items across
+ * products and render the selection rail even after paging away.
+ *
+ * @module apps/web/src/features/listings/components
+ */
+import { useEffect, useMemo, type ReactElement } from 'react';
+
+import { Alert } from '../../../shared/ui/alert';
+import { Button } from '../../../shared/ui/button';
+import { CheckboxCell } from '../../../shared/ui/checkbox-cell';
+import { ProductThumbnail } from '../../../shared/ui/product-thumbnail';
+import { useProductQuery } from '../../products';
+import type { Product, ProductVariant } from '../../products';
+import {
+  firstImage,
+  variantHasBarcode,
+  variantLabel,
+  variantShortLabel,
+} from '../lib/offer-product-picker-selectors';
+import { OFFER_PICKER_PRODUCT_CAP, type SelectionEntry } from './offer-product-picker.types';
+
+interface OfferProductPickerRowProps {
+  product: Product;
+  isExpanded: boolean;
+  entry: SelectionEntry | undefined;
+  capBlocked: boolean;
+  onToggleExpand: () => void;
+  onSelectAll: () => void;
+  onClear: () => void;
+  onToggleVariant: (variantId: string, loadedVariantIds: string[]) => void;
+  onVariantsLoaded: (variants: ProductVariant[]) => void;
+}
+
+export function OfferProductPickerRow({
+  product,
+  isExpanded,
+  entry,
+  capBlocked,
+  onToggleExpand,
+  onSelectAll,
+  onClear,
+  onToggleVariant,
+  onVariantsLoaded,
+}: OfferProductPickerRowProps): ReactElement {
+  const detailQuery = useProductQuery(isExpanded ? product.id : '');
+  const loadedVariants = useMemo(
+    () => detailQuery.data?.variants ?? [],
+    [detailQuery.data],
+  );
+  const loadedVariantIds = useMemo(() => loadedVariants.map((v) => v.id), [loadedVariants]);
+
+  // Report loaded variants up for the item-count total + rail review.
+  useEffect(() => {
+    if (isExpanded && detailQuery.data) {
+      onVariantsLoaded(loadedVariants);
+    }
+  }, [isExpanded, detailQuery.data, loadedVariants, onVariantsLoaded]);
+
+  const selectedVariantIds = entry instanceof Set ? entry : null;
+  const allLoadedSelected =
+    loadedVariantIds.length > 0 &&
+    selectedVariantIds !== null &&
+    loadedVariantIds.every((id) => selectedVariantIds.has(id));
+
+  const checkboxState: 'all' | 'some' | 'none' =
+    entry === 'ALL' || allLoadedSelected
+      ? 'all'
+      : selectedVariantIds !== null && selectedVariantIds.size > 0
+        ? 'some'
+        : 'none';
+
+  const handleToggleProduct = (): void => {
+    if (checkboxState === 'all') onClear();
+    else onSelectAll();
+  };
+
+  const variantCount = product.variantCount;
+  const isSimple = typeof variantCount === 'number' && variantCount <= 1;
+  const rowClasses = [
+    'offer-product-picker__prow',
+    isExpanded ? 'offer-product-picker__prow--open' : '',
+    isSimple ? 'offer-product-picker__prow--simple' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
+  return (
+    <li className={rowClasses}>
+      <div className="offer-product-picker__prow-main">
+        {/* Full 44px hit area for whole-product selection so it matches the
+            variant rows' tap target on mobile (a bare checkbox is ~16px). The
+            wrapping label toggles the nested checkbox natively. */}
+        <label className="offer-product-picker__prow-check">
+          <CheckboxCell
+            state={checkboxState}
+            onToggle={handleToggleProduct}
+            disabled={capBlocked}
+            ariaLabel={`Select ${product.name}`}
+            tooltip={
+              capBlocked
+                ? `Maximum ${OFFER_PICKER_PRODUCT_CAP} products per batch reached`
+                : undefined
+            }
+          />
+        </label>
+        <button
+          type="button"
+          className="offer-product-picker__prow-toggle"
+          onClick={onToggleExpand}
+          aria-expanded={isExpanded}
+          aria-label={`${isExpanded ? 'Collapse' : 'Expand'} ${product.name}`}
+        >
+          <ProductThumbnail name={product.name} src={firstImage(product.images)} size="md" />
+          <span className="offer-product-picker__pname">
+            <b>{product.name}</b>
+            <small className="mono-text">{product.sku ?? '—'}</small>
+          </span>
+          {typeof variantCount === 'number' ? (
+            <span
+              className={`offer-product-picker__vcount${
+                isSimple ? ' offer-product-picker__vcount--simple' : ''
+              }`}
+            >
+              {variantCount} {variantCount === 1 ? 'variant' : 'variants'}
+            </span>
+          ) : null}
+          <span className="offer-product-picker__chev" aria-hidden="true">
+            ▸
+          </span>
+        </button>
+      </div>
+
+      {isExpanded ? (
+        <ul className="offer-product-picker__vrows">
+          {detailQuery.isLoading ? (
+            <li className="muted-text">Loading variants…</li>
+          ) : detailQuery.error ? (
+            <li>
+              <Alert
+                tone="error"
+                title="Unable to load variants"
+                action={
+                  <Button
+                    tone="secondary"
+                    type="button"
+                    onClick={() => void detailQuery.refetch()}
+                  >
+                    Retry
+                  </Button>
+                }
+              >
+                {detailQuery.error.message}
+              </Alert>
+            </li>
+          ) : loadedVariants.length === 0 ? (
+            <li className="muted-text">No variants on this product.</li>
+          ) : (
+            loadedVariants.map((variant) => {
+              const picked = entry === 'ALL' || (selectedVariantIds?.has(variant.id) ?? false);
+              const hasBarcode = variantHasBarcode(variant);
+              return (
+                <li key={variant.id}>
+                  <label
+                    className={`offer-product-picker__vrow${picked ? ' offer-product-picker__vrow--picked' : ''}`}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={picked}
+                      disabled={capBlocked}
+                      onChange={() => onToggleVariant(variant.id, loadedVariantIds)}
+                    />
+                    <ProductThumbnail
+                      name={variantShortLabel(variant)}
+                      src={null}
+                      size="sm"
+                    />
+                    <span className="offer-product-picker__vname">
+                      <b>{variantLabel(detailQuery.data ?? product, variant)}</b>
+                      <small className={`mono-text${hasBarcode ? '' : ' offer-product-picker__vname-bad'}`}>
+                        SKU {variant.sku ?? '—'} · {hasBarcode ? `EAN ${variant.ean ?? variant.gtin ?? '—'}` : 'no EAN'}
+                      </small>
+                    </span>
+                  </label>
+                </li>
+              );
+            })
+          )}
+        </ul>
+      ) : null}
+    </li>
+  );
+}

--- a/apps/web/src/features/listings/components/offer-product-picker.types.ts
+++ b/apps/web/src/features/listings/components/offer-product-picker.types.ts
@@ -1,0 +1,38 @@
+/**
+ * OfferProductPickerModal shared types
+ *
+ * Types shared across the picker modal, its row and rail sub-components, and
+ * the pure selector helpers in `../lib/offer-product-picker-selectors.ts`
+ * (#1819 extraction). Component-local prop interfaces stay inline in their
+ * own component file; only cross-file shapes live here.
+ *
+ * @module apps/web/src/features/listings/components
+ */
+
+/** Max distinct products per batch (mirrors the `/products` BULK_SELECTION_CAP,
+ *  kept local per R1 to avoid a `features -> pages` import). */
+export const OFFER_PICKER_PRODUCT_CAP = 100;
+
+/** Per-product selection: whole product, or an explicit variant subset. */
+export type SelectionEntry = 'ALL' | Set<string>;
+
+/** Two-step wizard step (meaningful only <=1023px; desktop shows both regions). */
+export type PickerStep = 'products' | 'review';
+
+/** Derived per-product row for the selection rail. */
+export interface RailGroup {
+  productId: string;
+  name: string;
+  imageSrc: string | null;
+  whole: boolean;
+  totalVariants: number;
+  /**
+   * Barcode readiness for a whole-product pick, derived from loaded variant
+   * metadata; `null` for a subset pick (which shows per-variant chips instead).
+   * `loaded: false` means the product's variants have not been fetched yet, so
+   * the chip must read "not checked" rather than a confident "ready".
+   */
+  wholeEan: { loaded: boolean; needCount: number } | null;
+  /** Selected variants for a subset pick; `null` for a whole-product pick. */
+  selected: { id: string; label: string; hasBarcode: boolean }[] | null;
+}

--- a/apps/web/src/features/listings/lib/offer-product-picker-selectors.test.ts
+++ b/apps/web/src/features/listings/lib/offer-product-picker-selectors.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it } from 'vitest';
+import {
+  computeItemCount,
+  computeNeedEanCount,
+  computeRailGroups,
+  firstImage,
+  variantHasBarcode,
+  variantLabel,
+  variantShortLabel,
+} from './offer-product-picker-selectors';
+import type { RailGroup, SelectionEntry } from '../components/offer-product-picker.types';
+import type { Product, ProductVariant } from '../../products';
+
+function makeVariant(id: string, overrides: Partial<ProductVariant> = {}): ProductVariant {
+  return {
+    id,
+    productId: 'p1',
+    sku: null,
+    attributes: null,
+    ean: null,
+    gtin: null,
+    price: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeProduct(id: string, overrides: Partial<Product> = {}): Product {
+  return {
+    id,
+    name: `Product ${id}`,
+    sku: null,
+    price: null,
+    currency: null,
+    description: null,
+    images: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('variantLabel', () => {
+  const product = makeProduct('p1');
+
+  it('joins attributes when present', () => {
+    const variant = makeVariant('v1', { attributes: { Color: 'Red', Size: 'M' } });
+    expect(variantLabel(product, variant)).toBe('Product p1 - Red · M');
+  });
+
+  it('falls back to SKU when there are no attributes', () => {
+    const variant = makeVariant('v1', { sku: 'SKU-1' });
+    expect(variantLabel(product, variant)).toBe('Product p1 - SKU-1');
+  });
+
+  it('falls back to the product name alone when neither attributes nor SKU are present', () => {
+    const variant = makeVariant('v1');
+    expect(variantLabel(product, variant)).toBe('Product p1');
+  });
+});
+
+describe('variantShortLabel', () => {
+  it('joins attributes when present', () => {
+    const variant = makeVariant('v1', { attributes: { Color: 'Red', Size: 'M' } });
+    expect(variantShortLabel(variant)).toBe('Red · M');
+  });
+
+  it('falls back to SKU when there are no attributes', () => {
+    const variant = makeVariant('v1', { sku: 'SKU-1' });
+    expect(variantShortLabel(variant)).toBe('SKU-1');
+  });
+
+  it('falls back to the variant id when neither attributes nor SKU are present', () => {
+    const variant = makeVariant('v1');
+    expect(variantShortLabel(variant)).toBe('v1');
+  });
+});
+
+describe('variantHasBarcode', () => {
+  it('is true when EAN is present', () => {
+    expect(variantHasBarcode(makeVariant('v1', { ean: '5901234123457' }))).toBe(true);
+  });
+
+  it('falls back to GTIN when EAN is absent', () => {
+    expect(variantHasBarcode(makeVariant('v1', { ean: null, gtin: '00012345600012' }))).toBe(true);
+  });
+
+  it('is false when neither EAN nor GTIN is present', () => {
+    expect(variantHasBarcode(makeVariant('v1', { ean: null, gtin: null }))).toBe(false);
+  });
+
+  it('is false when EAN is present but blank/whitespace-only', () => {
+    expect(variantHasBarcode(makeVariant('v1', { ean: '   ', gtin: null }))).toBe(false);
+  });
+});
+
+describe('firstImage', () => {
+  it('returns the first image when present', () => {
+    expect(firstImage(['a.jpg', 'b.jpg'])).toBe('a.jpg');
+  });
+
+  it('returns null for an empty array', () => {
+    expect(firstImage([])).toBeNull();
+  });
+
+  it('returns null for null/undefined', () => {
+    expect(firstImage(null)).toBeNull();
+    expect(firstImage(undefined)).toBeNull();
+  });
+});
+
+describe('computeItemCount', () => {
+  it('sums explicit Set sizes directly', () => {
+    const selection = new Map<string, SelectionEntry>([
+      ['p1', new Set(['v1a', 'v1b'])],
+      ['p2', new Set(['v2a'])],
+    ]);
+    expect(computeItemCount(selection, new Map(), new Map())).toBe(3);
+  });
+
+  it('uses the loaded variantCounts entry for a whole-product pick', () => {
+    const selection = new Map<string, SelectionEntry>([['p1', 'ALL']]);
+    const variantCounts = new Map([['p1', 4]]);
+    expect(computeItemCount(selection, variantCounts, new Map())).toBe(4);
+  });
+
+  it('falls back to the product list variantCount when variantCounts is not loaded', () => {
+    const selection = new Map<string, SelectionEntry>([['p1', 'ALL']]);
+    const productMeta = new Map([['p1', makeProduct('p1', { variantCount: 3 })]]);
+    expect(computeItemCount(selection, new Map(), productMeta)).toBe(3);
+  });
+
+  it('falls back to 1 when neither variantCounts nor productMeta know the product', () => {
+    const selection = new Map<string, SelectionEntry>([['p1', 'ALL']]);
+    expect(computeItemCount(selection, new Map(), new Map())).toBe(1);
+  });
+
+  it('mixes explicit sets and whole-product picks across products', () => {
+    const selection = new Map<string, SelectionEntry>([
+      ['p1', new Set(['v1a'])],
+      ['p2', 'ALL'],
+    ]);
+    const variantCounts = new Map([['p2', 5]]);
+    expect(computeItemCount(selection, variantCounts, new Map())).toBe(6);
+  });
+});
+
+describe('computeRailGroups', () => {
+  it('reports wholeEan as not-loaded with needCount 0 when variant metadata has not arrived yet', () => {
+    const selection = new Map<string, SelectionEntry>([['p1', 'ALL']]);
+    const productMeta = new Map([['p1', makeProduct('p1')]]);
+    const groups = computeRailGroups(selection, productMeta, new Map(), new Map());
+    expect(groups).toHaveLength(1);
+    expect(groups[0].whole).toBe(true);
+    expect(groups[0].wholeEan).toEqual({ loaded: false, needCount: 0 });
+    expect(groups[0].selected).toBeNull();
+  });
+
+  it('counts variants missing a barcode once variant metadata is loaded', () => {
+    const selection = new Map<string, SelectionEntry>([['p1', 'ALL']]);
+    const productMeta = new Map([['p1', makeProduct('p1')]]);
+    const variantMeta = new Map([
+      [
+        'p1',
+        [
+          makeVariant('v1a', { ean: '111' }),
+          makeVariant('v1b', { ean: null, gtin: null }),
+          makeVariant('v1c', { ean: null, gtin: null }),
+        ],
+      ],
+    ]);
+    const groups = computeRailGroups(selection, productMeta, variantMeta, new Map());
+    expect(groups[0].wholeEan).toEqual({ loaded: true, needCount: 2 });
+  });
+
+  it('reports per-variant hasBarcode for a variant-subset pick', () => {
+    const selection = new Map<string, SelectionEntry>([['p1', new Set(['v1a', 'v1b'])]]);
+    const productMeta = new Map([['p1', makeProduct('p1')]]);
+    const variantMeta = new Map([
+      ['p1', [makeVariant('v1a', { ean: '111' }), makeVariant('v1b', { ean: null, gtin: null })]],
+    ]);
+    const groups = computeRailGroups(selection, productMeta, variantMeta, new Map());
+    expect(groups[0].whole).toBe(false);
+    expect(groups[0].selected).toEqual([
+      { id: 'v1a', label: 'v1a', hasBarcode: true },
+      { id: 'v1b', label: 'v1b', hasBarcode: false },
+    ]);
+  });
+
+  it('defaults hasBarcode to true for a selected variant not found in loaded metadata', () => {
+    const selection = new Map<string, SelectionEntry>([['p1', new Set(['unknown-variant'])]]);
+    const productMeta = new Map([['p1', makeProduct('p1')]]);
+    const variantMeta = new Map([['p1', [makeVariant('v1a', { ean: null, gtin: null })]]]);
+    const groups = computeRailGroups(selection, productMeta, variantMeta, new Map());
+    expect(groups[0].selected).toEqual([
+      { id: 'unknown-variant', label: 'unknown-variant', hasBarcode: true },
+    ]);
+  });
+
+  it('falls back to the raw productId as the display name when productMeta is missing', () => {
+    const selection = new Map<string, SelectionEntry>([['p-unknown', 'ALL']]);
+    const groups = computeRailGroups(selection, new Map(), new Map(), new Map());
+    expect(groups[0].name).toBe('p-unknown');
+    expect(groups[0].imageSrc).toBeNull();
+  });
+});
+
+describe('computeNeedEanCount', () => {
+  it('sums missing-barcode variants across whole-product and subset groups', () => {
+    const railGroups: RailGroup[] = [
+      {
+        productId: 'p1',
+        name: 'Product p1',
+        imageSrc: null,
+        whole: true,
+        totalVariants: 2,
+        wholeEan: { loaded: true, needCount: 1 },
+        selected: null,
+      },
+      {
+        productId: 'p2',
+        name: 'Product p2',
+        imageSrc: null,
+        whole: false,
+        totalVariants: 2,
+        wholeEan: null,
+        selected: [
+          { id: 'v2a', label: 'v2a', hasBarcode: false },
+          { id: 'v2b', label: 'v2b', hasBarcode: true },
+        ],
+      },
+    ];
+    const variantMeta = new Map([
+      ['p1', [makeVariant('v1a', { ean: null, gtin: null }), makeVariant('v1b', { ean: '1' })]],
+    ]);
+    // Whole-product group (p1) recomputes from loaded variantMeta: 1 missing.
+    // Subset group (p2) reads its own `selected.hasBarcode` flags: 1 missing.
+    expect(computeNeedEanCount(railGroups, variantMeta)).toBe(2);
+  });
+
+  it('returns 0 when every variant has a barcode', () => {
+    const railGroups: RailGroup[] = [
+      {
+        productId: 'p1',
+        name: 'Product p1',
+        imageSrc: null,
+        whole: false,
+        totalVariants: 1,
+        wholeEan: null,
+        selected: [{ id: 'v1a', label: 'v1a', hasBarcode: true }],
+      },
+    ];
+    expect(computeNeedEanCount(railGroups, new Map())).toBe(0);
+  });
+});

--- a/apps/web/src/features/listings/lib/offer-product-picker-selectors.ts
+++ b/apps/web/src/features/listings/lib/offer-product-picker-selectors.ts
@@ -1,0 +1,126 @@
+/**
+ * OfferProductPickerModal selectors
+ *
+ * Pure, side-effect-free derivation helpers extracted out of
+ * `OfferProductPickerModal` (#1819) so the component body only wires state to
+ * these functions instead of computing them inline. No React import - safe
+ * to unit-test in isolation.
+ *
+ * @module apps/web/src/features/listings/lib
+ */
+import type { Product, ProductVariant } from '../../products';
+import type { RailGroup, SelectionEntry } from '../components/offer-product-picker.types';
+
+/** Long label for a variant row: product name + attrs / SKU. */
+export function variantLabel(product: Product, variant: ProductVariant): string {
+  const attrs = variant.attributes ? Object.values(variant.attributes).join(' · ') : '';
+  if (attrs) return `${product.name} - ${attrs}`;
+  if (variant.sku) return `${product.name} - ${variant.sku}`;
+  return product.name;
+}
+
+/** Short, product-name-free label for the rail review (attrs, else SKU, else id). */
+export function variantShortLabel(variant: ProductVariant): string {
+  const attrs = variant.attributes ? Object.values(variant.attributes).join(' · ') : '';
+  return attrs || variant.sku || variant.id;
+}
+
+/** Whether a variant carries a barcode (EAN or GTIN). */
+export function variantHasBarcode(variant: ProductVariant): boolean {
+  return (variant.ean ?? variant.gtin ?? '').trim() !== '';
+}
+
+export function firstImage(images: string[] | null | undefined): string | null {
+  return images && images.length > 0 ? images[0] : null;
+}
+
+/**
+ * Item total across products: an explicit set counts its size; a whole
+ * product counts its known variant count (loaded count, else the list
+ * query's own variantCount, else 1 for a genuinely-unknown product).
+ */
+export function computeItemCount(
+  selection: Map<string, SelectionEntry>,
+  variantCounts: Map<string, number>,
+  productMeta: Map<string, Product>,
+): number {
+  let sum = 0;
+  for (const [productId, entry] of selection) {
+    if (entry instanceof Set) sum += entry.size;
+    else sum += variantCounts.get(productId) ?? productMeta.get(productId)?.variantCount ?? 1;
+  }
+  return sum;
+}
+
+/** Per-product rail rows, derived from the selection + accumulated metadata. */
+export function computeRailGroups(
+  selection: Map<string, SelectionEntry>,
+  productMeta: Map<string, Product>,
+  variantMeta: Map<string, ProductVariant[]>,
+  variantCounts: Map<string, number>,
+): RailGroup[] {
+  const groups: RailGroup[] = [];
+  for (const [productId, entry] of selection) {
+    const meta = productMeta.get(productId);
+    const variants = variantMeta.get(productId) ?? meta?.variants ?? [];
+    const totalVariants =
+      variantCounts.get(productId) ?? meta?.variantCount ?? (variants.length || 1);
+    if (entry === 'ALL') {
+      const loadedVariants = variantMeta.get(productId);
+      const wholeEan = loadedVariants
+        ? {
+            loaded: true,
+            needCount: loadedVariants.filter((v) => !variantHasBarcode(v)).length,
+          }
+        : { loaded: false, needCount: 0 };
+      groups.push({
+        productId,
+        name: meta?.name ?? productId,
+        imageSrc: firstImage(meta?.images),
+        whole: true,
+        totalVariants,
+        wholeEan,
+        selected: null,
+      });
+      continue;
+    }
+    const selected = [...entry].map((variantId) => {
+      const variant = variants.find((v) => v.id === variantId);
+      return {
+        id: variantId,
+        label: variant ? variantShortLabel(variant) : variantId,
+        hasBarcode: variant ? variantHasBarcode(variant) : true,
+      };
+    });
+    groups.push({
+      productId,
+      name: meta?.name ?? productId,
+      imageSrc: firstImage(meta?.images),
+      whole: false,
+      totalVariants,
+      wholeEan: null,
+      selected,
+    });
+  }
+  return groups;
+}
+
+/**
+ * Selected variants (across groups) whose barcode is missing, best-effort
+ * from loaded metadata. Whole-product picks contribute their known variants.
+ */
+export function computeNeedEanCount(
+  railGroups: RailGroup[],
+  variantMeta: Map<string, ProductVariant[]>,
+): number {
+  let sum = 0;
+  for (const group of railGroups) {
+    if (group.selected === null) {
+      const variants = variantMeta.get(group.productId) ?? [];
+      sum += variants.filter((v) => !variantHasBarcode(v)).length;
+    } else {
+      sum += group.selected.filter((s) => !s.hasBarcode).length;
+    }
+  }
+  return sum;
+}

--- a/apps/web/src/features/listings/lib/publish-destinations.test.ts
+++ b/apps/web/src/features/listings/lib/publish-destinations.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+import {
+  publishDestinationKind,
+  resolvePublishDestination,
+  selectPublishDestinations,
+} from './publish-destinations';
+import type { PublishDestination } from './publish-destinations';
+import type { Connection } from '../../connections';
+
+function makeConnection(overrides: Partial<Connection> = {}): Connection {
+  return {
+    id: 'c1',
+    name: 'Connection 1',
+    platformType: 'allegro',
+    status: 'active',
+    config: {},
+    credentialsBacked: true,
+    adapterKey: 'allegro.v1',
+    enabledCapabilities: [],
+    supportedCapabilities: [],
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function dest(id: string, name: string, kind: 'marketplace' | 'shop'): PublishDestination {
+  const connection = makeConnection({
+    id,
+    name,
+    supportedCapabilities: kind === 'marketplace' ? ['OfferCreator'] : [],
+    enabledCapabilities: kind === 'shop' ? ['ProductPublisher'] : [],
+  });
+  return { connection, kind };
+}
+
+describe('publishDestinationKind', () => {
+  it('resolves marketplace when the connection advertises OfferCreator', () => {
+    const connection = makeConnection({ supportedCapabilities: ['OfferCreator'] });
+    expect(publishDestinationKind(connection)).toBe('marketplace');
+  });
+
+  it('resolves shop when ProductPublisher is enabled', () => {
+    const connection = makeConnection({ enabledCapabilities: ['ProductPublisher'] });
+    expect(publishDestinationKind(connection)).toBe('shop');
+  });
+
+  it('prefers marketplace when a connection somehow advertises both', () => {
+    const connection = makeConnection({
+      supportedCapabilities: ['OfferCreator'],
+      enabledCapabilities: ['ProductPublisher'],
+    });
+    expect(publishDestinationKind(connection)).toBe('marketplace');
+  });
+
+  it('returns null when neither capability is present', () => {
+    const connection = makeConnection();
+    expect(publishDestinationKind(connection)).toBeNull();
+  });
+});
+
+describe('selectPublishDestinations', () => {
+  it('filters out inactive connections and connections with no publish capability', () => {
+    const active = makeConnection({ id: 'a', supportedCapabilities: ['OfferCreator'] });
+    const disabled = makeConnection({
+      id: 'b',
+      status: 'disabled',
+      supportedCapabilities: ['OfferCreator'],
+    });
+    const ineligible = makeConnection({ id: 'c' });
+    const result = selectPublishDestinations([active, disabled, ineligible]);
+    expect(result.map((d) => d.connection.id)).toEqual(['a']);
+  });
+
+  it('sorts marketplaces before shops, then alphabetically by name within each group', () => {
+    const shopB = makeConnection({
+      id: 's-b',
+      name: 'B Shop',
+      enabledCapabilities: ['ProductPublisher'],
+    });
+    const marketplaceB = makeConnection({
+      id: 'm-b',
+      name: 'B Marketplace',
+      supportedCapabilities: ['OfferCreator'],
+    });
+    const marketplaceA = makeConnection({
+      id: 'm-a',
+      name: 'A Marketplace',
+      supportedCapabilities: ['OfferCreator'],
+    });
+    const result = selectPublishDestinations([shopB, marketplaceB, marketplaceA]);
+    expect(result.map((d) => d.connection.id)).toEqual(['m-a', 'm-b', 's-b']);
+  });
+});
+
+describe('resolvePublishDestination', () => {
+  it('auto-resolves the single eligible destination regardless of pickedConnectionId', () => {
+    const destinations = [dest('m1', 'Allegro', 'marketplace')];
+    expect(resolvePublishDestination(destinations, '')).toEqual({
+      resolvedConnectionId: 'm1',
+      resolvedKind: 'marketplace',
+    });
+    expect(resolvePublishDestination(destinations, 'some-other-id')).toEqual({
+      resolvedConnectionId: 'm1',
+      resolvedKind: 'marketplace',
+    });
+  });
+
+  it('returns null/null when there are multiple destinations and nothing has been picked yet', () => {
+    const destinations = [dest('m1', 'Allegro', 'marketplace'), dest('s1', 'Shop', 'shop')];
+    expect(resolvePublishDestination(destinations, '')).toEqual({
+      resolvedConnectionId: null,
+      resolvedKind: null,
+    });
+  });
+
+  it('resolves the picked destination among multiple eligible ones', () => {
+    const destinations = [dest('m1', 'Allegro', 'marketplace'), dest('s1', 'Shop', 'shop')];
+    expect(resolvePublishDestination(destinations, 's1')).toEqual({
+      resolvedConnectionId: 's1',
+      resolvedKind: 'shop',
+    });
+  });
+
+  it('echoes back a stale pickedConnectionId as resolvedConnectionId while resolvedKind is null (asymmetry, not a bug)', () => {
+    // A previously-picked connection can drop out of the eligible set (e.g.
+    // disabled, or its capability revoked) between renders. The picked id is
+    // NOT nulled out here - only resolvedKind is, since there's no matching
+    // destination to read a kind from. A future "fix" that also nulls
+    // resolvedConnectionId in this branch would be a behavior change, so this
+    // test pins the exact current asymmetry.
+    const destinations = [dest('m1', 'Allegro', 'marketplace'), dest('s1', 'Shop', 'shop')];
+    const result = resolvePublishDestination(destinations, 'stale-id');
+    expect(result.resolvedConnectionId).toBe('stale-id');
+    expect(result.resolvedKind).toBeNull();
+  });
+});

--- a/apps/web/src/features/listings/lib/publish-destinations.ts
+++ b/apps/web/src/features/listings/lib/publish-destinations.ts
@@ -87,3 +87,24 @@ export function selectPublishDestinations(
       return a.connection.name.localeCompare(b.connection.name);
     });
 }
+
+/**
+ * Resolve which destination is the active pick: auto-resolves when exactly
+ * one destination is eligible, otherwise falls back to the operator's own
+ * pick (or `null`/`null` when nothing is eligible or nothing picked yet).
+ */
+export function resolvePublishDestination(
+  destinations: readonly PublishDestination[],
+  pickedConnectionId: string,
+): { resolvedConnectionId: string | null; resolvedKind: PublishDestinationKind | null } {
+  const resolvedConnectionId =
+    destinations.length === 1 ? destinations[0].connection.id : pickedConnectionId || null;
+  const resolvedDestination =
+    resolvedConnectionId !== null
+      ? destinations.find((d) => d.connection.id === resolvedConnectionId) ?? null
+      : null;
+  return {
+    resolvedConnectionId,
+    resolvedKind: resolvedDestination?.kind ?? null,
+  };
+}


### PR DESCRIPTION
## Summary
- Pure internal decomposition of `offer-product-picker-modal.tsx` (grown to ~1036 lines after the unify-publish work) into smaller, focused files, following this codebase's existing split precedent (`components/bulk/`) rather than an unrelated external convention.
- Extracted the per-product/variant row into `offer-product-picker-row.tsx` (`PickerProductRow` renamed to `OfferProductPickerRow` for filename/export convention), the selection review rail into `offer-product-picker-rail.tsx`, cross-file types into `offer-product-picker.types.ts`, and pure derivation logic into `lib/offer-product-picker-selectors.ts` + a new `resolvePublishDestination` helper alongside the existing `lib/publish-destinations.ts`.
- No behaviour change: the modal orchestrator keeps the same public API (`isOpen`, `onClose`, `initialProductIds`, `initialProductMeta`), same rendered DOM/classNames, same state/callbacks. The two existing consumers (`listings-list-page.tsx`, `products-list-page.tsx`) import by the same file path, unchanged.
- Modal shrinks from 1036 → ~588 lines.

## Test plan
- [x] `offer-product-picker-modal.test.tsx` passes unmodified (24/24)
- [x] Full `listings` feature test suite passes (356/356)
- [x] `pnpm --filter web lint` clean on all touched/new files
- [x] `pnpm --filter web type-check` clean
- [x] Manual browser verification against the demo stack (Playwright): open picker from `/listings`, expand a product, select a whole product, rail counts/chips update correctly, discard-guard confirm on close, mobile two-step wizard (`data-mstep` 1→2) with destination pick + Continue navigating to the bulk wizard with correct query params

Closes #1819

🤖 Generated with [Claude Code](https://claude.com/claude-code)