### PR TITLE
test(e2e): characterization suite for bulk-wizard preflight divergences

### DIFF
--- a/apps/e2e/playwright.config.ts
+++ b/apps/e2e/playwright.config.ts
@@ -196,5 +196,19 @@ export default defineConfig({
       dependencies: ['setup'],
       use: { ...devices['Desktop Chrome'], storageState: STORAGE_STATE },
     },
+    {
+      // Preflight-divergence characterization suite. Each spec pins one place
+      // where the bulk offer wizard reports a row as ready and the backend then
+      // rejects it. These are CHARACTERIZATION tests: they pass while the
+      // divergence exists and fail once it is closed, so a red run here is the
+      // signal that a finding was wrong or has been fixed - not a regression.
+      // `retries: 0`: several specs submit real batches, and a silent retry
+      // would double-submit against the shared stack.
+      name: 'preflight-divergence',
+      testMatch: /preflight-divergence\/.*\.spec\.ts/,
+      retries: 0,
+      dependencies: ['setup'],
+      use: { ...devices['Desktop Chrome'], storageState: STORAGE_STATE },
+    },
   ],
 });

--- a/apps/e2e/tests/preflight-divergence/README.md
+++ b/apps/e2e/tests/preflight-divergence/README.md
@@ -1,0 +1,151 @@
+# Preflight divergence suite
+
+Playwright project: `preflight-divergence` (registered in `apps/e2e/playwright.config.ts`).
+
+Every spec in this directory pins ONE divergence between what the **bulk offer wizard promises before
+submit** and what the **backend actually does after it**. The findings are numbered F1…F15; one spec file
+per finding (`fNN-<slug>.spec.ts`).
+
+---
+
+## These are characterization tests. Read this before "fixing" a red run.
+
+A characterization test documents behaviour **as it is**, not as it should be. Every spec here is written
+so that it **PASSES while the divergence exists**.
+
+> **A red run in this suite is not a product regression.** It means one of three things:
+> 1. the finding was wrong in the first place,
+> 2. the divergence has been **closed** (someone fixed it) — the spec should then be retired, or *inverted*
+>    into an ordinary regression test that asserts the corrected behaviour, or
+> 3. the stack under test is a different build from the one the finding was verified against.
+>
+> Re-read the spec's file header before touching anything: each one states the source evidence (file, symbol,
+> commit) the claim rests on, and what a red run would mean for that particular finding.
+
+Each spec asserts **both halves** of its divergence — (a) what the wizard shows/sends, and (b) what the
+server/worker does with it — because a one-sided assertion cannot distinguish "the promise is wrong" from
+"the execution is wrong".
+
+---
+
+## Coverage matrix
+
+Status legend:
+
+| Label | Meaning |
+|---|---|
+| **CONFIRMED live** | Runs on the current stack and passes: the divergence is reproducible here. |
+| **NOT REPRODUCED** | Runs, but the asserted behaviour did not occur on this stack. |
+| **SKIPPED — blocked on fixture** | `test.skip(...)`: the catalogue/connection state the divergence needs does not exist here. |
+| **SKIPPED — fixed on this stack** | `test.skip(...)`: the deployed build no longer contains the backend half (the finding is closed *here*, not necessarily on `main`). |
+
+Statuses below were derived by reading each spec's header, assertions and `test.skip` messages, cross-checked
+against read-only fixture probes of the running stack on **2026-07-30**. Only **F15** was executed (twice,
+green). No full-suite run was performed — see the filtering trap below for why that matters.
+
+| # | What it pins | Spec | Status | Un-skip requirement |
+|---|---|---|---|---|
+| **F1** | The wizard's readiness only checks `section: 'product'` required params (`use-bulk-required-product-params.ts`); the builder rejects unresolved `section: 'offer'` params (`Stan`, id 11323). Green row → 202 → record `failed` / `PARAMETER_REQUIRED`. | `f01-offer-section-params.spec.ts` | CONFIRMED live | Needs an Allegro connection **and** a single-variant, not-yet-listed variant whose EAN resolves to a unique Allegro product **card** and whose matched category carries a required `section: 'offer'` param. Both present here (12 card-matched variants, 6 of them unlisted; category `261481` has required offer-param `Stan`). |
+| **F2** | Already-listed variants: the wizard shows them `ready` (its duplicate guard even promises "creates a duplicate offer"), `filterAlreadyListed` silently drops them → smaller batch, or a 400 naming `productId`s the operator never saw. | `f02-already-listed-dropped.spec.ts` | Tests 1–2 CONFIRMED live; **test 3 SKIPPED — blocked on fixture** | Test 3 ("an offer that is no longer live still blocks its variant forever") needs a variant that is (1) already listed on Allegro, (2) barcode-matched to a product card, **and** (3) carries an `offer_status_snapshots` row whose `publicationStatus` is **not** `active` (ranked preference `ended` > `removed` > `unpublished` > `inactive` > `draft`). To create it: end or deactivate one of that connection's offers on the marketplace, then run the `marketplace.offer.statusSync` job so the snapshot refreshes. Every snapshot on this stack is `active`. |
+| **F3** | Price `0`: no client-side floor on the flat-price config field or the row price editor, rows stay `ready`, then `@IsPositive()` 400s the WHOLE batch with an opaque `price: invalid value`. | `f03-zero-price.spec.ts` | CONFIRMED live | Test 1 needs a borrows-taxonomy `OfferCreator` destination (no `EanCategoryMatcher`) — the active Erli connection. Test 2 needs a taxonomy-owning destination (Allegro) plus a card-matched, priced, in-stock variant. Both present. |
+| **F4** | A destination missing `config.masterCatalogConnectionId`: 100 % green wizard, 202 accepted, then every child record `failed` / `MASTER_CATALOG_NOT_CONFIGURED` — the preflight never reads that key. | `f04-master-catalog-missing.spec.ts` | CONFIRMED live | Needs a borrows-taxonomy `OfferCreator` connection that **currently has** `masterCatalogConnectionId` set (so the spec can clear and restore it), plus one priced, in-stock, barcoded, not-yet-listed variant. Erli has it (`→ 29bf253f…`). |
+| **F5** | An Allegro connection with `sellerDefaults` never configured: nothing in the preflight looks at it, submit is accepted, then `AllegroOfferManagerAdapter.createOffer` fails every record with `SELLER_DEFAULTS_NOT_CONFIGURED`. Test 2 verifies the failure is at least *legible* in the batch table (the audit's downgrade). | `f05-seller-defaults.spec.ts` | CONFIRMED live | Needs an Allegro connection that **currently has** `sellerDefaults` (present) and one unlisted variant whose EAN resolves to an Allegro category. |
+| **F6** | *(authored in parallel — file not present in this working tree at the time of writing)* | `f06-*.spec.ts` | not landed yet | Re-run this matrix once `f06-*` lands and fill in its row. |
+| **F7** | Duplicate EAN, two independent halves: (a) the backend keys its seen-set on `ean.padStart(14,'0')` so `5901234500012` and `05901234500012` collide → 400, while the wizard keys the raw string and flags neither; (b) `duplicateEanVariantIds` is documented "batch-wide" but its only call site passes a single row, so a batch-wide duplicate is never surfaced. | `f07-duplicate-ean.spec.ts` | Test 1 CONFIRMED live; **test 2 SKIPPED — blocked on fixture** | Test 1 needs two unlisted variants of two *different* single-variant products (39 available). Test 2 needs two variants of two **different multi-variant** products carrying the **same** barcode — no such pair exists in this catalogue, and the PrestaShop master adapter cannot produce it (it only inherits a product-level EAN onto a variant when `combinations.length === 1`). Provision it from a master source that can write a duplicate barcode across products. |
+| **F8** | The two invisible `1000` limits (`EXPANDED_OFFER_CEILING` → 422, `excludedVariantIds @ArrayMaxSize(1000)` → 400), neither surfaced anywhere in the wizard. Test 1 deliberately asserts the *non*-divergence: the 100-product cap **is** mirrored client-side. | `f08-ceilings.spec.ts` | Tests 1–3 CONFIRMED live; **test 4 SKIPPED — blocked on fixture** (hard `test.skip(true, …)`) | Test 4 (the 422 expansion ceiling) needs a selection expanding to **more than 1000 sibling variants after exclusions**, while `productIds` is itself capped at **100** — i.e. > 1000 variants concentrated in ≤ 100 products (e.g. 100 products × 11 combinations). This stack's whole catalogue is far below that. Requires bulk PrestaShop/WooCommerce provisioning the suite does not have: `OL_PS_WEBSERVICE_KEY` is unset by default and the webservice helper cannot create combinations. |
+| **F9** | (1) `flat`/`cap` stock policies are offered for a multi-variant product and emitted per variant, then discarded — `buildEnqueueInput` uses `useMasterStock` for every sibling. (2) `publishEffective = stock > 0 ? publishImmediately : false` silently downgrades a zero-stock sibling to a draft, unlogged and unwarnable. | `f09-multivariant-stock-policy.spec.ts` | Tests 1–2 CONFIRMED live; **test 3 SKIPPED — blocked on fixture** (hard `test.skip(true, …)`) | Test 3 needs a **sibling of a multi-variant product whose master availability is 0** (or which has no inventory row at all — `masterAvailable ?? 0` collapses both). The operator-supplied stock cannot substitute: that is exactly the value half 1 proves is discarded. This stack has **zero** such siblings; its two zero-stock variants belong to *single*-variant products, where `useMasterStock` is false. Provisioning needs a PrestaShop **combination** set to 0 stock (`OL_PS_WEBSERVICE_KEY` unset by default; the webservice helper cannot address individual combinations). |
+| **F10** | Capability-discovery mismatch: the backend arms its category gate by **duck-typing the resolved adapter instance** (`isCategoryBrowser`/`isEanCategoryMatcher`), which Erli satisfies whenever Allegro category *credentials* exist; the wizard reads the **static manifest**, which never lists `EanCategoryMatcher`, so it suppresses every category blocker. Green rows → 202 → every child `failed` on `overrides.categoryId / REQUIRED`. Test 2 sharpens it: unchecking "Allegro category access" does **not** disarm the backend. | `f10-erli-category-gate.spec.ts` | CONFIRMED live | Test 1 needs an active Erli connection that omits `EanCategoryMatcher` from `supportedCapabilities` **and** can actually read Allegro category parameters (probe returns 200 here), plus an unlisted, priced, imaged product. Test 2 additionally needs `config.allegroCategoryAccessEnabled === true` (it is). |
+| **F11** | A master product name over 75 chars is never measured: the row is `ready` with no chip, the request carries **no** `title` override (so `@MaxLength(75)` cannot apply), and OL never measures the `product.name` the builder falls back to. The FE limit exists only inside the row editor. | `f11-title-overflow.spec.ts` | **SKIPPED — blocked on fixture** (by default) | Needs `OL_PS_WEBSERVICE_KEY` (+ a reachable PrestaShop base URL) so the spec can **provision** a fresh master product with a deliberately over-long name; there is no way to lengthen an existing name without mutating shared catalogue data. It also needs a master connection with `ProductMaster` actually *enabled*, and a barcode that resolves to an Allegro product card. Set `OL_PS_WEBSERVICE_KEY` in `apps/e2e/.env` to un-skip. **Separately masked:** the *final* consequence — "would the marketplace reject the over-long title?" — is unobservable, because F1's gate fires first: the record dies on `PARAMETER_REQUIRED` (offer-section `Stan`) before Allegro ever validates the title. The spec therefore asserts only what is observable (OL never reports a title problem, no offer is created) and records the real terminal reason in its `divergence` annotation. |
+| **F12 / F12b** | The wizard injects `overrides.categoryId` into the per-product (multi-variant *family pin*) and per-variant (*edited row*) override maps, while `PerVariantOverrideDto.overrides = OmitType(CreateOfferOverridesDto, ['categoryId'])` forbids it under `whitelist + forbidNonWhitelisted` → whole-request 400. | `f12-category-override-rejected.spec.ts` | **SKIPPED — fixed on this stack** | The spec's own contract probe reports that this build **accepts** `categoryId` in both override maps, so the backend half is absent here and there is nothing to characterize *on this stack*. That is the fix from **PR #1930** (`a9477d60`, branch `1924-bulk-category-per-family-per-variant`), which is exactly what the running stack is built from: the DTO restores `categoryId` at the HTTP boundary and moves the variant-tier decision into `BulkListingSubmitService.stripVariantCategoryId`. The finding remains **REAL on `origin/main`** (verified by source read). To exercise it, deploy a build of `main` and re-run. Distinguish builds by grepping the deployed dist: `stripVariantCategoryId` present ⇒ the fix; `excludedVariantIds` absent ⇒ a pre-#1741 build. **Note:** #1930's description does not mention the *edit-modal* path, so re-check **F12b** explicitly against a post-fix build before retiring it. |
+| **F13** | An included-but-**blocked** sibling reaches the server in *neither* channel: not in `excludedVariantIds`, not in `perVariantOverrides`. The only barrier is the review CTA's `disabled` attribute — there is no guard in `handleApproveAll`/`handleSubmit`, and `expandVariantJobs` expands the sibling anyway, minting a job + record for a variant the wizard itself declared unlistable. | `f13-blocked-not-excluded.spec.ts` | **SKIPPED — blocked on fixture** (on this stack) | Needs a multi-variant, not-yet-listed product with **at least one READY sibling alongside the blocked one** (otherwise the CTA reads `(0)` and `includedReady > 0` never holds). On this stack **no multi-variant product has a single card-linked sibling**, so every sibling carries the `needs-product-parameters` blocker until the editor is opened, and the ready-sibling precondition cannot be met. Un-skip by giving one sibling of a multi-variant product a barcode that resolves to an Allegro product **card** (card-linked rows are exempt from the required-product-parameter gate), or by mapping it into a category with no required product params. Test 2 replays the body captured by test 1 and is skipped with it. |
+| **F14** | The FE trims the EAN (`effectiveVariantEan` → `raw.trim()`) so ` 5901234123457` reads as a valid GTIN-13 and the row is `ready`; `enforceIdentifierRules` reads `variant.ean` **literally**, sees a 14-char non-numeric string, fails the GS1 check digit and 400s the whole request. Only reachable through the state F13 creates (no per-variant override sent). | `f14-ean-trim.spec.ts` | Tests 1–2 CONFIRMED live; **test 3 SKIPPED — blocked on fixture** (hard `test.skip(true, …)`) | The divergence is real at the line level but its **precondition is unreachable**: no stored master `ean`/`gtin` can carry whitespace, because `MasterProductSyncService` normalises every ingested barcode through `normalizeToEan13`/`normalizeBarcode` (`trim()` + `replace(/\D/g,'')`, null for any non-12/13 length). Test 1 pins that normalisation invariant, so F14 becomes live — and this file goes red — the day it is relaxed (a new master adapter writing raw barcodes, a direct write path, a widened normaliser). Reproducing it end-to-end needs a `ProductVariant` row whose persisted `ean` starts with whitespace **plus** the F13 state; only a direct DB write (forbidden on this shared stack) or a normaliser-bypassing adapter can produce it. |
+| **F15** | The multi-variant row editor emits a top-level `pricingPolicy` (and `stockPolicy`) inside the override map value; the DTO's per-map value class declares no such property, so `@ValidateRecordValues` (whitelist + `forbidNonWhitelisted`) 400s the whole request after a Review step that showed the row `ready`. | `f15-pricing-policy-rejected.spec.ts` | **CONFIRMED live** (executed 2026-07-30, both tests green) | Test 1 (contract probe) needs only an Allegro connection. Test 2 needs a **multi-variant**, not-yet-listed, priced master product whose row can be cleared through the editor — `pricingPolicy` is emitted only for `isMultiVariant`, so a single-variant product cannot exercise it. Three unlisted multi-variant products are available here. |
+
+---
+
+## Environment facts that bite
+
+### The stack under test is **not** `main`
+
+The running demo stack (`ol-demo-fresh-*`, web `http://localhost:8090`, API `http://localhost:3000`) is built
+from the worktree **`/home/nor/projekty/blocky/ol-1924` @ `c7dd586f`** — a branch, not `origin/main`. That is
+why F12 skips as *already fixed* (its fix, PR #1930, is on that branch) while the finding is still live on
+`main`.
+
+Consequences for anyone reading a run:
+
+- A **skip** may mean "this build already fixed it", not "the finding is wrong". Every such skip message names
+  how to tell the two apart.
+- When a spec header cites source, it cites **both** trees (`ol-1924` and `origin/main`) whenever they differ,
+  and says explicitly when they are identical.
+- Read `ol-1924` **read-only**; it is a different worktree and must not be edited from here.
+
+### `pnpm … --` does not filter
+
+```bash
+# ✗ runs the ENTIRE e2e suite — the `--` args are NOT forwarded as a filter
+pnpm --filter @openlinker/e2e test:e2e -- --project=preflight-divergence tests/preflight-divergence/f03-zero-price.spec.ts
+
+# ✓ run one spec
+cd apps/e2e && npx playwright test --project=preflight-divergence tests/preflight-divergence/f03-zero-price.spec.ts
+
+# ✓ run the whole project (slow; several specs hold 300–600 s budgets)
+cd apps/e2e && npx playwright test --project=preflight-divergence
+```
+
+Several specs walk the whole catalogue, provision master products, and wait on worker round-trips. On a
+resource-constrained machine, run one file at a time.
+
+### Page-object drift — why these specs re-implement locators locally
+
+`apps/e2e/src/pages/bulk-offer-wizard.page.ts` was written against an older build of the bulk wizard. It is
+**shared with other suites and must not be edited from this suite**, so each spec re-implements the drifted
+parts locally. Three drifts matter:
+
+1. **`needsAttentionCount()` fails open.** It assumes the old "N row(s) need attention" hint and parses the
+   **first** number it finds. The current Review step renders `N ready · M need attention · K excluded`
+   (`bulk-review-step.tsx`), so the parse returns the **ready** count. A ready batch therefore reports a
+   non-zero "needs attention", and `advanceToConfirmModal`'s needs-attention loop — which requires that number
+   to *drop* after each edit — throws instead. Specs here read the labelled numbers off the `role="status"`
+   summary (`(\d+)\s*need attention`, `(\d+)\s*ready`) rather than the first integer.
+2. **The Review submit CTA was renamed.** The page object's `approveAllButton` matches `/^Approve all \(\d+\)$/`;
+   the current build renders `Create offers (N)`. Specs use a tolerant
+   `/^(Approve all|Create offers)\s*\(\d+\)$/` — the `(N)` suffix is what stops it from also matching the
+   confirm modal's own bare `Create offers` button.
+3. **The destination picker changed shape.** `selectConnectionIfPresent` drives a `<select>` labelled
+   "Marketplace connection"; the Config step now renders a grouped **radio rail** (`PublishDestinationRail`)
+   when more than one publish destination exists, and a plain "Publishing as {name}" alert when there is only
+   one. Specs try the radio first and fall back to the page object's select path.
+
+A fourth, smaller drift: `fillRowEditor` clicks **"Save row"**; the current edit modal's commit button is
+**"Save all"** (`bulk-edit-modal.tsx`). Any spec that saves a row does so through its own locator.
+
+### Specs that mutate shared state (and how they put it back)
+
+| Spec | Mutation | Restore |
+|---|---|---|
+| `f04-master-catalog-missing.spec.ts` | Temporarily removes `masterCatalogConnectionId` from the destination connection's config (connection config is replaced wholesale, so the full object is rewritten). | Restored in a `finally`, re-read and asserted; a module-level `test.afterAll` re-asserts and repairs, failing loudly if the stack was left doctored. |
+| `f05-seller-defaults.spec.ts` | Temporarily removes `sellerDefaults` from the shared Allegro connection's config. | Restored in `test.afterAll` and verified by re-reading the connection. The spec refuses to run at all if the connection has no `sellerDefaults` to restore. |
+| `f10-erli-category-gate.spec.ts` (test 2) | Flips `config.allegroCategoryAccessEnabled` to `false` on the Erli connection. | Restored in a `finally` and asserted back to `true`. |
+| `f11-title-overflow.spec.ts` | **Creates** a PrestaShop master product with a deliberately over-long name, then runs master product + inventory sync. | **Not** restored — the webservice client has no delete, so the product is left behind (same posture as the golden path's `E2E_FRESH_PRODUCT` mode). It is recorded in a `fixture` annotation. Submitted with "Publish immediately" unchecked. |
+| `f02-already-listed-dropped.spec.ts` (test 1) | Creates ONE real offer — the surviving, not-already-listed variant. | Not undone; submitted as a **draft** ("Publish immediately" unchecked) so nothing goes live. |
+| `f09-multivariant-stock-policy.spec.ts` (test 1) | Submits ONE real batch. | Not undone; created as **drafts** (`publishImmediately: false`). |
+| `f13-blocked-not-excluded.spec.ts` (test 2) | Replays the captured wizard body against the live API, which is accepted (202) and mints a batch + child records. | Not undone; forced to `publishImmediately: false` before replay. Test 1 aborts its own POST at the network layer, so it creates nothing. |
+
+Everything else in this directory is read-only: `f01`, `f03`, `f07`, `f08`, `f12`, `f14`, `f15` either end in a
+400 (rejected in the validation pipe, before `bulkBatchRepository.create`) or never submit at all.
+
+---
+
+## Adding a finding
+
+1. One file, `fNN-<slug>.spec.ts`, in this directory.
+2. Header must state: the divergence in one sentence, the **source evidence** (file + symbol + commit/branch,
+   for `ol-1924` *and* `origin/main` when they differ), which halves are asserted, what a red run means, and
+   the fixture/side-effect policy.
+3. Assert **both** halves — what the wizard shows/sends **and** what the server does.
+4. Every `test.skip` message must be actionable: name the exact fixture or state needed to un-skip, and how to
+   create it. A skip that only says "no fixture" is a bug in the spec.
+5. Do not edit `apps/e2e/src/**` or `playwright.config.ts` from this suite — re-implement drifted locators
+   locally and document the drift here.
+6. Add a row to the matrix above.

--- a/apps/e2e/tests/preflight-divergence/__proof__/README.md
+++ b/apps/e2e/tests/preflight-divergence/__proof__/README.md
@@ -1,0 +1,109 @@
+# Proof screenshots - preflight divergence
+
+Embeddable evidence for the findings pinned by `../fNN-*.spec.ts`. Each image is captured by the
+characterization spec itself, through `captureProof` (`./capture.ts`), while the spec runs against a live
+stack.
+
+**These are `before` shots: they are taken while the divergence still exists.** The `before` segment in every
+filename is deliberate - once a finding is fixed, the same specs are re-run to produce the `-after-`
+counterpart, and the two sit side by side in the issue / PR.
+
+Each finding gets a pair:
+
+| Frame | What it must show |
+|---|---|
+| `fNN-before-review-ready.png` | The Review step **presenting the row(s) as ready**: the `N ready · M need attention · K excluded` summary and the `Create offers (N)` CTA - the promise. |
+| `fNN-before-result.png` | What actually happened: the 400 banner in the confirm modal, or the batch-progress row `failed` with its error code, or (F6) the batch stuck on `Queued`. |
+
+Capture is documentation, never an assertion: `captureProof` swallows every error and returns `null`, so a
+missing image can never turn a spec red. The flip side is that **a green run does not imply an image** - a
+spec that `test.skip`s never reaches its capture call. Always `ls` this directory after a run.
+
+---
+
+## Status of this directory
+
+> ⚠️ **No `before` images have been produced yet.** They could not be captured on 2026-07-30: the
+> `ol-demo-fresh` stack (web `http://localhost:8090`, API `http://localhost:3000`) was re-deployed that
+> morning from `/home/nor/projekty/blocky/ol-1689` onto a **new, empty Postgres volume**
+> (`ol-demo-fresh_postgres-data`; the previous data is still in `ol-demo-fresh_postgres_data`). The fresh
+> database holds exactly **one** connection - the PrestaShop master - so the **Allegro and Erli destinations
+> every one of these specs needs are gone**, and all eleven self-skip in ~2 s with
+> `no Allegro connection on this stack` / `No active OfferCreator connection …`.
+>
+> The capture path itself is verified end-to-end (region shot, viewport fallback when the region never
+> appears, and a deliberately-throwing `prepare` returning `null` with a `[proof] could not capture …`
+> warning). Only the fixtures are missing.
+>
+> **To produce the images:** restore a stack that carries an active Allegro connection *and* an active Erli
+> connection with Allegro category credentials (that is what arms F6 / F10), then run the commands below.
+> The suite reads `OL_WEB_URL`, `OL_API_URL`, `OL_ADMIN_USER`, `OL_ADMIN_PASS`, so it can be pointed at any
+> stack without editing a file.
+
+---
+
+## Index
+
+Fill the Status column in as images land. "Pending" = not yet captured on any stack.
+
+| Image | Finding | What it shows | Captured by | Status |
+|---|---|---|---|---|
+| `f01-before-review-ready.png` | F1 | A card-linked row counted ready, `0 need attention`, submit enabled - though its category has a required **offer-section** parameter the wizard never checks. | `f01-offer-section-params.spec.ts`, test 1 | Pending |
+| `f01-before-result.png` | F1 | The batch it produced: every child `failed`, failure-details panel open on `PARAMETER_REQUIRED` / `parameters.Stan`. | same test, after the batch terminates | Pending |
+| `f02-before-review-ready.png` | F2 | Already-listed variants counted **ready** with the "already on {destination}" chip, submit enabled. | `f02-already-listed-dropped.spec.ts`, test 2 | Pending |
+| `f02-before-result.png` | F2 | The confirm modal's red alert: 400 `at least one productId` - the backend dropped every variant it had just called ready. | same test | Pending |
+| `f03-before-review-ready.png` | F3 | Flat price `0` accepted with no field error, rows ready, submit enabled. | `f03-zero-price.spec.ts`, test 1 | Pending |
+| `f03-before-result.png` | F3 | The confirm modal's red alert: whole-batch 400 with the opaque `price: invalid value`. | same test | Pending |
+| `f04-before-review-ready.png` | F4 | 100 % green Review while the destination has **no** `masterCatalogConnectionId` (temporarily cleared by the spec, restored after). | `f04-master-catalog-missing.spec.ts` | Pending |
+| `f04-before-result.png` | F4 | The batch: every record `failed` / `MASTER_CATALOG_NOT_CONFIGURED` on `connection.config.masterCatalogConnectionId`. | same test | Pending |
+| `f05-before-result.png` | F5 | Batch progress after an accepted submit: per-record failure + expanded `SELLER_DEFAULTS_NOT_CONFIGURED` detail. | `f05-seller-defaults.spec.ts`, test 2 | Pending |
+| `f06-before-review-ready.png` | F6 | An Erli row whose entire image set is a single `http://` URL, counted ready, submit enabled. | `f06-erli-image-stuck-pending.spec.ts`, test (a) | Pending |
+| `f06-before-result.png` | F6 | The batch that can never terminate: the row still reads **Queued**, no failure-details affordance, no inline reason. | same file, test (b) | Pending |
+| `f07-before-review-ready.png` | F7 | Two included rows carrying the **same** barcode, neither flagged - the duplicate check is never batch-wide. | `f07-duplicate-ean.spec.ts`, test 2 | Pending (fixture) |
+| `f09-before-review-ready.png` | F9 | Review showing the operator's flat stock (`777`) per sibling of a multi-variant product - the value the backend discards. | `f09-multivariant-stock-policy.spec.ts`, test 2 | Pending |
+| `f10-before-review-ready.png` | F10 | Every Erli row ready, `0 need attention`, submit enabled - no category blocker anywhere. | `f10-erli-category-gate.spec.ts`, test 1 | Pending |
+| `f10-before-result.png` | F10 | The batch: every child `failed` / `overrides.categoryId` `REQUIRED`. | same test | Pending |
+| `f13-before-review-ready.png` | F13 | The blocked sibling flagged **and still switched on**, beside a ready sibling; the CTA's `disabled` attribute is the only barrier. | `f13-blocked-not-excluded.spec.ts`, test 1 | Pending |
+| `f13-before-result.png` | F13 | The batch minted from that body - a record exists for the blocked sibling the wizard refused to approve. | same file, test 2 | Pending |
+| `f15-before-review-ready.png` | F15 | A multi-variant row still `ready` after a Price-policy edit, submit enabled. | `f15-pricing-policy-rejected.spec.ts`, test 2 | Pending |
+| `f15-before-result.png` | F15 | The confirm modal's red alert: whole-request 400, `perProductOverrides[…].pricingPolicy: property pricingPolicy should not exist`. | same test | Pending |
+
+### Findings with only one frame (by construction, not by omission)
+
+| Finding | Missing frame | Why |
+|---|---|---|
+| **F5** | `review-ready` | The spec submits through the raw API on purpose. The wizard has **no** seller-defaults preflight to photograph - that absence is the finding, and a screenshot of an unrelated Review step would misrepresent it. |
+| **F7** | `result` | F7's confirmed half is a wire-level 400 (`DuplicateBatchEanException`) raised before anything is persisted; there is no screen. The scope half (test 2) never submits. |
+| **F9** | `result` | The discard is only visible in the persisted offer-creation request snapshot (`request.stock`); no screen renders it - the batch-progress table has no stock column. |
+
+F8, F11, F12 and F14 are out of scope for proof: they are skipped, fixed on this build, or blocked on a
+fixture, so there is nothing to photograph.
+
+---
+
+## Regenerating
+
+Run **one spec at a time** - `f04`, `f05` and `f10` mutate shared connection config and restore it, and a
+parallel run would collide on the same connections. `pnpm --filter @openlinker/e2e test:e2e -- <args>`
+does **not** forward the filter; use `npx` directly from `apps/e2e`:
+
+```bash
+cd apps/e2e
+npx playwright test --project=preflight-divergence tests/preflight-divergence/f01-offer-section-params.spec.ts
+npx playwright test --project=preflight-divergence tests/preflight-divergence/f02-already-listed-dropped.spec.ts
+npx playwright test --project=preflight-divergence tests/preflight-divergence/f03-zero-price.spec.ts
+npx playwright test --project=preflight-divergence tests/preflight-divergence/f04-master-catalog-missing.spec.ts
+npx playwright test --project=preflight-divergence tests/preflight-divergence/f05-seller-defaults.spec.ts
+npx playwright test --project=preflight-divergence tests/preflight-divergence/f06-erli-image-stuck-pending.spec.ts
+npx playwright test --project=preflight-divergence tests/preflight-divergence/f07-duplicate-ean.spec.ts
+npx playwright test --project=preflight-divergence tests/preflight-divergence/f09-multivariant-stock-policy.spec.ts
+npx playwright test --project=preflight-divergence tests/preflight-divergence/f10-erli-category-gate.spec.ts
+npx playwright test --project=preflight-divergence tests/preflight-divergence/f13-blocked-not-excluded.spec.ts
+npx playwright test --project=preflight-divergence tests/preflight-divergence/f15-pricing-policy-rejected.spec.ts
+
+ls -la tests/preflight-divergence/__proof__/   # a green run does NOT imply an image
+```
+
+Each command overwrites its own images in place, so a re-run refreshes them without stale leftovers. After a
+fix lands, change the `before` literal in that spec's `captureProof(...)` calls to `after` and re-run the
+same command to produce the counterpart frames.

--- a/apps/e2e/tests/preflight-divergence/__proof__/capture.ts
+++ b/apps/e2e/tests/preflight-divergence/__proof__/capture.ts
@@ -1,0 +1,108 @@
+/**
+ * Proof-screenshot helper for the preflight-divergence suite
+ *
+ * The specs in this directory are characterization tests: each pins one place
+ * where the bulk offer wizard reports a row as READY and the backend then
+ * refuses it. `captureProof` writes the two frames that make that contradiction
+ * legible in an issue / PR - the Review step that promised, and the 400 banner /
+ * failed batch row that followed - next to this file.
+ *
+ * Contract:
+ *   - it NEVER throws and never fails a spec. Every capture is best-effort: a
+ *     missing locator, a navigation error or a filesystem problem is swallowed
+ *     and reported as `null`, because a capture is documentation, not an
+ *     assertion.
+ *   - it writes `<name>.png` into this directory, so the filename IS the
+ *     convention: `fNN-before-review-ready.png` / `fNN-before-result.png` while
+ *     the divergence exists, `-after-` once it is fixed and the same specs are
+ *     re-run.
+ *   - dependency-free (Playwright + node stdlib only) and it touches nothing
+ *     outside `tests/preflight-divergence/`.
+ *
+ * @module tests/preflight-divergence/__proof__
+ */
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { Locator, Page } from '@playwright/test';
+
+/** Directory this file lives in - every proof image is written beside it. */
+const PROOF_DIR = dirname(fileURLToPath(import.meta.url));
+
+/** How long to wait for a requested region to become visible before falling back. */
+const REGION_TIMEOUT_MS = 10_000;
+
+export interface CaptureProofOptions {
+  /**
+   * Frame this element instead of the viewport (a CSS selector or a Locator).
+   * A tight region keeps the decisive text - the readiness counts, the CTA
+   * label, the error code - legible at issue-embed width. When the region is
+   * missing or invisible the capture silently falls back to the viewport.
+   */
+  region?: Locator | string;
+  /**
+   * Work to do inside the same guarded block right before the shot (navigate to
+   * the batch page, expand a failure-details panel, scroll something into
+   * view). A throw here aborts the capture, never the spec.
+   */
+  prepare?: () => Promise<void>;
+  /** Capture the whole scrollable page rather than the viewport. Ignored when `region` is set. */
+  fullPage?: boolean;
+}
+
+/**
+ * Write one proof screenshot. Returns the file path, or `null` when nothing
+ * could be captured (the reason is printed as a warning).
+ *
+ * @param page  the live page
+ * @param name  file stem, e.g. `f01-before-review-ready` (no extension)
+ */
+export async function captureProof(
+  page: Page,
+  name: string,
+  options: CaptureProofOptions = {},
+): Promise<string | null> {
+  const path = join(PROOF_DIR, `${name}.png`);
+  try {
+    if (options.prepare !== undefined) {
+      await options.prepare();
+    }
+
+    const region = resolveRegion(page, options.region);
+    if (region !== null) {
+      const target = region.first();
+      const visible = await target
+        .waitFor({ state: 'visible', timeout: REGION_TIMEOUT_MS })
+        .then(() => true)
+        .catch(() => false);
+      if (visible) {
+        await target.screenshot({ path, timeout: 30_000 });
+        return path;
+      }
+    }
+
+    await page.screenshot({ path, fullPage: options.fullPage ?? false, timeout: 30_000 });
+    return path;
+  } catch (error) {
+    console.warn(`[proof] could not capture "${name}": ${describe(error)}`);
+    return null;
+  }
+}
+
+/**
+ * The Review step's decisive region: the header (with the `Create offers (N)`
+ * CTA), the `N ready · M need attention · K excluded` summary, and the row
+ * table - i.e. everything the operator reads before committing. Resolved as the
+ * summary's parent because the step has no single root class.
+ */
+export function reviewRegion(page: Page): Locator {
+  return page.locator('.bulk-review__summary').locator('..');
+}
+
+function resolveRegion(page: Page, region: Locator | string | undefined): Locator | null {
+  if (region === undefined) return null;
+  return typeof region === 'string' ? page.locator(region) : region;
+}
+
+function describe(error: unknown): string {
+  return error instanceof Error ? error.message.split('\n')[0] : String(error);
+}

--- a/apps/e2e/tests/preflight-divergence/f01-offer-section-params.spec.ts
+++ b/apps/e2e/tests/preflight-divergence/f01-offer-section-params.spec.ts
@@ -1,0 +1,417 @@
+/**
+ * F1 - the wizard only ever checks `section: 'product'` required parameters
+ *
+ * ⚠️ CHARACTERIZATION TEST. This spec passes **while the divergence exists** and
+ * goes RED once it is closed. A failure here is NOT a regression - it means the
+ * finding was wrong, or it has been fixed and this file should be retired (or
+ * inverted into a normal regression test).
+ *
+ * The divergence: the backend's second offer-build gate
+ * (`OfferBuilderService.buildOfferParameters`) rejects an offer whose category
+ * has an unresolved REQUIRED parameter in the **offer** section -
+ * `PARAMETER_REQUIRED` on e.g. `parameters.Stan` (id 11323). The wizard's
+ * readiness computation never looks at that section:
+ * `use-bulk-required-product-params.ts` filters
+ * `p.required && p.section === 'product' && !p.dependsOn`, and that set is the
+ * ONLY input to the `allegro:needs-product-parameters` blocker. The two sets are
+ * disjoint, so a row whose offer-section parameters are entirely unsupplied is
+ * rendered `ready`.
+ *
+ * The failure lands on a row the operator never opens. A row that IS edited is
+ * safe by accident: the edit modal fetches the schema itself and renders EVERY
+ * section, so filling it satisfies the gate. The regression came in with #1754
+ * (5fa88bbe), which removed the single-offer wizard - the only surface that
+ * hard-gated submit on the full parameter schema AND auto-prefilled `Stan`.
+ *
+ * The test asserts BOTH sides:
+ *   (a) the wizard shows the row ready and enables submit, with no editor
+ *       opened, and the submitted override carries no value for the required
+ *       offer-section parameter, AND
+ *   (b) the batch is accepted (202) and its child record terminates `failed`
+ *       with `PARAMETER_REQUIRED` on that exact parameter.
+ *
+ * @module tests/preflight-divergence
+ */
+import { test, expect } from '../../src/fixtures/test';
+import type { ApiClient } from '../../src/api/api-client';
+import type { CategoryParameter, Connection, Product, ProductVariant } from '../../src/api/api.types';
+import type { E2eEnv } from '../../src/config/env';
+import type { World } from '../../src/world/world';
+import type { BulkOfferWizard } from '../../src/pages/bulk-offer-wizard.page';
+import type { Poller } from '../../src/support/poller';
+import { captureProof, reviewRegion } from './__proof__/capture';
+
+/** Terminal batch statuses (mirror of `BulkBatchStatus`). */
+const TERMINAL_BATCH_STATUSES = new Set(['completed', 'partially-failed', 'failed']);
+
+/** `BulkBatchRecordSummaryDto.errors` - on the wire, absent from the shared local type. */
+interface RecordError {
+  field?: string | null;
+  code: string;
+  message: string;
+}
+
+async function bearer(env: E2eEnv): Promise<string> {
+  const response = await fetch(`${env.apiUrl}/v1/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: env.adminUser, password: env.adminPass }),
+  });
+  if (!response.ok) {
+    throw new Error(`E2E login failed: HTTP ${response.status} ${await response.text()}`);
+  }
+  return ((await response.json()) as { access_token: string }).access_token;
+}
+
+interface EanMatchLike {
+  kind: string;
+  allegroCategoryId?: string | null;
+  productCardId?: string | null;
+}
+
+/** Run the wizard's own Resolve-step query for one variant. */
+async function resolveCategory(
+  env: E2eEnv,
+  token: string,
+  connectionId: string,
+  variant: ProductVariant,
+  sourceCategoryIds: string[],
+): Promise<EanMatchLike | undefined> {
+  const response = await fetch(
+    `${env.apiUrl}/v1/listings/connections/${connectionId}/categories/resolve-batch`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify({
+        items: [
+          {
+            variantId: variant.id,
+            ean: variant.ean ?? variant.gtin ?? null,
+            ...(sourceCategoryIds.length > 0 ? { sourceCategoryIds } : {}),
+          },
+        ],
+      }),
+    },
+  );
+  if (!response.ok) return undefined;
+  const body = (await response.json()) as { results?: Record<string, EanMatchLike> };
+  return body.results?.[variant.id];
+}
+
+/** Every variant id that already carries an offer mapping on `connectionId`. */
+async function listedVariantIds(api: ApiClient, connectionId: string): Promise<Set<string>> {
+  const ids = new Set<string>();
+  let offset = 0;
+  for (;;) {
+    const page = await api.listings.list({ connectionId, limit: 100, offset });
+    for (const mapping of page.items) ids.add(mapping.internalId);
+    offset += 100;
+    if (page.items.length === 0 || offset >= page.total) break;
+  }
+  return ids;
+}
+
+/** The product's source-platform category ids (on the wire, absent from the local type). */
+function sourceCategoryIds(product: Product): string[] {
+  const categories = (product as unknown as { categories?: unknown }).categories;
+  return Array.isArray(categories) ? categories.map(String) : [];
+}
+
+interface Fixture {
+  product: Product;
+  variant: ProductVariant;
+  categoryId: string;
+  /** A REQUIRED parameter in the `offer` section of `categoryId`. */
+  offerParameter: CategoryParameter;
+}
+
+/**
+ * Find the shortest reproduction from the finding: a variant whose EAN gives a
+ * UNIQUE Allegro catalogue-card match. A card-linked row is exempt from
+ * `computeNeedsProductParameters` and its category is dropped from
+ * `noCardCategoryIds`, so the wizard never even fetches a schema for it - the
+ * row is unconditionally green - while the backend still demands the category's
+ * required offer-section parameters.
+ *
+ * Already-listed variants are excluded: `filterAlreadyListed` would silently
+ * drop them (F2's own divergence) and the batch would 400 instead.
+ */
+async function findCardLinkedFixture(
+  env: E2eEnv,
+  token: string,
+  api: ApiClient,
+  world: World,
+  connectionId: string,
+): Promise<Fixture | undefined> {
+  const listed = await listedVariantIds(api, connectionId);
+  for (const summary of await world.listProducts(60)) {
+    const product = await api.products.getById(summary.id);
+    const variants = product.variants ?? [];
+    // Single-variant only: a multi-variant row additionally triggers the F12
+    // family-category pin, which would change WHICH divergence fires first.
+    if (variants.length !== 1) continue;
+    const variant = variants[0];
+    if (listed.has(variant.id)) continue;
+    if (!(variant.ean ?? variant.gtin)) continue;
+
+    const match = await resolveCategory(env, token, connectionId, variant, sourceCategoryIds(product));
+    if (match?.kind !== 'matched') continue;
+    const categoryId = match.allegroCategoryId ?? '';
+    // A NON-EMPTY productCardId is what makes the row card-linked (and so
+    // exempt from every FE parameter blocker).
+    if (categoryId === '' || !match.productCardId) continue;
+
+    const parameters = await api.listings.categoryParameters(connectionId, categoryId);
+    const offerParameter = parameters.find((p) => p.required && p.section === 'offer');
+    if (!offerParameter) continue;
+
+    return { product, variant, categoryId, offerParameter };
+  }
+  return undefined;
+}
+
+/**
+ * The Review step's submit CTA, tolerant of both label generations: the build
+ * this suite's page object was written against renders "Approve all (N)", the
+ * current one renders "Create offers (N)". The `(N)` suffix is what keeps this
+ * from also matching the confirm modal's own bare "Create offers" button.
+ */
+function submitCta(page: import('@playwright/test').Page): import('@playwright/test').Locator {
+  return page.getByRole('button', { name: /^(Approve all|Create offers)\s*\(\d+\)$/ });
+}
+
+/**
+ * Read the Review step's readiness counters straight off its `role="status"`
+ * summary. The shared page object's `needsAttentionCount()` assumes the older
+ * "N row(s) need attention" phrasing and parses the FIRST number in the hint;
+ * the current build renders "N ready · M need attention · K excluded", so that
+ * parse returns the READY count. Anchor on the labelled number instead.
+ */
+async function readinessCounts(
+  page: import('@playwright/test').Page,
+): Promise<{ ready: number; needAttention: number; raw: string }> {
+  const hint = page.getByRole('status').filter({ hasText: /needs? attention/ }).first();
+  if ((await hint.count()) === 0) return { ready: 0, needAttention: 0, raw: '(no readiness hint)' };
+  const raw = (await hint.innerText()).replace(/\s+/g, ' ').trim();
+  const attention = /(\d+)\s+needs?\s+attention/i.exec(raw);
+  const ready = /(\d+)\s+ready/i.exec(raw);
+  return {
+    ready: ready ? Number(ready[1]) : 0,
+    needAttention: attention ? Number(attention[1]) : 0,
+    raw,
+  };
+}
+
+/**
+ * Pick the destination connection on the Config step.
+ *
+ * The step renders a grouped RADIO RAIL (`PublishDestinationRail`) when more
+ * than one publish destination exists, and a plain "Publishing as {name}" alert
+ * when there is only one - the shared page object's `<select>` path
+ * (`selectConnectionIfPresent`) only covers the older select-based layout, so
+ * try the rail first and fall back to it. Kept local per the suite's rule that
+ * a divergence spec must not edit shared page objects.
+ */
+async function selectDestination(
+  page: import('@playwright/test').Page,
+  wizard: BulkOfferWizard,
+  connectionName: string,
+): Promise<void> {
+  const escaped = connectionName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const radio = page.getByRole('radio', { name: new RegExp(escaped) });
+  if ((await radio.count()) > 0) {
+    await radio.first().click();
+    return;
+  }
+  await wizard.selectConnectionIfPresent(connectionName);
+}
+
+/**
+ * Wait until the Review step has SETTLED - the async per-category parameter
+ * schema has resolved and the row blockers reflect it. Mirrors the page
+ * object's own (private) settle gate so a transient "0 need attention, submit
+ * disabled" limbo is never read as readiness, but against the local
+ * build-tolerant locators above.
+ */
+async function waitForReviewSettled(page: import('@playwright/test').Page): Promise<void> {
+  await expect(async () => {
+    const cta = submitCta(page).first();
+    if ((await cta.count()) === 0) {
+      throw new Error('Review step has not rendered its submit CTA yet.');
+    }
+    const [enabled, counts] = await Promise.all([cta.isEnabled(), readinessCounts(page)]);
+    if (!enabled && counts.needAttention === 0) {
+      throw new Error(`Review still resolving: submit disabled with no needs-attention rows (${counts.raw}).`);
+    }
+  }).toPass({ timeout: 60_000 });
+}
+
+/** Every `overrides.parameters` entry submitted for `variantId`, across both maps. */
+function submittedParameters(body: unknown, variantId: string): { id?: string; name?: string }[] {
+  const request = body as Record<string, unknown>;
+  const collected: { id?: string; name?: string }[] = [];
+  for (const map of ['perProductOverrides', 'perVariantOverrides']) {
+    const entries = request[map];
+    if (typeof entries !== 'object' || entries === null) continue;
+    const entry = (entries as Record<string, unknown>)[variantId] as
+      | { overrides?: { parameters?: unknown } }
+      | undefined;
+    const parameters = entry?.overrides?.parameters;
+    if (Array.isArray(parameters)) collected.push(...(parameters as { id?: string; name?: string }[]));
+  }
+  return collected;
+}
+
+function platformConfig(connection: Connection): {
+  requiresDeliveryPolicy?: boolean;
+  requiresErliBuyabilityFields?: boolean;
+} {
+  return connection.platformType === 'erli'
+    ? { requiresErliBuyabilityFields: true }
+    : { requiresDeliveryPolicy: true };
+}
+
+test.describe('F1 - offer-section required parameters have no wizard-side counterpart', () => {
+  test('a card-linked row is green, submits 202, and its record fails PARAMETER_REQUIRED', async ({
+    env,
+    api,
+    world,
+    page,
+    pages,
+    poll,
+  }: {
+    env: E2eEnv;
+    api: ApiClient;
+    world: World;
+    page: import('@playwright/test').Page;
+    pages: import('../../src/pages').PageObjects;
+    poll: Poller;
+  }) => {
+    // Fixture resolution walks the catalogue and runs the real category-resolution
+    // chain per candidate, then waits on a worker round-trip - well past the
+    // suite's default 90s per-test budget. Local to this spec (the shared
+    // playwright.config is not touched).
+    test.setTimeout(300_000);
+    const allegro = world.connectionFor('allegro');
+    test.skip(!allegro, 'no Allegro connection on this stack');
+
+    const token = await bearer(env);
+    const fixture = await findCardLinkedFixture(env, token, api, world, allegro!.id);
+    test.skip(
+      !fixture,
+      'No usable fixture: this stack has no SINGLE-VARIANT master product that is (a) not yet ' +
+        'listed on the Allegro connection, (b) whose EAN resolves to a UNIQUE Allegro catalogue ' +
+        'product card (resolve-batch kind="matched" with a non-empty productCardId), and (c) ' +
+        'whose matched category carries a required section="offer" parameter. Create one by ' +
+        'importing a simple PrestaShop product whose ean13 is a real GS1 barcode present in the ' +
+        'Allegro (sandbox) catalogue - e.g. 3165140846264, which matches category 252043 whose ' +
+        '"Stan" (id 11323) is required + section="offer" - then run master.product.syncAll. ' +
+        'Without a card link the wizard raises its own needs-product-parameters blocker and the ' +
+        'row is no longer submittable un-edited, which is a different scenario.',
+    );
+
+    await page.goto(`/listings/bulk-create/wizard?productIds=${fixture!.product.id}`);
+    const wizard = pages.bulkOfferWizard;
+    await wizard.expectOnConfigStep();
+    await selectDestination(page, wizard, allegro!.name);
+
+    // Deliberately NO row editing - the edit modal renders every parameter
+    // section and would satisfy the backend gate, hiding the divergence.
+    await wizard.completePlatformConfig(platformConfig(allegro!));
+    await expect(wizard.proceedButton).toBeEnabled({ timeout: 30_000 });
+    await wizard.proceedButton.click();
+    await expect(submitCta(page).first()).toBeVisible({ timeout: 60_000 });
+    await waitForReviewSettled(page);
+
+    // ── (a) The wizard reports the row as ready ────────────────────────────
+    expect(
+      (await readinessCounts(page)).needAttention,
+      `the wizard flags nothing on a row whose category (${fixture!.categoryId}) requires the ` +
+        `offer-section parameter "${fixture!.offerParameter.name}" (id ${fixture!.offerParameter.id})`,
+    ).toBe(0);
+    await expect(
+      submitCta(page).first(),
+      'the wizard enables submit - the row reads "ready"',
+    ).toBeEnabled();
+
+    // PROOF (documentation only - never asserted on): the promise.
+    await captureProof(page, 'f01-before-review-ready', { region: reviewRegion(page) });
+
+    await submitCta(page).first().click();
+    await expect(wizard.confirmModalConfirmButton).toBeVisible();
+    await wizard.publishImmediatelyCheckbox.check();
+
+    const submitted = page.waitForResponse(
+      (response) =>
+        response.request().method() === 'POST' && response.url().includes('/listings/bulk-create'),
+      { timeout: 60_000 },
+    );
+    await wizard.confirmModalConfirmButton.click();
+    const response = await submitted;
+
+    // The submitted override carries no value for the parameter the backend
+    // is about to demand - the wizard never asked for it.
+    const requestBody: unknown = JSON.parse(response.request().postData() ?? '{}');
+    const parameters = submittedParameters(requestBody, fixture!.variant.id);
+    expect(
+      parameters.some(
+        (p) => p.id === fixture!.offerParameter.id || p.name === fixture!.offerParameter.name,
+      ),
+      `the batch is submitted without a value for "${fixture!.offerParameter.name}"`,
+    ).toBe(false);
+
+    // ── (b) The server accepts the batch, then the record dies on it ───────
+    expect(
+      response.status(),
+      'the submit is accepted - the divergence surfaces later, per record',
+    ).toBeGreaterThanOrEqual(200);
+    expect(response.status()).toBeLessThan(300);
+
+    // Confirm was already clicked above (to capture the request), so just wait
+    // for the redirect the wizard performs on a 2xx.
+    await page.waitForURL(/\/listings\/bulk-batches\/[^/]+$/, { timeout: 30_000 });
+    const batchId = pages.bulkBatchProgress.batchId;
+    expect(batchId, 'a batch id is minted - the request was NOT rejected').toBeTruthy();
+
+    const batch = await poll.until(
+      () => api.listings.getBulkBatch(batchId),
+      (summary) => TERMINAL_BATCH_STATUSES.has(summary.status),
+      { message: `bulk batch ${batchId} to reach a terminal status`, timeoutMs: 180_000 },
+    );
+
+    // PROOF (documentation only): what actually happened to the "ready" batch.
+    await captureProof(page, 'f01-before-result', {
+      fullPage: true,
+      prepare: async () => {
+        await page.goto(`/listings/bulk-batches/${batchId}`);
+        await page.locator('button[aria-label^="Failure details for"]').first().click();
+        await expect(page.locator('.bulk-batch__err-list').first()).toBeVisible({
+          timeout: 15_000,
+        });
+      },
+    });
+
+    const errors = batch.records.flatMap(
+      (record) => ((record as unknown as { errors?: RecordError[] | null }).errors ?? []),
+    );
+    expect(
+      batch.failedCount,
+      `every child of the batch the wizard called ready should fail. Records: ${JSON.stringify(
+        batch.records.map((r) => ({
+          variant: r.internalVariantId,
+          status: r.status,
+          errors: (r as unknown as { errors?: RecordError[] | null }).errors,
+        })),
+      )}`,
+    ).toBeGreaterThan(0);
+    expect(
+      errors.some(
+        (error) =>
+          error.code === 'PARAMETER_REQUIRED' &&
+          (error.field ?? '').includes(fixture!.offerParameter.name),
+      ),
+      `a record fails with PARAMETER_REQUIRED on parameters.${fixture!.offerParameter.name}. ` +
+        `Observed: ${JSON.stringify(errors)}`,
+    ).toBe(true);
+  });
+});

--- a/apps/e2e/tests/preflight-divergence/f02-already-listed-dropped.spec.ts
+++ b/apps/e2e/tests/preflight-divergence/f02-already-listed-dropped.spec.ts
@@ -1,0 +1,626 @@
+/**
+ * F2 - already-listed variants: the wizard promises a duplicate, the backend drops them
+ *
+ * CHARACTERIZATION TEST. Every test here asserts BOTH sides of one divergence:
+ *   (a) the bulk offer wizard presents the row as `ready` and lets the operator
+ *       submit (its duplicate guard even promises "creates a duplicate offer"), AND
+ *   (b) the backend silently removes those variants from the submission
+ *       (`filterAlreadyListed` in `BulkListingSubmitService`) - so the batch is
+ *       smaller than the wizard promised, or the whole request 400s with a
+ *       message about `productId`s the operator never saw.
+ *
+ * These tests PASS while the divergence exists. A failure here means the finding
+ * was wrong or the divergence has been closed (e.g. the preflight now excludes
+ * already-listed variants, the response reports which variants were dropped, or
+ * a force/allow-duplicates flag reaches the server). In that case re-read the
+ * finding before "fixing" the test.
+ *
+ * Fixture policy: nothing is mutated except the batch each scenario submits.
+ * Scenario 1 legitimately creates ONE real offer (that is the surviving variant);
+ * it is submitted with "Publish immediately" unchecked so the destination gets a
+ * draft. Scenarios 2 and 3 never reach the worker - they end in a 400.
+ *
+ * @module tests/preflight-divergence
+ */
+import type { Locator, Page } from '@playwright/test';
+import { test, expect } from '../../src/fixtures/test';
+import type { ApiClient } from '../../src/api/api-client';
+import type { Connection, Product, ProductVariant } from '../../src/api/api.types';
+import type { E2eEnv } from '../../src/config/env';
+import type { World } from '../../src/world/world';
+import { captureProof, reviewRegion } from './__proof__/capture';
+
+test.describe.configure({ mode: 'serial', timeout: 300_000 });
+
+/* ────────────────────────── local fixture discovery ────────────────────────── */
+
+interface VariantCandidate {
+  productId: string;
+  variantId: string;
+  ean: string;
+  price: number;
+  stock: number;
+}
+
+/**
+ * A destination whose wizard rows go `ready` WITHOUT the operator opening the
+ * per-row editor: a borrows-taxonomy destination (it does not own an EAN->category
+ * matcher, so the FE suppresses the category/parameter blockers - ADR-025, and
+ * finding F10). Resolved by capability, never by platformType.
+ */
+function pickBorrowsOfferDestination(world: World): Connection | undefined {
+  return world
+    .connectionsWithCapability('OfferCreator')
+    .find(
+      (connection) =>
+        connection.status === 'active' &&
+        !connection.supportedCapabilities.includes('EanCategoryMatcher'),
+    );
+}
+
+/** A destination that OWNS its taxonomy (Allegro-shaped): it advertises the EAN matcher. */
+function pickOwnsTaxonomyOfferDestination(world: World): Connection | undefined {
+  return world
+    .connectionsWithCapability('OfferCreator')
+    .find(
+      (connection) =>
+        connection.status === 'active' &&
+        connection.supportedCapabilities.includes('EanCategoryMatcher'),
+    );
+}
+
+interface CatalogueRow {
+  product: Product;
+  /** Master image URLs (not in the suite's mirrored `Product` type). */
+  images: string[];
+  variants: ProductVariant[];
+}
+
+async function loadCatalogue(api: ApiClient): Promise<CatalogueRow[]> {
+  const summaries: Product[] = [];
+  for (let offset = 0; ; offset += 50) {
+    const page = await api.products.list({ limit: 50, offset });
+    summaries.push(...page.items);
+    if (offset + 50 >= page.total || page.items.length === 0) break;
+  }
+  const rows: CatalogueRow[] = [];
+  for (const summary of summaries) {
+    const detail = (await api.products.getById(summary.id)) as Product & { images?: string[] };
+    const variants =
+      detail.variants && detail.variants.length > 0
+        ? detail.variants
+        : (await api.products.listVariants(summary.id)).items;
+    rows.push({ product: detail, images: detail.images ?? [], variants });
+  }
+  return rows;
+}
+
+/** Every variant id that already carries an offer mapping on the connection. */
+async function listedVariantIds(api: ApiClient, connectionId: string): Promise<Set<string>> {
+  const ids = new Set<string>();
+  for (let offset = 0; ; offset += 100) {
+    const page = await api.listings.list({ connectionId, limit: 100, offset });
+    page.items.forEach((mapping) => ids.add(mapping.internalId));
+    if (offset + 100 >= page.total || page.items.length === 0) break;
+  }
+  return ids;
+}
+
+async function stockByVariant(api: ApiClient, variantIds: string[]): Promise<Map<string, number>> {
+  const result = new Map<string, number>();
+  for (let i = 0; i < variantIds.length; i += 40) {
+    const items = await api.inventory.availability(variantIds.slice(i, i + 40));
+    items.forEach((item) => result.set(item.productVariantId, item.totalAvailable));
+  }
+  return result;
+}
+
+/**
+ * Variants the wizard can render as `ready` on a borrows destination: priced,
+ * in stock, barcoded. Split by whether they already carry an offer mapping on
+ * the destination.
+ */
+async function findCandidates(
+  api: ApiClient,
+  connectionId: string,
+): Promise<{ listed: VariantCandidate[]; unlisted: VariantCandidate[] }> {
+  const [catalogue, listed] = await Promise.all([
+    loadCatalogue(api),
+    listedVariantIds(api, connectionId),
+  ]);
+  const flat = catalogue
+    // A row with no master image is flagged by the destination's own validator,
+    // so it could never be `ready` - exclude it from candidate selection.
+    .filter((row) => row.images.length > 0)
+    .flatMap(({ product, variants }) =>
+      variants.map((variant) => ({
+        productId: product.id,
+        variantId: variant.id,
+        ean: variant.ean ?? variant.gtin ?? '',
+        price: variant.price ?? product.price ?? 0,
+      })),
+    );
+  const stock = await stockByVariant(
+    api,
+    flat.map((row) => row.variantId),
+  );
+  const usable = flat
+    .map((row) => ({ ...row, stock: stock.get(row.variantId) ?? 0 }))
+    .filter((row) => row.ean.length > 0 && row.price > 0 && row.stock > 0);
+  return {
+    listed: usable.filter((row) => listed.has(row.variantId)),
+    unlisted: usable.filter((row) => !listed.has(row.variantId)),
+  };
+}
+
+/* ─────────────────────────── raw API helpers (local) ────────────────────────── */
+
+async function bearerToken(env: E2eEnv): Promise<string> {
+  const response = await fetch(`${env.apiUrl}/v1/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: env.adminUser, password: env.adminPass }),
+  });
+  if (!response.ok) throw new Error(`E2E login failed: HTTP ${response.status}`);
+  const body = (await response.json()) as { access_token: string };
+  return body.access_token;
+}
+
+interface OfferStatusSnapshot {
+  connectionId: string;
+  externalOfferId: string;
+  internalVariantId: string;
+  publicationStatus: string;
+}
+
+/** `GET /listings/products/:productId/offer-status` - not on the shared ApiClient. */
+async function offerStatusFor(
+  env: E2eEnv,
+  token: string,
+  productId: string,
+): Promise<OfferStatusSnapshot[]> {
+  const response = await fetch(`${env.apiUrl}/v1/listings/products/${productId}/offer-status`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!response.ok) return [];
+  return (await response.json()) as OfferStatusSnapshot[];
+}
+
+interface ResolveBatchResult {
+  kind: string;
+  productCardId?: string;
+}
+
+/**
+ * `POST /listings/connections/:id/categories/resolve-batch` - the same call the
+ * wizard's Resolve step makes. A `matched` result carrying a `productCardId` is
+ * what releases the FE's required-parameter blocker on a taxonomy-owning
+ * destination, i.e. what makes a row `ready` without the operator editing it.
+ */
+async function resolveBatch(
+  env: E2eEnv,
+  token: string,
+  connectionId: string,
+  items: Array<{ variantId: string; ean: string; sourceCategoryIds: string[] }>,
+): Promise<Record<string, ResolveBatchResult>> {
+  const out: Record<string, ResolveBatchResult> = {};
+  for (let i = 0; i < items.length; i += 20) {
+    const response = await fetch(
+      `${env.apiUrl}/v1/listings/connections/${connectionId}/categories/resolve-batch`,
+      {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ items: items.slice(i, i + 20) }),
+      },
+    );
+    if (!response.ok) continue;
+    const body = (await response.json()) as { results?: Record<string, ResolveBatchResult> };
+    Object.assign(out, body.results ?? {});
+  }
+  return out;
+}
+
+/* ─────────────────────────────── wizard driving ─────────────────────────────── */
+
+interface WizardTarget {
+  productIds: string[];
+  variantIds: string[];
+  connectionId: string;
+}
+
+async function openWizard(page: Page, target: WizardTarget): Promise<void> {
+  const query = new URLSearchParams({
+    productIds: [...new Set(target.productIds)].join(','),
+    variantIds: target.variantIds.join(','),
+    connectionId: target.connectionId,
+  });
+  await page.goto(`/listings/bulk-create/wizard?${query.toString()}`);
+  await expect(
+    page.getByRole('heading', { name: 'Bulk marketplace offer creation' }),
+  ).toBeVisible({ timeout: 30_000 });
+}
+
+/**
+ * Complete the Config step: every platform-config select the destination
+ * lazily populates (shipping-rate package / delivery price list / producer)
+ * gets its first real option, then "Proceed" is clicked once it unlocks.
+ */
+async function completeConfigAndProceed(page: Page): Promise<void> {
+  const proceed = page.getByRole('button', { name: /^Proceed/ });
+  await expect(proceed).toBeVisible({ timeout: 30_000 });
+  await expect(async () => {
+    const selects = page.locator('select');
+    const count = await selects.count();
+    for (let index = 0; index < count; index += 1) {
+      const select = selects.nth(index);
+      if (!(await select.isEnabled())) continue;
+      if ((await select.inputValue()) !== '') continue;
+      const value = await select.locator('option:not([value=""])').first().getAttribute('value');
+      if (value) await select.selectOption(value);
+    }
+    expect(await proceed.isEnabled(), 'Config step "Proceed" should unlock').toBe(true);
+  }).toPass({ timeout: 90_000 });
+  await proceed.click();
+}
+
+function reviewCta(page: Page): Locator {
+  return page.getByRole('button', { name: /^Create offers \(\d+\)$/ }).first();
+}
+
+interface ReviewCounts {
+  ready: number;
+  attention: number;
+  excluded: number;
+}
+
+async function reviewCounts(page: Page): Promise<ReviewCounts> {
+  const summary = page.getByRole('status').filter({ hasText: /ready/i }).first();
+  const text = (await summary.innerText()).replace(/\s+/g, ' ');
+  const read = (pattern: RegExp): number => {
+    const match = pattern.exec(text);
+    return match ? Number(match[1]) : 0;
+  };
+  return {
+    ready: read(/(\d+)\s*ready/i),
+    attention: read(/(\d+)\s*need attention/i),
+    excluded: read(/(\d+)\s*excluded/i),
+  };
+}
+
+/** Wait until the Review step has settled (blockers computed) and return its counts. */
+async function waitForReview(page: Page): Promise<ReviewCounts> {
+  await expect(reviewCta(page)).toBeVisible({ timeout: 90_000 });
+  let counts: ReviewCounts = { ready: 0, attention: 0, excluded: 0 };
+  await expect(async () => {
+    counts = await reviewCounts(page);
+    const settled = counts.ready > 0 || counts.attention > 0 || counts.excluded > 0;
+    expect(settled, 'Review step should settle into per-row statuses').toBe(true);
+  }).toPass({ timeout: 90_000 });
+  return counts;
+}
+
+interface ConfirmStep {
+  /** The duplicate-guard modal text, when the wizard showed one. */
+  duplicateGuardText: string | null;
+  /** The confirm step's own promise ("You're about to create N offers on ..."). */
+  confirmText: string;
+}
+
+/** Click the review CTA, walk the duplicate guard, and land on the Confirm step. */
+async function goToConfirm(page: Page): Promise<ConfirmStep> {
+  await reviewCta(page).click();
+  const dialog = page.getByRole('dialog');
+  let duplicateGuardText: string | null = null;
+  const publishAnyway = dialog.getByRole('button', { name: /Publish anyway/ });
+  if (await publishAnyway.isVisible({ timeout: 5_000 }).catch(() => false)) {
+    duplicateGuardText = (await dialog.first().innerText()).replace(/\s+/g, ' ').trim();
+    await publishAnyway.click();
+  }
+  const confirmButton = page.getByRole('button', { name: 'Create offers', exact: true });
+  await expect(confirmButton).toBeVisible({ timeout: 30_000 });
+  return {
+    duplicateGuardText,
+    confirmText: (await page.locator('body').innerText()).replace(/\s+/g, ' ').trim(),
+  };
+}
+
+interface SubmitResult {
+  status: number;
+  body: unknown;
+  requestBody: string | null;
+}
+
+/** Submit from the Confirm step and capture the raw `POST /listings/bulk-create` exchange. */
+async function submitFromConfirm(
+  page: Page,
+  options: { publishImmediately: boolean },
+): Promise<SubmitResult> {
+  const publishToggle = page.getByRole('checkbox', { name: /Publish immediately/ });
+  if (await publishToggle.count()) {
+    if (options.publishImmediately) await publishToggle.check();
+    else await publishToggle.uncheck();
+  }
+  const [response] = await Promise.all([
+    page.waitForResponse(
+      (candidate) =>
+        candidate.url().endsWith('/listings/bulk-create') &&
+        candidate.request().method() === 'POST',
+      { timeout: 60_000 },
+    ),
+    page.getByRole('button', { name: 'Create offers', exact: true }).click(),
+  ]);
+  const text = await response.text();
+  let body: unknown = text;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    /* keep the raw text */
+  }
+  return { status: response.status(), body, requestBody: response.request().postData() };
+}
+
+/* ──────────────────────────────── the scenarios ─────────────────────────────── */
+
+test.describe('F2: already-listed variants counted ready, then silently dropped', () => {
+  test('mixed batch: the wizard promises N offers, the backend keeps only the unlisted one', async ({
+    page,
+    api,
+    world,
+  }, testInfo) => {
+    const destination = pickBorrowsOfferDestination(world);
+    test.skip(
+      !destination,
+      'No active OfferCreator connection without EanCategoryMatcher (a borrows-taxonomy ' +
+        'destination such as Erli). Needed because only such a destination renders rows ' +
+        '`ready` without the operator filling required category parameters per row. ' +
+        'Create/activate one to run this scenario.',
+    );
+    const connection = destination!;
+
+    const { listed, unlisted } = await findCandidates(api, connection.id);
+    test.skip(
+      listed.length === 0 || unlisted.length === 0,
+      `Stack has ${listed.length} already-listed and ${unlisted.length} not-yet-listed ` +
+        `priced/in-stock/barcoded variants on "${connection.name}". The mixed batch needs at ` +
+        'least 1 of each: list a variant on that connection (bulk wizard) and leave another unlisted.',
+    );
+
+    const alreadyListed = listed.slice(0, 3);
+    const fresh = unlisted[0];
+    const chosen = [...alreadyListed, fresh];
+
+    await openWizard(page, {
+      productIds: chosen.map((row) => row.productId),
+      variantIds: chosen.map((row) => row.variantId),
+      connectionId: connection.id,
+    });
+    await completeConfigAndProceed(page);
+    const counts = await waitForReview(page);
+
+    // (a) The wizard side: every already-listed variant counts as READY.
+    expect(
+      counts.ready,
+      'the wizard should count every selected variant (already-listed included) as ready',
+    ).toBe(chosen.length);
+    expect(counts.attention).toBe(0);
+
+    const alreadyChip = page.getByText(/already on /i).first();
+    await expect(
+      alreadyChip,
+      'the review step should flag the already-listed variants with an "already on {destination}" chip',
+    ).toBeVisible();
+
+    const confirm = await goToConfirm(page);
+    expect(
+      confirm.duplicateGuardText,
+      'the duplicate guard should appear for already-listed variants',
+    ).not.toBeNull();
+    expect(
+      confirm.duplicateGuardText,
+      'the guard promises a DUPLICATE offer - the exact opposite of what the backend does',
+    ).toMatch(/creates a duplicate offer/i);
+    expect(
+      confirm.confirmText,
+      `the confirm step should promise all ${chosen.length} offers`,
+    ).toMatch(new RegExp(`about to create ${chosen.length} offers`, 'i'));
+
+    const submitted = await submitFromConfirm(page, { publishImmediately: false });
+
+    // (b) The backend side: the already-listed variants never reach a job.
+    expect(submitted.status, `submit body: ${submitted.requestBody}`).toBe(202);
+    const response = submitted.body as { batchId: string; jobIds: string[] };
+    expect(
+      response.jobIds.length,
+      `the wizard promised ${chosen.length} offers; the backend enqueued ${response.jobIds.length}`,
+    ).toBeLessThan(chosen.length);
+
+    const batch = await api.listings.getBulkBatch(response.batchId);
+    expect(
+      batch.totalCount,
+      'the persisted batch is smaller than the wizard promised - the drop is never reported back',
+    ).toBeLessThan(chosen.length);
+    const recordedVariantIds = batch.records.map((record) => record.internalVariantId);
+    for (const dropped of alreadyListed) {
+      expect(
+        recordedVariantIds,
+        `already-listed variant ${dropped.variantId} was dropped without any response field naming it`,
+      ).not.toContain(dropped.variantId);
+    }
+    expect(recordedVariantIds).toContain(fresh.variantId);
+
+    testInfo.annotations.push({
+      type: 'divergence',
+      description:
+        `wizard promised ${chosen.length} offers, batch ${response.batchId} holds ` +
+        `${batch.totalCount} (dropped: ${alreadyListed.map((row) => row.variantId).join(', ')})`,
+    });
+  });
+
+  test('all-already-listed batch: ready rows, then a 400 about productIds the operator never saw', async ({
+    page,
+    api,
+    world,
+  }, testInfo) => {
+    const destination = pickBorrowsOfferDestination(world);
+    test.skip(
+      !destination,
+      'No active OfferCreator connection without EanCategoryMatcher (borrows-taxonomy ' +
+        'destination). See the mixed-batch scenario for why.',
+    );
+    const connection = destination!;
+
+    const { listed } = await findCandidates(api, connection.id);
+    test.skip(
+      listed.length === 0,
+      `No already-listed, priced, in-stock, barcoded variant on "${connection.name}". ` +
+        'Create at least one offer there first (bulk wizard) so the variant carries an offer mapping.',
+    );
+
+    const chosen = listed.slice(0, 2);
+    await openWizard(page, {
+      productIds: chosen.map((row) => row.productId),
+      variantIds: chosen.map((row) => row.variantId),
+      connectionId: connection.id,
+    });
+    await completeConfigAndProceed(page);
+    const counts = await waitForReview(page);
+
+    // (a) Every row is ready and the submit CTA is enabled.
+    expect(counts.ready).toBe(chosen.length);
+    expect(counts.attention).toBe(0);
+    await expect(reviewCta(page)).toBeEnabled();
+
+    // PROOF (documentation only - never asserted on): the promise.
+    await captureProof(page, 'f02-before-review-ready', { region: reviewRegion(page) });
+
+    const confirm = await goToConfirm(page);
+    expect(confirm.duplicateGuardText).toMatch(/creates a duplicate offer/i);
+
+    // (b) The backend removes every variant, then complains the request is empty.
+    const submitted = await submitFromConfirm(page, { publishImmediately: false });
+
+    // PROOF (documentation only): the 400 the confirm modal renders back.
+    await captureProof(page, 'f02-before-result', {
+      region: page.getByRole('dialog').filter({ has: page.locator('.alert--error') }),
+      prepare: async () => {
+        await expect(page.locator('.alert--error').first()).toBeVisible({ timeout: 15_000 });
+      },
+    });
+
+    expect(submitted.status).toBe(400);
+    const message = JSON.stringify(submitted.body);
+    expect(
+      message,
+      'the 400 talks about missing productIds - not about the variants being already listed',
+    ).toMatch(/at least one productId/i);
+
+    testInfo.annotations.push({
+      type: 'divergence',
+      description: `wizard said ${counts.ready} ready; server replied 400 ${message}`,
+    });
+  });
+
+  test('an offer that is no longer live still blocks its variant forever', async ({
+    page,
+    api,
+    world,
+    env,
+  }, testInfo) => {
+    // The "already listed" test is a bare offer-mapping lookup with no join to
+    // `offer_status_snapshots`, so a variant whose offer is no longer publicly
+    // live is still refused. The audit's sharpest case is an `ended` offer;
+    // ending an Allegro offer is a manual, external act, so this test accepts
+    // ANY non-active publication status as the reachable proxy and names the
+    // status it actually found.
+    const destination = pickOwnsTaxonomyOfferDestination(world);
+    test.skip(
+      !destination,
+      'No active OfferCreator connection advertising EanCategoryMatcher (a taxonomy-owning ' +
+        'destination such as Allegro). Offer-status snapshots only exist for such a destination.',
+    );
+    const connection = destination!;
+    const token = await bearerToken(env);
+
+    const { listed } = await findCandidates(api, connection.id);
+    test.skip(
+      listed.length === 0,
+      `No already-listed, priced, in-stock, barcoded variant on "${connection.name}".`,
+    );
+
+    // A row on a taxonomy-owning destination only reaches `ready` unedited when
+    // its barcode resolves to a marketplace product card.
+    const resolved = await resolveBatch(
+      env,
+      token,
+      connection.id,
+      listed.map((row) => ({
+        variantId: row.variantId,
+        ean: row.ean,
+        sourceCategoryIds: ['2'],
+      })),
+    );
+    const cardMatched = listed.filter((row) => {
+      const result = resolved[row.variantId];
+      return result?.kind === 'matched' && !!result.productCardId;
+    });
+
+    const rank = (status: string): number =>
+      ({ ended: 0, removed: 1, unpublished: 2, inactive: 3, draft: 4 })[status] ?? 9;
+    const staleCandidates: Array<{ candidate: (typeof listed)[number]; status: string }> = [];
+    for (const candidate of cardMatched) {
+      const snapshots = await offerStatusFor(env, token, candidate.productId);
+      const snapshot = snapshots
+        .filter(
+          (row) =>
+            row.connectionId === connection.id &&
+            row.internalVariantId === candidate.variantId &&
+            row.publicationStatus !== 'active',
+        )
+        .sort((a, b) => rank(a.publicationStatus) - rank(b.publicationStatus))[0];
+      if (snapshot) staleCandidates.push({ candidate, status: snapshot.publicationStatus });
+    }
+    staleCandidates.sort((a, b) => rank(a.status) - rank(b.status));
+
+    test.skip(
+      staleCandidates.length === 0,
+      `No variant on "${connection.name}" that is (1) already listed, (2) barcode-matched to a ` +
+        'marketplace product card (so its wizard row is ready unedited) and (3) carries an ' +
+        'offer-status snapshot that is NOT `active`. To create that state: end (or deactivate) ' +
+        'one of the connection\'s offers on the marketplace, then let the ' +
+        '`marketplace.offer.statusSync` job refresh its snapshot.',
+    );
+
+    const stale = staleCandidates[0];
+    testInfo.annotations.push({
+      type: 'fixture',
+      description: `variant ${stale.candidate.variantId} - offer publicationStatus "${stale.status}"`,
+    });
+
+    await openWizard(page, {
+      productIds: [stale.candidate.productId],
+      variantIds: [stale.candidate.variantId],
+      connectionId: connection.id,
+    });
+    await completeConfigAndProceed(page);
+    const counts = await waitForReview(page);
+
+    // (a) Ready, and the wizard offers to re-create the offer.
+    expect(
+      counts.ready,
+      `the wizard should present the variant (offer status "${stale.status}") as ready`,
+    ).toBe(1);
+    await expect(reviewCta(page)).toBeEnabled();
+    await expect(page.getByText(/already on /i).first()).toBeVisible();
+
+    const confirm = await goToConfirm(page);
+    expect(confirm.duplicateGuardText).toMatch(/creates a duplicate offer/i);
+
+    // (b) The backend still treats the stale offer as "listed" and refuses.
+    const submitted = await submitFromConfirm(page, { publishImmediately: false });
+    expect(
+      submitted.status,
+      `a variant whose offer is "${stale.status}" should have been re-listable`,
+    ).toBe(400);
+    expect(JSON.stringify(submitted.body)).toMatch(/at least one productId/i);
+  });
+});

--- a/apps/e2e/tests/preflight-divergence/f03-zero-price.spec.ts
+++ b/apps/e2e/tests/preflight-divergence/f03-zero-price.spec.ts
@@ -1,0 +1,490 @@
+/**
+ * F3 - price `0`: the wizard accepts it everywhere, the API rejects the whole batch
+ *
+ * CHARACTERIZATION TEST. Each test asserts BOTH sides of one divergence:
+ *   (a) the bulk offer wizard accepts a zero price (the flat-price config field has
+ *       no floor, unlike its markup / cap / flat-stock neighbours), keeps the rows
+ *       `ready`, and lets the operator submit, AND
+ *   (b) `POST /listings/bulk-create` rejects the ENTIRE request with 400 and an
+ *       opaque, non-field-level message (`...price: invalid value`), because the
+ *       price DTO is `@IsPositive()` and is enforced per map value.
+ *
+ * These tests PASS while the divergence exists. A failure here means the finding
+ * was wrong or the divergence has been closed (a client-side floor on the flat
+ * price / row price, or a backend that accepts 0). Re-read the finding before
+ * "fixing" the test.
+ *
+ * Fixture policy: read-only. Both scenarios end in a 400, so no batch is
+ * persisted, no job is enqueued and no offer is created on any marketplace.
+ *
+ * @module tests/preflight-divergence
+ */
+import type { Locator, Page } from '@playwright/test';
+import { test, expect } from '../../src/fixtures/test';
+import type { ApiClient } from '../../src/api/api-client';
+import type { Connection, Product, ProductVariant } from '../../src/api/api.types';
+import type { E2eEnv } from '../../src/config/env';
+import type { World } from '../../src/world/world';
+import { captureProof, reviewRegion } from './__proof__/capture';
+
+test.describe.configure({ mode: 'serial', timeout: 300_000 });
+
+/* ────────────────────────── local fixture discovery ────────────────────────── */
+
+interface VariantCandidate {
+  productId: string;
+  variantId: string;
+  ean: string;
+  price: number;
+  stock: number;
+}
+
+/** A borrows-taxonomy destination: its rows go `ready` without per-row editing. */
+function pickBorrowsOfferDestination(world: World): Connection | undefined {
+  return world
+    .connectionsWithCapability('OfferCreator')
+    .find(
+      (connection) =>
+        connection.status === 'active' &&
+        !connection.supportedCapabilities.includes('EanCategoryMatcher'),
+    );
+}
+
+/** A destination that owns its taxonomy (advertises the EAN->category matcher). */
+function pickOwnsTaxonomyOfferDestination(world: World): Connection | undefined {
+  return world
+    .connectionsWithCapability('OfferCreator')
+    .find(
+      (connection) =>
+        connection.status === 'active' &&
+        connection.supportedCapabilities.includes('EanCategoryMatcher'),
+    );
+}
+
+interface CatalogueRow {
+  product: Product;
+  /** Master image URLs (not in the suite's mirrored `Product` type). */
+  images: string[];
+  variants: ProductVariant[];
+}
+
+async function loadCatalogue(api: ApiClient): Promise<CatalogueRow[]> {
+  const summaries: Product[] = [];
+  for (let offset = 0; ; offset += 50) {
+    const page = await api.products.list({ limit: 50, offset });
+    summaries.push(...page.items);
+    if (offset + 50 >= page.total || page.items.length === 0) break;
+  }
+  const rows: CatalogueRow[] = [];
+  for (const summary of summaries) {
+    const detail = (await api.products.getById(summary.id)) as Product & { images?: string[] };
+    const variants =
+      detail.variants && detail.variants.length > 0
+        ? detail.variants
+        : (await api.products.listVariants(summary.id)).items;
+    rows.push({ product: detail, images: detail.images ?? [], variants });
+  }
+  return rows;
+}
+
+async function listedVariantIds(api: ApiClient, connectionId: string): Promise<Set<string>> {
+  const ids = new Set<string>();
+  for (let offset = 0; ; offset += 100) {
+    const page = await api.listings.list({ connectionId, limit: 100, offset });
+    page.items.forEach((mapping) => ids.add(mapping.internalId));
+    if (offset + 100 >= page.total || page.items.length === 0) break;
+  }
+  return ids;
+}
+
+async function stockByVariant(api: ApiClient, variantIds: string[]): Promise<Map<string, number>> {
+  const result = new Map<string, number>();
+  for (let i = 0; i < variantIds.length; i += 40) {
+    const items = await api.inventory.availability(variantIds.slice(i, i + 40));
+    items.forEach((item) => result.set(item.productVariantId, item.totalAvailable));
+  }
+  return result;
+}
+
+async function findCandidates(
+  api: ApiClient,
+  connectionId: string,
+): Promise<{ listed: VariantCandidate[]; unlisted: VariantCandidate[] }> {
+  const [catalogue, listed] = await Promise.all([
+    loadCatalogue(api),
+    listedVariantIds(api, connectionId),
+  ]);
+  const flat = catalogue
+    // A row with no master image is flagged by the destination's own validator,
+    // so it could never be `ready` - exclude it from candidate selection.
+    .filter((row) => row.images.length > 0)
+    .flatMap(({ product, variants }) =>
+      variants.map((variant) => ({
+        productId: product.id,
+        variantId: variant.id,
+        ean: variant.ean ?? variant.gtin ?? '',
+        price: variant.price ?? product.price ?? 0,
+      })),
+    );
+  const stock = await stockByVariant(
+    api,
+    flat.map((row) => row.variantId),
+  );
+  const usable = flat
+    .map((row) => ({ ...row, stock: stock.get(row.variantId) ?? 0 }))
+    .filter((row) => row.ean.length > 0 && row.price > 0 && row.stock > 0);
+  return {
+    listed: usable.filter((row) => listed.has(row.variantId)),
+    unlisted: usable.filter((row) => !listed.has(row.variantId)),
+  };
+}
+
+async function bearerToken(env: E2eEnv): Promise<string> {
+  const response = await fetch(`${env.apiUrl}/v1/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: env.adminUser, password: env.adminPass }),
+  });
+  if (!response.ok) throw new Error(`E2E login failed: HTTP ${response.status}`);
+  const body = (await response.json()) as { access_token: string };
+  return body.access_token;
+}
+
+interface ResolveBatchResult {
+  kind: string;
+  productCardId?: string;
+}
+
+/** The wizard's own Resolve-step call; a card match is what makes a row ready unedited. */
+async function resolveBatch(
+  env: E2eEnv,
+  token: string,
+  connectionId: string,
+  items: Array<{ variantId: string; ean: string; sourceCategoryIds: string[] }>,
+): Promise<Record<string, ResolveBatchResult>> {
+  const out: Record<string, ResolveBatchResult> = {};
+  for (let i = 0; i < items.length; i += 20) {
+    const response = await fetch(
+      `${env.apiUrl}/v1/listings/connections/${connectionId}/categories/resolve-batch`,
+      {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ items: items.slice(i, i + 20) }),
+      },
+    );
+    if (!response.ok) continue;
+    const body = (await response.json()) as { results?: Record<string, ResolveBatchResult> };
+    Object.assign(out, body.results ?? {});
+  }
+  return out;
+}
+
+/* ─────────────────────────────── wizard driving ─────────────────────────────── */
+
+interface WizardTarget {
+  productIds: string[];
+  variantIds: string[];
+  connectionId: string;
+}
+
+async function openWizard(page: Page, target: WizardTarget): Promise<void> {
+  const query = new URLSearchParams({
+    productIds: [...new Set(target.productIds)].join(','),
+    variantIds: target.variantIds.join(','),
+    connectionId: target.connectionId,
+  });
+  await page.goto(`/listings/bulk-create/wizard?${query.toString()}`);
+  await expect(
+    page.getByRole('heading', { name: 'Bulk marketplace offer creation' }),
+  ).toBeVisible({ timeout: 30_000 });
+}
+
+/** Fill the destination's lazily-populated platform-config selects. */
+async function completePlatformConfig(page: Page): Promise<void> {
+  const proceed = page.getByRole('button', { name: /^Proceed/ });
+  await expect(proceed).toBeVisible({ timeout: 30_000 });
+  await expect(async () => {
+    const selects = page.locator('select');
+    const count = await selects.count();
+    for (let index = 0; index < count; index += 1) {
+      const select = selects.nth(index);
+      if (!(await select.isEnabled())) continue;
+      if ((await select.inputValue()) !== '') continue;
+      const value = await select.locator('option:not([value=""])').first().getAttribute('value');
+      if (value) await select.selectOption(value);
+    }
+    expect(await proceed.isEnabled(), 'Config step "Proceed" should unlock').toBe(true);
+  }).toPass({ timeout: 90_000 });
+}
+
+function reviewCta(page: Page): Locator {
+  return page.getByRole('button', { name: /^Create offers \(\d+\)$/ }).first();
+}
+
+interface ReviewCounts {
+  ready: number;
+  attention: number;
+  excluded: number;
+}
+
+async function reviewCounts(page: Page): Promise<ReviewCounts> {
+  const summary = page.getByRole('status').filter({ hasText: /ready/i }).first();
+  const text = (await summary.innerText()).replace(/\s+/g, ' ');
+  const read = (pattern: RegExp): number => {
+    const match = pattern.exec(text);
+    return match ? Number(match[1]) : 0;
+  };
+  return {
+    ready: read(/(\d+)\s*ready/i),
+    attention: read(/(\d+)\s*need attention/i),
+    excluded: read(/(\d+)\s*excluded/i),
+  };
+}
+
+async function waitForReview(page: Page): Promise<ReviewCounts> {
+  await expect(reviewCta(page)).toBeVisible({ timeout: 90_000 });
+  let counts: ReviewCounts = { ready: 0, attention: 0, excluded: 0 };
+  await expect(async () => {
+    counts = await reviewCounts(page);
+    const settled = counts.ready > 0 || counts.attention > 0 || counts.excluded > 0;
+    expect(settled, 'Review step should settle into per-row statuses').toBe(true);
+  }).toPass({ timeout: 90_000 });
+  return counts;
+}
+
+interface SubmitResult {
+  status: number;
+  body: unknown;
+  requestBody: string | null;
+}
+
+/** Review CTA -> duplicate guard (if any) -> Confirm step -> submit, capturing the POST. */
+async function submitFromReview(page: Page): Promise<SubmitResult> {
+  await reviewCta(page).click();
+  const dialog = page.getByRole('dialog');
+  const publishAnyway = dialog.getByRole('button', { name: /Publish anyway/ });
+  if (await publishAnyway.isVisible({ timeout: 5_000 }).catch(() => false)) {
+    await publishAnyway.click();
+  }
+  const confirmButton = page.getByRole('button', { name: 'Create offers', exact: true });
+  await expect(confirmButton).toBeVisible({ timeout: 30_000 });
+  const publishToggle = page.getByRole('checkbox', { name: /Publish immediately/ });
+  if (await publishToggle.count()) await publishToggle.uncheck();
+
+  const [response] = await Promise.all([
+    page.waitForResponse(
+      (candidate) =>
+        candidate.url().endsWith('/listings/bulk-create') &&
+        candidate.request().method() === 'POST',
+      { timeout: 60_000 },
+    ),
+    confirmButton.click(),
+  ]);
+  const text = await response.text();
+  let body: unknown = text;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    /* keep the raw text */
+  }
+  return { status: response.status(), body, requestBody: response.request().postData() };
+}
+
+/** Every message string in a Nest validation error body. */
+function messagesOf(body: unknown): string[] {
+  const message = (body as { message?: unknown } | null)?.message;
+  if (Array.isArray(message)) return message.map(String);
+  if (typeof message === 'string') return [message];
+  return [JSON.stringify(body)];
+}
+
+/* ──────────────────────────────── the scenarios ─────────────────────────────── */
+
+test.describe('F3: price 0 passes the wizard, then 400s the whole batch', () => {
+  test('flat price 0 in the Config step: rows stay ready, submit 400s on price', async ({
+    page,
+    api,
+    world,
+  }, testInfo) => {
+    const destination = pickBorrowsOfferDestination(world);
+    test.skip(
+      !destination,
+      'No active OfferCreator connection without EanCategoryMatcher (a borrows-taxonomy ' +
+        'destination such as Erli). Needed because its rows go `ready` without the operator ' +
+        'filling required category parameters, isolating the price as the only submit gate.',
+    );
+    const connection = destination!;
+
+    const { unlisted } = await findCandidates(api, connection.id);
+    test.skip(
+      unlisted.length === 0,
+      `No priced, in-stock, barcoded variant that is NOT yet listed on "${connection.name}". ` +
+        'An already-listed variant would be dropped by the already-listed filter (F2) and ' +
+        'muddy which gate produced the 400. Sync a fresh product or list fewer variants.',
+    );
+    const candidate = unlisted[0];
+
+    await openWizard(page, {
+      productIds: [candidate.productId],
+      variantIds: [candidate.variantId],
+      connectionId: connection.id,
+    });
+    await completePlatformConfig(page);
+
+    // (a1) The flat-price field takes a bare `0` - no floor, no error, and the
+    // step's forward CTA stays enabled (its markup / cap / flat-stock siblings
+    // all carry floors).
+    await page
+      .locator('label')
+      .filter({ hasText: 'Flat price for all rows' })
+      .locator('input[type="radio"]')
+      .check();
+    const flatPrice = page.getByLabel('Flat price (PLN)');
+    await flatPrice.fill('0');
+    await expect(flatPrice).toHaveValue('0');
+    const proceed = page.getByRole('button', { name: /^Proceed/ });
+    await expect(
+      proceed,
+      'the Config step should still let the operator continue with a zero flat price',
+    ).toBeEnabled();
+    expect(
+      await page.locator('.form-field__error').allInnerTexts(),
+      'no client-side error is raised for the zero price',
+    ).toEqual([]);
+    await proceed.click();
+
+    // (a2) Every row is still `ready` and the submit CTA is enabled.
+    const counts = await waitForReview(page);
+    expect(counts.attention, 'a zero price is not a row blocker').toBe(0);
+    expect(counts.ready).toBeGreaterThan(0);
+    await expect(reviewCta(page)).toBeEnabled();
+
+    // PROOF (documentation only - never asserted on): the promise.
+    await captureProof(page, 'f03-before-review-ready', { region: reviewRegion(page) });
+
+    // (b) The API rejects the whole request.
+    const submitted = await submitFromReview(page);
+
+    // PROOF (documentation only): the opaque 400 the confirm modal renders back.
+    await captureProof(page, 'f03-before-result', {
+      region: page.getByRole('dialog').filter({ has: page.locator('.alert--error') }),
+      prepare: async () => {
+        await expect(page.locator('.alert--error').first()).toBeVisible({ timeout: 15_000 });
+      },
+    });
+
+    expect(
+      submitted.requestBody,
+      'the wizard really did send the zero price (it is not coerced away client-side)',
+    ).toContain('"amount":0');
+    expect(submitted.status, `request: ${submitted.requestBody}`).toBe(400);
+    const messages = messagesOf(submitted.body);
+    expect(
+      messages.join(' | '),
+      'the 400 blames the price - and says only "invalid value", with no field-level reason',
+    ).toMatch(/price/i);
+
+    testInfo.annotations.push({
+      type: 'divergence',
+      description: `wizard said ${counts.ready} ready with price 0; server replied 400 ${messages.join(' | ')}`,
+    });
+  });
+
+  test('per-row price override of 0: the row editor saves it, submit 400s on price', async ({
+    page,
+    api,
+    world,
+    env,
+  }, testInfo) => {
+    // The per-row path writes into the SAME `perVariantOverrides[...].price`
+    // slot, so it hits the same `@IsPositive()` gate. It is driven on a
+    // taxonomy-owning destination because that is where the row editor has a
+    // resolved category and can be saved.
+    const destination = pickOwnsTaxonomyOfferDestination(world);
+    test.skip(
+      !destination,
+      'No active OfferCreator connection advertising EanCategoryMatcher (a taxonomy-owning ' +
+        'destination such as Allegro).',
+    );
+    const connection = destination!;
+    const token = await bearerToken(env);
+
+    const { listed, unlisted } = await findCandidates(api, connection.id);
+    const all = [...unlisted, ...listed];
+    const resolved = await resolveBatch(
+      env,
+      token,
+      connection.id,
+      all.map((row) => ({ variantId: row.variantId, ean: row.ean, sourceCategoryIds: ['2'] })),
+    );
+    const cardMatched = all.filter((row) => {
+      const result = resolved[row.variantId];
+      return result?.kind === 'matched' && !!result.productCardId;
+    });
+    test.skip(
+      cardMatched.length === 0,
+      `No priced, in-stock variant on "${connection.name}" whose barcode resolves to a ` +
+        'marketplace product card. Without a card match the row carries a required-parameter ' +
+        'blocker, so its readiness could not be asserted. Add a product whose EAN exists in the ' +
+        "destination's catalogue (or list one there once, which creates the card).",
+    );
+    const candidate = cardMatched[0];
+
+    await openWizard(page, {
+      productIds: [candidate.productId],
+      variantIds: [candidate.variantId],
+      connectionId: connection.id,
+    });
+    await completePlatformConfig(page);
+    await page.getByRole('button', { name: /^Proceed/ }).click();
+    await waitForReview(page);
+
+    // Open the row editor and set this row's price to 0. The editor renders two
+    // shapes: a multi-variant product gets a "Price policy" select (whose `flat`
+    // option reveals a price field), a simple product gets a direct "Price" field.
+    await page.getByRole('button', { name: 'Edit', exact: true }).first().click();
+    const editor = page.getByRole('dialog').first();
+    await expect(editor.getByRole('button', { name: 'Save all' })).toBeVisible({ timeout: 20_000 });
+    const pricePolicy = editor.getByLabel('Price policy');
+    let rowPrice: Locator;
+    if (await pricePolicy.count()) {
+      await pricePolicy.selectOption('flat');
+      rowPrice = editor.getByLabel(/Flat price/);
+    } else {
+      rowPrice = editor.getByLabel('Price', { exact: true });
+    }
+    // Write a non-zero value first so the zero is a real change (a flat-price
+    // field defaults to "0", and an unchanged field would not be persisted).
+    await rowPrice.fill('12.34');
+    await rowPrice.fill('0');
+    expect(
+      await editor.locator('.form-field__error').allInnerTexts(),
+      'the row editor raises no error for a zero price',
+    ).toEqual([]);
+    await editor.getByRole('button', { name: 'Save all' }).click();
+    await expect(editor, 'the row editor accepts and saves the zero price').toBeHidden({
+      timeout: 20_000,
+    });
+
+    // (a) The row is still ready after the zero-price override.
+    const counts = await waitForReview(page);
+    expect(counts.attention, 'a zero per-row price is not a row blocker').toBe(0);
+    expect(counts.ready).toBeGreaterThan(0);
+    await expect(reviewCta(page)).toBeEnabled();
+
+    // (b) The whole request 400s on that one row's price.
+    const submitted = await submitFromReview(page);
+    expect(submitted.requestBody).toContain('"amount":0');
+    expect(submitted.status, `request: ${submitted.requestBody}`).toBe(400);
+    const messages = messagesOf(submitted.body);
+    expect(
+      messages.join(' | '),
+      'the per-row zero price is reported as an opaque "invalid value" on the override map',
+    ).toMatch(/price: invalid value/i);
+
+    testInfo.annotations.push({
+      type: 'divergence',
+      description: `row editor saved price 0 and kept the row ready; server replied 400 ${messages.join(' | ')}`,
+    });
+  });
+});

--- a/apps/e2e/tests/preflight-divergence/f04-master-catalog-missing.spec.ts
+++ b/apps/e2e/tests/preflight-divergence/f04-master-catalog-missing.spec.ts
@@ -1,0 +1,443 @@
+/**
+ * F4 - destination without `masterCatalogConnectionId`: 100% green, 100% failed
+ *
+ * CHARACTERIZATION TEST. It asserts BOTH sides of one divergence:
+ *   (a) with the destination connection missing `config.masterCatalogConnectionId`,
+ *       the bulk offer wizard still renders every row `ready`, enables the submit
+ *       CTA, and the API accepts the batch (202) - the preflight never looks at
+ *       that config key, AND
+ *   (b) every child record then terminates `failed` with
+ *       `MASTER_CATALOG_NOT_CONFIGURED` on `connection.config.masterCatalogConnectionId`,
+ *       because the offer builder resolves the master catalogue only at execution.
+ *
+ * The test PASSES while the divergence exists. A failure means the finding was
+ * wrong or the divergence has been closed (the wizard now blocks/warns, or the
+ * submit endpoint rejects a destination with no master catalogue).
+ *
+ * Fixture policy: this is the only spec in this suite that mutates shared state -
+ * it must temporarily remove ONE key from the destination connection's config
+ * (connection config is replaced wholesale, so the full object is written back).
+ * The original config is restored in a `finally` AND re-asserted in `afterAll`,
+ * which fails loudly if the stack was left in the doctored state. No offer is
+ * created on the marketplace: every record dies in the builder, before any
+ * platform call.
+ *
+ * @module tests/preflight-divergence
+ */
+import type { Locator, Page } from '@playwright/test';
+import { test, expect } from '../../src/fixtures/test';
+import type { ApiClient } from '../../src/api/api-client';
+import type { Connection, Product, ProductVariant } from '../../src/api/api.types';
+import type { E2eEnv } from '../../src/config/env';
+import type { World } from '../../src/world/world';
+import { captureProof, reviewRegion } from './__proof__/capture';
+
+test.describe.configure({ mode: 'serial', timeout: 420_000 });
+
+const MASTER_CATALOG_KEY = 'masterCatalogConnectionId';
+
+/** Set by the test before it doctors a connection, so `afterAll` can verify/repair. */
+let doctored: { connectionId: string; config: Record<string, unknown> } | null = null;
+
+/* ────────────────────────── local fixture discovery ────────────────────────── */
+
+interface VariantCandidate {
+  productId: string;
+  variantId: string;
+  ean: string;
+  price: number;
+  stock: number;
+}
+
+/** A borrows-taxonomy destination: its rows go `ready` without per-row editing. */
+function pickBorrowsOfferDestination(world: World): Connection | undefined {
+  return world
+    .connectionsWithCapability('OfferCreator')
+    .find(
+      (connection) =>
+        connection.status === 'active' &&
+        !connection.supportedCapabilities.includes('EanCategoryMatcher'),
+    );
+}
+
+interface CatalogueRow {
+  product: Product;
+  /** Master image URLs (not in the suite's mirrored `Product` type). */
+  images: string[];
+  variants: ProductVariant[];
+}
+
+async function loadCatalogue(api: ApiClient): Promise<CatalogueRow[]> {
+  const summaries: Product[] = [];
+  for (let offset = 0; ; offset += 50) {
+    const page = await api.products.list({ limit: 50, offset });
+    summaries.push(...page.items);
+    if (offset + 50 >= page.total || page.items.length === 0) break;
+  }
+  const rows: CatalogueRow[] = [];
+  for (const summary of summaries) {
+    const detail = (await api.products.getById(summary.id)) as Product & { images?: string[] };
+    const variants =
+      detail.variants && detail.variants.length > 0
+        ? detail.variants
+        : (await api.products.listVariants(summary.id)).items;
+    rows.push({ product: detail, images: detail.images ?? [], variants });
+  }
+  return rows;
+}
+
+async function listedVariantIds(api: ApiClient, connectionId: string): Promise<Set<string>> {
+  const ids = new Set<string>();
+  for (let offset = 0; ; offset += 100) {
+    const page = await api.listings.list({ connectionId, limit: 100, offset });
+    page.items.forEach((mapping) => ids.add(mapping.internalId));
+    if (offset + 100 >= page.total || page.items.length === 0) break;
+  }
+  return ids;
+}
+
+async function stockByVariant(api: ApiClient, variantIds: string[]): Promise<Map<string, number>> {
+  const result = new Map<string, number>();
+  for (let i = 0; i < variantIds.length; i += 40) {
+    const items = await api.inventory.availability(variantIds.slice(i, i + 40));
+    items.forEach((item) => result.set(item.productVariantId, item.totalAvailable));
+  }
+  return result;
+}
+
+/** Priced, in-stock, barcoded variants that are NOT yet listed on the destination. */
+async function findUnlistedCandidates(
+  api: ApiClient,
+  connectionId: string,
+): Promise<VariantCandidate[]> {
+  const [catalogue, listed] = await Promise.all([
+    loadCatalogue(api),
+    listedVariantIds(api, connectionId),
+  ]);
+  const flat = catalogue
+    // A row with no master image is flagged by the destination's own validator,
+    // so it could never be `ready` - exclude it from candidate selection.
+    .filter((row) => row.images.length > 0)
+    .flatMap(({ product, variants }) =>
+      variants.map((variant) => ({
+        productId: product.id,
+        variantId: variant.id,
+        ean: variant.ean ?? variant.gtin ?? '',
+        price: variant.price ?? product.price ?? 0,
+      })),
+    );
+  const stock = await stockByVariant(
+    api,
+    flat.map((row) => row.variantId),
+  );
+  return flat
+    .map((row) => ({ ...row, stock: stock.get(row.variantId) ?? 0 }))
+    .filter((row) => row.ean.length > 0 && row.price > 0 && row.stock > 0)
+    .filter((row) => !listed.has(row.variantId));
+}
+
+/* ─────────────────────────── raw API helpers (local) ────────────────────────── */
+
+async function bearerToken(env: E2eEnv): Promise<string> {
+  const response = await fetch(`${env.apiUrl}/v1/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: env.adminUser, password: env.adminPass }),
+  });
+  if (!response.ok) throw new Error(`E2E login failed: HTTP ${response.status}`);
+  const body = (await response.json()) as { access_token: string };
+  return body.access_token;
+}
+
+interface BatchRecordWithErrors {
+  id: string;
+  internalVariantId: string;
+  status: string;
+  errors: Array<{ field: string; code: string; message: string }> | null;
+}
+
+interface BatchWithErrors {
+  id: string;
+  status: string;
+  totalCount: number;
+  succeededCount: number;
+  failedCount: number;
+  records: BatchRecordWithErrors[];
+}
+
+/**
+ * `GET /listings/bulk-create/:batchId`, read raw because the suite's shared
+ * `BulkBatchSummary` type omits the per-record `errors[]` this test asserts on.
+ */
+async function getBatch(env: E2eEnv, token: string, batchId: string): Promise<BatchWithErrors> {
+  const response = await fetch(`${env.apiUrl}/v1/listings/bulk-create/${batchId}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!response.ok) throw new Error(`GET bulk-create/${batchId} -> HTTP ${response.status}`);
+  return (await response.json()) as BatchWithErrors;
+}
+
+/* ─────────────────────────────── wizard driving ─────────────────────────────── */
+
+interface WizardTarget {
+  productIds: string[];
+  variantIds: string[];
+  connectionId: string;
+}
+
+async function openWizard(page: Page, target: WizardTarget): Promise<void> {
+  const query = new URLSearchParams({
+    productIds: [...new Set(target.productIds)].join(','),
+    variantIds: target.variantIds.join(','),
+    connectionId: target.connectionId,
+  });
+  await page.goto(`/listings/bulk-create/wizard?${query.toString()}`);
+  await expect(
+    page.getByRole('heading', { name: 'Bulk marketplace offer creation' }),
+  ).toBeVisible({ timeout: 30_000 });
+}
+
+async function completeConfigAndProceed(page: Page): Promise<void> {
+  const proceed = page.getByRole('button', { name: /^Proceed/ });
+  await expect(proceed).toBeVisible({ timeout: 30_000 });
+  await expect(async () => {
+    const selects = page.locator('select');
+    const count = await selects.count();
+    for (let index = 0; index < count; index += 1) {
+      const select = selects.nth(index);
+      if (!(await select.isEnabled())) continue;
+      if ((await select.inputValue()) !== '') continue;
+      const value = await select.locator('option:not([value=""])').first().getAttribute('value');
+      if (value) await select.selectOption(value);
+    }
+    expect(await proceed.isEnabled(), 'Config step "Proceed" should unlock').toBe(true);
+  }).toPass({ timeout: 90_000 });
+  await proceed.click();
+}
+
+function reviewCta(page: Page): Locator {
+  return page.getByRole('button', { name: /^Create offers \(\d+\)$/ }).first();
+}
+
+interface ReviewCounts {
+  ready: number;
+  attention: number;
+  excluded: number;
+}
+
+async function reviewCounts(page: Page): Promise<ReviewCounts> {
+  const summary = page.getByRole('status').filter({ hasText: /ready/i }).first();
+  const text = (await summary.innerText()).replace(/\s+/g, ' ');
+  const read = (pattern: RegExp): number => {
+    const match = pattern.exec(text);
+    return match ? Number(match[1]) : 0;
+  };
+  return {
+    ready: read(/(\d+)\s*ready/i),
+    attention: read(/(\d+)\s*need attention/i),
+    excluded: read(/(\d+)\s*excluded/i),
+  };
+}
+
+async function waitForReview(page: Page): Promise<ReviewCounts> {
+  await expect(reviewCta(page)).toBeVisible({ timeout: 90_000 });
+  let counts: ReviewCounts = { ready: 0, attention: 0, excluded: 0 };
+  await expect(async () => {
+    counts = await reviewCounts(page);
+    const settled = counts.ready > 0 || counts.attention > 0 || counts.excluded > 0;
+    expect(settled, 'Review step should settle into per-row statuses').toBe(true);
+  }).toPass({ timeout: 90_000 });
+  return counts;
+}
+
+interface SubmitResult {
+  status: number;
+  body: unknown;
+  requestBody: string | null;
+}
+
+async function submitFromReview(page: Page): Promise<SubmitResult> {
+  await reviewCta(page).click();
+  const dialog = page.getByRole('dialog');
+  const publishAnyway = dialog.getByRole('button', { name: /Publish anyway/ });
+  if (await publishAnyway.isVisible({ timeout: 5_000 }).catch(() => false)) {
+    await publishAnyway.click();
+  }
+  const confirmButton = page.getByRole('button', { name: 'Create offers', exact: true });
+  await expect(confirmButton).toBeVisible({ timeout: 30_000 });
+  const publishToggle = page.getByRole('checkbox', { name: /Publish immediately/ });
+  if (await publishToggle.count()) await publishToggle.uncheck();
+
+  const [response] = await Promise.all([
+    page.waitForResponse(
+      (candidate) =>
+        candidate.url().endsWith('/listings/bulk-create') &&
+        candidate.request().method() === 'POST',
+      { timeout: 60_000 },
+    ),
+    confirmButton.click(),
+  ]);
+  const text = await response.text();
+  let body: unknown = text;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    /* keep the raw text */
+  }
+  return { status: response.status(), body, requestBody: response.request().postData() };
+}
+
+/* ──────────────────────────────── the scenario ──────────────────────────────── */
+
+test.afterAll(async ({ api }) => {
+  // Safety net: the test restores in its own `finally`; this re-asserts the
+  // shared connection really is back to its original config, and repairs it if
+  // the test died before its `finally` ran.
+  if (!doctored) return;
+  const current = await api.connections.getById(doctored.connectionId);
+  if (current.config?.[MASTER_CATALOG_KEY] === undefined) {
+    await api.connections.update(doctored.connectionId, { config: doctored.config });
+  }
+  const repaired = await api.connections.getById(doctored.connectionId);
+  expect(
+    repaired.config?.[MASTER_CATALOG_KEY],
+    `connection ${doctored.connectionId} must be left with its original ${MASTER_CATALOG_KEY}`,
+  ).toBe(doctored.config[MASTER_CATALOG_KEY]);
+});
+
+test.describe('F4: destination with no master catalogue - every row ready, every record failed', () => {
+  test('the wizard is 100% green and the batch is 100% MASTER_CATALOG_NOT_CONFIGURED', async ({
+    page,
+    api,
+    world,
+    env,
+    poll,
+  }, testInfo) => {
+    const destination = pickBorrowsOfferDestination(world);
+    test.skip(
+      !destination,
+      'No active OfferCreator connection without EanCategoryMatcher (a borrows-taxonomy ' +
+        'destination such as Erli). Needed because its rows go `ready` without the operator ' +
+        'filling required category parameters, so "every row green" is assertable.',
+    );
+    const connection = destination!;
+    const token = await bearerToken(env);
+
+    const original = await api.connections.getById(connection.id);
+    const originalConfig = (original.config ?? {}) as Record<string, unknown>;
+    test.skip(
+      originalConfig[MASTER_CATALOG_KEY] === undefined,
+      `Connection "${connection.name}" has no ${MASTER_CATALOG_KEY} to remove. Configure a ` +
+        'master catalogue on it first (Connections -> Edit -> master catalogue), so the test can ' +
+        'temporarily clear it and restore it.',
+    );
+
+    const candidates = await findUnlistedCandidates(api, connection.id);
+    test.skip(
+      candidates.length === 0,
+      `No priced, in-stock, barcoded variant that is NOT yet listed on "${connection.name}". ` +
+        'An already-listed variant would be dropped before any record is created (F2). ' +
+        'Sync a fresh master product, or unlist one.',
+    );
+    const { [MASTER_CATALOG_KEY]: removed, ...withoutMasterCatalog } = originalConfig;
+    doctored = { connectionId: connection.id, config: originalConfig };
+
+    try {
+      await api.connections.update(connection.id, { config: withoutMasterCatalog });
+      const doctoredConnection = await api.connections.getById(connection.id);
+      expect(
+        doctoredConnection.config?.[MASTER_CATALOG_KEY],
+        'precondition: the destination now has no master catalogue configured',
+      ).toBeUndefined();
+
+      // (a) The wizard never mentions the missing master catalogue: rows are
+      // ready, nothing needs attention, and submit is enabled + accepted.
+      // Candidates are tried in turn because an individual variant can carry an
+      // unrelated blocker (a destination-specific field the catalogue lacks);
+      // what matters is that SOME row is green while the master catalogue is gone.
+      let counts: ReviewCounts | null = null;
+      const attempts: string[] = [];
+      for (const candidate of candidates.slice(0, 3)) {
+        await openWizard(page, {
+          productIds: [candidate.productId],
+          variantIds: [candidate.variantId],
+          connectionId: connection.id,
+        });
+        await completeConfigAndProceed(page);
+        const seen = await waitForReview(page);
+        attempts.push(
+          `${candidate.variantId} -> ready=${seen.ready} attention=${seen.attention}`,
+        );
+        if (seen.attention === 0 && seen.ready > 0) {
+          counts = seen;
+          break;
+        }
+      }
+      expect(
+        counts,
+        'a destination with no master catalogue produces no wizard-side blocker, so at least ' +
+          `one candidate row must be fully ready (tried: ${attempts.join('; ')})`,
+      ).not.toBeNull();
+      await expect(reviewCta(page)).toBeEnabled();
+
+      // PROOF (documentation only - never asserted on): the promise.
+      await captureProof(page, 'f04-before-review-ready', { region: reviewRegion(page) });
+
+      const submitted = await submitFromReview(page);
+      expect(submitted.status, `request: ${submitted.requestBody}`).toBe(202);
+      const { batchId } = submitted.body as { batchId: string; jobIds: string[] };
+
+      // (b) Every child record dies in the builder with the config error the
+      // wizard could have checked before the operator ever clicked submit.
+      const batch = await poll.until(
+        () => getBatch(env, token, batchId),
+        (value) => value.status !== 'running' && value.status !== 'pending',
+        {
+          timeoutMs: 180_000,
+          intervalMs: 3_000,
+          message: `bulk batch ${batchId} to reach a terminal status`,
+        },
+      );
+      // PROOF (documentation only): what actually happened to the green batch.
+      await captureProof(page, 'f04-before-result', {
+        fullPage: true,
+        prepare: async () => {
+          await page.goto(`/listings/bulk-batches/${batchId}`);
+          await page.locator('button[aria-label^="Failure details for"]').first().click();
+          await expect(page.locator('.bulk-batch__err-list').first()).toBeVisible({
+            timeout: 15_000,
+          });
+        },
+      });
+
+      expect(batch.failedCount, 'every record in the batch fails').toBe(batch.totalCount);
+      expect(batch.succeededCount).toBe(0);
+      const codes = batch.records.flatMap((record) =>
+        (record.errors ?? []).map((error) => error.code),
+      );
+      expect(
+        codes,
+        'the failure is the config gate the preflight never checked',
+      ).toContain('MASTER_CATALOG_NOT_CONFIGURED');
+      const fields = batch.records.flatMap((record) =>
+        (record.errors ?? []).map((error) => error.field),
+      );
+      expect(fields).toContain(`connection.config.${MASTER_CATALOG_KEY}`);
+
+      testInfo.annotations.push({
+        type: 'divergence',
+        description:
+          `wizard: ${counts!.ready} ready / ${counts!.attention} attention, submit 202; ` +
+          `batch ${batchId}: ${batch.failedCount}/${batch.totalCount} failed with ` +
+          `${[...new Set(codes)].join(', ')}`,
+      });
+    } finally {
+      await api.connections.update(connection.id, { config: originalConfig });
+      const restored = await api.connections.getById(connection.id);
+      expect(
+        restored.config?.[MASTER_CATALOG_KEY],
+        `the destination's ${MASTER_CATALOG_KEY} must be restored`,
+      ).toBe(removed);
+    }
+  });
+});

--- a/apps/e2e/tests/preflight-divergence/f05-seller-defaults.spec.ts
+++ b/apps/e2e/tests/preflight-divergence/f05-seller-defaults.spec.ts
@@ -1,0 +1,370 @@
+/**
+ * F5 - an Allegro connection with `sellerDefaults` never configured: every row
+ * ready, every record terminates SELLER_DEFAULTS_NOT_CONFIGURED
+ *
+ * ⚠️ CHARACTERIZATION TEST. It passes while the divergence exists and FAILS the
+ * moment the finding is closed (or was wrong in the first place). A red run here
+ * is a signal to re-read the finding, not a regression in the product.
+ *
+ * Both sides asserted:
+ *
+ *   (a) What the wizard presents - nothing at all about seller defaults. There is
+ *       no preflight for them: the config step gates only on the shared slice +
+ *       the platform section (delivery policy), the review row computes no
+ *       blocker from connection config, so rows read `ready` and the submit is
+ *       accepted with 202.
+ *   (b) What actually happens - `AllegroOfferManagerAdapter.createOffer` runs
+ *       `collectMissingSellerDefaultsFields(this.sellerDefaults)` as its FIRST
+ *       statement, before `maybeResolveProductCard`, and throws
+ *       `OfferCreateRejectedException` with one issue per missing field, code
+ *       `SELLER_DEFAULTS_NOT_CONFIGURED`. Every child record terminates `failed`.
+ *
+ * The audit DOWNGRADED this to low severity, and that downgrade is itself part of
+ * the characterization, so this spec asserts the legibility too: the failure is
+ * per-record (not a silent batch death), the structured error names the missing
+ * field, the message names where to fix it, and the batch-progress table renders
+ * both. Test 2 checks that in the browser. Only the FEEDBACK TIMING is wrong -
+ * the operator learns after submitting, not before.
+ *
+ * The gate is all-or-nothing and sits ahead of card resolution, so it blocks even
+ * a catalogue-card-linked create where Allegro would inherit GPSR from the card
+ * and never read these fields.
+ *
+ * Reachable state, per the audit's own correction: `sellerDefaults` is
+ * `@IsOptional()` on `AllegroConnectionConfigDto`, but its nested `location` /
+ * `responsibleProducerId` / `safetyInformation` are all REQUIRED, so a
+ * half-saved blob cannot be persisted. "Never configured" is the only reachable
+ * failing state - which is what this spec provisions.
+ *
+ * MUTATION + RESTORE: `sellerDefaults` is temporarily removed from the shared
+ * Allegro connection's config (config is replaced wholesale by
+ * `ConnectionRepository.update`, so there is no other way to unset a key) and
+ * restored in `afterAll`, verified. No marketplace offer is ever created - the
+ * gate fires before any Allegro API call - so the only footprint is one failed
+ * batch record.
+ *
+ * @module tests/preflight-divergence
+ */
+import { randomUUID } from 'node:crypto';
+import { test, expect } from '../../src/fixtures/test';
+import type { ApiClient } from '../../src/api/api-client';
+import type { BulkBatchSummary, Product, ProductVariant } from '../../src/api/api.types';
+import type { E2eEnv } from '../../src/config/env';
+import { captureProof } from './__proof__/capture';
+
+/** Request body of `POST /listings/bulk-create` (mirrored locally, #1741 shape). */
+interface BulkCreateBody {
+  connectionId: string;
+  productIds: string[];
+  sharedConfig: { stock: number; publishImmediately: boolean };
+  perVariantOverrides?: Record<string, { stock?: number; overrides?: Record<string, unknown> }>;
+  excludedVariantIds?: string[];
+}
+
+/** `BulkBatchRecordSummaryDto` carries `errors[]`; the mirrored type omits it. */
+interface RecordErrors {
+  field?: string | null;
+  code: string;
+  message: string;
+}
+type BatchWithErrors = Omit<BulkBatchSummary, 'records'> & {
+  records: Array<BulkBatchSummary['records'][number] & { errors?: RecordErrors[] | null }>;
+};
+
+/** Restored in `afterAll` - captured before the config is stripped. */
+let originalConfig: Record<string, unknown> | null = null;
+let connectionId: string | null = null;
+let batchId: string | null = null;
+
+test.describe.configure({ mode: 'serial' });
+
+test.describe('F5 - Allegro sellerDefaults never configured', () => {
+  test.afterAll(async ({ api }) => {
+    if (connectionId === null || originalConfig === null) return;
+    await api.connections.update(connectionId, { config: originalConfig });
+    const restored = await api.connections.getById(connectionId);
+    expect(
+      (restored.config ?? {}).sellerDefaults,
+      'the shared Allegro connection MUST leave this spec with its sellerDefaults restored',
+    ).toBeTruthy();
+  });
+
+  test('rows are ready and the submit is accepted, then every record terminates SELLER_DEFAULTS_NOT_CONFIGURED', async ({
+    api,
+    world,
+    env,
+    poll,
+  }) => {
+    const allegro = world.connectionFor('allegro');
+    test.skip(allegro === undefined, 'F5 needs an Allegro connection on the stack.');
+    const connection = await api.connections.getById(allegro!.id);
+    const config = connection.config ?? {};
+    test.skip(
+      config.sellerDefaults === undefined,
+      'F5 provisions the failing state by temporarily REMOVING `sellerDefaults` from the ' +
+        'Allegro connection config, so it needs a connection that currently HAS them ' +
+        '(otherwise there is nothing to restore afterwards and the stack would be left ' +
+        'degraded by this spec).',
+    );
+
+    // The seller-defaults gate lives in the ADAPTER, and `OfferBuilderService`
+    // runs first: its required-OFFER-section-parameter gate (finding F1) throws
+    // PARAMETER_REQUIRED before `createOffer` is ever called. So the fixture must
+    // be a row that is genuinely complete - category resolved and every required
+    // offer-section parameter supplied, i.e. exactly what an operator gets after
+    // filling the row editor. Only such a row proves F5's actual claim: a green,
+    // fully-prepared batch still dies, all of it, on connection config.
+    const seed = await findBuilderReadyVariant(api, world, env, connection.id);
+    test.skip(
+      seed === null,
+      'F5 needs one master variant that (1) has no Allegro offer mapping yet and (2) resolves ' +
+        'to an Allegro category, so its required offer-section parameters can be supplied and ' +
+        "the builder's own PARAMETER_REQUIRED gate (F1) does not mask the seller-defaults " +
+        'gate. No such variant exists on this stack.',
+    );
+
+    // ── Provision: strip sellerDefaults (restored in afterAll) ────────────────
+    connectionId = connection.id;
+    originalConfig = { ...config };
+    const stripped = { ...config };
+    delete stripped.sellerDefaults;
+    const patched = await api.connections.update(connection.id, { config: stripped });
+    expect(
+      (patched.config ?? {}).sellerDefaults,
+      '`sellerDefaults` is @IsOptional() on the config DTO, so the never-configured state ' +
+        'is a legitimately persistable one',
+    ).toBeUndefined();
+
+    // (a) The wizard has no preflight for this: the submit is accepted outright.
+    const result = await submitBulkCreate(env, {
+      connectionId: connection.id,
+      productIds: [seed!.variant.id],
+      sharedConfig: { stock: 1, publishImmediately: true },
+      perVariantOverrides: {
+        [seed!.variant.id]: {
+          overrides: {
+            categoryId: seed!.categoryId,
+            parameters: seed!.requiredOfferParamIds.map((id) => ({
+              id,
+              values: ['1'],
+              section: 'offer',
+            })),
+          },
+        },
+      },
+      excludedVariantIds: [],
+    });
+    expect(
+      result.status,
+      `submit is accepted with sellerDefaults missing - 100% green: ${JSON.stringify(result.body)}`,
+    ).toBe(202);
+    batchId = (result.body as { batchId?: string }).batchId ?? null;
+    expect(batchId, 'the accept response carries a batchId').toBeTruthy();
+
+    // (b) …and then every child fails, one by one, at the adapter gate.
+    const batch = await poll.until(
+      () => api.listings.getBulkBatch(batchId!) as Promise<BatchWithErrors>,
+      (b) => b.records.length > 0 && b.records.every((r) => r.status === 'failed'),
+      {
+        timeoutMs: 180_000,
+        intervalMs: 3_000,
+        message: 'every offer-creation record in the batch to terminate `failed`',
+      },
+    );
+
+    expect(
+      batch.failedCount,
+      'the failure is PER-RECORD and the batch counters terminate (not a stuck batch) - ' +
+        'this is why the audit downgraded F5 to low severity',
+    ).toBe(batch.totalCount);
+
+    const codes = batch.records.flatMap((r) => (r.errors ?? []).map((e) => e.code));
+    expect(
+      codes,
+      'the terminal reason is the seller-defaults gate, not a generic marketplace rejection',
+    ).toContain('SELLER_DEFAULTS_NOT_CONFIGURED');
+
+    const issues = batch.records.flatMap((r) => r.errors ?? []);
+    const sellerDefaultIssues = issues.filter((e) => e.code === 'SELLER_DEFAULTS_NOT_CONFIGURED');
+    expect(
+      sellerDefaultIssues.every((e) => (e.field ?? '') !== ''),
+      `each issue names the missing field: ${JSON.stringify(sellerDefaultIssues)}`,
+    ).toBe(true);
+    expect(
+      sellerDefaultIssues[0].message,
+      'and the message names where to fix it - legible, just late',
+    ).toMatch(/seller-defaults|connection edit page/i);
+    expect(
+      batch.records.every((r) => r.externalOfferId === null),
+      'no Allegro offer was created: the gate is the FIRST statement of createOffer, ahead ' +
+        'of catalogue-card resolution and any outbound call',
+    ).toBe(true);
+  });
+
+  test('the batch progress table renders the reason legibly (the audit downgrade, verified)', async ({
+    page,
+  }) => {
+    test.skip(batchId === null, 'depends on the batch submitted by the test above.');
+
+    await page.goto(`/listings/bulk-batches/${batchId!}`);
+
+    const failedCell = page.locator('.bulk-batch__err').first();
+    await expect(
+      failedCell,
+      'the per-variant row shows the failure message inline, not a bare "failed"',
+    ).toBeVisible({ timeout: 30_000 });
+    await expect(failedCell).toContainText(/seller-defaults|Responsible Producer|GPSR/i);
+
+    // The structured detail panel carries the code + field, which is the whole
+    // basis for calling this "legible but late".
+    await page.locator('button[aria-label^="Failure details for"]').first().click();
+    const detail = page.locator('.bulk-batch__err-list').first();
+    await expect(detail, 'the failure-details panel lists the structured error').toBeVisible({
+      timeout: 15_000,
+    });
+
+    // PROOF (documentation only - never asserted on): what actually happened to
+    // the batch the API accepted without a word about seller defaults. There is
+    // no `f05-before-review-ready.png` counterpart: this spec submits through the
+    // raw API on purpose, because the wizard has no seller-defaults preflight to
+    // photograph (that absence IS the finding).
+    await captureProof(page, 'f05-before-result', { fullPage: true });
+
+    await expect(detail).toContainText('SELLER_DEFAULTS_NOT_CONFIGURED');
+  });
+});
+
+/** A fixture that clears `OfferBuilderService`'s own gates so F5's can be seen. */
+interface BuilderReadyVariant {
+  variant: ProductVariant;
+  categoryId: string;
+  /** Required `section: 'offer'` parameter ids the builder gate insists on. */
+  requiredOfferParamIds: string[];
+}
+
+/**
+ * First unmapped single-variant master product whose barcode resolves to an
+ * Allegro category, together with that category's required offer-section
+ * parameter ids. Single-variant keeps the fan-out at one job; the resolved
+ * category + parameters are what let the request reach the adapter at all.
+ */
+async function findBuilderReadyVariant(
+  api: ApiClient,
+  world: {
+    listProducts(limit?: number): Promise<Product[]>;
+    variantsOf(id: string): Promise<ProductVariant[]>;
+  },
+  env: E2eEnv,
+  connectionId_: string,
+): Promise<BuilderReadyVariant | null> {
+  const mapped = await mappedVariantIds(api, connectionId_);
+  const candidates: ProductVariant[] = [];
+  for (const product of await world.listProducts(100)) {
+    const variants = await world.variantsOf(product.id);
+    if (variants.length !== 1) continue;
+    const [variant] = variants;
+    if (mapped.has(variant.id)) continue;
+    if ((variant.ean ?? variant.gtin) === null) continue;
+    candidates.push(variant);
+  }
+  if (candidates.length === 0) return null;
+
+  const resolved = await resolveCategories(
+    env,
+    connectionId_,
+    candidates.map((v) => ({ variantId: v.id, ean: v.ean ?? v.gtin ?? null })),
+  );
+  for (const variant of candidates) {
+    const outcome = resolved[variant.id];
+    if (outcome === undefined || outcome.kind !== 'matched') continue;
+    const categoryId = outcome.allegroCategoryId;
+    if (typeof categoryId !== 'string' || categoryId === '') continue;
+    const parameters = await api.listings.categoryParameters(connectionId_, categoryId);
+    return {
+      variant,
+      categoryId,
+      requiredOfferParamIds: parameters
+        .filter((p) => p.required && p.section === 'offer')
+        .map((p) => p.id),
+    };
+  }
+  return null;
+}
+
+/** Raw `POST .../categories/resolve-batch` (no `ApiClient` method exists). */
+async function resolveCategories(
+  env: E2eEnv,
+  connectionId_: string,
+  items: Array<{ variantId: string; ean: string | null }>,
+): Promise<Record<string, { kind: string; allegroCategoryId?: string }>> {
+  const token = await loginForRawCalls(env);
+  const response = await fetch(
+    `${env.apiUrl}/v1/listings/connections/${connectionId_}/categories/resolve-batch`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        Authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ items }),
+    },
+  );
+  if (!response.ok) return {};
+  const body = (await response.json()) as {
+    results?: Record<string, { kind: string; allegroCategoryId?: string }>;
+  };
+  return body.results ?? {};
+}
+
+async function mappedVariantIds(api: ApiClient, connectionId_: string): Promise<Set<string>> {
+  const ids = new Set<string>();
+  for (let offset = 0; ; offset += 100) {
+    const page = await api.listings.list({ connectionId: connectionId_, limit: 100, offset });
+    page.items.forEach((mapping) => ids.add(mapping.internalId));
+    if (page.items.length === 0 || offset + 100 >= page.total) break;
+  }
+  return ids;
+}
+
+/**
+ * Raw `POST /listings/bulk-create`. The node `ApiClient` exposes no bulk-submit
+ * method and this suite must not modify `src/`, so the call is issued directly
+ * here. Returns status + parsed body rather than throwing.
+ */
+async function submitBulkCreate(
+  env: E2eEnv,
+  body: BulkCreateBody,
+): Promise<{ status: number; body: unknown }> {
+  const token = await loginForRawCalls(env);
+  const response = await fetch(`${env.apiUrl}/v1/listings/bulk-create`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      Authorization: `Bearer ${token}`,
+      'x-idempotency-key': randomUUID(),
+    },
+    body: JSON.stringify(body),
+  });
+  const raw = await response.text();
+  let parsed: unknown = raw;
+  try {
+    parsed = raw.length > 0 ? JSON.parse(raw) : undefined;
+  } catch {
+    /* non-JSON body - keep the raw text */
+  }
+  return { status: response.status, body: parsed };
+}
+
+async function loginForRawCalls(env: E2eEnv): Promise<string> {
+  const response = await fetch(`${env.apiUrl}/v1/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: env.adminUser, password: env.adminPass }),
+  });
+  if (!response.ok) {
+    throw new Error(`Login failed: HTTP ${response.status} ${await response.text()}`);
+  }
+  return ((await response.json()) as { access_token: string }).access_token;
+}

--- a/apps/e2e/tests/preflight-divergence/f06-erli-image-stuck-pending.spec.ts
+++ b/apps/e2e/tests/preflight-divergence/f06-erli-image-stuck-pending.spec.ts
@@ -1,0 +1,847 @@
+/**
+ * F6 - Erli images: the wizard counts strings, the adapter demands public https,
+ * and the record that loses that argument never terminates
+ *
+ * ⚠️ CHARACTERIZATION TEST. It passes **while the divergence exists** and goes RED
+ * once it is closed. A failure here is NOT a regression - it means the finding was
+ * wrong, or it has been fixed and this file should be retired (or inverted into a
+ * normal regression test).
+ *
+ * The divergence has two independent halves, and BOTH are asserted:
+ *
+ *   (a) THE WIZARD SAYS READY. `bulk-policy.ts` `imageCountForVariant` /
+ *       `imageCountForRow` count any NON-EMPTY STRING - zero protocol
+ *       validation - and that count is the only input the Erli plugin's
+ *       `erli:missing-image` blocker consumes. So a row whose entire image set
+ *       is `http://…` reads `ready`, the readiness summary reports 0 needing
+ *       attention, and the submit CTA is enabled. The row editor's "Add image"
+ *       field applies no URL-shape validation either: the image array is held in
+ *       component state outside react-hook-form, and `makeBulkEditModalSchema`
+ *       has no `imageUrls` member at all - so `baseForm.trigger()` (the editor's
+ *       only save gate) cannot see it. Contrast `categoryId`, which that schema
+ *       DOES require and which does block the save.
+ *
+ *   (b) THE RECORD NEVER TERMINATES. `ErliOfferManagerAdapter.sanitizeImageUrls`
+ *       FILTERS rather than rejects - every URL failing `isSafePublicHttpsUrl`
+ *       (non-https, localhost/`.internal`, RFC1918, IPv6 ULA/link-local,
+ *       169.254.169.254) is dropped with a `logger.warn` - and `resolveImages`
+ *       throws `ErliConfigException` only when ZERO survive. That exception
+ *       `extends Error` and is classified by NEITHER
+ *       `offer-creation-execution.service.ts` (whose adapter-call catch only
+ *       narrows `OfferCreateRejectedException`) NOR `mapBuilderException`. So it
+ *       is rethrown past the record, `advanceBatchStatus` is never reached, and:
+ *         - the `OfferCreationRecord` stays `pending` with `errors: null`,
+ *         - the parent batch stays `running` - `succeededCount + failedCount`
+ *           can never reach `totalCount`, so no terminal status is derivable,
+ *         - the batch-progress row renders "Queued", forever.
+ *       `ErliRetryClassifierAdapter` marks `ErliConfigException` non-retryable,
+ *       so the job is marked `dead` on the FIRST attempt and the only readable
+ *       reason lands in `sync_jobs.lastError` - a place the batch view, the
+ *       record, and the operator never look.
+ *
+ * Test 3 covers the SEPARATE, quieter case from the same mechanism: when SOME
+ * images survive sanitisation the gate stays silent and the offer goes out with a
+ * shortened gallery, with no signal anywhere. Proving that WITHOUT creating a real
+ * marketplace product needs a trick: `buildCreateBody` calls `resolveImages`
+ * BEFORE `resolveDispatchTime`, so a partially-unsafe image set plus a
+ * deliberately-malformed `dispatchTime` fails on the DISPATCH TIME. The image that
+ * was silently dropped is never mentioned by anything the operator can read - which
+ * is exactly the claim - and no offer reaches Erli. (What this cannot show
+ * end-to-end is the shortened gallery on a LIVE offer; asserting that would mean
+ * publishing a real sandbox product and permanently consuming the fixture variant.)
+ *
+ * GETTING PAST THE EARLIER GATES. An Erli row dies on F10
+ * (`overrides.categoryId` / `REQUIRED`) and then F1 (`parameters.Stan` /
+ * `PARAMETER_REQUIRED`) long before the adapter is reached, so tests 2 and 3
+ * submit through the raw API with a resolved `categoryId` + the category's
+ * required offer-section parameters supplied - exactly the shape an operator gets
+ * after filling the row editor, and the same manoeuvre F5 needed to see past F1.
+ * That in turn requires a stack whose `PerOverrideDto.overrides` still accepts
+ * `categoryId` (#1924); on a stack that still ships `OverridesNoCategoryDto` the
+ * submit 400s and the tests self-skip with the recipe rather than assert the
+ * wrong failure.
+ *
+ * Test 1 is the browser half and needs the unsafe URL to reach the row's override,
+ * which means saving the row editor - so it also picks a category there, because
+ * that IS a hard save gate on this destination. That pick is a precondition, not
+ * part of the claim; it makes the assertion strictly stronger, since the row is
+ * then as complete as the wizard is capable of asking for and STILL says nothing
+ * about the images.
+ *
+ * FOOTPRINT. The finding IS "the batch never terminates", so tests 2 and 3 each
+ * leave one permanently-`running` batch with a `pending` record behind on the
+ * stack; test 1 aborts its POST and leaves nothing. No Erli product is ever
+ * created and no offer mapping is written, so the fixture variant stays reusable
+ * by the next run. Every leftover is annotated.
+ *
+ * @module tests/preflight-divergence
+ */
+import { randomUUID } from 'node:crypto';
+import type { Locator, Page } from '@playwright/test';
+import { test, expect } from '../../src/fixtures/test';
+import type { ApiClient } from '../../src/api/api-client';
+import type { Connection, Product, ProductVariant, SyncJob } from '../../src/api/api.types';
+import type { E2eEnv } from '../../src/config/env';
+import type { World } from '../../src/world/world';
+import { captureProof, reviewRegion } from './__proof__/capture';
+
+test.describe.configure({ mode: 'serial' });
+
+/**
+ * A syntactically valid URL that `class-validator`'s `@IsUrl` accepts (so the
+ * request DTO lets it through) and `isSafePublicHttpsUrl` rejects on protocol
+ * alone. Deliberately NOT a localhost/RFC1918 host: the point is that the plain
+ * `http://` scheme - the shape a shop serves before its TLS terminator is wired -
+ * is enough, so this is not an exotic edge case.
+ */
+const UNSAFE_IMAGE_URL = 'http://example.com/openlinker-e2e-f6-unsafe.jpg';
+
+/** Batch statuses that mean "this batch will never move again". */
+const TERMINAL_BATCH_STATUSES = new Set(['completed', 'partially-failed', 'failed']);
+
+/**
+ * How long to keep watching after the worker has already given up. The job dies
+ * within a couple of seconds of enqueue; this is the settle window in which a
+ * healthy pipeline would have terminated the record and the batch.
+ */
+const STUCK_OBSERVATION_MS = 25_000;
+
+/** `BulkBatchRecordSummaryDto.errors` - on the wire, absent from the shared type. */
+interface RecordError {
+  field?: string | null;
+  code: string;
+  message: string;
+}
+
+interface BatchRecord {
+  id: string;
+  internalVariantId: string;
+  status: string;
+  externalOfferId: string | null;
+  errors?: RecordError[] | null;
+}
+
+interface BatchWithErrors {
+  id: string;
+  status: string;
+  totalCount: number;
+  succeededCount: number;
+  failedCount: number;
+  records: BatchRecord[];
+}
+
+/** Per-variant override entry of `POST /listings/bulk-create`. */
+interface BulkOverride {
+  stock?: number;
+  publishImmediately?: boolean;
+  price?: { amount: number; currency: string };
+  overrides?: Record<string, unknown>;
+}
+
+interface BulkCreateBody {
+  connectionId: string;
+  productIds: string[];
+  sharedConfig: { stock: number; publishImmediately: boolean };
+  perProductOverrides?: Record<string, BulkOverride>;
+  perVariantOverrides?: Record<string, BulkOverride>;
+  excludedVariantIds?: string[];
+}
+
+/** The fixture both the browser half and the API half run against. */
+interface Fixture {
+  product: Product;
+  variant: ProductVariant;
+  /** Master image URLs that DO survive `isSafePublicHttpsUrl` (test 3 needs one). */
+  safeImages: string[];
+  /** A category the Erli connection can read parameters for (clears F10's gate). */
+  categoryId: string;
+  /** That category's required `section: 'offer'` parameter ids (clears F1's gate). */
+  requiredOfferParamIds: string[];
+}
+
+/** Resolved once by test 1 and replayed by tests 2 and 3 (serial describe). */
+let fixture: Fixture | null = null;
+let erliConnection: Connection | null = null;
+
+/* ─────────────────────────────── raw API helpers ────────────────────────────── */
+
+async function bearer(env: E2eEnv): Promise<string> {
+  const response = await fetch(`${env.apiUrl}/v1/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: env.adminUser, password: env.adminPass }),
+  });
+  if (!response.ok) {
+    throw new Error(`E2E login failed: HTTP ${response.status} ${await response.text()}`);
+  }
+  return ((await response.json()) as { access_token: string }).access_token;
+}
+
+/**
+ * Raw `POST /listings/bulk-create`. The node `ApiClient` exposes no bulk-submit
+ * method and this suite must not modify `src/`, so the call is issued here.
+ * Returns status + parsed body rather than throwing, because a 400 is one of the
+ * outcomes this spec has to READ (it is the "stack predates #1924" skip signal).
+ */
+async function submitBulkCreate(
+  env: E2eEnv,
+  body: BulkCreateBody,
+): Promise<{ status: number; body: unknown; raw: string }> {
+  const token = await bearer(env);
+  const response = await fetch(`${env.apiUrl}/v1/listings/bulk-create`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      Authorization: `Bearer ${token}`,
+      'x-idempotency-key': randomUUID(),
+    },
+    body: JSON.stringify(body),
+  });
+  const raw = await response.text();
+  let parsed: unknown = raw;
+  try {
+    parsed = raw.length > 0 ? JSON.parse(raw) : undefined;
+  } catch {
+    /* non-JSON body - keep the raw text */
+  }
+  return { status: response.status, body: parsed, raw };
+}
+
+/** Raw read - the shared `BulkBatchSummary` type omits the per-record `errors[]`. */
+async function getBatch(env: E2eEnv, batchId: string): Promise<BatchWithErrors> {
+  const token = await bearer(env);
+  const response = await fetch(`${env.apiUrl}/v1/listings/bulk-create/${batchId}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!response.ok) {
+    throw new Error(`GET bulk-create/${batchId} -> HTTP ${response.status}`);
+  }
+  return (await response.json()) as BatchWithErrors;
+}
+
+/**
+ * The `marketplace.offer.create` job the bulk submit enqueued for one variant.
+ * Keyed on the batch-scoped idempotency key `BulkListingSubmitService` mints, so
+ * a concurrent batch on the same connection cannot be mistaken for this one.
+ */
+async function findChildJob(
+  api: ApiClient,
+  connectionId: string,
+  batchId: string,
+  variantId: string,
+): Promise<SyncJob | undefined> {
+  const page = await api.syncJobs.list({
+    connectionId,
+    jobType: 'marketplace.offer.create',
+    limit: 100,
+  });
+  const key = `bulk:${batchId}:variant:${variantId}`;
+  return page.items.find((job) => job.idempotencyKey === key);
+}
+
+/* ────────────────────────── local fixture discovery ─────────────────────────── */
+
+/** Mirror of `isSafePublicHttpsUrl` - which master images the adapter would keep. */
+function isSafePublicHttps(value: string): boolean {
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return false;
+  }
+  if (url.protocol !== 'https:') return false;
+  const host = url.hostname.toLowerCase();
+  if (host === 'localhost' || host.endsWith('.internal') || host === '169.254.169.254') return false;
+  if (host === '[::1]' || host === '[::]' || /^\[f[cd]/.test(host) || /^\[fe[89ab]/.test(host)) {
+    return false;
+  }
+  if (host === '0.0.0.0' || /^(127|10)\./.test(host) || /^192\.168\./.test(host)) return false;
+  return !/^172\.(1[6-9]|2\d|3[01])\./.test(host);
+}
+
+function productImages(product: Product): string[] {
+  const images = (product as unknown as { images?: unknown }).images;
+  return Array.isArray(images) ? images.filter((u): u is string => typeof u === 'string') : [];
+}
+
+/** Every variant id that already carries an offer mapping on `connectionId`. */
+async function listedVariantIds(api: ApiClient, connectionId: string): Promise<Set<string>> {
+  const ids = new Set<string>();
+  for (let offset = 0; ; offset += 100) {
+    const page = await api.listings.list({ connectionId, limit: 100, offset });
+    page.items.forEach((mapping) => ids.add(mapping.internalId));
+    if (page.items.length === 0 || offset + 100 >= page.total) break;
+  }
+  return ids;
+}
+
+/**
+ * A row that reaches Review green on Erli and can be pushed all the way to the
+ * adapter. Each condition closes a way the run could land on a DIFFERENT finding:
+ *
+ *   1. Single-variant     - keeps the fan-out at one job, so "the batch never
+ *                           terminates" is about ONE record, not a partial batch.
+ *   2. Not already listed - `filterAlreadyListed` would drop it and the submit
+ *                           would die on F2's empty-batch path instead.
+ *   3. Priced + stocked   - otherwise the wizard flags the row for the wrong
+ *                           reason and the readiness assertion is meaningless.
+ *   4. Carries a barcode  - `enforceIdentifierRules` runs at submit.
+ *   5. At least one image that WOULD survive sanitisation - test 3's mixed set
+ *      needs a genuine survivor, and test 1's "remove the master images" step
+ *      only means something if there were safe ones to remove.
+ */
+async function findFixtureCandidate(
+  api: ApiClient,
+  world: World,
+  connectionId: string,
+): Promise<{ product: Product; variant: ProductVariant; safeImages: string[] } | null> {
+  const listed = await listedVariantIds(api, connectionId);
+  for (const summary of await world.listProducts(100)) {
+    const product = await api.products.getById(summary.id);
+    const variants = product.variants ?? [];
+    if (variants.length !== 1) continue;
+    const [variant] = variants;
+    if (listed.has(variant.id)) continue;
+    if (product.price === null || product.price <= 0) continue;
+    if ((variant.ean ?? variant.gtin ?? null) === null) continue;
+    const safeImages = productImages(product).filter(isSafePublicHttps);
+    if (safeImages.length === 0) continue;
+    const availability = await api.inventory.availability([variant.id]);
+    if ((availability[0]?.totalAvailable ?? 0) <= 0) continue;
+    return { product, variant, safeImages };
+  }
+  return null;
+}
+
+/**
+ * A category the Erli connection can actually read parameters for, plus that
+ * category's required offer-section parameter ids. Erli borrows Allegro's
+ * taxonomy (#1045), so the probe category is the same `E2E_FRESH_ALLEGRO_CATEGORY_ID`
+ * the rest of the suite pins; a non-empty parameter list also proves the
+ * duck-typed catalogue client is attached (i.e. F10's gate is armed and the
+ * `categoryId` override is genuinely required).
+ */
+async function resolveCategoryGate(
+  api: ApiClient,
+  connectionId: string,
+  categoryId: string,
+): Promise<{ categoryId: string; requiredOfferParamIds: string[] } | null> {
+  try {
+    const parameters = await api.listings.categoryParameters(connectionId, categoryId);
+    if (parameters.length === 0) return null;
+    return {
+      categoryId,
+      requiredOfferParamIds: parameters
+        .filter((parameter) => parameter.required && parameter.section === 'offer')
+        .map((parameter) => parameter.id),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** The overrides block that clears F10 (category) and F1 (offer parameters). */
+function gateClearingOverrides(current: Fixture): Record<string, unknown> {
+  return {
+    categoryId: current.categoryId,
+    parameters: current.requiredOfferParamIds.map((id) => ({
+      id,
+      values: ['1'],
+      section: 'offer',
+    })),
+  };
+}
+
+/* ─────────────────────────────── wizard driving ─────────────────────────────── */
+
+/**
+ * The Review step's submit CTA, tolerant of both label generations ("Approve all
+ * (N)" on the build the shared page object was written against, "Create offers
+ * (N)" on the current one). The `(N)` suffix is what keeps it from also matching
+ * the confirm modal's own bare "Create offers" button.
+ */
+function submitCta(page: Page): Locator {
+  return page.getByRole('button', { name: /^(Approve all|Create offers)\s*\(\d+\)$/ }).first();
+}
+
+/**
+ * Read the Review step's readiness counters off its `role="status"` summary. The
+ * shared page object's `needsAttentionCount()` parses the FIRST number of the
+ * current "N ready · M need attention · K excluded" phrasing, i.e. it returns the
+ * READY count and fails open. Anchor on the labelled number instead.
+ */
+async function readinessCounts(
+  page: Page,
+): Promise<{ ready: number; needAttention: number; raw: string }> {
+  const hint = page.getByRole('status').filter({ hasText: /needs? attention/ }).first();
+  if ((await hint.count()) === 0) return { ready: 0, needAttention: 0, raw: '(no readiness hint)' };
+  const raw = (await hint.innerText()).replace(/\s+/g, ' ').trim();
+  const attention = /(\d+)\s+needs?\s+attention/i.exec(raw);
+  const ready = /(\d+)\s+ready/i.exec(raw);
+  return { ready: ready ? Number(ready[1]) : 0, needAttention: attention ? Number(attention[1]) : 0, raw };
+}
+
+/**
+ * Wait until the Review step has SETTLED - the async per-category parameter
+ * schema has resolved and the row blockers reflect it - so a transient
+ * "0 need attention, submit disabled" limbo is never read as readiness.
+ */
+async function waitForReviewSettled(page: Page): Promise<void> {
+  await expect(async () => {
+    const cta = submitCta(page);
+    if ((await cta.count()) === 0) throw new Error('Review step has not rendered its submit CTA.');
+    const [enabled, counts] = await Promise.all([cta.isEnabled(), readinessCounts(page)]);
+    if (!enabled && counts.needAttention === 0) {
+      throw new Error(`Review still resolving: submit disabled with no needs-attention rows (${counts.raw}).`);
+    }
+  }).toPass({ timeout: 60_000 });
+}
+
+/**
+ * Pick the destination on the Config step. The step renders a grouped RADIO RAIL
+ * when more than one publish destination exists and a plain alert when there is
+ * only one; the shared page object only covers the older `<select>` layout.
+ */
+async function selectDestination(page: Page, name: string): Promise<void> {
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const radio = page.getByRole('radio', { name: new RegExp(escaped) });
+  if ((await radio.count()) > 0) {
+    await radio.first().click();
+    return;
+  }
+  const select = page.locator('select#bulk-connection');
+  if ((await select.count()) > 0) await select.selectOption({ label: name });
+}
+
+/**
+ * Satisfy the row editor's ONLY hard save gate - the category. This Erli
+ * connection duck-types `fetchCategories`, so `makeBulkEditModalSchema` is built
+ * with `requireCategory: true` and `baseForm.trigger()` refuses to save while
+ * `categoryId` is blank ("Category is required" ▲ next to the crumb). Nothing
+ * comparable exists for the image set, which is the point: the editor blocks on
+ * the field it can validate and waves through the one it cannot.
+ *
+ * Drills `E2E_FRESH_ALLEGRO_CATEGORY_PATH` in the nested `BulkCategoryChooseModal`
+ * (non-leaf rows expose "Browse into {name}", leaves a "Select" button).
+ */
+async function pickCategoryIfRequired(page: Page, editor: Locator, path: string[]): Promise<void> {
+  if ((await editor.getByRole('img', { name: 'Category is required' }).count()) === 0) return;
+  await editor.getByRole('button', { name: 'Change category' }).first().click();
+
+  const picker = page.locator('.bulk-editor__catpick');
+  await expect(picker.getByLabel('Search categories')).toBeVisible({ timeout: 30_000 });
+  for (let depth = 0; depth < path.length; depth += 1) {
+    const name = path[depth];
+    const row = picker
+      .locator('li.bulk-editor__catpick-item')
+      .filter({ has: page.getByText(name, { exact: true }) })
+      .first();
+    await expect(row, `category node "${name}" (depth ${depth}) is listed`).toBeVisible({
+      timeout: 30_000,
+    });
+    if (depth === path.length - 1) {
+      await row.getByRole('button', { name: /^Select(ed)?$/ }).click();
+      break;
+    }
+    await row.getByRole('button', { name: `Browse into ${name}` }).click();
+    await expect(picker.getByText('Fetching categories')).toHaveCount(0, { timeout: 30_000 });
+  }
+  await expect(picker).toHaveCount(0, { timeout: 20_000 });
+  await expect(
+    editor.getByRole('img', { name: 'Category is required' }),
+    'the category the editor demanded is now set',
+  ).toHaveCount(0, { timeout: 20_000 });
+}
+
+/**
+ * Replace the row's whole image set with one `http://` URL, through the row
+ * editor an operator actually uses. `bulk-edit-modal.tsx` renders the image
+ * strip as a "Remove image" (`×`) button per thumbnail plus an "Add image"
+ * (`＋`) control that reveals a "New image URL" field committed by an "Add"
+ * button. Not one of those steps validates the URL's shape - the array lives in
+ * component state, outside the form the save gate validates.
+ */
+async function replaceImagesWithUnsafeUrl(page: Page, categoryPath: string[]): Promise<void> {
+  await page.getByRole('button', { name: 'Edit', exact: true }).first().click();
+  const editor = page.getByRole('dialog').first();
+  await expect(editor.getByRole('button', { name: 'Save all' })).toBeVisible({ timeout: 30_000 });
+  await pickCategoryIfRequired(page, editor, categoryPath);
+
+  // Strip the master set one thumbnail at a time. The `×` is `display: none`
+  // until its thumb is hovered (`.bulk-editor__img-strip--editable
+  // .bulk-editor__img-thumb:hover .bulk-editor__img-x`), so each removal is
+  // hover-then-click, and each is awaited before the next (the strip re-renders
+  // per change, so a blind click loop overshoots).
+  const thumbs = editor.locator('.bulk-editor__img-strip--editable .bulk-editor__img-thumb');
+  for (let remaining = await thumbs.count(); remaining > 0; remaining -= 1) {
+    const thumb = thumbs.first();
+    await thumb.hover();
+    await thumb.getByRole('button', { name: 'Remove image' }).click();
+    await expect(thumbs).toHaveCount(remaining - 1, { timeout: 15_000 });
+  }
+
+  await editor.getByRole('button', { name: 'Add image' }).first().click();
+  await editor.getByLabel('New image URL').first().fill(UNSAFE_IMAGE_URL);
+  await editor.getByRole('button', { name: 'Add', exact: true }).first().click();
+  await expect(
+    thumbs,
+    'exactly one image (the unsafe URL) survives in the editor',
+  ).toHaveCount(1, { timeout: 15_000 });
+
+  await editor.getByRole('button', { name: 'Save all' }).click();
+  await expect(page.getByRole('dialog')).toHaveCount(0, { timeout: 20_000 });
+}
+
+/* ──────────────────────────────── the scenario ──────────────────────────────── */
+
+test.describe('F6 - Erli image sanitisation vs the wizard string count', () => {
+  test('(a) an all-http image set reads READY and the wizard submits it verbatim', async ({
+    env,
+    api,
+    world,
+    page,
+  }, testInfo) => {
+    // Fixture resolution walks the catalogue (product detail + availability per
+    // candidate) and the wizard round-trips the category-parameter schema, both
+    // well past the suite's default per-test budget.
+    test.setTimeout(300_000);
+
+    const erli = world.connectionsFor('erli').find((connection) => connection.status === 'active');
+    test.skip(
+      !erli,
+      'No usable fixture: this stack has no ACTIVE Erli connection. F6 is triggered by ' +
+        "`ErliOfferManagerAdapter`'s image sanitisation, so it needs an Erli publish destination " +
+        '(Connections -> Add -> Erli, with an API key and `defaultDispatchTime` configured).',
+    );
+    erliConnection = erli!;
+
+    const gate = await resolveCategoryGate(api, erli!.id, env.freshAllegroCategoryId);
+    test.skip(
+      gate === null,
+      'No usable fixture: the Erli connection cannot read category parameters for ' +
+        `${env.freshAllegroCategoryId}, so tests 2/3 could not clear F10's ` +
+        '`overrides.categoryId / REQUIRED` gate and would assert the wrong failure. Give the Erli ' +
+        'connection Allegro category credentials (allegroClientId + allegroClientSecret), or ' +
+        'override the probe category with E2E_FRESH_ALLEGRO_CATEGORY_ID.',
+    );
+
+    const candidate = await findFixtureCandidate(api, world, erli!.id);
+    test.skip(
+      candidate === null,
+      'No usable fixture: this stack has no master product that is (a) single-variant, (b) not ' +
+        'yet listed on the Erli connection, (c) priced, stocked and carrying a barcode, and ' +
+        '(d) carrying at least one image URL that WOULD pass `isSafePublicHttpsUrl` (public ' +
+        'https host). Point the master shop\'s `config.storefrontBaseUrl` at an https tunnel and ' +
+        're-run master.product.syncAll + master.inventory.syncAll.',
+    );
+
+    fixture = { ...candidate!, ...gate! };
+
+    expect(
+      fixture.safeImages.length,
+      'fixture sanity: the master images the wizard counts are genuinely SAFE ones, so any ' +
+        'divergence observed below comes from the operator-supplied URL and not from the stack ' +
+        'happening to serve its catalogue over http',
+    ).toBeGreaterThan(0);
+
+    const query = new URLSearchParams({
+      productIds: fixture.product.id,
+      variantIds: fixture.variant.id,
+      connectionId: erli!.id,
+    });
+    await page.goto(`/listings/bulk-create/wizard?${query.toString()}`);
+    await expect(page.getByRole('heading', { name: 'Bulk marketplace offer creation' })).toBeVisible({
+      timeout: 30_000,
+    });
+    await selectDestination(page, erli!.name);
+
+    // Erli's buyability selects (delivery price list + responsible producer) are
+    // the config step's only platform gate; the image set is not asked about here
+    // either, which is the finding restated one step earlier.
+    const proceed = page.getByRole('button', { name: /^Proceed/ });
+    await expect(async () => {
+      const selects = page.locator('select');
+      const count = await selects.count();
+      for (let index = 0; index < count; index += 1) {
+        const select = selects.nth(index);
+        if (!(await select.isEnabled())) continue;
+        if ((await select.inputValue()) !== '') continue;
+        const value = await select.locator('option:not([value=""])').first().getAttribute('value');
+        if (value) await select.selectOption(value);
+      }
+      expect(await proceed.isEnabled(), 'the Config step "Proceed" CTA should unlock').toBe(true);
+    }).toPass({ timeout: 90_000 });
+    await proceed.click();
+
+    await expect(submitCta(page)).toBeVisible({ timeout: 60_000 });
+    await waitForReviewSettled(page);
+    await replaceImagesWithUnsafeUrl(page, env.freshAllegroCategoryPath);
+    await waitForReviewSettled(page);
+
+    const counts = await readinessCounts(page);
+    expect(
+      counts.needAttention,
+      `an image set the destination adapter will reject IN FULL raises no blocker: ${counts.raw}`,
+    ).toBe(0);
+    expect(counts.ready, `the row is counted ready: ${counts.raw}`).toBeGreaterThan(0);
+    await expect(
+      submitCta(page),
+      'the wizard enables submit - `imageCountForVariant` counted one non-empty string and stopped',
+    ).toBeEnabled();
+
+    // PROOF (documentation only - never asserted on): the promise.
+    await captureProof(page, 'f06-before-review-ready', { region: reviewRegion(page) });
+
+    // Capture the body the wizard actually builds, then ABORT at the network
+    // layer: submitting it here would die on F10's category gate (a different
+    // finding). Test 2 replays this shape with the category + parameters added.
+    let captured: string | null = null;
+    await page.route('**/listings/bulk-create', async (route) => {
+      if (route.request().method() !== 'POST') {
+        await route.continue();
+        return;
+      }
+      captured = route.request().postData();
+      await route.abort();
+    });
+
+    await submitCta(page).click();
+    const dialog = page.getByRole('dialog');
+    const publishAnyway = dialog.getByRole('button', { name: /Publish anyway/ });
+    if (await publishAnyway.isVisible({ timeout: 5_000 }).catch(() => false)) {
+      await publishAnyway.click();
+    }
+    const confirm = page.getByRole('button', { name: 'Create offers', exact: true });
+    await expect(confirm).toBeVisible({ timeout: 30_000 });
+    const publishToggle = page.getByRole('checkbox', { name: /Publish immediately/ });
+    if ((await publishToggle.count()) > 0) await publishToggle.uncheck();
+    await confirm.click();
+
+    await expect(async () => {
+      expect(captured, 'the wizard issued its POST /listings/bulk-create').not.toBeNull();
+    }).toPass({ timeout: 30_000 });
+    await page.unroute('**/listings/bulk-create');
+
+    const body = JSON.parse(captured!) as BulkCreateBody;
+    const emitted = [
+      ...Object.values(body.perVariantOverrides ?? {}),
+      ...Object.values(body.perProductOverrides ?? {}),
+    ]
+      .map((override) => override.overrides?.imageUrls)
+      .find((urls): urls is string[] => Array.isArray(urls));
+    expect(
+      emitted,
+      `the wizard forwards the operator's image set untouched: ${captured}`,
+    ).toContain(UNSAFE_IMAGE_URL);
+    expect(
+      emitted,
+      'and it is the ONLY image - nothing on the client re-added a usable one',
+    ).toHaveLength(1);
+
+    testInfo.annotations.push({
+      type: 'divergence',
+      description:
+        `wizard readiness with an all-http image set: ${counts.raw}; emitted imageUrls=${JSON.stringify(emitted)}`,
+    });
+  });
+
+  test('(b) the record never terminates: pending forever, batch stuck running, reason only in sync_jobs', async ({
+    env,
+    api,
+    page,
+    poll,
+  }, testInfo) => {
+    test.setTimeout(240_000);
+    test.skip(fixture === null || erliConnection === null, 'depends on the fixture resolved above.');
+    const current = fixture!;
+    const connection = erliConnection!;
+
+    const result = await submitBulkCreate(env, {
+      connectionId: connection.id,
+      productIds: [current.variant.id],
+      sharedConfig: { stock: 1, publishImmediately: false },
+      perVariantOverrides: {
+        [current.variant.id]: {
+          overrides: {
+            ...gateClearingOverrides(current),
+            imageUrls: [UNSAFE_IMAGE_URL],
+            platformParams: { dispatchTime: { period: 2, unit: 'day' } },
+          },
+        },
+      },
+      excludedVariantIds: [],
+    });
+    test.skip(
+      result.status === 400,
+      'This stack rejects a per-variant `overrides.categoryId` (`PerVariantOverrideDto.overrides` ' +
+        'is still `OverridesNoCategoryDto`, i.e. it predates #1924/PR #1930). Without it the row ' +
+        "dies on F10's `overrides.categoryId / REQUIRED` in the builder and never reaches the Erli " +
+        'adapter, so F6 cannot be observed here. Run this spec against a stack carrying #1924. ' +
+        `Server said: ${result.raw}`,
+    );
+    expect(
+      result.status,
+      `the submit is accepted - nothing on the request path measures an image URL: ${result.raw}`,
+    ).toBe(202);
+    const batchId = (result.body as { batchId?: string }).batchId ?? null;
+    expect(batchId, 'the accept response carries a batchId').toBeTruthy();
+
+    // The worker consumed the job and gave up. `ErliRetryClassifierAdapter` marks
+    // `ErliConfigException` non-retryable, so this is `dead` on the first attempt
+    // - there is no pending retry that could still terminate the record.
+    const job = await poll.until(
+      () => findChildJob(api, connection.id, batchId!, current.variant.id),
+      (candidate) => candidate !== undefined && candidate.status === 'dead',
+      {
+        timeoutMs: 120_000,
+        intervalMs: 3_000,
+        message: `the marketplace.offer.create job for batch ${batchId} to be marked dead`,
+      },
+    );
+    expect(
+      job!.attempts,
+      'non-retryable: the job is buried on attempt 1, so nothing will revisit the record',
+    ).toBeLessThanOrEqual(1);
+    expect(
+      job!.lastError ?? '',
+      'the ONLY readable reason - and it lives in sync_jobs, which the batch view never reads',
+    ).toMatch(/image/i);
+
+    // …and the record + batch are frozen. Watched past the point where a healthy
+    // pipeline would have terminated both.
+    const deadline = Date.now() + STUCK_OBSERVATION_MS;
+    let batch = await getBatch(env, batchId!);
+    while (Date.now() < deadline) {
+      batch = await getBatch(env, batchId!);
+      expect(
+        TERMINAL_BATCH_STATUSES.has(batch.status),
+        `the batch must NOT terminate - advanceBatchStatus is unreachable. Observed: ${batch.status}`,
+      ).toBe(false);
+      await new Promise((resolve) => setTimeout(resolve, 5_000));
+    }
+
+    expect(batch.records.length, 'the batch has exactly one child').toBe(1);
+    const [record] = batch.records;
+    expect(
+      record.status,
+      'the record is still `pending` long after the job was buried: the rethrown ' +
+        'ErliConfigException never reached `updateStatus`',
+    ).toBe('pending');
+    expect(
+      record.errors ?? null,
+      'and it carries NO structured error - the operator has nothing to read',
+    ).toBeNull();
+    expect(record.externalOfferId, 'no Erli product was created').toBeNull();
+    expect(
+      batch.succeededCount + batch.failedCount,
+      'the #737 counter gate can never fire: neither counter ever moves',
+    ).toBe(0);
+    expect(batch.totalCount).toBe(1);
+
+    // What the operator actually sees.
+    await page.goto(`/listings/bulk-batches/${batchId!}`);
+    await expect(
+      page.getByText('Queued', { exact: true }).first(),
+      'the batch-progress row reads "Queued" - indistinguishable from a job that has not run yet',
+    ).toBeVisible({ timeout: 30_000 });
+    await expect(
+      page.locator('button[aria-label^="Failure details for"]'),
+      'no failure-details affordance is offered, because the record never failed',
+    ).toHaveCount(0);
+    await expect(
+      page.locator('.bulk-batch__err'),
+      'and no inline reason is rendered anywhere on the row',
+    ).toHaveCount(0);
+
+    // PROOF (documentation only): the batch that can never terminate - the row
+    // still reads "Queued" long after the job was buried.
+    await captureProof(page, 'f06-before-result', { fullPage: true });
+
+    testInfo.annotations.push({
+      type: 'fixture',
+      description:
+        `left behind (this IS the finding): batch ${batchId} permanently \`${batch.status}\` with ` +
+        `record ${record.id} \`pending\`; job ${job!.id} dead: ${job!.lastError ?? ''}`,
+    });
+  });
+
+  test('(c) silent truncation: a partially-unsafe set is quietly shortened, and nothing says so', async ({
+    env,
+    api,
+    poll,
+  }, testInfo) => {
+    test.setTimeout(240_000);
+    test.skip(fixture === null || erliConnection === null, 'depends on the fixture resolved above.');
+    const current = fixture!;
+    const connection = erliConnection!;
+
+    // One survivor + one casualty. `sanitizeImageUrls` drops the http entry with a
+    // `logger.warn` and `resolveImages` does NOT throw, so the create proceeds
+    // with a gallery the operator never agreed to. The malformed dispatchTime -
+    // read AFTER the images in `buildCreateBody` - stops the request at the next
+    // step, so nothing is ever published: the failure that DOES surface is the
+    // proof that the image gate stayed silent.
+    const result = await submitBulkCreate(env, {
+      connectionId: connection.id,
+      productIds: [current.variant.id],
+      sharedConfig: { stock: 1, publishImmediately: false },
+      perVariantOverrides: {
+        [current.variant.id]: {
+          overrides: {
+            ...gateClearingOverrides(current),
+            imageUrls: [current.safeImages[0], UNSAFE_IMAGE_URL],
+            platformParams: { dispatchTime: { period: -1, unit: 'day' } },
+          },
+        },
+      },
+      excludedVariantIds: [],
+    });
+    test.skip(
+      result.status === 400,
+      'This stack rejects a per-variant `overrides.categoryId` (predates #1924/PR #1930) - see ' +
+        `the skip message on the previous test. Server said: ${result.raw}`,
+    );
+    expect(result.status, `submit accepted: ${result.raw}`).toBe(202);
+    const batchId = (result.body as { batchId?: string }).batchId ?? null;
+    expect(batchId, 'the accept response carries a batchId').toBeTruthy();
+
+    const job = await poll.until(
+      () => findChildJob(api, connection.id, batchId!, current.variant.id),
+      (candidate) => candidate !== undefined && candidate.status === 'dead',
+      {
+        timeoutMs: 120_000,
+        intervalMs: 3_000,
+        message: `the marketplace.offer.create job for batch ${batchId} to be marked dead`,
+      },
+    );
+    const lastError = job!.lastError ?? '';
+    expect(
+      lastError,
+      'the create got PAST the image gate with one of two images silently discarded, and stopped ' +
+        `on the very next field it reads. Observed: ${lastError}`,
+    ).toMatch(/dispatchTime/i);
+    expect(
+      lastError,
+      'nothing anywhere mentions the dropped image - the only trace is a worker-log `logger.warn` ' +
+        'that no API, record or screen surfaces',
+    ).not.toMatch(/image/i);
+
+    const batch = await getBatch(env, batchId!);
+    expect(
+      TERMINAL_BATCH_STATUSES.has(batch.status),
+      `same non-termination as (b) - every ErliConfigException takes this path. Observed: ${batch.status}`,
+    ).toBe(false);
+    const [record] = batch.records;
+    expect(record.status, 'the record is still pending').toBe('pending');
+    expect(record.errors ?? null, 'still no structured error for the operator').toBeNull();
+    expect(record.externalOfferId, 'nothing was published, so no gallery was truncated for real').toBeNull();
+
+    testInfo.annotations.push({
+      type: 'divergence',
+      description:
+        `2 image URLs submitted, 1 survives sanitisation; the create proceeded and failed on the ` +
+        `NEXT field instead: "${lastError}". Batch ${batchId} left \`${batch.status}\`.`,
+    });
+  });
+});

--- a/apps/e2e/tests/preflight-divergence/f07-duplicate-ean.spec.ts
+++ b/apps/e2e/tests/preflight-divergence/f07-duplicate-ean.spec.ts
@@ -1,0 +1,337 @@
+/**
+ * F7 - duplicate-EAN detection: the backend normalises to GTIN-14, the wizard
+ * keys the raw string, and the wizard's batch-wide check never runs batch-wide
+ *
+ * ⚠️ CHARACTERIZATION TEST. It passes while the divergence exists and FAILS the
+ * moment the finding is closed (or was wrong in the first place). A red run here
+ * is a signal to re-read the finding, not a regression in the product.
+ *
+ * Two independent halves, both asserted:
+ *
+ *   (a) NORMALISATION. `BulkListingSubmitService.enforceIdentifierRules` keys its
+ *       seen-set on `ean.padStart(14, '0')` for any GTIN-length value, so
+ *       "5901234500012" and "05901234500012" are the SAME identifier and the
+ *       second one throws `DuplicateBatchEanException` -> 400 on the whole
+ *       request. `duplicateEanVariantIds` (`bulk-policy.ts`) keys the raw trimmed
+ *       string, so to the wizard those are two different barcodes and neither row
+ *       is flagged. Both forms pass the wizard's own `isValidGtin` and the DTO
+ *       regex `^(\d{8}|\d{12,14})$`, so nothing else catches them either.
+ *
+ *   (b) SCOPE. `duplicateEanVariantIds` takes `rows: BulkWizardRow[]` and its own
+ *       docstring says "batch-wide", but the single production call site
+ *       (`bulk-edit-modal.tsx`) passes `[oneRow]`. So the check is intra-product
+ *       only and its result merely tints a chip inside the row editor - the
+ *       review table never surfaces a batch-wide duplicate at all. Test 2 proves
+ *       that with two DIFFERENT products whose variants carry a byte-identical
+ *       EAN: no normalisation subtlety involved, and still both rows read `ready`.
+ *
+ * Partially exonerated (do not widen the claim): the PrestaShop master adapter
+ * only inherits a product-level EAN onto a variant when
+ * `combinations.length === 1`, so "a whole sibling set sharing one EAN" is not
+ * reachable from that path.
+ *
+ * Side effects: none. The identifier gate runs BEFORE
+ * `bulkBatchRepository.create`, so the 400 in test 1 persists nothing and creates
+ * no marketplace offer. Test 2 is a read-only browser walk that stops at Review.
+ *
+ * @module tests/preflight-divergence
+ */
+import { randomUUID } from 'node:crypto';
+import { test, expect } from '../../src/fixtures/test';
+import type { ApiClient } from '../../src/api/api-client';
+import type { Product, ProductVariant } from '../../src/api/api.types';
+import type { E2eEnv } from '../../src/config/env';
+import { captureProof, reviewRegion } from './__proof__/capture';
+
+/** Per-variant override entry of `POST /listings/bulk-create`. */
+interface BulkOverride {
+  stock?: number;
+  publishImmediately?: boolean;
+  overrides?: Record<string, unknown>;
+}
+
+/** Request body of `POST /listings/bulk-create` (mirrored locally, #1741 shape). */
+interface BulkCreateBody {
+  connectionId: string;
+  productIds: string[];
+  sharedConfig: { stock: number; publishImmediately: boolean };
+  perVariantOverrides?: Record<string, BulkOverride>;
+  excludedVariantIds?: string[];
+}
+
+/** A valid GTIN-13 and its zero-padded GTIN-14 twin (same GS1 check digit). */
+const GTIN_13 = '5901234500012';
+const GTIN_14 = `0${GTIN_13}`;
+
+test.describe('F7 - duplicate EAN: GTIN-14 normalisation gap + never batch-wide', () => {
+  test('the wizard sees two distinct barcodes where the backend sees one duplicate', async ({
+    api,
+    world,
+    env,
+  }) => {
+    const allegro = world.connectionFor('allegro');
+    test.skip(allegro === undefined, 'F7 needs an Allegro connection as the wizard destination.');
+    const connection = allegro!;
+
+    const free = await findFreeSingleVariants(api, world, connection.id, 2);
+    test.skip(
+      free.length < 2,
+      'F7 needs two master variants of DIFFERENT single-variant products with no Allegro ' +
+        'offer mapping yet (mapped variants are dropped by `filterAlreadyListed` before the ' +
+        'identifier gate runs, which would surface as an empty-submission 400 instead).',
+    );
+    const [first, second] = free;
+
+    // (a1) Premise: the wizard's own validator accepts BOTH forms, and its
+    // duplicate key is the raw string, so the two are simply not equal.
+    expect(isValidGtin(GTIN_13), `${GTIN_13} passes the wizard's GS1 check`).toBe(true);
+    expect(isValidGtin(GTIN_14), `${GTIN_14} passes the wizard's GS1 check too`).toBe(true);
+    expect(
+      GTIN_13,
+      'the wizard keys `duplicateEanVariantIds` on the raw trimmed string, and these two ' +
+        'strings differ - so no client-side duplicate signal can ever fire for this pair',
+    ).not.toBe(GTIN_14);
+    expect(
+      GTIN_13.padStart(14, '0'),
+      'the backend keys on padStart(14) - where the very same pair collapses into one key',
+    ).toBe(GTIN_14.padStart(14, '0'));
+
+    // (a2) What actually happens on submit.
+    const result = await submitBulkCreate(env, {
+      connectionId: connection.id,
+      productIds: [first.id, second.id],
+      sharedConfig: { stock: 1, publishImmediately: false },
+      perVariantOverrides: {
+        [first.id]: { overrides: { ean: GTIN_13 } },
+        [second.id]: { overrides: { ean: GTIN_14 } },
+      },
+      excludedVariantIds: [],
+    });
+
+    expect(
+      result.status,
+      `the GTIN-13/GTIN-14 pair is rejected as a duplicate: ${JSON.stringify(result.body)}`,
+    ).toBe(400);
+    const message = messageOf(result.body);
+    expect(
+      message,
+      'the rejection names the shared barcode - the whole request dies, on variants the ' +
+        'review summary never flagged',
+    ).toMatch(/shared by more than one included variant/i);
+    expect(
+      message,
+      'and it names the NORMALISED GTIN-14 key, not either string the operator supplied - ' +
+        'which is exactly the collapse the wizard cannot see',
+    ).toContain(GTIN_14);
+  });
+
+  test('two included rows share one EAN and the wizard never says so - the check is not batch-wide', async ({
+    page,
+    pages,
+    world,
+  }) => {
+    const allegro = world.connectionFor('allegro');
+    test.skip(allegro === undefined, 'F7 needs an Allegro connection as the wizard destination.');
+    const connection = allegro!;
+
+    const pair = await findCrossProductDuplicateEan(world);
+    test.skip(
+      pair === null,
+      'F7 scope half needs two variants of DIFFERENT multi-variant master products carrying ' +
+        'the same barcode (the state the wizard cannot see, because its duplicate check is ' +
+        'called with a single row). No such pair exists in this catalogue.',
+    );
+    const { ean, productIds } = pair!;
+
+    await page.goto(
+      `/listings/bulk-create/wizard?productIds=${encodeURIComponent(productIds.join(','))}` +
+        `&connectionId=${encodeURIComponent(connection.id)}`,
+    );
+
+    await expect(page.getByRole('heading', { name: 'Configure batch' })).toBeVisible({
+      timeout: 30_000,
+    });
+    // Allegro gates Proceed on its own config section (shipping-rate package);
+    // reuse the suite's page object rather than re-deriving the control here.
+    await pages.bulkOfferWizard.completePlatformConfig({ requiresDeliveryPolicy: true });
+    const proceed = page.getByRole('button', { name: /^Proceed/ });
+    await expect(proceed).toBeEnabled({ timeout: 60_000 });
+    await proceed.click();
+
+    const cta = page.locator('button.bulk-review__cta--top');
+    await expect(cta).toBeVisible({ timeout: 60_000 });
+
+    // Expand every product row so the per-variant rows (which carry the EAN text)
+    // render.
+    const toggles = page.locator('button.bulk-review__toggle');
+    for (let i = 0; i < (await toggles.count()); i += 1) {
+      await toggles.nth(i).click();
+    }
+
+    const duplicateRows = page.locator('.bulk-review__vrow').filter({ hasText: ean });
+    await expect
+      .poll(async () => duplicateRows.count(), {
+        message: `both variants carrying EAN ${ean} render as review rows`,
+        timeout: 30_000,
+      })
+      .toBeGreaterThanOrEqual(2);
+
+    // (b) The divergence: the wizard says NOTHING about the collision. Both rows
+    // stay included, and neither carries a duplicate/collision chip - even though
+    // the review surface demonstrably CAN render per-variant signals (these rows
+    // show unrelated ones, e.g. "add product params" and the soft "already on
+    // {destination}" chip). There is simply no batch-wide duplicate signal to
+    // render, because `duplicateEanVariantIds` is only ever called with one row.
+    // PROOF (documentation only - never asserted on): the promise. Note there is
+    // no `f07-before-result.png` counterpart: F7's confirmed half (test 1 above)
+    // is a wire-level 400 with no screen of its own, and this scope half never
+    // submits.
+    await captureProof(page, 'f07-before-review-ready', { region: reviewRegion(page) });
+
+    const count = await duplicateRows.count();
+    expect(count, 'both halves of the duplicate pair are on screen').toBeGreaterThanOrEqual(2);
+    for (let i = 0; i < count; i += 1) {
+      const row = duplicateRows.nth(i);
+      await expect(
+        row.locator('input.bulk-review__chk'),
+        `row ${i + 1} of the duplicate pair is INCLUDED - both will be submitted together`,
+      ).toBeChecked();
+      await expect(
+        row.locator('.bulk-review__c-status'),
+        `row ${i + 1} of the duplicate pair carries no duplicate / shared-barcode chip, though ` +
+          'the same cell happily renders other blockers and soft warnings',
+      ).not.toContainText(/duplicate|shared|collision/i);
+    }
+    await expect(
+      page.locator('.bulk-review__summary'),
+      'nor does the batch summary mention a duplicate barcode anywhere',
+    ).not.toContainText(/duplicate|shared barcode/i);
+  });
+});
+
+/** `count` variants, each the ONLY variant of its product, with no offer mapping. */
+async function findFreeSingleVariants(
+  api: ApiClient,
+  world: {
+    listProducts(limit?: number): Promise<Product[]>;
+    variantsOf(id: string): Promise<ProductVariant[]>;
+  },
+  connectionId: string,
+  count: number,
+): Promise<ProductVariant[]> {
+  const mapped = await mappedVariantIds(api, connectionId);
+  const found: ProductVariant[] = [];
+  for (const product of await world.listProducts(100)) {
+    const variants = await world.variantsOf(product.id);
+    // Single-variant products only: the fan-out is then exactly one job each, so
+    // the pair under test is the entire batch and the 400 can only be theirs.
+    if (variants.length !== 1) continue;
+    if (mapped.has(variants[0].id)) continue;
+    found.push(variants[0]);
+    if (found.length === count) break;
+  }
+  return found;
+}
+
+/**
+ * Two variants of DIFFERENT products carrying a byte-identical barcode, where
+ * both owning products are MULTI-variant. The multi-variant requirement is a
+ * rendering constraint, not a semantic one: the review table only renders
+ * per-variant rows (`.bulk-review__vrow`, the element that prints the barcode)
+ * for an expanded multi-variant product, so a single-variant owner would leave
+ * its half of the duplicate pair unassertable.
+ */
+async function findCrossProductDuplicateEan(world: {
+  listProducts(limit?: number): Promise<Product[]>;
+  variantsOf(id: string): Promise<ProductVariant[]>;
+}): Promise<{ ean: string; productIds: string[] } | null> {
+  const byEan = new Map<string, Set<string>>();
+  for (const product of await world.listProducts(100)) {
+    const variants = await world.variantsOf(product.id);
+    if (variants.length < 2) continue;
+    for (const variant of variants) {
+      const ean = variant.ean ?? variant.gtin;
+      if (ean === null || ean === undefined) continue;
+      const owners = byEan.get(ean) ?? new Set<string>();
+      owners.add(product.id);
+      byEan.set(ean, owners);
+    }
+  }
+  for (const [ean, owners] of byEan) {
+    if (owners.size >= 2) return { ean, productIds: [...owners].slice(0, 2) };
+  }
+  return null;
+}
+
+async function mappedVariantIds(api: ApiClient, connectionId: string): Promise<Set<string>> {
+  const ids = new Set<string>();
+  for (let offset = 0; ; offset += 100) {
+    const page = await api.listings.list({ connectionId, limit: 100, offset });
+    page.items.forEach((mapping) => ids.add(mapping.internalId));
+    if (page.items.length === 0 || offset + 100 >= page.total) break;
+  }
+  return ids;
+}
+
+/** `isValidGtin` from `bulk-policy.ts`, transcribed so the premise is asserted. */
+function isValidGtin(code: string): boolean {
+  if (!/^(\d{8}|\d{12,14})$/.test(code)) return false;
+  const digits = [...code].map(Number);
+  const check = digits[digits.length - 1];
+  const body = digits.slice(0, -1);
+  let sum = 0;
+  for (let i = body.length - 1, pos = 0; i >= 0; i--, pos++) {
+    sum += body[i] * (pos % 2 === 0 ? 3 : 1);
+  }
+  return (10 - (sum % 10)) % 10 === check;
+}
+
+function messageOf(body: unknown): string {
+  if (typeof body === 'string') return body;
+  const message = (body as { message?: unknown } | null)?.message;
+  if (typeof message === 'string') return message;
+  if (Array.isArray(message)) return message.join('; ');
+  return JSON.stringify(body);
+}
+
+/**
+ * Raw `POST /listings/bulk-create`. The node `ApiClient` exposes no bulk-submit
+ * method and this suite must not modify `src/`, so the call is issued directly
+ * here. Returns status + parsed body rather than throwing.
+ */
+async function submitBulkCreate(
+  env: E2eEnv,
+  body: BulkCreateBody,
+): Promise<{ status: number; body: unknown }> {
+  const token = await loginForRawCalls(env);
+  const response = await fetch(`${env.apiUrl}/v1/listings/bulk-create`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      Authorization: `Bearer ${token}`,
+      'x-idempotency-key': randomUUID(),
+    },
+    body: JSON.stringify(body),
+  });
+  const raw = await response.text();
+  let parsed: unknown = raw;
+  try {
+    parsed = raw.length > 0 ? JSON.parse(raw) : undefined;
+  } catch {
+    /* non-JSON body - keep the raw text */
+  }
+  return { status: response.status, body: parsed };
+}
+
+async function loginForRawCalls(env: E2eEnv): Promise<string> {
+  const response = await fetch(`${env.apiUrl}/v1/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: env.adminUser, password: env.adminPass }),
+  });
+  if (!response.ok) {
+    throw new Error(`Login failed: HTTP ${response.status} ${await response.text()}`);
+  }
+  return ((await response.json()) as { access_token: string }).access_token;
+}

--- a/apps/e2e/tests/preflight-divergence/f08-ceilings.spec.ts
+++ b/apps/e2e/tests/preflight-divergence/f08-ceilings.spec.ts
@@ -1,0 +1,288 @@
+/**
+ * F8 - the two invisible 1000 limits
+ *
+ * ⚠️ CHARACTERIZATION TEST. It passes while the divergence exists and FAILS the
+ * moment the finding is closed (or was wrong in the first place). A red run here
+ * is a signal to re-read the finding, not a regression in the product.
+ *
+ * Scope, precisely (the audit RESCALED this finding - honour the narrowing):
+ *
+ *   NOT a divergence: the 100-product cap IS mirrored client-side.
+ *   `OFFER_PICKER_PRODUCT_CAP = 100` is enforced in `offer-product-picker-modal`
+ *   with a visible hint, the wizard page redirects on > 100 ids, and the DTO
+ *   carries `@ArrayMaxSize(100)` on `productIds`. Test 1 asserts that mirroring
+ *   POSITIVELY, so this file can never be read as claiming otherwise.
+ *
+ *   The two invisible ones, both keyed to 1000 and neither surfaced anywhere in
+ *   the wizard:
+ *     1. `EXPANDED_OFFER_CEILING = 1000` in `BulkListingSubmitService`, thrown
+ *        from `expandVariantJobs` AFTER exclusions are applied ->
+ *        `ExpandedOfferCeilingExceededException` -> 422.
+ *     2. `excludedVariantIds` `@ArrayMaxSize(1000)` on the request DTO -> 400.
+ *   Version 3 of the audit conflated these two statuses; they are distinct
+ *   codes from distinct layers, so test 2 pins the boundary exactly (1000 passes
+ *   DTO validation and fails later for an unrelated reason; 1001 never gets past
+ *   validation).
+ *
+ *   The wizard header prints the true variant count ("… · N variants") and never
+ *   compares it with 1000. Test 3 asserts no 1000-related hint exists on the
+ *   config/review surfaces.
+ *
+ * Side effects: none. The `@ArrayMaxSize` rejection happens in the validation
+ * pipe; the 1000-exclusion control case is engineered to end in
+ * `EmptyBulkSubmissionException`, which is thrown before
+ * `bulkBatchRepository.create`. Nothing is persisted on any path here.
+ *
+ * @module tests/preflight-divergence
+ */
+import { randomUUID } from 'node:crypto';
+import { test, expect } from '../../src/fixtures/test';
+import type { ApiClient } from '../../src/api/api-client';
+import type { Product, ProductVariant } from '../../src/api/api.types';
+import type { E2eEnv } from '../../src/config/env';
+
+/** Request body of `POST /listings/bulk-create` (mirrored locally, #1741 shape). */
+interface BulkCreateBody {
+  connectionId: string;
+  productIds: string[];
+  sharedConfig: { stock: number; publishImmediately: boolean };
+  excludedVariantIds?: string[];
+}
+
+/** Both server-side ceilings under test. */
+const EXCLUSIONS_CAP = 1000;
+const PRODUCT_IDS_CAP = 100;
+
+/** A syntactically valid internal variant id: `/^ol_variant_[a-f0-9]+$/`. */
+function syntheticVariantId(index: number): string {
+  return `ol_variant_${index.toString(16).padStart(32, '0')}`;
+}
+
+test.describe('F8 - invisible 1000 ceilings on expansion and exclusions', () => {
+  test('the 100-product cap IS mirrored client-side (this half is NOT a divergence)', async ({
+    page,
+    world,
+    env,
+  }) => {
+    const allegro = world.connectionFor('allegro');
+    test.skip(allegro === undefined, 'needs an Allegro connection as the wizard destination.');
+
+    // Client-side half: the wizard page refuses to mount for more than 100 ids
+    // and bounces back to /products, so the operator can never even reach a
+    // batch that would trip the server cap.
+    const tooMany = Array.from({ length: PRODUCT_IDS_CAP + 1 }, (_, i) => syntheticVariantId(i));
+    await page.goto(
+      `/listings/bulk-create/wizard?productIds=${encodeURIComponent(tooMany.join(','))}` +
+        `&connectionId=${encodeURIComponent(allegro!.id)}`,
+    );
+    await expect
+      .poll(() => new URL(page.url()).pathname, {
+        message: 'the wizard redirects a >100-product selection back to /products',
+        timeout: 30_000,
+      })
+      .toBe('/products');
+
+    // Server-side half: the same limit exists as `@ArrayMaxSize(100)`, so the two
+    // sides agree. Asserted so a future relaxation on one side alone is caught.
+    const result = await submitBulkCreate(env, {
+      connectionId: allegro!.id,
+      productIds: tooMany,
+      sharedConfig: { stock: 1, publishImmediately: false },
+    });
+    expect(
+      result.status,
+      `>100 productIds is rejected by the DTO too: ${JSON.stringify(result.body)}`,
+    ).toBe(400);
+  });
+
+  test('the excludedVariantIds cap is 1000, enforced only by the DTO and never surfaced', async ({
+    api,
+    world,
+    env,
+  }) => {
+    const allegro = world.connectionFor('allegro');
+    test.skip(allegro === undefined, 'needs an Allegro connection as the wizard destination.');
+    const connection = allegro!;
+
+    const seed = await findFreeSingleVariant(api, world, connection.id);
+    test.skip(
+      seed === null,
+      'needs one master variant with no Allegro offer mapping to use as the (self-excluded) ' +
+        'seed id, so the control case cannot create a batch.',
+    );
+
+    // Control: exactly 1000 exclusions passes DTO validation. The seed variant is
+    // itself excluded, so `expandVariantJobs` yields zero jobs and the request
+    // dies in `EmptyBulkSubmissionException` - a DIFFERENT 400 from a DIFFERENT
+    // layer, which is how we know the array size itself was accepted.
+    const atCap = await submitBulkCreate(env, {
+      connectionId: connection.id,
+      productIds: [seed!.id],
+      sharedConfig: { stock: 1, publishImmediately: false },
+      excludedVariantIds: [
+        seed!.id,
+        ...Array.from({ length: EXCLUSIONS_CAP - 1 }, (_, i) => syntheticVariantId(i + 1)),
+      ],
+    });
+    expect(
+      atCap.status,
+      `exactly ${EXCLUSIONS_CAP} exclusions clears the DTO: ${JSON.stringify(atCap.body)}`,
+    ).toBe(400);
+    expect(
+      messageOf(atCap.body),
+      `at the cap the request reaches the service and fails on the empty expansion, i.e. ` +
+        `the array size was accepted (proving ${EXCLUSIONS_CAP} is the boundary, not less)`,
+    ).toMatch(/at least one productId/i);
+
+    // One over: rejected by `@ArrayMaxSize(1000)` in the validation pipe, before
+    // any service code runs.
+    const overCap = await submitBulkCreate(env, {
+      connectionId: connection.id,
+      productIds: [seed!.id],
+      sharedConfig: { stock: 1, publishImmediately: false },
+      excludedVariantIds: [
+        seed!.id,
+        ...Array.from({ length: EXCLUSIONS_CAP }, (_, i) => syntheticVariantId(i + 1)),
+      ],
+    });
+    expect(
+      overCap.status,
+      `${EXCLUSIONS_CAP + 1} exclusions is rejected: ${JSON.stringify(overCap.body)}`,
+    ).toBe(400);
+    expect(
+      messageOf(overCap.body),
+      'one over the cap fails in the validation pipe naming excludedVariantIds - a hard ' +
+        'limit the wizard neither knows nor shows: it switches variants off without bound',
+    ).toMatch(/excludedVariantIds/i);
+  });
+
+  test('neither 1000 ceiling is surfaced anywhere in the wizard UI', async ({ page, world }) => {
+    const allegro = world.connectionFor('allegro');
+    test.skip(allegro === undefined, 'needs an Allegro connection as the wizard destination.');
+
+    const product = (await world.listProducts(100)).find((p) => p.id.length > 0);
+    test.skip(product === undefined, 'needs at least one master product to open the wizard.');
+
+    await page.goto(
+      `/listings/bulk-create/wizard?productIds=${encodeURIComponent(product!.id)}` +
+        `&connectionId=${encodeURIComponent(allegro!.id)}`,
+    );
+    await expect(page.getByRole('heading', { name: 'Configure batch' })).toBeVisible({
+      timeout: 30_000,
+    });
+
+    // The page description prints the real variant count. What it never does is
+    // compare it against anything: no "of 1000", no remaining-budget hint, no
+    // warning band. So an operator whose selection expands past 1000 variants
+    // learns about the ceiling from a 422 after clicking.
+    const body = await page.locator('body').innerText();
+    expect(body, 'the wizard reports the batch size in variants').toMatch(/\bvariants?\b/i);
+    expect(
+      body,
+      'no 1000 / 1,000 ceiling is mentioned on the config surface - both limits are ' +
+        'invisible until the submit fails',
+    ).not.toMatch(/1[,.\s]?000/);
+  });
+
+  test('the expansion ceiling (422) is unprovisionable on this stack', async ({ world }) => {
+    const products = await world.listProducts(100);
+    let variantTotal = 0;
+    let largestFanOut = 0;
+    for (const product of products) {
+      const variants = await world.variantsOf(product.id);
+      variantTotal += variants.length;
+      largestFanOut = Math.max(largestFanOut, variants.length);
+    }
+    test.skip(
+      true,
+      `BLOCKED ON FIXTURE. Tripping EXPANDED_OFFER_CEILING needs a selection that expands to ` +
+        `more than ${EXCLUSIONS_CAP} sibling variants AFTER exclusions. The expansion walks ` +
+        `the distinct variants of the selected products, and \`productIds\` is itself capped ` +
+        `at ${PRODUCT_IDS_CAP}, so the reachable maximum here is the whole catalogue: this ` +
+        `stack exposes ${variantTotal} variants across ${products.length} products (largest ` +
+        `single product fan-out: ${largestFanOut}). Reproducing it needs a seeded catalogue ` +
+        `with > ${EXCLUSIONS_CAP} variants concentrated in <= ${PRODUCT_IDS_CAP} products ` +
+        `(e.g. 100 products x 11 combinations), which requires bulk PrestaShop/WooCommerce ` +
+        `provisioning this suite does not have (OL_PS_WEBSERVICE_KEY is unset by default and ` +
+        `the webservice helper cannot create combinations).`,
+    );
+  });
+});
+
+/** First master variant that is the only variant of its product and unmapped. */
+async function findFreeSingleVariant(
+  api: ApiClient,
+  world: {
+    listProducts(limit?: number): Promise<Product[]>;
+    variantsOf(id: string): Promise<ProductVariant[]>;
+  },
+  connectionId: string,
+): Promise<ProductVariant | null> {
+  const mapped = await mappedVariantIds(api, connectionId);
+  for (const product of await world.listProducts(100)) {
+    const variants = await world.variantsOf(product.id);
+    if (variants.length !== 1) continue;
+    if (!mapped.has(variants[0].id)) return variants[0];
+  }
+  return null;
+}
+
+async function mappedVariantIds(api: ApiClient, connectionId: string): Promise<Set<string>> {
+  const ids = new Set<string>();
+  for (let offset = 0; ; offset += 100) {
+    const page = await api.listings.list({ connectionId, limit: 100, offset });
+    page.items.forEach((mapping) => ids.add(mapping.internalId));
+    if (page.items.length === 0 || offset + 100 >= page.total) break;
+  }
+  return ids;
+}
+
+function messageOf(body: unknown): string {
+  if (typeof body === 'string') return body;
+  const message = (body as { message?: unknown } | null)?.message;
+  if (typeof message === 'string') return message;
+  if (Array.isArray(message)) return message.join('; ');
+  return JSON.stringify(body);
+}
+
+/**
+ * Raw `POST /listings/bulk-create`. The node `ApiClient` exposes no bulk-submit
+ * method and this suite must not modify `src/`, so the call is issued directly
+ * here. Returns status + parsed body rather than throwing.
+ */
+async function submitBulkCreate(
+  env: E2eEnv,
+  body: BulkCreateBody,
+): Promise<{ status: number; body: unknown }> {
+  const token = await loginForRawCalls(env);
+  const response = await fetch(`${env.apiUrl}/v1/listings/bulk-create`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      Authorization: `Bearer ${token}`,
+      'x-idempotency-key': randomUUID(),
+    },
+    body: JSON.stringify(body),
+  });
+  const raw = await response.text();
+  let parsed: unknown = raw;
+  try {
+    parsed = raw.length > 0 ? JSON.parse(raw) : undefined;
+  } catch {
+    /* non-JSON body - keep the raw text */
+  }
+  return { status: response.status, body: parsed };
+}
+
+async function loginForRawCalls(env: E2eEnv): Promise<string> {
+  const response = await fetch(`${env.apiUrl}/v1/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: env.adminUser, password: env.adminPass }),
+  });
+  if (!response.ok) {
+    throw new Error(`Login failed: HTTP ${response.status} ${await response.text()}`);
+  }
+  return ((await response.json()) as { access_token: string }).access_token;
+}

--- a/apps/e2e/tests/preflight-divergence/f09-multivariant-stock-policy.spec.ts
+++ b/apps/e2e/tests/preflight-divergence/f09-multivariant-stock-policy.spec.ts
@@ -1,0 +1,347 @@
+/**
+ * F9 - `flat`/`cap` stock policies are offered for multi-variant products and
+ * discarded by the backend; the publish downgrade is unlogged and unwarnable
+ *
+ * ⚠️ CHARACTERIZATION TEST. It passes while the divergence exists and FAILS the
+ * moment the finding is closed (or was wrong in the first place). A red run here
+ * is a signal to re-read the finding, not a regression in the product.
+ *
+ * ── WHAT THE AUDIT RETRACTED (do not re-litigate) ────────────────────────────
+ * The version-3 headline "the stock shown in Review is fiction" was WRONG. Under
+ * the DEFAULT `use-master` policy the displayed value is exactly the submitted
+ * one: the Resolve step reads `item.totalAvailable`, the same field the backend
+ * reads, and `computeResolvedStock` returns it verbatim. The wizard also warns
+ * correctly there - the edit modal renders a master provenance badge, a readOnly
+ * input and the hint "Authoritative from master inventory. Out-of-stock lists as
+ * 0, never backfilled.", refuses to emit a base stock override for a
+ * multi-variant product, and the review summary prints 'per variant'. None of
+ * that is tested here. Only what survived the retraction is:
+ *
+ *   (1) OFFERED-THEN-DISCARDED. `flat` and `cap` are offered for a multi-variant
+ *       product (batch-wide radios on the config step, plus a per-product "Stock
+ *       policy" select in the edit modal), and `buildVariantOverride` duly emits
+ *       the resolved value as `perVariantOverrides[variantId].stock`. The
+ *       backend then ignores it: `buildEnqueueInput` computes
+ *         stock = job.useMasterStock ? (masterAvailable ?? 0) : operatorStock
+ *       and `useMasterStock` is TRUE for every sibling of a multi-variant
+ *       product. The operator's number never reaches the offer.
+ *         (a) is asserted in the browser: the Review row DISPLAYS the flat value.
+ *         (b) is asserted against the persisted request snapshot: the record
+ *             carries master availability, not the submitted number.
+ *
+ *   (2) UNLOGGED, UNWARNABLE DOWNGRADE. `publishEffective = stock > 0 ?
+ *       publishImmediately : false` silently turns a zero-stock sibling into a
+ *       draft, with no log line; and the wizard's only pre-submit warning
+ *       (`mixedPublish`) is derived purely from explicit per-row publish flags,
+ *       so it cannot warn about a downgrade caused by stock. Test 3 documents
+ *       why this half is not reproducible on this stack.
+ *
+ * Side effects: test 1 submits ONE real batch (created as drafts,
+ * `publishImmediately: false`) for a multi-variant product. Test 2 is a
+ * read-only browser walk that stops at Review.
+ *
+ * @module tests/preflight-divergence
+ */
+import { randomUUID } from 'node:crypto';
+import { test, expect } from '../../src/fixtures/test';
+import type { ApiClient } from '../../src/api/api-client';
+import type { Product, ProductVariant } from '../../src/api/api.types';
+import type { E2eEnv } from '../../src/config/env';
+import { captureProof, reviewRegion } from './__proof__/capture';
+
+/** Per-variant override entry of `POST /listings/bulk-create`. */
+interface BulkOverride {
+  stock?: number;
+  publishImmediately?: boolean;
+  price?: { amount: number; currency: string };
+  overrides?: Record<string, unknown>;
+}
+
+/** Request body of `POST /listings/bulk-create` (mirrored locally, #1741 shape). */
+interface BulkCreateBody {
+  connectionId: string;
+  productIds: string[];
+  sharedConfig: { stock: number; publishImmediately: boolean };
+  perProductOverrides?: Record<string, BulkOverride>;
+  perVariantOverrides?: Record<string, BulkOverride>;
+  excludedVariantIds?: string[];
+}
+
+interface Candidate {
+  product: Product;
+  free: ProductVariant[];
+}
+
+/** The "flat stock" an operator types. Deliberately unlike any master quantity. */
+const FLAT_STOCK = 777;
+
+test.describe('F9 - flat/cap stock policy on a multi-variant product', () => {
+  test('the wizard emits the operator flat stock per variant; the backend writes master stock instead', async ({
+    api,
+    world,
+    env,
+  }) => {
+    const allegro = world.connectionFor('allegro');
+    test.skip(allegro === undefined, 'F9 needs an Allegro connection as the wizard destination.');
+    const connection = allegro!;
+
+    const candidate = await findMultiVariantCandidate(api, world, connection.id);
+    test.skip(
+      candidate === null,
+      'F9 needs a MULTI-variant master product with >= 2 variants that have no Allegro offer ' +
+        'mapping yet. `useMasterStock` is only true for siblings of a multi-variant product, ' +
+        'so a single-variant product cannot exhibit the discard; and mapped variants are ' +
+        'dropped by `filterAlreadyListed` before any of this runs.',
+    );
+    const { product, free } = candidate!;
+
+    const availability = await api.inventory.availability(free.map((v) => v.id));
+    const masterByVariant = new Map(
+      availability.map((row) => [row.productVariantId, row.totalAvailable]),
+    );
+    expect(
+      free.every((v) => (masterByVariant.get(v.id) ?? 0) !== FLAT_STOCK),
+      `master availability must differ from the flat value ${FLAT_STOCK}, else the assertion ` +
+        'below could not tell the two apart',
+    ).toBe(true);
+
+    // Exactly the body a `flat` stock policy produces: `buildVariantOverride`
+    // stamps the policy-resolved value onto every included sibling.
+    const perVariantOverrides: Record<string, BulkOverride> = {};
+    for (const variant of free) {
+      perVariantOverrides[variant.id] = { stock: FLAT_STOCK, publishImmediately: false };
+    }
+
+    const result = await submitBulkCreate(env, {
+      connectionId: connection.id,
+      productIds: [free[0].id],
+      sharedConfig: { stock: 1, publishImmediately: false },
+      perVariantOverrides,
+      excludedVariantIds: [],
+    });
+    expect(
+      result.status,
+      `the flat-stock body is accepted without complaint: ${JSON.stringify(result.body)}`,
+    ).toBe(202);
+
+    const batchId = (result.body as { batchId?: string }).batchId;
+    expect(batchId, 'the accept response carries a batchId').toBeTruthy();
+    const batch = await api.listings.getBulkBatch(batchId!);
+    expect(
+      batch.records.length,
+      'the multi-variant product fanned out to one record per sibling',
+    ).toBeGreaterThanOrEqual(2);
+
+    // The persisted request snapshot is the offer's own resolved input - the
+    // authoritative answer to "what stock did the backend actually use?".
+    let checked = 0;
+    for (const record of batch.records) {
+      const master = masterByVariant.get(record.internalVariantId);
+      if (master === undefined) continue;
+      const detail = await api.listings.getOfferCreationRecord(connection.id, record.id);
+      expect(
+        detail.request?.stock,
+        `variant ${record.internalVariantId}: the operator's flat ${FLAT_STOCK} was DISCARDED - ` +
+          'the enqueued offer carries master availability, because `useMasterStock` is true ' +
+          'for every sibling of a multi-variant product',
+      ).toBe(master);
+      expect(
+        detail.request?.stock,
+        'and it is emphatically not the number the wizard offered to set',
+      ).not.toBe(FLAT_STOCK);
+      checked += 1;
+    }
+    expect(checked, 'at least one record was inspected against master availability')
+      .toBeGreaterThan(0);
+
+    // Belt and braces: the product this ran against is genuinely multi-variant,
+    // which is the precondition the whole finding hinges on.
+    const variants = await world.variantsOf(product.id);
+    expect(variants.length, 'the fixture product is multi-variant').toBeGreaterThan(1);
+  });
+
+  test('the wizard offers flat/cap for a multi-variant product and displays the flat value', async ({ page, pages, world }) => {
+    const allegro = world.connectionFor('allegro');
+    test.skip(allegro === undefined, 'F9 needs an Allegro connection as the wizard destination.');
+
+    // Readiness does not depend on offer mappings, so this read-only half can use
+    // ANY multi-variant product and leaves the unmapped ones for test 1.
+    const product = await findAnyMultiVariantProduct(world);
+    test.skip(product === null, 'F9 UI half needs any multi-variant master product.');
+
+    await page.goto(
+      `/listings/bulk-create/wizard?productIds=${encodeURIComponent(product!.id)}` +
+        `&connectionId=${encodeURIComponent(allegro!.id)}`,
+    );
+    await expect(page.getByRole('heading', { name: 'Configure batch' })).toBeVisible({
+      timeout: 30_000,
+    });
+
+    // (1a) The policy is offered - for a batch the wizard KNOWS is multi-variant
+    // (its own header prints the variant count).
+    await expect(
+      page.getByText(/·\s*\d+\s*variants/i),
+      'the wizard knows this batch is multi-variant',
+    ).toBeVisible();
+    const flatStockRadio = page.getByRole('radio', { name: /Flat stock for all rows/ });
+    await expect(
+      flatStockRadio,
+      'the `flat` stock policy is offered with no multi-variant caveat, even though the ' +
+        'backend will discard it for every sibling',
+    ).toBeVisible();
+    await flatStockRadio.check();
+
+    const stockFieldset = page
+      .locator('fieldset.bulk-config__policy')
+      .filter({ hasText: 'Stock policy' });
+    const flatInput = stockFieldset.locator('input[type="number"]').last();
+    await flatInput.fill(String(FLAT_STOCK));
+
+    // Allegro gates Proceed on its own config section (shipping-rate package);
+    // reuse the suite's page object rather than re-deriving the control here.
+    await pages.bulkOfferWizard.completePlatformConfig({ requiresDeliveryPolicy: true });
+    const proceed = page.getByRole('button', { name: /^Proceed/ });
+    await expect(proceed).toBeEnabled({ timeout: 60_000 });
+    await proceed.click();
+
+    await expect(page.locator('button.bulk-review__cta--top')).toBeVisible({ timeout: 60_000 });
+    await page.locator('button.bulk-review__toggle').first().click();
+
+    // (1a cont.) …and the Review step DISPLAYS that number as the per-variant
+    // stock, which is the operator-facing half of the contradiction: the value
+    // shown is the one the backend is about to throw away.
+    const stockCells = page.locator('.bulk-review__vrow .bulk-review__c-stock');
+    await expect
+      .poll(async () => stockCells.count(), {
+        message: 'per-variant rows render with a stock cell',
+        timeout: 30_000,
+      })
+      .toBeGreaterThan(0);
+    // PROOF (documentation only - never asserted on): the promise - the Review
+    // step showing the operator's flat stock per sibling. There is no
+    // `f09-before-result.png` counterpart: the discard is only observable in the
+    // persisted request snapshot (test 1), which no screen renders.
+    await captureProof(page, 'f09-before-review-ready', { region: reviewRegion(page) });
+
+    const shown = await stockCells.allInnerTexts();
+    expect(
+      shown.map((s) => s.trim()),
+      `the Review step shows the flat ${FLAT_STOCK} for the siblings - a value the backend ` +
+        'replaces with master availability at enqueue time (see test 1)',
+    ).toContain(String(FLAT_STOCK));
+  });
+
+  test('the unlogged publish-downgrade half is unprovisionable on this stack', async ({
+    api,
+    world,
+  }) => {
+    // Enumerate the exact missing state so the skip message is actionable.
+    const zeroStockMultiVariant: string[] = [];
+    for (const product of await world.listProducts(100)) {
+      const variants = await world.variantsOf(product.id);
+      if (variants.length < 2) continue;
+      const availability = await api.inventory.availability(variants.map((v) => v.id));
+      const byVariant = new Map(availability.map((r) => [r.productVariantId, r.totalAvailable]));
+      for (const variant of variants) {
+        if ((byVariant.get(variant.id) ?? 0) <= 0) zeroStockMultiVariant.push(variant.id);
+      }
+    }
+    test.skip(
+      true,
+      'BLOCKED ON FIXTURE. Observing `publishEffective = stock > 0 ? publishImmediately : ' +
+        'false` needs a sibling of a MULTI-variant product whose master availability is 0 (or ' +
+        'which has no inventory row at all, since `masterAvailable ?? 0` collapses both). Only ' +
+        'then does the backend flip a submit that asked for `publishImmediately: true` into a ' +
+        'draft - with no log line and no wizard warning, because `mixedPublish` is derived ' +
+        'solely from explicit per-row publish flags. The operator-supplied stock cannot force ' +
+        'it either: that is exactly the value F9 half 1 proves is discarded. This stack has ' +
+        `${zeroStockMultiVariant.length} such sibling(s), so the state cannot be reached; the ` +
+        'two zero-stock variants present belong to SINGLE-variant products, where ' +
+        '`useMasterStock` is false and the operator stock is used verbatim. Provisioning it ' +
+        'needs a PrestaShop combination set to 0 stock (OL_PS_WEBSERVICE_KEY is unset by ' +
+        'default and the webservice helper cannot address individual combinations).',
+    );
+  });
+});
+
+/** First multi-variant product with >= 2 variants unmapped on `connectionId`. */
+async function findMultiVariantCandidate(
+  api: ApiClient,
+  world: {
+    listProducts(limit?: number): Promise<Product[]>;
+    variantsOf(id: string): Promise<ProductVariant[]>;
+  },
+  connectionId: string,
+): Promise<Candidate | null> {
+  const mapped = await mappedVariantIds(api, connectionId);
+  for (const product of await world.listProducts(100)) {
+    const variants = await world.variantsOf(product.id);
+    if (variants.length < 2) continue;
+    const free = variants.filter((v) => !mapped.has(v.id));
+    if (free.length >= 2) return { product, free };
+  }
+  return null;
+}
+
+async function findAnyMultiVariantProduct(world: {
+  listProducts(limit?: number): Promise<Product[]>;
+  variantsOf(id: string): Promise<ProductVariant[]>;
+}): Promise<Product | null> {
+  for (const product of await world.listProducts(100)) {
+    const variants = await world.variantsOf(product.id);
+    if (variants.length > 1) return product;
+  }
+  return null;
+}
+
+async function mappedVariantIds(api: ApiClient, connectionId: string): Promise<Set<string>> {
+  const ids = new Set<string>();
+  for (let offset = 0; ; offset += 100) {
+    const page = await api.listings.list({ connectionId, limit: 100, offset });
+    page.items.forEach((mapping) => ids.add(mapping.internalId));
+    if (page.items.length === 0 || offset + 100 >= page.total) break;
+  }
+  return ids;
+}
+
+/**
+ * Raw `POST /listings/bulk-create`. The node `ApiClient` exposes no bulk-submit
+ * method and this suite must not modify `src/`, so the call is issued directly
+ * here. Returns status + parsed body rather than throwing.
+ */
+async function submitBulkCreate(
+  env: E2eEnv,
+  body: BulkCreateBody,
+): Promise<{ status: number; body: unknown }> {
+  const token = await loginForRawCalls(env);
+  const response = await fetch(`${env.apiUrl}/v1/listings/bulk-create`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      Authorization: `Bearer ${token}`,
+      'x-idempotency-key': randomUUID(),
+    },
+    body: JSON.stringify(body),
+  });
+  const raw = await response.text();
+  let parsed: unknown = raw;
+  try {
+    parsed = raw.length > 0 ? JSON.parse(raw) : undefined;
+  } catch {
+    /* non-JSON body - keep the raw text */
+  }
+  return { status: response.status, body: parsed };
+}
+
+async function loginForRawCalls(env: E2eEnv): Promise<string> {
+  const response = await fetch(`${env.apiUrl}/v1/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: env.adminUser, password: env.adminPass }),
+  });
+  if (!response.ok) {
+    throw new Error(`Login failed: HTTP ${response.status} ${await response.text()}`);
+  }
+  return ((await response.json()) as { access_token: string }).access_token;
+}

--- a/apps/e2e/tests/preflight-divergence/f10-erli-category-gate.spec.ts
+++ b/apps/e2e/tests/preflight-divergence/f10-erli-category-gate.spec.ts
@@ -1,0 +1,534 @@
+/**
+ * F10 - Erli's category gate: the backend requires, the frontend suppresses
+ *
+ * ⚠️ CHARACTERIZATION TEST. This spec passes **while the divergence exists** and
+ * goes RED once it is closed. A failure here is NOT a regression - it means the
+ * finding was wrong, or it has been fixed and this file should be retired (or
+ * inverted into a normal regression test).
+ *
+ * The divergence is a capability-discovery mismatch between a STATIC manifest
+ * and a RUNTIME duck-typed instance:
+ *
+ *   Backend: `OfferBuilderService` computes
+ *     `requiresResolvedCategory = isCategoryBrowser(destination) || isEanCategoryMatcher(destination)`
+ *   and both guards are pure duck-typing on the resolved adapter instance
+ *   (`typeof adapter.fetchCategories === 'function'`). `ErliOfferManagerAdapter`
+ *   attaches `fetchCategories` + `fetchCategoryParameters` in its constructor
+ *   whenever `ErliAdapterFactory.buildAllegroCategoryCatalog` returns a client -
+ *   and that decision is made SOLELY from the stored credentials
+ *   (`allegroClientId` + `allegroClientSecret`). `config.allegroCategoryAccessEnabled`
+ *   is never read there. So an Erli connection carrying Allegro category
+ *   credentials arms Gate 1: a null category ⇒ `overrides.categoryId / REQUIRED`.
+ *
+ *   Frontend: `bulk-wizard.tsx` derives
+ *     `destinationResolvesCategoryAtSubmit = !supportedCapabilities.includes('EanCategoryMatcher')`
+ *   from the connection response's STATIC manifest (`erli-plugin.ts`), which
+ *   never lists it. That is true for EVERY Erli connection, so `bulk-policy.ts`
+ *   skips the `no-match` / `no-ean` / `multi-match` category blockers entirely.
+ *   The wizard cannot discover otherwise either: `resolveCategoriesBatch`
+ *   short-circuits every borrows-taxonomy item to `{kind:'no-match'}` before the
+ *   mapping fallback, so `resolvedCategoryId` stays null and nothing is pinned.
+ *
+ * Both sides are asserted:
+ *   (a) the connection's advertised capabilities do NOT include a category
+ *       capability, the wizard shows every row ready and enables submit, AND
+ *   (b) the batch is accepted and every child terminates `failed` with
+ *       `overrides.categoryId` / `REQUIRED`.
+ *
+ * Plus the sharpening from the finding: the trigger is CREDENTIALS, not the UI
+ * toggle. Turning "Allegro category access" off writes
+ * `config.allegroCategoryAccessEnabled: false` while the Allegro keys stay in
+ * the credential store - so the backend gate stays armed and the frontend
+ * reports category browsing as disabled.
+ *
+ * @module tests/preflight-divergence
+ */
+import { test, expect } from '../../src/fixtures/test';
+import type { ApiClient } from '../../src/api/api-client';
+import type { Connection, Product, ProductVariant } from '../../src/api/api.types';
+import type { E2eEnv } from '../../src/config/env';
+import type { World } from '../../src/world/world';
+import type { BulkOfferWizard } from '../../src/pages/bulk-offer-wizard.page';
+import type { Poller } from '../../src/support/poller';
+import { captureProof, reviewRegion } from './__proof__/capture';
+
+const TERMINAL_BATCH_STATUSES = new Set(['completed', 'partially-failed', 'failed']);
+
+/** `BulkBatchRecordSummaryDto.errors` - on the wire, absent from the shared local type. */
+interface RecordError {
+  field?: string | null;
+  code: string;
+  message: string;
+}
+
+async function bearer(env: E2eEnv): Promise<string> {
+  const response = await fetch(`${env.apiUrl}/v1/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: env.adminUser, password: env.adminPass }),
+  });
+  if (!response.ok) {
+    throw new Error(`E2E login failed: HTTP ${response.status} ${await response.text()}`);
+  }
+  return ((await response.json()) as { access_token: string }).access_token;
+}
+
+/**
+ * Prove the Erli adapter instance really carries the duck-typed category
+ * methods, without inspecting credentials (which the API never exposes).
+ *
+ * `GET /listings/connections/:id/categories/:categoryId/parameters` reaches the
+ * SAME adapter instance the offer builder resolves, and only answers when
+ * `fetchCategoryParameters` was attached in the constructor - i.e. exactly when
+ * `buildAllegroCategoryCatalog` returned a client from the stored Allegro keys.
+ * A non-empty parameter list therefore means `isCategoryBrowser(adapter)` is
+ * true and `requiresResolvedCategory` is armed for this connection.
+ */
+async function backendCategoryGateArmed(
+  api: ApiClient,
+  connectionId: string,
+  probeCategoryId: string,
+): Promise<boolean> {
+  try {
+    const parameters = await api.listings.categoryParameters(connectionId, probeCategoryId);
+    return parameters.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/** Every variant id that already carries an offer mapping on `connectionId`. */
+async function listedVariantIds(api: ApiClient, connectionId: string): Promise<Set<string>> {
+  const ids = new Set<string>();
+  let offset = 0;
+  for (;;) {
+    const page = await api.listings.list({ connectionId, limit: 100, offset });
+    for (const mapping of page.items) ids.add(mapping.internalId);
+    offset += 100;
+    if (page.items.length === 0 || offset >= page.total) break;
+  }
+  return ids;
+}
+
+function sourceCategoryIds(product: Product): string[] {
+  const categories = (product as unknown as { categories?: unknown }).categories;
+  return Array.isArray(categories) ? categories.map(String) : [];
+}
+
+interface EanMatchLike {
+  kind: string;
+  allegroCategoryId?: string | null;
+}
+
+/** Run the wizard's own Resolve-step query, exactly as the Review step does. */
+async function resolveCategories(
+  env: E2eEnv,
+  token: string,
+  connectionId: string,
+  product: Product,
+): Promise<Record<string, EanMatchLike>> {
+  const categories = sourceCategoryIds(product);
+  const response = await fetch(
+    `${env.apiUrl}/v1/listings/connections/${connectionId}/categories/resolve-batch`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+      body: JSON.stringify({
+        items: (product.variants ?? []).map((variant: ProductVariant) => ({
+          variantId: variant.id,
+          ean: variant.ean ?? variant.gtin ?? null,
+          ...(categories.length > 0 ? { sourceCategoryIds: categories } : {}),
+        })),
+      }),
+    },
+  );
+  if (!response.ok) return {};
+  return ((await response.json()) as { results?: Record<string, EanMatchLike> }).results ?? {};
+}
+
+/**
+ * Source-category ids that the taxonomy OWNER has a configured destination
+ * mapping for. Erli borrows Allegro's taxonomy (#1045), so the server-side
+ * resolution chain falls back to these rows — a product sitting in one of these
+ * categories WILL resolve at submit and pass Gate 1 (it then dies on F1's
+ * offer-parameter gate instead, which is a different finding).
+ */
+async function mappedSourceCategoryIds(
+  env: E2eEnv,
+  token: string,
+  ownerConnectionId: string,
+): Promise<Set<string>> {
+  const response = await fetch(
+    `${env.apiUrl}/v1/connections/${ownerConnectionId}/mappings/categories`,
+    { headers: { Authorization: `Bearer ${token}` } },
+  );
+  if (!response.ok) return new Set();
+  const rows = (await response.json()) as { prestashopCategoryId?: unknown }[];
+  return new Set(
+    (Array.isArray(rows) ? rows : [])
+      .map((row) => (row.prestashopCategoryId === undefined ? '' : String(row.prestashopCategoryId)))
+      .filter((id) => id !== ''),
+  );
+}
+
+/**
+ * A product whose Erli rows reach Review green and whose category the backend
+ * genuinely cannot resolve. Four conditions, each closing a way the run could
+ * otherwise land on a DIFFERENT finding:
+ *
+ *   1. Not already listed on the connection — `filterAlreadyListed` would drop
+ *      it and the request would 400 on F2's path instead.
+ *   2. Priced, and carrying at least one image — Erli's only bulk blocker is
+ *      `missing-image`, so an image-less row would not be green.
+ *   3. Its source categories are disjoint from the taxonomy owner's configured
+ *      category mappings, AND the owner's own resolve chain finds no catalogue
+ *      match for any variant. This is the real Gate-1 predicate: the FE's own
+ *      Erli preview is useless here because `resolveCategoriesBatch`
+ *      short-circuits every borrows-taxonomy item to `no-match` before the
+ *      mapping fallback — a product in a MAPPED category still resolves at
+ *      submit and fails on F1's parameter gate instead.
+ *   4. The Erli-side preview also reports no match (documents the FE's view).
+ */
+async function findUnresolvableProduct(
+  env: E2eEnv,
+  token: string,
+  api: ApiClient,
+  world: World,
+  connectionId: string,
+  taxonomyOwner: Connection | undefined,
+): Promise<Product | undefined> {
+  const listed = await listedVariantIds(api, connectionId);
+  const mapped = taxonomyOwner
+    ? await mappedSourceCategoryIds(env, token, taxonomyOwner.id)
+    : new Set<string>();
+
+  for (const summary of await world.listProducts(60)) {
+    const product = await api.products.getById(summary.id);
+    const variants = product.variants ?? [];
+    if (variants.length === 0) continue;
+    if (variants.some((variant) => listed.has(variant.id))) continue;
+    const images = (product as unknown as { images?: unknown }).images;
+    if (!Array.isArray(images) || images.length === 0) continue;
+    if (product.price === null || product.price <= 0) continue;
+    if (sourceCategoryIds(product).some((id) => mapped.has(id))) continue;
+
+    if (taxonomyOwner) {
+      const ownerResolved = await resolveCategories(env, token, taxonomyOwner.id, product);
+      const ownerFindsNothing = variants.every((variant) => {
+        const match = ownerResolved[variant.id];
+        return !match || match.kind !== 'matched' || !match.allegroCategoryId;
+      });
+      if (!ownerFindsNothing) continue;
+    }
+
+    const resolved = await resolveCategories(env, token, connectionId, product);
+    const everyVariantUnresolved = variants.every((variant) => {
+      const match = resolved[variant.id];
+      return !match || match.kind !== 'matched' || !match.allegroCategoryId;
+    });
+    if (everyVariantUnresolved) return product;
+  }
+  return undefined;
+}
+
+/**
+ * The Review step's submit CTA, tolerant of both label generations: the build
+ * this suite's page object was written against renders "Approve all (N)", the
+ * current one renders "Create offers (N)". The `(N)` suffix is what keeps this
+ * from also matching the confirm modal's own bare "Create offers" button.
+ */
+function submitCta(page: import('@playwright/test').Page): import('@playwright/test').Locator {
+  return page.getByRole('button', { name: /^(Approve all|Create offers)\s*\(\d+\)$/ });
+}
+
+/**
+ * Read the Review step's readiness counters straight off its `role="status"`
+ * summary. The shared page object's `needsAttentionCount()` assumes the older
+ * "N row(s) need attention" phrasing and parses the FIRST number in the hint;
+ * the current build renders "N ready · M need attention · K excluded", so that
+ * parse returns the READY count. Anchor on the labelled number instead.
+ */
+async function readinessCounts(
+  page: import('@playwright/test').Page,
+): Promise<{ ready: number; needAttention: number; raw: string }> {
+  const hint = page.getByRole('status').filter({ hasText: /needs? attention/ }).first();
+  if ((await hint.count()) === 0) return { ready: 0, needAttention: 0, raw: '(no readiness hint)' };
+  const raw = (await hint.innerText()).replace(/\s+/g, ' ').trim();
+  const attention = /(\d+)\s+needs?\s+attention/i.exec(raw);
+  const ready = /(\d+)\s+ready/i.exec(raw);
+  return {
+    ready: ready ? Number(ready[1]) : 0,
+    needAttention: attention ? Number(attention[1]) : 0,
+    raw,
+  };
+}
+
+/**
+ * Pick the destination connection on the Config step.
+ *
+ * The step renders a grouped RADIO RAIL (`PublishDestinationRail`) when more
+ * than one publish destination exists, and a plain "Publishing as {name}" alert
+ * when there is only one - the shared page object's `<select>` path
+ * (`selectConnectionIfPresent`) only covers the older select-based layout, so
+ * try the rail first and fall back to it. Kept local per the suite's rule that
+ * a divergence spec must not edit shared page objects.
+ */
+async function selectDestination(
+  page: import('@playwright/test').Page,
+  wizard: BulkOfferWizard,
+  connectionName: string,
+): Promise<void> {
+  const escaped = connectionName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const radio = page.getByRole('radio', { name: new RegExp(escaped) });
+  if ((await radio.count()) > 0) {
+    await radio.first().click();
+    return;
+  }
+  await wizard.selectConnectionIfPresent(connectionName);
+}
+
+/**
+ * Wait until the Review step has SETTLED - the async per-category parameter
+ * schema has resolved and the row blockers reflect it. Mirrors the page
+ * object's own (private) settle gate so a transient "0 need attention, submit
+ * disabled" limbo is never read as readiness, but against the local
+ * build-tolerant locators above.
+ */
+async function waitForReviewSettled(page: import('@playwright/test').Page): Promise<void> {
+  await expect(async () => {
+    const cta = submitCta(page).first();
+    if ((await cta.count()) === 0) {
+      throw new Error('Review step has not rendered its submit CTA yet.');
+    }
+    const [enabled, counts] = await Promise.all([cta.isEnabled(), readinessCounts(page)]);
+    if (!enabled && counts.needAttention === 0) {
+      throw new Error(`Review still resolving: submit disabled with no needs-attention rows (${counts.raw}).`);
+    }
+  }).toPass({ timeout: 60_000 });
+}
+
+/** Resolve the Erli connection whose backend category gate is armed. */
+async function armedErliConnection(
+  api: ApiClient,
+  world: World,
+  probeCategoryId: string,
+): Promise<Connection | undefined> {
+  for (const connection of world.connectionsFor('erli')) {
+    if (connection.status !== 'active') continue;
+    // The FE-suppression half: the static manifest must NOT advertise the
+    // capability the wizard keys off. If it ever does, the FE stops suppressing
+    // and the divergence is closed.
+    if (connection.supportedCapabilities.includes('EanCategoryMatcher')) continue;
+    if (await backendCategoryGateArmed(api, connection.id, probeCategoryId)) return connection;
+  }
+  return undefined;
+}
+
+test.describe('F10 - Erli category gate: backend requires, frontend suppresses', () => {
+  test('rows are green, submit is accepted, every child fails overrides.categoryId/REQUIRED', async ({
+    env,
+    api,
+    world,
+    page,
+    pages,
+    poll,
+  }: {
+    env: E2eEnv;
+    api: ApiClient;
+    world: World;
+    page: import('@playwright/test').Page;
+    pages: import('../../src/pages').PageObjects;
+    poll: Poller;
+  }) => {
+    // Fixture resolution walks the catalogue and runs the real category-resolution
+    // chain per candidate, then waits on a worker round-trip - well past the
+    // suite's default 90s per-test budget. Local to this spec (the shared
+    // playwright.config is not touched).
+    test.setTimeout(300_000);
+    const probeCategoryId = env.freshAllegroCategoryId;
+    const erli = await armedErliConnection(api, world, probeCategoryId);
+    test.skip(
+      !erli,
+      'No usable fixture: this stack has no ACTIVE Erli connection that (a) omits ' +
+        '"EanCategoryMatcher" from its advertised supportedCapabilities and (b) can actually read ' +
+        `Allegro category parameters (probe: GET /listings/connections/:id/categories/${probeCategoryId}/parameters). ` +
+        'Configure an Erli connection with Allegro category credentials (allegroClientId + ' +
+        'allegroClientSecret in its credential payload) - that is what duck-types fetchCategories ' +
+        'onto the adapter and arms the backend gate. Override the probe category with ' +
+        'E2E_FRESH_ALLEGRO_CATEGORY_ID if 261481 is not reachable on your Allegro app.',
+    );
+
+    // (a) The FE-visible half, stated explicitly: nothing in the advertised
+    // capability set tells the wizard a category is required here.
+    expect(
+      erli!.supportedCapabilities,
+      'the static manifest advertises no EAN-category capability, so the wizard treats the ' +
+        'destination as resolving its category server-side at submit',
+    ).not.toContain('EanCategoryMatcher');
+    expect(erli!.supportedCapabilities).not.toContain('CategoryBrowser');
+
+    const token = await bearer(env);
+    // Erli borrows Allegro's taxonomy (#1045): the server-side chain falls back
+    // to the OWNER's category mappings, so the owner connection is the oracle
+    // for "will Gate 1 actually find a category?".
+    const taxonomyOwner = world
+      .connectionsWithCapability('EanCategoryMatcher')
+      .find((candidate) => candidate.status === 'active');
+    const product = await findUnresolvableProduct(env, token, api, world, erli!.id, taxonomyOwner);
+    test.skip(
+      !product,
+      'No usable fixture: this stack has no master product that is (a) not yet listed on the Erli ' +
+        'connection, (b) priced and carrying at least one image (Erli\'s only bulk blocker is ' +
+        'missing-image), and (c) genuinely unresolvable server-side: its source categories must be ' +
+        'disjoint from the taxonomy owner\'s configured category mappings AND its barcodes must ' +
+        'find no catalogue match. Import a fresh PrestaShop product (with an image and a price) ' +
+        'into a category that has NO PS->Allegro category mapping, then run ' +
+        'master.product.syncAll. NOTE: a product in a MAPPED source category resolves at submit ' +
+        'and fails on F1\'s parameters.Stan gate instead - a different finding.',
+    );
+
+    await page.goto(`/listings/bulk-create/wizard?productIds=${product!.id}`);
+    const wizard = pages.bulkOfferWizard;
+    await wizard.expectOnConfigStep();
+    await selectDestination(page, wizard, erli!.name);
+
+    // No row editing: the divergence is that the wizard never ASKS for a
+    // category here, so an operator has no reason to open the editor.
+    await wizard.completePlatformConfig({ requiresErliBuyabilityFields: true });
+    await expect(wizard.proceedButton).toBeEnabled({ timeout: 30_000 });
+    await wizard.proceedButton.click();
+    await expect(submitCta(page).first()).toBeVisible({ timeout: 60_000 });
+    await waitForReviewSettled(page);
+
+    expect(
+      (await readinessCounts(page)).needAttention,
+      'the wizard flags no category blocker even though no category resolved for any variant',
+    ).toBe(0);
+    await expect(
+      submitCta(page).first(),
+      'the wizard enables submit - every row reads "ready"',
+    ).toBeEnabled();
+
+    // PROOF (documentation only - never asserted on): the promise.
+    await captureProof(page, 'f10-before-review-ready', { region: reviewRegion(page) });
+
+    await submitCta(page).first().click();
+    await expect(wizard.confirmModalConfirmButton).toBeVisible();
+    await wizard.publishImmediatelyCheckbox.check();
+
+    const submitted = page.waitForResponse(
+      (response) =>
+        response.request().method() === 'POST' && response.url().includes('/listings/bulk-create'),
+      { timeout: 60_000 },
+    );
+    await wizard.confirmModalConfirmButton.click();
+    const response = await submitted;
+
+    expect(response.status(), 'the submit is accepted - the gate fires per record').toBeGreaterThanOrEqual(200);
+    expect(response.status()).toBeLessThan(300);
+
+    await page.waitForURL(/\/listings\/bulk-batches\/[^/]+$/, { timeout: 30_000 });
+    const batchId = pages.bulkBatchProgress.batchId;
+    expect(batchId, 'a batch id is minted').toBeTruthy();
+
+    // (b) …and every child dies on the category the wizard never asked for.
+    const batch = await poll.until(
+      () => api.listings.getBulkBatch(batchId),
+      (summary) => TERMINAL_BATCH_STATUSES.has(summary.status),
+      { message: `bulk batch ${batchId} to reach a terminal status`, timeoutMs: 180_000 },
+    );
+
+    // PROOF (documentation only): what actually happened to the green batch.
+    await captureProof(page, 'f10-before-result', {
+      fullPage: true,
+      prepare: async () => {
+        await page.goto(`/listings/bulk-batches/${batchId}`);
+        await page.locator('button[aria-label^="Failure details for"]').first().click();
+        await expect(page.locator('.bulk-batch__err-list').first()).toBeVisible({
+          timeout: 15_000,
+        });
+      },
+    });
+
+    const describeRecords = JSON.stringify(
+      batch.records.map((record) => ({
+        variant: record.internalVariantId,
+        status: record.status,
+        errors: (record as unknown as { errors?: RecordError[] | null }).errors,
+      })),
+    );
+    expect(batch.records.length, `the batch has children. ${describeRecords}`).toBeGreaterThan(0);
+    expect(
+      batch.failedCount,
+      `every child of the "ready" batch fails. ${describeRecords}`,
+    ).toBe(batch.records.length);
+
+    const errors = batch.records.flatMap(
+      (record) => (record as unknown as { errors?: RecordError[] | null }).errors ?? [],
+    );
+    expect(
+      errors.some((error) => error.field === 'overrides.categoryId' && error.code === 'REQUIRED'),
+      `a child fails with overrides.categoryId / REQUIRED. Observed: ${JSON.stringify(errors)}`,
+    ).toBe(true);
+  });
+
+  test('sharpening: unchecking "Allegro category access" does NOT disarm the backend gate', async ({
+    env,
+    api,
+    world,
+  }: {
+    env: E2eEnv;
+    api: ApiClient;
+    world: World;
+  }) => {
+    // Fixture resolution walks the catalogue and runs the real category-resolution
+    // chain per candidate, then waits on a worker round-trip - well past the
+    // suite's default 90s per-test budget. Local to this spec (the shared
+    // playwright.config is not touched).
+    test.setTimeout(300_000);
+    const probeCategoryId = env.freshAllegroCategoryId;
+    const erli = await armedErliConnection(api, world, probeCategoryId);
+    test.skip(
+      !erli,
+      'No usable fixture: no ACTIVE Erli connection whose backend category gate is armed ' +
+        '(see the first test in this file for how to configure one).',
+    );
+
+    const originalConfig = { ...(erli!.config ?? {}) };
+    test.skip(
+      originalConfig.allegroCategoryAccessEnabled !== true,
+      'The connection does not currently advertise `config.allegroCategoryAccessEnabled: true`, ' +
+        'so there is no "checked toggle" to uncheck. Enable Allegro category access on the Erli ' +
+        'connection first (Connections -> Erli -> credentials panel).',
+    );
+
+    try {
+      // Exactly what the credentials panel writes when the operator unchecks the
+      // toggle: a CONFIG update. The credentials object simply omits the Allegro
+      // keys, and rotation is skipped entirely when nothing else was typed - so
+      // the stored keys survive.
+      const updated = await api.connections.update(erli!.id, {
+        config: { ...originalConfig, allegroCategoryAccessEnabled: false },
+      });
+      expect(
+        (updated.config ?? {}).allegroCategoryAccessEnabled,
+        'the toggle is now off as far as the connection record (and the UI) is concerned',
+      ).toBe(false);
+
+      // …and the adapter still reads Allegro categories, because the factory
+      // decides on credentials alone. So `isCategoryBrowser(adapter)` is still
+      // true and Gate 1 is still armed.
+      expect(
+        await backendCategoryGateArmed(api, erli!.id, probeCategoryId),
+        'with the toggle OFF the backend still resolves Allegro category parameters through this ' +
+          'connection - ErliAdapterFactory.buildAllegroCategoryCatalog never reads ' +
+          'config.allegroCategoryAccessEnabled, so requiresResolvedCategory stays true',
+      ).toBe(true);
+    } finally {
+      // Always restore the operator-visible state, whatever happened above.
+      await api.connections.update(erli!.id, { config: originalConfig });
+      const restored = await api.connections.getById(erli!.id);
+      expect((restored.config ?? {}).allegroCategoryAccessEnabled).toBe(true);
+    }
+  });
+});

--- a/apps/e2e/tests/preflight-divergence/f11-title-overflow.spec.ts
+++ b/apps/e2e/tests/preflight-divergence/f11-title-overflow.spec.ts
@@ -1,0 +1,589 @@
+/**
+ * F11 - a master product name over 75 characters is never measured
+ *
+ * CHARACTERIZATION TEST. It asserts BOTH sides of one divergence:
+ *   (a) a master product whose name exceeds the destination's 75-character title
+ *       limit renders `ready` in the bulk offer wizard - no blocker, no chip, no
+ *       warning. The ONLY place that limit exists on the client is the per-row
+ *       edit modal (`maxLength=75` + a schema cap), which this test proves by
+ *       opening the editor and watching the save be refused, AND
+ *   (b) the submission is accepted (202) because the request carries NO `title`
+ *       override - `@MaxLength(75)` only guards a title that WAS sent - and OL
+ *       never measures the `product.name` the offer builder falls back to: no
+ *       OL-side error ever mentions the title, and no offer is created.
+ *
+ * The test PASSES while the divergence exists. It FAILS if the wizard starts
+ * flagging the row, if the request starts carrying a bounded title, or if OL
+ * starts reporting a title-length problem (builder gate, or a marketplace
+ * rejection that finally reaches the operator) - all of which mean the finding
+ * was wrong or has been closed.
+ *
+ * Fixture policy: REUSE FIRST, provision only as a last resort. The fixture is a
+ * master product whose name exceeds the title cap, and there is no way to lengthen
+ * an existing catalogue name without mutating shared data - so the first run has
+ * to create one. But `PrestashopWebserviceClient` exposes no delete, so every
+ * provisioning run strands a product on the shared shop forever. This spec
+ * therefore looks for a fixture a PREVIOUS run already left behind (an
+ * `E2E preflight F11 …` product, still over-length, still unlisted on the
+ * destination, still stocked, still resolving to a product card) and only
+ * provisions when the catalogue offers none. The spec creates no offer (it is
+ * submitted with "Publish immediately" unchecked, and on the stack this was
+ * written against the record dies before any marketplace call), so its own
+ * fixture stays reusable by the next run. Which path was taken is annotated.
+ *
+ * @module tests/preflight-divergence
+ */
+import type { Locator, Page } from '@playwright/test';
+import { test, expect } from '../../src/fixtures/test';
+import type { ApiClient } from '../../src/api/api-client';
+import type { Connection, Product, ProductVariant } from '../../src/api/api.types';
+import type { E2eEnv } from '../../src/config/env';
+import { PrestashopWebserviceClient } from '../../src/api/prestashop-webservice';
+import { JobType } from '../../src/support/jobs';
+import type { World } from '../../src/world/world';
+
+test.describe.configure({ mode: 'serial', timeout: 600_000 });
+
+/** The title cap the FE editor and the request DTO both encode. */
+const TITLE_MAX = 75;
+
+/**
+ * Name prefix every fixture this spec has ever created carries. It is the handle
+ * a later run recognises its predecessor's product by - so keep it stable, and
+ * keep it in sync with `buildFixtureName` below.
+ */
+const FIXTURE_NAME_PREFIX = 'E2E preflight F11';
+
+function buildFixtureName(reference: string): string {
+  return (
+    `${FIXTURE_NAME_PREFIX} characterization product with a deliberately over-long master ` +
+    `catalogue name ${reference}`
+  );
+}
+
+/* ────────────────────────── local fixture discovery ────────────────────────── */
+
+/** A destination that owns its taxonomy (advertises the EAN->category matcher). */
+function pickOwnsTaxonomyOfferDestination(world: World): Connection | undefined {
+  return world
+    .connectionsWithCapability('OfferCreator')
+    .find(
+      (connection) =>
+        connection.status === 'active' &&
+        connection.supportedCapabilities.includes('EanCategoryMatcher'),
+    );
+}
+
+/**
+ * The master-catalogue connection this fixture can provision a product on: it
+ * must have `ProductMaster` actually ENABLED (not merely advertised - a shop
+ * kept as a publish target advertises it too) and expose a PrestaShop-shaped
+ * webservice URL, since provisioning goes through `PrestashopWebserviceClient`.
+ */
+function pickMasterCatalogue(env: E2eEnv, world: World): Connection | undefined {
+  return world
+    .connectionsWithCapability('ProductMaster')
+    .filter(
+      (connection) =>
+        connection.status === 'active' &&
+        connection.enabledCapabilities.includes('ProductMaster'),
+    )
+    .find((connection) => webserviceBaseUrl(env, connection) !== null);
+}
+
+/**
+ * Host-reachable base URL for the PrestaShop webservice. The connection's own
+ * `baseUrl` is often the in-cluster hostname, so prefer the explicit override,
+ * then the storefront URL, before falling back to it.
+ */
+function webserviceBaseUrl(env: E2eEnv, connection: Connection): string | null {
+  const config = (connection.config ?? {}) as Record<string, unknown>;
+  const candidates = [
+    env.psAdminUrl,
+    typeof config['storefrontBaseUrl'] === 'string' ? config['storefrontBaseUrl'] : null,
+    typeof config['baseUrl'] === 'string' ? config['baseUrl'] : null,
+  ];
+  return candidates.find((value): value is string => !!value && /^https?:\/\//.test(value)) ?? null;
+}
+
+interface CatalogueRow {
+  product: Product;
+  /** Master image URLs (not in the suite's mirrored `Product` type). */
+  images: string[];
+  variants: ProductVariant[];
+}
+
+async function loadCatalogue(api: ApiClient): Promise<CatalogueRow[]> {
+  const summaries: Product[] = [];
+  for (let offset = 0; ; offset += 50) {
+    const page = await api.products.list({ limit: 50, offset });
+    summaries.push(...page.items);
+    if (offset + 50 >= page.total || page.items.length === 0) break;
+  }
+  const rows: CatalogueRow[] = [];
+  for (const summary of summaries) {
+    const detail = (await api.products.getById(summary.id)) as Product & { images?: string[] };
+    const variants =
+      detail.variants && detail.variants.length > 0
+        ? detail.variants
+        : (await api.products.listVariants(summary.id)).items;
+    rows.push({ product: detail, images: detail.images ?? [], variants });
+  }
+  return rows;
+}
+
+/** Every variant id that already carries an offer mapping on `connectionId`. */
+async function listedVariantIds(api: ApiClient, connectionId: string): Promise<Set<string>> {
+  const ids = new Set<string>();
+  for (let offset = 0; ; offset += 100) {
+    const page = await api.listings.list({ connectionId, limit: 100, offset });
+    page.items.forEach((mapping) => ids.add(mapping.internalId));
+    if (page.items.length === 0 || offset + 100 >= page.total) break;
+  }
+  return ids;
+}
+
+/**
+ * A fixture an earlier run of THIS spec left behind that is still usable, or
+ * `null`. Every condition mirrors what the provisioning path guarantees, so a
+ * reused fixture puts the test in exactly the state a fresh one would:
+ *
+ *   1. Named with this spec's prefix - never adopt an unrelated product, whose
+ *      name a future run might depend on staying short.
+ *   2. Still longer than the title cap (the whole point of the fixture).
+ *   3. Carries a variant that has NO offer mapping on the destination yet -
+ *      `filterAlreadyListed` would otherwise drop it and the submit would die on
+ *      F2's empty-batch path instead of reaching the assertions below.
+ *   4. That variant's barcode still resolves to a product card, which is what
+ *      releases the required-parameter blocker and lets the row read `ready`
+ *      without the operator editing it.
+ *   5. It still carries stock - a zero-stock row would be flagged for the WRONG
+ *      reason.
+ */
+async function findReusableFixture(
+  api: ApiClient,
+  catalogue: CatalogueRow[],
+  resolved: Record<string, ResolveBatchResult>,
+  listed: Set<string>,
+): Promise<{ product: Product; variant: ProductVariant } | null> {
+  for (const { product, variants } of catalogue) {
+    if (!product.name.startsWith(FIXTURE_NAME_PREFIX)) continue;
+    if (product.name.length <= TITLE_MAX) continue;
+    for (const variant of variants) {
+      if (listed.has(variant.id)) continue;
+      const match = resolved[variant.id];
+      if (match?.kind !== 'matched' || !match.productCardId) continue;
+      const availability = await api.inventory.availability([variant.id]);
+      if ((availability[0]?.totalAvailable ?? 0) <= 0) continue;
+      return { product, variant };
+    }
+  }
+  return null;
+}
+
+async function bearerToken(env: E2eEnv): Promise<string> {
+  const response = await fetch(`${env.apiUrl}/v1/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: env.adminUser, password: env.adminPass }),
+  });
+  if (!response.ok) throw new Error(`E2E login failed: HTTP ${response.status}`);
+  const body = (await response.json()) as { access_token: string };
+  return body.access_token;
+}
+
+interface ResolveBatchResult {
+  kind: string;
+  productCardId?: string;
+}
+
+/**
+ * The wizard's own Resolve-step call. A `matched` result with a `productCardId`
+ * is what releases the FE's required-parameter blocker, i.e. what lets a row on
+ * a taxonomy-owning destination be `ready` without the operator editing it -
+ * which is the state this finding is about.
+ */
+async function resolveBatch(
+  env: E2eEnv,
+  token: string,
+  connectionId: string,
+  items: Array<{ variantId: string; ean: string; sourceCategoryIds: string[] }>,
+): Promise<Record<string, ResolveBatchResult>> {
+  const out: Record<string, ResolveBatchResult> = {};
+  for (let i = 0; i < items.length; i += 20) {
+    const response = await fetch(
+      `${env.apiUrl}/v1/listings/connections/${connectionId}/categories/resolve-batch`,
+      {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ items: items.slice(i, i + 20) }),
+      },
+    );
+    if (!response.ok) continue;
+    const body = (await response.json()) as { results?: Record<string, ResolveBatchResult> };
+    Object.assign(out, body.results ?? {});
+  }
+  return out;
+}
+
+interface BatchRecordWithErrors {
+  id: string;
+  internalVariantId: string;
+  status: string;
+  externalOfferId: string | null;
+  errors: Array<{ field: string; code: string; message: string }> | null;
+}
+
+interface BatchWithErrors {
+  id: string;
+  status: string;
+  totalCount: number;
+  succeededCount: number;
+  failedCount: number;
+  records: BatchRecordWithErrors[];
+}
+
+/** Raw read - the shared `BulkBatchSummary` type omits the per-record `errors[]`. */
+async function getBatch(env: E2eEnv, token: string, batchId: string): Promise<BatchWithErrors> {
+  const response = await fetch(`${env.apiUrl}/v1/listings/bulk-create/${batchId}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!response.ok) throw new Error(`GET bulk-create/${batchId} -> HTTP ${response.status}`);
+  return (await response.json()) as BatchWithErrors;
+}
+
+/* ─────────────────────────────── wizard driving ─────────────────────────────── */
+
+async function openWizard(
+  page: Page,
+  target: { productId: string; variantId: string; connectionId: string },
+): Promise<void> {
+  const query = new URLSearchParams({
+    productIds: target.productId,
+    variantIds: target.variantId,
+    connectionId: target.connectionId,
+  });
+  await page.goto(`/listings/bulk-create/wizard?${query.toString()}`);
+  await expect(
+    page.getByRole('heading', { name: 'Bulk marketplace offer creation' }),
+  ).toBeVisible({ timeout: 30_000 });
+}
+
+async function completeConfigAndProceed(page: Page): Promise<void> {
+  const proceed = page.getByRole('button', { name: /^Proceed/ });
+  await expect(proceed).toBeVisible({ timeout: 30_000 });
+  await expect(async () => {
+    const selects = page.locator('select');
+    const count = await selects.count();
+    for (let index = 0; index < count; index += 1) {
+      const select = selects.nth(index);
+      if (!(await select.isEnabled())) continue;
+      if ((await select.inputValue()) !== '') continue;
+      const value = await select.locator('option:not([value=""])').first().getAttribute('value');
+      if (value) await select.selectOption(value);
+    }
+    expect(await proceed.isEnabled(), 'Config step "Proceed" should unlock').toBe(true);
+  }).toPass({ timeout: 90_000 });
+  await proceed.click();
+}
+
+function reviewCta(page: Page): Locator {
+  return page.getByRole('button', { name: /^Create offers \(\d+\)$/ }).first();
+}
+
+interface ReviewCounts {
+  ready: number;
+  attention: number;
+  excluded: number;
+}
+
+async function reviewCounts(page: Page): Promise<ReviewCounts> {
+  const summary = page.getByRole('status').filter({ hasText: /ready/i }).first();
+  const text = (await summary.innerText()).replace(/\s+/g, ' ');
+  const read = (pattern: RegExp): number => {
+    const match = pattern.exec(text);
+    return match ? Number(match[1]) : 0;
+  };
+  return {
+    ready: read(/(\d+)\s*ready/i),
+    attention: read(/(\d+)\s*need attention/i),
+    excluded: read(/(\d+)\s*excluded/i),
+  };
+}
+
+async function waitForReview(page: Page): Promise<ReviewCounts> {
+  await expect(reviewCta(page)).toBeVisible({ timeout: 90_000 });
+  let counts: ReviewCounts = { ready: 0, attention: 0, excluded: 0 };
+  await expect(async () => {
+    counts = await reviewCounts(page);
+    const settled = counts.ready > 0 || counts.attention > 0 || counts.excluded > 0;
+    expect(settled, 'Review step should settle into per-row statuses').toBe(true);
+  }).toPass({ timeout: 90_000 });
+  return counts;
+}
+
+interface SubmitResult {
+  status: number;
+  body: unknown;
+  requestBody: string | null;
+}
+
+async function submitFromReview(page: Page): Promise<SubmitResult> {
+  await reviewCta(page).click();
+  const dialog = page.getByRole('dialog');
+  const publishAnyway = dialog.getByRole('button', { name: /Publish anyway/ });
+  if (await publishAnyway.isVisible({ timeout: 5_000 }).catch(() => false)) {
+    await publishAnyway.click();
+  }
+  const confirmButton = page.getByRole('button', { name: 'Create offers', exact: true });
+  await expect(confirmButton).toBeVisible({ timeout: 30_000 });
+  const publishToggle = page.getByRole('checkbox', { name: /Publish immediately/ });
+  if (await publishToggle.count()) await publishToggle.uncheck();
+
+  const [response] = await Promise.all([
+    page.waitForResponse(
+      (candidate) =>
+        candidate.url().endsWith('/listings/bulk-create') &&
+        candidate.request().method() === 'POST',
+      { timeout: 60_000 },
+    ),
+    confirmButton.click(),
+  ]);
+  const text = await response.text();
+  let body: unknown = text;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    /* keep the raw text */
+  }
+  return { status: response.status(), body, requestBody: response.request().postData() };
+}
+
+/* ──────────────────────────────── the scenario ──────────────────────────────── */
+
+test.describe('F11: an over-length master name is never measured by the wizard or by OL', () => {
+  test('a 100+ character product name is ready, submits 202 with no title, and OL never flags it', async ({
+    page,
+    api,
+    world,
+    env,
+    jobs,
+    poll,
+  }, testInfo) => {
+    const destination = pickOwnsTaxonomyOfferDestination(world);
+    test.skip(
+      !destination,
+      'No active OfferCreator connection advertising EanCategoryMatcher (a taxonomy-owning ' +
+        'destination such as Allegro, whose 75-character title limit the FE editor encodes).',
+    );
+    const connection = destination!;
+    const token = await bearerToken(env);
+
+    // A barcode that resolves to a marketplace product card is what makes the
+    // row `ready` unedited - reuse one already present in the catalogue.
+    const catalogue = await loadCatalogue(api);
+    const flat = catalogue.flatMap(({ product, variants }) =>
+      variants.map((variant) => ({
+        variantId: variant.id,
+        ean: variant.ean ?? variant.gtin ?? '',
+        name: product.name,
+      })),
+    );
+    const withEan = flat.filter((row) => row.ean.length > 0);
+    const resolved = await resolveBatch(
+      env,
+      token,
+      connection.id,
+      withEan.map((row) => ({ variantId: row.variantId, ean: row.ean, sourceCategoryIds: ['2'] })),
+    );
+
+    // ── the fixture: adopt a previous run's, or (only then) create one ────────
+    const listed = await listedVariantIds(api, connection.id);
+    const reusable = await findReusableFixture(api, catalogue, resolved, listed);
+
+    let product: Product;
+    let variant: ProductVariant;
+
+    if (reusable) {
+      product = reusable.product;
+      variant = reusable.variant;
+      testInfo.annotations.push({
+        type: 'fixture',
+        description:
+          `reused: master product ${product.id} ("${product.name.slice(0, 40)}…", ` +
+          `${product.name.length} chars) left behind by an earlier run - nothing provisioned`,
+      });
+    } else {
+      const master = pickMasterCatalogue(env, world);
+      test.skip(
+        !master,
+        'No reusable `E2E preflight F11 …` fixture on the stack, and no active connection with ' +
+          'ProductMaster ENABLED and a host-reachable shop URL (config.storefrontBaseUrl / ' +
+          'config.baseUrl, or OL_PS_ADMIN_URL) to provision the over-long-named master product on.',
+      );
+      const baseUrl = master ? webserviceBaseUrl(env, master) : null;
+      test.skip(
+        !env.psWebserviceKey || !baseUrl,
+        'No reusable `E2E preflight F11 …` fixture on the stack, so one must be created - which ' +
+          'needs OL_PS_WEBSERVICE_KEY (and a host-reachable master-shop URL via OL_PS_ADMIN_URL or ' +
+          "the connection's storefrontBaseUrl). No pre-existing catalogue product can be used " +
+          `without renaming shared data, because the fixture's whole point is a name over ` +
+          `${TITLE_MAX} characters.`,
+      );
+      const cardEan = withEan.find((row) => {
+        const result = resolved[row.variantId];
+        return result?.kind === 'matched' && !!result.productCardId;
+      })?.ean;
+      test.skip(
+        !cardEan,
+        `No barcode in the catalogue resolves to a product card on "${connection.name}". The fresh ` +
+          'fixture needs one, otherwise its row carries a required-parameter blocker and its ' +
+          'readiness could not be asserted. Publish one offer on that destination (which creates ' +
+          'the card) or import a product whose EAN exists in its catalogue.',
+      );
+
+      const shop = new PrestashopWebserviceClient({
+        baseUrl: baseUrl!,
+        apiKey: env.psWebserviceKey!,
+      });
+      const reference = `E2E-F11-${Date.now()}`;
+      const longName = buildFixtureName(reference);
+      expect(
+        longName.length,
+        'fixture sanity: the master name must exceed the title cap',
+      ).toBeGreaterThan(TITLE_MAX);
+      const created = await shop.createProduct({
+        name: longName,
+        reference,
+        ean13: cardEan!,
+        price: '19.99',
+        quantity: 25,
+      });
+      testInfo.annotations.push({
+        type: 'fixture',
+        description:
+          `provisioned and left behind (the webservice client cannot delete): master-shop product ` +
+          `${created.id} (${reference}), name ${longName.length} chars. Later runs adopt it instead ` +
+          'of creating another.',
+      });
+
+      await jobs.triggerAndWait(
+        { connectionId: master!.id, jobType: JobType.masterProductSyncAll },
+        { timeoutMs: 240_000 },
+      );
+      product = await poll.until(
+        async () => (await api.products.list({ search: reference, limit: 5 })).items[0],
+        (value) => !!value,
+        { timeoutMs: 180_000, intervalMs: 5_000, message: `master product ${reference} to reach OL` },
+      );
+      const variants = await api.products.listVariants(product.id);
+      variant = variants.items[0];
+      expect(variant, 'the imported product has a variant to list').toBeTruthy();
+      // The first inventory pass after an import can miss a just-created product
+      // (its fan-out snapshot predates the row), so run the sync until the fresh
+      // variant actually carries stock - a zero-stock row would be flagged by the
+      // wizard for the WRONG reason. (The reuse path asserts stock as an adoption
+      // precondition instead, so it never needs this.)
+      let stocked = false;
+      for (let attempt = 0; attempt < 3 && !stocked; attempt += 1) {
+        await jobs.triggerAndWait(
+          { connectionId: master!.id, jobType: JobType.masterInventorySyncAll },
+          { timeoutMs: 240_000 },
+        );
+        stocked = await poll
+          .until(
+            () => api.inventory.availability([variant.id]),
+            (items) => (items[0]?.totalAvailable ?? 0) > 0,
+            { timeoutMs: 60_000, intervalMs: 5_000, message: 'the fixture variant to carry stock' },
+          )
+          .then(() => true)
+          .catch(() => false);
+      }
+      expect(stocked, 'the fixture variant must carry stock before the wizard sees it').toBe(true);
+    }
+
+    expect(
+      product.name.length,
+      'the over-length name survived the import unchanged (OL never truncates it)',
+    ).toBeGreaterThan(TITLE_MAX);
+
+    // ── (a) the wizard side ───────────────────────────────────────────────────
+    await openWizard(page, {
+      productId: product.id,
+      variantId: variant.id,
+      connectionId: connection.id,
+    });
+    await completeConfigAndProceed(page);
+    const counts = await waitForReview(page);
+    expect(
+      counts.attention,
+      'an over-length product name is not a wizard blocker',
+    ).toBe(0);
+    expect(counts.ready).toBe(1);
+    await expect(reviewCta(page)).toBeEnabled();
+    // `attention === 0` above IS the "no title blocker" proof: the review step's
+    // only per-row signal is the blocker chip set, and none of them measures the
+    // title (the row would otherwise be counted as needing attention).
+
+    // The FE limit exists ONLY inside the row editor: it holds the full
+    // over-length name, caps typing at 75, and refuses to save it.
+    await page.getByRole('button', { name: 'Edit', exact: true }).first().click();
+    const editor = page.getByRole('dialog').first();
+    await expect(editor.getByRole('button', { name: 'Save all' })).toBeVisible({ timeout: 20_000 });
+    const titleField = editor.getByLabel('Title');
+    expect(
+      (await titleField.inputValue()).length,
+      'the editor seeds the full master name, unbounded',
+    ).toBe(product.name.length);
+    expect(await titleField.getAttribute('maxlength')).toBe(String(TITLE_MAX));
+    await editor.getByRole('button', { name: 'Save all' }).click();
+    await expect(
+      editor,
+      'the editor is the ONLY client-side title gate: it refuses to save the over-length name',
+    ).toBeVisible({ timeout: 10_000 });
+    await editor.getByRole('button', { name: 'Cancel' }).click();
+    const discard = page.getByRole('dialog').getByRole('button', { name: /Discard/ });
+    if (await discard.isVisible({ timeout: 3_000 }).catch(() => false)) await discard.click();
+    await expect(page.getByRole('dialog')).toHaveCount(0, { timeout: 10_000 });
+
+    // ── (b) the backend side ──────────────────────────────────────────────────
+    const submitted = await submitFromReview(page);
+    expect(
+      submitted.requestBody ?? '',
+      'the unedited row sends NO title override, so @MaxLength(75) can never apply',
+    ).not.toContain('"title"');
+    expect(submitted.status, `request: ${submitted.requestBody}`).toBe(202);
+    const { batchId } = submitted.body as { batchId: string };
+
+    const batch = await poll.until(
+      () => getBatch(env, token, batchId),
+      (value) => value.status !== 'running' && value.status !== 'pending',
+      {
+        timeoutMs: 240_000,
+        intervalMs: 3_000,
+        message: `bulk batch ${batchId} to reach a terminal status`,
+      },
+    );
+    const errors = batch.records.flatMap((record) => record.errors ?? []);
+    const titleComplaint = errors.find((error) =>
+      /title|name|75|length/i.test(`${error.field} ${error.code} ${error.message}`),
+    );
+    expect(
+      titleComplaint,
+      'OL never measures the `product.name` it falls back to - no layer reports the over-length title',
+    ).toBeUndefined();
+    expect(
+      batch.records.every((record) => record.externalOfferId === null),
+      'the over-length row never produced a live offer either',
+    ).toBe(true);
+    expect(batch.succeededCount, 'the row the wizard called ready did not list').toBe(0);
+
+    testInfo.annotations.push({
+      type: 'divergence',
+      description:
+        `master name ${product.name.length} chars: wizard ready=${counts.ready}, submit 202 with ` +
+        `no title override; batch ${batchId} -> ${batch.status}, errors: ` +
+        (errors.map((error) => `${error.field}/${error.code}`).join(', ') || '(none)'),
+    });
+  });
+});

--- a/apps/e2e/tests/preflight-divergence/f12-category-override-rejected.spec.ts
+++ b/apps/e2e/tests/preflight-divergence/f12-category-override-rejected.spec.ts
@@ -1,0 +1,544 @@
+/**
+ * F12 / F12b - the wizard injects `overrides.categoryId`; the DTO deletes it
+ *
+ * ⚠️ CHARACTERIZATION TEST. These specs pass **while the divergence exists** and
+ * go RED once it is closed. A failure here is NOT a regression - it means the
+ * finding was wrong, or it has been fixed and this file should be retired (or
+ * inverted into a normal regression test).
+ *
+ * WHAT THIS FILE CHARACTERIZES: `main`'s behaviour, verified by source read -
+ * `origin/main:apps/api/src/listings/http/dto/bulk-offer-create.dto.ts` declares
+ * `OverridesNoCategoryDto = OmitType(CreateOfferOverridesDto, ['categoryId'])`,
+ * uses it as `PerVariantOverrideDto.overrides`, and validates BOTH
+ * `perProductOverrides` and `perVariantOverrides` through
+ * `@ValidateRecordValues(() => PerVariantOverrideDto)`, whose inner `validate()`
+ * runs with `whitelist: true, forbidNonWhitelisted: true`. A `categoryId` in
+ * either map is therefore a whole-request 400 on main.
+ *
+ * ⚠️ A FIX IS ALREADY IN FLIGHT. Commit `a9477d60` (2026-07-29) on branch
+ * `1924-bulk-category-per-family-per-variant`, open as **PR #1930** (not an
+ * ancestor of `main` at the time of writing), describes this finding verbatim
+ * and removes the `categoryId` restriction from BOTH override maps, turning the
+ * variant-tier strip into a destination-aware service decision. So once #1930
+ * merges these tests are EXPECTED to go red: that red run is the success
+ * signal, not a regression, and it is the moment to invert this file into the
+ * regression guard for the fix (assert the request is ACCEPTED and the category
+ * lands where the service intends).
+ *
+ * ⚠️ THE TWO PATHS HAVE DIFFERENT ORIGINS - and only one of them is covered by
+ * the in-flight fix's description:
+ *   - The multi-variant FAMILY PIN (`bulk-wizard.tsx`) was authored in the SAME
+ *     squashed commit as the DTO omission (`c2fc4238`, PR #1757 / issue #1741):
+ *     a self-inflicted regression, shipped broken on day one.
+ *   - The EDIT-MODAL emit (`bulk-edit-modal.tsx`) PREDATES #1741 and was legal
+ *     before it - the override maps used to nest the full
+ *     `CreateOfferOverridesDto` (`categoryId` included) and
+ *     `@ValidateRecordValues` did not exist. #1741 narrowed a backend contract
+ *     without auditing existing senders.
+ *   PR #1930's body does NOT mention the edit-modal path, so **F12b below is the
+ *   more valuable of the two tests**: it is the one that can survive the fix if
+ *   the fix only addresses the family pin.
+ *
+ * The divergence, in one sentence: `PerVariantOverrideDto.overrides` is
+ * `OmitType(CreateOfferOverridesDto, ['categoryId'])` (#1741,
+ * `apps/api/src/listings/http/dto/bulk-offer-create.dto.ts`) validated under
+ * `whitelist + forbidNonWhitelisted` via `@ValidateRecordValues`, while the
+ * bulk wizard puts `categoryId` into exactly that map on two independent paths:
+ *
+ *   F12  - the multi-variant FAMILY PIN. `bulk-wizard.tsx` deliberately stamps
+ *          `overrides.categoryId = row.override.overrides?.categoryId ??
+ *          row.resolvedCategoryId` onto `perProductOverrides[primaryVariantId]`
+ *          for a product with >1 variant, so Allegro groups the siblings under
+ *          one category. Nothing is edited; every row is green.
+ *   F12b - the EDITED-ROW path. The per-row edit modal seeds and emits
+ *          `categoryId` in its saved override, so any batch in which the
+ *          operator saved even one row carries the same forbidden key.
+ *
+ * Either way the rejection is whole-request: HTTP 400, zero batch, zero
+ * records - after a Review step that showed every row `ready`.
+ *
+ * Both tests assert BOTH sides:
+ *   (a) the wizard reports the rows as ready and enables the submit CTA, AND
+ *   (b) the submitted request carries `overrides.categoryId`, AND
+ *   (c) the API rejects the whole request with 400 naming the override map.
+ *
+ * There is no legal channel for the wizard to pass a category: the DTO's own
+ * contract says "base-only via `sharedConfig`", but the wizard's `sharedConfig`
+ * carries only `platformParams`.
+ *
+ * @module tests/preflight-divergence
+ */
+import { test, expect } from '../../src/fixtures/test';
+import type { ApiClient } from '../../src/api/api-client';
+import type { Connection, Product } from '../../src/api/api.types';
+import type { E2eEnv } from '../../src/config/env';
+import type { World } from '../../src/world/world';
+import type { BulkOfferWizard } from '../../src/pages/bulk-offer-wizard.page';
+
+/** A deliberately-unknown variant id used only by the read-only contract probe. */
+const PROBE_VARIANT_ID = 'ol_variant_preflight_divergence_probe';
+
+/** Minimal raw-API surface this spec needs but the shared client does not expose. */
+interface RawJsonResponse {
+  status: number;
+  body: unknown;
+}
+
+/** Acquire a bearer token for the raw calls below (the shared client hides its own). */
+async function bearer(env: E2eEnv): Promise<string> {
+  const response = await fetch(`${env.apiUrl}/v1/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: env.adminUser, password: env.adminPass }),
+  });
+  if (!response.ok) {
+    throw new Error(`E2E login failed: HTTP ${response.status} ${await response.text()}`);
+  }
+  return ((await response.json()) as { access_token: string }).access_token;
+}
+
+async function rawPost(
+  env: E2eEnv,
+  token: string,
+  path: string,
+  body: unknown,
+): Promise<RawJsonResponse> {
+  const response = await fetch(`${env.apiUrl}/v1${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify(body),
+  });
+  const text = await response.text();
+  let parsed: unknown = text;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    /* keep the raw text */
+  }
+  return { status: response.status, body: parsed };
+}
+
+/**
+ * Read-only probe of the live DTO contract: is `categoryId` actually forbidden
+ * inside the per-product / per-variant override maps on THIS stack?
+ *
+ * The probe deliberately fails an UNRELATED rule (`sharedConfig.stock: -1`
+ * violates `@Min(0)`), so the global ValidationPipe rejects before the handler
+ * ever runs - nothing is enqueued, no batch is created. class-validator reports
+ * every violation at once, so the response tells us whether the override maps
+ * also rejected `categoryId`.
+ *
+ * Returns the full 400 message list so a skip can quote what the stack said.
+ */
+async function probeCategoryOmittedFromOverrides(
+  env: E2eEnv,
+  token: string,
+  connectionId: string,
+): Promise<{ armed: boolean; messages: string[] }> {
+  const overrideValue = { overrides: { categoryId: '261481' } };
+  const result = await rawPost(env, token, '/listings/bulk-create', {
+    connectionId,
+    productIds: [PROBE_VARIANT_ID],
+    sharedConfig: { stock: -1, publishImmediately: true },
+    perProductOverrides: { [PROBE_VARIANT_ID]: overrideValue },
+    perVariantOverrides: { [PROBE_VARIANT_ID]: overrideValue },
+  });
+
+  expect(
+    result.status,
+    'the contract probe must be rejected by validation alone (stock: -1) and never reach the handler',
+  ).toBe(400);
+
+  const raw = (result.body as { message?: unknown }).message;
+  const messages = Array.isArray(raw) ? raw.map(String) : [String(raw ?? '')];
+  const armed = messages.some((m) => /per(Product|Variant)Overrides/i.test(m));
+  return { armed, messages };
+}
+
+/** Every variant id that already carries an offer mapping on `connectionId`. */
+async function listedVariantIds(api: ApiClient, connectionId: string): Promise<Set<string>> {
+  const ids = new Set<string>();
+  let offset = 0;
+  for (;;) {
+    const page = await api.listings.list({ connectionId, limit: 100, offset });
+    for (const mapping of page.items) ids.add(mapping.internalId);
+    offset += 100;
+    if (page.items.length === 0 || offset >= page.total) break;
+  }
+  return ids;
+}
+
+/** The product's source-platform category ids (present on the wire, absent from the local type). */
+function sourceCategoryIds(product: Product): string[] {
+  const categories = (product as unknown as { categories?: unknown }).categories;
+  return Array.isArray(categories) ? categories.map(String) : [];
+}
+
+interface EanMatchLike {
+  kind: string;
+  allegroCategoryId?: string | null;
+  productCardId?: string | null;
+}
+
+/** Run the wizard's own Resolve-step query for a product's variants. */
+async function resolveCategories(
+  env: E2eEnv,
+  token: string,
+  connectionId: string,
+  product: Product,
+): Promise<Record<string, EanMatchLike>> {
+  const categories = sourceCategoryIds(product);
+  const items = (product.variants ?? []).map((variant) => ({
+    variantId: variant.id,
+    ean: variant.ean ?? variant.gtin ?? null,
+    ...(categories.length > 0 ? { sourceCategoryIds: categories } : {}),
+  }));
+  const result = await rawPost(
+    env,
+    token,
+    `/listings/connections/${connectionId}/categories/resolve-batch`,
+    { items },
+  );
+  if (result.status !== 200) return {};
+  return ((result.body as { results?: Record<string, EanMatchLike> }).results ?? {});
+}
+
+/**
+ * Find a product on the stack matching a predicate, hydrated with its variants
+ * and never already listed on `connectionId` (an already-listed variant is
+ * silently dropped by `filterAlreadyListed`, which would mask this finding
+ * behind F2's own divergence).
+ */
+async function findFreshProduct(
+  api: ApiClient,
+  world: World,
+  connectionId: string,
+  accept: (product: Product) => boolean | Promise<boolean>,
+): Promise<Product | undefined> {
+  const listed = await listedVariantIds(api, connectionId);
+  for (const summary of await world.listProducts(60)) {
+    const product = await api.products.getById(summary.id);
+    const variants = product.variants ?? [];
+    if (variants.length === 0) continue;
+    if (variants.some((variant) => listed.has(variant.id))) continue;
+    if (await accept(product)) return product;
+  }
+  return undefined;
+}
+
+/**
+ * The Review step's submit CTA, tolerant of both label generations: the build
+ * this suite's page object was written against renders "Approve all (N)", the
+ * current one renders "Create offers (N)". The `(N)` suffix is what keeps this
+ * from also matching the confirm modal's own bare "Create offers" button.
+ */
+function submitCta(page: import('@playwright/test').Page): import('@playwright/test').Locator {
+  return page.getByRole('button', { name: /^(Approve all|Create offers)\s*\(\d+\)$/ });
+}
+
+/**
+ * Read the Review step's readiness counters straight off its `role="status"`
+ * summary. The shared page object's `needsAttentionCount()` assumes the older
+ * "N row(s) need attention" phrasing and parses the FIRST number in the hint;
+ * the current build renders "N ready · M need attention · K excluded", so that
+ * parse returns the READY count. Anchor on the labelled number instead.
+ */
+async function readinessCounts(
+  page: import('@playwright/test').Page,
+): Promise<{ ready: number; needAttention: number; raw: string }> {
+  const hint = page.getByRole('status').filter({ hasText: /needs? attention/ }).first();
+  if ((await hint.count()) === 0) return { ready: 0, needAttention: 0, raw: '(no readiness hint)' };
+  const raw = (await hint.innerText()).replace(/\s+/g, ' ').trim();
+  const attention = /(\d+)\s+needs?\s+attention/i.exec(raw);
+  const ready = /(\d+)\s+ready/i.exec(raw);
+  return {
+    ready: ready ? Number(ready[1]) : 0,
+    needAttention: attention ? Number(attention[1]) : 0,
+    raw,
+  };
+}
+
+/**
+ * Pick the destination connection on the Config step.
+ *
+ * The step renders a grouped RADIO RAIL (`PublishDestinationRail`) when more
+ * than one publish destination exists, and a plain "Publishing as {name}" alert
+ * when there is only one - the shared page object's `<select>` path
+ * (`selectConnectionIfPresent`) only covers the older select-based layout, so
+ * try the rail first and fall back to it. Kept local per the suite's rule that
+ * a divergence spec must not edit shared page objects.
+ */
+async function selectDestination(
+  page: import('@playwright/test').Page,
+  wizard: BulkOfferWizard,
+  connectionName: string,
+): Promise<void> {
+  const escaped = connectionName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const radio = page.getByRole('radio', { name: new RegExp(escaped) });
+  if ((await radio.count()) > 0) {
+    await radio.first().click();
+    return;
+  }
+  await wizard.selectConnectionIfPresent(connectionName);
+}
+
+/** Per-platform required config on the wizard's Config step. */
+function platformConfig(connection: Connection): {
+  requiresDeliveryPolicy?: boolean;
+  requiresErliBuyabilityFields?: boolean;
+} {
+  return connection.platformType === 'erli'
+    ? { requiresErliBuyabilityFields: true }
+    : { requiresDeliveryPolicy: true };
+}
+
+/**
+ * Wait until the Review step has SETTLED - the async per-category parameter
+ * schema has resolved and the row blockers reflect it. Mirrors the page
+ * object's own (private) settle gate so a transient "0 need attention, submit
+ * disabled" limbo is never read as readiness, but against the local
+ * build-tolerant locators above.
+ */
+async function waitForReviewSettled(page: import('@playwright/test').Page): Promise<void> {
+  await expect(async () => {
+    const cta = submitCta(page).first();
+    if ((await cta.count()) === 0) {
+      throw new Error('Review step has not rendered its submit CTA yet.');
+    }
+    const [enabled, counts] = await Promise.all([cta.isEnabled(), readinessCounts(page)]);
+    if (!enabled && counts.needAttention === 0) {
+      throw new Error(`Review still resolving: submit disabled with no needs-attention rows (${counts.raw}).`);
+    }
+  }).toPass({ timeout: 60_000 });
+}
+
+/**
+ * Drive Config → Resolve → Review WITHOUT opening a single row editor. The F12
+ * family-pin path is defined by "nothing was edited", so the page object's
+ * `advanceToConfirmModal` (which fills and saves every row) cannot be used here
+ * - saving a row would additionally trigger F12b and blur which path injected.
+ */
+async function driveToReviewWithoutEditing(
+  page: import('@playwright/test').Page,
+  wizard: BulkOfferWizard,
+  connection: Connection,
+): Promise<void> {
+  await wizard.completePlatformConfig(platformConfig(connection));
+  await expect(wizard.proceedButton).toBeEnabled({ timeout: 30_000 });
+  await wizard.proceedButton.click();
+  await expect(submitCta(page).first()).toBeVisible({ timeout: 60_000 });
+  await waitForReviewSettled(page);
+}
+
+/** Collect every `overrides.categoryId` present in a submitted bulk-create body. */
+function injectedCategoryIds(body: unknown): { map: string; variantId: string; categoryId: string }[] {
+  const found: { map: string; variantId: string; categoryId: string }[] = [];
+  const request = body as Record<string, unknown>;
+  for (const map of ['perProductOverrides', 'perVariantOverrides']) {
+    const entries = request[map];
+    if (typeof entries !== 'object' || entries === null) continue;
+    for (const [variantId, value] of Object.entries(entries as Record<string, unknown>)) {
+      const overrides = (value as { overrides?: { categoryId?: unknown } } | null)?.overrides;
+      const categoryId = overrides?.categoryId;
+      if (typeof categoryId === 'string' && categoryId !== '') {
+        found.push({ map, variantId, categoryId });
+      }
+    }
+  }
+  return found;
+}
+
+test.describe('F12 - the wizard sends a category the DTO deletes', () => {
+  test('F12: a multi-variant family pin is injected and the whole request is rejected', async ({
+    env,
+    api,
+    world,
+    page,
+    pages,
+  }) => {
+    // Fixture resolution walks the catalogue and runs the real category-resolution
+    // chain per candidate, then waits on a worker round-trip - well past the
+    // suite's default 90s per-test budget. Local to this spec (the shared
+    // playwright.config is not touched).
+    test.setTimeout(300_000);
+    const allegro = world.connectionFor('allegro');
+    test.skip(!allegro, 'no Allegro connection on this stack');
+
+    const token = await bearer(env);
+    const probe = await probeCategoryOmittedFromOverrides(env, token, allegro!.id);
+    test.skip(
+      !probe.armed,
+      'This API build ACCEPTS `categoryId` inside perProductOverrides / perVariantOverrides, so ' +
+        'the F12 backend half is not present in the deployed code and there is nothing to ' +
+        'characterize HERE. This does NOT mean the finding is wrong - it is verified by source ' +
+        'read against `main`. Two builds accept the key: one PREDATING #1741 (commit c2fc4238, ' +
+        'before `OverridesNoCategoryDto` existed), and one carrying the FIX (PR #1930, commit ' +
+        'a9477d60, branch 1924-bulk-category-per-family-per-variant), which restores `categoryId` ' +
+        'at the HTTP boundary and moves the variant-tier decision into ' +
+        '`BulkListingSubmitService.stripVariantCategoryId`. Tell them apart by grepping the ' +
+        'deployed dist: `stripVariantCategoryId` present => the FIX (retire/invert this file); ' +
+        '`excludedVariantIds` absent => a pre-#1741 build. To characterize main, deploy a build ' +
+        'of `main` and re-run. ' +
+        `Probe reported: ${probe.messages.join(' | ')}`,
+    );
+
+    // A multi-variant product, none of whose variants is already listed, whose
+    // siblings ALL resolve to a real category - the pin is only stamped when
+    // `familyCategoryId` (override ?? resolvedCategoryId) is non-null.
+    const product = await findFreshProduct(api, world, allegro!.id, async (candidate) => {
+      if ((candidate.variants ?? []).length < 2) return false;
+      const resolved = await resolveCategories(env, token, allegro!.id, candidate);
+      return (candidate.variants ?? []).every((variant) => {
+        const match = resolved[variant.id];
+        return match?.kind === 'matched' && !!match.allegroCategoryId;
+      });
+    });
+    test.skip(
+      !product,
+      'No usable fixture: this stack has no MULTI-VARIANT master product that is (a) not yet ' +
+        'listed on the Allegro connection and (b) whose every sibling resolves to a real Allegro ' +
+        'category (EAN catalogue match or a configured source-category mapping). Create one by ' +
+        'importing a PrestaShop product with >=2 combinations, each carrying a GTIN, into a ' +
+        'source category that has a PS->Allegro category mapping, then run master.product.syncAll.',
+    );
+
+    await page.goto(`/listings/bulk-create/wizard?productIds=${product!.id}`);
+    const wizard = pages.bulkOfferWizard;
+    await wizard.expectOnConfigStep();
+    await selectDestination(page, wizard, allegro!.name);
+
+    await driveToReviewWithoutEditing(page, wizard, allegro!);
+
+    // ── (a) The wizard says this batch is good to go ───────────────────────
+    const needsAttention = (await readinessCounts(page)).needAttention;
+    test.skip(
+      needsAttention > 0,
+      `The multi-variant rows are NOT green without editing (${needsAttention} need attention), ` +
+        'so reaching submit would require saving a row editor - which is the F12b path, not the ' +
+        'family pin. This test needs a multi-variant product whose Allegro rows are ready with ' +
+        'no operator edit: every sibling card-linked by a unique GTIN match, or mapped to an ' +
+        'Allegro category with no required product-section parameters.',
+    );
+    await expect(
+      submitCta(page).first(),
+      'the wizard enables submit - it considers every row ready',
+    ).toBeEnabled();
+    await submitCta(page).first().click();
+    await expect(wizard.confirmModalConfirmButton).toBeVisible();
+    await wizard.publishImmediatelyCheckbox.check();
+
+    // ── (b)+(c) …and the server refuses the whole thing ────────────────────
+    const submitted = page.waitForResponse(
+      (response) =>
+        response.request().method() === 'POST' && response.url().includes('/listings/bulk-create'),
+      { timeout: 60_000 },
+    );
+    await wizard.confirmModalConfirmButton.click();
+    const response = await submitted;
+
+    const requestBody: unknown = JSON.parse(response.request().postData() ?? '{}');
+    const injected = injectedCategoryIds(requestBody);
+    expect(
+      injected.filter((entry) => entry.map === 'perProductOverrides'),
+      'the family pin stamps overrides.categoryId onto perProductOverrides[primaryVariantId] ' +
+        'even though no row editor was ever opened',
+    ).not.toHaveLength(0);
+
+    expect(
+      response.status(),
+      'the whole request is rejected - not one record is created',
+    ).toBe(400);
+    const body = (await response.json()) as { message?: unknown };
+    const messages = Array.isArray(body.message) ? body.message.map(String) : [String(body.message)];
+    expect(
+      messages.join(' | '),
+      'the rejection names the override map the wizard just wrote into',
+    ).toMatch(/per(Product|Variant)Overrides/i);
+
+    // The browser stays on the wizard: no batch id was ever minted.
+    await expect(page).toHaveURL(/\/listings\/bulk-create\/wizard/);
+  });
+
+  test('F12b: an edited row injects categoryId and the whole request is rejected', async ({
+    env,
+    api,
+    world,
+    page,
+    pages,
+  }) => {
+    // Fixture resolution walks the catalogue and runs the real category-resolution
+    // chain per candidate, then waits on a worker round-trip - well past the
+    // suite's default 90s per-test budget. Local to this spec (the shared
+    // playwright.config is not touched).
+    test.setTimeout(300_000);
+    const allegro = world.connectionFor('allegro');
+    test.skip(!allegro, 'no Allegro connection on this stack');
+
+    const token = await bearer(env);
+    const probe = await probeCategoryOmittedFromOverrides(env, token, allegro!.id);
+    test.skip(
+      !probe.armed,
+      'This API build ACCEPTS `categoryId` inside perProductOverrides / perVariantOverrides, ' +
+        'so the F12b backend half is absent - the build either predates #1741 (c2fc4238) or ' +
+        'already carries the fix (PR #1930 / a9477d60). Note that the edit-modal path this test ' +
+        'covers PREDATES #1741 and is NOT named in #1930\'s description, so re-check it ' +
+        'explicitly against a post-fix build before retiring this test. ' +
+        `Probe reported: ${probe.messages.join(' | ')}`,
+    );
+
+    // Single-variant product: `isMulti` is false so the family pin never fires,
+    // isolating the edit-modal injection path.
+    const product = await findFreshProduct(
+      api,
+      world,
+      allegro!.id,
+      (candidate) => (candidate.variants ?? []).length === 1,
+    );
+    test.skip(
+      !product,
+      'No usable fixture: this stack has no SINGLE-VARIANT master product that is not already ' +
+        'listed on the Allegro connection. Import a simple PrestaShop product (one combination, ' +
+        'a GTIN, a mapped source category) and run master.product.syncAll.',
+    );
+
+    const gtin = product!.variants?.[0]?.ean ?? product!.variants?.[0]?.gtin ?? undefined;
+
+    await page.goto(`/listings/bulk-create/wizard?productIds=${product!.id}`);
+    const wizard = pages.bulkOfferWizard;
+    await wizard.expectOnConfigStep();
+    await selectDestination(page, wizard, allegro!.name);
+
+    // ── (a) Drive the wizard exactly as an operator who opens the row editor.
+    // `advanceToConfirmModal` opens each row's editor, fills its required
+    // fields and SAVES - the very act that seeds `overrides.categoryId`. It
+    // only reaches the confirm modal once "Approve all" is enabled, i.e. once
+    // the wizard itself declares every row ready.
+    await wizard.advanceToConfirmModal({
+      requiresDeliveryPolicy: allegro!.platformType !== 'erli',
+      requiresErliBuyabilityFields: allegro!.platformType === 'erli',
+      gtin,
+    });
+    await expect(wizard.confirmModalConfirmButton).toBeVisible();
+
+    // ── (b)+(c) …and the server refuses the whole thing ────────────────────
+    const submitted = page.waitForResponse(
+      (response) =>
+        response.request().method() === 'POST' && response.url().includes('/listings/bulk-create'),
+      { timeout: 60_000 },
+    );
+    await wizard.confirmModalConfirmButton.click();
+    const response = await submitted;
+
+    const requestBody: unknown = JSON.parse(response.request().postData() ?? '{}');
+    expect(
+      injectedCategoryIds(requestBody),
+      'the saved row editor emits overrides.categoryId into the per-override map',
+    ).not.toHaveLength(0);
+
+    expect(response.status(), 'the whole request is rejected - zero records').toBe(400);
+    const body = (await response.json()) as { message?: unknown };
+    const messages = Array.isArray(body.message) ? body.message.map(String) : [String(body.message)];
+    expect(messages.join(' | ')).toMatch(/per(Product|Variant)Overrides/i);
+    await expect(page).toHaveURL(/\/listings\/bulk-create\/wizard/);
+  });
+});

--- a/apps/e2e/tests/preflight-divergence/f13-blocked-not-excluded.spec.ts
+++ b/apps/e2e/tests/preflight-divergence/f13-blocked-not-excluded.spec.ts
@@ -1,0 +1,437 @@
+/**
+ * F13 - an included-but-BLOCKED variant is skipped without being excluded
+ *
+ * ⚠️ CHARACTERIZATION TEST. It passes while the divergence exists and FAILS the
+ * moment the finding is closed (or was wrong in the first place). A red run here
+ * is a signal to re-read the finding, not a regression in the product.
+ *
+ * The divergence, both sides asserted explicitly:
+ *
+ *   (a) What the wizard presents / emits - `bulk-wizard.tsx` `handleSubmit`
+ *       walks each row's variants and routes them into exactly two channels:
+ *         if (!v.included)          -> excludedVariantIds.push(v.variantId)
+ *         if (v.blockers.length>0)  -> continue        // ← NEITHER channel
+ *         else                      -> perVariantOverrides[v.variantId] = …
+ *       An included-but-blocked sibling therefore reaches the server in NO
+ *       channel at all: not excluded, not overridden, invisible. The only thing
+ *       standing between the operator and that submit is the `disabled`
+ *       attribute on the review CTA (`canApprove` = includedReady > 0 &&
+ *       includedNeedsAttention === 0 && !paramsResolving). There is no guard
+ *       inside `handleApproveAll` and none inside `handleSubmit`.
+ *
+ *   (b) What actually happens - `BulkListingSubmitService.expandVariantJobs`
+ *       expands every sibling of a multi-variant product and only skips ids
+ *       present in `excludedVariantIds`. The blocked sibling is not there, so a
+ *       job + an `OfferCreationRecord` are created for a variant the wizard
+ *       itself declared unlistable. There is no server-side equivalent of the
+ *       client readiness gate.
+ *
+ * Why this one is not clickable through a healthy UI: the CTA is disabled in
+ * exactly the state that triggers it. So test 1 drives the real browser, invokes
+ * the review CTA's own `onClick` directly (clearing the DOM `disabled` attribute
+ * is not enough - React gates dispatch on the element's props, which is the
+ * finding restated: the barrier is a rendering decision, not a check in the
+ * handler), and CAPTURES the request body the wizard actually builds. The POST
+ * is aborted at the network layer, so nothing is created. Test 2 then replays
+ * that captured body against the live API to observe the server half.
+ *
+ * F13 is the enabler for F14 (untrimmed master EAN) and F3 (price gates): both
+ * stand on the unspoken invariant "every backend job has a per-variant
+ * override", which this one `continue` breaks.
+ *
+ * Fixture requirements (self-skipping): one multi-variant product with at least
+ * two variants that carry NO Allegro offer mapping yet - `filterAlreadyListed`
+ * drops mapped variants before expansion, which would mask the whole effect.
+ *
+ * @module tests/preflight-divergence
+ */
+import { randomUUID } from 'node:crypto';
+import { test, expect } from '../../src/fixtures/test';
+import type { ApiClient } from '../../src/api/api-client';
+import type { Product, ProductVariant } from '../../src/api/api.types';
+import type { E2eEnv } from '../../src/config/env';
+import { captureProof, reviewRegion } from './__proof__/capture';
+
+/** Per-variant / per-product override entry of `POST /listings/bulk-create`. */
+interface BulkOverride {
+  stock?: number;
+  publishImmediately?: boolean;
+  price?: { amount: number; currency: string };
+  overrides?: Record<string, unknown>;
+}
+
+/** Request body of `POST /listings/bulk-create` (mirrored locally, #1741 shape). */
+interface BulkCreateBody {
+  connectionId: string;
+  productIds: string[];
+  sharedConfig: {
+    stock: number;
+    publishImmediately: boolean;
+    price?: { amount: number; currency: string };
+    overrides?: Record<string, unknown>;
+  };
+  perProductOverrides?: Record<string, BulkOverride>;
+  perVariantOverrides?: Record<string, BulkOverride>;
+  excludedVariantIds?: string[];
+}
+
+interface Candidate {
+  product: Product;
+  variants: ProductVariant[];
+  /** Variants with no Allegro offer mapping (survive `filterAlreadyListed`). */
+  free: ProductVariant[];
+}
+
+/** Shared between the two tests in this file (serial by declaration below). */
+let capturedBody: BulkCreateBody | null = null;
+let blockedVariant: ProductVariant | null = null;
+let readyVariant: ProductVariant | null = null;
+
+test.describe.configure({ mode: 'serial' });
+
+test.describe('F13 - blocked variant is skipped but never excluded', () => {
+  test('the wizard emits the blocked sibling in NEITHER channel, and only `disabled` guards submit', async ({
+    page,
+    pages,
+    api,
+    world,
+  }) => {
+    const allegro = world.connectionFor('allegro');
+    test.skip(
+      allegro === undefined,
+      'F13 needs an Allegro connection (the wizard destination) on the stack.',
+    );
+    const connection = allegro!;
+
+    const candidate = await findMultiVariantCandidate(api, world, connection.id, 2);
+    test.skip(
+      candidate === null,
+      'F13 needs a multi-variant master product with >= 2 variants that have NO Allegro ' +
+        'offer mapping yet (mapped variants are dropped by `filterAlreadyListed` before ' +
+        'expansion, which hides the effect). No such product exists on this stack.',
+    );
+    const { product, free } = candidate!;
+
+    // The SECOND free variant is the one we force into a blocked state; the
+    // first stays ready so `includedReady > 0` and the wizard still submits.
+    readyVariant = free[0];
+    blockedVariant = free[1];
+    const readyEan = barcodeOf(readyVariant);
+    const blockedEan = barcodeOf(blockedVariant);
+    expect(
+      readyEan && blockedEan,
+      'both chosen variants need a barcode - the review row anchors on the EAN text',
+    ).toBeTruthy();
+
+    // Isolate the ONE blocker under test. Every row in this catalogue also
+    // carries Allegro's `needs-product-parameters` blocker (that is finding F1,
+    // a different divergence), which would leave zero ready siblings and stop
+    // the wizard from submitting at all. Reporting the row's category as having
+    // no required product parameters is an ordinary state - plenty of Allegro
+    // categories have none - and it changes nothing about the submitted body.
+    await page.route('**/listings/connections/*/categories/*/parameters*', async (route) => {
+      if (route.request().method() !== 'GET') {
+        await route.continue();
+        return;
+      }
+      await route.fulfill({
+        response: await route.fetch(),
+        json: { parameters: [] },
+      });
+    });
+
+    // Force exactly one sibling into `no-match` by rewriting the batch
+    // category-resolution response. This is a real, everyday outcome (an EAN
+    // that resolves to nothing), and doing it at the wire keeps the master
+    // catalogue untouched. Everything else passes through verbatim.
+    await page.route('**/listings/connections/*/categories/resolve-batch', async (route) => {
+      if (route.request().method() !== 'POST') {
+        await route.continue();
+        return;
+      }
+      const response = await route.fetch();
+      const payload = (await response.json()) as { results: Record<string, unknown> };
+      payload.results[blockedVariant!.id] = { kind: 'no-match' };
+      await route.fulfill({ response, json: payload });
+    });
+
+    // Capture the submit body, then ABORT it. The whole point of test 1 is the
+    // shape of the request the wizard builds; aborting keeps the stack clean and
+    // sidesteps stubbing a cross-origin 202.
+    let submitAttempts = 0;
+    await page.route('**/listings/bulk-create', async (route) => {
+      if (route.request().method() !== 'POST') {
+        await route.continue();
+        return;
+      }
+      submitAttempts += 1;
+      const raw = route.request().postData();
+      capturedBody = raw === null ? null : (JSON.parse(raw) as BulkCreateBody);
+      await route.abort('failed');
+    });
+
+    await page.goto(
+      `/listings/bulk-create/wizard?productIds=${encodeURIComponent(product.id)}` +
+        `&connectionId=${encodeURIComponent(connection.id)}`,
+    );
+
+    // ── Config step ──────────────────────────────────────────────────────────
+    await expect(page.getByRole('heading', { name: 'Configure batch' })).toBeVisible({
+      timeout: 30_000,
+    });
+    // Allegro gates Proceed on its own config section (shipping-rate package);
+    // reuse the suite's page object rather than re-deriving the control here.
+    await pages.bulkOfferWizard.completePlatformConfig({ requiresDeliveryPolicy: true });
+    const proceed = page.getByRole('button', { name: /^Proceed/ });
+    await expect(
+      proceed,
+      'the Allegro config section must settle (delivery policy etc.) before Proceed enables',
+    ).toBeEnabled({ timeout: 60_000 });
+    await proceed.click();
+
+    // ── Review step ──────────────────────────────────────────────────────────
+    const cta = page.locator('button.bulk-review__cta--top');
+    await expect(cta).toBeVisible({ timeout: 60_000 });
+
+    // Expand the product so the per-variant rows render.
+    await page.locator('button.bulk-review__toggle').first().click();
+
+    const blockedRow = page.locator('.bulk-review__vrow').filter({ hasText: blockedEan! });
+    const readyRow = page.locator('.bulk-review__vrow').filter({ hasText: readyEan! });
+    await expect(blockedRow, 'the forced-`no-match` variant row renders').toBeVisible({
+      timeout: 30_000,
+    });
+
+    // (a1) The blocked sibling carries a blocker chip AND is still INCLUDED -
+    // the wizard never switches it off, which is precisely why it lands in
+    // neither `excludedVariantIds` nor `perVariantOverrides`.
+    await expect(
+      blockedRow.locator('.bulk-review__c-status'),
+      'the forced-`no-match` sibling shows the "manual category" blocker chip',
+    ).toContainText(/manual category/i, { timeout: 30_000 });
+    await expect(
+      blockedRow.locator('input.bulk-review__chk'),
+      'the blocked sibling stays INCLUDED (checked) - it is skipped, not excluded',
+    ).toBeChecked();
+    await expect(
+      readyRow.locator('.bulk-review__c-status'),
+      'the sibling left alone is ready, so the wizard still has something to submit',
+    ).toContainText(/\bready\b/i, { timeout: 30_000 });
+
+    const ctaLabel = (await cta.innerText()).trim();
+    test.skip(
+      /\(0\)$/.test(ctaLabel),
+      `F13 needs at least one READY sibling alongside the blocked one, but the review CTA ` +
+        `reads "${ctaLabel}" - the untouched sibling carries blockers of its own on this ` +
+        `stack (e.g. missing required product parameters).`,
+    );
+
+    // (a2) The ONLY barrier: the CTA's `disabled` attribute.
+    await expect(
+      cta,
+      'with one sibling needing attention the review CTA is disabled - the sole barrier',
+    ).toBeDisabled();
+    await expect(page.locator('.bulk-review__summary')).toContainText('need attention');
+
+    // PROOF (documentation only - never asserted on): the promise. The blocked
+    // sibling is flagged AND still switched on, so it is about to be submitted in
+    // neither channel; the CTA's `disabled` attribute is the only barrier.
+    await captureProof(page, 'f13-before-review-ready', { region: reviewRegion(page) });
+
+    // Invoke the SAME code path the enabled button would, and watch it sail
+    // through. Note what it takes: clearing the DOM `disabled` attribute is not
+    // enough, because React decides whether to dispatch `onClick` from the
+    // element's PROPS, not the DOM - which is the finding restated. The barrier
+    // is entirely a rendering decision; the handler itself
+    // (`handleApproveAll`) contains no readiness check at all, so reaching it
+    // by any means opens the confirm modal on a batch with a flagged row.
+    await cta.evaluate((el) => {
+      const propsKey = Object.keys(el).find((key) => key.startsWith('__reactProps$'));
+      if (propsKey === undefined) {
+        throw new Error('Could not reach the CTA React props handle to invoke its onClick.');
+      }
+      const props = (el as unknown as Record<string, { onClick?: (event: unknown) => void }>)[
+        propsKey
+      ];
+      if (typeof props.onClick !== 'function') {
+        throw new Error('The review CTA carries no onClick handler.');
+      }
+      props.onClick({});
+    });
+    const confirmModal = page.getByRole('dialog');
+    await expect(
+      confirmModal.getByRole('button', { name: 'Create offers' }),
+      'no guard in `handleApproveAll`: the confirm modal opens with a flagged row present',
+    ).toBeVisible({ timeout: 15_000 });
+
+    // Drafts, not live offers - test 2 replays this exact body for real.
+    const publishImmediately = confirmModal.getByRole('checkbox', {
+      name: /Publish immediately/,
+    });
+    if (await publishImmediately.isChecked()) {
+      await publishImmediately.uncheck();
+    }
+
+    await confirmModal.getByRole('button', { name: 'Create offers' }).click();
+
+    // (a3) No guard in `handleSubmit` either - the request goes out.
+    await expect(async () => {
+      expect(submitAttempts, 'the wizard issued POST /listings/bulk-create').toBeGreaterThan(0);
+    }).toPass({ timeout: 20_000 });
+
+    const body = capturedBody;
+    expect(body, 'the submit body was captured').not.toBeNull();
+    const submitted = body!;
+
+    // (a4) The heart of F13: the blocked sibling is in NO channel.
+    expect(
+      submitted.excludedVariantIds ?? [],
+      'the blocked sibling is NOT in excludedVariantIds - the wizard never tells the server ' +
+        'to skip it (contrast: a switched-OFF variant does land here)',
+    ).not.toContain(blockedVariant!.id);
+    expect(
+      Object.keys(submitted.perVariantOverrides ?? {}),
+      'the blocked sibling has no per-variant override either - it is simply absent',
+    ).not.toContain(blockedVariant!.id);
+    expect(
+      Object.keys(submitted.perVariantOverrides ?? {}),
+      'the ready sibling DOES get a per-variant override',
+    ).toContain(readyVariant!.id);
+    expect(
+      submitted.sharedConfig.price,
+      'the wizard never sends a batch-wide price, so an override-less job resolves ' +
+        'price = undefined and falls through to the master product price',
+    ).toBeUndefined();
+
+    await page.unrouteAll({ behavior: 'ignoreErrors' });
+  });
+
+  test('the backend expands the blocked sibling anyway - no server-side equivalent of the gate', async ({
+    api,
+    env,
+    page,
+  }) => {
+    test.skip(
+      capturedBody === null || blockedVariant === null,
+      'depends on the browser test above capturing the wizard submit body.',
+    );
+    const body: BulkCreateBody = {
+      ...capturedBody!,
+      sharedConfig: { ...capturedBody!.sharedConfig, publishImmediately: false },
+    };
+
+    const result = await submitBulkCreate(env, body);
+    expect(
+      result.status,
+      `the server accepts the body the wizard built: ${JSON.stringify(result.body)}`,
+    ).toBe(202);
+
+    const batchId = (result.body as { batchId?: string }).batchId;
+    expect(batchId, 'the accept response carries a batchId').toBeTruthy();
+
+    const batch = await api.listings.getBulkBatch(batchId!);
+    const recordVariantIds = batch.records.map((r) => r.internalVariantId);
+
+    // PROOF (documentation only): the batch the server minted from that body -
+    // one record per sibling, the blocked one included.
+    await captureProof(page, 'f13-before-result', {
+      fullPage: true,
+      prepare: async () => {
+        await page.goto(`/listings/bulk-batches/${batchId!}`);
+        await expect(page.locator('.bulk-batch__kpi-strip')).toBeVisible({ timeout: 30_000 });
+      },
+    });
+
+    // (b) The divergence: the server created work for the variant the wizard
+    // itself declared unlistable, because the body never said to skip it.
+    expect(
+      recordVariantIds,
+      'the blocked sibling - absent from BOTH client channels - still gets an ' +
+        'offer-creation record: `expandVariantJobs` only honours `excludedVariantIds`',
+    ).toContain(blockedVariant!.id);
+    expect(
+      batch.totalCount,
+      'totalCount counts the blocked sibling too, so even the batch size the operator ' +
+        'is shown includes a variant the wizard refused to approve',
+    ).toBeGreaterThanOrEqual(2);
+  });
+});
+
+/**
+ * First multi-variant product with at least `minFree` variants carrying no
+ * offer mapping on `connectionId`. Mapped variants are dropped by
+ * `filterAlreadyListed` before expansion, so they cannot demonstrate F13.
+ */
+async function findMultiVariantCandidate(
+  api: ApiClient,
+  world: { listProducts(limit?: number): Promise<Product[]>; variantsOf(id: string): Promise<ProductVariant[]> },
+  connectionId: string,
+  minFree: number,
+): Promise<Candidate | null> {
+  const mapped = await mappedVariantIds(api, connectionId);
+  for (const product of await world.listProducts(100)) {
+    const variants = await world.variantsOf(product.id);
+    if (variants.length < 2) continue;
+    const free = variants.filter((v) => !mapped.has(v.id) && barcodeOf(v) !== null);
+    if (free.length >= minFree) return { product, variants, free };
+  }
+  return null;
+}
+
+/** Every internal variant id that already has an offer mapping on a connection. */
+async function mappedVariantIds(api: ApiClient, connectionId: string): Promise<Set<string>> {
+  const ids = new Set<string>();
+  for (let offset = 0; ; offset += 100) {
+    const page = await api.listings.list({ connectionId, limit: 100, offset });
+    page.items.forEach((mapping) => ids.add(mapping.internalId));
+    if (page.items.length === 0 || offset + 100 >= page.total) break;
+  }
+  return ids;
+}
+
+function barcodeOf(variant: ProductVariant): string | null {
+  return variant.ean ?? variant.gtin ?? null;
+}
+
+/**
+ * Raw `POST /listings/bulk-create`. The node `ApiClient` exposes no bulk-submit
+ * method and this suite must not modify `src/`, so the call is issued directly
+ * here. Returns status + parsed body rather than throwing, so a spec can assert
+ * on the exact 2xx/4xx.
+ */
+async function submitBulkCreate(
+  env: E2eEnv,
+  body: BulkCreateBody,
+): Promise<{ status: number; body: unknown }> {
+  const token = await loginForRawCalls(env);
+  const response = await fetch(`${env.apiUrl}/v1/listings/bulk-create`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      Authorization: `Bearer ${token}`,
+      'x-idempotency-key': randomUUID(),
+    },
+    body: JSON.stringify(body),
+  });
+  const raw = await response.text();
+  let parsed: unknown = raw;
+  try {
+    parsed = raw.length > 0 ? JSON.parse(raw) : undefined;
+  } catch {
+    /* non-JSON body - keep the raw text */
+  }
+  return { status: response.status, body: parsed };
+}
+
+async function loginForRawCalls(env: E2eEnv): Promise<string> {
+  const response = await fetch(`${env.apiUrl}/v1/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: env.adminUser, password: env.adminPass }),
+  });
+  if (!response.ok) {
+    throw new Error(`Login failed: HTTP ${response.status} ${await response.text()}`);
+  }
+  return ((await response.json()) as { access_token: string }).access_token;
+}

--- a/apps/e2e/tests/preflight-divergence/f14-ean-trim.spec.ts
+++ b/apps/e2e/tests/preflight-divergence/f14-ean-trim.spec.ts
@@ -1,0 +1,283 @@
+/**
+ * F14 - the frontend trims the EAN, the backend does not
+ *
+ * ⚠️ CHARACTERIZATION TEST. It passes while the divergence exists and FAILS the
+ * moment the finding is closed (or was wrong in the first place). A red run here
+ * is a signal to re-read the finding, not a regression in the product.
+ *
+ * DEPENDS ON F13 (`f13-blocked-not-excluded.spec.ts`). The claimed divergence is:
+ *
+ *   (a) What the wizard presents - `effectiveVariantEan` (`bulk-policy.ts`) does
+ *       `raw.trim()`, so " 5901234123457" is read as a valid GTIN-13 and the row
+ *       renders `ready`.
+ *   (b) What actually happens - `BulkListingSubmitService.enforceIdentifierRules`
+ *       reads `variant?.ean` LITERALLY. With the leading space the string is 14
+ *       characters, hits `GTIN_LENGTHS.has(14)`, fails `isValidGs1CheckDigit`
+ *       (which rejects anything non-numeric outright) and throws
+ *       `InvalidEanException` → 400 on the WHOLE request, not just that row.
+ *
+ * It is normally masked because the wizard sends the already-trimmed value as
+ * `overrides.ean`. It only surfaces for a variant that has NO per-variant
+ * override - which is exactly the state F13 creates.
+ *
+ * VERDICT ON THE LIVE STACK: the divergence is real at the line level but its
+ * precondition is UNREACHABLE. A master variant's `ean` cannot carry whitespace,
+ * because `MasterProductSyncService` normalises every ingested barcode through
+ * `normalizeToEan13` → `normalizeBarcode`, which does `input.trim()
+ * .replace(/\D/g, '')` and returns null for any length that is not 12/13. So the
+ * stored value is always exactly 13 digits or null. Test 1 pins that invariant:
+ * the day it is relaxed (a new master adapter writing raw barcodes, a direct
+ * write path, a widened normaliser) this test goes red and F14 becomes live.
+ *
+ * Test 2 pins the other half: the OVERRIDE channel - the one the wizard actually
+ * uses - is guarded, but by the DTO regex, not by the identifier gate. Which is
+ * the whole point: two independently-written validators, only one of them on the
+ * path F13 opens up.
+ *
+ * @module tests/preflight-divergence
+ */
+import { randomUUID } from 'node:crypto';
+import { test, expect } from '../../src/fixtures/test';
+import type { ApiClient } from '../../src/api/api-client';
+import type { Product, ProductVariant } from '../../src/api/api.types';
+import type { E2eEnv } from '../../src/config/env';
+
+/** Per-variant / per-product override entry of `POST /listings/bulk-create`. */
+interface BulkOverride {
+  stock?: number;
+  publishImmediately?: boolean;
+  price?: { amount: number; currency: string };
+  overrides?: Record<string, unknown>;
+}
+
+/** Request body of `POST /listings/bulk-create` (mirrored locally, #1741 shape). */
+interface BulkCreateBody {
+  connectionId: string;
+  productIds: string[];
+  sharedConfig: { stock: number; publishImmediately: boolean };
+  perVariantOverrides?: Record<string, BulkOverride>;
+  excludedVariantIds?: string[];
+}
+
+/** A valid GTIN-13 (check digit verified below), with a leading space bolted on. */
+const VALID_GTIN13 = '5901234123457';
+const UNTRIMMED_EAN = ` ${VALID_GTIN13}`;
+
+test.describe('F14 - EAN trimming asymmetry between wizard and submit service', () => {
+  test('the wizard-side trim has no backend counterpart, but no stored master EAN can exercise it', async ({
+    world,
+  }) => {
+    // The FE treats " 5901234123457" as a valid GTIN-13 - assert the premise
+    // rather than trusting it. This mirrors `isValidGtin` / `isValidGs1CheckDigit`
+    // verbatim; both sides of the divergence run the same GS1 arithmetic, they
+    // just disagree about whitespace.
+    expect(isValidGs1CheckDigit(VALID_GTIN13), `${VALID_GTIN13} is a valid GTIN-13`).toBe(true);
+    expect(
+      isValidGs1CheckDigit(UNTRIMMED_EAN.trim()),
+      'the FE trims first, so it sees a valid GTIN-13',
+    ).toBe(true);
+    expect(
+      isValidGs1CheckDigit(UNTRIMMED_EAN),
+      'the BE does NOT trim, so it sees a non-numeric 14-char string and rejects it - ' +
+        'this asymmetry is F14',
+    ).toBe(false);
+    expect(
+      UNTRIMMED_EAN.length,
+      'the untrimmed string is 14 chars long, i.e. inside GTIN_LENGTHS - which is why the ' +
+        'backend runs the check-digit test on it at all instead of skipping it',
+    ).toBe(14);
+
+    // The precondition F14 needs: a master variant whose stored `ean`/`gtin`
+    // carries whitespace. Assert it cannot exist on this stack - every ingested
+    // barcode passes through `normalizeToEan13` / `normalizeBarcode`.
+    const offenders: string[] = [];
+    let inspected = 0;
+    for (const product of await world.listProducts(100)) {
+      for (const variant of await world.variantsOf(product.id)) {
+        for (const [field, value] of [
+          ['ean', variant.ean],
+          ['gtin', variant.gtin],
+        ] as const) {
+          if (value === null || value === undefined) continue;
+          inspected += 1;
+          if (!/^\d+$/.test(value)) {
+            offenders.push(`${variant.id}.${field}=${JSON.stringify(value)}`);
+          }
+        }
+      }
+    }
+    expect(inspected, 'the stack exposes at least one barcoded master variant to inspect')
+      .toBeGreaterThan(0);
+    expect(
+      offenders,
+      'no master variant carries a non-digit (e.g. whitespace-padded) barcode: ' +
+        '`MasterProductSyncService` normalises on ingest, so the state F14 needs is ' +
+        'unreachable through the master-sync path. If this list is ever non-empty, F14 is live ' +
+        'and a single such product 400s the entire bulk submit it appears in.',
+    ).toEqual([]);
+  });
+
+  test('the OVERRIDE channel is guarded - by the DTO regex, not by the identifier gate', async ({
+    api,
+    world,
+    env,
+  }) => {
+    const allegro = world.connectionFor('allegro');
+    test.skip(allegro === undefined, 'F14 needs an Allegro connection as the wizard destination.');
+    const connection = allegro!;
+
+    const variant = await findFreeVariant(api, world, connection.id);
+    test.skip(
+      variant === null,
+      'F14 needs one master variant with no Allegro offer mapping (mapped variants are ' +
+        'dropped by `filterAlreadyListed` before the identifier gate runs).',
+    );
+
+    const result = await submitBulkCreate(env, {
+      connectionId: connection.id,
+      productIds: [variant!.id],
+      sharedConfig: { stock: 1, publishImmediately: false },
+      perVariantOverrides: { [variant!.id]: { overrides: { ean: UNTRIMMED_EAN } } },
+      excludedVariantIds: [],
+    });
+
+    // Both halves of the assertion matter. It IS rejected (so the override path
+    // an operator can actually reach is safe) …
+    expect(
+      result.status,
+      `an untrimmed override EAN is rejected: ${JSON.stringify(result.body)}`,
+    ).toBe(400);
+    const message = messageOf(result.body);
+    // … but by `CreateOfferOverridesDto.@Matches(/^(\d{8}|\d{12,14})$/)` running
+    // under `@ValidateRecordValues`, i.e. a validator that exists ONLY on the
+    // override branch - and one that flattens the nested failure into an opaque
+    // "invalid value" naming neither the field nor the reason. The master-variant
+    // branch has no such pre-filter at all: it reaches `enforceIdentifierRules`,
+    // whose rejection would name the variant and the EAN.
+    expect(
+      message,
+      'rejected by the record-value DTO validator on the override branch, which reports the ' +
+        'whole override object as "invalid value" without ever naming `ean` - opaque, but ' +
+        'present. The master-EAN path F13 exposes has no equivalent pre-filter.',
+    ).toMatch(/perVariantOverrides\[.+\]\.overrides: invalid value/i);
+    expect(
+      message,
+      'the identifier gate (InvalidEanException) never got to run: the DTO short-circuited ' +
+        'first, which is why the untrimmed-master-EAN path is untested by construction',
+    ).not.toMatch(/check digit|invalid ean/i);
+  });
+
+  test('the divergence itself (InvalidEanException from an untrimmed MASTER ean) is unprovisionable', async () => {
+    test.skip(
+      true,
+      'BLOCKED ON FIXTURE. Reproducing F14 end-to-end needs a master ProductVariant whose ' +
+        'persisted `ean` starts with whitespace (e.g. " 5901234123457"), plus the F13 state ' +
+        '(that variant included-but-blocked, so the wizard sends no `overrides.ean` for it). ' +
+        'Neither the PrestaShop nor the WooCommerce master path can produce it: ' +
+        '`MasterProductSyncService.toVariant` normalises `ean` via `normalizeToEan13` and ' +
+        '`gtin` via `normalizeBarcode`, both of which trim and strip non-digits before the ' +
+        'row is written. The only remaining routes are a direct DB write (forbidden on this ' +
+        'shared demo stack) or a new master adapter bypassing the normaliser. Test 1 above ' +
+        'pins the normalisation invariant so this becomes reachable - and goes red - the day ' +
+        'it is relaxed.',
+    );
+  });
+});
+
+/** First master variant with a barcode and no offer mapping on `connectionId`. */
+async function findFreeVariant(
+  api: ApiClient,
+  world: {
+    listProducts(limit?: number): Promise<Product[]>;
+    variantsOf(id: string): Promise<ProductVariant[]>;
+  },
+  connectionId: string,
+): Promise<ProductVariant | null> {
+  const mapped = await mappedVariantIds(api, connectionId);
+  for (const product of await world.listProducts(100)) {
+    const variants = await world.variantsOf(product.id);
+    // A single-variant product keeps the fan-out to exactly one job, so the
+    // rejection can only come from the variant under test.
+    if (variants.length !== 1) continue;
+    const [variant] = variants;
+    if (!mapped.has(variant.id)) return variant;
+  }
+  return null;
+}
+
+async function mappedVariantIds(api: ApiClient, connectionId: string): Promise<Set<string>> {
+  const ids = new Set<string>();
+  for (let offset = 0; ; offset += 100) {
+    const page = await api.listings.list({ connectionId, limit: 100, offset });
+    page.items.forEach((mapping) => ids.add(mapping.internalId));
+    if (page.items.length === 0 || offset + 100 >= page.total) break;
+  }
+  return ids;
+}
+
+/**
+ * GS1 mod-10 check digit, transcribed from `isValidGs1CheckDigit`
+ * (`bulk-listing-submit.service.ts`) - including its `/^\d+$/` guard, which is
+ * the exact line the untrimmed value trips over.
+ */
+function isValidGs1CheckDigit(code: string): boolean {
+  if (!/^\d+$/.test(code)) return false;
+  const digits = [...code].map((c) => Number(c));
+  const check = digits[digits.length - 1];
+  const body = digits.slice(0, -1);
+  let sum = 0;
+  for (let i = body.length - 1, pos = 0; i >= 0; i--, pos++) {
+    sum += body[i] * (pos % 2 === 0 ? 3 : 1);
+  }
+  return (10 - (sum % 10)) % 10 === check;
+}
+
+function messageOf(body: unknown): string {
+  if (typeof body === 'string') return body;
+  const message = (body as { message?: unknown } | null)?.message;
+  if (typeof message === 'string') return message;
+  if (Array.isArray(message)) return message.join('; ');
+  return JSON.stringify(body);
+}
+
+/**
+ * Raw `POST /listings/bulk-create`. The node `ApiClient` exposes no bulk-submit
+ * method and this suite must not modify `src/`, so the call is issued directly
+ * here. Returns status + parsed body rather than throwing.
+ */
+async function submitBulkCreate(
+  env: E2eEnv,
+  body: BulkCreateBody,
+): Promise<{ status: number; body: unknown }> {
+  const token = await loginForRawCalls(env);
+  const response = await fetch(`${env.apiUrl}/v1/listings/bulk-create`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+      Authorization: `Bearer ${token}`,
+      'x-idempotency-key': randomUUID(),
+    },
+    body: JSON.stringify(body),
+  });
+  const raw = await response.text();
+  let parsed: unknown = raw;
+  try {
+    parsed = raw.length > 0 ? JSON.parse(raw) : undefined;
+  } catch {
+    /* non-JSON body - keep the raw text */
+  }
+  return { status: response.status, body: parsed };
+}
+
+async function loginForRawCalls(env: E2eEnv): Promise<string> {
+  const response = await fetch(`${env.apiUrl}/v1/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: env.adminUser, password: env.adminPass }),
+  });
+  if (!response.ok) {
+    throw new Error(`Login failed: HTTP ${response.status} ${await response.text()}`);
+  }
+  return ((await response.json()) as { access_token: string }).access_token;
+}

--- a/apps/e2e/tests/preflight-divergence/f15-pricing-policy-rejected.spec.ts
+++ b/apps/e2e/tests/preflight-divergence/f15-pricing-policy-rejected.spec.ts
@@ -1,0 +1,684 @@
+/**
+ * F15 - the row editor emits `pricingPolicy`; the DTO forbids the property
+ *
+ * ⚠️ CHARACTERIZATION TEST. These specs pass **while the divergence exists** and
+ * go RED once it is closed. A failure here is NOT a regression - it means the
+ * finding was wrong, or it has been fixed and this file should be retired (or
+ * inverted into a normal regression test asserting the request is ACCEPTED).
+ *
+ * THE DIVERGENCE, in one sentence: the bulk edit modal writes a per-product
+ * `pricingPolicy` (and `stockPolicy`) at the TOP LEVEL of the override map value,
+ * the wizard forwards that value verbatim as `perProductOverrides[primaryVariantId]`,
+ * and the request DTO declares no such property - so `@ValidateRecordValues`,
+ * which validates every map value under `whitelist + forbidNonWhitelisted`,
+ * rejects the WHOLE request with 400 after a Review step that showed the row
+ * `ready`. Same disease as F12 (`categoryId`), different property and a different
+ * mechanism: F12 was an explicitly OMITTED property (`OmitType`), F15 is a
+ * property that was never modelled at the HTTP boundary at all.
+ *
+ * SOURCE EVIDENCE - verified on BOTH trees (identical on each):
+ *
+ *   Emitter (frontend), `apps/web/src/features/listings/components/bulk/bulk-edit-modal.tsx`:
+ *     const pricingDiverges = isMultiVariant && !pricingPolicyEquals(pricingPolicy, batchPricingPolicy);
+ *     const baseOverride: BulkPerProductOverride = { …, ...(pricingDiverges ? { pricingPolicy } : {}), … };
+ *   (`ol-1924@c7dd586f` L656/L664 - the build the running stack is made of;
+ *    `origin/main` L655/L663 - byte-identical logic.) The same block emits
+ *   `stockPolicy` on `stockDiverges`. The shop half of the modal (L2943/L2952 on
+ *   1924, L2764/L2773 on main) repeats it for the shop-publish path.
+ *
+ *   Forwarder, `bulk-wizard.tsx` `handleSubmit`:
+ *     const familyOverride: BulkPerProductOverride = isMulti && familyCategoryId
+ *       ? { ...row.override, overrides: { …, categoryId: familyCategoryId } }
+ *       : row.override;
+ *     perProductOverrides[primaryId] = familyOverride;
+ *   `row.override` IS the modal's `baseOverride`. Nothing between the modal and
+ *   the wire strips the policy fields.
+ *
+ *   Rejecter (backend), `apps/api/src/listings/http/dto/bulk-offer-create.dto.ts`:
+ *   the per-map value class declares exactly four properties - `stock`,
+ *   `publishImmediately`, `price`, `overrides` - and neither `pricingPolicy` nor
+ *   `stockPolicy`. It is named `PerOverrideDto` on `ol-1924` and
+ *   `PerVariantOverrideDto` on `origin/main`; the property set is the same on
+ *   both, so the finding is version-independent. `apps/api` and `libs` contain
+ *   NO occurrence of the string `pricingPolicy` on either tree.
+ *
+ *   What makes it FATAL rather than ignored: `@ValidateRecordValues(() => …)`
+ *   (`validate-record-values.decorator.ts`) calls
+ *     validate(instance, { whitelist: true, forbidNonWhitelisted: true })
+ *   on every map value. That option pair is HARDCODED inside the decorator - the
+ *   global `ValidationPipe` in `apps/api/src/main.ts` also sets both, but it never
+ *   recurses into `Record<>` values, so the decorator is the operative gate. It
+ *   fails the whole property on the first offending entry and surfaces
+ *   `perProductOverrides["…"].pricingPolicy: property pricingPolicy should not exist`.
+ *
+ *   The FE type even documents the mistaken assumption
+ *   (`api/bulk-listings.types.ts`): "FE-only resolution input - the BE receives
+ *   the already-resolved amounts and ignores these fields". The BE does not
+ *   ignore them; it refuses the request.
+ *
+ * WHY THE OPERATOR REACHES IT: `pricingDiverges` requires (1) a MULTI-VARIANT
+ * row - `isMultiVariant` gates both policy fields - and (2) a policy that differs
+ * from the batch default. The multi-variant editor's shared-base scope renders a
+ * "Price policy" select precisely so the operator can diverge; picking "Markup on
+ * master price" seeds `percent: 10` (`nextPricingPolicy`) and arms the finding.
+ * The batch default is `use-master` (`bulk-config-step.tsx`), so ANY other choice
+ * diverges. Nothing in the Review step reflects the change as a blocker - the
+ * policy is an input to the row's resolved price, not a validity signal.
+ *
+ * ORDERING NOTE (matters when reading a 400 on `origin/main`): class-validator
+ * emits whitelist violations BEFORE per-property constraint errors, and
+ * `@ValidateRecordValues` reports only `errors[0]`. On a build where F12 is also
+ * live, a row carrying BOTH `categoryId` and `pricingPolicy` reports
+ * `pricingPolicy` and MASKS the `categoryId` rejection. The same applies to
+ * `stockPolicy`, which is shadowed by `pricingPolicy` whenever both diverge.
+ *
+ * Both halves are asserted:
+ *   (a) the wizard reports the edited row `ready` and enables the submit CTA, AND
+ *   (b) the submitted request really carries `perProductOverrides[…].pricingPolicy`, AND
+ *   (c) the API rejects the WHOLE request with 400 naming that exact property -
+ *       zero batch, zero records, the browser never leaves the wizard.
+ *
+ * Test 1 pins the backend half alone as a cheap, fixture-free contract probe, so
+ * this file still carries a live assertion when the browser fixture is absent.
+ *
+ * Fixture policy: read-only. Test 1 is rejected by validation before the handler
+ * runs; test 2 ends in a 400, so no batch is persisted, no job is enqueued and no
+ * offer is created on any marketplace.
+ *
+ * @module tests/preflight-divergence
+ */
+import type { Locator, Page } from '@playwright/test';
+import { test, expect } from '../../src/fixtures/test';
+import type { ApiClient } from '../../src/api/api-client';
+import type { Connection, Product } from '../../src/api/api.types';
+import type { E2eEnv } from '../../src/config/env';
+import type { World } from '../../src/world/world';
+import type { BulkOfferWizard } from '../../src/pages/bulk-offer-wizard.page';
+import { captureProof, reviewRegion } from './__proof__/capture';
+
+test.describe.configure({ mode: 'serial', timeout: 300_000 });
+
+/** A deliberately-unknown variant id used only by the read-only contract probe. */
+const PROBE_VARIANT_ID = 'ol_variant_preflight_f15_probe';
+
+/** The policy value the probe and the editor both produce (`nextPricingPolicy`). */
+const DIVERGED_PRICING_POLICY = { mode: 'markup', percent: 10 } as const;
+
+/* ─────────────────────────────── raw API access ─────────────────────────────── */
+
+interface RawJsonResponse {
+  status: number;
+  body: unknown;
+}
+
+/** Acquire a bearer token for the raw calls below (the shared client hides its own). */
+async function bearer(env: E2eEnv): Promise<string> {
+  const response = await fetch(`${env.apiUrl}/v1/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ username: env.adminUser, password: env.adminPass }),
+  });
+  if (!response.ok) {
+    throw new Error(`E2E login failed: HTTP ${response.status} ${await response.text()}`);
+  }
+  return ((await response.json()) as { access_token: string }).access_token;
+}
+
+async function rawPost(
+  env: E2eEnv,
+  token: string,
+  path: string,
+  body: unknown,
+): Promise<RawJsonResponse> {
+  const response = await fetch(`${env.apiUrl}/v1${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify(body),
+  });
+  const text = await response.text();
+  let parsed: unknown = text;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    /* keep the raw text */
+  }
+  return { status: response.status, body: parsed };
+}
+
+/** Every message string in a Nest validation error body. */
+function messagesOf(body: unknown): string[] {
+  const message = (body as { message?: unknown } | null)?.message;
+  if (Array.isArray(message)) return message.map(String);
+  if (typeof message === 'string') return [message];
+  return [JSON.stringify(body)];
+}
+
+/**
+ * Read-only probe of the live DTO contract: does THIS build reject a top-level
+ * `pricingPolicy` inside the per-product / per-variant override maps?
+ *
+ * The probe deliberately fails an UNRELATED rule (`sharedConfig.stock: -1`
+ * violates `@Min(0)`), so the global ValidationPipe rejects before the handler
+ * ever runs - nothing is enqueued, no batch is created. class-validator reports
+ * every top-level violation at once, so the response tells us whether the
+ * override maps also rejected the policy property.
+ */
+async function probePricingPolicyForbidden(
+  env: E2eEnv,
+  token: string,
+  connectionId: string,
+): Promise<{ armed: boolean; messages: string[] }> {
+  const overrideValue = {
+    pricingPolicy: DIVERGED_PRICING_POLICY,
+    stockPolicy: { mode: 'use-master' },
+  };
+  const result = await rawPost(env, token, '/listings/bulk-create', {
+    connectionId,
+    productIds: [PROBE_VARIANT_ID],
+    sharedConfig: { stock: -1, publishImmediately: true },
+    perProductOverrides: { [PROBE_VARIANT_ID]: overrideValue },
+    perVariantOverrides: { [PROBE_VARIANT_ID]: overrideValue },
+  });
+
+  expect(
+    result.status,
+    'the contract probe must be rejected by validation alone (stock: -1) and never reach the handler',
+  ).toBe(400);
+
+  const messages = messagesOf(result.body);
+  const armed = messages.some((m) => /pricingPolicy should not exist/i.test(m));
+  return { armed, messages };
+}
+
+/* ────────────────────────── local fixture discovery ────────────────────────── */
+
+/** Every variant id that already carries an offer mapping on `connectionId`. */
+async function listedVariantIds(api: ApiClient, connectionId: string): Promise<Set<string>> {
+  const ids = new Set<string>();
+  for (let offset = 0; ; offset += 100) {
+    const page = await api.listings.list({ connectionId, limit: 100, offset });
+    page.items.forEach((mapping) => ids.add(mapping.internalId));
+    if (page.items.length === 0 || offset + 100 >= page.total) break;
+  }
+  return ids;
+}
+
+/**
+ * A MULTI-VARIANT master product, none of whose variants is already listed on
+ * `connectionId`. Already-listed variants are silently dropped by
+ * `filterAlreadyListed`, which would mask this finding behind F2's divergence.
+ */
+async function findFreshMultiVariantProduct(
+  api: ApiClient,
+  world: World,
+  connectionId: string,
+): Promise<Product | undefined> {
+  const listed = await listedVariantIds(api, connectionId);
+  for (const summary of await world.listProducts(60)) {
+    const product = await api.products.getById(summary.id);
+    const variants = product.variants ?? [];
+    if (variants.length < 2) continue;
+    if (variants.some((variant) => listed.has(variant.id))) continue;
+    if ((product.price ?? 0) <= 0) continue; // a markup policy needs a master price.
+    return product;
+  }
+  return undefined;
+}
+
+/* ───────────────────────────── wizard driving (local) ───────────────────────── */
+
+/**
+ * The Review step's submit CTA, tolerant of both label generations: the build
+ * this suite's page object was written against renders "Approve all (N)", the
+ * current one renders "Create offers (N)". The `(N)` suffix is what keeps this
+ * from also matching the confirm modal's own bare "Create offers" button.
+ */
+function submitCta(page: Page): Locator {
+  return page.getByRole('button', { name: /^(Approve all|Create offers)\s*\(\d+\)$/ }).first();
+}
+
+interface ReviewCounts {
+  ready: number;
+  attention: number;
+  excluded: number;
+  raw: string;
+}
+
+/**
+ * Read the Review step's readiness counters straight off its `role="status"`
+ * summary. The shared page object's `needsAttentionCount()` assumes the older
+ * "N row(s) need attention" phrasing and parses the FIRST number in the hint;
+ * the current build renders "N ready · M need attention · K excluded", so that
+ * parse returns the READY count. Anchor on the labelled numbers instead.
+ */
+async function reviewCounts(page: Page): Promise<ReviewCounts> {
+  const summary = page.getByRole('status').filter({ hasText: /ready/i }).first();
+  if ((await summary.count()) === 0) {
+    return { ready: 0, attention: 0, excluded: 0, raw: '(no readiness hint)' };
+  }
+  const raw = (await summary.innerText()).replace(/\s+/g, ' ').trim();
+  const read = (pattern: RegExp): number => {
+    const match = pattern.exec(raw);
+    return match ? Number(match[1]) : 0;
+  };
+  return {
+    ready: read(/(\d+)\s*ready/i),
+    attention: read(/(\d+)\s*need attention/i),
+    excluded: read(/(\d+)\s*excluded/i),
+    raw,
+  };
+}
+
+/**
+ * Wait until the Review step has SETTLED - the async per-category parameter
+ * schema has resolved and the row blockers reflect it. Mirrors the page object's
+ * own (private) settle gate, but against the build-tolerant locators above, so a
+ * transient "0 need attention, submit disabled" limbo is never read as readiness.
+ */
+async function waitForReviewSettled(page: Page): Promise<ReviewCounts> {
+  let counts: ReviewCounts = { ready: 0, attention: 0, excluded: 0, raw: '(unread)' };
+  await expect(async () => {
+    const cta = submitCta(page);
+    if ((await cta.count()) === 0) throw new Error('Review step has not rendered its submit CTA.');
+    const [enabled, current] = await Promise.all([cta.isEnabled(), reviewCounts(page)]);
+    counts = current;
+    if (!enabled && current.attention === 0) {
+      throw new Error(`Review still resolving: submit disabled with no flagged rows (${current.raw}).`);
+    }
+  }).toPass({ timeout: 90_000 });
+  return counts;
+}
+
+/**
+ * Pick the destination connection on the Config step.
+ *
+ * The step renders a grouped RADIO RAIL (`PublishDestinationRail`) when more than
+ * one publish destination exists, and a plain "Publishing as {name}" alert when
+ * there is only one - the shared page object's `<select>` path
+ * (`selectConnectionIfPresent`) only covers the older select-based layout, so try
+ * the rail first and fall back to it. Kept local per the suite's rule that a
+ * divergence spec must not edit shared page objects.
+ */
+async function selectDestination(
+  page: Page,
+  wizard: BulkOfferWizard,
+  connectionName: string,
+): Promise<void> {
+  const escaped = connectionName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const radio = page.getByRole('radio', { name: new RegExp(escaped) });
+  if ((await radio.count()) > 0) {
+    await radio.first().click();
+    return;
+  }
+  await wizard.selectConnectionIfPresent(connectionName);
+}
+
+/* ─────────────────────────── row editor driving (local) ─────────────────────── */
+
+/** True if the locator's first match becomes visible within `timeoutMs`. */
+async function visibleWithin(locator: Locator, timeoutMs: number): Promise<boolean> {
+  return locator
+    .first()
+    .waitFor({ state: 'visible', timeout: timeoutMs })
+    .then(() => true)
+    .catch(() => false);
+}
+
+/**
+ * Fill the row editor's required, still-empty fields.
+ *
+ * A local (deliberately minimal) transplant of the page object's filler: the
+ * shared one is reached only through `advanceToConfirmModal`, which drives its
+ * needs-attention loop off `needsAttentionCount()` - the drifted parse that
+ * returns the READY count, so on the current build it demands the count to DROP
+ * as rows become ready and throws instead. This spec needs the editor open for
+ * its own reason (the Price-policy select), so it fills what it opened.
+ *
+ * Only REQUIRED parameters are touched; the optional set lives in a collapsed
+ * <details> and never gates readiness. Returns false when a required control
+ * could not be auto-filled, so the caller can skip with a precise reason instead
+ * of failing on fixture shape.
+ */
+async function fillRequiredFields(page: Page, dialog: Locator, gtin?: string): Promise<boolean> {
+  for (const [label, value] of [
+    ['Title', 'E2E F15 characterization offer'],
+    ['Description', 'Automated E2E preflight-divergence characterization offer.'],
+  ] as const) {
+    const field = dialog.getByLabel(label, { exact: true }).first();
+    if ((await field.count()) > 0 && (await field.inputValue()).trim() === '') {
+      await field.fill(value);
+    }
+  }
+
+  // Wait out the per-category schema load before concluding "nothing to fill".
+  await expect(async () => {
+    expect(await dialog.getByText('Loading category parameters').count()).toBe(0);
+  }).toPass({ timeout: 30_000 });
+
+  const required = dialog.locator(
+    'fieldset.category-parameters-step__group:not(.category-parameters-step__group--optional)',
+  );
+  await visibleWithin(required, 5_000);
+  if ((await required.count()) === 0) return true;
+
+  // Re-scan each pass: dependency-gated parameters only appear once their parent
+  // has a value.
+  for (let pass = 0; pass < 6; pass += 1) {
+    let filled = false;
+
+    const selects = required.locator('select.control');
+    for (let i = 0; i < (await selects.count()); i += 1) {
+      const select = selects.nth(i);
+      if ((await select.inputValue()) !== '') continue;
+      const value = await select.locator('option:not([value=""])').first().getAttribute('value');
+      if (!value) continue;
+      await select.selectOption(value);
+      filled = true;
+    }
+
+    const texts = required.locator('input.control[type="text"]');
+    for (let i = 0; i < (await texts.count()); i += 1) {
+      const input = texts.nth(i);
+      if ((await input.inputValue()).trim() !== '') continue;
+      // A GTIN/EAN-typed parameter must carry a REAL barcode - the marketplace
+      // rejects a placeholder - but this request never reaches the marketplace,
+      // so the variant's own barcode is used purely to keep the row valid.
+      const label = (await input.getAttribute('aria-label')) ?? '';
+      await input.fill(gtin && /ean|gtin/i.test(label) ? gtin : 'E2E');
+      filled = true;
+    }
+
+    const numbers = required.locator('input.control[type="number"]');
+    for (let i = 0; i < (await numbers.count()); i += 1) {
+      const input = numbers.nth(i);
+      if ((await input.inputValue()).trim() !== '') continue;
+      const min = await input.getAttribute('min');
+      await input.fill(min && Number(min) > 1 ? min : '1');
+      filled = true;
+    }
+
+    const combos = required.locator('button[role="combobox"]');
+    for (let i = 0; i < (await combos.count()); i += 1) {
+      const outcome = await fillComboboxIfEmpty(page, combos.nth(i));
+      if (outcome === 'unfillable') return false;
+      if (outcome === 'filled') filled = true;
+    }
+
+    if (!filled) return true; // steady state - every required control has a value.
+  }
+  return true;
+}
+
+/**
+ * Pick the first selectable option in an empty single-select Combobox (a large
+ * dictionary such as Allegro's 8k-entry `Marka` renders nothing until the query
+ * matches, so probe digits then letters). Returns 'skipped' when the control
+ * already carries a value, 'unfillable' when no option and no custom value can be
+ * committed - the caller turns that into a fixture skip rather than a failure.
+ */
+async function fillComboboxIfEmpty(
+  page: Page,
+  trigger: Locator,
+): Promise<'filled' | 'skipped' | 'unfillable'> {
+  if (!/^pick\b/i.test((await trigger.innerText()).trim())) return 'skipped';
+
+  await trigger.click();
+  // The popover is portaled to the document body - scope to the page, not the dialog.
+  const search = page.locator('.combobox__search');
+  if (!(await visibleWithin(search, 10_000))) return 'unfillable';
+  const listbox = page.getByRole('listbox');
+  const realOptions = listbox.locator(
+    '[role="option"]:not(.combobox__option--disabled):not(.combobox__option--custom)',
+  );
+  const anyOptions = listbox.locator('[role="option"]:not(.combobox__option--disabled)');
+
+  if (await visibleWithin(realOptions, 800)) {
+    await realOptions.first().click();
+    return 'filled';
+  }
+  for (const probe of '0123456789aeiouymslxrtnkpbcdfgh') {
+    await search.fill(probe);
+    if (await visibleWithin(realOptions, 400)) {
+      await realOptions.first().click();
+      return 'filled';
+    }
+  }
+  await search.fill('E2E');
+  if (await visibleWithin(anyOptions, 1_000)) {
+    await anyOptions.first().click();
+    return 'filled';
+  }
+  await page.keyboard.press('Escape');
+  return 'unfillable';
+}
+
+/** Collect every top-level `pricingPolicy` / `stockPolicy` in a submitted body. */
+function injectedPolicies(body: unknown): { map: string; variantId: string; field: string }[] {
+  const found: { map: string; variantId: string; field: string }[] = [];
+  const request = body as Record<string, unknown>;
+  for (const map of ['perProductOverrides', 'perVariantOverrides']) {
+    const entries = request[map];
+    if (typeof entries !== 'object' || entries === null) continue;
+    for (const [variantId, value] of Object.entries(entries as Record<string, unknown>)) {
+      const entry = (value ?? {}) as Record<string, unknown>;
+      for (const field of ['pricingPolicy', 'stockPolicy']) {
+        if (entry[field] !== undefined) found.push({ map, variantId, field });
+      }
+    }
+  }
+  return found;
+}
+
+/* ──────────────────────────────── the scenarios ─────────────────────────────── */
+
+test.describe('F15 - the wizard sends a pricing policy the DTO has never heard of', () => {
+  test('the DTO forbids `pricingPolicy` in BOTH override maps (contract half)', async ({
+    env,
+    world,
+  }) => {
+    const allegro = world.connectionFor('allegro');
+    test.skip(!allegro, 'no Allegro connection on this stack');
+
+    const token = await bearer(env);
+    const probe = await probePricingPolicyForbidden(env, token, allegro!.id);
+    const joined = probe.messages.join(' | ');
+
+    expect(
+      joined,
+      'the per-PRODUCT map - the one the wizard actually writes the family policy into - ' +
+        'rejects the property outright (`@ValidateRecordValues` validates each map value with ' +
+        'whitelist + forbidNonWhitelisted, and the value class declares no such property)',
+    ).toMatch(/perProductOverrides\[.+\]\.pricingPolicy: property pricingPolicy should not exist/i);
+    expect(
+      joined,
+      'the per-VARIANT map rejects it identically - both maps are validated against the SAME ' +
+        'value class, so a future per-variant policy emitter would fail the same way',
+    ).toMatch(/perVariantOverrides\[.+\]\.pricingPolicy: property pricingPolicy should not exist/i);
+    expect(
+      joined,
+      'and the rejection is a whole-request 400: the probe also reports the unrelated ' +
+        'sharedConfig violation, i.e. class-validator answered before any handler ran and ' +
+        'nothing was persisted',
+    ).toMatch(/sharedConfig\.stock/i);
+
+    // `stockPolicy` rides in the same override object and is forbidden by the same
+    // absence, but `@ValidateRecordValues` reports only `errors[0]`, so it is
+    // shadowed whenever `pricingPolicy` is present. Pin the shadowing itself:
+    // the day the message names `stockPolicy` instead, the emitter changed.
+    expect(
+      joined,
+      'only the FIRST offending property of a map value is reported - `stockPolicy` is masked',
+    ).not.toMatch(/stockPolicy should not exist/i);
+  });
+
+  test('a multi-variant row keeps `ready` after a Price-policy edit, then the whole request 400s', async ({
+    env,
+    api,
+    world,
+    page,
+    pages,
+  }, testInfo) => {
+    // Fixture resolution walks the catalogue and the editor drives the real
+    // category-parameter schema - well past the suite's default per-test budget.
+    // Local to this spec (the shared playwright.config is not touched).
+    test.setTimeout(600_000);
+    const allegro = world.connectionFor('allegro');
+    test.skip(!allegro, 'no Allegro connection on this stack');
+    const connection: Connection = allegro!;
+
+    const token = await bearer(env);
+    const probe = await probePricingPolicyForbidden(env, token, connection.id);
+    test.skip(
+      !probe.armed,
+      'This API build ACCEPTS `pricingPolicy` inside the override maps, so the F15 backend half ' +
+        'is not present in the deployed code and there is nothing to characterize HERE. Either ' +
+        'the DTO gained the property (the fix - retire/invert this file) or the map values are ' +
+        'no longer validated by `@ValidateRecordValues`. Confirm by reading ' +
+        '`apps/api/src/listings/http/dto/bulk-offer-create.dto.ts`: the finding is that its ' +
+        'per-map value class (`PerOverrideDto` / `PerVariantOverrideDto`) declares only ' +
+        '`stock`, `publishImmediately`, `price`, `overrides`. ' +
+        `Probe reported: ${probe.messages.join(' | ')}`,
+    );
+
+    const product = await findFreshMultiVariantProduct(api, world, connection.id);
+    test.skip(
+      !product,
+      'No usable fixture: this stack has no MULTI-VARIANT master product that is (a) not yet ' +
+        `listed on "${connection.name}" (an already-listed variant is dropped by ` +
+        '`filterAlreadyListed`, which would mask this finding behind F2) and (b) carries a ' +
+        'master price (a `markup` policy resolves to null without one, which would flag the row ' +
+        'for the WRONG reason). `pricingPolicy` is emitted ONLY for a multi-variant row - ' +
+        '`pricingDiverges = isMultiVariant && !pricingPolicyEquals(...)` - so a single-variant ' +
+        'product cannot exercise it. Import a PrestaShop product with >=2 priced combinations ' +
+        'and run master.product.syncAll.',
+    );
+    const variants = product!.variants ?? [];
+    const gtin = variants[0]?.ean ?? variants[0]?.gtin ?? undefined;
+
+    await page.goto(`/listings/bulk-create/wizard?productIds=${product!.id}`);
+    const wizard = pages.bulkOfferWizard;
+    await wizard.expectOnConfigStep();
+    await selectDestination(page, wizard, connection.name);
+    await wizard.completePlatformConfig({
+      requiresDeliveryPolicy: connection.platformType !== 'erli',
+      requiresErliBuyabilityFields: connection.platformType === 'erli',
+    });
+    await expect(wizard.proceedButton).toBeEnabled({ timeout: 30_000 });
+    await wizard.proceedButton.click();
+    const beforeEdit = await waitForReviewSettled(page);
+
+    // ── the operator action that arms the finding ─────────────────────────────
+    // Open the row editor, complete whatever the row needs, and diverge the
+    // shared-base Price policy from the batch default (`use-master`). Picking
+    // "markup" seeds percent 10 (`nextPricingPolicy`), so the policy differs
+    // structurally and `pricingPolicyEquals` returns false.
+    await page.getByRole('button', { name: 'Edit', exact: true }).first().click();
+    const editor = page.getByRole('dialog').first();
+    // The current build labels the editor's commit "Save all"; the shared page
+    // object still clicks "Save row" (a third page-object drift), so this spec
+    // drives the editor itself.
+    await expect(editor.getByRole('button', { name: 'Save all' })).toBeVisible({ timeout: 30_000 });
+
+    const pricePolicy = editor.getByLabel('Price policy');
+    test.skip(
+      (await pricePolicy.count()) === 0,
+      'The row editor rendered no "Price policy" select, so the per-product policy cannot be ' +
+        'diverged from this UI. That select is the multi-variant shared-base control ' +
+        '(`bulk-edit-modal.tsx`); a simple product gets direct Price/Stock inputs instead and ' +
+        'never emits `pricingPolicy`. Re-check that the chosen fixture really has >1 variant.',
+    );
+    await pricePolicy.selectOption('markup');
+    await expect(
+      editor.getByLabel('Markup percent'),
+      'switching to markup seeds the default percent, so the policy structurally diverges from ' +
+        'the batch `use-master` default',
+    ).toHaveValue(String(DIVERGED_PRICING_POLICY.percent));
+
+    const fillable = await fillRequiredFields(page, editor, gtin ?? undefined);
+    test.skip(
+      !fillable,
+      'A required category parameter on this row could not be auto-filled (a dictionary that ' +
+        'matched no probe and offers no custom value), so the editor cannot be saved and the ' +
+        'policy override never reaches the wire. Pick a fixture whose resolved category has ' +
+        'auto-fillable required parameters, or link the variants to a marketplace product card ' +
+        '(a card-linked row is exempt from the required-product-parameter gate entirely).',
+    );
+
+    await editor.getByRole('button', { name: 'Save all' }).click();
+    // A successful save closes the modal; a validation error keeps it open.
+    try {
+      await expect(editor).toBeHidden({ timeout: 20_000 });
+    } catch {
+      const errors = await editor.locator('.form-field__error').allInnerTexts();
+      throw new Error(
+        'The row editor refused to save the diverged Price policy: ' +
+          (errors.length > 0 ? errors.join('; ') : '(no field errors surfaced)'),
+      );
+    }
+
+    // ── (a) the wizard still calls the edited row ready ───────────────────────
+    const counts = await waitForReviewSettled(page);
+    test.skip(
+      counts.attention > 0,
+      `The edited row still needs attention (${counts.raw}), so submit is unreachable and the ` +
+        'wizard half cannot be asserted. A diverged pricing policy is NOT itself a blocker - ' +
+        'something else on this row is unresolved (a required parameter, an image, a category). ' +
+        'This test needs a multi-variant product whose row is clearable through the editor.',
+    );
+    expect(counts.ready, 'the wizard counts the edited row as ready').toBeGreaterThan(0);
+    await expect(
+      submitCta(page),
+      'the wizard enables submit - it considers the batch good to go',
+    ).toBeEnabled();
+
+    // PROOF (documentation only - never asserted on): the promise.
+    await captureProof(page, 'f15-before-review-ready', { region: reviewRegion(page) });
+
+    await submitCta(page).click();
+    await expect(wizard.confirmModalConfirmButton).toBeVisible({ timeout: 30_000 });
+
+    // ── (b) + (c) the server refuses the whole thing ──────────────────────────
+    const submitted = page.waitForResponse(
+      (response) =>
+        response.request().method() === 'POST' && response.url().includes('/listings/bulk-create'),
+      { timeout: 60_000 },
+    );
+    await wizard.confirmModalConfirmButton.click();
+    const response = await submitted;
+
+    // PROOF (documentation only): the whole-request 400 the confirm modal shows.
+    await captureProof(page, 'f15-before-result', {
+      region: page.getByRole('dialog').filter({ has: page.locator('.alert--error') }),
+      prepare: async () => {
+        await expect(page.locator('.alert--error').first()).toBeVisible({ timeout: 15_000 });
+      },
+    });
+
+    const requestBody: unknown = JSON.parse(response.request().postData() ?? '{}');
+    const injected = injectedPolicies(requestBody);
+    expect(
+      injected.filter((entry) => entry.map === 'perProductOverrides' && entry.field === 'pricingPolicy'),
+      'the saved editor stamps `pricingPolicy` at the TOP LEVEL of ' +
+        'perProductOverrides[primaryVariantId] - the wizard forwards `row.override` verbatim',
+    ).not.toHaveLength(0);
+
+    expect(response.status(), 'the whole request is rejected - not one record is created').toBe(400);
+    const messages = messagesOf(await response.json());
+    expect(
+      messages.join(' | '),
+      'the rejection names the exact property the wizard just wrote',
+    ).toMatch(/perProductOverrides\[.+\]\.pricingPolicy: property pricingPolicy should not exist/i);
+
+    // The browser stays on the wizard: no batch id was ever minted.
+    await expect(page).toHaveURL(/\/listings\/bulk-create\/wizard/);
+
+    testInfo.annotations.push({
+      type: 'divergence',
+      description:
+        `product ${product!.id} (${variants.length} variants): review ${beforeEdit.raw} before ` +
+        `the edit, ${counts.raw} after; submitted policies ` +
+        `${injected.map((e) => `${e.map}.${e.field}`).join(', ')}; server replied 400 ` +
+        messages.join(' | '),
+    });
+  });
+});


### PR DESCRIPTION
## What this adds

`apps/e2e/tests/preflight-divergence/` — one Playwright spec per finding from the bulk-wizard preflight audit, plus a coverage matrix and a proof-screenshot helper. New Playwright project `preflight-divergence`.

Findings and evidence live in #1934. This PR is only the suite.

## These are characterization tests — read this before reacting to a red run

Each spec **passes while the divergence exists** and **fails once it is closed**. A red run here is the signal that a finding was wrong or has been fixed — not a regression. Every spec header says so.

When a bug is fixed, the corresponding spec is **inverted, not deleted**, so it keeps guarding the fixed behaviour afterwards.

Every spec asserts **both halves** of its finding:
- what the wizard presents (ready row, enabled CTA, displayed value), and
- what actually happens (4xx, terminal record error code, or a batch that never terminates).

A spec asserting only the failure would be worthless — the contradiction is the whole claim.

## Status per finding

| Finding | Spec | Status |
|---|---|---|
| F1 | `f01-offer-section-params` | reproduced live |
| F2 | `f02-already-listed-dropped` | reproduced live (ended-offer case skipped) |
| F3 | `f03-zero-price` | reproduced live |
| F4 | `f04-master-catalog-missing` | reproduced live |
| F5 | `f05-seller-defaults` | reproduced live |
| F6 | `f06-erli-image-stuck-pending` | reproduced live |
| F7 | `f07-duplicate-ean` | reproduced live |
| F8 | `f08-ceilings` | partial — expansion ceiling needs >1000 variants |
| F9 | `f09-multivariant-stock-policy` | partial — zero-stock degradation needs a fixture |
| F10 | `f10-erli-category-gate` | reproduced live |
| F11 | `f11-title-overflow` | partial — final step masked by F1 |
| F12 | `f12-category-override-rejected` | skipped — the verification stack already carried PR #1930 |
| F13 | `f13-blocked-not-excluded` | reproduced live |
| F14 | `f14-ean-trim` | **finding disproved** — the spec now guards the invariant that makes it impossible |
| F15 | `f15-pricing-policy-rejected` | reproduced live |

Every skip carries an explicit message naming the missing fixture and how to create it; none silently pass. The suite README documents each un-skip recipe.

## ⚠️ Proof screenshots are not in yet

19 `captureProof(...)` calls are wired across the eleven live findings, and the capture path is verified end-to-end (region shot, viewport shot, fallback, and swallowed-failure behaviour all confirmed against real PNGs).

**No images were produced** because the shared `ol-demo-fresh` stack was rebuilt mid-run onto an empty database from a different branch. The Allegro and Erli connections every one of these specs needs no longer exist, so all eleven now self-skip in ~2 s. Nothing was fabricated to work around it.

Naming convention is already fixed so the before/after pairing works later: `fNN-before-review-ready.png` / `fNN-before-result.png`, with `-after-` counterparts to be produced from the same specs once the bugs are fixed.

Three frames are missing **by construction**, not by omission — documented in `__proof__/README.md`:
- **F5** has no review-ready frame: the spec submits through the raw API because the wizard has no seller-defaults preflight to photograph. That absence *is* the finding.
- **F7** and **F9** have no result frame: F7's confirmed half is a wire-level 400 raised before anything persists, and F9's discard is only visible in the persisted request snapshot — the progress table has no stock column.

## Notes

- Nothing under `apps/e2e/src/` was modified. The stale `bulk-offer-wizard.page.ts` is deliberately unused by this suite: its `needsAttentionCount()` **fails open** (it parses the first number of `"N ready · M need attention · K excluded"`, i.e. the ready count). Worth fixing separately — existing specs elsewhere may be asserting nothing.
- `pnpm --filter @openlinker/e2e test:e2e -- --project=X <file>` does **not** filter; the `--` swallows the arguments and runs everything. Use `cd apps/e2e && npx playwright test --project=preflight-divergence <file>`.
- Some specs mutate shared connection config (F4, F5, F10) and restore it in `finally` plus re-assert in `afterAll`. Run them sequentially.

## How to verify

```bash
cd apps/e2e
npx playwright test --project=preflight-divergence tests/preflight-divergence/f15-pricing-policy-rejected.spec.ts
```

Requires a stack with an active Allegro connection and an active Erli connection carrying Allegro category credentials. Points anywhere via `OL_WEB_URL` / `OL_API_URL` / `OL_ADMIN_USER` / `OL_ADMIN_PASS`.

Refs #1934

🤖 Generated with [Claude Code](https://claude.com/claude-code)
