### PR TITLE
docs: correct stale volume name, post-install script list, fixture count and web dev port

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,7 +179,7 @@ pnpm dev:stack:down
 # Start apps
 pnpm start:dev:api       # NestJS API on :3000
 pnpm start:dev:worker    # Background job worker
-pnpm start:dev:web       # React frontend on :5173
+pnpm start:dev:web       # React frontend on :4173
 
 # Testing
 pnpm test                # Unit tests (fast, no Docker)

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ The dev stack starts PostgreSQL, Redis, MySQL, PrestaShop, and WooCommerce in co
 >
 > Two changes combine into a **one-time data reset** of your local dev/demo stack:
 >
-> 1. **Every named volume was renamed** `_data` → `-data` (e.g. `postgres_data` → `postgres-data`). Docker qualifies volumes as `<project>_<name>`, so your existing `openlinker_postgres_data` is *orphaned* and Compose creates an empty `openlinker-postgres-data`.
+> 1. **Every named volume was renamed** `_data` → `-data` (e.g. `postgres_data` → `postgres-data`). Docker qualifies volumes as `<project>_<name>`, so your existing `openlinker_postgres_data` is *orphaned* and Compose creates an empty `openlinker_postgres-data`.
 > 2. **PostgreSQL moved 16 → 17.** PG17 refuses to start against a PG16 data directory (`database files are incompatible with server`), so preserving the old volume by hand would not work either.
 >
 > The next `pnpm dev:stack:up` / `pnpm demo:up` therefore starts with an **empty database, silently** — your configured connections, encrypted credentials, seeded PrestaShop catalog, and WooCommerce setup are still on disk in the orphaned volumes, just invisible. Re-seed from scratch and reclaim the disk:

--- a/docker/prestashop/post-install-lib/30-seed-test-products.php
+++ b/docker/prestashop/post-install-lib/30-seed-test-products.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * Seed five real-data dev fixtures sourced from the Allegro public catalogue
+ * Seed six real-data dev fixtures sourced from the Allegro public catalogue
  * (#521), with CC0 cover images sourced from Wikimedia Commons (#544 —
  * provenance in `seed-images/LICENSES.md`).
  *
- * Idempotent: re-runs early-exit when ≥5 products with reference prefix `OL-`
+ * Idempotent: re-runs early-exit when ≥6 products with reference prefix `OL-`
  * are already present.
  *
  * Reference-prefix convention (documented for operators):
@@ -13,10 +13,11 @@
  *     during testing if you want it to survive `pnpm dev:stack:seed-prestashop`
  *     re-runs. Anything else is treated as upstream demo data and wiped.
  *
- * The five fixtures cover the variant × EAN-coverage matrix our codebase
+ * The six fixtures cover the variant × EAN-coverage matrix our codebase
  * actually exercises (simple+EAN, simple-no-EAN, variant-full-EAN,
- * variant-partial-EAN, variant-no-EAN). Names, EANs, Kod produktu, and
- * categories are real product data sourced from current Allegro listings.
+ * variant-partial-EAN, variant-no-EAN, simple+EAN+MPN). Names, EANs, Kod
+ * produktu, and categories are real product data sourced from current Allegro
+ * listings.
  * Descriptions are short paraphrases (we don't paste seller copy verbatim).
  *
  * Implementation note: bootstraps the legacy config + boots AdminKernel. The

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -35,13 +35,15 @@ docker compose ps
 curl -sI http://localhost:8080 | head -1   # expect 302 → /en/
 ```
 
-The first `docker compose up` automatically renames the admin folder, sets PLN as the default currency, and seeds 5 fixtures sourced from real Allegro listings — the entrypoint wrapper polls for install completion and runs every script in `docker/prestashop/post-install/` in order:
+The first `docker compose up` automatically renames the admin folder, sets PLN as the default currency, and seeds 6 fixtures sourced from real Allegro listings — the entrypoint wrapper polls for install completion and runs every script in `docker/prestashop/post-install/` in order:
 
 - `10-rename-admin.sh` — renames the random `/admin{hash}/` folder to a stable `/admin-dev/`
 - `20-set-default-currency.sh` — flips the shop's default currency to **PLN** (EUR / USD remain active)
-- `30-seed-test-products.sh` — replaces the upstream demo catalogue with **five fixtures** sourced from real Allegro listings (full table below)
+- `25-activate-country-pl.sh` — activates the Poland (PL) country row, which PrestaShop ships inactive (order sync for a PL buyer address fails without it)
+- `30-seed-test-products.sh` — replaces the upstream demo catalogue with **six fixtures** sourced from real Allegro listings (full table below)
+- `40-configure-container-network.sh` — makes the shop reachable from the app-tier containers on the compose network
 
-All three scripts are idempotent — restarting the container or re-running the wrapper is a no-op once each piece has been applied.
+All five scripts are idempotent — restarting the container or re-running the wrapper is a no-op once each piece has been applied.
 
 To **force a re-seed** (e.g. after manually breaking PS data during development), run:
 
@@ -60,7 +62,7 @@ Log in to the PrestaShop admin at **http://localhost:8080/admin-dev/** with the 
 
 ### Dev fixture catalogue
 
-The seed populates exactly these five products, covering the variant × EAN-coverage matrix our codebase exercises (offer linking by barcode, simple-product synthetic variants, partial barcode coverage, etc.):
+The seed populates exactly these six products, covering the variant × EAN-coverage matrix our codebase exercises (offer linking by barcode, simple-product synthetic variants, partial barcode coverage, etc.):
 
 | Reference | Shape | EAN coverage | Source |
 |---|---|---|---|
@@ -69,6 +71,7 @@ The seed populates exactly these five products, covering the variant × EAN-cove
 | `OL-ADIDAS-IA4845` | variants × 3 sizes (S/M/L) | per-variant EAN on every combination | adidas Adicolor 3-Stripes Tee — Allegro: Moda / Odzież męska |
 | `OL-SOAP-NATURAL` | variants × 2 colours (Lavender/Rose) | partial — Lavender has EAN, Rose doesn't | Artisan cold-process soap — Allegro: Dom i Ogród / Wyposażenie |
 | `OL-RING-RESIN` | variants × 3 sizes (16/18/20mm) | empty on every combination | Handmade resin ring — Allegro: Biżuteria / Pierścionki |
+| `OL-CANON-SX740LE` | simple, no variants | yes (`4549292246117`) + MPN | Canon PowerShot SX740 HS Lite Edition, Polish-language copy — Allegro: Elektronika / Fotografia / Aparaty kompaktowe |
 
 **Reference prefix convention:** the seed treats `OL-*` as fixtures it owns (never wiped on re-seed) and **`OP-*`** as operator-preserve — if you hand-add a product through the PS admin during testing and want it to survive `pnpm dev:stack:seed-prestashop` re-runs, prefix its reference with `OP-`. Anything else is treated as upstream demo data and wiped.
 


### PR DESCRIPTION
Fixes four stale claims in the developer-facing docs and one stale header comment. Every fact was re-verified against current `main` before editing.

## Changes

**`README.md:322`** - the volume-rename migration note states the qualification rule (`<project>_<name>`) and then contradicts it in the same sentence. Compose creates `openlinker_postgres-data` (underscore joining the project name, hyphen inside the volume's own name), per `docker-compose.yml:316`. The line below it listing the *old* pre-migration names (`openlinker_postgres_data ...`) was already correct and is untouched.

**`docs/getting-started.md`** - the post-install section listed three scripts; `docker/prestashop/post-install/` has five. Added `25-activate-country-pl.sh` and `40-configure-container-network.sh` (descriptions taken from each script's own header), and changed "All three scripts" to "All five scripts". The fixture count went from 5 to 6 in both the prose and the "Dev fixture catalogue" heading, and the table gained the missing sixth row (`OL-CANON-SX740LE`) - bumping the count without listing the product would just have moved the drift.

**`docker/prestashop/post-install-lib/30-seed-test-products.php`** - the header comment claimed five fixtures and an early-exit at `>= 5`, while the guard at line 67 checks `>= 6` and the script creates six. Corrected the count, the documented guard threshold, and the coverage-matrix list (which now names the sixth shape, `simple+EAN+MPN`).

**`CLAUDE.md`** - `pnpm start:dev:web` serves on `:4173` per `apps/web/vite.config.ts:7`, not `:5173`. `README.md:292` and `docs/getting-started.md` already stated 4173 correctly, so `CLAUDE.md` was the only remaining instance.

## Verification

Docs and comment only - no code, no behaviour change. A final grep for `5173`, `five`, `three scripts`, `5 fixture` and `openlinker-postgres` across the four files leaves only two hits, both correct: the new "All five scripts" sentence, and `README.md:377`'s "five-step path", which matches the five numbered steps in the "Adding your own integration" section.

Closes #2110
