### PR TITLE
fix(web/connections): let a disabled connection be re-enabled from the UI

### DIFF
--- a/apps/web/e2e/README.md
+++ b/apps/web/e2e/README.md
@@ -39,4 +39,10 @@ required env vars either exit early with a message or produce error/404 shots.
 | `ksef-payment-config.mjs` | KSeF payment-config form | `KSEF_CONN_ID`, `WEB_USER`, `WEB_PASSWORD` |
 | `infakt-connection.mjs` | inFakt connection setup | `INFAKT_BASE_URL`, `INFAKT_SANDBOX_API_KEY`, `INFAKT_CONN_NAME` |
 | `infakt-invoice.mjs` | inFakt invoice + clearance | `INFAKT_CONNECTION_ID`, `ORDER_ID`, `CLEARANCE_POLL_MS` |
+| `connection-enable.mjs` | Connection disable → enable round trip (#1940) | `CONNECTION_ID`, `WEB_BASE`, `OUT_DIR`, `HEADED` |
 | `annotate.mjs` | Shared image-annotation helper | (imported by other scripts) |
+
+`connection-enable.mjs` is the one script here that asserts as it goes: every step
+waits for the control it expects and throws if the state is wrong, so a green run
+is evidence the flow works, not just that screenshots exist. It leaves the
+connection `active`, the state it found it in.

--- a/apps/web/e2e/connection-enable.mjs
+++ b/apps/web/e2e/connection-enable.mjs
@@ -62,8 +62,14 @@ async function resolveConnectionId(page) {
   return id;
 }
 
+/**
+ * `.status-badge` is `text-transform: uppercase`, and `innerText` returns the
+ * *rendered* text — so the DOM value "active" reads back as "ACTIVE". Normalise
+ * rather than comparing against the styled casing.
+ */
 async function statusBadgeText(page) {
-  return (await page.locator('.page-summary .status-badge').first().innerText()).trim();
+  const text = await page.locator('.page-summary .status-badge').first().innerText();
+  return text.trim().toLowerCase();
 }
 
 async function main() {

--- a/apps/web/e2e/connection-enable.mjs
+++ b/apps/web/e2e/connection-enable.mjs
@@ -1,0 +1,160 @@
+/**
+ * Connection enable/disable round-trip capture (#1940).
+ *
+ * Drives the real UI through the full loop on a live stack: disable an active
+ * connection, prove the recovery controls appear, enable it again, and prove the
+ * connection is back to `active`. Produces the screenshots that evidence the fix.
+ *
+ * Like every script in this folder it is a documentation-capture script, not an
+ * automated test — no runner executes it. It does, however, fail loudly: each
+ * step asserts the control it expects before shooting, so a green run means the
+ * flow genuinely worked rather than that a screenshot was taken of a broken page.
+ *
+ * Usage:
+ *   WEB_BASE=http://localhost:8090 API_BASE=http://localhost:3000 \
+ *   CONNECTION_ID=<uuid> node apps/web/e2e/connection-enable.mjs
+ *
+ * Env:
+ *   WEB_BASE          web app base URL (default http://localhost:4173)
+ *   API_BASE          API base URL, used only to restore state on failure
+ *   CONNECTION_ID     connection to drive; defaults to the first active one found
+ *   OL_ADMIN_USERNAME / OL_ADMIN_PASSWORD   admin login (default admin / admin)
+ *   OUT_DIR           screenshot output directory (default ./e2e-out)
+ *   HEADED            set to 1 to watch the run
+ */
+import { chromium } from '@playwright/test';
+import { mkdir } from 'node:fs/promises';
+import { annotate, clearAnnotations } from './annotate.mjs';
+
+const WEB_BASE = process.env.WEB_BASE ?? 'http://localhost:4173';
+const USERNAME = process.env.OL_ADMIN_USERNAME ?? 'admin';
+const PASSWORD = process.env.OL_ADMIN_PASSWORD ?? 'admin';
+const OUT_DIR = process.env.OUT_DIR ?? 'e2e-out';
+const CONNECTION_ID = process.env.CONNECTION_ID ?? '';
+
+let shotIndex = 0;
+async function shot(page, name) {
+  shotIndex += 1;
+  const path = `${OUT_DIR}/${String(shotIndex).padStart(2, '0')}-${name}.png`;
+  await page.screenshot({ path, fullPage: true });
+  console.log(`  captured ${path}`);
+  return path;
+}
+
+async function login(page) {
+  await page.goto(`${WEB_BASE}/login`, { waitUntil: 'domcontentloaded' });
+  await page.getByLabel(/username/i).fill(USERNAME);
+  await page.getByLabel(/password/i).fill(PASSWORD);
+  await page.getByRole('button', { name: /sign in/i }).click();
+  await page.waitForURL((url) => !url.pathname.startsWith('/login'), { timeout: 30_000 });
+}
+
+/** Resolve a connection to drive: the explicit id, else the first active row. */
+async function resolveConnectionId(page) {
+  if (CONNECTION_ID) return CONNECTION_ID;
+
+  await page.goto(`${WEB_BASE}/connections?status=active`, { waitUntil: 'domcontentloaded' });
+  const firstRow = page.locator('a[href^="/connections/"]').first();
+  await firstRow.waitFor({ timeout: 15_000 });
+  const href = await firstRow.getAttribute('href');
+  const id = href?.split('/').filter(Boolean)[1];
+  if (!id) throw new Error('No active connection found — pass CONNECTION_ID explicitly.');
+  return id;
+}
+
+async function statusBadgeText(page) {
+  return (await page.locator('.page-summary .status-badge').first().innerText()).trim();
+}
+
+async function main() {
+  await mkdir(OUT_DIR, { recursive: true });
+
+  const browser = await chromium.launch({ headless: process.env.HEADED !== '1' });
+  const context = await browser.newContext({
+    viewport: { width: 1440, height: 1000 },
+    colorScheme: 'dark',
+  });
+  const page = await context.newPage();
+
+  try {
+    await login(page);
+    const connectionId = await resolveConnectionId(page);
+    const detailUrl = `${WEB_BASE}/connections/${connectionId}`;
+    console.log(`Driving connection ${connectionId}`);
+
+    // ── 1. Starting point: an active connection, Actions tab ──────────────
+    await page.goto(`${detailUrl}?tab=actions`, { waitUntil: 'domcontentloaded' });
+    await page.getByRole('button', { name: 'Disable' }).waitFor({ timeout: 15_000 });
+    if ((await statusBadgeText(page)) !== 'active') {
+      throw new Error('Connection is not active at the start — cannot drive the round trip.');
+    }
+    await annotate(page, [
+      { locator: page.getByRole('button', { name: 'Disable' }), shape: 'ellipse', arrow: true },
+    ]);
+    await shot(page, 'active-actions-tab');
+    await clearAnnotations(page);
+
+    // ── 2. Disable it ─────────────────────────────────────────────────────
+    await page.getByRole('button', { name: 'Disable' }).click();
+    await page.getByRole('button', { name: 'Disable connection' }).click();
+    await page.waitForSelector('text=Connection disabled', { timeout: 15_000 });
+    await shot(page, 'disable-confirmed');
+
+    // ── 3. The fix, part 1: the Actions tab now offers Enable ─────────────
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    const enableRowButton = page.getByRole('button', { name: 'Enable', exact: true });
+    await enableRowButton.waitFor({ timeout: 15_000 });
+    if ((await statusBadgeText(page)) !== 'disabled') {
+      throw new Error('Status badge did not flip to disabled.');
+    }
+    await annotate(page, [{ locator: enableRowButton, shape: 'ellipse', arrow: true }]);
+    await shot(page, 'disabled-actions-tab-offers-enable');
+    await clearAnnotations(page);
+
+    // ── 4. The fix, part 2: the sync-paused banner on the detail page ─────
+    await page.goto(detailUrl, { waitUntil: 'domcontentloaded' });
+    const banner = page.locator('.alert', { hasText: 'Syncing is paused' });
+    await banner.waitFor({ timeout: 15_000 });
+    await annotate(page, [{ locator: banner }]);
+    await shot(page, 'disabled-sync-paused-banner');
+    await clearAnnotations(page);
+
+    // ── 5. Enable from the banner, and prove it took ──────────────────────
+    await page.getByRole('button', { name: 'Enable connection' }).click();
+    await page.waitForSelector('text=Connection enabled', { timeout: 15_000 });
+    await shot(page, 'enable-confirmed-toast');
+
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.waitForSelector('.page-summary .status-badge', { timeout: 15_000 });
+    const finalStatus = await statusBadgeText(page);
+    if (finalStatus !== 'active') {
+      throw new Error(`Expected status active after enable, got "${finalStatus}".`);
+    }
+    if (await page.locator('.alert', { hasText: 'Syncing is paused' }).count()) {
+      throw new Error('Sync-paused banner still present after enabling.');
+    }
+    await annotate(page, [
+      { locator: page.locator('.page-summary .status-badge').first(), padding: 6 },
+    ]);
+    await shot(page, 'active-again-after-enable');
+    await clearAnnotations(page);
+
+    // ── 6. Actions tab is whole again ─────────────────────────────────────
+    await page.goto(`${detailUrl}?tab=actions`, { waitUntil: 'domcontentloaded' });
+    await page.getByRole('button', { name: 'Disable' }).waitFor({ timeout: 15_000 });
+    if (await page.getByRole('button', { name: 'Enable', exact: true }).count()) {
+      throw new Error('Enable row is still rendered for an active connection.');
+    }
+    await shot(page, 'active-actions-tab-restored');
+
+    console.log('\nRound trip complete: active -> disabled -> active, all from the UI.');
+  } finally {
+    await context.close();
+    await browser.close();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/apps/web/src/features/connections/components/ConnectionActionsPanel.test.tsx
+++ b/apps/web/src/features/connections/components/ConnectionActionsPanel.test.tsx
@@ -40,13 +40,57 @@ describe('ConnectionActionsPanel', () => {
     expect(screen.getByRole('button', { name: 'Disable' })).toBeInTheDocument();
   });
 
-  it('hides trigger sync and disable when connection is already disabled', async () => {
+  it('offers enable instead of disable when connection is already disabled', async () => {
     const disabledConnection = { ...sampleConnection, status: 'disabled' as const };
     renderWithProviders(<ConnectionActionsPanel connection={disabledConnection} />, adminSession);
 
     expect(await screen.findByRole('link', { name: 'Edit' })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /trigger sync/i })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Disable' })).not.toBeInTheDocument();
+    // #1940 — the recovery control the panel used to omit entirely.
+    expect(screen.getByRole('button', { name: 'Enable' })).toBeInTheDocument();
+  });
+
+  it('does not offer enable for a connection that is not disabled', async () => {
+    renderWithProviders(<ConnectionActionsPanel connection={sampleConnection} />, adminSession);
+
+    expect(await screen.findByRole('button', { name: 'Disable' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Enable' })).not.toBeInTheDocument();
+  });
+
+  it('patches status to active and confirms with a toast when enable is clicked', async () => {
+    const disabledConnection = { ...sampleConnection, status: 'disabled' as const };
+    const update = vi.fn().mockResolvedValue({ ...disabledConnection, status: 'active' });
+    const apiClient = createMockApiClient({ connections: { update } });
+
+    renderWithProviders(<ConnectionActionsPanel connection={disabledConnection} />, {
+      apiClient,
+      ...adminSession,
+    });
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Enable' }));
+
+    await waitFor(() => {
+      expect(update).toHaveBeenCalledWith(disabledConnection.id, { status: 'active' });
+    });
+    expect(await screen.findByText('Connection enabled')).toBeInTheDocument();
+  });
+
+  it('surfaces an error toast and no success toast when enable fails', async () => {
+    const disabledConnection = { ...sampleConnection, status: 'disabled' as const };
+    const update = vi.fn().mockRejectedValue(new Error('Connection is locked by another job'));
+    const apiClient = createMockApiClient({ connections: { update } });
+
+    renderWithProviders(<ConnectionActionsPanel connection={disabledConnection} />, {
+      apiClient,
+      ...adminSession,
+    });
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Enable' }));
+
+    expect(await screen.findByText('Unable to enable connection')).toBeInTheDocument();
+    expect(screen.getByText('Connection is locked by another job')).toBeInTheDocument();
+    expect(screen.queryByText('Connection enabled')).not.toBeInTheDocument();
   });
 
   it('links edit action to the correct URL', async () => {
@@ -124,6 +168,16 @@ describe('ConnectionActionsPanel', () => {
       expect(captureDemoEvent).toHaveBeenCalledWith('demo_connection_test_attempted', {
         platform: 'prestashop',
       });
+    });
+
+    it('renders enable visible-but-disabled for a disabled connection (#1940)', async () => {
+      const disabledConnection = { ...sampleConnection, status: 'disabled' as const };
+      renderWithProviders(<ConnectionActionsPanel connection={disabledConnection} />, {
+        apiClient: demoApiClient(),
+        ...viewerSession,
+      });
+
+      expect(await screen.findByRole('button', { name: 'Enable' })).toBeDisabled();
     });
 
     it('opens the TriggerSyncDialog with an enabled job type select but a disabled Trigger submit', async () => {

--- a/apps/web/src/features/connections/components/ConnectionActionsPanel.tsx
+++ b/apps/web/src/features/connections/components/ConnectionActionsPanel.tsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import type { Connection } from '../api/connections.types';
 import { useDisableConnectionMutation } from '../hooks/use-disable-connection-mutation';
 import { useTestConnectionMutation } from '../hooks/use-test-connection-mutation';
+import { EnableConnectionButton } from './EnableConnectionButton';
 import { usePlatform } from '../../../shared/plugins';
 import { TriggerSyncDialog } from '../../sync-jobs';
 import { Button } from '../../../shared/ui/button';
@@ -153,6 +154,19 @@ export function ConnectionActionsPanel({ connection }: ConnectionActionsPanelPro
                 {disableConnection.isPending ? 'Disabling...' : 'Disable'}
               </Button>
             </ReadOnlyLock>
+          </div>
+        ) : null}
+
+        {write.visible && isDisabled ? (
+          <div className="action-list__item">
+            <div>
+              <strong>Enable connection</strong>
+              <p className="muted-text">
+                Resume sync activity for this connection. Scheduled jobs start again on the next
+                run.
+              </p>
+            </div>
+            <EnableConnectionButton connection={connection} />
           </div>
         ) : null}
       </div>

--- a/apps/web/src/features/connections/components/EnableConnectionButton.tsx
+++ b/apps/web/src/features/connections/components/EnableConnectionButton.tsx
@@ -1,0 +1,76 @@
+/**
+ * Enable Connection Button
+ *
+ * Returns a `disabled` connection to `active` by patching its status (#1940).
+ * Shared by the two surfaces that offer the recovery — the Actions panel row and
+ * the detail page's sync-paused banner — so the mutation, the toast copy, and the
+ * demo-mode lock live in one place instead of once per surface.
+ *
+ * Visibility is the caller's decision: both call sites already branch on
+ * `connections:write` before mounting this. The component owns interactivity only
+ * (pending state and the demo read-only lock).
+ *
+ * There is deliberately no confirm dialog. Disable opens one because it stops
+ * every job on a live integration; enabling is the recovery from that and should
+ * not charge an extra click.
+ *
+ * @module features/connections/components
+ * @see {@link ConnectionActionsPanel} for the Actions-tab row
+ */
+import type { ReactElement } from 'react';
+import type { Connection } from '../api/connections.types';
+import { useUpdateConnectionMutation } from '../hooks/use-update-connection-mutation';
+import { Button } from '../../../shared/ui/button';
+import { useToast } from '../../../shared/ui/toast-provider';
+import { ReadOnlyLock } from '../../../shared/ui/read-only-lock';
+import { useWriteAccess } from '../../../shared/auth/use-permission';
+import { DEMO_READ_ONLY_ACTION_MESSAGE } from '../../../shared/config/demo-mode';
+import { useDemoMode } from '../../system';
+
+interface EnableConnectionButtonProps {
+  connection: Connection;
+  /** Defaults to the terse form used inside the Actions panel's row. */
+  label?: string;
+}
+
+export function EnableConnectionButton({
+  connection,
+  label = 'Enable',
+}: EnableConnectionButtonProps): ReactElement {
+  const updateConnection = useUpdateConnectionMutation();
+  const { showToast } = useToast();
+
+  const demoMode = useDemoMode();
+  const write = useWriteAccess('connections:write', demoMode);
+
+  async function handleEnable(): Promise<void> {
+    try {
+      await updateConnection.mutateAsync({
+        connectionId: connection.id,
+        input: { status: 'active' },
+      });
+      showToast({
+        tone: 'success',
+        title: 'Connection enabled',
+        description: `"${connection.name}" is active again. Syncing resumes on the next scheduled run.`,
+      });
+    } catch (error) {
+      showToast({
+        tone: 'error',
+        title: 'Unable to enable connection',
+        description: (error as Error).message,
+      });
+    }
+  }
+
+  return (
+    <ReadOnlyLock active={write.demoReadOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
+      <Button
+        disabled={updateConnection.isPending || write.demoReadOnly}
+        onClick={() => void handleEnable()}
+      >
+        {updateConnection.isPending ? 'Enabling…' : label}
+      </Button>
+    </ReadOnlyLock>
+  );
+}

--- a/apps/web/src/pages/connections/connection-detail-page.test.tsx
+++ b/apps/web/src/pages/connections/connection-detail-page.test.tsx
@@ -392,4 +392,57 @@ describe('ConnectionDetailPage', () => {
       expect(screen.queryByText('Re-authentication required')).toBeNull();
     });
   });
+
+  describe('SyncPausedBanner (#1940)', () => {
+    it('explains the pause and offers a recovery control when status is disabled', async () => {
+      const connection = makeAllegro({ status: 'disabled' });
+      const apiClient = apiClientForBanner(connection, []);
+
+      renderWithProviders(
+        <Routes>
+          <Route path="/connections/:connectionId" element={<ConnectionDetailPage />} />
+        </Routes>,
+        {
+          apiClient,
+          route: `/connections/${connection.id}`,
+          sessionAdapter: createAuthenticatedSessionAdapter(),
+        },
+      );
+      await screen.findByRole('heading', { name: 'Overview' });
+
+      expect(await screen.findByText('Syncing is paused')).toBeInTheDocument();
+      expect(
+        await screen.findByRole('button', { name: 'Enable connection' }),
+      ).toBeInTheDocument();
+    });
+
+    it('omits the recovery control for a viewer without connections:write', async () => {
+      const connection = makeAllegro({ status: 'disabled' });
+      const apiClient = apiClientForBanner(connection, []);
+
+      renderWithProviders(
+        <Routes>
+          <Route path="/connections/:connectionId" element={<ConnectionDetailPage />} />
+        </Routes>,
+        {
+          apiClient,
+          route: `/connections/${connection.id}`,
+          sessionAdapter: viewerSessionAdapter,
+        },
+      );
+      await screen.findByRole('heading', { name: 'Overview' });
+
+      // The explanation is still worth showing; only the write control is gated.
+      expect(await screen.findByText('Syncing is paused')).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Enable connection' })).toBeNull();
+    });
+
+    it('does NOT show the sync-paused banner when the connection is active', async () => {
+      const connection = makeAllegro({ status: 'active' });
+      const apiClient = apiClientForBanner(connection, []);
+      await renderDetailPage(connection, apiClient);
+
+      expect(screen.queryByText('Syncing is paused')).toBeNull();
+    });
+  });
 });

--- a/apps/web/src/pages/connections/connection-detail-page.tsx
+++ b/apps/web/src/pages/connections/connection-detail-page.tsx
@@ -3,6 +3,7 @@ import { Link, useParams, useSearchParams } from 'react-router-dom';
 import { useConnectionQuery } from '../../features/connections/hooks/use-connection-query';
 import { useProductMasterConnections } from '../../features/connections/hooks/use-product-master-connections';
 import { ConnectionActionsPanel } from '../../features/connections/components/ConnectionActionsPanel';
+import { EnableConnectionButton } from '../../features/connections/components/EnableConnectionButton';
 import { ConnectionCapabilitiesPanel } from '../../features/connections/components/ConnectionCapabilitiesPanel';
 import { ConnectionConfigPanel } from '../../features/connections/components/ConnectionConfigPanel';
 import { ConnectionDiagnosticsPanel } from '../../features/connections/components/ConnectionDiagnosticsPanel';
@@ -16,6 +17,8 @@ import { TimeDisplay } from '../../shared/ui/time-display';
 import { StatusBadge, type StatusBadgeTone } from '../../shared/ui/status-badge';
 import { Alert } from '../../shared/ui/alert';
 import { usePlatform } from '../../shared/plugins';
+import { useWriteAccess } from '../../shared/auth/use-permission';
+import { useDemoMode } from '../../features/system';
 
 function toStatusTone(status: ConnectionStatus): StatusBadgeTone {
   switch (status) {
@@ -69,6 +72,39 @@ function ReauthRequiredBanner({ connection }: { connection: Connection }): React
       OpenLinker can no longer authenticate with {platformLabel} — the stored credentials were
       rejected, so syncing is paused for this connection. Re-authenticate to restore access; the
       connection and its mappings are preserved.
+    </Alert>
+  );
+}
+
+/**
+ * Sync-paused banner (#1940).
+ *
+ * Shown when an operator has disabled the connection. Mirrors
+ * {@link ReauthRequiredBanner} — one status, one explanation, one recovery
+ * control — so the pause is visible and reversible from the page itself rather
+ * than only from the Actions tab.
+ *
+ * Info tone, not warning: a disabled connection is a deliberate operator choice,
+ * not a fault. The warning tone stays reserved for states nobody asked for.
+ */
+function SyncPausedBanner({ connection }: { connection: Connection }): ReactElement | null {
+  const demoMode = useDemoMode();
+  const write = useWriteAccess('connections:write', demoMode);
+
+  if (connection.status !== 'disabled') return null;
+
+  return (
+    <Alert
+      tone="info"
+      title="Syncing is paused"
+      action={
+        write.visible ? (
+          <EnableConnectionButton connection={connection} label="Enable connection" />
+        ) : undefined
+      }
+    >
+      This connection is disabled, so OpenLinker runs no jobs against it. Its configuration,
+      credentials, and mappings are untouched. Enable it to resume.
     </Alert>
   );
 }
@@ -247,6 +283,7 @@ export function ConnectionDetailPage(): ReactElement {
         />
       ) : null}
       {connection ? <ReauthRequiredBanner connection={connection} /> : null}
+      {connection ? <SyncPausedBanner connection={connection} /> : null}
       {connection ? (
         <ProductCatalogLinkBanner
           connection={connection}


### PR DESCRIPTION
## What

Disabling a connection was a one-way door in the UI. A `disabled` connection's Actions tab rendered two configuration rows (Test, Edit) and no control that returns it to `active`.

`ConnectionActionsPanel.tsx:35` computes `isDisabled` and only ever *removes* rows with it - Trigger sync at `:120`, Disable at `:141` - with no counterpart branch. Meanwhile the copy promised the reversal on two surfaces:

- `:145` - "Stop all sync activity for this connection. This can be reversed by re-enabling."
- `:171` - confirm dialog: "You can re-enable it later."

The omission was pinned in place by `ConnectionActionsPanel.test.tsx:43`, which asserted only that the two rows disappear. Nothing asserted a recovery control, so nothing failed when one was never written.

**No backend change.** `PATCH /v1/connections/:id` already accepts `status: 'active'` - no state machine, no guard (`connection.service.ts:405-472`, `connection.repository.ts:105-107`). `apiClient.connections.update` and `UpdateConnectionInput.status` were already typed and wired; no caller had ever sent the field.

## How

**`EnableConnectionButton`** (new, `features/connections/components/`) owns the mutation, the toast copy, and the demo read-only lock once, shared by both surfaces. Visibility is the caller's decision - both call sites already branch on `connections:write` - so the component owns interactivity only (pending label, `ReadOnlyLock`).

**`ConnectionActionsPanel`** gains the mirrored `write.visible && isDisabled` row, in the position Disable vacates.

**`SyncPausedBanner`** (new, on the connection detail page) mirrors `ReauthRequiredBanner` (#819): one status, one explanation, one recovery control, so the pause is visible and reversible from the page itself rather than only from the Actions tab.

### Two deliberate decisions

- **No confirm dialog on Enable.** Disable opens one because it stops every job on a live integration; enabling is the recovery from that and should not charge an extra click. The row copy states what resumes, the change is immediately reversible by the control next to it, and the toast confirms the result.
- **`info` tone on the banner, not `warning`.** A disabled connection is a deliberate operator choice, not a fault. The warning tone stays reserved for states nobody asked for.

### Deviation from the issue

The issue's acceptance criteria said a failed enable renders "the panel's error `Alert`". Because the button is shared with the banner (which has no `Alert` slot), failures surface as an **error toast** instead - matching `handleTest` in the same panel, which already uses a toast for non-form action failures. Covered by a test.

## Side effect

This unblocks an existing dead end: `features/orders/components/delivery-rider-action.tsx:67-83` renders an `Enable {carrier}` button that deep-links to the connections list, with the source comment "so they can find and re-enable it". That path ended on a detail page with no enable control. It now ends on one, without touching the orders page.

## Tests

Per this repo's local-machine constraints the test suite was **not run locally** - CI is the gate. Added:

- `ConnectionActionsPanel.test.tsx` - Enable offered when disabled / absent when active; click patches `{ status: 'active' }` and toasts; failure path toasts the error and shows no success toast; demo viewer sees it visible-but-disabled. The `:43` test is rewritten from "hides trigger sync and disable" to "offers enable instead of disable".
- `connection-detail-page.test.tsx` - banner renders with its recovery control for an admin, renders the explanation without the control for a viewer, and is absent for an active connection.

`pnpm --filter @openlinker/web lint` and `type-check` both pass with zero errors.

## Verification

`apps/web/e2e/connection-enable.mjs` drives the full round trip on a live stack: active -> Disable -> Actions tab offers Enable -> banner appears -> Enable -> back to `active` with the banner gone and the Disable row restored. Unlike its siblings in that folder it asserts each step before shooting, so a green run is evidence rather than just screenshots.

Screenshots from a live run are posted in a comment below.

Closes #1940

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DuTgMJhzRRith8BAgY8hyy
