### PR TITLE
feat(web/listings): redesign the listings table per the #1965 mockup (#2028)

### DIFF
--- a/apps/web/src/features/listings/api/listings.types.ts
+++ b/apps/web/src/features/listings/api/listings.types.ts
@@ -5,14 +5,6 @@
  * backend OfferMappingResponseDto and PaginatedOfferMappingsResponseDto contracts.
  * All date fields are ISO 8601 strings.
  *
- * `OfferMapping` deliberately does NOT yet model the list-only `identity`,
- * `channelStatus` and `commercial` projections #2025 added - the current table
- * renders none of them, so they are modelled where they are consumed (#2028 /
- * #2029). Two things to carry over when they are: `channelStatus` is
- * non-nullable on a list row, and its `lifecycle` has FIVE values, not the
- * four tabs of the #1965 mockup (`Unsynced` was added deliberately - see the
- * union's docblock in core for what it does and does not promise).
- *
  * @module apps/web/src/features/listings/api
  */
 
@@ -24,6 +16,85 @@
 export const KNOWN_MAPPING_ENTITY_TYPES = ['Product', 'ProductVariant', 'InventoryItem'] as const;
 export type KnownMappingEntityType = (typeof KNOWN_MAPPING_ENTITY_TYPES)[number];
 
+/**
+ * The lifecycle buckets a list row is partitioned into. FIVE values, not the
+ * four tabs of the #1965 mockup: `Unsynced` is a deliberate #2025 addition for
+ * a mapping no status has ever been read for.
+ *
+ * `Unsynced` is NOT a promise that the row will resolve shortly, and UI copy
+ * must never say so. A successful wizard create lands here (the creation poller
+ * reconciles only on timeout and draft, tracked as #2039), and on a connection
+ * whose status-sync task is not scheduled - Erli's is opt-in and default OFF -
+ * it is permanent. It also does not mean unlisted: the duplicate guard reads an
+ * absent snapshot as still-listed.
+ */
+export const OFFER_LIFECYCLE_VALUES = [
+  'Active',
+  'Inactive',
+  'Draft',
+  'Ended',
+  'Unsynced',
+] as const;
+export type OfferLifecycle = (typeof OFFER_LIFECYCLE_VALUES)[number];
+
+/** Catalog identity of the variant a list row's mapping points at (#2025). */
+export interface OfferMappingIdentity {
+  productId: string;
+  /**
+   * `products.name` is NOT NULL behind a real FK, so null here means a corrupt
+   * row - report it rather than rendering a blank cell.
+   */
+  productName: string | null;
+  /** Null for a simple product's synthetic variant. */
+  variantLabel: string | null;
+  sku: string | null;
+  ean: string | null;
+  /** The owning product's first image; there is no dedicated thumbnail column. */
+  imageUrl: string | null;
+  /**
+   * The linked variant's master record is gone (#1689). Its offers should have
+   * been paused, but the quantity is not necessarily zero: on a connection with
+   * seller-frozen stock the pause is a documented no-op. `isStale` together
+   * with a non-zero `availableQuantity` is a live listing for a product that no
+   * longer exists - the overselling case, and worth louder treatment than an
+   * ordinary chip.
+   */
+  isStale: boolean;
+}
+
+/** Live channel publication state plus its derived lifecycle bucket (#2025). */
+export interface OfferMappingChannelStatus {
+  /** Null exactly when `lifecycle` is `Unsynced`. */
+  publicationStatus: OfferPublicationStatus | null;
+  lifecycle: OfferLifecycle;
+  /** Marketplace validator messages; empty when the validator raised none. */
+  validationMessages: string[];
+  /** Null exactly when `lifecycle` is `Unsynced`. */
+  lastStatusSyncedAt: string | null;
+}
+
+/**
+ * Channel-side price/quantity with their freshness stamp (#2024).
+ *
+ * Both values are what the CHANNEL reports: the price is already the output of
+ * the connection's `pricingRule` (#1843) and the quantity is already net of its
+ * `stockSafetyBuffer` (#1844). Surface them as "on channel", never as OL's own
+ * price/stock, or a correctly-configured buffer reads as a bug. A null is "not
+ * reported by the marketplace", never zero.
+ */
+export interface OfferMappingCommercial {
+  price: number | null;
+  currency: string | null;
+  availableQuantity: number | null;
+  /**
+   * Always present alongside the values - a both-null observation is never
+   * persisted. The scan is hourly at 100 offers/tick, so a row can legitimately
+   * be days old, which is why the age is surfaced with the values rather than
+   * left implicit.
+   */
+  lastCommercialSyncedAt: string;
+}
+
 export interface OfferMapping {
   id: string;
   entityType: string;
@@ -34,6 +105,22 @@ export interface OfferMapping {
   context: Record<string, unknown> | null;
   createdAt: string;
   updatedAt: string;
+  /**
+   * Populated only by `GET /listings`. Null when `internalId` no longer
+   * resolves to a live variant. Absent on `GET /listings/:id`.
+   */
+  identity?: OfferMappingIdentity | null;
+  /**
+   * Populated on EVERY row of `GET /listings` - a mapping with no snapshot
+   * carries `lifecycle: 'Unsynced'` rather than a null projection. Absent (not
+   * null) on `GET /listings/:id`.
+   */
+  channelStatus?: OfferMappingChannelStatus | null;
+  /**
+   * Populated only by `GET /listings`. Null when no commercial observation has
+   * been persisted for the offer yet.
+   */
+  commercial?: OfferMappingCommercial | null;
   /**
    * Populated only by the detail endpoint (`GET /listings/:id`) for Offer-type
    * mappings that originated from an OL-initiated create. Always absent on

--- a/apps/web/src/features/listings/api/listings.types.ts
+++ b/apps/web/src/features/listings/api/listings.types.ts
@@ -115,7 +115,7 @@ export interface OfferMapping {
    * carries `lifecycle: 'Unsynced'` rather than a null projection. Absent (not
    * null) on `GET /listings/:id`.
    */
-  channelStatus?: OfferMappingChannelStatus | null;
+  channelStatus?: OfferMappingChannelStatus;
   /**
    * Populated only by `GET /listings`. Null when no commercial observation has
    * been persisted for the offer yet.

--- a/apps/web/src/features/listings/lib/listing-row-state.test.ts
+++ b/apps/web/src/features/listings/lib/listing-row-state.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from 'vitest';
+import type { OfferMapping, OfferMappingIdentity } from '../api/listings.types';
+import { isOverselling, listingRowAlert, listingRowBadges } from './listing-row-state';
+
+const IDENTITY: OfferMappingIdentity = {
+  productId: 'ol_product_1',
+  productName: 'Doniczka ceramiczna Terra',
+  variantLabel: 'Terakota 24 cm',
+  sku: 'TERRA-24-TER',
+  ean: '5900000000138',
+  imageUrl: null,
+  isStale: false,
+};
+const STALE_IDENTITY: OfferMappingIdentity = { ...IDENTITY, isStale: true };
+
+function makeRow(overrides: Partial<OfferMapping> = {}): OfferMapping {
+  return {
+    id: 'uuid-1',
+    entityType: 'Offer',
+    internalId: 'ol_variant_abc',
+    externalId: '14829301',
+    platformType: 'erli',
+    connectionId: 'conn-1',
+    context: null,
+    createdAt: '2026-07-21T00:00:00.000Z',
+    updatedAt: '2026-07-21T00:00:00.000Z',
+    identity: IDENTITY,
+    channelStatus: {
+      publicationStatus: 'active',
+      lifecycle: 'Active',
+      validationMessages: [],
+      lastStatusSyncedAt: '2026-07-21T02:10:00.000Z',
+    },
+    commercial: {
+      price: 100,
+      currency: 'PLN',
+      availableQuantity: 41,
+      lastCommercialSyncedAt: '2026-07-21T02:10:00.000Z',
+    },
+    ...overrides,
+  };
+}
+
+describe('listingRowBadges', () => {
+  it('should badge nothing when the offer is plainly active', () => {
+    expect(listingRowBadges(makeRow())).toEqual([]);
+  });
+
+  it('should badge a mid-transition offer with a pulsing info badge', () => {
+    const badges = listingRowBadges(
+      makeRow({
+        channelStatus: {
+          publicationStatus: 'activating',
+          lifecycle: 'Active',
+          validationMessages: [],
+          lastStatusSyncedAt: '2026-07-21T02:12:00.000Z',
+        },
+      }),
+    );
+
+    expect(badges).toHaveLength(1);
+    expect(badges[0]).toMatchObject({ label: 'Activating', tone: 'info', pulse: true });
+  });
+
+  it('should badge a validator-refused offer as Rejected', () => {
+    const badges = listingRowBadges(
+      makeRow({
+        channelStatus: {
+          publicationStatus: 'inactive',
+          lifecycle: 'Inactive',
+          validationMessages: ['Brak wymaganego parametru: Materiał'],
+          lastStatusSyncedAt: '2026-07-20T23:12:00.000Z',
+        },
+      }),
+    );
+
+    expect(badges.map((b) => b.label)).toEqual(['Rejected']);
+  });
+
+  it('should badge an unsynced row without promising it will sync', () => {
+    const badges = listingRowBadges(
+      makeRow({
+        channelStatus: {
+          publicationStatus: null,
+          lifecycle: 'Unsynced',
+          validationMessages: [],
+          lastStatusSyncedAt: null,
+        },
+      }),
+    );
+
+    expect(badges[0]?.label).toBe('Not synced');
+    expect(badges[0]?.title).toBe('No channel status has ever been read for this offer.');
+    expect(badges[0]?.title).not.toMatch(/soon|shortly|will sync/i);
+  });
+
+  it('should badge a stale variant even when the channel reports no stock', () => {
+    const badges = listingRowBadges(
+      makeRow({
+        identity: STALE_IDENTITY,
+        commercial: {
+          price: 100,
+          currency: 'PLN',
+          availableQuantity: 0,
+          lastCommercialSyncedAt: '2026-07-21T02:10:00.000Z',
+        },
+      }),
+    );
+
+    expect(badges[0]).toMatchObject({ label: 'Product deleted', tone: 'error', solid: false });
+  });
+
+  it('should escalate a stale variant that still has channel stock to a solid badge', () => {
+    const badges = listingRowBadges(makeRow({ identity: STALE_IDENTITY }));
+
+    expect(badges[0]).toMatchObject({
+      label: 'Selling deleted product',
+      tone: 'error',
+      solid: true,
+    });
+  });
+
+  it('should keep both the stale badge and the lifecycle badge when a row earns each', () => {
+    const badges = listingRowBadges(
+      makeRow({
+        identity: STALE_IDENTITY,
+        channelStatus: {
+          publicationStatus: 'inactive',
+          lifecycle: 'Inactive',
+          validationMessages: ['Zdjęcie główne poniżej wymaganej rozdzielczości'],
+          lastStatusSyncedAt: '2026-07-20T22:40:00.000Z',
+        },
+      }),
+    );
+
+    expect(badges.map((b) => b.label)).toEqual(['Selling deleted product', 'Rejected']);
+  });
+});
+
+describe('isOverselling', () => {
+  it('should be false when the quantity is not reported, never treating null as stock', () => {
+    expect(
+      isOverselling(
+        makeRow({
+          identity: STALE_IDENTITY,
+          commercial: {
+            price: 100,
+            currency: 'PLN',
+            availableQuantity: null,
+            lastCommercialSyncedAt: '2026-07-21T02:10:00.000Z',
+          },
+        }),
+      ),
+    ).toBe(false);
+  });
+
+  it('should be false for a live variant with stock', () => {
+    expect(isOverselling(makeRow())).toBe(false);
+  });
+});
+
+describe('listingRowAlert', () => {
+  it('should return no alert for a healthy row', () => {
+    expect(listingRowAlert(makeRow())).toBeNull();
+  });
+
+  it('should surface the first validator message verbatim', () => {
+    const alert = listingRowAlert(
+      makeRow({
+        channelStatus: {
+          publicationStatus: 'inactive',
+          lifecycle: 'Inactive',
+          validationMessages: ['Brak wymaganego parametru: Materiał', 'second'],
+          lastStatusSyncedAt: '2026-07-20T23:12:00.000Z',
+        },
+      }),
+    );
+
+    expect(alert?.text).toBe('Brak wymaganego parametru: Materiał');
+  });
+
+  it('should outrank a validator message with the overselling warning', () => {
+    const alert = listingRowAlert(
+      makeRow({
+        identity: STALE_IDENTITY,
+        channelStatus: {
+          publicationStatus: 'inactive',
+          lifecycle: 'Inactive',
+          validationMessages: ['Brak wymaganego parametru: Materiał'],
+          lastStatusSyncedAt: '2026-07-20T23:12:00.000Z',
+        },
+      }),
+    );
+
+    expect(alert?.text).toBe('Still 41 available on channel - the master product no longer exists');
+  });
+});

--- a/apps/web/src/features/listings/lib/listing-row-state.test.ts
+++ b/apps/web/src/features/listings/lib/listing-row-state.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import type { OfferMapping, OfferMappingIdentity } from '../api/listings.types';
-import { isOverselling, listingRowAlert, listingRowBadges } from './listing-row-state';
+import { isOverselling, isUnlinked, listingRowAlert, listingRowBadges } from './listing-row-state';
 
 const IDENTITY: OfferMappingIdentity = {
   productId: 'ol_product_1',
@@ -62,7 +62,9 @@ describe('listingRowBadges', () => {
     expect(badges[0]).toMatchObject({ label: 'Activating', tone: 'info', pulse: true });
   });
 
-  it('should badge a validator-refused offer as Rejected', () => {
+  // NOT "Rejected": the bucket is `inactive` PLUS validator messages, which a
+  // seller who deactivated the offer himself also satisfies.
+  it('should label a validator-flagged inactive offer as Inactive, not Rejected', () => {
     const badges = listingRowBadges(
       makeRow({
         channelStatus: {
@@ -74,7 +76,9 @@ describe('listingRowBadges', () => {
       }),
     );
 
-    expect(badges.map((b) => b.label)).toEqual(['Rejected']);
+    expect(badges.map((b) => b.label)).toEqual(['Inactive']);
+    expect(badges[0]?.title).toMatch(/validator errors/i);
+    expect(badges[0]?.title).not.toMatch(/refused|rejected/i);
   });
 
   it('should badge an unsynced row without promising it will sync', () => {
@@ -90,11 +94,30 @@ describe('listingRowBadges', () => {
     );
 
     expect(badges[0]?.label).toBe('Not synced');
+    // The copy states only what has happened, never what is coming next.
     expect(badges[0]?.title).toBe('No channel status has ever been read for this offer.');
-    expect(badges[0]?.title).not.toMatch(/soon|shortly|will sync/i);
   });
 
-  it('should badge a stale variant even when the channel reports no stock', () => {
+  it('should keep Draft, Ended and Not synced all soft, reserving solid for escalation', () => {
+    const soft = (['Draft', 'Ended', 'Unsynced'] as const).map(
+      (lifecycle) =>
+        listingRowBadges(
+          makeRow({
+            channelStatus: {
+              publicationStatus: null,
+              lifecycle,
+              validationMessages: [],
+              lastStatusSyncedAt: null,
+            },
+          }),
+        )[0],
+    );
+
+    expect(soft.map((b) => b?.label)).toEqual(['Draft', 'Ended', 'Not synced']);
+    expect(soft.every((b) => b?.tone === 'neutral' && !b?.solid)).toBe(true);
+  });
+
+  it('should badge a stale variant as paused when the channel reports no stock', () => {
     const badges = listingRowBadges(
       makeRow({
         identity: STALE_IDENTITY,
@@ -108,6 +131,42 @@ describe('listingRowBadges', () => {
     );
 
     expect(badges[0]).toMatchObject({ label: 'Product deleted', tone: 'error', solid: false });
+    expect(badges[0]?.title).toMatch(/the pause took effect/i);
+  });
+
+  // The third branch: no commercial snapshot exists at all, which on a
+  // connection whose status-sync task is off is EVERY row.
+  it('should not claim a stale offer was paused when no channel quantity was ever read', () => {
+    const badges = listingRowBadges(makeRow({ identity: STALE_IDENTITY, commercial: null }));
+
+    expect(badges[0]).toMatchObject({ label: 'Product deleted', tone: 'error', solid: false });
+    expect(badges[0]?.title).toMatch(/not known whether this offer was paused/i);
+    expect(badges[0]?.title).not.toMatch(/should have been paused|pause took effect/i);
+  });
+
+  it('should badge a mapping with no linked variant, escalating when it still has channel stock', () => {
+    const paused = listingRowBadges(
+      makeRow({
+        identity: null,
+        commercial: {
+          price: 100,
+          currency: 'PLN',
+          availableQuantity: 0,
+          lastCommercialSyncedAt: '2026-07-21T02:10:00.000Z',
+        },
+      }),
+    );
+    const selling = listingRowBadges(makeRow({ identity: null }));
+
+    expect(paused[0]).toMatchObject({ id: 'unlinked', tone: 'error', solid: false });
+    expect(selling[0]).toMatchObject({ id: 'unlinked', tone: 'error', solid: true });
+  });
+
+  it('should leave an absent identity projection unbadged, since absence is not a missing variant', () => {
+    // `undefined` = the detail endpoint does not populate identity at all.
+    expect(listingRowBadges(makeRow({ identity: undefined })).map((b) => b.id)).not.toContain(
+      'unlinked',
+    );
   });
 
   it('should escalate a stale variant that still has channel stock to a solid badge', () => {
@@ -133,7 +192,15 @@ describe('listingRowBadges', () => {
       }),
     );
 
-    expect(badges.map((b) => b.label)).toEqual(['Selling deleted product', 'Rejected']);
+    expect(badges.map((b) => b.label)).toEqual(['Selling deleted product', 'Inactive']);
+  });
+});
+
+describe('isUnlinked', () => {
+  it('should be true only for an explicitly null identity projection', () => {
+    expect(isUnlinked(makeRow({ identity: null }))).toBe(true);
+    expect(isUnlinked(makeRow({ identity: undefined }))).toBe(false);
+    expect(isUnlinked(makeRow())).toBe(false);
   });
 });
 
@@ -152,6 +219,10 @@ describe('isOverselling', () => {
         }),
       ),
     ).toBe(false);
+  });
+
+  it('should be false when no commercial snapshot was ever persisted', () => {
+    expect(isOverselling(makeRow({ identity: STALE_IDENTITY, commercial: null }))).toBe(false);
   });
 
   it('should be false for a live variant with stock', () => {
@@ -193,5 +264,18 @@ describe('listingRowAlert', () => {
     );
 
     expect(alert?.text).toBe('Still 41 available on channel - the master product no longer exists');
+  });
+
+  it('should warn when an unlinked mapping still has channel stock', () => {
+    const alert = listingRowAlert(makeRow({ identity: null }));
+
+    expect(alert?.text).toBe(
+      'Still 41 available on channel - no OpenLinker product is linked to this listing',
+    );
+  });
+
+  it('should not invent an overselling line when the quantity was never read', () => {
+    expect(listingRowAlert(makeRow({ identity: null, commercial: null }))).toBeNull();
+    expect(listingRowAlert(makeRow({ identity: STALE_IDENTITY, commercial: null }))).toBeNull();
   });
 });

--- a/apps/web/src/features/listings/lib/listing-row-state.ts
+++ b/apps/web/src/features/listings/lib/listing-row-state.ts
@@ -34,14 +34,53 @@ export interface ListingRowAlert {
 }
 
 /**
+ * What the channel's own stock reading says about a row whose OL side is
+ * broken. `unknown` is a first-class answer, not a synonym for zero: on a
+ * connection whose offer-status sync has never run (Erli ships its scheduler
+ * task opt-in and off) EVERY row lands here, and claiming an offer "should
+ * have been paused" on a reading OL never took would be a fabrication.
+ */
+type ChannelStockSignal = 'selling' | 'paused' | 'unknown';
+
+function channelStockSignal(row: OfferMapping): ChannelStockSignal {
+  const quantity = row.commercial?.availableQuantity;
+  if (quantity == null) return 'unknown';
+  return quantity > 0 ? 'selling' : 'paused';
+}
+
+/**
  * The overselling case: a live listing for a product whose master record is
  * gone. `isStale` alone is not enough - the pause normally zeroes the offer, so
  * a non-zero channel quantity is what makes it sellable.
  */
 export function isOverselling(row: OfferMapping): boolean {
-  const quantity = row.commercial?.availableQuantity;
-  return Boolean(row.identity?.isStale) && quantity != null && quantity > 0;
+  return Boolean(row.identity?.isStale) && channelStockSignal(row) === 'selling';
 }
+
+/**
+ * A mapping whose `internalId` no longer resolves to any variant. Strictly
+ * `null`, never `undefined`: the detail endpoint omits the projection entirely,
+ * and an absent projection says nothing about whether a variant exists.
+ */
+export function isUnlinked(row: OfferMapping): boolean {
+  return row.identity === null;
+}
+
+const STALE_TITLE: Record<ChannelStockSignal, string> = {
+  selling:
+    'The master product is gone but the channel still reports stock, so this offer can still sell.',
+  paused: 'The master product is gone and the channel reports no stock, so the pause took effect.',
+  unknown:
+    'The master product is gone. No channel quantity has been read, so it is not known whether this offer was paused.',
+};
+
+const UNLINKED_TITLE: Record<ChannelStockSignal, string> = {
+  selling:
+    'No OpenLinker variant is linked to this listing, and the channel still reports stock - neither inventory nor pricing can reach it.',
+  paused: 'No OpenLinker variant is linked to this listing. The channel reports no stock.',
+  unknown:
+    'No OpenLinker variant is linked to this listing, and no channel quantity has been read, so it is not known whether it can still sell.',
+};
 
 /**
  * Badges for one row, loudest first. Zero, one or two: a stale row that is also
@@ -50,17 +89,25 @@ export function isOverselling(row: OfferMapping): boolean {
  */
 export function listingRowBadges(row: OfferMapping): ListingRowBadge[] {
   const badges: ListingRowBadge[] = [];
+  const signal = channelStockSignal(row);
 
   if (row.identity?.isStale) {
-    const overselling = isOverselling(row);
     badges.push({
       id: 'stale',
-      label: overselling ? 'Selling deleted product' : 'Product deleted',
+      label: signal === 'selling' ? 'Selling deleted product' : 'Product deleted',
       tone: 'error',
-      solid: overselling,
-      title: overselling
-        ? 'The master product is gone but the channel still reports stock, so this offer can still sell.'
-        : 'The master product is gone. This offer should have been paused.',
+      solid: signal === 'selling',
+      title: STALE_TITLE[signal],
+    });
+  } else if (isUnlinked(row)) {
+    // A listing OL can no longer key on is the same money-shaped state as a
+    // stale one, and per the delete-then-recreate note it never self-heals.
+    badges.push({
+      id: 'unlinked',
+      label: 'Unlinked',
+      tone: 'error',
+      solid: signal === 'selling',
+      title: UNLINKED_TITLE[signal],
     });
   }
 
@@ -78,19 +125,24 @@ export function listingRowBadges(row: OfferMapping): ListingRowBadge[] {
 
   switch (status.lifecycle) {
     case 'Inactive':
+      // NOT "Rejected": the backend derives this bucket from `inactive` PLUS
+      // validator messages, which a seller who deactivated the offer himself
+      // can also satisfy. The messages are real, the refusal may not be.
       badges.push({
         id: 'lifecycle',
-        label: 'Rejected',
+        label: 'Inactive',
         tone: 'error',
-        title: 'The marketplace validator refused this offer.',
+        title: 'Not live on the channel, with validator errors outstanding.',
       });
       break;
     case 'Draft':
+      // Soft, like Ended and Not synced: solid is the escalation treatment the
+      // overselling badge steps up to, and Draft is the least urgent of the
+      // three.
       badges.push({
         id: 'lifecycle',
         label: 'Draft',
         tone: 'neutral',
-        solid: true,
         title: 'On the channel but not live.',
       });
       break;
@@ -113,15 +165,23 @@ export function listingRowBadges(row: OfferMapping): ListingRowBadge[] {
 }
 
 /**
- * The one attention line under the identifiers. Staleness outranks a validator
- * message: a listing that can sell a deleted product is the more urgent of the
- * two, and stacking both would push every neighbouring row taller.
+ * The one attention line under the identifiers. A broken OL-side link outranks
+ * a validator message: a listing that can sell what OL cannot control is the
+ * more urgent of the two, and stacking both would push every neighbouring row
+ * taller.
  */
 export function listingRowAlert(row: OfferMapping): ListingRowAlert | null {
-  if (isOverselling(row)) {
-    const quantity = row.commercial?.availableQuantity ?? 0;
-    const text = `Still ${quantity} available on channel - the master product no longer exists`;
-    return { text, title: text };
+  const quantity = row.commercial?.availableQuantity;
+
+  if (quantity != null && quantity > 0) {
+    if (row.identity?.isStale) {
+      const text = `Still ${quantity} available on channel - the master product no longer exists`;
+      return { text, title: text };
+    }
+    if (isUnlinked(row)) {
+      const text = `Still ${quantity} available on channel - no OpenLinker product is linked to this listing`;
+      return { text, title: text };
+    }
   }
 
   const message = row.channelStatus?.validationMessages[0];

--- a/apps/web/src/features/listings/lib/listing-row-state.ts
+++ b/apps/web/src/features/listings/lib/listing-row-state.ts
@@ -1,0 +1,129 @@
+/**
+ * Listing row state (#2028)
+ *
+ * Pure derivations behind the redesigned `/listings` row anatomy: which badges
+ * a row earns, and whether it carries an attention line under its identifiers.
+ * Kept out of the page so the rules are unit-testable and so the lifecycle-tab
+ * work (#2029) can narrow them in one place.
+ *
+ * The #1965 mockup's rule is that a badge appears only when a row DEPARTS from
+ * its tab's nominal state, so the tab itself carries the lifecycle. Until the
+ * tabs exist every lifecycle shares one list, so `Active` stands in as nominal
+ * and the other four buckets are badged. When #2029 lands, pass the active tab
+ * in and suppress the badge whose label the tab already states.
+ *
+ * @module apps/web/src/features/listings/lib
+ */
+import type { StatusBadgeTone } from '../../../shared/ui/status-badge';
+import type { OfferMapping } from '../api/listings.types';
+
+export interface ListingRowBadge {
+  id: string;
+  label: string;
+  tone: StatusBadgeTone;
+  pulse?: boolean;
+  solid?: boolean;
+  /** Hover copy - carries the nuance the two-word label cannot. */
+  title?: string;
+}
+
+export interface ListingRowAlert {
+  text: string;
+  /** Rendered verbatim when it is the marketplace validator speaking. */
+  title: string;
+}
+
+/**
+ * The overselling case: a live listing for a product whose master record is
+ * gone. `isStale` alone is not enough - the pause normally zeroes the offer, so
+ * a non-zero channel quantity is what makes it sellable.
+ */
+export function isOverselling(row: OfferMapping): boolean {
+  const quantity = row.commercial?.availableQuantity;
+  return Boolean(row.identity?.isStale) && quantity != null && quantity > 0;
+}
+
+/**
+ * Badges for one row, loudest first. Zero, one or two: a stale row that is also
+ * rejected earns both, because suppressing either would hide a fact the
+ * operator needs to act on.
+ */
+export function listingRowBadges(row: OfferMapping): ListingRowBadge[] {
+  const badges: ListingRowBadge[] = [];
+
+  if (row.identity?.isStale) {
+    const overselling = isOverselling(row);
+    badges.push({
+      id: 'stale',
+      label: overselling ? 'Selling deleted product' : 'Product deleted',
+      tone: 'error',
+      solid: overselling,
+      title: overselling
+        ? 'The master product is gone but the channel still reports stock, so this offer can still sell.'
+        : 'The master product is gone. This offer should have been paused.',
+    });
+  }
+
+  const status = row.channelStatus;
+  if (!status) return badges;
+
+  if (status.publicationStatus === 'activating') {
+    badges.push({ id: 'lifecycle', label: 'Activating', tone: 'info', pulse: true });
+    return badges;
+  }
+  if (status.publicationStatus === 'inactivating') {
+    badges.push({ id: 'lifecycle', label: 'Deactivating', tone: 'info', pulse: true });
+    return badges;
+  }
+
+  switch (status.lifecycle) {
+    case 'Inactive':
+      badges.push({
+        id: 'lifecycle',
+        label: 'Rejected',
+        tone: 'error',
+        title: 'The marketplace validator refused this offer.',
+      });
+      break;
+    case 'Draft':
+      badges.push({
+        id: 'lifecycle',
+        label: 'Draft',
+        tone: 'neutral',
+        solid: true,
+        title: 'On the channel but not live.',
+      });
+      break;
+    case 'Ended':
+      badges.push({ id: 'lifecycle', label: 'Ended', tone: 'neutral' });
+      break;
+    case 'Unsynced':
+      badges.push({
+        id: 'lifecycle',
+        label: 'Not synced',
+        tone: 'neutral',
+        title: 'No channel status has ever been read for this offer.',
+      });
+      break;
+    case 'Active':
+      break;
+  }
+
+  return badges;
+}
+
+/**
+ * The one attention line under the identifiers. Staleness outranks a validator
+ * message: a listing that can sell a deleted product is the more urgent of the
+ * two, and stacking both would push every neighbouring row taller.
+ */
+export function listingRowAlert(row: OfferMapping): ListingRowAlert | null {
+  if (isOverselling(row)) {
+    const quantity = row.commercial?.availableQuantity ?? 0;
+    const text = `Still ${quantity} available on channel - the master product no longer exists`;
+    return { text, title: text };
+  }
+
+  const message = row.channelStatus?.validationMessages[0];
+  return message ? { text: message, title: message } : null;
+}

--- a/apps/web/src/features/mappings/index.ts
+++ b/apps/web/src/features/mappings/index.ts
@@ -15,6 +15,9 @@ export { useMappingOptions } from './hooks/use-mapping-options';
 export { useRoutingRulesQuery } from './hooks/use-routing-rules';
 // Delivery-mapping fix-it deep link (#1794) — built by the orders delivery
 // rider, parsed by the connection-mappings page.
+// Second cross-feature consumer as of #2028 (the listings channel pill), so the
+// resolver joins the barrel rather than being reached for by deep path.
+export { resolvePlatformLabel } from './lib/platform-label';
 export {
   DELIVERY_MAPPING_DEEP_LINK_PARAMS,
   DELIVERY_MAPPING_TAB,

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -17063,8 +17063,22 @@ textarea.bulk-editor__input { resize: vertical; min-height: 66px; font-family: i
    Transcribed from the #1965 mockup: a listing row leads with the catalog
    product name, groups its three identifiers on a second line, and keeps the
    two commercial columns mono + tabular so they scan as columns. */
+/* The identity column carries four facts, so it gets the width to keep them on
+   two lines; below this the row grows to four and the ~36px density budget is
+   gone. Scoped to this table's own container class - the mockup hung it off
+   `.data-table td:first-child`, which in the app would reach every other
+   DataTable. */
+.listings-table th:first-child,
+.listings-table td:first-child {
+  min-width: 28rem;
+}
+/* `inline-flex`, not `flex`: DataTable wraps the first cell in an INLINE <a>
+   whose focus ring is a box-shadow, and a block box inside an inline anchor
+   paints that ring around inline fragments wrapping an anonymous block - a
+   hairline or nothing. An atomic inline-level box keeps the ring intact. */
 .listing-cell {
-  display: flex;
+  display: inline-flex;
+  width: 100%;
   align-items: flex-start;
   gap: var(--space-3);
   min-width: 0;
@@ -17083,10 +17097,13 @@ textarea.bulk-editor__input { resize: vertical; min-height: 66px; font-family: i
 /* Shrink only when the row genuinely runs out of room (a long name next to a
    badge), never at a fixed character cap - a truncated name with empty space
    beside it reads as a bug. */
+/* Inherits from the row link / card title rather than declaring its own colour,
+   so DataTable's own `:hover .data-table__row-link` accent reaches it without a
+   listings rule keying off a DataTable-internal modifier. */
 .listing-cell__name {
   font-size: 0.8125rem;
   font-weight: 600;
-  color: var(--text-primary);
+  color: inherit;
   min-width: 0;
   flex: 0 1 auto;
   overflow: hidden;
@@ -17103,9 +17120,6 @@ textarea.bulk-editor__input { resize: vertical; min-height: 66px; font-family: i
 .listing-cell__badge {
   flex: 0 0 auto;
 }
-.data-table__row--linked:hover .listing-cell__name {
-  color: var(--accent-primary);
-}
 .listing-cell__variant {
   font-size: 0.75rem;
   color: var(--text-secondary);
@@ -17120,8 +17134,12 @@ textarea.bulk-editor__input { resize: vertical; min-height: 66px; font-family: i
   font-size: 0.6875rem;
   color: var(--text-muted);
 }
+/* Weight is declared, not inherited: on the mobile card DataTable wraps the
+   title in a 600-weight <strong>, which would otherwise make the identifier
+   line and the validator message read as headings. */
 .listing-cell__meta {
   font-size: 0.75rem;
+  font-weight: 400;
   color: var(--text-muted);
   display: flex;
   gap: var(--space-2);
@@ -17147,6 +17165,7 @@ textarea.bulk-editor__input { resize: vertical; min-height: 66px; font-family: i
    overselling warning for a stale variant that still reports channel stock. */
 .listing-cell__reason {
   font-size: 0.6875rem;
+  font-weight: 400;
   color: var(--status-error-strong);
   max-width: 46ch;
   overflow: hidden;
@@ -17154,21 +17173,49 @@ textarea.bulk-editor__input { resize: vertical; min-height: 66px; font-family: i
   white-space: nowrap;
 }
 
+/* Mobile card head (#1965 frame 05): at 360px the name is what the card is
+   about, so nothing next to it may hold a fixed width and nothing may clip. */
+.listing-cell--card .listing-cell__head {
+  flex-wrap: wrap;
+}
+.listing-cell--card .listing-cell__name {
+  flex: 1 1 auto;
+  overflow: visible;
+  white-space: normal;
+}
+.listing-cell--card .listing-cell__meta {
+  flex-wrap: wrap;
+  overflow: visible;
+  white-space: normal;
+}
+.listing-cell--card .listing-cell__reason {
+  max-width: none;
+  overflow: visible;
+  white-space: normal;
+}
+
 /* Whose number this column carries. Price and quantity are the channel's, not
-   OL's, and the note says so in the header rather than in a tooltip nobody
-   opens (#1843 / #1844). */
+   OL's, and Updated is when OL last READ the channel, not when the listing
+   changed - the note says so in the header rather than in a tooltip nobody
+   opens (#1843 / #1844 / ADR-009). */
 .listings-col-head {
   display: inline-flex;
   flex-direction: column;
-  align-items: flex-end;
+  align-items: flex-start;
   gap: 1px;
 }
+.listings-col-head--right {
+  align-items: flex-end;
+}
 .listings-col-head__note {
-  font-size: 0.5625rem;
+  font-size: 0.625rem;
   font-weight: 400;
   letter-spacing: var(--tracking-caps);
   text-transform: uppercase;
   color: var(--text-muted);
+  /* Nothing else in the system goes below 10px, and at 10px + caps tracking
+     this must not be allowed to wrap into the row beneath. */
+  white-space: nowrap;
 }
 
 .price-cell {
@@ -17180,13 +17227,6 @@ textarea.bulk-editor__input { resize: vertical; min-height: 66px; font-family: i
 .price-cell__value {
   font-family: var(--font-mono);
   font-variant-numeric: tabular-nums;
-  white-space: nowrap;
-}
-/* A channel price can legitimately be days old (hourly scan, 100 offers/tick),
-   so the value never appears without its age. */
-.price-cell__age {
-  font-size: 0.625rem;
-  color: var(--text-muted);
   white-space: nowrap;
 }
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -9260,6 +9260,10 @@ a.kpi-card:focus-visible {
 .channel-pill[data-channel='prestashop']::before { background: var(--channel-prestashop); }
 .channel-pill[data-channel='amazon']::before     { background: var(--channel-amazon); }
 .channel-pill[data-channel='shopify']::before    { background: var(--channel-shopify); }
+/* Erli and WooCommerce had their hues defined but never wired, so both rendered
+   the grey fallback dot on every surface using the pill (#2028). */
+.channel-pill[data-channel='erli']::before        { background: var(--channel-erli); }
+.channel-pill[data-channel='woocommerce']::before { background: var(--channel-woocommerce); }
 
 /* ── Patterns: entity label (thumb + name + sub-id) ──────────────── */
 .entity-label { display: inline-flex; align-items: center; gap: var(--space-2); }
@@ -17053,4 +17057,193 @@ textarea.bulk-editor__input { resize: vertical; min-height: 66px; font-family: i
   margin: 0;
   font-size: 0.75rem;
   color: var(--text-muted);
+}
+
+/* ── Listings table row anatomy (#2028) ──────────────────────────────────────
+   Transcribed from the #1965 mockup: a listing row leads with the catalog
+   product name, groups its three identifiers on a second line, and keeps the
+   two commercial columns mono + tabular so they scan as columns. */
+.listing-cell {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
+  min-width: 0;
+}
+.listing-cell__body {
+  display: grid;
+  gap: 1px;
+  min-width: 0;
+}
+.listing-cell__head {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+}
+/* Shrink only when the row genuinely runs out of room (a long name next to a
+   badge), never at a fixed character cap - a truncated name with empty space
+   beside it reads as a bug. */
+.listing-cell__name {
+  font-size: 0.8125rem;
+  font-weight: 600;
+  color: var(--text-primary);
+  min-width: 0;
+  flex: 0 1 auto;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.listing-cell__name--missing {
+  font-weight: 500;
+  font-style: italic;
+  color: var(--text-muted);
+}
+.listing-cell__variant,
+.listing-cell__offerid,
+.listing-cell__badge {
+  flex: 0 0 auto;
+}
+.data-table__row--linked:hover .listing-cell__name {
+  color: var(--accent-primary);
+}
+.listing-cell__variant {
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  padding: 1px 6px;
+  background: var(--bg-surface-muted);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-xs);
+  white-space: nowrap;
+}
+.listing-cell__offerid {
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  color: var(--text-muted);
+}
+.listing-cell__meta {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  display: flex;
+  gap: var(--space-2);
+  align-items: center;
+  white-space: nowrap;
+  overflow: hidden;
+}
+.listing-cell__meta span {
+  white-space: nowrap;
+}
+.listing-cell__meta span + span::before {
+  content: '·';
+  margin-right: var(--space-2);
+  color: var(--border-strong);
+}
+.listing-cell__meta em {
+  font-style: normal;
+  font-family: var(--font-mono);
+  color: var(--text-secondary);
+}
+/* The validator's own words, verbatim - this is the one place the marketplace
+   speaks directly to the seller, so it is not paraphrased. Also carries the
+   overselling warning for a stale variant that still reports channel stock. */
+.listing-cell__reason {
+  font-size: 0.6875rem;
+  color: var(--status-error-strong);
+  max-width: 46ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Whose number this column carries. Price and quantity are the channel's, not
+   OL's, and the note says so in the header rather than in a tooltip nobody
+   opens (#1843 / #1844). */
+.listings-col-head {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 1px;
+}
+.listings-col-head__note {
+  font-size: 0.5625rem;
+  font-weight: 400;
+  letter-spacing: var(--tracking-caps);
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.price-cell {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 1px;
+}
+.price-cell__value {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+/* A channel price can legitimately be days old (hourly scan, 100 offers/tick),
+   so the value never appears without its age. */
+.price-cell__age {
+  font-size: 0.625rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.qty-cell {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
+}
+.qty-cell__value {
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+}
+
+.time-cell {
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--text-secondary);
+  white-space: nowrap;
+}
+
+/* Mobile card fold (#1965 frame 05): the four columns the fold drops, as a
+   two-column fact list under the listing head. */
+.listings-card-facts {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-3) var(--space-4);
+  margin: 0;
+  padding: var(--space-3);
+  background: var(--bg-surface-muted);
+  border-radius: var(--radius-md);
+}
+.listings-card-facts > div {
+  min-width: 0;
+}
+.listings-card-facts dt {
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  letter-spacing: var(--tracking-caps);
+  text-transform: uppercase;
+  color: var(--text-muted);
+  margin-bottom: 3px;
+}
+.listings-card-facts dd {
+  margin: 0;
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+}
+/* Right-aligned in the table because they are columns; left-aligned here
+   because a card fact reads left-to-right under its label. */
+.listings-card-facts .price-cell,
+.listings-card-facts .qty-cell {
+  align-items: flex-start;
+}
+.listings-card-messages {
+  margin: 0;
+  padding-left: var(--space-4);
+  font-size: 0.75rem;
+  color: var(--status-error-strong);
 }

--- a/apps/web/src/pages/connections/connection-mappings-page.tsx
+++ b/apps/web/src/pages/connections/connection-mappings-page.tsx
@@ -43,8 +43,7 @@ import {
 } from '../../features/mappings/hooks/use-order-state-mappings';
 import { useRoutingRulesQuery } from '../../features/mappings/hooks/use-routing-rules';
 import { useMappingOptions } from '../../features/mappings/hooks/use-mapping-options';
-import { resolvePlatformLabel } from '../../features/mappings/lib/platform-label';
-import { DELIVERY_MAPPING_DEEP_LINK_PARAMS } from '../../features/mappings';
+import { DELIVERY_MAPPING_DEEP_LINK_PARAMS, resolvePlatformLabel } from '../../features/mappings';
 import { usePlatforms } from '../../shared/plugins';
 import {
   OL_ORDER_STATUS_OPTIONS,

--- a/apps/web/src/pages/listings/listings-list-page.test.tsx
+++ b/apps/web/src/pages/listings/listings-list-page.test.tsx
@@ -3,8 +3,12 @@ import userEvent from '@testing-library/user-event';
 import { afterEach, describe, it, expect, vi } from 'vitest';
 import type * as ReactRouterDom from 'react-router-dom';
 import { renderWithProviders, createMockApiClient, createAuthenticatedSessionAdapter } from '../../test/test-utils';
+import { mockMobileViewport } from '../../test/viewport';
 import { ListingsListPage } from './listings-list-page';
-import type { PaginatedOfferMappings } from '../../features/listings/api/listings.types';
+import type {
+  OfferMapping,
+  PaginatedOfferMappings,
+} from '../../features/listings/api/listings.types';
 
 const navigateMock = vi.fn();
 vi.mock('react-router-dom', async (): Promise<typeof ReactRouterDom> => {
@@ -17,29 +21,93 @@ const sampleMappings: PaginatedOfferMappings = {
     {
       id: 'uuid-mapping-1',
       entityType: 'Offer',
-      internalId: 'ol_offer_abc123',
+      internalId: 'ol_variant_abc123',
       externalId: 'allegro-offer-999',
       platformType: 'allegro',
       connectionId: 'conn_allegro_1',
       context: null,
       createdAt: '2026-01-20T09:00:00.000Z',
       updatedAt: '2026-01-20T09:00:00.000Z',
+      identity: {
+        productId: 'ol_product_1',
+        productName: 'Doniczka ceramiczna Terra',
+        variantLabel: 'Terakota 24 cm',
+        sku: 'TERRA-24-TER',
+        ean: '5900000000138',
+        imageUrl: null,
+        isStale: false,
+      },
+      channelStatus: {
+        publicationStatus: 'active',
+        lifecycle: 'Active',
+        validationMessages: [],
+        lastStatusSyncedAt: '2026-01-20T09:30:00.000Z',
+      },
+      commercial: {
+        price: 100,
+        currency: 'PLN',
+        availableQuantity: 41,
+        lastCommercialSyncedAt: '2026-01-20T09:30:00.000Z',
+      },
     },
     {
       id: 'uuid-mapping-2',
       entityType: 'Offer',
-      internalId: 'ol_offer_def456',
+      internalId: 'ol_variant_def456',
       externalId: 'allegro-offer-888',
       platformType: 'allegro',
       connectionId: 'conn_allegro_1',
       context: { parentEntityType: 'Order' },
       createdAt: '2026-02-10T11:00:00.000Z',
       updatedAt: '2026-02-10T11:00:00.000Z',
+      identity: {
+        productId: 'ol_product_2',
+        productName: 'Osłonka Nordic',
+        variantLabel: 'Biały mat 18 cm',
+        sku: 'NORD-18-WHT',
+        ean: '5900000000212',
+        imageUrl: null,
+        isStale: false,
+      },
+      channelStatus: {
+        publicationStatus: 'active',
+        lifecycle: 'Active',
+        validationMessages: [],
+        lastStatusSyncedAt: '2026-02-10T11:30:00.000Z',
+      },
+      commercial: {
+        price: 59,
+        currency: 'PLN',
+        availableQuantity: 0,
+        lastCommercialSyncedAt: '2026-02-10T11:30:00.000Z',
+      },
     },
   ],
   total: 2,
   limit: 20,
   offset: 0,
+};
+
+function oneRow(overrides: Partial<OfferMapping>): PaginatedOfferMappings {
+  return {
+    ...sampleMappings,
+    items: [{ ...sampleMappings.items[0], ...overrides }],
+    total: 1,
+  };
+}
+
+const ERLI_CONNECTION = {
+  id: 'conn_allegro_1',
+  name: 'Erli Demo',
+  platformType: 'erli',
+  status: 'active',
+  config: {},
+  credentialsBacked: true,
+  adapterKey: 'erli.shopapi.v1',
+  enabledCapabilities: ['OfferManager'],
+  supportedCapabilities: ['OfferManager'],
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
 };
 
 describe('ListingsListPage', () => {
@@ -57,19 +125,182 @@ describe('ListingsListPage', () => {
     expect(screen.getByRole('status')).toBeInTheDocument();
   });
 
-  it('should show mappings table when data loads', async () => {
+  it('should lead each row with the catalog product name, variant and identifiers', async () => {
     const mockApi = createMockApiClient({
       listings: {
         list: vi.fn().mockResolvedValue(sampleMappings),
       },
     });
 
+    const { container } = renderWithProviders(<ListingsListPage />, { apiClient: mockApi });
+
+    expect(await screen.findByText('Doniczka ceramiczna Terra')).toBeInTheDocument();
+    expect(screen.getByText('Terakota 24 cm')).toBeInTheDocument();
+    expect(screen.getByText('Osłonka Nordic')).toBeInTheDocument();
+    // The three identifiers group on the row's second line.
+    expect(screen.getByText('allegro-offer-999')).toBeInTheDocument();
+    expect(screen.getByText('TERRA-24-TER')).toBeInTheDocument();
+    expect(screen.getByText('5900000000138')).toBeInTheDocument();
+    // The raw internal-id column is gone - it is an identifier, not an identity.
+    expect(screen.queryByText('ol_variant_abc123')).not.toBeInTheDocument();
+    expect(container.querySelectorAll('.listing-cell')).toHaveLength(2);
+  });
+
+  it('should render the six redesigned column headers and drop the raw-ID ones', async () => {
+    const mockApi = createMockApiClient({
+      listings: { list: vi.fn().mockResolvedValue(sampleMappings) },
+    });
+
     renderWithProviders(<ListingsListPage />, { apiClient: mockApi });
 
-    expect(await screen.findByText('allegro-offer-999')).toBeInTheDocument();
-    expect(screen.getByText('ol_offer_abc123')).toBeInTheDocument();
-    expect(screen.getByText('allegro-offer-888')).toBeInTheDocument();
-    expect(screen.getAllByText('allegro')).toHaveLength(2);
+    await screen.findByText('Doniczka ceramiczna Terra');
+    const headers = screen.getAllByRole('columnheader').map((h) => h.textContent);
+    expect(headers).toEqual([
+      'Listing',
+      'Channel',
+      'Connection',
+      'Priceon channel',
+      'Quantityon channel',
+      'Updated',
+    ]);
+  });
+
+  it('should render a channel pill carrying the platform for its dot colour', async () => {
+    const mockApi = createMockApiClient({
+      listings: { list: vi.fn().mockResolvedValue(sampleMappings) },
+    });
+
+    const { container } = renderWithProviders(<ListingsListPage />, { apiClient: mockApi });
+
+    await screen.findByText('Doniczka ceramiczna Terra');
+    expect(container.querySelectorAll('.channel-pill[data-channel="allegro"]')).toHaveLength(2);
+  });
+
+  it('should resolve the connection column from one batched read, not a per-row fetch', async () => {
+    const connectionsList = vi.fn().mockResolvedValue([ERLI_CONNECTION]);
+    const connectionGetById = vi.fn();
+    const mockApi = createMockApiClient({
+      listings: { list: vi.fn().mockResolvedValue(sampleMappings) },
+      connections: { list: connectionsList, getById: connectionGetById },
+    });
+
+    renderWithProviders(<ListingsListPage />, { apiClient: mockApi });
+
+    expect(await screen.findAllByText('Erli Demo')).toHaveLength(2);
+    expect(connectionGetById).not.toHaveBeenCalled();
+  });
+
+  it('should render the channel price with its reading age, labelled as on-channel', async () => {
+    const mockApi = createMockApiClient({
+      listings: { list: vi.fn().mockResolvedValue(sampleMappings) },
+    });
+
+    const { container } = renderWithProviders(<ListingsListPage />, { apiClient: mockApi });
+
+    await screen.findByText('Doniczka ceramiczna Terra');
+    const price = container.querySelector('.price-cell__value');
+    expect(price?.textContent).toContain('100');
+    // A price without its age is a price an operator acts on (#2024 / ADR-009).
+    const age = container.querySelector('.price-cell__age');
+    expect(age).toHaveAttribute('datetime', '2026-01-20T09:30:00.000Z');
+    expect(age?.getAttribute('title')).toMatch(/^Price and quantity on channel, last read /);
+  });
+
+  it('should badge a zero channel quantity as out of stock', async () => {
+    const mockApi = createMockApiClient({
+      listings: { list: vi.fn().mockResolvedValue(sampleMappings) },
+    });
+
+    renderWithProviders(<ListingsListPage />, { apiClient: mockApi });
+
+    expect(await screen.findByText('Out of stock')).toBeInTheDocument();
+  });
+
+  it('should render an unreported price and quantity as absent, never as zero', async () => {
+    const mockApi = createMockApiClient({
+      listings: {
+        list: vi.fn().mockResolvedValue(
+          oneRow({
+            commercial: {
+              price: null,
+              currency: null,
+              availableQuantity: null,
+              lastCommercialSyncedAt: '2026-01-20T09:30:00.000Z',
+            },
+          }),
+        ),
+      },
+    });
+
+    const { container } = renderWithProviders(<ListingsListPage />, { apiClient: mockApi });
+
+    await screen.findByText('Doniczka ceramiczna Terra');
+    expect(screen.getByLabelText('Price not reported by the channel')).toBeInTheDocument();
+    expect(screen.getByLabelText('Quantity not reported by the channel')).toBeInTheDocument();
+    expect(screen.queryByText('Out of stock')).not.toBeInTheDocument();
+    // The reading is still dated even when neither value came back.
+    expect(container.querySelector('.price-cell__age')).toBeInTheDocument();
+  });
+
+  it('should give a stale variant that still has channel stock a solid overselling treatment', async () => {
+    const mockApi = createMockApiClient({
+      listings: {
+        list: vi.fn().mockResolvedValue(
+          oneRow({
+            identity: {
+              productId: 'ol_product_1',
+              productName: 'Doniczka ceramiczna Terra',
+              variantLabel: 'Terakota 24 cm',
+              sku: 'TERRA-24-TER',
+              ean: '5900000000138',
+              imageUrl: null,
+              isStale: true,
+            },
+          }),
+        ),
+      },
+    });
+
+    const { container } = renderWithProviders(<ListingsListPage />, { apiClient: mockApi });
+
+    expect(await screen.findByText('Selling deleted product')).toBeInTheDocument();
+    expect(container.querySelector('.status-badge--solid')).toBeInTheDocument();
+    expect(
+      screen.getByText('Still 41 available on channel - the master product no longer exists'),
+    ).toBeInTheDocument();
+  });
+
+  it('should mark an unsynced row without promising it will sync soon', async () => {
+    const mockApi = createMockApiClient({
+      listings: {
+        list: vi.fn().mockResolvedValue(
+          oneRow({
+            channelStatus: {
+              publicationStatus: null,
+              lifecycle: 'Unsynced',
+              validationMessages: [],
+              lastStatusSyncedAt: null,
+            },
+          }),
+        ),
+      },
+    });
+
+    renderWithProviders(<ListingsListPage />, { apiClient: mockApi });
+
+    expect(await screen.findByText('Not synced')).toBeInTheDocument();
+    expect(screen.getByLabelText('Channel status never read')).toBeInTheDocument();
+  });
+
+  it('should report a mapping whose variant no longer resolves instead of blanking the cell', async () => {
+    const mockApi = createMockApiClient({
+      listings: { list: vi.fn().mockResolvedValue(oneRow({ identity: null })) },
+    });
+
+    renderWithProviders(<ListingsListPage />, { apiClient: mockApi });
+
+    expect(await screen.findByText('No linked variant')).toBeInTheDocument();
+    expect(screen.getByText('allegro-offer-999')).toBeInTheDocument();
   });
 
   it('should show error state when fetch fails', async () => {
@@ -161,6 +392,59 @@ describe('ListingsListPage', () => {
 
     expect(await screen.findByRole('button', { name: /publish products/i })).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: /publish to shop/i })).not.toBeInTheDocument();
+  });
+
+  describe('mobile card fold (#1965 frame 05)', () => {
+    it('should fold to cards leading with the listing head and a four-fact list', async () => {
+      const viewport = mockMobileViewport();
+      try {
+        const mockApi = createMockApiClient({
+          listings: { list: vi.fn().mockResolvedValue(sampleMappings) },
+          connections: { list: vi.fn().mockResolvedValue([ERLI_CONNECTION]) },
+        });
+
+        const { container } = renderWithProviders(<ListingsListPage />, { apiClient: mockApi });
+
+        await screen.findByText('Doniczka ceramiczna Terra');
+        expect(container.querySelector('table')).not.toBeInTheDocument();
+        expect(container.querySelectorAll('.data-table__card')).toHaveLength(2);
+        // The head keeps the full row anatomy; the four dropped columns become
+        // the fact list beneath it.
+        expect(container.querySelectorAll('.listing-cell')).toHaveLength(2);
+        const facts = container.querySelector('.listings-card-facts');
+        expect(facts?.querySelectorAll('dt')).toHaveLength(4);
+        expect([...(facts?.querySelectorAll('dt') ?? [])].map((dt) => dt.textContent)).toEqual([
+          'Channel',
+          'Connection',
+          'Price on channel',
+          'Quantity on channel',
+        ]);
+      } finally {
+        viewport.restore();
+      }
+    });
+
+    it('should keep the long-form fields behind a disclosure', async () => {
+      const viewport = mockMobileViewport();
+      try {
+        const user = userEvent.setup();
+        const mockApi = createMockApiClient({
+          listings: { list: vi.fn().mockResolvedValue(oneRow({})) },
+        });
+
+        renderWithProviders(<ListingsListPage />, { apiClient: mockApi });
+
+        await screen.findByText('Doniczka ceramiczna Terra');
+        expect(screen.queryByText('ol_variant_abc123')).not.toBeInTheDocument();
+
+        await user.click(screen.getByRole('button', { name: /view full details/i }));
+
+        expect(screen.getByText('ol_variant_abc123')).toBeInTheDocument();
+        expect(screen.getByText('Lifecycle')).toBeInTheDocument();
+      } finally {
+        viewport.restore();
+      }
+    });
   });
 
   describe('demo read-only viewer (#1663)', () => {

--- a/apps/web/src/pages/listings/listings-list-page.test.tsx
+++ b/apps/web/src/pages/listings/listings-list-page.test.tsx
@@ -96,7 +96,9 @@ function oneRow(overrides: Partial<OfferMapping>): PaginatedOfferMappings {
   };
 }
 
-const ERLI_CONNECTION = {
+// Deliberately carries a DIFFERENT platformType than the rows it is wired to:
+// the channel pill must resolve from the ROW, never from its connection.
+const MISMATCHED_PLATFORM_CONNECTION = {
   id: 'conn_allegro_1',
   name: 'Erli Demo',
   platformType: 'erli',
@@ -161,7 +163,9 @@ describe('ListingsListPage', () => {
       'Connection',
       'Priceon channel',
       'Quantityon channel',
-      'Updated',
+      // Not "when this listing changed" - when OL last read the channel. The
+      // mobile card calls the identical value "Status read".
+      'Updatedstatus read',
     ]);
   });
 
@@ -177,20 +181,24 @@ describe('ListingsListPage', () => {
   });
 
   it('should resolve the connection column from one batched read, not a per-row fetch', async () => {
-    const connectionsList = vi.fn().mockResolvedValue([ERLI_CONNECTION]);
+    const connectionsList = vi.fn().mockResolvedValue([MISMATCHED_PLATFORM_CONNECTION]);
     const connectionGetById = vi.fn();
     const mockApi = createMockApiClient({
       listings: { list: vi.fn().mockResolvedValue(sampleMappings) },
       connections: { list: connectionsList, getById: connectionGetById },
     });
 
-    renderWithProviders(<ListingsListPage />, { apiClient: mockApi });
+    const { container } = renderWithProviders(<ListingsListPage />, { apiClient: mockApi });
 
     expect(await screen.findAllByText('Erli Demo')).toHaveLength(2);
     expect(connectionGetById).not.toHaveBeenCalled();
+    // The fixture's platformType ('erli') differs from its rows' ('allegro') -
+    // the pill must follow the row.
+    expect(container.querySelectorAll('.channel-pill[data-channel="allegro"]')).toHaveLength(2);
+    expect(container.querySelector('.channel-pill[data-channel="erli"]')).toBeNull();
   });
 
-  it('should render the channel price with its reading age, labelled as on-channel', async () => {
+  it('should date the channel price on the cell rather than repeating the Updated column', async () => {
     const mockApi = createMockApiClient({
       listings: { list: vi.fn().mockResolvedValue(sampleMappings) },
     });
@@ -198,12 +206,12 @@ describe('ListingsListPage', () => {
     const { container } = renderWithProviders(<ListingsListPage />, { apiClient: mockApi });
 
     await screen.findByText('Doniczka ceramiczna Terra');
-    const price = container.querySelector('.price-cell__value');
-    expect(price?.textContent).toContain('100');
-    // A price without its age is a price an operator acts on (#2024 / ADR-009).
-    const age = container.querySelector('.price-cell__age');
-    expect(age).toHaveAttribute('datetime', '2026-01-20T09:30:00.000Z');
-    expect(age?.getAttribute('title')).toMatch(/^Price and quantity on channel, last read /);
+    const price = container.querySelector('.price-cell');
+    expect(price?.querySelector('.price-cell__value')?.textContent).toContain('100');
+    expect(price?.getAttribute('title')).toMatch(/^Price and quantity on channel, last read /);
+    // The commercial and status snapshots come from the same statusSync pass
+    // (#2024), so the age is not printed a second time under the price.
+    expect(container.querySelector('.price-cell__age')).toBeNull();
   });
 
   it('should badge a zero channel quantity as out of stock', async () => {
@@ -239,7 +247,22 @@ describe('ListingsListPage', () => {
     expect(screen.getByLabelText('Quantity not reported by the channel')).toBeInTheDocument();
     expect(screen.queryByText('Out of stock')).not.toBeInTheDocument();
     // The reading is still dated even when neither value came back.
-    expect(container.querySelector('.price-cell__age')).toBeInTheDocument();
+    expect(container.querySelector('.price-cell')?.getAttribute('title')).toMatch(/last read/);
+  });
+
+  it('should say no reading was taken - not that the channel withheld one - when no snapshot exists', async () => {
+    const mockApi = createMockApiClient({
+      listings: { list: vi.fn().mockResolvedValue(oneRow({ commercial: null })) },
+    });
+
+    renderWithProviders(<ListingsListPage />, { apiClient: mockApi });
+
+    await screen.findByText('Doniczka ceramiczna Terra');
+    // Both commercial cells state the same fact: nothing was ever persisted for
+    // this offer. On a connection whose status-sync task is off, that is every
+    // row - so neither cell may blame the marketplace for withholding a number.
+    expect(screen.getAllByLabelText('No channel reading yet')).toHaveLength(2);
+    expect(screen.queryByLabelText('Quantity not reported by the channel')).not.toBeInTheDocument();
   });
 
   it('should give a stale variant that still has channel stock a solid overselling treatment', async () => {
@@ -297,10 +320,19 @@ describe('ListingsListPage', () => {
       listings: { list: vi.fn().mockResolvedValue(oneRow({ identity: null })) },
     });
 
-    renderWithProviders(<ListingsListPage />, { apiClient: mockApi });
+    const { container } = renderWithProviders(<ListingsListPage />, { apiClient: mockApi });
 
     expect(await screen.findByText('No linked variant')).toBeInTheDocument();
     expect(screen.getByText('allegro-offer-999')).toBeInTheDocument();
+    // A listing OL can no longer key on, still selling on the channel, is the
+    // same money-shaped state as a stale one - not quieter than a Draft chip.
+    expect(screen.getByText('Unlinked')).toBeInTheDocument();
+    expect(container.querySelector('.status-badge--solid')).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Still 41 available on channel - no OpenLinker product is linked to this listing',
+      ),
+    ).toBeInTheDocument();
   });
 
   it('should show error state when fetch fails', async () => {
@@ -400,7 +432,7 @@ describe('ListingsListPage', () => {
       try {
         const mockApi = createMockApiClient({
           listings: { list: vi.fn().mockResolvedValue(sampleMappings) },
-          connections: { list: vi.fn().mockResolvedValue([ERLI_CONNECTION]) },
+          connections: { list: vi.fn().mockResolvedValue([MISMATCHED_PLATFORM_CONNECTION]) },
         });
 
         const { container } = renderWithProviders(<ListingsListPage />, { apiClient: mockApi });
@@ -408,9 +440,9 @@ describe('ListingsListPage', () => {
         await screen.findByText('Doniczka ceramiczna Terra');
         expect(container.querySelector('table')).not.toBeInTheDocument();
         expect(container.querySelectorAll('.data-table__card')).toHaveLength(2);
-        // The head keeps the full row anatomy; the four dropped columns become
-        // the fact list beneath it.
-        expect(container.querySelectorAll('.listing-cell')).toHaveLength(2);
+        // The head is frame 05's own reshape, not the table cell squeezed; the
+        // four dropped columns become the fact list beneath it.
+        expect(container.querySelectorAll('.listing-cell--card')).toHaveLength(2);
         const facts = container.querySelector('.listings-card-facts');
         expect(facts?.querySelectorAll('dt')).toHaveLength(4);
         expect([...(facts?.querySelectorAll('dt') ?? [])].map((dt) => dt.textContent)).toEqual([
@@ -424,7 +456,7 @@ describe('ListingsListPage', () => {
       }
     });
 
-    it('should keep the long-form fields behind a disclosure', async () => {
+    it('should keep the card head to name, variant and SKU, with the rest behind a disclosure', async () => {
       const viewport = mockMobileViewport();
       try {
         const user = userEvent.setup();
@@ -435,10 +467,18 @@ describe('ListingsListPage', () => {
         renderWithProviders(<ListingsListPage />, { apiClient: mockApi });
 
         await screen.findByText('Doniczka ceramiczna Terra');
+        expect(screen.getByText('Terakota 24 cm')).toBeInTheDocument();
+        expect(screen.getByText('TERRA-24-TER')).toBeInTheDocument();
+        // At 360px the offer id and EAN would take the product name's room, so
+        // frame 05 drops them from the head - they move into the disclosure.
+        expect(screen.queryByText('allegro-offer-999')).not.toBeInTheDocument();
+        expect(screen.queryByText('5900000000138')).not.toBeInTheDocument();
         expect(screen.queryByText('ol_variant_abc123')).not.toBeInTheDocument();
 
         await user.click(screen.getByRole('button', { name: /view full details/i }));
 
+        expect(screen.getByText('allegro-offer-999')).toBeInTheDocument();
+        expect(screen.getByText('5900000000138')).toBeInTheDocument();
         expect(screen.getByText('ol_variant_abc123')).toBeInTheDocument();
         expect(screen.getByText('Lifecycle')).toBeInTheDocument();
       } finally {

--- a/apps/web/src/pages/listings/listings-list-page.tsx
+++ b/apps/web/src/pages/listings/listings-list-page.tsx
@@ -1,73 +1,198 @@
-import { useState, type ReactElement, type ReactNode } from 'react';
+import { useCallback, useMemo, useState, type ReactElement, type ReactNode } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
-import { useTableSort } from '../../shared/ui/use-table-sort';
 import { ErrorState, EmptyState } from '../../shared/ui/feedback-state';
 import { DataTableSkeleton } from '../../shared/ui/data-table-skeleton';
 import { Button } from '../../shared/ui/button';
+import { EmptyValue } from '../../shared/ui/empty-value';
 import { Input } from '../../shared/ui/input';
+import { KeyValueList } from '../../shared/ui/key-value-list';
+import { ProductThumbnail } from '../../shared/ui/product-thumbnail';
+import { StatusBadge } from '../../shared/ui/status-badge';
 import { TimeDisplay } from '../../shared/ui/time-display';
+import { formatAmount } from '../../shared/format/format-amount';
+import { formatDateTime } from '../../shared/format/format-date';
+import { usePlatforms } from '../../shared/plugins';
 import { useDebouncedValue } from '../../shared/hooks/use-debounced-value';
+import {
+  ConnectionCell,
+  useConnectionsQuery,
+  type ConnectionCellFacts,
+} from '../../features/connections';
+import { resolvePlatformLabel } from '../../features/mappings/lib/platform-label';
 import { useListingsQuery } from '../../features/listings/hooks/use-listings-query';
 import { OfferProductPickerModal } from '../../features/listings/components/offer-product-picker-modal';
+import {
+  listingRowAlert,
+  listingRowBadges,
+  type ListingRowBadge,
+} from '../../features/listings/lib/listing-row-state';
 import { useWriteAccess } from '../../shared/auth/use-permission';
 import { useDemoMode } from '../../features/system';
-import type {
-  ListingsFilters,
-  OfferMapping,
-} from '../../features/listings/api/listings.types';
+import type { ListingsFilters, OfferMapping } from '../../features/listings/api/listings.types';
 
 const PAGE_SIZE = 20;
 const SEARCH_DEBOUNCE_MS = 300;
 
-const COLUMNS: DataTableColumn<OfferMapping>[] = [
-  {
-    id: 'externalId',
-    header: 'External ID',
-    cell: (m): ReactNode => (
-      <span className="mono-text" title={m.externalId}>
-        {m.externalId}
+/**
+ * Column heading that names whose number the column carries. Price and quantity
+ * are what the CHANNEL reports - already the output of the connection's
+ * pricing rule and already net of its stock safety buffer - so a bare "Price"
+ * would read as OL's own catalog price and a correctly-configured buffer would
+ * look like a bug (#1843 / #1844).
+ */
+function ColumnHead({ label, note }: { label: string; note: string }): ReactElement {
+  return (
+    <span className="listings-col-head">
+      {label}
+      <span className="listings-col-head__note">{note}</span>
+    </span>
+  );
+}
+
+function RowBadge({ badge }: { badge: ListingRowBadge }): ReactElement {
+  return (
+    <StatusBadge
+      tone={badge.tone}
+      compact
+      withDot
+      pulse={badge.pulse ?? false}
+      solid={badge.solid ?? false}
+      className="listing-cell__badge"
+    >
+      {/* StatusBadge takes no native props, so the hover nuance rides a span. */}
+      <span title={badge.title}>{badge.label}</span>
+    </StatusBadge>
+  );
+}
+
+/**
+ * Thumbnail + product name + variant + conditional badges, over a line that
+ * groups the three identifiers (external offer id, SKU, EAN). The product name
+ * is deliberately NOT its own link: `DataTable` already wraps the first cell in
+ * the row link, and an anchor inside an anchor is invalid markup.
+ */
+function ListingCell({ row }: { row: OfferMapping }): ReactElement {
+  const identity = row.identity ?? null;
+  const badges = listingRowBadges(row);
+  const alert = listingRowAlert(row);
+  const name = identity?.productName ?? null;
+
+  return (
+    <span className="listing-cell">
+      <ProductThumbnail name={name ?? row.externalId} src={identity?.imageUrl ?? null} size="md" />
+      <span className="listing-cell__body">
+        <span className="listing-cell__head">
+          {name ? (
+            <span className="listing-cell__name" title={name}>
+              {name}
+            </span>
+          ) : (
+            <span className="listing-cell__name listing-cell__name--missing">
+              {identity ? 'Unnamed product' : 'No linked variant'}
+            </span>
+          )}
+          {identity?.variantLabel ? (
+            <span className="listing-cell__variant">{identity.variantLabel}</span>
+          ) : null}
+          {badges.map((badge) => (
+            <RowBadge key={badge.id} badge={badge} />
+          ))}
+        </span>
+        <span className="listing-cell__meta">
+          <span className="listing-cell__offerid" title={row.externalId}>
+            {row.externalId}
+          </span>
+          {identity?.sku ? (
+            <span>
+              SKU: <em>{identity.sku}</em>
+            </span>
+          ) : null}
+          {identity?.ean ? (
+            <span>
+              EAN: <em>{identity.ean}</em>
+            </span>
+          ) : null}
+        </span>
+        {alert ? (
+          <span className="listing-cell__reason" title={alert.title}>
+            {alert.text}
+          </span>
+        ) : null}
       </span>
-    ),
-  },
-  {
-    id: 'internalId',
-    header: 'Internal ID',
-    cell: (m): ReactNode => <span className="mono-text">{m.internalId}</span>,
-    hideBelow: 1024,
-  },
-  {
-    id: 'platformType',
-    header: 'Platform',
-    cell: (m): ReactNode => <span className="mono-text">{m.platformType}</span>,
-    accessor: (m): string => m.platformType,
-    sortable: true,
-  },
-  {
-    id: 'entityType',
-    header: 'Entity Type',
-    cell: (m): ReactNode => <span className="mono-text">{m.entityType}</span>,
-    hideBelow: 768,
-  },
-  {
-    id: 'connectionId',
-    header: 'Connection',
-    cell: (m): ReactNode => <span className="mono-text">{m.connectionId}</span>,
-    hideBelow: 768,
-  },
-  {
-    id: 'createdAt',
-    header: 'Created',
-    cell: (m): ReactNode => <TimeDisplay iso={m.createdAt} format="date" />,
-    accessor: (m): string => m.createdAt,
-    sortable: true,
-  },
-];
+    </span>
+  );
+}
+
+function ChannelPill({ row, label }: { row: OfferMapping; label: string }): ReactElement {
+  return (
+    <span className="channel-pill" data-channel={row.platformType}>
+      {label}
+    </span>
+  );
+}
+
+/**
+ * Price with the age of the observation it came from. The age lives here rather
+ * than being split across both commercial columns: it is one per-row fact, and
+ * a price shown without it is a price an operator acts on (ADR-009's #2024
+ * amendment). It renders even when the price itself was not reported, because
+ * "as of" stays true for the quantity beside it.
+ */
+function PriceCell({ row }: { row: OfferMapping }): ReactElement {
+  const commercial = row.commercial ?? null;
+  if (!commercial) return <EmptyValue label="No channel reading yet" />;
+
+  const readAt = `Price and quantity on channel, last read ${formatDateTime(
+    commercial.lastCommercialSyncedAt,
+  )}`;
+
+  return (
+    <span className="price-cell">
+      <span className="price-cell__value">
+        {commercial.price == null ? (
+          <EmptyValue label="Price not reported by the channel" />
+        ) : (
+          formatAmount(commercial.price, commercial.currency ?? undefined)
+        )}
+      </span>
+      <TimeDisplay
+        className="price-cell__age"
+        iso={commercial.lastCommercialSyncedAt}
+        format="relative"
+        title={readAt}
+      />
+    </span>
+  );
+}
+
+function QuantityCell({ row }: { row: OfferMapping }): ReactElement {
+  const quantity = row.commercial?.availableQuantity;
+  // Absence is not zero: a marketplace that reported no quantity says nothing
+  // about whether the offer has stock.
+  if (quantity == null) return <EmptyValue label="Quantity not reported by the channel" />;
+
+  return (
+    <span className="qty-cell">
+      <span className="qty-cell__value">{quantity}</span>
+      {quantity === 0 ? (
+        <StatusBadge tone="error" compact withDot>
+          Out of stock
+        </StatusBadge>
+      ) : null}
+    </span>
+  );
+}
+
+function UpdatedCell({ row }: { row: OfferMapping }): ReactElement {
+  const syncedAt = row.channelStatus?.lastStatusSyncedAt;
+  if (!syncedAt) return <EmptyValue label="Channel status never read" />;
+  return <TimeDisplay className="time-cell" iso={syncedAt} format="datetime" />;
+}
 
 export function ListingsListPage(): ReactElement {
   const [searchParams, setSearchParams] = useSearchParams();
-  const { sort, setSort } = useTableSort([{ id: 'createdAt', desc: true }]);
 
   const urlSearch = searchParams.get('search') ?? '';
   const urlConnectionId = searchParams.get('connectionId') ?? '';
@@ -86,6 +211,70 @@ export function ListingsListPage(): ReactElement {
   const pagination = { limit: PAGE_SIZE, offset };
 
   const query = useListingsQuery(filters, pagination);
+
+  const platforms = usePlatforms();
+  // One batched read for the whole page - the Connection column must never cost
+  // a request per row (#1996).
+  const connectionsQuery = useConnectionsQuery();
+  const connectionsById = useMemo(() => {
+    const map = new Map<string, ConnectionCellFacts>();
+    for (const connection of connectionsQuery.data ?? []) {
+      map.set(connection.id, { name: connection.name, status: connection.status });
+    }
+    return map;
+  }, [connectionsQuery.data]);
+
+  const channelLabel = useCallback(
+    (row: OfferMapping): string => resolvePlatformLabel(platforms, row),
+    [platforms],
+  );
+
+  const columns = useMemo<DataTableColumn<OfferMapping>[]>(
+    () => [
+      {
+        id: 'listing',
+        header: 'Listing',
+        cell: (row): ReactNode => <ListingCell row={row} />,
+      },
+      {
+        id: 'channel',
+        header: 'Channel',
+        cell: (row): ReactNode => <ChannelPill row={row} label={channelLabel(row)} />,
+      },
+      {
+        id: 'connection',
+        header: 'Connection',
+        // `.get()` returns undefined on a miss, which ConnectionCell reads as
+        // "resolve it yourself" and would turn back into a per-row fetch -
+        // coalesce to null and hand it the batched query's loading state.
+        cell: (row): ReactNode => (
+          <ConnectionCell
+            connectionId={row.connectionId}
+            connection={connectionsById.get(row.connectionId) ?? null}
+            loading={connectionsQuery.isLoading}
+          />
+        ),
+      },
+      {
+        id: 'price',
+        header: <ColumnHead label="Price" note="on channel" />,
+        align: 'right',
+        cell: (row): ReactNode => <PriceCell row={row} />,
+      },
+      {
+        id: 'quantity',
+        header: <ColumnHead label="Quantity" note="on channel" />,
+        align: 'right',
+        cell: (row): ReactNode => <QuantityCell row={row} />,
+      },
+      {
+        id: 'updated',
+        header: 'Updated',
+        cell: (row): ReactNode => <UpdatedCell row={row} />,
+      },
+    ],
+    [channelLabel, connectionsById, connectionsQuery.isLoading],
+  );
 
   function handleFilterChange(key: string, value: string): void {
     if (key === 'search') setSearchInput(value);
@@ -147,7 +336,7 @@ export function ListingsListPage(): ReactElement {
     <PageLayout
       eyebrow="Operations"
       title="Listings"
-      description="Offer mapping workbench — browse offer-to-variant identifier mappings across platforms."
+      description="Everything you sell on connected channels, and what state it is in right now."
       actions={
         write.visible ? (
           <Button onClick={() => setIsWizardOpen(true)}>Publish products</Button>
@@ -174,7 +363,7 @@ export function ListingsListPage(): ReactElement {
       </div>
 
       {query.isLoading ? (
-        <DataTableSkeleton columns={COLUMNS} />
+        <DataTableSkeleton columns={columns} />
       ) : query.error ? (
         <ErrorState
           title="Unable to load listings"
@@ -211,17 +400,91 @@ export function ListingsListPage(): ReactElement {
       ) : (
         <>
           <DataTable
-            caption="Offer mappings"
-            columns={COLUMNS}
+            caption="Listings"
+            columns={columns}
             rows={query.data?.items ?? []}
             rowKey={(m) => m.id}
             rowHref={(m) => m.id}
-            sort={sort}
-            onSortChange={setSort}
             cardView={{
-              title: (m) => m.externalId,
-              subtitle: (m) => `${m.platformType} · ${m.entityType}`,
-              meta: (m) => <TimeDisplay iso={m.createdAt} format="date" />,
+              title: (m) => <ListingCell row={m} />,
+              // Channel / Connection / Price / Quantity as a two-column fact
+              // list — the four columns the fold drops (#1965 frame 05).
+              summary: (m) => (
+                <dl className="listings-card-facts">
+                  <div>
+                    <dt>Channel</dt>
+                    <dd>
+                      <ChannelPill row={m} label={channelLabel(m)} />
+                    </dd>
+                  </div>
+                  <div>
+                    <dt>Connection</dt>
+                    <dd>
+                      <ConnectionCell
+                        connectionId={m.connectionId}
+                        connection={connectionsById.get(m.connectionId) ?? null}
+                        loading={connectionsQuery.isLoading}
+                      />
+                    </dd>
+                  </div>
+                  <div>
+                    <dt>Price on channel</dt>
+                    <dd>
+                      <PriceCell row={m} />
+                    </dd>
+                  </div>
+                  <div>
+                    <dt>Quantity on channel</dt>
+                    <dd>
+                      <QuantityCell row={m} />
+                    </dd>
+                  </div>
+                </dl>
+              ),
+              // The long-form fields stay behind a disclosure so the card leads
+              // with the four facts above rather than a wall of identifiers.
+              collapsibleDetail: true,
+              detail: (m) => (
+                <KeyValueList
+                  items={[
+                    {
+                      id: 'lifecycle',
+                      label: 'Lifecycle',
+                      value: m.channelStatus?.lifecycle ?? <EmptyValue />,
+                    },
+                    {
+                      id: 'publicationStatus',
+                      label: 'Channel status',
+                      value: m.channelStatus?.publicationStatus ?? <EmptyValue />,
+                      mono: true,
+                    },
+                    {
+                      id: 'updated',
+                      label: 'Status read',
+                      value: <UpdatedCell row={m} />,
+                    },
+                    {
+                      id: 'internalId',
+                      label: 'Variant ID',
+                      value: m.internalId,
+                      mono: true,
+                    },
+                    {
+                      id: 'validation',
+                      label: 'Validator messages',
+                      value: m.channelStatus?.validationMessages.length ? (
+                        <ul className="listings-card-messages">
+                          {m.channelStatus.validationMessages.map((message) => (
+                            <li key={message}>{message}</li>
+                          ))}
+                        </ul>
+                      ) : (
+                        <EmptyValue label="No validator messages" />
+                      ),
+                    },
+                  ]}
+                />
+              ),
             }}
           />
 
@@ -251,10 +514,7 @@ export function ListingsListPage(): ReactElement {
         </>
       )}
 
-      <OfferProductPickerModal
-        isOpen={isWizardOpen}
-        onClose={() => setIsWizardOpen(false)}
-      />
+      <OfferProductPickerModal isOpen={isWizardOpen} onClose={() => setIsWizardOpen(false)} />
     </PageLayout>
   );
 }

--- a/apps/web/src/pages/listings/listings-list-page.tsx
+++ b/apps/web/src/pages/listings/listings-list-page.tsx
@@ -20,7 +20,7 @@ import {
   useConnectionsQuery,
   type ConnectionCellFacts,
 } from '../../features/connections';
-import { resolvePlatformLabel } from '../../features/mappings/lib/platform-label';
+import { resolvePlatformLabel } from '../../features/mappings';
 import { useListingsQuery } from '../../features/listings/hooks/use-listings-query';
 import { OfferProductPickerModal } from '../../features/listings/components/offer-product-picker-modal';
 import {
@@ -40,14 +40,43 @@ const SEARCH_DEBOUNCE_MS = 300;
  * are what the CHANNEL reports - already the output of the connection's
  * pricing rule and already net of its stock safety buffer - so a bare "Price"
  * would read as OL's own catalog price and a correctly-configured buffer would
- * look like a bug (#1843 / #1844).
+ * look like a bug (#1843 / #1844). "Updated" needs the same qualifier for the
+ * opposite reason: it is when OL last READ the channel, not when the listing
+ * last changed, and a days-old value otherwise reads as a stalled sync.
  */
-function ColumnHead({ label, note }: { label: string; note: string }): ReactElement {
+function ColumnHead({
+  label,
+  note,
+  align,
+}: {
+  label: string;
+  note: string;
+  align?: 'right';
+}): ReactElement {
   return (
-    <span className="listings-col-head">
+    <span
+      className={
+        align === 'right' ? 'listings-col-head listings-col-head--right' : 'listings-col-head'
+      }
+    >
       {label}
       <span className="listings-col-head__note">{note}</span>
     </span>
+  );
+}
+
+/**
+ * `EmptyValue` names itself with `aria-label` on a bare `<span>` - a generic
+ * element ARIA prohibits naming, which screen readers commonly drop. The
+ * never-read-versus-zero distinction is the whole point of this page's
+ * commercial columns, so the wording is also carried visually-hidden.
+ */
+function AbsentValue({ label }: { label: string }): ReactElement {
+  return (
+    <>
+      <EmptyValue label={label} />
+      <span className="sr-only">{label}</span>
+    </>
   );
 }
 
@@ -61,8 +90,11 @@ function RowBadge({ badge }: { badge: ListingRowBadge }): ReactElement {
       solid={badge.solid ?? false}
       className="listing-cell__badge"
     >
-      {/* StatusBadge takes no native props, so the hover nuance rides a span. */}
+      {/* StatusBadge takes no native props, so the hover nuance rides a span -
+          and repeats visually-hidden, because a two-word label whose meaning
+          lives only in a tooltip is meaning a keyboard user cannot reach. */}
       <span title={badge.title}>{badge.label}</span>
+      {badge.title ? <span className="sr-only">. {badge.title}</span> : null}
     </StatusBadge>
   );
 }
@@ -72,15 +104,27 @@ function RowBadge({ badge }: { badge: ListingRowBadge }): ReactElement {
  * groups the three identifiers (external offer id, SKU, EAN). The product name
  * is deliberately NOT its own link: `DataTable` already wraps the first cell in
  * the row link, and an anchor inside an anchor is invalid markup.
+ *
+ * The `card` shape is frame 05's own reshape for 360px, not the table cell
+ * squeezed: name + badges lead, then variant and SKU only. The offer id and EAN
+ * move to the card's disclosure - at that width they would take the product
+ * name's room, and the name is what the card is about.
  */
-function ListingCell({ row }: { row: OfferMapping }): ReactElement {
+function ListingCell({
+  row,
+  shape = 'row',
+}: {
+  row: OfferMapping;
+  shape?: 'row' | 'card';
+}): ReactElement {
   const identity = row.identity ?? null;
   const badges = listingRowBadges(row);
   const alert = listingRowAlert(row);
   const name = identity?.productName ?? null;
+  const isCard = shape === 'card';
 
   return (
-    <span className="listing-cell">
+    <span className={isCard ? 'listing-cell listing-cell--card' : 'listing-cell'}>
       <ProductThumbnail name={name ?? row.externalId} src={identity?.imageUrl ?? null} size="md" />
       <span className="listing-cell__body">
         <span className="listing-cell__head">
@@ -93,7 +137,7 @@ function ListingCell({ row }: { row: OfferMapping }): ReactElement {
               {identity ? 'Unnamed product' : 'No linked variant'}
             </span>
           )}
-          {identity?.variantLabel ? (
+          {!isCard && identity?.variantLabel ? (
             <span className="listing-cell__variant">{identity.variantLabel}</span>
           ) : null}
           {badges.map((badge) => (
@@ -101,15 +145,21 @@ function ListingCell({ row }: { row: OfferMapping }): ReactElement {
           ))}
         </span>
         <span className="listing-cell__meta">
-          <span className="listing-cell__offerid" title={row.externalId}>
-            {row.externalId}
-          </span>
+          {isCard ? (
+            identity?.variantLabel ? (
+              <span>{identity.variantLabel}</span>
+            ) : null
+          ) : (
+            <span className="listing-cell__offerid" title={row.externalId}>
+              {row.externalId}
+            </span>
+          )}
           {identity?.sku ? (
             <span>
               SKU: <em>{identity.sku}</em>
             </span>
           ) : null}
-          {identity?.ean ? (
+          {!isCard && identity?.ean ? (
             <span>
               EAN: <em>{identity.ean}</em>
             </span>
@@ -134,44 +184,46 @@ function ChannelPill({ row, label }: { row: OfferMapping; label: string }): Reac
 }
 
 /**
- * Price with the age of the observation it came from. The age lives here rather
- * than being split across both commercial columns: it is one per-row fact, and
- * a price shown without it is a price an operator acts on (ADR-009's #2024
- * amendment). It renders even when the price itself was not reported, because
- * "as of" stays true for the quantity beside it.
+ * The channel's own price, on one mono/tabular line. The age of the reading is
+ * NOT repeated here: per #2024 the commercial snapshot is written by the same
+ * `marketplace.offer.statusSync` pass as the status snapshot, so for
+ * effectively every row it is the instant the Updated column already prints.
+ * Printing it twice in two formats costs a line on every row and leaves the
+ * operator to work out they are the same clock. It rides the cell's title
+ * instead, which stays true for the quantity beside it.
  */
 function PriceCell({ row }: { row: OfferMapping }): ReactElement {
   const commercial = row.commercial ?? null;
-  if (!commercial) return <EmptyValue label="No channel reading yet" />;
+  if (!commercial) return <AbsentValue label="No channel reading yet" />;
 
   const readAt = `Price and quantity on channel, last read ${formatDateTime(
     commercial.lastCommercialSyncedAt,
   )}`;
 
   return (
-    <span className="price-cell">
+    <span className="price-cell" title={readAt}>
       <span className="price-cell__value">
         {commercial.price == null ? (
-          <EmptyValue label="Price not reported by the channel" />
+          <AbsentValue label="Price not reported by the channel" />
         ) : (
           formatAmount(commercial.price, commercial.currency ?? undefined)
         )}
       </span>
-      <TimeDisplay
-        className="price-cell__age"
-        iso={commercial.lastCommercialSyncedAt}
-        format="relative"
-        title={readAt}
-      />
     </span>
   );
 }
 
 function QuantityCell({ row }: { row: OfferMapping }): ReactElement {
-  const quantity = row.commercial?.availableQuantity;
+  const commercial = row.commercial ?? null;
+  // Nothing was ever persisted for this offer, so no reading was taken - which
+  // is a different fact from a channel that answered and withheld the number.
+  // On a connection whose status-sync task is off this is every row.
+  if (!commercial) return <AbsentValue label="No channel reading yet" />;
+
+  const quantity = commercial.availableQuantity;
   // Absence is not zero: a marketplace that reported no quantity says nothing
   // about whether the offer has stock.
-  if (quantity == null) return <EmptyValue label="Quantity not reported by the channel" />;
+  if (quantity == null) return <AbsentValue label="Quantity not reported by the channel" />;
 
   return (
     <span className="qty-cell">
@@ -187,7 +239,7 @@ function QuantityCell({ row }: { row: OfferMapping }): ReactElement {
 
 function UpdatedCell({ row }: { row: OfferMapping }): ReactElement {
   const syncedAt = row.channelStatus?.lastStatusSyncedAt;
-  if (!syncedAt) return <EmptyValue label="Channel status never read" />;
+  if (!syncedAt) return <AbsentValue label="Channel status never read" />;
   return <TimeDisplay className="time-cell" iso={syncedAt} format="datetime" />;
 }
 
@@ -257,19 +309,22 @@ export function ListingsListPage(): ReactElement {
       },
       {
         id: 'price',
-        header: <ColumnHead label="Price" note="on channel" />,
+        header: <ColumnHead label="Price" note="on channel" align="right" />,
         align: 'right',
         cell: (row): ReactNode => <PriceCell row={row} />,
       },
       {
         id: 'quantity',
-        header: <ColumnHead label="Quantity" note="on channel" />,
+        header: <ColumnHead label="Quantity" note="on channel" align="right" />,
         align: 'right',
         cell: (row): ReactNode => <QuantityCell row={row} />,
       },
       {
         id: 'updated',
-        header: 'Updated',
+        // Not "when this listing changed" - when OL last read the channel. The
+        // hourly scan makes a days-old value ordinary, and the mobile card
+        // already calls the identical value "Status read".
+        header: <ColumnHead label="Updated" note="status read" />,
         cell: (row): ReactNode => <UpdatedCell row={row} />,
       },
     ],
@@ -401,12 +456,16 @@ export function ListingsListPage(): ReactElement {
         <>
           <DataTable
             caption="Listings"
+            // Scopes the identity column's width floor to this table - the
+            // mockup put `min-width: 28rem` on `.data-table td:first-child`,
+            // which here would reach ~12 unrelated tables (#2028).
+            className="listings-table"
             columns={columns}
             rows={query.data?.items ?? []}
             rowKey={(m) => m.id}
             rowHref={(m) => m.id}
             cardView={{
-              title: (m) => <ListingCell row={m} />,
+              title: (m) => <ListingCell row={m} shape="card" />,
               // Channel / Connection / Price / Quantity as a two-column fact
               // list — the four columns the fold drops (#1965 frame 05).
               summary: (m) => (
@@ -462,6 +521,21 @@ export function ListingsListPage(): ReactElement {
                       id: 'updated',
                       label: 'Status read',
                       value: <UpdatedCell row={m} />,
+                    },
+                    // The card head drops these two so the product name keeps
+                    // its room at 360px (#1965 frame 05) - they stay reachable
+                    // one tap away rather than disappearing.
+                    {
+                      id: 'externalId',
+                      label: 'Offer ID',
+                      value: m.externalId,
+                      mono: true,
+                    },
+                    {
+                      id: 'ean',
+                      label: 'EAN/GTIN',
+                      value: m.identity?.ean ?? <EmptyValue label="No EAN on the linked variant" />,
+                      mono: true,
                     },
                     {
                       id: 'internalId',


### PR DESCRIPTION
Rebuilds `/listings` as the six human-readable columns of the #1965 mockup, replacing the raw-ID table (External ID, Internal ID, Platform, Entity Type, Connection, Created).

Part of epic #2023. Stacked on `2023-listings-redesign`, on top of BE-B (#2025), FE-A (#2027) and FE-E (#2031).

Refs #2028

## What changed

**Columns** - Listing, Channel, Connection, Price, Quantity, Updated.

- **Listing** carries the mockup's row anatomy: thumbnail + catalog product name + variant pill + conditional badges, over a second line grouping the three identifiers (external offer id, SKU, EAN). A mapping whose variant no longer resolves reports "No linked variant" rather than rendering blank; a `productName` of `null` (a corrupt row behind a NOT NULL FK) reports "Unnamed product".
- **Channel** is `.channel-pill`, labelled from the plugin registry (`usePlatforms` + `resolvePlatformLabel`), never the raw `platformType`.
- **Connection** composes the shared `ConnectionCell` from #2027, with `connection={map.get(id) ?? null}` + `loading={connectionsQuery.isLoading}` so the batched read is not silently turned back into a per-row fetch. No `adornment` is passed - the Channel column already carries the channel, per the mockup's anatomy reasoning.
- **Price / Quantity** are right-aligned mono + tabular (relying on #2031's fix), with `OUT OF STOCK` at zero.
- **Updated** is `lastStatusSyncedAt` through `TimeDisplay`, not `updatedAt`.

**Semantics the DTO asked for, honoured:**

- Price and quantity are headed "on channel" as a visible sub-label, not a tooltip. Both are what the marketplace reports - already the output of the connection's `pricingRule` (#1843) and already net of its `stockSafetyBuffer` (#1844) - so a bare "Price" would read as OL's own and a correctly-configured buffer would look like a bug.
- `lastCommercialSyncedAt` renders under the price value, and still renders when the price itself was not reported, because "as of" stays true for the quantity beside it. The scan is hourly at 100 offers/tick, so a row can legitimately be days old.
- A **null** price or quantity renders as absence with an explicit `aria-label` ("not reported by the channel"), never as zero.
- `identity.isStale` + a non-zero channel quantity is the overselling case: it escalates to a **solid** error badge ("Selling deleted product") plus an explicit line, "Still N available on channel - the master product no longer exists". A stale variant with zero stock gets the ordinary error badge.
- `lifecycle` has **five** values. `Unsynced` renders as "Not synced" and its hover copy says only that no status has ever been read - it never promises one is coming.

**Mobile (frame 05)** - folds to cards: the listing head, a two-column fact list (Channel / Connection / Price / Quantity) as `summary`, and the long-form fields (lifecycle, channel status, status read, variant id, validator messages) behind `collapsibleDetail`.

**Tablet (frame 06)** - no `hideBelow` on any column, so 768-1023px keeps all six and scrolls horizontally in the table's own container rather than folding.

**CSS** - the two missing `.channel-pill[data-channel='erli'|'woocommerce']::before` selectors (the custom properties existed at `index.css:290-293` but were never wired, so both rendered a grey dot on every surface using the pill), plus a bounded `Listings table row anatomy (#2028)` section transcribed from the mockup.

**Types** - `OfferMapping` now models the list-only `identity` / `channelStatus` / `commercial` projections #2025 added, with the operator-facing semantics carried in the docblocks.

## Deviations from the mockup

1. **The product name is not its own link.** `DataTable` already wraps the first cell in the row link (`rowHref`), and an anchor inside an anchor is invalid markup. The row navigates to the listing detail as before; the name is styled text that still picks up the row-hover accent. Linking the name to `/products/:id` would mean giving up row-level navigation, which felt like the worse trade for a page whose rows are listings.
2. **Badges are shown for four of the five lifecycles, not zero.** The mockup's rule is that a badge appears only when a row *departs* from its tab's nominal state - which presumes tabs. Until #2029 lands, every lifecycle shares one list, so `Active` stands in as nominal and Inactive/Draft/Ended/Unsynced are badged; suppressing them now would make the interim table strictly less informative than either the old one or the target. The rule is a pure function in `features/listings/lib/listing-row-state.ts`, so #2029 can narrow it by passing the active tab in one place. No status *column* was added.
3. **Sorting was dropped** rather than re-pointed. The two sortable columns (Platform, Created) are gone, and client-side sort only reorders the visible page of 20, which would misreport. The mockup's headers carry no sort affordance.
4. **Empty-state copy is unchanged** ("No offer mappings found"). Frame 03's per-tab empty states are tab-shaped, so they belong with #2029/#2030.

## Deferred, deliberately

- Lifecycle tabs and their counts - **#2029**.
- Toolbar rework (channel select, Clear button, mobile search-only toolbar) - **#2030**. The existing two inputs are untouched.
- No per-row action column was added: the mockup does not call for one, so `stickyLeftColumns` and the pinned bulk-action rail stay unused rather than wired speculatively.

## Testing

**The specs in this PR have not been executed - not locally and not in CI.**

- Locally: this machine cannot run the vitest suite (it froze WSL on previous attempts), so `pnpm test` was deliberately not run.
- In CI: `ci.yml` triggers only on PRs targeting `main`. This PR targets `2023-listings-redesign`, so no workflow runs on it. The specs will first execute when the epic branch is PR'd to `main`.

What *was* run and passed:

- `pnpm --filter @openlinker/web type-check` - clean.
- ESLint over `apps/web/src` - **0 errors, 0 warnings on every file this PR touches** (the run reports 77 pre-existing `explicit-function-return-type` warnings in untouched files).
- `pnpm check:invariants` - all green, including the design-token drift check (109 tokens).

Two environment notes, both pre-existing and unrelated to this diff, which is `apps/web`-only:

- `pnpm lint` cannot run as a script in this worktree (no per-package `node_modules`, so the `eslint` binary is not on PATH); ESLint was invoked directly and resolves its plugins upward from the parent checkout.
- `pnpm type-check` fails in `apps/api` on `@openlinker/plugin-sdk` (`HostServices.http`, `RateLimitModule`, `HTTP_TRANSPORT_FACTORY_TOKEN`) - stale build artifacts. Verified identical with this branch's changes stashed.

Specs added/updated:

- `listing-row-state.test.ts` (new) - 12 cases over the badge/alert derivation: mid-transition pulse, Rejected, the Unsynced copy assertion (`not.toMatch(/soon|shortly|will sync/i)`), stale with and without stock, both-badges, null-quantity-is-not-stock, and the alert precedence.
- `listings-list-page.test.tsx` - the six headers, row anatomy, channel pill, one-batched-read for the Connection column (asserts `connections.getById` is never called), price + its age, out-of-stock, unreported price/quantity as absence, the overselling treatment, the unsynced row, an unresolved variant, and both mobile-card cases via `mockMobileViewport()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
