### PR TITLE
fix(web/listings): serialize a variant's parameters with its own category schema

### DIFF
--- a/apps/web/src/features/listings/components/bulk/bulk-edit-modal.test.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-edit-modal.test.tsx
@@ -33,6 +33,15 @@ vi.mock('../../hooks/use-category-parameters-query', () => ({
     error: null,
   }),
 }));
+// Mutable so a test can drive the schema of a category ONE sibling overrode
+// (#1946). Keyed by category id, mirroring the hook's own shape.
+let mockVariantSchemas = new Map<string, unknown[]>();
+vi.mock('../../hooks/use-category-parameter-schemas', () => ({
+  useCategoryParameterSchemas: () => ({
+    schemasByCategory: mockVariantSchemas,
+    isResolving: false,
+  }),
+}));
 vi.mock('../../../content', () => ({ SuggestionDialog: () => null }));
 // Stub only the heavy base-scope step; keep the real value<->combobox helpers
 // the per-variant dictionary override reuses.
@@ -186,9 +195,120 @@ function makeMultiRow(): BulkWizardRow {
   };
 }
 
+// A multi-variant product whose second sibling overrode its category (#1930):
+// base sits in `cat_men`, `var_m` in `cat_women`.
+function makeMultiRowWithVariantCategory(): BulkWizardRow {
+  const row = makeMultiRow();
+  return {
+    ...row,
+    override: { overrides: { categoryId: 'cat_men' } },
+    variants: row.variants.map((v) =>
+      v.variantId === 'var_m'
+        ? { ...v, override: { overrides: { categoryId: 'cat_women' } } }
+        : v,
+    ),
+  };
+}
+
+/** The EAN/GTIN slot of a category - the parameter `injectEanParameter` fills. */
+function eanSlot(id: string): Record<string, unknown> {
+  return { id, name: 'EAN (GTIN)', type: 'string', required: false, section: 'product' };
+}
+
+function savedVariantParams(
+  onSave: ReturnType<typeof vi.fn>,
+  variantId: string,
+): Array<{ id: string; values?: string[] }> {
+  const perVariant = onSave.mock.calls[0][2] as Record<
+    string,
+    { overrides?: { parameters?: Array<{ id: string; values?: string[] }> } }
+  >;
+  return perVariant[variantId]?.overrides?.parameters ?? [];
+}
+
 describe('BulkEditModal', () => {
   beforeEach(() => {
     mockCategoryParameters = [];
+    mockVariantSchemas = new Map();
+  });
+
+  // #1946: the sibling's fields are rendered from its OWN category's schema, so
+  // the save has to serialize against that same schema. Serializing against the
+  // base schema silently dropped every value keyed by the overridden category's
+  // parameter ids, and never filled that category's GTIN slot.
+  it('serializes a sibling with an overridden category against that category schema (#1946)', async () => {
+    const onSave = vi.fn();
+    mockCategoryParameters = [eanSlot('ean_men')];
+    mockVariantSchemas = new Map([['cat_women', [eanSlot('ean_women')]]]);
+
+    renderWithProviders(
+      <BulkEditModal
+        open
+        onOpenChange={() => undefined}
+        row={makeMultiRowWithVariantCategory()}
+        connection={connection}
+        canBrowseCategories={true}
+        currency="PLN"
+        defaults={DEFAULTS}
+        onSave={onSave}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save all' }));
+    await waitFor(() => { expect(onSave).toHaveBeenCalledTimes(1); });
+
+    // The overridden sibling carries ITS category's GTIN slot, not the base's.
+    expect(savedVariantParams(onSave, 'var_m').map((p) => p.id)).toEqual(['ean_women']);
+    expect(savedVariantParams(onSave, 'var_m')[0]?.values).toEqual(['5900531001130']);
+  });
+
+  it('keeps serializing a sibling without an overridden category against the base schema (#1946)', async () => {
+    const onSave = vi.fn();
+    mockCategoryParameters = [eanSlot('ean_men')];
+    mockVariantSchemas = new Map([['cat_women', [eanSlot('ean_women')]]]);
+
+    renderWithProviders(
+      <BulkEditModal
+        open
+        onOpenChange={() => undefined}
+        row={makeMultiRowWithVariantCategory()}
+        connection={connection}
+        canBrowseCategories={true}
+        currency="PLN"
+        defaults={DEFAULTS}
+        onSave={onSave}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save all' }));
+    await waitFor(() => { expect(onSave).toHaveBeenCalledTimes(1); });
+
+    expect(savedVariantParams(onSave, 'var_s').map((p) => p.id)).toEqual(['ean_men']);
+  });
+
+  it('blocks the save while an overridden category schema has not resolved (#1946)', async () => {
+    const onSave = vi.fn();
+    mockCategoryParameters = [eanSlot('ean_men')];
+    // `cat_women` absent ⇒ still loading. Emitting now would write base ids.
+    mockVariantSchemas = new Map();
+
+    renderWithProviders(
+      <BulkEditModal
+        open
+        onOpenChange={() => undefined}
+        row={makeMultiRowWithVariantCategory()}
+        connection={connection}
+        canBrowseCategories={true}
+        currency="PLN"
+        defaults={DEFAULTS}
+        onSave={onSave}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save all' }));
+    await new Promise((resolve) => { setTimeout(resolve, 50); });
+
+    expect(onSave).not.toHaveBeenCalled();
   });
 
   it('renders a suggested-category chip per multi-match candidate, falling back to the id', () => {

--- a/apps/web/src/features/listings/components/bulk/bulk-edit-modal.test.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-edit-modal.test.tsx
@@ -36,10 +36,15 @@ vi.mock('../../hooks/use-category-parameters-query', () => ({
 // Mutable so a test can drive the schema of a category ONE sibling overrode
 // (#1946). Keyed by category id, mirroring the hook's own shape.
 let mockVariantSchemas = new Map<string, unknown[]>();
+// Categories whose schema request FAILED (as opposed to being in flight) - the
+// distinction the panel's retry affordance and the blocked-save toast key on.
+let mockFailedSchemaCategories = new Set<string>();
+const mockRetryCategory = vi.fn();
 vi.mock('../../hooks/use-category-parameter-schemas', () => ({
   useCategoryParameterSchemas: () => ({
     schemasByCategory: mockVariantSchemas,
-    isResolving: false,
+    failedCategoryIds: mockFailedSchemaCategories,
+    retryCategory: mockRetryCategory,
   }),
 }));
 vi.mock('../../../content', () => ({ SuggestionDialog: () => null }));
@@ -230,6 +235,8 @@ describe('BulkEditModal', () => {
   beforeEach(() => {
     mockCategoryParameters = [];
     mockVariantSchemas = new Map();
+    mockFailedSchemaCategories = new Set();
+    mockRetryCategory.mockClear();
   });
 
   // #1946: the sibling's fields are rendered from its OWN category's schema, so
@@ -309,6 +316,47 @@ describe('BulkEditModal', () => {
     await new Promise((resolve) => { setTimeout(resolve, 50); });
 
     expect(onSave).not.toHaveBeenCalled();
+    // The block must say so - a click that switches scope and does nothing else
+    // is the same unexplained dead-end #1946 fixed, one step later.
+    expect(
+      await screen.findByText("Can't save yet - a variant's category parameters are still loading"),
+    ).toBeInTheDocument();
+  });
+
+  // A permanently-failed schema query is indistinguishable from a loading one at
+  // the map level, but only one of them ever resolves itself: without the split
+  // the blocked save loops forever with nothing to act on.
+  it('offers a retry when an overridden category schema failed rather than loading (#1946)', async () => {
+    const onSave = vi.fn();
+    mockCategoryParameters = [eanSlot('ean_men')];
+    mockVariantSchemas = new Map();
+    mockFailedSchemaCategories = new Set(['cat_women']);
+
+    renderWithProviders(
+      <BulkEditModal
+        open
+        onOpenChange={() => undefined}
+        row={makeMultiRowWithVariantCategory()}
+        connection={connection}
+        canBrowseCategories={true}
+        currency="PLN"
+        defaults={DEFAULTS}
+        onSave={onSave}
+      />,
+    );
+
+    // The blocked save opens the offending sibling's scope...
+    fireEvent.click(screen.getByRole('button', { name: 'Save all' }));
+
+    // ...and the toast names the failure, not a wait.
+    expect(
+      await screen.findByText("Can't save yet - a variant's category parameters failed to load"),
+    ).toBeInTheDocument();
+    expect(onSave).not.toHaveBeenCalled();
+
+    // The panel offers the way out.
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+    expect(mockRetryCategory).toHaveBeenCalledWith('cat_women');
   });
 
   it('renders a suggested-category chip per multi-match candidate, falling back to the id', () => {

--- a/apps/web/src/features/listings/components/bulk/bulk-edit-modal.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-edit-modal.tsx
@@ -1874,15 +1874,25 @@ function VariantScopeForm({
       ? baseCategoryPathNames.join(' › ')
       : baseValues.categoryId || 'Not set on base';
 
-  // The own-category schema is resolved by the parent (#1946) - it also needs it
-  // at save time for siblings whose panel is not the open scope, so fetching it
-  // here as well would be a second source of truth for the same values.
+  // The own-category schema is read from BOTH here and the parent (#1946): the
+  // parent needs it at save time for every sibling, including one whose panel is
+  // not the open scope, while this panel needs it to render. Both go through the
+  // same `listingsQueryKeys.categoryParameters` cache entry, so this is one
+  // network request with two readers, not two sources of truth - and keeping the
+  // read here means the fields still render if the parent's fan-out has not
+  // resolved this category yet.
+  const ownCategoryParametersQuery = useCategoryParametersQuery(
+    connectionId,
+    hasOwnCategory ? (edit.categoryId as string) : '',
+  );
   const effectiveCategoryParameters = useMemo(
     () =>
       hasOwnCategory
-        ? (ownCategoryParameters ?? []).filter((p) => !isEanParameterName(p.name))
+        ? (ownCategoryParameters ?? ownCategoryParametersQuery.data ?? []).filter(
+            (p) => !isEanParameterName(p.name),
+          )
         : categoryParameters,
-    [hasOwnCategory, ownCategoryParameters, categoryParameters],
+    [hasOwnCategory, ownCategoryParameters, ownCategoryParametersQuery.data, categoryParameters],
   );
 
   // Category parameters mirror the base scope: filter through parameter-level

--- a/apps/web/src/features/listings/components/bulk/bulk-edit-modal.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-edit-modal.tsx
@@ -64,6 +64,7 @@ import type { Connection } from '../../../connections';
 import { resolveVariantGroupingModel } from '../../../connections';
 import { Alert, Button, ConfirmDialog, FormField, Input, Textarea } from '../../../../shared/ui';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../../../../shared/ui/tooltip';
+import { useToast } from '../../../../shared/ui/toast-provider';
 import { ReadOnlyLock } from '../../../../shared/ui/read-only-lock';
 import { DEMO_READ_ONLY_ACTION_MESSAGE } from '../../../../shared/config/demo-mode';
 import {
@@ -471,6 +472,7 @@ function BulkEditModalForm({
   onClose,
 }: BulkEditModalFormProps): ReactElement {
   const connectionId = connection.id;
+  const { showToast } = useToast();
   const platform = usePlatform(connection.platformType);
   const platformName = platform?.displayName ?? connection.platformType;
   const platformSection = platform?.bulkOfferRowSection;
@@ -582,10 +584,10 @@ function BulkEditModalForm({
         .filter((id): id is string => typeof id === 'string' && id.length > 0),
     [row.variants, variantEdits],
   );
-  // `isResolving` is deliberately not consumed: `variantParamSchema` returning
-  // `null` is the per-sibling loading signal, which is finer-grained than one
-  // batch-wide flag (a sibling whose schema is ready must not be held back).
-  const { schemasByCategory } = useCategoryParameterSchemas(
+  // There is deliberately no batch-wide "still resolving" flag: a sibling whose
+  // schema is ready must not be held back by one that is not, so the per-sibling
+  // signal is `variantParamSchema` returning `null`.
+  const { schemasByCategory, failedCategoryIds, retryCategory } = useCategoryParameterSchemas(
     canBrowseCategories ? connectionId : undefined,
     variantCategoryIds,
   );
@@ -616,6 +618,29 @@ function BulkEditModalForm({
       return schemasByCategory.get(ownCategoryId);
     },
     [variantEdits, schemasByCategory],
+  );
+  /**
+   * True when this sibling's overridden category schema FAILED rather than being
+   * in flight. The two are indistinguishable from `variantParamSchema` alone
+   * (both are "no schema"), but only one of them ever resolves itself - so the
+   * panel must offer a retry instead of an indefinite spinner, and the blocked
+   * save must say which of the two it is (#1950 review).
+   */
+  const ownVariantSchemaFailed = useCallback(
+    (variantId: string): boolean => {
+      const ownCategoryId = variantEdits[variantId]?.categoryId;
+      if (ownCategoryId === undefined || ownCategoryId === '') return false;
+      return failedCategoryIds.has(ownCategoryId);
+    },
+    [variantEdits, failedCategoryIds],
+  );
+  const retryOwnVariantSchema = useCallback(
+    (variantId: string): void => {
+      const ownCategoryId = variantEdits[variantId]?.categoryId;
+      if (ownCategoryId === undefined || ownCategoryId === '') return;
+      retryCategory(ownCategoryId);
+    },
+    [variantEdits, retryCategory],
   );
 
   // ── Dirty tracking (vs the on-open snapshot) ──
@@ -677,12 +702,31 @@ function BulkEditModalForm({
     // With no schema at all there is nothing to serialize for any scope, and an
     // operator who picks a variant category must still be able to save the
     // override immediately, before its schema resolves (#1924).
-    if (isMultiVariant && categoryParameters.length > 0) {
+    //
+    // `canBrowseCategories` is load-bearing, not decorative: it is what feeds the
+    // fan-out its connectionId, so with it false NO variant schema can ever
+    // arrive. Today `categoryParameters` is also empty in that case (it comes
+    // from the same connection, guarded by the same flag) making this
+    // unreachable - but the block must never be able to outlive the queries that
+    // clear it, so the invariant is enforced here rather than assumed.
+    if (isMultiVariant && canBrowseCategories && categoryParameters.length > 0) {
       const unresolved = row.variants.find(
         (v) => variantParamSchema(variantEdits[v.variantId]) === null,
       );
       if (unresolved !== undefined) {
         setScope(unresolved.variantId);
+        // Without this the click is a silent no-op - the same unexplained
+        // dead-end #1946 was about, just moved one step later (#1950 review).
+        const failed = ownVariantSchemaFailed(unresolved.variantId);
+        showToast({
+          tone: failed ? 'error' : 'info',
+          title: failed
+            ? "Can't save yet - a variant's category parameters failed to load"
+            : "Can't save yet - a variant's category parameters are still loading",
+          description: failed
+            ? 'Retry from the variant panel below, or clear its category override, then save again.'
+            : 'Save again in a moment.',
+        });
         return;
       }
     }
@@ -1059,6 +1103,8 @@ function BulkEditModalForm({
                       baseCategoryPathNames={displayPathNames}
                       categoryParameters={renderableCategoryParameters}
                       ownCategoryParameters={ownVariantSchema(v.variantId)}
+                      ownCategoryParametersFailed={ownVariantSchemaFailed(v.variantId)}
+                      onRetryOwnCategoryParameters={() => retryOwnVariantSchema(v.variantId)}
                       duplicateEan={dupEanIds.has(v.variantId)}
                       onPatch={(patch) => patchVariant(v.variantId, patch)}
                       onParamChange={(paramId, value) => setVariantParam(v.variantId, paramId, value)}
@@ -1785,6 +1831,14 @@ interface VariantScopeFormProps {
    * while its schema is still loading.
    */
   ownCategoryParameters: CategoryParameter[] | undefined;
+  /**
+   * True when the overridden category's schema request FAILED (as opposed to
+   * still being in flight). Without the distinction a permanently-failed query
+   * renders as an eternal "Loading parameters..." while `Save all` keeps
+   * bouncing back to this scope with nothing to act on (#1950 review).
+   */
+  ownCategoryParametersFailed: boolean;
+  onRetryOwnCategoryParameters: () => void;
   duplicateEan: boolean;
   /** Opens the shared zoom lightbox for an image url (always allowed, #1741). */
   onZoom: (src: string) => void;
@@ -1806,6 +1860,8 @@ function VariantScopeForm({
   baseCategoryPathNames,
   categoryParameters,
   ownCategoryParameters,
+  ownCategoryParametersFailed,
+  onRetryOwnCategoryParameters,
   duplicateEan,
   onZoom,
   onPatch,
@@ -2452,6 +2508,33 @@ function VariantScopeForm({
             : 'Inherits the base images - add or remove to override for this variant.'}
         </div>
       </div>
+
+      {/* An own-category schema that FAILED renders here instead of the fields.
+          Without it the panel is indistinguishable from "still loading" while
+          `Save all` keeps bouncing back to this scope with nothing to act on -
+          the same unexplained dead-end #1946 fixed, one step later (#1950
+          review). Two ways out, both stated: retry, or drop the override. */}
+      {hasOwnCategory && ownCategoryParametersFailed ? (
+        <div className="bulk-editor__platform-slot">
+          <Alert
+            tone="error"
+            title="Couldn't load this variant's category parameters"
+            action={
+              <Button
+                tone="secondary"
+                type="button"
+                className="button--sm"
+                onClick={onRetryOwnCategoryParameters}
+              >
+                Retry
+              </Button>
+            }
+          >
+            Its parameters can't be filled in or saved until this loads. Retry, or clear the
+            category override to fall back to the shared base category.
+          </Alert>
+        </div>
+      ) : null}
 
       {/* Category parameters - inheritable; required first, optional collapsed
           behind an expander (mirrors the base CategoryParametersStep). Once

--- a/apps/web/src/features/listings/components/bulk/bulk-edit-modal.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-edit-modal.tsx
@@ -672,7 +672,12 @@ function BulkEditModalForm({
     // category's schema has arrived. Saving earlier would emit base-category ids
     // for it and silently drop everything the operator typed (#1946), so block
     // and open that sibling's scope instead - its fields are still loading there.
-    if (isMultiVariant) {
+    //
+    // Only when parameters are actually in play (`categoryParameters` non-empty).
+    // With no schema at all there is nothing to serialize for any scope, and an
+    // operator who picks a variant category must still be able to save the
+    // override immediately, before its schema resolves (#1924).
+    if (isMultiVariant && categoryParameters.length > 0) {
       const unresolved = row.variants.find(
         (v) => variantParamSchema(variantEdits[v.variantId]) === null,
       );

--- a/apps/web/src/features/listings/components/bulk/bulk-edit-modal.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-edit-modal.tsx
@@ -87,6 +87,7 @@ import { BulkImageLightbox } from './bulk-image-lightbox';
 import { blockerLabel, isVariantScopeFixable } from './bulk-blockers';
 import { ErliDeliveryPriceListOverrideField } from '../erli/erli-delivery-price-list-override-field';
 import { useCategoryParametersQuery } from '../../hooks/use-category-parameters-query';
+import { useCategoryParameterSchemas } from '../../hooks/use-category-parameter-schemas';
 import { useCategoryPathQuery } from '../../../mappings';
 import {
   MissingCategoryParameterSectionError,
@@ -569,6 +570,54 @@ function BulkEditModalForm({
     [categoryParameters],
   );
 
+  // Schemas of the categories individual siblings overrode (#1930). Resolved
+  // HERE rather than in `VariantScopeForm` because the panel mounts only for the
+  // open accordion scope, while `handleSaveAll` must serialize EVERY sibling -
+  // including one whose category came from a persisted override and whose panel
+  // was never opened (#1946).
+  const variantCategoryIds = useMemo(
+    () =>
+      row.variants
+        .map((v) => variantEdits[v.variantId]?.categoryId)
+        .filter((id): id is string => typeof id === 'string' && id.length > 0),
+    [row.variants, variantEdits],
+  );
+  // `isResolving` is deliberately not consumed: `variantParamSchema` returning
+  // `null` is the per-sibling loading signal, which is finer-grained than one
+  // batch-wide flag (a sibling whose schema is ready must not be held back).
+  const { schemasByCategory } = useCategoryParameterSchemas(
+    canBrowseCategories ? connectionId : undefined,
+    variantCategoryIds,
+  );
+  /**
+   * The schema a sibling's parameters must be serialized against: its own
+   * category's when it overrode the category, else the shared base's. Returns
+   * `null` while an overridden category's schema is still loading - the caller
+   * must skip emission rather than fall back to the base schema, whose ids do
+   * not exist in the overridden category (that silent drop is #1946).
+   */
+  const variantParamSchema = useCallback(
+    (edit: VariantEdit): CategoryParameter[] | null => {
+      if (edit.categoryId === undefined || edit.categoryId === '') return categoryParameters;
+      return schemasByCategory.get(edit.categoryId) ?? null;
+    },
+    [categoryParameters, schemasByCategory],
+  );
+  /**
+   * The overridden category's schema for one sibling, or `undefined` when it has
+   * no own category (the panel then falls back to the base set). Fed to
+   * `VariantScopeForm` so the fields it renders and the array `handleSaveAll`
+   * serializes come from the SAME source and cannot drift (#1946).
+   */
+  const ownVariantSchema = useCallback(
+    (variantId: string): CategoryParameter[] | undefined => {
+      const ownCategoryId = variantEdits[variantId]?.categoryId;
+      if (ownCategoryId === undefined || ownCategoryId === '') return undefined;
+      return schemasByCategory.get(ownCategoryId);
+    },
+    [variantEdits, schemasByCategory],
+  );
+
   // ── Dirty tracking (vs the on-open snapshot) ──
   const snapshotRef = useRef<string | null>(null);
   const liveState = JSON.stringify({
@@ -618,6 +667,21 @@ function BulkEditModalForm({
       setScope(isMultiVariant ? 'base' : 'simple');
       return;
     }
+
+    // A sibling that overrode its category can only be serialized once THAT
+    // category's schema has arrived. Saving earlier would emit base-category ids
+    // for it and silently drop everything the operator typed (#1946), so block
+    // and open that sibling's scope instead - its fields are still loading there.
+    if (isMultiVariant) {
+      const unresolved = row.variants.find(
+        (v) => variantParamSchema(variantEdits[v.variantId]) === null,
+      );
+      if (unresolved !== undefined) {
+        setScope(unresolved.variantId);
+        return;
+      }
+    }
+
     const values = baseForm.getValues();
 
     let baseParameters: OfferParameter[] = [];
@@ -691,15 +755,20 @@ function BulkEditModalForm({
         if (edit.productCardId !== undefined) overrides.productCardId = edit.productCardId;
 
         // Emit the effective parameters array whole (base ∪ per-variant param
-        // overrides) so the BE whole-array-replaces (plan §7).
-        if (categoryParameters.length > 0) {
+        // overrides) so the BE whole-array-replaces (plan §7). The schema is the
+        // sibling's OWN category's when it overrode the category (#1930) - the
+        // same one that rendered its fields. Serializing an overridden-category
+        // sibling against the base schema drops every value it typed, because
+        // the serializer looks each parameter up by the schema's own ids (#1946).
+        const paramSchema = variantParamSchema(edit);
+        if (paramSchema !== null && paramSchema.length > 0) {
           const effective: CategoryParameterFormValues = { ...baseParamValues, ...edit.params };
           try {
-            let params = categoryParametersToOfferParameters(effective, categoryParameters);
+            let params = categoryParametersToOfferParameters(effective, paramSchema);
             // Fill the (hidden) EAN/GTIN slot from this sibling's dedicated EAN
             // field (its single source, pre-filled from master) so the wire GTIN
             // and the catalog self-link key can never diverge (#1741).
-            params = injectEanParameter(params, categoryParameters, eanTrimmed);
+            params = injectEanParameter(params, paramSchema, eanTrimmed);
             if (params.length > 0) overrides.parameters = params;
           } catch {
             // Stale schema for this variant - skip its param emission; base
@@ -984,6 +1053,7 @@ function BulkEditModalForm({
                       connection={connection}
                       baseCategoryPathNames={displayPathNames}
                       categoryParameters={renderableCategoryParameters}
+                      ownCategoryParameters={ownVariantSchema(v.variantId)}
                       duplicateEan={dupEanIds.has(v.variantId)}
                       onPatch={(patch) => patchVariant(v.variantId, patch)}
                       onParamChange={(paramId, value) => setVariantParam(v.variantId, paramId, value)}
@@ -1703,6 +1773,13 @@ interface VariantScopeFormProps {
   /** Resolved breadcrumb for the shared base's category, already computed once by the parent (#1924) - shown instead of the raw id. Null when unresolved (falls back to the id). */
   baseCategoryPathNames: string[] | null;
   categoryParameters: CategoryParameter[];
+  /**
+   * Schema of the category THIS sibling overrode (#1930), resolved by the parent
+   * so the rendered fields and the serialized array share one source (#1946).
+   * `undefined` when the sibling has no own category (the base set applies) or
+   * while its schema is still loading.
+   */
+  ownCategoryParameters: CategoryParameter[] | undefined;
   duplicateEan: boolean;
   /** Opens the shared zoom lightbox for an image url (always allowed, #1741). */
   onZoom: (src: string) => void;
@@ -1723,6 +1800,7 @@ function VariantScopeForm({
   connection,
   baseCategoryPathNames,
   categoryParameters,
+  ownCategoryParameters,
   duplicateEan,
   onZoom,
   onPatch,
@@ -1791,16 +1869,15 @@ function VariantScopeForm({
       ? baseCategoryPathNames.join(' › ')
       : baseValues.categoryId || 'Not set on base';
 
-  const ownCategoryParametersQuery = useCategoryParametersQuery(
-    connectionId,
-    hasOwnCategory ? (edit.categoryId as string) : '',
-  );
+  // The own-category schema is resolved by the parent (#1946) - it also needs it
+  // at save time for siblings whose panel is not the open scope, so fetching it
+  // here as well would be a second source of truth for the same values.
   const effectiveCategoryParameters = useMemo(
     () =>
       hasOwnCategory
-        ? (ownCategoryParametersQuery.data ?? []).filter((p) => !isEanParameterName(p.name))
+        ? (ownCategoryParameters ?? []).filter((p) => !isEanParameterName(p.name))
         : categoryParameters,
-    [hasOwnCategory, ownCategoryParametersQuery.data, categoryParameters],
+    [hasOwnCategory, ownCategoryParameters, categoryParameters],
   );
 
   // Category parameters mirror the base scope: filter through parameter-level

--- a/apps/web/src/features/listings/hooks/use-category-parameter-schemas.test.tsx
+++ b/apps/web/src/features/listings/hooks/use-category-parameter-schemas.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * use-category-parameter-schemas tests (#1946)
+ *
+ * Pins the contract the bulk edit modal's save path depends on: a resolved
+ * category's FULL schema keyed by its id, an ABSENT key while it is in flight
+ * (never another category's schema - that silent fallback is #1946), a failed
+ * category reported distinctly from a loading one so the caller can explain the
+ * block, and dedupe + inertness without a connection.
+ *
+ * @module apps/web/src/features/listings/hooks
+ */
+import { renderHook, waitFor, cleanup, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ApiClientProvider } from '../../../app/api/api-client-provider';
+import { createMockApiClient } from '../../../test/test-utils';
+import { useCategoryParameterSchemas } from './use-category-parameter-schemas';
+import type { CategoryParameter } from '../api/listings.types';
+
+function param(overrides: Partial<CategoryParameter>): CategoryParameter {
+  return {
+    id: 'p',
+    name: 'P',
+    type: 'string',
+    required: false,
+    restrictions: {},
+    section: 'offer',
+    ...overrides,
+  };
+}
+
+describe('useCategoryParameterSchemas', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  afterEach(() => {
+    cleanup();
+  });
+
+  function wrap(
+    apiClient: ReturnType<typeof createMockApiClient>,
+  ): React.FC<{ children: React.ReactNode }> {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    return ({ children }) => (
+      <ApiClientProvider client={apiClient}>
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      </ApiClientProvider>
+    );
+  }
+
+  it('keys each category to its full schema and dedupes repeated ids', async () => {
+    // Arrange
+    const getCategoryParameters = vi.fn().mockImplementation((_conn: string, categoryId: string) =>
+      Promise.resolve({
+        parameters:
+          categoryId === 'cat-A'
+            ? [param({ id: 'a-1', required: true }), param({ id: 'a-2', section: 'product' })]
+            : [param({ id: 'b-1' })],
+      }),
+    );
+    const apiClient = createMockApiClient({ listings: { getCategoryParameters } });
+
+    // Act
+    const { result } = renderHook(
+      () => useCategoryParameterSchemas('conn-1', ['cat-B', 'cat-A', 'cat-B']),
+      { wrapper: wrap(apiClient) },
+    );
+
+    // Assert
+    await waitFor(() => expect(result.current.schemasByCategory.size).toBe(2));
+    // Full schema, not a projection - the serializer needs every parameter.
+    expect(result.current.schemasByCategory.get('cat-A')?.map((p) => p.id)).toEqual([
+      'a-1',
+      'a-2',
+    ]);
+    expect(result.current.schemasByCategory.get('cat-B')?.map((p) => p.id)).toEqual(['b-1']);
+    expect(result.current.failedCategoryIds.size).toBe(0);
+    expect(getCategoryParameters).toHaveBeenCalledTimes(2);
+  });
+
+  it('leaves the key absent while a category is still loading', async () => {
+    // Arrange - never-settling request keeps the query in flight.
+    const getCategoryParameters = vi.fn().mockReturnValue(new Promise<never>(() => {}));
+    const apiClient = createMockApiClient({ listings: { getCategoryParameters } });
+
+    // Act
+    const { result } = renderHook(() => useCategoryParameterSchemas('conn-1', ['cat-A']), {
+      wrapper: wrap(apiClient),
+    });
+
+    // Assert - absent from BOTH collections is what "still in flight" means.
+    expect(result.current.schemasByCategory.has('cat-A')).toBe(false);
+    expect(result.current.failedCategoryIds.has('cat-A')).toBe(false);
+  });
+
+  it('reports a failed category distinctly from a loading one', async () => {
+    // Arrange
+    const getCategoryParameters = vi.fn().mockRejectedValue(new Error('502 Bad Gateway'));
+    const apiClient = createMockApiClient({ listings: { getCategoryParameters } });
+
+    // Act
+    const { result } = renderHook(() => useCategoryParameterSchemas('conn-1', ['cat-A']), {
+      wrapper: wrap(apiClient),
+    });
+
+    // Assert
+    await waitFor(() => expect(result.current.failedCategoryIds.has('cat-A')).toBe(true));
+    expect(result.current.schemasByCategory.has('cat-A')).toBe(false);
+  });
+
+  it('re-runs a failed category on retry', async () => {
+    // Arrange - fails once, then succeeds.
+    const getCategoryParameters = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('502 Bad Gateway'))
+      .mockResolvedValue({ parameters: [param({ id: 'a-1' })] });
+    const apiClient = createMockApiClient({ listings: { getCategoryParameters } });
+    const { result } = renderHook(() => useCategoryParameterSchemas('conn-1', ['cat-A']), {
+      wrapper: wrap(apiClient),
+    });
+    await waitFor(() => expect(result.current.failedCategoryIds.has('cat-A')).toBe(true));
+
+    // Act
+    act(() => {
+      result.current.retryCategory('cat-A');
+    });
+
+    // Assert
+    await waitFor(() => expect(result.current.schemasByCategory.has('cat-A')).toBe(true));
+    expect(result.current.failedCategoryIds.has('cat-A')).toBe(false);
+  });
+
+  it('keeps the derived map referentially stable across re-renders', async () => {
+    // Arrange
+    const getCategoryParameters = vi
+      .fn()
+      .mockResolvedValue({ parameters: [param({ id: 'a-1' })] });
+    const apiClient = createMockApiClient({ listings: { getCategoryParameters } });
+    const categoryIds = ['cat-A'];
+    const { result, rerender } = renderHook(
+      () => useCategoryParameterSchemas('conn-1', categoryIds),
+      { wrapper: wrap(apiClient) },
+    );
+    await waitFor(() => expect(result.current.schemasByCategory.size).toBe(1));
+    const first = result.current.schemasByCategory;
+
+    // Act
+    rerender();
+
+    // Assert - a fresh Map per render would defeat the caller's useCallbacks.
+    expect(result.current.schemasByCategory).toBe(first);
+  });
+
+  it('does not fetch without a connection id', () => {
+    // Arrange
+    const getCategoryParameters = vi.fn();
+    const apiClient = createMockApiClient({ listings: { getCategoryParameters } });
+
+    // Act
+    const { result } = renderHook(() => useCategoryParameterSchemas(undefined, ['cat-A']), {
+      wrapper: wrap(apiClient),
+    });
+
+    // Assert
+    expect(getCategoryParameters).not.toHaveBeenCalled();
+    expect(result.current.schemasByCategory.size).toBe(0);
+    expect(result.current.failedCategoryIds.size).toBe(0);
+  });
+
+  it('does nothing when there are no categories to resolve', () => {
+    // Arrange
+    const getCategoryParameters = vi.fn();
+    const apiClient = createMockApiClient({ listings: { getCategoryParameters } });
+
+    // Act
+    const { result } = renderHook(() => useCategoryParameterSchemas('conn-1', []), {
+      wrapper: wrap(apiClient),
+    });
+
+    // Assert
+    expect(getCategoryParameters).not.toHaveBeenCalled();
+    expect(result.current.schemasByCategory.size).toBe(0);
+  });
+});

--- a/apps/web/src/features/listings/hooks/use-category-parameter-schemas.ts
+++ b/apps/web/src/features/listings/hooks/use-category-parameter-schemas.ts
@@ -1,0 +1,76 @@
+/**
+ * use-category-parameter-schemas (#1946)
+ *
+ * Fans the per-category parameter schema query out over a set of category ids
+ * and returns the FULL schema per category. The bulk edit modal needs this for
+ * the siblings that carry their own category (#1930): a variant's parameters
+ * must be serialized against the schema that rendered its fields, and the save
+ * path lives in the parent component while the variant panel is mounted only
+ * for the currently open accordion scope.
+ *
+ * Reuses the same query key + queryFn + staleTime as
+ * `useCategoryParametersQuery`, so a category already opened in the editor is a
+ * cache hit and several siblings sharing one category fetch it once. Unlike
+ * `use-bulk-required-product-params`, which projects each schema down to the
+ * required product-section ids, this hook keeps the schema intact - the
+ * serializer needs every parameter, including the hidden EAN/GTIN slot.
+ *
+ * @module apps/web/src/features/listings/hooks
+ */
+import { useMemo } from 'react';
+import { useQueries } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { listingsQueryKeys } from '../api/listings.query-keys';
+import type { CategoryParameter } from '../api/listings.types';
+import { CATEGORY_PARAMETERS_STALE_TIME_MS } from './use-category-parameters-query';
+
+export interface CategoryParameterSchemas {
+  /**
+   * category id → its full parameter schema. An absent key means the schema has
+   * not resolved yet; callers must NOT fall back to another category's schema
+   * (that is the silent-drop failure mode #1946 fixes).
+   */
+  schemasByCategory: Map<string, CategoryParameter[]>;
+  /** True while any requested category's schema is still loading. */
+  isResolving: boolean;
+}
+
+export function useCategoryParameterSchemas(
+  connectionId: string | undefined,
+  categoryIds: readonly string[],
+): CategoryParameterSchemas {
+  const apiClient = useApiClient();
+
+  // Distinct + stable order so the useQueries array stays index-aligned across
+  // renders that don't change the set.
+  const distinctIds = useMemo(
+    () => Array.from(new Set(categoryIds.filter((id) => id.length > 0))).sort(),
+    [categoryIds],
+  );
+
+  const results = useQueries({
+    queries: distinctIds.map((categoryId) => ({
+      queryKey: listingsQueryKeys.categoryParameters(connectionId ?? '', categoryId),
+      queryFn: async (): Promise<CategoryParameter[]> => {
+        const response = await apiClient.listings.getCategoryParameters(
+          connectionId as string,
+          categoryId,
+        );
+        return response.parameters;
+      },
+      enabled: Boolean(connectionId) && categoryId.length > 0,
+      staleTime: CATEGORY_PARAMETERS_STALE_TIME_MS,
+    })),
+  });
+
+  const isResolving = results.some((q) => q.isLoading);
+
+  const schemasByCategory = new Map<string, CategoryParameter[]>();
+  distinctIds.forEach((categoryId, i) => {
+    const data = results[i]?.data;
+    if (!data) return;
+    schemasByCategory.set(categoryId, data);
+  });
+
+  return { schemasByCategory, isResolving };
+}

--- a/apps/web/src/features/listings/hooks/use-category-parameter-schemas.ts
+++ b/apps/web/src/features/listings/hooks/use-category-parameter-schemas.ts
@@ -15,10 +15,15 @@
  * required product-section ids, this hook keeps the schema intact - the
  * serializer needs every parameter, including the hidden EAN/GTIN slot.
  *
+ * An absent map key is deliberately ambiguous, so a FAILED category is reported
+ * separately (`failedCategoryIds` + `retryCategory`): "still loading" resolves
+ * itself, "the request errored" never does, and a caller that blocks on an
+ * unresolved schema must be able to tell the operator which one they are in.
+ *
  * @module apps/web/src/features/listings/hooks
  */
-import { useMemo } from 'react';
-import { useQueries } from '@tanstack/react-query';
+import { useCallback, useMemo } from 'react';
+import { useQueries, useQueryClient } from '@tanstack/react-query';
 import { useApiClient } from '../../../app/api/api-client-provider';
 import { listingsQueryKeys } from '../api/listings.query-keys';
 import type { CategoryParameter } from '../api/listings.types';
@@ -31,8 +36,13 @@ export interface CategoryParameterSchemas {
    * (that is the silent-drop failure mode #1946 fixes).
    */
   schemasByCategory: Map<string, CategoryParameter[]>;
-  /** True while any requested category's schema is still loading. */
-  isResolving: boolean;
+  /**
+   * Categories whose schema request failed and will not arrive on its own. An id
+   * absent from BOTH this set and `schemasByCategory` is still in flight.
+   */
+  failedCategoryIds: Set<string>;
+  /** Re-runs one failed category's query - the operator-facing "Retry". */
+  retryCategory: (categoryId: string) => void;
 }
 
 export function useCategoryParameterSchemas(
@@ -40,6 +50,7 @@ export function useCategoryParameterSchemas(
   categoryIds: readonly string[],
 ): CategoryParameterSchemas {
   const apiClient = useApiClient();
+  const queryClient = useQueryClient();
 
   // Distinct + stable order so the useQueries array stays index-aligned across
   // renders that don't change the set.
@@ -48,7 +59,33 @@ export function useCategoryParameterSchemas(
     [categoryIds],
   );
 
-  const results = useQueries({
+  // `combine` derives the map/set inside the observer's own memoization, so both
+  // keep their identity while the underlying results are unchanged - a bare
+  // `new Map()` per render would defeat every `useCallback` the caller wraps
+  // around it (and, transitively, its save handler). The observer compares the
+  // combine function BY IDENTITY, so it has to be stable too: an inline arrow
+  // recomputes on every render and buys nothing.
+  const combine = useCallback(
+    (
+      results: readonly { data?: CategoryParameter[]; isError: boolean }[],
+    ): Omit<CategoryParameterSchemas, 'retryCategory'> => {
+      const schemasByCategory = new Map<string, CategoryParameter[]>();
+      const failedCategoryIds = new Set<string>();
+      distinctIds.forEach((categoryId, i) => {
+        const result = results[i];
+        if (result === undefined) return;
+        if (result.data !== undefined) {
+          schemasByCategory.set(categoryId, result.data);
+          return;
+        }
+        if (result.isError) failedCategoryIds.add(categoryId);
+      });
+      return { schemasByCategory, failedCategoryIds };
+    },
+    [distinctIds],
+  );
+
+  const { schemasByCategory, failedCategoryIds } = useQueries({
     queries: distinctIds.map((categoryId) => ({
       queryKey: listingsQueryKeys.categoryParameters(connectionId ?? '', categoryId),
       queryFn: async (): Promise<CategoryParameter[]> => {
@@ -61,16 +98,18 @@ export function useCategoryParameterSchemas(
       enabled: Boolean(connectionId) && categoryId.length > 0,
       staleTime: CATEGORY_PARAMETERS_STALE_TIME_MS,
     })),
+    combine,
   });
 
-  const isResolving = results.some((q) => q.isLoading);
+  const retryCategory = useCallback(
+    (categoryId: string): void => {
+      if (connectionId === undefined || categoryId.length === 0) return;
+      void queryClient.refetchQueries({
+        queryKey: listingsQueryKeys.categoryParameters(connectionId, categoryId),
+      });
+    },
+    [queryClient, connectionId],
+  );
 
-  const schemasByCategory = new Map<string, CategoryParameter[]>();
-  distinctIds.forEach((categoryId, i) => {
-    const data = results[i]?.data;
-    if (!data) return;
-    schemasByCategory.set(categoryId, data);
-  });
-
-  return { schemasByCategory, isResolving };
+  return { schemasByCategory, failedCategoryIds, retryCategory };
 }


### PR DESCRIPTION
## What changed

A sibling that overrode its Allegro category (#1930) had its parameters serialized against the **base** category's schema. `categoryParametersToOfferParameters` looks every parameter up by the schema's own ids, so each value the operator typed into that sibling's panel - rendered from the *overridden* category's schema - had no matching id and was silently dropped, and `injectEanParameter` never filled the overridden category's GTIN slot.

The visible symptom: the required-product-param gate (`bulk-policy.ts:484`) correctly asks for the variant category's required params post-#1930, finds none supplied, and the `add product params` chip cannot be cleared however many fields the operator fills. Publishing a multi-variant product with a divergent sibling category was impossible.

## Why the two halves had drifted

The own-category schema was fetched inside `VariantScopeForm`, while the save path lives in the parent. The variant panel is mounted only for the **open** accordion scope, so serializing from the child would still have missed a sibling whose category came from a persisted override and whose panel was never opened.

## How

- New `useCategoryParameterSchemas` hook fans the schema query out over the distinct set of overridden variant categories in the parent. Same query key and `staleTime` as `useCategoryParametersQuery` (mirroring the `use-bulk-required-product-params` precedent), so a category already opened in the editor is a cache hit and no duplicate request is issued.
- The resolved schema is both passed down for rendering and used for serialization - one source, no drift. `VariantScopeForm` no longer issues its own query.
- Both `categoryParametersToOfferParameters` and `injectEanParameter` receive the same schema, and the length guard keys on the resolved schema (a sibling with its own category is no longer skipped when the base category has no parameters).
- A sibling whose overridden category has not resolved yet **blocks the save** and opens its scope rather than emitting base-category ids - the silent-drop failure mode this PR fixes.

## Not in scope

`pricingPolicy` / `stockPolicy` reaching the wire and being rejected by `PerOverrideDto` was already fixed by #1934 (`toWireOverride`); recorded on the issue so it is not re-diagnosed. Three further defects found in the same area are listed under "Out of scope" on #1946.

## Tests

Three cases added to `bulk-edit-modal.test.tsx`: an overridden-category sibling serializes against its own schema (asserting its category's GTIN slot and value), a sibling without an override still serializes against the base schema, and an unresolved overridden schema blocks the save.

Closes #1946

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AK4TkoxtFGks2yFfuiVbhv