### PR TITLE
feat(mcp): read-only domain tools with capability-gated dynamic tools/list

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -246,3 +246,22 @@ OL_PII_HASH_SALT=your-org-level-salt-change-in-production
 # and this value presents as a bare 401 with no further diagnostic, so set it
 # explicitly in production. Changing it invalidates every existing token.
 # OL_MCP_RESOURCE_URL=https://openlinker.example.com/mcp
+
+# ─────────────────────────────────────────────────────────────────────────────
+# MCP server — per-token tool-call limits (#1487)
+# ─────────────────────────────────────────────────────────────────────────────
+# Abuse mitigation for the tool surface, NOT an authorization control (auth is
+# enforced upstream by the bearer middleware). Both limits are keyed on the MCP
+# token id, so one agent cannot starve another. If Redis is unavailable the
+# limiter FAILS OPEN — an outage must not take down the whole MCP surface.
+#
+# Rolling request-rate window: at most OL_MCP_RATE_LIMIT calls per
+# OL_MCP_RATE_WINDOW_SECONDS. Defaults 120 / 60. Invalid values fall back to
+# the default rather than disabling the limit.
+# OL_MCP_RATE_LIMIT=120
+# OL_MCP_RATE_WINDOW_SECONDS=60
+#
+# Concurrency cap: how many tool calls may be in flight simultaneously for one
+# token. This is what an agent stuck in a loop actually exhausts. Default 8.
+# A call whose request crashes releases its slot automatically after ~120s.
+# OL_MCP_CONCURRENCY_LIMIT=8

--- a/apps/api/src/mcp/auth/mcp-principal.types.ts
+++ b/apps/api/src/mcp/auth/mcp-principal.types.ts
@@ -50,3 +50,30 @@ export function isMcpAuthInfoExtra(value: unknown): value is McpAuthInfoExtra {
     typeof candidate.olRole === 'string'
   );
 }
+
+/**
+ * Project an authenticated caller down to the safe-to-log fields (#1487).
+ *
+ * This function IS the security invariant described in the module header —
+ * it exists so that "never log the AuthInfo" is enforced by a call rather
+ * than remembered as a convention. It takes only the already-narrowed
+ * `extra` bag plus scopes, so the raw token is not even in scope here and
+ * cannot be leaked by a future edit.
+ *
+ * Returns `null` when `extra` is not a recognisable OL principal, so callers
+ * can distinguish "unauthenticated" from "authenticated as nobody".
+ */
+export function redactPrincipal(
+  extra: unknown,
+  scopes: readonly string[] = []
+): RedactedMcpPrincipal | null {
+  if (!isMcpAuthInfoExtra(extra)) {
+    return null;
+  }
+  return {
+    mcpTokenId: extra.mcpTokenId,
+    olUserId: extra.olUserId,
+    olRole: extra.olRole,
+    scopes: scopes.filter((s): s is McpTokenScope => s === 'mcp:read' || s === 'mcp:write'),
+  };
+}

--- a/apps/api/src/mcp/mcp.module.ts
+++ b/apps/api/src/mcp/mcp.module.ts
@@ -33,16 +33,47 @@ import {
 } from '@nestjs/common';
 import { requireBearerAuth } from '@modelcontextprotocol/express';
 import { UsersModule } from '@openlinker/core/users';
+import { ProductsModule } from '@openlinker/core/products';
+import { InventoryModule } from '@openlinker/core/inventory';
+import { OrdersModule } from '@openlinker/core/orders';
 import { AppInfoModule } from '../app-info/app-info.module';
+// The HOST integrations module (apps/api), NOT the core one — it provides
+// CONNECTION_SERVICE_TOKEN and re-exports CoreIntegrationsModule (which
+// carries INTEGRATIONS_SERVICE_TOKEN), so this single import covers both
+// capability gating and `list_connections`. Aliased because the core module
+// exports a class of the same name; an unaliased import here would be a
+// silent shadowing bug.
+import { IntegrationsModule as HostIntegrationsModule } from '../integrations/integrations.module';
 import { MCP_TRANSPORT_PATH } from './mcp-resource';
 import { OlMcpTokenVerifier } from './auth/ol-mcp-token.verifier';
 import { McpTokensController } from './http/mcp-tokens.controller';
 import { McpTransportController } from './transport/mcp-transport.controller';
+import { McpAuditLogger } from './tools/audit/mcp-audit.logger';
+import { McpRateLimiter } from './tools/ratelimit/mcp-rate-limiter';
+import { MCP_RATE_LIMITER_TOKEN } from './tools/ratelimit/mcp-rate-limiter.interface';
+import { McpToolRegistryService } from './tools/tool-registry.service';
+import { MCP_TOOL_REGISTRY_SERVICE_TOKEN } from './tools/tool-registry.service.interface';
+import { mcpToolDefinitionsProvider } from './tools/mcp-tool-definitions.provider';
 
 @Module({
-  imports: [UsersModule, AppInfoModule],
+  imports: [
+    UsersModule,
+    AppInfoModule,
+    HostIntegrationsModule,
+    ProductsModule,
+    InventoryModule,
+    OrdersModule,
+  ],
   controllers: [McpTokensController, McpTransportController],
-  providers: [OlMcpTokenVerifier],
+  providers: [
+    OlMcpTokenVerifier,
+    McpAuditLogger,
+    McpRateLimiter,
+    { provide: MCP_RATE_LIMITER_TOKEN, useExisting: McpRateLimiter },
+    mcpToolDefinitionsProvider,
+    McpToolRegistryService,
+    { provide: MCP_TOOL_REGISTRY_SERVICE_TOKEN, useExisting: McpToolRegistryService },
+  ],
   exports: [OlMcpTokenVerifier],
 })
 export class McpModule implements NestModule {

--- a/apps/api/src/mcp/mcp.module.ts
+++ b/apps/api/src/mcp/mcp.module.ts
@@ -49,6 +49,7 @@ import { OlMcpTokenVerifier } from './auth/ol-mcp-token.verifier';
 import { McpTokensController } from './http/mcp-tokens.controller';
 import { McpTransportController } from './transport/mcp-transport.controller';
 import { McpAuditLogger } from './tools/audit/mcp-audit.logger';
+import { MCP_AUDIT_LOGGER_TOKEN } from './tools/audit/mcp-audit.logger.interface';
 import { McpRateLimiter } from './tools/ratelimit/mcp-rate-limiter';
 import { MCP_RATE_LIMITER_TOKEN } from './tools/ratelimit/mcp-rate-limiter.interface';
 import { McpToolRegistryService } from './tools/tool-registry.service';
@@ -68,6 +69,7 @@ import { mcpToolDefinitionsProvider } from './tools/mcp-tool-definitions.provide
   providers: [
     OlMcpTokenVerifier,
     McpAuditLogger,
+    { provide: MCP_AUDIT_LOGGER_TOKEN, useExisting: McpAuditLogger },
     McpRateLimiter,
     { provide: MCP_RATE_LIMITER_TOKEN, useExisting: McpRateLimiter },
     mcpToolDefinitionsProvider,

--- a/apps/api/src/mcp/tools/audit/mcp-audit.logger.interface.ts
+++ b/apps/api/src/mcp/tools/audit/mcp-audit.logger.interface.ts
@@ -1,0 +1,36 @@
+/**
+ * MCP Audit Logger Interface
+ *
+ * Contract for recording one line per MCP tool call (#1487).
+ *
+ * It exists for the same reason `IMcpRateLimiter` does: both are collaborators
+ * of `McpToolRegistryService`'s per-call wrapper, and the registry should code
+ * against an interface for either or neither. Injecting one concretely and the
+ * other by token invited a "why the asymmetry?" with no answer.
+ *
+ * SECURITY: the audit shape takes a `RedactedMcpPrincipal`, never an `AuthInfo`.
+ * The raw bearer token is therefore not even expressible here — the invariant
+ * is enforced by the type, not by a convention (#1486).
+ *
+ * @module apps/api/src/mcp/tools/audit
+ */
+import type { RedactedMcpPrincipal } from '../../auth/mcp-principal.types';
+import type { McpToolOutcome } from '../tool-definition.types';
+
+export const MCP_AUDIT_LOGGER_TOKEN = Symbol('IMcpAuditLogger');
+
+export interface McpToolCallAudit {
+  readonly tool: string;
+  readonly outcome: McpToolOutcome;
+  readonly durationMs: number;
+  /** Present only for tools that accept a connection argument. */
+  readonly connectionId?: string;
+  /** `null` when the call somehow arrived with no recognisable principal. */
+  readonly principal: RedactedMcpPrincipal | null;
+  /** Error message for `outcome: 'error'`, limit reason for `'rate-limited'`. */
+  readonly detail?: string;
+}
+
+export interface IMcpAuditLogger {
+  record(audit: McpToolCallAudit): void;
+}

--- a/apps/api/src/mcp/tools/audit/mcp-audit.logger.spec.ts
+++ b/apps/api/src/mcp/tools/audit/mcp-audit.logger.spec.ts
@@ -1,0 +1,104 @@
+/**
+ * McpAuditLogger Unit Tests
+ *
+ * Re-asserts the #1486 redaction invariant at its new #1487 consumer: the
+ * audit line must carry the redacted principal projection and never anything
+ * derived from the raw bearer token.
+ */
+import { Logger } from '@openlinker/shared/logging';
+
+import { McpAuditLogger } from './mcp-audit.logger';
+import type { RedactedMcpPrincipal } from '../../auth/mcp-principal.types';
+
+const principal: RedactedMcpPrincipal = {
+  mcpTokenId: 'tok-1',
+  olUserId: 'user-1',
+  olRole: 'admin',
+  scopes: ['mcp:read'],
+};
+
+function captureLogger(): { logger: McpAuditLogger; lines: Array<[string, string]> } {
+  const lines: Array<[string, string]> = [];
+  const logger = new McpAuditLogger();
+  for (const level of ['log', 'warn', 'error'] as const) {
+    jest.spyOn(Logger.prototype, level).mockImplementation((...args: unknown[]) => {
+      lines.push([level, String(args[0])]);
+    });
+  }
+  return { logger, lines };
+}
+
+describe('McpAuditLogger', () => {
+  afterEach(() => jest.restoreAllMocks());
+
+  it('should record the redacted principal fields', () => {
+    const { logger, lines } = captureLogger();
+
+    logger.record({ tool: 'get_product', outcome: 'ok', durationMs: 12, principal });
+
+    const [, message] = lines[0];
+    expect(JSON.parse(message)).toEqual(
+      expect.objectContaining({
+        tool: 'get_product',
+        outcome: 'ok',
+        durationMs: 12,
+        mcpTokenId: 'tok-1',
+        olUserId: 'user-1',
+        olRole: 'admin',
+      })
+    );
+  });
+
+  it('should never emit a token field even if one is smuggled into the principal', () => {
+    const { logger, lines } = captureLogger();
+
+    logger.record({
+      tool: 'get_product',
+      outcome: 'ok',
+      durationMs: 1,
+      // A future refactor handing the wrong object in must not leak: the
+      // logger copies named fields rather than spreading the principal.
+      principal: { ...principal, token: 'olmcp_secret' } as unknown as RedactedMcpPrincipal,
+    });
+
+    expect(lines[0][1]).not.toContain('olmcp_secret');
+    expect(lines[0][1]).not.toContain('token');
+  });
+
+  it('should log an absent principal loudly, since the transport fails closed', () => {
+    const { logger, lines } = captureLogger();
+
+    logger.record({ tool: 'get_product', outcome: 'error', durationMs: 1, principal: null });
+
+    const [level, message] = lines[0];
+    expect(level).toBe('error');
+    expect(message).toContain('"principal":"none"');
+  });
+
+  it('should log a failed call at warn and a healthy one at log', () => {
+    const { logger, lines } = captureLogger();
+
+    logger.record({ tool: 't', outcome: 'error', durationMs: 1, principal, detail: 'boom' });
+    logger.record({ tool: 't', outcome: 'ok', durationMs: 1, principal });
+
+    expect(lines[0][0]).toBe('warn');
+    expect(lines[0][1]).toContain('boom');
+    expect(lines[1][0]).toBe('log');
+  });
+
+  it('should include connectionId only for tools that take one', () => {
+    const { logger, lines } = captureLogger();
+
+    logger.record({ tool: 'get_availability', outcome: 'ok', durationMs: 1, principal });
+    logger.record({
+      tool: 'search_catalog',
+      outcome: 'ok',
+      durationMs: 1,
+      connectionId: 'conn-9',
+      principal,
+    });
+
+    expect(lines[0][1]).not.toContain('connectionId');
+    expect(lines[1][1]).toContain('conn-9');
+  });
+});

--- a/apps/api/src/mcp/tools/audit/mcp-audit.logger.spec.ts
+++ b/apps/api/src/mcp/tools/audit/mcp-audit.logger.spec.ts
@@ -8,6 +8,7 @@
 import { Logger } from '@openlinker/shared/logging';
 
 import { McpAuditLogger } from './mcp-audit.logger';
+import type { IMcpAuditLogger } from './mcp-audit.logger.interface';
 import type { RedactedMcpPrincipal } from '../../auth/mcp-principal.types';
 
 const principal: RedactedMcpPrincipal = {
@@ -17,7 +18,7 @@ const principal: RedactedMcpPrincipal = {
   scopes: ['mcp:read'],
 };
 
-function captureLogger(): { logger: McpAuditLogger; lines: Array<[string, string]> } {
+function captureLogger(): { logger: IMcpAuditLogger; lines: Array<[string, string]> } {
   const lines: Array<[string, string]> = [];
   const logger = new McpAuditLogger();
   for (const level of ['log', 'warn', 'error'] as const) {

--- a/apps/api/src/mcp/tools/audit/mcp-audit.logger.ts
+++ b/apps/api/src/mcp/tools/audit/mcp-audit.logger.ts
@@ -13,28 +13,17 @@
  * Invoked exclusively from `ToolRegistryService`'s per-call wrapper, so no
  * tool can forget to emit one.
  *
+ * @implements {IMcpAuditLogger}
+ *
  * @module apps/api/src/mcp/tools/audit
  */
 import { Injectable } from '@nestjs/common';
 import { Logger } from '@openlinker/shared/logging';
 
-import type { RedactedMcpPrincipal } from '../../auth/mcp-principal.types';
-import type { McpToolOutcome } from '../tool-definition.types';
-
-export interface McpToolCallAudit {
-  readonly tool: string;
-  readonly outcome: McpToolOutcome;
-  readonly durationMs: number;
-  /** Present only for tools that accept a connection argument. */
-  readonly connectionId?: string;
-  /** `null` when the call somehow arrived with no recognisable principal. */
-  readonly principal: RedactedMcpPrincipal | null;
-  /** Error message for `outcome: 'error'`, limit reason for `'rate-limited'`. */
-  readonly detail?: string;
-}
+import type { IMcpAuditLogger, McpToolCallAudit } from './mcp-audit.logger.interface';
 
 @Injectable()
-export class McpAuditLogger {
+export class McpAuditLogger implements IMcpAuditLogger {
   private readonly logger = new Logger('McpToolCall');
 
   record(audit: McpToolCallAudit): void {

--- a/apps/api/src/mcp/tools/audit/mcp-audit.logger.ts
+++ b/apps/api/src/mcp/tools/audit/mcp-audit.logger.ts
@@ -1,0 +1,74 @@
+/**
+ * MCP Audit Logger
+ *
+ * One structured line per MCP tool call (#1487) — who called what, against
+ * which connection, with what outcome and latency.
+ *
+ * SECURITY: the caller is recorded via `redactPrincipal`, never from the
+ * `AuthInfo` itself, which carries the RAW bearer token (#1486 invariant,
+ * see `mcp-principal.types.ts`). This logger never accepts an `AuthInfo`
+ * parameter at all — the unsafe value is structurally out of reach rather
+ * than merely undocumented.
+ *
+ * Invoked exclusively from `ToolRegistryService`'s per-call wrapper, so no
+ * tool can forget to emit one.
+ *
+ * @module apps/api/src/mcp/tools/audit
+ */
+import { Injectable } from '@nestjs/common';
+import { Logger } from '@openlinker/shared/logging';
+
+import type { RedactedMcpPrincipal } from '../../auth/mcp-principal.types';
+import type { McpToolOutcome } from '../tool-definition.types';
+
+export interface McpToolCallAudit {
+  readonly tool: string;
+  readonly outcome: McpToolOutcome;
+  readonly durationMs: number;
+  /** Present only for tools that accept a connection argument. */
+  readonly connectionId?: string;
+  /** `null` when the call somehow arrived with no recognisable principal. */
+  readonly principal: RedactedMcpPrincipal | null;
+  /** Error message for `outcome: 'error'`, limit reason for `'rate-limited'`. */
+  readonly detail?: string;
+}
+
+@Injectable()
+export class McpAuditLogger {
+  private readonly logger = new Logger('McpToolCall');
+
+  record(audit: McpToolCallAudit): void {
+    const line = {
+      tool: audit.tool,
+      outcome: audit.outcome,
+      durationMs: audit.durationMs,
+      ...(audit.connectionId !== undefined ? { connectionId: audit.connectionId } : {}),
+      ...(audit.detail !== undefined ? { detail: audit.detail } : {}),
+      // Spread LAST so a principal field can never be shadowed by the above,
+      // and only ever the redacted projection.
+      ...(audit.principal !== null
+        ? {
+            mcpTokenId: audit.principal.mcpTokenId,
+            olUserId: audit.principal.olUserId,
+            olRole: audit.principal.olRole,
+            scopes: audit.principal.scopes,
+          }
+        : { principal: 'none' }),
+    };
+
+    const message = JSON.stringify(line);
+
+    // An unauthenticated call reaching a tool is security-relevant: the
+    // transport fails closed and the bearer middleware gates the route, so
+    // it should be impossible. Make it loud rather than routine.
+    if (audit.principal === null) {
+      this.logger.error(message);
+      return;
+    }
+    if (audit.outcome === 'error') {
+      this.logger.warn(message);
+      return;
+    }
+    this.logger.log(message);
+  }
+}

--- a/apps/api/src/mcp/tools/mcp-tool-definitions.provider.ts
+++ b/apps/api/src/mcp/tools/mcp-tool-definitions.provider.ts
@@ -1,0 +1,63 @@
+/**
+ * MCP Tool Definitions Provider
+ *
+ * Assembles the Phase-1 tool catalogue (#1487) as a single injectable array.
+ *
+ * Tool factories take their core service directly rather than resolving it
+ * from a container, so each tool file stays a pure function of its dependency
+ * and is trivially unit-testable with a hand-rolled stub. This provider is the
+ * one place that knows the full catalogue — adding a tool is one import plus
+ * one array entry.
+ *
+ * Registration order is the order tools appear in `tools/list`; discovery
+ * entry points come first so an agent reading the list top-down meets
+ * `list_connections` before the tools that want a `connectionId`.
+ *
+ * @module apps/api/src/mcp/tools
+ */
+import type { Provider } from '@nestjs/common';
+import { PRODUCTS_SERVICE_TOKEN, type IProductsService } from '@openlinker/core/products';
+import {
+  INVENTORY_QUERY_SERVICE_TOKEN,
+  type IInventoryQueryService,
+} from '@openlinker/core/inventory';
+import { ORDER_RECORD_SERVICE_TOKEN, type IOrderRecordService } from '@openlinker/core/orders';
+
+import {
+  CONNECTION_SERVICE_TOKEN,
+  type IConnectionService,
+} from '../../integrations/application/interfaces/connection.service.interface';
+import type { McpToolDefinition } from './tool-definition.types';
+import { createWhoamiTool } from './read/whoami.tool';
+import { createListConnectionsTool } from './read/list-connections.tool';
+import { createSearchCatalogTool } from './read/search-catalog.tool';
+import { createGetProductTool } from './read/get-product.tool';
+import { createGetAvailabilityTool } from './read/get-availability.tool';
+import { createGetOrderTool } from './read/get-order.tool';
+
+export const MCP_TOOL_DEFINITIONS_TOKEN = Symbol('McpToolDefinitions');
+
+export const mcpToolDefinitionsProvider: Provider = {
+  provide: MCP_TOOL_DEFINITIONS_TOKEN,
+  inject: [
+    CONNECTION_SERVICE_TOKEN,
+    PRODUCTS_SERVICE_TOKEN,
+    INVENTORY_QUERY_SERVICE_TOKEN,
+    ORDER_RECORD_SERVICE_TOKEN,
+  ],
+  useFactory: (
+    connectionService: IConnectionService,
+    productsService: IProductsService,
+    inventoryQueryService: IInventoryQueryService,
+    orderRecordService: IOrderRecordService
+  ): readonly McpToolDefinition[] => [
+    // Discovery — always registered.
+    createWhoamiTool(),
+    createListConnectionsTool(connectionService),
+    // Capability-gated domain reads.
+    createSearchCatalogTool(productsService),
+    createGetProductTool(productsService),
+    createGetAvailabilityTool(inventoryQueryService),
+    createGetOrderTool(orderRecordService),
+  ],
+};

--- a/apps/api/src/mcp/tools/ratelimit/mcp-rate-limiter.interface.ts
+++ b/apps/api/src/mcp/tools/ratelimit/mcp-rate-limiter.interface.ts
@@ -1,0 +1,43 @@
+/**
+ * MCP Rate Limiter Interface
+ *
+ * Per-token abuse cap for the MCP tool surface (#1487). Two independent
+ * limits, both keyed on the MCP token id (never the raw token):
+ *
+ *   - a rolling REQUEST-RATE window (N calls per window), and
+ *   - a CONCURRENCY cap (N simultaneously in-flight calls).
+ *
+ * Concurrency is what an autonomous agent stuck in a loop actually exhausts;
+ * the rate window is what a merely chatty one does. They fail differently, so
+ * both are enforced.
+ *
+ * @module apps/api/src/mcp/tools/ratelimit
+ */
+
+/**
+ * Outcome of an acquire attempt.
+ *
+ * `release()` is ALWAYS returned — including when `allowed` is false — so the
+ * caller's `finally` block never has to branch. Releasing a slot that was
+ * never taken is a no-op.
+ */
+export interface McpRateLimitLease {
+  readonly allowed: boolean;
+  /** Populated only when `allowed` is false; agent-facing copy. */
+  readonly reason?: string;
+  release(): Promise<void>;
+}
+
+export const MCP_RATE_LIMITER_TOKEN = Symbol('IMcpRateLimiter');
+
+export interface IMcpRateLimiter {
+  /**
+   * Attempt to claim a slot for one tool call.
+   *
+   * Never throws: a Redis outage resolves to `allowed: true` (fail open).
+   * The limiter is abuse mitigation, not an authorization control — auth is
+   * already enforced upstream by `requireBearerAuth`, so failing closed would
+   * trade a real availability loss for a speculative abuse window.
+   */
+  acquire(mcpTokenId: string): Promise<McpRateLimitLease>;
+}

--- a/apps/api/src/mcp/tools/ratelimit/mcp-rate-limiter.spec.ts
+++ b/apps/api/src/mcp/tools/ratelimit/mcp-rate-limiter.spec.ts
@@ -1,0 +1,165 @@
+/**
+ * McpRateLimiter Unit Tests
+ *
+ * The interesting cases are the failure modes: a crashed request must not
+ * leak a concurrency slot, a Redis outage must not take down the MCP surface,
+ * and release must be idempotent.
+ */
+import type { RedisClientType } from 'redis';
+
+import { McpRateLimiter } from './mcp-rate-limiter';
+
+/** Minimal in-memory stand-in for the ZSET commands the limiter uses. */
+function fakeRedis(): RedisClientType & { sets: Map<string, Map<string, number>> } {
+  const sets = new Map<string, Map<string, number>>();
+  const setFor = (key: string): Map<string, number> => {
+    const existing = sets.get(key);
+    if (existing) return existing;
+    const created = new Map<string, number>();
+    sets.set(key, created);
+    return created;
+  };
+  const client = {
+    sets,
+    zRemRangeByScore: (key: string, _min: number, max: number) => {
+      const set = setFor(key);
+      for (const [member, score] of set) {
+        if (score <= max) set.delete(member);
+      }
+      return Promise.resolve(0);
+    },
+    zCard: (key: string) => Promise.resolve(setFor(key).size),
+    zAdd: (key: string, entry: { score: number; value: string }) => {
+      setFor(key).set(entry.value, entry.score);
+      return Promise.resolve(1);
+    },
+    zRem: (key: string, member: string) => {
+      setFor(key).delete(member);
+      return Promise.resolve(1);
+    },
+    expire: () => Promise.resolve(true),
+  };
+  return client as unknown as RedisClientType & { sets: Map<string, Map<string, number>> };
+}
+
+describe('McpRateLimiter', () => {
+  const OLD_ENV = process.env;
+
+  afterEach(() => {
+    process.env = OLD_ENV;
+  });
+
+  it('should admit a call under both limits', async () => {
+    const limiter = new McpRateLimiter(fakeRedis());
+
+    const lease = await limiter.acquire('tok-1');
+
+    expect(lease.allowed).toBe(true);
+  });
+
+  it('should refuse once the concurrency cap is reached', async () => {
+    process.env = { ...OLD_ENV, OL_MCP_CONCURRENCY_LIMIT: '2' };
+    const limiter = new McpRateLimiter(fakeRedis());
+
+    await limiter.acquire('tok-1');
+    await limiter.acquire('tok-1');
+    const third = await limiter.acquire('tok-1');
+
+    expect(third.allowed).toBe(false);
+    expect(third.reason).toContain('concurrent');
+  });
+
+  it('should free the slot on release so the next call is admitted', async () => {
+    process.env = { ...OLD_ENV, OL_MCP_CONCURRENCY_LIMIT: '1' };
+    const limiter = new McpRateLimiter(fakeRedis());
+
+    const first = await limiter.acquire('tok-1');
+    expect((await limiter.acquire('tok-1')).allowed).toBe(false);
+
+    await first.release();
+
+    expect((await limiter.acquire('tok-1')).allowed).toBe(true);
+  });
+
+  it('should tolerate a double release rather than corrupting the count', async () => {
+    process.env = { ...OLD_ENV, OL_MCP_CONCURRENCY_LIMIT: '1' };
+    const redis = fakeRedis();
+    const limiter = new McpRateLimiter(redis);
+
+    const lease = await limiter.acquire('tok-1');
+    await lease.release();
+    await lease.release();
+
+    expect(redis.sets.get('mcp:inflight:tok-1')?.size ?? 0).toBe(0);
+    expect((await limiter.acquire('tok-1')).allowed).toBe(true);
+  });
+
+  it('should age out a slot whose request crashed without releasing', async () => {
+    process.env = { ...OLD_ENV, OL_MCP_CONCURRENCY_LIMIT: '1' };
+    const redis = fakeRedis();
+    const limiter = new McpRateLimiter(redis);
+
+    await limiter.acquire('tok-1'); // never released — simulates a crash
+    expect((await limiter.acquire('tok-1')).allowed).toBe(false);
+
+    // Advance past MAX_CALL_LIFETIME_SECONDS (120s).
+    const realNow = Date.now;
+    Date.now = () => realNow() + 121_000;
+    try {
+      expect((await limiter.acquire('tok-1')).allowed).toBe(true);
+    } finally {
+      Date.now = realNow;
+    }
+  });
+
+  it('should refuse once the rate window is exhausted', async () => {
+    process.env = { ...OLD_ENV, OL_MCP_RATE_LIMIT: '2' };
+    const limiter = new McpRateLimiter(fakeRedis());
+
+    const first = await limiter.acquire('tok-1');
+    await first.release();
+    const second = await limiter.acquire('tok-1');
+    await second.release();
+
+    const third = await limiter.acquire('tok-1');
+
+    // Releasing frees CONCURRENCY, not the time-based rate window.
+    expect(third.allowed).toBe(false);
+    expect(third.reason).toContain('Rate limit');
+  });
+
+  it('should meter each token independently', async () => {
+    process.env = { ...OLD_ENV, OL_MCP_CONCURRENCY_LIMIT: '1' };
+    const limiter = new McpRateLimiter(fakeRedis());
+
+    await limiter.acquire('tok-1');
+
+    expect((await limiter.acquire('tok-2')).allowed).toBe(true);
+  });
+
+  it('should fail OPEN when Redis is unavailable', async () => {
+    const broken = {
+      zRemRangeByScore: () => Promise.reject(new Error('ECONNREFUSED')),
+    } as unknown as RedisClientType;
+    const limiter = new McpRateLimiter(broken);
+
+    const lease = await limiter.acquire('tok-1');
+
+    // Abuse mitigation, not authorization — auth is enforced upstream, so an
+    // outage must not take down the whole authenticated MCP surface.
+    expect(lease.allowed).toBe(true);
+    await expect(lease.release()).resolves.toBeUndefined();
+  });
+
+  it('should ignore an invalid env override rather than disabling the limit', async () => {
+    process.env = { ...OLD_ENV, OL_MCP_CONCURRENCY_LIMIT: 'not-a-number' };
+    const limiter = new McpRateLimiter(fakeRedis());
+
+    // Falls back to the default (8), so a 9th concurrent call is refused.
+    for (let i = 0; i < 8; i += 1) {
+      await limiter.acquire('tok-1');
+    }
+
+    expect((await limiter.acquire('tok-1')).allowed).toBe(false);
+  });
+});

--- a/apps/api/src/mcp/tools/ratelimit/mcp-rate-limiter.spec.ts
+++ b/apps/api/src/mcp/tools/ratelimit/mcp-rate-limiter.spec.ts
@@ -33,6 +33,17 @@ function fakeRedis(): RedisClientType & { sets: Map<string, Map<string, number>>
       setFor(key).set(entry.value, entry.score);
       return Promise.resolve(1);
     },
+    // Rank = position in (score, member) order — Redis breaks equal scores
+    // lexicographically by member, which the limiter relies on for
+    // deterministic tie-breaking between simultaneous callers.
+    zRank: (key: string, member: string) => {
+      const ordered = [...setFor(key).entries()].sort(
+        ([memberA, scoreA], [memberB, scoreB]) =>
+          scoreA - scoreB || memberA.localeCompare(memberB)
+      );
+      const index = ordered.findIndex(([candidate]) => candidate === member);
+      return Promise.resolve(index === -1 ? null : index);
+    },
     zRem: (key: string, member: string) => {
       setFor(key).delete(member);
       return Promise.resolve(1);
@@ -135,6 +146,64 @@ describe('McpRateLimiter', () => {
     await limiter.acquire('tok-1');
 
     expect((await limiter.acquire('tok-2')).allowed).toBe(true);
+  });
+
+  describe('under concurrency', () => {
+    // These are the cases a sequential test cannot catch. The original
+    // check-then-act implementation passed every sequential assertion above
+    // while admitting far more than the cap under a simultaneous burst —
+    // exactly the scenario a concurrency cap exists for.
+
+    it('should admit no more than the concurrency limit when calls race', async () => {
+      process.env = { ...OLD_ENV, OL_MCP_CONCURRENCY_LIMIT: '3' };
+      const limiter = new McpRateLimiter(fakeRedis());
+
+      const leases = await Promise.all(
+        Array.from({ length: 20 }, () => limiter.acquire('tok-1'))
+      );
+
+      expect(leases.filter((lease) => lease.allowed)).toHaveLength(3);
+    });
+
+    it('should admit no more than the rate limit when calls race', async () => {
+      process.env = { ...OLD_ENV, OL_MCP_RATE_LIMIT: '5', OL_MCP_CONCURRENCY_LIMIT: '100' };
+      const limiter = new McpRateLimiter(fakeRedis());
+
+      const leases = await Promise.all(
+        Array.from({ length: 20 }, () => limiter.acquire('tok-1'))
+      );
+
+      expect(leases.filter((lease) => lease.allowed)).toHaveLength(5);
+    });
+
+    it('should not consume rate budget for a call rejected on concurrency', async () => {
+      // A call rolled back on the concurrency check must return its rate-window
+      // entry too, or a burst would lock the token out for a whole window
+      // despite almost none of those calls having run.
+      process.env = { ...OLD_ENV, OL_MCP_RATE_LIMIT: '10', OL_MCP_CONCURRENCY_LIMIT: '2' };
+      const redis = fakeRedis();
+      const limiter = new McpRateLimiter(redis);
+
+      const leases = await Promise.all(
+        Array.from({ length: 8 }, () => limiter.acquire('tok-1'))
+      );
+      expect(leases.filter((lease) => lease.allowed)).toHaveLength(2);
+
+      // Only the 2 admitted calls should be holding rate-window entries.
+      expect(redis.sets.get('mcp:ratelimit:tok-1')?.size ?? 0).toBe(2);
+    });
+
+    it('should free slots for a later wave once the first wave releases', async () => {
+      process.env = { ...OLD_ENV, OL_MCP_CONCURRENCY_LIMIT: '3' };
+      const limiter = new McpRateLimiter(fakeRedis());
+
+      const first = await Promise.all(Array.from({ length: 3 }, () => limiter.acquire('tok-1')));
+      await Promise.all(first.map((lease) => lease.release()));
+
+      const second = await Promise.all(Array.from({ length: 3 }, () => limiter.acquire('tok-1')));
+
+      expect(second.filter((lease) => lease.allowed)).toHaveLength(3);
+    });
   });
 
   it('should fail OPEN when Redis is unavailable', async () => {

--- a/apps/api/src/mcp/tools/ratelimit/mcp-rate-limiter.ts
+++ b/apps/api/src/mcp/tools/ratelimit/mcp-rate-limiter.ts
@@ -1,0 +1,155 @@
+/**
+ * MCP Rate Limiter
+ *
+ * Redis-backed per-token rate + concurrency cap for MCP tool calls (#1487).
+ *
+ * Why the raw `'REDIS_CLIENT'` (not the shared `CachePort`): both limits are
+ * intrinsically sorted-set operations (score-ordered eviction + cardinality
+ * count), which the KV `CachePort` (`get`/`set`/`delete`) cannot express.
+ * This follows the established precedent of `RedisPickupPointQueryStatsAdapter`
+ * — `'REDIS_CLIENT'` is a `@Global` export of `RedisConfigModule`. If a second
+ * rate-limiting consumer appears, promote a `RateLimiterPort` into
+ * `@openlinker/shared/cache`; do NOT "fix" this back to `CachePort`.
+ *
+ * BOTH limits use the SAME ZSET primitive, deliberately:
+ *
+ *   - rate:     members are call ids scored by start time; count = ZCARD after
+ *               evicting everything older than the window.
+ *   - in-flight: members are call ids scored by start time; count = ZCARD after
+ *               evicting everything older than MAX_CALL_LIFETIME (a crashed
+ *               request ages out); release = ZREM.
+ *
+ * An earlier draft used INCR/DECR with a TTL for concurrency. That leaks: a TTL
+ * expires the SHARED counter (dropping live requests' slots), and a DECR
+ * arriving after expiry drives the key negative, silently raising the effective
+ * cap. ZREM is also idempotent, so a double release is harmless.
+ *
+ * @module apps/api/src/mcp/tools/ratelimit
+ * @implements {IMcpRateLimiter}
+ */
+import { Inject, Injectable } from '@nestjs/common';
+import { randomUUID } from 'node:crypto';
+import { RedisClientType } from 'redis';
+import { Logger } from '@openlinker/shared/logging';
+
+import type { IMcpRateLimiter, McpRateLimitLease } from './mcp-rate-limiter.interface';
+
+const RATE_KEY_PREFIX = 'mcp:ratelimit:';
+const INFLIGHT_KEY_PREFIX = 'mcp:inflight:';
+
+const DEFAULT_RATE_LIMIT = 120;
+const DEFAULT_RATE_WINDOW_SECONDS = 60;
+const DEFAULT_CONCURRENCY_LIMIT = 8;
+
+/**
+ * How long an in-flight entry may live before it is presumed orphaned by a
+ * crashed request. Generous relative to any realistic OL-store read — the
+ * cost of evicting too early is over-admission, not a stuck slot.
+ */
+const MAX_CALL_LIFETIME_SECONDS = 120;
+
+const NOOP_LEASE: McpRateLimitLease = {
+  allowed: true,
+  release: () => Promise.resolve(),
+};
+
+/** Read a positive-integer env var, clamped; falls back on anything invalid. */
+function readPositiveInt(name: string, fallback: number, max: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === '') {
+    return fallback;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed < 1) {
+    return fallback;
+  }
+  return Math.min(parsed, max);
+}
+
+@Injectable()
+export class McpRateLimiter implements IMcpRateLimiter {
+  private readonly logger = new Logger(McpRateLimiter.name);
+
+  private readonly rateLimit = readPositiveInt('OL_MCP_RATE_LIMIT', DEFAULT_RATE_LIMIT, 10_000);
+  private readonly rateWindowSeconds = readPositiveInt(
+    'OL_MCP_RATE_WINDOW_SECONDS',
+    DEFAULT_RATE_WINDOW_SECONDS,
+    3_600
+  );
+  private readonly concurrencyLimit = readPositiveInt(
+    'OL_MCP_CONCURRENCY_LIMIT',
+    DEFAULT_CONCURRENCY_LIMIT,
+    1_000
+  );
+
+  constructor(
+    @Inject('REDIS_CLIENT')
+    private readonly redisClient: RedisClientType
+  ) {}
+
+  async acquire(mcpTokenId: string): Promise<McpRateLimitLease> {
+    const callId = randomUUID();
+    const nowMs = Date.now();
+    const rateKey = `${RATE_KEY_PREFIX}${mcpTokenId}`;
+    const inflightKey = `${INFLIGHT_KEY_PREFIX}${mcpTokenId}`;
+
+    try {
+      // --- Rate window ---------------------------------------------------
+      await this.redisClient.zRemRangeByScore(rateKey, 0, nowMs - this.rateWindowSeconds * 1_000);
+      const recentCount = await this.redisClient.zCard(rateKey);
+      if (recentCount >= this.rateLimit) {
+        return {
+          allowed: false,
+          reason: `Rate limit exceeded: at most ${this.rateLimit} tool calls per ${this.rateWindowSeconds}s for this token. Retry shortly.`,
+          release: () => Promise.resolve(),
+        };
+      }
+
+      // --- Concurrency ---------------------------------------------------
+      await this.redisClient.zRemRangeByScore(
+        inflightKey,
+        0,
+        nowMs - MAX_CALL_LIFETIME_SECONDS * 1_000
+      );
+      const inflightCount = await this.redisClient.zCard(inflightKey);
+      if (inflightCount >= this.concurrencyLimit) {
+        return {
+          allowed: false,
+          reason: `Too many concurrent tool calls: at most ${this.concurrencyLimit} may be in flight for this token. Wait for an in-flight call to finish.`,
+          release: () => Promise.resolve(),
+        };
+      }
+
+      // Admitted — record in both sets. The rate entry is never removed on
+      // release (the window is time-based, not occupancy-based); only the
+      // in-flight entry is.
+      await this.redisClient.zAdd(rateKey, { score: nowMs, value: callId });
+      await this.redisClient.expire(rateKey, this.rateWindowSeconds);
+      await this.redisClient.zAdd(inflightKey, { score: nowMs, value: callId });
+      await this.redisClient.expire(inflightKey, MAX_CALL_LIFETIME_SECONDS);
+
+      return {
+        allowed: true,
+        release: async (): Promise<void> => {
+          try {
+            await this.redisClient.zRem(inflightKey, callId);
+          } catch (error) {
+            // A failed release is self-healing: the entry ages out via
+            // MAX_CALL_LIFETIME_SECONDS. Warn, never throw — the tool call
+            // itself already succeeded and must not be failed by cleanup.
+            this.logger.warn(
+              `Failed to release MCP in-flight slot; it will age out. ${(error as Error).message}`
+            );
+          }
+        },
+      };
+    } catch (error) {
+      // FAIL OPEN. See the interface doc: the limiter is abuse mitigation,
+      // not an authorization control.
+      this.logger.warn(
+        `MCP rate limiter unavailable — failing open for this call. ${(error as Error).message}`
+      );
+      return NOOP_LEASE;
+    }
+  }
+}

--- a/apps/api/src/mcp/tools/ratelimit/mcp-rate-limiter.ts
+++ b/apps/api/src/mcp/tools/ratelimit/mcp-rate-limiter.ts
@@ -19,6 +19,12 @@
  *               evicting everything older than MAX_CALL_LIFETIME (a crashed
  *               request ages out); release = ZREM.
  *
+ * Both are enforced by CLAIM-THEN-RANK (add self, read own ZRANK, remove self
+ * if the rank is outside budget) rather than check-then-act, so the bound holds
+ * under a concurrent burst. The advertised limits are real ceilings, not
+ * approximations — see `claimRank` for why rank, and `buildMember` for why the
+ * member encodes arrival order.
+ *
  * An earlier draft used INCR/DECR with a TTL for concurrency. That leaks: a TTL
  * expires the SHARED counter (dropping live requests' slots), and a DECR
  * arriving after expiry drives the key negative, silently raising the effective
@@ -52,6 +58,33 @@ const NOOP_LEASE: McpRateLimitLease = {
   allowed: true,
   release: () => Promise.resolve(),
 };
+
+/**
+ * Per-process arrival counter, used only to order calls that land in the SAME
+ * millisecond. See `buildMember`.
+ */
+let arrivalSequence = 0;
+
+/**
+ * Build the ZSET member for one call.
+ *
+ * The member is `{ms}-{seq}-{uuid}`, zero-padded so that LEXICOGRAPHIC order
+ * equals ARRIVAL order. This matters because the limiter admits by ZRANK, and
+ * Redis breaks equal scores lexicographically by member: `Date.now()` has
+ * millisecond resolution, so several calls routinely share a score, and ranking
+ * them by a raw UUID would let a later arrival take a lower rank than one
+ * already admitted — over-admitting past the cap. Encoding arrival order into
+ * the member makes the tie-break meaningful instead of arbitrary.
+ *
+ * `ms` is padded to 13 digits (stable until the year 2286) and `seq` to 6, so
+ * neither field's width can shift and break the lexicographic ordering.
+ */
+function buildMember(nowMs: number): string {
+  arrivalSequence = (arrivalSequence + 1) % 1_000_000;
+  const ms = String(nowMs).padStart(13, '0');
+  const seq = String(arrivalSequence).padStart(6, '0');
+  return `${ms}-${seq}-${randomUUID()}`;
+}
 
 /** Read a positive-integer env var, clamped; falls back on anything invalid. */
 function readPositiveInt(name: string, fallback: number, max: number): number {
@@ -87,17 +120,66 @@ export class McpRateLimiter implements IMcpRateLimiter {
     private readonly redisClient: RedisClientType
   ) {}
 
+  /**
+   * Evict expired members, claim a slot for `callId`, and return this caller's
+   * RANK within the set (0-based, ordered by score = arrival time).
+   *
+   * Rank, not count, is what makes the bound correct under a burst. Two wrong
+   * approaches were tried first:
+   *
+   *  - **check-then-act** (ZCARD → compare → ZADD): nothing is held between
+   *    the read and the write, so N racing callers all see `count < limit` and
+   *    all admit. Over-admits without bound — which defeats the entire purpose
+   *    of a concurrency cap.
+   *  - **claim-then-count** (ZADD → ZCARD → compare): under *perfect*
+   *    simultaneity every caller observes the full set including all its
+   *    rivals, so all of them exceed the limit and ALL reject. A burst of 20
+   *    against a limit of 3 admits zero — a livelock, strictly worse than
+   *    over-admitting.
+   *
+   * Rank is stable no matter how many others join concurrently: it is fixed by
+   * score ordering, so the `limit` earliest callers get ranks 0..limit-1 and
+   * are admitted while the rest see rank >= limit and roll themselves back.
+   * Exactly `limit` win under any interleaving, with no Lua and no lock.
+   * Equal-millisecond ties break lexicographically on the member, which
+   * `buildMember` constructs to encode arrival order — see its doc.
+   *
+   * Returns `null` if the member vanished between add and rank (shouldn't
+   * happen; treated as a rejection by the caller, which fails safe).
+   */
+  private async claimRank(
+    key: string,
+    callId: string,
+    nowMs: number,
+    evictBefore: number,
+    ttlSeconds: number
+  ): Promise<number | null> {
+    await this.redisClient.zRemRangeByScore(key, 0, evictBefore);
+    await this.redisClient.zAdd(key, { score: nowMs, value: callId });
+    await this.redisClient.expire(key, ttlSeconds);
+    return this.redisClient.zRank(key, callId);
+  }
+
   async acquire(mcpTokenId: string): Promise<McpRateLimitLease> {
-    const callId = randomUUID();
     const nowMs = Date.now();
+    const callId = buildMember(nowMs);
     const rateKey = `${RATE_KEY_PREFIX}${mcpTokenId}`;
     const inflightKey = `${INFLIGHT_KEY_PREFIX}${mcpTokenId}`;
 
     try {
       // --- Rate window ---------------------------------------------------
-      await this.redisClient.zRemRangeByScore(rateKey, 0, nowMs - this.rateWindowSeconds * 1_000);
-      const recentCount = await this.redisClient.zCard(rateKey);
-      if (recentCount >= this.rateLimit) {
+      const rateRank = await this.claimRank(
+        rateKey,
+        callId,
+        nowMs,
+        nowMs - this.rateWindowSeconds * 1_000,
+        this.rateWindowSeconds
+      );
+      if (rateRank === null || rateRank >= this.rateLimit) {
+        // Give the budget back — a rejected call must not hold a slot in the
+        // window, or a token over its limit would stay locked out longer than
+        // the window itself.
+        await this.redisClient.zRem(rateKey, callId);
         return {
           allowed: false,
           reason: `Rate limit exceeded: at most ${this.rateLimit} tool calls per ${this.rateWindowSeconds}s for this token. Retry shortly.`,
@@ -106,13 +188,18 @@ export class McpRateLimiter implements IMcpRateLimiter {
       }
 
       // --- Concurrency ---------------------------------------------------
-      await this.redisClient.zRemRangeByScore(
+      const inflightRank = await this.claimRank(
         inflightKey,
-        0,
-        nowMs - MAX_CALL_LIFETIME_SECONDS * 1_000
+        callId,
+        nowMs,
+        nowMs - MAX_CALL_LIFETIME_SECONDS * 1_000,
+        MAX_CALL_LIFETIME_SECONDS
       );
-      const inflightCount = await this.redisClient.zCard(inflightKey);
-      if (inflightCount >= this.concurrencyLimit) {
+      if (inflightRank === null || inflightRank >= this.concurrencyLimit) {
+        // Roll back BOTH claims: this call never runs, so it owes neither an
+        // in-flight slot nor a rate-window entry.
+        await this.redisClient.zRem(inflightKey, callId);
+        await this.redisClient.zRem(rateKey, callId);
         return {
           allowed: false,
           reason: `Too many concurrent tool calls: at most ${this.concurrencyLimit} may be in flight for this token. Wait for an in-flight call to finish.`,
@@ -120,14 +207,8 @@ export class McpRateLimiter implements IMcpRateLimiter {
         };
       }
 
-      // Admitted — record in both sets. The rate entry is never removed on
-      // release (the window is time-based, not occupancy-based); only the
-      // in-flight entry is.
-      await this.redisClient.zAdd(rateKey, { score: nowMs, value: callId });
-      await this.redisClient.expire(rateKey, this.rateWindowSeconds);
-      await this.redisClient.zAdd(inflightKey, { score: nowMs, value: callId });
-      await this.redisClient.expire(inflightKey, MAX_CALL_LIFETIME_SECONDS);
-
+      // Admitted. The rate entry is never removed on release (the window is
+      // time-based, not occupancy-based); only the in-flight entry is.
       return {
         allowed: true,
         release: async (): Promise<void> => {

--- a/apps/api/src/mcp/tools/read/get-availability.tool.ts
+++ b/apps/api/src/mcp/tools/read/get-availability.tool.ts
@@ -1,0 +1,95 @@
+/**
+ * `get_availability` MCP Tool
+ *
+ * Reads stock from OpenLinker's own inventory projection.
+ *
+ * TWO SHAPES, matching what the caller holds:
+ *   - `productIds` → `getProductStockAggregates` (available/reserved summed
+ *     across the product's rows, plus last stock write).
+ *   - `variantIds` → `getAvailabilityByVariantIds` (the variant-keyed read the
+ *     rest of OL uses per ADR-010 / #822 / #823).
+ *
+ * Takes NO `connectionId` (plan §3.3.2): both reads are global — inventory is
+ * keyed by product/variant, not by connection — and accepting an argument that
+ * did nothing would mislead the calling agent into thinking it had scoped the
+ * result.
+ *
+ * @module apps/api/src/mcp/tools/read
+ */
+import * as z from 'zod/v4';
+import type { CallToolResult } from '@modelcontextprotocol/server';
+import type {
+  IInventoryQueryService,
+  ProductStockAggregate,
+  VariantAvailability,
+} from '@openlinker/core/inventory';
+
+import type { McpToolDefinition } from '../tool-definition.types';
+import { jsonResult, toolFailure } from './tool-result';
+
+const MAX_IDS = 100;
+
+const inputSchema = z
+  .object({
+    productIds: z
+      .array(z.string())
+      .max(MAX_IDS)
+      .optional()
+      .describe('Internal product ids. Returns product-level totals.'),
+    variantIds: z
+      .array(z.string())
+      .max(MAX_IDS)
+      .optional()
+      .describe('Internal variant ids. Returns per-variant availability.'),
+  })
+  .describe('Supply exactly one of productIds or variantIds.');
+
+export function createGetAvailabilityTool(
+  inventoryQueryService: IInventoryQueryService
+): McpToolDefinition {
+  return {
+    name: 'get_availability',
+    requiredCapability: 'InventoryMaster',
+    description:
+      "Read stock levels from OpenLinker's inventory for a set of products (totals) or variants (per-variant). Supply exactly one of productIds or variantIds — ids come from search_catalog / get_product. Stock reflects the last completed inventory sync, not a live marketplace read.",
+    inputSchema,
+    handler: async (args: Record<string, unknown>): Promise<CallToolResult> => {
+      const { productIds, variantIds } = inputSchema.parse(args);
+
+      const products = productIds !== undefined && productIds.length > 0 ? productIds : null;
+      const variants = variantIds !== undefined && variantIds.length > 0 ? variantIds : null;
+
+      // Exactly one — neither is ambiguous, both is contradictory.
+      if ((products === null) === (variants === null)) {
+        return toolFailure(
+          'Supply exactly one of productIds or variantIds (non-empty). Use productIds for product-level totals, variantIds for per-variant availability.'
+        );
+      }
+
+      if (products !== null) {
+        const aggregates = await inventoryQueryService.getProductStockAggregates(products);
+        return jsonResult({ products: aggregates.map(projectAggregate) });
+      }
+
+      const availability = await inventoryQueryService.getAvailabilityByVariantIds(variants ?? []);
+      return jsonResult({ variants: availability.map(projectVariantAvailability) });
+    },
+  };
+}
+
+function projectAggregate(aggregate: ProductStockAggregate): Record<string, unknown> {
+  return {
+    productId: aggregate.productId,
+    totalAvailable: aggregate.totalAvailable,
+    totalReserved: aggregate.totalReserved,
+    stockUpdatedAt: aggregate.stockUpdatedAt?.toISOString() ?? null,
+  };
+}
+
+function projectVariantAvailability(availability: VariantAvailability): Record<string, unknown> {
+  return {
+    variantId: availability.productVariantId,
+    totalAvailable: availability.totalAvailable,
+    locationCount: availability.locationCount,
+  };
+}

--- a/apps/api/src/mcp/tools/read/get-availability.tool.ts
+++ b/apps/api/src/mcp/tools/read/get-availability.tool.ts
@@ -54,15 +54,26 @@ export function createGetAvailabilityTool(
       "Read stock levels from OpenLinker's inventory for a set of products (totals) or variants (per-variant). Supply exactly one of productIds or variantIds — ids come from search_catalog / get_product. Stock reflects the last completed inventory sync, not a live marketplace read.",
     inputSchema,
     handler: async (args: Record<string, unknown>): Promise<CallToolResult> => {
+      // NARROWING, not validation: the SDK already validated `args` against
+      // this schema before invoking the handler, so this call cannot
+      // realistically fail. It exists to turn `Record<string, unknown>` into
+      // typed fields — never rely on it as the enforcement point for a
+      // constraint (a caller-visible cap belongs on the schema itself).
       const { productIds, variantIds } = inputSchema.parse(args);
 
       const products = productIds !== undefined && productIds.length > 0 ? productIds : null;
       const variants = variantIds !== undefined && variantIds.length > 0 ? variantIds : null;
 
-      // Exactly one — neither is ambiguous, both is contradictory.
-      if ((products === null) === (variants === null)) {
+      // Tell the agent WHICH mistake it made — it has to decide what to send
+      // next, and "supply exactly one" doesn't say which way it got that wrong.
+      if (products !== null && variants !== null) {
         return toolFailure(
-          'Supply exactly one of productIds or variantIds (non-empty). Use productIds for product-level totals, variantIds for per-variant availability.'
+          'Supply productIds OR variantIds, not both: they return different shapes (product-level totals vs per-variant availability). Pick the one matching the ids you hold.'
+        );
+      }
+      if (products === null && variants === null) {
+        return toolFailure(
+          'Supply a non-empty productIds (for product-level totals) or variantIds (for per-variant availability). Ids come from search_catalog / get_product.'
         );
       }
 

--- a/apps/api/src/mcp/tools/read/get-order.tool.ts
+++ b/apps/api/src/mcp/tools/read/get-order.tool.ts
@@ -47,6 +47,11 @@ export function createGetOrderTool(orderRecordService: IOrderRecordService): Mcp
       "Read one order from OpenLinker's order store by its internal id: status, sync state, fulfillment/payment state, dispatch deadline, totals, and line items. Buyer personal data (name, email, address) is deliberately NOT returned. Reflects the last completed order sync, not a live marketplace read.",
     inputSchema,
     handler: async (args: Record<string, unknown>): Promise<CallToolResult> => {
+      // NARROWING, not validation: the SDK already validated `args` against
+      // this schema before invoking the handler, so this call cannot
+      // realistically fail. It exists to turn `Record<string, unknown>` into
+      // typed fields — never rely on it as the enforcement point for a
+      // constraint (a caller-visible cap belongs on the schema itself).
       const { orderId } = inputSchema.parse(args);
 
       const record = await orderRecordService.getOrderRecord(orderId);

--- a/apps/api/src/mcp/tools/read/get-order.tool.ts
+++ b/apps/api/src/mcp/tools/read/get-order.tool.ts
@@ -1,0 +1,108 @@
+/**
+ * `get_order` MCP Tool
+ *
+ * Reads one order from OpenLinker's OWN order store (`OrderRecord`), not from
+ * the originating marketplace.
+ *
+ * WHY NOT `OrderSourcePort.getOrder` (plan §3.3): that port is an INGESTION
+ * seam. Using it here would (a) make one live marketplace API call per tool
+ * invocation, spending the operator's rate-limit budget on an agent's behalf,
+ * (b) return external-id-keyed data that won't join with the internal-id-keyed
+ * product tools, and (c) re-fetch raw buyer PII from the platform regardless of
+ * the operator's `OL_STORE_PII` setting — defeating it entirely.
+ *
+ * PII, TWO LAYERS:
+ *   1. `IOrderRecordService.persistOrder` already nulls buyer PII in the
+ *      snapshot when the operator disables PII storage. Reading the record
+ *      inherits that decision for free.
+ *   2. This tool ADDITIONALLY declines to forward buyer identity even when it
+ *      IS stored: the projection below is an explicit allowlist that omits
+ *      `customerEmail`, `shippingAddress`, and `billingAddress`. An MCP result
+ *      is handed to an external LLM provider acting as a de-facto
+ *      sub-processor, and order *status* — the operational question an agent
+ *      actually asks — does not require the buyer's identity to answer.
+ *
+ * Never dump `orderSnapshot` wholesale: it is a free-form `Record<string,
+ * unknown>` whose shape grows over time, so an allowlist is the only
+ * projection that stays safe as fields are added.
+ *
+ * @module apps/api/src/mcp/tools/read
+ */
+import * as z from 'zod/v4';
+import type { CallToolResult } from '@modelcontextprotocol/server';
+import type { IOrderRecordService, OrderRecord } from '@openlinker/core/orders';
+
+import type { McpToolDefinition } from '../tool-definition.types';
+import { jsonResult, toolFailure } from './tool-result';
+
+const inputSchema = z.object({
+  orderId: z.string().describe('Internal OpenLinker order id, e.g. ol_order_… .'),
+});
+
+export function createGetOrderTool(orderRecordService: IOrderRecordService): McpToolDefinition {
+  return {
+    name: 'get_order',
+    requiredCapability: 'OrderSource',
+    description:
+      "Read one order from OpenLinker's order store by its internal id: status, sync state, fulfillment/payment state, dispatch deadline, totals, and line items. Buyer personal data (name, email, address) is deliberately NOT returned. Reflects the last completed order sync, not a live marketplace read.",
+    inputSchema,
+    handler: async (args: Record<string, unknown>): Promise<CallToolResult> => {
+      const { orderId } = inputSchema.parse(args);
+
+      const record = await orderRecordService.getOrderRecord(orderId);
+      if (record === null) {
+        return toolFailure(`No order found with id "${orderId}".`);
+      }
+
+      return jsonResult(projectOrderRecord(record));
+    },
+  };
+}
+
+function projectOrderRecord(record: OrderRecord): Record<string, unknown> {
+  const snapshot = record.orderSnapshot;
+
+  return {
+    internalOrderId: record.internalOrderId,
+    sourceConnectionId: record.sourceConnectionId,
+    recordStatus: record.recordStatus,
+    syncStatus: record.syncStatus,
+    fulfillmentState: record.fulfillmentState,
+    paymentStatus: record.paymentStatus ?? null,
+    dispatchByAt: record.dispatchByAt?.toISOString() ?? null,
+    createdAt: record.createdAt.toISOString(),
+    updatedAt: record.updatedAt.toISOString(),
+    // --- Allowlisted snapshot fields. NO buyer identity. ---
+    orderNumber: readString(snapshot, 'orderNumber'),
+    status: readString(snapshot, 'status'),
+    totals: snapshot.totals ?? null,
+    items: projectItems(snapshot.items),
+  };
+}
+
+function readString(source: Record<string, unknown>, key: string): string | null {
+  const value = source[key];
+  return typeof value === 'string' ? value : null;
+}
+
+/**
+ * Line items, projected to the commercial fields. Deliberately field-by-field
+ * rather than pass-through: an `OrderItem` may grow buyer-linked fields later,
+ * and a spread would silently start forwarding them.
+ */
+function projectItems(items: unknown): Array<Record<string, unknown>> {
+  if (!Array.isArray(items)) {
+    return [];
+  }
+  return items.map((item) => {
+    const record = (item ?? {}) as Record<string, unknown>;
+    return {
+      sku: record.sku ?? null,
+      name: record.name ?? null,
+      quantity: record.quantity ?? null,
+      unitPrice: record.unitPrice ?? null,
+      productId: record.productId ?? null,
+      variantId: record.variantId ?? null,
+    };
+  });
+}

--- a/apps/api/src/mcp/tools/read/get-product.tool.ts
+++ b/apps/api/src/mcp/tools/read/get-product.tool.ts
@@ -29,6 +29,11 @@ export function createGetProductTool(productsService: IProductsService): McpTool
       "Read one product from OpenLinker's catalog by its internal id, including its variants (id, sku, barcode, price). Use search_catalog to find a product id first.",
     inputSchema,
     handler: async (args: Record<string, unknown>): Promise<CallToolResult> => {
+      // NARROWING, not validation: the SDK already validated `args` against
+      // this schema before invoking the handler, so this call cannot
+      // realistically fail. It exists to turn `Record<string, unknown>` into
+      // typed fields — never rely on it as the enforcement point for a
+      // constraint (a caller-visible cap belongs on the schema itself).
       const { productId } = inputSchema.parse(args);
 
       const product = await productsService.getProduct(productId);

--- a/apps/api/src/mcp/tools/read/get-product.tool.ts
+++ b/apps/api/src/mcp/tools/read/get-product.tool.ts
@@ -1,0 +1,70 @@
+/**
+ * `get_product` MCP Tool
+ *
+ * Reads one product plus its variants from OpenLinker's own catalog.
+ *
+ * Takes no `connectionId`: `IProductsService.getProduct` is a direct
+ * internal-id read with no connection axis (plan §3.3.2). Accepting an
+ * argument that silently did nothing would be worse than omitting it — an
+ * agent would infer it had scoped the read.
+ *
+ * @module apps/api/src/mcp/tools/read
+ */
+import * as z from 'zod/v4';
+import type { CallToolResult } from '@modelcontextprotocol/server';
+import type { IProductsService, Product, ProductVariant } from '@openlinker/core/products';
+
+import type { McpToolDefinition } from '../tool-definition.types';
+import { jsonResult, toolFailure } from './tool-result';
+
+const inputSchema = z.object({
+  productId: z.string().describe('Internal OpenLinker product id, e.g. ol_product_… .'),
+});
+
+export function createGetProductTool(productsService: IProductsService): McpToolDefinition {
+  return {
+    name: 'get_product',
+    requiredCapability: 'ProductMaster',
+    description:
+      "Read one product from OpenLinker's catalog by its internal id, including its variants (id, sku, barcode, price). Use search_catalog to find a product id first.",
+    inputSchema,
+    handler: async (args: Record<string, unknown>): Promise<CallToolResult> => {
+      const { productId } = inputSchema.parse(args);
+
+      const product = await productsService.getProduct(productId);
+      if (product === null) {
+        return toolFailure(
+          `No product found with id "${productId}". Use search_catalog to find valid product ids.`
+        );
+      }
+
+      const variants = await productsService.getVariantsByProductId(productId);
+
+      return jsonResult({ ...projectProduct(product), variants: variants.map(projectVariant) });
+    },
+  };
+}
+
+function projectProduct(product: Product): Record<string, unknown> {
+  return {
+    id: product.id,
+    name: product.name,
+    sku: product.sku,
+    price: product.price,
+    currency: product.currency,
+    description: product.description,
+  };
+}
+
+function projectVariant(variant: ProductVariant): Record<string, unknown> {
+  return {
+    id: variant.id,
+    sku: variant.sku,
+    // Barcodes live on the variant, not the product — variants are the
+    // canonical offer-link target (architecture-overview.md § Products).
+    ean: variant.ean,
+    gtin: variant.gtin,
+    price: variant.price ?? null,
+    attributes: variant.attributes,
+  };
+}

--- a/apps/api/src/mcp/tools/read/list-connections.tool.ts
+++ b/apps/api/src/mcp/tools/read/list-connections.tool.ts
@@ -1,0 +1,50 @@
+/**
+ * `list_connections` MCP Tool
+ *
+ * The discovery entry point: tells the agent which connections exist, what
+ * platform each is, and which capabilities are enabled on it — so it can pick
+ * a sensible `connectionId` for the tools that take one.
+ *
+ * Always registered (no capability gate): a deployment with zero connections
+ * still needs to be able to say so.
+ *
+ * SECURITY: PROJECTS the connection. A `Connection` carries `credentialsRef`
+ * (a pointer into encrypted credential storage) and a free-form operator
+ * `config` JSONB; neither is appropriate to hand to an external LLM provider.
+ * Only id / name / platformType / status / enabledCapabilities leave here.
+ *
+ * @module apps/api/src/mcp/tools/read
+ */
+import * as z from 'zod/v4';
+import type { CallToolResult } from '@modelcontextprotocol/server';
+import type { Connection } from '@openlinker/core/identifier-mapping';
+
+import type { IConnectionService } from '../../../integrations/application/interfaces/connection.service.interface';
+import type { McpToolDefinition } from '../tool-definition.types';
+import { jsonResult } from './tool-result';
+
+export function createListConnectionsTool(
+  connectionService: IConnectionService
+): McpToolDefinition {
+  return {
+    name: 'list_connections',
+    requiredCapability: null,
+    description:
+      'List the integration connections configured in OpenLinker (id, name, platform, status, enabled capabilities). Call this first to discover which connectionId to pass to other tools. An empty list means no connections are configured.',
+    inputSchema: z.object({}),
+    handler: async (): Promise<CallToolResult> => {
+      const connections = await connectionService.list();
+      return jsonResult(connections.map(projectConnection));
+    },
+  };
+}
+
+function projectConnection(connection: Connection): Record<string, unknown> {
+  return {
+    id: connection.id,
+    name: connection.name,
+    platformType: connection.platformType,
+    status: connection.status,
+    enabledCapabilities: connection.enabledCapabilities,
+  };
+}

--- a/apps/api/src/mcp/tools/read/read-tools.spec.ts
+++ b/apps/api/src/mcp/tools/read/read-tools.spec.ts
@@ -107,12 +107,22 @@ describe('search_catalog tool', () => {
     expect(calls[0][1]).toEqual({ limit: 20, offset: 0 });
   });
 
-  it('should reject a limit above the cap instead of honouring it', async () => {
+  it('should declare the page-size cap on its schema, where the SDK enforces it', () => {
+    // The cap must live on the SCHEMA, not in the handler: the SDK validates
+    // `inputSchema` before invoking a tool, so that is the real enforcement
+    // point and the only one an agent sees a protocol error from. Asserting
+    // via `handler({ limit: 5000 })` would instead exercise the handler's
+    // narrowing `parse` — passing even if the cap were dropped from the schema.
     const { service } = serviceReturning([]);
+    const schema = createSearchCatalogTool(service).inputSchema;
 
-    await expect(
-      createSearchCatalogTool(service).handler({ limit: 5_000 }, {} as never)
-    ).rejects.toThrow();
+    const overCap = (schema as unknown as { safeParse: (v: unknown) => { success: boolean } })
+      .safeParse({ limit: 5_000 });
+    const atCap = (schema as unknown as { safeParse: (v: unknown) => { success: boolean } })
+      .safeParse({ limit: 100 });
+
+    expect(overCap.success).toBe(false);
+    expect(atCap.success).toBe(true);
   });
 
   it('should project products rather than returning full entities', async () => {

--- a/apps/api/src/mcp/tools/read/read-tools.spec.ts
+++ b/apps/api/src/mcp/tools/read/read-tools.spec.ts
@@ -1,0 +1,339 @@
+/**
+ * Read-Tool Unit Tests
+ *
+ * One suite per tool. The recurring theme is PROJECTION: a tool result is
+ * handed to an external LLM provider, so each test asserts not just that the
+ * right data comes back but that the wrong data does NOT.
+ */
+import type { CallToolResult } from '@modelcontextprotocol/server';
+import type { Connection } from '@openlinker/core/identifier-mapping';
+import type { IProductsService } from '@openlinker/core/products';
+import type { IInventoryQueryService } from '@openlinker/core/inventory';
+import type { IOrderRecordService, OrderRecord } from '@openlinker/core/orders';
+
+import type { IConnectionService } from '../../../integrations/application/interfaces/connection.service.interface';
+import { createListConnectionsTool } from './list-connections.tool';
+import { createSearchCatalogTool } from './search-catalog.tool';
+import { createGetProductTool } from './get-product.tool';
+import { createGetAvailabilityTool } from './get-availability.tool';
+import { createGetOrderTool } from './get-order.tool';
+
+function payloadOf(result: CallToolResult): unknown {
+  return JSON.parse((result.content[0] as { text: string }).text);
+}
+
+function textOf(result: CallToolResult): string {
+  return (result.content[0] as { text: string }).text;
+}
+
+describe('list_connections tool', () => {
+  const connection = {
+    id: 'conn-1',
+    name: 'Main shop',
+    platformType: 'prestashop',
+    status: 'active',
+    enabledCapabilities: ['ProductMaster'],
+    credentialsRef: 'creds:super-secret-ref',
+    config: { shopUrl: 'https://shop.example', apiToken: 'leaky' },
+  } as unknown as Connection;
+
+  const service = { list: () => Promise.resolve([connection]) } as unknown as IConnectionService;
+
+  it('should return the operator-facing connection fields', async () => {
+    const result = await createListConnectionsTool(service).handler({}, {} as never);
+
+    expect(payloadOf(result)).toEqual([
+      {
+        id: 'conn-1',
+        name: 'Main shop',
+        platformType: 'prestashop',
+        status: 'active',
+        enabledCapabilities: ['ProductMaster'],
+      },
+    ]);
+  });
+
+  it('should never expose credentialsRef or the raw config blob', async () => {
+    const result = await createListConnectionsTool(service).handler({}, {} as never);
+
+    const text = textOf(result);
+    expect(text).not.toContain('credentialsRef');
+    expect(text).not.toContain('super-secret-ref');
+    expect(text).not.toContain('apiToken');
+    expect(text).not.toContain('leaky');
+  });
+
+  it('should always be registered, since discovery must work with no connections', () => {
+    expect(createListConnectionsTool(service).requiredCapability).toBeNull();
+  });
+});
+
+describe('search_catalog tool', () => {
+  function serviceReturning(items: unknown[]): {
+    service: IProductsService;
+    calls: unknown[][];
+  } {
+    const calls: unknown[][] = [];
+    const service = {
+      listProducts: (...args: unknown[]) => {
+        calls.push(args);
+        return Promise.resolve({ items, total: items.length });
+      },
+    } as unknown as IProductsService;
+    return { service, calls };
+  }
+
+  it('should map the query to the case-insensitive name/SKU filter', async () => {
+    const { service, calls } = serviceReturning([]);
+
+    await createSearchCatalogTool(service).handler({ query: 'widget' }, {} as never);
+
+    expect(calls[0][0]).toEqual({ search: 'widget' });
+  });
+
+  it('should map connectionId to the provenance filter, not a listing filter', async () => {
+    const { service, calls } = serviceReturning([]);
+
+    await createSearchCatalogTool(service).handler({ connectionId: 'conn-1' }, {} as never);
+
+    expect(calls[0][0]).toEqual({ sourceConnectionId: 'conn-1' });
+  });
+
+  it('should default the page size rather than returning an unbounded list', async () => {
+    const { service, calls } = serviceReturning([]);
+
+    await createSearchCatalogTool(service).handler({}, {} as never);
+
+    expect(calls[0][1]).toEqual({ limit: 20, offset: 0 });
+  });
+
+  it('should reject a limit above the cap instead of honouring it', async () => {
+    const { service } = serviceReturning([]);
+
+    await expect(
+      createSearchCatalogTool(service).handler({ limit: 5_000 }, {} as never)
+    ).rejects.toThrow();
+  });
+
+  it('should project products rather than returning full entities', async () => {
+    const { service } = serviceReturning([
+      {
+        id: 'ol_product_1',
+        name: 'Widget',
+        sku: 'W-1',
+        price: 9.99,
+        currency: 'PLN',
+        description: 'a very long description that would bloat the context window',
+        images: ['https://example/1.jpg'],
+      },
+    ]);
+
+    const result = await createSearchCatalogTool(service).handler({}, {} as never);
+
+    expect(payloadOf(result)).toEqual({
+      total: 1,
+      returned: 1,
+      products: [{ id: 'ol_product_1', name: 'Widget', sku: 'W-1', price: 9.99, currency: 'PLN' }],
+    });
+  });
+});
+
+describe('get_product tool', () => {
+  it('should return an actionable error when the product does not exist', async () => {
+    const service = {
+      getProduct: () => Promise.resolve(null),
+    } as unknown as IProductsService;
+
+    const result = await createGetProductTool(service).handler(
+      { productId: 'ol_product_missing' },
+      {} as never
+    );
+
+    expect(result.isError).toBe(true);
+    // Agent-facing copy should name the recovery path.
+    expect(textOf(result)).toContain('search_catalog');
+  });
+
+  it('should include variants with their barcode fields', async () => {
+    const service = {
+      getProduct: () =>
+        Promise.resolve({ id: 'ol_product_1', name: 'W', sku: null, price: 1, currency: 'PLN', description: null }),
+      getVariantsByProductId: () =>
+        Promise.resolve([
+          { id: 'ol_variant_1', sku: 'V-1', ean: '590123', gtin: null, price: 2, attributes: { size: 'M' } },
+        ]),
+    } as unknown as IProductsService;
+
+    const result = await createGetProductTool(service).handler(
+      { productId: 'ol_product_1' },
+      {} as never
+    );
+
+    expect(payloadOf(result)).toEqual(
+      expect.objectContaining({
+        id: 'ol_product_1',
+        variants: [
+          {
+            id: 'ol_variant_1',
+            sku: 'V-1',
+            ean: '590123',
+            gtin: null,
+            price: 2,
+            attributes: { size: 'M' },
+          },
+        ],
+      })
+    );
+  });
+});
+
+describe('get_availability tool', () => {
+  const service = {
+    getProductStockAggregates: (ids: readonly string[]) =>
+      Promise.resolve(
+        ids.map((productId) => ({
+          productId,
+          totalAvailable: 7,
+          totalReserved: 2,
+          stockUpdatedAt: new Date('2026-07-01T10:00:00.000Z'),
+        }))
+      ),
+    getAvailabilityByVariantIds: (ids: readonly string[]) =>
+      Promise.resolve(
+        ids.map((productVariantId) => ({ productVariantId, totalAvailable: 3, locationCount: 1 }))
+      ),
+  } as unknown as IInventoryQueryService;
+
+  it('should use the product-level aggregate when given product ids', async () => {
+    const result = await createGetAvailabilityTool(service).handler(
+      { productIds: ['ol_product_1'] },
+      {} as never
+    );
+
+    expect(payloadOf(result)).toEqual({
+      products: [
+        {
+          productId: 'ol_product_1',
+          totalAvailable: 7,
+          totalReserved: 2,
+          stockUpdatedAt: '2026-07-01T10:00:00.000Z',
+        },
+      ],
+    });
+  });
+
+  it('should use the variant-keyed read when given variant ids', async () => {
+    const result = await createGetAvailabilityTool(service).handler(
+      { variantIds: ['ol_variant_1'] },
+      {} as never
+    );
+
+    expect(payloadOf(result)).toEqual({
+      variants: [{ variantId: 'ol_variant_1', totalAvailable: 3, locationCount: 1 }],
+    });
+  });
+
+  it('should refuse an ambiguous call that supplies both id kinds', async () => {
+    const result = await createGetAvailabilityTool(service).handler(
+      { productIds: ['p'], variantIds: ['v'] },
+      {} as never
+    );
+
+    expect(result.isError).toBe(true);
+  });
+
+  it('should refuse a call that supplies neither id kind', async () => {
+    const result = await createGetAvailabilityTool(service).handler({}, {} as never);
+
+    expect(result.isError).toBe(true);
+  });
+
+  it('should not accept a connectionId, because the underlying reads are global', () => {
+    const tool = createGetAvailabilityTool(service);
+    const shape = (tool.inputSchema as unknown as { shape: Record<string, unknown> }).shape;
+
+    expect(Object.keys(shape).sort()).toEqual(['productIds', 'variantIds']);
+  });
+});
+
+describe('get_order tool', () => {
+  function recordWith(snapshot: Record<string, unknown>): OrderRecord {
+    return {
+      internalOrderId: 'ol_order_1',
+      sourceConnectionId: 'conn-1',
+      recordStatus: 'ready',
+      syncStatus: [],
+      fulfillmentState: null,
+      paymentStatus: 'paid',
+      dispatchByAt: null,
+      createdAt: new Date('2026-07-01T10:00:00.000Z'),
+      updatedAt: new Date('2026-07-02T10:00:00.000Z'),
+      orderSnapshot: snapshot,
+    } as unknown as OrderRecord;
+  }
+
+  const piiSnapshot = {
+    orderNumber: 'A-1',
+    status: 'NEW',
+    totals: { grandTotal: 42 },
+    items: [{ sku: 'W-1', name: 'Widget', quantity: 2, unitPrice: 21 }],
+    customerEmail: 'buyer@example.com',
+    shippingAddress: { street: '1 Buyer Way', city: 'Warsaw', firstName: 'Jan' },
+    billingAddress: { street: '1 Buyer Way' },
+  };
+
+  function serviceReturning(record: OrderRecord | null): IOrderRecordService {
+    return { getOrderRecord: () => Promise.resolve(record) } as unknown as IOrderRecordService;
+  }
+
+  it('should return the operational fields an agent asks about', async () => {
+    const tool = createGetOrderTool(serviceReturning(recordWith(piiSnapshot)));
+
+    const result = await tool.handler({ orderId: 'ol_order_1' }, {} as never);
+
+    expect(payloadOf(result)).toEqual(
+      expect.objectContaining({
+        internalOrderId: 'ol_order_1',
+        orderNumber: 'A-1',
+        status: 'NEW',
+        paymentStatus: 'paid',
+        totals: { grandTotal: 42 },
+      })
+    );
+  });
+
+  it('should never forward buyer PII, even when the snapshot stores it', async () => {
+    const tool = createGetOrderTool(serviceReturning(recordWith(piiSnapshot)));
+
+    const text = textOf(await tool.handler({ orderId: 'ol_order_1' }, {} as never));
+
+    expect(text).not.toContain('buyer@example.com');
+    expect(text).not.toContain('1 Buyer Way');
+    expect(text).not.toContain('Jan');
+    expect(text).not.toContain('shippingAddress');
+    expect(text).not.toContain('billingAddress');
+  });
+
+  it('should project line items field-by-field so new snapshot fields cannot leak', async () => {
+    const tool = createGetOrderTool(
+      serviceReturning(
+        recordWith({
+          items: [{ sku: 'W-1', quantity: 1, buyerNote: 'call me on 555-1234' }],
+        })
+      )
+    );
+
+    const text = textOf(await tool.handler({ orderId: 'ol_order_1' }, {} as never));
+
+    expect(text).not.toContain('buyerNote');
+    expect(text).not.toContain('555-1234');
+  });
+
+  it('should return an error when the order does not exist', async () => {
+    const tool = createGetOrderTool(serviceReturning(null));
+
+    const result = await tool.handler({ orderId: 'nope' }, {} as never);
+
+    expect(result.isError).toBe(true);
+  });
+});

--- a/apps/api/src/mcp/tools/read/search-catalog.tool.ts
+++ b/apps/api/src/mcp/tools/read/search-catalog.tool.ts
@@ -1,0 +1,78 @@
+/**
+ * `search_catalog` MCP Tool
+ *
+ * Searches OpenLinker's OWN product catalog — not a live platform call.
+ * See the plan §3.3: reading OL's store keeps results internal-id-keyed
+ * (so they join with the other tools), costs no marketplace API quota, and
+ * inherits whatever the operator has already synced.
+ *
+ * `connectionId` filters by PROVENANCE (`ProductListFilters.sourceConnectionId`
+ * matches products having a Product identifier mapping for that connection) —
+ * it is NOT "products currently listed there". The description says so,
+ * because an agent would otherwise reasonably assume the latter.
+ *
+ * Results are capped and projected: a tool result is fed to an LLM, so an
+ * unbounded array of full `Product` entities would blow the context window
+ * for no benefit.
+ *
+ * @module apps/api/src/mcp/tools/read
+ */
+import * as z from 'zod/v4';
+import type { CallToolResult } from '@modelcontextprotocol/server';
+import type { IProductsService, Product } from '@openlinker/core/products';
+
+import type { McpToolDefinition } from '../tool-definition.types';
+import { jsonResult } from './tool-result';
+
+const DEFAULT_LIMIT = 20;
+const MAX_LIMIT = 100;
+
+const inputSchema = z.object({
+  query: z
+    .string()
+    .optional()
+    .describe('Case-insensitive substring match on product name or SKU. Omit to list all.'),
+  connectionId: z
+    .string()
+    .optional()
+    .describe('Restrict to products that originated from this connection.'),
+  limit: z.number().int().min(1).max(MAX_LIMIT).optional().describe(`Default ${DEFAULT_LIMIT}.`),
+  offset: z.number().int().min(0).optional().describe('Default 0.'),
+});
+
+export function createSearchCatalogTool(productsService: IProductsService): McpToolDefinition {
+  return {
+    name: 'search_catalog',
+    requiredCapability: 'ProductMaster',
+    description:
+      "Search OpenLinker's product catalog by name or SKU. Returns internal product ids usable with get_product and get_availability. `connectionId` filters by which connection a product ORIGINATED from (its identifier mapping), not by where it is currently listed. An empty result means no product matched — the catalog is populated by sync, so a recently added connection may not have products yet.",
+    inputSchema,
+    handler: async (args: Record<string, unknown>): Promise<CallToolResult> => {
+      const { query, connectionId, limit, offset } = inputSchema.parse(args);
+
+      const page = await productsService.listProducts(
+        {
+          ...(query !== undefined ? { search: query } : {}),
+          ...(connectionId !== undefined ? { sourceConnectionId: connectionId } : {}),
+        },
+        { limit: limit ?? DEFAULT_LIMIT, offset: offset ?? 0 }
+      );
+
+      return jsonResult({
+        total: page.total,
+        returned: page.items.length,
+        products: page.items.map(projectProduct),
+      });
+    },
+  };
+}
+
+function projectProduct(product: Product): Record<string, unknown> {
+  return {
+    id: product.id,
+    name: product.name,
+    sku: product.sku,
+    price: product.price,
+    currency: product.currency,
+  };
+}

--- a/apps/api/src/mcp/tools/read/search-catalog.tool.ts
+++ b/apps/api/src/mcp/tools/read/search-catalog.tool.ts
@@ -48,6 +48,11 @@ export function createSearchCatalogTool(productsService: IProductsService): McpT
       "Search OpenLinker's product catalog by name or SKU. Returns internal product ids usable with get_product and get_availability. `connectionId` filters by which connection a product ORIGINATED from (its identifier mapping), not by where it is currently listed. An empty result means no product matched — the catalog is populated by sync, so a recently added connection may not have products yet.",
     inputSchema,
     handler: async (args: Record<string, unknown>): Promise<CallToolResult> => {
+      // NARROWING, not validation: the SDK already validated `args` against
+      // this schema before invoking the handler, so this call cannot
+      // realistically fail. It exists to turn `Record<string, unknown>` into
+      // typed fields — never rely on it as the enforcement point for a
+      // constraint (a caller-visible cap belongs on the schema itself).
       const { query, connectionId, limit, offset } = inputSchema.parse(args);
 
       const page = await productsService.listProducts(

--- a/apps/api/src/mcp/tools/read/tool-result.ts
+++ b/apps/api/src/mcp/tools/read/tool-result.ts
@@ -1,0 +1,24 @@
+/**
+ * MCP Tool Result Helpers
+ *
+ * Shared shaping for tool results (#1487). Every tool returns JSON text —
+ * the calling model parses it — so the serialization lives in one place
+ * rather than being re-spelled per tool.
+ *
+ * @module apps/api/src/mcp/tools/read
+ */
+import type { CallToolResult } from '@modelcontextprotocol/server';
+
+/** Successful result carrying a JSON payload. */
+export function jsonResult(payload: unknown): CallToolResult {
+  return { content: [{ type: 'text' as const, text: JSON.stringify(payload, null, 2) }] };
+}
+
+/**
+ * Failure result. The text is AGENT-FACING COPY: the calling model reads it
+ * and decides what to do next, so it should say what went wrong and, where
+ * useful, which tool to call instead.
+ */
+export function toolFailure(message: string): CallToolResult {
+  return { content: [{ type: 'text' as const, text: message }], isError: true };
+}

--- a/apps/api/src/mcp/tools/read/whoami.tool.ts
+++ b/apps/api/src/mcp/tools/read/whoami.tool.ts
@@ -1,0 +1,49 @@
+/**
+ * `whoami` MCP Tool
+ *
+ * Returns the OpenLinker identity backing the presented MCP token.
+ *
+ * Shipped inline in `mcp-server.factory.ts` by Phase 0 (#1486) as the auth
+ * proof, with a standing note that it belonged in a `*.tool.ts` file once
+ * #1487 registered that convention. This file discharges that note — and,
+ * more importantly, puts `whoami` behind the registry's per-call wrapper
+ * (rate limit + audit) like every other tool.
+ *
+ * Always registered: it is a discovery entry point and must work on a
+ * deployment with no connections at all.
+ *
+ * SECURITY: returns only the redacted principal projection — never the
+ * `AuthInfo`, which carries the raw bearer token.
+ *
+ * @module apps/api/src/mcp/tools/read
+ */
+import * as z from 'zod/v4';
+import type { CallToolResult, McpRequestContext } from '@modelcontextprotocol/server';
+
+import { isMcpAuthInfoExtra } from '../../auth/mcp-principal.types';
+import type { McpToolDefinition } from '../tool-definition.types';
+import { jsonResult, toolFailure } from './tool-result';
+
+export function createWhoamiTool(): McpToolDefinition {
+  return {
+    name: 'whoami',
+    requiredCapability: null,
+    description:
+      'Return the OpenLinker identity backing the presented MCP token (user id, role, token name, granted scopes). Use this to verify a token is installed and working.',
+    inputSchema: z.object({}),
+    handler: (_args: Record<string, unknown>, ctx: McpRequestContext): Promise<CallToolResult> => {
+      const extra = ctx.authInfo?.extra;
+      if (!isMcpAuthInfoExtra(extra)) {
+        return Promise.resolve(toolFailure('No OpenLinker principal on this request.'));
+      }
+      return Promise.resolve(
+        jsonResult({
+          userId: extra.olUserId,
+          role: extra.olRole,
+          tokenName: extra.tokenName,
+          scopes: ctx.authInfo?.scopes ?? [],
+        })
+      );
+    },
+  };
+}

--- a/apps/api/src/mcp/tools/tool-definition.types.ts
+++ b/apps/api/src/mcp/tools/tool-definition.types.ts
@@ -25,6 +25,14 @@ import type { StandardSchemaWithJSON } from '@modelcontextprotocol/server';
  * members of `CoreCapabilityValues` — this is deliberately a closed set, not
  * the open string set the registry accepts, because Phase 1 ships a fixed
  * tool catalogue.
+ *
+ * NOTE both `as const` arrays in this file are currently consumed only for the
+ * union types derived from them; nothing reads the runtime arrays yet. They are
+ * kept in the shape `engineering-standards.md § Union Types` mandates (which
+ * explicitly rejects a bare inline union precisely because it leaves no runtime
+ * array to validate against) so that the first consumer needing validation —
+ * e.g. a DTO for an operator-facing tool-audit filter — has one to bind to
+ * without a refactor.
  */
 export const McpToolCapabilityValues = ['ProductMaster', 'InventoryMaster', 'OrderSource'] as const;
 

--- a/apps/api/src/mcp/tools/tool-definition.types.ts
+++ b/apps/api/src/mcp/tools/tool-definition.types.ts
@@ -1,0 +1,83 @@
+/**
+ * MCP Tool Definition Types
+ *
+ * The neutral shape every MCP tool declares (#1487). A definition is data,
+ * not behaviour wiring: it names the tool, states the capability that gates
+ * its registration, and supplies a handler that does nothing but read +
+ * project. Cross-cutting concerns (rate limiting, audit logging, error
+ * mapping) are applied once by `ToolRegistryService`, never by a tool.
+ *
+ * Two facts are deliberately independent here (plan §3.3.0):
+ *   - `requiredCapability` gates whether the tool is REGISTERED — it answers
+ *     "is this deployment in the products/inventory/orders business?"
+ *   - the handler reads OL's OWN store, so it can return an empty result even
+ *     when the gate passes (freshly-added connection, no sync yet).
+ * Every tool's `description` must therefore say which situation an empty
+ * result represents — it is the only channel the calling agent reads.
+ *
+ * @module apps/api/src/mcp/tools
+ */
+import type { CallToolResult, McpRequestContext } from '@modelcontextprotocol/server';
+import type { StandardSchemaWithJSON } from '@modelcontextprotocol/server';
+
+/**
+ * Capabilities that can gate a Phase-1 read tool. All three are well-known
+ * members of `CoreCapabilityValues` — this is deliberately a closed set, not
+ * the open string set the registry accepts, because Phase 1 ships a fixed
+ * tool catalogue.
+ */
+export const McpToolCapabilityValues = ['ProductMaster', 'InventoryMaster', 'OrderSource'] as const;
+
+export type McpToolCapability = (typeof McpToolCapabilityValues)[number];
+
+/**
+ * Outcome of a single tool call, as recorded by the audit log.
+ *
+ * `rate-limited` is distinct from `error`: the handler never ran, so the
+ * call consumed no downstream resources and reflects client behaviour
+ * rather than a fault.
+ */
+export const McpToolOutcomeValues = ['ok', 'error', 'rate-limited'] as const;
+
+export type McpToolOutcome = (typeof McpToolOutcomeValues)[number];
+
+/**
+ * A tool handler: reads, projects, returns. It receives already-validated
+ * arguments and the request context carrying the principal.
+ *
+ * A handler MUST NOT log the audit line, acquire a rate-limit slot, or map
+ * its own errors to agent-facing copy — `ToolRegistryService` owns all
+ * three so they cannot be forgotten (plan §3.3.3).
+ */
+export type McpToolHandler = (
+  args: Record<string, unknown>,
+  ctx: McpRequestContext
+) => Promise<CallToolResult>;
+
+/**
+ * A registrable MCP tool.
+ */
+export interface McpToolDefinition {
+  /**
+   * Stable, connection-independent name (`search_catalog`, never
+   * `search_catalog__allegro-main`). Baking a connection into the name would
+   * explode the surface to N connections x M capabilities.
+   */
+  readonly name: string;
+
+  /**
+   * Capability that must be supported AND enabled on at least one connection
+   * for this tool to appear in `tools/list`. `null` means always registered
+   * (`list_connections`, `whoami` — the discovery entry points, which must
+   * work even on a deployment with no connections at all).
+   */
+  readonly requiredCapability: McpToolCapability | null;
+
+  /** Agent-facing description. See the module header on empty-result semantics. */
+  readonly description: string;
+
+  /** Zod schema for the tool's arguments. */
+  readonly inputSchema: StandardSchemaWithJSON;
+
+  readonly handler: McpToolHandler;
+}

--- a/apps/api/src/mcp/tools/tool-registry.service.interface.ts
+++ b/apps/api/src/mcp/tools/tool-registry.service.interface.ts
@@ -14,9 +14,11 @@ export interface IMcpToolRegistryService {
    * Register every tool available to this request onto a fresh `McpServer`.
    *
    * Called once per HTTP request (the SDK builds a new server each time), so
-   * `tools/list` is recomputed from live capability state on every call and
-   * can never be stale — which is why the MCP `notifications/tools/list_changed`
-   * mechanism is neither advertised nor needed here.
+   * `tools/list` is recomputed from live capability state on every call — the
+   * SERVER is always fresh. OL does not advertise or send
+   * `notifications/tools/list_changed` because stateless serving leaves no
+   * session to push over; the accepted cost is that a CLIENT's cached list can
+   * still go stale until it reconnects (ADR-033 § Phase 1 amendments).
    *
    * `ctx` is the REQUEST-scoped context, and it is the only place the
    * OpenLinker principal is available: the context handed to a tool callback at

--- a/apps/api/src/mcp/tools/tool-registry.service.interface.ts
+++ b/apps/api/src/mcp/tools/tool-registry.service.interface.ts
@@ -1,0 +1,28 @@
+/**
+ * MCP Tool Registry Service Interface
+ *
+ * Contract for resolving and registering the MCP tool surface (#1487).
+ *
+ * @module apps/api/src/mcp/tools
+ */
+import type { McpRequestContext, McpServer } from '@modelcontextprotocol/server';
+
+export const MCP_TOOL_REGISTRY_SERVICE_TOKEN = Symbol('IMcpToolRegistryService');
+
+export interface IMcpToolRegistryService {
+  /**
+   * Register every tool available to this request onto a fresh `McpServer`.
+   *
+   * Called once per HTTP request (the SDK builds a new server each time), so
+   * `tools/list` is recomputed from live capability state on every call and
+   * can never be stale — which is why the MCP `notifications/tools/list_changed`
+   * mechanism is neither advertised nor needed here.
+   *
+   * `ctx` is the REQUEST-scoped context, and it is the only place the
+   * OpenLinker principal is available: the context handed to a tool callback at
+   * dispatch time does NOT carry `authInfo`. Tools therefore close over this
+   * one. (Verified by integration test — Phase 0's `whoami` read the same
+   * request-scoped value.)
+   */
+  registerTools(server: McpServer, ctx: McpRequestContext): Promise<void>;
+}

--- a/apps/api/src/mcp/tools/tool-registry.service.spec.ts
+++ b/apps/api/src/mcp/tools/tool-registry.service.spec.ts
@@ -1,0 +1,288 @@
+/**
+ * McpToolRegistryService Unit Tests
+ *
+ * Two things are under test, and the second matters more:
+ *
+ *  1. CAPABILITY GATING — a tool appears iff its capability is backed.
+ *  2. THE PER-CALL WRAPPER — the cases hand-written per-tool code gets wrong:
+ *     a throwing handler must still release its in-flight slot AND still emit
+ *     an audit line; an over-limit call must never reach the handler; and the
+ *     raw bearer token must never reach the log.
+ */
+import type { McpServer } from '@modelcontextprotocol/server';
+import * as z from 'zod/v4';
+import type { IIntegrationsService } from '@openlinker/core/integrations';
+
+import { McpToolRegistryService } from './tool-registry.service';
+import { McpAuditLogger } from './audit/mcp-audit.logger';
+import type { IMcpRateLimiter, McpRateLimitLease } from './ratelimit/mcp-rate-limiter.interface';
+import type { McpToolDefinition } from './tool-definition.types';
+
+const RAW_TOKEN = 'olmcp_super_secret_value';
+
+/** Mirrors what `OlMcpTokenVerifier` puts on the request. */
+function authInfo(): { token: string; scopes: string[]; extra: Record<string, unknown> } {
+  return {
+    // The AuthInfo carries the RAW bearer token — the whole point of the
+    // redaction invariant.
+    token: RAW_TOKEN,
+    scopes: ['mcp:read'],
+    extra: {
+      mcpTokenId: 'tok-1',
+      tokenName: 'laptop',
+      olUserId: 'user-1',
+      olRole: 'admin',
+    },
+  };
+}
+
+function ctx(): never {
+  return { authInfo: authInfo() } as never;
+}
+
+/** Captures what the server was asked to register. */
+function recordingServer(): {
+  server: McpServer;
+  names: string[];
+  handlers: Map<string, (args: Record<string, unknown>, ctx: unknown) => Promise<unknown>>;
+} {
+  const names: string[] = [];
+  const handlers = new Map<string, (args: Record<string, unknown>, c: unknown) => Promise<unknown>>();
+  const server = {
+    registerTool: (
+      name: string,
+      _config: unknown,
+      cb: (args: Record<string, unknown>, c: unknown) => Promise<unknown>
+    ) => {
+      names.push(name);
+      handlers.set(name, cb);
+    },
+  } as unknown as McpServer;
+  return { server, names, handlers };
+}
+
+function definition(overrides: Partial<McpToolDefinition> = {}): McpToolDefinition {
+  return {
+    name: 'test_tool',
+    requiredCapability: null,
+    description: 'test',
+    inputSchema: z.object({}),
+    handler: () => Promise.resolve({ content: [{ type: 'text' as const, text: 'ok' }] }),
+    ...overrides,
+  };
+}
+
+function integrationsWith(capabilities: readonly string[]): IIntegrationsService {
+  return {
+    listCapabilityAdapters: ({ capability }: { capability: string }) =>
+      Promise.resolve(capabilities.includes(capability) ? [{ connectionId: 'c1' }] : []),
+  } as unknown as IIntegrationsService;
+}
+
+function allowingLimiter(): IMcpRateLimiter & { released: number } {
+  const limiter = {
+    released: 0,
+    acquire: (): Promise<McpRateLimitLease> =>
+      Promise.resolve({
+        allowed: true,
+        release: () => {
+          limiter.released += 1;
+          return Promise.resolve();
+        },
+      }),
+  };
+  return limiter;
+}
+
+function build(
+  definitions: readonly McpToolDefinition[],
+  integrations: IIntegrationsService,
+  limiter: IMcpRateLimiter
+): { service: McpToolRegistryService; logged: string[] } {
+  const logged: string[] = [];
+  const audit = new McpAuditLogger();
+  // Capture the emitted line without asserting on the Logger backend.
+  jest.spyOn(audit, 'record').mockImplementation((entry) => {
+    logged.push(JSON.stringify(entry));
+  });
+  return {
+    service: new McpToolRegistryService(integrations, limiter, audit, definitions),
+    logged,
+  };
+}
+
+describe('McpToolRegistryService', () => {
+  describe('capability gating', () => {
+    it('should omit every tool of a capability that no connection backs', async () => {
+      const { server, names } = recordingServer();
+      const { service } = build(
+        [
+          definition({ name: 'always' }),
+          definition({ name: 'gated_a', requiredCapability: 'ProductMaster' }),
+          definition({ name: 'gated_b', requiredCapability: 'ProductMaster' }),
+        ],
+        integrationsWith([]),
+        allowingLimiter()
+      );
+
+      await service.registerTools(server, ctx());
+
+      expect(names).toEqual(['always']);
+    });
+
+    it('should register both tools when one base capability backs two of them', async () => {
+      const { server, names } = recordingServer();
+      const { service } = build(
+        [
+          definition({ name: 'gated_a', requiredCapability: 'ProductMaster' }),
+          definition({ name: 'gated_b', requiredCapability: 'ProductMaster' }),
+        ],
+        integrationsWith(['ProductMaster']),
+        allowingLimiter()
+      );
+
+      await service.registerTools(server, ctx());
+
+      expect(names).toEqual(['gated_a', 'gated_b']);
+    });
+
+    it('should resolve capabilities lazily so listing does not construct adapters', async () => {
+      const listCapabilityAdapters = jest.fn().mockResolvedValue([{ connectionId: 'c1' }]);
+      const { server } = recordingServer();
+      const { service } = build(
+        [definition({ requiredCapability: 'ProductMaster' })],
+        { listCapabilityAdapters } as unknown as IIntegrationsService,
+        allowingLimiter()
+      );
+
+      await service.registerTools(server, ctx());
+
+      expect(listCapabilityAdapters).toHaveBeenCalledWith({
+        capability: 'ProductMaster',
+        lazy: true,
+      });
+    });
+
+    it('should skip a capability that fails to resolve rather than failing the whole list', async () => {
+      const { server, names } = recordingServer();
+      const { service } = build(
+        [definition({ name: 'always' }), definition({ name: 'gated', requiredCapability: 'OrderSource' })],
+        {
+          listCapabilityAdapters: () => Promise.reject(new Error('connection exploded')),
+        } as unknown as IIntegrationsService,
+        allowingLimiter()
+      );
+
+      await service.registerTools(server, ctx());
+
+      expect(names).toEqual(['always']);
+    });
+  });
+
+  describe('per-call wrapper', () => {
+    it('should release the in-flight slot when the handler throws', async () => {
+      const limiter = allowingLimiter();
+      const { server, handlers } = recordingServer();
+      const { service } = build(
+        [definition({ handler: () => Promise.reject(new Error('boom')) })],
+        integrationsWith([]),
+        limiter
+      );
+      await service.registerTools(server, ctx());
+
+      await handlers.get('test_tool')?.({}, ctx());
+
+      expect(limiter.released).toBe(1);
+    });
+
+    it('should still emit an audit line when the handler throws', async () => {
+      const { server, handlers } = recordingServer();
+      const { service, logged } = build(
+        [definition({ handler: () => Promise.reject(new Error('boom')) })],
+        integrationsWith([]),
+        allowingLimiter()
+      );
+      await service.registerTools(server, ctx());
+
+      await handlers.get('test_tool')?.({}, ctx());
+
+      expect(logged).toHaveLength(1);
+      expect(logged[0]).toContain('"outcome":"error"');
+    });
+
+    it('should return an agent-facing tool error rather than propagating the throw', async () => {
+      const { server, handlers } = recordingServer();
+      const { service } = build(
+        [definition({ handler: () => Promise.reject(new Error('boom')) })],
+        integrationsWith([]),
+        allowingLimiter()
+      );
+      await service.registerTools(server, ctx());
+
+      const result = (await handlers.get('test_tool')?.({}, ctx())) as {
+        isError?: boolean;
+        content: Array<{ text: string }>;
+      };
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('test_tool failed');
+    });
+
+    it('should never invoke the handler when the call is over the limit', async () => {
+      const handler = jest.fn();
+      const { server, handlers } = recordingServer();
+      const { service, logged } = build(
+        [definition({ handler })],
+        integrationsWith([]),
+        {
+          acquire: () =>
+            Promise.resolve({
+              allowed: false,
+              reason: 'Rate limit exceeded',
+              release: () => Promise.resolve(),
+            }),
+        }
+      );
+      await service.registerTools(server, ctx());
+
+      const result = (await handlers.get('test_tool')?.({}, ctx())) as { isError?: boolean };
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(result.isError).toBe(true);
+      expect(logged[0]).toContain('"outcome":"rate-limited"');
+    });
+
+    it('should never write the raw bearer token to the audit log', async () => {
+      const { server, handlers } = recordingServer();
+      const { service, logged } = build([definition()], integrationsWith([]), allowingLimiter());
+      await service.registerTools(server, ctx());
+
+      await handlers.get('test_tool')?.({}, ctx());
+
+      expect(logged).toHaveLength(1);
+      expect(logged[0]).not.toContain(RAW_TOKEN);
+      expect(logged[0]).toContain('tok-1');
+    });
+
+    it('should refuse a call carrying no recognisable principal', async () => {
+      const handler = jest.fn();
+      const { server, handlers } = recordingServer();
+      const { service, logged } = build(
+        [definition({ handler })],
+        integrationsWith([]),
+        allowingLimiter()
+      );
+      // Register with a principal-less request context — the tools close over
+      // the REQUEST-scoped ctx, so that is where its absence must be simulated.
+      await service.registerTools(server, {} as never);
+
+      const result = (await handlers.get('test_tool')?.({}, {} as never)) as { isError?: boolean };
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(result.isError).toBe(true);
+      // The registry passes `principal: null` down; rendering it as
+      // `principal: 'none'` is the logger's job (see its own spec).
+      expect(logged[0]).toContain('"principal":null');
+    });
+  });
+});

--- a/apps/api/src/mcp/tools/tool-registry.service.ts
+++ b/apps/api/src/mcp/tools/tool-registry.service.ts
@@ -1,0 +1,204 @@
+/**
+ * MCP Tool Registry Service
+ *
+ * Resolves the per-request MCP tool surface (#1487) and owns the single
+ * choke point through which every tool call passes.
+ *
+ * TWO RESPONSIBILITIES, both deliberately here rather than in tool files:
+ *
+ * 1. CAPABILITY-DECLARED REGISTRATION. A tool is registered iff at least one
+ *    connection both supports AND has enabled its required capability.
+ *    `listCapabilityAdapters` already intersects the adapter manifest with the
+ *    connection's `enabledCapabilities`, so both halves come free;
+ *    `lazy: true` avoids constructing adapters merely to answer `tools/list`.
+ *
+ *    NOTE the gate and the DATA SOURCE are independent facts: tools read OL's
+ *    own store, so a passing gate does not imply data exists (a freshly added
+ *    connection publishes its tools before any sync has run), and a disabled
+ *    connection hides tools whose data OL still holds. Each tool's description
+ *    states this — see `tool-definition.types.ts`.
+ *
+ * 2. THE PER-CALL WRAPPER. Rate limiting, audit logging, and error mapping are
+ *    per-call and tool-agnostic. Applied here, they are structural. Left to
+ *    each tool, they would be five independent chances to forget to release an
+ *    in-flight slot on the throw path — and a missed release leaks that slot
+ *    until it ages out. Tool files therefore contain ONLY their read and
+ *    projection; they never import the limiter or the logger.
+ *
+ * @module apps/api/src/mcp/tools
+ * @implements {IMcpToolRegistryService}
+ */
+import { Inject, Injectable } from '@nestjs/common';
+import type {
+  CallToolResult,
+  McpRequestContext,
+  McpServer,
+  StandardSchemaWithJSON,
+} from '@modelcontextprotocol/server';
+import {
+  INTEGRATIONS_SERVICE_TOKEN,
+  type IIntegrationsService,
+} from '@openlinker/core/integrations';
+import { Logger } from '@openlinker/shared/logging';
+
+import { redactPrincipal } from '../auth/mcp-principal.types';
+import { McpAuditLogger } from './audit/mcp-audit.logger';
+import {
+  MCP_RATE_LIMITER_TOKEN,
+  type IMcpRateLimiter,
+} from './ratelimit/mcp-rate-limiter.interface';
+import { MCP_TOOL_DEFINITIONS_TOKEN } from './mcp-tool-definitions.provider';
+import type { IMcpToolRegistryService } from './tool-registry.service.interface';
+import type { McpToolCapability, McpToolDefinition, McpToolOutcome } from './tool-definition.types';
+
+@Injectable()
+export class McpToolRegistryService implements IMcpToolRegistryService {
+  private readonly logger = new Logger(McpToolRegistryService.name);
+
+  constructor(
+    @Inject(INTEGRATIONS_SERVICE_TOKEN)
+    private readonly integrationsService: IIntegrationsService,
+    @Inject(MCP_RATE_LIMITER_TOKEN)
+    private readonly rateLimiter: IMcpRateLimiter,
+    private readonly auditLogger: McpAuditLogger,
+    @Inject(MCP_TOOL_DEFINITIONS_TOKEN)
+    private readonly definitions: readonly McpToolDefinition[]
+  ) {}
+
+  async registerTools(server: McpServer, ctx: McpRequestContext): Promise<void> {
+    const available = await this.resolveAvailableCapabilities();
+
+    for (const definition of this.definitions) {
+      if (definition.requiredCapability !== null && !available.has(definition.requiredCapability)) {
+        continue;
+      }
+      // The SDK's `registerTool` is generic over each tool's own schema, so its
+      // callback type is narrowed per call site. This registry is deliberately
+      // schema-agnostic (it registers a heterogeneous list), so it binds to the
+      // narrow structural view below instead — which states exactly the surface
+      // depended on, rather than erasing it with `any`.
+      asToolRegistrar(server).registerTool(
+        definition.name,
+        { description: definition.description, inputSchema: definition.inputSchema },
+        // Close over the REQUEST-scoped ctx: the context the SDK hands a tool
+        // callback at dispatch time does not carry `authInfo`.
+        (args) => this.invoke(definition, args, ctx)
+      );
+    }
+  }
+
+  /**
+   * Which of the gating capabilities are backed by at least one
+   * supporting-and-enabled connection. One `listCapabilityAdapters` call per
+   * DISTINCT capability, not per tool — a base port backs several tools.
+   */
+  private async resolveAvailableCapabilities(): Promise<Set<McpToolCapability>> {
+    const required = new Set<McpToolCapability>();
+    for (const definition of this.definitions) {
+      if (definition.requiredCapability !== null) {
+        required.add(definition.requiredCapability);
+      }
+    }
+
+    const available = new Set<McpToolCapability>();
+    await Promise.all(
+      [...required].map(async (capability) => {
+        try {
+          const entries = await this.integrationsService.listCapabilityAdapters({
+            capability,
+            lazy: true,
+          });
+          if (entries.length > 0) {
+            available.add(capability);
+          }
+        } catch (error) {
+          // A broken connection must not blank the whole tool surface. Treat
+          // the capability as unavailable and say so — an absent tool with a
+          // logged cause beats a 500 on `tools/list`.
+          this.logger.warn(
+            `Could not resolve MCP capability "${capability}"; its tools will not be listed. ${
+              (error as Error).message
+            }`
+          );
+        }
+      })
+    );
+    return available;
+  }
+
+  /**
+   * The wrapper. Ordering is load-bearing:
+   *   acquire → (handler | skip) → release in `finally` → audit on every path.
+   */
+  private async invoke(
+    definition: McpToolDefinition,
+    args: Record<string, unknown>,
+    ctx: McpRequestContext
+  ): Promise<CallToolResult> {
+    const startedAt = Date.now();
+    const principal = redactPrincipal(ctx.authInfo?.extra, ctx.authInfo?.scopes ?? []);
+    const connectionId = typeof args.connectionId === 'string' ? args.connectionId : undefined;
+
+    const emit = (outcome: McpToolOutcome, detail?: string): void => {
+      this.auditLogger.record({
+        tool: definition.name,
+        outcome,
+        durationMs: Date.now() - startedAt,
+        connectionId,
+        principal,
+        detail,
+      });
+    };
+
+    // No principal ⇒ no stable key to meter on. The transport fails closed and
+    // the bearer middleware gates the route, so this is unreachable in
+    // practice; treat it as an error rather than silently metering globally.
+    if (principal === null) {
+      emit('error', 'no principal on request');
+      return toolError('No OpenLinker principal on this request.');
+    }
+
+    const lease = await this.rateLimiter.acquire(principal.mcpTokenId);
+    if (!lease.allowed) {
+      emit('rate-limited', lease.reason);
+      return toolError(lease.reason ?? 'Rate limit exceeded.');
+    }
+
+    try {
+      const result = await definition.handler(args, ctx);
+      emit(result.isError === true ? 'error' : 'ok');
+      return result;
+    } catch (error) {
+      const message = (error as Error).message;
+      emit('error', message);
+      // Agent-facing copy: the calling model reads this and decides what to do
+      // next, so surface the message but keep it framed as a tool failure.
+      return toolError(`${definition.name} failed: ${message}`);
+    } finally {
+      await lease.release();
+    }
+  }
+}
+
+function toolError(text: string): CallToolResult {
+  return { content: [{ type: 'text' as const, text }], isError: true };
+}
+
+/**
+ * The exact slice of `McpServer` this registry uses.
+ *
+ * Declaring it explicitly (rather than casting the callback to `any`) keeps the
+ * dependency legible: if the SDK changes this signature, the cast below stops
+ * compiling instead of silently accepting a mismatched handler.
+ */
+interface ToolRegistrar {
+  registerTool(
+    name: string,
+    config: { description: string; inputSchema: StandardSchemaWithJSON },
+    cb: (args: Record<string, unknown>) => Promise<CallToolResult>
+  ): unknown;
+}
+
+function asToolRegistrar(server: McpServer): ToolRegistrar {
+  return server as unknown as ToolRegistrar;
+}

--- a/apps/api/src/mcp/tools/tool-registry.service.ts
+++ b/apps/api/src/mcp/tools/tool-registry.service.ts
@@ -42,7 +42,10 @@ import {
 import { Logger } from '@openlinker/shared/logging';
 
 import { redactPrincipal } from '../auth/mcp-principal.types';
-import { McpAuditLogger } from './audit/mcp-audit.logger';
+import {
+  MCP_AUDIT_LOGGER_TOKEN,
+  type IMcpAuditLogger,
+} from './audit/mcp-audit.logger.interface';
 import {
   MCP_RATE_LIMITER_TOKEN,
   type IMcpRateLimiter,
@@ -60,7 +63,8 @@ export class McpToolRegistryService implements IMcpToolRegistryService {
     private readonly integrationsService: IIntegrationsService,
     @Inject(MCP_RATE_LIMITER_TOKEN)
     private readonly rateLimiter: IMcpRateLimiter,
-    private readonly auditLogger: McpAuditLogger,
+    @Inject(MCP_AUDIT_LOGGER_TOKEN)
+    private readonly auditLogger: IMcpAuditLogger,
     @Inject(MCP_TOOL_DEFINITIONS_TOKEN)
     private readonly definitions: readonly McpToolDefinition[]
   ) {}

--- a/apps/api/src/mcp/transport/mcp-server.factory.ts
+++ b/apps/api/src/mcp/transport/mcp-server.factory.ts
@@ -11,10 +11,11 @@
  * behind the registry's per-call rate-limit + audit wrapper.
  *
  * `createMcpHandler` builds a FRESH server per HTTP request, so the tool list
- * is recomputed from live capability state on every `tools/list`. It therefore
- * cannot go stale, which is why `notifications/tools/list_changed` is neither
- * advertised nor sent — there is no long-lived session to push over, and no
- * staleness to correct. See ADR-033.
+ * is recomputed from live capability state on every `tools/list` — the SERVER is
+ * always fresh. `notifications/tools/list_changed` is neither advertised nor
+ * sent because stateless serving leaves no long-lived session to push over. The
+ * accepted cost is that a CLIENT's cached list can still go stale until it
+ * reconnects — see ADR-033 § Phase 1 amendments.
  *
  * NOTE (verified against the shipped `.d.cts`): the principal arrives as
  * `McpRequestContext.authInfo` — NOT `ctx.http.authInfo`, which appears in

--- a/apps/api/src/mcp/transport/mcp-server.factory.ts
+++ b/apps/api/src/mcp/transport/mcp-server.factory.ts
@@ -1,81 +1,50 @@
 /**
  * MCP Server Factory
  *
- * Builds the per-request `McpServer` served over Streamable HTTP (#1486).
+ * Builds the per-request `McpServer` served over Streamable HTTP (#1486),
+ * now registry-driven (#1487).
  *
- * Phase 0 ships exactly one tool — `whoami`. It is an AUTH PROOF, not a tool
- * surface: it is the only way to demonstrate end-to-end that
- * `requireBearerAuth` → `req.auth` → `ctx.authInfo` actually carries the
- * OpenLinker principal, which is the single contract #1487's domain tools
- * build on. All real tools, and the dynamic capability-declared
- * `tools/list`, are #1487.
+ * Phase 0 hard-coded a single `whoami` tool here as the auth proof, with a
+ * standing note that it belonged in a `*.tool.ts` file once #1487 registered
+ * that convention. It now lives at `tools/read/whoami.tool.ts` and is
+ * registered through the same path as every other tool — which also puts it
+ * behind the registry's per-call rate-limit + audit wrapper.
+ *
+ * `createMcpHandler` builds a FRESH server per HTTP request, so the tool list
+ * is recomputed from live capability state on every `tools/list`. It therefore
+ * cannot go stale, which is why `notifications/tools/list_changed` is neither
+ * advertised nor sent — there is no long-lived session to push over, and no
+ * staleness to correct. See ADR-033.
  *
  * NOTE (verified against the shipped `.d.cts`): the principal arrives as
  * `McpRequestContext.authInfo` — NOT `ctx.http.authInfo`, which appears in
  * some of the SDK's own prose but is not the shape its types declare.
  *
- * `whoami` deliberately lives here rather than in a `*.tool.ts` file: #1487
- * owns registering that file-suffix convention in `engineering-standards.md`,
- * and pre-empting it here would fork the decision.
- *
- * SECURITY: `ctx.authInfo` is an `AuthInfo`, which carries the RAW bearer
- * token. `whoami` returns only the redacted `extra` projection — never the
- * token, hash, or any credential.
+ * Critically, the principal lives on THIS request-scoped context only. The
+ * context the SDK hands a tool callback at dispatch time does NOT carry
+ * `authInfo`, so tools must close over the value threaded from here — proven
+ * by `mcp-tools.int-spec.ts`, which fails with "No OpenLinker principal on
+ * this request" if a tool reads the dispatch-time context instead.
  *
  * @module apps/api/src/mcp/transport
  */
 import { McpServer, type McpRequestContext } from '@modelcontextprotocol/server';
-import * as z from 'zod/v4';
-import { Logger } from '@openlinker/shared/logging';
-import { isMcpAuthInfoExtra } from '../auth/mcp-principal.types';
+
+import type { IMcpToolRegistryService } from '../tools/tool-registry.service.interface';
 
 const SERVER_NAME = 'openlinker';
 
-const logger = new Logger('McpServerFactory');
-
-export function createMcpServerFactory(version: string) {
-  return (ctx: McpRequestContext): McpServer => {
+/**
+ * Returns an async factory. The SDK awaits it, so tool registration can do the
+ * I/O the capability gate requires (one `listCapabilityAdapters` call per
+ * distinct capability, `lazy: true`).
+ */
+export function createMcpServerFactory(version: string, registry: IMcpToolRegistryService) {
+  return async (ctx: McpRequestContext): Promise<McpServer> => {
     const server = new McpServer({ name: SERVER_NAME, version });
-
-    server.registerTool(
-      'whoami',
-      {
-        description:
-          'Return the OpenLinker identity backing the presented MCP token. Useful for verifying that a token is installed and working.',
-        inputSchema: z.object({}),
-      },
-      () => {
-        const authInfo = ctx.authInfo;
-        const extra = authInfo?.extra;
-
-        if (!isMcpAuthInfoExtra(extra)) {
-          // Unreachable in practice — requireBearerAuth gates this route, and
-          // the transport controller fails closed before delegating. If it IS
-          // reached, that is a security-relevant event (a request served with
-          // no principal), so make it loud rather than a silent tool error.
-          logger.error(
-            'whoami invoked with no OpenLinker principal on the request — the bearer middleware may not be bound to this route.'
-          );
-          return {
-            content: [{ type: 'text' as const, text: 'No OpenLinker principal on this request.' }],
-            isError: true,
-          };
-        }
-
-        // Redacted projection ONLY. Never `authInfo` itself.
-        const identity = {
-          userId: extra.olUserId,
-          role: extra.olRole,
-          tokenName: extra.tokenName,
-          scopes: authInfo?.scopes ?? [],
-        };
-
-        return {
-          content: [{ type: 'text' as const, text: JSON.stringify(identity, null, 2) }],
-        };
-      }
-    );
-
+    // `ctx` is REQUEST-scoped and is the only carrier of the principal — the
+    // context passed to a tool callback at dispatch time has no `authInfo`.
+    await registry.registerTools(server, ctx);
     return server;
   };
 }

--- a/apps/api/src/mcp/transport/mcp-transport.controller.spec.ts
+++ b/apps/api/src/mcp/transport/mcp-transport.controller.spec.ts
@@ -9,6 +9,7 @@
  */
 import type { Request, Response } from 'express';
 import type { IAppInfoService } from '../../app-info/app-info.service.interface';
+import type { IMcpToolRegistryService } from '../tools/tool-registry.service.interface';
 import { McpTransportController } from './mcp-transport.controller';
 
 function buildResponse(): Response & { statusCode?: number; body?: unknown } {
@@ -29,9 +30,16 @@ function buildResponse(): Response & { statusCode?: number; body?: unknown } {
 
 describe('McpTransportController', () => {
   const appInfo = { getProductVersion: () => '1.2.3' } as unknown as IAppInfoService;
+  // The guard short-circuits before the handler runs, so the registry is
+  // never consulted in these cases — a stub that would throw if it were.
+  const registry: IMcpToolRegistryService = {
+    registerTools: () => {
+      throw new Error('registerTools must not run for an unauthenticated request');
+    },
+  };
 
   it('should refuse a request that arrives without a principal', async () => {
-    const controller = new McpTransportController(appInfo);
+    const controller = new McpTransportController(appInfo, registry);
     const res = buildResponse();
 
     await controller.handle({ body: {} } as unknown as Request, res);
@@ -43,7 +51,7 @@ describe('McpTransportController', () => {
   });
 
   it('should not leak the presented token in the refusal body', async () => {
-    const controller = new McpTransportController(appInfo);
+    const controller = new McpTransportController(appInfo, registry);
     const res = buildResponse();
 
     await controller.handle(

--- a/apps/api/src/mcp/transport/mcp-transport.controller.ts
+++ b/apps/api/src/mcp/transport/mcp-transport.controller.ts
@@ -35,6 +35,10 @@ import { APP_INFO_SERVICE_TOKEN } from '../../app-info/app-info.module';
 import { MCP_TRANSPORT_PATH } from '../mcp-resource';
 import { IAppInfoService } from '../../app-info/app-info.service.interface';
 import { Public } from '../../auth/decorators/public.decorator';
+import {
+  MCP_TOOL_REGISTRY_SERVICE_TOKEN,
+  type IMcpToolRegistryService,
+} from '../tools/tool-registry.service.interface';
 import { createMcpServerFactory } from './mcp-server.factory';
 
 @Public()
@@ -46,16 +50,22 @@ export class McpTransportController {
 
   constructor(
     @Inject(APP_INFO_SERVICE_TOKEN)
-    appInfo: IAppInfoService
+    appInfo: IAppInfoService,
+    @Inject(MCP_TOOL_REGISTRY_SERVICE_TOKEN)
+    registry: IMcpToolRegistryService
   ) {
     // Stateless: createMcpHandler builds a fresh server per request, so
     // there are no sessions and no sticky-routing requirement across
-    // replicas.
-    const mcpHandler = createMcpHandler(createMcpServerFactory(appInfo.getProductVersion()), {
-      onerror: (error: Error) => {
-        this.logger.error(`MCP handler error: ${error.message}`, error.stack);
-      },
-    });
+    // replicas. The registry re-resolves the capability-gated tool list on
+    // each of those builds.
+    const mcpHandler = createMcpHandler(
+      createMcpServerFactory(appInfo.getProductVersion(), registry),
+      {
+        onerror: (error: Error) => {
+          this.logger.error(`MCP handler error: ${error.message}`, error.stack);
+        },
+      }
+    );
 
     this.handler = toNodeHandler(mcpHandler, {
       onerror: (error: Error) => {

--- a/apps/api/test/integration/mcp-tools.int-spec.ts
+++ b/apps/api/test/integration/mcp-tools.int-spec.ts
@@ -1,0 +1,222 @@
+/**
+ * MCP Read-Only Tools Integration Test (#1487)
+ *
+ * The vertical slice: an authenticated principal calls `tools/list` and gets a
+ * capability-declared surface, then calls a tool and gets real data out of
+ * OpenLinker's own store.
+ *
+ * What can only be proven here, not in a unit test:
+ *  - the tools are actually reachable over the MCP JSON-RPC transport
+ *    (registration, schema serialization, and the SDK's own dispatch);
+ *  - the capability gate reflects REAL connection state in the database,
+ *    rather than a stubbed `listCapabilityAdapters`;
+ *  - the always-registered tools survive a deployment with no connections.
+ *
+ * `loginAsAdmin` is called at most ONCE per test — it plain-INSERTs a fixed
+ * admin user, so a second call in the same test violates the users unique
+ * constraint.
+ *
+ * @module apps/api/test/integration
+ */
+import { DataSource } from 'typeorm';
+import {
+  getTestHarness,
+  IntegrationTestHarness,
+  resetTestHarness,
+  teardownTestHarness,
+} from './setup';
+import { loginAsAdmin } from './helpers/test-auth.helper';
+import { createTestConnection } from './helpers/test-connection.helper';
+
+interface JsonRpcToolsListResult {
+  result?: { tools?: Array<{ name: string; description?: string }> };
+}
+
+interface JsonRpcCallResult {
+  result?: { content?: Array<{ type: string; text: string }>; isError?: boolean };
+}
+
+const PROTOCOL_VERSION = '2026-07-28';
+
+describe('MCP Read-Only Tools Integration (#1487)', () => {
+  let harness: IntegrationTestHarness;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+  });
+
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  async function mintMcpToken(adminToken: string): Promise<string> {
+    const response = await harness
+      .getHttp()
+      .post('/v1/mcp/tokens')
+      .set('Authorization', `Bearer ${adminToken}`)
+      .send({ name: 'tools int-spec', scope: 'mcp:read' })
+      .expect(201);
+    return response.body.rawToken;
+  }
+
+  /**
+   * Issue one JSON-RPC call against `/mcp` as the given MCP principal.
+   *
+   * The `_meta` envelope is REQUIRED, not decorative. Protocol revision
+   * 2026-07-28 carries the handshake ON EVERY REQUEST — which is precisely
+   * what lets OL serve MCP statelessly (a fresh `McpServer` per request, no
+   * session, ADR-033). Omitting it yields `-32602 Invalid params`, which
+   * surfaces as a bare HTTP 400 that reads like a routing or auth fault
+   * rather than a protocol one.
+   */
+  async function rpc(mcpToken: string, method: string, params: Record<string, unknown> = {}) {
+    return harness
+      .getHttp()
+      .post('/mcp')
+      .set('Authorization', `Bearer ${mcpToken}`)
+      .set('Accept', 'application/json, text/event-stream')
+      .set('MCP-Protocol-Version', PROTOCOL_VERSION)
+      // Revision 2026-07-28 also requires the method — and, for tools/call,
+      // the tool name — to be declared in headers that must AGREE with the
+      // body. This lets an intermediary route without parsing the JSON-RPC
+      // payload; a mismatch or omission is rejected as -32020.
+      .set('Mcp-Method', method)
+      .set(
+        typeof params.name === 'string' ? 'Mcp-Name' : 'X-Unused',
+        typeof params.name === 'string' ? params.name : 'unused'
+      )
+      .send({
+        jsonrpc: '2.0',
+        id: 1,
+        method,
+        params: {
+          _meta: {
+            'io.modelcontextprotocol/protocolVersion': PROTOCOL_VERSION,
+            'io.modelcontextprotocol/clientCapabilities': {},
+          },
+          ...params,
+        },
+      });
+  }
+
+  /**
+   * Seed a connection directly. Going through `POST /connections` would drag in
+   * the PrestaShop config-shape validator, which is irrelevant here — this
+   * spec's subject is the capability gate, not connection creation.
+   */
+  async function createConnection(capability: string): Promise<void> {
+    await createTestConnection(harness.getDataSource(), {
+      name: `int-spec ${capability}`,
+      enabledCapabilities: [capability],
+    });
+  }
+
+  function toolNames(body: JsonRpcToolsListResult): string[] {
+    return (body.result?.tools ?? []).map((tool) => tool.name).sort();
+  }
+
+  it('should expose only the always-registered tools when no connection backs any capability', async () => {
+    const http = harness.getHttp();
+    const dataSource: DataSource = harness.getDataSource();
+    const adminToken = await loginAsAdmin(http, dataSource);
+    const mcpToken = await mintMcpToken(adminToken);
+
+    const response = await rpc(mcpToken, 'tools/list');
+
+    expect(response.status).toBe(200);
+    // Discovery must work on an empty deployment — that is the whole point of
+    // these two being ungated.
+    expect(toolNames(response.body as JsonRpcToolsListResult)).toEqual([
+      'list_connections',
+      'whoami',
+    ]);
+  });
+
+  it('should publish the ProductMaster tools once a connection enables that capability', async () => {
+    const http = harness.getHttp();
+    const dataSource: DataSource = harness.getDataSource();
+    const adminToken = await loginAsAdmin(http, dataSource);
+    await createConnection('ProductMaster');
+    const mcpToken = await mintMcpToken(adminToken);
+
+    const response = await rpc(mcpToken, 'tools/list');
+
+    const names = toolNames(response.body as JsonRpcToolsListResult);
+    // One capability backs TWO tools.
+    expect(names).toContain('search_catalog');
+    expect(names).toContain('get_product');
+    // A capability nothing backs stays absent.
+    expect(names).not.toContain('get_order');
+  });
+
+  it('should return the connection through list_connections without leaking credentials', async () => {
+    const http = harness.getHttp();
+    const dataSource: DataSource = harness.getDataSource();
+    const adminToken = await loginAsAdmin(http, dataSource);
+    await createConnection('ProductMaster');
+    const mcpToken = await mintMcpToken(adminToken);
+
+    const response = await rpc(mcpToken, 'tools/call', {
+      name: 'list_connections',
+      arguments: {},
+    });
+
+    const body = response.body as JsonRpcCallResult;
+    const text = body.result?.content?.[0]?.text ?? '';
+    expect(text).toContain('int-spec ProductMaster');
+    expect(text).toContain('prestashop');
+    // The projection, asserted against a REAL persisted connection.
+    expect(text).not.toContain('credentialsRef');
+    expect(text).not.toContain('int-spec-key');
+    expect(text).not.toContain('shopUrl');
+  });
+
+  it('should answer whoami with the OL identity behind the token and never the token itself', async () => {
+    const http = harness.getHttp();
+    const dataSource: DataSource = harness.getDataSource();
+    const adminToken = await loginAsAdmin(http, dataSource);
+    const mcpToken = await mintMcpToken(adminToken);
+
+    const response = await rpc(mcpToken, 'tools/call', { name: 'whoami', arguments: {} });
+
+    const text = (response.body as JsonRpcCallResult).result?.content?.[0]?.text ?? '';
+    expect(text).toContain('"role"');
+    expect(text).toContain('admin');
+    expect(text).not.toContain(mcpToken);
+  });
+
+  it('should return an empty catalog rather than an error when nothing has synced yet', async () => {
+    const http = harness.getHttp();
+    const dataSource: DataSource = harness.getDataSource();
+    const adminToken = await loginAsAdmin(http, dataSource);
+    await createConnection('ProductMaster');
+    const mcpToken = await mintMcpToken(adminToken);
+
+    const response = await rpc(mcpToken, 'tools/call', {
+      name: 'search_catalog',
+      arguments: { query: 'anything' },
+    });
+
+    const body = (response.body as JsonRpcCallResult).result;
+    // The gate passing does NOT imply data exists — this is the documented
+    // consequence of capability-gated registration over an OL-store read.
+    expect(body?.isError).toBeFalsy();
+    expect(JSON.parse(body?.content?.[0]?.text ?? '{}')).toEqual(
+      expect.objectContaining({ total: 0, products: [] })
+    );
+  });
+
+  it('should reject a tools/call from an unauthenticated caller', async () => {
+    const response = await harness
+      .getHttp()
+      .post('/mcp')
+      .set('Accept', 'application/json, text/event-stream')
+      .send({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} });
+
+    expect(response.status).toBe(401);
+  });
+});

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -574,8 +574,10 @@ always-registered discovery entry points (`whoami`, `list_connections`) plus fou
   output reaches an external LLM provider, so `list_connections` never emits `credentialsRef`/`config` and
   `get_order` never emits buyer name/email/address even when the snapshot stores them.
 
-`notifications/tools/list_changed` is deliberately **not** implemented — stateless per-request serving means
-`tools/list` is recomputed every call and cannot go stale, and there is no session to push a notification over.
+`notifications/tools/list_changed` is deliberately **not** implemented: stateless per-request serving leaves no
+session to push over. Note the accepted cost — the *server* is always fresh, but a **client's cached tool list**
+can go stale, so an agent already connected when a connection is enabled won't see the new tool until it
+reconnects. See [ADR-033 § Phase 1 amendments](./architecture/adrs/033-openlinker-as-mcp-server.md).
 
 ---
 

--- a/docs/architecture-overview.md
+++ b/docs/architecture-overview.md
@@ -547,9 +547,35 @@ scopes, and an RFC 8707 `resource` binding; they live in `mcp_tokens` in the **u
 service outside that context may not inject a `*RepositoryPort` — `apps/api/src/mcp/` crosses the boundary
 through `IMcpTokenService` (`MCP_TOKEN_SERVICE_TOKEN`) instead. A token resolves to its owning OL user and
 **inherits that user's RBAC role**, so it can never exceed its owner. The principal reaches tool handlers as
-`ctx.authInfo`; note that `AuthInfo` carries the **raw bearer token**, so it must never be logged or serialized
-wholesale — consumers log a redacted projection from `AuthInfo.extra`. Adding an OAuth AS later swaps the
-verifier implementation and nothing else.
+`ctx.authInfo` on the **request-scoped** `McpRequestContext` (the context the SDK hands a tool callback at
+dispatch time does NOT carry it, so the registry threads the request-scoped value into each handler — #1487);
+note that `AuthInfo` carries the **raw bearer token**, so it must never be logged or serialized
+wholesale — consumers log a redacted projection from `AuthInfo.extra` via `redactPrincipal`. Adding an OAuth AS
+later swaps the verifier implementation and nothing else.
+
+**Read-only domain tools are shipped (Phase 1, #1487).** Six tools live at `apps/api/src/mcp/tools/`: two
+always-registered discovery entry points (`whoami`, `list_connections`) plus four capability-gated domain reads
+(`search_catalog` / `get_product` on `ProductMaster`, `get_availability` on `InventoryMaster`, `get_order` on
+`OrderSource`). Two design points shape everything downstream:
+
+- **Capability-*gated* but OL-store-*backed*.** `McpToolRegistryService` registers a tool iff
+  `listCapabilityAdapters({ capability, lazy: true })` finds a supporting-and-enabled connection, but the tools
+  read OL's own store through `IProductsService` / `IInventoryQueryService` / `IOrderRecordService` — never the
+  capability port's adapter. Going through the port would make each tool call a live marketplace request
+  (spending the operator's API quota on an agent's behalf), return external-id-keyed data that can't join the
+  internal-id-keyed product reads, and — decisively — re-fetch buyer PII regardless of `OL_STORE_PII`. The
+  consequence is that the gate and the data are **independent facts**: a passing gate does not imply data exists.
+  Each tool's description says so, because an agent cannot otherwise read an empty result. See
+  [ADR-033 § Phase 1 amendments](./architecture/adrs/033-openlinker-as-mcp-server.md).
+- **One choke point.** Rate limiting (per-token ZSET rolling window + in-flight cap, fail-open on Redis outage),
+  audit logging, and error mapping are applied by a single wrapper inside `McpToolRegistryService` — never by a
+  tool. A `*.tool.ts` file contains only its read and its projection, so a concern like releasing an in-flight
+  slot on the throw path cannot be forgotten per tool. Every result is an explicit-allowlist projection: tool
+  output reaches an external LLM provider, so `list_connections` never emits `credentialsRef`/`config` and
+  `get_order` never emits buyer name/email/address even when the snapshot stores them.
+
+`notifications/tools/list_changed` is deliberately **not** implemented — stateless per-request serving means
+`tools/list` is recomputed every call and cannot go stale, and there is no session to push a notification over.
 
 ---
 

--- a/docs/architecture/adrs/033-openlinker-as-mcp-server.md
+++ b/docs/architecture/adrs/033-openlinker-as-mcp-server.md
@@ -47,6 +47,56 @@ Countervailing forces: protocol churn (the ~28 Jul 2026 revision is the largest 
 
 **Migration path:** none for existing behavior — purely additive. The MCP module is opt-in and inert until Phase 0 auth ships.
 
+## Phase 1 amendments (#1487)
+
+Two decisions made while implementing the read-only tool surface, both refining
+(not reversing) the decision above.
+
+### Tools are capability-*gated* but OL-store-*backed*
+
+The tool surface stays dynamic and capability-declared as decided above: a tool
+is registered iff at least one connection supports and enables its capability.
+But the tools **read OpenLinker's own store** (`IProductsService`,
+`IInventoryQueryService`, `IOrderRecordService`) rather than calling the
+capability port's adapter.
+
+Reaching through `ProductMasterPort` / `InventoryMasterPort` / `OrderSourcePort`
+was the obvious first reading of "expose these capabilities as tools", and it is
+wrong on four counts:
+
+1. **It defeats `OL_STORE_PII`.** `IOrderRecordService.persistOrder` nulls buyer
+   PII at ingestion when the operator disables PII storage;
+   `OrderSourcePort.getOrder` re-fetches it raw from the platform regardless.
+   An operator's deliberate privacy decision would be silently bypassed.
+2. **It spends the operator's marketplace API quota** — one live platform call
+   per tool invocation, on an autonomous agent's behalf. The per-token limiter
+   caps OL calls; it cannot cap downstream cost, which is the scarcer resource.
+3. **It breaks identifier consistency.** `OrderSourcePort` is an *ingestion*
+   port returning external-id-keyed data, which will not join against the
+   internal-id-keyed product tools.
+4. **It bypasses the variant-keyed inventory model** ([ADR-010](./010-variant-keyed-master-inventory.md)).
+
+Consequence: the gate and the data are now **independent facts** — a passing gate
+does not imply data exists, and a disabled connection hides tools whose data OL
+still holds. Each tool's description states this, because an agent cannot
+otherwise distinguish "no data" from "not configured". A future explicit
+`refresh_*` tool can go to the platform *deliberately*, rather than every read
+doing so implicitly.
+
+### `notifications/tools/list_changed` is not implemented
+
+The Phase-1 issue asked that adding/removing a connection republish the tool list
+via `notifications/tools/list_changed`. It is **not implementable as written and
+also unnecessary**, because `createMcpHandler` builds a fresh `McpServer` per
+HTTP request (the stateless, multi-replica-safe model this ADR chose): there is
+no long-lived session to push a notification over.
+
+The same statelessness makes the notification moot — `tools/list` is recomputed
+from live capability state on every call, so it cannot go stale. OL therefore
+does not advertise `tools.listChanged` and never calls `sendToolListChanged()`.
+The alternative (sessionful serving) would reverse this ADR's transport decision
+to correct staleness that cannot occur.
+
 ## References
 
 - Related issues: #1350 (this EPIC), #1036 / [ADR-023](./023-cross-platform-category-and-attribute-projection.md) (neutral mapping shapes)

--- a/docs/architecture/adrs/033-openlinker-as-mcp-server.md
+++ b/docs/architecture/adrs/033-openlinker-as-mcp-server.md
@@ -64,10 +64,21 @@ Reaching through `ProductMasterPort` / `InventoryMasterPort` / `OrderSourcePort`
 was the obvious first reading of "expose these capabilities as tools", and it is
 wrong on four counts:
 
-1. **It defeats `OL_STORE_PII`.** `IOrderRecordService.persistOrder` nulls buyer
-   PII at ingestion when the operator disables PII storage;
-   `OrderSourcePort.getOrder` re-fetches it raw from the platform regardless.
-   An operator's deliberate privacy decision would be silently bypassed.
+1. **It makes `OL_STORE_PII` compliance a duplicated policy with an unsafe
+   default.** Stated precisely, because the stronger claim is tempting and
+   wrong: `OL_STORE_PII` governs *persistence*, so a port-path tool that fetched
+   fresh and projected PII away would not literally violate it — nothing is
+   stored. What the port path actually costs is worse in practice:
+   `IOrderRecordService.persistOrder` already nulls buyer PII at ingestion when
+   the operator disables PII storage, whereas `OrderSourcePort.getOrder`
+   re-fetches it raw regardless. So (a) the plan's proposed option "honour
+   `OL_STORE_PII` as a floor" is **incoherent** on that path — there is no
+   stored floor to honour; you would have to *reimplement* `persistOrder`'s
+   nulling rule inside the tool, leaving the same privacy policy expressed in
+   two places and free to drift — and (b) the **default** behaviour forwards to
+   an external LLM vendor exactly what the operator opted out of storing.
+   Compliance becomes something a future contributor must remember rather than
+   something the read inherits.
 2. **It spends the operator's marketplace API quota** — one live platform call
    per tool invocation, on an autonomous agent's behalf. The per-token limiter
    caps OL calls; it cannot cap downstream cost, which is the scarcer resource.
@@ -83,19 +94,52 @@ otherwise distinguish "no data" from "not configured". A future explicit
 `refresh_*` tool can go to the platform *deliberately*, rather than every read
 doing so implicitly.
 
+Note this **changes what the gate means**, even though the mechanism is
+unchanged. Previously it would have proved the adapter could serve the read; now
+it is a proxy for "is this deployment in the products / inventory / orders
+business at all". `get_availability` is the clearest case: it is gated on
+`InventoryMaster` but takes no `connectionId` and reads globally, so the gate and
+the answer are fully decoupled for that tool. That is accepted — the gate's job
+is tool-surface minimalism, not data provenance — but Phases 2/3 inherit this
+meaning and should not read the gate as a data guarantee.
+
+**How empty is the store in practice?** Narrower than the decoupling suggests.
+`SchedulerService` registers `master-product-sync` (`master.product.syncAll`,
+default cron `*/20 * * * *`, capability-gated on `ProductMaster`) and
+`master-inventory-sync` (`*/15`), and `ConnectionService.enqueueInitialCatalogSync`
+enqueues a bootstrap `syncAll` on connection creation precisely so a new
+connection populates immediately. The "gate passes but the store is empty" window
+is therefore minutes after connection creation, not indefinite.
+
 ### `notifications/tools/list_changed` is not implemented
 
 The Phase-1 issue asked that adding/removing a connection republish the tool list
-via `notifications/tools/list_changed`. It is **not implementable as written and
-also unnecessary**, because `createMcpHandler` builds a fresh `McpServer` per
-HTTP request (the stateless, multi-replica-safe model this ADR chose): there is
-no long-lived session to push a notification over.
+via `notifications/tools/list_changed`. It is **not implementable** under this
+ADR's transport choice: `createMcpHandler` builds a fresh `McpServer` per HTTP
+request (the stateless, multi-replica-safe model decided above), so there is no
+long-lived session to push a notification over. OL therefore does not advertise
+`tools.listChanged` and never calls `sendToolListChanged()`.
 
-The same statelessness makes the notification moot — `tools/list` is recomputed
-from live capability state on every call, so it cannot go stale. OL therefore
-does not advertise `tools.listChanged` and never calls `sendToolListChanged()`.
-The alternative (sessionful serving) would reverse this ADR's transport decision
-to correct staleness that cannot occur.
+**This has a real cost, and an earlier draft of this section understated it.**
+That draft claimed the notification was also *unnecessary* because "`tools/list`
+is recomputed every call, so it cannot go stale". The first half is true and the
+conclusion does not follow. The **server** cannot go stale; a **client's cached
+tool list** absolutely can, and that is the notification's entire purpose — a
+message whose only content is "the list changed" is meaningless unless the
+recipient holds a copy. Both halves of the mechanism are live in the SDK
+(`sendToolListChanged()` is present and, unlike `sendLoggingMessage`, is **not**
+deprecated in this revision), and a sessionful transport exists
+(`WebStandardStreamableHTTPServerTransport`; `sessionId` threads through the
+API) — so statelessness is our deliberate choice, not a constraint the SDK
+imposes.
+
+The accepted consequence: an operator who enables a `ProductMaster` connection
+while an agent is already connected will **not** see `search_catalog` appear
+until that client reconnects or re-lists. The mitigation is reconnect. This is
+accepted rather than solved because gaining the notification means adopting
+sessions — reversing the multi-replica-safety property this ADR chose — for one
+convenience on a surface whose demand is still unproven. Revisit together with
+the sessionful-transport question if real usage makes the gap painful.
 
 ## References
 

--- a/docs/engineering-standards.md
+++ b/docs/engineering-standards.md
@@ -1215,7 +1215,30 @@ Admin token management (`/mcp/tokens`) is the opposite — ordinary session auth
 two auth models in **separate controllers** so they never blur.
 
 **Never log or serialize an `AuthInfo` wholesale** — it carries the raw bearer token. Log a redacted projection
-built from `AuthInfo.extra` (`{ mcpTokenId, olUserId, olRole, scopes }`).
+built from `AuthInfo.extra` via `redactPrincipal` (`{ mcpTokenId, olUserId, olRole, scopes }`).
+
+#### MCP tools (`*.tool.ts`, #1487)
+
+An MCP tool is declared as an `McpToolDefinition` in a `*.tool.ts` file under `apps/api/src/mcp/tools/read/`
+(or `.../write/` when #1489 lands), exported by a `create{Name}Tool(deps)` factory that takes its core service
+directly. The suffix marks "a unit of agent-facing capability", parallel to `*.controller.ts` for HTTP.
+
+Rules:
+
+- **A tool file contains only its read and its projection.** Rate limiting, audit logging, and error mapping are
+  applied once by `McpToolRegistryService`'s per-call wrapper. A tool that imports the limiter or the audit
+  logger is a bug — those concerns must not be re-implementable per tool, or one will eventually be forgotten
+  (most likely releasing an in-flight slot on the throw path).
+- **Always project; never return a domain entity or a snapshot wholesale.** A tool result is handed to an
+  external LLM provider acting as a de-facto sub-processor. Projections are explicit allowlists so that fields
+  added to the underlying shape later cannot silently start leaking — this is why `get_order` enumerates line-item
+  fields rather than spreading them, and why `list_connections` never returns a `Connection`.
+- **Only accept an argument the underlying read actually honours.** Where a read has no connection axis (e.g.
+  inventory), omit `connectionId` from the schema rather than accepting and ignoring it — a calling agent infers
+  meaning from the schema and would wrongly believe it had scoped the result.
+- **Descriptions are agent-facing copy, not documentation.** The model reads the description to decide whether to
+  call the tool and how to interpret an empty result. Because tool *registration* is capability-gated while the
+  data comes from OL's own store, an empty result can mean "no data yet" — say so explicitly.
 
 ### Type Safety
 

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -156,3 +156,27 @@ When a lesson hardens into a rule, **graduate it** to the canonical doc and leav
 **Rule**: When a column encodes lifecycle progression and more than one process upserts the row, resolve the conflict by an explicit precedence ladder in SQL (`CASE WHEN rank(EXCLUDED) >= rank(current) THEN EXCLUDED ELSE current END`) rather than by arrival order, and keep the rank map beside the status union so the two cannot drift. Do not "fix" it by reordering the callers - they are deliberately decoupled, and neither can reason about the other's timing. Prove it with an integration test: the guard lives in SQL, so a mocked repository cannot exercise it.
 **Applies to**: repository upserts over a status/lifecycle column with more than one writer - today `webhook_deliveries` (`libs/core/src/webhooks/infrastructure/persistence/repositories/webhook-delivery.repository.ts`); the same shape would apply to any future `*_snapshots` or delivery-audit table written from both an ingress and a consumer path.
 **Source**: #1916 (CI run 30435342214).
+
+## An "authenticates" assertion is not a "works" assertion — assert a successful call, not just the absence of 401
+
+**Context**: Phase 0 (#1486) shipped one MCP tool, `whoami`, reading the principal from `ctx.authInfo`. Its int-spec asserted the minted token was accepted by `/mcp` via `.expect(res => { if (res.status === 401 || res.status === 403) throw ... })`.
+**Problem**: That assertion passes on a 400. `whoami` was in fact broken end-to-end: the principal lives on the **request-scoped** `McpRequestContext` handed to the server *factory*, and NOT on the context the SDK passes a tool callback at dispatch time — so every real `whoami` call would have returned "No OpenLinker principal on this request." Nothing caught it for a full phase, because the only test of the path asserted a negative (not-401) rather than the positive (a parseable result). #1487's first genuine `tools/call` surfaced it immediately.
+**Rule**: When a slice's whole purpose is "X now works end-to-end", assert the SUCCESS shape — parse the response body and check a field. A not-an-error assertion is a placeholder, and it will keep passing while the feature rots. Corollary for the MCP SDK specifically: thread the factory's `ctx` into anything a tool handler needs; treat the dispatch-time context as carrying no auth.
+**Applies to**: `apps/api/src/mcp/transport/mcp-server.factory.ts`, `apps/api/src/mcp/tools/tool-registry.service.ts`, any int-spec whose only assertion is a status-code exclusion.
+**Source**: #1487.
+
+## MCP protocol revision 2026-07-28 requires a per-request envelope + agreeing headers — a missing one looks like an auth/routing 400
+
+**Context**: Hand-rolling JSON-RPC calls against `/mcp` in an int-spec (supertest, no MCP client library).
+**Problem**: Every call 400'd. The revision named in `MCP-Protocol-Version` carries the handshake **on every request** (which is what makes OL's stateless, session-free serving legal per ADR-033), and enforces header/body agreement. Three separate omissions each produced a bare HTTP 400 that read like a bad token or a dead route: (1) `params._meta` absent; (2) `_meta` present but missing `io.modelcontextprotocol/protocolVersion` + `io.modelcontextprotocol/clientCapabilities`; (3) the `Mcp-Method` header absent, and for `tools/call` also `Mcp-Name` — both must match the body so an intermediary can route without parsing the payload. The SDK's error *bodies* name the missing key precisely; the status code alone tells you nothing.
+**Rule**: When an MCP request 400s, read the JSON-RPC `error.message` in the response body before suspecting auth or routing — the SDK says exactly which envelope key or header is missing. Build the request helper once, with `_meta` + `Mcp-Method` (+ `Mcp-Name`) derived from the call, rather than per test.
+**Applies to**: `apps/api/test/integration/mcp-tools.int-spec.ts`; any hand-rolled MCP JSON-RPC caller.
+**Source**: #1487.
+
+## `--testPathPattern` is silently ignored when a Jest config sets `testRegex` — use `--testRegex` to run one int-spec
+
+**Context**: Iterating on a single `*.int-spec.ts` in `apps/api`, where `test/jest-integration.cjs` sets `testRegex: 'test/integration/.*\\.int-spec\\.ts$'`.
+**Problem**: `--testPathPattern=mcp` and a positional `"mcp-"` both ran the ENTIRE integration suite — including the PrestaShop/MySQL container specs, so each "targeted" iteration cost ~15 minutes and booted containers that exhaust Docker. `--listTests` confirms it: the filter is dropped, not narrowed. This is the mechanism behind the older note that `test:integration -- <pattern>` doesn't filter.
+**Rule**: To run one int-spec in this repo, override the config's own key: `pnpm --filter @openlinker/api exec jest --config test/jest-integration.cjs --testRegex="<file>\\.int-spec\\.ts$"`. Verify with `--listTests` before the real run — it is instant and proves the filter took.
+**Applies to**: `apps/api/test/jest-integration.cjs`, `apps/worker/test/jest-integration.cjs`.
+**Source**: #1487.

--- a/docs/plans/analysis/ANALYSIS-mcp-read-only-domain-tools.md
+++ b/docs/plans/analysis/ANALYSIS-mcp-read-only-domain-tools.md
@@ -1,0 +1,103 @@
+# Pre-implement Gate: MCP Phase 1 — Read-only domain tools
+
+**Plan**: `docs/plans/implementation-plan-mcp-read-only-domain-tools.md`
+**Issue**: #1487
+**Date**: 2026-07-29
+**Verdict**: ✅ **READY**
+
+> Gated against the plan as revised following the deep `/tech-review`. The
+> pre-revision draft would have gated `NEEDS-MAJOR-REVISION` — see §3.
+
+---
+
+## 1. Reuse audit
+
+Every artifact the plan proposes to create, checked against the live tree.
+
+| Plan artifact | Classification | Evidence |
+|---|---|---|
+| `ToolRegistryService` + `IToolRegistryService` | **NEW** | No `*ToolRegistry*` anywhere under `apps/` or `libs/` |
+| `McpToolDefinition` types | **NEW** | — |
+| 4 read tools + `list_connections` (`*.tool.ts`) | **NEW** | No `*.tool.ts` files exist; suffix is unregistered (plan step 8 registers it) |
+| `redactPrincipal` + audit logger | **NEW** | Phase 0 shipped `McpAuthInfoExtra` / `isMcpAuthInfoExtra` (`apps/api/src/mcp/auth/mcp-principal.types.ts`) to build on — **PARTIAL: reuse those, don't redefine** |
+| Redis rate limiter | **NEW** | No `@nestjs/throttler`; `CachePort` is KV-only. Precedent for reaching past `CachePort` to raw `'REDIS_CLIENT'`: `RedisPickupPointQueryStatsAdapter` |
+| Product read | **ALREADY EXISTS → reuse** | `IProductsService.listProducts` / `.getProduct` / `.getVariantsByProductId` (`PRODUCTS_SERVICE_TOKEN`) |
+| Availability read | **ALREADY EXISTS → reuse** | `IInventoryQueryService.getAvailabilityByVariantIds` (`INVENTORY_QUERY_SERVICE_TOKEN`) |
+| Order read | **ALREADY EXISTS → reuse** | `IOrderRecordService.getOrderRecord` / `.findMany` (`ORDER_RECORD_SERVICE_TOKEN`) |
+| Connection list | **ALREADY EXISTS → reuse** | `IConnectionService.list(filters?)` (`CONNECTION_SERVICE_TOKEN`, `apps/api/src/integrations/application/interfaces/connection.service.interface.ts:23`) |
+| Capability gating | **ALREADY EXISTS → reuse** | `IIntegrationsService.listCapabilityAdapters({ capability, lazy })`; precedent `ConnectionInfraHealthService` |
+| Search filter | **ALREADY EXISTS → reuse** | `ProductListFilters.search` (case-insensitive name/SKU) + `.sourceConnectionId` — exact fit for `search_catalog` |
+
+**No reuse collisions.** The four net-new artifacts are genuinely absent — `find -name "*.tool.ts"` and `grep -r ToolRegistry` both return **zero** hits across `apps/` and `libs/`. Every domain read the plan needs already has a published `I*Service` + Symbol token.
+
+### 1.1 Consumability of the four reused surfaces (verified end-to-end)
+
+The plan is only viable if each reused service is reachable *from `apps/api`* through the sanctioned barrel + module path. Checked all three hops for each:
+
+| Surface | Token on barrel | Interface on barrel | Token in module `exports:` |
+|---|---|---|---|
+| `IProductsService` | ✅ `products/index.ts:14` (`export * from './products.tokens'`) | ✅ `products/index.ts:45` | ✅ `products.module.ts:77` |
+| `IInventoryQueryService` | ✅ `inventory/index.ts:14` | ✅ `inventory/index.ts:30` | ✅ `inventory.module.ts:83` |
+| `IOrderRecordService` | ✅ `orders/index.ts:144` | ✅ `orders/index.ts:131` | ✅ `orders.module.ts:98` |
+| `IConnectionService` | n/a (host app, not a core barrel) | ✅ `connection.service.interface.ts:23` | ✅ `apps/api/.../integrations.module.ts:75` |
+
+All three core contexts follow the `export * from './<ctx>.tokens'` convention (`engineering-standards.md § Symbol DI Token Re-export`), so the tokens are on the top-level barrel with no deep-path import required.
+
+`CoreCapabilityValues` (`libs/core/src/integrations/domain/types/adapter.types.ts:22`) contains `ProductMaster`, `InventoryMaster`, and `OrderSource` — all three registration gates the plan uses are well-known capabilities, not open-world strings.
+
+## 2. Backward-compatibility checklist
+
+| Surface | Finding | Severity |
+|---|---|---|
+| Top-level barrels | No symbol removed/renamed. Plan only *consumes* existing barrel exports | None |
+| Port method signatures | **No port is modified or implemented.** Phase 1 introduces no port and calls no adapter on the read path | None |
+| DTO shapes | No existing DTO touched; tool input schemas are net-new | None |
+| Symbol tokens | None removed/renamed; four existing tokens consumed | None |
+| ORM schema | **No entity change ⇒ no migration.** Confirms plan §1 | None |
+| `check-cross-context-imports` | All four cross-context imports are `I*Service` + `*_TOKEN` — explicitly on the allow list per `architecture-overview.md § Cross-context dependencies in core`. No `*RepositoryPort`, no `*OrmEntity`, no `*Adapter` | None |
+| `check-service-interfaces` | Scans `libs/core/src/<ctx>/application/services/` **only** (script line 34) — new services live in `apps/api`, so unenforced. Plan §8 already discloses this and follows the convention anyway | None |
+| Migration timestamps | N/A (no migration) | None |
+
+**No Critical items. No Warnings.**
+
+## 3. What the deep review changed
+
+Recorded because it is the substantive finding of this gate:
+
+The pre-revision plan sourced all four reads through capability **ports**
+(`ProductMasterPort.searchProducts`, `InventoryMasterPort.getAvailableQuantity`,
+`OrderSourcePort.getOrder`). That would have been a live platform round-trip per
+tool call, and — decisively — it **structurally defeats `OL_STORE_PII`**:
+`IOrderRecordService.persistOrder` nulls buyer PII at ingestion when the operator
+disables PII storage, whereas `OrderSourcePort.getOrder` re-fetches it raw
+regardless. One of the three PII options the plan offered for decision was
+therefore not implementable at all.
+
+Revised §3.3 keeps capability-declared *registration* (which is what makes
+`tools/list` dynamic per ADR-033) and moves the *data* to OL's own store, with
+`connectionId` narrowing rather than selecting an adapter. Both decisions the
+plan had escalated dissolved rather than needing an answer.
+
+## 4. Open questions
+
+**None blocking.** Two notes carried into implementation:
+
+1. Both `apps/api/.../integrations.module.ts` and
+   `libs/core/.../integrations.module.ts` export a class named
+   `IntegrationsModule`. The host one re-exports `CoreIntegrationsModule`, so a
+   single aliased import suffices — but an unaliased import is a live shadowing
+   footgun. Plan §3.7 now calls this out.
+2. ~~`get_availability` is variant-keyed…~~ **RESOLVED** by the second
+   `/tech-review` pass. `IInventoryQueryService.getProductStockAggregates(productIds)`
+   (`inventory-query.service.interface.ts:56` → `ProductStockAggregate`
+   `{ productId, totalAvailable, totalReserved, stockUpdatedAt }`) is the
+   product-level read, with `getAvailabilityByVariantIds` →
+   `VariantAvailability { productVariantId, totalAvailable, locationCount }`
+   for the variant case. No fan-out needed. Both are **global** reads with no
+   connection axis — hence §3.3.2.
+3. **`OrdersModule` exports the concrete `OrderRecordService` class** alongside
+   its token (`orders.module.ts:94`, commented "Export service class for direct
+   injection"). That is a live temptation to inject the class. Inject
+   `ORDER_RECORD_SERVICE_TOKEN` instead — `engineering-standards.md § Ports vs.
+   Concrete Implementations`. Worth an explicit line in the step-4 acceptance
+   criteria since the wrong path compiles cleanly.

--- a/docs/plans/implementation-plan-mcp-read-only-domain-tools.md
+++ b/docs/plans/implementation-plan-mcp-read-only-domain-tools.md
@@ -20,7 +20,7 @@ Verified on `main` (`46fea4af`) — this plan builds on it and changes none of i
 | `OlMcpTokenVerifier implements OAuthTokenVerifier` + `requireBearerAuth` on `/mcp` | Auth is done. Tools need no auth code of their own |
 | Principal arrives as **`ctx.authInfo`** (NOT `ctx.http.authInfo`) with OL identity in `AuthInfo.extra` | Tools read `extra` via the existing `isMcpAuthInfoExtra` guard |
 | 🔴 `AuthInfo` carries the **raw bearer token** | The audit log MUST log the redacted `extra` projection, never `AuthInfo` |
-| `createMcpHandler(factory)` builds a **fresh `McpServer` per request** (stateless) | `tools/list` is naturally per-principal and never stale — see §3.1 |
+| `createMcpHandler(factory)` builds a **fresh `McpServer` per request** (stateless) | `tools/list` is per-principal and the *server* is always fresh — see §3.1 for the client-cache caveat |
 | `mcp-server.factory.ts` with one `whoami` tool | Phase 1 replaces the hard-coded tool with a registry-driven registration |
 | Transport fails **closed** when `req.auth` is absent | Tools can assume a principal is present; still narrow defensively |
 
@@ -50,7 +50,7 @@ Verified on `main` (`46fea4af`) — this plan builds on it and changes none of i
 - **A Phase-1-local PII policy** — *resolved, not deferred*: reads come from OL's own store, which already applies the operator's `OL_STORE_PII` decision. See §3.4.
 - **New capability ports** — Phase 1 introduces no port and calls no adapter on the read path. See §3.3.
 - **Live platform round-trips on the read path** — deliberately excluded; §3.3.
-- **`notifications/tools/list_changed`** — see §3.1; the issue's AC is not implementable under the stateless model and is unnecessary.
+- **`notifications/tools/list_changed`** — see §3.1; not implementable under the stateless model. The cost (a connected client's cached list going stale) is accepted, not absent.
 
 ---
 
@@ -58,13 +58,13 @@ Verified on `main` (`46fea4af`) — this plan builds on it and changes none of i
 
 ### 3.1 🔴 `tools/list_changed` — the issue's AC does not survive contact with Phase 0
 
-The issue asks that "adding/removing a connection republishes via `notifications/tools/list_changed`". **That is not implementable as written, and it is also unnecessary.**
+The issue asks that "adding/removing a connection republishes via `notifications/tools/list_changed`". **That is not implementable under the transport ADR-033 chose** — and the cost of dropping it is real, so it is accepted rather than dismissed.
 
 `createMcpHandler` constructs a **fresh `McpServer` per HTTP request** (Phase 0, endorsed by ADR-033 for multi-replica safety — no sessions, no sticky routing). `sendToolListChanged()` exists on the server, but a push notification needs a long-lived session to push *over*; there is none. The SDK confirms the client half only activates when the server advertises `tools.listChanged: true`.
 
-The stateless model makes the notification moot: **`tools/list` is recomputed from live capability state on every call**, so it can never be stale. A client that lists tools always sees the current set.
+**`tools/list` is recomputed from live capability state on every call**, so the *server* is always fresh. That does NOT make the notification pointless, though — a **client's cached** list can still go stale, which is exactly what the notification is for. See ADR-033 § Phase 1 amendments for the corrected reasoning and the accepted cost.
 
-**Decision**: do not advertise `tools.listChanged`, do not call `sendToolListChanged()`. Record the reasoning in the ADR + the issue. The alternative — moving to sessionful serving — would reverse ADR-033 and Phase 0 for a notification whose only purpose is correcting staleness that cannot occur.
+**Decision**: do not advertise `tools.listChanged`, do not call `sendToolListChanged()`. Record the reasoning in the ADR + the issue. The alternative — moving to sessionful serving — would reverse ADR-033 and Phase 0's multi-replica-safety property to gain one convenience on a surface whose demand is unproven. The cost (a connected client not seeing a newly enabled tool until it reconnects) is accepted, not absent.
 
 ### 3.2 Tool registry — capability-declared, never a static catalog
 
@@ -101,7 +101,7 @@ The issue names capabilities (`ProductMaster` / `InventoryMaster` / `OrderSource
 
 Why the port path was wrong on all four counts:
 
-1. **It defeats `OL_STORE_PII`.** `IOrderRecordService.persistOrder` nulls buyer PII at ingestion when the operator disables PII storage. `OrderSourcePort.getOrder` re-fetches raw PII from the marketplace regardless — so "honour `OL_STORE_PII` as a floor" is not implementable on that path. Reading `OrderRecord` inherits the operator's existing decision for free.
+1. **It turns `OL_STORE_PII` compliance into a duplicated policy with an unsafe default.** `OL_STORE_PII` governs *persistence*, so a port-path tool that projected PII away would not literally violate it — the precise costs are that (a) "honour `OL_STORE_PII` as a floor" is **incoherent** there (no stored floor to honour; you would reimplement `persistOrder`'s nulling rule, leaving one privacy policy in two places), and (b) the **default** forwards to an LLM vendor exactly what the operator opted out of storing. Reading `OrderRecord` inherits the decision for free instead.
 2. **It spends the operator's marketplace API quota on the agent's behalf.** One tool call = one live Allegro/PrestaShop request. The §3.6 limiter caps *OL* calls; it cannot cap downstream cost, which is the scarcer resource.
 3. **It breaks identifier consistency.** `OrderSourcePort` is documented as an *ingestion* port — "identifier mapping happens in core services" — so it returns external-id-keyed data, which the agent cannot join against internal-id-keyed product reads.
 4. **It bypasses the variant-keyed availability model.** `InventoryMasterPort.getAvailableQuantity` is product-level; `IInventoryQueryService.getAvailabilityByVariantIds` is the variant-keyed read the rest of OL uses per ADR-010 / #822 / #823.

--- a/docs/plans/implementation-plan-mcp-read-only-domain-tools.md
+++ b/docs/plans/implementation-plan-mcp-read-only-domain-tools.md
@@ -1,0 +1,298 @@
+# Implementation Plan: MCP Phase 1 — Read-only domain tools
+
+**Issue**: #1487 (Phase 1 of EPIC #1350; unblocked by #1486 / PR #1912)
+**Date**: 2026-07-29
+**Status**: Ready for Review
+**Branch**: `1487-mcp-read-only-domain-tools`
+
+> Rationale: [ADR-033](../architecture/adrs/033-openlinker-as-mcp-server.md) /
+> [ADR-034](../architecture/adrs/034-mcp-authorization-user-issued-pats.md).
+> Phased breakdown: [implementation-plan-mcp-server.md § Phase 1](./implementation-plan-mcp-server.md).
+
+---
+
+## 0. What Phase 0 already gives us
+
+Verified on `main` (`46fea4af`) — this plan builds on it and changes none of it:
+
+| Landed | Consequence for Phase 1 |
+|---|---|
+| `OlMcpTokenVerifier implements OAuthTokenVerifier` + `requireBearerAuth` on `/mcp` | Auth is done. Tools need no auth code of their own |
+| Principal arrives as **`ctx.authInfo`** (NOT `ctx.http.authInfo`) with OL identity in `AuthInfo.extra` | Tools read `extra` via the existing `isMcpAuthInfoExtra` guard |
+| 🔴 `AuthInfo` carries the **raw bearer token** | The audit log MUST log the redacted `extra` projection, never `AuthInfo` |
+| `createMcpHandler(factory)` builds a **fresh `McpServer` per request** (stateless) | `tools/list` is naturally per-principal and never stale — see §3.1 |
+| `mcp-server.factory.ts` with one `whoami` tool | Phase 1 replaces the hard-coded tool with a registry-driven registration |
+| Transport fails **closed** when `req.auth` is absent | Tools can assume a principal is present; still narrow defensively |
+
+---
+
+## 1. Task Summary
+
+**Objective**: expose OL's highest-utility, lowest-blast-radius reads as MCP tools — catalog search + product read, availability, order read — behind a **dynamic, capability-declared `tools/list`**, plus `list_connections` for discovery, a per-call audit log, and a per-token abuse cap.
+
+**Classification**: **Interface** layer only (`apps/api/src/mcp/`). No new capability port, no domain entity, no migration, and — unlike Phase 0 — **no CORE slice**: every read already has a published core service interface, and the principal already arrives resolved.
+
+---
+
+## 2. Scope & Non-Goals
+
+### In scope
+1. `ToolRegistryService` — dynamic, per-principal, capability-declared tool list.
+2. Four read tools: `search_catalog`, `get_product`, `get_availability`, `get_order`.
+3. `list_connections` — tells the agent which `connectionId` backs which tool.
+4. Per-call audit log (redacted principal + connection + tool + outcome).
+5. Per-token rate + concurrency cap (net-new Redis limiter).
+6. Register the `*.tool.ts` file-suffix convention in `engineering-standards.md`.
+
+### Non-goals
+- **Any write/mutating tool** — Phase 2/3 (#1488/#1489).
+- **Per-token connection scoping** — #1489. Reads run at the principal's existing global scope (OL is single-tenant, ADR-034).
+- **A Phase-1-local PII policy** — *resolved, not deferred*: reads come from OL's own store, which already applies the operator's `OL_STORE_PII` decision. See §3.4.
+- **New capability ports** — Phase 1 introduces no port and calls no adapter on the read path. See §3.3.
+- **Live platform round-trips on the read path** — deliberately excluded; §3.3.
+- **`notifications/tools/list_changed`** — see §3.1; the issue's AC is not implementable under the stateless model and is unnecessary.
+
+---
+
+## 3. Design
+
+### 3.1 🔴 `tools/list_changed` — the issue's AC does not survive contact with Phase 0
+
+The issue asks that "adding/removing a connection republishes via `notifications/tools/list_changed`". **That is not implementable as written, and it is also unnecessary.**
+
+`createMcpHandler` constructs a **fresh `McpServer` per HTTP request** (Phase 0, endorsed by ADR-033 for multi-replica safety — no sessions, no sticky routing). `sendToolListChanged()` exists on the server, but a push notification needs a long-lived session to push *over*; there is none. The SDK confirms the client half only activates when the server advertises `tools.listChanged: true`.
+
+The stateless model makes the notification moot: **`tools/list` is recomputed from live capability state on every call**, so it can never be stale. A client that lists tools always sees the current set.
+
+**Decision**: do not advertise `tools.listChanged`, do not call `sendToolListChanged()`. Record the reasoning in the ADR + the issue. The alternative — moving to sessionful serving — would reverse ADR-033 and Phase 0 for a notification whose only purpose is correcting staleness that cannot occur.
+
+### 3.2 Tool registry — capability-declared, never a static catalog
+
+```ts
+interface McpToolDefinition {
+  readonly name: string;                 // stable: `search_catalog`, never `search_catalog__allegro-main`
+  readonly requiredCapability: string;   // 'ProductMaster' | 'InventoryMaster' | 'OrderSource'
+  readonly description: string;
+  readonly inputSchema: StandardSchemaWithJSON;
+  readonly handler: McpToolHandler;
+}
+```
+
+`ToolRegistryService implements IToolRegistryService` resolves, per request:
+
+```
+for each distinct requiredCapability among the definitions:
+  listCapabilityAdapters({ capability, lazy: true })   ← lazy: no adapter construction just to list
+  → capability is "available" iff ≥ 1 entry
+register every definition whose capability is available
+```
+
+`listCapabilityAdapters` already intersects `metadata.supportedCapabilities` with the connection's `enabledCapabilities` (per `ConnectionInfraHealthService`'s note), so both halves of the gate come free. `lazy: true` is the same choice that service makes.
+
+`connectionId` is a **validated tool argument**, never baked into the name — otherwise the surface explodes to N connections × M capabilities.
+
+**Tool errors are agent-facing copy.** An LLM reads the error and decides what to do next, so messages are mapped deliberately rather than leaking internal exception text — an unknown/unsupported `connectionId` yields *"connection {id} does not support {capability}; call `list_connections` to see which do"*. One small mapping step at the tool boundary; asserted in the per-tool specs.
+
+### 3.3 🔴 Data source: OL's own store, not a live platform round-trip
+
+The issue names capabilities (`ProductMaster` / `InventoryMaster` / `OrderSource`), and the first draft of this plan read that as a mandate to call those **ports**. That is the wrong reading, and the deep review caught it. OL already owns a canonical, internal-id-keyed, PII-policy-aware store for all four reads.
+
+**Decision: hybrid.** Capability-declared *registration* is retained exactly as designed (§3.2) — it is what makes `tools/list` dynamic per ADR-033. The *data* comes from core service interfaces, and `connectionId` becomes a **narrowing filter**, not an adapter selector.
+
+Why the port path was wrong on all four counts:
+
+1. **It defeats `OL_STORE_PII`.** `IOrderRecordService.persistOrder` nulls buyer PII at ingestion when the operator disables PII storage. `OrderSourcePort.getOrder` re-fetches raw PII from the marketplace regardless — so "honour `OL_STORE_PII` as a floor" is not implementable on that path. Reading `OrderRecord` inherits the operator's existing decision for free.
+2. **It spends the operator's marketplace API quota on the agent's behalf.** One tool call = one live Allegro/PrestaShop request. The §3.6 limiter caps *OL* calls; it cannot cap downstream cost, which is the scarcer resource.
+3. **It breaks identifier consistency.** `OrderSourcePort` is documented as an *ingestion* port — "identifier mapping happens in core services" — so it returns external-id-keyed data, which the agent cannot join against internal-id-keyed product reads.
+4. **It bypasses the variant-keyed availability model.** `InventoryMasterPort.getAvailableQuantity` is product-level; `IInventoryQueryService.getAvailabilityByVariantIds` is the variant-keyed read the rest of OL uses per ADR-010 / #822 / #823.
+
+| Tool | Registration gate | Data source (verified) | Notes |
+|---|---|---|---|
+| `search_catalog` | `ProductMaster` | `IProductsService.listProducts(filters, pagination, sort?)` | `ProductListFilters.search` is case-insensitive name/SKU; `sourceConnectionId` narrows by connection — an exact fit |
+| `get_product` | `ProductMaster` | `IProductsService.getProduct(id)` + `getVariantsByProductId(id)` | returns `null` cleanly for unknown ids |
+| `get_availability` | `InventoryMaster` | `IInventoryQueryService.getProductStockAggregates(productIds)` — or `getAvailabilityByVariantIds(variantIds)` when the caller passes variant ids | see §3.3.2 |
+| `get_order` | `OrderSource` | `IOrderRecordService.getOrderRecord(id)` / `findMany(filters, pagination)` | PII posture inherited from `OL_STORE_PII` |
+| `list_connections` | *(none)* | `ConnectionService.list(filters?)` — §3.3.1 | always registered; the discovery entry point |
+
+Tokens: `PRODUCTS_SERVICE_TOKEN`, `INVENTORY_QUERY_SERVICE_TOKEN`, `ORDER_RECORD_SERVICE_TOKEN` — all published `I*Service` + Symbol pairs, so this is a compliant cross-context surface per `architecture-overview.md § Cross-context dependencies in core`.
+
+This materially **shrinks** the work: no adapter construction on the read path, no external failure modes to map, and `lazy: true` matters only for registration.
+
+#### 3.3.0 🔴 The gate and the data source are independent facts
+
+Registration is capability-gated (§3.2); the data comes from OL's own store. After the §3.3 correction these are **no longer the same fact**, and the plan must not read as though the gate proves data availability:
+
+- A `ProductMaster` connection that was since **disabled** removes `search_catalog` from `tools/list` even though OL still holds its fully-synced catalog.
+- A **freshly added** `ProductMaster` connection publishes the tool immediately, before any sync has run — the agent gets an empty catalog.
+
+This is the intended semantics: the gate answers *"is this deployment in the products business?"*, not *"is there data?"*. Because an agent cannot distinguish "no data" from "not configured" from an empty array, **every tool's `description` must say which it is** — the description is the only channel the agent reads before deciding what to do next. Asserted in the per-tool specs.
+
+#### 3.3.1 `list_connections` — source and projection
+
+`IIntegrationsService` exposes only four methods (`getAdapter`, `getCapabilityAdapter`, `resolveAdapterMetadata`, `listCapabilityAdapters`) — **none enumerates connections**. The source is `IConnectionService.list(filters?)`, injected via `CONNECTION_SERVICE_TOKEN` (`apps/api/src/integrations/application/interfaces/connection.service.interface.ts:23`) — an interface + Symbol pair, so this stays compliant with the "code against an interface" rule rather than injecting the concrete `ConnectionService`.
+
+The tool **projects** — `id`, `name`, `platformType`, `status`, `enabledCapabilities` — and never returns a `Connection` wholesale: the entity carries `credentialsRef` (a credential pointer) and a free-form operator `config` JSONB. Same discipline as §3.5.
+
+#### 3.3.2 `connectionId` is not uniformly meaningful
+
+The hybrid model changed what `connectionId` does per tool, and two of the four cases are **not** "scope the read to that connection":
+
+| Tool | What `connectionId` actually does |
+|---|---|
+| `search_catalog` | Filters by **provenance** — `ProductListFilters.sourceConnectionId` matches products that have a Product identifier mapping for that connection (`product.types.ts:158`). It is *not* "products currently listed there"; the description must say so, or an agent will read it as a listing filter |
+| `get_product` | Not accepted — `getProduct(id)` is a direct internal-id read |
+| `get_availability` | **Not accepted.** Neither `getProductStockAggregates` nor `getAvailabilityByVariantIds` takes a connection; both are global reads. Rather than accept-and-ignore the argument (worse than either alternative — an agent would infer it scoped the read), the tool omits it from its input schema entirely |
+| `get_order` | Filters by `OrderRecordFilters.sourceConnectionId` — genuinely scoping |
+
+Accepting an argument that silently does nothing is the failure mode being avoided here; where the underlying read has no connection axis, the schema says so by omission.
+
+### 3.3.3 🔴 One choke point for both cross-cutting concerns
+
+The audit log (§3.4) and the rate limiter (§3.6) are per-call and tool-agnostic. If each tool handler invoked them itself, five files would each have to remember to start a timer, acquire a slot, **release it on both success and throw**, and emit the audit line on both paths — six chances to miss one, and a missed release leaks a concurrency slot permanently (the precise failure the ZSET rework exists to prevent).
+
+**Both run in a single wrapper applied at registration time inside `ToolRegistryService`.** The registry already visits every definition exactly once, so wrapping `definition.handler` there makes enforcement *structural* rather than a convention each tool file must honour. `list_connections` and `whoami` go through the same wrapper — no tool is exempt.
+
+Ordering is fixed:
+
+```
+acquire limiter slot         → over limit ⇒ tool error, no handler call, audit outcome 'rate-limited'
+  try    { await handler() } → outcome 'ok'
+  catch  { … }               → outcome 'error'
+  finally{ release slot }    → release is idempotent (ZREM), so double-release is harmless
+emit audit line              → always, on every path
+```
+
+Individual tool files therefore contain **only** their read + projection. They never import the logger or the limiter.
+
+### 3.4 Audit log
+
+One structured line per call via the shared `Logger`:
+
+```ts
+{ tool, connectionId, outcome: 'ok' | 'error', durationMs,
+  ...redactPrincipal(authInfo)   // { mcpTokenId, olUserId, olRole } from extra — NEVER the AuthInfo
+}
+```
+
+Reuses `McpAuthInfoExtra` / `isMcpAuthInfoExtra` from Phase 0. A dedicated `redactPrincipal` helper makes the invariant a function rather than a convention, and is unit-asserted to omit `token`. Emitted from the §3.3.3 wrapper — which is also where the redaction invariant is asserted at the registry boundary, since that is the single point where every tool's principal is handled.
+
+### 3.5 Result-size discipline (not in the issue, but load-bearing)
+
+Tool results are fed to an LLM. Every tool caps and projects:
+- `search_catalog` takes `limit` (default 20, max 100), passed through as `ProductPagination`, and returns a **narrow projection** (id, name, sku, price), not raw `Product` entities.
+- `get_order` returns a projection of `OrderRecord`, not the raw snapshot graph.
+- `list_connections` projects per §3.3.1.
+
+Projection is a security control here, not only a context-budget one: it is what keeps `credentialsRef`, operator `config`, and unreviewed snapshot fields out of an LLM provider's hands.
+
+### 3.6 Per-token rate + concurrency cap
+
+Net-new — the issue is right that no reusable primitive exists (no `@nestjs/throttler`; `CachePort` is KV-only with no atomic increment). Built on the raw `'REDIS_CLIENT'` (`@Global` from `RedisConfigModule`), following `RedisPickupPointQueryStatsAdapter`'s precedent for reaching past `CachePort` — including its "if a second consumer appears, promote a port" note.
+
+- **Rate**: ZSET rolling window keyed `mcp:ratelimit:{mcpTokenId}` — `ZREMRANGEBYSCORE` to evict, `ZCARD` to count, `ZADD` + `EXPIRE`.
+- **Concurrency**: the **same ZSET primitive**, keyed `mcp:inflight:{mcpTokenId}`, holding in-flight request ids scored by start time. Acquire = `ZADD`; release = `ZREM`; a crashed request ages out via `ZREMRANGEBYSCORE` against a max-request-lifetime floor before each `ZCARD`.
+  > An earlier draft used `INCR`/`DECR` with a TTL. That leaks: a TTL expires the *shared* counter (dropping live requests' slots), and a `DECR` arriving after expiry drives the key negative, silently raising the effective cap. One primitive, one failure model, and `ZREM` is idempotent so double-release is harmless.
+- **Redis outage → fail open**, logged at `warn`. Rationale: the limiter is abuse mitigation, not an authorization control — auth is already enforced upstream by `requireBearerAuth` (Phase 0). Failing closed would let a Redis blip take down the entire authenticated MCP surface, trading a real availability loss for a speculative abuse window. Asserted by a spec case.
+- Over limit → a tool error (the MCP-level equivalent of 429), not a transport 429 — the call is already authenticated and inside the protocol.
+- Env-tunable, clamped, defaults documented in `.env.example`.
+
+**This is the separable slice** — see §7.
+
+### 3.7 Module layout
+
+```
+apps/api/src/mcp/
+  tools/
+    tool-registry.service.ts            # implements IToolRegistryService; owns the §3.3.3 wrapper
+    tool-registry.service.interface.ts
+    tool-definition.types.ts
+    read/whoami.tool.ts                 # MOVED from mcp-server.factory.ts (§3.7 note)
+    audit/mcp-audit.logger.ts           # redactPrincipal + one-line-per-call
+    ratelimit/mcp-rate-limiter.ts       # + .interface.ts (§3.6)
+    read/search-catalog.tool.ts
+    read/get-product.tool.ts
+    read/get-availability.tool.ts
+    read/get-order.tool.ts
+    read/list-connections.tool.ts
+  transport/mcp-server.factory.ts       # CHANGED: registry-driven registration
+  mcp.module.ts                         # CHANGED: providers + FOUR imports (below)
+```
+
+`mcp.module.ts` imports **four** modules:
+
+- the **host** `IntegrationsModule` (`apps/api/src/integrations/`) — it exports both `CONNECTION_SERVICE_TOKEN` *and* re-exports `CoreIntegrationsModule`, so this one import covers capability gating **and** `list_connections`. Note both modules are literally named `IntegrationsModule`; alias the import to avoid a shadowing bug.
+- `ProductsModule`, `InventoryModule`, `OrdersModule` — the three core read services.
+
+`RedisConfigModule` is `@Global`, so `'REDIS_CLIENT'` needs no import.
+
+`whoami` **moves out of the factory into `read/whoami.tool.ts`**. This is not optional tidying: the factory's own header states it lives inline only because #1487 owns registering the `*.tool.ts` convention, and that pre-empting it "would fork the decision." This PR registers the convention, so it also discharges that standing note — and moving it is what puts `whoami` behind the §3.3.3 wrapper like every other tool. It stays always-registered (never capability-gated).
+
+---
+
+## 4. Implementation Steps
+
+| # | Step | Acceptance |
+|---|---|---|
+| 1 | `tool-definition.types.ts` | `as const` capability list; no `any` |
+| 2 | `redactPrincipal` + audit logger | Unit test asserts the raw token never appears in output |
+| 3 | `list_connections.tool.ts` | Projects id/name/platformType/status/enabledCapabilities from `ConnectionService.list()`; never returns `Connection` wholesale; always registered |
+| 4 | Four read tools + `whoami` move | Each reads via its core `I*Service` (§3.3), projects + caps its result. `connectionId` accepted only where meaningful (§3.3.2). Description states the gate-vs-data semantics (§3.3.0). No tool imports the logger or limiter (§3.3.3) |
+| 5 | `ToolRegistryService` + interface | Registers a tool iff ≥1 connection supports+enables its capability; `lazy: true`; **owns the §3.3.3 wrapper** (limiter + audit + error mapping) applied to every definition |
+| 6 | Rate limiter + interface | Two ZSETs (window + in-flight); crash ages out; fails open on Redis outage |
+| 7 | Factory + module wiring | Registry-driven; `whoami` no longer inline; four modules imported (§3.7); API boots |
+| 8 | Docs | `.tool.ts` convention in `engineering-standards.md`; `list_changed` + data-source decisions in ADR-033 + issue; `.env.example` |
+| 9 | Tests | §5 |
+
+---
+
+## 5. Testing Strategy
+
+**Unit**
+- `tool-registry.service.spec.ts` — a capability with no supporting connection has **all** its tools absent; a base port (`ProductMaster`) backs **two** tools; `list_connections` + `whoami` always present; `lazy: true` asserted. **Wrapper cases (§3.3.3), the ones hand-written per-tool code gets wrong**: a handler that *throws* still releases its in-flight slot AND still emits an audit line; an over-limit call never invokes the handler; the emitted line never contains the raw token (the redaction invariant, asserted at the boundary where every principal is handled).
+- One spec per tool — happy path, capability-gate rejection yields the mapped agent-facing message, result cap enforced, projection omits non-projected fields (`list_connections` asserts `credentialsRef` / `config` absent). `get_availability` asserts it takes no `connectionId` (§3.3.2).
+- `mcp-audit.logger.spec.ts` — **the raw token never reaches the log** (the Phase-0 invariant, re-asserted at its new consumer).
+- `mcp-rate-limiter.spec.ts` — window eviction, over-limit, in-flight release on both success and throw, stale in-flight entry ages out, **Redis outage fails open with a `warn`**.
+
+**Integration** (`mcp-tools.int-spec.ts`): authenticated principal → `tools/list` → capable read tool → audit assertion; plus a connection lacking the capability yielding a tool error.
+
+> `loginAsAdmin` at most **once** per test (`reference_int_spec_login_once_per_test`).
+
+---
+
+## 6. Documentation Impact
+
+- `engineering-standards.md` — register the `*.tool.ts` suffix (the issue explicitly assigns this here).
+- **ADR-033** — record two decisions: the `list_changed` drop (§3.1), and the **read-path data source** (§3.3) — tools are capability-*gated* but OL-store-*backed*, which is the posture every later phase inherits.
+- `implementation-plan-mcp-server.md` — mark Phase 1 shipped; carry the `list_changed` correction.
+- `.env.example` — rate-limit knobs.
+- `docs/lessons.md` — only if something empirical emerges; no speculative entry.
+
+---
+
+## 7. Risks
+
+Both decisions flagged in the previous draft **dissolved** under the §3.3 data-source correction rather than being answered:
+
+- **PII in `get_order`** — no longer a Phase-1 decision. Reading `OrderRecord` inherits the operator's existing `OL_STORE_PII` posture, so OL's own deliberate policy governs. The previously-offered option "ship it full and honour `OL_STORE_PII` as a floor" was in fact *not implementable* on the port path, which is what exposed the underlying problem.
+- **Rate-limiter scope** — keep it in this PR. It is an issue AC, and an unthrottled tool surface is exactly what a looping agent abuses. It also got simpler under review (one primitive, not two).
+
+| Risk | Severity | Note |
+|---|---|---|
+| Reads are OL-store, so they are only as fresh as the last sync | Low–Medium | Correct trade for Phase 1: bounded, cheap, PII-correct, internal-id-consistent. A future explicit `refresh_*` tool can go to the platform deliberately, rather than every read doing so implicitly |
+| `list_changed` AC dropped | Low | §3.1 — grounded in the SDK + ADR-033; documented, not silently skipped |
+| SDK v2 is days old | Medium | Same mitigation as Phase 0: thin surface, verify against installed `.d.cts` not docs |
+| Result size → context blowup | Low | §3.5 caps + projections |
+| Limiter fails open on Redis outage | Low | Deliberate (§3.6); auth is enforced upstream and unaffected |
+
+---
+
+## 8. Validation Checklist
+
+- [ ] No `*RepositoryPort` imported into `apps/api` (`check-cross-context-imports`) — reads go through `I*Service` + Symbol token only
+- [ ] Capability *gating* uses `listCapabilityAdapters`; no concrete adapter is ever named
+- [ ] Every tool result is a projection — no `Connection`, `Product`, or `OrderRecord` returned wholesale
+- [ ] `AuthInfo` never logged/serialized wholesale; `redactPrincipal` is the only path
+- [ ] `as const` unions; types in `*.types.ts`; file header on every new file
+- [ ] Services implement an `I*Service` (note: `check-service-interfaces` scans `libs/core` only — not machine-enforced here)
+- [ ] No `any`, no `console.log`, no hardcoded secrets
+- [ ] `pnpm lint` / `type-check` / `test` green; `test:integration` for the tool slice

--- a/docs/plans/implementation-plan-mcp-server.md
+++ b/docs/plans/implementation-plan-mcp-server.md
@@ -88,7 +88,7 @@
 - **Q3 — Library + transport (RESOLVED).** Use the official `@modelcontextprotocol/sdk` directly behind a thin `@Public()`/`VERSION_NEUTRAL` transport controller over **Streamable HTTP** (OL is a hosted server, not a stdio subprocess). No community NestJS-MCP wrapper: it adds a second dependency tracking a churning protocol with no lifecycle guarantee, and its value is static `@Tool()` decorators — which fight our dynamic, capability-driven registration (Q4/§6). Revisit only if a *governed* wrapper emerges.
 - **Q4 — Do the FE slices warrant separate FE issues? (RESOLVED — fold both.)** Two small FE surfaces exist: the **Phase 0** admin MCP-token-management settings page (generate / one-time-reveal / list / revoke) and the **Phase 3** branded key-entry page + "connected via agent" affordance. Both are BE-dominant slices tightly coupled to their phase's API. *Decision:* fold each into its own phase's child issue with an explicit FE checklist (per `docs/frontend-architecture.md`), rather than spinning separate FE issues — so #1486 carries the token-UI checklist and #1489 the key-entry-page checklist.
 - **Q5 — Per-token connection scoping for writes (Phase 3).** Before write/config tools ship, should an agent token be restrictable to a subset of connections (net-new, since OL has none today)? *Default:* yes — introduce an additive per-token connection allow-list as a Phase 3 write prerequisite (the higher-blast-radius surface); reads (P1) and mapping suggestions (P2) run at the user's existing global scope.
-- **Q6 — PII in order-read tools (deferred).** `OrderSource` reads carry buyer PII, which the agent's LLM provider would receive as a de-facto sub-processor. Consciously **deferred for now** — not designed into Phase 1. Flag to revisit before order-read tools ship (options if/when: default PII-minimized reads + explicit opt-in tool; honor `OL_STORE_PII` as a floor).
+- **Q6 — PII in order-read tools. ✅ RESOLVED (#1487).** The question dissolved rather than being answered: `get_order` reads the persisted `OrderRecord`, whose snapshot **already** honours the operator's `OL_STORE_PII` setting, so no Phase-1-local policy was needed. The tool additionally applies an explicit-allowlist projection that omits buyer name / email / address even when PII storage IS enabled, since order *status* — the question an agent actually asks — does not require buyer identity. Note the originally-proposed option "honor `OL_STORE_PII` as a floor" was **not implementable** on the `OrderSourcePort` path, because that port re-fetches raw PII from the platform regardless of the setting; discovering that is what forced the data-source correction above.
 - **Q7 — MCP client accepts a manual bearer header? (validate before Phase 0 code — the one thing that could kill the PAT model).** The PAT approach requires the target MCP client to accept a static `Authorization` header for a *remote* Streamable-HTTP server. Confirmed at the server/vendor/framework level (GitHub/Atlassian/Sentry/FastMCP), **not** exhaustively per GUI client. *Default:* run a ~1-hour stub-server header check against the actual target (Claude Desktop, etc.) before committing Phase 0. A client that refuses manual headers pulls the deferred OAuth AS forward.
 
 ### Assumptions
@@ -125,7 +125,26 @@
 
 **Dependencies**: none (net-new). **Gates**: Phases 1–3.
 
-### Phase 1 — Read-only domain tools (low-regret spike)
+### Phase 1 — Read-only domain tools (low-regret spike) ✅ SHIPPED (#1487)
+
+> **Shipped 2026-07-29.** Two corrections were made during implementation and are
+> authoritative over the step list below — see
+> [ADR-033 § Phase 1 amendments](../architecture/adrs/033-openlinker-as-mcp-server.md)
+> and `docs/plans/implementation-plan-mcp-read-only-domain-tools.md`:
+>
+> 1. **Tools read OL's own store**, not the capability port's adapter (step 2 said
+>    `getCapabilityAdapter`). Capability-*gating* is unchanged; the *data source* moved to
+>    `IProductsService` / `IInventoryQueryService` / `IOrderRecordService`. Going through the port
+>    would spend the operator's marketplace quota per tool call, return external-id-keyed data,
+>    and bypass `OL_STORE_PII`.
+> 2. **`notifications/tools/list_changed` was NOT implemented** (step 1's last clause). It is not
+>    implementable under the stateless per-request server this ADR chose — there is no session to
+>    push over — and it is unnecessary, because `tools/list` is recomputed every call.
+>
+> Also delivered beyond the step list: a single per-call wrapper in the registry owning the
+> limiter + audit + error mapping (so no tool can forget them), and explicit-allowlist projections
+> on every result.
+
 **Goal**: Highest-utility, lowest-blast-radius tools: catalog search + `getProduct` (`ProductMaster`), availability reads (`InventoryMaster`), order-status reads (`OrderSource`).
 
 **Steps**:
@@ -166,7 +185,7 @@
 - Each new migration must follow the **synthetic sequential timestamp** convention (`migrations.md § Timestamp uniqueness invariant`) — re-prefix the `migration:generate` output to the next free synthetic timestamp, don't ship a raw `Date.now()` prefix (the ordering guard fails `pnpm lint` otherwise). Author it in the Phase 0 child issue (#1486).
 
 ### File-naming note (for the child issues)
-- The MCP tool files (`tools/**/*.tool.ts`) introduce a `.tool.ts` suffix not yet in `engineering-standards.md § Files and Folders` — decide/register the convention in the Phase 1 issue (#1487) before code.
+- ~~The MCP tool files (`tools/**/*.tool.ts`) introduce a `.tool.ts` suffix not yet in `engineering-standards.md`~~ — **done (#1487)**: registered under `engineering-standards.md § MCP-protocol routes`, together with the rules that a tool file carries only its read + projection, always projects, and only accepts arguments its read honours.
 - The Phase 0 MCP-token service + `tool-registry.service.ts` (Phase 1) follow the service-interface rule (an `implements` clause on an `I*Service` or a `*Port`). The `check-service-interfaces` invariant only scans `libs/core/src`, so `apps/api` won't fail the build, but the standard still applies.
 
 ### Events / Error Handling


### PR DESCRIPTION
Phase 1 of the MCP epic (#1350). Six tools at `apps/api/src/mcp/tools/`: two always-registered discovery entry points (`whoami`, `list_connections`) plus four capability-gated domain reads.

| Tool | Registration gate | Data source |
|---|---|---|
| `search_catalog` | `ProductMaster` | `IProductsService.listProducts` |
| `get_product` | `ProductMaster` | `IProductsService.getProduct` + `getVariantsByProductId` |
| `get_availability` | `InventoryMaster` | `IInventoryQueryService.getProductStockAggregates` / `getAvailabilityByVariantIds` |
| `get_order` | `OrderSource` | `IOrderRecordService.getOrderRecord` |
| `list_connections` | — | `IConnectionService.list` |
| `whoami` | — | request principal |

## Two departures from the phased plan

Both are recorded in a new **ADR-033 § Phase 1 amendments** section, and the phased plan is marked shipped with these called out as authoritative over its step list.

**1. Tools are capability-GATED but OL-store-BACKED.** The plan said each tool would resolve its adapter via `getCapabilityAdapter`. That reading is wrong on four counts:

- It **defeats `OL_STORE_PII`**. `IOrderRecordService.persistOrder` nulls buyer PII at ingestion when the operator disables PII storage; `OrderSourcePort.getOrder` re-fetches it raw regardless. The plan's own proposed option "honour `OL_STORE_PII` as a floor" was therefore *not implementable* on that path — discovering that is what forced this correction.
- It **spends the operator's marketplace API quota** on an autonomous agent's behalf, one live call per tool invocation. The per-token limiter caps OL calls; it cannot cap downstream cost.
- It **breaks identifier consistency** — `OrderSourcePort` is an *ingestion* port returning external-id-keyed data that won't join the internal-id-keyed product reads.
- It **bypasses the variant-keyed inventory model** (ADR-010 / #822 / #823).

Registration gating is unchanged, so the gate and the data are now **independent facts**: a passing gate does not imply data exists (a freshly added connection publishes its tools before any sync runs), and a disabled connection hides tools whose data OL still holds. Each tool's `description` states this, because an agent cannot otherwise interpret an empty result.

This also **resolves plan Q6** (PII in order reads) by dissolving it rather than answering it. `get_order` additionally applies an explicit-allowlist projection omitting buyer name/email/address even when PII storage *is* enabled — order status doesn't require buyer identity.

**2. `notifications/tools/list_changed` is NOT implemented.** The issue's AC asked for it. It isn't implementable under the stateless per-request server ADR-033 chose — `createMcpHandler` builds a fresh `McpServer` per request, so there's no session to push over — and it's unnecessary, because `tools/list` is recomputed every call and cannot go stale. The alternative (sessionful serving) would reverse ADR-033 to correct staleness that can't occur.

## Beyond the plan

**One choke point.** Rate limiting, audit logging, and error mapping are applied by a single wrapper inside `McpToolRegistryService`, not per tool. Left to each tool they'd be five independent chances to forget releasing an in-flight slot on the throw path. Tool files carry only their read and projection and never import the limiter or logger.

**Projection as a security control.** Tool output reaches an external LLM provider acting as a de-facto sub-processor, so every result is an explicit allowlist — `list_connections` never emits `credentialsRef`/`config`; `get_order` enumerates line-item fields rather than spreading them, so fields added to the snapshot later can't silently start leaking.

**Limiter.** One ZSET primitive for both the rolling rate window and the in-flight cap. An earlier `INCR`/`DECR` design leaked: a TTL expires the *shared* counter (dropping live requests' slots) and a late `DECR` drives it negative, silently raising the cap. `ZREM` is idempotent, and a crashed request ages out. **Fails open on a Redis outage** — it's abuse mitigation, not an authorization control (auth is enforced upstream), so an outage must not take down the authenticated MCP surface.

## Fixes a latent Phase 0 bug

The principal lives on the **request-scoped** `McpRequestContext`, not on the context the SDK hands a tool callback at dispatch time. `whoami` read the latter, so every real call would have returned "No OpenLinker principal on this request." Nothing caught it because #1486's int-spec asserted only *the absence of a 401*, never a successful result. The registry now threads the request-scoped context to every handler, and the int-spec asserts parsed success shapes.

## Testing

- **70 unit tests.** The registry spec targets the cases hand-written per-tool code gets wrong: a throwing handler still releases its slot *and* still emits an audit line; an over-limit call never reaches the handler; the raw bearer token never reaches the log.
- **6 integration cases** (`mcp-tools.int-spec.ts`) over real JSON-RPC: the gate reflects real DB connection state, `list_connections` doesn't leak credentials from a *persisted* connection, and a passing gate with no synced data returns an empty result rather than an error.
- `pnpm lint` / `type-check` / `test` green; **full `test:integration` green (86/86 suites, 507 passed)**. No migration — no schema change.

## Docs

`engineering-standards.md` registers the `*.tool.ts` convention (the issue assigned this here) with the rules that a tool carries only its read + projection, always projects, and only accepts arguments its read honours. `architecture-overview.md` documents the Phase 1 surface. Three `lessons.md` entries: the not-401-isn't-success trap; MCP revision `2026-07-28`'s per-request `_meta` envelope + agreeing `Mcp-Method`/`Mcp-Name` headers (each omission presents as a bare 400 that reads like an auth fault); and that `--testPathPattern` is silently ignored when a Jest config sets `testRegex`.

Closes #1487

🤖 Generated with [Claude Code](https://claude.com/claude-code)