### PR TITLE
fix(prestashop): hydrate the buyer e-mail on ingested orders (#1928)

### DIFF
--- a/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-order-source.adapter.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-order-source.adapter.spec.ts
@@ -465,13 +465,20 @@ describe('PrestashopOrderSourceAdapter', () => {
         inpostConnection
       );
       const orderWithoutAddress: PrestashopOrder = { ...baseOrder, id_address_delivery: undefined };
-      mockHttpClient.getResource = jest.fn().mockResolvedValueOnce(orderWithoutAddress);
+      mockHttpClient.getResource = jest.fn().mockImplementation((resource: string) => {
+        if (resource === 'orders') return Promise.resolve(orderWithoutAddress);
+        return Promise.resolve({});
+      });
       mockHttpClient.listResources = jest.fn().mockResolvedValueOnce(baseOrderRows);
 
       const incoming = await inpostAdapter.getOrder({ externalOrderId: '42' });
 
       expect(incoming.pickupPoint).toBeUndefined();
-      expect(mockHttpClient.getResource).toHaveBeenCalledTimes(1);
+      // No address/country round-trips; the only other read is the buyer
+      // e-mail hydration (#1928), which is keyed on id_customer, not address.
+      expect(mockHttpClient.getResource).toHaveBeenCalledTimes(2);
+      expect(mockHttpClient.getResource).toHaveBeenCalledWith('orders', '42');
+      expect(mockHttpClient.getResource).toHaveBeenCalledWith('customers', '7');
     });
   });
 
@@ -572,15 +579,21 @@ describe('PrestashopOrderSourceAdapter', () => {
       const orderNoAddr: PrestashopOrder = { ...orderWithAddresses };
       delete orderNoAddr.id_address_invoice;
       delete orderNoAddr.id_address_delivery;
-      mockHttpClient.getResource = jest.fn().mockResolvedValueOnce(orderNoAddr);
+      mockHttpClient.getResource = jest.fn().mockImplementation((resource: string) => {
+        if (resource === 'orders') return Promise.resolve(orderNoAddr);
+        return Promise.resolve({});
+      });
       mockHttpClient.listResources = jest.fn().mockResolvedValueOnce([]);
 
       const incoming = await adapter.getOrder({ externalOrderId: '42' });
 
       expect(incoming.billingAddress).toBeUndefined();
       expect(incoming.shippingAddress).toBeUndefined();
-      // Only the order itself is fetched — no address/country round-trips.
-      expect(mockHttpClient.getResource).toHaveBeenCalledTimes(1);
+      // No address/country round-trips — the order plus the buyer e-mail read
+      // (#1928) are the only calls.
+      expect(mockHttpClient.getResource).toHaveBeenCalledTimes(2);
+      expect(mockHttpClient.getResource).toHaveBeenCalledWith('orders', '42');
+      expect(mockHttpClient.getResource).toHaveBeenCalledWith('customers', '7');
     });
 
     it('should fall back to billing address for shipping when delivery hydration fails', async () => {
@@ -600,6 +613,104 @@ describe('PrestashopOrderSourceAdapter', () => {
 
       expect(incoming.shippingAddress).toEqual(incoming.billingAddress);
       expect(incoming.billingAddress?.address1).toBe('Bill St 1');
+    });
+  });
+
+  describe('getOrder — buyer e-mail hydration (#1928)', () => {
+    const baseOrder: PrestashopOrder = {
+      id: '42',
+      reference: 'ORDER-042',
+      id_customer: '7',
+      current_state: '2',
+      total_paid: '99.99',
+      date_add: '2024-01-01 10:00:00',
+      date_upd: '2024-01-01 12:00:00',
+    };
+
+    /**
+     * `customer` as an Error rejects the `customers` read; as a record it
+     * resolves. Keyed by resource so the assertion never depends on call order.
+     */
+    const keyedGetResource = (
+      customer: Record<string, unknown> | Error,
+      order: PrestashopOrder = baseOrder
+    ): void => {
+      mockHttpClient.getResource = jest.fn().mockImplementation((resource: string, id: string) => {
+        if (resource === 'orders') return Promise.resolve(order);
+        if (resource === 'customers') {
+          return customer instanceof Error
+            ? Promise.reject(customer)
+            : Promise.resolve({ id, ...customer });
+        }
+        return Promise.resolve({});
+      });
+      mockHttpClient.listResources = jest.fn().mockResolvedValue([]);
+    };
+
+    it('should populate customerEmail from the customers resource', async () => {
+      keyedGetResource({ email: 'buyer@example.com' });
+
+      const incoming = await adapter.getOrder({ externalOrderId: '42' });
+
+      expect(incoming.customerEmail).toBe('buyer@example.com');
+      expect(mockHttpClient.getResource).toHaveBeenCalledWith('customers', '7');
+    });
+
+    it('should leave customerEmail undefined and still return the order when the customers read fails', async () => {
+      keyedGetResource(new PrestashopApiException('Forbidden', 403));
+
+      const incoming = await adapter.getOrder({ externalOrderId: '42' });
+
+      // Best-effort, mirroring hydrateAddress: a revoked `customers` WS
+      // permission must not fail ingestion of an otherwise-valid order.
+      expect(incoming.customerEmail).toBeUndefined();
+      expect(incoming.externalOrderId).toBe('42');
+      expect(incoming.customerExternalId).toBe('7');
+    });
+
+    it('should leave customerEmail undefined when the customer record carries no email', async () => {
+      keyedGetResource({});
+
+      const incoming = await adapter.getOrder({ externalOrderId: '42' });
+
+      expect(incoming.customerEmail).toBeUndefined();
+    });
+
+    it('should treat a blank email as absent rather than emitting an empty string', async () => {
+      keyedGetResource({ email: '   ' });
+
+      const incoming = await adapter.getOrder({ externalOrderId: '42' });
+
+      expect(incoming.customerEmail).toBeUndefined();
+    });
+
+    it('should trim surrounding whitespace off the email', async () => {
+      keyedGetResource({ email: '  buyer@example.com  ' });
+
+      const incoming = await adapter.getOrder({ externalOrderId: '42' });
+
+      expect(incoming.customerEmail).toBe('buyer@example.com');
+    });
+
+    it('should skip the customers read entirely when the order carries no id_customer', async () => {
+      const orderNoCustomer: PrestashopOrder = { ...baseOrder, id_customer: undefined };
+      keyedGetResource({ email: 'buyer@example.com' }, orderNoCustomer);
+
+      const incoming = await adapter.getOrder({ externalOrderId: '42' });
+
+      expect(incoming.customerEmail).toBeUndefined();
+      expect(incoming.customerExternalId).toBeUndefined();
+      expect(mockHttpClient.getResource).not.toHaveBeenCalledWith('customers', expect.anything());
+    });
+
+    it('should accept a numeric id_customer', async () => {
+      const numericOrder: PrestashopOrder = { ...baseOrder, id_customer: 7 };
+      keyedGetResource({ email: 'buyer@example.com' }, numericOrder);
+
+      const incoming = await adapter.getOrder({ externalOrderId: '42' });
+
+      expect(incoming.customerEmail).toBe('buyer@example.com');
+      expect(mockHttpClient.getResource).toHaveBeenCalledWith('customers', '7');
     });
   });
 });

--- a/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-source.adapter.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-source.adapter.ts
@@ -21,7 +21,10 @@ import type {
   OrderPickupPoint,
 } from '@openlinker/core/orders';
 import type { PrestashopConnectionConfig } from '../../domain/types/prestashop-config.types';
-import type { PrestashopAddress } from '../provisioners/prestashop-provisioner.types';
+import type {
+  PrestashopAddress,
+  PrestashopCustomer,
+} from '../provisioners/prestashop-provisioner.types';
 import type { Connection } from '@openlinker/core/identifier-mapping';
 import { CORE_ENTITY_TYPE } from '@openlinker/core/identifier-mapping';
 import type { IPrestashopWebserviceClient } from '../http/prestashop-webservice.client.interface';
@@ -171,6 +174,13 @@ export class PrestashopOrderSourceAdapter implements OrderSourcePort {
     const orderRows = await this.fetchOrderRows(externalOrderId);
     const mapped = this.orderMapper.mapOrder(prestashopOrder, orderRows);
     const config = this.connection.config as unknown as PrestashopConnectionConfig;
+
+    // Started before the pickup-point / address awaits so the extra customer
+    // read overlaps them rather than lengthening the hydration chain (#1928).
+    // `hydrateCustomerEmail` never rejects, so the pending promise is safe to
+    // hold across the awaits below.
+    const customerEmailPromise = this.hydrateCustomerEmail(prestashopOrder.id_customer);
+
     const pickupPoint = await this.resolvePickupPoint(prestashopOrder, config);
 
     // The order JSON carries only address IDs, so the mapper cannot populate
@@ -231,6 +241,7 @@ export class PrestashopOrderSourceAdapter implements OrderSourcePort {
       status: mapped.status,
       customerExternalId:
         prestashopOrder.id_customer !== undefined ? String(prestashopOrder.id_customer) : undefined,
+      customerEmail: await customerEmailPromise,
       items,
       totals: mapped.totals,
       shippingAddress,
@@ -336,6 +347,39 @@ export class PrestashopOrderSourceAdapter implements OrderSourcePort {
     } catch (error) {
       this.logger.warn(
         `Failed to hydrate address ${String(addressId)}: ${(error as Error).message}`
+      );
+      return undefined;
+    }
+  }
+
+  /**
+   * Fetch the buyer's e-mail from the PrestaShop `customers` resource (#1928).
+   *
+   * The `orders` resource carries only `id_customer`, so the e-mail needs its
+   * own read — the same reason the outbound provisioner queries `customers`
+   * separately. Without it `IncomingOrder.customerEmail` stays undefined for
+   * every PrestaShop-sourced order, which both empties the order snapshot's
+   * label recipient and makes `OrderIngestionService.resolveCustomerId` skip
+   * customer-identity resolution entirely (no `customer_projections` row).
+   *
+   * Best-effort, mirroring `hydrateAddress`: a revoked `customers` WS
+   * permission, a purged customer, or a transport error warns and yields
+   * undefined rather than failing ingestion of an otherwise-valid order.
+   */
+  private async hydrateCustomerEmail(
+    customerId: string | number | undefined
+  ): Promise<string | undefined> {
+    if (!customerId) return undefined;
+    try {
+      const customer = await this.httpClient.getResource<PrestashopCustomer>(
+        'customers',
+        String(customerId)
+      );
+      const email = customer.email?.trim();
+      return email ? email : undefined;
+    } catch (error) {
+      this.logger.warn(
+        `Failed to hydrate customer e-mail for customer ${String(customerId)}: ${(error as Error).message}`
       );
       return undefined;
     }


### PR DESCRIPTION
## What & why

Closes #1928.

`PrestashopOrderSourceAdapter.getOrder()` mapped only `id_customer`, so **`IncomingOrder.customerEmail` was `undefined` for every PrestaShop-sourced order**. PrestaShop was the only one of the four `OrderSourcePort` adapters that never populated the field - Allegro (`allegro-order-source.adapter.ts:348`), WooCommerce (`woocommerce-order-source.adapter.ts:159`) and Erli (`erli-order.mapper.ts:70`) all do. `git grep -niI email` on the adapter returned zero hits.

Core is a pure passthrough (`order-ingestion.service.ts:590` is the only assignment, with no billing-address or projection fallback), so two things broke downstream:

1. **The snapshot key was absent entirely.** `order-record.service.ts:86` persists `customerEmail` through a conditional spread, so `dispatch-input.ts:70` rejected **Generate-Label for every PrestaShop-sourced order** with *"Buyer email is missing from the order snapshot."*, and the inFakt send-by-email path added in #1811/#1797 had no recipient (`order-to-issue-invoice-command.mapper.ts:154`).
2. **Customer identity resolution was skipped entirely** - the larger, less obvious half. `resolveCustomerId` (`order-ingestion.service.ts:536-556`) gates the resolver on the e-mail being present, so PrestaShop always took the bare `getOrCreateInternalId` branch and **no `customer_projections` row was ever created**. That in turn hard-fails guest provisioning when such an order is relayed to a PrestaShop destination (`prestashop-order-processor-manager.adapter.ts:179-185` throws `"customer projection not found or email missing"`), and makes `backfillCustomerNames` warn-skip.

#948 fixed the core-side snapshot persistence on the stated assumption that *"adapters capture the buyer e-mail on `IncomingOrder`"*; #1811 fixed the invoicing consumer. Both left this producer-side gap in place.

## Approach

The `orders` webservice resource does **not** carry the e-mail - verified against PS 9.0.2: a full `GET /api/orders/60` returns 37 keys, none matching `mail`. So it needs its own `customers/{id_customer}` read, the same reason the outbound provisioner queries `customers` separately (`prestashop-customer-provisioner.ts:227`).

- New private `hydrateCustomerEmail()` using the existing `IPrestashopWebserviceClient.getResource<T>`, shaped exactly like the neighbouring `hydrateAddress`: **best-effort** - a revoked `customers` WS permission, a purged customer, or a transport error warns and yields `undefined` rather than failing ingestion of an otherwise-valid order.
- The read is **started before** the pickup-point / address awaits so it overlaps them instead of lengthening the hydration chain. It never rejects (internal catch), so holding the pending promise across those awaits cannot produce an unhandled rejection.
- Reuses the existing `PrestashopCustomer` wire type (`prestashop-provisioner.types.ts`) rather than declaring a new one - it already had `{ id, email?, is_guest? }`.
- Blank / whitespace-only e-mails are normalised to `undefined` rather than emitted as `''`.

**No core, API or frontend change.** Every consumer already treats `customerEmail` as optional (`order-snapshot.schema.ts:177`, `dispatch-input.ts:70`, `generate-label-form.tsx:788`, `orders-list-page.tsx:229`), so populating it is a pure upgrade. PII gating stays exactly where it was - `OL_STORE_PII=false` deployments keep seeing no `customerEmail` in the snapshot, by design.

**N+1 note.** One extra read per order on `getOrder`, which is already a multi-read hydration (order, order_details, 2x addresses, countries). `getOrder` is invoked per-order by the sync job, not in a tight feed loop, so batching is deliberately out of scope; if it ever matters the natural fix is a short-lived per-run cache keyed on `id_customer` (repeat buyers), not a feed-level join.

## How tested

**Unit** - `prestashop-order-source.adapter.spec.ts`: 7 new cases (populated, failing `customers` read, customer without e-mail, blank e-mail, whitespace trim, absent `id_customer` ⇒ read skipped, numeric `id_customer`). Two existing `toHaveBeenCalledTimes(1)` assertions legitimately changed - they now assert the exact resource set (`orders` + `customers`) instead of a bare count, which is a sharper assertion than before.

Gate: `pnpm type-check` clean repo-wide, `pnpm lint` clean incl. all 17 invariant checks, `@openlinker/integrations-prestashop` **506/506 tests, 33/33 suites**. Tests scoped to the affected package - nothing outside it changed.

**Live, on a demo stack** - the fix branch's `api` + `worker` were built and run as isolated containers against the demo Postgres (own Redis, so job consumption could not race the stack's own worker), then torn down. Re-ingesting PrestaShop order 60:

| | before | after |
|---|---|---|
| `orderSnapshot.customerEmail` | key absent | `e2e-invoicing-…@e2e.openlinker.test` |
| `customer_projections` rows | **0** | **1** |
| `customerId` | `ol_customer_9052e63…` | unchanged (no identity churn) |
| `dispatch-input.ts:70` gate | blocks | passes |

The resolved e-mail matches PrestaShop ground truth for that order's customer, and the 0 → 1 projection proves `resolveCustomerIdentity` now actually runs - the second half of the bug.

Snapshot state by source on that stack before the fix, for scale: allegro 20/20 with e-mail, erli 7/7, woocommerce 8/8, **prestashop 0/41**.

## Note for reviewers

**Already-ingested orders do not self-heal** - their snapshots are persisted without the key and need a re-ingest (`marketplace.order.sync` per order). The 10-minute reconcile poll (#904) heals orders whose `date_upd` moves, but not dormant ones. Whether to ship a backfill is deliberately out of scope here; say the word if you want it in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WVCdJqPhgrqNSPqF2t1UPn
