### PR TITLE
fix(prestashop): refuse an unresolvable order currency instead of defaulting to id 1

### DIFF
--- a/libs/integrations/prestashop/src/domain/exceptions/prestashop-currency-unknown.exception.ts
+++ b/libs/integrations/prestashop/src/domain/exceptions/prestashop-currency-unknown.exception.ts
@@ -17,8 +17,11 @@
  * read SUCCEEDED and reported data the order cannot be denominated with, so a
  * retry re-reads the same record. `PrestashopRetryClassifierAdapter` classifies
  * this class as non-retryable for exactly that reason - a transport failure of
- * the same `GET /currencies` read stays a `PrestashopApiException` and keeps its
- * retries. The class IS the retry decision; the two must never be conflated.
+ * the same `GET /currencies` read stays a `PrestashopApiException`. The class IS
+ * the retry decision; the two must never be conflated. (On the order-create path
+ * as shipped, neither reaches the runner - see the note in
+ * `PrestashopRetryClassifierAdapter` - so the split is correct-by-construction
+ * rather than currently load-bearing.)
  *
  * `message` is operator-facing interface copy, not a log line: `OrderSyncService`
  * stores it verbatim in `syncStatus[].error` and the frontend renders that string

--- a/libs/integrations/prestashop/src/domain/exceptions/prestashop-currency-unknown.exception.ts
+++ b/libs/integrations/prestashop/src/domain/exceptions/prestashop-currency-unknown.exception.ts
@@ -1,0 +1,43 @@
+/**
+ * PrestaShop Currency Unknown Exception
+ *
+ * Thrown when the destination PrestaShop currency for an order cannot be
+ * determined (#2139): the source order carries no currency code, the shop has
+ * no currency row for the order's ISO 4217 code, or the matching row carries an
+ * id PrestaShop cannot be addressed with. Refusing the order is the correct
+ * outcome: line amounts are the buyer-paid source numerals (#895 / ADR-014), so
+ * booking them under a substituted currency produces an order with the right
+ * numbers under the wrong denomination, and the `conversion_rate`
+ * `PaymentModule::validateOrder` stamps from that currency then relates the
+ * header to the shop default at the wrong factor. Invoicing and analytics
+ * inherit the wrong denomination downstream, and the sync still reports success.
+ *
+ * Deliberately distinct from `PrestashopApiException`: this is not a failed
+ * call. Either there was nothing to read (an order with no currency), or the
+ * read SUCCEEDED and reported data the order cannot be denominated with, so a
+ * retry re-reads the same record. `PrestashopRetryClassifierAdapter` classifies
+ * this class as non-retryable for exactly that reason - a transport failure of
+ * the same `GET /currencies` read stays a `PrestashopApiException` and keeps its
+ * retries. The class IS the retry decision; the two must never be conflated.
+ *
+ * `message` is operator-facing interface copy, not a log line: `OrderSyncService`
+ * stores it verbatim in `syncStatus[].error` and the frontend renders that string
+ * with no translation layer, the tightest surface being the orders-list Status
+ * sub-line clipped to ~40 characters. The message therefore LEADS with the
+ * identity (the currency code, or the order when there is no code at all), then
+ * states the cause, then the action. Keep the leading clause intact when editing.
+ *
+ * @module libs/integrations/prestashop/src/domain/exceptions
+ */
+export class PrestashopCurrencyUnknownException extends Error {
+  constructor(
+    message: string,
+    /** ISO 4217 code that could not be resolved, when the order carried one. */
+    public readonly isoCode?: string,
+    public readonly connectionId?: string
+  ) {
+    super(message);
+    this.name = 'PrestashopCurrencyUnknownException';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/integrations/prestashop/src/index.ts
+++ b/libs/integrations/prestashop/src/index.ts
@@ -48,6 +48,11 @@ export { PrestashopProvisioningException } from './domain/exceptions/prestashop-
 // configuration cannot supply. Exported because it is the input the retry
 // classifier keys on (a configuration error must not be retried).
 export { PrestashopTaxRateUnknownException } from './domain/exceptions/prestashop-tax-rate-unknown.exception';
+// #2139 - raised when the destination currency for an order cannot be
+// determined (no source currency, ISO absent from the shop, unusable row id).
+// Exported for the same reason as the tax-rate class: the retry classifier keys
+// on it, and a shop-configuration gap must not be retried.
+export { PrestashopCurrencyUnknownException } from './domain/exceptions/prestashop-currency-unknown.exception';
 
 // Retry classification (#581 / #2052) — registered by the plugin descriptor;
 // exported so specs can exercise the real classifier instead of a mock.

--- a/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-order-processor-manager.create-order.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-order-processor-manager.create-order.spec.ts
@@ -784,6 +784,10 @@ describe('PrestashopOrderProcessorManagerAdapter — createOrder', () => {
         // resolver's own guards were never reached.
         expect(mockCurrencyResolver.resolveCurrencyId).not.toHaveBeenCalled();
         expect(mockOpenLinkerModuleClient.importOrder).not.toHaveBeenCalled();
+        // The guard is pure, so it sits ahead of guest-customer provisioning
+        // (Step 1) and address provisioning (Step 3) - both of which create
+        // real PrestaShop rows. A refusal must leave nothing behind.
+        expect(mockHttpClient.createResource).not.toHaveBeenCalled();
       });
 
       it('refuses a whitespace-only currency the same way', async () => {

--- a/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-order-processor-manager.create-order.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-order-processor-manager.create-order.spec.ts
@@ -19,6 +19,7 @@ import {
 import {
   PrestashopApiException,
   PrestashopTaxRateUnknownException,
+  PrestashopCurrencyUnknownException,
 } from '@openlinker/integrations-prestashop';
 import type { OrderCreate } from '@openlinker/core/orders';
 import type { PrestashopOrder } from '../../mappers/prestashop.mapper.interface';
@@ -28,6 +29,7 @@ describe('PrestashopOrderProcessorManagerAdapter — createOrder', () => {
   let mockHttpClient: OrderProcessorHarness['mockHttpClient'];
   let mockIdentifierMapping: OrderProcessorHarness['mockIdentifierMapping'];
   let mockOrderMapper: OrderProcessorHarness['mockOrderMapper'];
+  let mockCurrencyResolver: OrderProcessorHarness['mockCurrencyResolver'];
   let mockTaxRateResolver: OrderProcessorHarness['mockTaxRateResolver'];
   let mockCustomerProjectionRepository: OrderProcessorHarness['mockCustomerProjectionRepository'];
   let mockOpenLinkerModuleClient: OrderProcessorHarness['mockOpenLinkerModuleClient'];
@@ -40,6 +42,7 @@ describe('PrestashopOrderProcessorManagerAdapter — createOrder', () => {
       mockHttpClient,
       mockIdentifierMapping,
       mockOrderMapper,
+      mockCurrencyResolver,
       mockTaxRateResolver,
       mockCustomerProjectionRepository,
       mockOpenLinkerModuleClient,
@@ -735,6 +738,112 @@ describe('PrestashopOrderProcessorManagerAdapter — createOrder', () => {
         // rate 0 → net == gross, and the order is created normally.
         expect(specificPriceFor('100')?.price).toBe((29.99).toFixed(6));
         expect(mockOpenLinkerModuleClient.importOrder).toHaveBeenCalled();
+      });
+    });
+
+    // #2139 - the destination currency used to be guessed: the adapter
+    // substituted 'EUR' for a missing code and the resolver returned a
+    // hardcoded id 1 for anything it could not resolve, so the order was booked
+    // with the buyer's amounts under the wrong denomination and the sync still
+    // reported success.
+    describe('destination currency refusal (#2139)', () => {
+      const arrangeIds = (): void => {
+        mockIdentifierMapping.getExternalIds = jest
+          .fn()
+          .mockImplementation((entityType: string, internalId: string) => {
+            const map: Record<string, Record<string, string>> = {
+              Customer: { 'internal-customer-123': '42' },
+              Product: { 'internal-product-456': '100', 'internal-product-789': '200' },
+              ProductVariant: { 'internal-variant-789': '300' },
+            };
+            const externalId = map[entityType]?.[internalId];
+            return Promise.resolve(
+              externalId ? [{ connectionId: connection.id, externalId, entityType }] : []
+            );
+          });
+        setCreateResourceDispatch({ id: '123' }, {
+          id: '999',
+          reference: 'TEST-ORDER-001',
+        } as PrestashopOrder);
+      };
+
+      const orderWithCurrency = (currency: string): OrderCreate =>
+        createTestOrder({
+          totals: { subtotal: 109.97, tax: 10.0, shipping: 5.0, total: 124.97, currency },
+        });
+
+      it('refuses an order carrying no currency instead of substituting EUR', async () => {
+        arrangeIds();
+
+        await expect(adapter.createOrder(orderWithCurrency(''))).rejects.toThrow(
+          PrestashopCurrencyUnknownException
+        );
+
+        // The substituted 'EUR' is what made this silent: on a shop where EUR
+        // happens to be active it resolved to a real-but-wrong id, so the
+        // resolver's own guards were never reached.
+        expect(mockCurrencyResolver.resolveCurrencyId).not.toHaveBeenCalled();
+        expect(mockOpenLinkerModuleClient.importOrder).not.toHaveBeenCalled();
+      });
+
+      it('refuses a whitespace-only currency the same way', async () => {
+        arrangeIds();
+
+        await expect(adapter.createOrder(orderWithCurrency('   '))).rejects.toThrow(
+          PrestashopCurrencyUnknownException
+        );
+        expect(mockCurrencyResolver.resolveCurrencyId).not.toHaveBeenCalled();
+      });
+
+      it('leads the message with the order reference for the truncated operator surfaces', async () => {
+        arrangeIds();
+
+        const error = await adapter.createOrder(orderWithCurrency('')).then(
+          () => null,
+          (e: unknown) => e as Error
+        );
+
+        expect(error?.message.slice(0, 40)).toBe('Order TEST-ORDER-001: no currency - the ');
+      });
+
+      it('re-throws the resolver refusal unchanged so the operator message and class survive', async () => {
+        arrangeIds();
+        mockCurrencyResolver.resolveCurrencyId.mockRejectedValue(
+          new PrestashopCurrencyUnknownException(
+            'Currency EUR unknown in PrestaShop - the shop has no currency for that code.',
+            'EUR',
+            connection.id
+          )
+        );
+
+        const error = await adapter.createOrder(orderWithCurrency('EUR')).then(
+          () => null,
+          (e: unknown) => e as Error
+        );
+
+        // Wrapping would prepend 35 characters and hide the class the retry
+        // classifier keys on, turning a configuration gap back into retries.
+        expect(error).toBeInstanceOf(PrestashopCurrencyUnknownException);
+        expect(error?.message).toBe(
+          'Currency EUR unknown in PrestaShop - the shop has no currency for that code.'
+        );
+        expect(mockOpenLinkerModuleClient.importOrder).not.toHaveBeenCalled();
+      });
+
+      it('keeps a failed currency READ a retryable API error, never the refusal class', async () => {
+        arrangeIds();
+        mockCurrencyResolver.resolveCurrencyId.mockRejectedValue(
+          new PrestashopApiException('GET currencies returned 503', 503)
+        );
+
+        const error = await adapter.createOrder(orderWithCurrency('EUR')).then(
+          () => null,
+          (e: unknown) => e as Error
+        );
+
+        expect(error).toBeInstanceOf(PrestashopApiException);
+        expect(error).not.toBeInstanceOf(PrestashopCurrencyUnknownException);
+        expect((error as PrestashopApiException).statusCode).toBe(503);
       });
     });
 

--- a/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-retry-classifier.adapter.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-retry-classifier.adapter.spec.ts
@@ -1,10 +1,11 @@
 /**
- * Unit tests for the PrestaShop retry classifier (#581 / #2052).
+ * Unit tests for the PrestaShop retry classifier (#581 / #2052 / #2139).
  *
  * @module libs/integrations/prestashop/src/infrastructure/adapters
  */
 import { PrestashopRetryClassifierAdapter } from '../prestashop-retry-classifier.adapter';
 import { PrestashopTaxRateUnknownException } from '../../../domain/exceptions/prestashop-tax-rate-unknown.exception';
+import { PrestashopCurrencyUnknownException } from '../../../domain/exceptions/prestashop-currency-unknown.exception';
 import { PrestashopApiException } from '../../../domain/exceptions/prestashop-api.exception';
 import { PrestashopAuthenticationException } from '../../../domain/exceptions/prestashop-authentication.exception';
 
@@ -17,7 +18,15 @@ describe('PrestashopRetryClassifierAdapter', () => {
     ).toBe(true);
   });
 
-  it('should keep an API error retryable, including the transport half of the same tax read', () => {
+  it('should classify an unresolvable order currency as non-retryable', () => {
+    expect(
+      classifier.isNonRetryable(
+        new PrestashopCurrencyUnknownException('Currency EUR unknown in PrestaShop', 'EUR')
+      )
+    ).toBe(true);
+  });
+
+  it('should keep an API error retryable, including the transport half of the same tax or currency read', () => {
     expect(classifier.isNonRetryable(new PrestashopApiException('gateway timeout', 504))).toBe(
       false
     );

--- a/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-processor-manager.adapter.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-processor-manager.adapter.ts
@@ -53,6 +53,7 @@ import {
   PrestashopApiException,
   PrestashopProvisioningException,
   PrestashopTaxRateUnknownException,
+  PrestashopCurrencyUnknownException,
 } from '@openlinker/integrations-prestashop';
 import { Logger, formatBodyForLog } from '@openlinker/shared/logging';
 import type { PrestashopCustomerProvisioner } from '../provisioners/prestashop-customer-provisioner';
@@ -311,8 +312,26 @@ export class PrestashopOrderProcessorManagerAdapter
         this.logger.debug(`Resolved billing address ID: ${externalBillingAddressId}`);
       }
 
-      // Step 4: Resolve currency ID
-      const currencyCode = order.totals.currency || 'EUR'; // Default to EUR if not specified
+      // Step 4: Resolve currency ID.
+      //
+      // A missing currency is refused, never substituted (#2139). This used to
+      // read `order.totals.currency || 'EUR'`, while the snapshot path defaults
+      // the field to `''` (`order-from-ready-snapshot.ts`) - so an order that
+      // carried no currency asked the shop for EUR, and on a shop where EUR is
+      // active that resolved to a real-but-wrong id without ever reaching the
+      // resolver's own guards. The line amounts pinned downstream are the
+      // buyer-paid source numerals (#895 / ADR-014), so the order would be
+      // booked with the right numbers under the wrong denomination.
+      const currencyCode = order.totals.currency?.trim() ?? '';
+      if (currencyCode === '') {
+        throw new PrestashopCurrencyUnknownException(
+          `Order ${order.orderNumber || '(no reference)'}: no currency - the source ` +
+            `order carries no ISO 4217 code, so its PrestaShop currency cannot be ` +
+            `resolved. No order was created.`,
+          undefined,
+          this.connection.id
+        );
+      }
       const externalCurrencyId = await this.currencyResolver.resolveCurrencyId(
         currencyCode,
         this.connection.id,
@@ -539,7 +558,12 @@ export class PrestashopOrderProcessorManagerAdapter
         // `syncStatus[].error` verbatim: the wrapping below would prepend 35
         // characters and push the product identity out of every truncated
         // surface that renders it (#2052 — see `taxRateUnknownError`).
-        error instanceof PrestashopTaxRateUnknownException
+        error instanceof PrestashopTaxRateUnknownException ||
+        // Same contract for the currency refusal (#2139): wrapping would both
+        // bury the operator-facing message and hide the class the retry
+        // classifier keys on, turning a non-retryable configuration gap back
+        // into five retryable attempts.
+        error instanceof PrestashopCurrencyUnknownException
       ) {
         throw error;
       }

--- a/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-processor-manager.adapter.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-processor-manager.adapter.ts
@@ -147,6 +147,37 @@ export class PrestashopOrderProcessorManagerAdapter
 
     this.logger.debug(`order: ${JSON.stringify(order)}`);
 
+    // Step 0: Refuse an order that carries no currency, before ANY PrestaShop
+    // write (#2139).
+    //
+    // This used to read `order.totals.currency || 'EUR'`, while the snapshot
+    // path defaults the field to `''` (`order-from-ready-snapshot.ts`) - so an
+    // order that carried no currency asked the shop for EUR, and on a shop
+    // where EUR is active that resolved to a real-but-wrong id without ever
+    // reaching the resolver's own guards. The line amounts pinned downstream
+    // are the buyer-paid source numerals (#895 / ADR-014), so the order would
+    // be booked with the right numbers under the wrong denomination.
+    //
+    // The check is pure - it reads only fields this method already holds on
+    // entry - so it sits ahead of guest-customer provisioning (Step 1) and
+    // address provisioning (Step 3). Both create real PrestaShop rows, and a
+    // refusal must not leave any behind. The resolver-side refusal cannot be
+    // hoisted the same way: it needs the shop read, so it stays at Step 4.
+    //
+    // `?? ''` before `.trim()` is defensive against untyped snapshot JSON;
+    // `OrderTotals.currency` is a required `string` and the real-world value
+    // is `''`, not `undefined`.
+    const currencyCode = (order.totals.currency ?? '').trim();
+    if (currencyCode === '') {
+      throw new PrestashopCurrencyUnknownException(
+        `Order ${order.orderNumber || '(no reference)'}: no currency - the source ` +
+          `order carries no ISO 4217 code, so its PrestaShop currency cannot be ` +
+          `resolved. No order was created.`,
+        undefined,
+        this.connection.id
+      );
+    }
+
     // Cart-scoped `specific_prices` rows created to pin line prices (#895).
     // Declared outside the try so the success path and the catch can both
     // best-effort clean them up. They're transient (the price is materialised
@@ -312,26 +343,9 @@ export class PrestashopOrderProcessorManagerAdapter
         this.logger.debug(`Resolved billing address ID: ${externalBillingAddressId}`);
       }
 
-      // Step 4: Resolve currency ID.
-      //
-      // A missing currency is refused, never substituted (#2139). This used to
-      // read `order.totals.currency || 'EUR'`, while the snapshot path defaults
-      // the field to `''` (`order-from-ready-snapshot.ts`) - so an order that
-      // carried no currency asked the shop for EUR, and on a shop where EUR is
-      // active that resolved to a real-but-wrong id without ever reaching the
-      // resolver's own guards. The line amounts pinned downstream are the
-      // buyer-paid source numerals (#895 / ADR-014), so the order would be
-      // booked with the right numbers under the wrong denomination.
-      const currencyCode = order.totals.currency?.trim() ?? '';
-      if (currencyCode === '') {
-        throw new PrestashopCurrencyUnknownException(
-          `Order ${order.orderNumber || '(no reference)'}: no currency - the source ` +
-            `order carries no ISO 4217 code, so its PrestaShop currency cannot be ` +
-            `resolved. No order was created.`,
-          undefined,
-          this.connection.id
-        );
-      }
+      // Step 4: Resolve the currency ID. `currencyCode` is non-empty by the
+      // Step 0 guard above; an ISO the shop does not carry, or a row with an
+      // unusable id, is refused by the resolver itself (#2139).
       const externalCurrencyId = await this.currencyResolver.resolveCurrencyId(
         currencyCode,
         this.connection.id,
@@ -559,10 +573,15 @@ export class PrestashopOrderProcessorManagerAdapter
         // characters and push the product identity out of every truncated
         // surface that renders it (#2052 — see `taxRateUnknownError`).
         error instanceof PrestashopTaxRateUnknownException ||
-        // Same contract for the currency refusal (#2139): wrapping would both
-        // bury the operator-facing message and hide the class the retry
-        // classifier keys on, turning a non-retryable configuration gap back
-        // into five retryable attempts.
+        // Same contract for the currency refusal (#2139). What it buys today is
+        // the operator-facing message: wrapping prepends 35 characters and
+        // pushes the currency identity out of the truncated surfaces. It also
+        // preserves the class the retry classifier keys on - which the shipped
+        // caller chain does not currently consult, since `OrderSyncService`
+        // reduces a per-destination create rejection to its message under
+        // `Promise.allSettled` and `OrderIngestionService` records it without
+        // rethrowing, so the job succeeds and is never retried. Preserved for
+        // correctness, and for the day the failure does reach the retry path.
         error instanceof PrestashopCurrencyUnknownException
       ) {
         throw error;

--- a/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-retry-classifier.adapter.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-retry-classifier.adapter.ts
@@ -20,6 +20,15 @@
  *     id is unusable. Same reasoning as above - nothing about the order or the
  *     shop changes between attempts, so the answer is identical every time.
  *
+ * Neither class reaches this classifier on the shipped ORDER-CREATE path today,
+ * so the "attempts" above describe what retrying would cost, not what currently
+ * happens: `OrderSyncService` reduces a per-destination `createOrder` rejection
+ * to its message under `Promise.allSettled`, and `OrderIngestionService` records
+ * that message without rethrowing - the job succeeds and the runner never asks.
+ * Both registrations are kept because the classification is correct by
+ * construction and is already right for the day the failure does propagate; the
+ * value they carry unconditionally is on the message, not on the retry count.
+ *
  * Retryable, deliberately left out (return `false`):
  *   - `PrestashopApiException` — a failed CALL, including the transport failure
  *     of the very same tax-rate or `GET /currencies` read (5xx / timeout /

--- a/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-retry-classifier.adapter.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-retry-classifier.adapter.ts
@@ -14,13 +14,18 @@
  *     reported unusable data, so every retry re-reads the same record and fails
  *     identically; burning five attempts with backoff only delays the moment an
  *     operator sees the message that tells them what to fix.
+ *   - `PrestashopCurrencyUnknownException` (#2139) - the order's currency cannot
+ *     be denominated at the destination: the source order carries no currency
+ *     code, the shop has no currency row for its ISO code, or the matching row's
+ *     id is unusable. Same reasoning as above - nothing about the order or the
+ *     shop changes between attempts, so the answer is identical every time.
  *
  * Retryable, deliberately left out (return `false`):
  *   - `PrestashopApiException` — a failed CALL, including the transport failure
- *     of the very same tax-rate read (5xx / timeout / connection reset). These
- *     do fix themselves and MUST keep their retries. This is why an unresolvable
- *     tax rate raises two different classes rather than one class with a flag:
- *     the class IS the retry decision.
+ *     of the very same tax-rate or `GET /currencies` read (5xx / timeout /
+ *     connection reset). These do fix themselves and MUST keep their retries.
+ *     This is why an unresolvable tax rate or currency raises two different
+ *     classes rather than one class with a flag: the class IS the retry decision.
  *   - `PrestashopAuthenticationException` — routed through the separate
  *     auth-failure classifier (#819 / ADR-008), which flips the connection to
  *     `needs_reauth`; classifying it here as well would pre-empt that path.
@@ -36,9 +41,13 @@
  */
 import type { RetryClassifierPort } from '@openlinker/core/sync';
 import { PrestashopTaxRateUnknownException } from '../../domain/exceptions/prestashop-tax-rate-unknown.exception';
+import { PrestashopCurrencyUnknownException } from '../../domain/exceptions/prestashop-currency-unknown.exception';
 
 export class PrestashopRetryClassifierAdapter implements RetryClassifierPort {
   isNonRetryable(cause: unknown): boolean {
-    return cause instanceof PrestashopTaxRateUnknownException;
+    return (
+      cause instanceof PrestashopTaxRateUnknownException ||
+      cause instanceof PrestashopCurrencyUnknownException
+    );
   }
 }

--- a/libs/integrations/prestashop/src/infrastructure/mappers/__tests__/prestashop-order.mapper.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/mappers/__tests__/prestashop-order.mapper.spec.ts
@@ -7,6 +7,7 @@
  * @module libs/integrations/prestashop/src/infrastructure/mappers/__tests__
  */
 import { PrestashopOrderMapper } from '../prestashop-order.mapper';
+import { PrestashopCurrencyUnknownException } from '../../../domain/exceptions/prestashop-currency-unknown.exception';
 import { PrestashopParseException } from '../../../domain/exceptions/prestashop-parse.exception';
 import type { PrestashopOrder, PrestashopOrderRow } from '../prestashop.mapper.interface';
 import type { OrderCreate } from '@openlinker/core/orders';
@@ -457,11 +458,39 @@ describe('PrestashopOrderMapper', () => {
         externalProductIds,
         externalVariantIds,
         '200', // Only shipping
-        undefined // No billing
+        undefined, // No billing
+        '1',
+        '1'
       );
 
       expect(result.id_address_delivery).toBe('200');
       expect(result.id_address_invoice).toBe('200');
+    });
+
+    // #2139: the cart's id_currency is the live write the refusal protects -
+    // `importorder` builds the PrestaShop context from `$cart->id_currency`,
+    // and the cart-scoped `specific_prices` rows are keyed to the same id.
+    it('should refuse a cart with no currency ID instead of defaulting it to 1', () => {
+      const externalProductIds = new Map<string, string | number>([['ol_product_1', '10']]);
+      const externalVariantIds = new Map<string, string | number>();
+
+      const refuse = (): unknown =>
+        mapper.mapCartCreate(
+          mockOrderCreate,
+          '100',
+          externalProductIds,
+          externalVariantIds,
+          '200',
+          '201',
+          undefined, // No currency
+          '1'
+        );
+
+      expect(refuse).toThrow('No PrestaShop currency id was resolved');
+      // The class carries the retry decision: no retry can supply the id, so
+      // this must be the non-retryable currency class, not the generic
+      // provisioning one the retry classifier leaves retryable.
+      expect(refuse).toThrow(PrestashopCurrencyUnknownException);
     });
 
     it('should map cart rows correctly', () => {
@@ -474,7 +503,9 @@ describe('PrestashopOrderMapper', () => {
         externalProductIds,
         externalVariantIds,
         '200',
-        '201'
+        '201',
+        '1',
+        '1'
       );
 
       const cartRows = (result.associations as Record<string, unknown>).cart_rows as Record<

--- a/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-order.mapper.ts
+++ b/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-order.mapper.ts
@@ -20,6 +20,7 @@ import type {
 import type { Order, OrderItem, OrderTotals } from '@openlinker/core/orders';
 import type { OrderCreate, OrderStatus } from '@openlinker/core/orders';
 import { PrestashopProvisioningException } from '@openlinker/integrations-prestashop';
+import { PrestashopCurrencyUnknownException } from '../../domain/exceptions/prestashop-currency-unknown.exception';
 import { PrestashopParseException } from '../../domain/exceptions/prestashop-parse.exception';
 import { Logger } from '@openlinker/shared/logging';
 import { toPrestashopProductAttributeId } from './prestashop-variant-id';
@@ -29,7 +30,13 @@ import { toPrestashopProductAttributeId } from './prestashop-variant-id';
  * single source of truth. Future enhancement: move to connection config so
  * per-store overrides don't require a code change.
  */
-const DEFAULT_CURRENCY_ID = 1; // EUR
+// No DEFAULT_CURRENCY_ID (#2139). Currency is the one field here that must not
+// have a default: id 1 is not EUR and not the shop default (currency ids are
+// auto-increment and localization-pack dependent), and line amounts are the
+// buyer-paid source numerals (#895 / ADR-014), so substituting an id books the
+// order with the right numbers under the wrong denomination. The caller
+// resolves the id or refuses (`PrestashopCurrencyResolver`); an absent id is
+// refused here too rather than filled in.
 const DEFAULT_LANGUAGE_ID = 1; // First language
 const DEFAULT_CARRIER_ID = 1; // First carrier
 
@@ -246,11 +253,25 @@ export class PrestashopOrderMapper implements IPrestashopOrderMapper {
       };
     });
 
+    // The cart's `id_currency` is the live write the #2139 refusal protects:
+    // `importorder` builds the PrestaShop context from `$cart->id_currency`,
+    // and the cart-scoped `specific_prices` rows are keyed to the same id.
+    // Unreachable today (the adapter's Step 0 guard guarantees a non-empty code
+    // and the resolver returns a positive integer or throws), so this is
+    // defence-in-depth - but it raises the same non-retryable class as every
+    // other currency refusal on this path, since no retry can supply the id.
+    if (externalCurrencyId === undefined || externalCurrencyId === '') {
+      throw new PrestashopCurrencyUnknownException(
+        'No PrestaShop currency id was resolved for this order, so its cart cannot ' +
+          'be denominated. No cart was created.'
+      );
+    }
+
     // Build PrestaShop cart structure. id_carrier is set here because PS
     // resolves the order's carrier from the cart (#503).
     const prestashopCart: Record<string, unknown> = {
       id_customer: externalCustomerId,
-      id_currency: externalCurrencyId || DEFAULT_CURRENCY_ID,
+      id_currency: externalCurrencyId,
       id_lang: externalLangId || DEFAULT_LANGUAGE_ID,
       id_carrier: externalCarrierId ?? DEFAULT_CARRIER_ID,
       associations: {

--- a/libs/integrations/prestashop/src/infrastructure/provisioners/__tests__/prestashop-currency-resolver.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/provisioners/__tests__/prestashop-currency-resolver.spec.ts
@@ -138,6 +138,20 @@ describe('PrestashopCurrencyResolver', () => {
       );
     });
 
+    // `Number.parseInt` is not a validity check: '0' parses to 0 and '12abc'
+    // parses to 12. A 0 in particular used to clear the old NaN-only guard and
+    // then be rewritten to 1 by the order mapper's `||` fallback (#2139).
+    it.each([['0'], ['-1'], ['0.4']])(
+      'should refuse a currency id that parses to a non-positive number (%s)',
+      async (rawId) => {
+        client.listResources.mockResolvedValue([{ id: rawId, iso_code: 'EUR' }]);
+
+        await expect(resolver.resolveCurrencyId('EUR', 'conn-1', client)).rejects.toThrow(
+          PrestashopCurrencyUnknownException
+        );
+      }
+    );
+
     it('should refuse an empty ISO code without querying the shop', async () => {
       await expect(resolver.resolveCurrencyId('   ', 'conn-1', client)).rejects.toThrow(
         PrestashopCurrencyUnknownException

--- a/libs/integrations/prestashop/src/infrastructure/provisioners/__tests__/prestashop-currency-resolver.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/provisioners/__tests__/prestashop-currency-resolver.spec.ts
@@ -1,0 +1,203 @@
+/**
+ * Unit tests for PrestashopCurrencyResolver (#2139)
+ *
+ * The resolver had no spec at all while every failure branch returned a
+ * hardcoded id `1`, so the guessing was never codified as intended anywhere.
+ * These tests pin the opposite contract: resolve, cache, or refuse - and refuse
+ * with the class that carries the right retry decision.
+ *
+ * @module libs/integrations/prestashop/src/infrastructure/provisioners
+ */
+import { PrestashopCurrencyResolver } from '../prestashop-currency-resolver';
+import { PrestashopCurrencyUnknownException } from '../../../domain/exceptions/prestashop-currency-unknown.exception';
+import { PrestashopApiException } from '../../../domain/exceptions/prestashop-api.exception';
+import { PrestashopRetryClassifierAdapter } from '../../adapters/prestashop-retry-classifier.adapter';
+import type { IPrestashopWebserviceClient } from '../../http/prestashop-webservice.client.interface';
+
+describe('PrestashopCurrencyResolver', () => {
+  let resolver: PrestashopCurrencyResolver;
+  let client: jest.Mocked<IPrestashopWebserviceClient>;
+
+  beforeEach(() => {
+    resolver = new PrestashopCurrencyResolver();
+    client = {
+      getResource: jest.fn(),
+      listResources: jest.fn().mockResolvedValue([{ id: '3', iso_code: 'PLN' }]),
+      createResource: jest.fn(),
+      updateResource: jest.fn(),
+      deleteResource: jest.fn(),
+      uploadImage: jest.fn(),
+    } as unknown as jest.Mocked<IPrestashopWebserviceClient>;
+  });
+
+  describe('resolution', () => {
+    it('should resolve an ISO code to the shop currency id', async () => {
+      const id = await resolver.resolveCurrencyId('PLN', 'conn-1', client);
+
+      expect(id).toBe(3);
+      expect(client.listResources).toHaveBeenCalledWith(
+        'currencies',
+        { custom: { iso_code: 'PLN' } },
+        1,
+        0
+      );
+    });
+
+    it('should normalise the ISO code before querying', async () => {
+      await resolver.resolveCurrencyId('  pln  ', 'conn-1', client);
+
+      expect(client.listResources).toHaveBeenCalledWith(
+        'currencies',
+        { custom: { iso_code: 'PLN' } },
+        1,
+        0
+      );
+    });
+  });
+
+  describe('caching', () => {
+    it('should cache a resolved id per connection - a second call makes no WS request', async () => {
+      await resolver.resolveCurrencyId('PLN', 'conn-1', client);
+      const second = await resolver.resolveCurrencyId('PLN', 'conn-1', client);
+
+      expect(second).toBe(3);
+      expect(client.listResources).toHaveBeenCalledTimes(1);
+    });
+
+    it('should fetch independently for different connections', async () => {
+      await resolver.resolveCurrencyId('PLN', 'conn-1', client);
+      await resolver.resolveCurrencyId('PLN', 'conn-2', client);
+
+      expect(client.listResources).toHaveBeenCalledTimes(2);
+    });
+
+    it('should refetch after the cache is cleared for the connection', async () => {
+      await resolver.resolveCurrencyId('PLN', 'conn-1', client);
+      resolver.clearCache('conn-1');
+      await resolver.resolveCurrencyId('PLN', 'conn-1', client);
+
+      expect(client.listResources).toHaveBeenCalledTimes(2);
+    });
+
+    it('should refetch after the full cache is cleared', async () => {
+      await resolver.resolveCurrencyId('PLN', 'conn-1', client);
+      resolver.clearCache();
+      await resolver.resolveCurrencyId('PLN', 'conn-1', client);
+
+      expect(client.listResources).toHaveBeenCalledTimes(2);
+    });
+
+    it('should re-read once the 24h TTL has elapsed', async () => {
+      await resolver.resolveCurrencyId('PLN', 'conn-1', client);
+
+      const past = Date.now();
+      jest.spyOn(Date, 'now').mockReturnValue(past + 25 * 60 * 60 * 1000);
+      try {
+        expect(await resolver.resolveCurrencyId('PLN', 'conn-1', client)).toBe(3);
+      } finally {
+        (Date.now as jest.Mock).mockRestore();
+      }
+
+      expect(client.listResources).toHaveBeenCalledTimes(2);
+    });
+
+    it('should NOT cache a refusal - the next attempt sees a currency the operator just added', async () => {
+      client.listResources.mockResolvedValueOnce([]);
+
+      await expect(resolver.resolveCurrencyId('EUR', 'conn-1', client)).rejects.toBeInstanceOf(
+        PrestashopCurrencyUnknownException
+      );
+
+      client.listResources.mockResolvedValueOnce([{ id: '4', iso_code: 'EUR' }]);
+      expect(await resolver.resolveCurrencyId('EUR', 'conn-1', client)).toBe(4);
+    });
+  });
+
+  describe('refusal (shop-configuration gap)', () => {
+    it('should refuse an ISO the shop has no currency for, instead of returning id 1', async () => {
+      client.listResources.mockResolvedValue([]);
+
+      await expect(resolver.resolveCurrencyId('EUR', 'conn-1', client)).rejects.toThrow(
+        PrestashopCurrencyUnknownException
+      );
+    });
+
+    it('should refuse when the WS reports no rows at all (null response)', async () => {
+      client.listResources.mockResolvedValue(null as unknown as Array<Record<string, unknown>>);
+
+      await expect(resolver.resolveCurrencyId('EUR', 'conn-1', client)).rejects.toThrow(
+        PrestashopCurrencyUnknownException
+      );
+    });
+
+    it('should refuse an unparseable currency id, instead of returning id 1', async () => {
+      client.listResources.mockResolvedValue([{ id: 'not-a-number', iso_code: 'EUR' }]);
+
+      await expect(resolver.resolveCurrencyId('EUR', 'conn-1', client)).rejects.toThrow(
+        PrestashopCurrencyUnknownException
+      );
+    });
+
+    it('should refuse an empty ISO code without querying the shop', async () => {
+      await expect(resolver.resolveCurrencyId('   ', 'conn-1', client)).rejects.toThrow(
+        PrestashopCurrencyUnknownException
+      );
+      expect(client.listResources).not.toHaveBeenCalled();
+    });
+
+    it('should carry the ISO code, the connection and an operator-actionable message', async () => {
+      client.listResources.mockResolvedValue([]);
+
+      await expect(resolver.resolveCurrencyId('eur', 'conn-1', client)).rejects.toMatchObject({
+        name: 'PrestashopCurrencyUnknownException',
+        isoCode: 'EUR',
+        connectionId: 'conn-1',
+        // Leads with the identity - the message is rendered verbatim in
+        // operator-facing surfaces that clip it hard.
+        message: expect.stringMatching(/^Currency EUR unknown in PrestaShop/),
+      });
+    });
+  });
+
+  describe('failed read (transport)', () => {
+    it('should propagate the read failure as the retryable PrestashopApiException', async () => {
+      client.listResources.mockRejectedValue(new PrestashopApiException('gateway timeout', 504));
+
+      await expect(resolver.resolveCurrencyId('PLN', 'conn-1', client)).rejects.toThrow(
+        PrestashopApiException
+      );
+    });
+
+    it('should NOT conflate a failed read with an unresolvable currency', async () => {
+      const classifier = new PrestashopRetryClassifierAdapter();
+
+      client.listResources.mockRejectedValue(new PrestashopApiException('gateway timeout', 504));
+      const transport = await resolver
+        .resolveCurrencyId('PLN', 'conn-1', client)
+        .catch((error: unknown) => error);
+
+      client.listResources.mockReset();
+      client.listResources.mockResolvedValue([]);
+      const configuration = await resolver
+        .resolveCurrencyId('PLN', 'conn-1', client)
+        .catch((error: unknown) => error);
+
+      // Different classes, and therefore opposite retry decisions: a 504 keeps
+      // its retries, a shop-configuration gap does not.
+      expect(transport).toBeInstanceOf(PrestashopApiException);
+      expect(transport).not.toBeInstanceOf(PrestashopCurrencyUnknownException);
+      expect(configuration).toBeInstanceOf(PrestashopCurrencyUnknownException);
+      expect(configuration).not.toBeInstanceOf(PrestashopApiException);
+      expect(classifier.isNonRetryable(transport)).toBe(false);
+      expect(classifier.isNonRetryable(configuration)).toBe(true);
+    });
+
+    it('should propagate a non-PrestaShop read failure unchanged (default-retryable)', async () => {
+      client.listResources.mockRejectedValue(new Error('socket hang up'));
+
+      await expect(resolver.resolveCurrencyId('PLN', 'conn-1', client)).rejects.toThrow(
+        'socket hang up'
+      );
+    });
+  });
+});

--- a/libs/integrations/prestashop/src/infrastructure/provisioners/prestashop-currency-resolver.ts
+++ b/libs/integrations/prestashop/src/infrastructure/provisioners/prestashop-currency-resolver.ts
@@ -2,22 +2,35 @@
  * PrestaShop Currency Resolver
  *
  * Resolves ISO 4217 currency codes to PrestaShop currency IDs.
- * Caches results per connection to reduce API calls.
+ * Caches successful resolutions per connection to reduce API calls.
  *
- * KNOWN GAP (not addressed here, tracked as #2139): all three failure branches
- * silently fall back to `DEFAULT_CURRENCY_ID = 1` - the ISO is absent from the
- * shop, the shop returned an unparseable currency id, or the read threw - so a
- * currency the destination shop does not carry books the cart in currency 1
- * instead of failing. The fallback is cached, but only for this instance's
- * lifetime: `PrestashopAdapterFactory` constructs a new resolver per adapter
- * build and `prestashop-plugin.ts` constructs a new factory per
- * `createCapabilityAdapter`, so the cache never outlives a single
- * `createOrder`. Changing the fallback changes live order-creation behaviour.
+ * Refuses rather than guesses (#2139). Until then every failure branch returned
+ * a hardcoded id `1`, so an order in a currency the destination shop does not
+ * carry was booked under whichever currency that shop happened to create first,
+ * with the buyer's raw amounts - the right numbers under the wrong
+ * denomination, reported to the operator as a success. The same reasoning ADR-014
+ * / #895 applies to prices applies here: a visibly failed order beats a quietly
+ * mis-denominated financial document. A deployment that genuinely wants a
+ * permissive fallback should get an explicit per-connection setting, not an
+ * unconditional constant.
+ *
+ * Two failure kinds, two exception classes, because the class IS the retry
+ * decision (see `PrestashopRetryClassifierAdapter`):
+ *   - a shop-configuration gap (ISO absent, unusable row id) raises the
+ *     non-retryable `PrestashopCurrencyUnknownException` - the read succeeded
+ *     and reported data the order cannot be denominated with, so every retry
+ *     re-reads the same record;
+ *   - a failed READ propagates untouched, so the client's `PrestashopApiException`
+ *     keeps its status code and its retries. The two must never be conflated.
+ *
+ * Mirrors the sibling `PrestashopCountryResolver`, which has always refused an
+ * ISO the shop does not carry rather than substituting an id.
  *
  * @module libs/integrations/prestashop/src/infrastructure/provisioners
  */
 import { Injectable, Logger } from '@nestjs/common';
 import type { IPrestashopWebserviceClient } from '../http/prestashop-webservice.client.interface';
+import { PrestashopCurrencyUnknownException } from '../../domain/exceptions/prestashop-currency-unknown.exception';
 import { readPrestashopCurrencyByIso } from './prestashop-currency-read';
 
 /**
@@ -32,14 +45,11 @@ interface CacheEntry {
  * Cache TTL in milliseconds (24 hours)
  * Currencies are rarely added/changed in PrestaShop, but cache should expire
  * to handle configuration changes.
+ *
+ * Only RESOLVED ids are cached. A refusal is never cached, so an operator who
+ * adds the missing currency in the back office is picked up by the next attempt.
  */
 const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
-
-/**
- * Default currency ID fallback (EUR = 1 is common default in PrestaShop)
- * Used if currency lookup fails
- */
-const DEFAULT_CURRENCY_ID = 1;
 
 @Injectable()
 export class PrestashopCurrencyResolver {
@@ -49,13 +59,16 @@ export class PrestashopCurrencyResolver {
   /**
    * Resolve ISO 4217 currency code to PrestaShop currency ID
    *
-   * Queries PrestaShop currencies by ISO code, caches result per connection.
-   * Falls back to default currency ID (1 = EUR) if currency not found.
+   * Queries PrestaShop currencies by ISO code, caches the result per connection.
    *
    * @param isoCode - ISO 4217 currency code (e.g., 'PLN', 'EUR', 'USD')
    * @param connectionId - Connection ID for cache key
    * @param webserviceClient - PrestaShop WebService client
    * @returns PrestaShop currency ID
+   * @throws PrestashopCurrencyUnknownException when the shop has no currency row
+   *   for the ISO code, or the matching row's id is unusable (non-retryable)
+   * @throws PrestashopApiException when the `GET /currencies` read itself fails
+   *   (retryable - raised by the WebService client and propagated unchanged)
    */
   async resolveCurrencyId(
     isoCode: string,
@@ -64,6 +77,15 @@ export class PrestashopCurrencyResolver {
   ): Promise<number> {
     // Normalize ISO code (uppercase, trim)
     const normalizedIso = isoCode.trim().toUpperCase();
+
+    if (normalizedIso === '') {
+      throw new PrestashopCurrencyUnknownException(
+        'Currency missing - the order carries no ISO 4217 currency code, so no ' +
+          'PrestaShop currency can be resolved. No order was created.',
+        undefined,
+        connectionId
+      );
+    }
 
     // Check cache
     const cacheKey = `${connectionId}:${normalizedIso}`;
@@ -81,58 +103,50 @@ export class PrestashopCurrencyResolver {
       }
     }
 
-    try {
-      // Query PrestaShop currencies through the shared ISO read
-      // (`prestashop-currency-read`) so the filter shape lives in one place.
-      const currency = await readPrestashopCurrencyByIso(webserviceClient, normalizedIso);
+    // Query PrestaShop currencies through the shared ISO read
+    // (`prestashop-currency-read`) so the filter shape lives in one place.
+    // Deliberately NOT wrapped in a try/catch: a read failure is a different
+    // failure kind from an unresolvable currency and must keep the retryable
+    // `PrestashopApiException` the client raises.
+    const currency = await readPrestashopCurrencyByIso(webserviceClient, normalizedIso);
 
-      if (!currency) {
-        this.logger.warn(
-          `Currency not found in PrestaShop: ${normalizedIso} (connection: ${connectionId}), using default currency ID: ${DEFAULT_CURRENCY_ID}`
-        );
-        // Cache default to avoid repeated lookups
-        this.cache.set(cacheKey, {
-          currencyId: DEFAULT_CURRENCY_ID,
-          timestamp: Date.now(),
-        });
-        return DEFAULT_CURRENCY_ID;
-      }
-
-      // Extract currency ID from the matched row
-      const currencyId = Number.parseInt(currency.id, 10);
-
-      if (Number.isNaN(currencyId)) {
-        this.logger.warn(
-          `Invalid currency ID returned from PrestaShop: ${currency.id} for ISO: ${normalizedIso}, using default: ${DEFAULT_CURRENCY_ID}`
-        );
-        // Cache default
-        this.cache.set(cacheKey, {
-          currencyId: DEFAULT_CURRENCY_ID,
-          timestamp: Date.now(),
-        });
-        return DEFAULT_CURRENCY_ID;
-      }
-
-      // Cache result with timestamp
-      this.cache.set(cacheKey, {
-        currencyId,
-        timestamp: Date.now(),
-      });
-      this.logger.debug(`Resolved currency ID: ${normalizedIso} → ${currencyId}`);
-
-      return currencyId;
-    } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
-      this.logger.warn(
-        `Failed to resolve currency ${normalizedIso} in PrestaShop (connection: ${connectionId}): ${errorMessage}, using default currency ID: ${DEFAULT_CURRENCY_ID}`
+    if (!currency) {
+      this.logger.error(
+        `Currency not configured in PrestaShop: ${normalizedIso} (connection: ${connectionId})`
       );
-      // Cache default to avoid repeated failed lookups
-      this.cache.set(cacheKey, {
-        currencyId: DEFAULT_CURRENCY_ID,
-        timestamp: Date.now(),
-      });
-      return DEFAULT_CURRENCY_ID;
+      throw new PrestashopCurrencyUnknownException(
+        `Currency ${normalizedIso} unknown in PrestaShop - the shop has no ` +
+          `currency for that code. No order was created; add ${normalizedIso} in ` +
+          `PrestaShop (International > Locations > Currencies), then retry.`,
+        normalizedIso,
+        connectionId
+      );
     }
+
+    // Extract currency ID from the matched row
+    const currencyId = Number.parseInt(currency.id, 10);
+
+    if (Number.isNaN(currencyId)) {
+      this.logger.error(
+        `Invalid currency ID returned from PrestaShop: ${currency.id} for ISO: ${normalizedIso} (connection: ${connectionId})`
+      );
+      throw new PrestashopCurrencyUnknownException(
+        `Currency ${normalizedIso} unknown in PrestaShop - its currency row has ` +
+          `an unusable id "${currency.id}". No order was created; check the ` +
+          `currency in PrestaShop, then retry.`,
+        normalizedIso,
+        connectionId
+      );
+    }
+
+    // Cache result with timestamp
+    this.cache.set(cacheKey, {
+      currencyId,
+      timestamp: Date.now(),
+    });
+    this.logger.debug(`Resolved currency ID: ${normalizedIso} → ${currencyId}`);
+
+    return currencyId;
   }
 
   /**

--- a/libs/integrations/prestashop/src/infrastructure/provisioners/prestashop-currency-resolver.ts
+++ b/libs/integrations/prestashop/src/infrastructure/provisioners/prestashop-currency-resolver.ts
@@ -78,6 +78,11 @@ export class PrestashopCurrencyResolver {
     // Normalize ISO code (uppercase, trim)
     const normalizedIso = isoCode.trim().toUpperCase();
 
+    // Defence in depth: the sole production caller
+    // (`PrestashopOrderProcessorManagerAdapter.createOrder`, Step 0) already
+    // refuses an empty currency before it reaches here, and its message - the
+    // one an operator actually sees - leads with the order reference rather
+    // than with this one. Kept so a future caller cannot reintroduce the gap.
     if (normalizedIso === '') {
       throw new PrestashopCurrencyUnknownException(
         'Currency missing - the order carries no ISO 4217 currency code, so no ' +
@@ -126,7 +131,11 @@ export class PrestashopCurrencyResolver {
     // Extract currency ID from the matched row
     const currencyId = Number.parseInt(currency.id, 10);
 
-    if (Number.isNaN(currencyId)) {
+    // Not just `NaN`: `Number.parseInt('0', 10)` is `0` and
+    // `Number.parseInt('12abc', 10)` is `12`, neither of which addresses a
+    // PrestaShop currency row. A `0` in particular used to survive every guard
+    // and then get rewritten to `1` by the mapper's `||` fallback (#2139).
+    if (!Number.isInteger(currencyId) || currencyId <= 0) {
       this.logger.error(
         `Invalid currency ID returned from PrestaShop: ${currency.id} for ISO: ${normalizedIso} (connection: ${connectionId})`
       );


### PR DESCRIPTION
## Problem

`PrestashopCurrencyResolver.resolveCurrencyId` never failed - it guessed. All three failure branches returned the hardcoded `DEFAULT_CURRENCY_ID = 1` and logged a `warn`:

| Branch | Old behaviour |
|---|---|
| the shop has no currency row for that ISO | return `1` |
| `Number.parseInt(currency.id, 10)` is `NaN` | return `1` |
| any thrown webservice error | return `1` |

This is on the live destination-order path. The resolved id is written to the cart's `id_currency` and to every cart-scoped `specific_prices` row, and the OL module's `importorder` then builds the PrestaShop context from `new Currency((int) $cart->id_currency)` before `PaymentModule::validateOrder`. Line amounts are the buyer-paid source numerals (#895 / ADR-014), so the order was booked with the right numbers under the wrong denomination, the `conversion_rate` `validateOrder` stamps related the header to the shop default at the wrong factor, and invoicing and analytics inherited it downstream. The sync reported success.

Two things worth stating plainly, because both are commonly assumed and both are false:

- **Id `1` is not EUR and not the shop default.** Currency ids are auto-increment and install-dependent; in this repo's stack the shop default (PLN) is created post-install. The `EUR = 1` claim traced only to the constant's own stale comment.
- **The wrong answer was not cached for 24h.** The TTL constant is 24h, but the resolver instance is rebuilt per adapter resolution (`prestashop-plugin.ts` -> `prestashop-adapter.factory.ts`), so its cache never outlived a single `createOrder`. Not a severity multiplier.

There was also no spec file for this resolver at all, so the guessing was never codified as intended anywhere.

## Change

The resolver refuses, mirroring the sibling `PrestashopCountryResolver` in the same folder, which has always thrown on an ISO the shop does not carry rather than substituting an id.

- **New non-retryable `PrestashopCurrencyUnknownException`** (`domain/exceptions/`, modelled on `PrestashopTaxRateUnknownException` #2052), exported from the package barrel and registered in `PrestashopRetryClassifierAdapter`. The read succeeded and reported data the order cannot be denominated with, so every retry would re-read the same record. See *Scope of the retry classification* below for what that registration does and does not do today.
- **A failed read stays retryable.** The `try/catch` that swallowed everything is gone entirely, so the client's `PrestashopApiException` propagates unchanged with its status code, and a non-PrestaShop failure propagates raw (default-retryable). The two are deliberately not conflated - the class *is* the retry decision - and a test asserts exactly that by driving both branches through the real classifier.
- **`order.totals.currency || 'EUR'` at the adapter is replaced by a refusal, placed above every PrestaShop write.** `order-from-ready-snapshot.ts` defaults `currency` to `''`, so an order carrying no currency asked the shop for EUR - and on a shop where EUR is active that resolved to a *real-but-wrong* id without ever reaching the resolver's own guards. This was the silent half of the same defect. The guard is pure (it reads only fields `createOrder` already holds on entry), so it sits at the top of the method, ahead of guest-customer provisioning (Step 1) and address provisioning (Step 3) - both of which create real PrestaShop rows. A spec asserts no `createResource` call is made on the refusal path. The resolver-side refusal genuinely cannot be hoisted (it needs the shop read) and stays at Step 4.
- **The new exception joins the `createOrder` catch's re-throw allowlist** (alongside `PrestashopTaxRateUnknownException`), so the operator-facing message reaches `syncStatus[].error` unwrapped instead of being buried inside a `PrestashopApiException` with 35 characters prepended.
- **`DEFAULT_CURRENCY_ID = 1 // EUR` is removed from `prestashop-order.mapper.ts` too.** It was applied at `mapCartCreate` - the exact live cart-create line - as `id_currency: externalCurrencyId || DEFAULT_CURRENCY_ID`, so without this the refusal could be undone one layer down. `mapCartCreate` now throws on an absent id, since that path has no validation step. It raises `PrestashopCurrencyUnknownException` rather than the generic `PrestashopProvisioningException` (review suggestion): the branch is unreachable today - the adapter's Step 0 guard guarantees a non-empty code and the resolver returns a positive integer or throws - but if it ever fires, no retry can supply the id, so it must carry the same non-retryable class as every other currency refusal on this path instead of being retried five times. A spec pins the class, not just the message. (`mapOrderCreate` and its `validateOrderData` path no longer exist - they were deleted with #2111.)
- **The resolver's id guard is tightened past `NaN`.** `Number.parseInt('0', 10)` is `0` - falsy, so it cleared the old guard and was then rewritten to `1` by the mapper's `||`. A parse that is not a positive integer is now refused.
- **Only resolved ids are cached.** A refusal is never cached, so an operator who adds the missing currency in the back office is picked up by the next attempt.
- **Messages follow the established #2052 format** - identity first, then cause, then action - because `OrderSyncService` stores them verbatim in `syncStatus[].error` and the frontend renders that string with no translation layer, the tightest surface clipping at ~40 characters. A test pins the first 40 characters of the no-currency message.

## Scope of the retry classification

The non-retryable registration is **inert on the order-create path as shipped**, and the code comments now say so rather than claiming it saves five retryable attempts.

`OrderSyncService.syncOrder` dispatches destinations under `Promise.allSettled` and maps a rejection to `{ status: 'failed', error: { message } }`, discarding the exception class; `OrderIngestionService.syncOrderFromSource` records that message without rethrowing. The `marketplace.order.sync` job therefore succeeds, and the runner never asks the classifier anything. This is not introduced here - the #2052 `PrestashopTaxRateUnknownException` registration has the same property.

The registration stays: the classification is correct by construction and is already right for the day the failure propagates. What the re-throw allowlist entry buys **unconditionally** is the operator-facing message reaching `syncStatus[].error` intact.

## Tests

New `prestashop-currency-resolver.spec.ts` (the resolver had none) covers resolution, ISO normalisation, per-connection caching, cache clearing, TTL expiry, refusal-is-not-cached, all three refusal branches plus the empty-ISO guard and the tightened non-positive-id guard, exception payload and message shape, and the transport-vs-configuration split through the real `PrestashopRetryClassifierAdapter`. Adapter-level tests cover the empty / whitespace currency refusal, that the refusal leaves no PrestaShop rows behind, the message's leading clause, the unwrapped re-throw of a resolver refusal, and a failed currency read staying a `PrestashopApiException`. One classifier test for the new non-retryable class.

**Existing specs updated:** removing the mapper's `DEFAULT_CURRENCY_ID` changed `prestashop-order.mapper.spec.ts`. `should default currency and language IDs to 1 when not provided` asserted `id_currency === 1` and is now split - language still defaults to 1, and a missing currency is refused - plus a cart-path refusal spec (asserting both the message and `PrestashopCurrencyUnknownException`) and the existing calls that omitted the currency argument now pass one explicitly. No spec in the resolver or adapter layer depended on the old fallback.

Full package suite after the rebase onto #2111: **35 suites, 558 tests, all passing** (the count moved because #2111 deleted the `mapOrderCreate` specs along with the method). Package-scoped `type-check` and `lint` both clean.

## Rebased onto #2111 (merged)

#2111 (issue #2102) merged first and this branch is rebased onto it, as planned. That PR removed the dead raw-webservice order-create surface per ADR-016, taking `PrestashopOrderMapper.mapOrderCreate`, `PrestashopConversionRateResolver` and `PrestashopConversionRateUnknownException` with it, and extracted the ISO read into `readPrestashopCurrencyByIso`.

The conflict resolution was the mechanical one described before the rebase: this PR's throws are kept, the read now goes through the shared `readPrestashopCurrencyByIso` helper (it returns the row or `undefined`, so the empty-array branch collapsed to `!currency`), #2111's `KNOWN GAP` header note is dropped since this PR closes the gap it described, and the mapper hunks that touched `mapOrderCreate` resolved to the deletion. No second, divergent read helper exists.

## Deliberately deferred: filtering `active` / soft-`deleted` currency rows

The resolver matches the first row `GET /currencies?filter[iso_code]=...` returns, regardless of an `active` or `deleted` flag. That is unchanged from before this PR and is **deferred on purpose**, not overlooked:

- **It is a different failure.** This PR fixes booking an order in the *wrong denomination* - a financial-correctness bug. A row that matches the ISO but is inactive books the order in the *right* denomination on a currency the shop has disabled: a configuration oddity with front-office consequences, not a mis-denominated financial document.
- **It is not a one-line change.** `PrestashopCurrency` carries only `id` and `iso_code`, so a filter needs the type widened plus the WebService `display` set changed, plus a decision on the "if `active` is absent, assume active" semantics the country resolver uses.
- **Sequencing favours waiting.** After #2111 lands, the read lives in one place (`readPrestashopCurrencyByIso`) serving both callers, so the fix is written once instead of twice. The soft-`deleted` case is arguably the sharper one: the read is `limit 1`, so a shop carrying both a deleted and a live row for the same ISO can have the deleted one win with no second row to fall back to.

## Not verified

No live PrestaShop was available. Everything here is verified by unit tests and by reading the call chain; the following were **not** exercised against a real shop:

- the end-to-end operator experience of the new message in the orders list and detail views;
- the behaviour of `GET /currencies?filter[iso_code]=...` against a shop with a soft-deleted or inactive currency row (see the deferral above).

The "a refused order leaves no partial artefacts" claim is now structural rather than merely asserted: the empty-currency guard runs before any PrestaShop write, and a spec pins that no `createResource` call is made.

Closes #2139

