### PR TITLE
refactor(web): one plugin-registry path for every platform label (#2088)

### DIFF
--- a/apps/web/src/features/listings/components/bulk/bulk-edit-modal.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-edit-modal.tsx
@@ -59,7 +59,12 @@ import {
   type UseFormReturn,
 } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { usePlatform, type BulkOfferRowSectionProps } from '../../../../shared/plugins';
+import {
+  usePlatform,
+  usePlatforms,
+  type BulkOfferRowSectionProps,
+} from '../../../../shared/plugins';
+import { resolvePlatformLabel } from '../../../mappings';
 import type { Connection } from '../../../connections';
 import { resolveVariantGroupingModel } from '../../../connections';
 import { Alert, Button, ConfirmDialog, FormField, Input, Textarea } from '../../../../shared/ui';
@@ -474,7 +479,8 @@ function BulkEditModalForm({
   const connectionId = connection.id;
   const { showToast } = useToast();
   const platform = usePlatform(connection.platformType);
-  const platformName = platform?.displayName ?? connection.platformType;
+  const platforms = usePlatforms();
+  const platformName = resolvePlatformLabel(platforms, connection);
   const platformSection = platform?.bulkOfferRowSection;
   const isMultiVariant = row.variants.length > 1;
   const masterImages = useMemo(

--- a/apps/web/src/features/listings/components/bulk/bulk-wizard.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-wizard.tsx
@@ -18,6 +18,7 @@ import { useNavigate } from 'react-router-dom';
 import { Alert, Button, PageLayout, SetupStepper } from '../../../../shared/ui';
 import { useToast } from '../../../../shared/ui/toast-provider';
 import { usePlatforms, type OfferRowValidationInput } from '../../../../shared/plugins';
+import { resolvePlatformLabel } from '../../../mappings';
 import { useWriteAccess } from '../../../../shared/auth/use-permission';
 import { useDemoMode } from '../../../system';
 import { useConnectionsQuery } from '../../../connections';
@@ -519,7 +520,13 @@ export function BulkWizard({
   );
 
   const counts = useMemo(() => countBatch(rows), [rows]);
-  const marketplaceName = batchPlatform?.displayName ?? 'marketplace';
+  // `'marketplace'` stays the fallback for "no destination chosen yet"; once a
+  // connection IS chosen its label comes from the registry like everywhere else,
+  // so an unregistered platform reads as its raw type rather than the generic
+  // word (#2088).
+  const marketplaceName = batchConnection
+    ? resolvePlatformLabel(platforms, batchConnection)
+    : 'marketplace';
 
   // Every seeded variant id, checked against the destination in one call.
   const allSeededVariantIds = useMemo(() => {

--- a/apps/web/src/features/mappings/index.ts
+++ b/apps/web/src/features/mappings/index.ts
@@ -16,8 +16,10 @@ export { useRoutingRulesQuery } from './hooks/use-routing-rules';
 // Delivery-mapping fix-it deep link (#1794) — built by the orders delivery
 // rider, parsed by the connection-mappings page.
 // Second cross-feature consumer as of #2028 (the listings channel pill), so the
-// resolver joins the barrel rather than being reached for by deep path.
-export { resolvePlatformLabel } from './lib/platform-label';
+// resolver joins the barrel rather than being reached for by deep path. #2088
+// made it the app's ONLY platform-label path (14 call sites), which is why the
+// no-fallback variant is exported too — see `lib/platform-label.ts`.
+export { findPlatformDisplayName, resolvePlatformLabel } from './lib/platform-label';
 export {
   DELIVERY_MAPPING_DEEP_LINK_PARAMS,
   DELIVERY_MAPPING_TAB,

--- a/apps/web/src/features/mappings/lib/platform-label.test.ts
+++ b/apps/web/src/features/mappings/lib/platform-label.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Platform-label resolver tests (#2088)
+ *
+ * @module apps/web/src/features/mappings/lib
+ */
+
+import { describe, expect, it } from 'vitest';
+import { findPlatformDisplayName, resolvePlatformLabel } from './platform-label';
+
+const PLATFORMS = [
+  { platformType: 'allegro', displayName: 'Allegro' },
+  { platformType: 'prestashop', displayName: 'PrestaShop' },
+  // The two the deleted `CHANNEL_LABELS` map had no row for, which is what made
+  // them render raw and lowercase on the Orders list before #2088.
+  { platformType: 'erli', displayName: 'Erli' },
+  { platformType: 'woocommerce', displayName: 'WooCommerce' },
+] as const;
+
+describe('resolvePlatformLabel', () => {
+  it('returns the registry display name for a known platform', () => {
+    expect(resolvePlatformLabel(PLATFORMS, 'woocommerce')).toBe('WooCommerce');
+    expect(resolvePlatformLabel(PLATFORMS, 'erli')).toBe('Erli');
+  });
+
+  it('accepts anything carrying a platformType, not just a bare string', () => {
+    expect(resolvePlatformLabel(PLATFORMS, { platformType: 'prestashop' })).toBe('PrestaShop');
+  });
+
+  it('falls back to the raw platformType for an unregistered platform', () => {
+    expect(resolvePlatformLabel(PLATFORMS, 'shopify')).toBe('shopify');
+    expect(resolvePlatformLabel(PLATFORMS, { platformType: 'shopify' })).toBe('shopify');
+  });
+
+  it('falls back to the raw platformType when the plugin list is empty', () => {
+    // The state every render hits before the registry provider settles.
+    expect(resolvePlatformLabel([], 'allegro')).toBe('allegro');
+  });
+
+  it('returns an empty string rather than throwing on an empty platformType', () => {
+    expect(resolvePlatformLabel(PLATFORMS, '')).toBe('');
+  });
+});
+
+describe('findPlatformDisplayName', () => {
+  it('returns the registry display name for a known platform', () => {
+    expect(findPlatformDisplayName(PLATFORMS, 'allegro')).toBe('Allegro');
+    expect(findPlatformDisplayName(PLATFORMS, { platformType: 'allegro' })).toBe('Allegro');
+  });
+
+  it('returns undefined for an unregistered platform so the caller can pick its own fallback', () => {
+    // The coverage pills and the product row detail fall back to
+    // `connection.name`, not to the raw type — that is the whole reason this
+    // variant exists.
+    expect(findPlatformDisplayName(PLATFORMS, 'shopify')).toBeUndefined();
+  });
+
+  it('returns undefined when the plugin list is empty', () => {
+    expect(findPlatformDisplayName([], 'allegro')).toBeUndefined();
+  });
+});

--- a/apps/web/src/features/mappings/lib/platform-label.test.ts
+++ b/apps/web/src/features/mappings/lib/platform-label.test.ts
@@ -32,7 +32,10 @@ describe('resolvePlatformLabel', () => {
   });
 
   it('falls back to the raw platformType when the plugin list is empty', () => {
-    // The state every render hits before the registry provider settles.
+    // Not a production state — the provider flattens a synchronous module
+    // constant, so no render ever sees an empty registry. Pinned because
+    // fixture-driven suites do pass one, and because the defensive contract is
+    // what lets every call site drop its own `?? platformType`.
     expect(resolvePlatformLabel([], 'allegro')).toBe('allegro');
   });
 

--- a/apps/web/src/features/mappings/lib/platform-label.ts
+++ b/apps/web/src/features/mappings/lib/platform-label.ts
@@ -55,7 +55,27 @@ export function findPlatformDisplayName(
   return platforms.find((p) => p.platformType === platformType)?.displayName;
 }
 
-/** The lookup plus the app-wide fallback: the raw `platformType`. */
+/**
+ * The lookup plus the app-wide fallback: the raw `platformType`.
+ *
+ * **Why raw and not title-cased.** The dashboard used to capitalise its own
+ * fallback (`woocommerce` → `Woocommerce`), and #2088 deleted that rather than
+ * promoting it, deliberately. Title-casing a slug manufactures a plausible but
+ * WRONG brand name for exactly the platforms whose names are not one word —
+ * `Woocommerce`, `Bigcommerce`, `Prestashop` — so it reads as a product name
+ * while being incorrect. A raw slug reads as an unresolved identifier, which is
+ * what it is: the fallback only fires when no plugin declares the platform,
+ * i.e. a misconfiguration, and an ops surface should show that rather than
+ * disguise it. #2088's AC states it as "renders the raw string rather than
+ * blank".
+ *
+ * The cost, accepted: `amazon` and `shopify` had hand-written Title Case in the
+ * Orders list's deleted `CHANNEL_LABELS` map and now render raw. Neither has a
+ * backend adapter, so no shipped connection can reach it. A site that has a
+ * `Connection` in hand and wants something friendlier than a slug should use
+ * `findPlatformDisplayName(...) ?? connection.name` instead — the operator's own
+ * name for the destination beats both a slug and a mis-cased brand.
+ */
 export function resolvePlatformLabel(
   platforms: readonly PlatformLike[],
   platform: string | ConnectionLike,

--- a/apps/web/src/features/mappings/lib/platform-label.ts
+++ b/apps/web/src/features/mappings/lib/platform-label.ts
@@ -1,11 +1,21 @@
 /**
- * Platform-label resolver (#1784 follow-up)
+ * Platform-label resolver (#1784 follow-up, #2088)
  *
- * Resolves a connection's human-readable platform label from the plugin
- * registry, falling back to the raw `platformType` when no plugin is
- * registered for it. Extracted so the Mapping Configuration page and the
- * `MappingPairingBar` share one implementation instead of duplicating the
- * `platforms.find(...)?.displayName ?? platformType` lookup.
+ * The single path from a `platformType` to the human-readable label the plugin
+ * registry declares for it, falling back to the raw `platformType` when no
+ * plugin is registered.
+ *
+ * This is the ONLY place the `platforms.find(...)?.displayName ?? platformType`
+ * lookup may live. Before #2088 it was re-inlined at 13 call sites and shadowed
+ * by a hardcoded four-entry map on the Orders list, so `erli` and `woocommerce`
+ * rendered raw and lowercase there while rendering correctly two pages over —
+ * a registry that half the app disagreed with (#1996).
+ *
+ * Deliberately still in `features/mappings` rather than `shared/plugins`, where
+ * frame 13 of the #1996 mockup proposed moving it: PR #2032 established the
+ * barrel path for its second cross-feature consumer, and re-litigating it would
+ * churn ~14 import lines for no behavioural gain. Recorded so nobody reading the
+ * mockup "fixes" it back.
  *
  * @module apps/web/src/features/mappings/lib
  */
@@ -19,12 +29,37 @@ interface ConnectionLike {
   platformType: string;
 }
 
+/**
+ * The registry lookup with NO fallback — `undefined` when no plugin declares
+ * this `platformType`.
+ *
+ * Exists because two call sites fall back to the operator-authored
+ * `connection.name` rather than the raw type (the coverage pills on the products
+ * list and the product row detail, where a name disambiguates two shops on one
+ * platform far better than a lowercase slug would). They need the lookup without
+ * the policy, and routing them through `resolvePlatformLabel` would have swapped
+ * their fallback silently. Callers that want the raw-type fallback use
+ * `resolvePlatformLabel` instead — do not re-inline the `find` for either.
+ *
+ * @param platform a bare `platformType`, or anything carrying one (a
+ *   `Connection`, an offer mapping, a publish destination). Both shapes exist at
+ *   the call sites in roughly equal number, so accepting both is what keeps the
+ *   sites from wrapping a string in an object literal just to satisfy a
+ *   signature.
+ */
+export function findPlatformDisplayName(
+  platforms: readonly PlatformLike[],
+  platform: string | ConnectionLike,
+): string | undefined {
+  const platformType = typeof platform === 'string' ? platform : platform.platformType;
+  return platforms.find((p) => p.platformType === platformType)?.displayName;
+}
+
+/** The lookup plus the app-wide fallback: the raw `platformType`. */
 export function resolvePlatformLabel(
   platforms: readonly PlatformLike[],
-  connection: ConnectionLike,
+  platform: string | ConnectionLike,
 ): string {
-  return (
-    platforms.find((p) => p.platformType === connection.platformType)?.displayName ??
-    connection.platformType
-  );
+  const platformType = typeof platform === 'string' ? platform : platform.platformType;
+  return findPlatformDisplayName(platforms, platformType) ?? platformType;
 }

--- a/apps/web/src/features/products/components/product-source-section.tsx
+++ b/apps/web/src/features/products/components/product-source-section.tsx
@@ -13,6 +13,7 @@ import type { ReactElement } from 'react';
 import { Link } from 'react-router-dom';
 import { StatusBadge } from '../../../shared/ui/status-badge';
 import { usePlatforms } from '../../../shared/plugins';
+import { resolvePlatformLabel } from '../../mappings';
 import type { Connection } from '../../connections';
 import type { ExternalIdMapping } from '../api/products.types';
 
@@ -32,9 +33,7 @@ export function ProductSourceSection({
   }
 
   const [primary, ...rest] = mappings;
-  const platformLabel =
-    platforms.find((p) => p.platformType === primary.platformType)?.displayName ??
-    primary.platformType;
+  const platformLabel = resolvePlatformLabel(platforms, primary);
   const connectionName = connections.find((c) => c.id === primary.connectionId)?.name;
 
   return (

--- a/apps/web/src/pages/connections/connection-detail-page.tsx
+++ b/apps/web/src/pages/connections/connection-detail-page.tsx
@@ -16,7 +16,8 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '../../shared/ui/tabs';
 import { TimeDisplay } from '../../shared/ui/time-display';
 import { StatusBadge, type StatusBadgeTone } from '../../shared/ui/status-badge';
 import { Alert } from '../../shared/ui/alert';
-import { usePlatform } from '../../shared/plugins';
+import { usePlatform, usePlatforms } from '../../shared/plugins';
+import { resolvePlatformLabel } from '../../features/mappings';
 import { useWriteAccess } from '../../shared/auth/use-permission';
 import { useDemoMode } from '../../features/system';
 
@@ -44,10 +45,11 @@ function toStatusTone(status: ConnectionStatus): StatusBadgeTone {
  */
 function ReauthRequiredBanner({ connection }: { connection: Connection }): ReactElement | null {
   const platform = usePlatform(connection.platformType);
+  const platforms = usePlatforms();
 
   if (connection.status !== 'needs_reauth') return null;
 
-  const platformLabel = platform?.displayName ?? connection.platformType;
+  const platformLabel = resolvePlatformLabel(platforms, connection);
   const oauthReauthTo =
     platform?.requiresExternalAuthRedirect && platform.setupCard?.to
       ? `${platform.setupCard.to}?reauth=${connection.id}`

--- a/apps/web/src/pages/dashboard/dashboard-page.tsx
+++ b/apps/web/src/pages/dashboard/dashboard-page.tsx
@@ -14,7 +14,8 @@ import { useDevStackHealthQuery } from '../../features/health/hooks/use-dev-stac
 import { useSyncJobsQuery } from '../../features/sync-jobs/hooks/use-sync-jobs-query';
 import { useFailedJobGroupsQuery } from '../../features/sync-jobs/hooks/use-failed-job-groups-query';
 import { useRetryGroupedSyncJobsMutation } from '../../features/sync-jobs/hooks/use-retry-grouped-sync-jobs-mutation';
-import { usePlatforms } from '../../shared/plugins';
+import { usePlatforms, type Platform } from '../../shared/plugins';
+import { resolvePlatformLabel } from '../../features/mappings';
 import type {
   DevStackHealth,
   ServiceHealth,
@@ -96,17 +97,6 @@ function ServiceHealthRow({ name, health }: { name: string; health: ServiceHealt
 }
 
 /**
- * Capitalizes a bare platform-type key (e.g. `woocommerce` → `Woocommerce`)
- * for when no plugin-contributed display name is registered. This is only a
- * fallback — the dashboard prefers `usePlatforms()` display names.
- */
-function fallbackPlatformLabel(platformType: string): string {
-  return platformType.length > 0
-    ? platformType[0].toUpperCase() + platformType.slice(1)
-    : platformType;
-}
-
-/**
  * Builds the ordered list of infrastructure node labels backing both the
  * Infrastructure panel and the KPI-strip summary (#1619). Core services are
  * always listed first, followed by one entry per infra-bearing connection
@@ -115,7 +105,7 @@ function fallbackPlatformLabel(platformType: string): string {
  */
 function buildInfraNodeLabels(
   data: DevStackHealth | undefined,
-  platformDisplayNames: Map<string, string>
+  platforms: readonly Platform[]
 ): string[] {
   if (!data) return [];
   const labels = ['Postgres', 'Redis', 'PrestaShop'];
@@ -123,9 +113,7 @@ function buildInfraNodeLabels(
     labels.push('Worker');
   }
   for (const connection of data.connections ?? []) {
-    const platformLabel =
-      platformDisplayNames.get(connection.platformType) ??
-      fallbackPlatformLabel(connection.platformType);
+    const platformLabel = resolvePlatformLabel(platforms, connection.platformType);
     labels.push(connection.name ? `${platformLabel} (${connection.name})` : platformLabel);
   }
   return labels;
@@ -250,17 +238,10 @@ export function DashboardPage(): ReactElement {
   );
 
   const platforms = usePlatforms();
-  const platformDisplayNames = useMemo(
-    () =>
-      new Map<string, string>(
-        platforms.map((platform): [string, string] => [platform.platformType, platform.displayName])
-      ),
-    [platforms]
-  );
   const infraConnections = healthQuery.data?.connections ?? [];
   const infraNodeLabels = useMemo(
-    () => buildInfraNodeLabels(healthQuery.data, platformDisplayNames),
-    [healthQuery.data, platformDisplayNames]
+    () => buildInfraNodeLabels(healthQuery.data, platforms),
+    [healthQuery.data, platforms]
   );
   const systemHealthDescription = healthQuery.isLoading
     ? 'Checking dependencies…'
@@ -649,9 +630,8 @@ export function DashboardPage(): ReactElement {
                   key={connection.connectionId}
                   name={
                     connection.name
-                      ? `${platformDisplayNames.get(connection.platformType) ?? fallbackPlatformLabel(connection.platformType)} — ${connection.name}`
-                      : (platformDisplayNames.get(connection.platformType) ??
-                        fallbackPlatformLabel(connection.platformType))
+                      ? `${resolvePlatformLabel(platforms, connection.platformType)} — ${connection.name}`
+                      : resolvePlatformLabel(platforms, connection.platformType)
                   }
                   health={{ status: connection.status, message: connection.message }}
                 />

--- a/apps/web/src/pages/orders/orders-list-page.test.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.test.tsx
@@ -420,6 +420,32 @@ describe('OrdersListPage', () => {
     expect(pill?.textContent).toBe('Allegro');
   });
 
+  it.each([
+    ['erli', 'Erli'],
+    ['woocommerce', 'WooCommerce'],
+  ])(
+    'should resolve the %s channel-pill from the plugin registry, not a local map',
+    async (platformType, expectedLabel) => {
+      // The deleted `CHANNEL_LABELS` map (#2088) covered only allegro /
+      // prestashop / amazon / shopify, so these two rendered raw and lowercase
+      // here while rendering correctly two pages over. The test above passes on
+      // either implementation because `allegro` was in that map — these two are
+      // what actually pin the registry as the single source of the label.
+      const mockApi = createMockApiClient({
+        orders: { list: vi.fn().mockResolvedValue(paginated([syncedOrder])) },
+        connections: {
+          list: vi.fn().mockResolvedValue([{ ...sampleConnection, platformType }]),
+        },
+      });
+
+      const { container } = renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
+
+      await screen.findByText('ALG-882414');
+      const pill = container.querySelector(`.channel-pill[data-channel="${platformType}"]`);
+      expect(pill?.textContent).toBe(expectedLabel);
+    },
+  );
+
   it('should fall back to the internalOrderId when the snapshot has no orderNumber', async () => {
     const orderWithoutNumber: OrderRecord = {
       ...syncedOrder,

--- a/apps/web/src/pages/orders/orders-list-page.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.tsx
@@ -911,6 +911,11 @@ export function OrdersListPage(): ReactElement {
     [
       locale,
       platformByConnection,
+      // `channelLabel` closes over the plugin registry as of #2088. The registry
+      // array is referentially stable (a provider-level memo over a module
+      // constant), so listing it costs no rebuild — but that invariant lives two
+      // files away, and a stale closure here would render stale channel labels.
+      platforms,
       retryMutation.isPending,
       retryMutation.variables,
       retryWrite.visible,

--- a/apps/web/src/pages/orders/orders-list-page.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.tsx
@@ -80,15 +80,10 @@ import {
   FulfillmentRollupStateValues,
 } from '../../features/orders/api/orders.types';
 import { useConnectionsQuery } from '../../features/connections';
+import { resolvePlatformLabel } from '../../features/mappings';
+import { usePlatforms } from '../../shared/plugins';
 
 const PAGE_SIZE = 20;
-
-const CHANNEL_LABELS: Record<string, string> = {
-  allegro: 'Allegro',
-  prestashop: 'PrestaShop',
-  amazon: 'Amazon',
-  shopify: 'Shopify',
-};
 
 /**
  * Status segments — partition the order set (#929). The "All" card carries the
@@ -347,8 +342,13 @@ export function OrdersListPage(): ReactElement {
     return map;
   }, [connectionsQuery.data]);
 
+  // Registry-resolved, never a local map: the four-entry `CHANNEL_LABELS` this
+  // replaced (#2088) had no row for `erli` or `woocommerce`, so both rendered
+  // raw and lowercase here while rendering correctly two pages over.
+  const platforms = usePlatforms();
+
   const channelLabel = (platform: string | undefined): string | undefined =>
-    platform ? (CHANNEL_LABELS[platform] ?? platform) : undefined;
+    platform ? resolvePlatformLabel(platforms, platform) : undefined;
 
   // Resolve a connectionId to a human channel label (never undefined) for the
   // bulk-dispatch per-row source pill.

--- a/apps/web/src/pages/products/listings-coverage-pills.tsx
+++ b/apps/web/src/pages/products/listings-coverage-pills.tsx
@@ -18,6 +18,7 @@ import type { ReactElement } from 'react';
 import type { Connection } from '../../features/connections';
 import type { ProductListingsCoverage } from '../../features/products/api/products.types';
 import { usePlatforms } from '../../shared/plugins';
+import { findPlatformDisplayName } from '../../features/mappings';
 
 export interface ListingsCoveragePillsProps {
   coverage: ProductListingsCoverage[] | undefined;
@@ -59,8 +60,7 @@ export function ListingsCoveragePills({
         const soleOfPlatform =
           connections.filter((c) => c.platformType === connection.platformType).length === 1;
         const label = soleOfPlatform
-          ? (platforms.find((p) => p.platformType === connection.platformType)?.displayName ??
-            connection.name)
+          ? (findPlatformDisplayName(platforms, connection) ?? connection.name)
           : connection.name;
         return (
           <span

--- a/apps/web/src/pages/products/product-row-detail.tsx
+++ b/apps/web/src/pages/products/product-row-detail.tsx
@@ -24,6 +24,7 @@ import type { Product, ProductVariant } from '../../features/products/api/produc
 import type { InventoryItem } from '../../features/inventory/api/inventory.types';
 import type { Connection } from '../../features/connections';
 import { usePlatforms } from '../../shared/plugins';
+import { findPlatformDisplayName } from '../../features/mappings';
 import {
   deriveStockStatus,
   STOCK_STATUS_BADGE_TONE,
@@ -230,8 +231,7 @@ function ProductVariantRow({
             const soleOfPlatform =
               connections.filter((c) => c.platformType === connection.platformType).length === 1;
             const label = soleOfPlatform
-              ? (platforms.find((p) => p.platformType === connection.platformType)?.displayName ??
-                connection.name)
+              ? (findPlatformDisplayName(platforms, connection) ?? connection.name)
               : connection.name;
             return (
               <span

--- a/apps/web/src/pages/products/products-list-page.tsx
+++ b/apps/web/src/pages/products/products-list-page.tsx
@@ -45,6 +45,7 @@ import { CheckboxCell } from '../../shared/ui/checkbox-cell';
 import { useMediaQuery } from '../../shared/ui/use-media-query';
 import { useDebouncedValue } from '../../shared/hooks/use-debounced-value';
 import { usePlatforms } from '../../shared/plugins';
+import { resolvePlatformLabel } from '../../features/mappings';
 import { useWriteAccess } from '../../shared/auth/use-permission';
 import { useDemoMode } from '../../features/system';
 import { useProductsQuery } from '../../features/products/hooks/use-products-query';
@@ -282,8 +283,7 @@ export function ProductsListPage(): ReactElement {
   }, [connectionsQuery.data]);
 
   const platformLabel = useCallback(
-    (platformType: string): string =>
-      platforms.find((p) => p.platformType === platformType)?.displayName ?? platformType,
+    (platformType: string): string => resolvePlatformLabel(platforms, platformType),
     [platforms],
   );
 
@@ -552,8 +552,7 @@ export function ProductsListPage(): ReactElement {
 
   const soleConnectionName =
     publishDestinations.length === 1
-      ? (platforms.find((p) => p.platformType === publishDestinations[0]!.connection.platformType)
-          ?.displayName ?? publishDestinations[0]!.connection.platformType)
+      ? resolvePlatformLabel(platforms, publishDestinations[0]!.connection)
       : null;
 
   const atCap = selectedIds.size >= BULK_SELECTION_CAP;

--- a/apps/web/src/pages/products/variant-stock-table.tsx
+++ b/apps/web/src/pages/products/variant-stock-table.tsx
@@ -25,7 +25,7 @@ import { TimeDisplay } from '../../shared/ui/time-display';
 import { StatusBadge, type StatusBadgeTone } from '../../shared/ui/status-badge';
 import { useMediaQuery } from '../../shared/ui/use-media-query';
 import { usePlatforms } from '../../shared/plugins';
-import { resolvePlatformLabel } from '../../features/mappings';
+import { findPlatformDisplayName, resolvePlatformLabel } from '../../features/mappings';
 import {
   deriveStockStatus,
   STOCK_STATUS_BADGE_TONE,
@@ -216,7 +216,15 @@ function VariantCoverage({
       ? listedConnections.map((connection) => {
           const soleOfPlatform =
             connections.filter((c) => c.platformType === connection.platformType).length === 1;
-          const label = soleOfPlatform ? platformLabel(connection.platformType) : connection.name;
+          // Same fallback as the other two renderings of this pill
+          // (`listings-coverage-pills.tsx`, `product-row-detail.tsx`): with no
+          // registered platform, the operator-authored connection name beats a
+          // lowercase slug. Before #2088 this one site disagreed with its two
+          // siblings, so the same variant read `My Shopify Store` on the products
+          // list and `shopify` on the product detail page.
+          const label = soleOfPlatform
+            ? (findPlatformDisplayName(platforms, connection) ?? connection.name)
+            : connection.name;
           return { key: connection.id, label, channel: connection.platformType };
         })
       : listings.map((listing) => ({

--- a/apps/web/src/pages/products/variant-stock-table.tsx
+++ b/apps/web/src/pages/products/variant-stock-table.tsx
@@ -25,6 +25,7 @@ import { TimeDisplay } from '../../shared/ui/time-display';
 import { StatusBadge, type StatusBadgeTone } from '../../shared/ui/status-badge';
 import { useMediaQuery } from '../../shared/ui/use-media-query';
 import { usePlatforms } from '../../shared/plugins';
+import { resolvePlatformLabel } from '../../features/mappings';
 import {
   deriveStockStatus,
   STOCK_STATUS_BADGE_TONE,
@@ -203,7 +204,7 @@ function VariantCoverage({
   const platforms = usePlatforms();
   const listedConnectionIds = new Set(listings.map((l) => l.connectionId));
   const platformLabel = (platformType: string): string =>
-    platforms.find((p) => p.platformType === platformType)?.displayName ?? platformType;
+    resolvePlatformLabel(platforms, platformType);
 
   const listedConnections = connections.filter((c) => listedConnectionIds.has(c.id));
 
@@ -266,9 +267,7 @@ function DrawerChannelLink({
   const offerQuery = useListingMarketplaceOfferQuery(listing.id, { enabled: enabled && isOffer });
   const url = offerQuery.data?.marketplaceUrl;
   if (!url) return null;
-  const label =
-    platforms.find((p) => p.platformType === listing.platformType)?.displayName ??
-    listing.platformType;
+  const label = resolvePlatformLabel(platforms, listing);
   return (
     <a
       className="variant-drawer__link"
@@ -342,7 +341,7 @@ function ListingsSummary({
 }): ReactElement {
   const platforms = usePlatforms();
   const platformLabel = (platformType: string): string =>
-    platforms.find((p) => p.platformType === platformType)?.displayName ?? platformType;
+    resolvePlatformLabel(platforms, platformType);
   const listedConnectionIds = new Set(listings.map((l) => l.connectionId));
   const gapConnections = connections.filter((c) => !listedConnectionIds.has(c.id));
   const gapChannels = Array.from(
@@ -487,9 +486,7 @@ function ListingDetailCard({
     categoryPathQuery.data && categoryPathQuery.data.length > 0
       ? categoryPathQuery.data.map((segment) => segment.name).join(' › ')
       : null;
-  const label =
-    platforms.find((p) => p.platformType === listing.platformType)?.displayName ??
-    listing.platformType;
+  const label = resolvePlatformLabel(platforms, listing);
 
   // Meta items are conditional (Qty / Category only when the live offer
   // resolves). Build the rendered nodes first, then interleave a muted `·`


### PR DESCRIPTION
## Summary

Stops duplicating the plugin registry. `usePlatforms()` has exposed a correct `displayName` per plugin all along and `resolvePlatformLabel` was already the extracted helper — almost nothing used either.

**A hardcoded map competed with the registry.** `CHANNEL_LABELS` on the Orders list covered only allegro / prestashop / amazon / shopify, so `erli` and `woocommerce` rendered raw and lowercase there while rendering correctly two pages over. Its single consumer `channelLabel` feeds five surfaces — the Order cell, the Channel column, the mobile-card subtitle, the bulk-dispatch source pill and `OrderRowDetail` — so one missing row showed up five times. It is deleted.

**The same lookup was re-inlined 13 more times** across products, dashboard, connections and the bulk flow. All now go through the resolver.

Label text only. No cell composition, no CSS, no column changes.

## Four sites that were not plain duplicates

Handled rather than normalised away:

| Site | Its own fallback | What this PR does |
|---|---|---|
| `listings-coverage-pills.tsx` | `connection.name` | keeps it — see below |
| `product-row-detail.tsx` | `connection.name` | keeps it — see below |
| `variant-stock-table.tsx` (`VariantCoverage`) | raw type — **diverged from the two above** | aligns it onto `connection.name` |
| `bulk-wizard.tsx` | literal `'marketplace'` | narrows it to "no destination chosen yet" |

The first two label a pill by platform display name only when it is the *sole* connection of that platform, and fall back to the operator-authored connection name — which disambiguates two shops on one platform far better than a lowercase slug would. Routing them through `resolvePlatformLabel` would have swapped that fallback silently, so **`findPlatformDisplayName`** (the same registry lookup, no fallback) is exported alongside the resolver and both sites keep their own `?? connection.name`. The `find` still lives in exactly one place, which was the point.

`VariantCoverage` was found in review: it has the *same* `soleOfPlatform` logic and the *same* `coverage-pill--full` class as the two above, but fell back to the raw type — so the same variant read `My Shopify Store` on the products list and `shopify` on the product detail page. Pre-existing, not introduced here, but three identical pills must not answer differently, so its connection-derived branch is aligned. Its listing-derived branch stays on the resolver: an `OfferMapping` carries no connection name to fall back to.

`bulk-wizard.tsx`'s `'marketplace'` now covers only the case it is actually for — no destination chosen yet. Once a connection IS chosen the label comes from the registry like everywhere else, so an unregistered platform reads as its raw type rather than the generic word.

## The dashboard carried a third label behaviour

A local `fallbackPlatformLabel` capitalised the raw type (`woocommerce` → `Woocommerce`), giving the app three different answers for an unregistered platform: registry name, raw type, or capitalised type. Both it and the `platformDisplayNames` Map are deleted and `buildInfraNodeLabels` takes `platforms` directly.

**Behaviour change:** an unregistered platform now reads as its raw lowercase type on the dashboard, matching every other list and the issue's AC ("an unknown `platformType` still renders the raw string"). The capitalising branch was dead for every shipped platform anyway — all nine are registered.

## Why the fallback is the raw type and not title-cased

One review lens argued for title-casing the slug, since `amazon` and `shopify` had hand-written Title Case in the deleted map, and a lowercase slug reads poorly in prose (`View on shopify`) and in the dashboard's Infrastructure column, whose neighbours are `PostgreSQL` / `Redis` / `PrestaShop` / `Worker`.

Rejected, and recorded in the resolver's docstring so it is not re-litigated: title-casing manufactures a **plausible but wrong** brand name for exactly the platforms whose names are not one word — `Woocommerce`, `Bigcommerce`, `Prestashop`. It reads as a product name while being incorrect. A raw slug reads as an unresolved identifier, which is what it is: the fallback fires only when no plugin declares the platform, i.e. a misconfiguration, and an ops surface should show that rather than disguise it. It is also what the issue's AC states ("renders the raw string rather than blank").

**The accepted cost:** `amazon` and `shopify` were two of `CHANNEL_LABELS`' four rows and have no registry counterpart, so those two labels degrade from `Amazon` / `Shopify` to raw slugs on the five Orders surfaces. Unreachable in practice — neither has a backend adapter, so no shipped connection can carry those platform types. A site that holds a `Connection` and wants something friendlier than a slug has the documented alternative: `findPlatformDisplayName(...) ?? connection.name`, the operator's own name for the destination, which beats both a slug and a mis-cased brand.

## A 14th site the issue's table missed

`dashboard-page.tsx:633-635` — the Infrastructure panel's `ServiceHealthRow` name used the same Map-plus-capitalising-fallback pair inline, twice in one ternary. Fixed in the same pass.

## Deliberate deviation from the mockup

The helper stays in `features/mappings/lib/platform-label.ts`. Frame 13 of `docs/plans/mockups/list-identity-cells-1996.html` proposed moving it to `shared/plugins/platform-label.ts` (reasoning that `shared` cannot import from `features`), but PR #2032 already established the barrel path for its second cross-feature consumer, and re-litigating it would churn ~14 import lines for no behavioural gain. Recorded in the file header so nobody "fixes" it back.

## Untouched, as the issue requires

- `create-connection-form.tsx` — maps the whole plugin list into `<select>` options. A different operation, not a label lookup.
- `prompt-templates-list-page.tsx` — falls back to `humaniseChannel(channel)` for non-plugin channels. Different semantics.

## Observed but out of scope

- `bulk-wizard.tsx:191` still inlines `platforms.find(...)` — but it resolves the **`Platform` object** for validation-slot dispatch, not a label, and `usePlatform()` is the shared hook for that. Object-resolution cleanup belongs with `usePlatform`, not in a label PR.
- `prompt-templates-list-page.tsx` still title-cases an unregistered channel via `humaniseChannel`, so the app retains two answers for that case. The issue excluded the file as "different semantics", which holds for its `master` sentinel but not for the capitalising half. Resolving it means deciding whether the sentinel keeps its own helper — a follow-up, not this PR.
- `connections-list-page.tsx:44/198` renders `{platformType} · {adapterKey}` and never shows a display name. Defensible as a technical identity line (same posture as `product-source-section.tsx:56`), but it does mean "one label everywhere" is not literally true; the Connections list is arguably where an operator most expects the product name.

## Base branch

Targets `2086-list-identity-cells` (the #2086 epic branch), now **rebased onto `main`** since PR #2032 merged (`805e29ca3`).

## Testing

- 8 new tests for `resolvePlatformLabel` / `findPlatformDisplayName` — known platform, both accepted argument shapes, unregistered platform, empty plugin list (the state every render hits before the registry provider settles), empty `platformType`.
- **2 rendering tests pin the acceptance criterion** (`orders-list-page.test.tsx`): an `it.each` over `erli` / `woocommerce` asserting the channel pill reads `Erli` / `WooCommerce`. Added in review — the pre-existing channel-pill test used `allegro`, which the deleted map *also* handled, so nothing in the suite would have caught a regression to the old behaviour and the code comment was the only thing defending the change.
- 305 existing tests across every touched page and feature pass **with no assertion changes** (`dashboard-page`, `orders-list-page`, `products-list-page`, `listings-coverage-pills`, `connection-detail-page`, `features/listings/components/bulk`, `features/products`).
- `pnpm --filter @openlinker/web lint` — 0 errors, no new warnings. `type-check` — clean. `check-design-tokens` + `check-cross-context-imports` — green.
- Verified against the registry that `Erli` and `WooCommerce` are the declared display names (`plugins/erli/index.ts:47`, `plugins/woocommerce/index.ts:31`), so the AC is met by data and not just by wiring.

⚠️ `pnpm check:invariants` fails on a clash that is now **on `main`**, unrelated to this PR: `1833000000002-create-refund-records.ts` (#2046) and `1833000000002-add-identifier-mappings-offer-created-index.ts` (came in with #2032) share a migration timestamp, so TypeORM's ordering between them is undefined.

## Architecture

Frontend only. Cross-feature imports go through the `features/mappings` barrel.

Closes #2088
