### PR TITLE
fix(web): raise specificity of .data-table__cell--right (#2031)

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2767,12 +2767,12 @@ a.delivery-rider-banner__button:focus-visible {
   box-shadow: var(--shadow-focus);
 }
 
-.data-table td.data-table__cell--right {
+.data-table .data-table__cell--right {
   text-align: right;
   font-variant-numeric: tabular-nums;
 }
 
-.data-table__cell--center {
+.data-table .data-table__cell--center {
   text-align: center;
 }
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2767,7 +2767,7 @@ a.delivery-rider-banner__button:focus-visible {
   box-shadow: var(--shadow-focus);
 }
 
-.data-table__cell--right {
+.data-table td.data-table__cell--right {
   text-align: right;
   font-variant-numeric: tabular-nums;
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2772,10 +2772,6 @@ a.delivery-rider-banner__button:focus-visible {
   font-variant-numeric: tabular-nums;
 }
 
-.data-table .data-table__cell--center {
-  text-align: center;
-}
-
 .data-table__empty-cell {
   padding: var(--space-5) var(--space-3);
   color: var(--text-muted);

--- a/apps/web/src/pages/adapters/adapters-catalog-page.tsx
+++ b/apps/web/src/pages/adapters/adapters-catalog-page.tsx
@@ -45,7 +45,6 @@ const COLUMNS: DataTableColumn<AdapterSummary>[] = [
   {
     id: 'version',
     header: 'Version',
-    align: 'right',
     cell: (adapter) => (
       <span className="mono-text">{adapter.version ?? '—'}</span>
     ),

--- a/apps/web/src/pages/dashboard/dashboard-page.tsx
+++ b/apps/web/src/pages/dashboard/dashboard-page.tsx
@@ -448,7 +448,7 @@ export function DashboardPage(): ReactElement {
       {
         id: 'attempts',
         header: 'Attempts',
-        align: 'center',
+        align: 'right',
         cell: (job) => `${job.attempts}/${job.maxAttempts}`,
         hideBelow: 768,
       },

--- a/apps/web/src/pages/orders/failed-orders-page.tsx
+++ b/apps/web/src/pages/orders/failed-orders-page.tsx
@@ -56,7 +56,7 @@ const COLUMNS: DataTableColumn<OrderRecord>[] = [
     id: 'items',
     header: 'Items',
     cell: (order) => snapshotItemCount(order.orderSnapshot),
-    align: 'center',
+    align: 'right',
     hideBelow: 480,
   },
   {

--- a/apps/web/src/shared/ui/data-table.tsx
+++ b/apps/web/src/shared/ui/data-table.tsx
@@ -30,7 +30,7 @@ import { useMediaQuery } from './use-media-query';
 export type DataTableHideBreakpoint = 480 | 768 | 1024;
 
 export interface DataTableColumn<Row> {
-  align?: 'center' | 'left' | 'right';
+  align?: 'left' | 'right';
   cell: (row: Row) => ReactNode;
   header: ReactNode;
   hideBelow?: DataTableHideBreakpoint;


### PR DESCRIPTION
## Problem

`.data-table__cell--right` (`apps/web/src/index.css:2770`) had specificity **(0,1,0)**, while the base rule
`.data-table th, .data-table td { text-align: left }` (`index.css:2797-2805`, `text-align: left` on line 2801)
has specificity **(0,1,1)** *and* comes later in source order. The base rule therefore won on both counts, so
the right-align class was dead everywhere it was applied - every numeric column marked `align: 'right'`
rendered left-aligned.

## Fix

Raise the selector by adding the block ancestor, which brings it to **(0,2,0)** and beats the base rule's
(0,1,1) on class count, so source order no longer matters:

```css
.data-table .data-table__cell--right {
  text-align: right;
  font-variant-numeric: tabular-nums;
}
```

The ancestor is a pure specificity lever - a `__cell--right` element is by definition inside a `data-table`.
It is deliberately **not** element-qualified: a `td.data-table__cell--right` form would reach (0,2,1) but
would exclude `<th>`, leaving right-aligned headers sitting over right-aligned values. `DataTable` emits the
class on both the body cell (`data-table.tsx:496`) and the header (`:569`), and one right-aligned column is
sortable (`sync-jobs-page.tsx:62`), whose `.data-table__header-button` is `display: inline-flex` - an
inline-level box that does move to the right edge under `text-align`.

The `font-variant-numeric: tabular-nums` declaration was equally dead before and is now live too, which is
the intended convention for numeric columns.

## Scope

4 files, 3 insertions, 8 deletions - one CSS rule rewritten, one CSS rule deleted, three column definitions
touched.

### Numeric columns that now render right-aligned

All already routed through `DataTable`'s `align` prop, so the CSS fix reaches them with no call-site edits:

- **Orders** - `orders-list-page.tsx:849` (merged money column: total / payment / created)
- **Products** - `products-list-page.tsx:748` (money column: price + updated/created dates)
- **Sync jobs** - `sync-jobs-page.tsx:62` (Attempts)
- **Connection diagnostics** - `ConnectionDiagnosticsPanel.tsx:40` (Attempts)
- **Dashboard** - `dashboard-page.tsx:369,393,402,458`
- **Order line items panel** - `order-line-items-panel.tsx:57,63,71` (Qty / Unit price / Total)
- **Bulk batch progress table** - `bulk-batch-progress-table.tsx:137`
- **Product variant stock table** - `variant-stock-table.tsx:82,630` (Price; the only hand-written consumer)
- **Dev-UI patterns section** - `patterns-section.tsx:105`

### Adapters catalog version column: right-align removed (opposite direction, deliberate)

`adapters-catalog-page.tsx:48` carried `align: 'right'`, but the column renders a version *string*
(`adapter.version ?? '—'`), not a number. Activating a long-dead declaration is the moment to ask whether it
was ever the right treatment, and for a left-anchored identifier it is not - `tabular-nums` buys nothing and
ragged-left version strings are harder to scan. The prop is dropped, so the column stays left-aligned and
keeps `mono-text`.

### Two centered count columns flipped to right

- `dashboard-page.tsx:451` - Attempts, renders `${job.attempts}/${job.maxAttempts}`
- `failed-orders-page.tsx:59` - Items, renders `snapshotItemCount(...)`

Both are numeric counts. The identical attempts-over-max field is already right-aligned on
`sync-jobs-page.tsx:62` and `ConnectionDiagnosticsPanel.tsx:40`, so leaving Dashboard centered would make the
retry counter change alignment as an operator follows one incident across those pages.
`.claude/rules/ui-components.md:182` pairs tabular-nums with right-aligned cells, and the in-repo
precedent already right-aligns the identical attempts-over-max field (`sync-jobs-page.tsx:62`,
`ConnectionDiagnosticsPanel.tsx:40`).

### `.data-table__cell--center` deleted

With those two flipped, the rule has **zero consumers**. The class is only ever produced from
`DataTableColumn.align` (`data-table.tsx:496,569` emit `data-table__cell--${column.align}`), and `'center'`
now appears in no column definition anywhere in `apps/web/src` or `apps/e2e` - the only align values left in
the repo are `'right'` (15) and `'left'` (2). Deleting the rule also retires the fact that it was missing
`font-variant-numeric: tabular-nums`, rather than that needing its own fix. `DataTableColumn.align` still
accepts `'center'` in its union; narrowing the type was left out of scope.

## `--end`-suffixed workaround classes: left in place (deliberate)

The issue asked to remove the Orders/Products `--end` workarounds if now redundant. Both are **not**
redundant, so they stay:

- `.orders-cell-stack--end` (`index.css:8843`) - `align-items: flex-end; text-align: right; min-width: 8rem`
- `.products-cell-stack--end` (`index.css:16048`) - `align-items: flex-end; min-width: 8rem`

Both apply to a `<span>` **inside** the cell, not to the `<td>`. They are flex-column stacks whose
`align-items: flex-end` is what actually right-aligns the stacked child lines - `text-align` on the `td` does
not position flex items. The `min-width: 8rem` additionally co-anchors the body column width with the header
sort buttons so the column does not resize between sorts (documented at `index.css:8840-8842`, #1747).
Removing either would regress the layout. Only `.orders-cell-stack--end`'s `text-align: right` is now
redundant with the `td`, and it is harmless (it also still covers non-flex text nodes).

## Verification

`pnpm lint` - zero errors (pre-existing warnings only; `check:invariants` including `check-design-tokens` all
green). `pnpm type-check` - zero errors across all packages including `@openlinker/web`.

Unit tests are deferred to CI: a full `pnpm test` run is not viable on the contributor machine used here (it
exhausts the WSL instance), so per this repo's local-machine constraint the gate run locally is lint +
type-check. This is a CSS-and-column-config change with no test surface. For what it is worth, the `apps/web`
suite was observed green (303 files / 2912 tests) before that constraint was applied.

Refs #2031



## Follow-up applied after review round 3

`DataTableColumn.align` (`data-table.tsx:33`) no longer accepts `'center'`. With its CSS rule deleted, the
member type-checked, stamped a class nothing matched, and rendered left - the same silent-lie failure mode
this PR exists to fix. `'left'` stays because it is a no-op that yields the *declared* result (the base rule
is already left); `'center'` would have yielded the opposite of what it declares. Type-check passes
unchanged, which re-confirms zero consumers.
