### PR TITLE
feat(web/invoicing): merge the document column and adopt the shared identity cells (#2090)

### DIFF
--- a/apps/web/src/features/invoicing/components/document-type-select.tsx
+++ b/apps/web/src/features/invoicing/components/document-type-select.tsx
@@ -18,11 +18,31 @@ const OPTIONS = ['invoice', 'receipt'] as const;
 /** EN fallbacks for the well-known document types (PL via `t()`). Exported as
  *  the single source of truth so the issued-state line in `OrderInvoicePanel`
  *  reuses the same labels instead of re-declaring them. Unknown adapter-supplied
- *  types fall back to the raw string (open-world). */
+ *  types fall back to the raw string (open-world).
+ *
+ *  Covers all six of `DocumentTypeValues`, not just the two this picker offers
+ *  (#2090): the map is read by the invoices list, the invoice detail page and
+ *  `OrderInvoicePanel`, which render whatever a provider issued — Subiekt issues
+ *  `credit-note`, KSeF and inFakt issue `corrected`, inFakt also `proforma`. With
+ *  only `invoice`/`receipt` mapped, a correction read as the raw slug
+ *  `corrected` on all three surfaces, and telling a correction from an original
+ *  is the one distinction an accountant needs at a glance. */
 export const DOCUMENT_TYPE_LABEL_FALLBACK: Record<string, string> = {
   invoice: 'Invoice (faktura)',
   receipt: 'Receipt (paragon)',
+  corrected: 'Correction (korekta)',
+  'credit-note': 'Credit note (nota kredytowa)',
+  proforma: 'Proforma (faktura pro forma)',
+  prepayment: 'Prepayment (faktura zaliczkowa)',
 };
+
+/** Shown where `documentType` is the empty string — the state a record carries
+ *  between creation and a successful issue (`InvoiceService` writes
+ *  `cmd.documentType ?? ''` on the pending row and the failure patch never
+ *  backfills it), which means every `pending` / `issuing` / `failed` row. Both
+ *  production issuance paths omit the type, so this is the common case on a
+ *  triage-filtered list, not an edge (#2090). */
+export const DOCUMENT_TYPE_UNKNOWN_LABEL = 'Not yet issued';
 
 interface DocumentTypeSelectProps {
   value: string;

--- a/apps/web/src/features/invoicing/components/invoice-pdf-link.tsx
+++ b/apps/web/src/features/invoicing/components/invoice-pdf-link.tsx
@@ -32,7 +32,14 @@ export function InvoicePdfLink({ invoiceNumber, pdfUrl }: InvoicePdfLinkProps): 
         target="_blank"
         rel="noopener noreferrer"
         className="invoice-pdf-link"
-        aria-label={t('invoice.pdf.aria', 'Open invoice PDF (opens in new tab)')}
+        aria-label={t(
+        'invoice.pdf.aria',
+        // The number, not just "invoice PDF": `aria-label` overrides the
+        // name-from-content, so without it a 20-row page exposes 20 links with
+        // identical accessible names and a screen reader's link list is useless
+        // (#2090). Doubly so now the number is a merged identity cell's headline.
+        `Open invoice PDF for ${invoiceNumber} (opens in new tab)`,
+      )}
       >
         <span className="mono-text">{invoiceNumber}</span>
       </a>

--- a/apps/web/src/features/invoicing/components/invoice-pdf-link.tsx
+++ b/apps/web/src/features/invoicing/components/invoice-pdf-link.tsx
@@ -32,14 +32,14 @@ export function InvoicePdfLink({ invoiceNumber, pdfUrl }: InvoicePdfLinkProps): 
         target="_blank"
         rel="noopener noreferrer"
         className="invoice-pdf-link"
-        aria-label={t(
-        'invoice.pdf.aria',
         // The number, not just "invoice PDF": `aria-label` overrides the
         // name-from-content, so without it a 20-row page exposes 20 links with
         // identical accessible names and a screen reader's link list is useless
         // (#2090). Doubly so now the number is a merged identity cell's headline.
-        `Open invoice PDF for ${invoiceNumber} (opens in new tab)`,
-      )}
+        aria-label={t(
+          'invoice.pdf.aria',
+          `Open invoice PDF for ${invoiceNumber} (opens in new tab)`
+        )}
       >
         <span className="mono-text">{invoiceNumber}</span>
       </a>

--- a/apps/web/src/features/invoicing/index.ts
+++ b/apps/web/src/features/invoicing/index.ts
@@ -25,8 +25,16 @@ export {
   RegulatoryStatusBadge,
   REGULATORY_STATUS_LABEL_FALLBACK,
 } from './components/regulatory-status-badge';
-export { regCardToneFor, type RegCardTone } from './lib/derive-invoice-display';
+export {
+  deriveInvoiceDisplayStatus,
+  regCardToneFor,
+  type RegCardTone,
+} from './lib/derive-invoice-display';
 export { InvoicePdfLink } from './components/invoice-pdf-link';
+export {
+  DOCUMENT_TYPE_LABEL_FALLBACK,
+  DOCUMENT_TYPE_UNKNOWN_LABEL,
+} from './components/document-type-select';
 export { useOrderInvoiceQuery } from './hooks/use-order-invoice-query';
 export { useInvoiceQuery } from './hooks/use-invoice-query';
 export { useIssueInvoiceMutation } from './hooks/use-issue-invoice-mutation';

--- a/apps/web/src/features/invoicing/index.ts
+++ b/apps/web/src/features/invoicing/index.ts
@@ -8,10 +8,12 @@
  * filter guards on the list page.
  *
  * `resolveIssueErrorMessage` and `DocumentTypeSelect` stay internal (only used by
- * the panel itself or tests that deep-import them). Its two label maps do NOT:
- * the invoices list, the invoice detail page and `OrderInvoicePanel` all render a
- * `documentType`, so `DOCUMENT_TYPE_LABEL_FALLBACK` / `DOCUMENT_TYPE_UNKNOWN_LABEL`
- * are exported to keep that one map the single source of truth (#2090).
+ * the panel itself or tests that deep-import them). Its `documentType` labels do
+ * NOT: three surfaces render one — the invoices list, the invoice detail page and
+ * `OrderInvoicePanel` — so `DOCUMENT_TYPE_LABEL_FALLBACK` (the map) and
+ * `DOCUMENT_TYPE_UNKNOWN_LABEL` (the not-yet-issued string) are exported to keep
+ * that map the single source of truth (#2090). The detail page still reaches it by
+ * deep path; migrating that call site is a follow-up, not a blocker.
  *
  * Exception: `RegulatoryStatusBadge` and `regCardToneFor` are exported so
  * per-provider `invoiceDetailSection` slot components (KSeF, Subiekt,

--- a/apps/web/src/features/invoicing/index.ts
+++ b/apps/web/src/features/invoicing/index.ts
@@ -7,8 +7,11 @@
  * components (status badges, PDF link), and the runtime value arrays used for
  * filter guards on the list page.
  *
- * `resolveIssueErrorMessage`, `DocumentTypeSelect`, and `DOCUMENT_TYPE_LABEL_FALLBACK`
- * stay internal (only used by the panel itself or tests that deep-import them).
+ * `resolveIssueErrorMessage` and `DocumentTypeSelect` stay internal (only used by
+ * the panel itself or tests that deep-import them). Its two label maps do NOT:
+ * the invoices list, the invoice detail page and `OrderInvoicePanel` all render a
+ * `documentType`, so `DOCUMENT_TYPE_LABEL_FALLBACK` / `DOCUMENT_TYPE_UNKNOWN_LABEL`
+ * are exported to keep that one map the single source of truth (#2090).
  *
  * Exception: `RegulatoryStatusBadge` and `regCardToneFor` are exported so
  * per-provider `invoiceDetailSection` slot components (KSeF, Subiekt,

--- a/apps/web/src/features/orders/components/order-identity-cell.tsx
+++ b/apps/web/src/features/orders/components/order-identity-cell.tsx
@@ -179,6 +179,12 @@ const ORDER_REF_MAX_LENGTH = 18;
  * Shorten a long order reference to a `head…tail` form so line 1 reads as a
  * reference; short numbers (most shops) pass through untouched.
  *
+ * Exported since #2090: a surface that must render this identity as PLAIN TEXT
+ * (the invoices mobile card, whose title and subtitle sit inside the row's own
+ * `<Link>` and so cannot carry this cell's link and Copy button) needs the same
+ * shortening, or an Allegro-sourced row prints a 36-character UUID on the card
+ * while the desktop column shortens it.
+ *
  * Absorbed from the Orders page's own `formatOrderRef` (which #2091 deletes) so
  * all three lists shorten identically. It is not optional cosmetics: Allegro's
  * `orderNumber` IS its `checkoutFormId`, a 36-character UUID, and
@@ -189,7 +195,7 @@ const ORDER_REF_MAX_LENGTH = 18;
  * The marketplace itself is conveyed by each list's own Channel column, so no
  * channel prefix is added here.
  */
-function formatOrderRef(orderNumber: string): string {
+export function formatOrderRef(orderNumber: string): string {
   if (orderNumber.length <= ORDER_REF_MAX_LENGTH) return orderNumber;
   return `${orderNumber.slice(0, 8)}…${orderNumber.slice(-6)}`;
 }

--- a/apps/web/src/features/orders/index.ts
+++ b/apps/web/src/features/orders/index.ts
@@ -29,5 +29,5 @@ export type {
   PaginatedOrders,
 } from './api/orders.types';
 export { ConnectionDot } from './components/connection-dot';
-export { OrderIdentityCell } from './components/order-identity-cell';
+export { OrderIdentityCell, formatOrderRef } from './components/order-identity-cell';
 export type { OrderIdentityCellProps } from './components/order-identity-cell';

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -9518,6 +9518,23 @@ a.kpi-card:focus-visible {
   max-width: 100%;
 }
 
+/* Merged Document-type cell (#2090). Two columns answering one question became
+ * one two-line cell: the document number (a PDF link) over the document type.
+ * Same two-level shape as the identity cells above, without a thumbnail — there
+ * is no product to picture. No cap: both lines are short, bounded strings
+ * (`FV/2026/08/0042`, `Invoice`), so nothing here can widen a column. */
+.invoice-document-cell {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  align-items: flex-start;
+  min-width: 0;
+}
+
+.invoice-document-cell__type {
+  font-size: 0.75rem;
+}
+
 /* Frozen-pane budget (#2089). 1024px is the worst case by construction: the
  * sidebar becomes a persistent 240px grid column at exactly this width (:1048)
  * AND the tables hosting this cell un-hide their Connection column there, so

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -9521,18 +9521,46 @@ a.kpi-card:focus-visible {
 /* Merged Document-type cell (#2090). Two columns answering one question became
  * one two-line cell: the document number (a PDF link) over the document type.
  * Same two-level shape as the identity cells above, without a thumbnail — there
- * is no product to picture. No cap: both lines are short, bounded strings
- * (`FV/2026/08/0042`, `Invoice`), so nothing here can widen a column. */
+ * is no product to picture.
+ *
+ * Capped like its siblings, and for the same reason: neither line is actually
+ * bounded. `providerInvoiceNumber` is a `text` column filled from an
+ * operator-authored numbering pattern or from whatever the provider assigns
+ * (`FS/MAGAZYN-1/2026/08/000042` is a routine PL series), and `documentType` is
+ * open-world at the boundary. In an auto-layout `.data-table` a flex column with
+ * `align-items: flex-start` sizes to content, so without a cap no child's
+ * ellipsis can fire and one long series widens the column. 220px matches
+ * `.connection-cell__body`. */
 .invoice-document-cell {
   display: flex;
   flex-direction: column;
   gap: 2px;
   align-items: flex-start;
   min-width: 0;
+  max-width: 220px;
+}
+
+.invoice-document-cell > * {
+  max-width: 100%;
 }
 
 .invoice-document-cell__type {
   font-size: 0.75rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* The row's leading checkbox is the primary control on a list whose main action
+ * is "select rows -> Retry selected". `.data-table td` is `vertical-align:
+ * middle` (:2798), so at the ~60px identity-row height a 13px checkbox centres
+ * opposite the GAP between the two identity lines instead of the identity it
+ * selects — the same geometry #2089 fixed for its leading expander, but that rule
+ * is keyed on `.data-table__row--expandable` and this table has no expander. A
+ * column of misaligned boxes at 60px pitch is how an operator mis-ticks the
+ * neighbouring row. */
+.invoices-table td:first-child {
+  vertical-align: top;
 }
 
 /* Frozen-pane budget (#2089). 1024px is the worst case by construction: the

--- a/apps/web/src/pages/invoicing/invoices-list-page.test.tsx
+++ b/apps/web/src/pages/invoicing/invoices-list-page.test.tsx
@@ -142,6 +142,195 @@ describe('InvoicesListPage', () => {
     });
   });
 
+  it('merges the document number and type into one column, keeping the PDF link (#2090)', async () => {
+    const list = vi.fn().mockResolvedValue(makeEnvelope({ items: [makeInvoice()], total: 1 }));
+    const { container } = renderWithProviders(<InvoicesListPage />, {
+      apiClient: mockApi(list),
+      route: '/invoices',
+    });
+
+    await screen.findByRole('link', { name: /open invoice pdf/i });
+    const cell = container.querySelector('.invoice-document-cell');
+    expect(cell).not.toBeNull();
+    // Number on line 1 (still the PDF anchor), type on line 2.
+    expect(within(cell as HTMLElement).getByText('FV/2026/001')).toBeInTheDocument();
+    expect(within(cell as HTMLElement).getByText('invoice')).toBeInTheDocument();
+
+    // The separate "Invoice no." column is gone; the list is 8 columns wide.
+    const headers = container.querySelectorAll('thead th');
+    expect(headers).toHaveLength(8);
+    expect(screen.queryByText('Invoice no.')).toBeNull();
+  });
+
+  it('renders the em dash over the document type for a receipt with no provider number', async () => {
+    // Expected shape, not an error state: the type on line 2 still identifies it.
+    const list = vi.fn().mockResolvedValue(
+      makeEnvelope({
+        items: [makeInvoice({ documentType: 'receipt', providerInvoiceNumber: null })],
+        total: 1,
+      }),
+    );
+    const { container } = renderWithProviders(<InvoicesListPage />, {
+      apiClient: mockApi(list),
+      route: '/invoices',
+    });
+
+    await screen.findByText('receipt');
+    const cell = container.querySelector('.invoice-document-cell') as HTMLElement;
+    expect(within(cell).getByText('—')).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /open invoice pdf/i })).toBeNull();
+  });
+
+  it('renders the Order column from the orderSummary projection, linking to the order (#2090)', async () => {
+    const list = vi.fn().mockResolvedValue(
+      makeEnvelope({
+        items: [
+          makeInvoice({
+            orderId: 'ol_order_a4f3b9c1d8e2f0a9b6c3d4e5f6a7b8c9',
+            orderSummary: {
+              orderNumber: '6839-2911-4402',
+              firstItemName: 'Terra Wool Coat',
+              firstItemImageUrl: null,
+              itemCount: 3,
+            },
+          }),
+        ],
+        total: 1,
+      }),
+    );
+    const { container } = renderWithProviders(<InvoicesListPage />, {
+      apiClient: mockApi(list),
+      route: '/invoices',
+    });
+
+    // Was the raw 41-character orderId in a mono span — no link, no Copy.
+    expect(await screen.findByRole('link', { name: '6839-2911-4402' })).toHaveAttribute(
+      'href',
+      '/orders/ol_order_a4f3b9c1d8e2f0a9b6c3d4e5f6a7b8c9',
+    );
+    expect(screen.getByText('Terra Wool Coat')).toBeInTheDocument();
+    expect(screen.getByText('+2')).toBeInTheDocument();
+    expect(
+      screen.queryByText('ol_order_a4f3b9c1d8e2f0a9b6c3d4e5f6a7b8c9'),
+    ).toBeNull();
+
+    // The row still navigates to the INVOICE; the in-cell order link is nested in
+    // no anchor, since `DataTable` linkifies the first cell only.
+    expect(
+      screen.getAllByRole('link').some((a) => a.getAttribute('href') === '/invoices/inv_1'),
+    ).toBe(true);
+    expect(container.querySelector('a a')).toBeNull();
+  });
+
+  it('copies the full internal order id from the Order cell (#2090)', async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('navigator', { clipboard: { writeText } });
+
+    const list = vi.fn().mockResolvedValue(
+      makeEnvelope({
+        items: [
+          makeInvoice({
+            orderId: 'ol_order_a4f3b9c1d8e2f0a9b6c3d4e5f6a7b8c9',
+            orderSummary: {
+              orderNumber: '6839-2911-4402',
+              firstItemName: null,
+              firstItemImageUrl: null,
+              itemCount: 1,
+            },
+          }),
+        ],
+        total: 1,
+      }),
+    );
+    renderWithProviders(<InvoicesListPage />, { apiClient: mockApi(list), route: '/invoices' });
+
+    const copy = await screen.findByRole('button', {
+      name: 'Copy internal order ID for order 6839-2911-4402',
+    });
+    copy.click();
+
+    expect(writeText).toHaveBeenCalledWith('ol_order_a4f3b9c1d8e2f0a9b6c3d4e5f6a7b8c9');
+    vi.unstubAllGlobals();
+  });
+
+  it('links the shortened internal order id when no order summary resolves', async () => {
+    // #2090's AC asked for `–`; the shared cell deliberately renders a link
+    // instead, because `buildOrderSummary` also returns null for "the snapshot
+    // carried no parseable items" — a live order. What the issue actually removes
+    // is the raw 41-character UUID, and a shortened link removes it.
+    const list = vi.fn().mockResolvedValue(
+      makeEnvelope({
+        items: [
+          makeInvoice({
+            orderId: 'ol_order_a4f3b9c1d8e2f0a9b6c3d4e5f6a7b8c9',
+            orderSummary: null,
+          }),
+        ],
+        total: 1,
+      }),
+    );
+    renderWithProviders(<InvoicesListPage />, { apiClient: mockApi(list), route: '/invoices' });
+
+    expect(await screen.findByRole('link', { name: 'ol_order_a4f3…c9' })).toHaveAttribute(
+      'href',
+      '/orders/ol_order_a4f3b9c1d8e2f0a9b6c3d4e5f6a7b8c9',
+    );
+    // The raw untruncated id — what this issue removes — is nowhere on the row.
+    expect(
+      screen.queryByText('ol_order_a4f3b9c1d8e2f0a9b6c3d4e5f6a7b8c9'),
+    ).toBeNull();
+  });
+
+  it('renders the connection as the shared cell, not an id hidden in a title attribute (#2090)', async () => {
+    const list = vi.fn().mockResolvedValue(makeEnvelope({ items: [makeInvoice()], total: 1 }));
+    const { container } = renderWithProviders(<InvoicesListPage />, {
+      apiClient: mockApi(list),
+      route: '/invoices',
+    });
+
+    await screen.findByText('order_1');
+    const cell = container.querySelector('.connection-cell') as HTMLElement;
+    expect(cell).not.toBeNull();
+    expect(within(cell).getByRole('link', { name: 'PrestaShop Main' })).toHaveAttribute(
+      'href',
+      '/connections/conn_1',
+    );
+    // The id is now readable and copyable text, not a `title` on a muted span.
+    expect(within(cell).getByText('conn_1')).toBeInTheDocument();
+    expect(
+      within(cell).getByRole('button', { name: 'Copy connection ID for PrestaShop Main' }),
+    ).toBeInTheDocument();
+    // No adornment on this page — an invoice's connection IS its issuing provider.
+    expect(cell.querySelector('.connection-cell__adornment')).toBeNull();
+  });
+
+  it('issues one connections request for the whole page, never one per row', async () => {
+    const connectionsList = vi.fn().mockResolvedValue([makeConnection()]);
+    const getById = vi.fn();
+    const list = vi.fn().mockResolvedValue(
+      makeEnvelope({
+        items: [
+          makeInvoice({ id: 'inv_1', connectionId: 'conn_1' }),
+          makeInvoice({ id: 'inv_2', connectionId: 'conn_1' }),
+          makeInvoice({ id: 'inv_3', connectionId: 'conn_missing' }),
+        ],
+        total: 3,
+      }),
+    );
+    renderWithProviders(<InvoicesListPage />, {
+      apiClient: createMockApiClient({
+        invoicing: { list },
+        connections: { list: connectionsList, getById },
+      }),
+      route: '/invoices',
+    });
+
+    // Two rows share conn_1, so this is intentionally findAll.
+    await screen.findAllByText('PrestaShop Main');
+    expect(connectionsList).toHaveBeenCalledTimes(1);
+    expect(getById).not.toHaveBeenCalled();
+  });
+
   it('drives the query with the regulatoryStatus filter', async () => {
     const user = userEvent.setup();
     const list = vi.fn().mockResolvedValue(makeEnvelope({ items: [], total: 0 }));

--- a/apps/web/src/pages/invoicing/invoices-list-page.test.tsx
+++ b/apps/web/src/pages/invoicing/invoices-list-page.test.tsx
@@ -281,6 +281,9 @@ describe('InvoicesListPage', () => {
       expect(screen.queryByRole('table')).toBeNull();
       // Same facts as the desktop columns, never a raw id.
       expect(screen.getByText(/6839-2911-4402/)).toBeInTheDocument();
+      // …and shortened by the SAME rule as the desktop cell: Allegro's
+      // `orderNumber` is a 36-character `checkoutFormId` handed to this page raw.
+      expect(screen.queryByText(/d1f4a2c3-9b8e-4f7a-a1b2-c3d4e5f60789/)).toBeNull();
       expect(
         screen.queryByText('ol_order_a4f3b9c1d8e2f0a9b6c3d4e5f6a7b8c9'),
       ).toBeNull();
@@ -319,6 +322,35 @@ describe('InvoicesListPage', () => {
       await screen.findByRole('button', { name: 'Copy document number FV/2026/08/0042' }),
     ).toBeInTheDocument();
     expect(screen.queryByRole('link', { name: /open invoice pdf/i })).toBeNull();
+  });
+
+  it('shortens a long order number on the mobile card, matching the desktop cell', async () => {
+    const viewport = mockMobileViewport();
+    try {
+      const list = vi.fn().mockResolvedValue(
+        makeEnvelope({
+          items: [
+            makeInvoice({
+              orderSummary: {
+                orderNumber: 'd1f4a2c3-9b8e-4f7a-a1b2-c3d4e5f60789',
+                firstItemName: null,
+                firstItemImageUrl: null,
+                itemCount: 1,
+              },
+            }),
+          ],
+          total: 1,
+        }),
+      );
+      renderWithProviders(<InvoicesListPage />, { apiClient: mockApi(list), route: '/invoices' });
+
+      // `formatOrderRef`'s head-tail form, the same shortening the desktop cell
+      // applies — the card reimplementing identity resolution is how it drifted.
+      expect(await screen.findByText('d1f4a2c3…f60789')).toBeInTheDocument();
+      expect(screen.queryByText('d1f4a2c3-9b8e-4f7a-a1b2-c3d4e5f60789')).toBeNull();
+    } finally {
+      viewport.restore();
+    }
   });
 
   it('shows the connection loading state rather than Unknown on a cold load', async () => {

--- a/apps/web/src/pages/invoicing/invoices-list-page.test.tsx
+++ b/apps/web/src/pages/invoicing/invoices-list-page.test.tsx
@@ -271,18 +271,54 @@ describe('InvoicesListPage', () => {
           total: 1,
         }),
       );
-      renderWithProviders(<InvoicesListPage />, { apiClient: mockApi(list), route: '/invoices' });
+      const rendered = renderWithProviders(<InvoicesListPage />, {
+        apiClient: mockApi(list),
+        route: '/invoices',
+      });
 
+      const { container } = rendered;
       expect(await screen.findByText('Not yet issued')).toBeInTheDocument();
       expect(screen.queryByRole('table')).toBeNull();
-      // The order is the card's subtitle, as the shared cell — never a raw id.
-      expect(screen.getByRole('link', { name: '6839-2911-4402' })).toBeInTheDocument();
+      // Same facts as the desktop columns, never a raw id.
+      expect(screen.getByText(/6839-2911-4402/)).toBeInTheDocument();
       expect(
         screen.queryByText('ol_order_a4f3b9c1d8e2f0a9b6c3d4e5f6a7b8c9'),
       ).toBeNull();
+
+      // `DataTableCard` wraps title + subtitle in the row's `<Link>`, so the card
+      // renderers must be text-only: an `<a>` or `<button>` in there is invalid
+      // AND its click bubbles to the card link, so the control navigates instead
+      // of doing its job.
+      const cardMain = container.querySelector('.data-table__card-main');
+      expect(cardMain).not.toBeNull();
+      expect((cardMain as HTMLElement).querySelector('a, button')).toBeNull();
     } finally {
       viewport.restore();
     }
+  });
+
+  it('keeps the document number copyable when the provider pdf url is not http(s)', async () => {
+    // `InvoicePdfLink` renders an anchor only for a safe http(s) URL and nothing
+    // validates the scheme server-side, so branching on `pdfUrl` truthiness left a
+    // relative or garbage URL rendering inert plain text — the exact state the
+    // Copy fallback exists to remove.
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('navigator', { clipboard: { writeText } });
+
+    const list = vi.fn().mockResolvedValue(
+      makeEnvelope({
+        items: [
+          makeInvoice({ pdfUrl: 'javascript:alert(1)', providerInvoiceNumber: 'FV/2026/08/0042' }),
+        ],
+        total: 1,
+      }),
+    );
+    renderWithProviders(<InvoicesListPage />, { apiClient: mockApi(list), route: '/invoices' });
+
+    expect(
+      await screen.findByRole('button', { name: 'Copy document number FV/2026/08/0042' }),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /open invoice pdf/i })).toBeNull();
   });
 
   it('shows the connection loading state rather than Unknown on a cold load', async () => {

--- a/apps/web/src/pages/invoicing/invoices-list-page.test.tsx
+++ b/apps/web/src/pages/invoicing/invoices-list-page.test.tsx
@@ -8,11 +8,17 @@
  *   - rowHref is `/invoices/:id` (was `/orders/:orderId`)
  *   - taxId filter drives the query
  *   - BulkActionBar appears on row selection
+ *
+ * New #2090 assertions: the merged `Document type` column (numbered, receipt,
+ * not-yet-issued and copy-instead-of-link branches, plus the `hideBelow`
+ * absence #2094 depends on), the two shared identity cells, mobile-card parity
+ * with the desktop columns, and one connections request per page.
  */
-import { cleanup, screen, waitFor, within } from '@testing-library/react';
+import { cleanup, fireEvent, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, it, expect, vi } from 'vitest';
 import { renderWithProviders, createMockApiClient } from '../../test/test-utils';
+import { mockMobileViewport } from '../../test/viewport';
 import { InvoicesListPage } from './invoices-list-page';
 import type { InvoicingApi } from '../../features/invoicing/api/invoicing.api';
 import type { InvoiceRecord, PaginatedInvoices } from '../../features/invoicing/api/invoicing.types';
@@ -75,7 +81,12 @@ function mockApi(
 }
 
 describe('InvoicesListPage', () => {
-  afterEach(cleanup);
+  afterEach(() => {
+    cleanup();
+    // Two tests stub `navigator` for the clipboard; inline cleanup would leak the
+    // stub into every later test in the file if the assertion threw first.
+    vi.unstubAllGlobals();
+  });
 
   it('renders the loading skeleton while the list query is pending', () => {
     const list = vi.fn().mockReturnValue(new Promise<PaginatedInvoices>(() => undefined));
@@ -149,17 +160,144 @@ describe('InvoicesListPage', () => {
       route: '/invoices',
     });
 
-    await screen.findByRole('link', { name: /open invoice pdf/i });
+    // The accessible name carries the number, so 20 rows are 20 distinct links.
+    await screen.findByRole('link', { name: 'Open invoice PDF for FV/2026/001 (opens in new tab)' });
     const cell = container.querySelector('.invoice-document-cell');
     expect(cell).not.toBeNull();
-    // Number on line 1 (still the PDF anchor), type on line 2.
+    // Number on line 1 (still the PDF anchor), LABELLED type on line 2 — the raw
+    // slug `invoice` is what the sibling detail page never showed.
     expect(within(cell as HTMLElement).getByText('FV/2026/001')).toBeInTheDocument();
-    expect(within(cell as HTMLElement).getByText('invoice')).toBeInTheDocument();
+    expect(within(cell as HTMLElement).getByText('Invoice (faktura)')).toBeInTheDocument();
+    expect(within(cell as HTMLElement).queryByText('invoice')).toBeNull();
 
     // The separate "Invoice no." column is gone; the list is 8 columns wide.
     const headers = container.querySelectorAll('thead th');
     expect(headers).toHaveLength(8);
     expect(screen.queryByText('Invoice no.')).toBeNull();
+
+    // The merged column must survive 768px — it hosts #2094's tablet fold, so it
+    // cannot be the thing that disappears there. Connection keeps its 1024 gate.
+    expect(headers[2]?.className).not.toContain('data-table__cell--hide-below-768');
+    expect(headers[6]?.className).toContain('data-table__cell--hide-below-1024');
+  });
+
+  it('labels every document type the providers can issue, not just invoice and receipt', async () => {
+    // Subiekt issues credit-note, KSeF and inFakt issue corrected, inFakt also
+    // proforma. Before #2090 all four read as the raw slug on three surfaces.
+    const list = vi.fn().mockResolvedValue(
+      makeEnvelope({
+        items: [
+          makeInvoice({ id: 'inv_c', documentType: 'corrected', providerInvoiceNumber: 'KOR/1' }),
+          makeInvoice({ id: 'inv_n', documentType: 'credit-note', providerInvoiceNumber: 'NK/1' }),
+        ],
+        total: 2,
+      }),
+    );
+    renderWithProviders(<InvoicesListPage />, { apiClient: mockApi(list), route: '/invoices' });
+
+    expect(await screen.findByText('Correction (korekta)')).toBeInTheDocument();
+    expect(screen.getByText('Credit note (nota kredytowa)')).toBeInTheDocument();
+    expect(screen.queryByText('corrected')).toBeNull();
+    expect(screen.queryByText('credit-note')).toBeNull();
+  });
+
+  it('says "Not yet issued" rather than rendering a blank cell for a failed record', async () => {
+    // `InvoiceService` writes `documentType: ''` on the pending row and the
+    // failure patch never backfills it, and both production issuance paths omit
+    // the type — so a raw render left the merged cell's ONLY text empty on every
+    // row a triage filter selects.
+    const list = vi.fn().mockResolvedValue(
+      makeEnvelope({
+        items: [
+          makeInvoice({ status: 'failed', documentType: '', providerInvoiceNumber: null }),
+        ],
+        total: 1,
+      }),
+    );
+    const { container } = renderWithProviders(<InvoicesListPage />, {
+      apiClient: mockApi(list),
+      route: '/invoices',
+    });
+
+    const cell = (await screen.findByText('Not yet issued')).closest('.invoice-document-cell');
+    expect(cell).not.toBeNull();
+    // The dash is an `EmptyValue`, so a screen reader hears a word.
+    expect(within(cell as HTMLElement).getByLabelText('No value')).toBeInTheDocument();
+    expect(container.querySelector('.invoice-document-cell')?.textContent).not.toBe('—');
+  });
+
+  it('makes the document number copyable when the provider ships no PDF url', async () => {
+    // KSeF and inFakt both hard-null `pdfUrl`, so line 1 was inert text — the one
+    // identifier on the row with no affordance at all, on a page organised around
+    // reconciling by document number.
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal('navigator', { clipboard: { writeText } });
+
+    const list = vi.fn().mockResolvedValue(
+      makeEnvelope({
+        items: [makeInvoice({ pdfUrl: null, providerInvoiceNumber: 'FV/2026/08/0042' })],
+        total: 1,
+      }),
+    );
+    renderWithProviders(<InvoicesListPage />, { apiClient: mockApi(list), route: '/invoices' });
+
+    fireEvent.click(
+      await screen.findByRole('button', { name: 'Copy document number FV/2026/08/0042' }),
+    );
+    expect(writeText).toHaveBeenCalledWith('FV/2026/08/0042');
+    expect(screen.queryByRole('link', { name: /open invoice pdf/i })).toBeNull();
+  });
+
+  it('renders the mobile card from the same two renderers as the desktop columns', async () => {
+    // The card used to headline `providerInvoiceNumber ?? r.orderId`, i.e. the raw
+    // 41-character UUID this issue exists to remove, on every not-yet-issued row.
+    const viewport = mockMobileViewport();
+    try {
+      const list = vi.fn().mockResolvedValue(
+        makeEnvelope({
+          items: [
+            makeInvoice({
+              orderId: 'ol_order_a4f3b9c1d8e2f0a9b6c3d4e5f6a7b8c9',
+              providerInvoiceNumber: null,
+              documentType: '',
+              orderSummary: {
+                orderNumber: '6839-2911-4402',
+                firstItemName: 'Terra Wool Coat',
+                firstItemImageUrl: null,
+                itemCount: 1,
+              },
+            }),
+          ],
+          total: 1,
+        }),
+      );
+      renderWithProviders(<InvoicesListPage />, { apiClient: mockApi(list), route: '/invoices' });
+
+      expect(await screen.findByText('Not yet issued')).toBeInTheDocument();
+      expect(screen.queryByRole('table')).toBeNull();
+      // The order is the card's subtitle, as the shared cell — never a raw id.
+      expect(screen.getByRole('link', { name: '6839-2911-4402' })).toBeInTheDocument();
+      expect(
+        screen.queryByText('ol_order_a4f3b9c1d8e2f0a9b6c3d4e5f6a7b8c9'),
+      ).toBeNull();
+    } finally {
+      viewport.restore();
+    }
+  });
+
+  it('shows the connection loading state rather than Unknown on a cold load', async () => {
+    const list = vi.fn().mockResolvedValue(makeEnvelope({ items: [makeInvoice()], total: 1 }));
+    const { container } = renderWithProviders(<InvoicesListPage />, {
+      apiClient: createMockApiClient({
+        invoicing: { list },
+        connections: { list: vi.fn().mockReturnValue(new Promise(() => {})) },
+      }),
+      route: '/invoices',
+    });
+
+    await screen.findByText('Invoice (faktura)');
+    expect(container.querySelector('.connection-cell [aria-busy="true"]')).not.toBeNull();
+    expect(screen.queryByText('Unknown')).toBeNull();
   });
 
   it('renders the em dash over the document type for a receipt with no provider number', async () => {
@@ -175,9 +313,9 @@ describe('InvoicesListPage', () => {
       route: '/invoices',
     });
 
-    await screen.findByText('receipt');
+    await screen.findByText('Receipt (paragon)');
     const cell = container.querySelector('.invoice-document-cell') as HTMLElement;
-    expect(within(cell).getByText('—')).toBeInTheDocument();
+    expect(within(cell).getByLabelText('No value')).toBeInTheDocument();
     expect(screen.queryByRole('link', { name: /open invoice pdf/i })).toBeNull();
   });
 
@@ -247,10 +385,9 @@ describe('InvoicesListPage', () => {
     const copy = await screen.findByRole('button', {
       name: 'Copy internal order ID for order 6839-2911-4402',
     });
-    copy.click();
+    fireEvent.click(copy);
 
     expect(writeText).toHaveBeenCalledWith('ol_order_a4f3b9c1d8e2f0a9b6c3d4e5f6a7b8c9');
-    vi.unstubAllGlobals();
   });
 
   it('links the shortened internal order id when no order summary resolves', async () => {

--- a/apps/web/src/pages/invoicing/invoices-list-page.test.tsx
+++ b/apps/web/src/pages/invoicing/invoices-list-page.test.tsx
@@ -281,9 +281,6 @@ describe('InvoicesListPage', () => {
       expect(screen.queryByRole('table')).toBeNull();
       // Same facts as the desktop columns, never a raw id.
       expect(screen.getByText(/6839-2911-4402/)).toBeInTheDocument();
-      // …and shortened by the SAME rule as the desktop cell: Allegro's
-      // `orderNumber` is a 36-character `checkoutFormId` handed to this page raw.
-      expect(screen.queryByText(/d1f4a2c3-9b8e-4f7a-a1b2-c3d4e5f60789/)).toBeNull();
       expect(
         screen.queryByText('ol_order_a4f3b9c1d8e2f0a9b6c3d4e5f6a7b8c9'),
       ).toBeNull();

--- a/apps/web/src/pages/invoicing/invoices-list-page.tsx
+++ b/apps/web/src/pages/invoicing/invoices-list-page.tsx
@@ -44,6 +44,8 @@ import { Select } from '../../shared/ui/select';
 import { TimeDisplay } from '../../shared/ui/time-display';
 import { CopyableId } from '../../shared/ui/copyable-id';
 import { EmptyValue } from '../../shared/ui/empty-value';
+import { isSafeHttpUrl } from '../../shared/lib/is-safe-http-url';
+import { shortenId } from '../../shared/ui/entity-label';
 import { useTranslation } from '../../shared/i18n';
 import {
   deriveInvoiceDisplayStatus,
@@ -152,12 +154,13 @@ export function InvoicesListPage(): ReactElement {
     return (
       <span className="invoice-document-cell">
         {r.providerInvoiceNumber ? (
-          // Still a PDF link when the provider gave us a URL. KSeF and inFakt
-          // both hard-null `pdfUrl`, and `InvoicePdfLink` degrades to plain text
-          // there — so the number, the string this workflow is organised around,
-          // was the one identifier on the row with no affordance at all. Copy is
-          // that affordance on the degraded path.
-          r.pdfUrl ? (
+          // `isSafeHttpUrl`, not `r.pdfUrl` truthiness: `InvoicePdfLink` renders an
+          // anchor only for an http(s) URL, and nothing validates the scheme
+          // server-side — so branching on truthiness left a relative or garbage
+          // URL rendering inert plain text, which is the very state this branch
+          // exists to remove. KSeF and inFakt hard-null `pdfUrl` outright, so the
+          // Copy path is the common one, not the exception.
+          r.pdfUrl !== null && isSafeHttpUrl(r.pdfUrl) ? (
             <InvoicePdfLink invoiceNumber={r.providerInvoiceNumber} pdfUrl={r.pdfUrl} />
           ) : (
             <CopyableId
@@ -175,6 +178,35 @@ export function InvoicesListPage(): ReactElement {
         </span>
       </span>
     );
+  };
+
+  // `DataTableCard` wraps `title` + `subtitle` in the row's `<Link>` whenever
+  // `rowHref` is set (`data-table.tsx`), and this page always sets it. So the CARD
+  // gets text-only renderers: putting the desktop cells there nested an `<a>` and
+  // two `<button>`s inside an anchor — invalid, and worse, the clicks bubbled to
+  // the card link, so the PDF number navigated to the invoice instead of opening
+  // the PDF and both Copy buttons copied AND navigated away. #2089 never hit this
+  // because Shipments uses `expandable` and passes no `rowHref`.
+  //
+  // Same facts, same single-sourced label — just no affordances, which the card
+  // does not need: the whole card already navigates to the document.
+  const renderDocumentCardTitle = (r: InvoiceRecord): ReactElement => (
+    <span className="invoice-document-cell">
+      {r.providerInvoiceNumber ? (
+        <span className="mono-text">{r.providerInvoiceNumber}</span>
+      ) : (
+        <EmptyValue />
+      )}
+      <span className="text-muted invoice-document-cell__type">{documentTypeLabel(r)}</span>
+    </span>
+  );
+
+  const renderOrderCardSubtitle = (r: InvoiceRecord): string => {
+    const number = r.orderSummary?.orderNumber?.trim();
+    // Never the raw 41-character id — the shortened form is the point of #2090.
+    const identity = number || shortenId(r.orderId);
+    const item = r.orderSummary?.firstItemName?.trim();
+    return item ? `${identity} · ${item}` : identity;
   };
 
   const renderOrderCell = (r: InvoiceRecord): ReactElement => (
@@ -566,10 +598,10 @@ export function InvoicesListPage(): ReactElement {
             rowKey={(r) => r.id}
             rowHref={(r) => `/invoices/${r.id}`}
             cardView={{
-              // Same two renderers as the desktop columns — the document is what
-              // titles an invoice card, the order is what qualifies it.
-              title: renderDocumentCell,
-              subtitle: renderOrderCell,
+              // Text-only, deliberately — see `renderDocumentCardTitle`. Same
+              // facts as the desktop columns, no nested interactive content.
+              title: renderDocumentCardTitle,
+              subtitle: renderOrderCardSubtitle,
               meta: (r) => <InvoiceStatusBadge status={deriveInvoiceDisplayStatus(r)} />,
             }}
           />

--- a/apps/web/src/pages/invoicing/invoices-list-page.tsx
+++ b/apps/web/src/pages/invoicing/invoices-list-page.tsx
@@ -18,7 +18,7 @@
  *
  * @module apps/web/src/pages/invoicing
  */
-import { useState, useCallback, type ReactElement } from 'react';
+import { useState, useCallback, useMemo, type ReactElement } from 'react';
 import { useSearchParams } from 'react-router-dom';
 import { PageLayout } from '../../shared/ui/page-layout';
 import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
@@ -49,6 +49,8 @@ import {
   type RegulatoryStatus,
 } from '../../features/invoicing';
 import { useConnectionsQuery } from '../../features/connections/hooks/use-connections-query';
+import { ConnectionCell } from '../../features/connections';
+import { OrderIdentityCell } from '../../features/orders';
 
 const PAGE_SIZE = 20;
 
@@ -105,7 +107,15 @@ export function InvoicesListPage(): ReactElement {
 
   const connectionsQuery = useConnectionsQuery();
   const connections = connectionsQuery.data ?? [];
-  const connectionMap = Object.fromEntries(connections.map((c) => [c.id, c.name]));
+  // `{ name, status }`, not just the name: that is `ConnectionCellFacts`, and
+  // supplying only part of it used to leave the cell's status note unresolved on
+  // exactly the batched path #1996 requires (#2027). A Map so a miss coalesces to
+  // `null` — `undefined` reads as "resolve it yourself" and reinstates a per-row
+  // fetch.
+  const connectionsById = useMemo(
+    () => new Map(connections.map((c) => [c.id, { name: c.name, status: c.status }])),
+    [connections],
+  );
 
   // Batch retry state
   const [selected, setSelected] = useState<Set<string>>(new Set());
@@ -222,32 +232,45 @@ export function InvoicesListPage(): ReactElement {
     {
       id: 'orderId',
       header: t('invoice.column.orderId', 'Order'),
+      // Was the raw 41-character `orderId` in a `mono-text` span: no truncation,
+      // no Copy, no link. `orderSummary` has been on this response since #1995 /
+      // PR #2012 and was typed-but-unconsumed until now (#2090).
       cell: (r) => (
-        <span className="mono-text" title={r.orderId}>
-          {r.orderId}
-        </span>
+        <OrderIdentityCell
+          orderId={r.orderId}
+          orderNumber={r.orderSummary?.orderNumber}
+          firstItemName={r.orderSummary?.firstItemName}
+          firstItemImageUrl={r.orderSummary?.firstItemImageUrl}
+          itemCount={r.orderSummary?.itemCount}
+        />
       ),
-      accessor: (r) => r.orderId,
+      accessor: (r) => r.orderSummary?.orderNumber ?? r.orderId,
     },
     {
-      id: 'invoiceNumber',
-      header: t('invoice.column.invoiceNumber', 'Invoice no.'),
-      cell: (r) =>
-        r.providerInvoiceNumber ? (
-          <InvoicePdfLink invoiceNumber={r.providerInvoiceNumber} pdfUrl={r.pdfUrl} />
-        ) : (
-          <span className="text-muted">—</span>
-        ),
-    },
-    {
+      // `invoiceNumber` and `documentType` were two columns answering one
+      // question — *what document is this?* — in a nine-column budget (#2090).
+      // Merged: the number over the type, the number still a working PDF link.
+      //
+      // Deliberately NOT `hideBelow: 768` (which `documentType` carried): the
+      // merged column is the host for #2094's tablet fold of the Connection
+      // cell, so it cannot be the thing that disappears at that width.
       id: 'documentType',
       header: t('invoice.column.documentType', 'Document type'),
       cell: (r) => (
-        <span className="mono-text" title={r.documentType}>
-          {r.documentType}
+        <span className="invoice-document-cell">
+          {r.providerInvoiceNumber ? (
+            <InvoicePdfLink invoiceNumber={r.providerInvoiceNumber} pdfUrl={r.pdfUrl} />
+          ) : (
+            // A receipt carries no provider number — an expected shape, not an
+            // error state, so the type on line 2 still identifies the document.
+            <span className="text-muted">—</span>
+          )}
+          <span className="text-muted invoice-document-cell__type" title={r.documentType}>
+            {r.documentType}
+          </span>
         </span>
       ),
-      hideBelow: 768,
+      accessor: (r) => r.documentType,
     },
     {
       id: 'status',
@@ -279,10 +302,15 @@ export function InvoicesListPage(): ReactElement {
     {
       id: 'connection',
       header: t('invoice.column.connection', 'Connection'),
+      // The id used to live in a `title` attribute — invisible, unselectable and
+      // unreachable on touch. No adornment: an invoice's connection IS its
+      // issuing provider and the column header already says so (#2090).
       cell: (r) => (
-        <span className="text-muted" title={r.connectionId}>
-          {connectionMap[r.connectionId] ?? r.connectionId}
-        </span>
+        <ConnectionCell
+          connectionId={r.connectionId}
+          connection={connectionsById.get(r.connectionId) ?? null}
+          loading={connectionsQuery.isLoading}
+        />
       ),
       hideBelow: 1024,
     },

--- a/apps/web/src/pages/invoicing/invoices-list-page.tsx
+++ b/apps/web/src/pages/invoicing/invoices-list-page.tsx
@@ -18,8 +18,11 @@
  *   - Order column -> the shared `OrderIdentityCell`, fed from `orderSummary`
  *   - Connection column -> the shared `ConnectionCell` (no adornment), replacing
  *     an id hidden in a `title` attribute
- *   - Both cells rendered by ONE local function each, shared with `cardView`, so
- *     the mobile card cannot drift back to printing a raw order UUID
+ *   - One desktop renderer and one CARD renderer per identity fact. They cannot
+ *     be the same function: `DataTableCard` wraps title + subtitle in the row's
+ *     `<Link>` (this page sets `rowHref`), so the card's versions are text-only.
+ *     Both share the label helper and the same shortening, so neither can drift
+ *     back to printing a raw order UUID.
  *
  * Structural mirror: `pages/webhook-deliveries/webhook-deliveries-page.tsx`
  * (layout, pagination, DataTable + cardView, feedback states, setFilter/setOffset
@@ -66,7 +69,7 @@ import {
   DOCUMENT_TYPE_UNKNOWN_LABEL,
 } from '../../features/invoicing';
 import { ConnectionCell, useConnectionsQuery } from '../../features/connections';
-import { OrderIdentityCell } from '../../features/orders';
+import { OrderIdentityCell, formatOrderRef } from '../../features/orders';
 
 const PAGE_SIZE = 20;
 
@@ -133,11 +136,16 @@ export function InvoicesListPage(): ReactElement {
     [connections],
   );
 
-  // ONE renderer per identity fact, used by both the desktop column and the
-  // mobile card. The card used to headline `providerInvoiceNumber ?? r.orderId`,
-  // i.e. the raw 41-character UUID this issue exists to remove, on every row
-  // without a provider number — which is every pending / issuing / failed row.
-  // Functions rather than two matching call sites, mirroring #2089.
+  // Two renderers per identity fact: one for the desktop column, one text-only
+  // for the mobile card (see `renderDocumentCardTitle` for why they cannot be the
+  // same function). The card used to headline `providerInvoiceNumber ?? r.orderId`
+  // — the raw 41-character UUID this issue exists to remove — on every row without
+  // a provider number, i.e. every pending / issuing / failed row.
+  //
+  // What IS single-sourced across the pair: the document-type label
+  // (`documentTypeLabel`) and the order-number shortening (`formatOrderRef`,
+  // exported from `features/orders` for exactly this reason). Those are the two
+  // places the desktop and card renderings could silently disagree.
   const documentTypeLabel = (r: InvoiceRecord): string =>
     r.documentType
       ? t(
@@ -203,8 +211,10 @@ export function InvoicesListPage(): ReactElement {
 
   const renderOrderCardSubtitle = (r: InvoiceRecord): string => {
     const number = r.orderSummary?.orderNumber?.trim();
-    // Never the raw 41-character id — the shortened form is the point of #2090.
-    const identity = number || shortenId(r.orderId);
+    // `formatOrderRef` / `shortenId`, never a raw id: the desktop cell shortens
+    // both halves, and Allegro's `orderNumber` IS a 36-character `checkoutFormId`
+    // that `buildOrderSummary` hands this page raw.
+    const identity = number ? formatOrderRef(number) : shortenId(r.orderId);
     const item = r.orderSummary?.firstItemName?.trim();
     return item ? `${identity} · ${item}` : identity;
   };

--- a/apps/web/src/pages/invoicing/invoices-list-page.tsx
+++ b/apps/web/src/pages/invoicing/invoices-list-page.tsx
@@ -10,6 +10,17 @@
  *   - Checkbox selection + BulkActionBar + ConfirmDialog for batch retry
  *   - Result banner after batch retry
  *
+ * #2090 (epic #2086):
+ *   - `invoiceNumber` + `documentType` merged into one `Document type` column
+ *     (9 -> 8): the provider number over a LABELLED type, `Not yet issued` when
+ *     the record carries neither. The column deliberately has no `hideBelow` —
+ *     it hosts #2094's tablet fold of the connection.
+ *   - Order column -> the shared `OrderIdentityCell`, fed from `orderSummary`
+ *   - Connection column -> the shared `ConnectionCell` (no adornment), replacing
+ *     an id hidden in a `title` attribute
+ *   - Both cells rendered by ONE local function each, shared with `cardView`, so
+ *     the mobile card cannot drift back to printing a raw order UUID
+ *
  * Structural mirror: `pages/webhook-deliveries/webhook-deliveries-page.tsx`
  * (layout, pagination, DataTable + cardView, feedback states, setFilter/setOffset
  * URL helpers). Enum-param reading + the date-range widen-to-UTC sub-pattern
@@ -31,11 +42,13 @@ import { Button } from '../../shared/ui/button';
 import { Input } from '../../shared/ui/input';
 import { Select } from '../../shared/ui/select';
 import { TimeDisplay } from '../../shared/ui/time-display';
+import { CopyableId } from '../../shared/ui/copyable-id';
+import { EmptyValue } from '../../shared/ui/empty-value';
 import { useTranslation } from '../../shared/i18n';
-import { useRetryInvoicesMutation } from '../../features/invoicing/hooks/use-retry-invoices-mutation';
-import { useBulkIssueInvoicesMutation } from '../../features/invoicing/hooks/use-bulk-issue-invoices-mutation';
-import { deriveInvoiceDisplayStatus } from '../../features/invoicing/lib/derive-invoice-display';
 import {
+  deriveInvoiceDisplayStatus,
+  useBulkIssueInvoicesMutation,
+  useRetryInvoicesMutation,
   useInvoicesQuery,
   InvoiceStatusBadge,
   RegulatoryStatusBadge,
@@ -47,9 +60,10 @@ import {
   type InvoiceRecord,
   type InvoiceStatus,
   type RegulatoryStatus,
+  DOCUMENT_TYPE_LABEL_FALLBACK,
+  DOCUMENT_TYPE_UNKNOWN_LABEL,
 } from '../../features/invoicing';
-import { useConnectionsQuery } from '../../features/connections/hooks/use-connections-query';
-import { ConnectionCell } from '../../features/connections';
+import { ConnectionCell, useConnectionsQuery } from '../../features/connections';
 import { OrderIdentityCell } from '../../features/orders';
 
 const PAGE_SIZE = 20;
@@ -115,6 +129,62 @@ export function InvoicesListPage(): ReactElement {
   const connectionsById = useMemo(
     () => new Map(connections.map((c) => [c.id, { name: c.name, status: c.status }])),
     [connections],
+  );
+
+  // ONE renderer per identity fact, used by both the desktop column and the
+  // mobile card. The card used to headline `providerInvoiceNumber ?? r.orderId`,
+  // i.e. the raw 41-character UUID this issue exists to remove, on every row
+  // without a provider number — which is every pending / issuing / failed row.
+  // Functions rather than two matching call sites, mirroring #2089.
+  const documentTypeLabel = (r: InvoiceRecord): string =>
+    r.documentType
+      ? t(
+          `invoice.documentType.${r.documentType}`,
+          DOCUMENT_TYPE_LABEL_FALLBACK[r.documentType] ?? r.documentType,
+        )
+      : // `''` is what `InvoiceService` writes on the pending row, and the failure
+        // patch never backfills it — so a raw render left the merged cell's only
+        // text blank on exactly the rows a triage filter selects.
+        t('invoice.documentType.unknown', DOCUMENT_TYPE_UNKNOWN_LABEL);
+
+  const renderDocumentCell = (r: InvoiceRecord): ReactElement => {
+    const label = documentTypeLabel(r);
+    return (
+      <span className="invoice-document-cell">
+        {r.providerInvoiceNumber ? (
+          // Still a PDF link when the provider gave us a URL. KSeF and inFakt
+          // both hard-null `pdfUrl`, and `InvoicePdfLink` degrades to plain text
+          // there — so the number, the string this workflow is organised around,
+          // was the one identifier on the row with no affordance at all. Copy is
+          // that affordance on the degraded path.
+          r.pdfUrl ? (
+            <InvoicePdfLink invoiceNumber={r.providerInvoiceNumber} pdfUrl={r.pdfUrl} />
+          ) : (
+            <CopyableId
+              id={r.providerInvoiceNumber}
+              copyLabel={t('invoice.copyNumber', `Copy document number ${r.providerInvoiceNumber}`)}
+            />
+          )
+        ) : (
+          // Not a receipt-only branch: every not-yet-issued record lands here, so
+          // line 2 has to carry a real word rather than an empty string.
+          <EmptyValue />
+        )}
+        <span className="text-muted invoice-document-cell__type" title={label}>
+          {label}
+        </span>
+      </span>
+    );
+  };
+
+  const renderOrderCell = (r: InvoiceRecord): ReactElement => (
+    <OrderIdentityCell
+      orderId={r.orderId}
+      orderNumber={r.orderSummary?.orderNumber}
+      firstItemName={r.orderSummary?.firstItemName}
+      firstItemImageUrl={r.orderSummary?.firstItemImageUrl}
+      itemCount={r.orderSummary?.itemCount}
+    />
   );
 
   // Batch retry state
@@ -235,15 +305,7 @@ export function InvoicesListPage(): ReactElement {
       // Was the raw 41-character `orderId` in a `mono-text` span: no truncation,
       // no Copy, no link. `orderSummary` has been on this response since #1995 /
       // PR #2012 and was typed-but-unconsumed until now (#2090).
-      cell: (r) => (
-        <OrderIdentityCell
-          orderId={r.orderId}
-          orderNumber={r.orderSummary?.orderNumber}
-          firstItemName={r.orderSummary?.firstItemName}
-          firstItemImageUrl={r.orderSummary?.firstItemImageUrl}
-          itemCount={r.orderSummary?.itemCount}
-        />
-      ),
+      cell: renderOrderCell,
       accessor: (r) => r.orderSummary?.orderNumber ?? r.orderId,
     },
     {
@@ -256,20 +318,7 @@ export function InvoicesListPage(): ReactElement {
       // cell, so it cannot be the thing that disappears at that width.
       id: 'documentType',
       header: t('invoice.column.documentType', 'Document type'),
-      cell: (r) => (
-        <span className="invoice-document-cell">
-          {r.providerInvoiceNumber ? (
-            <InvoicePdfLink invoiceNumber={r.providerInvoiceNumber} pdfUrl={r.pdfUrl} />
-          ) : (
-            // A receipt carries no provider number — an expected shape, not an
-            // error state, so the type on line 2 still identifies the document.
-            <span className="text-muted">—</span>
-          )}
-          <span className="text-muted invoice-document-cell__type" title={r.documentType}>
-            {r.documentType}
-          </span>
-        </span>
-      ),
+      cell: renderDocumentCell,
       accessor: (r) => r.documentType,
     },
     {
@@ -507,14 +556,20 @@ export function InvoicesListPage(): ReactElement {
       ) : (
         <>
           <DataTable
+            // Scopes the leading-checkbox alignment for the ~60px identity row —
+            // `DataTable` lands `className` on its container, so the rule is a
+            // descendant selector on this page's table only (see `index.css`).
+            className="invoices-table"
             caption={t('invoice.list.caption', 'Invoices')}
             columns={columns}
             rows={query.data?.items ?? []}
             rowKey={(r) => r.id}
             rowHref={(r) => `/invoices/${r.id}`}
             cardView={{
-              title: (r) => r.providerInvoiceNumber ?? r.orderId,
-              subtitle: (r) => r.documentType,
+              // Same two renderers as the desktop columns — the document is what
+              // titles an invoice card, the order is what qualifies it.
+              title: renderDocumentCell,
+              subtitle: renderOrderCell,
               meta: (r) => <InvoiceStatusBadge status={deriveInvoiceDisplayStatus(r)} />,
             }}
           />

--- a/docs/user-guide/04-invoices.md
+++ b/docs/user-guide/04-invoices.md
@@ -34,7 +34,7 @@ Open **Invoices** in the sidebar (under **Operations**).
 | Column | Description |
 |---|---|
 | **Order** | The marketplace order number the invoice was issued for, linked to the order, over the first item name and a `+N` count. **Copy** writes the full internal order ID (`ol_order_*`) — the button says so. When the order can't be resolved the number falls back to a shortened internal ID, still linked. |
-| **Document type** | Two lines: the provider-assigned document number over the document type (`Invoice (faktura)`, `Receipt (paragon)`, `Correction (korekta)`, `Credit note (nota kredytowa)`, `Proforma`, `Prepayment`). The number links to the PDF when the provider ships one, and is copyable when it doesn't (KSeF and inFakt ship no PDF URL). A record that hasn't been issued yet has no number and no type, so it reads `—` over **Not yet issued**. |
+| **Document type** | Two lines: the provider-assigned document number over the document type (`Invoice (faktura)`, `Receipt (paragon)`, `Correction (korekta)`, `Credit note (nota kredytowa)`, `Proforma (faktura pro forma)`, `Prepayment (faktura zaliczkowa)`). The number links to the PDF when the provider ships one, and is copyable when it doesn't (KSeF and inFakt ship no PDF URL). A record that hasn't been issued yet has no number and no type, so it reads `—` over **Not yet issued**. |
 | **Status** | Derived display status — see **Invoice statuses** below |
 | **Regulatory** | Clearance status with the connected tax authority, when applicable |
 | **Clearance ref.** | The authority-assigned reference (e.g. KSeF number), once cleared |

--- a/docs/user-guide/04-invoices.md
+++ b/docs/user-guide/04-invoices.md
@@ -16,7 +16,7 @@ If no active invoicing connection exists, the **Invoice** panel on an order's de
 
 Open **Invoices** in the sidebar (under **Operations**).
 
-<!-- screenshot: invoices list showing filter row (status, regulatory, connection, tax ID, date range), the data table with Order/Invoice no./Document type/Status/Regulatory/Clearance ref./Connection columns -->
+<!-- screenshot: invoices list showing filter row (status, regulatory, connection, tax ID, date range), the data table with Order/Document type/Status/Regulatory/Clearance ref./Connection/Issued columns. NOTE: the PNG below still shows the pre-#2090 nine-column layout with a separate "Invoice no." column — reshoot on the epic's visual pass. -->
 ![Invoices list](./images/04-invoices.png)
 
 ### Filters
@@ -33,13 +33,12 @@ Open **Invoices** in the sidebar (under **Operations**).
 
 | Column | Description |
 |---|---|
-| **Order** | Internal order ID (`ol_order_*`) the invoice was issued for |
-| **Invoice no.** | Provider-assigned invoice number, linked to the PDF when available |
-| **Document type** | e.g. `invoice`, `receipt`, `credit-note`, `corrected`, `proforma`, `prepayment` |
+| **Order** | The marketplace order number the invoice was issued for, linked to the order, over the first item name and a `+N` count. **Copy** writes the full internal order ID (`ol_order_*`) — the button says so. When the order can't be resolved the number falls back to a shortened internal ID, still linked. |
+| **Document type** | Two lines: the provider-assigned document number over the document type (`Invoice (faktura)`, `Receipt (paragon)`, `Correction (korekta)`, `Credit note (nota kredytowa)`, `Proforma`, `Prepayment`). The number links to the PDF when the provider ships one, and is copyable when it doesn't (KSeF and inFakt ship no PDF URL). A record that hasn't been issued yet has no number and no type, so it reads `—` over **Not yet issued**. |
 | **Status** | Derived display status — see **Invoice statuses** below |
 | **Regulatory** | Clearance status with the connected tax authority, when applicable |
 | **Clearance ref.** | The authority-assigned reference (e.g. KSeF number), once cleared |
-| **Connection** | Which invoicing connection issued the document |
+| **Connection** | Which invoicing connection issued the document: its name (linked) over a shortened, copyable connection ID, plus a status note when the connection needs attention. Hidden below 1024 px. |
 | **Issued** | Date the document was issued |
 
 ### Invoice statuses


### PR DESCRIPTION
## Summary

The Invoices list rendered the worst version of both identity cells in the app.

| | Before | After |
|---|---|---|
| Order column | the raw 41-character `orderId` in a `mono-text` span — no truncation, no Copy, no link | `OrderIdentityCell` fed from `orderSummary` |
| Connection column | `<span title={r.connectionId}>` — the id hidden in a `title`: invisible, unselectable, unreachable on touch | `ConnectionCell`, no adornment |
| Document identity | **two** columns (`invoiceNumber`, `documentType`) answering one question | one merged `Document type` column, 9 → 8 |

`r.orderSummary` has been on this response since #1995 / PR #2012 (deduped by #2021) and was **typed but consumed by zero production code** until now.

## The merged Document type column

```
FV/2026/08/0042      ← providerInvoiceNumber, still a working InvoicePdfLink
Invoice              ← the document type
```

Line 2 is a **labelled** type, not the raw slug: `Invoice (faktura)`, `Correction (korekta)`, `Credit note (nota kredytowa)`. The app already owned that seam (`DOCUMENT_TYPE_LABEL_FALLBACK`, read through `t()` by the invoice detail page and `OrderInvoicePanel`), so the list used to say `credit-note` while the detail page for the same record said a human label. The map is extended from two entries to all six of `DocumentTypeValues` — it covered only `invoice` and `receipt`, so a correction read as `corrected` on **all three** surfaces, and telling a correction from an original is the one distinction an accountant needs at a glance.

A record with no number **and** no type reads `—` over **Not yet issued**. That is not the receipt case the first draft claimed: no shipped provider issues a number-less receipt (Subiekt is the only adapter supporting `receipt`, and its bridge types the number non-nullable), while `InvoiceService` writes `documentType: ''` on the pending row and the failure patch never backfills it — and both production issuance paths omit the type. So the `—` branch belongs to every `pending` / `issuing` / `failed` row, i.e. exactly what a triage filter selects, and before this fix those rows rendered a **blank** identity cell. The dash is an `EmptyValue`, so a screen reader hears a word rather than punctuation.

The number is a PDF link when the provider ships a URL and a `CopyableId` when it does not. KSeF and inFakt both hard-null `pdfUrl` and `InvoicePdfLink` degrades to plain text there, so the one string this workflow is organised around was inert on most production rows while the two internal ids an accountant needs least both had Copy buttons. `InvoicePdfLink`'s `aria-label` now carries the number too — it overrode the name-from-content, so a 20-row page exposed 20 links with identical accessible names (fixes the detail page and `OrderInvoicePanel` in the same change).

The merged column deliberately **drops `documentType`'s `hideBelow: 768`**. It becomes the host for #2094's tablet fold of the Connection cell, so it cannot be the thing that disappears at that width.

## Connection cell, no adornment

An invoice's connection *is* its issuing provider and the column header already says so, so there is no channel signal worth adding (contrast Products, which gets a pill, and Shipments, which keeps its carrier dot).

The page's batched lookup widens from `id → name` to a `Map<string, { name, status }>` — that is `ConnectionCellFacts`, and supplying only part of it would leave the cell's status note unresolved on exactly the batched path #1996 requires (#2027's own docstring calls this out). Every lookup coalesces to `?? null`, so the cell never falls back to its per-row fetch, and `loading` is threaded so a cold load renders the loading state rather than a column of "Unknown".

## The mobile card

`cardView.title` was `providerInvoiceNumber ?? r.orderId`, so on a phone every not-yet-issued row headlined `ol_order_a4f3b9c1…` — verbatim the defect this issue exists to remove, on the surface where it looks worst, and invisible to every desktop test.

The first fix reused the desktop cells for the card. **That was wrong, and review caught it:** `DataTableCard` wraps `title` + `subtitle` in the row's own `<Link>` whenever `rowHref` is set, and this page always sets it. So the desktop cells nested an `<a>` and two `<button>`s inside an anchor — invalid markup, and functionally broken, because neither copy handler calls `stopPropagation`: both Copy buttons copied *and* navigated away, and the PDF number navigated to the invoice instead of opening the PDF. #2089 never hit this because Shipments uses `expandable` and passes no `rowHref`, and this PR's own nested-anchor assertion had only covered the desktop path.

So the card gets **text-only** renderers. What is single-sourced across the desktop/card pair is what could otherwise silently disagree: the document-type label (`documentTypeLabel`) and the order-number shortening (`formatOrderRef`, now exported from `features/orders` for exactly this case — the card had reimplemented identity resolution and printed an Allegro `checkoutFormId` raw while the column shortened it). Asserted directly: the card's main region contains no `a` or `button`, and a card with an Allegro-length number renders the same `head…tail` form as the cell.

## The leading checkbox at the taller row

`.data-table td` is `vertical-align: middle`, so at the ~60 px identity-row height a 13 px checkbox centres opposite the **gap** between the two identity lines rather than the identity it selects. This is the same geometry #2089 fixed for its leading expander, except that rule is keyed on `.data-table__row--expandable` and this table has no expander. On a list whose primary action is *select rows → Retry selected*, a column of misaligned boxes at 60 px pitch is how an operator mis-ticks the neighbouring row. Scoped to this table through `DataTable`'s `className` (which lands on its container), not made global.

## Deviation from the AC — the same one #2089 hit

The issue asked for `–` when `orderSummary === null`; the shared cell renders a **shortened internal-id link** instead. `buildOrderSummary` returns null both for "no order record" *and* for "the snapshot carried no parseable items" — the latter is a live order, and a dash would strand it with no way to navigate.

What this issue actually set out to remove is the **raw 41-character UUID**, and a shortened link removes it while keeping the row usable. #2090's AC and Assumption are amended with the reasoning rather than left contradicting the code.

## Nested interactive content — both surfaces, the hard way

**Desktop:** this table uses `rowHref` with no `expandable`, so `DataTable` linkifies the **first** cell only (`linkifyFirstCell && href && index === 0`), which is the select checkbox. The Order cell is index 1, so its own `<a>` is not inside the row anchor. Asserted (`container.querySelector('a a')` is null) — the row navigates to `/invoices/:id` while the order number navigates to `/orders/:id`.

**Mobile:** that reasoning is what missed the card, where `DataTableCard` linkifies the whole title+subtitle region regardless of cell index. Now asserted separately, on the card, in a `mockMobileViewport()` test. Checking one surface and generalising is exactly how the first fix broke the second one.

## Recorded, not fixed here

**No `stickyLeftColumns`.** At 1024 px the sidebar becomes a persistent 240 px column *and* the Connection column un-hides, leaving 720 px of content for eight columns — so scrolling right to read Clearance ref. or Connection takes the Order and Document columns off screen and the row loses its identity mid-read. That is the defect #1905 fixed on Shipments (`stickyLeftColumns={2}`, with a comment saying a horizontally-scrolled row read "failed - sender postcode invalid" with no way to tell which order it belonged to). Choosing which columns to freeze here interacts with the frozen-pane budget rule (`.data-table__sticky-col .order-cell__body` narrows to 11 rem below 1280 px) and needs a real render to settle, so it belongs in the epic's visual pass rather than an arithmetic-only edit. Inherited, not introduced — the merge *reduces* total width versus the pre-PR state.

**The two-line cells are the fifth clone of one shape** (`.orders-cell-stack`, `.products-cell-stack`, `.connection-cell__body`, `.order-cell__body`, `.invoice-document-cell`), in the epic whose thesis is "stop rendering the same thing five ways". Borrowing `orders-cell-*` from the invoicing page would be cross-page class reuse, so a page-local class is the right local call; a shared `.cell-stack` primitive is the epic-level fix and is noted for #2091–#2093.

**The row exposes ~7 tab stops** (row link, checkbox, order link, order Copy, document link/Copy, connection link, connection Copy) where it had ~2. Nothing is trapped or invisible while focused, so this is a burden rather than a bug — but it is now a shared epic cost that deserves one decision rather than five.

## Testing

- 17 → **31** tests (an earlier draft of this body mis-stated the base count as 25). New cases: the merged column across all four branches (numbered, receipt, not-yet-issued, and copy-instead-of-link), every provider-issuable document type reading as a label, the `orderSummary` wiring, the **full** internal id reaching the clipboard from a shortened display, the null-summary link, the connection cell replacing the `title`-hidden id (name link + readable id + copy button + no adornment), the connection loading state on a cold load, mobile-card parity with the desktop columns, one connections request for a page of three rows spanning two connection ids, a `javascript:` PDF URL still yielding Copy rather than inert text, no interactive descendant inside the mobile card's row link, and the card's order shortening matching the desktop cell's.
- Two ACs that were true-by-inspection are now asserted: the merged column's `hideBelow` **absence** (what #2094 depends on) and the connection column's `hideBelow: 1024`.
- `docs/user-guide/04-invoices.md` documented the deleted column and described the Order column as "Internal order ID (`ol_order_*`)" — the exact rendering removed here. Rewritten; the stale screenshot is flagged in a comment for the epic's visual pass rather than silently left.
- `pnpm --filter @openlinker/web lint` — 0 errors, no new warnings. `type-check` — clean. `check-design-tokens` + `check-cross-context-imports` — green.

⚠️ `pnpm check:invariants` fails on this branch on a migration-timestamp clash unrelated to this PR — and **already fixed upstream**: #2057 renamed the second file to `1833000000004-…` on `main`. The epic branch forked at #2032 and is 7 commits behind, so it still carries the `…002` name. It clears when the epic branch rebases onto `main`, not through anything in #2090.

## Base branch

Targets `2086-list-identity-cells` (the #2086 epic branch), which is rebased onto `main` and already carries #2087 (`OrderIdentityCell`), #2088 (the platform-label path) and #2089 (Shipments).

## Architecture

Frontend only. Cross-feature imports go through the `features/orders` and `features/connections` public barrels; `InvoicePdfLink` is reused unchanged.

Closes #2090
