### PR TITLE
fix(infakt): stamp the invoice currency instead of booking in the account default

### DIFF
--- a/apps/web/src/features/invoicing/api/invoicing.types.ts
+++ b/apps/web/src/features/invoicing/api/invoicing.types.ts
@@ -40,6 +40,7 @@ export type FailureMode = (typeof FailureModeValues)[number];
  *  raw provider message is never carried (the DTO omits `errorMessage`). */
 export const FailureCodeValues = [
   'buyer-tax-id-invalid',
+  'invalid-currency',
   'provider-rejected',
   'transport-timeout',
   'provider-error',

--- a/apps/web/src/features/invoicing/lib/derive-invoice-display.ts
+++ b/apps/web/src/features/invoicing/lib/derive-invoice-display.ts
@@ -68,6 +68,8 @@ export function canRetryInvoice(invoice: InvoiceRecord | null): boolean {
 const FAILURE_CODE_FALLBACK: Record<FailureCode, string> = {
   'buyer-tax-id-invalid':
     'The provider rejected the buyer’s tax ID. Check the tax ID on the order’s customer, then retry. Nothing was issued.',
+  'invalid-currency':
+    'The document’s settlement currency is missing, malformed, or not accepted for this document. Fix the currency on the source order, then retry. Nothing was issued.',
   'provider-rejected':
     'The provider rejected the document. Check the order’s data, then retry. Nothing was issued.',
   'transport-timeout':

--- a/libs/core/src/invoicing/application/services/invoice.service.spec.ts
+++ b/libs/core/src/invoicing/application/services/invoice.service.spec.ts
@@ -547,6 +547,50 @@ describe('InvoiceService', () => {
       );
     });
 
+    it("(d4) failureCode: a 'rejected' throwable naming the settlement currency maps to 'invalid-currency'", async () => {
+      repo.findByIdempotencyKey.mockResolvedValue(null);
+      repo.create.mockResolvedValue(makeRecord({ id: 'rec-1', status: 'pending' }));
+      // The message an adapter raises when it refuses a malformed currency BEFORE
+      // contacting the provider (#2103, inFakt's `toInfaktCurrency`). The generic
+      // 'provider-rejected' copy would claim the provider rejected a request it
+      // never saw, so the operator must get currency-specific copy instead.
+      const rejection = Object.assign(
+        new Error('Infakt requires an ISO 4217 currency on invoice for order ol_order_1, got ""'),
+        { failureMode: 'rejected' as const },
+      );
+      adapter.issueInvoice.mockRejectedValue(rejection);
+      repo.updateOutcome.mockResolvedValue(makeRecord({ id: 'rec-1', status: 'failed' }));
+
+      await expect(service.issueInvoice(makeCmd())).rejects.toBe(rejection);
+      expect(repo.updateOutcome).toHaveBeenCalledWith(
+        'rec-1',
+        expect.objectContaining({
+          status: 'failed',
+          failureMode: 'rejected',
+          failureCode: 'invalid-currency',
+          failureReason:
+            'The settlement currency is missing, malformed, or not accepted for this document. Fix the currency on the order and re-issue.',
+        }),
+      );
+    });
+
+    it("(d5) failureCode: a tax-id rejection that also mentions a currency stays 'buyer-tax-id-invalid'", async () => {
+      repo.findByIdempotencyKey.mockResolvedValue(null);
+      repo.create.mockResolvedValue(makeRecord({ id: 'rec-1', status: 'pending' }));
+      const rejection = Object.assign(new Error('rejected'), {
+        failureMode: 'rejected' as const,
+        reason: 'Buyer tax id is malformed for an invalid currency document',
+      });
+      adapter.issueInvoice.mockRejectedValue(rejection);
+      repo.updateOutcome.mockResolvedValue(makeRecord({ id: 'rec-1', status: 'failed' }));
+
+      await expect(service.issueInvoice(makeCmd())).rejects.toBe(rejection);
+      expect(repo.updateOutcome).toHaveBeenCalledWith(
+        'rec-1',
+        expect.objectContaining({ failureCode: 'buyer-tax-id-invalid' }),
+      );
+    });
+
     it('(e) unreachable transport: adapter throws -> failed + rethrow (per-design propagation)', async () => {
       repo.findByIdempotencyKey.mockResolvedValue(null);
       repo.create.mockResolvedValue(makeRecord({ id: 'rec-1', status: 'pending' }));

--- a/libs/core/src/invoicing/application/services/invoice.service.ts
+++ b/libs/core/src/invoicing/application/services/invoice.service.ts
@@ -102,6 +102,27 @@ const MAX_FAILURE_REASON_LENGTH = 200;
 const TAX_ID_REJECTION_MARKERS = ['tax id', 'tax-id', 'taxid', 'tax identifier'] as const;
 
 /**
+ * Substrings (case-insensitive) that mark a `rejected` failure as a settlement-
+ * currency problem, so the operator is told to fix the ORDER's currency rather
+ * than reading that "the provider rejected the request" — which is actively
+ * misleading when the adapter refused the currency shape BEFORE any provider
+ * call (#2103). Same structural-read pattern as the tax-id markers above, and
+ * the same neutral-vocabulary constraint (ADR-026): "currency"/"ISO 4217" name
+ * no country or tax system.
+ *
+ * Deliberately narrow phrases rather than the bare word `currency`, which would
+ * also match an unrelated provider message that merely mentions a currency
+ * (e.g. an amount-formatting rejection) and mis-route the operator's fix.
+ */
+const CURRENCY_REJECTION_MARKERS = [
+  'iso 4217',
+  'invalid currency',
+  'unsupported currency',
+  'currency is required',
+  'currency code',
+] as const;
+
+/**
  * Lifetime of an `issuing` CAS lease (#1200). Bounds how long a crashed
  * mid-call attempt can block same-key retries before the slot becomes
  * re-claimable.
@@ -751,9 +772,13 @@ export class InvoiceService implements IInvoiceService {
    * classified {@link InvoiceFailureMode} plus a STRUCTURAL read of the adapter
    * throwable's `reason`/message — never value-importing an adapter error class.
    *
-   *   - `rejected` (TERMINAL): a tax-identifier rejection → `buyer-tax-id-invalid`
-   *     (operator-fixable); anything else → `provider-rejected`.
+   *   - `rejected` (TERMINAL): a tax-identifier rejection → `buyer-tax-id-invalid`;
+   *     a settlement-currency rejection → `invalid-currency` (both operator-
+   *     fixable on the source order); anything else → `provider-rejected`.
    *   - `in-doubt` (transient/indeterminate transport): `transport-timeout`.
+   *
+   * Tax id is checked first purely for determinism — a message naming both is
+   * routed to the buyer-data fix, which is the more specific remedy.
    *
    * The mode is the source of truth for re-attemptability; the code is the FE-
    * facing cause refinement. An unrecognised mode can never reach here (the only
@@ -777,9 +802,13 @@ export class InvoiceService implements IInvoiceService {
           ? error.message
           : '';
     const haystack = reasonText.toLowerCase();
-    return TAX_ID_REJECTION_MARKERS.some((marker) => haystack.includes(marker))
-      ? 'buyer-tax-id-invalid'
-      : 'provider-rejected';
+    if (TAX_ID_REJECTION_MARKERS.some((marker) => haystack.includes(marker))) {
+      return 'buyer-tax-id-invalid';
+    }
+    if (CURRENCY_REJECTION_MARKERS.some((marker) => haystack.includes(marker))) {
+      return 'invalid-currency';
+    }
+    return 'provider-rejected';
   }
 
   /**
@@ -791,6 +820,11 @@ export class InvoiceService implements IInvoiceService {
   private deriveFailureReason(failureCode: InvoiceFailureCode): string {
     const reasons: Record<InvoiceFailureCode, string> = {
       'buyer-tax-id-invalid': 'The buyer tax identifier was rejected as invalid.',
+      // Wording covers BOTH the adapter's pre-call shape refusal and a genuine
+      // provider-side currency rejection, so it can never claim the provider saw
+      // a request it did not.
+      'invalid-currency':
+        'The settlement currency is missing, malformed, or not accepted for this document. Fix the currency on the order and re-issue.',
       'provider-rejected': 'The invoicing provider rejected the request.',
       'transport-timeout':
         'The invoicing request timed out; the document may or may not have been created.',

--- a/libs/core/src/invoicing/application/services/invoice.service.ts
+++ b/libs/core/src/invoicing/application/services/invoice.service.ts
@@ -802,9 +802,11 @@ export class InvoiceService implements IInvoiceService {
   private deriveFailureReason(failureCode: InvoiceFailureCode): string {
     const reasons: Record<InvoiceFailureCode, string> = {
       'buyer-tax-id-invalid': 'The buyer tax identifier was rejected as invalid.',
-      // Wording covers BOTH the adapter's pre-call shape refusal and a genuine
-      // provider-side currency rejection, so it can never claim the provider saw
-      // a request it did not.
+      // Worded to fit an adapter PRE-CALL refusal, which is the only origin
+      // that actually reaches this code today (see InvoiceFailureCode's doc):
+      // it never claims the provider saw a request it did not. It stays
+      // accurate for a provider-side currency rejection too, should one ever
+      // route here, which is why it names the condition rather than the actor.
       'invalid-currency':
         'The settlement currency is missing, malformed, or not accepted for this document. Fix the currency on the order and re-issue.',
       'provider-rejected': 'The invoicing provider rejected the request.',

--- a/libs/core/src/invoicing/application/services/invoice.service.ts
+++ b/libs/core/src/invoicing/application/services/invoice.service.ts
@@ -51,6 +51,9 @@ import {
 } from './invoice-issue-lock';
 import { MissingNumberingSeriesException } from '../../domain/exceptions/missing-numbering-series.exception';
 import { CapabilityNotSupportedException } from '@openlinker/core/integrations';
+// Published so an adapter spec can pin its own pre-call refusal message against
+// the very markers this service matches on (#2103 review) — see the constant's doc.
+import { CURRENCY_REJECTION_MARKERS } from '../../domain/types/invoicing.types';
 import type {
   CorrectionLine,
   GetInvoiceByOrderQuery,
@@ -100,27 +103,6 @@ const MAX_FAILURE_REASON_LENGTH = 200;
  * matches the generic "tax id" the adapter surfaces in its rejection reason.
  */
 const TAX_ID_REJECTION_MARKERS = ['tax id', 'tax-id', 'taxid', 'tax identifier'] as const;
-
-/**
- * Substrings (case-insensitive) that mark a `rejected` failure as a settlement-
- * currency problem, so the operator is told to fix the ORDER's currency rather
- * than reading that "the provider rejected the request" — which is actively
- * misleading when the adapter refused the currency shape BEFORE any provider
- * call (#2103). Same structural-read pattern as the tax-id markers above, and
- * the same neutral-vocabulary constraint (ADR-026): "currency"/"ISO 4217" name
- * no country or tax system.
- *
- * Deliberately narrow phrases rather than the bare word `currency`, which would
- * also match an unrelated provider message that merely mentions a currency
- * (e.g. an amount-formatting rejection) and mis-route the operator's fix.
- */
-const CURRENCY_REJECTION_MARKERS = [
-  'iso 4217',
-  'invalid currency',
-  'unsupported currency',
-  'currency is required',
-  'currency code',
-] as const;
 
 /**
  * Lifetime of an `issuing` CAS lease (#1200). Bounds how long a crashed

--- a/libs/core/src/invoicing/domain/types/invoicing.types.spec.ts
+++ b/libs/core/src/invoicing/domain/types/invoicing.types.spec.ts
@@ -41,6 +41,7 @@ describe('invoicing.types', () => {
   it('exposes the closed neutral failure-code taxonomy (W1)', () => {
     expect([...InvoiceFailureCodeValues]).toEqual([
       'buyer-tax-id-invalid',
+      'invalid-currency',
       'provider-rejected',
       'transport-timeout',
       'provider-error',

--- a/libs/core/src/invoicing/domain/types/invoicing.types.ts
+++ b/libs/core/src/invoicing/domain/types/invoicing.types.ts
@@ -98,6 +98,33 @@ export const InvoiceFailureCodeValues = [
 export type InvoiceFailureCode = (typeof InvoiceFailureCodeValues)[number];
 
 /**
+ * Substrings (case-insensitive) that mark a `rejected` failure as a settlement-
+ * currency problem, so `classifyFailureCode` can resolve `invalid-currency`
+ * instead of the generic `provider-rejected` — whose operator-facing copy
+ * asserts the PROVIDER rejected the request, which is untrue when an adapter
+ * refuses the currency shape BEFORE any provider call (#2103).
+ *
+ * Deliberately narrow phrases rather than the bare word `currency`, which would
+ * also match an unrelated provider message that merely mentions a currency
+ * (e.g. an amount-formatting rejection) and mis-route the operator's fix.
+ *
+ * PUBLISHED (unlike the sibling tax-id markers, which stay private to
+ * `InvoiceService`) because for this code BOTH ends of the structural read live
+ * in this repo: the phrase an adapter throws pre-call is OL-authored, so an
+ * adapter spec can assert its own message still matches one of these markers
+ * and a reword breaks the build rather than silently degrading the operator's
+ * failure reason (#2103 review). Neutral vocabulary only — "currency" and
+ * "ISO 4217" name no country or tax system (ADR-026).
+ */
+export const CURRENCY_REJECTION_MARKERS = [
+  'iso 4217',
+  'invalid currency',
+  'unsupported currency',
+  'currency is required',
+  'currency code',
+] as const;
+
+/**
  * Neutral Continuous-Transaction-Controls clearance lifecycle. The adapter maps
  * a regime's native states (KSeF, IT SDI, ES SII…) onto these. `not-applicable`
  * is the default for providers without regulatory transmission.

--- a/libs/core/src/invoicing/domain/types/invoicing.types.ts
+++ b/libs/core/src/invoicing/domain/types/invoicing.types.ts
@@ -75,12 +75,18 @@ export type InvoiceFailureMode = (typeof InvoiceFailureModeValues)[number];
  *   - `buyer-tax-id-invalid`: a TERMINAL `rejected` failure caused by an invalid
  *     buyer tax identifier — the operator can fix the buyer data and re-issue.
  *   - `invalid-currency`: a TERMINAL `rejected` failure caused by the document's
- *     settlement currency — missing, malformed, or one the provider will not
- *     settle in. Operator-fixable on the source order, so it earns its own code
- *     rather than collapsing into `provider-rejected`, whose copy asserts the
- *     PROVIDER rejected the request (untrue when an adapter refuses the shape
- *     before any provider call, as #2103 does). Currency and ISO 4217 are
- *     country-agnostic vocabulary, so this stays ADR-026-clean.
+ *     settlement currency. In practice this is an ADAPTER PRE-CALL REFUSAL —
+ *     the adapter rejected a missing or malformed currency before any provider
+ *     round-trip (#2103) — which is precisely why it must not collapse into
+ *     `provider-rejected`, whose copy asserts the PROVIDER rejected a request
+ *     it never saw. A genuine provider-side currency rejection would classify
+ *     here too if its text reached `classifyFailureCode`, but no shipped
+ *     adapter routes one: inFakt's HTTP client deliberately keeps the provider
+ *     body out of the error message (it can echo buyer PII) and core never
+ *     reads `responseBody`, so such a rejection lands on `provider-rejected` —
+ *     accurately, since the provider did reject it. Operator-fixable on the
+ *     source order either way. Currency and ISO 4217 are country-agnostic
+ *     vocabulary, so this stays ADR-026-clean.
  *   - `provider-rejected`: any other TERMINAL `rejected` failure (safe to
  *     re-attempt once the underlying input is corrected).
  *   - `transport-timeout`: an `in-doubt` transport failure — the document MAY

--- a/libs/core/src/invoicing/domain/types/invoicing.types.ts
+++ b/libs/core/src/invoicing/domain/types/invoicing.types.ts
@@ -74,6 +74,13 @@ export type InvoiceFailureMode = (typeof InvoiceFailureModeValues)[number];
  *
  *   - `buyer-tax-id-invalid`: a TERMINAL `rejected` failure caused by an invalid
  *     buyer tax identifier — the operator can fix the buyer data and re-issue.
+ *   - `invalid-currency`: a TERMINAL `rejected` failure caused by the document's
+ *     settlement currency — missing, malformed, or one the provider will not
+ *     settle in. Operator-fixable on the source order, so it earns its own code
+ *     rather than collapsing into `provider-rejected`, whose copy asserts the
+ *     PROVIDER rejected the request (untrue when an adapter refuses the shape
+ *     before any provider call, as #2103 does). Currency and ISO 4217 are
+ *     country-agnostic vocabulary, so this stays ADR-026-clean.
  *   - `provider-rejected`: any other TERMINAL `rejected` failure (safe to
  *     re-attempt once the underlying input is corrected).
  *   - `transport-timeout`: an `in-doubt` transport failure — the document MAY
@@ -83,6 +90,7 @@ export type InvoiceFailureMode = (typeof InvoiceFailureModeValues)[number];
  */
 export const InvoiceFailureCodeValues = [
   'buyer-tax-id-invalid',
+  'invalid-currency',
   'provider-rejected',
   'transport-timeout',
   'provider-error',

--- a/libs/integrations/infakt/docs/setup-guide.md
+++ b/libs/integrations/infakt/docs/setup-guide.md
@@ -269,11 +269,15 @@ itself.
 Two operator-visible consequences:
 
 - An order whose currency is not a well-formed ISO 4217 code is refused before
-  anything reaches inFakt (a terminal business failure naming the offending value),
-  rather than being booked in the account's default currency. Omitting the field is
-  what inFakt treats as "use the account default", and it answers success either
-  way - so a refusal is the only way to avoid a silently mis-denominated document
-  that inFakt then relays to KSeF.
+  anything reaches inFakt, rather than being booked in the account's default
+  currency. Omitting the field is what inFakt treats as "use the account default",
+  and it answers success either way - so a refusal is the only way to avoid a
+  silently mis-denominated document that inFakt then relays to KSeF. The refusal is
+  a terminal business failure the operator can re-submit: the invoice reads
+  **Failed** and its reason names the currency ("The settlement currency is missing,
+  malformed, or not accepted for this document. Fix the currency on the order and
+  re-issue."). The offending value itself is **not** shown in the UI - reasons are
+  fixed, PII-free strings by design - and appears only in the API server log.
 - The seller's inFakt account must actually be allowed to settle in that currency.
   inFakt owns that rule and enforces it server-side, so an unsupported currency
   surfaces as an inFakt rejection at issuance rather than as an OL-side error.
@@ -288,7 +292,7 @@ Two operator-visible consequences:
 | Webhook deliveries return 401 | `X-Infakt-Signature` (HMAC-SHA256 hex of the raw body) doesn't match the secret OL resolved | Copy the secret from inFakt's webhook-details view and set `OPENLINKER_WEBHOOK_SECRET__INFAKT__<CONNECTION_ID_UPPERCASE>` (or `OPENLINKER_WEBHOOK_SECRET__INFAKT`); do **not** use the `secret/rotate` endpoint for inFakt (it generates a random secret inFakt doesn't know). See [Webhook configuration](#2-webhook-configuration). |
 | Webhook subscription never activates | The verification-ping echo didn't reach inFakt (host unreachable, TLS issue, or the connection ID in the URL is wrong) | Confirm the URL path matches `POST /webhooks/infakt/{connectionId}` exactly and the host is publicly reachable from inFakt's servers. |
 | Invoice stays `submitted` forever, never reaches `accepted` | KSeF itself rejected the document after inFakt submitted it, or (less likely, since OL's `sendToKsef` call would normally fail outright at issuance time if this were disabled) KSeF integration is off in inFakt's account settings | Check inFakt's own invoice/KSeF status in its dashboard first — `ksef_data.status: error` there means inFakt attempted submission and KSeF rejected it (fix the underlying document data and re-issue). If `getClearanceStatus()` keeps returning `not-applicable` with no `ksef_data` at all, confirm KSeF integration is enabled in inFakt's account settings (the [Prerequisites](#prerequisites) requirement). |
-| Issuance fails with "Infakt requires an ISO 4217 currency" | The order's currency is blank or not a three-letter code, so OL refuses to issue rather than let inFakt book the document in the account default | Fix the currency on the source order (it is echoed from the order totals) and re-issue. Nothing was created at inFakt, so re-issuing is safe. |
+| Invoice fails with "The settlement currency is missing, malformed, or not accepted for this document" | The order's currency is blank or not a three-letter code, so OL refuses to issue rather than let inFakt book the document in the account default | Fix the currency on the source order (it is echoed from the order totals) and re-issue. Nothing was created at inFakt, so re-issuing is safe. The offending value is in the API server log (`Infakt requires an ISO 4217 currency on ... , got "..."`), not in the UI. |
 | inFakt rejects a non-PLN invoice at issuance (422) | The seller's inFakt account is not configured to settle in that currency, or inFakt wants additional foreign-currency fields (e.g. an exchange-date kind) for it | Enable the currency in inFakt's own account settings and re-issue. The rejection is terminal and nothing was created, so the operator can re-submit. |
 | Rate limiting / `429` from inFakt | Sandbox and low-tier plans enforce API rate limits | Space out bulk issuance; inFakt's retry classifier (`InfaktRetryClassifierAdapter`) already treats `429` as retryable in the worker's job runner. |
 

--- a/libs/integrations/infakt/docs/setup-guide.md
+++ b/libs/integrations/infakt/docs/setup-guide.md
@@ -293,13 +293,18 @@ apart from a correct one. Because inFakt relays to KSeF on the seller's behalf,
 such a document may already have been filed with the tax authority.
 
 **How much of your data this touches.** For a PLN-denominated account selling in
-PLN only - the shipped assumption, and the only configuration exercised in
-testing before #2103 - nothing is wrong: the account default *was* the right
-currency, so those documents are correct as issued. The defect was found by code
-reading rather than from an operator report, so there is no known
-mis-denominated production document; that is an absence of evidence for this
-repository, **not** a guarantee about your deployment. If you have ever invoiced
-a non-default-currency order through inFakt, check.
+PLN only - the shipped assumption, and the only configuration this integration's
+own tests exercised before #2103 (every currency literal in the inFakt package,
+specs and sandbox script alike, was `PLN`) - nothing is wrong: the account
+default *was* the right currency, so those documents are correct as issued. The
+defect was found by code reading rather than from an operator report, so there is
+no known mis-denominated production document; that is an absence of evidence for
+this repository, **not** a guarantee about your deployment. Note that the neutral
+layer above the adapter always could carry a non-PLN currency - the order-to-command
+mapper echoes `order.totals.currency` verbatim and the numbering series routes on
+it - so nothing structurally prevented a foreign-currency order from reaching
+inFakt. If you have ever invoiced a non-default-currency order through inFakt,
+check.
 
 **How to check.** For records issued after #1297 the currency as issued is
 persisted on the invoice record, so the reconciliation is a single query - run it
@@ -354,6 +359,7 @@ reaches inFakt.
 | Invoice stays `submitted` forever, never reaches `accepted` | KSeF itself rejected the document after inFakt submitted it, or (less likely, since OL's `sendToKsef` call would normally fail outright at issuance time if this were disabled) KSeF integration is off in inFakt's account settings | Check inFakt's own invoice/KSeF status in its dashboard first — `ksef_data.status: error` there means inFakt attempted submission and KSeF rejected it (fix the underlying document data and re-issue). If `getClearanceStatus()` keeps returning `not-applicable` with no `ksef_data` at all, confirm KSeF integration is enabled in inFakt's account settings (the [Prerequisites](#prerequisites) requirement). |
 | Invoice fails with "The settlement currency is missing, malformed, or not accepted for this document" | The order's currency is blank or not a three-letter code, so OL refuses to issue rather than let inFakt book the document in the account default | Fix the currency on the source order (it is echoed from the order totals) and re-issue. Nothing was created at inFakt, so re-issuing is safe. The offending value is in the API server log (`Infakt requires an ISO 4217 currency on ... , got "..."`), not in the UI. |
 | inFakt rejects a non-PLN invoice at issuance (422) | The seller's inFakt account is not configured to settle in that currency, or inFakt wants additional foreign-currency fields (e.g. an exchange-date kind) for it | Enable the currency in inFakt's own account settings and re-issue. The rejection is terminal and nothing was created, so the operator can re-submit. |
+| An invoice issued **before** #2103 shows the inFakt account's default currency for a foreign-currency order | OL never sent a `currency` at all, and inFakt reads an absent field as "use the account default" | Reconcile with the query in [Documents issued before OL sent the currency](#documents-issued-before-ol-sent-the-currency). A correction cannot re-denominate the document - remediation is a withdraw-and-re-issue on the accounting side. |
 | Rate limiting / `429` from inFakt | Sandbox and low-tier plans enforce API rate limits | Space out bulk issuance; inFakt's retry classifier (`InfaktRetryClassifierAdapter`) already treats `429` as retryable in the worker's job runner. |
 
 ---

--- a/libs/integrations/infakt/docs/setup-guide.md
+++ b/libs/integrations/infakt/docs/setup-guide.md
@@ -261,7 +261,10 @@ The order's settlement currency is sent explicitly on every issued document as
 inFakt's invoice-level `currency` field, and a correction is always denominated in
 the currency inFakt holds for the document it corrects. inFakt performs the
 conversion itself and reports the rate back on its read-only `exchange_rates_data`
-block, so OL never sends an exchange rate.
+block, so OL never sends an exchange rate. Verified live against the sandbox
+(2026-08-14): a EUR invoice issues with `currency: "EUR"` and its amount stated in
+EUR on the document, and inFakt fills in the foreign-currency exchange-date kind
+itself.
 
 Two operator-visible consequences:
 

--- a/libs/integrations/infakt/docs/setup-guide.md
+++ b/libs/integrations/infakt/docs/setup-guide.md
@@ -255,6 +255,26 @@ the others.
 
 *(screenshot pending)*
 
+### Foreign-currency invoices
+
+The order's settlement currency is sent explicitly on every issued document as
+inFakt's invoice-level `currency` field, and a correction is always denominated in
+the currency inFakt holds for the document it corrects. inFakt performs the
+conversion itself and reports the rate back on its read-only `exchange_rates_data`
+block, so OL never sends an exchange rate.
+
+Two operator-visible consequences:
+
+- An order whose currency is not a well-formed ISO 4217 code is refused before
+  anything reaches inFakt (a terminal business failure naming the offending value),
+  rather than being booked in the account's default currency. Omitting the field is
+  what inFakt treats as "use the account default", and it answers success either
+  way - so a refusal is the only way to avoid a silently mis-denominated document
+  that inFakt then relays to KSeF.
+- The seller's inFakt account must actually be allowed to settle in that currency.
+  inFakt owns that rule and enforces it server-side, so an unsupported currency
+  surfaces as an inFakt rejection at issuance rather than as an OL-side error.
+
 ---
 
 ## Troubleshooting
@@ -265,6 +285,8 @@ the others.
 | Webhook deliveries return 401 | `X-Infakt-Signature` (HMAC-SHA256 hex of the raw body) doesn't match the secret OL resolved | Copy the secret from inFakt's webhook-details view and set `OPENLINKER_WEBHOOK_SECRET__INFAKT__<CONNECTION_ID_UPPERCASE>` (or `OPENLINKER_WEBHOOK_SECRET__INFAKT`); do **not** use the `secret/rotate` endpoint for inFakt (it generates a random secret inFakt doesn't know). See [Webhook configuration](#2-webhook-configuration). |
 | Webhook subscription never activates | The verification-ping echo didn't reach inFakt (host unreachable, TLS issue, or the connection ID in the URL is wrong) | Confirm the URL path matches `POST /webhooks/infakt/{connectionId}` exactly and the host is publicly reachable from inFakt's servers. |
 | Invoice stays `submitted` forever, never reaches `accepted` | KSeF itself rejected the document after inFakt submitted it, or (less likely, since OL's `sendToKsef` call would normally fail outright at issuance time if this were disabled) KSeF integration is off in inFakt's account settings | Check inFakt's own invoice/KSeF status in its dashboard first — `ksef_data.status: error` there means inFakt attempted submission and KSeF rejected it (fix the underlying document data and re-issue). If `getClearanceStatus()` keeps returning `not-applicable` with no `ksef_data` at all, confirm KSeF integration is enabled in inFakt's account settings (the [Prerequisites](#prerequisites) requirement). |
+| Issuance fails with "Infakt requires an ISO 4217 currency" | The order's currency is blank or not a three-letter code, so OL refuses to issue rather than let inFakt book the document in the account default | Fix the currency on the source order (it is echoed from the order totals) and re-issue. Nothing was created at inFakt, so re-issuing is safe. |
+| inFakt rejects a non-PLN invoice at issuance (422) | The seller's inFakt account is not configured to settle in that currency, or inFakt wants additional foreign-currency fields (e.g. an exchange-date kind) for it | Enable the currency in inFakt's own account settings and re-issue. The rejection is terminal and nothing was created, so the operator can re-submit. |
 | Rate limiting / `429` from inFakt | Sandbox and low-tier plans enforce API rate limits | Space out bulk issuance; inFakt's retry classifier (`InfaktRetryClassifierAdapter`) already treats `429` as retryable in the worker's job runner. |
 
 ---

--- a/libs/integrations/infakt/docs/setup-guide.md
+++ b/libs/integrations/infakt/docs/setup-guide.md
@@ -282,6 +282,66 @@ Two operator-visible consequences:
   inFakt owns that rule and enforces it server-side, so an unsupported currency
   surfaces as an inFakt rejection at issuance rather than as an OL-side error.
 
+#### Documents issued before OL sent the currency
+
+**What was wrong.** Until #2103, OL never sent inFakt a `currency` at all. inFakt
+reads an absent field as "use the account's default currency" and answers success
+either way, so **every** document OL issued was booked in the account default no
+matter what the order's currency said: a EUR 811.37 order was issued as
+PLN 811.37, with no error, no log line and nothing on the document to tell it
+apart from a correct one. Because inFakt relays to KSeF on the seller's behalf,
+such a document may already have been filed with the tax authority.
+
+**How much of your data this touches.** For a PLN-denominated account selling in
+PLN only - the shipped assumption, and the only configuration exercised in
+testing before #2103 - nothing is wrong: the account default *was* the right
+currency, so those documents are correct as issued. The defect was found by code
+reading rather than from an operator report, so there is no known
+mis-denominated production document; that is an absence of evidence for this
+repository, **not** a guarantee about your deployment. If you have ever invoiced
+a non-default-currency order through inFakt, check.
+
+**How to check.** For records issued after #1297 the currency as issued is
+persisted on the invoice record, so the reconciliation is a single query - run it
+against the OL database, replacing `'PLN'` with your inFakt account's own default
+currency:
+
+```sql
+SELECT ir.id,
+       ir."orderId",
+       ir."documentNumber",
+       ir."issuedAt",
+       ir."issuedLineSnapshot"->>'currency'            AS issued_currency,
+       o."orderSnapshot"->'totals'->>'currency'        AS order_currency
+FROM invoice_records ir
+JOIN connections c ON c.id = ir."connectionId"
+LEFT JOIN order_records o ON o."internalOrderId" = ir."orderId"
+WHERE c."platformType" = 'infakt'
+  AND ir.status = 'issued'
+  AND COALESCE(
+        NULLIF(ir."issuedLineSnapshot"->>'currency', ''),
+        NULLIF(o."orderSnapshot"->'totals'->>'currency', '')
+      ) <> 'PLN'
+ORDER BY ir."issuedAt" DESC;
+```
+
+Every returned row is a document whose order was **not** in the account default,
+which before #2103 means it was booked in the account default anyway. Records
+issued before the `issuedLineSnapshot` column existed carry no currency of their
+own, so the query falls back to the order's current snapshot for those - which is
+the order's currency today, not necessarily its currency at issuance.
+
+**How to fix.** OL cannot repair these itself, and neither can an ordinary
+correction: inFakt denominates a correction in the currency of the document it
+corrects, so correcting a wrongly-PLN document produces another PLN document. A
+mis-denominated document has to be withdrawn and re-issued in the right currency
+on the accounting side. Take the query's output to whoever keeps the books -
+correcting a document that has already cleared the tax authority is their call,
+not OL's, and this guide is not legal or tax advice. Once the account default and
+the order currency agree again, re-issuing from OL is safe: the currency is now
+always stamped explicitly, and an ambiguous one is refused before anything
+reaches inFakt.
+
 ---
 
 ## Troubleshooting

--- a/libs/integrations/infakt/src/domain/types/infakt.types.ts
+++ b/libs/integrations/infakt/src/domain/types/infakt.types.ts
@@ -164,6 +164,60 @@ export interface InfaktListResponse<T> {
 }
 
 /**
+ * One service (line) row on a `POST invoices.json` request.
+ *
+ * Deliberately a WRITE-side type rather than a reuse of {@link
+ * InfaktInvoiceService}: the read shape carries provider-computed totals
+ * (`net_price`/`tax_price`/`gross_price`) and correction bookkeeping
+ * (`correction`/`group`) that must NOT be sent on a create.
+ *
+ * `unit_net_price` is a plain integer count of groszy, the same minor-unit
+ * convention as everywhere else in this API — see `toGroszy`.
+ */
+export interface InfaktInvoiceServiceRequest {
+  name: string;
+  tax_symbol: string;
+  quantity: number;
+  unit: string;
+  unit_net_price: number;
+}
+
+/**
+ * Body of a `POST invoices.json` request, under its `invoice` wrapper key.
+ *
+ * The REQUEST shape is kept distinct from the {@link InfaktInvoice} RESPONSE
+ * shape on purpose (#2103 review). Sharing one interface for both had a
+ * concrete cost: the whole of #2103 was `currency` being absent from the
+ * outbound request while nothing — no compiler, no test, no provider response —
+ * objected, because the request was an untyped inline object literal. Declaring
+ * `currency` REQUIRED here means a future refactor of that literal fails
+ * type-check instead of silently re-booking every document in the account's
+ * default currency. The correction path already had this protection via
+ * {@link InfaktCorrectiveInvoiceRequest}; this is the issue path catching up.
+ *
+ * Only fields OL actually sends are modelled — inFakt defaults or derives the
+ * rest (dates, totals, `vat_exchange_date_kind`, `exchange_rates_data`).
+ */
+export interface InfaktInvoiceRequest {
+  invoice: {
+    kind: InfaktInvoiceKind;
+    /**
+     * ISO 4217 settlement currency (#2103). REQUIRED, never optional: omitting
+     * the field is exactly what inFakt reads as "use the account default", and
+     * it answers 200/201 either way — see {@link InfaktInvoice.currency}.
+     */
+    currency: string;
+    payment_method: string;
+    /** Numeric client id — inFakt silently ignores `client_uuid` here. */
+    client_id: number;
+    services: InfaktInvoiceServiceRequest[];
+    bank_account?: string;
+    bank_name?: string;
+    external_id?: string;
+  };
+}
+
+/**
  * One "before"/"after" service row on a POST /async/corrective_invoices.json
  * request. Rows come in pairs per `group`: `correction: false` (original
  * values) then `correction: true` (corrected values).

--- a/libs/integrations/infakt/src/domain/types/infakt.types.ts
+++ b/libs/integrations/infakt/src/domain/types/infakt.types.ts
@@ -52,6 +52,26 @@ export interface InfaktInvoice {
   number: string | null;
   kind: InfaktInvoiceKind;
   status: string;
+  /**
+   * ISO 4217 settlement currency of the document (#2103).
+   *
+   * A WRITABLE field on inFakt's invoice resource - "`currency` | string |
+   * Waluta (domyślnie PLN)" in inFakt's own API reference, with no `(readonly)`
+   * marker (unlike `net_price`/`gross_price`/`exchange_rates_data`, which carry
+   * one). Confirmed present on live reads of BOTH document resources
+   * (`GET /invoices.json` and `GET /corrective_invoices.json`, sandbox
+   * 2026-08-14) and selectable via `fields=`.
+   *
+   * Because the field DEFAULTS to the account currency when omitted, leaving it
+   * off the request booked every document in the account default no matter what
+   * the neutral `IssueInvoiceCommand.currency` said - silently, since inFakt
+   * answers 200/201 either way (#2103). It is therefore stamped explicitly on
+   * every write path, never omitted.
+   *
+   * inFakt owns the conversion itself: the rate is reported back on the
+   * read-only `exchange_rates_data` block, so OL never sends a rate.
+   */
+  currency: string;
   // Infakt's public API represents every monetary field as a PLAIN INTEGER
   // count of groszy (1 PLN = 100 grosze) — confirmed both live against the
   // real sandbox (a 349.00 PLN order landed as gross_price=348, i.e. 3.48 PLN,
@@ -173,6 +193,15 @@ export interface InfaktCorrectiveInvoiceServiceRequest {
 export interface InfaktCorrectiveInvoiceRequest {
   corrective_invoice: {
     payment_method: string;
+    /**
+     * ISO 4217 currency of the CORRECTION document (#2103). Required here for
+     * the same reason as on `async/invoices.json`: omitted, inFakt falls back to
+     * the account default, which would denominate a correction differently from
+     * the document it corrects. Taken from the corrected original's own
+     * `currency`, never from the account default or a caller-supplied value -
+     * see `InfaktInvoice.currency`.
+     */
+    currency: string;
     client_id: number | null;
     bank_account?: string;
     bank_name?: string;

--- a/libs/integrations/infakt/src/domain/types/infakt.types.ts
+++ b/libs/integrations/infakt/src/domain/types/infakt.types.ts
@@ -62,6 +62,15 @@ export interface InfaktInvoice {
    * (`GET /invoices.json` and `GET /corrective_invoices.json`, sandbox
    * 2026-08-14) and selectable via `fields=`.
    *
+   * WRITE path verified live too (sandbox 2026-08-14): a `currency: 'EUR'`
+   * invoice returned `201` with `currency: "EUR"`, `gross_price: 81137` and
+   * `amount_in_words: "osiemset jedenaście EUR 37/100"` - denominated in EUR on
+   * the document itself, not reinterpreted as the account default. The same run
+   * showed inFakt populating `vat_exchange_date_kind` ("vat") server-side, so
+   * that field is NOT a required input for a foreign-currency VAT invoice.
+   * `exchange_rates_data` stayed absent while the document was `draft`, so the
+   * applied rate is still unobserved.
+   *
    * Because the field DEFAULTS to the account currency when omitted, leaving it
    * off the request booked every document in the account default no matter what
    * the neutral `IssueInvoiceCommand.currency` said - silently, since inFakt

--- a/libs/integrations/infakt/src/domain/types/infakt.types.ts
+++ b/libs/integrations/infakt/src/domain/types/infakt.types.ts
@@ -164,6 +164,35 @@ export interface InfaktListResponse<T> {
 }
 
 /**
+ * Body of a `POST clients.json` request, under its `client` wrapper key.
+ *
+ * Kept distinct from the {@link InfaktClient} RESPONSE shape for the same
+ * reason as {@link InfaktInvoiceRequest} (#2103 review): the response carries
+ * provider-assigned identity (`id`, `uuid`) that must not be sent on a create,
+ * and an untyped inline literal is exactly how a field name drifts unnoticed.
+ * This write has already suffered that: #1926 was `name`/`post_code` being sent
+ * where inFakt wants `company_name`/`postal_code` — silently ignored, so
+ * first-time client creation always 422'd, with no compiler or test objecting.
+ * Naming the shape here means a future rename fails type-check instead.
+ *
+ * `company_name` is required (it is the client's display identity, and inFakt
+ * rejects a create without it); the rest are optional because OL genuinely may
+ * not hold them — a B2C buyer has no `nip`, and `email` is absent whenever the
+ * source order carries none (#1797 notes what that costs downstream).
+ */
+export interface InfaktClientRequest {
+  client: {
+    company_name: string;
+    nip?: string;
+    email?: string;
+    city?: string;
+    street?: string;
+    postal_code?: string;
+    country?: string;
+  };
+}
+
+/**
  * One service (line) row on a `POST invoices.json` request.
  *
  * Deliberately a WRITE-side type rather than a reuse of {@link

--- a/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-invoicing.adapter.spec.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-invoicing.adapter.spec.ts
@@ -21,6 +21,7 @@ import { resolve } from 'path';
 import type { LoggerPort } from '@openlinker/shared/logging';
 import {
   BuyerProfile,
+  CURRENCY_REJECTION_MARKERS,
   InvoiceRecord,
   UnsupportedRegulatoryDocumentKindError,
 } from '@openlinker/core/invoicing';
@@ -550,6 +551,26 @@ describe('InfaktInvoicingAdapter', () => {
         expect(http.calls).toHaveLength(0);
       },
     );
+
+    it('should phrase the refusal so core still classifies it as invalid-currency (#2103 review)', async () => {
+      // Core's `classifyFailureCode` resolves the operator-facing
+      // `invalid-currency` code by a structural substring read of the rejection
+      // reason (the same pattern the tax-id markers use). That makes the message
+      // thrown HERE part of the contract: reword it out of every marker and the
+      // operator silently drops back to "the provider rejected the request" -
+      // which is false, since nothing was sent. Asserted from the side that
+      // changes, against the published marker list rather than a copied string.
+      http.seed('POST', 'invoices.json', invoiceFixture());
+
+      const error = await adapter
+        .issueInvoice({ ...baseCmd, currency: '' })
+        .then(() => null)
+        .catch((e: unknown) => e as Error);
+
+      const haystack = (error?.message ?? '').toLowerCase();
+      expect(error).toBeInstanceOf(InfaktApiError);
+      expect(CURRENCY_REJECTION_MARKERS.some((marker) => haystack.includes(marker))).toBe(true);
+    });
 
     it('should default an empty taxRate to the Polish standard VAT rate (regime-rate fallback)', async () => {
       // Core always leaves InvoiceLine.taxRate empty (documented contract:

--- a/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-invoicing.adapter.spec.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-invoicing.adapter.spec.ts
@@ -83,6 +83,8 @@ function invoiceFixture(overrides: Partial<InfaktInvoice> = {}): InfaktInvoice {
     number: 'FV/1/2026',
     kind: 'vat',
     status: 'sent',
+    // Present on every live read of both document resources (#2103).
+    currency: 'PLN',
     gross_price: 12300,
     net_price: 10000,
     tax_price: 2300,
@@ -495,6 +497,60 @@ describe('InfaktInvoicingAdapter', () => {
       );
     });
 
+    it('should stamp the command currency on the invoice payload (#2103)', async () => {
+      http.seed('POST', 'invoices.json', invoiceFixture({ currency: 'EUR' }));
+
+      await adapter.issueInvoice({ ...baseCmd, currency: 'EUR' });
+
+      const invoiceCall = http.calls.find((c) => c.method === 'POST' && c.path === 'invoices.json');
+      expect(invoiceCall?.body).toMatchObject({
+        invoice: expect.objectContaining({ currency: 'EUR' }),
+      });
+    });
+
+    it('should never fall back to the account default currency for a non-PLN command (#2103)', async () => {
+      // The whole point of #2103: omitting `currency` makes Infakt book the
+      // document in the account's default (PLN) with no error anywhere, and
+      // Infakt relays it to KSeF. A EUR command must reach the wire as EUR.
+      http.seed('POST', 'invoices.json', invoiceFixture({ currency: 'EUR' }));
+
+      await adapter.issueInvoice({ ...baseCmd, currency: 'EUR' });
+
+      const invoice = (
+        http.calls.find((c) => c.method === 'POST' && c.path === 'invoices.json')?.body as {
+          invoice: Record<string, unknown>;
+        }
+      ).invoice;
+      expect(invoice).toHaveProperty('currency');
+      expect(invoice.currency).not.toBe('PLN');
+    });
+
+    it('should normalise a lower-case currency code to Infakt uppercase (#2103)', async () => {
+      http.seed('POST', 'invoices.json', invoiceFixture({ currency: 'EUR' }));
+
+      await adapter.issueInvoice({ ...baseCmd, currency: 'eur' });
+
+      const invoiceCall = http.calls.find((c) => c.method === 'POST' && c.path === 'invoices.json');
+      expect(invoiceCall?.body).toMatchObject({
+        invoice: expect.objectContaining({ currency: 'EUR' }),
+      });
+    });
+
+    it.each([['', 'blank'], ['PLNN', 'over-long'], ['EU2', 'non-alphabetic']])(
+      'should reject a malformed currency (%s, %s) before any provider call (#2103)',
+      async (currency) => {
+        http.seed('POST', 'invoices.json', invoiceFixture());
+
+        // 422 -> failureMode 'rejected': nothing crossed the provider boundary,
+        // so the operator can safely re-submit. The alternative (dropping the
+        // field) is a silently mis-denominated, KSeF-cleared document.
+        await expect(adapter.issueInvoice({ ...baseCmd, currency })).rejects.toMatchObject({
+          statusCode: 422,
+        });
+        expect(http.calls).toHaveLength(0);
+      },
+    );
+
     it('should default an empty taxRate to the Polish standard VAT rate (regime-rate fallback)', async () => {
       // Core always leaves InvoiceLine.taxRate empty (documented contract:
       // "the provider adapter resolves the regime rate"). Verified live
@@ -870,6 +926,22 @@ describe('InfaktInvoicingAdapter', () => {
       });
     });
 
+    it('should carry no monetary value, hence no currency, on the mark-paid payload (#2103)', async () => {
+      // `paid.json` settles the document in full against the currency the
+      // document itself already carries - there is no amount here that could be
+      // mis-denominated. Pinned so a future partial-payment amount cannot be
+      // added without revisiting the currency question.
+      http.seed('POST', 'async/invoices/inv-uuid-1/paid.json', {});
+
+      await adapter.markPaid({
+        externalInvoiceId: 'inv-uuid-1',
+        paidDate: new Date('2026-07-08T12:34:56Z'),
+      });
+
+      const body = http.calls[0]?.body as { invoice: Record<string, unknown> };
+      expect(Object.keys(body.invoice)).toEqual(['paid_date']);
+    });
+
     it('should URL-encode the external invoice id', async () => {
       http.seed('POST', 'async/invoices/inv%2Fuuid/paid.json', {});
 
@@ -1046,6 +1118,72 @@ describe('InfaktInvoicingAdapter', () => {
           (c) => c.method === 'POST' && c.path === 'corrective_invoices/corr-uuid-1/send_to_ksef.json',
         ),
       ).toBe(true);
+    });
+
+    it('should denominate the correction in the corrected original currency (#2103)', async () => {
+      // A correction must be booked in the same currency as the document it
+      // corrects - and the before/after rows are built verbatim from that
+      // document's own services, so the provider's value is the only correct
+      // source. Omitting the field would fall back to the account default.
+      http.seed('GET', 'invoices/inv-uuid-1.json', invoiceFixture({ currency: 'EUR' }));
+      http.seed('POST', 'async/corrective_invoices.json', asyncTaskFixture());
+      http.seed(
+        'GET',
+        'corrective_invoices/corr-uuid-1.json',
+        invoiceFixture({ uuid: 'corr-uuid-1', kind: 'correction', currency: 'EUR' }),
+      );
+      http.seed('POST', 'corrective_invoices/corr-uuid-1/send_to_ksef.json', ksefResponseFixture());
+
+      await adapter.issueCorrection(baseCmd);
+
+      const call = http.calls.find(
+        (c) => c.method === 'POST' && c.path === 'async/corrective_invoices.json',
+      );
+      expect(call?.body).toMatchObject({
+        corrective_invoice: expect.objectContaining({ currency: 'EUR' }),
+      });
+    });
+
+    it("should warn but still use the provider's currency when OL's snapshot disagrees (#2103)", async () => {
+      http.seed('GET', 'invoices/inv-uuid-1.json', invoiceFixture({ currency: 'EUR' }));
+      http.seed('POST', 'async/corrective_invoices.json', asyncTaskFixture());
+      http.seed(
+        'GET',
+        'corrective_invoices/corr-uuid-1.json',
+        invoiceFixture({ uuid: 'corr-uuid-1', kind: 'correction', currency: 'EUR' }),
+      );
+      http.seed('POST', 'corrective_invoices/corr-uuid-1/send_to_ksef.json', ksefResponseFixture());
+
+      await adapter.issueCorrection({
+        ...baseCmd,
+        originalDocument: {
+          buyer: buyer({ nip: '1234567890' }),
+          currency: 'PLN',
+          documentType: 'invoice',
+          lines: [{ name: 'Widget', quantity: 1, unitPriceGross: 123, taxRate: '23' }],
+          clearanceReference: null,
+          documentNumber: 'FV/1/2026',
+          issueDate: '2026-07-01',
+        },
+      });
+
+      const call = http.calls.find(
+        (c) => c.method === 'POST' && c.path === 'async/corrective_invoices.json',
+      );
+      expect(call?.body).toMatchObject({
+        corrective_invoice: expect.objectContaining({ currency: 'EUR' }),
+      });
+      expect(logger.warn).toHaveBeenCalledWith(expect.stringContaining('PLN'));
+    });
+
+    it('should refuse to correct a document whose currency Infakt does not report, before any POST (#2103)', async () => {
+      http.seed('GET', 'invoices/inv-uuid-1.json', invoiceFixture({ currency: '' }));
+      http.seed('POST', 'async/corrective_invoices.json', asyncTaskFixture());
+
+      await expect(adapter.issueCorrection(baseCmd)).rejects.toMatchObject({ statusCode: 422 });
+      expect(
+        http.calls.some((c) => c.method === 'POST' && c.path === 'async/corrective_invoices.json'),
+      ).toBe(false);
     });
 
     it('should send corrected_invoice_uuid and a correction_reason SYMBOL, never the read-only correction_reason_symbol (#1763)', async () => {

--- a/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
@@ -56,6 +56,7 @@ import type {
   InfaktAsyncTaskAccepted,
   InfaktBankAccount,
   InfaktClient,
+  InfaktClientRequest,
   InfaktCorrectiveInvoiceRequest,
   InfaktCorrectiveInvoiceServiceRequest,
   InfaktInvoice,
@@ -481,7 +482,10 @@ export class InfaktInvoicingAdapter
     // #1797: without `email`, Infakt creates the client with no email on
     // file, so a later `deliver_via_email.json` call 422s ("adres e-mail
     // Klienta jest nieznany") — confirmed live against the sandbox.
-    const payload = {
+    // Typed against the WRITE shape (#2103 review) so the field-name drift that
+    // caused #1926 fails type-check rather than 422-ing live. Same guard the
+    // issue path got via `InfaktInvoiceRequest`.
+    const payload: InfaktClientRequest = {
       client: {
         company_name: buyer.name,
         nip: nip ?? undefined,

--- a/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
@@ -101,6 +101,41 @@ function normalizeNip(taxId: string): string {
 }
 
 /**
+ * Normalises the neutral `IssueInvoiceCommand.currency` to inFakt's `currency`
+ * field (#2103).
+ *
+ * inFakt's `currency` DEFAULTS to the account currency when the field is absent
+ * or unusable, and the API answers 200/201 either way - so a dropped or
+ * malformed code is not a rejected request, it is a document booked in the wrong
+ * units with no error anywhere. Since inFakt relays to KSeF on the seller's
+ * behalf, that wrong document then clears the tax authority, which OL cannot
+ * quietly re-issue. Hence: uppercase the code, and refuse the write outright
+ * rather than let anything ambiguous reach the provider.
+ *
+ * Status 422 (a 4xx → `failureMode: 'rejected'`) is deliberate: the throw
+ * happens BEFORE the POST, so nothing crossed the provider boundary and core can
+ * safely surface a terminal business failure the operator can re-submit.
+ *
+ * The check is a shape check (three ASCII letters), not a closed allow-list of
+ * codes: inFakt owns which currencies the seller's account may settle in and
+ * rejects the rest itself, so an allow-list here would only add a second, staler
+ * gate. KSeF's own adapter does hold a closed list, but only because FA(3)'s
+ * `KodWaluty` is an XSD enum it must satisfy before submitting.
+ */
+function toInfaktCurrency(currency: string | null | undefined, context: string): string {
+  const normalized = (currency ?? '').trim().toUpperCase();
+  if (!/^[A-Z]{3}$/.test(normalized)) {
+    throw new InfaktApiError(
+      `Infakt requires an ISO 4217 currency on ${context}, got "${currency ?? ''}" - refusing to ` +
+        `issue a document that Infakt would silently book in the account's default currency`,
+      422,
+      { currency: currency ?? null },
+    );
+  }
+  return normalized;
+}
+
+/**
  * Maps Infakt ksef_data.status → neutral RegulatoryStatus.
  *
  * `success` is the TERMINAL accepted state — it must map to `accepted`, not
@@ -465,6 +500,9 @@ export class InfaktInvoicingAdapter
 
   async issueInvoice(cmd: IssueInvoiceCommand): Promise<IssueInvoiceResult> {
     const { lines, documentType, idempotencyKey, orderId } = cmd;
+    // Resolved BEFORE the client upsert so a malformed currency costs no
+    // provider round-trip and cannot leave a freshly-created client behind.
+    const currency = toInfaktCurrency(cmd.currency, `invoice for order ${orderId}`);
     const clientId = await this.resolveClientId(cmd);
 
     const kind = documentType === 'proforma' ? 'proforma' : 'vat';
@@ -480,6 +518,11 @@ export class InfaktInvoicingAdapter
     const payload = {
       invoice: {
         kind,
+        // ISO 4217 settlement currency (#2103). Stamped explicitly and
+        // unconditionally - omitting it makes Infakt book the document in the
+        // account's default currency with no error, so a EUR order issued (and
+        // KSeF-cleared) as PLN. See `toInfaktCurrency` / `InfaktInvoice.currency`.
+        currency,
         // Per-connection setting (#1303) — see `this.paymentMethod` doc.
         payment_method: this.paymentMethod,
         // Infakt's invoices.json wants the NUMERIC client id, not the client
@@ -665,6 +708,17 @@ export class InfaktInvoicingAdapter
    * `getPaymentStatus` afterward if it needs OL's own projection updated -
    * this method only confirms the provider ACCEPTED the mark, not that its
    * processing has finished.
+   *
+   * NO currency is stamped here, deliberately (#2103). Unlike the two issue
+   * paths, this write carries no monetary value at all: neutral
+   * `MarkInvoicePaidCommand` is `{ externalInvoiceId, paidDate }`, and inFakt's
+   * `paid.json` accepts only `paid_date` (plus an `allow_correction` flag) - it
+   * settles the document in full, against the currency the document itself
+   * already carries. There is therefore no amount that could be mis-denominated,
+   * and adding a `currency` field here would be a second, drift-prone opinion
+   * about a document inFakt already owns. The unit spec pins the payload to
+   * exactly `paid_date` so a future partial-payment amount cannot be added
+   * without revisiting the currency question.
    */
   async markPaid(cmd: MarkInvoicePaidCommand): Promise<void> {
     await this.http.post(`async/invoices/${encodeURIComponent(cmd.externalInvoiceId)}/paid.json`, {
@@ -681,6 +735,30 @@ export class InfaktInvoicingAdapter
       `invoices/${encodeURIComponent(originalProviderInvoiceId)}.json`,
       { invoice_type: 'vat' },
     );
+
+    // A correction is denominated by the document it corrects, so the currency
+    // comes from the ORIGINAL as Infakt actually holds it (#2103) - not from the
+    // account default (what omitting the field would fall back to) and not from
+    // core, which carries no top-level currency on `IssueCorrectionCommand`. It
+    // must match `original.services`, from which the before/after rows below are
+    // built verbatim.
+    const currency = toInfaktCurrency(
+      original.currency,
+      `correction of invoice ${original.number ?? originalProviderInvoiceId}`,
+    );
+
+    // `originalDocument` is OL's own issuance-time snapshot of the same document
+    // (#1297). It is NOT used as the correction's currency - the provider's value
+    // is authoritative and is what the corrected amounts are expressed in - but a
+    // divergence means OL's fiscal projection disagrees with the provider about a
+    // document it already issued, which is worth surfacing rather than swallowing.
+    const snapshotCurrency = cmd.originalDocument?.currency?.trim().toUpperCase();
+    if (snapshotCurrency && snapshotCurrency !== currency) {
+      this.logger.warn(
+        `Infakt correction of ${originalProviderInvoiceId}: OL's issuance snapshot says ` +
+          `${snapshotCurrency} but Infakt holds ${currency}; correcting in ${currency} (the provider's own currency)`,
+      );
+    }
 
     // The operator's free-text reason cannot be forwarded to this provider
     // (see `correction_reason` on the payload below). Log the loss so it is
@@ -801,6 +879,10 @@ export class InfaktInvoicingAdapter
     // path rather than a genuine provider bug). See `createCorrectionAsync`.
     const payload: InfaktCorrectiveInvoiceRequest = {
       corrective_invoice: {
+        // Same explicit stamp as the issue path (#2103) - the corrected
+        // original's own currency, so a correction can never be booked in a
+        // different currency than the document it corrects.
+        currency,
         // Per-connection setting (#1303) — see `this.paymentMethod` doc.
         payment_method: this.paymentMethod,
         // Required by Infakt on every invoice, corrective included — verified

--- a/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
@@ -59,6 +59,7 @@ import type {
   InfaktCorrectiveInvoiceRequest,
   InfaktCorrectiveInvoiceServiceRequest,
   InfaktInvoice,
+  InfaktInvoiceRequest,
   InfaktKsefStatus,
   InfaktListResponse,
   InfaktSendToKsefResponse,
@@ -515,7 +516,11 @@ export class InfaktInvoicingAdapter
       unit_net_price: toGroszy(grossToNet(l.unitPriceGross, l.taxRate)),
     }));
 
-    const payload = {
+    // Typed against the WRITE shape, not the response shape (#2103 review): with
+    // `InfaktInvoiceRequest.currency` required, dropping the field from this
+    // literal again is a type error rather than a silently mis-denominated
+    // document. Mirrors the correction path's `InfaktCorrectiveInvoiceRequest`.
+    const payload: InfaktInvoiceRequest = {
       invoice: {
         kind,
         // ISO 4217 settlement currency (#2103). Stamped explicitly and


### PR DESCRIPTION
## Problem

The neutral `IssueInvoiceCommand.currency` never reached inFakt. `InfaktInvoice` had no currency field and `infakt-invoicing.adapter.ts` had zero `.currency` references, so amounts went out as bare minor-unit integers and inFakt booked them in the account's default currency: a EUR 811.37 invoice was issued as PLN 811.37.

That is worse than an ordinary mapping gap on two counts. It is silent - inFakt answers 200/201 whether or not the field is present, so nothing distinguished a mis-denominated document from a correct one. And it propagates - inFakt relays to KSeF on the seller's behalf, so the wrong fiscal document clears the tax authority, which OL cannot quietly re-issue.

## API contract (branch 2: inFakt does support it)

`currency` is a writable invoice-level field on inFakt's API v3 invoice resource, described as `Waluta (domyślnie PLN)` in [inFakt's own reference](https://github.com/infakt/API/blob/master/readme.md#definicja-faktury-vat) (rendered at docs.infakt.pl). Readonly fields in that reference are marked as such (`net_price`, `gross_price`, `exchange_rates_data`, ...); `currency` is not. Read-only sandbox GETs (2026-08-14) confirm the field is present on both `GET /invoices.json` and `GET /corrective_invoices.json`, and that it is selectable via `fields=`.

inFakt owns the conversion: the applied rate comes back on the read-only `exchange_rates_data` block, so OL sends no exchange rate. Full finding with the field table is posted on the issue.

## Change

- `InfaktInvoice.currency` and `InfaktCorrectiveInvoiceRequest.corrective_invoice.currency` added to the wire types, documented with the writable/default-PLN evidence.
- `issueInvoice` stamps the normalised command currency on every request. Resolution happens before the client upsert, so a bad value costs no provider round-trip.
- A blank or malformed currency is refused with a `422` (`failureMode: 'rejected'`) raised **before** the POST, rather than being omitted. Omitting the field is precisely what inFakt reads as "use the account default", and it succeeds either way - so refusing is the only way to keep a mis-denominated document from being issued and cleared. Nothing crosses the provider boundary, so the operator can safely re-submit. The check is a shape check (three ASCII letters), not an allow-list: inFakt decides which currencies the seller's account may settle in and rejects the rest itself.
- `issueCorrection` stamps the **corrected original's own** currency, read back from inFakt. A correction is denominated by the document it corrects, and the before/after rows are built verbatim from that document's `services`, so the provider's value is the only correct source. A divergent OL issuance snapshot (`originalDocument.currency`, #1297) is warn-logged rather than silently preferred; an original whose currency inFakt does not report is refused before the POST.
- `markPaid` carries no monetary value at all - `MarkInvoicePaidCommand` is `{ externalInvoiceId, paidDate }` and inFakt's `paid.json` accepts only `paid_date` - so there is no amount that could be mis-denominated and no currency to stamp. This is now stated in the method doc and pinned by a spec asserting the payload is exactly `paid_date`, so a future partial-payment amount cannot be added without revisiting the currency question.
- Operator docs: a "Foreign-currency invoices" section plus two troubleshooting rows in the inFakt setup guide.

No change in `libs/core`. The neutral command already carried the currency; the defect was confined to the adapter boundary, and no inFakt/PLN/KSeF vocabulary was added to core (ADR-026).

## Tests

Added to `infakt-invoicing.adapter.spec.ts` (94 pass):

- the command currency reaches `invoice.currency`;
- a non-PLN command is never booked as PLN (asserts the field is present and not `PLN`);
- a lower-case code is normalised to uppercase;
- blank / over-long / non-alphabetic codes reject with `422` and issue **zero** HTTP calls;
- a correction of a EUR original is posted with `currency: 'EUR'`;
- a divergent OL snapshot warns but still uses the provider's currency;
- an original with no reported currency is refused before any POST;
- the mark-paid payload's `invoice` object has exactly the `paid_date` key.

## Subiekt nexo audit (reported, no issue filed)

`SubiektInvoicingAdapter` does **not** have this defect:

- `issueInvoice` already maps `cmd.currency` onto `BridgeIssueInvoiceRequest.currency`, a required field, so the currency is always on the wire.
- `issueCorrection` correctly has no currency field: the bridge's `POST /api/invoices/{origId}/corrections` identifies the corrected document by the path segment and applies per-line deltas (`nowaIlosc` / `nowaCena`) to it, so Subiekt derives the currency from the document itself. Structurally unlike inFakt, whose correction is an independent document body that must declare its own currency.
- `markPaid` is not implemented (the adapter does not declare `PaymentMarker`), so there is nothing to cover.

Two narrower observations, neither of them the silent-drop class of bug: the adapter forwards `cmd.currency` verbatim with no shape validation, and whether the bridge rejects or defaults a blank code is bridge-side behaviour not verifiable from this repo; and every currency fixture in the Subiekt specs is `'PLN'`, so the non-PLN path is unexercised.

## Verified live against the inFakt sandbox

One throwaway EUR document was issued against `https://api.sandbox-infakt.pl/api/v3` with the exact payload shape this branch produces (`invoice.currency` stamped, `payment_method: 'cash'`, numeric `client_id`, one integer-minor-unit line). Result: **verified live - a EUR invoice issued via the sandbox rendered with `currency=EUR`**, not silently coerced to PLN.

`POST /invoices.json` returned `201` and an independent `GET /invoices/{uuid}.json` reads back the same values:

| Field | Value |
|---|---|
| `currency` | `"EUR"` |
| `net_price` / `tax_price` / `gross_price` | `65965` / `15172` / `81137`, i.e. 811.37 EUR gross - the figure from the issue |
| `amount_in_words` | `"osiemset jedenaście EUR 37/100"` |
| `vat_exchange_date_kind` | `"vat"`, populated by inFakt server-side (OL sends nothing for it) |
| `status` | `draft` |

Two of the unknowns flagged earlier are now settled, two remain:

- **`vat_exchange_date_kind` is not a required request field.** inFakt defaulted it for a foreign-currency VAT invoice, so the adapter does not need to send it. The troubleshooting row mentioning it is kept, since it is still documented as required for margin invoices.
- **This account was permitted to settle in EUR** with no extra configuration, so no per-currency account gate fired. It remains inFakt-side policy and can still reject another currency or another account.
- **The applied exchange rate could not be observed.** `exchange_rates_data` was absent from both the create response and the read-back while the document is `draft`.
- **The currency's onward journey into KSeF is unverified.** What the probe covers is the **wire contract**, not `issueInvoice` end to end: the method calls `sendToKsef(invoice.uuid)` unconditionally right after the create, so a document left in `draft` with no `send_to_ksef` call cannot have come from `issueInvoice` itself - the run replicated the payload out-of-band. That is the right call for a fiscal sandbox, but it means inFakt relaying the currency correctly into FA(3) `KodWaluty` is **not** confirmed - and inFakt relaying a wrong document to KSeF is the actual harm #2103 describes. It belongs in this same "still unobserved" list, and closing it needs a deliberate KSeF-submitting run, not another draft.

The test document was deliberately left in `draft` and **not** submitted to KSeF (no `send_to_ksef` call), so nothing was filed with the tax authority. It is identifiable by its line name `OL-2103-CURRENCY-TEST throwaway (do not book)` and `external_id: ol-2103-eur-currency-probe`. No correction, mark-paid, email or delete was run against it, so those adapter paths stay unit-tested only.

## Review fixes

- **Operator-facing accuracy.** A new neutral, PII-free `invalid-currency` failure code (closed `InvoiceFailureCode` taxonomy + FE mirror) replaces the generic `provider-rejected` for this refusal, so the operator is no longer told the provider rejected a request it never saw. `classifyFailureCode` gains a `CURRENCY_REJECTION_MARKERS` branch mirroring the existing tax-id structural read; nullable-varchar column, so no migration. The setup guide now states what the UI actually shows and that the offending value is log-only.
- **Request-shape typing.** `InfaktInvoiceRequest` (+ `InfaktInvoiceServiceRequest`) models the `POST invoices.json` body with `currency` **required**, and `issueInvoice`'s literal is typed against it - so the field can no longer be dropped without a type error. Kept separate from the `InfaktInvoice` response shape, which carries provider-computed totals that must not be sent on a create.

### Review fixes (round 2)

- **Pre-fix documents are now addressed in the operator docs.** A "Documents issued before OL sent the currency" section in the inFakt setup guide states what the absent field did (inFakt read it as "use the account default", so *every* pre-fix document was booked in the account default regardless of the order), gives a reconciliation query over `invoice_records.issuedLineSnapshot` (with the pre-#1297 fallback and its caveat spelled out), and says plainly that the defect was found by code reading - there is no known mis-denominated production document, which is an absence of evidence for this repo rather than a guarantee about a given deployment. It also records that an ordinary correction **cannot** re-denominate: inFakt takes a correction's currency from the document it corrects, so a correction of a wrongly-PLN document is another PLN document, and remediation is an accounting-side withdraw-and-re-issue.
- **The stringly-typed core->adapter coupling is pinned from the side that changes.** `CURRENCY_REJECTION_MARKERS` moved to `invoicing.types.ts` and is published from `@openlinker/core/invoicing`; a new adapter spec asserts the message `toInfaktCurrency` throws still matches one of those markers, so rewording it fails the build instead of silently dropping the operator back to `provider-rejected`. Only the currency markers are published - the sibling tax-id markers stay private to `InvoiceService`, because their phrases come from provider messages rather than OL-authored text, so no in-repo spec can pin them.
- **`markPaid` payload assertion re-checked**: `expect(Object.keys(body.invoice)).toEqual(['paid_date'])` is an exact-key assertion, so adding a partial-payment amount fails that spec rather than passing silently.

### Review fixes (round 3)

- **`invalid-currency` reachability corrected.** The `InvoiceFailureCode` doc and `deriveFailureReason`'s comment claimed the code covers both an adapter pre-call refusal and a genuine provider-side currency rejection. Only the first is reachable: `InfaktHttpClient` withholds the provider body from the error message (inFakt payloads echo buyer PII) and core never reads `responseBody`, so a provider-side currency rejection classifies `provider-rejected` - accurately, since the provider did reject it. Both comments now state that; the copy still names the condition rather than the actor, so it stays correct if such an origin ever routes here. Comment-only.
- **`upsertCustomer` typed.** `InfaktClientRequest` models the `POST clients.json` body and the literal is annotated against it, closing the last untyped write on the adapter - and the one with a track record, since #1926 was `name`/`post_code` sent where inFakt wants `company_name`/`postal_code`. Kept separate from the `InfaktClient` response shape (provider-assigned `id`/`uuid` must not be POSTed on a create), mirroring `InfaktInvoiceRequest`.

Closes #2103
