### PR TITLE
feat(web/listings): rework toolbar with channel select and clear button

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -17122,6 +17122,17 @@ textarea.bulk-editor__input { resize: vertical; min-height: 66px; font-family: i
 .listings-toolbar .toolbar__group {
   flex-wrap: wrap;
 }
+/* `.toolbar`'s base `justify-content: space-between` only right-anchors Clear
+   while it shares a line with `.toolbar__group`. The moment the row above
+   wraps, Clear becomes the lone item on its own line, and `space-between`
+   degrades to `flex-start` per the flexbox spec - stranding it at the LEFT
+   edge instead. `.orders-toolbar` never hit this because it has no separate
+   Clear sibling (all its controls sit inside one `.toolbar__group`). `margin
+   -left: auto` absorbs the leftover space itself, so Clear stays right-
+   anchored whether it's sharing a line or wrapped onto its own. */
+.listings-toolbar > .button {
+  margin-left: auto;
+}
 
 /* ── Listings table row anatomy (#2028) ──────────────────────────────────────
    Transcribed from the #1965 mockup: a listing row leads with the catalog

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -17108,6 +17108,21 @@ textarea.bulk-editor__input { resize: vertical; min-height: 66px; font-family: i
   color: var(--text-muted);
 }
 
+/* ── Listings toolbar wrap opt-in (#2030) ────────────────────────────────────
+   `.toolbar` / `.toolbar__group` stay `nowrap` by default (see the comment on
+   `.orders-toolbar` below) because most toolbars fit their controls on one
+   row. This page's toolbar (search + channel select + Clear) doesn't at
+   tablet/phone widths, so it opts in the same way `.orders-toolbar` does:
+   wrap the toolbar itself, and wrap its `.toolbar__group` child so the
+   search/select pair inside it can also drop onto their own lines rather
+   than being squeezed into a single nowrap row. */
+.listings-toolbar {
+  flex-wrap: wrap;
+}
+.listings-toolbar .toolbar__group {
+  flex-wrap: wrap;
+}
+
 /* ── Listings table row anatomy (#2028) ──────────────────────────────────────
    Transcribed from the #1965 mockup: a listing row leads with the catalog
    product name, groups its three identifiers on a second line, and keeps the

--- a/apps/web/src/pages/listings/listings-list-page.test.tsx
+++ b/apps/web/src/pages/listings/listings-list-page.test.tsx
@@ -736,7 +736,7 @@ describe('ListingsListPage', () => {
       expect(screen.getByRole('tab', { name: 'Active 7' })).toBeInTheDocument();
 
       fireEvent.change(
-        screen.getByLabelText('Search listings by product name, SKU, EAN/GTIN or external ID'),
+        screen.getByLabelText('Search listings by product name, SKU, EAN or external ID'),
         { target: { value: 'brand new search term' } },
       );
 
@@ -822,6 +822,117 @@ describe('ListingsListPage', () => {
       // "taken offline" is Draft's defining case (a deliberately deactivated
       // offer), not Inactive's (validator-rejected) - it must not appear here.
       expect(screen.queryByText(/taken offline/)).not.toBeInTheDocument();
+    });
+  });
+
+  describe('toolbar rework (#2030)', () => {
+    const SECOND_CONNECTION = {
+      id: 'conn_1',
+      name: 'Main PrestaShop Store',
+      platformType: 'prestashop',
+      status: 'active',
+      config: {},
+      credentialsBacked: true,
+      adapterKey: 'prestashop.webservice.v1',
+      enabledCapabilities: ['ProductMaster'],
+      supportedCapabilities: ['ProductMaster'],
+      createdAt: '2026-01-01T00:00:00Z',
+      updatedAt: '2026-01-01T00:00:00Z',
+    };
+    const TWO_CONNECTIONS = [SECOND_CONNECTION, MISMATCHED_PLATFORM_CONNECTION];
+
+    it('renders the channel select with connection names, not raw ids or platform types, from one shared connections read', async () => {
+      const connectionsList = vi.fn().mockResolvedValue(TWO_CONNECTIONS);
+      const mockApi = createMockApiClient({
+        listings: { list: vi.fn().mockResolvedValue(sampleMappings) },
+        connections: { list: connectionsList },
+      });
+
+      renderWithProviders(<ListingsListPage />, { apiClient: mockApi });
+
+      await screen.findByText('Doniczka ceramiczna Terra');
+      const select = screen.getByRole('combobox', { name: 'Filter by channel' });
+      const optionLabels = [...select.querySelectorAll('option')].map((o) => o.textContent);
+      expect(optionLabels).toEqual(['All channels', 'Main PrestaShop Store', 'Erli Demo']);
+      // Names only - never the raw connection id or its platformType string.
+      expect(screen.queryByText('conn_allegro_1')).not.toBeInTheDocument();
+      expect(screen.queryByText('prestashop')).not.toBeInTheDocument();
+      // The Connection column already reads `useConnectionsQuery()` once for the
+      // whole page (#1996) - the toolbar select must reuse that same result
+      // rather than firing a second connections request.
+      expect(connectionsList).toHaveBeenCalledTimes(1);
+    });
+
+    it('filters the request by the selected channel connection id', async () => {
+      const user = userEvent.setup();
+      const list = vi.fn().mockResolvedValue(sampleMappings);
+      const mockApi = createMockApiClient({
+        listings: { list },
+        connections: { list: vi.fn().mockResolvedValue(TWO_CONNECTIONS) },
+      });
+
+      renderWithProviders(<ListingsListPage />, { apiClient: mockApi });
+
+      await screen.findByText('Doniczka ceramiczna Terra');
+      const select = screen.getByRole('combobox', { name: 'Filter by channel' });
+      await user.selectOptions(select, 'conn_allegro_1');
+
+      await vi.waitFor(() => {
+        const [filters] = list.mock.calls.at(-1) ?? [];
+        expect((filters as { connectionId?: string } | undefined)?.connectionId).toBe(
+          'conn_allegro_1',
+        );
+      });
+      expect(select).toHaveValue('conn_allegro_1');
+    });
+
+    it('no longer renders the pre-#2030 raw connection-id text input', async () => {
+      const mockApi = createMockApiClient({
+        listings: { list: vi.fn().mockResolvedValue(sampleMappings) },
+      });
+
+      renderWithProviders(<ListingsListPage />, { apiClient: mockApi });
+
+      await screen.findByText('Doniczka ceramiczna Terra');
+      expect(screen.queryByLabelText('Filter by connection ID')).not.toBeInTheDocument();
+      expect(screen.queryByPlaceholderText('Connection ID…')).not.toBeInTheDocument();
+    });
+
+    it('resets search, the channel filter and the lifecycle tab together when Clear is clicked, without a full reload', async () => {
+      const user = userEvent.setup();
+      const mockApi = createMockApiClient({
+        listings: { list: vi.fn().mockResolvedValue(sampleMappings) },
+        connections: { list: vi.fn().mockResolvedValue(TWO_CONNECTIONS) },
+      });
+
+      renderWithProviders(<ListingsListPage />, {
+        apiClient: mockApi,
+        route: '/listings?search=terra&connectionId=conn_allegro_1&tab=draft',
+      });
+
+      await screen.findByText('Doniczka ceramiczna Terra');
+      expect(
+        screen.getByLabelText('Search listings by product name, SKU, EAN or external ID'),
+      ).toHaveValue('terra');
+      expect(screen.getByRole('combobox', { name: 'Filter by channel' })).toHaveValue(
+        'conn_allegro_1',
+      );
+      expect(screen.getByRole('tab', { name: /^Draft/ })).toHaveAttribute('aria-selected', 'true');
+
+      // A plain URL-state reset (react-router `setSearchParams`), never a full
+      // page reload - the table re-renders in place from the cleared params.
+      await user.click(screen.getByRole('button', { name: 'Clear' }));
+
+      await vi.waitFor(() => {
+        expect(screen.getByRole('tab', { name: /^Active/ })).toHaveAttribute(
+          'aria-selected',
+          'true',
+        );
+      });
+      expect(
+        screen.getByLabelText('Search listings by product name, SKU, EAN or external ID'),
+      ).toHaveValue('');
+      expect(screen.getByRole('combobox', { name: 'Filter by channel' })).toHaveValue('');
     });
   });
 });

--- a/apps/web/src/pages/listings/listings-list-page.test.tsx
+++ b/apps/web/src/pages/listings/listings-list-page.test.tsx
@@ -841,7 +841,7 @@ describe('ListingsListPage', () => {
     };
     const TWO_CONNECTIONS = [SECOND_CONNECTION, MISMATCHED_PLATFORM_CONNECTION];
 
-    it('renders the channel select with connection names, not raw ids or platform types, from one shared connections read', async () => {
+    it('renders the channel select with connection names for OfferManager-capable connections only, from one shared connections read', async () => {
       const connectionsList = vi.fn().mockResolvedValue(TWO_CONNECTIONS);
       const mockApi = createMockApiClient({
         listings: { list: vi.fn().mockResolvedValue(sampleMappings) },
@@ -853,14 +853,34 @@ describe('ListingsListPage', () => {
       await screen.findByText('Doniczka ceramiczna Terra');
       const select = screen.getByRole('combobox', { name: 'Filter by channel' });
       const optionLabels = [...select.querySelectorAll('option')].map((o) => o.textContent);
-      expect(optionLabels).toEqual(['All channels', 'Main PrestaShop Store', 'Erli Demo']);
+      // SECOND_CONNECTION only has ProductMaster - /listings is backed
+      // exclusively by offer mappings, so a ProductMaster-only connection can
+      // never produce a row here and must not be offered as a filter option
+      // (it would deterministically empty the table forever if selected).
+      // Only the OfferManager-capable MISMATCHED_PLATFORM_CONNECTION appears.
+      expect(optionLabels).toEqual(['All channels', 'Erli Demo']);
+      expect(screen.queryByText('Main PrestaShop Store')).not.toBeInTheDocument();
       // Names only - never the raw connection id or its platformType string.
       expect(screen.queryByText('conn_allegro_1')).not.toBeInTheDocument();
-      expect(screen.queryByText('prestashop')).not.toBeInTheDocument();
+      expect(screen.queryByText('erli')).not.toBeInTheDocument();
       // The Connection column already reads `useConnectionsQuery()` once for the
       // whole page (#1996) - the toolbar select must reuse that same result
       // rather than firing a second connections request.
       expect(connectionsList).toHaveBeenCalledTimes(1);
+    });
+
+    it('excludes a connection that lacks OfferManager even when it is otherwise active and named', async () => {
+      const mockApi = createMockApiClient({
+        listings: { list: vi.fn().mockResolvedValue(sampleMappings) },
+        connections: { list: vi.fn().mockResolvedValue([SECOND_CONNECTION]) },
+      });
+
+      renderWithProviders(<ListingsListPage />, { apiClient: mockApi });
+
+      await screen.findByText('Doniczka ceramiczna Terra');
+      const select = screen.getByRole('combobox', { name: 'Filter by channel' });
+      const optionLabels = [...select.querySelectorAll('option')].map((o) => o.textContent);
+      expect(optionLabels).toEqual(['All channels']);
     });
 
     it('filters the request by the selected channel connection id', async () => {

--- a/apps/web/src/pages/listings/listings-list-page.tsx
+++ b/apps/web/src/pages/listings/listings-list-page.tsx
@@ -14,6 +14,7 @@ import { DataTableSkeleton } from '../../shared/ui/data-table-skeleton';
 import { Button } from '../../shared/ui/button';
 import { EmptyValue } from '../../shared/ui/empty-value';
 import { Input } from '../../shared/ui/input';
+import { Select } from '../../shared/ui/select';
 import { KeyValueList } from '../../shared/ui/key-value-list';
 import { ProductThumbnail } from '../../shared/ui/product-thumbnail';
 import { StatusBadge } from '../../shared/ui/status-badge';
@@ -338,14 +339,15 @@ export function ListingsListPage(): ReactElement {
   const activeTabDef = LIFECYCLE_TABS.find((def) => def.key === tab) ?? LIFECYCLE_TABS[0];
 
   const [searchInput, setSearchInput] = useState(urlSearch);
-  const [connectionIdInput, setConnectionIdInput] = useState(urlConnectionId);
 
   const debouncedSearch = useDebouncedValue(searchInput, SEARCH_DEBOUNCE_MS);
-  const debouncedConnectionId = useDebouncedValue(connectionIdInput, SEARCH_DEBOUNCE_MS);
 
+  // The channel filter is a discrete <Select> value, not free text, so it
+  // reads/writes the URL directly with no debounce - unlike search, there is
+  // no keystroke-by-keystroke value to settle.
   const filters: ListingsFilters = {
     search: debouncedSearch || undefined,
-    connectionId: debouncedConnectionId || undefined,
+    connectionId: urlConnectionId || undefined,
     lifecycle: activeTabDef.lifecycle,
   };
   const pagination = { limit: PAGE_SIZE, offset };
@@ -374,7 +376,7 @@ export function ListingsListPage(): ReactElement {
   const lifecycleCountsRef = useRef<{ fingerprint: string; counts: OfferLifecycleCounts } | null>(
     null,
   );
-  const countsFingerprint = `${debouncedSearch}::${debouncedConnectionId}`;
+  const countsFingerprint = `${debouncedSearch}::${urlConnectionId}`;
   if (query.data?.lifecycleCounts) {
     lifecycleCountsRef.current = { fingerprint: countsFingerprint, counts: query.data.lifecycleCounts };
   }
@@ -451,9 +453,8 @@ export function ListingsListPage(): ReactElement {
     [channelLabel, connectionsById, connectionsQuery.isLoading],
   );
 
-  function handleFilterChange(key: string, value: string): void {
+  function handleFilterChange(key: 'search' | 'connectionId', value: string): void {
     if (key === 'search') setSearchInput(value);
-    if (key === 'connectionId') setConnectionIdInput(value);
     setSearchParams((prev) => {
       const next = new URLSearchParams(prev);
       if (value) {
@@ -496,23 +497,29 @@ export function ListingsListPage(): ReactElement {
     });
   }
 
+  /**
+   * Resets search, the channel filter and the lifecycle tab back to their
+   * defaults in one URL-state update (#2030) - a plain `setSearchParams` call,
+   * never `window.location`, so the table re-renders from the new (empty)
+   * filter set without a full page reload.
+   */
   function clearFilters(): void {
     setSearchInput('');
-    setConnectionIdInput('');
     setSearchParams((prev) => {
       const next = new URLSearchParams(prev);
       next.delete('search');
       next.delete('connectionId');
       next.delete('offset');
-      // The platform-type filter is gone (#2025) but a bookmarked URL can still
-      // carry it - strip it so the address bar cannot claim a scope the table
-      // no longer applies. FE-D (#2030) replaces it with a channel select.
+      next.delete('tab');
+      // The platform-type filter is gone (#2025/#2030) but a bookmarked URL can
+      // still carry it - strip it so the address bar cannot claim a scope the
+      // table no longer applies.
       next.delete('platformType');
       return next;
     });
   }
 
-  const hasFilters = !!(debouncedSearch || debouncedConnectionId);
+  const hasFilters = !!(debouncedSearch || urlConnectionId);
   const total = query.data?.total ?? 0;
   const hasPrev = offset > 0;
   const hasNext = offset + PAGE_SIZE < total;
@@ -543,22 +550,38 @@ export function ListingsListPage(): ReactElement {
       }
     >
       <div className="toolbar toolbar--compact">
-        <Input
-          aria-label="Search listings by product name, SKU, EAN/GTIN or external ID"
-          placeholder="Name, SKU, EAN/GTIN or external ID…"
-          value={searchInput}
-          onChange={(e) => {
-            handleFilterChange('search', e.target.value);
-          }}
-        />
-        <Input
-          aria-label="Filter by connection ID"
-          placeholder="Connection ID…"
-          value={connectionIdInput}
-          onChange={(e) => {
-            handleFilterChange('connectionId', e.target.value);
-          }}
-        />
+        <div className="toolbar__group">
+          <Input
+            aria-label="Search listings by product name, SKU, EAN or external ID"
+            placeholder="Product name, SKU, EAN or external ID"
+            value={searchInput}
+            onChange={(e) => {
+              handleFilterChange('search', e.target.value);
+            }}
+          />
+          {/* Channel select replaces the old raw connectionId/platformType text
+              inputs (#2030) - populated from the same batched connections read
+              already used for the Connection column (#1996), so it never costs
+              a second request, and shows each connection's own NAME rather than
+              its raw id or platformType. */}
+          <Select
+            aria-label="Filter by channel"
+            value={urlConnectionId}
+            onChange={(e) => {
+              handleFilterChange('connectionId', e.target.value);
+            }}
+          >
+            <option value="">All channels</option>
+            {(connectionsQuery.data ?? []).map((connection) => (
+              <option key={connection.id} value={connection.id}>
+                {connection.name}
+              </option>
+            ))}
+          </Select>
+        </div>
+        <Button tone="ghost" className="button--sm" onClick={clearFilters}>
+          Clear
+        </Button>
       </div>
 
       <Tabs

--- a/apps/web/src/pages/listings/listings-list-page.tsx
+++ b/apps/web/src/pages/listings/listings-list-page.tsx
@@ -549,7 +549,7 @@ export function ListingsListPage(): ReactElement {
         ) : null
       }
     >
-      <div className="toolbar toolbar--compact">
+      <div className="toolbar toolbar--compact listings-toolbar">
         <div className="toolbar__group">
           <Input
             aria-label="Search listings by product name, SKU, EAN or external ID"
@@ -563,7 +563,11 @@ export function ListingsListPage(): ReactElement {
               inputs (#2030) - populated from the same batched connections read
               already used for the Connection column (#1996), so it never costs
               a second request, and shows each connection's own NAME rather than
-              its raw id or platformType. */}
+              its raw id or platformType. Scoped to OfferManager-capable
+              connections (mirrors useProductMasterConnections' ProductMaster
+              filter) - /listings is backed exclusively by offer mappings, so a
+              ProductMaster/ProductPublisher-only connection can never produce a
+              row here and would otherwise dead-end the table on selection. */}
           <Select
             aria-label="Filter by channel"
             value={urlConnectionId}
@@ -572,11 +576,13 @@ export function ListingsListPage(): ReactElement {
             }}
           >
             <option value="">All channels</option>
-            {(connectionsQuery.data ?? []).map((connection) => (
-              <option key={connection.id} value={connection.id}>
-                {connection.name}
-              </option>
-            ))}
+            {(connectionsQuery.data ?? [])
+              .filter((connection) => connection.enabledCapabilities.includes('OfferManager'))
+              .map((connection) => (
+                <option key={connection.id} value={connection.id}>
+                  {connection.name}
+                </option>
+              ))}
           </Select>
         </div>
         <Button tone="ghost" className="button--sm" onClick={clearFilters}>


### PR DESCRIPTION
## Summary

Replaces the raw text-input filters on `/listings` with the mockup's toolbar shape:

- **Search** — kept (already wired to `ListingsFilters.search`), copy widened to match the mockup: placeholder "Product name, SKU, EAN or external ID", matching aria-label.
- **Channel select** — replaces the raw `connectionId` free-text `Input`. Populated from `useConnectionsQuery()` — the **same** query instance the page's Connection column already uses (#1996), so this never costs a second request — filtered to `OfferManager`-capable connections only, since `/listings` is backed exclusively by offer mappings and a `ProductMaster`/`ProductPublisher`-only connection could never produce a row here (mirrors the `ProductMaster` filter in `useProductMasterConnections`). Options render each connection's `name`, never a raw id or `platformType`. The dropped `platformType` filter (#2025) stays dropped; a bookmarked URL that still carries it is stripped by `clearFilters`, not resurrected.
- **Clear button** — resets `search`, the channel filter, and the lifecycle `tab` param together in one `setSearchParams` call. Pure URL-state reset, no `window.location` reload.
- **Toolbar wraps at tablet/phone widths** — opts into the same `flex-wrap` pattern `orders-list-page.tsx`'s `.orders-toolbar` already uses (`.listings-toolbar` + its `.toolbar__group` child), since the 3-control toolbar (search, channel, Clear) no longer fits one row below ~768px.

## Deviation from the issue body

The issue's own body already notes `platformType` was never a real filter on `ListingsFilters` in this codebase (only a bookmark-cleanup concern) — that's preserved as-is, not reintroduced.

**Correction on scope vs. the mockup**: the mockup (#1965) actually ships **four** toolbar controls at both its desktop and tablet frames — search, a raw connection-ID input, the channel select, and Clear. Its "explicit removal note" applies only to `platformType` (#2025), not to the raw connection-ID box. Collapsing that raw ID input into the new named channel select (rather than keeping both, as the mockup literally shows) is a deliberate simplification made in this PR **beyond** what the mockup asked for — the two controls filter by the same underlying field, so shipping only the named picker reads as strictly better UX, but it is not something the mockup itself requested. Flagging this explicitly so it doesn't read as full mockup fidelity.

## Files

- `apps/web/src/pages/listings/listings-list-page.tsx`
- `apps/web/src/pages/listings/listings-list-page.test.tsx`
- `apps/web/src/index.css`

## Testing

Added: channel select renders connection names (not ids/platformTypes) for `OfferManager`-capable connections only, and excludes a connection that lacks that capability; reuses the single shared connections query (asserted via call count); selecting a channel filters the request by `connectionId`; the old raw connection-id input is gone; Clear resets search + channel + tab together, verified by asserting the resulting DOM/URL state (input value, select value, active tab) rather than by inspecting `window.location`. One pre-existing test's stale aria-label assertion was updated to match the new copy.

**These specs are unexecuted.** This development machine cannot run `vitest`/`jest`/`pnpm test` without freezing, and CI does not fire on this epic's sub-PRs (only on the epic PR to `main`). They run for the first time when epic PR #2032 un-drafts.

Gate run locally: `pnpm lint` (0 errors, repo-wide), `pnpm type-check` (clean across all 18 projects), `pnpm check:invariants` (all green). A stray `libs/integrations/woocommerce` import-style churn from `pnpm lint`'s auto-fix (a known recurring side effect in this repo) was reverted before committing - not part of this diff.

## Dependencies

FE-C (#2029, merged) — same file, landed on the epic branch before this branch was cut.

Refs #2030