### PR TITLE
docs(lessons): record the ADR-numbering collision and the RolesGuard fail-open trap

### DIFF
--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -23,6 +23,22 @@ When a lesson hardens into a rule, **graduate it** to the canonical doc and leav
 
 ---
 
+## Claim an ADR number from the "Reserved numbers" note, not from the last row of the index table
+
+**Context**: #2066 authored three ADRs and numbered them 039/040/041 by reading the index table in `docs/architecture/adrs/README.md` and taking "last merged row + 1".
+**Problem**: The index lists only **merged** ADRs; several are normally in flight. All three numbers were taken — 041 was already merged, 039 was claimed by #2014 **and already referenced by name six times from `docs/plans/implementation-plan-order-cancellation-record-state.md` on `main`**, and 040 was claimed by #2050. Merging would have silently repointed a live link on `main` to the wrong ADR. Compounding it, the branch had also deleted `main`'s ADR-041 row *and* the "Reserved numbers" note itself — removing the warning against the exact mistake, then making it. That was the third numbering collision in two days.
+**Rule**: Before authoring an ADR, read `git show origin/main:docs/architecture/adrs/README.md | tail -12` — the last rows **and** the reserved-numbers note beneath them — and claim your number by adding it to that note in your PR. Never edit the README from a stale local copy; `git fetch origin main` first, because a stale copy silently drops other people's rows. When renumbering afterwards, **never blanket find-replace `ADR-0NN` across `docs/`** — other plans legitimately reference the real ADR at that number. Scope the replace to an explicit list of files your PR authored, then verify the untouched ones are byte-identical to `main`.
+**Applies to**: `docs/architecture/adrs/**`, and any doc that references an ADR by number.
+**Source**: #2066 (found in review). Mechanical enforcement tracked as #2082.
+
+## A new authenticated principal must never land on `req.user` — `RolesGuard` default-allows every route without `@Roles()`
+
+**Context**: #1032's planned pack station proposed a warehouse "device principal" placed on `req.user`, with an endpoint allowlist described in the design as "the security boundary".
+**Problem**: `RolesGuard.canActivate` returns **`true`** when a route carries no `@Roles()` decorator (`apps/api/src/auth/guards/roles.guard.ts`), and it is a global `APP_GUARD`. So any principal that satisfies `JwtAuthGuard` and reaches `req.user` is authorized on **every undecorated route** — including the customers controller (buyer PII), products, inventory, webhooks and cursors. The allowlist would have been decorative. This is currently latent, not exploitable, only because every principal in the system today is an OL user with a role.
+**Rule**: A non-user principal (device, station, WMS service identity, agent token) gets `@Public()` plus its own dedicated verifier, in its own controller — never `req.user`. This is the split MCP already uses (`mcp-transport.controller.ts` vs `mcp-tokens.controller.ts`, which documents it). Copying only the *storage* half of the `mcp_tokens` pattern (opaque prefix + SHA-256 + revoke) is not enough; the auth-model separation is the load-bearing half. Where a service identity genuinely suits an OL user, prefer a service-account user under the existing role ladder over a new principal type.
+**Applies to**: `apps/api/src/**/http/*.controller.ts`, `apps/api/src/auth/**`, any PR introducing a new authentication path.
+**Source**: #1032 planning (found in stress test); guard hardening tracked as #2079.
+
 ## A supplementary write added inside an existing per-item sync loop must degrade, never abort
 
 **Context**: #2024 extends the existing #816 `marketplace.offer.statusSync` per-offer loop to also persist a commercial (price/quantity) observation, reusing the same fetched object rather than a second marketplace call.


### PR DESCRIPTION
Docs-only. Two entries in `docs/lessons.md`, both empirical gotchas from the #1032 OMS review (#2066).

## 1. Claim an ADR number from the "Reserved numbers" note, not the last row of the index

#2066 numbered three ADRs by reading the index table and taking "last merged row + 1". **All three were taken**, because the table lists only *merged* ADRs while several are normally in flight:

- `041` was already **merged** on `main`
- `039` was claimed by #2014 **and already referenced by name six times** from `docs/plans/implementation-plan-order-cancellation-record-state.md` on `main` — merging would have silently repointed a live link to the wrong ADR
- `040` was claimed by #2050

Compounding it, that branch had also deleted `main`'s ADR-041 row **and** the "Reserved numbers" note itself — removing the warning against the exact mistake, then making it. Per the review, the third numbering collision in two days.

The entry also records the *renumber* hazard, which is the more dangerous half: a blanket find-replace of `ADR-0NN` across `docs/` corrupts other plans' legitimate references to the real ADR at that number. The fix is to scope the replace to files your PR authored and verify the rest byte-identical to `main`.

Points at **#2082** for mechanical enforcement rather than duplicating it.

## 2. A new authenticated principal must never land on `req.user`

`RolesGuard.canActivate` returns **`true`** when a route carries no `@Roles()` decorator, and it is registered as a global `APP_GUARD`. So any principal satisfying `JwtAuthGuard` that reaches `req.user` is authorized on **every undecorated route** — including the customers controller (buyer PII), products, inventory, webhooks and cursors.

#1032's planned pack station proposed exactly that: a device principal on `req.user` with an endpoint allowlist the design called "the security boundary". It would have been decorative.

**This is latent, not exploitable today** — every principal currently in the system is an OL user with a role, and MCP correctly avoids the trap via `@Public()` + its own verifier (the split `mcp-tokens.controller.ts` documents). The entry records that separation as the rule, and notes that copying only the *storage* half of the `mcp_tokens` pattern is not enough.

Points at **#2079** for the guard hardening.

## Why `lessons.md` rather than a canonical doc

Per that file's own scope note, this is a regression ledger for empirical gotchas — not architectural rules. Neither entry states new policy: (1) is a process gotcha about a file's structure, and (2) restates an existing pattern that a design nearly violated. Both carry `Applies to` scopes and cite their tracking issue, so they graduate cleanly if either hardens into a rule.

Refs #1032
