### PR TITLE
feat(web/listings): add lifecycle tabs with URL state and live counts

### DIFF
--- a/apps/web/src/app/hooks/use-nav-counts.test.tsx
+++ b/apps/web/src/app/hooks/use-nav-counts.test.tsx
@@ -44,7 +44,13 @@ describe('useNavCounts', () => {
         list: vi.fn().mockResolvedValue({ items: [], total: 12, limit: 1, offset: 0 }),
       },
       listings: {
-        list: vi.fn().mockResolvedValue({ items: [], total: 5, limit: 1, offset: 0 }),
+        list: vi.fn().mockResolvedValue({
+          items: [],
+          total: 5,
+          limit: 1,
+          offset: 0,
+          lifecycleCounts: { Active: 5, Inactive: 0, Draft: 0, Ended: 0, Unsynced: 0 },
+        }),
       },
       syncJobs: {
         list: vi.fn().mockResolvedValue({ items: [], total: 9, limit: 1, offset: 0 }),

--- a/apps/web/src/features/listings/api/listings.api.ts
+++ b/apps/web/src/features/listings/api/listings.api.ts
@@ -212,6 +212,7 @@ function buildQuery(filters?: ListingsFilters, pagination?: ListingsPagination):
   if (filters?.connectionId) params.set('connectionId', filters.connectionId);
   if (filters?.internalId) params.set('internalId', filters.internalId);
   if (filters?.search) params.set('search', filters.search);
+  if (filters?.lifecycle) params.set('lifecycle', filters.lifecycle);
   if (pagination?.limit !== undefined) params.set('limit', String(pagination.limit));
   if (pagination?.offset !== undefined) params.set('offset', String(pagination.offset));
   const qs = params.toString();

--- a/apps/web/src/features/listings/api/listings.types.ts
+++ b/apps/web/src/features/listings/api/listings.types.ts
@@ -37,6 +37,14 @@ export const OFFER_LIFECYCLE_VALUES = [
 ] as const;
 export type OfferLifecycle = (typeof OFFER_LIFECYCLE_VALUES)[number];
 
+/**
+ * Per-bucket row counts backing the lifecycle tab bar (#2026 / #2029). Mirrors
+ * the backend `OfferLifecycleCountsResponseDto` verbatim - keyed by the same
+ * `OfferLifecycle` token the FE reads off each row's `channelStatus.lifecycle`,
+ * so there is no second naming to keep in sync.
+ */
+export type OfferLifecycleCounts = Record<OfferLifecycle, number>;
+
 /** Catalog identity of the variant a list row's mapping points at (#2025). */
 export interface OfferMappingIdentity {
   productId: string;
@@ -147,6 +155,12 @@ export interface ListingsFilters {
    * the external offer ID (#2025).
    */
   search?: string;
+  /**
+   * Restrict the page to one lifecycle bucket (#2026 / #2029) - server-side,
+   * so a tab pages through the whole catalog rather than filtering the
+   * returned page client-side. Does NOT affect `lifecycleCounts`.
+   */
+  lifecycle?: OfferLifecycle;
 }
 
 export interface ListingsPagination {
@@ -157,6 +171,14 @@ export interface ListingsPagination {
 export interface PaginatedOfferMappings {
   items: OfferMapping[];
   total: number;
+  /**
+   * Row count per lifecycle bucket under the same search/connection/variant
+   * filters as the list, but never narrowed by `lifecycle` itself - otherwise
+   * selecting a tab would zero every other tab's badge (#2026 / #2029). The
+   * buckets partition the filtered set, so they sum to `total` for the same
+   * request without a `lifecycle` filter.
+   */
+  lifecycleCounts: OfferLifecycleCounts;
   limit: number;
   offset: number;
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -5584,6 +5584,33 @@ a.kpi-card:focus-visible {
   color: var(--accent-primary-soft-strong);
 }
 
+/* ── Lifecycle tab count skeleton (#2029) ──────────────────────────────
+   Reuses the shimmer keyframe already defined for `.data-table-skeleton__bar`
+   so a loading count never snaps from a skeleton straight to a real number
+   using two different animation curves. */
+.tabs__count-skeleton {
+  display: inline-block;
+  width: 14px;
+  height: 0.625rem;
+  border-radius: var(--radius-xs);
+  background-color: var(--bg-surface-muted);
+  background-image: linear-gradient(
+    90deg,
+    var(--bg-surface-muted) 0%,
+    var(--bg-surface-hover) 50%,
+    var(--bg-surface-muted) 100%
+  );
+  background-size: 200% 100%;
+  animation: data-table-skeleton-shimmer 1.4s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tabs__count-skeleton {
+    animation: none;
+    background-image: none;
+  }
+}
+
 .tabs__trigger:hover {
   color: var(--text-primary);
   background: transparent;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -5640,6 +5640,28 @@ a.kpi-card:focus-visible {
   outline: none;
 }
 
+/* ── Listings lifecycle tab bar: scroll, don't wrap, at phone widths
+   (#2029 / #2042 round 1) ───────────────────────────────────────────
+   Five buckets (the original four plus Unsynced) no longer fit unwrapped at
+   360px, so this bar scrolls horizontally instead of wrapping each trigger
+   onto two lines. Scoped to this page's own aria-label, not a shared rule -
+   the mapping tab bar's own mobile treatment (`aria-label='Mapping types'`,
+   above) targets the wrong element there and isn't a working reference. */
+@media (max-width: 640px) {
+  .tabs__list[aria-label='Listing lifecycle'] {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+  .tabs__list[aria-label='Listing lifecycle']::-webkit-scrollbar {
+    display: none;
+  }
+  .tabs__list[aria-label='Listing lifecycle'] .tabs__trigger {
+    white-space: nowrap;
+    flex-shrink: 0;
+  }
+}
+
 /*
  * ── Phase 5 primitives — SetupStepper ────────────────────────────────
  * Horizontal stepper used by multi-step setup wizards. The full list

--- a/apps/web/src/pages/listings/listings-list-page.test.tsx
+++ b/apps/web/src/pages/listings/listings-list-page.test.tsx
@@ -683,5 +683,108 @@ describe('ListingsListPage', () => {
       expect(screen.getAllByRole('tab')).toHaveLength(5);
       expect(container.querySelectorAll('.tabs__count-skeleton')).toHaveLength(5);
     });
+
+    it("keeps every tab's already-known count visible - no skeleton reappears - while a switched-to tab is still loading its own rows", async () => {
+      const user = userEvent.setup();
+      const list = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ...sampleMappings,
+          lifecycleCounts: { Active: 7, Inactive: 3, Draft: 2, Ended: 1, Unsynced: 0 },
+        })
+        // The Draft tab's own fetch never resolves in this test - it is the
+        // "still loading" window the skeleton must not reappear during.
+        .mockReturnValueOnce(new Promise(() => {}));
+      const mockApi = createMockApiClient({ listings: { list } });
+
+      const { container } = renderWithProviders(<ListingsListPage />, { apiClient: mockApi });
+
+      await screen.findByText('Doniczka ceramiczna Terra');
+      expect(screen.getByRole('tab', { name: 'Active 7' })).toBeInTheDocument();
+
+      await user.click(screen.getByRole('tab', { name: /^Draft/ }));
+
+      // The Draft tab's own request is now pending (a fresh query key with no
+      // cached data), which used to blank every badge - including the four
+      // that did not just change - back to skeleton.
+      expect(container.querySelectorAll('.tabs__count-skeleton')).toHaveLength(0);
+      expect(screen.getByRole('tab', { name: 'Active 7' })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: 'Inactive 3' })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: 'Draft 2' })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: 'Ended 1' })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: 'Unsynced 0' })).toBeInTheDocument();
+    });
+
+    it("separates a tab's label from its count badge in the accessible name", async () => {
+      const mockApi = createMockApiClient({
+        listings: {
+          list: vi.fn().mockResolvedValue({
+            ...sampleMappings,
+            lifecycleCounts: { Active: 7, Inactive: 3, Draft: 2, Ended: 1, Unsynced: 0 },
+          }),
+        },
+      });
+
+      renderWithProviders(<ListingsListPage />, { apiClient: mockApi });
+
+      await screen.findByText('Doniczka ceramiczna Terra');
+      // A missing separator collapses the JSX whitespace entirely, so the
+      // accessible name would read the run-on "Active7" instead of "Active 7".
+      expect(screen.getByRole('tab', { name: 'Active 7' })).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: 'Inactive 3' })).toBeInTheDocument();
+    });
+
+    it('announces via a live region once the tab counts resolve from skeleton to real numbers', async () => {
+      const mockApi = createMockApiClient({
+        listings: { list: vi.fn().mockResolvedValue(sampleMappings) },
+      });
+
+      renderWithProviders(<ListingsListPage />, { apiClient: mockApi });
+
+      expect(screen.getByText('Loading listing counts…')).toBeInTheDocument();
+      await screen.findByText('Doniczka ceramiczna Terra');
+      expect(screen.getByText('Listing counts loaded.')).toBeInTheDocument();
+      expect(screen.queryByText('Loading listing counts…')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('lifecycle tab empty-state copy (#2042 review)', () => {
+    it("does not overclaim the Draft bucket will go live, and avoids a double negative", async () => {
+      const mockApi = createMockApiClient({
+        listings: { list: vi.fn().mockResolvedValue(emptyPage()) },
+      });
+
+      renderWithProviders(<ListingsListPage />, {
+        apiClient: mockApi,
+        route: '/listings?tab=draft',
+      });
+
+      expect(await screen.findByText('No draft listings')).toBeInTheDocument();
+      expect(
+        screen.getByText('Nothing here is currently live, and none of it has been rejected.'),
+      ).toBeInTheDocument();
+      // Draft carries offers an operator deliberately deactivated and will
+      // never relist - the copy must not promise a future "will go live".
+      expect(screen.queryByText(/without being live yet/)).not.toBeInTheDocument();
+    });
+
+    it("does not borrow Draft's definition into the Inactive tab's empty state", async () => {
+      const mockApi = createMockApiClient({
+        listings: { list: vi.fn().mockResolvedValue(emptyPage()) },
+      });
+
+      renderWithProviders(<ListingsListPage />, {
+        apiClient: mockApi,
+        route: '/listings?tab=inactive',
+      });
+
+      expect(await screen.findByText('No inactive listings')).toBeInTheDocument();
+      expect(
+        screen.getByText('Nothing here has been rejected by a channel validator.'),
+      ).toBeInTheDocument();
+      // "taken offline" is Draft's defining case (a deliberately deactivated
+      // offer), not Inactive's (validator-rejected) - it must not appear here.
+      expect(screen.queryByText(/taken offline/)).not.toBeInTheDocument();
+    });
   });
 });

--- a/apps/web/src/pages/listings/listings-list-page.test.tsx
+++ b/apps/web/src/pages/listings/listings-list-page.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, screen } from '@testing-library/react';
+import { cleanup, fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, it, expect, vi } from 'vitest';
 import type * as ReactRouterDom from 'react-router-dom';
@@ -713,6 +713,43 @@ describe('ListingsListPage', () => {
       expect(screen.getByRole('tab', { name: 'Draft 2' })).toBeInTheDocument();
       expect(screen.getByRole('tab', { name: 'Ended 1' })).toBeInTheDocument();
       expect(screen.getByRole('tab', { name: 'Unsynced 0' })).toBeInTheDocument();
+    });
+
+    it("falls back to skeletons - not the pre-search counts - once the search term changes and the new query has not resolved (#2029 round 2 review)", async () => {
+      const list = vi
+        .fn()
+        .mockResolvedValueOnce({
+          ...sampleMappings,
+          lifecycleCounts: { Active: 7, Inactive: 3, Draft: 2, Ended: 1, Unsynced: 0 },
+        })
+        // The new search term's query key has never been fetched before - it
+        // hangs, which is the window during which a state+Effect pair used to
+        // keep showing the now-wrong "Active 7" (it only ever cleared on the
+        // NEXT successful fetch, so an error here would have left it stuck
+        // forever). The fingerprint-gated ref must drop it immediately.
+        .mockReturnValueOnce(new Promise(() => {}));
+      const mockApi = createMockApiClient({ listings: { list } });
+
+      const { container } = renderWithProviders(<ListingsListPage />, { apiClient: mockApi });
+
+      await screen.findByText('Doniczka ceramiczna Terra');
+      expect(screen.getByRole('tab', { name: 'Active 7' })).toBeInTheDocument();
+
+      fireEvent.change(
+        screen.getByLabelText('Search listings by product name, SKU, EAN/GTIN or external ID'),
+        { target: { value: 'brand new search term' } },
+      );
+
+      // Wait past the debounce window for the new (still-pending) request.
+      await vi.waitFor(() => {
+        expect(list).toHaveBeenCalledTimes(2);
+      });
+
+      // The stale count must not survive the filter change - it falls
+      // through to the skeleton, the honest state while the real count for
+      // the new search term is unknown.
+      expect(screen.queryByRole('tab', { name: 'Active 7' })).not.toBeInTheDocument();
+      expect(container.querySelectorAll('.tabs__count-skeleton')).toHaveLength(5);
     });
 
     it("separates a tab's label from its count badge in the accessible name", async () => {

--- a/apps/web/src/pages/listings/listings-list-page.test.tsx
+++ b/apps/web/src/pages/listings/listings-list-page.test.tsx
@@ -6,9 +6,22 @@ import { renderWithProviders, createMockApiClient, createAuthenticatedSessionAda
 import { mockMobileViewport } from '../../test/viewport';
 import { ListingsListPage } from './listings-list-page';
 import type {
+  OfferLifecycleCounts,
   OfferMapping,
   PaginatedOfferMappings,
 } from '../../features/listings/api/listings.types';
+
+const ZERO_LIFECYCLE_COUNTS: OfferLifecycleCounts = {
+  Active: 0,
+  Inactive: 0,
+  Draft: 0,
+  Ended: 0,
+  Unsynced: 0,
+};
+
+function emptyPage(counts: OfferLifecycleCounts = ZERO_LIFECYCLE_COUNTS): PaginatedOfferMappings {
+  return { items: [], total: 0, limit: 20, offset: 0, lifecycleCounts: counts };
+}
 
 const navigateMock = vi.fn();
 vi.mock('react-router-dom', async (): Promise<typeof ReactRouterDom> => {
@@ -86,6 +99,7 @@ const sampleMappings: PaginatedOfferMappings = {
   total: 2,
   limit: 20,
   offset: 0,
+  lifecycleCounts: { ...ZERO_LIFECYCLE_COUNTS, Active: 2 },
 };
 
 function oneRow(overrides: Partial<OfferMapping>): PaginatedOfferMappings {
@@ -348,17 +362,31 @@ describe('ListingsListPage', () => {
     expect(screen.getByText('Network error')).toBeInTheDocument();
   });
 
-  it('should show empty state with a Manage connections CTA when no mappings exist', async () => {
+  it("should show the Active tab's own empty state when a connection exists but nothing is synced", async () => {
     const mockApi = createMockApiClient({
       listings: {
-        list: vi.fn().mockResolvedValue({ items: [], total: 0, limit: 20, offset: 0 }),
+        list: vi.fn().mockResolvedValue(emptyPage()),
       },
     });
 
     renderWithProviders(<ListingsListPage />, { apiClient: mockApi });
 
-    expect(await screen.findByText('No offer mappings found')).toBeInTheDocument();
-    const cta = screen.getByRole('link', { name: 'Manage connections' });
+    expect(await screen.findByText('No active listings')).toBeInTheDocument();
+    expect(screen.getByText('Nothing here is currently live on a channel.')).toBeInTheDocument();
+    // No connections CTA - a connection already exists (test-utils default).
+    expect(screen.queryByRole('link', { name: 'Connect a channel' })).not.toBeInTheDocument();
+  });
+
+  it('should show a channel-connect empty state when no connections are configured', async () => {
+    const mockApi = createMockApiClient({
+      listings: { list: vi.fn().mockResolvedValue(emptyPage()) },
+      connections: { list: vi.fn().mockResolvedValue([]) },
+    });
+
+    renderWithProviders(<ListingsListPage />, { apiClient: mockApi });
+
+    expect(await screen.findByText('No channels connected yet')).toBeInTheDocument();
+    const cta = screen.getByRole('link', { name: 'Connect a channel' });
     expect(cta).toHaveAttribute('href', '/connections');
   });
 
@@ -366,7 +394,7 @@ describe('ListingsListPage', () => {
     const user = userEvent.setup();
     const mockApi = createMockApiClient({
       listings: {
-        list: vi.fn().mockResolvedValue({ items: [], total: 0, limit: 20, offset: 0 }),
+        list: vi.fn().mockResolvedValue(emptyPage()),
       },
     });
 
@@ -380,7 +408,7 @@ describe('ListingsListPage', () => {
     ).toBeInTheDocument();
     await user.click(screen.getByRole('button', { name: 'Clear filters' }));
 
-    expect(await screen.findByRole('link', { name: 'Manage connections' })).toBeInTheDocument();
+    expect(await screen.findByText('No active listings')).toBeInTheDocument();
   });
 
   it('renders a single "Publish products" entry (no separate shop CTA) with no pre-filter', async () => {
@@ -555,6 +583,105 @@ describe('ListingsListPage', () => {
 
       await screen.findByText('allegro-offer-999');
       expect(screen.queryByRole('button', { name: /publish products/i })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('lifecycle tabs (#2029)', () => {
+    it('defaults to the Active tab and filters the request by lifecycle=Active', async () => {
+      const list = vi.fn().mockResolvedValue(sampleMappings);
+      const mockApi = createMockApiClient({ listings: { list } });
+
+      renderWithProviders(<ListingsListPage />, { apiClient: mockApi });
+
+      await screen.findByText('Doniczka ceramiczna Terra');
+      expect(screen.getByRole('tab', { name: /^Active/ })).toHaveAttribute('aria-selected', 'true');
+      const calledWithActive = list.mock.calls.some(
+        ([filters]) => (filters as { lifecycle?: string } | undefined)?.lifecycle === 'Active'
+      );
+      expect(calledWithActive).toBe(true);
+    });
+
+    it('reads a valid ?tab param, marks it active and filters the request by its lifecycle', async () => {
+      const list = vi.fn().mockResolvedValue(emptyPage());
+      const mockApi = createMockApiClient({ listings: { list } });
+
+      renderWithProviders(<ListingsListPage />, {
+        apiClient: mockApi,
+        route: '/listings?tab=ended',
+      });
+
+      expect(await screen.findByText('No ended listings')).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /^Ended/ })).toHaveAttribute('aria-selected', 'true');
+      const calledWithEnded = list.mock.calls.some(
+        ([filters]) => (filters as { lifecycle?: string } | undefined)?.lifecycle === 'Ended'
+      );
+      expect(calledWithEnded).toBe(true);
+    });
+
+    it('falls back to the Active tab for an unrecognized ?tab param', async () => {
+      const mockApi = createMockApiClient({
+        listings: { list: vi.fn().mockResolvedValue(emptyPage()) },
+      });
+
+      renderWithProviders(<ListingsListPage />, {
+        apiClient: mockApi,
+        route: '/listings?tab=bogus',
+      });
+
+      expect(await screen.findByText('No active listings')).toBeInTheDocument();
+      expect(screen.getByRole('tab', { name: /^Active/ })).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('updates the ?tab URL param and resets pagination to page 1 when a tab is clicked', async () => {
+      const user = userEvent.setup();
+      const list = vi.fn().mockResolvedValue(emptyPage());
+      const mockApi = createMockApiClient({ listings: { list } });
+
+      renderWithProviders(<ListingsListPage />, {
+        apiClient: mockApi,
+        route: '/listings?offset=40',
+      });
+
+      await screen.findByText('No active listings');
+      await user.click(screen.getByRole('tab', { name: /^Draft/ }));
+
+      expect(await screen.findByText('No draft listings')).toBeInTheDocument();
+      await vi.waitFor(() => {
+        const [filters, pagination] = list.mock.calls.at(-1) ?? [];
+        expect((filters as { lifecycle?: string } | undefined)?.lifecycle).toBe('Draft');
+        expect((pagination as { offset?: number } | undefined)?.offset).toBe(0);
+      });
+    });
+
+    it("renders each tab's own count from lifecycleCounts, not the active bucket's row count", async () => {
+      const mockApi = createMockApiClient({
+        listings: {
+          list: vi.fn().mockResolvedValue({
+            ...sampleMappings,
+            lifecycleCounts: { Active: 7, Inactive: 3, Draft: 2, Ended: 1, Unsynced: 0 },
+          }),
+        },
+      });
+
+      renderWithProviders(<ListingsListPage />, { apiClient: mockApi });
+
+      await screen.findByText('Doniczka ceramiczna Terra');
+      expect(screen.getByRole('tab', { name: /^Active/ })).toHaveTextContent('7');
+      expect(screen.getByRole('tab', { name: /^Inactive/ })).toHaveTextContent('3');
+      expect(screen.getByRole('tab', { name: /^Draft/ })).toHaveTextContent('2');
+      expect(screen.getByRole('tab', { name: /^Ended/ })).toHaveTextContent('1');
+      expect(screen.getByRole('tab', { name: /^Unsynced/ })).toHaveTextContent('0');
+    });
+
+    it('renders tab counts as skeleton placeholders while loading, never as a placeholder zero', () => {
+      const mockApi = createMockApiClient({
+        listings: { list: vi.fn().mockReturnValue(new Promise(() => {})) },
+      });
+
+      const { container } = renderWithProviders(<ListingsListPage />, { apiClient: mockApi });
+
+      expect(screen.getAllByRole('tab')).toHaveLength(5);
+      expect(container.querySelectorAll('.tabs__count-skeleton')).toHaveLength(5);
     });
   });
 });

--- a/apps/web/src/pages/listings/listings-list-page.tsx
+++ b/apps/web/src/pages/listings/listings-list-page.tsx
@@ -1,7 +1,7 @@
 import {
   useCallback,
-  useEffect,
   useMemo,
+  useRef,
   useState,
   type ReactElement,
   type ReactNode,
@@ -353,20 +353,36 @@ export function ListingsListPage(): ReactElement {
   const query = useListingsQuery(filters, pagination);
 
   /**
-   * Held separately from `query.data` so a tab switch - a distinct query key,
-   * hence `query.isLoading` true for that fetch - does not blank every tab's
-   * count badge back to skeleton (#2029 round 1 review). The five buckets are
-   * unaffected by which tab is active (the backend excludes `lifecycle` from
-   * the counts aggregate), so the last-known value stays correct while the
-   * new tab's own rows load; only the very first-ever load has nothing to
-   * fall back on and shows the skeleton.
+   * Held in a ref (mutated during render, not an Effect) so a tab switch -
+   * a distinct query key, hence `query.isLoading` true for that fetch - does
+   * not blank every tab's count badge back to skeleton (#2029 round 1
+   * review). The five buckets are unaffected by which tab is active (the
+   * backend excludes `lifecycle` from the counts aggregate), so the
+   * last-known value stays correct while the new tab's own rows load.
+   *
+   * Gated on a fingerprint of `search` + `connectionId` - deliberately
+   * excluding `lifecycle` - because those two filters DO change what the
+   * counts should be. A state+Effect pair here held the value across ANY
+   * `query.data` transition, so a search/connection change kept showing the
+   * old, now-wrong counts with no way to self-correct if the new request
+   * errored (#2029 round 2 review). Changing the fingerprint immediately
+   * invalidates the held value even before the new fetch's data arrives, so
+   * a stale count is never surfaced - it falls through to the skeleton
+   * guard instead, which is the honest state while the real count for the
+   * new filter combination is unknown.
    */
-  const [lifecycleCounts, setLifecycleCounts] = useState<OfferLifecycleCounts | null>(null);
-  useEffect(() => {
-    if (query.data) {
-      setLifecycleCounts(query.data.lifecycleCounts);
-    }
-  }, [query.data]);
+  const lifecycleCountsRef = useRef<{ fingerprint: string; counts: OfferLifecycleCounts } | null>(
+    null,
+  );
+  const countsFingerprint = `${debouncedSearch}::${debouncedConnectionId}`;
+  if (query.data?.lifecycleCounts) {
+    lifecycleCountsRef.current = { fingerprint: countsFingerprint, counts: query.data.lifecycleCounts };
+  }
+  const lifecycleCounts =
+    query.data?.lifecycleCounts ??
+    (lifecycleCountsRef.current?.fingerprint === countsFingerprint
+      ? lifecycleCountsRef.current.counts
+      : null);
 
   const platforms = usePlatforms();
   // One batched read for the whole page - the Connection column must never cost
@@ -568,7 +584,7 @@ export function ListingsListPage(): ReactElement {
                 {lifecycleCounts === null && query.isLoading ? (
                   <span className="tabs__count-skeleton" aria-hidden="true" />
                 ) : (
-                  (lifecycleCounts ?? query.data?.lifecycleCounts)?.[def.lifecycle] ?? '—'
+                  (lifecycleCounts?.[def.lifecycle] ?? '—')
                 )}
               </span>
             </TabsTrigger>

--- a/apps/web/src/pages/listings/listings-list-page.tsx
+++ b/apps/web/src/pages/listings/listings-list-page.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useMemo, useState, type ReactElement, type ReactNode } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactElement,
+  type ReactNode,
+} from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
@@ -34,6 +41,7 @@ import { useDemoMode } from '../../features/system';
 import type {
   ListingsFilters,
   OfferLifecycle,
+  OfferLifecycleCounts,
   OfferMapping,
 } from '../../features/listings/api/listings.types';
 
@@ -82,15 +90,17 @@ const LIFECYCLE_TABS: readonly LifecycleTabDef[] = [
     lifecycle: 'Inactive',
     label: 'Inactive',
     emptyTitle: 'No inactive listings',
-    emptyMessage:
-      'Nothing here has been rejected by a channel validator, or otherwise taken offline.',
+    emptyMessage: 'Nothing here has been rejected by a channel validator.',
   },
   {
     key: 'draft',
     lifecycle: 'Draft',
     label: 'Draft',
     emptyTitle: 'No draft listings',
-    emptyMessage: 'Nothing here exists on a channel without being live yet.',
+    // Deliberately NOT "not live yet" - Draft also holds an offer an operator
+    // deliberately deactivated weeks ago and will never relist
+    // (offer-lifecycle.types.ts), so the copy must not promise a future state.
+    emptyMessage: 'Nothing here is currently live, and none of it has been rejected.',
   },
   {
     key: 'ended',
@@ -342,6 +352,22 @@ export function ListingsListPage(): ReactElement {
 
   const query = useListingsQuery(filters, pagination);
 
+  /**
+   * Held separately from `query.data` so a tab switch - a distinct query key,
+   * hence `query.isLoading` true for that fetch - does not blank every tab's
+   * count badge back to skeleton (#2029 round 1 review). The five buckets are
+   * unaffected by which tab is active (the backend excludes `lifecycle` from
+   * the counts aggregate), so the last-known value stays correct while the
+   * new tab's own rows load; only the very first-ever load has nothing to
+   * fall back on and shows the skeleton.
+   */
+  const [lifecycleCounts, setLifecycleCounts] = useState<OfferLifecycleCounts | null>(null);
+  useEffect(() => {
+    if (query.data) {
+      setLifecycleCounts(query.data.lifecycleCounts);
+    }
+  }, [query.data]);
+
   const platforms = usePlatforms();
   // One batched read for the whole page - the Connection column must never cost
   // a request per row (#1996).
@@ -528,20 +554,33 @@ export function ListingsListPage(): ReactElement {
         <TabsList aria-label="Listing lifecycle">
           {LIFECYCLE_TABS.map((def) => (
             <TabsTrigger key={def.key} value={def.key}>
-              {def.label}
+              {/* Explicit {' '} - not JSX whitespace, which collapses away
+                  entirely - so the accessible name reads "Active 7", not the
+                  run-on "Active7" (#2029 round 1 review). */}
+              {def.label}{' '}
               <span className="tabs__count">
                 {/* A count that snaps from 0 to its real value reads as a
                     bug (#2029 / mockup frame 04) - render a skeleton line
-                    instead of a placeholder zero while it's unknown. */}
-                {query.isLoading ? (
+                    instead of a placeholder zero while it's unknown. Once any
+                    counts have ever loaded, a tab switch keeps showing them
+                    (rather than reverting to skeleton) so switching tabs never
+                    blanks the four buckets that did not just change. */}
+                {lifecycleCounts === null && query.isLoading ? (
                   <span className="tabs__count-skeleton" aria-hidden="true" />
                 ) : (
-                  query.data?.lifecycleCounts?.[def.lifecycle] ?? '—'
+                  (lifecycleCounts ?? query.data?.lifecycleCounts)?.[def.lifecycle] ?? '—'
                 )}
               </span>
             </TabsTrigger>
           ))}
         </TabsList>
+        {/* Screen-reader-only counterpart to the skeleton-to-number transition
+            above: DataTableSkeleton uses the same role/aria-live pattern for
+            the row table, so the tab bar announces its own loading -> loaded
+            transition the same way (#2029 round 1 review). */}
+        <span className="sr-only" role="status" aria-live="polite">
+          {lifecycleCounts ? 'Listing counts loaded.' : 'Loading listing counts…'}
+        </span>
 
         <TabsContent value={tab}>
           {query.isLoading ? (

--- a/apps/web/src/pages/listings/listings-list-page.tsx
+++ b/apps/web/src/pages/listings/listings-list-page.tsx
@@ -10,6 +10,7 @@ import { Input } from '../../shared/ui/input';
 import { KeyValueList } from '../../shared/ui/key-value-list';
 import { ProductThumbnail } from '../../shared/ui/product-thumbnail';
 import { StatusBadge } from '../../shared/ui/status-badge';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '../../shared/ui/tabs';
 import { TimeDisplay } from '../../shared/ui/time-display';
 import { formatAmount } from '../../shared/format/format-amount';
 import { formatDateTime } from '../../shared/format/format-date';
@@ -30,10 +31,82 @@ import {
 } from '../../features/listings/lib/listing-row-state';
 import { useWriteAccess } from '../../shared/auth/use-permission';
 import { useDemoMode } from '../../features/system';
-import type { ListingsFilters, OfferMapping } from '../../features/listings/api/listings.types';
+import type {
+  ListingsFilters,
+  OfferLifecycle,
+  OfferMapping,
+} from '../../features/listings/api/listings.types';
 
 const PAGE_SIZE = 20;
 const SEARCH_DEBOUNCE_MS = 300;
+
+/**
+ * Lowercase URL-state token for each lifecycle bucket (#2029). Kept distinct
+ * from the PascalCase `OfferLifecycle` the API speaks, mirroring the existing
+ * `?health=` convention (`orders-list-page.tsx`) of a lowercase URL param.
+ */
+const LIFECYCLE_TAB_VALUES = ['active', 'inactive', 'draft', 'ended', 'unsynced'] as const;
+type LifecycleTab = (typeof LIFECYCLE_TAB_VALUES)[number];
+
+const DEFAULT_TAB: LifecycleTab = 'active';
+
+/** Type-guard for the `tab` URL param, mirroring `isOrderHealth` in `orders-list-page.tsx`. */
+function isLifecycleTab(value: string | null): value is LifecycleTab {
+  return value !== null && (LIFECYCLE_TAB_VALUES as readonly string[]).includes(value);
+}
+
+/**
+ * One entry per lifecycle tab: its URL token, the `OfferLifecycle` value it
+ * filters by, its label, and its own empty-state copy (#2029) - each bucket
+ * means something different (see `offer-lifecycle.types.ts` docblocks), so a
+ * single generic "no results" message would under-inform the operator.
+ */
+interface LifecycleTabDef {
+  key: LifecycleTab;
+  lifecycle: OfferLifecycle;
+  label: string;
+  emptyTitle: string;
+  emptyMessage: string;
+}
+
+const LIFECYCLE_TABS: readonly LifecycleTabDef[] = [
+  {
+    key: 'active',
+    lifecycle: 'Active',
+    label: 'Active',
+    emptyTitle: 'No active listings',
+    emptyMessage: 'Nothing here is currently live on a channel.',
+  },
+  {
+    key: 'inactive',
+    lifecycle: 'Inactive',
+    label: 'Inactive',
+    emptyTitle: 'No inactive listings',
+    emptyMessage:
+      'Nothing here has been rejected by a channel validator, or otherwise taken offline.',
+  },
+  {
+    key: 'draft',
+    lifecycle: 'Draft',
+    label: 'Draft',
+    emptyTitle: 'No draft listings',
+    emptyMessage: 'Nothing here exists on a channel without being live yet.',
+  },
+  {
+    key: 'ended',
+    lifecycle: 'Ended',
+    label: 'Ended',
+    emptyTitle: 'No ended listings',
+    emptyMessage: 'Nothing here has been ended by a channel.',
+  },
+  {
+    key: 'unsynced',
+    lifecycle: 'Unsynced',
+    label: 'Unsynced',
+    emptyTitle: 'No unsynced listings',
+    emptyMessage: 'Every mapping here has had its channel status read at least once.',
+  },
+];
 
 /**
  * Column heading that names whose number the column carries. Price and quantity
@@ -250,6 +323,10 @@ export function ListingsListPage(): ReactElement {
   const urlConnectionId = searchParams.get('connectionId') ?? '';
   const offset = Number(searchParams.get('offset') ?? '0');
 
+  const rawTab = searchParams.get('tab');
+  const tab: LifecycleTab = isLifecycleTab(rawTab) ? rawTab : DEFAULT_TAB;
+  const activeTabDef = LIFECYCLE_TABS.find((def) => def.key === tab) ?? LIFECYCLE_TABS[0];
+
   const [searchInput, setSearchInput] = useState(urlSearch);
   const [connectionIdInput, setConnectionIdInput] = useState(urlConnectionId);
 
@@ -259,6 +336,7 @@ export function ListingsListPage(): ReactElement {
   const filters: ListingsFilters = {
     search: debouncedSearch || undefined,
     connectionId: debouncedConnectionId || undefined,
+    lifecycle: activeTabDef.lifecycle,
   };
   const pagination = { limit: PAGE_SIZE, offset };
 
@@ -346,6 +424,24 @@ export function ListingsListPage(): ReactElement {
     });
   }
 
+  /**
+   * Selecting a tab sets the `tab` URL param (omitted at the default 'active'
+   * value, mirroring the `offset=0` omission convention below) and resets
+   * paging - a tab switch always lands on page 1 of the new bucket (#2029).
+   */
+  function setTab(next: LifecycleTab): void {
+    setSearchParams((prev) => {
+      const p = new URLSearchParams(prev);
+      if (next === DEFAULT_TAB) {
+        p.delete('tab');
+      } else {
+        p.set('tab', next);
+      }
+      p.delete('offset');
+      return p;
+    });
+  }
+
   function setOffset(next: number): void {
     setSearchParams((prev) => {
       const p = new URLSearchParams(prev);
@@ -378,6 +474,12 @@ export function ListingsListPage(): ReactElement {
   const total = query.data?.total ?? 0;
   const hasPrev = offset > 0;
   const hasNext = offset + PAGE_SIZE < total;
+
+  // Distinct from the generic "connections exist but this bucket is empty"
+  // case (#2029) - clearing filters can't help an operator with zero
+  // connections configured, so it gets its own empty state + CTA.
+  const noConnectionsConfigured =
+    !connectionsQuery.isLoading && (connectionsQuery.data ?? []).length === 0;
 
   const demoMode = useDemoMode();
   // The unified "Publish products" entry opens a picker first — visible
@@ -417,176 +519,212 @@ export function ListingsListPage(): ReactElement {
         />
       </div>
 
-      {query.isLoading ? (
-        <DataTableSkeleton columns={columns} />
-      ) : query.error ? (
-        <ErrorState
-          title="Unable to load listings"
-          message={query.error.message}
-          action={
-            <Button
-              onClick={() => {
-                void query.refetch();
-              }}
-            >
-              Retry
-            </Button>
-          }
-        />
-      ) : (query.data?.items.length ?? 0) === 0 ? (
-        <EmptyState
-          liveRegion="off"
-          title="No offer mappings found"
-          message={
-            hasFilters
-              ? 'No offer mappings match the current filters.'
-              : 'No offer mappings have been synced yet.'
-          }
-          action={
-            hasFilters ? (
-              <Button onClick={clearFilters}>Clear filters</Button>
-            ) : (
-              <Link className="button button--primary" to="/connections">
-                Manage connections
-              </Link>
-            )
-          }
-        />
-      ) : (
-        <>
-          <DataTable
-            caption="Listings"
-            // Scopes the identity column's width floor to this table - the
-            // mockup put `min-width: 28rem` on `.data-table td:first-child`,
-            // which here would reach ~12 unrelated tables (#2028).
-            className="listings-table"
-            columns={columns}
-            rows={query.data?.items ?? []}
-            rowKey={(m) => m.id}
-            rowHref={(m) => m.id}
-            cardView={{
-              title: (m) => <ListingCell row={m} shape="card" />,
-              // Channel / Connection / Price / Quantity as a two-column fact
-              // list — the four columns the fold drops (#1965 frame 05).
-              summary: (m) => (
-                <dl className="listings-card-facts">
-                  <div>
-                    <dt>Channel</dt>
-                    <dd>
-                      <ChannelPill row={m} label={channelLabel(m)} />
-                    </dd>
-                  </div>
-                  <div>
-                    <dt>Connection</dt>
-                    <dd>
-                      <ConnectionCell
-                        connectionId={m.connectionId}
-                        connection={connectionsById.get(m.connectionId) ?? null}
-                        loading={connectionsQuery.isLoading}
-                      />
-                    </dd>
-                  </div>
-                  <div>
-                    <dt>Price on channel</dt>
-                    <dd>
-                      <PriceCell row={m} />
-                    </dd>
-                  </div>
-                  <div>
-                    <dt>Quantity on channel</dt>
-                    <dd>
-                      <QuantityCell row={m} />
-                    </dd>
-                  </div>
-                </dl>
-              ),
-              // The long-form fields stay behind a disclosure so the card leads
-              // with the four facts above rather than a wall of identifiers.
-              collapsibleDetail: true,
-              detail: (m) => (
-                <KeyValueList
-                  items={[
-                    {
-                      id: 'lifecycle',
-                      label: 'Lifecycle',
-                      value: m.channelStatus?.lifecycle ?? <EmptyValue />,
-                    },
-                    {
-                      id: 'publicationStatus',
-                      label: 'Channel status',
-                      value: m.channelStatus?.publicationStatus ?? <EmptyValue />,
-                      mono: true,
-                    },
-                    {
-                      id: 'updated',
-                      label: 'Status read',
-                      value: <UpdatedCell row={m} />,
-                    },
-                    // The card head drops these two so the product name keeps
-                    // its room at 360px (#1965 frame 05) - they stay reachable
-                    // one tap away rather than disappearing.
-                    {
-                      id: 'externalId',
-                      label: 'Offer ID',
-                      value: m.externalId,
-                      mono: true,
-                    },
-                    {
-                      id: 'ean',
-                      label: 'EAN/GTIN',
-                      value: m.identity?.ean ?? <EmptyValue label="No EAN on the linked variant" />,
-                      mono: true,
-                    },
-                    {
-                      id: 'internalId',
-                      label: 'Variant ID',
-                      value: m.internalId,
-                      mono: true,
-                    },
-                    {
-                      id: 'validation',
-                      label: 'Validator messages',
-                      value: m.channelStatus?.validationMessages.length ? (
-                        <ul className="listings-card-messages">
-                          {m.channelStatus.validationMessages.map((message) => (
-                            <li key={message}>{message}</li>
-                          ))}
-                        </ul>
-                      ) : (
-                        <EmptyValue label="No validator messages" />
-                      ),
-                    },
-                  ]}
-                />
-              ),
-            }}
-          />
+      <Tabs
+        value={tab}
+        onValueChange={(value) => {
+          if (isLifecycleTab(value)) setTab(value);
+        }}
+      >
+        <TabsList aria-label="Listing lifecycle">
+          {LIFECYCLE_TABS.map((def) => (
+            <TabsTrigger key={def.key} value={def.key}>
+              {def.label}
+              <span className="tabs__count">
+                {/* A count that snaps from 0 to its real value reads as a
+                    bug (#2029 / mockup frame 04) - render a skeleton line
+                    instead of a placeholder zero while it's unknown. */}
+                {query.isLoading ? (
+                  <span className="tabs__count-skeleton" aria-hidden="true" />
+                ) : (
+                  query.data?.lifecycleCounts?.[def.lifecycle] ?? '—'
+                )}
+              </span>
+            </TabsTrigger>
+          ))}
+        </TabsList>
 
-          <div className="pagination">
-            <span className="text-muted">
-              Showing {offset + 1}–{Math.min(offset + PAGE_SIZE, total)} of {total}
-            </span>
-            <div className="pagination__actions">
-              <Button
-                disabled={!hasPrev}
-                onClick={() => {
-                  setOffset(offset - PAGE_SIZE);
+        <TabsContent value={tab}>
+          {query.isLoading ? (
+            <DataTableSkeleton columns={columns} />
+          ) : query.error ? (
+            <ErrorState
+              title="Unable to load listings"
+              message={query.error.message}
+              action={
+                <Button
+                  onClick={() => {
+                    void query.refetch();
+                  }}
+                >
+                  Retry
+                </Button>
+              }
+            />
+          ) : (query.data?.items.length ?? 0) === 0 ? (
+            hasFilters ? (
+              <EmptyState
+                liveRegion="off"
+                title="No offer mappings found"
+                message="No offer mappings match the current filters."
+                action={<Button onClick={clearFilters}>Clear filters</Button>}
+              />
+            ) : noConnectionsConfigured ? (
+              <EmptyState
+                liveRegion="off"
+                title="No channels connected yet"
+                message="Listings are published to connected sales channels."
+                action={
+                  <Link className="button button--primary" to="/connections">
+                    Connect a channel
+                  </Link>
+                }
+              />
+            ) : (
+              <EmptyState
+                liveRegion="off"
+                title={activeTabDef.emptyTitle}
+                message={activeTabDef.emptyMessage}
+              />
+            )
+          ) : (
+            <>
+              <DataTable
+                caption="Listings"
+                // Scopes the identity column's width floor to this table - the
+                // mockup put `min-width: 28rem` on `.data-table td:first-child`,
+                // which here would reach ~12 unrelated tables (#2028).
+                className="listings-table"
+                columns={columns}
+                rows={query.data?.items ?? []}
+                rowKey={(m) => m.id}
+                rowHref={(m) => m.id}
+                cardView={{
+                  title: (m) => <ListingCell row={m} shape="card" />,
+                  // Channel / Connection / Price / Quantity as a two-column fact
+                  // list — the four columns the fold drops (#1965 frame 05).
+                  summary: (m) => (
+                    <dl className="listings-card-facts">
+                      <div>
+                        <dt>Channel</dt>
+                        <dd>
+                          <ChannelPill row={m} label={channelLabel(m)} />
+                        </dd>
+                      </div>
+                      <div>
+                        <dt>Connection</dt>
+                        <dd>
+                          <ConnectionCell
+                            connectionId={m.connectionId}
+                            connection={connectionsById.get(m.connectionId) ?? null}
+                            loading={connectionsQuery.isLoading}
+                          />
+                        </dd>
+                      </div>
+                      <div>
+                        <dt>Price on channel</dt>
+                        <dd>
+                          <PriceCell row={m} />
+                        </dd>
+                      </div>
+                      <div>
+                        <dt>Quantity on channel</dt>
+                        <dd>
+                          <QuantityCell row={m} />
+                        </dd>
+                      </div>
+                    </dl>
+                  ),
+                  // The long-form fields stay behind a disclosure so the card leads
+                  // with the four facts above rather than a wall of identifiers.
+                  collapsibleDetail: true,
+                  detail: (m) => (
+                    <KeyValueList
+                      items={[
+                        {
+                          id: 'lifecycle',
+                          label: 'Lifecycle',
+                          value: m.channelStatus?.lifecycle ?? <EmptyValue />,
+                        },
+                        {
+                          id: 'publicationStatus',
+                          label: 'Channel status',
+                          value: m.channelStatus?.publicationStatus ?? <EmptyValue />,
+                          mono: true,
+                        },
+                        {
+                          id: 'updated',
+                          label: 'Status read',
+                          value: <UpdatedCell row={m} />,
+                        },
+                        // The card head drops these two so the product name keeps
+                        // its room at 360px (#1965 frame 05) - they stay reachable
+                        // one tap away rather than disappearing.
+                        {
+                          id: 'externalId',
+                          label: 'Offer ID',
+                          value: m.externalId,
+                          mono: true,
+                        },
+                        {
+                          id: 'ean',
+                          label: 'EAN/GTIN',
+                          value: m.identity?.ean ?? (
+                            <EmptyValue label="No EAN on the linked variant" />
+                          ),
+                          mono: true,
+                        },
+                        {
+                          id: 'internalId',
+                          label: 'Variant ID',
+                          value: m.internalId,
+                          mono: true,
+                        },
+                        {
+                          id: 'validation',
+                          label: 'Validator messages',
+                          value: m.channelStatus?.validationMessages.length ? (
+                            <ul className="listings-card-messages">
+                              {m.channelStatus.validationMessages.map((message) => (
+                                <li key={message}>{message}</li>
+                              ))}
+                            </ul>
+                          ) : (
+                            <EmptyValue label="No validator messages" />
+                          ),
+                        },
+                      ]}
+                    />
+                  ),
                 }}
-              >
-                Previous
-              </Button>
-              <Button
-                disabled={!hasNext}
-                onClick={() => {
-                  setOffset(offset + PAGE_SIZE);
-                }}
-              >
-                Next
-              </Button>
-            </div>
-          </div>
-        </>
-      )}
+              />
+
+              <div className="pagination">
+                <span className="text-muted">
+                  Showing {offset + 1}–{Math.min(offset + PAGE_SIZE, total)} of {total}
+                </span>
+                <div className="pagination__actions">
+                  <Button
+                    disabled={!hasPrev}
+                    onClick={() => {
+                      setOffset(offset - PAGE_SIZE);
+                    }}
+                  >
+                    Previous
+                  </Button>
+                  <Button
+                    disabled={!hasNext}
+                    onClick={() => {
+                      setOffset(offset + PAGE_SIZE);
+                    }}
+                  >
+                    Next
+                  </Button>
+                </div>
+              </div>
+            </>
+          )}
+        </TabsContent>
+      </Tabs>
 
       <OfferProductPickerModal isOpen={isWizardOpen} onClose={() => setIsWizardOpen(false)} />
     </PageLayout>

--- a/apps/web/src/pages/products/product-detail-page.test.tsx
+++ b/apps/web/src/pages/products/product-detail-page.test.tsx
@@ -10,7 +10,19 @@ import {
 import { ProductDetailPage } from './product-detail-page';
 import type { Product } from '../../features/products/api/products.types';
 import type { InventoryItem, PaginatedInventory } from '../../features/inventory/api/inventory.types';
-import type { OfferMapping, PaginatedOfferMappings } from '../../features/listings/api/listings.types';
+import type {
+  OfferLifecycleCounts,
+  OfferMapping,
+  PaginatedOfferMappings,
+} from '../../features/listings/api/listings.types';
+
+const ZERO_LIFECYCLE_COUNTS: OfferLifecycleCounts = {
+  Active: 0,
+  Inactive: 0,
+  Draft: 0,
+  Ended: 0,
+  Unsynced: 0,
+};
 
 const sampleProduct: Product = {
   id: 'ol_product_abc123',
@@ -100,7 +112,13 @@ function offerMapping(overrides: Partial<OfferMapping>): OfferMapping {
 }
 
 function paginatedListings(items: OfferMapping[]): PaginatedOfferMappings {
-  return { items, total: items.length, limit: 50, offset: 0 };
+  return {
+    items,
+    total: items.length,
+    limit: 50,
+    offset: 0,
+    lifecycleCounts: ZERO_LIFECYCLE_COUNTS,
+  };
 }
 
 async function findAvailableKpiCard(): Promise<HTMLElement> {


### PR DESCRIPTION
## Summary

Adds a controlled `Tabs` bar to `/listings` for all five lifecycle buckets — Active, Inactive, Draft, Ended, **Unsynced** — sourced from BE-C's `lifecycleCounts` (#2026).

- Selection lives in a lowercase `?tab=` URL param (mirroring `orders-list-page`'s `?health=` convention: a type guard, default value omitted from the URL). Bookmarkable, survives refresh, resets `offset` to 0 on switch.
- The selected tab sets the `lifecycle` request filter, so a tab pages through the whole bucket server-side rather than filtering the current page client-side.
- Tab counts render as a shimmer skeleton (reusing the existing `data-table-skeleton__bar` keyframe, respecting `prefers-reduced-motion`) while loading, never a placeholder `0` — a count that snaps from 0 to a real number reads as a bug.
- Each tab has its own empty-state copy reflecting what that bucket actually means (an Unsynced-empty catalog says something different from an Ended-empty one). A separate "no channels connected yet" state covers the zero-connections case, distinct from "this bucket is empty."

## Deviation from the issue body — not actually a deviation

Issue #2029's body says "4 disjoint lifecycle tabs (Active/Inactive/Draft/Ended)". That predates a later epic decision: the epic owner approved a fifth bucket, **Unsynced**, for mappings whose channel status has never been read at all — a large fraction of any big catalog under the hourly 100-offer status-sync scan (documented on epic #2023 and in BE-C's `offer-lifecycle.types.ts` docblocks). This PR implements the current, correct scope: **five** tabs, not four. The mockup (frame 03) only shows four because it predates this decision too.

## Files

- `apps/web/src/features/listings/api/listings.types.ts` — `OfferLifecycleCounts`, `ListingsFilters.lifecycle`, `PaginatedOfferMappings.lifecycleCounts` (mirrors the BE-C response DTO verbatim)
- `apps/web/src/features/listings/api/listings.api.ts` — threads `lifecycle` onto the query string
- `apps/web/src/pages/listings/listings-list-page.tsx` — the `Tabs`/`TabsList`/`TabsTrigger`/`TabsContent` wiring, `LIFECYCLE_TABS` definition table (label + empty-state copy per bucket), `isLifecycleTab` guard, `setTab`
- `apps/web/src/index.css` — `.tabs__count-skeleton`
- `apps/web/src/pages/listings/listings-list-page.test.tsx` — new `describe('lifecycle tabs (#2029)')` block plus two new empty-state tests
- `apps/web/src/app/hooks/use-nav-counts.test.tsx`, `apps/web/src/pages/products/product-detail-page.test.tsx` — updated fixture builders for the now-required `lifecycleCounts` field on `PaginatedOfferMappings` (not otherwise related to this issue; required by the type change)

## Testing

Added: default-tab + lifecycle filter, reading a valid `?tab` param, falling back to Active on an unrecognized `?tab` value, tab click updating the URL and resetting `offset`, per-tab counts rendering from `lifecycleCounts` independent of the active bucket's row count, skeleton-not-zero while loading, the Active-tab-specific empty state, and the no-connections-configured empty state.

**These specs are unexecuted.** This development machine cannot run `vitest`/`jest`/`pnpm test` without freezing, and CI does not fire on this epic's sub-PRs (only on the epic PR to `main`, `ci.yml`'s `pull_request: branches: [main]` trigger). They run for the first time when epic PR #2032 un-drafts.

Gate run locally: `pnpm lint` (0 errors), `pnpm type-check` (clean across all 18 projects — confirms no other `PaginatedOfferMappings` fixture site was missed, since `lifecycleCounts` is a required field), `pnpm check:invariants` (all green).

## Dependencies

FE-B (#2028, merged) and BE-C (#2026, merged) — both landed on the epic branch before this branch was cut.

Refs #2029