### PR TITLE
feat(listings): category per family and per variant in bulk offer creation

### DIFF
--- a/apps/api/src/integrations/http/connection.controller.spec.ts
+++ b/apps/api/src/integrations/http/connection.controller.spec.ts
@@ -36,6 +36,7 @@ describe('ConnectionController', () => {
   let demoModeService: jest.Mocked<IDemoModeService>;
   let webhookSecretService: { rotate: jest.Mock; set: jest.Mock };
   let webhookStatusService: { getStatus: jest.Mock };
+  let integrationsService: { resolveAdapterMetadata: jest.Mock };
 
   const mockConnection = new Connection(
     'connection-123',
@@ -156,6 +157,7 @@ describe('ConnectionController', () => {
     demoModeService = module.get(DEMO_MODE_SERVICE_TOKEN);
     webhookSecretService = module.get(WEBHOOK_SECRET_SERVICE_TOKEN);
     webhookStatusService = module.get(WEBHOOK_STATUS_SERVICE_TOKEN);
+    integrationsService = module.get(INTEGRATIONS_SERVICE_TOKEN);
   });
 
   describe('setWebhookSecret', () => {
@@ -285,6 +287,31 @@ describe('ConnectionController', () => {
       });
 
       expect(result.config).toEqual({});
+    });
+
+    it('should project the resolved adapter variantGrouping (#1924)', async () => {
+      integrationsService.resolveAdapterMetadata.mockResolvedValueOnce({
+        adapterKey: 'allegro.publicapi.v1',
+        platformType: 'allegro',
+        supportedCapabilities: ['OfferManager'],
+        variantGrouping: 'catalog-implicit',
+      });
+      service.get.mockResolvedValue(mockConnection);
+
+      const result = await controller.get('connection-123', mockAdminUser);
+
+      expect(result.variantGrouping).toBe('catalog-implicit');
+    });
+
+    it('should default variantGrouping to the locked parent-child shape when adapter metadata cannot be resolved', async () => {
+      integrationsService.resolveAdapterMetadata.mockRejectedValueOnce(
+        new Error('unknown adapter')
+      );
+      service.get.mockResolvedValue(mockConnection);
+
+      const result = await controller.get('connection-123', mockAdminUser);
+
+      expect(result.variantGrouping).toBe('parent-child');
     });
   });
 

--- a/apps/api/src/integrations/http/connection.controller.ts
+++ b/apps/api/src/integrations/http/connection.controller.ts
@@ -55,7 +55,12 @@ import type {
 } from '@openlinker/core/identifier-mapping';
 import { SyncJobRepositoryPort } from '@openlinker/core/sync';
 import { SYNC_JOB_REPOSITORY_TOKEN } from '@openlinker/core/sync';
-import { IIntegrationsService, INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
+import {
+  IIntegrationsService,
+  INTEGRATIONS_SERVICE_TOKEN,
+  resolveVariantGroupingModel,
+} from '@openlinker/core/integrations';
+import type { VariantGroupingModel } from '@openlinker/core/integrations';
 import {
   DEMO_MODE_SERVICE_TOKEN,
   type IDemoModeService,
@@ -86,17 +91,20 @@ export class ConnectionController {
     user?: AuthenticatedUser
   ): Promise<ConnectionResponseDto> {
     let supported: string[] = [];
+    let variantGrouping: VariantGroupingModel = resolveVariantGroupingModel(undefined);
     try {
       const metadata = await this.integrationsService.resolveAdapterMetadata({
         platformType: connection.platformType,
         adapterKey: connection.adapterKey,
       });
       supported = metadata.supportedCapabilities;
+      variantGrouping = resolveVariantGroupingModel(metadata);
     } catch (error) {
       // Unknown adapter (e.g., legacy row with unmapped platformType). Leave
-      // supportedCapabilities empty; the FE will render an "adapter not
-      // recognized" notice. We still want this to be observable in the API
-      // logs so operators can spot and fix the offending row.
+      // supportedCapabilities empty (and variantGrouping at its locked
+      // default); the FE will render an "adapter not recognized" notice. We
+      // still want this to be observable in the API logs so operators can
+      // spot and fix the offending row.
       this.logger.warn(
         `Could not resolve adapter metadata for connection ${connection.id} (platformType=${connection.platformType}, adapterKey=${connection.adapterKey ?? '<derived>'}): ${(error as Error).message}`
       );
@@ -105,6 +113,7 @@ export class ConnectionController {
     return ConnectionResponseDto.fromDomain(
       connection,
       supported,
+      variantGrouping,
       user?.role,
       this.demoModeService.isDemoModeEnabled()
     );

--- a/apps/api/src/integrations/http/dto/connection-response.dto.spec.ts
+++ b/apps/api/src/integrations/http/dto/connection-response.dto.spec.ts
@@ -30,12 +30,14 @@ const supportedCapabilities = ['ProductMaster', 'InventoryMaster'];
 describe('ConnectionResponseDto.fromDomain', () => {
   describe('config redaction', () => {
     it('should return full config for admin role', () => {
-      const dto = ConnectionResponseDto.fromDomain(baseConnection, supportedCapabilities, 'admin');
+      const dto = ConnectionResponseDto.fromDomain(baseConnection, supportedCapabilities,
+        'parent-child', 'admin');
       expect(dto.config).toEqual({ baseUrl: 'https://shop.example.com', apiKey: 'secret-key-123' });
     });
 
     it('should return empty config for viewer role outside demo mode', () => {
-      const dto = ConnectionResponseDto.fromDomain(baseConnection, supportedCapabilities, 'viewer');
+      const dto = ConnectionResponseDto.fromDomain(baseConnection, supportedCapabilities,
+        'parent-child', 'viewer');
       expect(dto.config).toEqual({});
     });
 
@@ -43,6 +45,7 @@ describe('ConnectionResponseDto.fromDomain', () => {
       const dto = ConnectionResponseDto.fromDomain(
         baseConnection,
         supportedCapabilities,
+        'parent-child',
         'viewer',
         false
       );
@@ -53,6 +56,7 @@ describe('ConnectionResponseDto.fromDomain', () => {
       const dto = ConnectionResponseDto.fromDomain(
         baseConnection,
         supportedCapabilities,
+        'parent-child',
         'viewer',
         true
       );
@@ -66,6 +70,7 @@ describe('ConnectionResponseDto.fromDomain', () => {
       const dto = ConnectionResponseDto.fromDomain(
         baseConnection,
         supportedCapabilities,
+        'parent-child',
         'operator',
         true
       );
@@ -76,6 +81,7 @@ describe('ConnectionResponseDto.fromDomain', () => {
       const dto = ConnectionResponseDto.fromDomain(
         baseConnection,
         supportedCapabilities,
+        'parent-child',
         'admin',
         false
       );
@@ -86,12 +92,14 @@ describe('ConnectionResponseDto.fromDomain', () => {
     });
 
     it('should return empty config when role is undefined (no secret reaches unauthenticated callers)', () => {
-      const dto = ConnectionResponseDto.fromDomain(baseConnection, supportedCapabilities, undefined);
+      const dto = ConnectionResponseDto.fromDomain(baseConnection, supportedCapabilities,
+        'parent-child', undefined);
       expect(dto.config).toEqual({});
     });
 
     it('should return {} not null or undefined for non-admin — preserves FE Record<string,unknown> contract', () => {
-      const dto = ConnectionResponseDto.fromDomain(baseConnection, supportedCapabilities, 'viewer');
+      const dto = ConnectionResponseDto.fromDomain(baseConnection, supportedCapabilities,
+        'parent-child', 'viewer');
       expect(dto.config).not.toBeNull();
       expect(dto.config).not.toBeUndefined();
       expect(typeof dto.config).toBe('object');
@@ -107,7 +115,8 @@ describe('ConnectionResponseDto.fromDomain', () => {
           oauthClientId: 'client-id',
         },
       };
-      const dto = ConnectionResponseDto.fromDomain(connection, supportedCapabilities, 'viewer');
+      const dto = ConnectionResponseDto.fromDomain(connection, supportedCapabilities,
+        'parent-child', 'viewer');
       expect(Object.keys(dto.config)).toHaveLength(0);
     });
   });
@@ -115,7 +124,8 @@ describe('ConnectionResponseDto.fromDomain', () => {
   describe('non-sensitive fields', () => {
     it('should always project id, platformType, name, status regardless of role', () => {
       for (const role of ['admin', 'viewer', undefined] as const) {
-        const dto = ConnectionResponseDto.fromDomain(baseConnection, supportedCapabilities, role);
+        const dto = ConnectionResponseDto.fromDomain(baseConnection, supportedCapabilities,
+        'parent-child', role);
         expect(dto.id).toBe('conn-uuid-001');
         expect(dto.platformType).toBe('prestashop');
         expect(dto.name).toBe('Test Store');
@@ -125,18 +135,31 @@ describe('ConnectionResponseDto.fromDomain', () => {
 
     it('should always project supportedCapabilities regardless of role', () => {
       for (const role of ['admin', 'viewer', undefined] as const) {
-        const dto = ConnectionResponseDto.fromDomain(baseConnection, supportedCapabilities, role);
+        const dto = ConnectionResponseDto.fromDomain(baseConnection, supportedCapabilities,
+        'parent-child', role);
         expect(dto.supportedCapabilities).toEqual(['ProductMaster', 'InventoryMaster']);
       }
     });
 
     it('should derive credentialsBacked from credentialsRef prefix', () => {
-      const dto = ConnectionResponseDto.fromDomain(baseConnection, supportedCapabilities, 'viewer');
+      const dto = ConnectionResponseDto.fromDomain(baseConnection, supportedCapabilities,
+        'parent-child', 'viewer');
       expect(dto.credentialsBacked).toBe(true);
 
       const envBacked: Connection = { ...baseConnection, credentialsRef: 'env:PRESTASHOP_KEY' };
-      const dto2 = ConnectionResponseDto.fromDomain(envBacked, supportedCapabilities, 'viewer');
+      const dto2 = ConnectionResponseDto.fromDomain(envBacked, supportedCapabilities,
+        'parent-child', 'viewer');
       expect(dto2.credentialsBacked).toBe(false);
+    });
+
+    it('should project the resolved variantGrouping regardless of role (#1924)', () => {
+      const dto = ConnectionResponseDto.fromDomain(
+        baseConnection,
+        supportedCapabilities,
+        'catalog-implicit',
+        'viewer'
+      );
+      expect(dto.variantGrouping).toBe('catalog-implicit');
     });
   });
 });

--- a/apps/api/src/integrations/http/dto/connection-response.dto.ts
+++ b/apps/api/src/integrations/http/dto/connection-response.dto.ts
@@ -8,7 +8,11 @@
  */
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import type { Connection } from '@openlinker/core/identifier-mapping';
-import { CoreCapabilityValues } from '@openlinker/core/integrations';
+import {
+  CoreCapabilityValues,
+  VariantGroupingModelValues,
+} from '@openlinker/core/integrations';
+import { VariantGroupingModel } from '@openlinker/core/integrations';
 import type { UserRole } from '@openlinker/core/users';
 
 export class ConnectionResponseDto {
@@ -63,6 +67,13 @@ export class ConnectionResponseDto {
   })
   supportedCapabilities!: string[];
 
+  @ApiProperty({
+    description:
+      "How this destination groups sibling variants into one listing, and therefore whether - and how consequentially - a single variant may carry its own category (derived from the resolved adapter's manifest, defaulting to the most restrictive shape when undeclared).",
+    enum: VariantGroupingModelValues,
+  })
+  variantGrouping!: VariantGroupingModel;
+
   @ApiProperty({ description: 'Creation timestamp' })
   createdAt!: Date;
 
@@ -72,6 +83,7 @@ export class ConnectionResponseDto {
   static fromDomain(
     connection: Connection,
     supportedCapabilities: string[],
+    variantGrouping: VariantGroupingModel,
     role?: UserRole,
     isDemoModeEnabled = false
   ): ConnectionResponseDto {
@@ -93,6 +105,7 @@ export class ConnectionResponseDto {
     dto.adapterKey = connection.adapterKey;
     dto.enabledCapabilities = connection.enabledCapabilities;
     dto.supportedCapabilities = supportedCapabilities;
+    dto.variantGrouping = variantGrouping;
     dto.createdAt = connection.createdAt;
     dto.updatedAt = connection.updatedAt;
     return dto;

--- a/apps/api/src/listings/http/dto/bulk-offer-create.dto.spec.ts
+++ b/apps/api/src/listings/http/dto/bulk-offer-create.dto.spec.ts
@@ -1,8 +1,10 @@
 /**
- * Bulk Offer Create DTO validation tests (#1741) - focused on the nested
- * `@ValidateRecordValues` map-value validation for `perVariantOverrides` /
- * `perProductOverrides` (class-validator does not recurse into `Record<>`
- * values on its own) and the categoryId-omitted `OverridesNoCategoryDto`.
+ * Bulk Offer Create DTO validation tests (#1741, #1924) - focused on the
+ * nested `@ValidateRecordValues` map-value validation for
+ * `perVariantOverrides` / `perProductOverrides` (class-validator does not
+ * recurse into `Record<>` values on its own), and on `categoryId` being
+ * accepted at both tiers (#1924 — enforcement of whether it survives to the
+ * built offer moved to `BulkListingSubmitService`, destination-aware).
  */
 import 'reflect-metadata';
 import { plainToInstance } from 'class-transformer';
@@ -119,5 +121,42 @@ describe('BulkOfferCreateRequestDto map-value validation (#1741)', () => {
       })
     );
     expect(errs).toContain('validateRecordValues');
+  });
+
+  it('accepts a family-tier (perProductOverrides) categoryId (#1924 Part 1 - the previously-blocking bug)', async () => {
+    const errs = await constraintKeysFor(
+      baseRequest({
+        perProductOverrides: {
+          ol_variant_a: { overrides: { categoryId: '89508' } },
+        },
+      })
+    );
+    expect(errs).toEqual([]);
+  });
+
+  it('accepts a variant-tier (perVariantOverrides) categoryId at the DTO layer (#1924 Part 2 - enforcement moved to the service)', async () => {
+    const errs = await constraintKeysFor(
+      baseRequest({
+        perVariantOverrides: {
+          ol_variant_a: { overrides: { categoryId: '89509' } },
+        },
+      })
+    );
+    expect(errs).toEqual([]);
+  });
+
+  it('rejects a mixed batch shape (one family override + one variant override, both non-empty) with only field-level errors, not a 400 on categoryId presence', async () => {
+    const errs = await constraintKeysFor(
+      baseRequest({
+        productIds: ['ol_variant_a', 'ol_variant_b'],
+        perProductOverrides: {
+          ol_variant_a: { overrides: { categoryId: '89508', title: 'Family title' } },
+        },
+        perVariantOverrides: {
+          ol_variant_b: { overrides: { categoryId: '89510' } },
+        },
+      })
+    );
+    expect(errs).toEqual([]);
   });
 });

--- a/apps/api/src/listings/http/dto/bulk-offer-create.dto.ts
+++ b/apps/api/src/listings/http/dto/bulk-offer-create.dto.ts
@@ -10,6 +10,14 @@
  * wizard's review-table edit modal (#740) can emit one row at a time and
  * the validator rejects malformed overrides at the boundary.
  *
+ * `categoryId` is accepted at BOTH the family (`perProductOverrides`) and
+ * variant (`perVariantOverrides`) tiers (#1924) — the same `CreateOfferOverridesDto`
+ * shape backs both maps. Whether a per-variant `categoryId` actually survives
+ * to the built offer is a destination-shape question the HTTP boundary has no
+ * visibility into (it doesn't know the resolved connection's adapter); that
+ * enforcement lives in `BulkListingSubmitService.stripVariantCategoryId`,
+ * conditional on the destination's declared `variantGrouping` model.
+ *
  * @module apps/api/src/listings/http/dto
  */
 import {
@@ -28,7 +36,7 @@ import {
   ValidateNested,
 } from 'class-validator';
 import { Type } from 'class-transformer';
-import { ApiProperty, ApiPropertyOptional, OmitType } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 import {
   CreateOfferOverridesDto,
@@ -82,23 +90,16 @@ export class BulkSharedConfigDto {
 }
 
 /**
- * Category-omitted offer-overrides shape (#1741). `categoryId` is
- * grouping-determining and product-level (base-only via `sharedConfig`), so it
- * is not overridable per-product / per-variant - `OmitType` drops it while
- * carrying every other nested validation rule (title MaxLength, imageUrls
- * IsUrl, price positivity, ean digit-shape, platformParams size cap, parameters
- * bounds).
+ * Per-product / per-variant override value (#1741, #1924). Same shape as the
+ * batch shared config's overrides, `categoryId` included at both tiers — a
+ * per-variant `categoryId` is only meaningful for a destination whose
+ * declared `variantGrouping` model permits it, which is a service-layer
+ * concern (`stripVariantCategoryId`), not something this HTTP-boundary shape
+ * can decide (it validates shape, not cross-field business rules against a
+ * resolved connection). Used as the nested value type validated by
+ * `@ValidateRecordValues` on BOTH override maps below.
  */
-export class OverridesNoCategoryDto extends OmitType(CreateOfferOverridesDto, [
-  'categoryId',
-] as const) {}
-
-/**
- * Per-product / per-variant override value (#1741). Same shape as the batch
- * shared config's overrides minus `categoryId`. Used as the nested value type
- * validated by `@ValidateRecordValues` on BOTH override maps below.
- */
-export class PerVariantOverrideDto {
+export class PerOverrideDto {
   @ApiPropertyOptional({ minimum: 0 })
   @IsOptional()
   @IsInt()
@@ -116,11 +117,11 @@ export class PerVariantOverrideDto {
   @Type(() => CreateOfferPriceDto)
   price?: CreateOfferPriceDto;
 
-  @ApiPropertyOptional({ type: OverridesNoCategoryDto })
+  @ApiPropertyOptional({ type: CreateOfferOverridesDto })
   @IsOptional()
   @ValidateNested()
-  @Type(() => OverridesNoCategoryDto)
-  overrides?: OverridesNoCategoryDto;
+  @Type(() => CreateOfferOverridesDto)
+  overrides?: CreateOfferOverridesDto;
 }
 
 export class BulkOfferCreateRequestDto {
@@ -151,36 +152,37 @@ export class BulkOfferCreateRequestDto {
 
   /**
    * Per-product (family) overrides keyed by `productIds[i]`. Each value is the
-   * narrow `PerVariantOverrideDto` shape; class-validator does not recurse into
-   * `Record<>` values, so `@ValidateRecordValues` validates each one (title
-   * MaxLength, imageUrls IsUrl, price positivity, ean digit-shape, …). Key-shape
+   * `PerOverrideDto` shape; class-validator does not recurse into `Record<>`
+   * values, so `@ValidateRecordValues` validates each one (title MaxLength,
+   * imageUrls IsUrl, price positivity, ean digit-shape, …). Key-shape
    * (`ol_variant_{hex}`), currency divergence, and effective-identifier
    * enforcement are applied in `BulkListingSubmitService` at submit (#1741).
    */
   @ApiPropertyOptional({
     description:
       'Optional per-product overrides keyed by productId. Unknown keys are ignored.',
-    additionalProperties: { $ref: '#/components/schemas/PerVariantOverrideDto' },
+    additionalProperties: { $ref: '#/components/schemas/PerOverrideDto' },
   })
   @IsOptional()
   @IsObject()
-  @ValidateRecordValues(() => PerVariantOverrideDto)
-  perProductOverrides?: Record<string, PerVariantOverrideDto>;
+  @ValidateRecordValues(() => PerOverrideDto)
+  perProductOverrides?: Record<string, PerOverrideDto>;
 
   /**
-   * Per-variant overrides keyed by the actual variant id (#1741). Same narrow
-   * `PerVariantOverrideDto` shape; wins over `perProductOverrides` per field in
-   * the service. Value-level validation via `@ValidateRecordValues`; key-shape /
-   * currency / GS1 / uniqueness enforcement is in `BulkListingSubmitService`.
+   * Per-variant overrides keyed by the actual variant id (#1741). Same
+   * `PerOverrideDto` shape; wins over `perProductOverrides` per field in the
+   * service. Value-level validation via `@ValidateRecordValues`; key-shape /
+   * currency / GS1 / uniqueness enforcement, and destination-aware
+   * `categoryId` enforcement, are in `BulkListingSubmitService`.
    */
   @ApiPropertyOptional({
     description: 'Optional per-variant overrides keyed by variant id. Unknown keys ignored.',
-    additionalProperties: { $ref: '#/components/schemas/PerVariantOverrideDto' },
+    additionalProperties: { $ref: '#/components/schemas/PerOverrideDto' },
   })
   @IsOptional()
   @IsObject()
-  @ValidateRecordValues(() => PerVariantOverrideDto)
-  perVariantOverrides?: Record<string, PerVariantOverrideDto>;
+  @ValidateRecordValues(() => PerOverrideDto)
+  perVariantOverrides?: Record<string, PerOverrideDto>;
 
   /**
    * Variant ids to exclude from the fan-out (#1741). Capped generously above

--- a/apps/web/src/features/connections/api/connections.types.ts
+++ b/apps/web/src/features/connections/api/connections.types.ts
@@ -43,6 +43,32 @@ export const CORE_CAPABILITY_VALUES = [
  */
 export type CoreCapability = (typeof CORE_CAPABILITY_VALUES)[number];
 
+/**
+ * How a destination groups sibling variants into one listing, and therefore
+ * whether - and how consequentially - a single variant may carry its own
+ * category. Mirrors `VariantGroupingModelValues` on the backend (#1924).
+ */
+export const VARIANT_GROUPING_MODEL_VALUES = [
+  'catalog-implicit',
+  'explicit-group',
+  'parent-child',
+] as const;
+
+export type VariantGroupingModel = (typeof VARIANT_GROUPING_MODEL_VALUES)[number];
+
+/**
+ * Resolve the effective variant-grouping model for a connection, defaulting
+ * to the most restrictive shape (`'parent-child'`) when absent — mirrors the
+ * backend's `resolveVariantGroupingModel` (#1924). The API always sends a
+ * resolved value; this keeps older/hand-rolled test fixtures that omit the
+ * field working without a mass edit.
+ */
+export function resolveVariantGroupingModel(
+  connection: Pick<Connection, 'variantGrouping'> | undefined | null
+): VariantGroupingModel {
+  return connection?.variantGrouping ?? 'parent-child';
+}
+
 export interface Connection {
   id: string;
   name: string;
@@ -54,6 +80,8 @@ export interface Connection {
   adapterKey?: string;
   enabledCapabilities: string[];
   supportedCapabilities: string[];
+  /** Derived from the resolved adapter's manifest (#1924). Read via `resolveVariantGroupingModel`, not directly, so an absent value still resolves to the locked default. */
+  variantGrouping?: VariantGroupingModel;
   createdAt: string;
   updatedAt: string;
 }

--- a/apps/web/src/features/connections/index.ts
+++ b/apps/web/src/features/connections/index.ts
@@ -27,8 +27,14 @@ export type {
   UpdateConnectionInput,
   PlatformType,
   CoreCapability,
+  VariantGroupingModel,
 } from './api/connections.types';
-export { CORE_PLATFORM_TYPES, CORE_CAPABILITY_VALUES } from './api/connections.types';
+export {
+  CORE_PLATFORM_TYPES,
+  CORE_CAPABILITY_VALUES,
+  VARIANT_GROUPING_MODEL_VALUES,
+  resolveVariantGroupingModel,
+} from './api/connections.types';
 
 export { useConnectionsQuery } from './hooks/use-connections-query';
 export { useConnectionQuery } from './hooks/use-connection-query';

--- a/apps/web/src/features/listings/components/bulk/bulk-category-choose-modal.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-category-choose-modal.tsx
@@ -6,15 +6,19 @@
  * the approved mockup: a search input, a clickable breadcrumb, and a list of
  * child categories with Browse (drill-in) / Select (pick) affordances.
  *
- * The category lives in the BASE scope only (grouping-determining, base-only -
- * a per-variant category would split Allegro's catalog-product family), so this
- * modal only fires `onSelect(categoryId, pathNames)`. `pathNames` is the full
- * breadcrumb (ancestors + leaf) captured at selection time, used to render the
- * chip breadcrumb without a second round-trip.
+ * The category lives in the BASE scope by default (grouping-determining,
+ * shared across variants) - and, for a `'catalog-implicit'` destination
+ * (Allegro), can also be given per-variant via the variant scope's 3-state
+ * ladder (#1924), where picking one splits that variant out of the grouped
+ * listing. Either mount fires `onSelect(categoryId, pathNames)`. `pathNames`
+ * is the full breadcrumb (ancestors + leaf) captured at selection time, used
+ * to render the chip breadcrumb without a second round-trip.
  *
- * Only mounted for a browsable destination (`canBrowseCategories === true`).
- * The borrowed-taxonomy path (Erli) keeps its inline "Allegro category ID" text
- * input in the base form instead.
+ * Only mounted for a browsable destination (`canBrowseCategories === true` at
+ * the base scope; `variantGrouping === 'catalog-implicit'` at the variant
+ * scope). The borrowed-taxonomy path (Erli) keeps its inline "Allegro
+ * category ID" text input in the base form instead, and has no variant-scope
+ * picker yet (#1045 follow-up).
  *
  * @module apps/web/src/features/listings/components/bulk
  */
@@ -37,6 +41,14 @@ interface BulkCategoryChooseModalProps {
   selectedId: string | null;
   /** Fires with the leaf id + the full breadcrumb path names (ancestors + leaf). */
   onSelect: (categoryId: string, pathNames: string[]) => void;
+  /**
+   * Which scope this picker is choosing a category for (#1924). `'base'`
+   * (default) is the shared-base pick that seeds every variant; `'variant'`
+   * is a single variant overriding its own category, which splits it out of
+   * the grouped listing rather than applying to every sibling — the footer
+   * copy reflects the actual consequence for each.
+   */
+  scope?: 'base' | 'variant';
 }
 
 export function BulkCategoryChooseModal({
@@ -46,6 +58,7 @@ export function BulkCategoryChooseModal({
   productName,
   selectedId,
   onSelect,
+  scope = 'base',
 }: BulkCategoryChooseModalProps): ReactElement {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -60,6 +73,7 @@ export function BulkCategoryChooseModal({
             selectedId={selectedId}
             onSelect={onSelect}
             onClose={() => onOpenChange(false)}
+            scope={scope}
           />
         ) : null}
       </DialogContent>
@@ -73,12 +87,14 @@ function BulkCategoryChooseBody({
   selectedId,
   onSelect,
   onClose,
+  scope,
 }: {
   connectionId: string;
   productName: string;
   selectedId: string | null;
   onSelect: (categoryId: string, pathNames: string[]) => void;
   onClose: () => void;
+  scope: 'base' | 'variant';
 }): ReactElement {
   const [breadcrumb, setBreadcrumb] = useState<Crumb[]>([]);
   const [search, setSearch] = useState('');
@@ -230,7 +246,11 @@ function BulkCategoryChooseBody({
       </div>
 
       <div className="bulk-editor__catpick-foot">
-        <span className="grow">Applies to all variants - Allegro groups siblings under one category.</span>
+        <span className="grow">
+          {scope === 'variant'
+            ? 'Applies to this variant only - it leaves the grouped listing.'
+            : 'Applies to all variants - Allegro groups siblings under one category.'}
+        </span>
         <Button tone="ghost" type="button" onClick={onClose}>
           Cancel
         </Button>

--- a/apps/web/src/features/listings/components/bulk/bulk-edit-modal.test.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-edit-modal.test.tsx
@@ -824,6 +824,9 @@ describe('BulkEditModal', () => {
           { apiClient },
         );
 
+        // Category lives inside the collapsed per-variant accordion (#1924).
+        fireEvent.click(screen.getByText('Override base title / description / category'));
+
         fireEvent.click(screen.getByRole('button', { name: 'Override for this variant' }));
         expect(screen.getByText(/splits it into its own Allegro listing/)).toBeInTheDocument();
 
@@ -861,6 +864,7 @@ describe('BulkEditModal', () => {
           { apiClient },
         );
 
+        fireEvent.click(screen.getByText('Override base title / description / category'));
         fireEvent.click(screen.getByRole('button', { name: 'Override for this variant' }));
         fireEvent.click(screen.getByRole('button', { name: 'Override anyway' }));
         fireEvent.click(await screen.findByRole('button', { name: 'Select' }));
@@ -894,6 +898,7 @@ describe('BulkEditModal', () => {
           { apiClient },
         );
 
+        fireEvent.click(screen.getByText('Override base title / description / category'));
         fireEvent.click(screen.getByRole('button', { name: 'Override for this variant' }));
         fireEvent.click(screen.getByRole('button', { name: 'Override anyway' }));
         fireEvent.click(await screen.findByRole('button', { name: 'Select' }));
@@ -919,6 +924,7 @@ describe('BulkEditModal', () => {
           />,
         );
 
+        fireEvent.click(screen.getByText('Override base title / description / category'));
         expect(screen.queryByRole('button', { name: 'Override for this variant' })).not.toBeInTheDocument();
         expect(screen.getByText(/cannot be overridden per variant here/)).toBeInTheDocument();
       });
@@ -938,6 +944,7 @@ describe('BulkEditModal', () => {
           />,
         );
 
+        fireEvent.click(screen.getByText('Override base title / description / category'));
         expect(screen.queryByRole('button', { name: 'Override for this variant' })).not.toBeInTheDocument();
       });
     });

--- a/apps/web/src/features/listings/components/bulk/bulk-edit-modal.test.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-edit-modal.test.tsx
@@ -784,6 +784,164 @@ describe('BulkEditModal', () => {
       });
     });
 
+    describe('per-variant category override (#1924)', () => {
+      // A dedicated fixture (not the shared `connection` used everywhere else in
+      // this file) so declaring `variantGrouping` here can never make an
+      // unrelated grouping-param test's `getByText('Override for this variant')`
+      // ambiguous (that button label is intentionally shared between the two
+      // ladders).
+      const catalogImplicitConnection: Connection = {
+        ...connection,
+        variantGrouping: 'catalog-implicit',
+      };
+      const parentChildConnection: Connection = {
+        ...connection,
+        id: 'conn_woo',
+        platformType: 'woocommerce',
+        variantGrouping: 'parent-child',
+      };
+
+      it('renders an interactive ladder for a catalog-implicit destination (Allegro-like)', async () => {
+        const apiClient = createMockApiClient({
+          mappings: {
+            getAllegroCategories: vi.fn().mockResolvedValue([
+              { id: 'cat-tester', name: 'Testery perfum', parentId: null, leaf: true },
+            ]),
+          },
+        });
+        renderWithProviders(
+          <BulkEditModal
+            open
+            onOpenChange={() => undefined}
+            row={makeMultiRow()}
+            connection={catalogImplicitConnection}
+            canBrowseCategories={true}
+            currency="PLN"
+            defaults={DEFAULTS}
+            focusVariantId="var_m"
+            onSave={() => undefined}
+          />,
+          { apiClient },
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: 'Override for this variant' }));
+        expect(screen.getByText(/splits it into its own Allegro listing/)).toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Override anyway' }));
+        fireEvent.click(await screen.findByRole('button', { name: 'Select' }));
+
+        expect(screen.getByText('splits listing')).toBeInTheDocument();
+        expect(screen.getByText('Testery perfum')).toBeInTheDocument();
+      });
+
+      it('emits the per-variant categoryId override on save (#1924)', async () => {
+        const onSave = vi.fn();
+        const apiClient = createMockApiClient({
+          mappings: {
+            getAllegroCategories: vi.fn().mockResolvedValue([
+              { id: 'cat-tester', name: 'Testery perfum', parentId: null, leaf: true },
+            ]),
+          },
+        });
+        renderWithProviders(
+          <BulkEditModal
+            open
+            onOpenChange={() => undefined}
+            // Base carries its own resolved category so the base form's
+            // required-categoryId validation doesn't block "Save all" - this
+            // test is only about the variant-tier override layering on top.
+            row={{ ...makeMultiRow(), resolvedCategoryId: 'cat-base' }}
+            connection={catalogImplicitConnection}
+            canBrowseCategories={true}
+            currency="PLN"
+            defaults={DEFAULTS}
+            focusVariantId="var_m"
+            onSave={onSave}
+          />,
+          { apiClient },
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: 'Override for this variant' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Override anyway' }));
+        fireEvent.click(await screen.findByRole('button', { name: 'Select' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Save all' }));
+
+        await waitFor(() => { expect(onSave).toHaveBeenCalledTimes(1); });
+        const perVariantOverrides = onSave.mock.calls[0][2] as Record<string, { overrides?: { categoryId?: string } }>;
+        expect(perVariantOverrides.var_m?.overrides?.categoryId).toBe('cat-tester');
+      });
+
+      it('reset-to-shared clears the per-variant category and re-locks it to inherited', async () => {
+        const apiClient = createMockApiClient({
+          mappings: {
+            getAllegroCategories: vi.fn().mockResolvedValue([
+              { id: 'cat-tester', name: 'Testery perfum', parentId: null, leaf: true },
+            ]),
+          },
+        });
+        renderWithProviders(
+          <BulkEditModal
+            open
+            onOpenChange={() => undefined}
+            row={makeMultiRow()}
+            connection={catalogImplicitConnection}
+            canBrowseCategories={true}
+            currency="PLN"
+            defaults={DEFAULTS}
+            focusVariantId="var_m"
+            onSave={() => undefined}
+          />,
+          { apiClient },
+        );
+
+        fireEvent.click(screen.getByRole('button', { name: 'Override for this variant' }));
+        fireEvent.click(screen.getByRole('button', { name: 'Override anyway' }));
+        fireEvent.click(await screen.findByRole('button', { name: 'Select' }));
+        expect(screen.getByText('splits listing')).toBeInTheDocument();
+
+        fireEvent.click(screen.getByText(/reset to shared/));
+        expect(screen.queryByText('splits listing')).not.toBeInTheDocument();
+        expect(screen.getByRole('button', { name: 'Override for this variant' })).toBeInTheDocument();
+      });
+
+      it('renders read-only with no override affordance for a parent-child destination (WooCommerce-like)', () => {
+        renderWithProviders(
+          <BulkEditModal
+            open
+            onOpenChange={() => undefined}
+            row={makeMultiRow()}
+            connection={parentChildConnection}
+            canBrowseCategories={false}
+            currency="PLN"
+            defaults={DEFAULTS}
+            focusVariantId="var_m"
+            onSave={() => undefined}
+          />,
+        );
+
+        expect(screen.queryByRole('button', { name: 'Override for this variant' })).not.toBeInTheDocument();
+        expect(screen.getByText(/cannot be overridden per variant here/)).toBeInTheDocument();
+      });
+
+      it('renders read-only with no override affordance when the adapter declares no variantGrouping (locked default)', () => {
+        renderWithProviders(
+          <BulkEditModal
+            open
+            onOpenChange={() => undefined}
+            row={makeMultiRow()}
+            connection={connection}
+            canBrowseCategories={true}
+            currency="PLN"
+            defaults={DEFAULTS}
+            focusVariantId="var_m"
+            onSave={() => undefined}
+          />,
+        );
+
+        expect(screen.queryByRole('button', { name: 'Override for this variant' })).not.toBeInTheDocument();
+      });
+    });
+
     it('emits a per-variant EAN override when the operator edits a sibling EAN', async () => {
       const onSave = vi.fn();
       renderWithProviders(

--- a/apps/web/src/features/listings/components/bulk/bulk-edit-modal.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-edit-modal.tsx
@@ -982,6 +982,7 @@ function BulkEditModalForm({
                       masterImages={masterImages}
                       onZoom={setZoomSrc}
                       connection={connection}
+                      baseCategoryPathNames={displayPathNames}
                       categoryParameters={renderableCategoryParameters}
                       duplicateEan={dupEanIds.has(v.variantId)}
                       onPatch={(patch) => patchVariant(v.variantId, patch)}
@@ -1688,6 +1689,8 @@ interface VariantScopeFormProps {
   masterImages: string[];
   /** Drives the per-variant category bar's declared grouping model (#1924). */
   connection: Connection;
+  /** Resolved breadcrumb for the shared base's category, already computed once by the parent (#1924) - shown instead of the raw id. Null when unresolved (falls back to the id). */
+  baseCategoryPathNames: string[] | null;
   categoryParameters: CategoryParameter[];
   duplicateEan: boolean;
   /** Opens the shared zoom lightbox for an image url (always allowed, #1741). */
@@ -1707,6 +1710,7 @@ function VariantScopeForm({
   basePriceValue,
   masterImages,
   connection,
+  baseCategoryPathNames,
   categoryParameters,
   duplicateEan,
   onZoom,
@@ -1768,6 +1772,13 @@ function VariantScopeForm({
   const [categoryPickerOpen, setCategoryPickerOpen] = useState(false);
   const [ownCategoryPathNames, setOwnCategoryPathNames] = useState<string[] | null>(null);
   const hasOwnCategory = edit.categoryId !== undefined;
+  // Breadcrumb name instead of the raw id when the base's path is already
+  // resolved (#1924) - falls back to the id (or "Not set on base") only
+  // while the path hasn't resolved yet.
+  const baseCategoryDisplay =
+    baseCategoryPathNames && baseCategoryPathNames.length > 0
+      ? baseCategoryPathNames.join(' › ')
+      : baseValues.categoryId || 'Not set on base';
 
   const ownCategoryParametersQuery = useCategoryParametersQuery(
     connectionId,
@@ -2032,10 +2043,13 @@ function VariantScopeForm({
         Per-variant
       </div>
 
-      {/* Title + description overrides - collapsed at the top; inherit base by default. */}
+      {/* Title / description / category overrides - collapsed at the top;
+          inherit base by default. Category joins this accordion (#1924)
+          rather than getting its own - all three are rarely-touched
+          per-variant overrides. */}
       <details className="bulk-editor__field">
         <summary style={{ cursor: 'pointer', color: 'var(--accent-primary)' }}>
-          Override base title / description
+          Override base title / description / category
         </summary>
         <div style={{ marginTop: 'var(--space-3)' }}>
           <InheritableTextField
@@ -2068,8 +2082,132 @@ function VariantScopeForm({
               }
             />
           </div>
+
+          {/* Per-variant category (#1924). Only `'catalog-implicit'` (Allegro)
+              renders the interactive ladder - giving this variant its own
+              category is a real, consequential choice there (it leaves the
+              grouped listing). Every other declared model (or none) renders
+              read-only: `'explicit-group'` (Erli) has no browsable picker yet
+              (#1045 follow-up), `'parent-child'` (WooCommerce) is
+              structurally parent-only, and an undeclared adapter resolves to
+              the same locked shape. */}
+          <div className="bulk-editor__field">
+            <label>
+              Category {hasOwnCategory ? <ProvBadge kind="override" /> : <ProvBadge kind="inherit" />}
+            </label>
+            {!canOverrideCategory ? (
+              <>
+                <Input
+                  className="bulk-editor__input bulk-editor__input--inherited"
+                  value={baseCategoryDisplay}
+                  readOnly
+                  aria-readonly="true"
+                />
+                <div className="hint" style={{ color: 'var(--text-muted)', fontSize: 12 }}>
+                  {variantGroupingModel === 'parent-child'
+                    ? 'Category is set on the parent product - it cannot be overridden per variant here.'
+                    : 'Shared across all variants.'}
+                </div>
+              </>
+            ) : hasOwnCategory ? (
+              <>
+                <div className="bulk-editor__cat-chip">
+                  <span className="mono-text">
+                    {ownCategoryPathNames && ownCategoryPathNames.length > 0
+                      ? ownCategoryPathNames.join(' › ')
+                      : edit.categoryId}
+                  </span>
+                  <span className="bulk-editor__prov bulk-editor__prov--split">splits listing</span>
+                </div>
+                <div
+                  className="bulk-editor__scope-toggles"
+                  style={{ marginTop: 'var(--space-2)', gap: 'var(--space-2)' }}
+                >
+                  <Button
+                    tone="ghost"
+                    type="button"
+                    className="button--sm"
+                    onClick={() => setCategoryPickerOpen(true)}
+                  >
+                    Change category
+                  </Button>
+                  <button
+                    type="button"
+                    className="bulk-editor__reset"
+                    onClick={() => {
+                      onPatch({ categoryId: undefined });
+                      setOwnCategoryPathNames(null);
+                      setCategoryWarn(false);
+                    }}
+                  >
+                    ↺ reset to shared
+                  </button>
+                </div>
+                <div className="hint" style={{ color: 'var(--text-muted)', fontSize: 12 }}>
+                  Publishes as its own listing, outside the grouped card.
+                </div>
+              </>
+            ) : categoryWarn ? (
+              <div className="bulk-editor__split-warn" role="alert">
+                <p>
+                  Giving this variant its own category splits it into its own Allegro listing - it stops
+                  grouping with the other variants.
+                </p>
+                <div className="bulk-editor__split-warn-actions">
+                  <Button
+                    tone="primary"
+                    type="button"
+                    className="button--sm"
+                    onClick={() => {
+                      setCategoryWarn(false);
+                      setCategoryPickerOpen(true);
+                    }}
+                  >
+                    Override anyway
+                  </Button>
+                  <Button tone="ghost" type="button" className="button--sm" onClick={() => setCategoryWarn(false)}>
+                    Keep shared
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <>
+                <Input
+                  className="bulk-editor__input bulk-editor__input--inherited"
+                  value={baseCategoryDisplay}
+                  readOnly
+                  aria-readonly="true"
+                />
+                <div className="hint" style={{ color: 'var(--text-muted)', fontSize: 12 }}>
+                  Shared across all variants - overriding splits this variant into its own listing.
+                </div>
+                <button
+                  type="button"
+                  className="bulk-editor__override-link"
+                  onClick={() => setCategoryWarn(true)}
+                >
+                  Override for this variant
+                </button>
+              </>
+            )}
+          </div>
         </div>
       </details>
+
+      {canOverrideCategory ? (
+        <BulkCategoryChooseModal
+          open={categoryPickerOpen}
+          onOpenChange={setCategoryPickerOpen}
+          connectionId={connectionId}
+          productName={`${label} (variant)`}
+          selectedId={edit.categoryId ?? null}
+          scope="variant"
+          onSelect={(categoryId, pathNames) => {
+            onPatch({ categoryId });
+            setOwnCategoryPathNames(pathNames);
+          }}
+        />
+      ) : null}
 
       {/* EAN - from master, editable, GS1 + intra-group duplicate validated. */}
       <div className="bulk-editor__field">
@@ -2211,130 +2349,6 @@ function VariantScopeForm({
             : 'Inherits the base images - add or remove to override for this variant.'}
         </div>
       </div>
-
-      {/* Per-variant category (#1924). Only `'catalog-implicit'` (Allegro)
-          renders the interactive ladder - giving this variant its own
-          category is a real, consequential choice there (it leaves the
-          grouped listing). Every other declared model (or none) renders
-          read-only: `'explicit-group'` (Erli) has no browsable picker yet
-          (#1045 follow-up), `'parent-child'` (WooCommerce) is structurally
-          parent-only, and an undeclared adapter resolves to the same locked
-          shape. */}
-      <div className="bulk-editor__field">
-        <label>
-          Category {hasOwnCategory ? <ProvBadge kind="override" /> : <ProvBadge kind="inherit" />}
-        </label>
-        {!canOverrideCategory ? (
-          <>
-            <Input
-              className="bulk-editor__input bulk-editor__input--inherited"
-              value={baseValues.categoryId || 'Not set on base'}
-              readOnly
-              aria-readonly="true"
-            />
-            <div className="hint" style={{ color: 'var(--text-muted)', fontSize: 12 }}>
-              {variantGroupingModel === 'parent-child'
-                ? 'Category is set on the parent product - it cannot be overridden per variant here.'
-                : 'Shared across all variants.'}
-            </div>
-          </>
-        ) : hasOwnCategory ? (
-          <>
-            <div className="bulk-editor__cat-chip">
-              <span className="mono-text">
-                {ownCategoryPathNames && ownCategoryPathNames.length > 0
-                  ? ownCategoryPathNames.join(' › ')
-                  : edit.categoryId}
-              </span>
-              <span className="bulk-editor__prov bulk-editor__prov--split">splits listing</span>
-            </div>
-            <div
-              className="bulk-editor__scope-toggles"
-              style={{ marginTop: 'var(--space-2)', gap: 'var(--space-2)' }}
-            >
-              <Button
-                tone="ghost"
-                type="button"
-                className="button--sm"
-                onClick={() => setCategoryPickerOpen(true)}
-              >
-                Change category
-              </Button>
-              <button
-                type="button"
-                className="bulk-editor__reset"
-                onClick={() => {
-                  onPatch({ categoryId: undefined });
-                  setOwnCategoryPathNames(null);
-                  setCategoryWarn(false);
-                }}
-              >
-                ↺ reset to shared
-              </button>
-            </div>
-            <div className="hint" style={{ color: 'var(--text-muted)', fontSize: 12 }}>
-              Publishes as its own listing, outside the grouped card.
-            </div>
-          </>
-        ) : categoryWarn ? (
-          <div className="bulk-editor__split-warn" role="alert">
-            <p>
-              Giving this variant its own category splits it into its own Allegro listing - it stops
-              grouping with the other variants.
-            </p>
-            <div className="bulk-editor__split-warn-actions">
-              <Button
-                tone="primary"
-                type="button"
-                className="button--sm"
-                onClick={() => {
-                  setCategoryWarn(false);
-                  setCategoryPickerOpen(true);
-                }}
-              >
-                Override anyway
-              </Button>
-              <Button tone="ghost" type="button" className="button--sm" onClick={() => setCategoryWarn(false)}>
-                Keep shared
-              </Button>
-            </div>
-          </div>
-        ) : (
-          <>
-            <Input
-              className="bulk-editor__input bulk-editor__input--inherited"
-              value={baseValues.categoryId || 'Not set on base'}
-              readOnly
-              aria-readonly="true"
-            />
-            <div className="hint" style={{ color: 'var(--text-muted)', fontSize: 12 }}>
-              Shared across all variants - overriding splits this variant into its own listing.
-            </div>
-            <button
-              type="button"
-              className="bulk-editor__override-link"
-              onClick={() => setCategoryWarn(true)}
-            >
-              Override for this variant
-            </button>
-          </>
-        )}
-      </div>
-
-      {canOverrideCategory ? (
-        <BulkCategoryChooseModal
-          open={categoryPickerOpen}
-          onOpenChange={setCategoryPickerOpen}
-          connectionId={connectionId}
-          productName={`${label} (variant)`}
-          selectedId={edit.categoryId ?? null}
-          scope="variant"
-          onSelect={(categoryId, pathNames) => {
-            onPatch({ categoryId });
-            setOwnCategoryPathNames(pathNames);
-          }}
-        />
-      ) : null}
 
       {/* Category parameters - inheritable; required first, optional collapsed
           behind an expander (mirrors the base CategoryParametersStep). Once

--- a/apps/web/src/features/listings/components/bulk/bulk-edit-modal.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-edit-modal.tsx
@@ -61,6 +61,7 @@ import {
 import { zodResolver } from '@hookform/resolvers/zod';
 import { usePlatform, type BulkOfferRowSectionProps } from '../../../../shared/plugins';
 import type { Connection } from '../../../connections';
+import { resolveVariantGroupingModel } from '../../../connections';
 import { Alert, Button, ConfirmDialog, FormField, Input, Textarea } from '../../../../shared/ui';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../../../../shared/ui/tooltip';
 import { ReadOnlyLock } from '../../../../shared/ui/read-only-lock';
@@ -980,6 +981,7 @@ function BulkEditModalForm({
                       basePriceValue={resolveBasePrice(baseValues, pricingPolicy, v.masterPrice)}
                       masterImages={masterImages}
                       onZoom={setZoomSrc}
+                      connection={connection}
                       categoryParameters={renderableCategoryParameters}
                       duplicateEan={dupEanIds.has(v.variantId)}
                       onPatch={(patch) => patchVariant(v.variantId, patch)}
@@ -1684,6 +1686,8 @@ interface VariantScopeFormProps {
   /** Concrete base price this variant inherits (pre-filled value, #1741). */
   basePriceValue: string;
   masterImages: string[];
+  /** Drives the per-variant category bar's declared grouping model (#1924). */
+  connection: Connection;
   categoryParameters: CategoryParameter[];
   duplicateEan: boolean;
   /** Opens the shared zoom lightbox for an image url (always allowed, #1741). */
@@ -1702,6 +1706,7 @@ function VariantScopeForm({
   baseValues,
   basePriceValue,
   masterImages,
+  connection,
   categoryParameters,
   duplicateEan,
   onZoom,
@@ -1746,18 +1751,50 @@ function VariantScopeForm({
     .filter(Boolean)
     .join(' ');
 
+  // Per-variant category (#1924). Whether - and how consequentially - this
+  // variant may carry its own category depends on the destination's declared
+  // grouping model. Only `'catalog-implicit'` (Allegro) renders the
+  // interactive 3-state ladder: giving this variant its own category is a
+  // real choice there (it splits the variant out of the grouped listing).
+  // Every other model (`'explicit-group'` - Erli has no browsable picker yet,
+  // #1045 follow-up; `'parent-child'` - WooCommerce; or undeclared, the
+  // locked default) renders read-only - there is nothing functional to hand
+  // off to regardless of the declared model, or the destination structurally
+  // cannot carry it.
+  const connectionId = connection.id;
+  const variantGroupingModel = resolveVariantGroupingModel(connection);
+  const canOverrideCategory = variantGroupingModel === 'catalog-implicit';
+  const [categoryWarn, setCategoryWarn] = useState(false);
+  const [categoryPickerOpen, setCategoryPickerOpen] = useState(false);
+  const [ownCategoryPathNames, setOwnCategoryPathNames] = useState<string[] | null>(null);
+  const hasOwnCategory = edit.categoryId !== undefined;
+
+  const ownCategoryParametersQuery = useCategoryParametersQuery(
+    connectionId,
+    hasOwnCategory ? (edit.categoryId as string) : '',
+  );
+  const effectiveCategoryParameters = useMemo(
+    () =>
+      hasOwnCategory
+        ? (ownCategoryParametersQuery.data ?? []).filter((p) => !isEanParameterName(p.name))
+        : categoryParameters,
+    [hasOwnCategory, ownCategoryParametersQuery.data, categoryParameters],
+  );
+
   // Category parameters mirror the base scope: filter through parameter-level
   // visibility (a `dependsOn`-gated param is hidden until its parent has a
   // qualifying value), then split required-first / optional-behind-expander
   // (#1741). The effective values are the base values overridden by this
   // variant's own overrides (variant wins; inherited entries fall back to base).
+  // Once this variant has its own category (#1924), its required/optional
+  // schema resolves from THAT category, not the shared base's.
   const effectiveParamValues: CategoryParameterFormValues = useMemo(
     () => ({ ...((baseValues.parameters as CategoryParameterFormValues | undefined) ?? {}), ...edit.params }),
     [baseValues.parameters, edit.params],
   );
   const visibleParams = useMemo(
-    () => categoryParameters.filter((p) => isParameterVisible(p, effectiveParamValues)),
-    [categoryParameters, effectiveParamValues],
+    () => effectiveCategoryParameters.filter((p) => isParameterVisible(p, effectiveParamValues)),
+    [effectiveCategoryParameters, effectiveParamValues],
   );
   const requiredParams = visibleParams.filter((p) => p.required);
   const optionalParams = visibleParams.filter((p) => !p.required);
@@ -2175,15 +2212,143 @@ function VariantScopeForm({
         </div>
       </div>
 
+      {/* Per-variant category (#1924). Only `'catalog-implicit'` (Allegro)
+          renders the interactive ladder - giving this variant its own
+          category is a real, consequential choice there (it leaves the
+          grouped listing). Every other declared model (or none) renders
+          read-only: `'explicit-group'` (Erli) has no browsable picker yet
+          (#1045 follow-up), `'parent-child'` (WooCommerce) is structurally
+          parent-only, and an undeclared adapter resolves to the same locked
+          shape. */}
+      <div className="bulk-editor__field">
+        <label>
+          Category {hasOwnCategory ? <ProvBadge kind="override" /> : <ProvBadge kind="inherit" />}
+        </label>
+        {!canOverrideCategory ? (
+          <>
+            <Input
+              className="bulk-editor__input bulk-editor__input--inherited"
+              value={baseValues.categoryId || 'Not set on base'}
+              readOnly
+              aria-readonly="true"
+            />
+            <div className="hint" style={{ color: 'var(--text-muted)', fontSize: 12 }}>
+              {variantGroupingModel === 'parent-child'
+                ? 'Category is set on the parent product - it cannot be overridden per variant here.'
+                : 'Shared across all variants.'}
+            </div>
+          </>
+        ) : hasOwnCategory ? (
+          <>
+            <div className="bulk-editor__cat-chip">
+              <span className="mono-text">
+                {ownCategoryPathNames && ownCategoryPathNames.length > 0
+                  ? ownCategoryPathNames.join(' › ')
+                  : edit.categoryId}
+              </span>
+              <span className="bulk-editor__prov bulk-editor__prov--split">splits listing</span>
+            </div>
+            <div
+              className="bulk-editor__scope-toggles"
+              style={{ marginTop: 'var(--space-2)', gap: 'var(--space-2)' }}
+            >
+              <Button
+                tone="ghost"
+                type="button"
+                className="button--sm"
+                onClick={() => setCategoryPickerOpen(true)}
+              >
+                Change category
+              </Button>
+              <button
+                type="button"
+                className="bulk-editor__reset"
+                onClick={() => {
+                  onPatch({ categoryId: undefined });
+                  setOwnCategoryPathNames(null);
+                  setCategoryWarn(false);
+                }}
+              >
+                ↺ reset to shared
+              </button>
+            </div>
+            <div className="hint" style={{ color: 'var(--text-muted)', fontSize: 12 }}>
+              Publishes as its own listing, outside the grouped card.
+            </div>
+          </>
+        ) : categoryWarn ? (
+          <div className="bulk-editor__split-warn" role="alert">
+            <p>
+              Giving this variant its own category splits it into its own Allegro listing - it stops
+              grouping with the other variants.
+            </p>
+            <div className="bulk-editor__split-warn-actions">
+              <Button
+                tone="primary"
+                type="button"
+                className="button--sm"
+                onClick={() => {
+                  setCategoryWarn(false);
+                  setCategoryPickerOpen(true);
+                }}
+              >
+                Override anyway
+              </Button>
+              <Button tone="ghost" type="button" className="button--sm" onClick={() => setCategoryWarn(false)}>
+                Keep shared
+              </Button>
+            </div>
+          </div>
+        ) : (
+          <>
+            <Input
+              className="bulk-editor__input bulk-editor__input--inherited"
+              value={baseValues.categoryId || 'Not set on base'}
+              readOnly
+              aria-readonly="true"
+            />
+            <div className="hint" style={{ color: 'var(--text-muted)', fontSize: 12 }}>
+              Shared across all variants - overriding splits this variant into its own listing.
+            </div>
+            <button
+              type="button"
+              className="bulk-editor__override-link"
+              onClick={() => setCategoryWarn(true)}
+            >
+              Override for this variant
+            </button>
+          </>
+        )}
+      </div>
+
+      {canOverrideCategory ? (
+        <BulkCategoryChooseModal
+          open={categoryPickerOpen}
+          onOpenChange={setCategoryPickerOpen}
+          connectionId={connectionId}
+          productName={`${label} (variant)`}
+          selectedId={edit.categoryId ?? null}
+          scope="variant"
+          onSelect={(categoryId, pathNames) => {
+            onPatch({ categoryId });
+            setOwnCategoryPathNames(pathNames);
+          }}
+        />
+      ) : null}
+
       {/* Category parameters - inheritable; required first, optional collapsed
-          behind an expander (mirrors the base CategoryParametersStep). */}
-      {categoryParameters.length > 0 ? (
+          behind an expander (mirrors the base CategoryParametersStep). Once
+          this variant has its own category (#1924), the schema resolves from
+          THAT category rather than the shared base's. */}
+      {effectiveCategoryParameters.length > 0 ? (
         <div className="bulk-editor__platform-slot">
           <div className="bulk-editor__slot-tag">
             <span className="eyebrow">Category parameters</span>
           </div>
           <div className="hint" style={{ color: 'var(--text-muted)', fontSize: 12, marginBottom: 'var(--space-3)' }}>
-            Everything inherits from base. Override only the parameters that differ for this variant.
+            {hasOwnCategory
+              ? "Resolved from this variant's own category."
+              : 'Everything inherits from base. Override only the parameters that differ for this variant.'}
           </div>
           {requiredParams.length > 0 ? (
             <div className="bulk-editor__vparams-grid">{requiredParams.map(renderVariantParam)}</div>

--- a/apps/web/src/features/listings/components/bulk/bulk-policy.test.ts
+++ b/apps/web/src/features/listings/components/bulk/bulk-policy.test.ts
@@ -522,4 +522,57 @@ describe('recomputeVariantBlockers', () => {
     expect(blockers).not.toContain('no-ean');
     expect(blockers).toHaveLength(0);
   });
+
+  it('validates a variant with its own category (#1924) against THAT category required params, not the family resolved one', () => {
+    // Family/resolved category ('cat-1') requires 'brand'; the variant's own
+    // override category ('cat-tester') requires 'material' instead. A variant
+    // given its own category via the per-variant bar (#1924) must be checked
+    // against its own schema, not the family's.
+    const requiredByCategory = new Map<string, readonly string[]>([
+      ['cat-1', ['brand']],
+      ['cat-tester', ['material']],
+    ]);
+    const withOwnCategory = makeVariant('ol_variant_1', {
+      resolvedCategoryId: 'cat-1',
+      resolvedProductCardId: null,
+      override: { overrides: { categoryId: 'cat-tester' } },
+    });
+    const row = makeWizardRow([withOwnCategory]);
+
+    const blockers = recomputeVariantBlockers(
+      row,
+      withOwnCategory,
+      CONFIG,
+      requiredByCategory,
+      allegroValidate,
+    );
+
+    expect(blockers).toContain(NEEDS_PARAMS);
+  });
+
+  it('does not block on the family category requirement once satisfied by the variant own category override', () => {
+    // 'cat-1' requires 'brand' (unsatisfied), but this variant overrides to
+    // 'cat-tester', which has no required params at all - it must not inherit
+    // the family category's blocker.
+    const requiredByCategory = new Map<string, readonly string[]>([
+      ['cat-1', ['brand']],
+      ['cat-tester', []],
+    ]);
+    const withOwnCategory = makeVariant('ol_variant_1', {
+      resolvedCategoryId: 'cat-1',
+      resolvedProductCardId: null,
+      override: { overrides: { categoryId: 'cat-tester' } },
+    });
+    const row = makeWizardRow([withOwnCategory]);
+
+    const blockers = recomputeVariantBlockers(
+      row,
+      withOwnCategory,
+      CONFIG,
+      requiredByCategory,
+      allegroValidate,
+    );
+
+    expect(blockers).not.toContain(NEEDS_PARAMS);
+  });
 });

--- a/docs/plans/analysis/ANALYSIS-bulk-offer-category-family-variant.md
+++ b/docs/plans/analysis/ANALYSIS-bulk-offer-category-family-variant.md
@@ -1,0 +1,62 @@
+# Pre-implement analysis — Category per family and per variant in bulk offer creation
+
+- Plan: `docs/plans/implementation-plan-bulk-offer-category-family-variant.md`
+- Issue: [#1924](https://github.com/openlinker-project/openlinker/issues/1924)
+- Date: 2026-07-29
+
+## Verdict: READY (with 2 plan corrections applied below, no re-gate needed)
+
+No reuse collisions, no undisclosed contract breaks. Two factual corrections to the plan surfaced during this gate — both narrow the scope of work, not widen it. No architectural rework needed.
+
+## Reuse findings
+
+| Plan artifact | Status | File |
+|---|---|---|
+| `VariantGroupingModelValues` / `VariantGroupingModel` / `resolveVariantGroupingModel` | NEW (confirmed absent — no existing grouping-model concept anywhere in `adapter.types.ts` or sibling type files) | `libs/core/src/integrations/domain/types/adapter.types.ts` |
+| `variantGrouping?` field on `AdapterMetadata` | NEW | same file |
+| Manifest field additions (Allegro/Erli/WooCommerce) | NEW (one-line each); manifests are plain object literals, no factory indirection to fight | `allegro-plugin.ts:75-107`, `erli-plugin.ts:55-77`, `woocommerce-plugin.ts:51-91` |
+| `ConnectionResponseDto.variantGrouping` | NEW field; existing `supportedCapabilities` field is the direct precedent to copy | `connection-response.dto.ts:14-100` |
+| `PerOverrideDto` (merge of `PerVariantOverrideDto`/`OverridesNoCategoryDto`) | PARTIAL — renames/deletes two existing classes rather than adding a third; confirmed no other file imports `OverridesNoCategoryDto` or `PerVariantOverrideDto` by name outside this DTO file and its spec | `apps/api/src/listings/http/dto/bulk-offer-create.dto.ts` |
+| Conditional `stripVariantCategoryId` | PARTIAL — extends an existing free function's signature | `bulk-listing-submit.service.ts:733-740` |
+| FE `VariantGroupingModel` mirror type | NEW, but the **exact pattern to copy already exists** for `CoreCapability`: `apps/web/src/features/connections/api/connections.types.ts:22-40` (`CORE_CAPABILITY_VALUES` / `CoreCapability` — FE hand-rolls its own literal-union mirror of the BE `as const`, no cross-package import). Resolves the plan's open question #4: add `VARIANT_GROUPING_MODEL_VALUES` / `VariantGroupingModel` the same way, plus `variantGrouping: VariantGroupingModel` (required, not optional, since the BE always resolves a default) on `Connection` at line ~53. |
+| Category 3-state ladder pattern | EXISTS, reuse confirmed → `bulk-edit-modal.tsx:1732-1939` (`warnParamIds`/`unlockedParamIds`, `renderVariantParam`) |
+| `BulkCategoryChooseModal` | EXISTS, reuse confirmed → `bulk-edit-modal.tsx:1023-1030` |
+
+### Correction 1 — `OverridesNoCategoryDto`/`PerVariantOverrideDto` have no other consumers
+
+Grepped every file in the repo for both names outside `bulk-offer-create.dto.ts` and its own spec — zero hits. The rename/delete in plan §3.4 is fully self-contained; no ripple into `BulkListingSubmitInput`/`PerProductOverride` (those core-side types are separately defined in `libs/core/src/listings/application/types/bulk-listing-submit.types.ts` and already type `overrides` as the core `CreateOfferOverrides`, unaffected by the HTTP-layer rename).
+
+### Correction 2 — Plan step 8 (`useBulkRequiredProductParams` per-variant attribution) is **already correct today, no fix needed**
+
+The plan flagged this as unconfirmed and a possible real fix. Traced the full call chain:
+
+- `useBulkRequiredProductParams` (`apps/web/src/features/listings/hooks/use-bulk-required-product-params.ts:33-60`) returns `requiredByCategory: Map<categoryId, requiredParamIds>` — already keyed **per distinct category id**, not merged into one pool.
+- The consumer, `recomputeVariantBlockers` (`apps/web/src/features/listings/components/bulk/bulk-policy.ts:461-497`), already computes `submitCategoryId = variant.override.overrides?.categoryId ?? variant.resolvedCategoryId` **per variant** (line 468) and looks up `requiredByCategory.get(submitCategoryId)` (line 483) — i.e. a variant with its own category override is already validated against that category's own required-param set, not the family's.
+
+This was built defensively ahead of the FE bar existing (likely as part of #1741's own per-variant `categoryId` plumbing, even though nothing wrote to it yet). **Downgrade plan step 8 from "verify/fix" to "verify only, expect no change"** — remove it as an implementation risk; keep one assertion in `bulk-edit-modal.test.tsx` or `bulk-wizard.test.tsx` proving it (a variant on its own category surfaces/clears blockers independently of the family's required params), since today nothing exercises this path end-to-end (no code writes `edit.categoryId` yet).
+
+### Test-file path correction
+
+`bulk-listing-submit.service.spec.ts` exists at `libs/core/src/listings/application/services/__tests__/bulk-listing-submit.service.spec.ts` (a `__tests__/` subfolder, not directly beside the service file as the plan's table implied). No content risk — just the path for step 7's edits.
+
+## Backward-compatibility findings
+
+| Surface | Check | Severity | Note |
+|---|---|---|---|
+| `AdapterMetadata` interface (barrel-exported type) | Adding an **optional** field | None | Every existing manifest object literal still conforms; no call site destructures an exhaustive field list |
+| `ConnectionResponseDto` (response DTO) | Adding a **new required** field (`variantGrouping!: VariantGroupingModel`) | Warning | Additive for JSON consumers (extra field, non-breaking wire-wise), but any FE test that does an exact-shape snapshot/deep-equal against a `Connection` fixture will need updating — expected, not a hidden break. Swagger schema gains one property, non-breaking for existing clients. |
+| `PerVariantOverrideDto` / `OverridesNoCategoryDto` (deleted/renamed) | These are **not** re-exported from any barrel (`apps/api` doesn't publish a package barrel the way `libs/core` does) and have zero external consumers per Correction 1 | None (Critical-surface checklist doesn't apply — this is an API-app-internal DTO, not a `@openlinker/core/*` barrel export) | Confirmed via grep, not assumption |
+| `stripVariantCategoryId` (private free function, module-internal) | Signature gains a required second parameter | None | Not exported; only one call site (`buildEnqueueInput`, same file) |
+| ORM schema | No entity/column change anywhere in the plan | None | No migration needed — matches the plan's own §4 note and the architecture doc's "capabilities are code-driven, not DB-persisted" principle |
+| `check-cross-context-imports` | `resolveVariantGroupingModel` is consumed by `libs/core/src/listings/**` from `@openlinker/core/integrations` — an existing, already-allowed cross-context pattern (the file already imports `IIntegrationsService`/`INTEGRATIONS_SERVICE_TOKEN` from the same barrel) | None | No new cross-context shape introduced — a plain exported function joins existing named exports from the same barrel |
+| `check-service-interfaces` | No new `*.service.ts` added | None | N/A |
+
+## Open questions (none blocking)
+
+The plan's own §6 items are resolved:
+1. DTO end-state scope — user already signed off (see conversation).
+2. Erli declared-but-unavailable — intentional, matches issue text.
+3. `useBulkRequiredProductParams` — resolved above (Correction 2), already correct.
+4. FE `Connection` type import path — resolved above (mirror-literal-union pattern, same as `CoreCapability`).
+
+No remaining open questions. Proceed to implementation as planned, applying Corrections 1 and 2 above (both reduce scope: no ripple-import cleanup needed, and step 8 becomes a verification-only test rather than a fix).

--- a/docs/plans/implementation-plan-bulk-offer-category-family-variant.md
+++ b/docs/plans/implementation-plan-bulk-offer-category-family-variant.md
@@ -1,0 +1,166 @@
+# Implementation Plan — Category per family and per variant in bulk offer creation
+
+- **Issue**: [#1924](https://github.com/openlinker-project/openlinker/issues/1924)
+- **Branch**: `1924-bulk-category-per-family-per-variant`
+- **Layers**: Interface (API DTO), CORE (integrations + listings application), Integration (Allegro/Erli/WooCommerce manifests), Frontend
+
+## 1. Understand the task
+
+Two bugs in the same field, same flow, fixed together:
+
+- **Part 1 (blocking bug)**: `perProductOverrides` (family tier) is validated with a DTO class that strips `categoryId`, but the core service and the FE both already treat `categoryId` as family-tier data. Every multi-variant bulk-publish submit 400s at the HTTP boundary. Single-variant products are unaffected (the FE never pins a family category for them), which is why this shipped unnoticed.
+- **Part 2 (feature)**: category is currently resolved once per **product**. Some destinations let a specific variant (e.g. a "tester" SKU) live in its own category. Whether that is even meaningful, and what happens when it diverges, is destination-shape-dependent:
+  - **Allegro** (`catalog-implicit`): grouping happens by linking each offer to the same catalog product; siblings must share a category for that catalog product to resolve. Giving a variant its own category is a **real, consequential choice** — it splits that variant out of the grouped listing.
+  - **Erli** (`explicit-group`): grouping is carried explicitly (`externalVariantGroup.groupId`), independent of category. A per-variant category is just metadata — no confirm, no split. (Out of scope to actually *ship* interactively — Erli has no `CategoryBrowser`, so even the base scope's picker is read-only today. Declared for discovery; unavailable in practice until a borrowed-taxonomy browse capability exists, #1045 follow-up.)
+  - **WooCommerce** (`parent-child`): a WC product *variation* has no `categories` field in the REST API — category is structurally parent-only. Not a policy choice, a hard no.
+
+**Non-goals** (explicit, from the issue):
+- Category browsing through a borrowed-taxonomy owner (Erli's actual interactive picker) — separate, unfiled follow-up.
+- A batch-level summary of which product goes to which category.
+- Any change to `POST /listings/bulk-shop-publish` (the shop-publish endpoint is unaffected — WC gets correct behavior for free from the locked default, no code path there needs to change).
+- A real Erli interactive variant-category bar — model is declared, FE renders the same locked/no-override shape as WooCommerce (there's no functional picker to hand off to regardless of the declared model).
+
+## 2. Research summary (already verified against the live repo at `origin/main`)
+
+| Concern | File:line | Current state |
+|---|---|---|
+| Family-tier DTO strips categoryId | `apps/api/src/listings/http/dto/bulk-offer-create.dto.ts:130-170` (`PerVariantOverrideDto` reused for both maps, nested `overrides: OverridesNoCategoryDto`) | Confirmed live; `perProductOverrides` and `perVariantOverrides` both point at the same restrictive class |
+| Core service already treats categoryId as family-tier | `libs/core/src/listings/application/services/bulk-listing-submit.service.ts:659-666` (`buildEnqueueInput`), `:733-740` (`stripVariantCategoryId`) | Unconditional strip on variant tier only; family tier keeps it |
+| Adapter metadata shape | `libs/core/src/integrations/domain/types/adapter.types.ts:67-108` (`AdapterMetadata` interface) | No grouping-model field today; `supportedCapabilities: string[]`, `displayName?`, `version?`, `isDefault?` |
+| Static manifests | `libs/integrations/allegro/src/allegro-plugin.ts:74-107` (`allegroAdapterManifest`), `libs/integrations/erli/src/erli-plugin.ts:54-77` (`erliAdapterManifest`), `libs/integrations/woocommerce/src/woocommerce-plugin.ts:51-91` (`woocommerceAdapterManifest`) | Plain object literals; one-line addition each once the interface gains the field |
+| Manifest → FE surfacing | `apps/api/src/integrations/http/connection.controller.ts:84-111` (`toResponse`, calls `resolveAdapterMetadata`), `apps/api/src/integrations/http/dto/connection-response.dto.ts:14-100` (`ConnectionResponseDto`, `supportedCapabilities` field + `fromDomain`) | `resolveAdapterMetadata` already injected everywhere needed; adding a field is the same shape as `supportedCapabilities` |
+| Service already resolves the adapter | `bulk-listing-submit.service.ts:149-152` (`getCapabilityAdapter<OfferManagerPort>`) inside `submit()` | Need a **second**, sibling call to `resolveAdapterMetadata` (metadata, not capability-adapter — `variantGrouping` isn't a capability) — new plumbing, threaded from `submit()` into `buildEnqueueInput`/`stripVariantCategoryId` (currently a free function without access to instance state) |
+| Existing 3-state ladder precedent | `apps/web/src/features/listings/components/bulk/bulk-edit-modal.tsx:124` (`BASE_ONLY_PARAM_NAMES`), `:1732-1733` (`warnParamIds`/`unlockedParamIds` state), `:1850-1939` (`renderVariantParam` — 3 render branches: inherited-readonly-with-override-link / warn-confirm-callout / unlocked-picker-with-split-badge) | Mirror this pattern exactly for the category bar |
+| Reusable category picker | `apps/web/src/features/listings/components/bulk/bulk-edit-modal.tsx:1023-1030` (`BulkCategoryChooseModal`, used by `BaseScopeForm`) | Same component reusable for the variant-scope override |
+| `connection` already reaches the base scope | `bulk-edit-modal.tsx:936` (`connection={connection}` passed to `BaseScopeForm`), `:1552` (`connection.supportedCapabilities?.includes(...)`) | `VariantScopeForm` (props at `:1678-1691`, render call `:974-990`) does **not** currently receive `connection` — needs adding |
+| Per-product category-param schema resolved once | `bulk-edit-modal.tsx:554-560` (`useCategoryParametersQuery(connectionId, baseValues.categoryId)`), result passed identically to `BaseScopeForm` (`:953`) and every `VariantScopeForm` (`:983`) | Only one query call in the whole file — variant override needs its own second query, scoped to that variant only |
+| Bulk-wizard blocker validation already variant-aware | `apps/web/src/features/listings/components/bulk/bulk-wizard.tsx:169-183` (`noCardCategoryIds`, already reads `variant.override.overrides?.categoryId ?? variant.resolvedCategoryId` per-variant) | The 422-blocker gate (`useBulkRequiredProductParams`) already collects per-variant category ids into one set — needs verification (not yet confirmed) that it validates each variant against **its own** category's required-param schema rather than a merged pool |
+| `VariantEdit.categoryId` is dead today | `bulk-edit-modal.tsx:409` (field), `:431` (read from existing override), `:689` (written to `perVariantOverrides` at submit) | Confirmed no `onPatch` call site ever sets it — it round-trips a pre-seeded value only, never operator-set. This plan makes it live. |
+| Erli/WC adapter category wire shapes | `libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts:791-794` (`externalCategories`, per-offer), `:848-855` (`externalVariantGroup.id`, independent of category); `libs/integrations/woocommerce/src/infrastructure/adapters/product-publisher/woocommerce-product-publisher.adapter.ts:478-479`/`530-531` (`categories` on parent/simple only), `:574-589` (`buildVariationBody` — no `categories` field) | Confirmed — matches the 3-model design exactly |
+| FE `Connection` type | `apps/web/src/features/connections/api/connections.types.ts:46-56` (`interface Connection`, `supportedCapabilities: string[]`) | Needs a `variantGrouping?: VariantGroupingModel` field alongside `supportedCapabilities` |
+
+## 3. Design
+
+### 3.1 Declared grouping model (new cross-cutting type)
+
+New `as const` union in `libs/core/src/integrations/domain/types/adapter.types.ts` (extends the existing types file, same file the `AdapterMetadata` interface lives in — no new file needed since it's one tightly-coupled concept):
+
+```ts
+export const VariantGroupingModelValues = [
+  'catalog-implicit',   // grouping via a shared catalog product keyed by category (Allegro)
+  'explicit-group',     // grouping via an explicit group id, category is ordinary metadata (Erli)
+  'parent-child',       // variant is not a taxonomy-bearing object; category is parent-only (WooCommerce)
+] as const;
+export type VariantGroupingModel = (typeof VariantGroupingModelValues)[number];
+```
+
+Add optional field to `AdapterMetadata`:
+```ts
+variantGrouping?: VariantGroupingModel;
+```
+
+Pure resolver (co-located in the same file, mirroring the `pricing-rule.types.ts` / `stockSafetyBuffer` precedent of small pure helpers living beside their type):
+```ts
+/** Most-restrictive default: an adapter that declares nothing is treated as parent-child (locked). */
+export function resolveVariantGroupingModel(metadata: Pick<AdapterMetadata, 'variantGrouping'> | undefined | null): VariantGroupingModel {
+  return metadata?.variantGrouping ?? 'parent-child';
+}
+```
+
+This is the **single seam** every layer (service strip logic, connection response, FE bar) reads through — never `platformType` comparisons (acceptance criterion, ESLint-checkable by grep in review).
+
+### 3.2 Manifests
+
+One line each:
+- `allegroAdapterManifest` (`allegro-plugin.ts:75` area) → `variantGrouping: 'catalog-implicit'`
+- `erliAdapterManifest` (`erli-plugin.ts:56` area) → `variantGrouping: 'explicit-group'`
+- `woocommerceAdapterManifest` (`woocommerce-plugin.ts:52` area) → `variantGrouping: 'parent-child'` (documents the structural default explicitly, even though omitting it would resolve the same via `resolveVariantGroupingModel`)
+
+### 3.3 Connection response surfacing
+
+- `ConnectionResponseDto` (`connection-response.dto.ts`): add `variantGrouping!: VariantGroupingModel` field (`@ApiProperty({ enum: VariantGroupingModelValues })`), populate in `fromDomain` from a new `variantGrouping` parameter.
+- `connection.controller.ts` `toResponse`: after resolving `metadata`, compute `resolveVariantGroupingModel(metadata)` (defaulting the same way on the resolve-failure catch branch, so an unrecognized adapter also reports the locked shape) and pass it to `fromDomain`.
+- FE `Connection` type (`connections.types.ts`): add `variantGrouping: VariantGroupingModel` (import the union — re-exported through whatever the FE's existing capability-string import path is, or a local FE literal union mirroring the 3 values; confirm during implementation whether FE types import BE unions or hand-roll them — follow whatever `supportedCapabilities`' sibling fields do today).
+
+### 3.4 Final DTO shape (Part 1 folded into the Part-2 end-state)
+
+Since both parts land together, the DTO goes straight to its final form rather than through the Part-1-only interim (which would reject variant-tier `categoryId` and need a second migration commit). Decision, called out explicitly for review:
+
+- Delete `OverridesNoCategoryDto` (no longer needed — no tier is DTO-restricted anymore).
+- Rename `PerVariantOverrideDto` → `PerOverrideDto` (one shape, used by **both** `perProductOverrides` and `perVariantOverrides`), with `overrides?: CreateOfferOverridesDto` (the full shape, `categoryId` included).
+- `perProductOverrides` and `perVariantOverrides` both type as `Record<string, PerOverrideDto>`.
+- Enforcement of "can this variant actually keep its own category" moves entirely to the **application layer** (conditional `stripVariantCategoryId`), never the HTTP boundary — because whether a variant may diverge depends on the *destination adapter*, which the DTO layer has no visibility into (it validates shape, not cross-field business rules against a resolved connection).
+- Update the module header comment + the doc comment that used to sit on `OverridesNoCategoryDto`.
+
+### 3.5 Conditional strip in the core service
+
+`BulkListingSubmitService.submit()` already resolves `adapter` via `getCapabilityAdapter`. Add a sibling resolve:
+```ts
+const metadata = await this.integrationsService.resolveAdapterMetadata({ ... });
+const variantGroupingModel = resolveVariantGroupingModel(metadata);
+```
+Thread `variantGroupingModel` as a parameter into `buildEnqueueInput` (currently reads only `input`/`bulkBatchId`/`job`/`masterStock`) and into `stripVariantCategoryId` (currently a bare free function). New signature:
+```ts
+function stripVariantCategoryId(overrides, variantGroupingModel: VariantGroupingModel) {
+  if (variantGroupingModel !== 'parent-child') return overrides; // Allegro + Erli both keep it
+  // ... existing strip logic, unchanged
+}
+```
+Only `'parent-child'` (WooCommerce, and the locked default for anything undeclared) strips. `'catalog-implicit'` (Allegro) and `'explicit-group'` (Erli) both pass the variant-tier `categoryId` through — Allegro's consequence (splitting the grouped listing) is a downstream/FE-only concern, not something the submit service needs to police (the offer builder / adapter already resolve category per-offer field-for-field once it reaches them).
+
+### 3.6 Bulk wizard blocker validation (`bulk-wizard.tsx` + `useBulkRequiredProductParams`)
+
+Investigate at implementation time (not fully confirmed by research) whether `useBulkRequiredProductParams` already validates each variant's required-params against **its own** resolved category schema, or lumps `noCardCategoryIds` into one merged pool and cross-attributes params. If the latter, it needs to key its resolved-schema lookup per variant id (not just per distinct category id merged flat) so a tester's required params are checked against the tester's category, not the family's.
+
+### 3.7 FE bar (`bulk-edit-modal.tsx`)
+
+- Thread `connection` (already fetched) into `VariantScopeForm` (new prop, passed at the render call site `:974-990` alongside the existing props).
+- Derive `variantGroupingModel = connection.variantGrouping` once in `VariantScopeForm`.
+- Only `'catalog-implicit'` (Allegro) renders the interactive 3-state ladder — mirroring `warnParamIds`/`unlockedParamIds` exactly, but as **new, category-specific state** (not reusing the param-id sets, since `categoryId` isn't a `CategoryParameter`):
+  ```ts
+  const [categoryWarn, setCategoryWarn] = useState(false);
+  const [categoryUnlocked, setCategoryUnlocked] = useState(edit.categoryId !== undefined);
+  ```
+  - **State 1 (inherited)**: read-only chip showing the base category path + "Override for this variant" link → sets `categoryWarn = true`.
+  - **State 2 (warn)**: consequence callout ("Splits this variant into its own Allegro listing") + "Override anyway" (→ `categoryUnlocked = true`, seed `edit.categoryId` from base) / "Keep shared" (→ `categoryWarn = false`).
+  - **State 3 (unlocked)**: `BulkCategoryChooseModal` (same component the base scope already uses) scoped to this variant, a "splits listing" badge, reset link (clears `edit.categoryId`, `categoryUnlocked = false`).
+- Any other `variantGroupingModel` (`'explicit-group'`, `'parent-child'`, or the field missing) renders **only** state 1's read-only chip, no override link — Erli gets no functional picker today (no `CategoryBrowser`) so there's nothing useful to hand off to regardless of its declared model; WooCommerce additionally states "set on the parent product" per acceptance criteria. Distinguish the two only by copy, not by behavior.
+- Second `useCategoryParametersQuery(connectionId, edit.categoryId)` inside `VariantScopeForm`, gated on `edit.categoryId !== undefined && edit.categoryId !== baseValues.categoryId`; when active, its result set replaces the shared `categoryParameters` prop for that variant's own param rendering (`renderVariantParam` / `requiredParams`/`optionalParams` computation) — every other variant keeps reading the shared query.
+- No `platformType` comparisons anywhere in this component — only `variantGroupingModel === 'catalog-implicit'` (or equivalent switch).
+
+### 3.8 Outcome strip
+
+Per the issue's approved mock: a small strip inside the category bar stating what the current choice publishes as (`one card` / `separate` / `one group` / `parent-only`), driven by `variantGroupingModel` + `categoryUnlocked`. Small, presentational — implemented as part of 3.7, no separate step.
+
+## 4. Step-by-step plan
+
+Each step includes its acceptance check.
+
+| # | Step | File(s) | Acceptance |
+|---|---|---|---|
+| 1 | Add `VariantGroupingModelValues`/`VariantGroupingModel`/`resolveVariantGroupingModel` | `libs/core/src/integrations/domain/types/adapter.types.ts` | Exported from `@openlinker/core/integrations` barrel (already re-exports the types file's other exports — confirm) |
+| 2 | Add `variantGrouping?: VariantGroupingModel` to `AdapterMetadata` | same file | Type-checks; existing manifests still conform (field optional) |
+| 3 | Declare `variantGrouping` on the 3 manifests | `allegro-plugin.ts`, `erli-plugin.ts`, `woocommerce-plugin.ts` | Each manifest's existing `*.spec.ts` (if any asserts full manifest shape) still passes or is updated |
+| 4 | Surface `variantGrouping` on `ConnectionResponseDto` + `toResponse` | `connection-response.dto.ts`, `connection.controller.ts` | `connection.controller.spec.ts` covers a connection whose adapter declares each of the 3 models + the resolve-failure fallback (locked) |
+| 5 | Add `variantGrouping` to FE `Connection` type | `apps/web/src/features/connections/api/connections.types.ts` | Type-checks against the API response shape |
+| 6 | Rewrite `bulk-offer-create.dto.ts`: delete `OverridesNoCategoryDto`, rename/merge into `PerOverrideDto`, both maps point at it | `apps/api/src/listings/http/dto/bulk-offer-create.dto.ts` | `bulk-offer-create.dto.spec.ts`: family-tier `categoryId` accepted, variant-tier `categoryId` now also accepted at the DTO layer (validation moved to the service); every other field's existing validation (title MaxLength, imageUrls IsUrl, price positivity, ean digit-shape, platformParams cap, parameters bounds) still enforced on both maps |
+| 7 | Thread `variantGroupingModel` resolution into `BulkListingSubmitService.submit()` → `buildEnqueueInput` → `stripVariantCategoryId` | `bulk-listing-submit.service.ts` | `bulk-listing-submit.service.spec.ts`: catalog-implicit + explicit-group → categoryId survives; parent-child + undeclared/unresolvable → stripped |
+| 8 | Verify/fix `useBulkRequiredProductParams` per-variant category schema attribution | `apps/web/src/features/listings/hooks/use-bulk-required-product-params.ts` (confirm path) | A variant with its own category is validated against that category's required params, not the family's — add/adjust a test case |
+| 9 | Thread `connection` into `VariantScopeForm`; add category 3-state bar + second `useCategoryParametersQuery` | `bulk-edit-modal.tsx` | New render branch per `variantGroupingModel`; `bulk-edit-modal.test.tsx` covers all 3 models |
+| 10 | Mixed-batch + multi-variant submit end-to-end sanity | `bulk-wizard.test.tsx` or a new focused test | A multi-variant product submits without a 400; a mixed batch (1 single-variant + 1 multi-variant) submits in full |
+
+No DB migration: `variantGrouping` lives in code (manifest), same as every other capability declaration — consistent with "Capability Assignment (Implicit Capabilities)" in the architecture doc.
+
+## 5. Validate
+
+- Architecture: capability/model resolution is manifest-declared and read through a single pure resolver — never `platformType` string comparisons outside `plugins/<platformType>/` (acceptance criterion; verify by grep before opening the PR).
+- Naming: `VariantGroupingModelValues`/`VariantGroupingModel` follows the `as const` + union convention (engineering-standards.md); `resolveVariantGroupingModel` is a pure, side-effect-free function colocated with its type, matching the `stockSafetyBuffer`/pricing-rule precedent.
+- Testing: unit tests at every layer touched (DTO, service, connection response, FE modal). Per `resource-constrained-pc-test-prefs` memory, scope test runs to the affected packages rather than the full `pnpm test`; skip `pnpm test:integration` unless explicitly requested (no schema/migration change, so low risk there).
+- Security: no new user input surface beyond what already exists (`categoryId` was always acceptable as a string at the family tier; this only widens where it's *allowed*, no new validation gap — GS1/currency/key-shape guards untouched).
+
+## 6. Risks / open questions
+
+1. **DTO scope decision (3.4)**: going straight to the end-state (deleting `OverridesNoCategoryDto` rather than keeping Part 1's interim restriction) changes behavior beyond the issue's Part-1-only acceptance criterion ("perVariantOverrides still rejects categoryId with a 400"). Since Part 2 supersedes that within the same PR, this is intentional — flagging for explicit sign-off before implementation.
+2. **Erli's declared-but-unavailable model**: confirmed by the issue itself as intentional (no `CategoryBrowser` yet), so the FE renders it identically to the locked WooCommerce shape today. Revisit once the borrowed-taxonomy browse capability (#1045 follow-up) exists.
+3. **`useBulkRequiredProductParams` exact behavior** (step 8) is unconfirmed — needs a short Explore pass at the start of implementation before deciding whether it's a no-op verification or a real fix.
+4. **FE `Connection` type import path** for the new union (step 5) — whether FE hand-rolls a mirrored literal union or there's an existing cross-package type-sharing convention for such enums; resolve during implementation by checking how `supportedCapabilities`' sibling FE fields are typed.

--- a/libs/core/src/integrations/domain/types/adapter.types.ts
+++ b/libs/core/src/integrations/domain/types/adapter.types.ts
@@ -105,5 +105,58 @@ export interface AdapterMetadata {
    * `DuplicatePlatformDefaultException`. (#571)
    */
   isDefault?: boolean;
+
+  /**
+   * Declares how this destination groups sibling variants into one
+   * buyer-facing listing, and therefore whether — and how consequentially —
+   * a single variant may carry its own category (#1924).
+   *
+   * Advertised-without-dispatch, same as `CategoryBrowser` /
+   * `EanCategoryMatcher` on Allegro (#1367) and `ShopCategoryBrowser` on
+   * WooCommerce (#1834): read directly off the manifest for host/FE
+   * discovery, never resolved through `getCapabilityAdapter` (it is not a
+   * capability name).
+   *
+   * Absent when an adapter declares nothing — use
+   * {@link resolveVariantGroupingModel} rather than reading this field
+   * directly, so the most-restrictive default is always applied.
+   */
+  variantGrouping?: VariantGroupingModel;
+}
+
+/**
+ * Variant-grouping model values (#1924).
+ *
+ * - `'catalog-implicit'` — siblings group by sharing a catalog product keyed
+ *   by category (Allegro). Giving one variant its own category is a real,
+ *   consequential choice: it splits that variant out of the grouped listing.
+ * - `'explicit-group'` — grouping is carried by an explicit group id,
+ *   independent of category (Erli's `externalVariantGroup`). A per-variant
+ *   category is ordinary metadata — no split, no confirm.
+ * - `'parent-child'` — the variant is not a taxonomy-bearing object at all
+ *   (a WooCommerce product variation has no `categories` field); category is
+ *   structurally parent-only.
+ */
+export const VariantGroupingModelValues = [
+  'catalog-implicit',
+  'explicit-group',
+  'parent-child',
+] as const;
+
+/** Derived union type from {@link VariantGroupingModelValues}. */
+export type VariantGroupingModel = (typeof VariantGroupingModelValues)[number];
+
+/**
+ * Resolve the effective variant-grouping model for an adapter, defaulting to
+ * the most restrictive shape (`'parent-child'`) when the adapter declares
+ * nothing (#1924). The opposite default would let an undeclared destination
+ * silently offer a per-variant category override its API cannot actually
+ * carry — the operator would only discover that from a rejected publish.
+ * Pure, no I/O.
+ */
+export function resolveVariantGroupingModel(
+  metadata: Pick<AdapterMetadata, 'variantGrouping'> | undefined | null
+): VariantGroupingModel {
+  return metadata?.variantGrouping ?? 'parent-child';
 }
 

--- a/libs/core/src/integrations/index.ts
+++ b/libs/core/src/integrations/index.ts
@@ -51,6 +51,9 @@ export {
   CoreCapability,
   CoreCapabilityValues,
   AdapterMetadata,
+  VariantGroupingModel,
+  VariantGroupingModelValues,
+  resolveVariantGroupingModel,
 } from './domain/types/adapter.types';
 export { ConnectionTestResult } from './domain/types/connection-test.types';
 export { WebhookProvisioningResult } from './domain/types/webhook-provisioning.types';

--- a/libs/core/src/listings/application/services/__tests__/bulk-listing-submit.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/bulk-listing-submit.service.spec.ts
@@ -60,6 +60,20 @@ describe('BulkListingSubmitService', () => {
         : {}),
     }) as unknown as OfferManagerPort;
 
+  /** Minimal `getAdapter` resolution for a given declared variant-grouping model (#1924). */
+  const adapterResolutionWith = (
+    variantGrouping?: 'catalog-implicit' | 'explicit-group' | 'parent-child'
+  ): Awaited<ReturnType<IIntegrationsService['getAdapter']>> =>
+    ({
+      connection: {},
+      metadata: {
+        adapterKey: 'test.adapter.v1',
+        platformType: 'test',
+        supportedCapabilities: ['OfferManager'],
+        ...(variantGrouping ? { variantGrouping } : {}),
+      },
+    }) as unknown as Awaited<ReturnType<IIntegrationsService['getAdapter']>>;
+
   const variant = (overrides: Partial<ProductVariant> & Pick<ProductVariant, 'id' | 'productId'>): ProductVariant => ({
     sku: null,
     attributes: null,
@@ -127,7 +141,10 @@ describe('BulkListingSubmitService', () => {
     };
 
     integrations = {
-      getAdapter: jest.fn(),
+      // Default: no declared variantGrouping → resolves to the locked
+      // 'parent-child' default (#1924). Tests exercising a specific model
+      // override this per-case.
+      getAdapter: jest.fn().mockResolvedValue(adapterResolutionWith()),
       getCapabilityAdapter: jest.fn().mockResolvedValue(adapterWith(jest.fn())),
       listCapabilityAdapters: jest.fn(),
       resolveAdapterMetadata: jest.fn(),
@@ -989,7 +1006,9 @@ describe('BulkListingSubmitService', () => {
       expect(enqueueService.enqueueCreation).not.toHaveBeenCalled();
     });
 
-    it('strips categoryId from a per-variant override', async () => {
+    it('strips categoryId from a per-variant override for a parent-child destination (WooCommerce-like, #1924)', async () => {
+      integrations.getAdapter.mockResolvedValue(adapterResolutionWith('parent-child'));
+
       await service.submit({
         connectionId,
         initiatedBy,
@@ -1003,6 +1022,57 @@ describe('BulkListingSubmitService', () => {
       const overrides = enqueueService.enqueueCreation.mock.calls[0][0].overrides;
       expect(overrides).toEqual({ title: 'Variant title' });
       expect(overrides).not.toHaveProperty('categoryId');
+    });
+
+    it('strips categoryId from a per-variant override when the adapter declares nothing (locked default, #1924)', async () => {
+      integrations.getAdapter.mockResolvedValue(adapterResolutionWith());
+
+      await service.submit({
+        connectionId,
+        initiatedBy,
+        productIds: ['ol_variant_a'],
+        sharedConfig: { stock: 1, publishImmediately: false },
+        perVariantOverrides: {
+          ol_variant_a: { overrides: { categoryId: 'cat-x', title: 'Variant title' } },
+        },
+      });
+
+      const overrides = enqueueService.enqueueCreation.mock.calls[0][0].overrides;
+      expect(overrides).not.toHaveProperty('categoryId');
+    });
+
+    it('keeps a per-variant categoryId for a catalog-implicit destination (Allegro-like, #1924)', async () => {
+      integrations.getAdapter.mockResolvedValue(adapterResolutionWith('catalog-implicit'));
+
+      await service.submit({
+        connectionId,
+        initiatedBy,
+        productIds: ['ol_variant_a'],
+        sharedConfig: { stock: 1, publishImmediately: false },
+        perVariantOverrides: {
+          ol_variant_a: { overrides: { categoryId: 'cat-x', title: 'Variant title' } },
+        },
+      });
+
+      const overrides = enqueueService.enqueueCreation.mock.calls[0][0].overrides;
+      expect(overrides).toEqual({ categoryId: 'cat-x', title: 'Variant title' });
+    });
+
+    it('keeps a per-variant categoryId for an explicit-group destination (Erli-like, #1924)', async () => {
+      integrations.getAdapter.mockResolvedValue(adapterResolutionWith('explicit-group'));
+
+      await service.submit({
+        connectionId,
+        initiatedBy,
+        productIds: ['ol_variant_a'],
+        sharedConfig: { stock: 1, publishImmediately: false },
+        perVariantOverrides: {
+          ol_variant_a: { overrides: { categoryId: 'cat-x', title: 'Variant title' } },
+        },
+      });
+
+      const overrides = enqueueService.enqueueCreation.mock.calls[0][0].overrides;
+      expect(overrides).toEqual({ categoryId: 'cat-x', title: 'Variant title' });
     });
 
     it('rejects a per-variant override whose price currency diverges from the batch currency', async () => {

--- a/libs/core/src/listings/application/services/bulk-listing-submit.service.ts
+++ b/libs/core/src/listings/application/services/bulk-listing-submit.service.ts
@@ -51,7 +51,9 @@ import type {
 import {
   IIntegrationsService,
   INTEGRATIONS_SERVICE_TOKEN,
+  resolveVariantGroupingModel,
 } from '@openlinker/core/integrations';
+import type { VariantGroupingModel } from '@openlinker/core/integrations';
 import {
   IProductsService,
   PRODUCTS_SERVICE_TOKEN,
@@ -166,6 +168,14 @@ export class BulkListingSubmitService implements IBulkListingSubmitService {
     // strategy leaking into the platform-agnostic submit service.
     const dropBarcodelessSiblings = isCatalogProductReader(adapter);
 
+    // Variant-grouping model (#1924): declared on the manifest, read directly
+    // off the metadata `getAdapter` already resolves — not a capability, so
+    // never dispatched through `getCapabilityAdapter`. Drives whether a
+    // per-variant categoryId survives to the built offer (buildEnqueueInput →
+    // stripVariantCategoryId below).
+    const { metadata } = await this.integrationsService.getAdapter(input.connectionId);
+    const variantGroupingModel = resolveVariantGroupingModel(metadata);
+
     // 2. Expand submitted primary-variant ids into the per-offer job list.
     //    A multi-variant product fans out into one job per sibling variant
     //    (#824); single-variant products and unknown ids pass through
@@ -234,7 +244,13 @@ export class BulkListingSubmitService implements IBulkListingSubmitService {
     const enqueuedRecordIds = new Set<string>();
     try {
       for (const job of jobs) {
-        const enqueueInput = this.buildEnqueueInput(input, batch.id, job, masterStock);
+        const enqueueInput = this.buildEnqueueInput(
+          input,
+          batch.id,
+          job,
+          masterStock,
+          variantGroupingModel
+        );
         const { jobId, offerCreationRecord } =
           await this.offerCreationEnqueue.enqueueCreation(enqueueInput);
         jobIds.push(jobId);
@@ -495,11 +511,11 @@ export class BulkListingSubmitService implements IBulkListingSubmitService {
    *   `sharedConfig.price.currency` throws `CurrencyMismatchException`
    *   (currency is batch-wide).
    *
-   * A per-variant `categoryId` (grouping-determining and product-level) is not
-   * mutated away here — the DTO already omits it via `OmitType`, and
-   * `buildEnqueueInput` strips it non-destructively from the variant tier before
-   * merging, so this validator leaves its input untouched (#1741 review — no
-   * input mutation).
+   * A per-variant `categoryId` is not mutated away here — the DTO accepts it at
+   * both tiers (#1924), and `buildEnqueueInput` conditionally strips it
+   * non-destructively from the variant tier before merging (destination-aware,
+   * via `stripVariantCategoryId`), so this validator leaves its input untouched
+   * (#1741 review — no input mutation).
    *
    * Iterates with `Object.keys` (own enumerable keys only) so a JSON
    * `__proto__` own-property key is enumerated + rejected and the prototype
@@ -625,7 +641,8 @@ export class BulkListingSubmitService implements IBulkListingSubmitService {
     input: BulkListingSubmitInput,
     bulkBatchId: string,
     job: ExpandedVariantJob,
-    masterStock: Map<string, number>
+    masterStock: Map<string, number>,
+    variantGroupingModel: VariantGroupingModel
   ): EnqueueOfferCreationInput {
     // 3-way precedence (#1741): base sharedConfig → family (perProductOverrides
     // by selectedId) → variant (perVariantOverrides by variantId); the variant
@@ -656,13 +673,19 @@ export class BulkListingSubmitService implements IBulkListingSubmitService {
     const publishEffective = stock > 0 ? publishImmediately : false;
     // Layer overrides base → family → variant; `platformParams` deep-merged
     // across all three so shared keys (e.g. `deliveryPolicyId`, #808) survive.
-    // `categoryId` is stripped from the variant tier here (non-destructively) so
-    // a per-variant category can never override the shared/family category and
-    // split the listing — the family tier keeps it (product-level, shared).
+    // `categoryId` is stripped from the variant tier here (non-destructively)
+    // only when the destination's declared `variantGrouping` model requires it
+    // (#1924) - a `'parent-child'` shop (or any undeclared/unresolved adapter,
+    // via the locked default) cannot carry a per-variant category at all, so
+    // it is silently dropped rather than rejected upstream. `'catalog-implicit'`
+    // (Allegro) and `'explicit-group'` (Erli) both let the variant tier's
+    // categoryId through — Allegro's consequence (splitting the grouped
+    // listing) is a downstream FE/operator concern, not something this service
+    // polices.
     let overrides = this.mergeOverrides(
       input.sharedConfig.overrides,
       familyOverride?.overrides,
-      stripVariantCategoryId(variantOverride?.overrides)
+      stripVariantCategoryId(variantOverride?.overrides, variantGroupingModel)
     );
     // Strip the wizard-resolved card for expanded siblings so each self-links
     // by its own barcode - UNLESS the operator explicitly picked a per-variant
@@ -726,14 +749,21 @@ export class BulkListingSubmitService implements IBulkListingSubmitService {
 }
 
 /**
- * Return a copy of the variant-tier overrides with any `categoryId` removed
- * (#1741). Non-destructive — the caller's input object is never mutated. Returns
- * `undefined` unchanged so `mergeOverrides` keeps omitting an absent tier.
+ * Return a copy of the variant-tier overrides with any `categoryId` removed,
+ * conditional on the destination's declared variant-grouping model (#1741,
+ * #1924). Only `'parent-child'` (a variation has no `categories` field at
+ * all - WooCommerce, and the locked default for any undeclared adapter)
+ * strips it; `'catalog-implicit'` (Allegro) and `'explicit-group'` (Erli)
+ * both let a per-variant categoryId through. Non-destructive — the caller's
+ * input object is never mutated. Returns `undefined` unchanged so
+ * `mergeOverrides` keeps omitting an absent tier.
  */
 function stripVariantCategoryId(
-  overrides: CreateOfferOverrides | undefined
+  overrides: CreateOfferOverrides | undefined,
+  variantGroupingModel: VariantGroupingModel
 ): CreateOfferOverrides | undefined {
   if (!overrides || overrides.categoryId === undefined) return overrides;
+  if (variantGroupingModel !== 'parent-child') return overrides;
   const rest: CreateOfferOverrides = { ...overrides };
   delete rest.categoryId;
   return rest;

--- a/libs/integrations/allegro/src/__tests__/allegro-plugin.spec.ts
+++ b/libs/integrations/allegro/src/__tests__/allegro-plugin.spec.ts
@@ -46,6 +46,10 @@ describe('allegroAdapterManifest', () => {
       expect.arrayContaining(['OfferCreator', 'OfferEventReader']),
     );
   });
+
+  it('declares catalog-implicit variant grouping so a per-variant category override is treated as consequential (#1924)', () => {
+    expect(allegroAdapterManifest.variantGrouping).toBe('catalog-implicit');
+  });
 });
 
 describe('createAllegroPlugin → register(host)', () => {

--- a/libs/integrations/allegro/src/allegro-plugin.ts
+++ b/libs/integrations/allegro/src/allegro-plugin.ts
@@ -105,6 +105,9 @@ export const allegroAdapterManifest: AdapterMetadata = {
   displayName: 'Allegro Public API v1',
   version: '1.0.0',
   isDefault: true,
+  // Siblings group by sharing a catalog product keyed by category (#1924) —
+  // giving one variant its own category splits it out of the grouped listing.
+  variantGrouping: 'catalog-implicit',
 };
 
 /**

--- a/libs/integrations/erli/src/__tests__/erli-plugin.spec.ts
+++ b/libs/integrations/erli/src/__tests__/erli-plugin.spec.ts
@@ -127,6 +127,10 @@ describe('erliAdapterManifest', () => {
     expect(erliAdapterManifest.isDefault).toBe(true);
   });
 
+  it('should declare explicit-group variant grouping so a per-variant category is treated as ordinary metadata, not a split (#1924)', () => {
+    expect(erliAdapterManifest.variantGrouping).toBe('explicit-group');
+  });
+
   it('should carry a display name and version', () => {
     expect(erliAdapterManifest.displayName).toBe('Erli Shop API v1');
     expect(erliAdapterManifest.version).toBe('1.0.0');

--- a/libs/integrations/erli/src/erli-plugin.ts
+++ b/libs/integrations/erli/src/erli-plugin.ts
@@ -75,6 +75,12 @@ export const erliAdapterManifest: AdapterMetadata = {
   displayName: 'Erli Shop API v1',
   version: '1.0.0',
   isDefault: true,
+  // Grouping is carried by an explicit group id (`externalVariantGroup`),
+  // independent of category (#1924) — a per-variant category is ordinary
+  // metadata here, no split. Declared for discovery; not yet interactively
+  // available (Erli borrows Allegro's taxonomy and ships no CategoryBrowser,
+  // so even the base-scope picker is read-only today, #1045 follow-up).
+  variantGrouping: 'explicit-group',
 };
 
 /**

--- a/libs/integrations/woocommerce/src/__tests__/woocommerce-plugin.spec.ts
+++ b/libs/integrations/woocommerce/src/__tests__/woocommerce-plugin.spec.ts
@@ -131,6 +131,10 @@ describe('woocommerceAdapterManifest', () => {
   it('should be marked as the default adapter for the platform', () => {
     expect(woocommerceAdapterManifest.isDefault).toBe(true);
   });
+
+  it('should declare parent-child variant grouping so a variation cannot carry its own category (#1924)', () => {
+    expect(woocommerceAdapterManifest.variantGrouping).toBe('parent-child');
+  });
 });
 
 describe('createWooCommercePlugin → register(host)', () => {

--- a/libs/integrations/woocommerce/src/woocommerce-plugin.ts
+++ b/libs/integrations/woocommerce/src/woocommerce-plugin.ts
@@ -88,6 +88,10 @@ export const woocommerceAdapterManifest: AdapterMetadata = {
   displayName: 'WooCommerce REST API v3',
   version: '1.0.0',
   isDefault: true,
+  // A WC product variation has no `categories` field in the REST API (#1924)
+  // - category is structurally parent-only, not a policy choice. Also the
+  // locked default any undeclared adapter resolves to.
+  variantGrouping: 'parent-child',
 };
 
 /** Short brand label for domain-exception prefixes (manifest.displayName is too long). */


### PR DESCRIPTION
## Summary

**Part 1 (bug fix):** the bulk-create request DTO restricted `categoryId` at both the family tier (`perProductOverrides`) and the variant tier (`perVariantOverrides`) via the same `OmitType`'d class, even though the family tier was always meant to carry it. Every multi-variant bulk publish that set a family category 400'd at the HTTP boundary.

**Part 2 (new capability):** each destination now declares a `variantGrouping` model on its manifest (`'catalog-implicit' | 'explicit-group' | 'parent-child'` — Allegro / Erli / WooCommerce respectively), surfaced on the connection response and resolved through one pure helper with a locked default (`parent-child`) for anything undeclared. `BulkListingSubmitService.stripVariantCategoryId` is now conditional on that model instead of unconditional. The bulk edit modal's variant scope gets a 3-state category ladder (inherited → confirm → picker, mirroring the existing grouping-param ladder used for Marka/Stan) on a `catalog-implicit` destination; every other model renders read-only.

Both maps now accept the full override shape at the DTO layer; whether a variant-tier `categoryId` actually survives to the built offer is a destination-aware decision made in the service, not the HTTP boundary.

## Screenshot walkthrough

**[→ Live walkthrough with screenshots](https://claude.ai/code/artifact/21d9935b-2df5-418e-be15-ba47b6420f73)**

Captured from an isolated stack (api/worker/web built off this branch) pointed at the real demo database — a real unlisted multi-variant product, a real Allegro sandbox connection, family category set → accepted (previously 400'd), one variant given its own category through the new 3-state ladder, submitted and persisted correctly.

## Test plan

- [x] `pnpm lint` / `pnpm type-check` / `pnpm check:invariants` — all clean across every touched package
- [x] Unit tests: core (1962), api (1072), web (2835), allegro (545), erli (425), woocommerce (492) — all green
- [x] Live E2E: real multi-variant product bulk-published on the real Allegro sandbox connection with a family category + a per-variant override category; verified persisted correctly via direct DB query (`offer_creation_records.request->overrides->categoryId` differs per variant as expected)
- [x] Live E2E: FE 3-state category ladder exercised in a real browser session against the live stack (inherited → confirm → picker), including a copy-accuracy bug found and fixed during this check

Closes #1924
