### PR TITLE
feat(orders): capture order cancellation as first-class record state

### DIFF
--- a/apps/api/src/migrations/1832000000008-add-order-record-cancelled-at.ts
+++ b/apps/api/src/migrations/1832000000008-add-order-record-cancelled-at.ts
@@ -1,0 +1,45 @@
+/**
+ * Add OrderRecord cancelledAt Migration
+ *
+ * Adds `cancelledAt` (nullable timestamptz) to `order_records` (#1984) —
+ * durably records the instant the source reported an order cancelled,
+ * independent of `recordStatus` (which tracks item-mapping resolution, not
+ * business status — an order can be `ready` and cancelled at once).
+ *
+ * Backfill: for existing rows where the raw snapshot's `status` key already
+ * reads 'cancelled' (the same top-level key on both the pre-mapping
+ * IncomingOrder shape and the resolved Order shape), sets
+ * `cancelledAt := "updatedAt"` as a best-effort proxy for "the last time we
+ * observed this order's cancelled state" — NOT the true cancellation instant,
+ * which cannot be reconstructed from data OL already holds. Rows whose
+ * snapshot does not report 'cancelled' are left NULL (never cancelled).
+ * Idempotent: `WHERE "cancelledAt" IS NULL` makes re-running this migration
+ * (or a from-scratch replay) a no-op on rows already backfilled.
+ *
+ * @module apps/api/src/migrations
+ */
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddOrderRecordCancelledAt1832000000008 implements MigrationInterface {
+  name = 'AddOrderRecordCancelledAt1832000000008';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "order_records" ADD COLUMN IF NOT EXISTS "cancelledAt" timestamptz`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_order_records_cancelledAt" ON "order_records" ("cancelledAt")`,
+    );
+    await queryRunner.query(
+      `UPDATE "order_records"
+       SET "cancelledAt" = "updatedAt"
+       WHERE "cancelledAt" IS NULL
+         AND "orderSnapshot"->>'status' = 'cancelled'`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_order_records_cancelledAt"`);
+    await queryRunner.query(`ALTER TABLE "order_records" DROP COLUMN IF EXISTS "cancelledAt"`);
+  }
+}

--- a/apps/api/src/orders/http/dto/order-record-response.dto.ts
+++ b/apps/api/src/orders/http/dto/order-record-response.dto.ts
@@ -86,6 +86,14 @@ export class OrderRecordResponseDto {
   })
   dispatchByAt!: string | null;
 
+  @ApiPropertyOptional({
+    nullable: true,
+    description:
+      'Instant the source reported this order cancelled (ISO 8601, #1984). null = never cancelled. ' +
+      'Set once and never cleared — a later re-poll of a cancelled order cannot change this timestamp.',
+  })
+  cancelledAt!: string | null;
+
   @ApiProperty({
     description:
       'True when `dispatchByAt` is an OL-side ESTIMATE rather than a marketplace-authoritative ' +

--- a/apps/api/src/orders/http/orders.controller.spec.ts
+++ b/apps/api/src/orders/http/orders.controller.spec.ts
@@ -71,6 +71,7 @@ describe('OrdersController', () => {
       countBySla: jest.fn(),
       updateFulfillmentState: jest.fn(),
       updateItemResolutionFailure: jest.fn(),
+      markCancelled: jest.fn(),
     };
 
     const mockRetryService: jest.Mocked<IOrderDestinationRetryService> = {
@@ -334,6 +335,31 @@ describe('OrdersController', () => {
 
       expect(result.items[0].dispatchByAt).toBe('2026-04-02T16:00:00.000Z');
       expect(result.items[1].dispatchByAt).toBeNull();
+    });
+
+    it('should serialize cancelledAt as an ISO string, or null when absent (#1984)', async () => {
+      const cancelledOrder = new OrderRecord(
+        'ol_order_cancelled',
+        null,
+        'conn-source-001',
+        null,
+        {},
+        [],
+        'ready',
+        new Date('2026-04-01T00:00:00Z'),
+        new Date('2026-04-01T00:00:00Z'),
+        [],
+        null,
+        null,
+        null,
+        new Date('2026-08-05T09:30:00Z')
+      );
+      repository.findMany.mockResolvedValue({ items: [cancelledOrder, mockOrder], total: 2 });
+
+      const result = await controller.listOrders({ limit: 20, offset: 0 });
+
+      expect(result.items[0].cancelledAt).toBe('2026-08-05T09:30:00.000Z');
+      expect(result.items[1].cancelledAt).toBeNull();
     });
 
     it('should derive dispatchByEstimated from the snapshot dispatch window (#1776)', async () => {

--- a/apps/api/src/orders/http/orders.controller.ts
+++ b/apps/api/src/orders/http/orders.controller.ts
@@ -324,6 +324,7 @@ export class OrdersController {
       createdAt: order.createdAt instanceof Date ? order.createdAt.toISOString() : order.createdAt,
       updatedAt: order.updatedAt instanceof Date ? order.updatedAt.toISOString() : order.updatedAt,
       dispatchByAt: order.dispatchByAt ? order.dispatchByAt.toISOString() : null,
+      cancelledAt: order.cancelledAt ? order.cancelledAt.toISOString() : null,
       // Ship-by estimate flag (#1776): a typed, fail-safe read off the snapshot's
       // dispatch window. Erli marks its derived window `estimated: true`; Allegro
       // leaves it absent (authoritative). Narrowing lives on the entity getter.

--- a/apps/api/src/shipping/http/shipment.controller.spec.ts
+++ b/apps/api/src/shipping/http/shipment.controller.spec.ts
@@ -128,6 +128,7 @@ describe('ShipmentController', () => {
       findByIds: jest.fn().mockResolvedValue([]),
       updateFulfillmentState: jest.fn(),
       markItemResolutionFailure: jest.fn(),
+      markCancelled: jest.fn(),
     };
     controller = new ShipmentController(
       query,

--- a/apps/api/test/integration/orders/order-cancellation-record-state.int-spec.ts
+++ b/apps/api/test/integration/orders/order-cancellation-record-state.int-spec.ts
@@ -1,0 +1,240 @@
+/**
+ * Order Cancellation Record State Int-Spec (#1984)
+ *
+ * Exercises the two real cancellation-observation paths against the real
+ * Postgres harness — the layer the unit specs mock. In particular this
+ * proves two things the mocked specs cannot:
+ *
+ * 1. The raw `UPDATE ... SET "cancelledAt" = COALESCE("cancelledAt", $1)`
+ *    issued by `OrderRecordRepository.markCancelled` actually round-trips
+ *    through the real `cancelledAt` column (added by migration
+ *    `1832000000008-add-order-record-cancelled-at.ts`) with the right
+ *    quoting/casing, and that a redelivered cancel event or a later re-poll
+ *    is a true no-op against real Postgres (first-write-wins).
+ * 2. `OrderRecordRepository.upsert()` (a full-object `save()`) never
+ *    overwrites `cancelledAt` — verified by round-tripping `persistOrder`
+ *    twice for the same order and asserting the second call preserves the
+ *    first-observed instant, which is exactly the hazard the `toOrm()`
+ *    comment in the repository documents (a mocked repository spec can
+ *    assert "the property was never set on the ORM entity", but only a real
+ *    `save()` proves TypeORM actually omits the column from the generated
+ *    `UPDATE`).
+ *
+ * @module apps/api/test/integration/orders
+ */
+import {
+  CORE_ENTITY_TYPE,
+  IDENTIFIER_MAPPING_SERVICE_TOKEN,
+  type IIdentifierMappingService,
+} from '@openlinker/core/identifier-mapping';
+import {
+  ORDER_INGESTION_SERVICE_TOKEN,
+  ORDER_RECORD_SERVICE_TOKEN,
+  type IOrderIngestionService,
+  type IOrderRecordService,
+  type Order,
+} from '@openlinker/core/orders';
+import { OrderRecordOrmEntity } from '@openlinker/core/orders/orm-entities';
+import {
+  getTestHarness,
+  resetTestHarness,
+  teardownTestHarness,
+  type IntegrationTestHarness,
+} from '../setup';
+import { createTestConnection } from '../helpers/test-connection.helper';
+import { createTestOrderRecord } from '../fixtures/order.fixtures';
+
+function makeOrder(overrides: Partial<Order> = {}): Order {
+  return {
+    id: 'ol_order_cancellation_test',
+    orderNumber: 'ORD-CANCEL-1',
+    status: 'cancelled',
+    customerId: null,
+    items: [],
+    totals: { subtotal: 0, tax: 0, shipping: 0, total: 0, currency: 'PLN' },
+    shippingAddress: {
+      firstName: 'Jan',
+      lastName: 'Kowalski',
+      address1: 'ul. Testowa 1',
+      city: 'Warszawa',
+      postalCode: '00-001',
+      country: 'PL',
+    },
+    billingAddress: {
+      firstName: 'Jan',
+      lastName: 'Kowalski',
+      address1: 'ul. Testowa 1',
+      city: 'Warszawa',
+      postalCode: '00-001',
+      country: 'PL',
+    },
+    createdAt: new Date('2026-08-01T00:00:00Z'),
+    updatedAt: new Date('2026-08-01T00:00:00Z'),
+    ...overrides,
+  } as Order;
+}
+
+describe('Order cancellation durably recorded on the record (#1984)', () => {
+  let harness: IntegrationTestHarness;
+  let ingestion: IOrderIngestionService;
+  let identifierMapping: IIdentifierMappingService;
+  let orderRecordService: IOrderRecordService;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+    ingestion = harness.getApp().get<IOrderIngestionService>(ORDER_INGESTION_SERVICE_TOKEN);
+    identifierMapping = harness
+      .getApp()
+      .get<IIdentifierMappingService>(IDENTIFIER_MAPPING_SERVICE_TOKEN);
+    orderRecordService = harness.getApp().get<IOrderRecordService>(ORDER_RECORD_SERVICE_TOKEN);
+  });
+
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  it('durably records a source cancellation via handleSourceCancellation, and a redelivered cancel event leaves the instant unchanged', async () => {
+    const dataSource = harness.getDataSource();
+    const recordRepo = dataSource.getRepository(OrderRecordOrmEntity);
+
+    const connection = await createTestConnection(dataSource, {
+      platformType: 'allegro',
+      name: 'Allegro source',
+      adapterKey: 'allegro.test.unused',
+    });
+
+    const internalOrderId = 'ol_order_cancel_relay_test';
+    const externalOrderId = 'allegro-checkout-cancel-1';
+
+    await identifierMapping.createMapping(
+      CORE_ENTITY_TYPE.Order,
+      externalOrderId,
+      connection.id,
+      internalOrderId
+    );
+
+    await createTestOrderRecord(dataSource, {
+      internalOrderId,
+      sourceConnectionId: connection.id,
+      sourceEventId: 'allegro-evt-0',
+      orderSnapshot: { status: 'BOUGHT', orderNumber: externalOrderId, items: [] },
+      recordStatus: 'ready',
+      cancelledAt: null,
+    });
+
+    // Act: a source cancel event arrives. No other participant is mapped to
+    // this order, so `OrderLifecycleRelay.relay` resolves zero targets and the
+    // handler returns cleanly — the interesting assertion is the DB write.
+    const firstResult = await ingestion.syncOrderFromSource(
+      connection.id,
+      externalOrderId,
+      'cancel-evt-1',
+      'cancelled'
+    );
+    expect(firstResult).toEqual([]);
+
+    const afterFirst = await recordRepo.findOne({ where: { internalOrderId } });
+    expect(afterFirst).not.toBeNull();
+    expect(afterFirst!.cancelledAt).not.toBeNull();
+    const firstCancelledAt = afterFirst!.cancelledAt;
+
+    // Act: the same cancel event is redelivered (at-least-once delivery is the
+    // platform-wide invariant). first-write-wins must leave the instant intact.
+    const secondResult = await ingestion.syncOrderFromSource(
+      connection.id,
+      externalOrderId,
+      'cancel-evt-1-redelivered',
+      'cancelled'
+    );
+    expect(secondResult).toEqual([]);
+
+    const afterSecond = await recordRepo.findOne({ where: { internalOrderId } });
+    expect(afterSecond!.cancelledAt).toEqual(firstCancelledAt);
+  });
+
+  it('does not mark a destination-echo cancellation, leaving cancelledAt null', async () => {
+    const dataSource = harness.getDataSource();
+    const recordRepo = dataSource.getRepository(OrderRecordOrmEntity);
+
+    // Order originated on Allegro; PrestaShop is only a sync destination.
+    const allegroConnection = await createTestConnection(dataSource, {
+      platformType: 'allegro',
+      name: 'Allegro source',
+      adapterKey: 'allegro.test.unused',
+    });
+    const prestashopConnection = await createTestConnection(dataSource, {
+      platformType: 'prestashop',
+      name: 'PrestaShop destination',
+    });
+
+    const internalOrderId = 'ol_order_cancel_echo_test';
+    const prestashopOrderId = 'ps-order-9';
+
+    await identifierMapping.createMapping(
+      CORE_ENTITY_TYPE.Order,
+      prestashopOrderId,
+      prestashopConnection.id,
+      internalOrderId
+    );
+
+    await createTestOrderRecord(dataSource, {
+      internalOrderId,
+      sourceConnectionId: allegroConnection.id,
+      orderSnapshot: { status: 'BOUGHT', items: [] },
+      recordStatus: 'ready',
+      cancelledAt: null,
+    });
+
+    // Act: PrestaShop (a destination, not the source) reports a "cancel" for
+    // its own order id — the ADR-017 destination-echo guard must skip it.
+    const result = await ingestion.syncOrderFromSource(
+      prestashopConnection.id,
+      prestashopOrderId,
+      'ps-evt-1',
+      'cancelled'
+    );
+    expect(result).toEqual([]);
+
+    const found = await recordRepo.findOne({ where: { internalOrderId } });
+    expect(found!.cancelledAt).toBeNull();
+  });
+
+  it('preserves the first-observed cancellation instant across a later re-poll of the same order (persistOrder)', async () => {
+    const dataSource = harness.getDataSource();
+    const recordRepo = dataSource.getRepository(OrderRecordOrmEntity);
+
+    const connection = await createTestConnection(dataSource, {
+      platformType: 'allegro',
+      name: 'Allegro source',
+      adapterKey: 'allegro.test.unused',
+    });
+
+    const order = makeOrder({ id: 'ol_order_cancel_persist_test' });
+
+    // First observation: the order's own feed already reports `status:
+    // 'cancelled'` (no separate cancel event) — the ordinary persistOrder
+    // path, not handleSourceCancellation.
+    const firstSaved = await orderRecordService.persistOrder(order, connection.id, 'evt-1');
+    expect(firstSaved.cancelledAt).not.toBeNull();
+    const firstCancelledAt = firstSaved.cancelledAt;
+
+    // A later reconciliation poll re-pulls the same (still cancelled) order.
+    // Its full-object upsert() must not clobber the already-recorded instant.
+    const secondSaved = await orderRecordService.persistOrder(
+      makeOrder({
+        id: order.id,
+        updatedAt: new Date('2026-08-02T00:00:00Z'),
+      }),
+      connection.id,
+      'evt-2'
+    );
+    expect(secondSaved.cancelledAt).toEqual(firstCancelledAt);
+
+    const found = await recordRepo.findOne({ where: { internalOrderId: order.id } });
+    expect(found!.cancelledAt).toEqual(firstCancelledAt);
+  });
+});

--- a/docs/plans/analysis/ANALYSIS-order-cancellation-record-state.md
+++ b/docs/plans/analysis/ANALYSIS-order-cancellation-record-state.md
@@ -1,0 +1,42 @@
+# Pre-implement analysis: order-cancellation-record-state (#1984)
+
+**Verdict: READY** (one non-blocking correction applied below)
+
+## Reuse findings
+
+| Plan artifact | Classification | Evidence |
+|---|---|---|
+| `OrderRecord.cancelledAt` field + `isCancelled` getter | NEW | `libs/core/src/orders/domain/entities/order-record.entity.ts` has no `cancelledAt`; last trailing field is `totalAmount`. |
+| `deriveCancelledAt` pure helper | NEW | No `order-cancellation-projection.ts`, no `deriveCancelledAt` anywhere under `libs/core/src/orders/`. |
+| `OrderRecordRepositoryPort.markCancelled` | NEW | Port currently ends at `updateItemResolutionFailure` (line 112); no `markCancelled`. |
+| `OrderRecordOrmEntity.cancelledAt` column | NEW | Only pre-existing `cancelledAt` in the repo is `shipments.cancelledAt` (`1799000000000-add-shipments-table.ts`) — a different table, no collision. |
+| `OrderRecordFilters.cancelled` | NEW | Current interface has 8 filter fields (`sourceConnectionId` … `slaState`); no `cancelled`. |
+| `OrderRecordResponseDto.cancelledAt` | NEW | DTO's newest field is `dispatchByAt`/`sourceDeliveryMethodName`; no `cancelledAt`. |
+| `handleSourceCancellation` write-through to `markCancelled` | PARTIAL — extend existing method | Method exists at `order-ingestion.service.ts:485-536`, currently ends at the relay call with no record write. |
+| `persistOrder` / `persistIncomingSnapshot` cancellation preservation | PARTIAL — extend existing methods | Both exist in `order-record.service.ts`; neither reads or writes `cancelledAt` today. |
+
+No reinvention risk: every new symbol the plan proposes is confirmed absent.
+
+## Correction required before/during implementation
+
+**Migration timestamp.** The plan's own § 5 "Open Questions" flagged this as unresolved until implementation time — now resolved: this worktree is branched from current `origin/main`, whose migration tail is `1832000000007-add-shipment-waybill-relayed-at.ts`. The order-analytics-read-model PR (#2014/#1985) that would add `1832000000008` **has not merged** — that file does not exist on this branch. The plan drafted `1832000000009` defensively; the correct filename/class suffix on this branch, right now, is **`1832000000008`**. If PR #2014 merges before this branch does, re-timestamp to sort after whatever #2014 lands as (re-run `git ls-tree origin/main -- apps/api/src/migrations/` immediately before finalizing).
+
+**Domain-file precedent note.** The plan cites `order-analytics-projection.ts` (from #1985) as the naming precedent for `order-cancellation-projection.ts`. That file does not exist on `main` either (same reason — #1985 unmerged), so it is not literally available to copy from. Not a blocker: the plan's own inline code for `deriveCancelledAt` is fully self-contained and needs no sibling file to exist. Proceeding as specified.
+
+## Backward-compatibility findings
+
+| Surface | Check | Result |
+|---|---|---|
+| `@openlinker/core/orders` barrel | Any export removed/renamed? | No — plan only adds new optional trailing fields/methods. |
+| `OrderRecordRepositoryPort` | Signature changed on an implemented method? | No — `markCancelled` is additive; no existing method signature changes. |
+| `OrderRecordResponseDto` | Field removed/required/retyped? | No — `cancelledAt` is additive and optional. |
+| `*.tokens.ts` | Token removed/renamed? | N/A — plan adds no new DI token; `markCancelled` is a plain interface method reached through the existing `ORDER_RECORD_REPOSITORY_TOKEN`. |
+| ORM schema | Migration required? | Yes — covered by plan Phase 2 step 7, additive nullable column + index. |
+| `check:invariants` | Cross-context imports, service-interface check, deep-barrel imports? | Clean — no new cross-context import, `OrderRecordService` keeps implementing `IOrderRecordService`, no deep imports introduced. |
+
+No Critical items. No Warning items beyond the already-planned migration (expected, not a defect).
+
+## Open questions carried into implementation
+
+- Confirm final migration timestamp per the correction above before running `migration:generate`/committing the file.
+- Everything else in the plan's own § 5 (KPI-bucket exclusion scope) remains a genuine open product question, not an implementation blocker — the plan's chosen default (leave health/SLA buckets untouched) is safe to proceed with.

--- a/docs/plans/implementation-plan-order-cancellation-record-state.md
+++ b/docs/plans/implementation-plan-order-cancellation-record-state.md
@@ -1,0 +1,751 @@
+# Implementation Plan: Capture order cancellation as first-class record state
+
+**Date**: 2026-08-11
+**Status**: Draft
+**Estimated Effort**: 1–2 days
+
+---
+
+## 1. Task Summary
+
+**Objective**: Make order cancellation a durable, queryable fact on `OrderRecord`, written at the
+moment the source reports it — not only if a later poll happens to re-ingest the order.
+
+**Context**: Issue [#1984](https://github.com/openlinker-project/openlinker/issues/1984), part of
+the `/analytics` epic (#1976, spec `docs/specs/product-spec-1976-analytics.md` § 1a, dependency
+**[C]**). Today `recordStatus` is only `ready | awaiting_mapping | source_deleted` (item-mapping
+resolution state — orthogonal to business status), and `handleSourceCancellation`
+(`libs/core/src/orders/application/services/order-ingestion.service.ts:485-536`) relays the
+cancellation to destinations and returns **without touching the order record at all**. Cancelled
+state survives only as a string inside `orderSnapshot.status`, invisible to SQL and only present if
+a later poll happens to re-ingest the order through the ordinary `syncOrderFromSource` path.
+
+Consequence: any revenue aggregate built on top of `order_records` would silently include cancelled
+orders, and cancellation rate cannot be reported at all.
+
+**Classification**: CORE (`libs/core/src/orders/`) + a nullable, additive migration in
+`apps/api/src/migrations/`. No integration/adapter change — the source adapters already report
+`status: 'cancelled'` on the neutral `IncomingOrder`/`Order` types; this issue only makes OL persist
+that fact durably.
+
+---
+
+## 2. Scope & Non-Goals
+
+### In Scope
+
+- A new nullable `cancelledAt: timestamptz` column on `order_records`, set once and preserved
+  thereafter (first-write-wins).
+- Writing `cancelledAt` from **both** cancellation-observation paths:
+  1. `handleSourceCancellation` — the dedicated cancel-event handler, which today writes nothing.
+  2. `OrderRecordService.persistOrder` / `persistIncomingSnapshot` — the ordinary polling/ingestion
+     path, for the case where a source's order feed reports `status: 'cancelled'` directly (no
+     separate cancel event) or an order is (re-)ingested after cancellation.
+- A minimal `OrderRecordFilters` extension (`cancelled?: boolean`) so the fact is queryable/
+  excludable from SQL without parsing `orderSnapshot` — satisfying the issue's own "queryable
+  without JSON" acceptance criterion. Wiring this into an actual revenue aggregate is explicitly
+  deferred to the aggregate issues (#1987/#1988), per ADR-039's own deferral note (see § 4).
+- Surfacing `cancelledAt` on `OrderRecordResponseDto` (mirrors the existing `dispatchByAt` /
+  `mappingFailureReason` precedent), so the order detail/list already shows the fact.
+- One additive migration with a best-effort, explicitly-documented backfill for historical rows.
+- Unit tests (core + api) and one integration test.
+
+### Out of Scope
+
+- Refunds (`refunded` is an unwritten `PriceTaxTreatment`-adjacent enum member today — no refund
+  amount is stored anywhere; a separate data-capture feature).
+- Returns / withdrawals — no return entity exists.
+- Restock behaviour on cancellation — already handled by `marketplace.offer.stockRestore` (#1146),
+  unchanged by this plan.
+- The sales/channel/top-products aggregate endpoints that will *use* the new exclusion filter
+  (#1987, #1988) — this issue only makes the exclusion possible.
+- Any FE change. The order detail page renders `orderSnapshot` today and is unaffected; a future FE
+  slice can add a "Cancelled" badge off the new `cancelledAt` DTO field, but is not required by this
+  issue's acceptance criteria.
+- Un-cancelling: once `cancelledAt` is set it is never cleared by this plan. No source adapter in
+  the repo emits an "uncancelled" transition today, so this is a safe simplification — see
+  § 5 Assumptions.
+
+### Constraints
+
+- Must not change existing cancellation-relay behaviour to destinations (explicit acceptance
+  criterion).
+- Must follow the existing denormalized-scalar-column precedent (`dispatchByAt`, `fulfillmentState`,
+  `mappingFailureReason`) rather than overloading `recordStatus` — cancellation is a business fact
+  orthogonal to item-mapping resolution state (an order can be `ready` *and* cancelled).
+- Migration timestamp ordering: `main`'s current migration tail is
+  `1832000000007-add-shipment-waybill-relayed-at.ts`. PR #2014 (issue #1985, order analytics read
+  model — **open, not yet merged**) adds `1832000000008-add-order-analytics-read-model.ts` on top of
+  that. See § 5 Open Questions for how this plan's migration timestamp must be finalized at
+  implementation time.
+
+---
+
+## 3. Architecture Mapping
+
+**Target Layer**: CORE (`libs/core/src/orders/`) — domain entity, repository port/impl, application
+service. Plus the API interface layer (`apps/api/src/orders/http/`) for DTO surfacing, and
+`apps/api/src/migrations/` for schema.
+
+**Capabilities Involved**: None new. This does not touch any capability port
+(`OrderSourcePort`, `OrderProcessorManagerPort`) — the neutral `IncomingOrder.status` /
+`Order.status` union already includes `'cancelled'` (`libs/core/src/orders/domain/types/order.types.ts:28`)
+and every adapter already reports it; this is purely a persistence/read-model change downstream of
+that existing contract.
+
+**Existing Services Reused**:
+- `OrderRecordService` (`persistOrder`, `persistIncomingSnapshot`) — extended, not replaced.
+- `OrderRecordRepository` — new narrow method added, mirroring `updateFulfillmentState` /
+  `updateItemResolutionFailure`.
+- `OrderIngestionService.handleSourceCancellation` — the load-bearing fix; gets the one new call
+  that was missing.
+
+**New Components Required**:
+- `OrderRecord.cancelledAt: Date | null` constructor field (domain entity) + `isCancelled` pure
+  getter.
+- `OrderRecordOrmEntity.cancelledAt` column.
+- `OrderRecordRepositoryPort.markCancelled(internalOrderId, cancelledAt)` — new port method, narrow
+  absolute-set-once (COALESCE), mirrors `updateFulfillmentState`'s "no-op if row missing" contract.
+- A pure helper `deriveCancelledAt(priorCancelledAt, isCancelled, now)` in
+  `libs/core/src/orders/domain/order-cancellation-projection.ts` (mirrors the existing
+  `order-analytics-projection.ts` pure-helper precedent from #1985), used by `persistOrder` /
+  `persistIncomingSnapshot`.
+- One migration: adds the column + best-effort backfill.
+
+**Core vs Integration Justification**: Squarely CORE. Cancellation is a cross-cutting order-lifecycle
+fact independent of which marketplace/shop reported it; no platform-specific behaviour is
+introduced. `handleSourceCancellation` already lives in CORE's `OrderIngestionService` and is the
+correct place to durably record the fact — no adapter change is needed because every
+`OrderSourcePort` implementation already surfaces cancellation via the existing neutral
+`OrderFeedEventType = 'cancelled'` / `IncomingOrder.status = 'cancelled'` contract.
+
+---
+
+## 4. External / Domain Research
+
+### Internal Patterns (codebase search findings)
+
+- **Denormalized scalar precedent**: `dispatchByAt` (#927) and `fulfillmentState` (#1108) are both
+  nullable columns on `order_records`, re-derived/pushed at write time rather than parsed from
+  `orderSnapshot` on every read. `mappingFailureReason` (#1689) is the closest sibling: a single
+  nullable column, one migration, one repository absolute-set method
+  (`updateItemResolutionFailure`), surfaced on the response DTO. This plan's `cancelledAt` follows
+  the exact same shape.
+- **"Claim once, preserve" precedent**: `Shipment.waybillRelayedAt` (documented in
+  `docs/architecture-overview.md` § Orders — "Late-arriving waybills reach the source too (#1947)")
+  is claimed conditionally (`WHERE "waybillRelayedAt" IS NULL`) precisely because it is a fact that,
+  once true, must never be overwritten by a later write. `cancelledAt` has the identical shape: "the
+  moment the source reports it" must survive every subsequent re-ingestion of the same order.
+- **`handleSourceCancellation` today** (`order-ingestion.service.ts:485-536`): resolves
+  `internalOrderId`, applies the ADR-017 destination-echo guard (skip if the order originated from
+  a *different* connection than the one reporting the cancel — this is a re-read of an order OL
+  itself pushed there as a destination), then calls `orderLifecycleRelay.relay(...)` and returns.
+  `existing` (the pre-fetched `OrderRecord`) is already available at this point via
+  `this.orderRecordService.getOrderRecord(internalOrderId)` — the plan reuses it, no extra read
+  needed for this path.
+- **`persistOrder` / `persistIncomingSnapshot` today**
+  (`order-record.service.ts`): both build a fresh `OrderRecord` and call
+  `repository.upsert()`, which is a **full-object `save()`** — every column on the row is
+  overwritten with whatever the freshly-constructed domain entity carries. This is the reason a
+  naive "only set `cancelledAt` when status is cancelled, default `null` otherwise" would silently
+  **erase** a previously-recorded cancellation on any later re-poll of the same order (the
+  reconciliation flow, #904, explicitly re-pulls already-synced orders — "re-pull is authoritative;
+  last write wins"). The fix is to read the row's current `cancelledAt` before constructing the new
+  entity and carry it through, exactly like `deriveDispatchByAt` re-derives its column on every
+  persist but — unlike `dispatchByAt`, which is safely re-derivable from the same source data every
+  time — `cancelledAt`'s *first-observed* timestamp is not re-derivable, so it must be preserved,
+  not re-derived.
+- **`priorStatus` gate already in `syncOrderFromSource`** (lines 246–252, 280, 368): the ingestion
+  flow already reads the order's prior business status off the pre-persist snapshot to gate the
+  `marketplace.offer.stockRestore` job on the `→ cancelled` **transition**. That gate gets no
+  cheaper or more correct by touching `cancelledAt` — it stays exactly as-is (explicit non-goal:
+  "Existing cancellation relay behaviour... unchanged" extends to this adjacent stock-restore hook
+  too, which is unrelated to the relay but equally must not regress).
+- **#1985 / ADR-039** (`docs/architecture/adrs/039-order-analytics-read-model-persistence-strategy.md`,
+  PR #2014, branch `1985-order-analytics-read-model`, still open): adds `placedAt`, `currency`,
+  `taxTreatment`, `totalAmount` scalar columns plus a new `order_line_items` table to
+  `order_records`, migration `1832000000008-add-order-analytics-read-model.ts`. Its own "Cons /
+  trade-offs" section states explicitly: *"Cancellation exclusion depends on #1984 landing first
+  with its own column; this ADR's tables are designed to be additive and independent of that column
+  so the two efforts don't block each other's schema work, but the exclusion predicate itself
+  cannot be wired until #1984 merges."* This plan is exactly that follow-up: additive, independent
+  schema, no dependency on #1985's columns or table. No coordination is needed beyond the migration
+  timestamp (see § 5).
+- **PR #2018** (`docs/plans/mockups/analytics-ledger-2003.html`, docs-only visual design package for
+  `/analytics`): confirms in its own body that a "Cancellations" KPI card is drawn in the mockup but
+  explicitly marked as a currently-**blocked** figure (dashed border, "Data order" tag) — i.e. the
+  design already anticipates this issue landing before that card can go live. No code dependency;
+  informs only that the eventual FE consumer of `cancelledAt` already has a place to render it.
+
+### External System
+
+Not applicable — no new external API surface. The source adapters (Allegro, PrestaShop, WooCommerce,
+Erli) already report cancellation via the existing `OrderSourcePort` contract
+(`OrderFeedEventTypeValues` includes `'cancelled'`; `IncomingOrder.status` / `Order.status` include
+`'cancelled'`). No adapter code changes.
+
+---
+
+## 5. Questions & Assumptions
+
+### Open Questions
+
+- **Migration timestamp**: at implementation time, `git ls-tree origin/main -- apps/api/src/migrations/`
+  must be re-checked. If PR #2014 (#1985) has merged by then, this plan's migration must sort
+  *after* `1832000000008-add-order-analytics-read-model.ts` (e.g. `1832000000009`). If #2014 is
+  still open, either migration could land first; whichever merges second must rebase its own
+  timestamp to sort after the other, per `docs/migrations.md` § Timestamp uniqueness invariant rule
+  3 (enforced by `scripts/check-migration-timestamps.mjs` against `origin/main` at lint time — this
+  is not something the plan can pre-decide). **Assumption for this plan**: draft the migration as
+  `1832000000009-add-order-record-cancelled-at.ts`; re-timestamp at implementation time if it no
+  longer sorts strictly after `origin/main`'s tail.
+- Should `cancelledAt` also be excluded from the `countByHealth` / `countBySla` KPI-strip aggregates
+  on the orders list today? **Assumption**: no — those buckets partition on item-mapping resolution
+  state (`recordStatus` + `syncStatus[]`), not business status; a cancelled-but-`ready` order stays
+  in whichever health bucket it already occupies. Excluding cancelled orders from *revenue*
+  aggregates is the concern of #1987/#1988, not the operational orders-list KPIs. Flagged here in
+  case product intent differs.
+
+### Assumptions
+
+- Cancellation is treated as a **monotonic, one-way** fact: once `cancelledAt` is set, nothing in
+  this plan clears it. No adapter in the repo emits an "order un-cancelled" signal today (`Order.status`
+  union has no such transition documented), so this is safe. If a future source can genuinely
+  reverse a cancellation, that is a new, separate design question — not silently absorbed here.
+- For **historical rows** where `orderSnapshot.status` (or, for `awaiting_mapping` rows,
+  `orderSnapshot->>'status'`) is already `'cancelled'` but `cancelledAt` is `NULL` (every row that
+  predates this migration), the migration backfills `cancelledAt := "updatedAt"` as a best-effort
+  proxy for "when we last observed the cancellation" — not the true cancellation instant, which
+  cannot be reconstructed from data OL already holds. This is called out explicitly in the migration
+  file header per the issue's own acceptance criterion ("the backfill or default position for
+  historical rows is explicit and documented"). Rows whose snapshot doesn't report `'cancelled'` are
+  left `NULL` (default: never cancelled).
+- The stock-restore-job transition gate (`priorStatus !== 'cancelled'`, read from the snapshot) is
+  left untouched rather than rewired onto `cancelledAt`. They are two independent representations of
+  "was this order cancelled before this call": the snapshot-status check already works correctly
+  today for its narrow purpose (job-enqueue dedup within a single ingestion call), and rewiring it
+  onto the new column would be an unrelated refactor with no acceptance-criterion behind it.
+- `markCancelled`'s no-op-when-row-missing behavior (mirroring `updateFulfillmentState`) is accepted
+  for the documented residual race (#1160: a cancel event arriving before the order's own create/sync
+  job has run). This plan does not attempt to close that race — it is out of scope and explicitly
+  flagged as a pre-existing, separately-tracked gap in the architecture doc.
+
+### Documentation Gaps
+
+None identified — `docs/architecture-overview.md` § Orders already documents the neutral
+`OrderFeedEventType`/`Order.status` cancellation vocabulary and the existing relay flow in enough
+detail to implement against without further discovery.
+
+---
+
+## 6. Proposed Implementation Plan
+
+### Phase 1: Domain — entity, port, pure helper
+
+**Goal**: Introduce the new fact at the domain layer, with no wiring yet.
+
+**Steps**:
+
+1. **Add `cancelledAt` to `OrderRecord`**
+   - **File**: `libs/core/src/orders/domain/entities/order-record.entity.ts`
+   - **Action**: append a new trailing constructor parameter
+     `public readonly cancelledAt: Date | null = null` (after `totalAmount`, following the existing
+     pattern of appending new optional fields at the end so old call sites keep compiling), with a
+     doc comment mirroring `mappingFailureReason`'s. Add a pure getter:
+     ```ts
+     /**
+      * True once the source has reported this order cancelled (#1984). Pure
+      * derivation of an already-loaded field (ADR-011): no I/O, no mutation.
+      */
+     get isCancelled(): boolean {
+       return this.cancelledAt !== null;
+     }
+     ```
+   - **Acceptance**: `libs/core/src/orders/domain/entities/order-record.entity.spec.ts` (new, or
+     extend an existing entity spec if one exists) asserts `isCancelled` is `false` for
+     `cancelledAt: null` and `true` otherwise.
+   - **Dependencies**: none.
+
+2. **Add the pure `deriveCancelledAt` helper**
+   - **File**: `libs/core/src/orders/domain/order-cancellation-projection.ts` (new, mirrors the
+     existing `order-analytics-projection.ts` sibling from #1985 — a plain function file, no class,
+     no I/O)
+   - **Action**:
+     ```ts
+     /**
+      * Order Cancellation Projection
+      *
+      * Pure derivation of the `cancelledAt` scalar to persist on an OrderRecord
+      * (#1984). First-write-wins: once a cancellation instant is recorded it is
+      * never replaced by a later persist of the same order, even if the source
+      * keeps reporting `status: 'cancelled'` on every subsequent poll.
+      *
+      * @module domain
+      */
+     export function deriveCancelledAt(
+       priorCancelledAt: Date | null,
+       isCancelled: boolean,
+       now: Date
+     ): Date | null {
+       if (priorCancelledAt) {
+         return priorCancelledAt;
+       }
+       return isCancelled ? now : null;
+     }
+     ```
+   - **Acceptance**: `order-cancellation-projection.spec.ts` — table-driven: (a) prior null, not
+     cancelled → null; (b) prior null, cancelled → `now`; (c) prior set, cancelled → prior
+     (unchanged); (d) prior set, not cancelled (an already-cancelled order re-ingested with a
+     status that no longer says cancelled — shouldn't happen per source contracts, but must not
+     regress) → prior (never cleared).
+   - **Dependencies**: none.
+
+3. **Add `markCancelled` to the repository port**
+   - **File**: `libs/core/src/orders/domain/ports/order-record-repository.port.ts`
+   - **Action**: add after `updateItemResolutionFailure`:
+     ```ts
+     /**
+      * Durably record the instant the source reported this order cancelled
+      * (#1984), directly from `handleSourceCancellation` — the one ingestion
+      * path that never calls `persistOrder`/`persistIncomingSnapshot`.
+      * First-write-wins (`COALESCE`): a redelivered cancel event or a later
+      * re-poll can never overwrite an already-recorded cancellation instant.
+      * No-op (no throw) when the order row doesn't exist yet — mirrors
+      * {@link updateFulfillmentState}'s residual-race tolerance (#1160: a
+      * cancel event racing ahead of the order's own create/sync job).
+      */
+     markCancelled(internalOrderId: string, cancelledAt: Date): Promise<void>;
+     ```
+   - **Acceptance**: compiles; no behavior yet (implemented in Phase 2).
+   - **Dependencies**: step 1 (import cleanliness only — no direct type dependency).
+
+### Phase 2: Infrastructure — ORM column, repository implementation, migration
+
+**Goal**: Make `cancelledAt` a real, queryable database column.
+
+**Steps**:
+
+4. **Add the ORM column**
+   - **File**: `libs/core/src/orders/infrastructure/persistence/entities/order-record.orm-entity.ts`
+   - **Action**: add, mirroring `dispatchByAt`'s decorator shape:
+     ```ts
+     /**
+      * Instant the source reported this order cancelled (#1984). `null` =
+      * never cancelled (or a historical row this migration's backfill could
+      * not derive a proxy timestamp for). Indexed for the future exclusion
+      * predicate (#1987/#1988: `WHERE "cancelledAt" IS NULL`).
+      */
+     @Column({ type: 'timestamptz', nullable: true })
+     @Index()
+     cancelledAt!: Date | null;
+     ```
+   - **Acceptance**: `pnpm --filter @openlinker/core type-check` passes.
+   - **Dependencies**: step 4 depends on nothing upstream in this plan; independent of steps 1–3.
+
+5. **Wire `toDomain` / `toOrm` mapping**
+   - **File**: `libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts`
+   - **Action**: in `toDomain`, pass `entity.cancelledAt` as the new trailing constructor arg; in
+     `toOrm`, set `orm.cancelledAt = orderRecord.cancelledAt`.
+   - **Acceptance**: existing repository spec's round-trip assertions (`order-record.repository.spec.ts`)
+     still pass; add one new case asserting `cancelledAt` round-trips through `toOrm`/`toDomain`.
+   - **Dependencies**: step 4.
+
+6. **Implement `markCancelled`**
+   - **File**: `libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts`
+   - **Action**: add near `updateFulfillmentState`/`updateItemResolutionFailure`:
+     ```ts
+     async markCancelled(internalOrderId: string, cancelledAt: Date): Promise<void> {
+       await this.repository.query(
+         `UPDATE "order_records"
+          SET "cancelledAt" = COALESCE("cancelledAt", $1)
+          WHERE "internalOrderId" = $2`,
+         [cancelledAt, internalOrderId]
+       );
+     }
+     ```
+     (Raw parameterized query — mirrors the existing raw-SQL idiom in `updateSyncStatus` — because
+     TypeORM's `Repository.update()` partial-entity API cannot express a `COALESCE(...)`
+     right-hand side without an unsafe string-interpolated `() => '...'` function value.)
+   - **Acceptance**: new repository spec case — call twice with two different `Date`s for the same
+     `internalOrderId`; assert the second call is a no-op (the row keeps the first timestamp).
+     Second case: call for a non-existent `internalOrderId`; assert no throw.
+   - **Dependencies**: step 4.
+
+7. **Migration**
+   - **File**: `apps/api/src/migrations/1832000000009-add-order-record-cancelled-at.ts` (timestamp
+     to be reconfirmed at implementation time — see § 5 Open Questions)
+   - **Action**:
+     ```ts
+     /**
+      * Add OrderRecord cancelledAt Migration
+      *
+      * Adds `cancelledAt` (nullable timestamptz) to `order_records` (#1984) —
+      * durably records the instant the source reported an order cancelled,
+      * independent of `recordStatus` (which tracks item-mapping resolution,
+      * not business status).
+      *
+      * Backfill: for existing rows where the raw snapshot's `status` key
+      * already reads 'cancelled' (parsed defensively — some rows carry a
+      * pre-mapping IncomingOrder shape, others a resolved Order shape, but
+      * both use the same top-level `status` key), sets `cancelledAt :=
+      * "updatedAt"` as a best-effort proxy for "the last time we observed
+      * this order's cancelled state" — NOT the true cancellation instant,
+      * which cannot be reconstructed from data OL already holds. Rows whose
+      * snapshot does not report 'cancelled' are left NULL (never cancelled).
+      * Idempotent: `WHERE "cancelledAt" IS NULL` re-running this migration
+      * (or a from-scratch replay) is a no-op on rows already backfilled.
+      *
+      * @module apps/api/src/migrations
+      */
+     import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+     export class AddOrderRecordCancelledAt1832000000009 implements MigrationInterface {
+       name = 'AddOrderRecordCancelledAt1832000000009';
+
+       public async up(queryRunner: QueryRunner): Promise<void> {
+         await queryRunner.query(
+           `ALTER TABLE "order_records" ADD COLUMN IF NOT EXISTS "cancelledAt" timestamptz`
+         );
+         await queryRunner.query(
+           `CREATE INDEX IF NOT EXISTS "IDX_order_records_cancelledAt" ON "order_records" ("cancelledAt")`
+         );
+         await queryRunner.query(
+           `UPDATE "order_records"
+            SET "cancelledAt" = "updatedAt"
+            WHERE "cancelledAt" IS NULL
+              AND "orderSnapshot"->>'status' = 'cancelled'`
+         );
+       }
+
+       public async down(queryRunner: QueryRunner): Promise<void> {
+         await queryRunner.query(
+           `DROP INDEX IF EXISTS "IDX_order_records_cancelledAt"`
+         );
+         await queryRunner.query(
+           `ALTER TABLE "order_records" DROP COLUMN IF EXISTS "cancelledAt"`
+         );
+       }
+     }
+     ```
+   - **Acceptance**: `pnpm --filter @openlinker/api migration:run` / `migration:revert` both succeed
+     locally against the dev Postgres; `pnpm --filter @openlinker/api migration:show` lists it with
+     no pending gaps.
+   - **Dependencies**: step 4 (column name/type must match the ORM entity exactly).
+
+### Phase 3: Application — wire both cancellation-observation paths
+
+**Goal**: Actually populate `cancelledAt` from the two places cancellation is observed.
+
+**Steps**:
+
+8. **`OrderRecordService.persistOrder`**
+   - **File**: `libs/core/src/orders/application/services/order-record.service.ts`
+   - **Action**: before constructing the `OrderRecord`, read the row's current `cancelledAt`:
+     ```ts
+     const priorCancelledAt = (await this.repository.findById(order.id))?.cancelledAt ?? null;
+     const cancelledAt = deriveCancelledAt(priorCancelledAt, order.status === 'cancelled', now);
+     ```
+     Pass `cancelledAt` as the new trailing constructor arg. One extra `findById` per persist call —
+     accepted given the documented 10–100 orders/day volume (ADR-039 § Context).
+   - **Acceptance**: existing `order-record.service.spec.ts` cases still pass; new cases: (a) a
+     fresh, never-before-seen cancelled order gets `cancelledAt` set to (approximately) `now`; (b)
+     an order that was already cancelled in a prior `persistOrder` call keeps its original
+     `cancelledAt` on a second call with a later `now`.
+   - **Dependencies**: Phase 1 step 2, Phase 2 steps 4–5.
+
+9. **`OrderRecordService.persistIncomingSnapshot`**
+   - **File**: `libs/core/src/orders/application/services/order-record.service.ts`
+   - **Action**: identical pattern, keyed on `incoming.status === 'cancelled'`.
+   - **Acceptance**: mirrors step 8's cases, applied to the `awaiting_mapping` path — e.g. a
+     cancelled order whose items never resolve still gets `cancelledAt` recorded (satisfies the
+     acceptance criterion independent of `recordStatus`).
+   - **Dependencies**: Phase 1 step 2, Phase 2 steps 4–5.
+
+10. **`OrderIngestionService.handleSourceCancellation` — the load-bearing fix**
+    - **File**: `libs/core/src/orders/application/services/order-ingestion.service.ts`
+    - **Action**: immediately after the destination-echo guard (line ~511, after the `existing`
+      check) and **before** the `orderLifecycleRelay.relay(...)` call, add:
+      ```ts
+      await this.orderRecordService.markCancelled(internalOrderId, new Date());
+      ```
+      Placed before the relay call so the durable record write cannot be lost if the relay itself
+      throws (relay failures are pre-existing, unguarded by a try/catch today — out of scope to
+      change here). Add `markCancelled` to `IOrderRecordService` as a thin pass-through to the
+      repository (mirrors how `updateFulfillmentState`/`markItemResolutionFailure` are exposed).
+    - **Acceptance**: **This is the primary fix for the issue's first acceptance criterion.** New
+      test in `order-ingestion.service.spec.ts`: a cancel event for a known order calls
+      `orderRecordService.markCancelled` exactly once with the correct `internalOrderId`, *before*
+      `orderLifecycleRelay.relay` is invoked (assert call order via mock invocation ordering, or via
+      two separate `toHaveBeenCalledBefore`-style assertions if the test harness supports it —
+      otherwise assert both calls happened and document the intended ordering in a comment). Also:
+      the destination-echo-guard early-return path (unknown order / cross-origin echo) does **not**
+      call `markCancelled` (no regression on the existing skip branches).
+    - **Dependencies**: Phase 1 step 3, Phase 2 step 6.
+
+### Phase 4: Interface — surface on the API response
+
+**Goal**: The operator (and any future FE consumer) can see the fact without querying Postgres
+directly.
+
+**Steps**:
+
+11. **`OrderRecordResponseDto` + controller mapping**
+    - **Files**: `apps/api/src/orders/http/dto/order-record-response.dto.ts`,
+      `apps/api/src/orders/http/orders.controller.ts`
+    - **Action**: add, mirroring `dispatchByAt`'s DTO shape exactly:
+      ```ts
+      @ApiPropertyOptional({
+        nullable: true,
+        description:
+          'Instant the source reported this order cancelled (ISO 8601, #1984). null = never ' +
+          'cancelled. Set once and never cleared — a later re-poll of a cancelled order cannot ' +
+          'change this timestamp.',
+      })
+      cancelledAt!: string | null;
+      ```
+      In `orders.controller.ts#toDto`: `cancelledAt: order.cancelledAt ? order.cancelledAt.toISOString() : null,`
+    - **Acceptance**: new case in `orders.controller.spec.ts` mirroring the existing
+      `'should serialize dispatchByAt as an ISO string, or null when absent (#927)'` case, adapted
+      for `cancelledAt`.
+    - **Dependencies**: Phase 1 step 1.
+
+12. **`OrderRecordFilters.cancelled` — the queryability acceptance criterion**
+    - **Files**: `libs/core/src/orders/domain/types/order-record.types.ts`,
+      `libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts`
+      (`findMany`)
+    - **Action**: add `cancelled?: boolean` to `OrderRecordFilters` with a doc comment explaining it
+      maps to `cancelledAt IS [NOT] NULL`; in `findMany`'s `qb` construction, add:
+      ```ts
+      if (filters.cancelled !== undefined) {
+        qb.andWhere(filters.cancelled ? 'rec.cancelledAt IS NOT NULL' : 'rec.cancelledAt IS NULL');
+      }
+      ```
+      **Not** wired into any HTTP query param or FE control in this plan — this satisfies "cancelled
+      orders are queryable... sufficient to exclude them from an aggregate or count them on their
+      own" (the issue's own wording, matched almost verbatim) as a repository-level capability;
+      exposing it as an actual list filter or aggregate predicate is #1987/#1988's job.
+    - **Acceptance**: new `order-record.repository.spec.ts` case: seed one cancelled + one
+      non-cancelled record, assert `findMany({ cancelled: true }, ...)` and
+      `findMany({ cancelled: false }, ...)` each return exactly the expected row.
+    - **Dependencies**: Phase 2 step 4.
+
+### Implementation Details Summary
+
+**New Components**:
+- **Domain**: `OrderRecord.cancelledAt` + `isCancelled` getter;
+  `order-cancellation-projection.ts` (`deriveCancelledAt`); `OrderRecordRepositoryPort.markCancelled`.
+- **Application**: `IOrderRecordService.markCancelled` pass-through; `persistOrder` /
+  `persistIncomingSnapshot` extended; `handleSourceCancellation` extended.
+- **Infrastructure**: `OrderRecordOrmEntity.cancelledAt` column; `OrderRecordRepository.markCancelled`;
+  `toDomain`/`toOrm` mapping; `findMany` filter clause.
+- **Interface**: `OrderRecordResponseDto.cancelledAt`; controller `toDto` mapping.
+
+**Configuration Changes**: None.
+
+**Database Migrations**: One — `apps/api/src/migrations/1832000000009-add-order-record-cancelled-at.ts`
+(see Phase 2 step 7; timestamp reconfirmed at implementation time per § 5).
+
+**Events**: None emitted or consumed. This plan deliberately does **not** introduce a new domain
+event (e.g. an `order.cancelled` event on the `events.master.deletion`-style stream) — the existing
+`OrderLifecycleRelay` call already carries the cross-cutting notification responsibility for
+cancellation, and adding a second notification channel for the same fact is unjustified scope for
+this issue.
+
+**Error Handling**: No new domain exceptions. `markCancelled`'s no-op-on-missing-row behavior is a
+deliberate design choice (documented in step 3/6), not an error path.
+
+---
+
+## 7. Alternatives Considered
+
+### Alternative 1: Add `'cancelled'` as a fourth `OrderRecordStatus` value
+
+- **Description**: Extend `OrderRecordStatusValues` to `['ready', 'awaiting_mapping',
+  'source_deleted', 'cancelled']` instead of a separate column.
+- **Why Rejected**: `recordStatus` tracks item-mapping resolution state, which is orthogonal to
+  business/cancellation status — an order can be fully `ready` (all items resolved) *and*
+  cancelled. Folding both concerns into one enum would make the two facts mutually exclusive when
+  they aren't, and would require every existing `recordStatus`-branching call site (health-bucket
+  derivation, mapping-failure UI, item-resolution retry logic) to also reason about cancellation,
+  which was explicitly not their contract.
+- **Trade-offs**: A single-column boolean-ish enum is marginally simpler to query
+  (`recordStatus = 'cancelled'` vs. `cancelledAt IS NOT NULL`), but at the cost of conflating two
+  independent facts — exactly the anti-pattern the architecture doc's precedent
+  (`dispatchByAt`/`fulfillmentState` as separate orthogonal columns) was designed to avoid.
+
+### Alternative 2: A boolean `isCancelled` column instead of a nullable timestamp
+
+- **Description**: `isCancelled: boolean NOT NULL DEFAULT false` instead of `cancelledAt: timestamptz NULL`.
+- **Why Rejected**: The issue's own acceptance criteria explicitly require the *time* to be
+  recorded, not just the fact ("an order cancelled today should not silently alter last month's
+  reported figures") — a plain boolean cannot support "cancelled orders from January" vs.
+  "cancelled orders from August" bucketing that a future analytics slice will need. A nullable
+  timestamp captures both the fact (`IS NOT NULL`) and the time in one column, with no redundant
+  pair of columns to keep in sync.
+
+---
+
+## 8. Validation & Risks
+
+### Architecture Compliance
+- ✅ Follows hexagonal layering: domain entity/port change → infrastructure implementation →
+  application wiring → interface surfacing, in that dependency order.
+- ✅ CORE-only change; no capability port touched; no adapter code changes.
+- **Reference**: `docs/architecture-overview.md` § Orders, § Hexagonal Architecture Structure.
+
+### Naming Conventions
+- ✅ `cancelledAt` matches the existing `dispatchByAt` / camelCase timestamp-column convention.
+- ✅ `order-cancellation-projection.ts` mirrors the `order-analytics-projection.ts` file-naming
+  precedent for a pure-function domain module (no `*.entity.ts`/`*.port.ts` suffix needed — it's a
+  plain function file, same shape as its sibling from #1985).
+- ✅ Migration filename/class both carry the same 13-digit timestamp suffix, per
+  `docs/migrations.md` § Timestamp uniqueness invariant.
+
+### Existing Patterns
+- ✅ `markCancelled`'s COALESCE-based first-write-wins update directly follows the
+  `Shipment.waybillRelayedAt` claim-once precedent documented in the architecture overview.
+- ✅ Repository absolute-set methods (`markCancelled`) mirror `updateFulfillmentState` /
+  `updateItemResolutionFailure` exactly: narrow, single-column, no read-modify-write race on other
+  columns, no-op-not-throw when the row is missing.
+
+### Risks
+
+- **Risk: the extra `findById` read in `persistOrder`/`persistIncomingSnapshot` adds a query to the
+  hot ingestion path.** Mitigation: at the documented 10–100 orders/day volume (ADR-039), this is
+  negligible; if a future high-volume deployment makes it measurable, the read can be folded into
+  the same transaction as the eventual `upsert()` call (a `SELECT ... FOR UPDATE` or a single
+  `INSERT ... ON CONFLICT DO UPDATE SET "cancelledAt" = COALESCE(...)` raw upsert) — deferred until
+  there's a real number to justify it, matching the ADR-036/ADR-039 "revisit only with real numbers"
+  discipline.
+- **Risk: migration timestamp collision with PR #2014 (#1985).** Mitigation: documented as an open
+  question (§ 5); `scripts/check-migration-timestamps.mjs` will hard-fail `pnpm lint` at
+  implementation time if the chosen timestamp doesn't sort strictly after `origin/main`'s tail —
+  the fix is a one-line re-timestamp before commit, not a design change.
+- **Risk: the backfill's `"updatedAt"` proxy could be significantly later than the true
+  cancellation instant** for an order that was cancelled long ago but only recently touched by an
+  unrelated write (e.g. a `fulfillmentState` push). Mitigation: this is explicitly documented as a
+  best-effort approximation in the migration's own header and in this plan's § 5 Assumptions — the
+  alternative (leaving all historical cancelled orders un-flagged, `cancelledAt = NULL`) is strictly
+  worse for the epic's stated data-trust goal, since it would silently include real historical
+  cancelled orders in future revenue aggregates.
+
+### Edge Cases
+
+- **Cancel event arrives before the order's create/sync job has run** (#1160, known residual):
+  `existing` is `null`, `internalOrderId` may not even resolve (no identifier mapping yet) →
+  `handleSourceCancellation` returns early at the "unknown order" branch, same as today. If
+  `internalOrderId` *does* resolve (mapping created by an earlier partial attempt) but no
+  `order_records` row exists yet, `markCancelled` is a documented no-op. Genuinely closing this race
+  needs the deferred monotonic/relay-log machinery already called out in the architecture doc for
+  ADR-027 — out of scope here.
+- **Redelivered cancel webhook/event** (at-least-once delivery is the platform-wide invariant, per
+  `docs/architecture-overview.md` § Webhook Ingestion Flow): `markCancelled`'s COALESCE makes a
+  second call for the same order a true no-op — no duplicate timestamp drift.
+- **An order cancelled, then later re-ingested via the ordinary poll with a *stale* snapshot that
+  still says `'cancelled'`**: `deriveCancelledAt` returns the prior value unchanged — no drift.
+- **An order whose source stops reporting `'cancelled'` on a later poll** (not expected per any
+  adapter's contract today, but defensively handled): `deriveCancelledAt`'s prior-value branch fires
+  first regardless of the new `isCancelled` flag, so `cancelledAt` is never cleared — see § 5
+  Assumptions for why this is treated as correct-by-design rather than a bug.
+
+### Backward Compatibility
+- ✅ Fully additive: new nullable column, new optional trailing constructor param (default `null`),
+  new optional DTO field, new optional filter field. No existing call site, test, or API consumer
+  breaks.
+- ✅ No breaking change to the cancellation-relay contract (`OrderLifecycleRelay.relay` call is
+  unchanged — only a preceding, independent write is added).
+
+---
+
+## 9. Testing Strategy & Acceptance Criteria
+
+### Unit Tests
+
+- `libs/core/src/orders/domain/order-cancellation-projection.spec.ts` — pure `deriveCancelledAt`
+  table-driven cases (§ 6 step 2).
+- `libs/core/src/orders/domain/entities/order-record.entity.spec.ts` — `isCancelled` getter (new
+  file if none exists yet for this entity, otherwise extend).
+- `libs/core/src/orders/application/services/order-record.service.spec.ts` — `persistOrder` /
+  `persistIncomingSnapshot` cancellation-preservation cases (§ 6 steps 8–9).
+- `libs/core/src/orders/application/services/order-ingestion.service.spec.ts` —
+  `handleSourceCancellation` now calls `markCancelled` before `relay` (§ 6 step 10); destination-echo
+  and unknown-order branches still skip it.
+- `libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.spec.ts` —
+  `markCancelled` first-write-wins + no-op-on-missing-row; `findMany({ cancelled })` filter
+  correctness; `toDomain`/`toOrm` round-trip.
+- `apps/api/src/orders/http/orders.controller.spec.ts` — `cancelledAt` DTO serialization.
+
+### Integration Tests
+
+- One new case in the existing orders integration suite (`apps/api/test/integration/orders/`, file
+  TBD at implementation time — extend the closest existing cancellation-relay int-spec if one
+  exists, otherwise add a narrow new one): ingest an order, fire a source cancellation event through
+  the same path a webhook/poll would, assert `GET /orders/:id` returns a non-null `cancelledAt`;
+  fire the cancellation a second time (simulating redelivery), assert the timestamp is unchanged.
+
+### Mocking Strategy
+
+- Mock `OrderRecordRepositoryPort` (not the concrete `OrderRecordRepository`) in
+  `order-record.service.spec.ts` and `order-ingestion.service.spec.ts`, per
+  `docs/engineering-standards.md` § Mocking Ports.
+- The repository spec itself runs against the real Testcontainers Postgres (unit-level repository
+  specs in this codebase already do — confirm placement matches the existing
+  `order-record.repository.spec.ts` convention, which the codebase search found runs as a `.spec.ts`,
+  not an `.int-spec.ts`, presumably against an in-memory or lightly-mocked `Repository<T>`; mirror
+  whatever that file's existing setup already does rather than introducing a new pattern).
+
+### Acceptance Criteria
+
+- [ ] A source-reported cancellation is durably recorded on the order record when
+  `handleSourceCancellation` runs, independent of any later poll.
+- [ ] `cancelledAt IS NOT NULL` (via `OrderRecordFilters.cancelled`) is sufficient to exclude or
+  count cancelled orders without touching `orderSnapshot`.
+- [ ] `cancelledAt` records the cancellation time, not just the fact.
+- [ ] Re-ingesting or re-delivering an already-cancelled order's cancel event does not change
+  `cancelledAt`.
+- [ ] `OrderLifecycleRelay.relay(...)` call site and its behaviour are byte-for-byte unchanged.
+- [ ] Historical rows are backfilled per the documented `"updatedAt"` best-effort proxy, or left
+  `NULL` when the snapshot never reported `'cancelled'` — both explicit and documented in the
+  migration file.
+- [ ] Unit + integration tests added per § 9 above, all passing.
+- [ ] `pnpm --filter @openlinker/core lint` / `type-check` and `pnpm --filter @openlinker/api lint`
+  / `type-check` all pass with zero new errors/warnings.
+- [ ] `pnpm --filter @openlinker/api migration:show` shows the new migration with no gaps.
+
+**Reference**: `docs/testing-guide.md`, `docs/engineering-standards.md` § Testing Standards.
+
+---
+
+## 10. Alignment Checklist
+
+- [x] Follows hexagonal architecture
+- [x] Respects CORE vs Integration boundaries (no integration/adapter touched)
+- [x] Uses existing patterns (`dispatchByAt`/`mappingFailureReason`/`waybillRelayedAt` precedents;
+  no unnecessary new abstraction)
+- [x] Idempotency considered (COALESCE first-write-wins; migration backfill is re-runnable)
+- [x] Event-driven patterns used where applicable (deliberately does *not* add a redundant new
+  event — reuses the existing relay call as the notification path)
+- [x] Rate limits & retries — not applicable, no external API call introduced
+- [x] Error handling comprehensive (no-op-not-throw for the documented #1160 residual race; no new
+  exception types needed)
+- [x] Testing strategy complete
+- [x] Naming conventions followed
+- [x] File structure matches standards
+- [x] Plan is execution-ready
+- [x] Plan is saved as markdown file
+
+---
+
+## Related Documentation
+
+- [Architecture Overview](../architecture-overview.md) — § Orders, § Data Flow
+- [Engineering Standards](../engineering-standards.md)
+- [Testing Guide](../testing-guide.md)
+- [Migrations Guide](../migrations.md)
+- [ADR-039: Order analytics read model persistence strategy](../architecture/adrs/039-order-analytics-read-model-persistence-strategy.md)
+- Issue [#1984](https://github.com/openlinker-project/openlinker/issues/1984) (this plan)
+- Issue [#1985](https://github.com/openlinker-project/openlinker/issues/1985) / PR
+  [#2014](https://github.com/openlinker-project/openlinker/pull/2014) — order analytics read model,
+  the downstream consumer of this plan's exclusion filter
+- PR [#2018](https://github.com/openlinker-project/openlinker/pull/2018) — `/analytics` v1 visual
+  design package, whose "Cancellations" KPI card is drawn-but-blocked pending this issue

--- a/libs/core/src/orders/application/interfaces/order-record.service.interface.ts
+++ b/libs/core/src/orders/application/interfaces/order-record.service.interface.ts
@@ -135,4 +135,14 @@ export interface IOrderRecordService {
     internalOrderId: string,
     input: { status: OrderRecordStatus; reason: string }
   ): Promise<void>;
+
+  /**
+   * Durably record the instant this order was cancelled (#1984). Called by
+   * `OrderIngestionService.handleSourceCancellation` — the one ingestion path
+   * that never calls `persistOrder`/`persistIncomingSnapshot`, and today
+   * writes nothing to the order record at all. First-write-wins: a redelivered
+   * cancel event or a later re-poll can never overwrite an already-recorded
+   * instant. No-op (no throw) when no record exists yet for `internalOrderId`.
+   */
+  markCancelled(internalOrderId: string, cancelledAt: Date): Promise<void>;
 }

--- a/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
@@ -103,6 +103,7 @@ describe('OrderIngestionService', () => {
       findMany: jest.fn(),
       findByIds: jest.fn(),
       markItemResolutionFailure: jest.fn().mockResolvedValue(undefined),
+      markCancelled: jest.fn().mockResolvedValue(undefined),
     } as unknown as jest.Mocked<IOrderRecordService>;
 
     customerIdentityResolver = {
@@ -1148,6 +1149,80 @@ describe('OrderIngestionService', () => {
       await service.syncOrderFromSource(connectionId, externalOrderId, 'evt-1', 'cancelled');
 
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('dest-conn-1=rejected'));
+    });
+  });
+
+  describe('syncOrderFromSource – inbound cancellation durably recorded on the record (#1984)', () => {
+    const externalOrderId = 'checkout-cancel-1984';
+
+    it('marks the order record cancelled BEFORE relaying to destinations', async () => {
+      identifierMapping.getInternalId.mockResolvedValue('ol_order_cancel');
+      orderRecordService.getOrderRecord.mockResolvedValue({
+        sourceConnectionId: connectionId,
+      } as unknown as OrderRecord);
+      orderLifecycleRelay.relay.mockResolvedValue({
+        targets: [{ connectionId: 'dest-conn-1', outcome: 'applied' }],
+      });
+
+      await service.syncOrderFromSource(connectionId, externalOrderId, 'evt-1', 'cancelled');
+
+      expect(orderRecordService.markCancelled).toHaveBeenCalledWith(
+        'ol_order_cancel',
+        expect.any(Date)
+      );
+      const markCancelledOrder =
+        orderRecordService.markCancelled.mock.invocationCallOrder[0];
+      const relayOrder = orderLifecycleRelay.relay.mock.invocationCallOrder[0];
+      expect(markCancelledOrder).toBeLessThan(relayOrder);
+    });
+
+    it('does NOT mark the record cancelled when the order was never ingested (no internal mapping)', async () => {
+      identifierMapping.getInternalId.mockResolvedValue(null);
+
+      await service.syncOrderFromSource(connectionId, externalOrderId, 'evt-1', 'cancelled');
+
+      expect(orderRecordService.markCancelled).not.toHaveBeenCalled();
+    });
+
+    it('does NOT mark the record cancelled on a destination-echo cancel', async () => {
+      identifierMapping.getInternalId.mockResolvedValue('ol_order_cancel');
+      orderRecordService.getOrderRecord.mockResolvedValue({
+        sourceConnectionId: 'allegro-connection',
+      } as unknown as OrderRecord);
+
+      await service.syncOrderFromSource(connectionId, externalOrderId, 'evt-1', 'cancelled');
+
+      expect(orderRecordService.markCancelled).not.toHaveBeenCalled();
+    });
+
+    it('still relays to destinations when markCancelled throws (the write is best-effort, never blocking)', async () => {
+      identifierMapping.getInternalId.mockResolvedValue('ol_order_cancel');
+      orderRecordService.getOrderRecord.mockResolvedValue({
+        sourceConnectionId: connectionId,
+      } as unknown as OrderRecord);
+      orderRecordService.markCancelled.mockRejectedValueOnce(new Error('db unavailable'));
+      orderLifecycleRelay.relay.mockResolvedValue({
+        targets: [{ connectionId: 'dest-conn-1', outcome: 'applied' }],
+      });
+      const errorSpy = jest.spyOn(service['logger'], 'error').mockImplementation();
+
+      const result = await service.syncOrderFromSource(
+        connectionId,
+        externalOrderId,
+        'evt-1',
+        'cancelled'
+      );
+
+      expect(result).toEqual([]);
+      expect(orderLifecycleRelay.relay).toHaveBeenCalledWith({
+        internalOrderId: 'ol_order_cancel',
+        originConnectionId: connectionId,
+        event: { type: 'cancelled' },
+      });
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to record cancellation'),
+        expect.anything()
+      );
     });
   });
 });

--- a/libs/core/src/orders/application/services/__tests__/order-record.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-record.service.spec.ts
@@ -421,11 +421,14 @@ describe('OrderRecordService', () => {
       service = new OrderRecordService(repository);
     });
 
-    it('does not send cancelledAt through the upsert() call for a cancelled order', async () => {
-      // upsert() must never carry cancelledAt — see the toOrm comment on
-      // OrderRecordRepository. The domain OrderRecord constructed here still
-      // defaults cancelledAt to null; markCancelled (asserted below) is the
-      // only writer.
+    it('never constructs the OrderRecord passed to upsert() with a non-null cancelledAt, even for a cancelled order', async () => {
+      // The domain OrderRecord built here always defaults cancelledAt to null
+      // (persistOrder never threads order.status into the constructor) —
+      // markCancelled (asserted in the next test) is the sole writer. This
+      // guards against a future regression where someone "helpfully" starts
+      // passing a derived cancelledAt into the constructor, which would let
+      // upsert()'s full-object save() race markCancelled's atomic COALESCE
+      // update — see the toOrm comment on OrderRecordRepository.
       const order = createMockOrder();
       order.status = 'cancelled';
       repository.upsert.mockResolvedValue({} as OrderRecord);
@@ -679,7 +682,7 @@ describe('OrderRecordService', () => {
       service = new OrderRecordService(repository);
     });
 
-    it('does not send cancelledAt through the upsert() call for a cancelled order', async () => {
+    it('never constructs the OrderRecord passed to upsert() with a non-null cancelledAt, even for a cancelled order', async () => {
       const incoming = createMockIncomingOrder();
       incoming.status = 'cancelled';
       repository.upsert.mockResolvedValue({} as OrderRecord);

--- a/libs/core/src/orders/application/services/__tests__/order-record.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-record.service.spec.ts
@@ -31,6 +31,7 @@ describe('OrderRecordService', () => {
       upsert: jest.fn(),
       updateSyncStatus: jest.fn(),
       updateItemResolutionFailure: jest.fn(),
+      markCancelled: jest.fn(),
     } as unknown as jest.Mocked<OrderRecordRepositoryPort>;
 
     const module: TestingModule = await Test.createTestingModule({
@@ -414,6 +415,74 @@ describe('OrderRecordService', () => {
     });
   });
 
+  describe('persistOrder — cancellation recorded via markCancelled (#1984)', () => {
+    beforeEach(() => {
+      process.env.OL_STORE_PII = 'true';
+      service = new OrderRecordService(repository);
+    });
+
+    it('does not send cancelledAt through the upsert() call for a cancelled order', async () => {
+      // upsert() must never carry cancelledAt — see the toOrm comment on
+      // OrderRecordRepository. The domain OrderRecord constructed here still
+      // defaults cancelledAt to null; markCancelled (asserted below) is the
+      // only writer.
+      const order = createMockOrder();
+      order.status = 'cancelled';
+      repository.upsert.mockResolvedValue({} as OrderRecord);
+      repository.findById.mockResolvedValue({} as OrderRecord);
+
+      await service.persistOrder(order, 'source-connection-123', 'event-456');
+
+      const callArg = repository.upsert.mock.calls[0][0];
+      expect(callArg.cancelledAt).toBeNull();
+    });
+
+    it('calls markCancelled with (approximately) now for a cancelled order, AFTER upsert', async () => {
+      const order = createMockOrder();
+      order.status = 'cancelled';
+      repository.upsert.mockResolvedValue({} as OrderRecord);
+      repository.findById.mockResolvedValue({} as OrderRecord);
+
+      const before = new Date();
+      await service.persistOrder(order, 'source-connection-123', 'event-456');
+      const after = new Date();
+
+      expect(repository.markCancelled).toHaveBeenCalledTimes(1);
+      const [calledId, calledAt] = repository.markCancelled.mock.calls[0];
+      expect(calledId).toBe(order.id);
+      expect(calledAt.getTime()).toBeGreaterThanOrEqual(before.getTime());
+      expect(calledAt.getTime()).toBeLessThanOrEqual(after.getTime());
+      const upsertOrder = repository.upsert.mock.invocationCallOrder[0];
+      const markCancelledOrder = repository.markCancelled.mock.invocationCallOrder[0];
+      expect(upsertOrder).toBeLessThan(markCancelledOrder);
+    });
+
+    it('returns the re-fetched record so the caller sees the recorded cancellation', async () => {
+      const order = createMockOrder();
+      order.status = 'cancelled';
+      const refetched = { cancelledAt: new Date() } as unknown as OrderRecord;
+      repository.upsert.mockResolvedValue({ cancelledAt: null } as unknown as OrderRecord);
+      repository.findById.mockResolvedValue(refetched);
+
+      const result = await service.persistOrder(order, 'source-connection-123', 'event-456');
+
+      expect(result).toBe(refetched);
+    });
+
+    it('does not call markCancelled or re-fetch for a non-cancelled order', async () => {
+      const order = createMockOrder();
+      order.status = 'pending';
+      const saved = {} as OrderRecord;
+      repository.upsert.mockResolvedValue(saved);
+
+      const result = await service.persistOrder(order, 'source-connection-123', 'event-456');
+
+      expect(repository.markCancelled).not.toHaveBeenCalled();
+      expect(repository.findById).not.toHaveBeenCalled();
+      expect(result).toBe(saved);
+    });
+  });
+
   describe('persistIncomingSnapshot', () => {
     beforeEach(() => {
       process.env.OL_STORE_PII = 'true';
@@ -604,6 +673,49 @@ describe('OrderRecordService', () => {
     });
   });
 
+  describe('persistIncomingSnapshot — cancellation recorded via markCancelled (#1984)', () => {
+    beforeEach(() => {
+      process.env.OL_STORE_PII = 'true';
+      service = new OrderRecordService(repository);
+    });
+
+    it('does not send cancelledAt through the upsert() call for a cancelled order', async () => {
+      const incoming = createMockIncomingOrder();
+      incoming.status = 'cancelled';
+      repository.upsert.mockResolvedValue({} as OrderRecord);
+      repository.findById.mockResolvedValue({} as OrderRecord);
+
+      await service.persistIncomingSnapshot(incoming, 'ol_order_abc', null, 'conn-123', null);
+
+      const callArg = repository.upsert.mock.calls[0][0];
+      expect(callArg.cancelledAt).toBeNull();
+    });
+
+    it('calls markCancelled AFTER upsert for a cancelled order whose items have not resolved yet', async () => {
+      const incoming = createMockIncomingOrder();
+      incoming.status = 'cancelled';
+      repository.upsert.mockResolvedValue({} as OrderRecord);
+      repository.findById.mockResolvedValue({} as OrderRecord);
+
+      await service.persistIncomingSnapshot(incoming, 'ol_order_abc', null, 'conn-123', null);
+
+      expect(repository.markCancelled).toHaveBeenCalledWith('ol_order_abc', expect.any(Date));
+      const upsertOrder = repository.upsert.mock.invocationCallOrder[0];
+      const markCancelledOrder = repository.markCancelled.mock.invocationCallOrder[0];
+      expect(upsertOrder).toBeLessThan(markCancelledOrder);
+    });
+
+    it('does not call markCancelled for a non-cancelled order', async () => {
+      const incoming = createMockIncomingOrder();
+      incoming.status = 'pending';
+      repository.upsert.mockResolvedValue({} as OrderRecord);
+
+      await service.persistIncomingSnapshot(incoming, 'ol_order_abc', null, 'conn-123', null);
+
+      expect(repository.markCancelled).not.toHaveBeenCalled();
+    });
+  });
+
   describe('updateSyncStatus', () => {
     const FROZEN_NOW = new Date('2026-04-30T11:22:33.000Z');
 
@@ -746,6 +858,17 @@ describe('OrderRecordService', () => {
         status: 'source_deleted',
         reason: 'variant ol_variant_b deleted at the master',
       });
+    });
+  });
+
+  describe('markCancelled (#1984)', () => {
+    it('delegates to the repository as a pure passthrough', async () => {
+      const internalOrderId = 'order-123';
+      const cancelledAt = new Date('2026-08-11T09:00:00Z');
+
+      await service.markCancelled(internalOrderId, cancelledAt);
+
+      expect(repository.markCancelled).toHaveBeenCalledWith(internalOrderId, cancelledAt);
     });
   });
 });

--- a/libs/core/src/orders/application/services/order-ingestion.service.ts
+++ b/libs/core/src/orders/application/services/order-ingestion.service.ts
@@ -511,6 +511,26 @@ export class OrderIngestionService implements IOrderIngestionService {
       return [];
     }
 
+    // Durably record the cancellation on the order record itself (#1984) —
+    // previously this handler only relayed to destinations and returned,
+    // leaving no queryable trace of the cancellation on the order record.
+    // Attempted BEFORE the relay call so the record write isn't skipped if
+    // the relay itself throws; first-write-wins, so a redelivered cancel
+    // event is a harmless no-op. Swallowed (logged, not rethrown): the
+    // pre-existing relay-to-destinations behaviour must not regress because
+    // of this new, best-effort write — a transient DB error here must not
+    // prevent the cancel from reaching the destination shop.
+    try {
+      await this.orderRecordService.markCancelled(internalOrderId, new Date());
+    } catch (error) {
+      this.logger.error(
+        `Failed to record cancellation on order record ${internalOrderId} — proceeding with the ` +
+          `destination relay regardless; the record will remain queryable as non-cancelled until a ` +
+          `future re-poll or retry observes the cancellation again`,
+        (error as Error).stack
+      );
+    }
+
     const result = await this.orderLifecycleRelay.relay({
       internalOrderId,
       originConnectionId: connectionId,

--- a/libs/core/src/orders/application/services/order-ingestion.service.ts
+++ b/libs/core/src/orders/application/services/order-ingestion.service.ts
@@ -479,8 +479,11 @@ export class OrderIngestionService implements IOrderIngestionService {
    * Resolves the existing internal order; if unknown (never ingested) there is
    * nothing to cancel. Applies the same destination-echo guard as ingestion
    * (ADR-017) so a re-read of an order OL itself created elsewhere doesn't
-   * propagate a spurious cancel. Returns an empty result set — a cancel is not
-   * an order-create, so there are no OrderSyncResults to report.
+   * propagate a spurious cancel. Also durably records the cancellation on the
+   * order record itself via `markCancelled` (#1984), best-effort and before
+   * the relay call — see the inline comment at the call site for why a DB
+   * failure there must never block the relay. Returns an empty result set —
+   * a cancel is not an order-create, so there are no OrderSyncResults to report.
    */
   private async handleSourceCancellation(
     connectionId: string,

--- a/libs/core/src/orders/application/services/order-record.service.ts
+++ b/libs/core/src/orders/application/services/order-record.service.ts
@@ -137,7 +137,8 @@ export class OrderRecordService implements IOrderRecordService {
       this.deriveDispatchByAt(order.dispatchTime)
     );
 
-    return this.repository.upsert(orderRecord);
+    const saved = await this.repository.upsert(orderRecord);
+    return this.recordCancellationIfNeeded(order.id, order.status === 'cancelled', now, saved);
   }
 
   async persistIncomingSnapshot(
@@ -211,7 +212,13 @@ export class OrderRecordService implements IOrderRecordService {
       this.deriveDispatchByAt(incoming.dispatchTime)
     );
 
-    return this.repository.upsert(orderRecord);
+    const saved = await this.repository.upsert(orderRecord);
+    return this.recordCancellationIfNeeded(
+      internalOrderId,
+      incoming.status === 'cancelled',
+      now,
+      saved
+    );
   }
 
   /**
@@ -240,6 +247,35 @@ export class OrderRecordService implements IOrderRecordService {
     }
     const parsed = new Date(to);
     return Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+
+  /**
+   * Durably record a cancellation observed by the ordinary ingestion path
+   * (#1984) — the case where a source's order feed reports
+   * `status: 'cancelled'` directly, rather than via the dedicated
+   * `handleSourceCancellation` cancel-event path. Called AFTER `upsert()`
+   * (never before): `upsert()` never touches `cancelledAt` (see the `toOrm`
+   * comment in `OrderRecordRepository`), so this is the only writer, using
+   * the same atomic, first-write-wins `markCancelled` the cancel-event path
+   * uses — no read-before-write race between concurrent ingestion calls for
+   * the same order (webhook + reconciliation poll can legitimately overlap).
+   *
+   * `upsert()`'s returned record never reflects `cancelledAt` (the column
+   * was never sent to the database in that statement), so a re-fetch is
+   * needed to return an accurate record when a cancellation was recorded;
+   * the extra read is paid only on this rare path, not on every persist.
+   */
+  private async recordCancellationIfNeeded(
+    internalOrderId: string,
+    isCancelled: boolean,
+    cancelledAt: Date,
+    saved: OrderRecord
+  ): Promise<OrderRecord> {
+    if (!isCancelled) {
+      return saved;
+    }
+    await this.repository.markCancelled(internalOrderId, cancelledAt);
+    return (await this.repository.findById(internalOrderId)) ?? saved;
   }
 
   /**
@@ -314,6 +350,15 @@ export class OrderRecordService implements IOrderRecordService {
     // to any other column on the same row (e.g. a syncStatus update racing
     // in from OrderSyncService). Mirrors updateFulfillmentState's pattern.
     await this.repository.updateItemResolutionFailure(internalOrderId, input);
+  }
+
+  /**
+   * Durably record the instant this order was cancelled (#1984). Thin
+   * pass-through to the repository's first-write-wins absolute-set — see
+   * {@link OrderRecordRepositoryPort.markCancelled}.
+   */
+  async markCancelled(internalOrderId: string, cancelledAt: Date): Promise<void> {
+    await this.repository.markCancelled(internalOrderId, cancelledAt);
   }
 
   /**

--- a/libs/core/src/orders/domain/entities/order-record.entity.spec.ts
+++ b/libs/core/src/orders/domain/entities/order-record.entity.spec.ts
@@ -143,3 +143,32 @@ describe('OrderRecord.dispatchByEstimated (#1776)', () => {
     expect(makeRecord({ dispatchTime: { estimated: 1 } }).dispatchByEstimated).toBe(false);
   });
 });
+
+describe('OrderRecord.isCancelled (#1984)', () => {
+  function makeRecordWithCancelledAt(cancelledAt: Date | null): OrderRecord {
+    return new OrderRecord(
+      'ol_order_1',
+      'ol_customer_1',
+      'conn-1',
+      null,
+      {},
+      [],
+      'ready',
+      new Date(),
+      new Date(),
+      [],
+      null,
+      null,
+      null,
+      cancelledAt,
+    );
+  }
+
+  it('returns false when cancelledAt is null', () => {
+    expect(makeRecordWithCancelledAt(null).isCancelled).toBe(false);
+  });
+
+  it('returns true when cancelledAt is set', () => {
+    expect(makeRecordWithCancelledAt(new Date('2026-08-01T00:00:00Z')).isCancelled).toBe(true);
+  });
+});

--- a/libs/core/src/orders/domain/entities/order-record.entity.ts
+++ b/libs/core/src/orders/domain/entities/order-record.entity.ts
@@ -64,6 +64,16 @@ export class OrderRecord {
      * `null` for a `'ready'` record, or a historical row predating the column.
      */
     public readonly mappingFailureReason: string | null = null,
+    /**
+     * Instant the source reported this order cancelled (#1984). `null` = never
+     * cancelled (or a historical row the backfill migration could not derive a
+     * proxy timestamp for). Independent of `recordStatus` — an order can be
+     * `ready` (all items resolved) and cancelled at the same time. Set once
+     * and never cleared: `markCancelled` is the sole writer of this column
+     * and applies a first-write-wins (`COALESCE`) update, so the
+     * first-observed instant survives every later re-persist.
+     */
+    public readonly cancelledAt: Date | null = null,
   ) {}
 
   /**
@@ -157,5 +167,13 @@ export class OrderRecord {
       return false;
     }
     return (value as Partial<OrderDispatchWindow>).estimated === true;
+  }
+
+  /**
+   * True once the source has reported this order cancelled (#1984). Pure
+   * derivation of an already-loaded field (ADR-011): no I/O, no mutation.
+   */
+  get isCancelled(): boolean {
+    return this.cancelledAt !== null;
   }
 }

--- a/libs/core/src/orders/domain/ports/order-record-repository.port.ts
+++ b/libs/core/src/orders/domain/ports/order-record-repository.port.ts
@@ -113,4 +113,16 @@ export interface OrderRecordRepositoryPort {
     internalOrderId: string,
     input: { status: OrderRecordStatus; reason: string }
   ): Promise<void>;
+
+  /**
+   * Durably record the instant the source reported this order cancelled
+   * (#1984), directly from `handleSourceCancellation` — the one ingestion
+   * path that never calls `persistOrder`/`persistIncomingSnapshot`.
+   * First-write-wins (`COALESCE`): a redelivered cancel event or a later
+   * re-poll can never overwrite an already-recorded cancellation instant.
+   * No-op (no throw) when the order row doesn't exist yet — mirrors
+   * {@link updateFulfillmentState}'s residual-race tolerance (#1160: a cancel
+   * event racing ahead of the order's own create/sync job).
+   */
+  markCancelled(internalOrderId: string, cancelledAt: Date): Promise<void>;
 }

--- a/libs/core/src/orders/domain/types/order-record.types.ts
+++ b/libs/core/src/orders/domain/types/order-record.types.ts
@@ -154,6 +154,13 @@ export interface OrderRecordFilters {
    */
   fulfillmentState?: FulfillmentRollupState;
   /**
+   * Cancellation filter (#1984). Maps directly to `cancelledAt IS [NOT] NULL`
+   * — `true` keeps only cancelled orders, `false` excludes them. Queryable
+   * without parsing `orderSnapshot`; not yet wired into any HTTP query param
+   * or FE control — that is the aggregate endpoints' job (#1987/#1988).
+   */
+  cancelled?: boolean;
+  /**
    * Result ordering (#927/#944/#1108). Maps to a SQL `ORDER BY` by
    * `OrderRecordRepository.applySort`. `dispatchBy` (ship-by deadline, NULLs
    * last) is the list's triage default; the JSONB-derived keys (`customer`,

--- a/libs/core/src/orders/infrastructure/persistence/entities/order-record.orm-entity.ts
+++ b/libs/core/src/orders/infrastructure/persistence/entities/order-record.orm-entity.ts
@@ -86,6 +86,16 @@ export class OrderRecordOrmEntity {
   mappingFailureReason!: string | null;
 
   /**
+   * Instant the source reported this order cancelled (#1984). `null` = never
+   * cancelled (or a historical row the backfill migration could not derive a
+   * proxy timestamp for). Independent of `recordStatus`. Indexed for the
+   * future exclusion predicate (#1987/#1988: `WHERE "cancelledAt" IS NULL`).
+   */
+  @Column({ type: 'timestamptz', nullable: true })
+  @Index()
+  cancelledAt!: Date | null;
+
+  /**
    * Derived marketplace dispatch (ship-by) deadline (#927) — the `.to` of the
    * source dispatch window, denormalized from the snapshot so the orders list
    * can sort/filter on the SLA via an index without parsing JSONB. `null` when

--- a/libs/core/src/orders/infrastructure/persistence/repositories/__tests__/order-record.repository.spec.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/__tests__/order-record.repository.spec.ts
@@ -256,6 +256,32 @@ describe('OrderRecordRepository', () => {
       const callArg = ormRepository.save.mock.calls[0][0] as OrderRecordOrmEntity;
       expect(callArg.recordStatus).toBe('awaiting_mapping');
     });
+
+    it('should read cancelledAt back via toDomain when present on the ORM row', async () => {
+      const cancelledAt = new Date('2026-08-01T12:00:00Z');
+      const savedEntity = createOrmEntity();
+      savedEntity.cancelledAt = cancelledAt;
+      ormRepository.save.mockResolvedValue(savedEntity);
+
+      const result = await repository.upsert(createDomainEntity());
+
+      expect(result.cancelledAt).toBe(cancelledAt);
+    });
+
+    it('should NOT include cancelledAt in the entity passed to save() (#1984)', async () => {
+      // upsert() is a full-object save() with no per-order lock around it, so
+      // writing cancelledAt here would race with the atomic, COALESCE-based
+      // markCancelled() a concurrent cancel-event call may commit at the same
+      // time. Leaving the property unset lets TypeORM omit the column from
+      // the generated UPDATE entirely — markCancelled is the sole writer.
+      const domainEntity = createDomainEntity();
+      ormRepository.save.mockResolvedValue(createOrmEntity());
+
+      await repository.upsert(domainEntity);
+
+      const callArg = ormRepository.save.mock.calls[0][0] as OrderRecordOrmEntity;
+      expect(callArg.cancelledAt).toBeUndefined();
+    });
   });
 
   describe('findMany', () => {
@@ -293,6 +319,36 @@ describe('OrderRecordRepository', () => {
       expect(andWhere).toHaveBeenCalledWith('rec.recordStatus = :recordStatus', {
         recordStatus: 'awaiting_mapping',
       });
+    });
+
+    it('should add cancelledAt IS NOT NULL when cancelled=true (#1984)', async () => {
+      const andWhere = jest.fn().mockReturnThis();
+      (ormRepository.createQueryBuilder as jest.Mock).mockReturnValue({
+        orderBy: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        andWhere,
+        getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+      });
+
+      await repository.findMany({ cancelled: true }, { limit: 20, offset: 0 });
+
+      expect(andWhere).toHaveBeenCalledWith('rec.cancelledAt IS NOT NULL');
+    });
+
+    it('should add cancelledAt IS NULL when cancelled=false (#1984)', async () => {
+      const andWhere = jest.fn().mockReturnThis();
+      (ormRepository.createQueryBuilder as jest.Mock).mockReturnValue({
+        orderBy: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        andWhere,
+        getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+      });
+
+      await repository.findMany({ cancelled: false }, { limit: 20, offset: 0 });
+
+      expect(andWhere).toHaveBeenCalledWith('rec.cancelledAt IS NULL');
     });
   });
 
@@ -334,6 +390,28 @@ describe('OrderRecordRepository', () => {
           newAttempt
         )
       ).rejects.toThrow(OrderRecordNotFoundException);
+    });
+  });
+
+  describe('markCancelled (#1984)', () => {
+    it('should issue a COALESCE update carrying the given instant and order id', async () => {
+      (ormRepository.query as jest.Mock).mockResolvedValue([[], 1]);
+      const cancelledAt = new Date('2026-08-11T09:00:00Z');
+
+      await repository.markCancelled('order-123', cancelledAt);
+
+      expect(ormRepository.query).toHaveBeenCalledWith(
+        expect.stringContaining('COALESCE("cancelledAt", $1)'),
+        [cancelledAt, 'order-123']
+      );
+    });
+
+    it('should not throw when no row matches the given order id', async () => {
+      (ormRepository.query as jest.Mock).mockResolvedValue([[], 0]);
+
+      await expect(
+        repository.markCancelled('non-existent-order', new Date())
+      ).resolves.toBeUndefined();
     });
   });
 });

--- a/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
@@ -149,6 +149,12 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
       this.applySlaFilter(qb, filters.slaState);
     }
 
+    if (filters.cancelled !== undefined) {
+      // #1984 — queryable without parsing orderSnapshot. `undefined` means
+      // "don't filter"; both `true` and `false` are meaningful predicates.
+      qb.andWhere(filters.cancelled ? 'rec.cancelledAt IS NOT NULL' : 'rec.cancelledAt IS NULL');
+    }
+
     this.applySort(qb, filters.sort, filters.dir);
 
     const [entities, total] = await qb.getManyAndCount();
@@ -543,6 +549,24 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
     );
   }
 
+  /**
+   * Durably record the instant this order was cancelled (#1984).
+   * First-write-wins via `COALESCE` — a redelivered cancel event or a later
+   * re-poll can never overwrite an already-recorded instant. Raw parameterized
+   * query (mirrors {@link updateSyncStatus}'s idiom) because
+   * `Repository.update()`'s partial-entity API cannot express a `COALESCE(...)`
+   * right-hand side without an unsafe string-interpolated function value.
+   * No-op (no throw, no rows affected) when the order row doesn't exist yet.
+   */
+  async markCancelled(internalOrderId: string, cancelledAt: Date): Promise<void> {
+    await this.repository.query(
+      `UPDATE "order_records"
+       SET "cancelledAt" = COALESCE("cancelledAt", $1)
+       WHERE "internalOrderId" = $2`,
+      [cancelledAt, internalOrderId]
+    );
+  }
+
   async upsert(orderRecord: OrderRecord): Promise<OrderRecord> {
     const entity = this.toOrm(orderRecord);
     // TypeORM save() performs upsert on primary key (internalOrderId)
@@ -673,7 +697,8 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
       syncAttempts,
       entity.dispatchByAt,
       (entity.fulfillmentState as FulfillmentRollupState | null) ?? null,
-      entity.mappingFailureReason ?? null
+      entity.mappingFailureReason ?? null,
+      entity.cancelledAt ?? null
     );
   }
 
@@ -707,6 +732,16 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
     entity.mappingFailureReason = orderRecord.mappingFailureReason;
     entity.dispatchByAt = orderRecord.dispatchByAt;
     entity.fulfillmentState = orderRecord.fulfillmentState;
+    // cancelledAt is deliberately NOT mapped here (#1984 follow-up). upsert()
+    // is a full-object save() with no per-order lock around it (two ingestion
+    // paths — webhook + reconciliation poll — legitimately race for the same
+    // order per docs/architecture-overview.md § "Webhook = trigger, poll =
+    // reconciliation backstop"), so writing this column here would let a
+    // stale in-memory read stomp a value {@link markCancelled} already
+    // committed concurrently. Leaving the ORM entity's `cancelledAt` property
+    // unset means TypeORM omits the column from the generated UPDATE
+    // entirely — the row's existing value survives untouched. `markCancelled`
+    // (COALESCE-based, atomic) is the single writer for this column.
     entity.createdAt = orderRecord.createdAt;
     entity.updatedAt = orderRecord.updatedAt;
     return entity;

--- a/libs/core/src/shipping/application/services/fulfillment-status-sync.service.spec.ts
+++ b/libs/core/src/shipping/application/services/fulfillment-status-sync.service.spec.ts
@@ -101,6 +101,7 @@ describe('FulfillmentStatusSyncService', () => {
       findByIds: jest.fn(),
       updateFulfillmentState: jest.fn(),
       markItemResolutionFailure: jest.fn(),
+      markCancelled: jest.fn(),
     };
 
     routing = {

--- a/libs/core/src/shipping/application/services/shipment-dispatch-notification.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-dispatch-notification.service.spec.ts
@@ -99,6 +99,7 @@ describe('ShipmentDispatchNotificationService', () => {
       findByIds: jest.fn(),
       updateFulfillmentState: jest.fn(),
       markItemResolutionFailure: jest.fn(),
+      markCancelled: jest.fn(),
     };
 
     integrations = {

--- a/libs/core/src/shipping/application/services/shipment-dispatch.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-dispatch.service.spec.ts
@@ -166,6 +166,7 @@ describe('ShipmentDispatchService', () => {
       findByIds: jest.fn(),
       updateFulfillmentState: jest.fn(),
       markItemResolutionFailure: jest.fn(),
+      markCancelled: jest.fn(),
     };
     const fulfillmentProjection = { recompute: jest.fn() };
     // Uncontended by default (#1917): every pre-existing test asserts the


### PR DESCRIPTION
## Summary
- `handleSourceCancellation` previously relayed a source cancellation to destinations and returned — nothing was written to the order record, so cancellation was invisible to SQL and only present in `orderSnapshot.status` if a later poll happened to re-ingest the order.
- Adds a nullable `cancelledAt` column on `order_records`, written once and preserved via an atomic `COALESCE` update (`markCancelled`) — a redelivered cancel event or a later re-poll can never overwrite an already-recorded instant.
- `handleSourceCancellation` now calls `markCancelled` before relaying to destinations; the write is best-effort (logged, not rethrown) so a transient DB error can never block the pre-existing relay behaviour.
- `persistOrder`/`persistIncomingSnapshot` (the ordinary polling/ingestion path, for sources that report `status: 'cancelled'` directly) record it through the same atomic `markCancelled`, called **after** `upsert()` rather than folded into it — `upsert()` never touches `cancelledAt`, so two ingestion paths (webhook + reconciliation poll) racing for the same order can't stomp each other's write. Verified empirically against a live Postgres that TypeORM's `save()` omits an `undefined`-left column from the generated `UPDATE`.
- `OrderRecordFilters.cancelled` + a `findMany` predicate make the fact queryable without parsing `orderSnapshot`; not wired into any HTTP filter or FE control yet — that's the aggregate endpoints' job (#1987/#1988).
- `cancelledAt` surfaced on `OrderRecordResponseDto`.
- Additive migration with a documented best-effort backfill (`cancelledAt := updatedAt`) for historical rows whose snapshot already reports `'cancelled'`.

## Context
- Plan: `docs/plans/implementation-plan-order-cancellation-record-state.md`
- Pre-implement gate: `docs/plans/analysis/ANALYSIS-order-cancellation-record-state.md`
- Part of the `/analytics` epic (#1976) — this is dependency **[C]**, blocking the order analytics read model (#1985) from excluding cancelled orders.

## Test plan
- [x] Unit tests added across all touched layers (domain entity, pure helper removed in favor of the atomic-write redesign, repository, application service, ingestion service, controller) — all passing locally.
- [x] `pnpm --filter @openlinker/core type-check` / `pnpm --filter @openlinker/api type-check` — clean.
- [x] `pnpm --filter @openlinker/core lint` — clean (0 errors, pre-existing warnings only).
- [x] `pnpm check:invariants` — all invariants pass, including migration-timestamp ordering vs `origin/main`.
- [x] Migration applied + reverted + re-applied against the local dev Postgres; backfill confirmed against real pre-existing data.
- [ ] `apps/api` full lint run was interrupted locally mid-session — CI will confirm.
- [ ] Full `pnpm test` / `pnpm test:integration` 

Closes #1984

🤖 Generated with [Claude Code](https://claude.com/claude-code)