### PR TITLE
fix(api/auth): clear stale host-only ol_refresh/ol_csrf duplicates on set/clear

### DIFF
--- a/apps/api/src/auth/auth.cookies.spec.ts
+++ b/apps/api/src/auth/auth.cookies.spec.ts
@@ -10,14 +10,13 @@
 import type { CookieOptions, Response } from 'express';
 import {
   CSRF_COOKIE_NAME,
+  CSRF_COOKIE_PATH,
   REFRESH_COOKIE_NAME,
   REFRESH_COOKIE_PATH,
   clearAuthCookies,
   setCsrfCookie,
   setRefreshCookie,
 } from './auth.cookies';
-
-const CSRF_COOKIE_PATH = '/';
 
 interface CookieCall {
   name: string;
@@ -183,6 +182,33 @@ describe('auth.cookies', () => {
 
       const set = cookies.find((c) => c.name === CSRF_COOKIE_NAME);
       expect(set?.options.domain).toBeUndefined();
+    });
+
+    // #1998 follow-up: the extra host-only clear only matters once
+    // OL_COOKIE_DOMAIN introduces a Domain-scoped identity to collapse a
+    // stale host-only one into — with it unset there's nothing to collapse,
+    // so the clear must be skipped rather than firing as a redundant
+    // clear-then-immediately-reissue of the same cookie identity.
+    it('should not clear the current-path refresh cookie before (re-)issuing it', () => {
+      const { res, clears } = createResponseSpy();
+
+      setRefreshCookie(res, 'raw-refresh-token');
+
+      const currentPathClears = clears.filter(
+        (c) => c.name === REFRESH_COOKIE_NAME && c.options.path === REFRESH_COOKIE_PATH,
+      );
+      expect(currentPathClears).toHaveLength(0);
+    });
+
+    it('should not clear the current-path CSRF cookie before (re-)issuing it', () => {
+      const { res, clears } = createResponseSpy();
+
+      setCsrfCookie(res);
+
+      const currentPathClears = clears.filter(
+        (c) => c.name === CSRF_COOKIE_NAME && c.options.path === CSRF_COOKIE_PATH,
+      );
+      expect(currentPathClears).toHaveLength(0);
     });
 
     it('should not clear the current-path cookies twice on logout', () => {

--- a/apps/api/src/auth/auth.cookies.spec.ts
+++ b/apps/api/src/auth/auth.cookies.spec.ts
@@ -11,10 +11,13 @@ import type { CookieOptions, Response } from 'express';
 import {
   CSRF_COOKIE_NAME,
   REFRESH_COOKIE_NAME,
+  REFRESH_COOKIE_PATH,
   clearAuthCookies,
   setCsrfCookie,
   setRefreshCookie,
 } from './auth.cookies';
+
+const CSRF_COOKIE_PATH = '/';
 
 interface CookieCall {
   name: string;
@@ -102,6 +105,61 @@ describe('auth.cookies', () => {
         expect(legacy.options.domain).toBeUndefined();
       }
     });
+
+    // #1998: a browser that logged in before OL_COOKIE_DOMAIN was configured
+    // still carries a host-only cookie at the CURRENT path. (name, domain,
+    // path) together identify a cookie, so that host-only copy and a fresh
+    // Domain-scoped copy coexist as two distinct, simultaneously-valid
+    // cookies rather than one overwriting the other — collapsing it back to
+    // one requires an explicit host-only clear on every set/clear.
+    it('should also clear the host-only identity of the refresh cookie at the current path', () => {
+      const { res, clears } = createResponseSpy();
+
+      setRefreshCookie(res, 'raw-refresh-token');
+
+      const hostOnlyClear = clears.find(
+        (c) =>
+          c.name === REFRESH_COOKIE_NAME &&
+          c.options.path === REFRESH_COOKIE_PATH &&
+          c.options.domain === undefined,
+      );
+      expect(hostOnlyClear).toBeDefined();
+    });
+
+    it('should also clear the host-only identity of the CSRF cookie at the current path', () => {
+      const { res, clears } = createResponseSpy();
+
+      setCsrfCookie(res);
+
+      const hostOnlyClear = clears.find(
+        (c) =>
+          c.name === CSRF_COOKIE_NAME &&
+          c.options.path === CSRF_COOKIE_PATH &&
+          c.options.domain === undefined,
+      );
+      expect(hostOnlyClear).toBeDefined();
+    });
+
+    it('should also clear the host-only identity of both cookies on logout', () => {
+      const { res, clears } = createResponseSpy();
+
+      clearAuthCookies(res);
+
+      const hostOnlyRefreshClear = clears.find(
+        (c) =>
+          c.name === REFRESH_COOKIE_NAME &&
+          c.options.path === REFRESH_COOKIE_PATH &&
+          c.options.domain === undefined,
+      );
+      const hostOnlyCsrfClear = clears.find(
+        (c) =>
+          c.name === CSRF_COOKIE_NAME &&
+          c.options.path === CSRF_COOKIE_PATH &&
+          c.options.domain === undefined,
+      );
+      expect(hostOnlyRefreshClear).toBeDefined();
+      expect(hostOnlyCsrfClear).toBeDefined();
+    });
   });
 
   describe('when OL_COOKIE_DOMAIN is unset', () => {
@@ -125,6 +183,21 @@ describe('auth.cookies', () => {
 
       const set = cookies.find((c) => c.name === CSRF_COOKIE_NAME);
       expect(set?.options.domain).toBeUndefined();
+    });
+
+    it('should not clear the current-path cookies twice on logout', () => {
+      const { res, clears } = createResponseSpy();
+
+      clearAuthCookies(res);
+
+      const refreshCurrentClears = clears.filter(
+        (c) => c.name === REFRESH_COOKIE_NAME && c.options.path === REFRESH_COOKIE_PATH,
+      );
+      const csrfCurrentClears = clears.filter(
+        (c) => c.name === CSRF_COOKIE_NAME && c.options.path === CSRF_COOKIE_PATH,
+      );
+      expect(refreshCurrentClears.length).toBe(1);
+      expect(csrfCurrentClears.length).toBe(1);
     });
 
     it('should leave every clear host-only', () => {

--- a/apps/api/src/auth/auth.cookies.ts
+++ b/apps/api/src/auth/auth.cookies.ts
@@ -38,7 +38,7 @@ const LEGACY_AUTH_COOKIE_PATH = '/auth';
 // readCsrfCookie() returns null on every route outside /auth/* and silent
 // refresh breaks after a full-page reload (e.g. OAuth bounce back from
 // allegro.pl). See #748.
-const CSRF_COOKIE_PATH = '/';
+export const CSRF_COOKIE_PATH = '/';
 
 const isProd = (): boolean => process.env.NODE_ENV === 'production';
 
@@ -117,9 +117,12 @@ export function setRefreshCookie(res: Response, rawToken: string): void {
   // document.cookie (running on the WEB host) can never see a cookie scoped
   // to the API host in the first place. Clearing the host-only identity
   // before (re-)issuing the current one collapses it back to a single
-  // cookie on every login/refresh. No-op when OL_COOKIE_DOMAIN is unset,
-  // since the cookie being (re-)issued below is itself host-only then.
-  res.clearCookie(REFRESH_COOKIE_NAME, { path: REFRESH_COOKIE_PATH });
+  // cookie on every login/refresh. Only relevant once OL_COOKIE_DOMAIN is
+  // configured — guarded so deployments that never set it don't emit a
+  // redundant extra Set-Cookie header on every login/refresh.
+  if (domainOption()) {
+    res.clearCookie(REFRESH_COOKIE_NAME, { path: REFRESH_COOKIE_PATH });
+  }
   res.cookie(REFRESH_COOKIE_NAME, rawToken, refreshCookieOptions());
 }
 
@@ -135,8 +138,10 @@ export function setCsrfCookie(res: Response): string {
   // they're being silently bounced to /auth/login.
   res.clearCookie(CSRF_COOKIE_NAME, { path: LEGACY_AUTH_COOKIE_PATH });
   // Migration cleanup (#1998): same host-only-vs-Domain-scoped duplicate
-  // hazard as setRefreshCookie above.
-  res.clearCookie(CSRF_COOKIE_NAME, { path: CSRF_COOKIE_PATH });
+  // hazard as setRefreshCookie above — guarded the same way.
+  if (domainOption()) {
+    res.clearCookie(CSRF_COOKIE_NAME, { path: CSRF_COOKIE_PATH });
+  }
   res.cookie(CSRF_COOKIE_NAME, csrf, csrfCookieOptions());
   return csrf;
 }

--- a/apps/api/src/auth/auth.cookies.ts
+++ b/apps/api/src/auth/auth.cookies.ts
@@ -107,6 +107,19 @@ export function setRefreshCookie(res: Response, rawToken: string): void {
   // Has to run on every login/refresh — affected users never reach logout
   // while they're being silently bounced to /auth/login.
   res.clearCookie(REFRESH_COOKIE_NAME, { path: LEGACY_AUTH_COOKIE_PATH });
+  // Migration cleanup (#1998): a browser that logged in before
+  // OL_COOKIE_DOMAIN was configured (#1725) still carries a host-only
+  // ol_refresh at this SAME path. (name, domain, path) together identify a
+  // cookie, so the host-only copy and a Domain-scoped copy coexist as two
+  // distinct, simultaneously-valid cookies instead of one overwriting the
+  // other — both get sent to the API host, cookie-parser keeps only the
+  // first ("only assign once"), which can be the stale one, while the SPA's
+  // document.cookie (running on the WEB host) can never see a cookie scoped
+  // to the API host in the first place. Clearing the host-only identity
+  // before (re-)issuing the current one collapses it back to a single
+  // cookie on every login/refresh. No-op when OL_COOKIE_DOMAIN is unset,
+  // since the cookie being (re-)issued below is itself host-only then.
+  res.clearCookie(REFRESH_COOKIE_NAME, { path: REFRESH_COOKIE_PATH });
   res.cookie(REFRESH_COOKIE_NAME, rawToken, refreshCookieOptions());
 }
 
@@ -121,6 +134,9 @@ export function setCsrfCookie(res: Response): string {
   // only) isn't enough because affected users never reach logout while
   // they're being silently bounced to /auth/login.
   res.clearCookie(CSRF_COOKIE_NAME, { path: LEGACY_AUTH_COOKIE_PATH });
+  // Migration cleanup (#1998): same host-only-vs-Domain-scoped duplicate
+  // hazard as setRefreshCookie above.
+  res.clearCookie(CSRF_COOKIE_NAME, { path: CSRF_COOKIE_PATH });
   res.cookie(CSRF_COOKIE_NAME, csrf, csrfCookieOptions());
   return csrf;
 }
@@ -132,6 +148,15 @@ export function clearAuthCookies(res: Response): void {
   // never Domain-scoped.
   res.clearCookie(REFRESH_COOKIE_NAME, { path: REFRESH_COOKIE_PATH, ...domainOption() });
   res.clearCookie(CSRF_COOKIE_NAME, { path: CSRF_COOKIE_PATH, ...domainOption() });
+  // Migration cleanup (#1998): when OL_COOKIE_DOMAIN is configured, also
+  // clear the host-only identity at the current path — see setRefreshCookie
+  // above for why the two can coexist as distinct cookies. Skipped when
+  // OL_COOKIE_DOMAIN is unset, since the clears above are already host-only
+  // in that case and this would just be a redundant duplicate.
+  if (domainOption()) {
+    res.clearCookie(REFRESH_COOKIE_NAME, { path: REFRESH_COOKIE_PATH });
+    res.clearCookie(CSRF_COOKIE_NAME, { path: CSRF_COOKIE_PATH });
+  }
   // Migration cleanup: ol_csrf was previously set at /auth (#748), ol_refresh
   // until #1327. Clear those copies too so stale cookies from the buggy
   // windows don't linger (csrf could even shadow the new /-scoped value).


### PR DESCRIPTION
## Summary

- Fixes logout-on-page-refresh caused by a stale-cookie collision: a browser that logged in before `OL_COOKIE_DOMAIN` was configured (#1725) still carries a host-only `ol_refresh`/`ol_csrf` cookie at the current path. Since `(name, domain, path)` together identify a cookie, that host-only copy and a newer Domain-scoped copy coexist as two distinct, simultaneously-valid cookies instead of one overwriting the other.
- Both copies are sent to the API host; `cookie-parser` keeps only the first occurrence, which can be the stale value, while the SPA's `document.cookie` (on the WEB host) can never see a cookie scoped to the API host at all — so `CsrfGuard` compares a stale value against a fresh one and rejects `/v1/auth/refresh` with `403 CSRF token mismatch`.
- `setRefreshCookie` and `setCsrfCookie` now clear the host-only identity of the current path before (re-)issuing the current cookie; `clearAuthCookies` does the same on logout when `OL_COOKIE_DOMAIN` is configured. No-op (and no behavior change) for deployments that never set `OL_COOKIE_DOMAIN`.

## Test plan

- [x] Unit tests added in `auth.cookies.spec.ts` covering the new host-only clear calls when `OL_COOKIE_DOMAIN` is set, and asserting no duplicate/extra clear when it is unset.
- [x] `pnpm --filter @openlinker/api test` — full suite passes, including pre-existing `auth.controller.spec.ts` exact-call-count assertions (unaffected since `OL_COOKIE_DOMAIN` is unset in that spec's env).
- [x] `pnpm type-check` (root, all workspaces) — passes.
- [x] `pnpm --filter @openlinker/api lint` — zero errors (pre-existing unrelated warnings only).
- [x] Manually reproduced and verified locally: logged in once without `OL_COOKIE_DOMAIN` (host-only cookie), then again with it set in the same browser without clearing cookies (Domain-scoped cookie) — DevTools showed two `ol_csrf`/`ol_refresh` entries and a page reload's silent `/auth/refresh` returned `403 CSRF token mismatch`. After the fix, a fresh login collapsed the duplicate back to a single cookie and the session survived a reload.

Closes #1998

🤖 Generated with [Claude Code](https://claude.com/claude-code)