### PR TITLE
feat(web/orders): add shared OrderIdentityCell component (#2087)

### DIFF
--- a/apps/web/src/features/orders/components/order-identity-cell.test.tsx
+++ b/apps/web/src/features/orders/components/order-identity-cell.test.tsx
@@ -90,6 +90,25 @@ describe('OrderIdentityCell', () => {
     expect(screen.getByRole('link', { name: 'ORD-2026-000123' })).toBeInTheDocument();
   });
 
+  it('should render an order number of exactly the threshold length verbatim', () => {
+    // 18 chars. Pins the threshold itself, so #2091 cannot silently shorten
+    // differently once it deletes the Orders page's own copy of this rule.
+    renderWithProviders(
+      <OrderIdentityCell orderId={ORDER_ID} orderNumber="ORD-2026-000123456" itemCount={1} />,
+    );
+
+    expect(screen.getByRole('link', { name: 'ORD-2026-000123456' })).toBeInTheDocument();
+  });
+
+  it('should shorten an order number one character past the threshold', () => {
+    // 19 chars ⇒ head 8 + ellipsis + tail 6.
+    renderWithProviders(
+      <OrderIdentityCell orderId={ORDER_ID} orderNumber="ORD-2026-0001234567" itemCount={1} />,
+    );
+
+    expect(screen.getByRole('link', { name: 'ORD-2026…234567' })).toBeInTheDocument();
+  });
+
   it('should render the item thumbnail when the first item carries an image', () => {
     const { container } = renderWithProviders(
       <OrderIdentityCell
@@ -159,6 +178,38 @@ describe('OrderIdentityCell', () => {
       'title',
       '4 more line items (5 in this order)',
     );
+  });
+
+  it('should keep the +N tooltip singular when exactly one item is hidden', () => {
+    renderWithProviders(
+      <OrderIdentityCell
+        orderId={ORDER_ID}
+        orderNumber="6839-2911-4402"
+        firstItemName="Terra Wool Coat"
+        itemCount={2}
+      />,
+    );
+
+    expect(screen.getByText('+1')).toHaveAttribute(
+      'title',
+      '1 more line item (2 in this order)',
+    );
+  });
+
+  it('should render the item name with no chip when the item count is unknown', () => {
+    // Shipments and Invoices feed a nullable `orderSummary` (#1995), so a null
+    // count is a real production input, not a defensive branch.
+    const { container } = renderWithProviders(
+      <OrderIdentityCell
+        orderId={ORDER_ID}
+        orderNumber="6839-2911-4402"
+        firstItemName="Terra Wool Coat"
+        itemCount={null}
+      />,
+    );
+
+    expect(screen.getByText('Terra Wool Coat')).toBeInTheDocument();
+    expect(container.querySelector('.orders-more-count')).toBeNull();
   });
 
   it('should state the line-item count as a sentence when the first item name is unavailable', () => {

--- a/apps/web/src/features/orders/components/order-identity-cell.test.tsx
+++ b/apps/web/src/features/orders/components/order-identity-cell.test.tsx
@@ -32,10 +32,20 @@ describe('OrderIdentityCell', () => {
     );
   });
 
-  it('should treat a blank order number as absent', () => {
+  it('should fall back to the shortened internal id when the order number is only whitespace', () => {
     renderWithProviders(<OrderIdentityCell orderId={ORDER_ID} orderNumber="   " itemCount={1} />);
 
     expect(screen.getByRole('link', { name: SHORT_ORDER_ID })).toBeInTheDocument();
+  });
+
+  it('should render the trimmed order number when the number carries surrounding space', () => {
+    renderWithProviders(
+      <OrderIdentityCell orderId={ORDER_ID} orderNumber="  6839-2911-4402  " itemCount={1} />,
+    );
+
+    // `textContent`, not the accessible name — the latter normalises whitespace
+    // and would pass on an untrimmed render.
+    expect(screen.getByRole('link').textContent).toBe('6839-2911-4402');
   });
 
   it('should render the item thumbnail when the first item carries an image', () => {
@@ -69,6 +79,16 @@ describe('OrderIdentityCell', () => {
     expect(thumbnail).toHaveTextContent('T');
   });
 
+  it('should take the thumbnail glyph from the display name when the item has no name either', () => {
+    // The commonest production state: no adapter populates `firstItemImageUrl`
+    // and `firstItemName` is nullable, so Shipments and Invoices rows land here.
+    const { container } = renderWithProviders(
+      <OrderIdentityCell orderId={ORDER_ID} orderNumber="6839-2911-4402" itemCount={1} />,
+    );
+
+    expect(container.querySelector('.product-thumbnail')).toHaveTextContent('6');
+  });
+
   it('should render no +N chip when the order has exactly one item', () => {
     renderWithProviders(
       <OrderIdentityCell
@@ -93,10 +113,10 @@ describe('OrderIdentityCell', () => {
       />,
     );
 
-    expect(screen.getByText('+4')).toBeInTheDocument();
+    expect(screen.getByText('+4')).toHaveAttribute('title', '5 line items in this order');
   });
 
-  it('should render no second line when the first item name is unavailable', () => {
+  it('should state the line-item count as a sentence when the first item name is unavailable', () => {
     const { container } = renderWithProviders(
       <OrderIdentityCell
         orderId={ORDER_ID}
@@ -106,32 +126,61 @@ describe('OrderIdentityCell', () => {
       />,
     );
 
-    expect(container.querySelector('.orders-items-line')).toBeNull();
-    expect(screen.queryByText('+2')).toBeNull();
+    expect(screen.getByText('3 line items')).toBeInTheDocument();
+    // Never a dangling `+N` with nothing to attach it to.
+    expect(container.querySelector('.orders-more-count')).toBeNull();
   });
 
-  it('should render an empty-value placeholder when no order resolves', () => {
-    renderWithProviders(<OrderIdentityCell orderId="" orderNumber="6839-2911-4402" />);
+  it('should render no second line when the order has a single unnamed item', () => {
+    const { container } = renderWithProviders(
+      <OrderIdentityCell
+        orderId={ORDER_ID}
+        orderNumber="6839-2911-4402"
+        firstItemName={null}
+        itemCount={1}
+      />,
+    );
+
+    expect(container.querySelector('.orders-items-line')).toBeNull();
+    expect(container.querySelector('.orders-cell-sub')).toBeNull();
+  });
+
+  it('should render an empty-value placeholder when there is no order id to resolve', () => {
+    renderWithProviders(<OrderIdentityCell orderId="" />);
 
     expect(screen.getByLabelText('No value')).toBeInTheDocument();
     expect(screen.queryByRole('link')).toBeNull();
     expect(screen.queryByRole('button')).toBeNull();
   });
 
-  it('should copy the full internal order id, never the shortened form', async () => {
+  it('should copy the full internal order id when the shortened form is the one displayed', async () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
     vi.stubGlobal('navigator', { clipboard: { writeText } });
 
     renderWithProviders(<OrderIdentityCell orderId={ORDER_ID} orderNumber={null} itemCount={1} />);
 
-    fireEvent.click(screen.getByRole('button', { name: `Copy ${ORDER_ID}` }));
+    fireEvent.click(screen.getByRole('button', { name: 'Copy internal order ID' }));
 
+    expect(writeText).toHaveBeenCalledTimes(1);
     expect(writeText).toHaveBeenCalledWith(ORDER_ID);
-    expect(writeText).not.toHaveBeenCalledWith(SHORT_ORDER_ID);
-    expect(await screen.findByRole('button', { name: `Copied ${ORDER_ID}` })).toBeInTheDocument();
+    expect(
+      await screen.findByRole('button', { name: 'Copied internal order ID' }),
+    ).toBeInTheDocument();
   });
 
-  it('should fire onNavigate on the name link but not on Copy', () => {
+  it('should name the copy button after the order number when one is present', () => {
+    renderWithProviders(
+      <OrderIdentityCell orderId={ORDER_ID} orderNumber="6839-2911-4402" itemCount={1} />,
+    );
+
+    // Never the spelled-out 41-character id (#1996).
+    expect(
+      screen.getByRole('button', { name: 'Copy order ID 6839-2911-4402' }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: `Copy ${ORDER_ID}` })).toBeNull();
+  });
+
+  it('should fire onNavigate when the name link is clicked but not when Copy is clicked', () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
     vi.stubGlobal('navigator', { clipboard: { writeText } });
     const onNavigate = vi.fn();
@@ -145,7 +194,7 @@ describe('OrderIdentityCell', () => {
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: `Copy ${ORDER_ID}` }));
+    fireEvent.click(screen.getByRole('button', { name: 'Copy order ID 6839-2911-4402' }));
     expect(onNavigate).not.toHaveBeenCalled();
 
     fireEvent.click(screen.getByRole('link', { name: '6839-2911-4402' }));

--- a/apps/web/src/features/orders/components/order-identity-cell.test.tsx
+++ b/apps/web/src/features/orders/components/order-identity-cell.test.tsx
@@ -45,7 +45,49 @@ describe('OrderIdentityCell', () => {
 
     // `textContent`, not the accessible name — the latter normalises whitespace
     // and would pass on an untrimmed render.
-    expect(screen.getByRole('link').textContent).toBe('6839-2911-4402');
+    const link = screen.getByRole('link');
+    expect(link.textContent).toBe('6839-2911-4402');
+    expect(link).toHaveAttribute('title', '6839-2911-4402');
+  });
+
+  it('should render the trimmed item name when the name carries surrounding space', () => {
+    renderWithProviders(
+      <OrderIdentityCell
+        orderId={ORDER_ID}
+        orderNumber="6839-2911-4402"
+        firstItemName="  Terra Wool Coat  "
+        itemCount={1}
+      />,
+    );
+
+    expect(screen.getByText('Terra Wool Coat')).toHaveAttribute('title', 'Terra Wool Coat');
+  });
+
+  it('should shorten a long order reference to a head-tail form', () => {
+    // Allegro's `orderNumber` IS its `checkoutFormId` — a 36-char UUID that
+    // `buildOrderSummary` hands Shipments and Invoices raw (#1995).
+    renderWithProviders(
+      <OrderIdentityCell
+        orderId={ORDER_ID}
+        orderNumber="d1f4a2c3-9b8e-4f7a-a1b2-c3d4e5f60789"
+        itemCount={1}
+      />,
+    );
+
+    expect(screen.getByRole('link', { name: 'd1f4a2c3…f60789' })).toBeInTheDocument();
+    // The full number stays recoverable through the copy button's name, since
+    // Copy itself writes the internal id.
+    expect(
+      screen.getByRole('button', { name: 'Copy order ID d1f4a2c3-9b8e-4f7a-a1b2-c3d4e5f60789' }),
+    ).toBeInTheDocument();
+  });
+
+  it('should render a short shop order number verbatim', () => {
+    renderWithProviders(
+      <OrderIdentityCell orderId={ORDER_ID} orderNumber="ORD-2026-000123" itemCount={1} />,
+    );
+
+    expect(screen.getByRole('link', { name: 'ORD-2026-000123' })).toBeInTheDocument();
   });
 
   it('should render the item thumbnail when the first item carries an image', () => {
@@ -113,7 +155,10 @@ describe('OrderIdentityCell', () => {
       />,
     );
 
-    expect(screen.getByText('+4')).toHaveAttribute('title', '5 line items in this order');
+    expect(screen.getByText('+4')).toHaveAttribute(
+      'title',
+      '4 more line items (5 in this order)',
+    );
   });
 
   it('should state the line-item count as a sentence when the first item name is unavailable', () => {
@@ -159,12 +204,14 @@ describe('OrderIdentityCell', () => {
 
     renderWithProviders(<OrderIdentityCell orderId={ORDER_ID} orderNumber={null} itemCount={1} />);
 
-    fireEvent.click(screen.getByRole('button', { name: 'Copy internal order ID' }));
+    fireEvent.click(
+      screen.getByRole('button', { name: `Copy internal order ID ${SHORT_ORDER_ID}` }),
+    );
 
     expect(writeText).toHaveBeenCalledTimes(1);
     expect(writeText).toHaveBeenCalledWith(ORDER_ID);
     expect(
-      await screen.findByRole('button', { name: 'Copied internal order ID' }),
+      await screen.findByRole('button', { name: `Copied internal order ID ${SHORT_ORDER_ID}` }),
     ).toBeInTheDocument();
   });
 

--- a/apps/web/src/features/orders/components/order-identity-cell.test.tsx
+++ b/apps/web/src/features/orders/components/order-identity-cell.test.tsx
@@ -1,0 +1,154 @@
+import { cleanup, fireEvent, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { OrderIdentityCell } from './order-identity-cell';
+import { renderWithProviders } from '../../../test/test-utils';
+
+const ORDER_ID = 'ol_order_a4f3b9c1d8e2f0a9b6c3d4e5f6a7b8c9';
+/** What `shortenId()` emits for `ORDER_ID` — prefix + 4 + ellipsis + 2. */
+const SHORT_ORDER_ID = 'ol_order_a4f3…c9';
+
+describe('OrderIdentityCell', () => {
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it('should lead with the order number linking to the order when the number is present', () => {
+    renderWithProviders(
+      <OrderIdentityCell orderId={ORDER_ID} orderNumber="6839-2911-4402" itemCount={1} />,
+    );
+
+    const link = screen.getByRole('link', { name: '6839-2911-4402' });
+    expect(link).toHaveAttribute('href', `/orders/${ORDER_ID}`);
+    expect(screen.queryByText(SHORT_ORDER_ID)).toBeNull();
+  });
+
+  it('should fall back to the shortened internal id when the order number is absent', () => {
+    renderWithProviders(<OrderIdentityCell orderId={ORDER_ID} orderNumber={null} itemCount={1} />);
+
+    expect(screen.getByRole('link', { name: SHORT_ORDER_ID })).toHaveAttribute(
+      'href',
+      `/orders/${ORDER_ID}`,
+    );
+  });
+
+  it('should treat a blank order number as absent', () => {
+    renderWithProviders(<OrderIdentityCell orderId={ORDER_ID} orderNumber="   " itemCount={1} />);
+
+    expect(screen.getByRole('link', { name: SHORT_ORDER_ID })).toBeInTheDocument();
+  });
+
+  it('should render the item thumbnail when the first item carries an image', () => {
+    const { container } = renderWithProviders(
+      <OrderIdentityCell
+        orderId={ORDER_ID}
+        orderNumber="6839-2911-4402"
+        firstItemName="Terra Wool Coat"
+        firstItemImageUrl="https://cdn.example.com/coat.jpg"
+        itemCount={1}
+      />,
+    );
+
+    const image = container.querySelector('.product-thumbnail img');
+    expect(image).toHaveAttribute('src', 'https://cdn.example.com/coat.jpg');
+  });
+
+  it("should render the thumbnail's initial-glyph placeholder when the item has no image", () => {
+    const { container } = renderWithProviders(
+      <OrderIdentityCell
+        orderId={ORDER_ID}
+        orderNumber="6839-2911-4402"
+        firstItemName="Terra Wool Coat"
+        firstItemImageUrl={null}
+        itemCount={1}
+      />,
+    );
+
+    const thumbnail = container.querySelector('.product-thumbnail');
+    expect(thumbnail?.querySelector('img')).toBeNull();
+    expect(thumbnail).toHaveTextContent('T');
+  });
+
+  it('should render no +N chip when the order has exactly one item', () => {
+    renderWithProviders(
+      <OrderIdentityCell
+        orderId={ORDER_ID}
+        orderNumber="6839-2911-4402"
+        firstItemName="Terra Wool Coat"
+        itemCount={1}
+      />,
+    );
+
+    expect(screen.getByText('Terra Wool Coat')).toBeInTheDocument();
+    expect(screen.queryByText(/^\+/)).toBeNull();
+  });
+
+  it('should render the remaining-item count when the order has more than one item', () => {
+    renderWithProviders(
+      <OrderIdentityCell
+        orderId={ORDER_ID}
+        orderNumber="6839-2911-4402"
+        firstItemName="Terra Wool Coat"
+        itemCount={5}
+      />,
+    );
+
+    expect(screen.getByText('+4')).toBeInTheDocument();
+  });
+
+  it('should render no second line when the first item name is unavailable', () => {
+    const { container } = renderWithProviders(
+      <OrderIdentityCell
+        orderId={ORDER_ID}
+        orderNumber="6839-2911-4402"
+        firstItemName={null}
+        itemCount={3}
+      />,
+    );
+
+    expect(container.querySelector('.orders-items-line')).toBeNull();
+    expect(screen.queryByText('+2')).toBeNull();
+  });
+
+  it('should render an empty-value placeholder when no order resolves', () => {
+    renderWithProviders(<OrderIdentityCell orderId="" orderNumber="6839-2911-4402" />);
+
+    expect(screen.getByLabelText('No value')).toBeInTheDocument();
+    expect(screen.queryByRole('link')).toBeNull();
+    expect(screen.queryByRole('button')).toBeNull();
+  });
+
+  it('should copy the full internal order id, never the shortened form', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('navigator', { clipboard: { writeText } });
+
+    renderWithProviders(<OrderIdentityCell orderId={ORDER_ID} orderNumber={null} itemCount={1} />);
+
+    fireEvent.click(screen.getByRole('button', { name: `Copy ${ORDER_ID}` }));
+
+    expect(writeText).toHaveBeenCalledWith(ORDER_ID);
+    expect(writeText).not.toHaveBeenCalledWith(SHORT_ORDER_ID);
+    expect(await screen.findByRole('button', { name: `Copied ${ORDER_ID}` })).toBeInTheDocument();
+  });
+
+  it('should fire onNavigate on the name link but not on Copy', () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('navigator', { clipboard: { writeText } });
+    const onNavigate = vi.fn();
+
+    renderWithProviders(
+      <OrderIdentityCell
+        orderId={ORDER_ID}
+        orderNumber="6839-2911-4402"
+        itemCount={1}
+        onNavigate={onNavigate}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: `Copy ${ORDER_ID}` }));
+    expect(onNavigate).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('link', { name: '6839-2911-4402' }));
+    expect(onNavigate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/features/orders/components/order-identity-cell.tsx
+++ b/apps/web/src/features/orders/components/order-identity-cell.tsx
@@ -7,7 +7,8 @@
  * `.connection-cell__body`) — what a person reads on top, the rest beneath.
  *
  * Line 1 leads with the marketplace-facing order number, because that is the
- * string a buyer quotes and a seller searches for, and falls back to a shortened
+ * string a buyer quotes and a seller searches for — shortened to a `head…tail`
+ * form past 18 characters (see `formatOrderRef`) — and falls back to a shortened
  * internal id only when the number is absent (every Shipments and Invoices row
  * hits that branch today). Copy always writes the **full** internal id — the
  * shortened string exists to be read, not to be pasted into a support ticket.
@@ -18,7 +19,7 @@
  * holding `orderSummary === null` still renders the id-only branch without
  * synthesising an object of nulls.
  *
- * Three recorded deviations from the mockup's frame 02, so no later reviewer
+ * Four recorded deviations from the mockup's frame 02, so no later reviewer
  * "fixes" them back:
  *
  * 1. **Frame 02's sixth state (`–`) is unreachable from production.** The mockup
@@ -109,6 +110,10 @@ export function OrderIdentityCell({
   // `+N` counts what is NOT shown, so a single-item order renders no chip at
   // all — it must never read as though something is hidden.
   const moreCount = totalItems > 1 ? totalItems - 1 : 0;
+  // `+4` alone leaves an operator (and a screen reader) to guess what is being
+  // counted — lines, not units — so the chip states both facts on hover.
+  const moreLabel = `more line item${moreCount === 1 ? '' : 's'}`;
+  const moreCountTitle = `${moreCount} ${moreLabel} (${totalItems} in this order)`;
   // Reading out a 41-character internal id per row is not an accessible name.
   // With no number to quote, name the *kind* of id and qualify it with the
   // shortened form already on screen, so 50 rows do not all read identically.
@@ -141,13 +146,8 @@ export function OrderIdentityCell({
             <span className="text-muted orders-cell-sub orders-items-preview" title={itemName}>
               {itemName}
             </span>
-            {/* `title` because `+4` alone leaves an operator (and a screen
-                reader) to guess what is being counted — lines, not units. */}
             {moreCount > 0 ? (
-              <span
-                className="orders-more-count"
-                title={`${moreCount} more line items (${totalItems} in this order)`}
-              >
+              <span className="orders-more-count" title={moreCountTitle}>
                 +{moreCount}
               </span>
             ) : null}

--- a/apps/web/src/features/orders/components/order-identity-cell.tsx
+++ b/apps/web/src/features/orders/components/order-identity-cell.tsx
@@ -1,0 +1,103 @@
+/**
+ * OrderIdentityCell — shared two-line order identity cell (#1996, #2087).
+ *
+ * One renderer for the question three lists answer three different ways today:
+ * *which order is this row?* A thumbnail beside the same two-level stack the app
+ * already ships three times over (`.orders-cell-stack`, `.products-cell-stack`,
+ * `.connection-cell__body`) — what a person reads on top, the rest beneath.
+ *
+ * Line 1 leads with the marketplace-facing order number, because that is the
+ * string a buyer quotes and a seller searches for, and falls back to a shortened
+ * internal id only when the number is absent (every Shipments and Invoices row
+ * hits that branch today). Copy always writes the **full** internal id — the
+ * shortened string exists to be read, not to be pasted into a support ticket.
+ *
+ * Props are flat and source-agnostic rather than an `OrderSummary` object:
+ * Orders feeds them from `parseOrderSnapshot()` while Shipments and Invoices
+ * feed them from the *nullable* `orderSummary` projection (#1995), so a caller
+ * holding `orderSummary === null` still renders the id-only branch without
+ * synthesising an object of nulls.
+ *
+ * No page consumes it yet — #2089 (Shipments), #2090 (Invoices) and #2091
+ * (Orders) wire it in, mirroring how #2027 delivered `ConnectionCell`.
+ *
+ * @module features/orders/components
+ */
+import type { ReactElement } from 'react';
+import { EmptyValue } from '../../../shared/ui/empty-value';
+import { EntityLabel, shortenId } from '../../../shared/ui/entity-label';
+import { ProductThumbnail } from '../../../shared/ui/product-thumbnail';
+
+export interface OrderIdentityCellProps {
+  /**
+   * Internal OL order id. Drives the link target and is what Copy writes —
+   * never the shortened display form.
+   */
+  orderId: string;
+  /** Source-native order number; the string a buyer quotes. */
+  orderNumber?: string | null;
+  /** The order's first line item's display name. */
+  firstItemName?: string | null;
+  /** The order's first line item's image URL, frozen at order-snapshot time. */
+  firstItemImageUrl?: string | null;
+  /**
+   * The order's FULL item count, not the number of items projected here. Drives
+   * the `+N` chip, so `2` renders `+1`.
+   */
+  itemCount?: number | null;
+  /**
+   * Fired on name-link navigation only, never on Copy. Exists because the
+   * Orders list captures a demo-analytics event when a row is opened (#1786),
+   * and that call site must survive the migration to this cell.
+   */
+  onNavigate?: () => void;
+  className?: string;
+}
+
+export function OrderIdentityCell({
+  orderId,
+  orderNumber,
+  firstItemName,
+  firstItemImageUrl,
+  itemCount,
+  onNavigate,
+  className = '',
+}: OrderIdentityCellProps): ReactElement {
+  if (!orderId) return <EmptyValue />;
+
+  const displayName = orderNumber?.trim() ? orderNumber : shortenId(orderId);
+  const itemName = firstItemName?.trim() ? firstItemName : null;
+  // `+N` counts what is NOT shown, so a single-item order renders no chip at
+  // all — it must never read as though something is hidden.
+  const moreCount = typeof itemCount === 'number' && itemCount > 1 ? itemCount - 1 : 0;
+  const classes = ['order-cell', className].filter(Boolean).join(' ');
+
+  return (
+    <span className={classes}>
+      {/* Decorative by default (`alt=''` ⇒ aria-hidden): the item name is
+          already text on line 2, and the order number is the row's label. Its
+          initial-glyph fallback covers the image-less case, which is every row
+          today — no adapter populates `OrderItem.imageUrl` on ingestion yet. */}
+      <ProductThumbnail name={itemName ?? displayName} src={firstItemImageUrl} size="sm" />
+      <span className="order-cell__body">
+        <EntityLabel
+          id={orderId}
+          name={displayName}
+          showId={false}
+          to={`/orders/${orderId}`}
+          onNavigate={onNavigate}
+        />
+        {/* No item name ⇒ no second line at all. A bare `+2` beside nothing
+            states a quantity of an unnamed thing, which reads as a defect. */}
+        {itemName ? (
+          <span className="orders-items-line">
+            <span className="text-muted orders-cell-sub orders-items-preview" title={itemName}>
+              {itemName}
+            </span>
+            {moreCount > 0 ? <span className="orders-more-count">+{moreCount}</span> : null}
+          </span>
+        ) : null}
+      </span>
+    </span>
+  );
+}

--- a/apps/web/src/features/orders/components/order-identity-cell.tsx
+++ b/apps/web/src/features/orders/components/order-identity-cell.tsx
@@ -18,6 +18,25 @@
  * holding `orderSummary === null` still renders the id-only branch without
  * synthesising an object of nulls.
  *
+ * Three recorded deviations from the mockup's frame 02, so no later reviewer
+ * "fixes" them back:
+ *
+ * 1. **Frame 02's sixth state (`–`) is unreachable from production.** The mockup
+ *    keys it on `orderSummary === null`, but `buildOrderSummary` returns null
+ *    both for "no order record" AND for "the snapshot carries no parseable
+ *    items", so a dash there would hide a live order. This cell keys the dash on
+ *    a missing `orderId` instead and renders the id-only link for a null
+ *    summary. A genuinely unresolvable order (an invoice pointing at an order OL
+ *    can no longer resolve) has no signal yet — `EntityLabel`'s `name={null}`
+ *    "Unknown" branch is where it belongs, and #2090 owns that decision.
+ * 2. **An unnamed multi-item order states its count as a sentence**, not as a
+ *    bare `+N`. The mockup gates all of line 2 on the item name, which silently
+ *    drops a known item count on exactly the rows an operator triages
+ *    (`awaiting_mapping` / `source_deleted` snapshots carry lines with no name).
+ * 3. **The copy button is not hover-gated**, unlike `.copyable-id__copy`. That
+ *    is `EntityLabel`'s app-wide behaviour at every existing call site, not
+ *    something this cell chooses; changing it is a shared-primitive decision.
+ *
  * No page consumes it yet — #2089 (Shipments), #2090 (Invoices) and #2091
  * (Orders) wire it in, mirroring how #2027 delivered `ConnectionCell`.
  *
@@ -41,13 +60,20 @@ export interface OrderIdentityCellProps {
   /** The order's first line item's image URL, frozen at order-snapshot time. */
   firstItemImageUrl?: string | null;
   /**
-   * The order's FULL item count, not the number of items projected here. Drives
-   * the `+N` chip, so `2` renders `+1`.
+   * The order's FULL line-item count (`items.length`), not the number of items
+   * projected here and not a unit total — `2` renders `+1`.
+   *
+   * **Migration note for #2091:** the Orders page derives its `+N` today from
+   * `itemsSummary()`, which filters to items that *have a name* before counting
+   * the rest. Feed `parsed.items.length` instead, matching what
+   * `buildOrderSummary` sends to Shipments and Invoices (#1995) — otherwise the
+   * same chip means two different things on the same page, which is exactly the
+   * divergence #1996 exists to end.
    */
   itemCount?: number | null;
   /**
    * Fired on name-link navigation only, never on Copy. Exists because the
-   * Orders list captures a demo-analytics event when a row is opened (#1786),
+   * Orders list captures a demo-analytics event when a row is opened (#1788),
    * and that call site must survive the migration to this cell.
    */
   onNavigate?: () => void;
@@ -65,11 +91,19 @@ export function OrderIdentityCell({
 }: OrderIdentityCellProps): ReactElement {
   if (!orderId) return <EmptyValue />;
 
-  const displayName = orderNumber?.trim() ? orderNumber : shortenId(orderId);
-  const itemName = firstItemName?.trim() ? firstItemName : null;
+  // Trim what is RENDERED, not just what is tested: a padded order number would
+  // otherwise reach the DOM and the `title` verbatim, and accessible-name
+  // normalisation hides that from a `getByRole` assertion.
+  const trimmedNumber = orderNumber?.trim() || null;
+  const itemName = firstItemName?.trim() || null;
+  const displayName = trimmedNumber ?? shortenId(orderId);
+  const totalItems = typeof itemCount === 'number' && itemCount > 0 ? itemCount : 0;
   // `+N` counts what is NOT shown, so a single-item order renders no chip at
   // all — it must never read as though something is hidden.
-  const moreCount = typeof itemCount === 'number' && itemCount > 1 ? itemCount - 1 : 0;
+  const moreCount = totalItems > 1 ? totalItems - 1 : 0;
+  // Reading out a 41-character internal id per row is not an accessible name.
+  // With no number to quote, name the *kind* of id rather than spelling it.
+  const copySubject = trimmedNumber ? `order ID ${trimmedNumber}` : 'internal order ID';
   const classes = ['order-cell', className].filter(Boolean).join(' ');
 
   return (
@@ -84,18 +118,29 @@ export function OrderIdentityCell({
           id={orderId}
           name={displayName}
           showId={false}
+          copyLabel={`Copy ${copySubject}`}
+          copiedLabel={`Copied ${copySubject}`}
           to={`/orders/${orderId}`}
           onNavigate={onNavigate}
         />
-        {/* No item name ⇒ no second line at all. A bare `+2` beside nothing
-            states a quantity of an unnamed thing, which reads as a defect. */}
         {itemName ? (
           <span className="orders-items-line">
             <span className="text-muted orders-cell-sub orders-items-preview" title={itemName}>
               {itemName}
             </span>
-            {moreCount > 0 ? <span className="orders-more-count">+{moreCount}</span> : null}
+            {/* `title` because `+4` alone leaves an operator (and a screen
+                reader) to guess what is being counted — lines, not units. */}
+            {moreCount > 0 ? (
+              <span className="orders-more-count" title={`${totalItems} line items in this order`}>
+                +{moreCount}
+              </span>
+            ) : null}
           </span>
+        ) : totalItems > 1 ? (
+          /* Deviation 2 (see the file header): a known count with no name to
+             attach it to reads as a sentence, never as a dangling `+N`. Keeps
+             the row's height stable across the named and unnamed cases. */
+          <span className="text-muted orders-cell-sub">{totalItems} line items</span>
         ) : null}
       </span>
     </span>

--- a/apps/web/src/features/orders/components/order-identity-cell.tsx
+++ b/apps/web/src/features/orders/components/order-identity-cell.tsx
@@ -36,6 +36,14 @@
  * 3. **The copy button is not hover-gated**, unlike `.copyable-id__copy`. That
  *    is `EntityLabel`'s app-wide behaviour at every existing call site, not
  *    something this cell chooses; changing it is a shared-primitive decision.
+ * 4. **The cell owns order-reference shortening** (`formatOrderRef` below),
+ *    absorbed from the Orders page rather than left to each caller. The mockup
+ *    shows short shop numbers only, so it never faced Allegro's 36-character
+ *    `checkoutFormId`. A known limitation: the full order number is then
+ *    readable only through the copy button's accessible name, because Copy
+ *    writes the internal id and `EntityLabel`'s `title` follows the rendered
+ *    name. Overriding that title is a fourth prop on a shared primitive, so it
+ *    is deferred — no list shows a hover-readable full order number today.
  *
  * No page consumes it yet — #2089 (Shipments), #2090 (Invoices) and #2091
  * (Orders) wire it in, mirroring how #2027 delivered `ConnectionCell`.
@@ -96,14 +104,19 @@ export function OrderIdentityCell({
   // normalisation hides that from a `getByRole` assertion.
   const trimmedNumber = orderNumber?.trim() || null;
   const itemName = firstItemName?.trim() || null;
-  const displayName = trimmedNumber ?? shortenId(orderId);
+  const displayName = trimmedNumber ? formatOrderRef(trimmedNumber) : shortenId(orderId);
   const totalItems = typeof itemCount === 'number' && itemCount > 0 ? itemCount : 0;
   // `+N` counts what is NOT shown, so a single-item order renders no chip at
   // all — it must never read as though something is hidden.
   const moreCount = totalItems > 1 ? totalItems - 1 : 0;
   // Reading out a 41-character internal id per row is not an accessible name.
-  // With no number to quote, name the *kind* of id rather than spelling it.
-  const copySubject = trimmedNumber ? `order ID ${trimmedNumber}` : 'internal order ID';
+  // With no number to quote, name the *kind* of id and qualify it with the
+  // shortened form already on screen, so 50 rows do not all read identically.
+  // The FULL order number goes here when one exists — it is otherwise
+  // unrecoverable, since Copy writes the internal id.
+  const copySubject = trimmedNumber
+    ? `order ID ${trimmedNumber}`
+    : `internal order ID ${displayName}`;
   const classes = ['order-cell', className].filter(Boolean).join(' ');
 
   return (
@@ -131,7 +144,10 @@ export function OrderIdentityCell({
             {/* `title` because `+4` alone leaves an operator (and a screen
                 reader) to guess what is being counted — lines, not units. */}
             {moreCount > 0 ? (
-              <span className="orders-more-count" title={`${totalItems} line items in this order`}>
+              <span
+                className="orders-more-count"
+                title={`${moreCount} more line items (${totalItems} in this order)`}
+              >
                 +{moreCount}
               </span>
             ) : null}
@@ -139,10 +155,34 @@ export function OrderIdentityCell({
         ) : totalItems > 1 ? (
           /* Deviation 2 (see the file header): a known count with no name to
              attach it to reads as a sentence, never as a dangling `+N`. Keeps
-             the row's height stable across the named and unnamed cases. */
+             the row height equal across the multi-item named and unnamed cases
+             — a SINGLE unnamed item still renders no second line, deliberately,
+             since there is no count worth stating. */
           <span className="text-muted orders-cell-sub">{totalItems} line items</span>
         ) : null}
       </span>
     </span>
   );
+}
+
+/** Longest order number rendered verbatim before it reads as noise. */
+const ORDER_REF_MAX_LENGTH = 18;
+
+/**
+ * Shorten a long order reference to a `head…tail` form so line 1 reads as a
+ * reference; short numbers (most shops) pass through untouched.
+ *
+ * Absorbed from the Orders page's own `formatOrderRef` (which #2091 deletes) so
+ * all three lists shorten identically. It is not optional cosmetics: Allegro's
+ * `orderNumber` IS its `checkoutFormId`, a 36-character UUID, and
+ * `buildOrderSummary` (#1995) hands Shipments and Invoices that value raw. CSS
+ * ellipsis is not a substitute — it truncates from the right and drops the tail,
+ * which is the disambiguating half of a UUID.
+ *
+ * The marketplace itself is conveyed by each list's own Channel column, so no
+ * channel prefix is added here.
+ */
+function formatOrderRef(orderNumber: string): string {
+  if (orderNumber.length <= ORDER_REF_MAX_LENGTH) return orderNumber;
+  return `${orderNumber.slice(0, 8)}…${orderNumber.slice(-6)}`;
 }

--- a/apps/web/src/features/orders/index.ts
+++ b/apps/web/src/features/orders/index.ts
@@ -16,6 +16,10 @@
  * — both this feature's `ShipmentActionButtons` and the `/shipments`
  * accordion import them from there, so neither barrel depends on the other
  * for that policy.
+ *
+ * `OrderIdentityCell` (#2087) is exported for the same reason `ConnectionDot`
+ * is: the Shipments and Invoices lists render an order's identity and orders is
+ * the feature that owns what an order identity looks like (#1996).
  */
 export { ordersQueryKeys } from './api/orders.query-keys';
 export type {
@@ -25,3 +29,5 @@ export type {
   PaginatedOrders,
 } from './api/orders.types';
 export { ConnectionDot } from './components/connection-dot';
+export { OrderIdentityCell } from './components/order-identity-cell';
+export type { OrderIdentityCellProps } from './components/order-identity-cell';

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -9417,13 +9417,16 @@ a.kpi-card:focus-visible {
   background: var(--bg-surface-muted);
   padding: 1px 6px;
   border-radius: var(--radius-xs);
-  /* 24ch is the widest string `shortenId()` can emit: the longest `ol_<entity>_`
-   * prefix in the system (`ol_inventoryitem_`, 17) plus 4 + ellipsis + 2. The
-   * previous 18ch was sized for a shortened bare UUID (13 chars) and clipped
-   * every `ol_<entity>_…` short form a SECOND time, appending a meaningless
-   * ellipsis to an already-elided id (#2087). A genuinely long raw value (a
-   * webhook URL, a tracking number) still ellipsises here as before. */
-  max-width: 24ch;
+  /* 18ch was sized for a shortened bare UUID (13 chars) and clipped the longer
+   * `ol_<entity>_…` short forms a SECOND time, appending a meaningless ellipsis
+   * to an already-elided id (#2087). `shortenId()` emits `prefix + 7`, and the
+   * longest prefix `formatInternalId` can produce is `ol_shopproduct_` (15, from
+   * `CoreEntityTypeValues` + `ENTITY_TYPE_ID_PREFIX`), so the ceiling is 22
+   * characters. 26ch rather than 22ch because `box-sizing: border-box` (:498)
+   * makes this rule's own `padding: 1px 6px` count against `max-width` and
+   * `--tracking-wide` adds 0.02em of advance per glyph. A genuinely long raw
+   * value (a webhook URL, a tracking number) still ellipsises here as before. */
+  max-width: 26ch;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -9499,6 +9502,14 @@ a.kpi-card:focus-visible {
   align-items: flex-start;
   min-width: 0;
   flex: 1 1 auto;
+  /* The mockup omits this cap, but its own specimen tables are auto-layout too,
+   * so it never exercised the failure: `max-width: 100%` below resolves against
+   * a container whose width is content-derived inside `.data-table`
+   * (`width: auto`, :2699), so line 1's ellipsis can never fire and a 30-char
+   * shop order ref widens the Order column and scrolls the whole table. 250px
+   * matches `.orders-items-line`, which already governs line 2 of this same
+   * cell, and mirrors why `.connection-cell__body` caps at 220px (:9536). */
+  max-width: 250px;
 }
 
 .order-cell__body > * {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -9510,7 +9510,7 @@ a.kpi-card:focus-visible {
    * (`width: auto`, :2699), so line 1's ellipsis can never fire and a 30-char
    * shop order ref widens the Order column and scrolls the whole table. 250px
    * matches `.orders-items-line`, which already governs line 2 of this same
-   * cell, and mirrors why `.connection-cell__body` caps at 220px (:9536). */
+   * cell, and mirrors why `.connection-cell__body` caps at 220px (:9538). */
   max-width: 250px;
 }
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -9420,9 +9420,11 @@ a.kpi-card:focus-visible {
   /* 18ch was sized for a shortened bare UUID (13 chars) and clipped the longer
    * `ol_<entity>_…` short forms a SECOND time, appending a meaningless ellipsis
    * to an already-elided id (#2087). `shortenId()` emits `prefix + 7`, and the
-   * longest prefix `formatInternalId` can produce is `ol_shopproduct_` (15, from
-   * `CoreEntityTypeValues` + `ENTITY_TYPE_ID_PREFIX`), so the ceiling is 22
-   * characters. 26ch rather than 22ch because `box-sizing: border-box` (:498)
+   * longest prefix `formatInternalId` produces for a WELL-KNOWN entity type is
+   * `ol_shopproduct_` (15, from `CoreEntityTypeValues` + `ENTITY_TYPE_ID_PREFIX`;
+   * a plugin-registered type falls through to its own lowercased name and could
+   * exceed this), so the ceiling is 22 characters. 26ch rather than 22ch because
+   * `box-sizing: border-box` (:498)
    * makes this rule's own `padding: 1px 6px` count against `max-width` and
    * `--tracking-wide` adds 0.02em of advance per glyph. A genuinely long raw
    * value (a webhook URL, a tracking number) still ellipsises here as before. */

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -9417,7 +9417,13 @@ a.kpi-card:focus-visible {
   background: var(--bg-surface-muted);
   padding: 1px 6px;
   border-radius: var(--radius-xs);
-  max-width: 18ch;
+  /* 24ch is the widest string `shortenId()` can emit: the longest `ol_<entity>_`
+   * prefix in the system (`ol_inventoryitem_`, 17) plus 4 + ellipsis + 2. The
+   * previous 18ch was sized for a shortened bare UUID (13 chars) and clipped
+   * every `ol_<entity>_…` short form a SECOND time, appending a meaningless
+   * ellipsis to an already-elided id (#2087). A genuinely long raw value (a
+   * webhook URL, a tracking number) still ellipsises here as before. */
+  max-width: 24ch;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -9461,6 +9467,42 @@ a.kpi-card:focus-visible {
 .copyable-id:focus-within .copyable-id__copy {
   opacity: 1;
   transform: translateX(0);
+}
+
+/* ── OrderIdentityCell (#2087) ───────────────────────────────────────
+ * A thumbnail beside the same two-level stack `.orders-cell-stack` (:8894) and
+ * `.connection-cell__body` (below) already describe — what a person reads on
+ * top, the rest beneath. The thumbnail is what Orders lacks today and what
+ * Shipments and Invoices lack entirely.
+ *
+ * A column flex container with `align-items: flex-start` sizes each child to its
+ * own content, so a long order number or item title escapes the box once the
+ * column narrows; capping the children at the container width lets the ellipsis
+ * these primitives ALREADY declare (`.entity-label__name`,
+ * `.orders-items-preview`) actually fire, instead of introducing a character cap.
+ *
+ * No new colour, radius, shadow or spacing value: `--space-3` is the existing
+ * token, 2px matches the sibling stacks' inner gap, and 100% / `flex` are
+ * structural.
+ */
+.order-cell {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-3);
+  min-width: 0;
+}
+
+.order-cell__body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  align-items: flex-start;
+  min-width: 0;
+  flex: 1 1 auto;
+}
+
+.order-cell__body > * {
+  max-width: 100%;
 }
 
 /* ── ConnectionCell (#2027) ──────────────────────────────────────────

--- a/apps/web/src/shared/ui/entity-label.test.tsx
+++ b/apps/web/src/shared/ui/entity-label.test.tsx
@@ -74,6 +74,41 @@ describe('EntityLabel', () => {
     expect(copy).toHaveAttribute('type', 'button');
   });
 
+  it('uses copyLabel and copiedLabel for the copy button accessible name when supplied', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    });
+
+    renderWithRouter(
+      <EntityLabel
+        id="ol_order_abc123def456"
+        name="6839-2911-4402"
+        copyLabel="Copy order ID 6839-2911-4402"
+        copiedLabel="Copied order ID 6839-2911-4402"
+      />,
+    );
+
+    const copy = screen.getByRole('button', { name: 'Copy order ID 6839-2911-4402' });
+    expect(screen.queryByRole('button', { name: /ol_order_abc/ })).toBeNull();
+
+    fireEvent.click(copy);
+
+    expect(writeText).toHaveBeenCalledWith('ol_order_abc123def456');
+    expect(
+      await screen.findByRole('button', { name: 'Copied order ID 6839-2911-4402' }),
+    ).toBeInTheDocument();
+  });
+
+  it('falls back to the spelled-out id for the copy button accessible name when no label is supplied', () => {
+    renderWithRouter(<EntityLabel id="ol_connection_abc123def456" name="Store" />);
+
+    expect(
+      screen.getByRole('button', { name: 'Copy ol_connection_abc123def456' }),
+    ).toBeInTheDocument();
+  });
+
   it('copies the full ID to the clipboard when the copy button is pressed', () => {
     const writeText = vi.fn().mockResolvedValue(undefined);
     Object.defineProperty(navigator, 'clipboard', {

--- a/apps/web/src/shared/ui/entity-label.tsx
+++ b/apps/web/src/shared/ui/entity-label.tsx
@@ -19,6 +19,16 @@ interface EntityLabelProps extends Omit<ComponentPropsWithoutRef<'span'>, 'id'> 
    * same id never grows two copy controls (#2027).
    */
   showCopy?: boolean;
+  /**
+   * Accessible name of the built-in copy button. Defaults to `Copy {id}`, which
+   * a screen reader spells out character by character — 32 hex digits on every
+   * row of a table. A caller that can resolve the id to something human should
+   * pass it ("Copy order ID 6839-2911-4402"), mirroring `CopyableId`'s
+   * `copyLabel` (#1996). Kept optional so no existing call site changes.
+   */
+  copyLabel?: string;
+  /** Accessible name once the copy succeeded. Defaults to `Copied {id}`. */
+  copiedLabel?: string;
   to?: string;
   /**
    * Fired when the inner name link is clicked (navigation), never when the
@@ -35,6 +45,8 @@ export const EntityLabel = forwardRef<HTMLSpanElement, EntityLabelProps>(functio
     name,
     showId = true,
     showCopy = true,
+    copyLabel,
+    copiedLabel,
     to,
     onNavigate,
     className = '',
@@ -111,7 +123,7 @@ export const EntityLabel = forwardRef<HTMLSpanElement, EntityLabelProps>(functio
           type="button"
           className="entity-label__copy"
           onClick={handleCopy}
-          aria-label={copied ? `Copied ${id}` : `Copy ${id}`}
+          aria-label={copied ? (copiedLabel ?? `Copied ${id}`) : (copyLabel ?? `Copy ${id}`)}
         >
           {copied ? 'Copied' : 'Copy'}
         </button>


### PR DESCRIPTION
## Summary

Adds the shared `OrderIdentityCell` — the one renderer for the question three lists answer three different ways today: *which order is this row?*

| List | Today |
|---|---|
| Orders | two-level stack + first item + `+N`, but **no thumbnail**, an `entity-label__id` chip, and a fallback to the **full** internal id |
| Shipments | `EntityLabel` with `truncateOrderId()` — no thumbnail, no item name, no `+N`, plus a second hand-rolled copy in the mobile-card branch |
| Invoices | raw 41-character UUID in a `mono-text` span — no truncation, no Copy, no link |

#1996 specified one shared cell for all three and PR #1999 landed its visual spec (`docs/plans/mockups/list-identity-cells-1996.html`, frame 02), but that PR was docs-only and carried `Closes #1996`, so the issue auto-closed and the component was never built.

**No page consumes it in this PR** — #2089 (Shipments), #2090 (Invoices) and #2091 (Orders) wire it in, mirroring how #2027 delivered `ConnectionCell`.

## What it renders

```
[thumbnail]  6839-2911-4402  [Copy]
             Terra Wool Coat  +2
```

- `ProductThumbnail size='sm'` — its initial-glyph fallback covers the image-less case, which is every row today (no adapter populates `OrderItem.imageUrl` on ingestion yet).
- Line 1: `EntityLabel showId={false}` with the order number (shortened to `head…tail` past 18 characters) falling back to `shortenId(orderId)`, linking to `/orders/:orderId`. **Copy always writes the full internal id** — the shortened string exists to be read, not pasted into a support ticket.
- Line 2: first item name plus the existing `orders-more-count` `+N` chip. `+N` counts what is *not* shown, so a single-item order renders no chip at all.
- `–` when there is no order id to resolve.

Class-for-class and value-for-value identical to the mockup's `orderCell()` builder and its `.order-cell` CSS, with the deviations below recorded explicitly.

## Deliberate deviations from frame 02

All four are in the component's file header so a later reviewer does not "fix" them back.

1. **Frame 02's sixth state (`–`) is unreachable from production.** The mockup keys it on `orderSummary === null`, but `buildOrderSummary` returns null both for "no order record" *and* for "the snapshot carries no parseable items" — a dash there would hide a live order. This cell keys the dash on a missing `orderId` and renders the id-only link for a null summary. The genuinely-unresolvable case (an invoice pointing at an order OL can no longer resolve) has no signal yet; `EntityLabel`'s `name={null}` "Unknown" branch is where it belongs and **#2090 owns that decision**.
2. **An unnamed multi-item order states its count as a sentence** (`3 line items`) instead of rendering nothing. The mockup gates all of line 2 on the item name, which silently drops a known count on exactly the rows an operator triages — `awaiting_mapping` / `source_deleted` snapshots carry lines with no name. A bare `+2` beside nothing was the other option and reads as a defect; a sentence also keeps row height stable across both states.
3. **The copy button is not hover-gated**, unlike `.copyable-id__copy`. That is `EntityLabel`'s app-wide behaviour at every existing call site, not something this cell chooses — changing it is a shared-primitive decision, not S1's.
4. **The cell owns order-reference shortening** (`formatOrderRef`), absorbed from the Orders page rather than left to each caller. The mockup shows short shop numbers only, so it never faced Allegro's 36-character `checkoutFormId` — which `buildOrderSummary` hands Shipments and Invoices **raw**, and which the 250px cap would then ellipsise from the right, dropping the tail that disambiguates it. Leaving the shortening at the Orders call site would have reinstated exactly the three-different-renderings divergence #1996 exists to end; #2091 now simply deletes the page-local copy, as the epic already plans. Known limitation: the full order number is then readable only through the copy button's accessible name, because Copy writes the internal id and `EntityLabel`'s `title` follows the rendered name. Overriding that title is a fourth prop on a shared primitive, so it is deferred — no list shows a hover-readable full order number today either.

## Other decisions

- **Flat props, not an `OrderSummary` object.** Orders feeds them from `parseOrderSnapshot()` while Shipments and Invoices feed them from the *nullable* `orderSummary` projection (#1995) — a flat shape lets a caller holding `orderSummary === null` render the id-only branch without synthesising an object of nulls.
- **`onNavigate` passthrough.** The Orders list captures a demo-analytics event when a row is opened (#1788); the prop exists so those two call sites survive #2091's migration.
- **`copyLabel` / `copiedLabel` added to `EntityLabel`** (optional, defaults unchanged, no existing call site affected). Without them the copy button read out `Copy ol_order_a4f3b9c1d8e2…` — 32 spelled-out hex digits per row. The style guide already mandates this and credits it to #1996, and `ConnectionCell` already does it, so shipping without it would give the two cells #1996 exists to unify different a11y quality in the same table row. This is a deviation from the issue's "reuses `entity-label.tsx` unchanged" file note, and mirrors how #2027 added `showCopy` to the same primitive for the same composite reason.
- **`.order-cell__body` capped at 250px** — the mockup omits the cap because its own specimen tables are auto-layout too, so it never exercised the failure. `max-width: 100%` on the children resolves against a content-derived box inside `.data-table` (`width: auto`), so line 1's ellipsis could never fire and a 30-character shop order ref (`WEB-ORDER-2026-08-14-000123456`) would widen the Order column and scroll the whole table sideways. 250px matches `.orders-items-line`, which already governs line 2 of this same cell.
- **`.copyable-id__value` 18ch → 26ch.** 18ch was sized for a shortened bare UUID (13 chars) and clipped the longer `ol_<entity>_…` short forms a **second** time. `shortenId()` emits `prefix + 7`; the longest prefix `formatInternalId` can produce is `ol_shopproduct_` (15, from `CoreEntityTypeValues` plus the single `ProductVariant → variant` override), so the ceiling is 22 characters. 26ch rather than 22ch because `box-sizing: border-box` makes the rule's own `padding: 1px 6px` count against `max-width` and `--tracking-wide` adds 0.02em of advance per glyph. This was a review finding on PR #1999; fixing it here keeps #2093 (Customers) clean.
  - Regression sweep of all 9 `CopyableId` call sites: `ConnectionCell` passes a 13-char shortened UUID and is provably unaffected; the other **eight** behave as raw values (full order id, two webhook URLs, an HMAC secret, a carrier trace id, a tracking number, a KSeF number, the dev-ui specimen) and render **~58px** wider (8ch) inside wrapping flex/grid parents with no overflow — several simply show more of a value that was being clipped. The one worth an eyeball on a narrow viewport is `.infakt-webhook__exchange`'s `1fr 1px 1fr` grid, which clips rather than reflows.
  - A narrower alternative exists (lift the cap only where a caller passes a pre-shortened `label`, via a modifier class) and was **not** taken: two of the `label`-passing sites pass a full-length value (`shipment-row-detail`'s tracking number, `infakt-invoice-detail-section`'s KSeF number), so "has a label" is not a reliable proxy for "already shortened". Raising the shared cap is the honest fix for a shared rule.
- **No new design token.** `--space-3` is existing, 2px matches the sibling stacks' inner gap, 250px matches `.orders-items-line`, and `100%` / `flex` are structural — `check-design-tokens` green.

## Handover to S3 / S4 / S5

Three things the wire-in PRs need that do not exist yet, found while checking the consuming frames:

- **Frame 12's skeleton cannot be built as drawn** — it uses `.skeleton--thumb` / `.skeleton--line`, and no `.skeleton*` rule exists in `index.css`.
- **Frame 10's mobile cards rely on `.data-card .copyable-id__value { max-width: 100% }`**, which also does not exist. Relevant to #2089, whose card puts `ConnectionCell` in a card fact.
- **Consumers must pass `rowLinkDisplay="block"`** on `DataTable`, or the row's focus ring paints a band across the middle of this tall composite.
- **`docs/frontend-ui-style-guide.md` needs two catalog updates** — `EntityLabel`'s new `copyLabel` / `copiedLabel` (§ Shared UI catalog documents the identical props on `CopyableId` and `showCopy` on `EntityLabel`). Deferred on the #2027 precedent: that PR added `showCopy` without touching the guide, and the entries arrived with the consuming PR #2032. Recorded here so it is a decision, not a miss.
- **The app now says both "items" and "line items"** for the same fact (`order-health-summary.tsx` renders `${itemCount} item${…}`). "line items" is deliberate here — it is the lines-not-units disambiguation — but the vocabulary split should be resolved rather than left, and the style guide has no entry for it.
- **The two-line row height needs a style-guide entry** (§ Density & Row Heights is categorical about this). Shipments and Invoices are single-line 36px rows today, so #2089 is the first PR that actually changes a row height and is where the entry belongs.

## Base branch

Targets `2086-list-identity-cells` (the #2086 epic branch), cut from `2023-listings-redesign` (head of PR #2032) rather than `main`: `shortenId`'s export and `ConnectionCell` exist only there.

## Testing

- `pnpm --filter @openlinker/web lint` — 0 errors, no new warnings
- `pnpm --filter @openlinker/web type-check` — clean
- `vitest run` on `order-identity-cell`, `entity-label`, `copyable-id`, `ConnectionCell` — **58 passed** (22 of them this cell's, covering all six frame-02 states, both copy-label branches, both trim paths, the 18-character shortening threshold from both sides, `itemCount: null`, and the singular/plural `+N` tooltip; plus 2 new tests asserting `EntityLabel`'s own `copyLabel` contract and its untouched default)
- `check-design-tokens` + `check-cross-context-imports` — green

⚠️ `pnpm check:invariants` fails on a **pre-existing** clash unrelated to this PR: `1833000000002-create-refund-records.ts` (landed on `main` via #2046) and `1833000000002-add-identifier-mappings-offer-created-index.ts` (added on `2023-listings-redesign` by a #2032 review fix) share a migration timestamp, so TypeORM's ordering between them is undefined. It needs fixing on PR #2032's branch, not here.

## Architecture

Frontend only. Exported from `features/orders/index.ts` for the same reason `ConnectionDot` is: Shipments and Invoices render an order's identity, and `orders` is the feature that owns what an order identity looks like.

Closes #2087
