### PR TITLE
feat(web/connections): add shared ConnectionCell component (#2027)

### DIFF
--- a/apps/web/src/features/connections/components/ConnectionCell.test.tsx
+++ b/apps/web/src/features/connections/components/ConnectionCell.test.tsx
@@ -1,0 +1,141 @@
+import { cleanup, fireEvent, screen, within } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ConnectionCell } from './ConnectionCell';
+import { createMockApiClient, renderWithProviders } from '../../../test/test-utils';
+
+const CONNECTION_ID = 'aa966882-0d21-4e2f-9d5a-71c4a5f14cfb';
+
+function mockConnection(overrides: Partial<{ name: string }> = {}): {
+  id: string;
+  name: string;
+  platformType: string;
+  status: 'active';
+  config: Record<string, never>;
+  credentialsBacked: boolean;
+  enabledCapabilities: never[];
+  supportedCapabilities: never[];
+  createdAt: string;
+  updatedAt: string;
+} {
+  return {
+    id: CONNECTION_ID,
+    name: overrides.name ?? 'Erli Demo',
+    platformType: 'erli',
+    status: 'active',
+    config: {},
+    credentialsBacked: true,
+    enabledCapabilities: [],
+    supportedCapabilities: [],
+    createdAt: '2026-04-20T00:00:00.000Z',
+    updatedAt: '2026-04-20T00:00:00.000Z',
+  };
+}
+
+describe('ConnectionCell', () => {
+  afterEach(cleanup);
+
+  it('renders the connection name as a link to the connection detail page', async () => {
+    const api = createMockApiClient({
+      connections: { getById: vi.fn().mockResolvedValue(mockConnection()) },
+    });
+
+    renderWithProviders(<ConnectionCell connectionId={CONNECTION_ID} />, { apiClient: api });
+
+    const link = await screen.findByRole('link', { name: 'Erli Demo' });
+    expect(link).toHaveAttribute('href', `/connections/${CONNECTION_ID}`);
+  });
+
+  it('renders the shortened connection id alongside the name', async () => {
+    const api = createMockApiClient({
+      connections: { getById: vi.fn().mockResolvedValue(mockConnection()) },
+    });
+
+    renderWithProviders(<ConnectionCell connectionId={CONNECTION_ID} />, { apiClient: api });
+
+    await screen.findByRole('link', { name: 'Erli Demo' });
+    expect(screen.getByText('aa966882…4cfb')).toBeInTheDocument();
+  });
+
+  it('copies the full connection id when the copy button is clicked', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+
+    const api = createMockApiClient({
+      connections: { getById: vi.fn().mockResolvedValue(mockConnection()) },
+    });
+
+    const { container } = renderWithProviders(<ConnectionCell connectionId={CONNECTION_ID} />, {
+      apiClient: api,
+    });
+
+    await screen.findByRole('link', { name: 'Erli Demo' });
+
+    // `EntityLabel` always renders its own Copy button too (suppressed only
+    // by CSS, which jsdom doesn't apply) — scope to the `CopyableId` line so
+    // this exercises the cell's intended, hover-revealed copy control.
+    const copyableId = container.querySelector('.copyable-id');
+    expect(copyableId).not.toBeNull();
+    const copyButton = within(copyableId as HTMLElement).getByRole('button', {
+      name: `Copy ${CONNECTION_ID}`,
+    });
+
+    fireEvent.click(copyButton);
+
+    expect(writeText).toHaveBeenCalledWith(CONNECTION_ID);
+    expect(
+      await within(copyableId as HTMLElement).findByRole('button', {
+        name: `Copied ${CONNECTION_ID}`,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('shows a loading placeholder while the connection is fetching', () => {
+    const api = createMockApiClient({
+      connections: { getById: vi.fn().mockReturnValue(new Promise(() => {})) },
+    });
+
+    renderWithProviders(<ConnectionCell connectionId={CONNECTION_ID} />, { apiClient: api });
+
+    expect(screen.getByText('…')).toHaveAttribute('aria-busy', 'true');
+  });
+
+  it('falls back to Unknown when the connection name cannot be resolved', async () => {
+    const api = createMockApiClient({
+      connections: { getById: vi.fn().mockRejectedValue(new Error('not found')) },
+    });
+
+    renderWithProviders(<ConnectionCell connectionId={CONNECTION_ID} />, { apiClient: api });
+
+    expect(await screen.findByText('Unknown')).toBeInTheDocument();
+    expect(screen.getByText('aa966882…4cfb')).toBeInTheDocument();
+  });
+
+  it('renders nothing when connectionId is empty', () => {
+    const api = createMockApiClient({
+      connections: { getById: vi.fn() },
+    });
+
+    const { container } = renderWithProviders(<ConnectionCell connectionId="" />, {
+      apiClient: api,
+    });
+
+    expect(container.querySelector('.connection-cell')).toBeNull();
+  });
+
+  it('renders an adornment when provided', async () => {
+    const api = createMockApiClient({
+      connections: { getById: vi.fn().mockResolvedValue(mockConnection()) },
+    });
+
+    renderWithProviders(
+      <ConnectionCell connectionId={CONNECTION_ID} adornment={<span>pill</span>} />,
+      { apiClient: api },
+    );
+
+    await screen.findByRole('link', { name: 'Erli Demo' });
+    expect(screen.getByText('pill')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/connections/components/ConnectionCell.test.tsx
+++ b/apps/web/src/features/connections/components/ConnectionCell.test.tsx
@@ -1,25 +1,15 @@
-import { cleanup, fireEvent, screen, within } from '@testing-library/react';
+import { cleanup, fireEvent, screen } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ConnectionCell } from './ConnectionCell';
+import type { Connection } from '../api/connections.types';
 import { createMockApiClient, renderWithProviders } from '../../../test/test-utils';
 
 const CONNECTION_ID = 'aa966882-0d21-4e2f-9d5a-71c4a5f14cfb';
 
-function mockConnection(overrides: Partial<{ name: string }> = {}): {
-  id: string;
-  name: string;
-  platformType: string;
-  status: 'active';
-  config: Record<string, never>;
-  credentialsBacked: boolean;
-  enabledCapabilities: never[];
-  supportedCapabilities: never[];
-  createdAt: string;
-  updatedAt: string;
-} {
+function mockConnection(overrides: Partial<Connection> = {}): Connection {
   return {
     id: CONNECTION_ID,
-    name: overrides.name ?? 'Erli Demo',
+    name: 'Erli Demo',
     platformType: 'erli',
     status: 'active',
     config: {},
@@ -28,11 +18,15 @@ function mockConnection(overrides: Partial<{ name: string }> = {}): {
     supportedCapabilities: [],
     createdAt: '2026-04-20T00:00:00.000Z',
     updatedAt: '2026-04-20T00:00:00.000Z',
+    ...overrides,
   };
 }
 
 describe('ConnectionCell', () => {
-  afterEach(cleanup);
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
 
   it('renders the connection name as a link to the connection detail page', async () => {
     const api = createMockApiClient({
@@ -56,39 +50,42 @@ describe('ConnectionCell', () => {
     expect(screen.getByText('aa966882…4cfb')).toBeInTheDocument();
   });
 
-  it('copies the full connection id when the copy button is clicked', async () => {
+  it('uses the page-supplied name without fetching the connection', async () => {
+    const getById = vi.fn();
+    const api = createMockApiClient({ connections: { getById } });
+
+    renderWithProviders(
+      <ConnectionCell connectionId={CONNECTION_ID} name="Warehouse EU" platformType="prestashop" />,
+      { apiClient: api },
+    );
+
+    expect(await screen.findByRole('link', { name: 'Warehouse EU' })).toBeInTheDocument();
+    expect(getById).not.toHaveBeenCalled();
+  });
+
+  it('renders the single copy button with a human-readable accessible name', async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
-    Object.defineProperty(navigator, 'clipboard', {
-      value: { writeText },
-      configurable: true,
-    });
+    vi.stubGlobal('navigator', { clipboard: { writeText } });
 
     const api = createMockApiClient({
       connections: { getById: vi.fn().mockResolvedValue(mockConnection()) },
     });
 
-    const { container } = renderWithProviders(<ConnectionCell connectionId={CONNECTION_ID} />, {
-      apiClient: api,
-    });
+    renderWithProviders(<ConnectionCell connectionId={CONNECTION_ID} />, { apiClient: api });
 
     await screen.findByRole('link', { name: 'Erli Demo' });
 
-    // `EntityLabel` always renders its own Copy button too (suppressed only
-    // by CSS, which jsdom doesn't apply) — scope to the `CopyableId` line so
-    // this exercises the cell's intended, hover-revealed copy control.
-    const copyableId = container.querySelector('.copyable-id');
-    expect(copyableId).not.toBeNull();
-    const copyButton = within(copyableId as HTMLElement).getByRole('button', {
-      name: `Copy ${CONNECTION_ID}`,
-    });
+    const copyButtons = screen.getAllByRole('button');
+    expect(copyButtons).toHaveLength(1);
 
+    const copyButton = screen.getByRole('button', {
+      name: 'Copy connection ID for Erli Demo',
+    });
     fireEvent.click(copyButton);
 
     expect(writeText).toHaveBeenCalledWith(CONNECTION_ID);
     expect(
-      await within(copyableId as HTMLElement).findByRole('button', {
-        name: `Copied ${CONNECTION_ID}`,
-      }),
+      await screen.findByRole('button', { name: 'Copied connection ID for Erli Demo' }),
     ).toBeInTheDocument();
   });
 
@@ -113,16 +110,54 @@ describe('ConnectionCell', () => {
     expect(screen.getByText('aa966882…4cfb')).toBeInTheDocument();
   });
 
-  it('renders nothing when connectionId is empty', () => {
+  it('drops the link when the current path already matches the connection', async () => {
     const api = createMockApiClient({
-      connections: { getById: vi.fn() },
+      connections: { getById: vi.fn().mockResolvedValue(mockConnection()) },
     });
+
+    renderWithProviders(<ConnectionCell connectionId={CONNECTION_ID} />, {
+      apiClient: api,
+      route: `/connections/${CONNECTION_ID}`,
+    });
+
+    expect(await screen.findByText('Erli Demo')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Erli Demo' })).toBeNull();
+  });
+
+  it('surfaces a status note when the connection needs attention', async () => {
+    const api = createMockApiClient({
+      connections: {
+        getById: vi.fn().mockResolvedValue(mockConnection({ status: 'needs_reauth' })),
+      },
+    });
+
+    renderWithProviders(<ConnectionCell connectionId={CONNECTION_ID} />, { apiClient: api });
+
+    expect(await screen.findByText('Reauth needed')).toBeInTheDocument();
+  });
+
+  it('renders no status note for a healthy connection', async () => {
+    const api = createMockApiClient({
+      connections: { getById: vi.fn().mockResolvedValue(mockConnection()) },
+    });
+
+    const { container } = renderWithProviders(<ConnectionCell connectionId={CONNECTION_ID} />, {
+      apiClient: api,
+    });
+
+    await screen.findByRole('link', { name: 'Erli Demo' });
+    expect(container.querySelector('.connection-cell__status')).toBeNull();
+  });
+
+  it('renders an empty-value placeholder when connectionId is empty', () => {
+    const api = createMockApiClient({ connections: { getById: vi.fn() } });
 
     const { container } = renderWithProviders(<ConnectionCell connectionId="" />, {
       apiClient: api,
     });
 
     expect(container.querySelector('.connection-cell')).toBeNull();
+    expect(screen.getByLabelText('No value')).toBeInTheDocument();
   });
 
   it('renders an adornment when provided', async () => {
@@ -137,5 +172,21 @@ describe('ConnectionCell', () => {
 
     await screen.findByRole('link', { name: 'Erli Demo' });
     expect(screen.getByText('pill')).toBeInTheDocument();
+  });
+
+  it('hands the resolved connection to a function adornment', async () => {
+    const api = createMockApiClient({
+      connections: { getById: vi.fn().mockResolvedValue(mockConnection()) },
+    });
+
+    renderWithProviders(
+      <ConnectionCell
+        connectionId={CONNECTION_ID}
+        adornment={(facts) => <span>{facts.platformType}</span>}
+      />,
+      { apiClient: api },
+    );
+
+    expect(await screen.findByText('erli')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/connections/components/ConnectionCell.test.tsx
+++ b/apps/web/src/features/connections/components/ConnectionCell.test.tsx
@@ -78,7 +78,7 @@ describe('ConnectionCell', () => {
       { apiClient: api },
     );
 
-    expect(await screen.findByText('Reauth needed')).toBeInTheDocument();
+    expect(await screen.findByText('Re-auth')).toBeInTheDocument();
     expect(getById).not.toHaveBeenCalled();
   });
 
@@ -91,7 +91,20 @@ describe('ConnectionCell', () => {
     });
 
     expect(screen.getByText('Unknown')).toBeInTheDocument();
-    expect(screen.queryByText('Reauth needed')).toBeNull();
+    expect(screen.queryByText('Re-auth')).toBeNull();
+    expect(getById).not.toHaveBeenCalled();
+  });
+
+  it('renders the loading state rather than Unknown while the page reports its batch as loading', () => {
+    const getById = vi.fn();
+    const api = createMockApiClient({ connections: { getById } });
+
+    renderWithProviders(
+      <ConnectionCell connectionId={CONNECTION_ID} connection={null} loading />,
+      { apiClient: api },
+    );
+
+    expect(screen.queryByText('Unknown')).toBeNull();
     expect(getById).not.toHaveBeenCalled();
   });
 
@@ -165,7 +178,7 @@ describe('ConnectionCell', () => {
 
     renderWithProviders(<ConnectionCell connectionId={CONNECTION_ID} />, { apiClient: api });
 
-    expect(await screen.findByText('Reauth needed')).toBeInTheDocument();
+    expect(await screen.findByText('Re-auth')).toBeInTheDocument();
   });
 
   it('renders no status note for a healthy connection', async () => {
@@ -176,7 +189,7 @@ describe('ConnectionCell', () => {
     renderWithProviders(<ConnectionCell connectionId={CONNECTION_ID} />, { apiClient: api });
 
     await screen.findByRole('link', { name: 'Erli Demo' });
-    expect(screen.queryByText('Reauth needed')).toBeNull();
+    expect(screen.queryByText('Re-auth')).toBeNull();
     expect(screen.queryByText('Disabled')).toBeNull();
     expect(screen.queryByText('Error')).toBeNull();
   });

--- a/apps/web/src/features/connections/components/ConnectionCell.test.tsx
+++ b/apps/web/src/features/connections/components/ConnectionCell.test.tsx
@@ -104,6 +104,7 @@ describe('ConnectionCell', () => {
       { apiClient: api },
     );
 
+    expect(screen.getByText('…')).toHaveAttribute('aria-busy', 'true');
     expect(screen.queryByText('Unknown')).toBeNull();
     expect(getById).not.toHaveBeenCalled();
   });

--- a/apps/web/src/features/connections/components/ConnectionCell.test.tsx
+++ b/apps/web/src/features/connections/components/ConnectionCell.test.tsx
@@ -50,16 +50,48 @@ describe('ConnectionCell', () => {
     expect(screen.getByText('aa966882…4cfb')).toBeInTheDocument();
   });
 
-  it('uses the page-supplied name without fetching the connection', async () => {
+  it('uses the page-supplied connection without fetching it', async () => {
     const getById = vi.fn();
     const api = createMockApiClient({ connections: { getById } });
 
     renderWithProviders(
-      <ConnectionCell connectionId={CONNECTION_ID} name="Warehouse EU" platformType="prestashop" />,
+      <ConnectionCell
+        connectionId={CONNECTION_ID}
+        connection={{ name: 'Warehouse EU', status: 'active' }}
+      />,
       { apiClient: api },
     );
 
     expect(await screen.findByRole('link', { name: 'Warehouse EU' })).toBeInTheDocument();
+    expect(getById).not.toHaveBeenCalled();
+  });
+
+  it('surfaces the status note from the page-supplied connection', async () => {
+    const getById = vi.fn();
+    const api = createMockApiClient({ connections: { getById } });
+
+    renderWithProviders(
+      <ConnectionCell
+        connectionId={CONNECTION_ID}
+        connection={{ name: 'Warehouse EU', status: 'needs_reauth' }}
+      />,
+      { apiClient: api },
+    );
+
+    expect(await screen.findByText('Reauth needed')).toBeInTheDocument();
+    expect(getById).not.toHaveBeenCalled();
+  });
+
+  it('renders Unknown without fetching when the page reports the connection as unknown', () => {
+    const getById = vi.fn();
+    const api = createMockApiClient({ connections: { getById } });
+
+    renderWithProviders(<ConnectionCell connectionId={CONNECTION_ID} connection={null} />, {
+      apiClient: api,
+    });
+
+    expect(screen.getByText('Unknown')).toBeInTheDocument();
+    expect(screen.queryByText('Reauth needed')).toBeNull();
     expect(getById).not.toHaveBeenCalled();
   });
 
@@ -141,23 +173,22 @@ describe('ConnectionCell', () => {
       connections: { getById: vi.fn().mockResolvedValue(mockConnection()) },
     });
 
-    const { container } = renderWithProviders(<ConnectionCell connectionId={CONNECTION_ID} />, {
-      apiClient: api,
-    });
+    renderWithProviders(<ConnectionCell connectionId={CONNECTION_ID} />, { apiClient: api });
 
     await screen.findByRole('link', { name: 'Erli Demo' });
-    expect(container.querySelector('.connection-cell__status')).toBeNull();
+    expect(screen.queryByText('Reauth needed')).toBeNull();
+    expect(screen.queryByText('Disabled')).toBeNull();
+    expect(screen.queryByText('Error')).toBeNull();
   });
 
   it('renders an empty-value placeholder when connectionId is empty', () => {
     const api = createMockApiClient({ connections: { getById: vi.fn() } });
 
-    const { container } = renderWithProviders(<ConnectionCell connectionId="" />, {
-      apiClient: api,
-    });
+    renderWithProviders(<ConnectionCell connectionId="" />, { apiClient: api });
 
-    expect(container.querySelector('.connection-cell')).toBeNull();
     expect(screen.getByLabelText('No value')).toBeInTheDocument();
+    expect(screen.queryByRole('link')).toBeNull();
+    expect(screen.queryByRole('button')).toBeNull();
   });
 
   it('renders an adornment when provided', async () => {
@@ -172,21 +203,5 @@ describe('ConnectionCell', () => {
 
     await screen.findByRole('link', { name: 'Erli Demo' });
     expect(screen.getByText('pill')).toBeInTheDocument();
-  });
-
-  it('hands the resolved connection to a function adornment', async () => {
-    const api = createMockApiClient({
-      connections: { getById: vi.fn().mockResolvedValue(mockConnection()) },
-    });
-
-    renderWithProviders(
-      <ConnectionCell
-        connectionId={CONNECTION_ID}
-        adornment={(facts) => <span>{facts.platformType}</span>}
-      />,
-      { apiClient: api },
-    );
-
-    expect(await screen.findByText('erli')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/connections/components/ConnectionCell.tsx
+++ b/apps/web/src/features/connections/components/ConnectionCell.tsx
@@ -6,11 +6,14 @@
  * adornment; line 2 pairs `CopyableId`'s shortened UUID with an
  * attention-only status note.
  *
- * `name` / `platformType` / `status` are page-supplied: a list page already
- * holds them from one batched `useConnectionsQuery()` read, and #1996 requires
- * the Connection column to cost one request per page rather than one per row.
- * The internal `useConnectionQuery` stays as the standalone fallback for a
- * caller that holds nothing but an id (#2027's own scope).
+ * The page-supplied facts arrive as ONE object because they are correlated: a
+ * list page already holds the whole `Connection` from a batched
+ * `useConnectionsQuery()` read (#1996 requires the Connection column to cost
+ * one request per page, not one per row), and supplying only part of it used to
+ * disable the internal query while leaving the status unresolved - silently
+ * dropping the operator-facing status note on exactly the batched path the AC
+ * demands. The internal `useConnectionQuery` stays as the standalone fallback
+ * for a caller that holds nothing but an id (#2027's own scope).
  */
 import type { ReactElement, ReactNode } from 'react';
 import { CopyableId } from '../../../shared/ui/copyable-id';
@@ -20,26 +23,22 @@ import type { ConnectionStatus } from '../api/connections.types';
 import { useConnectionQuery } from '../hooks/use-connection-query';
 import { ConnectionEntityLabel } from './ConnectionEntityLabel';
 
-/** What the cell resolved, handed back so an adornment needs no second lookup. */
+/** The connection facts this cell renders. A whole `Connection` satisfies it. */
 export interface ConnectionCellFacts {
-  connectionId: string;
-  name: string | null;
-  platformType: string | null;
-  status: ConnectionStatus | null;
+  name: string;
+  status: ConnectionStatus;
 }
 
 export interface ConnectionCellProps {
   connectionId: string;
-  /** `undefined` = resolve internally; a value (including `null`) = page-supplied. */
-  name?: string | null;
-  platformType?: string | null;
-  status?: ConnectionStatus | null;
   /**
-   * Leading glyph on line 1 - a channel pill or `ConnectionDot`. The function
-   * form receives the resolved connection so the consumer does not have to
-   * re-resolve what this cell already knows.
+   * `undefined` = resolve internally; a value = page-supplied, and `null`
+   * specifically means "the page looked and this connection is unknown", which
+   * renders the Unknown label without a per-row fetch.
    */
-  adornment?: ReactNode | ((facts: ConnectionCellFacts) => ReactNode);
+  connection?: ConnectionCellFacts | null;
+  /** Leading glyph on line 1 - a channel pill or `ConnectionDot`. */
+  adornment?: ReactNode;
   className?: string;
 }
 
@@ -51,31 +50,20 @@ const STATUS_NOTES: Record<Exclude<ConnectionStatus, 'active'>, string> = {
 
 export function ConnectionCell({
   connectionId,
-  name,
-  platformType,
-  status,
+  connection,
   adornment,
   className = '',
 }: ConnectionCellProps): ReactElement {
-  const nameSupplied = name !== undefined;
-  const query = useConnectionQuery(connectionId, { enabled: !nameSupplied });
+  const factsSupplied = connection !== undefined;
+  const query = useConnectionQuery(connectionId, { enabled: !factsSupplied });
 
   if (!connectionId) return <EmptyValue />;
 
-  const resolvedName = (nameSupplied ? name : query.data?.name) ?? null;
-  const resolvedPlatformType = platformType ?? query.data?.platformType ?? null;
-  const resolvedStatus = status ?? query.data?.status ?? null;
-  const loading = !nameSupplied && query.isLoading;
-
-  const adornmentNode =
-    typeof adornment === 'function'
-      ? adornment({
-          connectionId,
-          name: resolvedName,
-          platformType: resolvedPlatformType,
-          status: resolvedStatus,
-        })
-      : adornment;
+  const facts: ConnectionCellFacts | null =
+    connection !== undefined ? connection : (query.data ?? null);
+  const resolvedName = facts?.name ?? null;
+  const resolvedStatus = facts?.status ?? null;
+  const loading = !factsSupplied && query.isLoading;
 
   const statusNote =
     resolvedStatus && resolvedStatus !== 'active' ? STATUS_NOTES[resolvedStatus] : null;
@@ -87,9 +75,7 @@ export function ConnectionCell({
     <span className={classes}>
       <span className="connection-cell__body">
         <span className="connection-cell__line">
-          {adornmentNode ? (
-            <span className="connection-cell__adornment">{adornmentNode}</span>
-          ) : null}
+          {adornment ? <span className="connection-cell__adornment">{adornment}</span> : null}
           <ConnectionEntityLabel
             connectionId={connectionId}
             name={resolvedName}
@@ -108,7 +94,7 @@ export function ConnectionCell({
           {statusNote ? (
             <span className={`connection-cell__status connection-cell__status--${resolvedStatus}`}>
               <span className="connection-cell__status-dot" aria-hidden="true" />
-              {statusNote}
+              <span className="connection-cell__status-label">{statusNote}</span>
             </span>
           ) : null}
         </span>

--- a/apps/web/src/features/connections/components/ConnectionCell.tsx
+++ b/apps/web/src/features/connections/components/ConnectionCell.tsx
@@ -35,22 +35,45 @@ export interface ConnectionCellProps {
    * `undefined` = resolve internally; a value = page-supplied, and `null`
    * specifically means "the page looked and this connection is unknown", which
    * renders the Unknown label without a per-row fetch.
+   *
+   * A list page MUST coalesce its lookup: `connectionsById.get(id)` and
+   * `connections.find(...)` both return `undefined` on a miss, which this cell
+   * reads as "resolve it yourself" and would silently reinstate the per-row
+   * fetch #1996 rejected. Pass `connection={map.get(id) ?? null}` together with
+   * `loading={connectionsQuery.isLoading}`, so an unresolved row renders Unknown
+   * and a not-yet-loaded one renders the loading state instead.
    */
   connection?: ConnectionCellFacts | null;
-  /** Leading glyph on line 1 - a channel pill or `ConnectionDot`. */
+  /**
+   * Page-supplied loading state, for the window before the batched connections
+   * query settles. Without it a page that coalesces to `null` (as it must)
+   * would render a column of "Unknown" on every cold load - indistinguishable
+   * from a genuinely deleted connection.
+   */
+  loading?: boolean;
+  /**
+   * Leading glyph on line 1 - a channel pill or `ConnectionDot`. The cell ships
+   * no built-in channel signal, so pass one on any list where two connections
+   * can share a `platformType`: otherwise the only disambiguators between two
+   * same-platform shops are the operator-authored name and a shortened id.
+   */
   adornment?: ReactNode;
   className?: string;
 }
 
+// "Re-auth" rather than the app's longer "Re-authentication required": line 2's
+// fixed cost (shortened id + copy control) leaves ~58px inside the 220px cap, so
+// a longer label truncates on every affected row.
 const STATUS_NOTES: Record<Exclude<ConnectionStatus, 'active'>, string> = {
   disabled: 'Disabled',
   error: 'Error',
-  needs_reauth: 'Reauth needed',
+  needs_reauth: 'Re-auth',
 };
 
 export function ConnectionCell({
   connectionId,
   connection,
+  loading: loadingProp = false,
   adornment,
   className = '',
 }: ConnectionCellProps): ReactElement {
@@ -63,7 +86,7 @@ export function ConnectionCell({
     connection !== undefined ? connection : (query.data ?? null);
   const resolvedName = facts?.name ?? null;
   const resolvedStatus = facts?.status ?? null;
-  const loading = !factsSupplied && query.isLoading;
+  const loading = loadingProp || (!factsSupplied && query.isLoading);
 
   const statusNote =
     resolvedStatus && resolvedStatus !== 'active' ? STATUS_NOTES[resolvedStatus] : null;
@@ -94,7 +117,9 @@ export function ConnectionCell({
           {statusNote ? (
             <span className={`connection-cell__status connection-cell__status--${resolvedStatus}`}>
               <span className="connection-cell__status-dot" aria-hidden="true" />
-              <span className="connection-cell__status-label">{statusNote}</span>
+              <span className="connection-cell__status-label" title={statusNote}>
+                {statusNote}
+              </span>
             </span>
           ) : null}
         </span>

--- a/apps/web/src/features/connections/components/ConnectionCell.tsx
+++ b/apps/web/src/features/connections/components/ConnectionCell.tsx
@@ -1,58 +1,117 @@
 /**
  * ConnectionCell — shared two-line connection identity cell (#1996, #2027).
  *
- * Line 1 reuses `EntityLabel` (name resolution, loading state, link to
- * `/connections/:id`) with `showId={false}`. Line 2 reuses `CopyableId` for
- * the shortened UUID plus the hover-reveal Copy affordance. `EntityLabel`
- * always renders its own (always-visible) Copy button regardless of
- * `showId` — left in place here rather than reimplementing the name/link
- * composition by hand, but suppressed visually via the `.connection-cell
- * .entity-label__copy` rule in index.css, since `CopyableId`'s hover-reveal
- * button on line 2 is the cell's single intended copy action (matches the
- * #1996 mockup, which shows exactly one Copy control per cell).
+ * Line 1 composes `ConnectionEntityLabel` (name resolution, the link to
+ * `/connections/:id` and its self-page suppression) beside the optional
+ * adornment; line 2 pairs `CopyableId`'s shortened UUID with an
+ * attention-only status note.
  *
- * Resolves its own `connectionId -> name` via `useConnectionQuery`, one
- * request per row — the same per-row fetch `ConnectionEntityLabel` uses.
- * A page-supplied name (from a single batched `useConnectionsQuery()` map)
- * is the eventual list-page optimization #1996 describes, but wiring that
- * through is deferred to the follow-up issue that consumes this component
- * on an actual page (#2027 is standalone-component scope only).
+ * `name` / `platformType` / `status` are page-supplied: a list page already
+ * holds them from one batched `useConnectionsQuery()` read, and #1996 requires
+ * the Connection column to cost one request per page rather than one per row.
+ * The internal `useConnectionQuery` stays as the standalone fallback for a
+ * caller that holds nothing but an id (#2027's own scope).
  */
 import type { ReactElement, ReactNode } from 'react';
-import { EntityLabel, shortenId } from '../../../shared/ui/entity-label';
 import { CopyableId } from '../../../shared/ui/copyable-id';
+import { EmptyValue } from '../../../shared/ui/empty-value';
+import { shortenId } from '../../../shared/ui/entity-label';
+import type { ConnectionStatus } from '../api/connections.types';
 import { useConnectionQuery } from '../hooks/use-connection-query';
+import { ConnectionEntityLabel } from './ConnectionEntityLabel';
+
+/** What the cell resolved, handed back so an adornment needs no second lookup. */
+export interface ConnectionCellFacts {
+  connectionId: string;
+  name: string | null;
+  platformType: string | null;
+  status: ConnectionStatus | null;
+}
 
 export interface ConnectionCellProps {
   connectionId: string;
-  /** Optional leading glyph — e.g. a channel pill or connection dot. */
-  adornment?: ReactNode;
+  /** `undefined` = resolve internally; a value (including `null`) = page-supplied. */
+  name?: string | null;
+  platformType?: string | null;
+  status?: ConnectionStatus | null;
+  /**
+   * Leading glyph on line 1 - a channel pill or `ConnectionDot`. The function
+   * form receives the resolved connection so the consumer does not have to
+   * re-resolve what this cell already knows.
+   */
+  adornment?: ReactNode | ((facts: ConnectionCellFacts) => ReactNode);
   className?: string;
 }
 
+const STATUS_NOTES: Record<Exclude<ConnectionStatus, 'active'>, string> = {
+  disabled: 'Disabled',
+  error: 'Error',
+  needs_reauth: 'Reauth needed',
+};
+
 export function ConnectionCell({
   connectionId,
+  name,
+  platformType,
+  status,
   adornment,
   className = '',
-}: ConnectionCellProps): ReactElement | null {
-  const query = useConnectionQuery(connectionId);
+}: ConnectionCellProps): ReactElement {
+  const nameSupplied = name !== undefined;
+  const query = useConnectionQuery(connectionId, { enabled: !nameSupplied });
 
-  if (!connectionId) return null;
+  if (!connectionId) return <EmptyValue />;
 
+  const resolvedName = (nameSupplied ? name : query.data?.name) ?? null;
+  const resolvedPlatformType = platformType ?? query.data?.platformType ?? null;
+  const resolvedStatus = status ?? query.data?.status ?? null;
+  const loading = !nameSupplied && query.isLoading;
+
+  const adornmentNode =
+    typeof adornment === 'function'
+      ? adornment({
+          connectionId,
+          name: resolvedName,
+          platformType: resolvedPlatformType,
+          status: resolvedStatus,
+        })
+      : adornment;
+
+  const statusNote =
+    resolvedStatus && resolvedStatus !== 'active' ? STATUS_NOTES[resolvedStatus] : null;
+
+  const copySubject = resolvedName ? `connection ID for ${resolvedName}` : 'connection ID';
   const classes = ['connection-cell', className].filter(Boolean).join(' ');
 
   return (
     <span className={classes}>
-      {adornment ? <span className="connection-cell__adornment">{adornment}</span> : null}
       <span className="connection-cell__body">
-        <EntityLabel
-          id={connectionId}
-          name={query.data?.name}
-          loading={query.isLoading}
-          showId={false}
-          to={`/connections/${connectionId}`}
-        />
-        <CopyableId id={connectionId} label={shortenId(connectionId)} />
+        <span className="connection-cell__line">
+          {adornmentNode ? (
+            <span className="connection-cell__adornment">{adornmentNode}</span>
+          ) : null}
+          <ConnectionEntityLabel
+            connectionId={connectionId}
+            name={resolvedName}
+            loading={loading}
+            showId={false}
+            showCopy={false}
+          />
+        </span>
+        <span className="connection-cell__meta">
+          <CopyableId
+            id={connectionId}
+            label={shortenId(connectionId)}
+            copyLabel={`Copy ${copySubject}`}
+            copiedLabel={`Copied ${copySubject}`}
+          />
+          {statusNote ? (
+            <span className={`connection-cell__status connection-cell__status--${resolvedStatus}`}>
+              <span className="connection-cell__status-dot" aria-hidden="true" />
+              {statusNote}
+            </span>
+          ) : null}
+        </span>
       </span>
     </span>
   );

--- a/apps/web/src/features/connections/components/ConnectionCell.tsx
+++ b/apps/web/src/features/connections/components/ConnectionCell.tsx
@@ -1,0 +1,59 @@
+/**
+ * ConnectionCell — shared two-line connection identity cell (#1996, #2027).
+ *
+ * Line 1 reuses `EntityLabel` (name resolution, loading state, link to
+ * `/connections/:id`) with `showId={false}`. Line 2 reuses `CopyableId` for
+ * the shortened UUID plus the hover-reveal Copy affordance. `EntityLabel`
+ * always renders its own (always-visible) Copy button regardless of
+ * `showId` — left in place here rather than reimplementing the name/link
+ * composition by hand, but suppressed visually via the `.connection-cell
+ * .entity-label__copy` rule in index.css, since `CopyableId`'s hover-reveal
+ * button on line 2 is the cell's single intended copy action (matches the
+ * #1996 mockup, which shows exactly one Copy control per cell).
+ *
+ * Resolves its own `connectionId -> name` via `useConnectionQuery`, one
+ * request per row — the same per-row fetch `ConnectionEntityLabel` uses.
+ * A page-supplied name (from a single batched `useConnectionsQuery()` map)
+ * is the eventual list-page optimization #1996 describes, but wiring that
+ * through is deferred to the follow-up issue that consumes this component
+ * on an actual page (#2027 is standalone-component scope only).
+ */
+import type { ReactElement, ReactNode } from 'react';
+import { EntityLabel, shortenId } from '../../../shared/ui/entity-label';
+import { CopyableId } from '../../../shared/ui/copyable-id';
+import { useConnectionQuery } from '../hooks/use-connection-query';
+
+export interface ConnectionCellProps {
+  connectionId: string;
+  /** Optional leading glyph — e.g. a channel pill or connection dot. */
+  adornment?: ReactNode;
+  className?: string;
+}
+
+export function ConnectionCell({
+  connectionId,
+  adornment,
+  className = '',
+}: ConnectionCellProps): ReactElement | null {
+  const query = useConnectionQuery(connectionId);
+
+  if (!connectionId) return null;
+
+  const classes = ['connection-cell', className].filter(Boolean).join(' ');
+
+  return (
+    <span className={classes}>
+      {adornment ? <span className="connection-cell__adornment">{adornment}</span> : null}
+      <span className="connection-cell__body">
+        <EntityLabel
+          id={connectionId}
+          name={query.data?.name}
+          loading={query.isLoading}
+          showId={false}
+          to={`/connections/${connectionId}`}
+        />
+        <CopyableId id={connectionId} label={shortenId(connectionId)} />
+      </span>
+    </span>
+  );
+}

--- a/apps/web/src/features/connections/components/ConnectionEntityLabel.test.tsx
+++ b/apps/web/src/features/connections/components/ConnectionEntityLabel.test.tsx
@@ -46,6 +46,44 @@ describe('ConnectionEntityLabel', () => {
     expect(link).toHaveAttribute('href', '/connections/ol_connection_abc');
   });
 
+  it('renders the caller-supplied name without fetching the connection', async () => {
+    const getById = vi.fn();
+    const api = createMockApiClient({ connections: { getById } });
+
+    renderWithProviders(
+      <ConnectionEntityLabel connectionId="ol_connection_abc" name="Warehouse EU" />,
+      { apiClient: api },
+    );
+
+    expect(await screen.findByRole('link', { name: 'Warehouse EU' })).toBeInTheDocument();
+    expect(getById).not.toHaveBeenCalled();
+  });
+
+  it('renders Unknown without fetching when the caller supplies name={null}', () => {
+    const getById = vi.fn();
+    const api = createMockApiClient({ connections: { getById } });
+
+    renderWithProviders(<ConnectionEntityLabel connectionId="ol_connection_abc" name={null} />, {
+      apiClient: api,
+    });
+
+    expect(screen.getByText('Unknown')).toBeInTheDocument();
+    expect(getById).not.toHaveBeenCalled();
+  });
+
+  it('shows a loading placeholder when the caller drives the loading flag', () => {
+    const getById = vi.fn();
+    const api = createMockApiClient({ connections: { getById } });
+
+    renderWithProviders(
+      <ConnectionEntityLabel connectionId="ol_connection_abc" name={null} loading />,
+      { apiClient: api },
+    );
+
+    expect(screen.getByText('…')).toHaveAttribute('aria-busy', 'true');
+    expect(getById).not.toHaveBeenCalled();
+  });
+
   it('falls back to Unknown when the API errors', async () => {
     const api = createMockApiClient({
       connections: {

--- a/apps/web/src/features/connections/components/ConnectionEntityLabel.tsx
+++ b/apps/web/src/features/connections/components/ConnectionEntityLabel.tsx
@@ -7,17 +7,30 @@ interface ConnectionEntityLabelProps {
   className?: string;
   connectionId: string;
   linkToDetail?: boolean;
+  /**
+   * Caller-resolved name. `undefined` means "resolve it yourself" (the
+   * detail-page convention); passing a value - including `null` for a
+   * connection that could not be resolved - suppresses the per-row fetch so a
+   * list page can serve every row from one batched read (#1996).
+   */
+  name?: string | null;
+  loading?: boolean;
   showId?: boolean;
+  showCopy?: boolean;
 }
 
 export function ConnectionEntityLabel({
   className,
   connectionId,
   linkToDetail = true,
+  name,
+  loading,
   showId = true,
+  showCopy = true,
 }: ConnectionEntityLabelProps): ReactElement | null {
   const location = useLocation();
-  const query = useConnectionQuery(connectionId);
+  const nameSupplied = name !== undefined;
+  const query = useConnectionQuery(connectionId, { enabled: !nameSupplied });
 
   if (!connectionId) return null;
 
@@ -28,9 +41,10 @@ export function ConnectionEntityLabel({
   return (
     <EntityLabel
       id={connectionId}
-      name={query.data?.name}
-      loading={query.isLoading}
+      name={nameSupplied ? name : query.data?.name}
+      loading={loading ?? (!nameSupplied && query.isLoading)}
       showId={showId}
+      showCopy={showCopy}
       to={shouldLink ? targetPath : undefined}
       className={className}
     />

--- a/apps/web/src/features/connections/hooks/use-connection-query.ts
+++ b/apps/web/src/features/connections/hooks/use-connection-query.ts
@@ -3,11 +3,19 @@ import { connectionsQueryKeys } from '../api/connections.query-keys';
 import type { Connection } from '../api/connections.types';
 import { useApiClient } from '../../../app/api/api-client-provider';
 
-export function useConnectionQuery(connectionId: string): UseQueryResult<Connection> {
+/**
+ * `enabled` lets a composite opt the per-row fetch out when its page already
+ * resolved the connection from a single batched `useConnectionsQuery()` read
+ * (#1996) - the hook still runs unconditionally, so hook order is stable.
+ */
+export function useConnectionQuery(
+  connectionId: string,
+  options?: { enabled?: boolean },
+): UseQueryResult<Connection> {
   const apiClient = useApiClient();
 
   return useQuery({
-    enabled: connectionId.length > 0,
+    enabled: connectionId.length > 0 && (options?.enabled ?? true),
     queryKey: connectionsQueryKeys.detail(connectionId),
     queryFn: () => apiClient.connections.getById(connectionId),
   });

--- a/apps/web/src/features/connections/index.ts
+++ b/apps/web/src/features/connections/index.ts
@@ -81,6 +81,8 @@ export {
 } from './components/infakt-webhook-config';
 
 export { ConnectionEntityLabel } from './components/ConnectionEntityLabel';
+export { ConnectionCell } from './components/ConnectionCell';
+export type { ConnectionCellProps } from './components/ConnectionCell';
 export { PrestashopRateLimitReadout } from './components/prestashop-rate-limit-readout';
 export { AllegroSellerDefaultsSection } from './components/allegro-seller-defaults-section';
 export { CapabilityTogglesSection } from './components/CapabilityTogglesSection';

--- a/apps/web/src/features/connections/index.ts
+++ b/apps/web/src/features/connections/index.ts
@@ -82,7 +82,7 @@ export {
 
 export { ConnectionEntityLabel } from './components/ConnectionEntityLabel';
 export { ConnectionCell } from './components/ConnectionCell';
-export type { ConnectionCellProps } from './components/ConnectionCell';
+export type { ConnectionCellProps, ConnectionCellFacts } from './components/ConnectionCell';
 export { PrestashopRateLimitReadout } from './components/prestashop-rate-limit-readout';
 export { AllegroSellerDefaultsSection } from './components/allegro-seller-defaults-section';
 export { CapabilityTogglesSection } from './components/CapabilityTogglesSection';

--- a/apps/web/src/features/shipments/lib/shipment-severity.ts
+++ b/apps/web/src/features/shipments/lib/shipment-severity.ts
@@ -9,29 +9,19 @@
  *
  * @module apps/web/src/features/shipments/lib
  */
+import { shortenId } from '../../../shared/ui/entity-label';
 import type { Shipment } from '../api/shipments.types';
 import { isPreWaybill } from './shipment-action-eligibility';
 
-const OL_ID_PATTERN = /^(ol_[a-z][a-z0-9-]*_)(.+)$/;
-
 /**
  * Truncates an order id for use as `EntityLabel`'s `name` (#1826 AC —
- * `EntityLabel` never truncates `name` itself, only its own `id` chip via a
- * private `shortenId`; with `showId={false}` and `name` set to the raw id,
- * the real component would render the full untruncated id as link text,
- * blowing out row density). Mirrors `shortenId`'s own prefix + first-4…last-2
- * algorithm exactly, so both id renderings look consistent.
+ * `EntityLabel` never truncates `name` itself, only its own `id` chip; with
+ * `showId={false}` and `name` set to the raw id, it would render the full
+ * untruncated id as link text, blowing out row density). This was a byte-copy
+ * of that algorithm while `shortenId` was private to `EntityLabel`; #2027
+ * exported it, so the copy is now an alias and the two cannot drift.
  */
-export function truncateOrderId(orderId: string): string {
-  const match = OL_ID_PATTERN.exec(orderId);
-  if (match) {
-    const [, prefix, rest] = match;
-    if (rest.length <= 6) return orderId;
-    return `${prefix}${rest.slice(0, 4)}…${rest.slice(-2)}`;
-  }
-  if (orderId.length <= 14) return orderId;
-  return `${orderId.slice(0, 8)}…${orderId.slice(-4)}`;
-}
+export const truncateOrderId = shortenId;
 
 export type ShipmentSeverity = 'Fix' | 'Finish' | 'Send' | 'View';
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -9370,6 +9370,36 @@ a.kpi-card:focus-visible {
   transform: translateX(0);
 }
 
+/* ── ConnectionCell (#2027) ──────────────────────────────────────────
+ * Two-line composition: EntityLabel (name + link) on line 1, CopyableId
+ * (shortened id + hover-Copy) on line 2. EntityLabel's own Copy button is
+ * always-visible by design elsewhere, but here it would duplicate
+ * CopyableId's hover-reveal Copy of the same id with no benefit, so it's
+ * hidden within this cell's scope.
+ */
+.connection-cell {
+  display: inline-flex;
+  align-items: flex-start;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.connection-cell__body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  align-items: flex-start;
+  min-width: 0;
+}
+
+.connection-cell__body > * {
+  max-width: 100%;
+}
+
+.connection-cell .entity-label__copy {
+  display: none;
+}
+
 /* ── Structured error list (#775) ───────────────────────────────────
  * Compact tone-tinted rows that replace the "wall of red pills"
  * treatment for repeated errors on connection-detail health tabs.

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -9377,6 +9377,9 @@ a.kpi-card:focus-visible {
  * .orders-carrier :8922) - without it the cell is content-sized inside an
  * auto-layout table, so a long connection name widens the column instead of
  * firing the children's own ellipsis.
+ *
+ * Gaps are raw px throughout: 2px and 6px have no token at this density, and
+ * mixing them with var(--space-*) inside one block reads as an accident.
  */
 .connection-cell {
   display: inline-flex;
@@ -9417,28 +9420,57 @@ a.kpi-card:focus-visible {
   min-width: 0;
 }
 
+/* The shortened id is the disambiguator an operator scans, so it never absorbs
+ * the line's width deficit - the status note is the accessory that truncates. */
+.connection-cell__meta > .copyable-id {
+  flex: none;
+}
+
 .connection-cell__status {
   display: inline-flex;
   align-items: center;
-  flex: none;
-  gap: var(--space-1);
+  gap: 4px;
+  min-width: 0;
   font-size: 0.6875rem;
   color: var(--text-muted);
+}
+
+.connection-cell__status-label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .connection-cell__status-dot {
   width: 6px;
   height: 6px;
+  flex: none;
   border-radius: var(--radius-pill);
-  background: var(--status-disabled);
+  background: var(--text-muted);
+}
+
+/* The -fg family, not the raw hue: --status-warning is ~2.5:1 on white, under
+ * the 3:1 WCAG 1.4.11 non-text minimum, so a 6px amber dot vanishes in light
+ * theme. Every status carries an explicit modifier so a fourth one added later
+ * fails visibly instead of silently inheriting the neutral base. */
+.connection-cell__status--disabled .connection-cell__status-dot {
+  background: var(--status-disabled-fg);
+}
+
+.connection-cell__status--error {
+  color: var(--status-error-fg);
 }
 
 .connection-cell__status--error .connection-cell__status-dot {
-  background: var(--status-error);
+  background: var(--status-error-fg);
+}
+
+.connection-cell__status--needs_reauth {
+  color: var(--status-warning-fg);
 }
 
 .connection-cell__status--needs_reauth .connection-cell__status-dot {
-  background: var(--status-warning);
+  background: var(--status-warning-fg);
 }
 
 /* ── Structured error list (#775) ───────────────────────────────────

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -9441,18 +9441,20 @@ a.kpi-card:focus-visible {
   white-space: nowrap;
 }
 
+/* No base background: every status supplies its own below, so a fourth one
+ * added later renders no dot at all rather than a silent grey one that reads
+ * as a deliberate tone. The TS side is already exhaustive (STATUS_NOTES is a
+ * Record over every non-active ConnectionStatus), so the two fail together. */
 .connection-cell__status-dot {
   width: 6px;
   height: 6px;
   flex: none;
   border-radius: var(--radius-pill);
-  background: var(--text-muted);
 }
 
 /* The -fg family, not the raw hue: --status-warning is ~2.5:1 on white, under
  * the 3:1 WCAG 1.4.11 non-text minimum, so a 6px amber dot vanishes in light
- * theme. Every status carries an explicit modifier so a fourth one added later
- * fails visibly instead of silently inheriting the neutral base. */
+ * theme. */
 .connection-cell__status--disabled .connection-cell__status-dot {
   background: var(--status-disabled-fg);
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -9371,16 +9371,16 @@ a.kpi-card:focus-visible {
 }
 
 /* ── ConnectionCell (#2027) ──────────────────────────────────────────
- * Two-line composition: EntityLabel (name + link) on line 1, CopyableId
- * (shortened id + hover-Copy) on line 2. EntityLabel's own Copy button is
- * always-visible by design elsewhere, but here it would duplicate
- * CopyableId's hover-reveal Copy of the same id with no benefit, so it's
- * hidden within this cell's scope.
+ * Two-line composition: adornment + name link on line 1, shortened id with
+ * hover-Copy plus an attention-only status note on line 2. The 220px cap
+ * matches the neighbouring stacked cells (.orders-items-line :8852,
+ * .orders-carrier :8922) - without it the cell is content-sized inside an
+ * auto-layout table, so a long connection name widens the column instead of
+ * firing the children's own ellipsis.
  */
 .connection-cell {
   display: inline-flex;
   align-items: flex-start;
-  gap: var(--space-2);
   min-width: 0;
 }
 
@@ -9390,14 +9390,55 @@ a.kpi-card:focus-visible {
   gap: 2px;
   align-items: flex-start;
   min-width: 0;
+  max-width: 220px;
 }
 
 .connection-cell__body > * {
   max-width: 100%;
 }
 
-.connection-cell .entity-label__copy {
-  display: none;
+.connection-cell__line {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.connection-cell__adornment {
+  display: inline-flex;
+  align-items: center;
+  flex: none;
+}
+
+.connection-cell__meta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-width: 0;
+}
+
+.connection-cell__status {
+  display: inline-flex;
+  align-items: center;
+  flex: none;
+  gap: var(--space-1);
+  font-size: 0.6875rem;
+  color: var(--text-muted);
+}
+
+.connection-cell__status-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: var(--radius-pill);
+  background: var(--status-disabled);
+}
+
+.connection-cell__status--error .connection-cell__status-dot {
+  background: var(--status-error);
+}
+
+.connection-cell__status--needs_reauth .connection-cell__status-dot {
+  background: var(--status-warning);
 }
 
 /* ── Structured error list (#775) ───────────────────────────────────

--- a/apps/web/src/shared/ui/copyable-id.test.tsx
+++ b/apps/web/src/shared/ui/copyable-id.test.tsx
@@ -1,0 +1,75 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { CopyableId } from './copyable-id';
+
+const ID = 'aa966882-0d21-4e2f-9d5a-71c4a5f14cfb';
+
+/**
+ * Keeps the real Navigator prototype (happy-dom internals and React's scheduler
+ * both read off it) while overriding only `clipboard`, and stays restorable via
+ * `vi.unstubAllGlobals()` — unlike a bare `Object.defineProperty(navigator, …)`.
+ */
+function stubClipboard(): ReturnType<typeof vi.fn> {
+  const writeText = vi.fn().mockResolvedValue(undefined);
+  vi.stubGlobal(
+    'navigator',
+    Object.create(navigator, { clipboard: { value: { writeText }, configurable: true } }),
+  );
+  return writeText;
+}
+
+describe('CopyableId', () => {
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it('renders the full id when no label is given', () => {
+    render(<CopyableId id={ID} />);
+    expect(screen.getByText(ID)).toBeInTheDocument();
+  });
+
+  it('renders the shorter label while still copying the full id', () => {
+    const writeText = stubClipboard();
+    render(<CopyableId id={ID} label="aa966882…4cfb" />);
+
+    expect(screen.getByText('aa966882…4cfb')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button'));
+
+    expect(writeText).toHaveBeenCalledWith(ID);
+  });
+
+  it('names the copy button after the raw id by default', () => {
+    render(<CopyableId id={ID} />);
+    expect(screen.getByRole('button', { name: `Copy ${ID}` })).toBeInTheDocument();
+  });
+
+  it('uses copyLabel and copiedLabel for the accessible name when supplied', async () => {
+    stubClipboard();
+    render(
+      <CopyableId
+        id={ID}
+        copyLabel="Copy connection ID for Erli Demo"
+        copiedLabel="Copied connection ID for Erli Demo"
+      />,
+    );
+
+    const button = screen.getByRole('button', { name: 'Copy connection ID for Erli Demo' });
+    fireEvent.click(button);
+
+    expect(
+      await screen.findByRole('button', { name: 'Copied connection ID for Erli Demo' }),
+    ).toBeInTheDocument();
+  });
+
+  it('merges a custom className with the internal classes', () => {
+    const { container } = render(<CopyableId id={ID} className="custom" />);
+    expect(container.firstElementChild).toHaveClass('copyable-id', 'custom');
+  });
+
+  it('forwards the ref to the root span', () => {
+    const ref = { current: null as HTMLSpanElement | null };
+    render(<CopyableId id={ID} ref={ref} />);
+    expect(ref.current).toBeInstanceOf(HTMLSpanElement);
+  });
+});

--- a/apps/web/src/shared/ui/copyable-id.tsx
+++ b/apps/web/src/shared/ui/copyable-id.tsx
@@ -24,10 +24,18 @@ interface CopyableIdProps extends Omit<ComponentPropsWithoutRef<'span'>, 'childr
   id: string;
   /** Optional shorter display label. Defaults to the full id. */
   label?: string;
+  /**
+   * Accessible name of the copy button. Defaults to `Copy {id}`, which reads
+   * as a spelled-out UUID; a caller that can resolve the id to something
+   * human ("Copy connection ID for Erli Demo") should pass it (#1996).
+   */
+  copyLabel?: string;
+  /** Accessible name once the copy succeeded. Defaults to `Copied {id}`. */
+  copiedLabel?: string;
 }
 
 export const CopyableId = forwardRef<HTMLSpanElement, CopyableIdProps>(function CopyableId(
-  { id, label, className = '', ...props },
+  { id, label, copyLabel, copiedLabel, className = '', ...props },
   ref,
 ): ReactElement {
   const [copied, setCopied] = useState(false);
@@ -65,7 +73,7 @@ export const CopyableId = forwardRef<HTMLSpanElement, CopyableIdProps>(function 
         type="button"
         className="copyable-id__copy"
         onClick={handleCopy}
-        aria-label={copied ? `Copied ${id}` : `Copy ${id}`}
+        aria-label={copied ? (copiedLabel ?? `Copied ${id}`) : (copyLabel ?? `Copy ${id}`)}
       >
         {copied ? 'Copied' : 'Copy'}
       </button>

--- a/apps/web/src/shared/ui/entity-label.test.tsx
+++ b/apps/web/src/shared/ui/entity-label.test.tsx
@@ -54,6 +54,20 @@ describe('EntityLabel', () => {
     expect(screen.queryByText(/ol_conn/)).toBeNull();
   });
 
+  it('hides the copy button when showCopy={false}', () => {
+    renderWithRouter(<EntityLabel id="ol_connection_abc123" name="Store" showCopy={false} />);
+    expect(screen.queryByRole('button')).toBeNull();
+    expect(screen.getByText('Store')).toBeInTheDocument();
+  });
+
+  it('exposes the full name as a title on the non-link name', () => {
+    renderWithRouter(<EntityLabel id="ol_connection_abc" name="Warehouse EU - Warszawa" />);
+    expect(screen.getByText('Warehouse EU - Warszawa')).toHaveAttribute(
+      'title',
+      'Warehouse EU - Warszawa',
+    );
+  });
+
   it('renders the copy control as an explicit type=button', () => {
     renderWithRouter(<EntityLabel id="ol_connection_abc" name="Store" />);
     const copy = screen.getByRole('button', { name: /Copy ol_connection/ });

--- a/apps/web/src/shared/ui/entity-label.tsx
+++ b/apps/web/src/shared/ui/entity-label.tsx
@@ -13,6 +13,12 @@ interface EntityLabelProps extends Omit<ComponentPropsWithoutRef<'span'>, 'id'> 
   loading?: boolean;
   name?: string | null;
   showId?: boolean;
+  /**
+   * Composites that pair this label with their own copy affordance (e.g.
+   * `ConnectionCell`'s `CopyableId` line) opt the built-in button out, so the
+   * same id never grows two copy controls (#2027).
+   */
+  showCopy?: boolean;
   to?: string;
   /**
    * Fired when the inner name link is clicked (navigation), never when the
@@ -23,7 +29,17 @@ interface EntityLabelProps extends Omit<ComponentPropsWithoutRef<'span'>, 'id'> 
 }
 
 export const EntityLabel = forwardRef<HTMLSpanElement, EntityLabelProps>(function EntityLabel(
-  { id, loading = false, name, showId = true, to, onNavigate, className = '', ...props },
+  {
+    id,
+    loading = false,
+    name,
+    showId = true,
+    showCopy = true,
+    to,
+    onNavigate,
+    className = '',
+    ...props
+  },
   ref,
 ) {
   const [copied, setCopied] = useState(false);
@@ -63,7 +79,12 @@ export const EntityLabel = forwardRef<HTMLSpanElement, EntityLabelProps>(functio
     </span>
   ) : resolvedName ? (
     to ? (
-      <Link to={to} className="entity-label__name entity-label__name--link" onClick={onNavigate}>
+      <Link
+        to={to}
+        className="entity-label__name entity-label__name--link"
+        onClick={onNavigate}
+        title={resolvedName}
+      >
         {resolvedName}
       </Link>
     ) : (
@@ -83,14 +104,16 @@ export const EntityLabel = forwardRef<HTMLSpanElement, EntityLabelProps>(functio
           {shortenId(id)}
         </code>
       ) : null}
-      <button
-        type="button"
-        className="entity-label__copy"
-        onClick={handleCopy}
-        aria-label={copied ? `Copied ${id}` : `Copy ${id}`}
-      >
-        {copied ? 'Copied' : 'Copy'}
-      </button>
+      {showCopy ? (
+        <button
+          type="button"
+          className="entity-label__copy"
+          onClick={handleCopy}
+          aria-label={copied ? `Copied ${id}` : `Copy ${id}`}
+        >
+          {copied ? 'Copied' : 'Copy'}
+        </button>
+      ) : null}
     </span>
   );
 });

--- a/apps/web/src/shared/ui/entity-label.tsx
+++ b/apps/web/src/shared/ui/entity-label.tsx
@@ -97,7 +97,12 @@ export const EntityLabel = forwardRef<HTMLSpanElement, EntityLabelProps>(functio
 
 const OL_ID_PATTERN = /^(ol_[a-z][a-z0-9-]*_)(.+)$/;
 
-function shortenId(id: string): string {
+/**
+ * Shared id-shortening rule (#2027). Exported so composites like
+ * `ConnectionCell` that pair `EntityLabel` with `CopyableId` reuse the exact
+ * same shortening algorithm instead of growing a second implementation.
+ */
+export function shortenId(id: string): string {
   const match = OL_ID_PATTERN.exec(id);
   if (match) {
     const [, prefix, rest] = match;

--- a/apps/web/src/shared/ui/entity-label.tsx
+++ b/apps/web/src/shared/ui/entity-label.tsx
@@ -88,7 +88,9 @@ export const EntityLabel = forwardRef<HTMLSpanElement, EntityLabelProps>(functio
         {resolvedName}
       </Link>
     ) : (
-      <span className="entity-label__name">{resolvedName}</span>
+      <span className="entity-label__name" title={resolvedName}>
+        {resolvedName}
+      </span>
     )
   ) : (
     <span className="entity-label__name entity-label__name--unknown" title={id}>

--- a/apps/web/src/shared/ui/index.ts
+++ b/apps/web/src/shared/ui/index.ts
@@ -67,7 +67,7 @@ export { MetricCard } from './metric-card';
 export { KpiCard } from './kpi-card';
 
 // ── Identity / labels ──────────────────────────────────────────────
-export { EntityLabel } from './entity-label';
+export { EntityLabel, shortenId } from './entity-label';
 export { ProductThumbnail } from './product-thumbnail';
 export { CopyableId } from './copyable-id';
 export { DensityToggle, useDensity } from './density-toggle';


### PR DESCRIPTION
## What changed

Adds `ConnectionCell` at `apps/web/src/features/connections/components/ConnectionCell.tsx` - the two-line
connection identity cell specified in #1996 but never implemented:

- Line 1: connection name as a link to `/connections/:id` (composes `EntityLabel` with `showId={false}`)
- Line 2: shortened connection UUID with a hover-reveal Copy button (composes `CopyableId`)
- Optional `adornment` slot for a channel pill, per #1996's spec - unused by Listings itself, since
  Channel is its own column there, but present so later consumers can pass one

Also exports `shortenId` from `apps/web/src/shared/ui/entity-label.tsx` so both cells shorten ids the
same way, and adds the accompanying CSS in `apps/web/src/index.css`.

## Why

Six list pages render the same two facts (which connection a row came from, and its id) six different
ways, so an operator cannot recognise a record without opening its detail page. #1996 specified one
shared cell to collapse that. This lands the component itself.

## Scope

**No page consumes it yet.** Listings wires it up in #2028; migrating the other five lists
(Orders, Shipments, Invoices, Products, Customers) to it is a deliberate follow-up after this epic
ships, not part of #2023.

## Tests

`ConnectionCell.test.tsx` covers name+link render, shortened id, copy behaviour, loading state, and the
missing-name fallback. Test execution is deferred to CI per this repo's local-machine constraint;
`pnpm lint` and `pnpm type-check` pass clean locally.

Refs #2027