### PR TITLE
feat(orders,shipping,invoicing): orderSummary projection for shipments/invoices lists

### DIFF
--- a/apps/api/src/invoicing/http/dto/invoice-record-response.dto.spec.ts
+++ b/apps/api/src/invoicing/http/dto/invoice-record-response.dto.spec.ts
@@ -1,0 +1,47 @@
+/**
+ * InvoiceRecordResponseDto unit tests (#1995 — orderSummary projection).
+ */
+import { InvoiceRecord } from '@openlinker/core/invoicing';
+import { InvoiceRecordResponseDto } from './invoice-record-response.dto';
+import type { OrderSummary } from '@openlinker/core/orders';
+
+function makeInvoiceRecord(): InvoiceRecord {
+  return new InvoiceRecord(
+    'inv_1',
+    'connection_1',
+    'ol_order_1',
+    'subiekt',
+    'invoice',
+    'issued',
+    'provider-inv-1',
+    'FV/1/2026',
+    'not-applicable',
+    null,
+    null,
+    null,
+    new Date('2026-05-20T10:00:00.000Z'),
+    null,
+    new Date('2026-05-20T10:00:00.000Z'),
+    new Date('2026-05-20T10:00:00.000Z'),
+  );
+}
+
+describe('InvoiceRecordResponseDto.fromDomain', () => {
+  it('sets orderSummary to null when no summary is supplied', () => {
+    const dto = InvoiceRecordResponseDto.fromDomain(makeInvoiceRecord(), null);
+    expect(dto.orderSummary).toBeNull();
+  });
+
+  it('maps a supplied OrderSummary onto the DTO', () => {
+    const summary: OrderSummary = {
+      orderNumber: 'ORD-001',
+      firstItemName: 'Terra Wool Coat',
+      firstItemImageUrl: 'https://example.com/coat.png',
+      itemCount: 2,
+    };
+
+    const dto = InvoiceRecordResponseDto.fromDomain(makeInvoiceRecord(), summary);
+
+    expect(dto.orderSummary).toEqual(summary);
+  });
+});

--- a/apps/api/src/invoicing/http/dto/invoice-record-response.dto.ts
+++ b/apps/api/src/invoicing/http/dto/invoice-record-response.dto.ts
@@ -32,6 +32,8 @@ import {
   RegulatoryStatus,
   RegulatoryStatusValues,
 } from '@openlinker/core/invoicing';
+import type { OrderSummary } from '@openlinker/core/orders';
+import { OrderSummaryProjectionDto } from '../../../orders/http/dto/order-summary-projection.dto';
 
 export class InvoiceRecordResponseDto {
   @ApiProperty({ description: 'Internal invoice record id' })
@@ -104,7 +106,23 @@ export class InvoiceRecordResponseDto {
   @ApiProperty({ description: 'Record last-update time (ISO 8601)' })
   updatedAt!: string;
 
-  static fromDomain(record: InvoiceRecord): InvoiceRecordResponseDto {
+  @ApiProperty({
+    nullable: true,
+    type: OrderSummaryProjectionDto,
+    description:
+      "Order-identity projection (#1995) for the unified Order cell — null when no order record resolves for `orderId`, or its snapshot has no parseable items. Only populated on the list endpoint (`GET /invoices`); single-invoice reads pass null (not fetched there).",
+  })
+  orderSummary!: OrderSummaryProjectionDto | null;
+
+  /**
+   * @param orderSummary Batched order-identity projection (#1995), or `null`
+   *   when not resolved for this call site. Required (not defaulted) so a
+   *   future read path can't silently omit it.
+   */
+  static fromDomain(
+    record: InvoiceRecord,
+    orderSummary: OrderSummary | null,
+  ): InvoiceRecordResponseDto {
     const dto = new InvoiceRecordResponseDto();
     dto.id = record.id;
     dto.connectionId = record.connectionId;
@@ -123,6 +141,7 @@ export class InvoiceRecordResponseDto {
     dto.issuedAt = record.issuedAt ? record.issuedAt.toISOString() : null;
     dto.createdAt = record.createdAt.toISOString();
     dto.updatedAt = record.updatedAt.toISOString();
+    dto.orderSummary = orderSummary ? OrderSummaryProjectionDto.fromSummary(orderSummary) : null;
     return dto;
   }
 }

--- a/apps/api/src/invoicing/http/invoicing.controller.spec.ts
+++ b/apps/api/src/invoicing/http/invoicing.controller.spec.ts
@@ -292,6 +292,7 @@ describe('InvoicingController', () => {
     } as unknown as jest.Mocked<IInvoiceService>;
     orders = {
       getOrderRecord: jest.fn(),
+      findByIds: jest.fn().mockResolvedValue([]),
     } as unknown as jest.Mocked<IOrderRecordService>;
 
     const mockIntegrations = {
@@ -886,6 +887,57 @@ describe('InvoicingController', () => {
         limit: 20,
         offset: 0,
       });
+    });
+
+    it('should populate orderSummary (#1995) from a single batched order read, deduped by orderId', async () => {
+      invoiceService.listInvoices.mockResolvedValue({
+        items: [
+          makeInvoiceRecord({ id: 'inv_1', orderId: 'ol_order_1' }),
+          makeInvoiceRecord({ id: 'inv_2', orderId: 'ol_order_1' }), // same order → deduped
+          makeInvoiceRecord({ id: 'inv_3', orderId: 'ol_order_2' }),
+        ],
+        total: 3,
+      });
+      orders.findByIds.mockResolvedValue([
+        {
+          internalOrderId: 'ol_order_1',
+          orderSnapshot: {
+            orderNumber: 'ORD-001',
+            items: [{ name: 'Terra Wool Coat', imageUrl: null }],
+          },
+        } as unknown as OrderRecord,
+      ]);
+
+      const result = await controller.listInvoices({ limit: 20, offset: 0 });
+
+      expect(orders.findByIds).toHaveBeenCalledTimes(1);
+      expect(orders.findByIds).toHaveBeenCalledWith(['ol_order_1', 'ol_order_2']);
+      expect(result.items[0].orderSummary).toEqual({
+        orderNumber: 'ORD-001',
+        firstItemName: 'Terra Wool Coat',
+        firstItemImageUrl: null,
+        itemCount: 1,
+      });
+      expect(result.items[1].orderSummary).toEqual(result.items[0].orderSummary);
+      expect(result.items[2].orderSummary).toBeNull();
+    });
+
+    it('should degrade orderSummary to null (not throw) when the batch order read fails', async () => {
+      invoiceService.listInvoices.mockResolvedValue({
+        items: [makeInvoiceRecord({ orderId: 'ol_order_x' })],
+        total: 1,
+      });
+      orders.findByIds.mockRejectedValue(new Error('db blip'));
+
+      const result = await controller.listInvoices({ limit: 20, offset: 0 });
+
+      expect(result.items[0].orderSummary).toBeNull();
+    });
+
+    it('should not call findByIds at all for an empty page', async () => {
+      invoiceService.listInvoices.mockResolvedValue({ items: [], total: 0 });
+      await controller.listInvoices({});
+      expect(orders.findByIds).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/invoicing/http/invoicing.controller.ts
+++ b/apps/api/src/invoicing/http/invoicing.controller.ts
@@ -103,8 +103,9 @@ import {
   IOrderRecordService,
   orderFromReadySnapshot,
   OrderSnapshotUnavailableError,
+  buildOrderSummary,
 } from '@openlinker/core/orders';
-import type { Order, OrderRecord } from '@openlinker/core/orders';
+import type { Order, OrderRecord, OrderSummary } from '@openlinker/core/orders';
 import {
   CONNECTION_PORT_TOKEN,
   ConnectionPort,
@@ -114,6 +115,7 @@ import { IssueCorrectionRequestDto } from './dto/issue-correction-request.dto';
 import { GetInvoiceForOrderQueryDto } from './dto/get-invoice-for-order-query.dto';
 import { ListInvoicesQueryDto } from './dto/list-invoices-query.dto';
 import { InvoiceRecordResponseDto } from './dto/invoice-record-response.dto';
+import { OrderSummaryProjectionDto } from '../../orders/http/dto/order-summary-projection.dto';
 import { IssuedDocumentContentDto } from './dto/issued-document-content.dto';
 import { PaginatedInvoicesResponseDto } from './dto/paginated-invoices-response.dto';
 import { RetryInvoicesRequestDto } from './dto/retry-invoices-request.dto';
@@ -1098,12 +1100,43 @@ export class InvoicingController {
       taxId: query.taxId,
     };
     const page = await this.invoiceService.listInvoices(filter, { limit, offset });
+    const orderSummaryByOrderId = await this.resolveOrderSummaries(
+      page.items.map((record) => record.orderId),
+    );
     return {
-      items: page.items.map((record) => this.toDto(record)),
+      items: page.items.map((record) =>
+        this.toDto(record, orderSummaryByOrderId.get(record.orderId) ?? null),
+      ),
       total: page.total,
       limit,
       offset,
     };
+  }
+
+  /**
+   * Batch-resolve #1995's `orderSummary` projection for a page of invoices. A
+   * SINGLE `IOrderRecordService.findByIds` call scoped to the page's
+   * deduplicated order ids — never a per-order fan-out (mirrors the shipping
+   * context's `ShipmentController.resolveOrderContext`). Degrades to an empty
+   * map (every row's summary `null`) on a batch-read failure — a broken
+   * enrichment must never take down the primary invoices read.
+   */
+  private async resolveOrderSummaries(orderIds: string[]): Promise<Map<string, OrderSummary | null>> {
+    const distinct = [...new Set(orderIds)];
+    if (distinct.length === 0) {
+      return new Map();
+    }
+    let records: Awaited<ReturnType<IOrderRecordService['findByIds']>> = [];
+    try {
+      records = await this.orders.findByIds(distinct);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn(`Failed to batch-resolve orders for invoices list: ${message}`);
+    }
+    const recordByOrderId = new Map(records.map((record) => [record.internalOrderId, record]));
+    return new Map(
+      distinct.map((orderId) => [orderId, buildOrderSummary(recordByOrderId.get(orderId))]),
+    );
   }
 
   /**
@@ -1291,8 +1324,12 @@ export class InvoicingController {
   /**
    * Explicit field projection (mirrors customers `toDto`): never spreads the
    * entity, and DELIBERATELY omits `idempotencyKey` + `errorMessage`.
+   *
+   * @param orderSummary Batched order-identity projection (#1995). Defaults to
+   *   `null` — every call site except `listInvoices` is a single-record
+   *   read/write with no batched order context to hand it.
    */
-  private toDto(record: InvoiceRecord): InvoiceRecordResponseDto {
+  private toDto(record: InvoiceRecord, orderSummary: OrderSummary | null = null): InvoiceRecordResponseDto {
     return {
       id: record.id,
       connectionId: record.connectionId,
@@ -1312,6 +1349,7 @@ export class InvoicingController {
       issuedAt: record.issuedAt ? record.issuedAt.toISOString() : null,
       createdAt: record.createdAt.toISOString(),
       updatedAt: record.updatedAt.toISOString(),
+      orderSummary: orderSummary ? OrderSummaryProjectionDto.fromSummary(orderSummary) : null,
     };
   }
 
@@ -1478,7 +1516,7 @@ export class InvoicingController {
     if (!record) {
       throw new NotFoundException(`Invoice not found: ${invoiceId}`);
     }
-    return InvoiceRecordResponseDto.fromDomain(record);
+    return InvoiceRecordResponseDto.fromDomain(record, null);
   }
 
   /**

--- a/apps/api/src/orders/http/dto/order-summary-projection.dto.ts
+++ b/apps/api/src/orders/http/dto/order-summary-projection.dto.ts
@@ -1,0 +1,48 @@
+/**
+ * Order Summary Projection DTO
+ *
+ * Neutral order-identity projection (#1995) shared by the Shipments and
+ * Invoices list responses, so a row can identify its order (order number,
+ * first line-item name/image, item count) without a detail-page round trip.
+ * Derived server-side from the order's own snapshot via
+ * `buildOrderSummary` (`@openlinker/core/orders`) — no new persistence.
+ *
+ * @module apps/api/src/orders/http/dto
+ */
+import { ApiProperty } from '@nestjs/swagger';
+import type { OrderSummary } from '@openlinker/core/orders';
+
+export class OrderSummaryProjectionDto {
+  @ApiProperty({
+    nullable: true,
+    description: 'Source-native order number from the order snapshot; null when absent.',
+  })
+  orderNumber!: string | null;
+
+  @ApiProperty({
+    nullable: true,
+    description: "The order's first line item's display name; null when unavailable.",
+  })
+  firstItemName!: string | null;
+
+  @ApiProperty({
+    nullable: true,
+    description:
+      "The order's first line item's image URL, frozen at order-snapshot time (NOT the live product catalog image); null when the source never populated it.",
+  })
+  firstItemImageUrl!: string | null;
+
+  @ApiProperty({
+    description: "The order's full item count (not the number of items projected here).",
+  })
+  itemCount!: number;
+
+  static fromSummary(summary: OrderSummary): OrderSummaryProjectionDto {
+    const dto = new OrderSummaryProjectionDto();
+    dto.orderNumber = summary.orderNumber;
+    dto.firstItemName = summary.firstItemName;
+    dto.firstItemImageUrl = summary.firstItemImageUrl;
+    dto.itemCount = summary.itemCount;
+    return dto;
+  }
+}

--- a/apps/api/src/orders/http/orders.controller.spec.ts
+++ b/apps/api/src/orders/http/orders.controller.spec.ts
@@ -63,6 +63,7 @@ describe('OrdersController', () => {
   beforeEach(async () => {
     const mockRepository: jest.Mocked<OrderRecordRepositoryPort> = {
       findById: jest.fn(),
+      findByIds: jest.fn(),
       upsert: jest.fn(),
       updateSyncStatus: jest.fn(),
       findMany: jest.fn(),

--- a/apps/api/src/shipping/http/dto/bulk-dispatch-result-response.dto.ts
+++ b/apps/api/src/shipping/http/dto/bulk-dispatch-result-response.dto.ts
@@ -41,7 +41,7 @@ export class PerOrderDispatchResultDto {
       // `canWrite: true` — POST /shipments/bulk/generate-labels is
       // `@Roles('admin', 'operator')`-gated, so the caller already holds
       // `shipments:write` and there is nothing to redact (#1826).
-      dto.shipment = ShipmentResponseDto.fromDomain(result.shipment, null, true);
+      dto.shipment = ShipmentResponseDto.fromDomain(result.shipment, null, true, null);
     } else if (result.kind === 'failed') {
       dto.error = result.error;
     }

--- a/apps/api/src/shipping/http/dto/dispatch-result-response.dto.ts
+++ b/apps/api/src/shipping/http/dto/dispatch-result-response.dto.ts
@@ -29,7 +29,7 @@ export class DispatchResultResponseDto {
       // `canWrite: true` — POST /shipments/generate-label is `@Roles('admin',
       // 'operator')`-gated, so a caller who reached this projection already
       // holds `shipments:write` and there is nothing to redact (#1826).
-      dto.shipment = ShipmentResponseDto.fromDomain(result.shipment, null, true);
+      dto.shipment = ShipmentResponseDto.fromDomain(result.shipment, null, true, null);
     }
     return dto;
   }

--- a/apps/api/src/shipping/http/dto/shipment-response.dto.spec.ts
+++ b/apps/api/src/shipping/http/dto/shipment-response.dto.spec.ts
@@ -1,0 +1,52 @@
+/**
+ * ShipmentResponseDto unit tests (#1995 — orderSummary projection).
+ */
+import { Shipment } from '@openlinker/core/shipping';
+import { ShipmentResponseDto } from './shipment-response.dto';
+import type { OrderSummary } from '@openlinker/core/orders';
+
+function makeShipment(): Shipment {
+  return new Shipment(
+    'ol_shipment_1',
+    'ol_order_1',
+    'b3f1c2d4-0000-4000-8000-000000000001',
+    'paczkomat',
+    'generated',
+    'shipx-1',
+    'POZ08A',
+    '6800000001',
+    'shipx:label:1',
+    null,
+    null,
+    null,
+    null,
+    null,
+    new Date('2026-05-20T10:00:00.000Z'),
+    new Date('2026-05-20T10:00:00.000Z'),
+    null,
+    null,
+    null,
+    null,
+    null,
+  );
+}
+
+describe('ShipmentResponseDto.fromDomain', () => {
+  it('sets orderSummary to null when no summary is supplied', () => {
+    const dto = ShipmentResponseDto.fromDomain(makeShipment(), null, true, null);
+    expect(dto.orderSummary).toBeNull();
+  });
+
+  it('maps a supplied OrderSummary onto the DTO', () => {
+    const summary: OrderSummary = {
+      orderNumber: 'ORD-001',
+      firstItemName: 'Terra Wool Coat',
+      firstItemImageUrl: 'https://example.com/coat.png',
+      itemCount: 2,
+    };
+
+    const dto = ShipmentResponseDto.fromDomain(makeShipment(), null, true, summary);
+
+    expect(dto.orderSummary).toEqual(summary);
+  });
+});

--- a/apps/api/src/shipping/http/dto/shipment-response.dto.ts
+++ b/apps/api/src/shipping/http/dto/shipment-response.dto.ts
@@ -27,6 +27,8 @@ import {
   ShippingMethod,
 } from '@openlinker/core/shipping';
 import type { Shipment, DeliveryIntent } from '@openlinker/core/shipping';
+import type { OrderSummary } from '@openlinker/core/orders';
+import { OrderSummaryProjectionDto } from '../../../orders/http/dto/order-summary-projection.dto';
 
 /** Mirrors the FE's redaction placeholder (`shipments-page.tsx`,
  *  `shipment-row-detail.tsx`) so the copy is identical regardless of which
@@ -117,17 +119,29 @@ export class ShipmentResponseDto {
   @ApiProperty({ type: String, format: 'date-time' })
   updatedAt!: string;
 
+  @ApiProperty({
+    nullable: true,
+    type: OrderSummaryProjectionDto,
+    description:
+      "Order-identity projection (#1995) for the unified Order cell — null when no order record resolves for `orderId`, or its snapshot has no parseable items. Only populated on the list endpoint (`GET /shipments`); single-shipment reads pass null (not fetched there).",
+  })
+  orderSummary!: OrderSummaryProjectionDto | null;
+
   /**
    * @param canWrite Whether the requester holds `shipments:write` (resolved
    *   by the controller from `@CurrentUser()`'s role via `ROLE_PERMISSIONS`).
    *   Deliberately REQUIRED and un-defaulted: a default would make "forgot to
    *   thread the requester through a new read endpoint" a silent disclosure
    *   instead of a compile error.
+   * @param orderSummary Batched order-identity projection (#1995), or `null`
+   *   when not resolved for this call site. Also required (not defaulted) so
+   *   a future read path can't silently omit it.
    */
   static fromDomain(
     shipment: Shipment,
     customerId: string | null,
     canWrite: boolean,
+    orderSummary: OrderSummary | null,
   ): ShipmentResponseDto {
     const dto = new ShipmentResponseDto();
     dto.id = shipment.id;
@@ -152,6 +166,7 @@ export class ShipmentResponseDto {
     dto.providerCode = shipment.providerCode;
     dto.createdAt = shipment.createdAt.toISOString();
     dto.updatedAt = shipment.updatedAt.toISOString();
+    dto.orderSummary = orderSummary ? OrderSummaryProjectionDto.fromSummary(orderSummary) : null;
     return dto;
   }
 }

--- a/apps/api/src/shipping/http/shipment.controller.spec.ts
+++ b/apps/api/src/shipping/http/shipment.controller.spec.ts
@@ -124,6 +124,8 @@ describe('ShipmentController', () => {
       // Default: order/customer unknown → customerId resolves to null.
       getOrderRecord: jest.fn().mockResolvedValue(null),
       findMany: jest.fn(),
+      // Default: batch order lookup resolves nothing → context degrades to null.
+      findByIds: jest.fn().mockResolvedValue([]),
       updateFulfillmentState: jest.fn(),
       markItemResolutionFailure: jest.fn(),
     };
@@ -179,7 +181,7 @@ describe('ShipmentController', () => {
       );
     });
 
-    it("should resolve each row's customerId from its order (deduped) and set it on the DTO", async () => {
+    it("should resolve each row's customerId from a single batched order read (deduped) and set it on the DTO", async () => {
       query.list.mockResolvedValue({
         items: [
           makeShipment({ id: 'ol_shipment_1', orderId: 'ol_order_1' }),
@@ -188,31 +190,85 @@ describe('ShipmentController', () => {
         ],
         total: 3,
       });
-      orders.getOrderRecord.mockImplementation((orderId: string) =>
-        Promise.resolve(
-          orderId === 'ol_order_1'
-            ? ({ customerId: 'ol_customer_a' } as OrderRecord)
-            : ({ customerId: null } as OrderRecord),
-        ),
-      );
+      orders.findByIds.mockResolvedValue([
+        { internalOrderId: 'ol_order_1', customerId: 'ol_customer_a' } as OrderRecord,
+      ]);
 
       const result = await controller.list({}, ADMIN_USER);
 
       expect(result.items[0].customerId).toBe('ol_customer_a');
       expect(result.items[1].customerId).toBe('ol_customer_a');
       expect(result.items[2].customerId).toBeNull();
-      // Deduped: 2 distinct order ids → 2 lookups, not 3.
-      expect(orders.getOrderRecord).toHaveBeenCalledTimes(2);
+      // Deduped, single real batch call — 2 distinct order ids across 3 rows,
+      // never a per-order fan-out (#1995).
+      expect(orders.findByIds).toHaveBeenCalledTimes(1);
+      expect(orders.findByIds).toHaveBeenCalledWith(['ol_order_1', 'ol_order_2']);
     });
 
-    it('should degrade customerId to null (not 500) when an order lookup fails', async () => {
+    it('should degrade customerId/orderSummary to null (not 500) when the batch order lookup fails', async () => {
       query.list.mockResolvedValue({ items: [makeShipment({ orderId: 'ol_order_x' })], total: 1 });
-      orders.getOrderRecord.mockRejectedValue(new Error('db blip'));
+      orders.findByIds.mockRejectedValue(new Error('db blip'));
 
       const result = await controller.list({}, ADMIN_USER);
 
       expect(result.items).toHaveLength(1);
       expect(result.items[0].customerId).toBeNull();
+      expect(result.items[0].orderSummary).toBeNull();
+    });
+
+    it('should issue a bounded number of order reads independent of page size (#1995)', async () => {
+      query.list.mockResolvedValue({
+        items: Array.from({ length: 20 }, (_, i) =>
+          makeShipment({ id: `ol_shipment_${i}`, orderId: `ol_order_${i % 5}` }),
+        ),
+        total: 20,
+      });
+
+      await controller.list({}, ADMIN_USER);
+
+      // 20 rows across only 5 distinct orders → exactly one batched call.
+      expect(orders.findByIds).toHaveBeenCalledTimes(1);
+      expect(orders.findByIds).toHaveBeenCalledWith([
+        'ol_order_0',
+        'ol_order_1',
+        'ol_order_2',
+        'ol_order_3',
+        'ol_order_4',
+      ]);
+    });
+
+    it('should populate orderSummary (#1995) from the batched order read', async () => {
+      query.list.mockResolvedValue({
+        items: [makeShipment({ id: 'ol_shipment_1', orderId: 'ol_order_1' })],
+        total: 1,
+      });
+      orders.findByIds.mockResolvedValue([
+        {
+          internalOrderId: 'ol_order_1',
+          customerId: null,
+          orderSnapshot: {
+            orderNumber: 'ORD-001',
+            items: [{ name: 'Terra Wool Coat', imageUrl: 'https://example.com/coat.png' }],
+          },
+        } as unknown as OrderRecord,
+      ]);
+
+      const result = await controller.list({}, ADMIN_USER);
+
+      expect(result.items[0].orderSummary).toEqual({
+        orderNumber: 'ORD-001',
+        firstItemName: 'Terra Wool Coat',
+        firstItemImageUrl: 'https://example.com/coat.png',
+        itemCount: 1,
+      });
+    });
+
+    it('should not call findByIds at all for an empty page', async () => {
+      query.list.mockResolvedValue({ items: [], total: 0 });
+
+      await controller.list({}, ADMIN_USER);
+
+      expect(orders.findByIds).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/api/src/shipping/http/shipment.controller.ts
+++ b/apps/api/src/shipping/http/shipment.controller.ts
@@ -68,7 +68,12 @@ import {
   OrderNotDispatchablePaymentStatusException,
   ShipmentDispatchContendedException,
 } from '@openlinker/core/shipping';
-import { type IOrderRecordService, ORDER_RECORD_SERVICE_TOKEN } from '@openlinker/core/orders';
+import {
+  type IOrderRecordService,
+  ORDER_RECORD_SERVICE_TOKEN,
+  buildOrderSummary,
+  type OrderSummary,
+} from '@openlinker/core/orders';
 import { ROLE_PERMISSIONS } from '@openlinker/core/users';
 import { Logger } from '@openlinker/shared/logging';
 import { CurrentUser } from '../../auth/decorators/current-user.decorator';
@@ -129,15 +134,17 @@ export class ShipmentController {
 
     const canWrite = this.hasShipmentsWrite(user);
     const page = await this.query.list(filters, { limit, offset });
-    const customerByOrder = await this.resolveCustomerIds(page.items.map((s) => s.orderId));
+    const orderContext = await this.resolveOrderContext(page.items.map((s) => s.orderId));
     return {
-      items: page.items.map((shipment) =>
-        ShipmentResponseDto.fromDomain(
+      items: page.items.map((shipment) => {
+        const context = orderContext.get(shipment.orderId);
+        return ShipmentResponseDto.fromDomain(
           shipment,
-          customerByOrder.get(shipment.orderId) ?? null,
+          context?.customerId ?? null,
           canWrite,
-        ),
-      ),
+          context?.orderSummary ?? null,
+        );
+      }),
       total: page.total,
       limit,
       offset,
@@ -166,6 +173,7 @@ export class ShipmentController {
       shipment,
       await this.resolveCustomerId(shipment.orderId),
       this.hasShipmentsWrite(user),
+      null,
     );
   }
 
@@ -185,6 +193,7 @@ export class ShipmentController {
       shipment,
       await this.resolveCustomerId(shipment.orderId),
       this.hasShipmentsWrite(user),
+      null,
     );
   }
 
@@ -347,7 +356,7 @@ export class ShipmentController {
     try {
       const shipment = await this.cancellation.cancel(id);
       // `@Roles('admin', 'operator')`-gated — the caller holds `shipments:write`.
-      return ShipmentResponseDto.fromDomain(shipment, null, true);
+      return ShipmentResponseDto.fromDomain(shipment, null, true, null);
     } catch (error) {
       throw this.toHttpException(error, true);
     }
@@ -425,20 +434,42 @@ export class ShipmentController {
   }
 
   /**
-   * Batch-resolve customer ids for a page of shipments. Dedupes order ids so a
-   * page with N shipments across M distinct orders costs M lookups, not N.
-   * NOTE: no batch read exists on `IOrderRecordService` yet — this is M single
-   * `getOrderRecord` calls; a `findByIds` batch is a tracked follow-up.
+   * Batch-resolve per-order context (customerId + #1995 orderSummary) for a
+   * page of shipments. A SINGLE `IOrderRecordService.findByIds` call scoped to
+   * the page's deduplicated order ids — deliberately NOT a `Promise.all` fan-out
+   * of single reads (that shape used to live here; see the #1995 issue body's
+   * "anti-pattern" callout). Degrades to an empty map (every row's context
+   * `undefined`) on a batch-read failure — a broken enrichment must never take
+   * down the primary shipments read, mirroring `resolveCustomerId`'s per-row
+   * degrade-to-null.
    */
-  private async resolveCustomerIds(orderIds: string[]): Promise<Map<string, string | null>> {
+  private async resolveOrderContext(
+    orderIds: string[],
+  ): Promise<Map<string, { customerId: string | null; orderSummary: OrderSummary | null }>> {
     const distinct = [...new Set(orderIds)];
-    const entries = await Promise.all(
-      distinct.map(async (orderId): Promise<[string, string | null]> => [
-        orderId,
-        await this.resolveCustomerId(orderId),
-      ]),
+    if (distinct.length === 0) {
+      return new Map();
+    }
+    let records: Awaited<ReturnType<IOrderRecordService['findByIds']>> = [];
+    try {
+      records = await this.orders.findByIds(distinct);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.warn(`Failed to batch-resolve orders for shipments list: ${message}`);
+    }
+    const recordByOrderId = new Map(records.map((record) => [record.internalOrderId, record]));
+    return new Map(
+      distinct.map((orderId) => {
+        const record = recordByOrderId.get(orderId);
+        return [
+          orderId,
+          {
+            customerId: record?.customerId ?? null,
+            orderSummary: buildOrderSummary(record),
+          },
+        ];
+      }),
     );
-    return new Map(entries);
   }
 
   /**

--- a/apps/web/src/features/invoicing/api/invoicing.types.ts
+++ b/apps/web/src/features/invoicing/api/invoicing.types.ts
@@ -79,6 +79,28 @@ export const DocumentTypeValues = [
 export type DocumentType = (typeof DocumentTypeValues)[number];
 
 /**
+ * Order-identity projection (#1995) mirroring the API's
+ * `OrderSummaryProjectionDto` — backs the shared `OrderIdentityCell` (#1996).
+ * `null` when no order record resolves for the row's `orderId`, or its
+ * snapshot has no parseable items.
+ */
+export interface OrderSummary {
+  /** Source-native order number from the order snapshot; null when absent. */
+  orderNumber: string | null;
+  /** The order's first line item's display name; null when unavailable. */
+  firstItemName: string | null;
+  /**
+   * The order's first line item's image URL, frozen at order-snapshot time
+   * (NOT the live product catalog image); null when the source never
+   * populated it — the common case today, since no adapter sets
+   * `OrderItem.imageUrl` on ingestion yet.
+   */
+  firstItemImageUrl: string | null;
+  /** The order's full item count (not the number of items projected here). */
+  itemCount: number;
+}
+
+/**
  * Exact field set of `InvoiceRecordResponseDto`. Dates are ISO strings;
  * nullables `| null`. NO `errorMessage`, NO `idempotencyKey`.
  *
@@ -104,6 +126,12 @@ export interface InvoiceRecord {
   issuedAt: string | null;
   createdAt: string;
   updatedAt: string;
+  /**
+   * Batched order-identity projection (#1995). Only populated by `GET
+   * /invoices` (the list endpoint) — single-invoice reads carry `null` (not
+   * fetched there).
+   */
+  orderSummary: OrderSummary | null;
 }
 
 /** `POST /invoices` request body. No `idempotencyKey` in v1 (the controller

--- a/apps/web/src/features/invoicing/components/invoice-timeline.test.tsx
+++ b/apps/web/src/features/invoicing/components/invoice-timeline.test.tsx
@@ -31,6 +31,7 @@ function makeInvoice(over: Partial<InvoiceRecord> = {}): InvoiceRecord {
     issuedAt: '2026-06-02T10:00:00.000Z',
     createdAt: '2026-06-02T09:00:00.000Z',
     updatedAt: '2026-06-02T10:00:00.000Z',
+    orderSummary: null,
     ...over,
   };
 }

--- a/apps/web/src/features/invoicing/components/order-invoice-panel.test.tsx
+++ b/apps/web/src/features/invoicing/components/order-invoice-panel.test.tsx
@@ -105,6 +105,7 @@ function makeInvoice(over: Partial<InvoiceRecord> = {}): InvoiceRecord {
     issuedAt: '2026-06-02T00:00:00.000Z',
     createdAt: '2026-06-02T00:00:00.000Z',
     updatedAt: '2026-06-02T00:00:00.000Z',
+    orderSummary: null,
     ...over,
   };
 }

--- a/apps/web/src/features/invoicing/hooks/use-issue-correction-mutation.test.tsx
+++ b/apps/web/src/features/invoicing/hooks/use-issue-correction-mutation.test.tsx
@@ -28,6 +28,7 @@ function makeInvoiceRecord(overrides: Partial<InvoiceRecord> = {}): InvoiceRecor
     issuedAt: null,
     createdAt: '2026-06-25T00:00:00.000Z',
     updatedAt: '2026-06-25T00:00:00.000Z',
+    orderSummary: null,
     ...overrides,
   };
 }

--- a/apps/web/src/features/invoicing/hooks/use-order-invoice-query.test.tsx
+++ b/apps/web/src/features/invoicing/hooks/use-order-invoice-query.test.tsx
@@ -45,6 +45,7 @@ const invoice = (over: Partial<InvoiceRecord> = {}): InvoiceRecord => ({
   issuedAt: null,
   createdAt: '2026-06-01T00:00:00.000Z',
   updatedAt: '2026-06-01T00:00:00.000Z',
+  orderSummary: null,
   ...over,
 });
 

--- a/apps/web/src/features/invoicing/hooks/use-resend-to-ksef-mutation.test.tsx
+++ b/apps/web/src/features/invoicing/hooks/use-resend-to-ksef-mutation.test.tsx
@@ -28,6 +28,7 @@ function makeInvoiceRecord(overrides: Partial<InvoiceRecord> = {}): InvoiceRecor
     issuedAt: null,
     createdAt: '2026-07-01T00:00:00.000Z',
     updatedAt: '2026-07-01T00:00:00.000Z',
+    orderSummary: null,
     ...overrides,
   };
 }

--- a/apps/web/src/features/invoicing/lib/derive-invoice-display.test.ts
+++ b/apps/web/src/features/invoicing/lib/derive-invoice-display.test.ts
@@ -34,6 +34,7 @@ function makeRecord(overrides: Partial<InvoiceRecord> = {}): InvoiceRecord {
     issuedAt: null,
     createdAt: '2026-01-01T00:00:00Z',
     updatedAt: '2026-01-01T00:00:00Z',
+    orderSummary: null,
     ...overrides,
   };
 }

--- a/apps/web/src/features/orders/components/bulk-dispatch-dialog.test.tsx
+++ b/apps/web/src/features/orders/components/bulk-dispatch-dialog.test.tsx
@@ -68,6 +68,7 @@ function shipment(id: string, carrier: string, connectionId: string): Shipment {
     providerCode: null,
     createdAt: '2026-01-01T00:00:00.000Z',
     updatedAt: '2026-01-01T00:00:00.000Z',
+    orderSummary: null,
   };
 }
 

--- a/apps/web/src/features/orders/components/order-shipment-panel.test.tsx
+++ b/apps/web/src/features/orders/components/order-shipment-panel.test.tsx
@@ -92,6 +92,7 @@ function makeShipment(overrides: Partial<Shipment> = {}): Shipment {
     providerCode: null,
     createdAt: '2026-05-28T10:00:00.000Z',
     updatedAt: '2026-05-28T11:00:00.000Z',
+    orderSummary: null,
     ...overrides,
   };
 }

--- a/apps/web/src/features/shipments/api/shipments.types.ts
+++ b/apps/web/src/features/shipments/api/shipments.types.ts
@@ -96,6 +96,28 @@ export const SHIPPING_METHOD_LABEL: Record<ShippingMethod, string> = {
  */
 export const REDACTED_ERROR_MESSAGE = 'Details hidden for this role.';
 
+/**
+ * Order-identity projection (#1995) mirroring the API's
+ * `OrderSummaryProjectionDto` — backs the shared `OrderIdentityCell` (#1996).
+ * `null` when no order record resolves for the row's `orderId`, or its
+ * snapshot has no parseable items.
+ */
+export interface OrderSummary {
+  /** Source-native order number from the order snapshot; null when absent. */
+  orderNumber: string | null;
+  /** The order's first line item's display name; null when unavailable. */
+  firstItemName: string | null;
+  /**
+   * The order's first line item's image URL, frozen at order-snapshot time
+   * (NOT the live product catalog image); null when the source never
+   * populated it — the common case today, since no adapter sets
+   * `OrderItem.imageUrl` on ingestion yet.
+   */
+  firstItemImageUrl: string | null;
+  /** The order's full item count (not the number of items projected here). */
+  itemCount: number;
+}
+
 export interface Shipment {
   id: string;
   orderId: string;
@@ -139,6 +161,12 @@ export interface Shipment {
   errorMessage: string | null;
   createdAt: string;
   updatedAt: string;
+  /**
+   * Batched order-identity projection (#1995). Only populated by `GET
+   * /shipments` (the list endpoint) — single-shipment reads carry `null`
+   * (not fetched there).
+   */
+  orderSummary: OrderSummary | null;
 }
 
 /**

--- a/apps/web/src/features/shipments/components/shipment-row-detail.test.tsx
+++ b/apps/web/src/features/shipments/components/shipment-row-detail.test.tsx
@@ -36,6 +36,7 @@ function makeShipment(overrides: Partial<Shipment> = {}): Shipment {
     providerCode: null,
     createdAt: '2026-07-24T09:11:00.000Z',
     updatedAt: '2026-07-24T09:12:00.000Z',
+    orderSummary: null,
     ...overrides,
   };
 }

--- a/apps/web/src/features/shipments/components/shipment-triage-strip.test.tsx
+++ b/apps/web/src/features/shipments/components/shipment-triage-strip.test.tsx
@@ -39,6 +39,7 @@ function makeShipment(overrides: Partial<Shipment> = {}): Shipment {
     providerCode: null,
     createdAt: '2026-07-24T09:11:00.000Z',
     updatedAt: '2026-07-24T09:12:00.000Z',
+    orderSummary: null,
     ...overrides,
   };
 }

--- a/apps/web/src/features/shipments/lib/carrier-tracking-url.test.ts
+++ b/apps/web/src/features/shipments/lib/carrier-tracking-url.test.ts
@@ -32,6 +32,7 @@ function makeShipment(overrides: Partial<Shipment> = {}): Shipment {
     providerCode: null,
     createdAt: '2026-05-28T09:00:00.000Z',
     updatedAt: '2026-05-28T10:00:00.000Z',
+    orderSummary: null,
     ...overrides,
   };
 }

--- a/apps/web/src/features/shipments/lib/group-failed-shipments-by-cause.test.ts
+++ b/apps/web/src/features/shipments/lib/group-failed-shipments-by-cause.test.ts
@@ -29,6 +29,7 @@ function makeShipment(overrides: Partial<Shipment> = {}): Shipment {
     providerCode: null,
     createdAt: '2026-07-24T09:11:00.000Z',
     updatedAt: '2026-07-24T09:12:00.000Z',
+    orderSummary: null,
     ...overrides,
   };
 }

--- a/apps/web/src/features/shipments/lib/processor.test.ts
+++ b/apps/web/src/features/shipments/lib/processor.test.ts
@@ -33,6 +33,7 @@ function makeShipment(overrides: Partial<Shipment> = {}): Shipment {
     providerCode: null,
     createdAt: '2026-05-29T10:00:00.000Z',
     updatedAt: '2026-05-29T10:00:00.000Z',
+    orderSummary: null,
     ...overrides,
   };
 }

--- a/apps/web/src/features/shipments/lib/shipment-action-eligibility.test.ts
+++ b/apps/web/src/features/shipments/lib/shipment-action-eligibility.test.ts
@@ -41,6 +41,7 @@ function makeShipment(overrides: Partial<Shipment> = {}): Shipment {
     providerCode: null,
     createdAt: '2026-07-24T09:11:00.000Z',
     updatedAt: '2026-07-24T09:12:00.000Z',
+    orderSummary: null,
     ...overrides,
   };
 }

--- a/apps/web/src/features/shipments/lib/shipment-severity.test.ts
+++ b/apps/web/src/features/shipments/lib/shipment-severity.test.ts
@@ -30,6 +30,7 @@ function makeShipment(overrides: Partial<Shipment> = {}): Shipment {
     providerCode: null,
     createdAt: '2026-07-24T09:11:00.000Z',
     updatedAt: '2026-07-24T09:12:00.000Z',
+    orderSummary: null,
     ...overrides,
   };
 }

--- a/apps/web/src/pages/invoicing/invoice-detail-page.test.tsx
+++ b/apps/web/src/pages/invoicing/invoice-detail-page.test.tsx
@@ -53,6 +53,7 @@ function makeInvoice(over: Partial<InvoiceRecord> = {}): InvoiceRecord {
     issuedAt: '2026-06-02T10:00:00.000Z',
     createdAt: '2026-06-02T09:00:00.000Z',
     updatedAt: '2026-06-02T10:00:00.000Z',
+    orderSummary: null,
     ...over,
   };
 }

--- a/apps/web/src/pages/invoicing/invoices-list-page.test.tsx
+++ b/apps/web/src/pages/invoicing/invoices-list-page.test.tsx
@@ -53,6 +53,7 @@ function makeInvoice(overrides: Partial<InvoiceRecord> = {}): InvoiceRecord {
     issuedAt: '2026-06-01T10:00:00.000Z',
     createdAt: '2026-06-01T10:00:00.000Z',
     updatedAt: '2026-06-01T10:00:00.000Z',
+    orderSummary: null,
     ...overrides,
   };
 }

--- a/apps/web/src/pages/shipments/shipments-page.test.tsx
+++ b/apps/web/src/pages/shipments/shipments-page.test.tsx
@@ -34,6 +34,7 @@ function makeShipment(overrides: Partial<Shipment> = {}): Shipment {
     providerCode: null,
     createdAt: '2026-05-20T10:00:00.000Z',
     updatedAt: '2026-05-20T10:00:00.000Z',
+    orderSummary: null,
     ...overrides,
   };
 }

--- a/apps/web/src/plugins/infakt/components/infakt-invoice-correction-flow.test.tsx
+++ b/apps/web/src/plugins/infakt/components/infakt-invoice-correction-flow.test.tsx
@@ -34,6 +34,7 @@ function makeInvoice(overrides: Partial<InvoiceRecord> = {}): InvoiceRecord {
     issuedAt: '2026-06-25T10:00:00.000Z',
     createdAt: '2026-06-25T09:59:00.000Z',
     updatedAt: '2026-06-25T10:00:00.000Z',
+    orderSummary: null,
     ...overrides,
   };
 }

--- a/apps/web/src/plugins/infakt/components/infakt-invoice-detail-section.test.tsx
+++ b/apps/web/src/plugins/infakt/components/infakt-invoice-detail-section.test.tsx
@@ -30,6 +30,7 @@ function makeInvoice(overrides: Partial<InvoiceRecord> = {}): InvoiceRecord {
     issuedAt: '2026-06-25T10:00:00.000Z',
     createdAt: '2026-06-25T09:59:00.000Z',
     updatedAt: '2026-06-25T10:00:00.000Z',
+    orderSummary: null,
     ...overrides,
   };
 }

--- a/apps/web/src/plugins/ksef/components/ksef-invoice-correction-flow.test.tsx
+++ b/apps/web/src/plugins/ksef/components/ksef-invoice-correction-flow.test.tsx
@@ -34,6 +34,7 @@ function makeInvoice(overrides: Partial<InvoiceRecord> = {}): InvoiceRecord {
     issuedAt: '2026-06-25T10:00:00.000Z',
     createdAt: '2026-06-25T09:59:00.000Z',
     updatedAt: '2026-06-25T10:00:00.000Z',
+    orderSummary: null,
     ...overrides,
   };
 }

--- a/apps/web/src/plugins/ksef/components/ksef-invoice-detail-section.test.tsx
+++ b/apps/web/src/plugins/ksef/components/ksef-invoice-detail-section.test.tsx
@@ -38,6 +38,7 @@ function makeInvoice(over: Partial<InvoiceRecord> = {}): InvoiceRecord {
     issuedAt: '2026-06-25T14:08:00.000Z',
     createdAt: '2026-06-25T13:50:00.000Z',
     updatedAt: '2026-06-25T14:08:00.000Z',
+    orderSummary: null,
     ...over,
   };
 }

--- a/apps/web/src/plugins/subiekt/components/subiekt-invoice-correction-flow.test.tsx
+++ b/apps/web/src/plugins/subiekt/components/subiekt-invoice-correction-flow.test.tsx
@@ -30,6 +30,7 @@ function makeInvoice(overrides: Partial<InvoiceRecord> = {}): InvoiceRecord {
     issuedAt: '2026-06-25T10:00:00.000Z',
     createdAt: '2026-06-25T09:59:00.000Z',
     updatedAt: '2026-06-25T10:00:00.000Z',
+    orderSummary: null,
     ...overrides,
   };
 }

--- a/apps/web/src/plugins/subiekt/components/subiekt-invoice-detail-section.test.tsx
+++ b/apps/web/src/plugins/subiekt/components/subiekt-invoice-detail-section.test.tsx
@@ -30,6 +30,7 @@ function makeInvoice(overrides: Partial<InvoiceRecord> = {}): InvoiceRecord {
     issuedAt: '2026-06-25T10:00:00.000Z',
     createdAt: '2026-06-25T09:59:00.000Z',
     updatedAt: '2026-06-25T10:00:00.000Z',
+    orderSummary: null,
     ...overrides,
   };
 }

--- a/docs/plans/implementation-plan-order-summary-projection.md
+++ b/docs/plans/implementation-plan-order-summary-projection.md
@@ -1,0 +1,364 @@
+# Implementation Plan: Order-Summary Projection for Shipments & Invoices Lists
+
+**Date**: 2026-08-06
+**Status**: Draft
+**Estimated Effort**: 1–1.5 days
+
+**Source issue**: [#1995](https://github.com/openlinker-project/openlinker/issues/1995) — "[TASK] CORE — order-summary projection for the unified Order identity cell on Shipments and Invoices"
+**Consumed by**: [#1996](https://github.com/openlinker-project/openlinker/issues/1996) — one shared `OrderIdentityCell` / `ConnectionCell` across six list pages, visually specified in `docs/plans/mockups/list-identity-cells-1996.html` (accepted mockup, merged via #1999). This plan implements only the backend data gap #1996 depends on — no rendering work.
+
+---
+
+## 1. Task Summary
+
+**Objective**: Add a read-only `orderSummary` projection to the `GET /shipments` and `GET /invoices` list responses, so an operator can identify which order a shipment/invoice row belongs to (order number, first line-item name + image, item count) without opening the detail page.
+
+**Context**: Six list pages (Orders, Products, Listings, Customers, Shipments, Invoices) are being visually unified around one `OrderIdentityCell` (#1996). Orders already carries everything that cell needs via `OrderRecordResponseDto.orderSnapshot` (`orderNumber`, `items[]`). Shipments and Invoices carry only a bare `orderId` today — no amount of client-side composition can invent the missing fields, so this is a backend-only prerequisite.
+
+**Classification**: CORE (application-layer batch read) + Interface (two list-response DTOs, two controllers).
+
+---
+
+## 2. Scope & Non-Goals
+
+### In Scope
+- A new `IOrderRecordService.findByIds(orderIds: string[]): Promise<OrderRecord[]>` batch method (+ matching `OrderRecordRepositoryPort.findByIds`, TypeORM implementation).
+- A pure, order-context-owned helper that projects an `OrderRecord.orderSnapshot` into the neutral `orderSummary` shape (handles the untyped-JSONB / unparseable-snapshot case → `null`).
+- `orderSummary` added to `ShipmentResponseDto` and `InvoiceRecordResponseDto`, assembled by a **batched** join in each controller (one `findByIds` call per page, not one read per row).
+- FE transport types mirrored: `apps/web/src/features/shipments/api/shipments.types.ts`, `apps/web/src/features/invoicing/api/invoicing.types.ts` (+ a shared `OrderSummary` type, colocated per-feature per the existing hand-mirror convention — no cross-feature type sharing is required since both are structurally identical but independently owned per FE contract-mirroring convention).
+- Unit tests for the projection helper (edge cases: missing record, unparseable snapshot, single item, multi item) and for both controllers' batching behavior (bounded read count independent of N).
+
+### Out of Scope
+- Any rendering work — `OrderIdentityCell`, `ConnectionCell`, and all six list-page changes are #1996, a separate (frontend) issue/plan.
+- A `connectionName` projection (explicitly refused in #1995's body, § B).
+- A composed `name` field on the Customers list response.
+- `ean` on the Products list row (cut from #1995's scope on 2026-08-04; Products' identifier line needs no backend change).
+- Sorting/filtering on the unified cells (investigated and dropped in both issues; not filed as a follow-up).
+- Populating `Order.items[].imageUrl` at ingestion — per `order.types.ts`, no current adapter sets this field. `firstItemImageUrl` will legitimately be `null` for effectively all orders today; this plan only wires the passthrough, per the accepted mockup's `†` annotation convention marking not-yet-populated data.
+
+### Constraints
+- No new persistence, no new column, no migration — `orderSummary` is a server-side join over data that already exists (`order_records.orderSnapshot` JSONB).
+- Must not repeat the `resolveCustomerIds` anti-pattern already present in `ShipmentController` (a de-duplicated `Promise.all` fan-out that reads one order at a time) — see `apps/api/src/shipping/http/shipment.controller.ts:433-442`. The acceptance criteria for #1995 are explicitly worded so that shape fails the batching test.
+- Cross-context reads must go through `IOrderRecordService` (`@openlinker/core/orders`), never `OrderRecordRepositoryPort`, per `docs/architecture-overview.md § Cross-context dependencies in core`.
+
+---
+
+## 3. Architecture Mapping
+
+**Target Layer**: CORE (`libs/core/src/orders/` — new repository/service method + pure projection helper) and Interface (`apps/api/src/shipping/`, `apps/api/src/invoicing/` — DTO + controller changes).
+
+**Capabilities Involved**: None (no `*Port` capability adapter is touched) — this is a same-process cross-context service read, not an integration capability.
+
+**Existing Services Reused**:
+- `IOrderRecordService` (token `ORDER_RECORD_SERVICE_TOKEN`) — already injected into both `ShipmentController` and `InvoicingController`. No new DI wiring needed at either controller; both modules (`libs/core/src/shipping/shipping.module.ts`, `apps/api/src/invoicing/invoicing.module.ts`) already import `OrdersModule`.
+- The `getLatestInvoicesForOrders` / `resolveDeliveryForOrders` batched-join pattern in `apps/api/src/orders/http/orders.controller.ts` (lines ~136-170, ~371-405) is the precedent to copy: one call scoped to the whole page's ids, then a `Map` join in the controller.
+
+**New Components Required**:
+- `OrderRecordRepositoryPort.findByIds(orderIds: string[]): Promise<OrderRecord[]>` (domain port method).
+- `OrderRecordRepository.findByIds` TypeORM implementation (`WHERE id IN (...)`, single query).
+- `IOrderRecordService.findByIds(orderIds: string[]): Promise<OrderRecord[]>` (application service passthrough, mirroring the existing `findMany` passthrough pattern).
+- A pure projection function `buildOrderSummary(record: OrderRecord | undefined): OrderSummary | null` — lives in the `orders` context (it owns `orderSnapshot`'s shape) and is exported from the top-level barrel so `shipping`/`invoicing` controllers can call it.
+- `OrderSummaryProjectionDto` (shared response shape, one file, reused by both response DTOs) mirroring the existing `OrderInvoiceProjectionDto` sub-DTO pattern (`apps/api/src/orders/http/dto/order-invoice-projection.dto.ts`).
+
+**Core vs Integration Justification**: This is CORE, not an integration adapter — it reads OL's own `order_records` table (already populated by every order source) and projects a subset of an existing JSONB column. No external platform is involved. It stays inside the `orders` bounded context because `orderSnapshot`'s internal shape (how `items[]`/`orderNumber` are laid out, and how to safely parse an untyped `Record<string, unknown>`) is a fact only `orders` should know — `shipping` and `invoicing` must not duplicate that parsing logic, mirroring why `orderFromReadySnapshot` and its private `readItems` parser already live in `libs/core/src/orders/domain/`.
+
+---
+
+## 4. External / Domain Research
+
+### Internal Patterns (from codebase research)
+
+**Response DTO shapes today:**
+- `ShipmentResponseDto` (`apps/api/src/shipping/http/dto/shipment-response.dto.ts:36-118`) — flat fields (`id, orderId, customerId, connectionId, ...`), built via `static fromDomain(shipment, customerId, canWrite)` (lines 127-156). `customerId` is already threaded in as an out-of-band enrichment parameter — `orderSummary` follows the same shape.
+- `InvoiceRecordResponseDto` (`apps/api/src/invoicing/http/dto/invoice-record-response.dto.ts:36-105`) — flat fields, built via `static fromDomain(record: InvoiceRecord)` (lines 107-127), **no enrichment params today** — this signature needs widening to `fromDomain(record, orderSummary)`.
+
+**List handlers:**
+- `ShipmentController.list` (`shipment.controller.ts:108-133`): `this.query.list(filters, {limit, offset})` → `resolveCustomerIds(...)` → `.map(s => ShipmentResponseDto.fromDomain(s, customerByOrder.get(...), canWrite))`. The new `orderSummary` Map join slots in right next to the existing `customerByOrder` Map join.
+- `InvoicingController.listInvoices` (`invoicing.controller.ts:1073-1103`): `this.invoiceService.listInvoices(filter, {limit, offset})` → `.map(record => this.toDto(record))`. `this.orders` (`IOrderRecordService`, `ORDER_RECORD_SERVICE_TOKEN`) is **already injected** into this controller for other purposes — reused here.
+- **Anti-pattern already in the codebase, must not be copied**: `ShipmentController.resolveCustomerIds` (`shipment.controller.ts:433-442`) is a de-duplicated `Promise.all` over single `getOrderRecord` calls — a per-id fan-out disguised as batching. Its own code comment says a real `findByIds` batch is a tracked follow-up. #1995 is that follow-up, scoped now to also serve `orderSummary`.
+- **Correct precedent**: `OrdersController` (`apps/api/src/orders/http/orders.controller.ts:136-170` `getLatestInvoicesForOrders`, `:371-405` `resolveDeliveryForOrders`) — one real batched call per page, then a `Map` join. This is the shape #1995's AC requires.
+
+**`IOrderRecordService` today** (`libs/core/src/orders/application/interfaces/order-record.service.interface.ts`): `persistOrder`, `updateSyncStatus`, `persistIncomingSnapshot`, `getOrderRecord(id)` (single), `findMany(filters, pagination)` (paginated, not id-set-scoped), `updateFulfillmentState`, `markItemResolutionFailure`. **No batch-by-ids method exists** — confirmed gap this plan closes.
+
+**`OrderRecordRepositoryPort`** (`libs/core/src/orders/domain/ports/order-record-repository.port.ts`): `findById`, `upsert`, `updateSyncStatus`, `findMany`, `countByHealth`, `countBySla`, `updateFulfillmentState`, `updateItemResolutionFailure`. Same gap at the port level.
+
+**`OrderRecord.orderSnapshot`** (`libs/core/src/orders/domain/entities/order-record.entity.ts:39`): typed as `Record<string, unknown>` — untyped JSONB. `orderFromReadySnapshot` (`libs/core/src/orders/domain/order-from-ready-snapshot.ts:27-90`) is the existing rehydrator, but it **throws `OrderSnapshotUnavailableError`** when `recordStatus !== 'ready'` or the snapshot lacks a usable buyer address — **not safe to reuse for this projection**, since a `source_deleted` / `awaiting_mapping` shipment or invoice row must still render `–` gracefully, not 500. This plan needs a new, narrower, non-throwing parser that reads only `orderNumber` + `items[].name` + `items[].imageUrl` + `items.length`, tolerant of any snapshot shape.
+
+**`Order.items[]` / `OrderItem`** (`order.types.ts:235-254`): `name` and `imageUrl` are both documented as adapter-optional (`imageUrl`: "Reserved for future enrichment — no current adapter sets this on ingestion"). This confirms `firstItemImageUrl: null` is the expected, correct value for virtually every order today — not a bug to chase in this plan.
+
+**FE transport types**: `apps/web/src/features/shipments/api/shipments.types.ts` (`interface Shipment`, hand-mirrors the BE DTO per its file-header convention) and `apps/web/src/features/invoicing/api/invoicing.types.ts` (`interface InvoiceRecord`, same convention) — both need the new field added, matching the existing "hand-written types until the contract stabilizes" FE convention (`docs/frontend-architecture.md § API Client Conventions`).
+
+**Module wiring**: `libs/core/src/shipping/shipping.module.ts` and `apps/api/src/invoicing/invoicing.module.ts` already import `OrdersModule` for `ORDER_RECORD_SERVICE_TOKEN` (acyclic — `OrdersModule` does not import either back). **No new module wiring required.**
+
+### External System
+Not applicable — no external platform involved.
+
+---
+
+## 5. Questions & Assumptions
+
+### Open Questions
+- None blocking. The issue body is unusually precise (rewritten 2026-08-04) and already resolves the ambiguous points (batching shape, assembly location, PII stance, out-of-scope items).
+
+### Assumptions
+- **`findByIds` returns `OrderRecord[]` (order unspecified), never throws for missing ids.** A missing/soft-deleted order id is simply absent from the returned array; the controller's `Map.get(orderId)` naturally yields `undefined` → `orderSummary: null`. This matches the AC "`orderSummary` is `null` when no order record resolves for the row's `orderId`."
+- **The projection helper does not use `orderFromReadySnapshot`.** It reads `orderSnapshot.orderNumber` and `orderSnapshot.items` directly with defensive `unknown`-narrowing (mirroring the tolerant style of `readItems` in `order-from-ready-snapshot.ts`, but non-throwing) so a `recordStatus !== 'ready'` row still degrades to a partial or `null` `orderSummary` instead of failing the whole list request.
+- **Line-item name and image are not PII** (per the issue body) — not gated by `OL_STORE_PII`.
+- **Only the first line item is projected**; `itemCount` carries the rest via the existing `+N` UI convention (frontend concern, out of scope here).
+- **The batch method takes an unbounded `orderIds: string[]` scoped to one page** (typically ≤ the list's page size, e.g. 20–50) — no additional chunking/pagination is needed on `findByIds` itself since callers always pass a bounded, already-paginated id set.
+- **No new DI tokens or module imports are needed** — both controllers already have `IOrderRecordService` injected for other purposes.
+
+### Documentation Gaps
+- None identified; `docs/architecture-overview.md § Identifier Mapping Service` / `§ Cross-context dependencies in core` and the existing `orders.controller.ts` precedent fully cover the pattern this plan follows.
+
+---
+
+## 6. Proposed Implementation Plan
+
+### Phase 1: CORE — batch read + projection helper
+
+**Goal**: Give `orders` a real batch-by-ids read, and a pure, non-throwing projection from `OrderRecord` to the neutral `orderSummary` shape.
+
+**Steps**:
+
+1. **Add `findByIds` to the repository port**
+   - **File**: `libs/core/src/orders/domain/ports/order-record-repository.port.ts`
+   - **Action**: Add `findByIds(orderIds: string[]): Promise<OrderRecord[]>` to `OrderRecordRepositoryPort`, with a doc comment stating it returns only the records that exist (silently omits missing ids), single query, no pagination.
+   - **Acceptance**: Interface compiles; no existing implementer breaks (added as a new method, not a signature change).
+   - **Dependencies**: None.
+
+2. **Implement `findByIds` in the TypeORM repository**
+   - **File**: `libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts`
+   - **Action**: `async findByIds(orderIds: string[]): Promise<OrderRecord[]> { if (orderIds.length === 0) return []; const entities = await this.ormRepository.find({ where: { id: In(orderIds) } }); return entities.map((e) => this.toDomain(e)); }` — reuse the repository's existing private `toDomain` mapper. Early-return `[]` on an empty input array avoids TypeORM emitting `WHERE id IN ()` (which some drivers reject).
+   - **Acceptance**: Unit test — given 3 seeded ids + 1 non-existent id, returns exactly the 3 matching domain entities, no error on the 4th.
+   - **Dependencies**: Step 1.
+
+3. **Add `findByIds` to `IOrderRecordService` + implement in `OrderRecordService`**
+   - **Files**: `libs/core/src/orders/application/interfaces/order-record.service.interface.ts`, `libs/core/src/orders/application/services/order-record.service.ts` (or the equivalent implementer file — confirm exact filename during implementation; it's the class registered under `ORDER_RECORD_SERVICE_TOKEN`).
+   - **Action**: Add `findByIds(orderIds: string[]): Promise<OrderRecord[]>` to the interface with a doc comment matching the existing `findMany` doc's framing ("the cross-context surface... repository ports are forbidden across context boundaries..."). Implement as a pure passthrough to `this.repo.findByIds(orderIds)`, mirroring the existing `findMany` passthrough.
+   - **Acceptance**: Unit test — service method delegates to the mocked repository port and returns its result unchanged.
+   - **Dependencies**: Steps 1–2.
+
+4. **Add a pure `buildOrderSummary` projection helper**
+   - **File**: New `libs/core/src/orders/domain/order-summary-projection.ts` (domain-layer, pure function — no I/O, no framework — consistent with `order-from-ready-snapshot.ts` sitting in `domain/`).
+   - **Action**:
+     ```typescript
+     export interface OrderSummary {
+       orderNumber: string | null;
+       firstItemName: string | null;
+       firstItemImageUrl: string | null;
+       itemCount: number;
+     }
+
+     export function buildOrderSummary(record: OrderRecord | undefined): OrderSummary | null {
+       if (!record) return null;
+       const snapshot = record.orderSnapshot;
+       const items = Array.isArray(snapshot?.items) ? snapshot.items : [];
+       if (items.length === 0) return null;
+       const first = items[0] as Record<string, unknown>;
+       return {
+         orderNumber: typeof snapshot?.orderNumber === 'string' ? snapshot.orderNumber : null,
+         firstItemName: typeof first?.name === 'string' ? first.name : null,
+         firstItemImageUrl: typeof first?.imageUrl === 'string' ? first.imageUrl : null,
+         itemCount: items.length,
+       };
+     }
+     ```
+     (Exact narrowing style to match project conventions — no `any`, `unknown`-narrow per field, matching engineering-standards.md § Type Safety.)
+   - **Acceptance**: Unit tests — (a) `undefined` record → `null`; (b) record with empty/missing `items` → `null` (AC: "`orderSummary` is `null` when the order record exists but its snapshot has no parseable items"); (c) record with 1 item → `itemCount: 1`, fields populated; (d) record with 3 items → `itemCount: 3`, only first item's fields surfaced; (e) snapshot missing `orderNumber` → `orderNumber: null`, other fields still populated.
+   - **Dependencies**: None (independent of steps 1–3, can be built in parallel).
+
+5. **Export the new surface from the `orders` barrel**
+   - **File**: `libs/core/src/orders/index.ts`
+   - **Action**: Export `buildOrderSummary`, `OrderSummary` (type) from the top-level barrel (`@openlinker/core/orders`) so `apps/api/src/shipping/` and `apps/api/src/invoicing/` can import them — matches the allowed cross-context symbol shapes (`type alias`/value export) documented in `docs/architecture-overview.md § Cross-context dependencies in core`. `findByIds` reaches consumers only through `IOrderRecordService`, already exported.
+   - **Acceptance**: `import { buildOrderSummary, type OrderSummary } from '@openlinker/core/orders';` resolves from `apps/api/**`.
+   - **Dependencies**: Step 4.
+
+### Phase 2: Interface — Shipments
+
+**Goal**: `GET /shipments` returns `orderSummary` per row, batched.
+
+**Steps**:
+
+6. **Add `OrderSummaryProjectionDto`**
+   - **File**: New `apps/api/src/orders/http/dto/order-summary-projection.dto.ts` (colocated with the existing sibling `order-invoice-projection.dto.ts`, since both are small enrichment sub-DTOs reused across contexts).
+   - **Action**: Class with `@ApiProperty` decorators for `orderNumber`, `firstItemName`, `firstItemImageUrl` (all `string | null`), `itemCount` (`number`), plus a `static fromSummary(summary: OrderSummary): OrderSummaryProjectionDto` mapper.
+   - **Acceptance**: Swagger schema renders correctly; unit test for `fromSummary`.
+   - **Dependencies**: Phase 1 step 4 (needs the `OrderSummary` type).
+
+7. **Add `orderSummary` to `ShipmentResponseDto`**
+   - **File**: `apps/api/src/shipping/http/dto/shipment-response.dto.ts`
+   - **Action**: Add `orderSummary!: OrderSummaryProjectionDto | null;` field with `@ApiProperty({ nullable: true, type: OrderSummaryProjectionDto })`. Widen `static fromDomain(shipment, customerId, canWrite, orderSummary: OrderSummary | null)` to accept and map the new param (mirrors the existing `customerId` enrichment-param pattern).
+   - **Acceptance**: Existing `fromDomain` call sites (only the controller, per research) updated; DTO unit test asserts `orderSummary` round-trips.
+   - **Dependencies**: Step 6.
+
+8. **Batch-join in `ShipmentController.list`**
+   - **File**: `apps/api/src/shipping/http/shipment.controller.ts`
+   - **Action**: In `list(...)`, after fetching `page.items`, call `this.orders.findByIds(page.items.map((s) => s.orderId))` **once**, build `const summaryByOrderId = new Map(records.map((r) => [r.id, buildOrderSummary(r)]))`, then pass `summaryByOrderId.get(s.orderId) ?? null` into `ShipmentResponseDto.fromDomain(...)`. Import `buildOrderSummary`/`OrderSummary` from `@openlinker/core/orders`.
+   - **Acceptance**: Integration/unit test asserts exactly **one** `findByIds` call per `list` invocation regardless of page size (the AC explicitly requires this to distinguish it from the `resolveCustomerIds` anti-pattern already in the file). Do **not** add a second `Promise.all`-style loop next to the existing `resolveCustomerIds` — the two Maps (`customerByOrder`, `summaryByOrderId`) can be built from sibling batched calls, or combined into one call if `findByIds` conveniently returns enough to resolve both (see step 11 for the optional consolidation note).
+   - **Dependencies**: Phase 1 steps 1-5, step 7.
+
+### Phase 3: Interface — Invoices
+
+**Goal**: `GET /invoices` returns the same `orderSummary` shape per row, batched.
+
+**Steps**:
+
+9. **Add `orderSummary` to `InvoiceRecordResponseDto`**
+   - **File**: `apps/api/src/invoicing/http/dto/invoice-record-response.dto.ts`
+   - **Action**: Add `orderSummary!: OrderSummaryProjectionDto | null;` field. Widen `static fromDomain(record: InvoiceRecord, orderSummary: OrderSummary | null)`.
+   - **Acceptance**: DTO unit test round-trips the field; existing single-arg call sites updated (`fromDomain` currently has no enrichment params, so every call site in `invoicing.controller.ts`'s `toDto` needs the new argument threaded through).
+   - **Dependencies**: Step 6.
+
+10. **Batch-join in `InvoicingController.listInvoices`**
+    - **File**: `apps/api/src/invoicing/http/invoicing.controller.ts`
+    - **Action**: In `listInvoices(...)`, after `this.invoiceService.listInvoices(filter, {limit, offset})` resolves `page`, call `this.orders.findByIds(page.items.map((r) => r.orderId))` once, build the `orderId → OrderSummary|null` map, thread through `this.toDto(record, summaryByOrderId.get(record.orderId) ?? null)` (widen `toDto`'s signature to accept the summary and forward it to `InvoiceRecordResponseDto.fromDomain`).
+    - **Acceptance**: Same batching test as step 8 — one `findByIds` call per `listInvoices` invocation, independent of N. `InvoiceService.listInvoices` itself is **untouched** (stays a pure repository projection, per research finding #5 — the join happens in the controller, matching where `this.orders` is already injected).
+    - **Dependencies**: Phase 1, step 9.
+
+### Phase 4: Frontend transport types (mirror only — no rendering)
+
+**Goal**: FE-side hand-mirrored types stay in sync with the BE contract, unblocking #1996's `OrderIdentityCell` work without doing any of it here.
+
+**Steps**:
+
+11. **Mirror `orderSummary` on both FE feature types**
+    - **Files**: `apps/web/src/features/shipments/api/shipments.types.ts`, `apps/web/src/features/invoicing/api/invoicing.types.ts`
+    - **Action**: Add an `OrderSummary` interface (`{ orderNumber: string | null; firstItemName: string | null; firstItemImageUrl: string | null; itemCount: number }`) and `orderSummary: OrderSummary | null;` on `Shipment` / `InvoiceRecord` respectively. Per the existing FE convention (hand-written mirrors, no shared cross-feature type for this shape yet — each feature owns its own copy, matching how both files already duplicate their BE DTO independently).
+    - **Acceptance**: `pnpm type-check` passes; no runtime behavior change (the field is unused until #1996 consumes it).
+    - **Dependencies**: Phase 2 + 3 (needs the final field shape).
+
+---
+
+### Implementation Details
+
+**New Components**:
+- **Domain** (`libs/core/src/orders/domain/`): `order-summary-projection.ts` (pure function `buildOrderSummary` + `OrderSummary` type — no new entity/exception).
+- **Domain ports** (`libs/core/src/orders/domain/ports/`): `OrderRecordRepositoryPort.findByIds` (method addition, no new file).
+- **Application** (`libs/core/src/orders/application/`): `IOrderRecordService.findByIds` (interface addition) + implementation in the existing service class (no new file).
+- **Infrastructure** (`libs/core/src/orders/infrastructure/persistence/repositories/`): `OrderRecordRepository.findByIds` (method addition, no new file).
+- **Interface** (`apps/api/src/orders/http/dto/`): new `order-summary-projection.dto.ts`.
+- **Interface** (`apps/api/src/shipping/`, `apps/api/src/invoicing/`): DTO field + controller batch-join additions (no new files beyond #6).
+
+**Configuration Changes**: None.
+
+**Database Migrations**: None — `orderSummary` reads an existing JSONB column (`order_records.orderSnapshot`), no schema change.
+
+**Events**: None emitted or consumed — this is a synchronous read-path projection.
+
+**Error Handling**:
+- `buildOrderSummary` never throws — it degrades to `null` or partial-`null` fields on any unexpected/missing snapshot shape (explicit design choice; see Phase 1 step 4's acceptance criteria).
+- `findByIds` with an empty input array short-circuits to `[]` before hitting the database (avoids a malformed `IN ()` query).
+- A missing order id (deleted, or a shipment/invoice orphaned from its order) simply doesn't appear in the `findByIds` result, and the `Map.get(...) ?? null` join degrades to `orderSummary: null` — no exception path needed at the controller layer.
+
+---
+
+## 7. Alternatives Considered
+
+### Alternative 1: Add an `ids` filter to `OrderRecordFilters` and reuse `findMany` instead of a new `findByIds` method
+- **Description**: Extend `OrderRecordFilters` with an optional `ids?: string[]` field, translate it to `WHERE id IN (...)` inside the existing `findMany` repository method, and call `findMany({ ids: orderIds }, { limit: orderIds.length, offset: 0 })` from the controllers.
+- **Why Rejected**: `findMany` is paginated-list-shaped (returns `PaginatedOrderRecords` with a `total` count, sorting, etc.) — semantically wrong for "give me exactly these N known ids, unordered, no total needed." Forcing a page-size pagination param onto an id-set lookup is a category error that would confuse future callers. A dedicated `findByIds` is smaller, clearer, and matches `InvoiceService.getLatestInvoicesForOrders`'s already-established shape (`orderId → entity` batch lookup, no pagination).
+- **Trade-offs**: One more interface method vs. widening an existing filter type. The extra method is worth it for API clarity.
+
+### Alternative 2: Reuse `orderFromReadySnapshot` for the projection instead of a new lightweight parser
+- **Description**: Call the existing `orderFromReadySnapshot(record)` rehydrator and read `.orderNumber` / `.items` off the resulting `Order`.
+- **Why Rejected**: `orderFromReadySnapshot` throws `OrderSnapshotUnavailableError` whenever `recordStatus !== 'ready'` (e.g. `awaiting_mapping`, `source_deleted`) or the snapshot lacks a usable buyer address. A shipment or invoice can legitimately exist for an order in any of those states, and the whole list request must not 500 because one row's order snapshot is incomplete — it should just render `orderSummary: null` or a partial value for that row. A non-throwing, narrower parser is required.
+- **Trade-offs**: Slight duplication of "how to read `items[]` off an untyped snapshot" between `readItems` (private to the rehydrator) and the new `buildOrderSummary`. Accepted because the two functions have genuinely different failure semantics (fail-fast rehydration for downstream order-processing vs. tolerant best-effort projection for a list cell) — conflating them would make one of the two behave wrong.
+
+---
+
+## 8. Validation & Risks
+
+### Architecture Compliance
+- ✅ Cross-context read goes through `IOrderRecordService` (a service interface + Symbol token), never `OrderRecordRepositoryPort` directly — `shipping`/`invoicing` controllers only ever import from `@openlinker/core/orders`'s top-level barrel.
+- ✅ Domain layer (`buildOrderSummary`) has zero framework dependencies — pure TypeScript, no NestJS/TypeORM imports.
+- ✅ No repository port or ORM entity crosses the context boundary (only the service interface, the pure helper function, and its plain `OrderSummary` type — all allowed shapes per `docs/architecture-overview.md § Cross-context dependencies in core`).
+
+### Naming Conventions
+- ✅ `order-summary-projection.ts` follows `*.types.ts`-adjacent domain-helper naming used by `order-from-ready-snapshot.ts` (a precedent for a domain-layer pure function file that isn't a `.entity.ts`/`.vo.ts`).
+- ✅ `OrderSummaryProjectionDto` matches the sibling `OrderInvoiceProjectionDto` naming exactly.
+
+### Existing Patterns
+- ✅ Batched Map-join in the controller mirrors `getLatestInvoicesForOrders` / `resolveDeliveryForOrders` in `orders.controller.ts` verbatim.
+- ✅ `fromDomain(entity, ...enrichmentParams)` signature widening mirrors the existing `customerId` param on `ShipmentResponseDto.fromDomain`.
+
+### Risks
+- **Risk**: A future call site of `ShipmentResponseDto.fromDomain` / `InvoiceRecordResponseDto.fromDomain` forgets to pass the new `orderSummary` param, since TypeScript won't catch a *forgotten* new required param at existing call sites only if it's optional. **Mitigation**: make the new param required (not optional) on both `fromDomain` signatures — the compiler then forces every call site to supply it (even if `null`), which is exactly what `pnpm type-check` in the quality gate will catch.
+- **Risk**: `resolveCustomerIds`'s per-id fan-out already exists in `ShipmentController` — a reviewer or future contributor might copy that shape by proximity when adding the `orderSummary` join right next to it. **Mitigation**: add a short code comment at the new `findByIds` call site explicitly contrasting it with `resolveCustomerIds` below it, and cover the bounded-read-count behavior with an explicit unit test (per AC).
+- **Risk**: `orderSnapshot` is `Record<string, unknown>` with no runtime schema validation — a malformed/legacy snapshot (e.g. from a schema version predating some field) could have `items` as something other than an array. **Mitigation**: `buildOrderSummary`'s `Array.isArray(snapshot?.items)` guard + per-field `typeof` narrowing already covers this defensively (Phase 1 step 4).
+
+### Edge Cases
+- Order record does not exist for `orderId` → `orderSummary: null`.
+- Order record exists but `orderSnapshot.items` is missing/empty/not an array → `orderSummary: null`.
+- Order record exists, `items` non-empty, but `orderNumber` missing → `orderSummary` populated with `orderNumber: null` (partial, not fully null — matches the "leads with order number, falls back to shortened id" convention documented in #1996, which the FE will handle).
+- A page contains duplicate `orderId`s across rows (e.g. two shipments for the same order) → `findByIds` naturally de-dupes via the `Map` key; no repeated DB work, no double-counting in the read-count assertion (dedupe `orderIds` before calling `findByIds`, mirroring `resolveCustomerIds`'s existing `[...new Set(...)]` step — the one part of that method worth keeping).
+- Empty page (`page.items.length === 0`) → `findByIds([])` short-circuits to `[]`, no DB round-trip at all.
+
+### Backward Compatibility
+- ✅ Purely additive — a new nullable field on two existing response DTOs. No existing consumer breaks; the OpenAPI schema gains one new optional/nullable property per endpoint.
+- No breaking changes; no migration required.
+
+---
+
+## 9. Testing Strategy & Acceptance Criteria
+
+### Unit Tests
+- `libs/core/src/orders/domain/order-summary-projection.spec.ts`:
+  - `undefined` record → `null`.
+  - Missing/empty/non-array `items` → `null`.
+  - Single-item snapshot → correct `orderNumber`/`firstItemName`/`firstItemImageUrl`/`itemCount: 1`.
+  - Multi-item snapshot → only first item surfaced, `itemCount` reflects full length.
+  - Missing `orderNumber` → `orderNumber: null`, rest populated.
+- `libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.spec.ts`: `findByIds` — empty array input → `[]` with no query issued (mock assertion); non-empty ids → maps through `toDomain` correctly; a requested id with no matching row is simply absent from the result.
+- `libs/core/src/orders/application/services/order-record.service.spec.ts` (or existing file): `findByIds` passthrough delegates to the mocked repository port.
+- `apps/api/src/shipping/http/dto/shipment-response.dto.spec.ts`: `fromDomain` with a non-null `orderSummary` round-trips it onto the DTO.
+- `apps/api/src/invoicing/http/dto/invoice-record-response.dto.spec.ts`: same, for `InvoiceRecordResponseDto`.
+- `apps/api/src/shipping/http/shipment.controller.spec.ts`: given N shipments across M distinct order ids (M < N, to prove dedup), `list()` calls the mocked `IOrderRecordService.findByIds` **exactly once**, with the deduplicated id set; each returned DTO carries the correct `orderSummary` (or `null`) for its `orderId`.
+- `apps/api/src/invoicing/http/invoicing.controller.spec.ts`: same shape for `listInvoices`.
+
+### Integration Tests
+- Not strictly required (no new schema, no new HTTP-boundary contract behavior beyond an additive field) — the unit-test coverage above (particularly the controller-level batching assertion) is sufficient per `docs/testing-guide.md`'s guidance to reserve integration tests for behavior that depends on real Postgres/Redis wiring. If the team wants belt-and-suspenders coverage, extend the existing `apps/api/test/integration/` shipments/invoices list specs (if any) to assert the new field's presence end-to-end against a seeded order + shipment/invoice row — optional, not blocking.
+
+### Mocking Strategy
+- Mock `OrderRecordRepositoryPort` in the repository/service unit tests (per `docs/engineering-standards.md § Mocking Ports`).
+- Mock `IOrderRecordService` (specifically `findByIds`) in both controller unit tests — never a concrete `OrderRecordService` instance.
+
+### Acceptance Criteria (from #1995, verbatim, mapped to this plan)
+- [ ] `GET /shipments` returns `orderSummary` per row with `orderNumber`, `firstItemName`, `firstItemImageUrl`, `itemCount` — Phase 2.
+- [ ] `GET /invoices` returns the same `orderSummary` shape per row — Phase 3.
+- [ ] `orderSummary` is `null` when no order record resolves for the row's `orderId` — Phase 1 step 4.
+- [ ] `orderSummary` is `null` when the order record exists but its snapshot has no parseable items — Phase 1 step 4.
+- [ ] `itemCount` reflects the order's full item count, not the number of projected items — Phase 1 step 4.
+- [ ] `firstItemImageUrl` comes from the order snapshot, not from the live product catalogue — Phase 1 step 4 (no `ProductMasterPort` call anywhere in this plan).
+- [ ] A page of N rows issues a bounded number of order reads independent of N — Phase 2 step 8 / Phase 3 step 10, explicitly tested.
+- [ ] No list response gained a `connectionName` field — confirmed out of scope, not touched anywhere in this plan.
+- [ ] FE transport types mirror the new field on shipments and invoicing — Phase 4.
+- [ ] Tests added or updated for non-trivial logic — § 9 above.
+- [ ] No architecture boundary violations — § 8 Architecture Compliance.
+
+---
+
+## 10. Alignment Checklist
+
+- [x] Follows hexagonal architecture — projection helper in domain, service/repository in application/infrastructure, DTOs in interface.
+- [x] Respects CORE vs Integration boundaries — no integration/adapter touched; cross-context read via `IOrderRecordService` only.
+- [x] Uses existing patterns (no unnecessary abstractions) — reuses the `getLatestInvoicesForOrders`/`resolveDeliveryForOrders` batched-Map-join shape and the `OrderInvoiceProjectionDto` sub-DTO precedent; no new capability port, no new module.
+- [x] Idempotency considered — pure read, no side effects; N/A for mutation idempotency.
+- [x] Event-driven patterns used where applicable — N/A, synchronous read-path only.
+- [x] Rate limits & retries addressed — N/A, internal DB read only, no external API call.
+- [x] Error handling comprehensive — `buildOrderSummary` never throws; `findByIds` short-circuits on empty input; missing ids degrade to `null` via `Map.get(...) ?? null`.
+- [x] Testing strategy complete — unit coverage at every new layer, explicit batching assertion at both controllers.
+- [x] Naming conventions followed — `*.port.ts` method addition, `*.service.interface.ts` method addition, `*.dto.ts` sibling to existing `OrderInvoiceProjectionDto`.
+- [x] File structure matches standards — new files land in the same directories as their siblings (`domain/`, `http/dto/`).
+- [x] Plan is execution-ready.
+- [x] Plan is saved as markdown file.
+
+---
+
+## Related Documentation
+
+- [Architecture Overview](../architecture-overview.md) — § Orders, § Cross-context dependencies in core
+- [Engineering Standards](../engineering-standards.md) — § Repository Ports Pattern, § Type Safety, § Symbol DI Token Re-export Convention
+- [Testing Guide](../testing-guide.md)
+- [Code Review Guide](../code-review-guide.md)
+- Consuming issue / mockup: [#1996](https://github.com/openlinker-project/openlinker/issues/1996), `docs/plans/mockups/list-identity-cells-1996.html`

--- a/libs/core/src/listings/application/services/__tests__/offer-stock-restore.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/offer-stock-restore.service.spec.ts
@@ -67,6 +67,7 @@ describe('OfferStockRestoreService', () => {
 
     orderRecordService = {
       getOrderRecord: jest.fn(),
+      findByIds: jest.fn(),
     } as unknown as jest.Mocked<IOrderRecordService>;
 
     offerMappings = {

--- a/libs/core/src/orders/application/interfaces/order-record.service.interface.ts
+++ b/libs/core/src/orders/application/interfaces/order-record.service.interface.ts
@@ -99,6 +99,18 @@ export interface IOrderRecordService {
   ): Promise<PaginatedOrderRecords>;
 
   /**
+   * Batch-find order records by internal order ID (#1995). The cross-context
+   * surface for a page-scoped join (e.g. the Shipments/Invoices lists'
+   * `orderSummary` projection) — repository ports are forbidden across context
+   * boundaries per architecture-overview.md § "Cross-context dependencies in
+   * core", so callers go through this service method instead of
+   * `OrderRecordRepositoryPort.findByIds` directly. Ids with no matching
+   * record are simply absent from the result. Delegates to
+   * `OrderRecordRepositoryPort.findByIds`.
+   */
+  findByIds(internalOrderIds: string[]): Promise<OrderRecord[]>;
+
+  /**
    * Push a per-order fulfillment rollup (#1108) onto the order record. The
    * cross-context surface the shipping context calls after a shipment-status
    * change (`shipping → orders`, via this service — never the repository port).

--- a/libs/core/src/orders/application/services/__tests__/order-destination-retry.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-destination-retry.service.spec.ts
@@ -53,6 +53,7 @@ describe('OrderDestinationRetryService', () => {
   beforeEach(() => {
     orderRepo = {
       findById: jest.fn(),
+      findByIds: jest.fn(),
       findMany: jest.fn(),
       upsert: jest.fn(),
       updateSyncStatus: jest.fn(),
@@ -64,6 +65,7 @@ describe('OrderDestinationRetryService', () => {
       persistIncomingSnapshot: jest.fn(),
       getOrderRecord: jest.fn(),
       findMany: jest.fn(),
+      findByIds: jest.fn(),
     } as unknown as jest.Mocked<IOrderRecordService>;
 
     identifierMapping = {

--- a/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
@@ -101,6 +101,7 @@ describe('OrderIngestionService', () => {
       updateSyncStatus: jest.fn().mockResolvedValue(undefined),
       getOrderRecord: jest.fn(),
       findMany: jest.fn(),
+      findByIds: jest.fn(),
       markItemResolutionFailure: jest.fn().mockResolvedValue(undefined),
     } as unknown as jest.Mocked<IOrderRecordService>;
 

--- a/libs/core/src/orders/application/services/__tests__/order-record.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-record.service.spec.ts
@@ -27,6 +27,7 @@ describe('OrderRecordService', () => {
     process.env.OL_PII_HASH_SALT = 'test-salt-for-hashing';
     repository = {
       findById: jest.fn(),
+      findByIds: jest.fn(),
       upsert: jest.fn(),
       updateSyncStatus: jest.fn(),
       updateItemResolutionFailure: jest.fn(),
@@ -704,6 +705,30 @@ describe('OrderRecordService', () => {
 
       expect(result).toBeNull();
       expect(repository.findById).toHaveBeenCalledWith(internalOrderId);
+    });
+  });
+
+  describe('findByIds (#1995)', () => {
+    it('delegates to the repository as a pure passthrough', async () => {
+      const records = [
+        new OrderRecord(
+          'order-123',
+          'customer-456',
+          'source-connection-123',
+          'event-456',
+          { id: 'order-123' },
+          [],
+          'ready',
+          new Date(),
+          new Date()
+        ),
+      ];
+      repository.findByIds.mockResolvedValue(records);
+
+      const result = await service.findByIds(['order-123', 'order-456']);
+
+      expect(result).toBe(records);
+      expect(repository.findByIds).toHaveBeenCalledWith(['order-123', 'order-456']);
     });
   });
 

--- a/libs/core/src/orders/application/services/order-record.service.ts
+++ b/libs/core/src/orders/application/services/order-record.service.ts
@@ -294,6 +294,10 @@ export class OrderRecordService implements IOrderRecordService {
     return this.repository.findMany(filters, pagination);
   }
 
+  async findByIds(internalOrderIds: string[]): Promise<OrderRecord[]> {
+    return this.repository.findByIds(internalOrderIds);
+  }
+
   async updateFulfillmentState(
     internalOrderId: string,
     fulfillmentState: FulfillmentRollupState

--- a/libs/core/src/orders/domain/order-summary-projection.spec.ts
+++ b/libs/core/src/orders/domain/order-summary-projection.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * buildOrderSummary Unit Tests (#1995)
+ *
+ * @module libs/core/src/orders/domain
+ */
+import { buildOrderSummary } from './order-summary-projection';
+import { OrderRecord } from './entities/order-record.entity';
+
+describe('buildOrderSummary', () => {
+  const buildRecord = (orderSnapshot: Record<string, unknown>): OrderRecord =>
+    new OrderRecord(
+      'order-123',
+      'customer-456',
+      'source-connection-123',
+      'event-456',
+      orderSnapshot,
+      [],
+      'ready',
+      new Date('2025-01-01T00:00:00Z'),
+      new Date('2025-01-01T00:00:00Z')
+    );
+
+  it('returns null when no record resolves', () => {
+    expect(buildOrderSummary(undefined)).toBeNull();
+  });
+
+  it('returns null when the snapshot has no items array', () => {
+    const record = buildRecord({ orderNumber: 'ORD-001' });
+    expect(buildOrderSummary(record)).toBeNull();
+  });
+
+  it('returns null when items is an empty array', () => {
+    const record = buildRecord({ orderNumber: 'ORD-001', items: [] });
+    expect(buildOrderSummary(record)).toBeNull();
+  });
+
+  it('returns null when items is not an array', () => {
+    const record = buildRecord({ orderNumber: 'ORD-001', items: 'not-an-array' });
+    expect(buildOrderSummary(record)).toBeNull();
+  });
+
+  it('projects the first item of a single-item snapshot', () => {
+    const record = buildRecord({
+      orderNumber: 'ORD-001',
+      items: [{ name: 'Terra Wool Coat', imageUrl: 'https://example.com/coat.png' }],
+    });
+
+    expect(buildOrderSummary(record)).toEqual({
+      orderNumber: 'ORD-001',
+      firstItemName: 'Terra Wool Coat',
+      firstItemImageUrl: 'https://example.com/coat.png',
+      itemCount: 1,
+    });
+  });
+
+  it('surfaces only the first item of a multi-item snapshot but reports the full count', () => {
+    const record = buildRecord({
+      orderNumber: 'ORD-002',
+      items: [
+        { name: 'First Item', imageUrl: null },
+        { name: 'Second Item', imageUrl: 'https://example.com/second.png' },
+        { name: 'Third Item' },
+      ],
+    });
+
+    expect(buildOrderSummary(record)).toEqual({
+      orderNumber: 'ORD-002',
+      firstItemName: 'First Item',
+      firstItemImageUrl: null,
+      itemCount: 3,
+    });
+  });
+
+  it('falls back to null orderNumber when the snapshot omits it, without losing item fields', () => {
+    const record = buildRecord({
+      items: [{ name: 'Terra Wool Coat' }],
+    });
+
+    expect(buildOrderSummary(record)).toEqual({
+      orderNumber: null,
+      firstItemName: 'Terra Wool Coat',
+      firstItemImageUrl: null,
+      itemCount: 1,
+    });
+  });
+
+  it('degrades gracefully when the first item is malformed (not an object)', () => {
+    const record = buildRecord({ orderNumber: 'ORD-003', items: ['not-an-object'] });
+
+    expect(buildOrderSummary(record)).toEqual({
+      orderNumber: 'ORD-003',
+      firstItemName: null,
+      firstItemImageUrl: null,
+      itemCount: 1,
+    });
+  });
+});

--- a/libs/core/src/orders/domain/order-summary-projection.ts
+++ b/libs/core/src/orders/domain/order-summary-projection.ts
@@ -1,0 +1,67 @@
+/**
+ * buildOrderSummary — project an OrderRecord's snapshot into the neutral
+ * order-summary shape used by the Shipments/Invoices list responses (#1995)
+ *
+ * A shipment or invoice must be able to show which order it belongs to
+ * (order number, first line-item name/image, item count) without opening the
+ * order detail page. Deliberately NOT built on `orderFromReadySnapshot`:
+ * that rehydrator throws `OrderSnapshotUnavailableError` for any
+ * `recordStatus` other than `ready` (or a redacted/missing buyer address),
+ * and a shipment/invoice can legitimately reference an order in ANY state —
+ * the list row must still render (as `null`/partial), never 500. This helper
+ * therefore never throws: it degrades to `null` (no record, or no parseable
+ * items) or to partial fields (e.g. a missing `orderNumber`) instead.
+ *
+ * @module libs/core/src/orders/domain
+ */
+import type { OrderRecord } from './entities/order-record.entity';
+
+/**
+ * Neutral order-identity projection for a list row (#1995). `null` when no
+ * order record resolves, or its snapshot has no parseable items.
+ */
+export interface OrderSummary {
+  /** Source-native order number from the snapshot; `null` when absent. */
+  orderNumber: string | null;
+  /** `items[0].name`; `null` when the first item carries no name. */
+  firstItemName: string | null;
+  /**
+   * `items[0].imageUrl`, snapshot-frozen (NOT the live catalog image).
+   * `null` for effectively every order today — no current order-source
+   * adapter populates `OrderItem.imageUrl` on ingestion (see `order.types.ts`).
+   */
+  firstItemImageUrl: string | null;
+  /** `items.length` — the full item count, not the number of fields projected. */
+  itemCount: number;
+}
+
+/**
+ * Project an {@link OrderRecord} (or its absence) into an {@link OrderSummary}.
+ *
+ * @param record `undefined` when no order record resolved for the row's
+ *   `orderId` (i.e. absent from a batched `findByIds` result).
+ * @returns `null` when there is no record, or its snapshot's `items` is
+ *   missing/empty/not an array. Otherwise an `OrderSummary` derived from the
+ *   first item; individual fields fall back to `null` when unparseable.
+ */
+export function buildOrderSummary(record: OrderRecord | undefined): OrderSummary | null {
+  if (!record) {
+    return null;
+  }
+  const snapshot = record.orderSnapshot;
+  const items = Array.isArray(snapshot?.items) ? snapshot.items : [];
+  if (items.length === 0) {
+    return null;
+  }
+  const first = (typeof items[0] === 'object' && items[0] !== null ? items[0] : {}) as Record<
+    string,
+    unknown
+  >;
+
+  return {
+    orderNumber: typeof snapshot?.orderNumber === 'string' ? snapshot.orderNumber : null,
+    firstItemName: typeof first.name === 'string' ? first.name : null,
+    firstItemImageUrl: typeof first.imageUrl === 'string' ? first.imageUrl : null,
+    itemCount: items.length,
+  };
+}

--- a/libs/core/src/orders/domain/order-summary-projection.ts
+++ b/libs/core/src/orders/domain/order-summary-projection.ts
@@ -15,25 +15,9 @@
  * @module libs/core/src/orders/domain
  */
 import type { OrderRecord } from './entities/order-record.entity';
+import type { OrderSummary } from './types/order-summary.types';
 
-/**
- * Neutral order-identity projection for a list row (#1995). `null` when no
- * order record resolves, or its snapshot has no parseable items.
- */
-export interface OrderSummary {
-  /** Source-native order number from the snapshot; `null` when absent. */
-  orderNumber: string | null;
-  /** `items[0].name`; `null` when the first item carries no name. */
-  firstItemName: string | null;
-  /**
-   * `items[0].imageUrl`, snapshot-frozen (NOT the live catalog image).
-   * `null` for effectively every order today — no current order-source
-   * adapter populates `OrderItem.imageUrl` on ingestion (see `order.types.ts`).
-   */
-  firstItemImageUrl: string | null;
-  /** `items.length` — the full item count, not the number of fields projected. */
-  itemCount: number;
-}
+export type { OrderSummary } from './types/order-summary.types';
 
 /**
  * Project an {@link OrderRecord} (or its absence) into an {@link OrderSummary}.

--- a/libs/core/src/orders/domain/ports/order-record-repository.port.ts
+++ b/libs/core/src/orders/domain/ports/order-record-repository.port.ts
@@ -27,6 +27,19 @@ export interface OrderRecordRepositoryPort {
   findById(internalOrderId: string): Promise<OrderRecord | null>;
 
   /**
+   * Batch-find order records by internal order ID (#1995).
+   *
+   * A single query scoped to the given id set — the real batch a cross-context
+   * list join (Shipments, Invoices) needs, as opposed to a de-duplicated
+   * `Promise.all` fan-out over {@link findById}. Ids with no matching row are
+   * silently omitted from the result (never throws, never pads with nulls);
+   * callers join back onto their own rows via a `Map` keyed by
+   * `internalOrderId`. Returns `[]` immediately for an empty `internalOrderIds`
+   * input, without issuing a query.
+   */
+  findByIds(internalOrderIds: string[]): Promise<OrderRecord[]>;
+
+  /**
    * Upsert order record (create or update)
    * Uses internalOrderId as the primary key
    */

--- a/libs/core/src/orders/domain/types/order-summary.types.ts
+++ b/libs/core/src/orders/domain/types/order-summary.types.ts
@@ -1,0 +1,28 @@
+/**
+ * Order Summary Types
+ *
+ * Type shape produced by `buildOrderSummary` (#1995) — the neutral
+ * order-identity projection used by the Shipments/Invoices list responses.
+ *
+ * @module libs/core/src/orders/domain/types
+ * @see {@link buildOrderSummary} for the projection function
+ */
+
+/**
+ * Neutral order-identity projection for a list row (#1995). `null` when no
+ * order record resolves, or its snapshot has no parseable items.
+ */
+export interface OrderSummary {
+  /** Source-native order number from the snapshot; `null` when absent. */
+  orderNumber: string | null;
+  /** `items[0].name`; `null` when the first item carries no name. */
+  firstItemName: string | null;
+  /**
+   * `items[0].imageUrl`, snapshot-frozen (NOT the live catalog image).
+   * `null` for effectively every order today — no current order-source
+   * adapter populates `OrderItem.imageUrl` on ingestion (see `order.types.ts`).
+   */
+  firstItemImageUrl: string | null;
+  /** `items.length` — the full item count, not the number of fields projected. */
+  itemCount: number;
+}

--- a/libs/core/src/orders/index.ts
+++ b/libs/core/src/orders/index.ts
@@ -163,6 +163,10 @@ export { OrderSnapshotUnavailableError } from './domain/exceptions/order-snapsho
 // Typed-Order accessor for cross-context command composition (#1119).
 export { orderFromReadySnapshot } from './domain/order-from-ready-snapshot';
 
+// Order-identity list projection for Shipments/Invoices (#1995).
+export { buildOrderSummary } from './domain/order-summary-projection';
+export type { OrderSummary } from './domain/order-summary-projection';
+
 // Ports
 export { OrderRecordRepositoryPort } from './domain/ports/order-record-repository.port';
 

--- a/libs/core/src/orders/infrastructure/persistence/repositories/__tests__/order-record.repository.spec.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/__tests__/order-record.repository.spec.ts
@@ -32,6 +32,7 @@ describe('OrderRecordRepository', () => {
 
     const mockOrmRepository = {
       findOne: jest.fn(),
+      find: jest.fn(),
       save: jest.fn(),
       query: jest.fn(),
       createQueryBuilder: jest.fn().mockReturnValue(qb),
@@ -140,6 +141,36 @@ describe('OrderRecordRepository', () => {
       expect(result?.syncStatus[0].status).toBe('synced');
       expect(result?.syncStatus[0].syncedAt).toEqual(new Date('2025-01-01T11:00:00Z'));
       expect(result?.syncStatus[0].externalOrderId).toBe('external-order-999');
+    });
+  });
+
+  describe('findByIds', () => {
+    it('should return [] without querying when given an empty array', async () => {
+      const result = await repository.findByIds([]);
+
+      expect(result).toEqual([]);
+      expect(ormRepository.find).not.toHaveBeenCalled();
+    });
+
+    it('should return matching domain entities for a batch of ids', async () => {
+      const entity = createOrmEntity();
+      ormRepository.find.mockResolvedValue([entity]);
+
+      const result = await repository.findByIds(['order-123', 'non-existent-order']);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].internalOrderId).toBe('order-123');
+      expect(ormRepository.find).toHaveBeenCalledWith({
+        where: { internalOrderId: expect.anything() },
+      });
+    });
+
+    it('should silently omit ids with no matching row', async () => {
+      ormRepository.find.mockResolvedValue([]);
+
+      const result = await repository.findByIds(['missing-1', 'missing-2']);
+
+      expect(result).toEqual([]);
     });
   });
 

--- a/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
@@ -11,7 +11,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import type { SelectQueryBuilder } from 'typeorm';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 import type { OrderSyncStatusJson, SyncAttemptJson } from '../entities/order-record.orm-entity';
 import { OrderRecordOrmEntity } from '../entities/order-record.orm-entity';
 import type { OrderRecordRepositoryPort } from '../../../domain/ports/order-record-repository.port';
@@ -51,6 +51,20 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
     }
 
     return this.toDomain(entity);
+  }
+
+  /**
+   * Batch-find by internal order ID (#1995) — single `IN (...)` query, no
+   * pagination. Ids with no matching row are simply absent from the result.
+   */
+  async findByIds(internalOrderIds: string[]): Promise<OrderRecord[]> {
+    if (internalOrderIds.length === 0) {
+      return [];
+    }
+    const entities = await this.repository.find({
+      where: { internalOrderId: In(internalOrderIds) },
+    });
+    return entities.map((e) => this.toDomain(e));
   }
 
   async findMany(

--- a/libs/core/src/shipping/application/services/fulfillment-status-sync.service.spec.ts
+++ b/libs/core/src/shipping/application/services/fulfillment-status-sync.service.spec.ts
@@ -98,6 +98,7 @@ describe('FulfillmentStatusSyncService', () => {
       persistIncomingSnapshot: jest.fn(),
       getOrderRecord: jest.fn(),
       findMany: jest.fn(),
+      findByIds: jest.fn(),
       updateFulfillmentState: jest.fn(),
       markItemResolutionFailure: jest.fn(),
     };

--- a/libs/core/src/shipping/application/services/shipment-dispatch-notification.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-dispatch-notification.service.spec.ts
@@ -96,6 +96,7 @@ describe('ShipmentDispatchNotificationService', () => {
       persistIncomingSnapshot: jest.fn(),
       getOrderRecord: jest.fn().mockResolvedValue(makeRecord()),
       findMany: jest.fn(),
+      findByIds: jest.fn(),
       updateFulfillmentState: jest.fn(),
       markItemResolutionFailure: jest.fn(),
     };

--- a/libs/core/src/shipping/application/services/shipment-dispatch.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-dispatch.service.spec.ts
@@ -163,6 +163,7 @@ describe('ShipmentDispatchService', () => {
       updateSyncStatus: jest.fn(),
       getOrderRecord: jest.fn().mockResolvedValue(null),
       findMany: jest.fn(),
+      findByIds: jest.fn(),
       updateFulfillmentState: jest.fn(),
       markItemResolutionFailure: jest.fn(),
     };


### PR DESCRIPTION
## Summary

`GET /shipments` and `GET /invoices` carried only a bare `orderId` — an operator had to open the order detail page to see which order a row belonged to. This adds a batched, read-only `orderSummary` projection to both list responses:

```ts
orderSummary: {
  orderNumber: string | null;
  firstItemName: string | null;
  firstItemImageUrl: string | null;
  itemCount: number;
} | null
```

No new persistence, no migration — it's derived server-side from each order's existing `orderSnapshot` JSONB column.

- **`IOrderRecordService.findByIds`** (+ repository port/impl) gives both list controllers a real single-query batch read for the page's order ids, replacing the per-order `Promise.all` fan-out anti-pattern that already existed in `ShipmentController.resolveCustomerIds` (explicitly called out in the issue body as the shape to avoid).
- **`buildOrderSummary`** (`libs/core/src/orders/domain/order-summary-projection.ts`) is a pure, non-throwing projection. Deliberately *not* built on `orderFromReadySnapshot` — that rehydrator throws `OrderSnapshotUnavailableError` for any non-`ready` record or missing buyer address, which would 500 the whole list because of one bad row. This helper degrades to `null` (no record, or no parseable items) or partial fields instead.
- **`OrderSummaryProjectionDto`** is one shared sub-DTO reused by both `ShipmentResponseDto` and `InvoiceRecordResponseDto`.
- FE `shipments.types.ts` / `invoicing.types.ts` mirror the new field (transport types only — no rendering; that's the separate #1996 frontend work).

Implementation plan: `docs/plans/implementation-plan-order-summary-projection.md`.

## Live verification

Ran the actual (already-running) local API against a real dev Postgres, hit `GET /v1/shipments` and `GET /v1/invoices` with a dev JWT, using two real orders already in the `order_records` table (one demo row per table inserted to make the list non-empty, then deleted immediately after capture — DB back to its original state). Captured responses, screenshot/page here:

**https://claude.ai/code/artifact/70dc87a6-7152-47e5-95dc-692f5be740b8**

## Test plan

- [x] `pnpm lint` — clean (only pre-existing unrelated warnings)
- [x] `pnpm type-check` — clean
- [x] Unit tests added: `order-summary-projection.spec.ts` (projection edge cases), repository/service `findByIds` specs, both controllers' batching behavior (`findByIds` called once per page, not per row), both response DTOs' `fromDomain`
- [ ] `pnpm test` / `pnpm test:integration` — not run in this environment (Docker unavailable here); CI will run the full suite
- [x] Manually verified against a real local Postgres dev DB (see artifact above)

Closes #1995

🤖 Generated with [Claude Code](https://claude.com/claude-code)