### PR TITLE
fix(web): persist explicit config.rateLimit: null on revert-to-default (#2016)

### DIFF
--- a/apps/web/src/features/connections/components/EditConnectionForm.test.tsx
+++ b/apps/web/src/features/connections/components/EditConnectionForm.test.tsx
@@ -177,6 +177,39 @@ describe('EditConnectionForm', () => {
     });
   });
 
+  it('persists an explicit config.rateLimit: null when the operator reverts to the adapter default, even though the pre-submit refetch still returns the old value (#2016)', async () => {
+    // Reproduces the reported scenario: an Allegro connection with
+    // config.rateLimit set, reverted via the "Enable rate limiting" toggle,
+    // saved while the getById refetch races ahead of the not-yet-persisted
+    // change. Ships an explicit `null` (not an absent key) so the value
+    // survives the pre-submit `{ ...fresh.config, ...input.config }` merge.
+    const connectionWithRateLimit: Connection = {
+      ...sampleConnection,
+      config: { ...sampleConnection.config, rateLimit: { requestsPerMinute: 10, maxConcurrent: 11 } },
+    };
+    const updateFn = vi.fn().mockResolvedValue(connectionWithRateLimit);
+    const apiClient = createMockApiClient({
+      connections: {
+        update: updateFn,
+        // Refetch still reports the old rateLimit — nothing has persisted yet.
+        getById: vi.fn().mockResolvedValue(connectionWithRateLimit),
+      },
+    });
+
+    renderWithProviders(<EditConnectionForm connection={connectionWithRateLimit} />, { apiClient });
+
+    expect(screen.getByLabelText('Enable rate limiting')).toBeChecked();
+    fireEvent.click(screen.getByLabelText('Enable rate limiting'));
+    fireEvent.click(screen.getByRole('button', { name: 'Save changes' }));
+
+    await waitFor(() => {
+      expect(updateFn).toHaveBeenCalled();
+    });
+    const [, submittedInput] = updateFn.mock.calls[0] as [string, { config: Record<string, unknown> }];
+    expect('rateLimit' in submittedInput.config).toBe(true);
+    expect(submittedInput.config.rateLimit).toBeNull();
+  });
+
   describe('structured PrestaShop inputs + raw JSON toggle', () => {
     it('renders Shop URL / Storefront URL / Shop ID inputs for a PrestaShop connection', () => {
       renderWithProviders(<EditConnectionForm connection={sampleConnection} />);

--- a/apps/web/src/features/connections/components/edit-connection.schema.test.ts
+++ b/apps/web/src/features/connections/components/edit-connection.schema.test.ts
@@ -305,6 +305,44 @@ describe('editConnectionSchema — unmanagedStockQuantity (WooCommerce, #969 §7
   );
 });
 
+describe('mergeStructuredIntoConfig — rateLimit (#1810, #2016)', () => {
+  it('writes the pruned object when at least one knob is set', () => {
+    const result = mergeStructuredIntoConfig(
+      {},
+      { rateLimit: { requestsPerMinute: '60', maxConcurrent: '' } },
+    );
+    expect(result).toEqual({ rateLimit: { requestsPerMinute: 60 } });
+  });
+
+  it('writes an EXPLICIT null (not a deleted key) when both knobs are cleared (#2016)', () => {
+    const base = { rateLimit: { requestsPerMinute: 60, maxConcurrent: 4 } };
+    const result = mergeStructuredIntoConfig(base, {
+      rateLimit: { requestsPerMinute: '', maxConcurrent: '' },
+    });
+    // The key must stay PRESENT with value null — a deleted key would let a
+    // stale `fresh.config.rateLimit` survive EditConnectionForm's pre-submit
+    // `{ ...fresh.config, ...input.config }` merge (#2016).
+    expect('rateLimit' in result).toBe(true);
+    expect(result.rateLimit).toBeNull();
+  });
+
+  it('writes an EXPLICIT null when the patch clears rateLimit to null directly', () => {
+    const base = { rateLimit: { requestsPerMinute: 60 } };
+    const result = mergeStructuredIntoConfig(base, { rateLimit: null });
+    expect('rateLimit' in result).toBe(true);
+    expect(result.rateLimit).toBeNull();
+  });
+
+  it('leaves rateLimit untouched when the patch omits it', () => {
+    const base = { rateLimit: { requestsPerMinute: 60 } };
+    const result = mergeStructuredIntoConfig(base, { baseUrl: 'https://shop.example.com' });
+    expect(result).toEqual({
+      rateLimit: { requestsPerMinute: 60 },
+      baseUrl: 'https://shop.example.com',
+    });
+  });
+});
+
 describe('mergeStructuredIntoConfig — inpostPsModuleType (#767/#1155)', () => {
   it("writes 'official_inpost' to config", () => {
     const result = mergeStructuredIntoConfig({}, { inpostPsModuleType: 'official_inpost' });

--- a/apps/web/src/features/connections/components/edit-connection.schema.ts
+++ b/apps/web/src/features/connections/components/edit-connection.schema.ts
@@ -436,8 +436,9 @@ export type StructuredConfigPatch = {
    * (#1810). Platform-neutral, rendered for every connection regardless of
    * `platformType` (unlike every other field in this type, which is
    * platform-specific). Each knob is a digit-string field (empty clears,
-   * mirrors `unmanagedStockQuantity`/`defaultCarrierId`); an all-empty
-   * result drops the key entirely rather than persisting `{}`.
+   * mirrors `unmanagedStockQuantity`/`defaultCarrierId`); an all-empty result
+   * persists an EXPLICIT `config.rateLimit: null` rather than deleting the
+   * key (#2016) — see `mergeStructuredIntoConfig`'s rateLimit clause for why.
    */
   rateLimit?: RateLimitFormValues | null;
 };
@@ -662,12 +663,21 @@ export function mergeStructuredIntoConfig(
       next.bankAccount = structured.infaktBankAccount;
     }
   }
-  // Outbound rate limit (#1810) — whole-object `config.rateLimit`, platform-
-  // neutral. `null` (or an all-empty result after pruning empty-string knobs)
-  // clears the key entirely rather than persisting `{}`.
+  // Outbound rate limit (#1810). Platform-neutral. `null` (or an all-empty
+  // result after pruning empty-string knobs) sets `config.rateLimit` to an
+  // EXPLICIT `null` (#2016) rather than deleting the key. This matters for
+  // the pre-submit merge in `EditConnectionForm.onSubmit`
+  // (`{ ...fresh.config, ...input.config }`): a shallow spread can only
+  // override a key present on the right side — deleting the key would let a
+  // stale, still-configured `rateLimit` from the pre-submit refetch survive
+  // an operator's "revert to adapter default / unlimited" edit. Every
+  // consumer already treats `null` the same as absent (`validateRateLimitConfig`
+  // early-returns on `null`; `RateLimitStatusService` / `HttpTransportFactory`
+  // fall through via `?? defaultRateLimit`), so persisting `null` instead of
+  // omitting the key changes nothing downstream.
   if (structured.rateLimit !== undefined) {
     if (structured.rateLimit === null) {
-      delete next.rateLimit;
+      next.rateLimit = null;
     } else {
       const pruned: Record<string, number> = {};
       if (structured.rateLimit.requestsPerMinute) {
@@ -676,11 +686,7 @@ export function mergeStructuredIntoConfig(
       if (structured.rateLimit.maxConcurrent) {
         pruned.maxConcurrent = Number.parseInt(structured.rateLimit.maxConcurrent, 10);
       }
-      if (Object.keys(pruned).length === 0) {
-        delete next.rateLimit;
-      } else {
-        next.rateLimit = pruned;
-      }
+      next.rateLimit = Object.keys(pruned).length === 0 ? null : pruned;
     }
   }
   // Platform-owned assembly pass (#1330): plugin field names on the patch are

--- a/apps/web/src/features/connections/components/rate-limit-section.test.tsx
+++ b/apps/web/src/features/connections/components/rate-limit-section.test.tsx
@@ -1,5 +1,5 @@
 /**
- * RateLimitSection tests (#1810)
+ * RateLimitSection tests (#1810, #2016)
  *
  * @module features/connections/components
  */
@@ -40,20 +40,53 @@ function Harness({
 describe('RateLimitSection', () => {
   afterEach(cleanup);
 
-  it('renders both knobs empty by default — matches "unlimited"', () => {
+  it('renders the toggle unchecked and hides the knobs by default — matches "unlimited"', () => {
     render(<Harness />);
-    expect(screen.getByLabelText('Requests per minute')).toHaveValue('');
-    expect(screen.getByLabelText('Max concurrent requests')).toHaveValue('');
+    expect(screen.getByLabelText('Enable rate limiting')).not.toBeChecked();
+    expect(screen.queryByLabelText('Requests per minute')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Max concurrent requests')).not.toBeInTheDocument();
   });
 
-  it('hydrates from existing form values', () => {
+  it('hydrates as checked and shows the knobs when the connection already has a rate limit', () => {
     render(<Harness initialRateLimit={{ requestsPerMinute: '60', maxConcurrent: '4' }} />);
+    expect(screen.getByLabelText('Enable rate limiting')).toBeChecked();
     expect(screen.getByLabelText('Requests per minute')).toHaveValue('60');
     expect(screen.getByLabelText('Max concurrent requests')).toHaveValue('4');
   });
 
-  it('disables both inputs when configIsParseable is false (divergence gate)', () => {
-    render(<Harness configIsParseable={false} />);
+  it('reveals the knobs, blank, when the toggle is checked', () => {
+    render(<Harness />);
+    fireEvent.click(screen.getByLabelText('Enable rate limiting'));
+    expect(screen.getByLabelText('Requests per minute')).toHaveValue('');
+    expect(screen.getByLabelText('Max concurrent requests')).toHaveValue('');
+  });
+
+  it('clears both knobs and re-syncs when the toggle is unchecked (#2016 — revert to adapter default)', () => {
+    const syncRateLimitToJson = vi.fn();
+    render(
+      <Harness
+        initialRateLimit={{ requestsPerMinute: '60', maxConcurrent: '4' }}
+        syncRateLimitToJson={syncRateLimitToJson}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText('Enable rate limiting'));
+
+    expect(screen.queryByLabelText('Requests per minute')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Max concurrent requests')).not.toBeInTheDocument();
+    // Both fields are cleared via setValue BEFORE this single sync call, so
+    // syncRateLimitToJson reads the fully-cleared state in one re-serialization.
+    expect(syncRateLimitToJson).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables the toggle and both inputs when configIsParseable is false (divergence gate)', () => {
+    render(
+      <Harness
+        configIsParseable={false}
+        initialRateLimit={{ requestsPerMinute: '60', maxConcurrent: '4' }}
+      />,
+    );
+    expect(screen.getByLabelText('Enable rate limiting')).toBeDisabled();
     expect(screen.getByLabelText('Requests per minute')).toBeDisabled();
     expect(screen.getByLabelText('Max concurrent requests')).toBeDisabled();
   });
@@ -63,7 +96,7 @@ describe('RateLimitSection', () => {
     const syncRateLimitToJson = vi.fn(() => calls.push('sync'));
 
     function OrderingHarness(): ReactElement {
-      const form = useForm<any>({ defaultValues: { rateLimit: {} } });
+      const form = useForm<any>({ defaultValues: { rateLimit: { requestsPerMinute: '10' } } });
       const realSetValue = form.setValue.bind(form);
       form.setValue = ((...args: Parameters<typeof realSetValue>) => {
         calls.push('setValue');
@@ -89,37 +122,27 @@ describe('RateLimitSection', () => {
 
   it('says "unlimited" when the adapter declares no defaultRateLimit (#1810 FE honesty)', () => {
     render(<Harness defaultRateLimit={null} />);
-    expect(
-      screen.getByText(/Leave both fields empty for unlimited/i)
-    ).toBeInTheDocument();
-    expect(screen.getByLabelText('Requests per minute')).toHaveAttribute(
-      'placeholder',
-      'Unlimited'
-    );
+    expect(screen.getByText(/Leave rate limiting off for unlimited/i)).toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText('Enable rate limiting'));
+    expect(screen.getByLabelText('Requests per minute')).toHaveAttribute('placeholder', 'Unlimited');
   });
 
   it('surfaces the resolved adapter defaultRateLimit instead of claiming "unlimited" (#1810 FE honesty)', () => {
-    render(
-      <Harness defaultRateLimit={{ requestsPerMinute: 60, maxConcurrent: 4 }} />
-    );
-    expect(
-      screen.getByText(/60 requests\/min, 4 concurrent/i)
-    ).toBeInTheDocument();
-    expect(screen.queryByText(/^Leave both fields empty for unlimited/i)).not.toBeInTheDocument();
-    expect(screen.getByLabelText('Requests per minute')).toHaveAttribute(
-      'placeholder',
-      'Default: 60'
-    );
+    render(<Harness defaultRateLimit={{ requestsPerMinute: 60, maxConcurrent: 4 }} />);
+    expect(screen.getByText(/60 requests\/min, 4 concurrent/i)).toBeInTheDocument();
+    expect(screen.queryByText(/^Leave rate limiting off for unlimited/i)).not.toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText('Enable rate limiting'));
+    expect(screen.getByLabelText('Requests per minute')).toHaveAttribute('placeholder', 'Default: 60');
     expect(screen.getByLabelText('Max concurrent requests')).toHaveAttribute(
       'placeholder',
-      'Default: 4'
+      'Default: 4',
     );
   });
 
   it('reads the just-written value via getValues at sync time (both knobs independently editable)', () => {
     let captured: unknown;
     function CaptureHarness(): ReactElement {
-      const form = useForm<any>({ defaultValues: { rateLimit: {} } });
+      const form = useForm<any>({ defaultValues: { rateLimit: { requestsPerMinute: '1' } } });
       return (
         <RateLimitSection
           form={form as any}
@@ -133,6 +156,6 @@ describe('RateLimitSection', () => {
     }
     render(<CaptureHarness />);
     fireEvent.change(screen.getByLabelText('Max concurrent requests'), { target: { value: '4' } });
-    expect(captured).toEqual({ maxConcurrent: '4' });
+    expect(captured).toEqual({ requestsPerMinute: '1', maxConcurrent: '4' });
   });
 });

--- a/apps/web/src/features/connections/components/rate-limit-section.test.tsx
+++ b/apps/web/src/features/connections/components/rate-limit-section.test.tsx
@@ -79,6 +79,39 @@ describe('RateLimitSection', () => {
     expect(syncRateLimitToJson).toHaveBeenCalledTimes(1);
   });
 
+  it('clears both knobs before re-syncing when unchecked (#2016) — asserts on captured form state, not just call count', () => {
+    let capturedAtSync: unknown;
+    function Harness2(): ReactElement {
+      const form = useForm<any>({
+        defaultValues: { rateLimit: { requestsPerMinute: '60', maxConcurrent: '4' } },
+      });
+      return (
+        <RateLimitSection
+          form={form as any}
+          configIsParseable={true}
+          syncRateLimitToJson={() => {
+            capturedAtSync = form.getValues('rateLimit');
+          }}
+          defaultRateLimit={null}
+        />
+      );
+    }
+    render(<Harness2 />);
+    fireEvent.click(screen.getByLabelText('Enable rate limiting'));
+    expect(capturedAtSync).toEqual({ requestsPerMinute: '', maxConcurrent: '' });
+  });
+
+  it('re-syncs when the toggle is checked with both knobs still blank (no silent no-op on Save)', () => {
+    const syncRateLimitToJson = vi.fn();
+    render(<Harness syncRateLimitToJson={syncRateLimitToJson} />);
+
+    fireEvent.click(screen.getByLabelText('Enable rate limiting'));
+
+    expect(screen.getByLabelText('Requests per minute')).toHaveValue('');
+    expect(screen.getByLabelText('Max concurrent requests')).toHaveValue('');
+    expect(syncRateLimitToJson).toHaveBeenCalledTimes(1);
+  });
+
   it('disables the toggle and both inputs when configIsParseable is false (divergence gate)', () => {
     render(
       <Harness

--- a/apps/web/src/features/connections/components/rate-limit-section.tsx
+++ b/apps/web/src/features/connections/components/rate-limit-section.tsx
@@ -70,6 +70,9 @@ export function RateLimitSection({
   // render: turning the checkbox ON with both fields still empty must keep
   // the inputs visible (a derived `enabled` would immediately flip back to
   // "off" the instant it's checked, since neither field has a value yet).
+  // Invariant: nothing outside this component may call
+  // `form.setValue('rateLimit.*', …)` — this frozen state won't notice, and a
+  // knob could populate behind a checkbox still rendered unchecked.
   const [enabled, setEnabled] = useState(hasStoredValue);
 
   const handleChange = (field: 'requestsPerMinute' | 'maxConcurrent', value: string): void => {
@@ -83,13 +86,16 @@ export function RateLimitSection({
   // Clearing both fields (rather than just hiding them) is what makes
   // `mergeStructuredIntoConfig`'s rateLimit clause persist an explicit
   // `config.rateLimit: null` instead of leaving a stale value in place.
+  // Always sync (checking and unchecking alike) — otherwise checking the box
+  // with both knobs left blank never re-serializes into `configText`, and
+  // Save fires its success toast over a payload that silently didn't change.
   const handleEnabledChange = (checked: boolean): void => {
     setEnabled(checked);
     if (!checked) {
       form.setValue('rateLimit.requestsPerMinute', '', { shouldDirty: true });
       form.setValue('rateLimit.maxConcurrent', '', { shouldDirty: true });
-      syncRateLimitToJson();
     }
+    syncRateLimitToJson();
   };
 
   return (
@@ -100,19 +106,24 @@ export function RateLimitSection({
         {defaultRateLimit ? (
           <>
             Leave rate limiting off to use this connection&apos;s adapter default —{' '}
-            <strong>{formatRateLimit(defaultRateLimit)}</strong>. Setting either field replaces the
-            adapter default entirely — the other field is then genuinely unlimited, not still
-            capped by the default.
+            <strong>{formatRateLimit(defaultRateLimit)}</strong>.
           </>
         ) : (
           <>Leave rate limiting off for unlimited (the default for this adapter).</>
-        )}{' '}
-        Enforcement is rolling out sync path by sync path — setting a cap here has no effect until
-        this connection&apos;s outbound traffic has been migrated onto it. If you run multiple
-        API/worker replicas (<code>OL_WORKER_REPLICAS</code>), each value is divided evenly across
-        them, so the real aggregate throughput matches what you configure below rather than
-        multiplying it per replica.
+        )}
       </p>
+
+      {enabled ? (
+        <p className="rate-limit-section__help">
+          Setting either field below replaces the adapter default entirely — the other field is
+          then genuinely unlimited, not still capped by the default. Enforcement is rolling out
+          sync path by sync path — setting a cap here has no effect until this connection&apos;s
+          outbound traffic has been migrated onto it. If you run multiple API/worker replicas
+          (<code>OL_WORKER_REPLICAS</code>), each value is divided evenly across them, so the real
+          aggregate throughput matches what you configure below rather than multiplying it per
+          replica.
+        </p>
+      ) : null}
 
       <label className="rate-limit-section__toggle">
         <input

--- a/apps/web/src/features/connections/components/rate-limit-section.tsx
+++ b/apps/web/src/features/connections/components/rate-limit-section.tsx
@@ -113,18 +113,6 @@ export function RateLimitSection({
         )}
       </p>
 
-      {enabled ? (
-        <p className="rate-limit-section__help">
-          Setting either field below replaces the adapter default entirely — the other field is
-          then genuinely unlimited, not still capped by the default. Enforcement is rolling out
-          sync path by sync path — setting a cap here has no effect until this connection&apos;s
-          outbound traffic has been migrated onto it. If you run multiple API/worker replicas
-          (<code>OL_WORKER_REPLICAS</code>), each value is divided evenly across them, so the real
-          aggregate throughput matches what you configure below rather than multiplying it per
-          replica.
-        </p>
-      ) : null}
-
       <label className="rate-limit-section__toggle">
         <input
           type="checkbox"
@@ -137,6 +125,16 @@ export function RateLimitSection({
 
       {enabled ? (
         <>
+          <p className="rate-limit-section__help">
+            Setting either field below replaces the adapter default entirely — the other field is
+            then genuinely unlimited, not still capped by the default. Enforcement is rolling out
+            sync path by sync path — setting a cap here has no effect until this connection&apos;s
+            outbound traffic has been migrated onto it. If you run multiple API/worker replicas
+            (<code>OL_WORKER_REPLICAS</code>), each value is divided evenly across them, so the
+            real aggregate throughput matches what you configure below rather than multiplying it
+            per replica.
+          </p>
+
           <FormField
             label="Requests per minute"
             name="rateLimit.requestsPerMinute"

--- a/apps/web/src/features/connections/components/rate-limit-section.tsx
+++ b/apps/web/src/features/connections/components/rate-limit-section.tsx
@@ -19,7 +19,7 @@
  *
  * @module features/connections/components
  */
-import type { ReactElement } from 'react';
+import { useState, type ReactElement } from 'react';
 import type { UseFormReturn } from 'react-hook-form';
 import { FormField } from '../../../shared/ui/form-field';
 import { Input } from '../../../shared/ui/input';
@@ -62,11 +62,34 @@ export function RateLimitSection({
 }: RateLimitSectionProps): ReactElement {
   const errors = form.formState.errors.rateLimit;
 
+  const hasStoredValue =
+    Boolean(form.getValues('rateLimit.requestsPerMinute')) ||
+    Boolean(form.getValues('rateLimit.maxConcurrent'));
+  // Local UI state (docs/frontend-architecture.md § Local UI State) — whether
+  // the override inputs are shown. NOT derived from the field values on every
+  // render: turning the checkbox ON with both fields still empty must keep
+  // the inputs visible (a derived `enabled` would immediately flip back to
+  // "off" the instant it's checked, since neither field has a value yet).
+  const [enabled, setEnabled] = useState(hasStoredValue);
+
   const handleChange = (field: 'requestsPerMinute' | 'maxConcurrent', value: string): void => {
     // ORDERING TRAP: write the form field FIRST, then re-serialize — the
     // sync function reads CURRENT form state via getValues.
     form.setValue(`rateLimit.${field}`, value, { shouldDirty: true });
     syncRateLimitToJson();
+  };
+
+  // #2016 — unchecking is the "revert to adapter default / unlimited" action.
+  // Clearing both fields (rather than just hiding them) is what makes
+  // `mergeStructuredIntoConfig`'s rateLimit clause persist an explicit
+  // `config.rateLimit: null` instead of leaving a stale value in place.
+  const handleEnabledChange = (checked: boolean): void => {
+    setEnabled(checked);
+    if (!checked) {
+      form.setValue('rateLimit.requestsPerMinute', '', { shouldDirty: true });
+      form.setValue('rateLimit.maxConcurrent', '', { shouldDirty: true });
+      syncRateLimitToJson();
+    }
   };
 
   return (
@@ -76,13 +99,13 @@ export function RateLimitSection({
         OpenLinker spaces requests evenly rather than sending them in bursts.{' '}
         {defaultRateLimit ? (
           <>
-            Leave both fields empty to use this connection&apos;s adapter default —{' '}
+            Leave rate limiting off to use this connection&apos;s adapter default —{' '}
             <strong>{formatRateLimit(defaultRateLimit)}</strong>. Setting either field replaces the
             adapter default entirely — the other field is then genuinely unlimited, not still
             capped by the default.
           </>
         ) : (
-          <>Leave both fields empty for unlimited (the default for this adapter).</>
+          <>Leave rate limiting off for unlimited (the default for this adapter).</>
         )}{' '}
         Enforcement is rolling out sync path by sync path — setting a cap here has no effect until
         this connection&apos;s outbound traffic has been migrated onto it. If you run multiple
@@ -91,45 +114,59 @@ export function RateLimitSection({
         multiplying it per replica.
       </p>
 
-      <FormField
-        label="Requests per minute"
-        name="rateLimit.requestsPerMinute"
-        error={errors?.requestsPerMinute?.message}
-        description="Smooth-paced cap, split evenly across replicas — e.g. 60 with 1 replica spaces requests roughly one per second."
-      >
-        <Input
-          value={form.watch('rateLimit.requestsPerMinute') ?? ''}
-          onChange={(event) => handleChange('requestsPerMinute', event.target.value)}
+      <label className="rate-limit-section__toggle">
+        <input
+          type="checkbox"
+          checked={enabled}
           disabled={!configIsParseable}
-          placeholder={
-            defaultRateLimit?.requestsPerMinute !== undefined
-              ? `Default: ${defaultRateLimit.requestsPerMinute}`
-              : 'Unlimited'
-          }
-          inputMode="numeric"
-          invalid={Boolean(errors?.requestsPerMinute)}
+          onChange={(event) => handleEnabledChange(event.target.checked)}
         />
-      </FormField>
+        <span>Enable rate limiting</span>
+      </label>
 
-      <FormField
-        label="Max concurrent requests"
-        name="rateLimit.maxConcurrent"
-        error={errors?.maxConcurrent?.message}
-        description="Caps simultaneous in-flight requests to this connection, split evenly across replicas. These two caps are independent — whichever one binds first wins."
-      >
-        <Input
-          value={form.watch('rateLimit.maxConcurrent') ?? ''}
-          onChange={(event) => handleChange('maxConcurrent', event.target.value)}
-          disabled={!configIsParseable}
-          placeholder={
-            defaultRateLimit?.maxConcurrent !== undefined
-              ? `Default: ${defaultRateLimit.maxConcurrent}`
-              : 'Unlimited'
-          }
-          inputMode="numeric"
-          invalid={Boolean(errors?.maxConcurrent)}
-        />
-      </FormField>
+      {enabled ? (
+        <>
+          <FormField
+            label="Requests per minute"
+            name="rateLimit.requestsPerMinute"
+            error={errors?.requestsPerMinute?.message}
+            description="Smooth-paced cap, split evenly across replicas — e.g. 60 with 1 replica spaces requests roughly one per second."
+          >
+            <Input
+              value={form.watch('rateLimit.requestsPerMinute') ?? ''}
+              onChange={(event) => handleChange('requestsPerMinute', event.target.value)}
+              disabled={!configIsParseable}
+              placeholder={
+                defaultRateLimit?.requestsPerMinute !== undefined
+                  ? `Default: ${defaultRateLimit.requestsPerMinute}`
+                  : 'Unlimited'
+              }
+              inputMode="numeric"
+              invalid={Boolean(errors?.requestsPerMinute)}
+            />
+          </FormField>
+
+          <FormField
+            label="Max concurrent requests"
+            name="rateLimit.maxConcurrent"
+            error={errors?.maxConcurrent?.message}
+            description="Caps simultaneous in-flight requests to this connection, split evenly across replicas. These two caps are independent — whichever one binds first wins."
+          >
+            <Input
+              value={form.watch('rateLimit.maxConcurrent') ?? ''}
+              onChange={(event) => handleChange('maxConcurrent', event.target.value)}
+              disabled={!configIsParseable}
+              placeholder={
+                defaultRateLimit?.maxConcurrent !== undefined
+                  ? `Default: ${defaultRateLimit.maxConcurrent}`
+                  : 'Unlimited'
+              }
+              inputMode="numeric"
+              invalid={Boolean(errors?.maxConcurrent)}
+            />
+          </FormField>
+        </>
+      ) : null}
     </section>
   );
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -4224,6 +4224,16 @@ a.delivery-rider-banner__button:focus-visible {
   font-size: 0.875rem;
 }
 
+.rate-limit-section__toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  cursor: pointer;
+  font-weight: 500;
+  color: var(--text-primary);
+  font-size: 0.875rem;
+}
+
 .capability-list__name {
   font-weight: 500;
   color: var(--text-primary);


### PR DESCRIPTION
## Summary
- Fixes a race condition where reverting the "Enable rate limiting" toggle on a connection's edit form could be silently overwritten by a stale pre-submit refetch.
- `mergeStructuredIntoConfig` now writes an explicit `config.rateLimit: null` instead of deleting the key, so it survives EditConnectionForm's `{ ...fresh.config, ...input.config }` merge.
- `RateLimitSection` gains a checkbox ("Enable rate limiting") that reveals/hides the two knobs and clears them (triggering the explicit-null sync) when unchecked.

Closes #2016

## Test plan
- [x] Unit tests added/updated for `mergeStructuredIntoConfig` (explicit-null cases)
- [x] Unit tests added/updated for `RateLimitSection` (toggle show/hide/clear behavior)
- [x] Unit test added for `EditConnectionForm` reproducing the race and asserting the submitted payload carries `rateLimit: null`
- [ ] `pnpm lint && pnpm type-check && pnpm test`

<img width="1890" height="837" alt="image" src="https://github.com/user-attachments/assets/3ee940f2-cc16-41e7-b408-4c4fd9960bc1" />

- Toggle off (default/"unlimited") — no override configured. For adapters with no built-in default (e.g. Allegro), outbound calls are truly unlimited. For adapters that ship their own default (e.g. PrestaShop, WooCommerce), the connection still runs under that adapter's default cap even with the toggle off — the help text shows the actual value instead of falsely claiming "unlimited."
- Toggle on — reveals two independent knobs:
  - Requests per minute — a smooth-paced cap, spread evenly across requests (e.g. 60/min ≈ one request/sec).
  - Max concurrent requests — caps simultaneous in-flight requests.
  - Setting either one fully replaces the adapter's default for that connection — the untouched knob becomes genuinely unlimited, not silently capped by the old default.
  - Both values are divided evenly across OL_WORKER_REPLICAS if you run multiple API/worker replicas, so the real aggregate throughput matches what you configure.
- Reverting to default — unchecking the toggle clears both fields and persists an explicit config.rateLimit: null. This fixes #2016: previously, clearing the fields could get silently overwritten by a stale in-flight refetch during save, so the "revert to default" edit was sometimes lost. Now the explicit null always wins.
- Platform-neutral — this section renders identically for every connection type regardless of platform; it's not marketplace- or shop-specific.

🤖 Generated with [Claude Code](https://claude.com/claude-code)