### PR TITLE
feat(listings): recover a failed bulk batch without starting over

### DIFF
--- a/apps/api/src/listings/http/bulk-listing.controller.spec.ts
+++ b/apps/api/src/listings/http/bulk-listing.controller.spec.ts
@@ -225,7 +225,11 @@ describe('BulkListingController', () => {
           errors: [{ field: 'price', code: 'INVALID', message: 'Price too low' }],
         } as unknown as OfferCreationRecord,
       ];
-      bulkSubmit.getBatch.mockResolvedValue({ batch, records });
+      bulkSubmit.getBatch.mockResolvedValue({
+        batch,
+        records,
+        productIdByVariantId: { 'v-a': 'p-a' },
+      });
 
       const response = await controller.getBatch('b-1');
 
@@ -247,6 +251,7 @@ describe('BulkListingController', () => {
             createdAt: '2026-05-17T10:01:00.000Z',
             updatedAt: '2026-05-17T10:02:00.000Z',
             errors: null,
+            productId: 'p-a',
           },
           {
             id: 'r-2',
@@ -256,6 +261,7 @@ describe('BulkListingController', () => {
             createdAt: '2026-05-17T10:01:00.000Z',
             updatedAt: '2026-05-17T10:03:00.000Z',
             errors: [{ field: 'price', code: 'INVALID', message: 'Price too low' }],
+            productId: null,
           },
         ],
       });

--- a/apps/api/src/listings/http/bulk-listing.controller.ts
+++ b/apps/api/src/listings/http/bulk-listing.controller.ts
@@ -231,6 +231,7 @@ export class BulkListingController {
       createdAt: record.createdAt.toISOString(),
       updatedAt: record.updatedAt.toISOString(),
       errors: record.errors,
+      productId: summary.productIdByVariantId[record.internalVariantId] ?? null,
     }));
     return {
       id: summary.batch.id,

--- a/apps/api/src/listings/http/dto/bulk-offer-create-response.dto.ts
+++ b/apps/api/src/listings/http/dto/bulk-offer-create-response.dto.ts
@@ -61,6 +61,13 @@ export class BulkBatchRecordSummaryDto {
     description: 'Structured failure reasons populated when status=failed; null otherwise.',
   })
   errors!: OfferCreationError[] | null;
+
+  @ApiPropertyOptional({
+    nullable: true,
+    description:
+      'OL product id owning this record\'s variant (#2234). Lets the operator reopen the bulk wizard on a failed batch\'s variants. Null when the variant no longer resolves.',
+  })
+  productId!: string | null;
 }
 
 export class BulkBatchSummaryDto {

--- a/apps/api/src/listings/http/listings.controller.spec.ts
+++ b/apps/api/src/listings/http/listings.controller.spec.ts
@@ -184,6 +184,7 @@ describe('ListingsController', () => {
       countByProductIds: jest.fn().mockResolvedValue(new Map<string, number>()),
       findBySku: jest.fn(),
       findBySkuIn: jest.fn(),
+    findByIdIn: jest.fn(),
       findByEanOrGtinIn: jest.fn(),
       upsert: jest.fn(),
       upsertMany: jest.fn(),

--- a/apps/api/src/products/http/products.controller.spec.ts
+++ b/apps/api/src/products/http/products.controller.spec.ts
@@ -58,6 +58,7 @@ function createMockProductsService(): jest.Mocked<IProductsService> {
     getVariant: jest.fn(),
     getVariantsByProductId: jest.fn(),
     getVariantsBySkus: jest.fn(),
+  getVariantsByIds: jest.fn(),
     getVariantsByBarcodes: jest.fn(),
     listProducts: jest.fn(),
     listVariants: jest.fn(),

--- a/apps/web/src/features/listings/api/bulk-listings.types.ts
+++ b/apps/web/src/features/listings/api/bulk-listings.types.ts
@@ -147,7 +147,13 @@ export interface BulkBatchRecordSummary {
    * #1741). When absent the progress table falls back to the raw variant id.
    */
   variantLabel?: string | null;
-  /** OL product id, for grouping records into a per-product rollup (#1741). */
+  /**
+   * OL product id owning this record's variant. Populated by the BE record
+   * projection since #2234 (resolved with one batched variant lookup); null
+   * when the variant no longer resolves. Drives the per-product rollup
+   * grouping (#1741) and the failed-batch "Fix and resubmit" wizard link.
+   * Kept optional so a response from an older API still type-checks.
+   */
   productId?: string | null;
 }
 

--- a/apps/web/src/features/listings/components/bulk/bulk-batch-progress-table.test.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-batch-progress-table.test.tsx
@@ -174,6 +174,32 @@ describe('BulkBatchProgressTable', () => {
     ).toBeInTheDocument();
   });
 
+  it('renders a per-row Fix this one link when the record has a fix URL (#2234)', () => {
+    renderWithProviders(
+      <BulkBatchProgressTable
+        records={[rec({ productId: 'ol_product_1' })]}
+        buildFixUrl={(record) =>
+          `/listings/bulk-create/wizard?variantIds=${record.internalVariantId}`
+        }
+      />,
+    );
+
+    const link = screen.getByRole('link', { name: /Fix and resubmit ol_variant_abc/ });
+    expect(link).toHaveAttribute(
+      'href',
+      '/listings/bulk-create/wizard?variantIds=ol_variant_abc',
+    );
+  });
+
+  it('omits the per-row fix action when the record resolves to no fix URL (#2234)', () => {
+    renderWithProviders(
+      <BulkBatchProgressTable records={[rec()]} buildFixUrl={() => null} />,
+    );
+
+    expect(screen.queryByText('Fix this one')).not.toBeInTheDocument();
+    expect(screen.getByText('Details')).toBeInTheDocument();
+  });
+
   it('prefers the variant label over the raw id in the flat records table (#1741)', () => {
     renderWithProviders(
       <BulkBatchProgressTable

--- a/apps/web/src/features/listings/components/bulk/bulk-batch-progress-table.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-batch-progress-table.tsx
@@ -19,6 +19,7 @@
  * @module apps/web/src/features/listings/components/bulk
  */
 import { useMemo, useState, type ReactElement } from 'react';
+import { Link } from 'react-router-dom';
 import { Button, DataTable, StatusBadge, TimeDisplay } from '../../../../shared/ui';
 import type { DataTableColumn } from '../../../../shared/ui';
 import {
@@ -36,6 +37,13 @@ interface BulkBatchProgressTableProps {
   records: BulkBatchRecordSummary[];
   /** Marketplace URL builder (e.g. for Allegro: allegro.pl/oferta/...). */
   buildExternalOfferUrl?: (externalOfferId: string) => string;
+  /**
+   * Per-record bulk-wizard URL for the data-fix path (#2234). Returns null
+   * when this record carries no product link, so a mixed batch can still
+   * offer the action on the rows that do. Omitted entirely when the viewer
+   * cannot write.
+   */
+  buildFixUrl?: (record: BulkBatchRecordSummary) => string | null;
 }
 
 /** Statuses that count as a live offer for the per-product rollup (#1741). */
@@ -52,6 +60,7 @@ const VIRTUALIZE_THRESHOLD = 200;
 export function BulkBatchProgressTable({
   records,
   buildExternalOfferUrl,
+  buildFixUrl,
 }: BulkBatchProgressTableProps): ReactElement {
   const [detailRecord, setDetailRecord] = useState<BulkBatchRecordSummary | null>(null);
 
@@ -100,6 +109,7 @@ export function BulkBatchProgressTable({
           }
           if (record.status === 'failed') {
             const firstMessage = record.errors?.[0]?.message;
+            const fixUrl = buildFixUrl?.(record);
             return (
               <span className="bulk-batch__err-cell">
                 <span className="bulk-batch__err" title={firstMessage ?? 'Failed'}>
@@ -115,6 +125,15 @@ export function BulkBatchProgressTable({
                 >
                   Details
                 </Button>
+                {fixUrl !== null && fixUrl !== undefined ? (
+                  <Link
+                    className="button button--ghost button--xs"
+                    to={fixUrl}
+                    aria-label={`Fix and resubmit ${record.internalVariantId}`}
+                  >
+                    Fix this one
+                  </Link>
+                ) : null}
               </span>
             );
           }
@@ -146,7 +165,7 @@ export function BulkBatchProgressTable({
         hideBelow: 768,
       },
     ],
-    [buildExternalOfferUrl],
+    [buildExternalOfferUrl, buildFixUrl],
   );
 
   return (
@@ -160,8 +179,8 @@ export function BulkBatchProgressTable({
           </ul>
           {hasFailedGroup ? (
             <p className="dim" style={{ marginTop: 'var(--space-3)', fontSize: 12 }}>
-              Retry re-runs the saved data; a data fix is a new batch excluding the
-              already-live siblings.
+              Retry re-runs the saved data. Fix and resubmit opens the wizard on the
+              failed variants; already-live siblings are excluded.
             </p>
           ) : null}
         </section>

--- a/apps/web/src/features/listings/components/bulk/bulk-wizard.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-wizard.tsx
@@ -83,6 +83,13 @@ interface BulkWizardProps {
    * to the `/products` entry point.
    */
   preSelectedVariantIds?: ReadonlySet<string>;
+  /**
+   * Set when the wizard was reopened from a failed bulk batch's "Fix and
+   * resubmit" action (#2234). Renders a banner naming the batch so the
+   * pre-filled selection reads as intentional rather than as a bug. Purely
+   * informational - nothing in the submit path consumes it.
+   */
+  resumedFromBatchId?: string;
 }
 
 const WIZARD_STEPS: { id: BulkWizardStep; label: string }[] = [
@@ -110,6 +117,7 @@ export function BulkWizard({
   resolveConnectionName,
   preselectedConnectionId,
   preSelectedVariantIds,
+  resumedFromBatchId,
 }: BulkWizardProps): ReactElement {
   const navigate = useNavigate();
   const { showToast } = useToast();
@@ -637,6 +645,14 @@ export function BulkWizard({
             completedSteps={new Set(Array.from({ length: stepperCurrent }, (_, i) => i))}
           />
         </div>
+
+        {resumedFromBatchId !== undefined && resumedFromBatchId !== '' ? (
+          <Alert tone="info">
+            Resuming from batch <span className="mono-text">{resumedFromBatchId.slice(0, 8)}</span>
+            {' - '}the variants that failed there are pre-selected. Offers already live
+            are not included.
+          </Alert>
+        ) : null}
 
         {counts.noVariants > 0 ? (
           <Alert tone="warning">

--- a/apps/web/src/features/listings/lib/batch-recovery.test.ts
+++ b/apps/web/src/features/listings/lib/batch-recovery.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildBatchFixUrl,
+  describeBatchFixBlocker,
+  MAX_WIZARD_PRODUCTS,
+  resolveBatchFixTarget,
+  selectFailedRecords,
+} from './batch-recovery';
+import type { BulkBatchRecordSummary } from '../api/bulk-listings.types';
+
+function record(overrides: Partial<BulkBatchRecordSummary> = {}): BulkBatchRecordSummary {
+  return {
+    id: 'rec_1',
+    internalVariantId: 'ol_variant_1',
+    status: 'failed',
+    externalOfferId: null,
+    createdAt: '2026-08-20T10:00:00.000Z',
+    updatedAt: '2026-08-20T10:01:00.000Z',
+    errors: null,
+    productId: 'ol_product_1',
+    ...overrides,
+  };
+}
+
+describe('selectFailedRecords', () => {
+  it('should return only failed records when the batch is mixed', () => {
+    const records = [
+      record({ id: 'a', status: 'active' }),
+      record({ id: 'b', status: 'failed' }),
+      record({ id: 'c', status: 'pending' }),
+    ];
+
+    expect(selectFailedRecords(records).map((r) => r.id)).toEqual(['b']);
+  });
+});
+
+describe('resolveBatchFixTarget', () => {
+  it('should dedupe product ids and keep every variant id when records share a product', () => {
+    const target = resolveBatchFixTarget([
+      record({ id: 'a', internalVariantId: 'v1', productId: 'p1' }),
+      record({ id: 'b', internalVariantId: 'v2', productId: 'p1' }),
+    ]);
+
+    expect(target.productIds).toEqual(['p1']);
+    expect(target.variantIds).toEqual(['v1', 'v2']);
+    expect(target.blocker).toBeNull();
+  });
+
+  it('should block with no-product-link when no record carries a product id', () => {
+    const target = resolveBatchFixTarget([
+      record({ productId: null }),
+      record({ id: 'b', productId: undefined }),
+    ]);
+
+    expect(target.productIds).toEqual([]);
+    expect(target.blocker).toBe('no-product-link');
+  });
+
+  it('should ignore records without a product link when siblings have one', () => {
+    const target = resolveBatchFixTarget([
+      record({ id: 'a', internalVariantId: 'v1', productId: null }),
+      record({ id: 'b', internalVariantId: 'v2', productId: 'p2' }),
+    ]);
+
+    expect(target.productIds).toEqual(['p2']);
+    expect(target.variantIds).toEqual(['v1', 'v2']);
+    expect(target.blocker).toBeNull();
+  });
+
+  it('should block with over-product-cap when the deduped product count exceeds the wizard cap', () => {
+    const records = Array.from({ length: MAX_WIZARD_PRODUCTS + 1 }, (_, i) =>
+      record({ id: `r${i.toString()}`, internalVariantId: `v${i.toString()}`, productId: `p${i.toString()}` }),
+    );
+
+    expect(resolveBatchFixTarget(records).blocker).toBe('over-product-cap');
+  });
+
+  it('should block with no-product-link when there are no records at all', () => {
+    expect(resolveBatchFixTarget([]).blocker).toBe('no-product-link');
+  });
+});
+
+describe('buildBatchFixUrl', () => {
+  it('should carry products, variants, connection and the originating batch', () => {
+    const url = buildBatchFixUrl({
+      productIds: ['p1', 'p2'],
+      variantIds: ['v1', 'v2'],
+      connectionId: 'conn_1',
+      batchId: 'batch_1',
+    });
+
+    const query = new URLSearchParams(url.slice(url.indexOf('?')));
+    expect(url.startsWith('/listings/bulk-create/wizard?')).toBe(true);
+    expect(query.get('productIds')).toBe('p1,p2');
+    expect(query.get('variantIds')).toBe('v1,v2');
+    expect(query.get('connectionId')).toBe('conn_1');
+    expect(query.get('fromBatch')).toBe('batch_1');
+  });
+});
+
+describe('describeBatchFixBlocker', () => {
+  it('should state the reason and that retry still works for every blocker', () => {
+    expect(describeBatchFixBlocker('no-product-link')).toContain('Retry is unaffected.');
+    expect(describeBatchFixBlocker('over-product-cap')).toContain('Retry is unaffected.');
+  });
+});

--- a/apps/web/src/features/listings/lib/batch-recovery.ts
+++ b/apps/web/src/features/listings/lib/batch-recovery.ts
@@ -1,0 +1,100 @@
+/**
+ * Bulk batch recovery helpers (#2234)
+ *
+ * A terminal batch with failures has two ways out, and they are not two
+ * flavours of the same action: retry re-sends the saved payload (right for a
+ * transient error), while a data fix reopens the bulk wizard on the failed
+ * variants (the only thing that helps once the platform rejected the payload).
+ * This module owns the pure half of the second road - which records are
+ * recoverable, and the wizard URL that carries them.
+ *
+ * @module apps/web/src/features/listings/lib
+ */
+import type { BulkBatchRecordSummary } from '../api/bulk-listings.types';
+
+/**
+ * Product cap enforced by the bulk wizard route, which redirects back to
+ * /products above it. Shared so the recovery action can disable itself with a
+ * stated reason instead of routing into a bounce.
+ */
+export const MAX_WIZARD_PRODUCTS = 100;
+
+/** Why the fix action cannot be offered for a given failed set. */
+export const BatchFixBlockerValues = ['no-product-link', 'over-product-cap'] as const;
+export type BatchFixBlocker = (typeof BatchFixBlockerValues)[number];
+
+export interface BatchFixTarget {
+  /** Deduped owning product ids of the failed records. */
+  productIds: string[];
+  /** Failed variant ids, in record order. */
+  variantIds: string[];
+  /** Set when the fix action must be disabled; null when it can be offered. */
+  blocker: BatchFixBlocker | null;
+}
+
+/**
+ * Resolve the wizard target for a set of records.
+ *
+ * `productId` is optional on the record summary, so a batch whose records
+ * carry no product link yields `no-product-link` rather than a half-populated
+ * URL - the wizard hydrates from product ids and would bounce to /products.
+ */
+export function resolveBatchFixTarget(
+  records: readonly BulkBatchRecordSummary[],
+): BatchFixTarget {
+  const variantIds = records.map((record) => record.internalVariantId);
+  const productIds = [
+    ...new Set(
+      records
+        .map((record) => record.productId)
+        .filter((id): id is string => typeof id === 'string' && id.length > 0),
+    ),
+  ];
+
+  let blocker: BatchFixBlocker | null = null;
+  if (productIds.length === 0) {
+    blocker = 'no-product-link';
+  } else if (productIds.length > MAX_WIZARD_PRODUCTS) {
+    blocker = 'over-product-cap';
+  }
+
+  return { productIds, variantIds, blocker };
+}
+
+/** Failed records of a batch, in the order the table renders them. */
+export function selectFailedRecords(
+  records: readonly BulkBatchRecordSummary[],
+): BulkBatchRecordSummary[] {
+  return records.filter((record) => record.status === 'failed');
+}
+
+/**
+ * Bulk wizard URL carrying a recovery selection.
+ *
+ * `fromBatch` is read only to render the wizard's "resuming" banner - nothing
+ * in the submit path consumes it.
+ */
+export function buildBatchFixUrl(input: {
+  productIds: readonly string[];
+  variantIds: readonly string[];
+  connectionId: string;
+  batchId: string;
+}): string {
+  const params = new URLSearchParams({
+    productIds: input.productIds.join(','),
+    variantIds: input.variantIds.join(','),
+    connectionId: input.connectionId,
+    fromBatch: input.batchId,
+  });
+  return `/listings/bulk-create/wizard?${params.toString()}`;
+}
+
+/** Operator-facing reason a fix cannot be offered. */
+export function describeBatchFixBlocker(blocker: BatchFixBlocker): string {
+  switch (blocker) {
+    case 'no-product-link':
+      return 'Fix and resubmit needs the product link, which this batch did not record. Retry is unaffected.';
+    case 'over-product-cap':
+      return `Fix and resubmit handles up to ${MAX_WIZARD_PRODUCTS.toString()} products at a time. Retry is unaffected.`;
+  }
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -11180,6 +11180,33 @@ input.bulk-dispatch__num--wide {
   }
 }
 
+/* Recovery bar on a terminal batch with failures (#2234). Two ranked actions
+   share one row; the copy column carries the optional blocked-reason line. */
+.bulk-batch__recovery {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.bulk-batch__recovery-copy {
+  flex: 1 1 22rem;
+  min-width: 0;
+}
+
+.bulk-batch__recovery-reason {
+  margin-top: var(--space-1);
+  font-size: 12px;
+  color: var(--text-muted);
+}
+
+.bulk-batch__recovery-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
 .bulk-batch__summary {
   display: flex;
   align-items: center;

--- a/apps/web/src/pages/listings/bulk-batch-progress-page.test.tsx
+++ b/apps/web/src/pages/listings/bulk-batch-progress-page.test.tsx
@@ -1,7 +1,11 @@
 import { cleanup, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { renderWithProviders, createMockApiClient } from '../../test/test-utils';
+import {
+  renderWithProviders,
+  createMockApiClient,
+  createAuthenticatedSessionAdapter,
+} from '../../test/test-utils';
 import { Routes, Route } from 'react-router-dom';
 import { BulkBatchProgressPage } from './bulk-batch-progress-page';
 import type { BulkBatchSummary } from '../../features/listings/api/bulk-listings.types';
@@ -42,7 +46,27 @@ function makeBatch(overrides: Partial<BulkBatchSummary> = {}): BulkBatchSummary 
   };
 }
 
-function renderPage(apiClient: ReturnType<typeof createMockApiClient>) {
+function failedRecord(
+  overrides: Partial<BulkBatchSummary['records'][number]> = {},
+): BulkBatchSummary['records'][number] {
+  return {
+    id: 'rec_f',
+    internalVariantId: 'ol_variant_333',
+    status: 'failed',
+    externalOfferId: null,
+    createdAt: '2026-05-18T15:00:02.000Z',
+    updatedAt: '2026-05-18T15:01:00.000Z',
+    errors: [{ code: 'REJECTED', message: 'Produkt juz istnieje w Katalogu' }],
+    productId: 'ol_product_aaa',
+    ...overrides,
+  };
+}
+
+function renderPage(
+  apiClient: ReturnType<typeof createMockApiClient>,
+  options: { authenticated?: boolean } = {},
+) {
+  const { authenticated = true } = options;
   return renderWithProviders(
     <Routes>
       <Route path="/listings/bulk-batches/:batchId" element={<BulkBatchProgressPage />} />
@@ -50,6 +74,9 @@ function renderPage(apiClient: ReturnType<typeof createMockApiClient>) {
     {
       apiClient,
       route: `/listings/bulk-batches/${BATCH_ID}`,
+      // The recovery actions are permission-gated (#2234), so the default
+      // no-op (anonymous) adapter would hide them.
+      ...(authenticated ? { sessionAdapter: createAuthenticatedSessionAdapter() } : {}),
     },
   );
 }
@@ -79,7 +106,7 @@ describe('BulkBatchProgressPage', () => {
     expect(totals.length).toBeGreaterThan(0);
   });
 
-  it('shows the partially-failed banner with Retry button when terminal with failures', async () => {
+  it('shows the recovery bar with both actions when terminal with failures', async () => {
     const apiClient = createMockApiClient({
       listings: {
         getBulkBatch: vi.fn().mockResolvedValue(
@@ -95,11 +122,11 @@ describe('BulkBatchProgressPage', () => {
     renderPage(apiClient);
 
     expect(
-      await screen.findByRole('button', { name: /Retry all failed/ }),
+      await screen.findByRole('button', { name: /Retry unchanged/ }),
     ).toBeInTheDocument();
   });
 
-  it('does not show the Retry banner when batch is still running', async () => {
+  it('does not show the recovery bar when batch is still running', async () => {
     const apiClient = createMockApiClient({
       listings: {
         getBulkBatch: vi.fn().mockResolvedValue(makeBatch({ status: 'running' })),
@@ -110,8 +137,107 @@ describe('BulkBatchProgressPage', () => {
 
     await screen.findByText('Total');
     expect(
-      screen.queryByRole('button', { name: /Retry all failed/ }),
+      screen.queryByRole('button', { name: /Retry unchanged/ }),
     ).not.toBeInTheDocument();
+  });
+
+  it('shows the recovery bar on a fully failed batch', async () => {
+    const apiClient = createMockApiClient({
+      listings: {
+        getBulkBatch: vi.fn().mockResolvedValue(
+          makeBatch({
+            status: 'failed',
+            totalCount: 1,
+            succeededCount: 0,
+            failedCount: 1,
+            records: [failedRecord()],
+          }),
+        ),
+      },
+    });
+
+    renderPage(apiClient);
+
+    expect(
+      await screen.findByText('1 variant failed. Nothing went live.'),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Retry unchanged \(1\)/ })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /Fix and resubmit \(1\)/ })).toBeInTheDocument();
+  });
+
+  it('links Fix and resubmit to the wizard with the failed products, variants and connection', async () => {
+    const apiClient = createMockApiClient({
+      listings: {
+        getBulkBatch: vi.fn().mockResolvedValue(
+          makeBatch({
+            status: 'partially-failed',
+            totalCount: 3,
+            succeededCount: 2,
+            failedCount: 1,
+            records: [failedRecord()],
+          }),
+        ),
+      },
+    });
+
+    renderPage(apiClient);
+
+    const link = await screen.findByRole('link', { name: /Fix and resubmit \(1\) →/ });
+    const href = link.getAttribute('href') ?? '';
+    const query = new URLSearchParams(href.slice(href.indexOf('?')));
+    expect(href.startsWith('/listings/bulk-create/wizard?')).toBe(true);
+    expect(query.get('productIds')).toBe('ol_product_aaa');
+    expect(query.get('variantIds')).toBe('ol_variant_333');
+    expect(query.get('connectionId')).toBe('conn_1');
+    expect(query.get('fromBatch')).toBe(BATCH_ID);
+  });
+
+  it('disables Fix and resubmit and states why when no record carries a product link', async () => {
+    const apiClient = createMockApiClient({
+      listings: {
+        getBulkBatch: vi.fn().mockResolvedValue(
+          makeBatch({
+            status: 'failed',
+            totalCount: 1,
+            succeededCount: 0,
+            failedCount: 1,
+            records: [failedRecord({ productId: null })],
+          }),
+        ),
+      },
+    });
+
+    renderPage(apiClient);
+
+    expect(
+      await screen.findByRole('button', { name: /Fix and resubmit/ }),
+    ).toBeDisabled();
+    expect(
+      screen.getByText(/needs the product link, which this batch did not record/),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Retry unchanged/ })).toBeEnabled();
+  });
+
+  it('hides the recovery bar for a session without listings:write', async () => {
+    const apiClient = createMockApiClient({
+      listings: {
+        getBulkBatch: vi.fn().mockResolvedValue(
+          makeBatch({
+            status: 'failed',
+            totalCount: 1,
+            succeededCount: 0,
+            failedCount: 1,
+            records: [failedRecord()],
+          }),
+        ),
+      },
+    });
+
+    renderPage(apiClient, { authenticated: false });
+
+    await screen.findByText('Total');
+    expect(screen.queryByRole('button', { name: /Retry unchanged/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: /Fix and resubmit/ })).not.toBeInTheDocument();
   });
 
   it('shows error state when the fetch fails', async () => {
@@ -163,7 +289,7 @@ describe('BulkBatchProgressPage', () => {
     renderPage(apiClient);
 
     const retryBtn = await screen.findByRole('button', {
-      name: /Retry all failed/,
+      name: /Retry unchanged/,
     });
     await user.click(retryBtn);
 

--- a/apps/web/src/pages/listings/bulk-batch-progress-page.tsx
+++ b/apps/web/src/pages/listings/bulk-batch-progress-page.tsx
@@ -20,15 +20,28 @@ import {
   PageLayout,
   StatusBadge,
 } from '../../shared/ui';
+import { ReadOnlyLock } from '../../shared/ui/read-only-lock';
 import { useToast } from '../../shared/ui/toast-provider';
+import { useWriteAccess } from '../../shared/auth/use-permission';
+import { useDemoMode } from '../../features/system';
 import { BulkBatchProgressTable } from '../../features/listings/components/bulk/bulk-batch-progress-table';
+import {
+  buildBatchFixUrl,
+  describeBatchFixBlocker,
+  resolveBatchFixTarget,
+  selectFailedRecords,
+} from '../../features/listings/lib/batch-recovery';
 import { useBulkBatchQuery } from '../../features/listings/hooks/use-bulk-batch-query';
 import { useBulkRetryFailedMutation } from '../../features/listings/hooks/use-bulk-retry-failed-mutation';
 import { useConnectionsQuery } from '../../features/connections';
 import {
   TERMINAL_BULK_BATCH_STATUSES,
+  type BulkBatchRecordSummary,
   type BulkBatchStatus,
 } from '../../features/listings/api/bulk-listings.types';
+
+/** Tooltip copy for a demo viewer, matching the wizard's own locked submit. */
+const DEMO_LOCK_MESSAGE = 'Read-only demo - recovery actions are disabled.';
 
 export function BulkBatchProgressPage(): ReactElement {
   const { batchId } = useParams<{ batchId: string }>();
@@ -36,6 +49,35 @@ export function BulkBatchProgressPage(): ReactElement {
   const retryMutation = useBulkRetryFailedMutation();
   const connectionsQuery = useConnectionsQuery();
   const { showToast } = useToast();
+  const demoMode = useDemoMode();
+  // Both recovery actions are writes on the same resource, so they share the
+  // gate the wizard's own submit uses (#1615 visible-but-disabled in demo).
+  const write = useWriteAccess('listings:write', demoMode);
+
+  const failedRecords = useMemo(
+    () => selectFailedRecords(query.data?.records ?? []),
+    [query.data],
+  );
+  const fixTarget = useMemo(() => resolveBatchFixTarget(failedRecords), [failedRecords]);
+
+  const batchId_ = query.data?.id;
+  const batchConnectionId = query.data?.connectionId;
+  // Stable identity so the records table doesn't rebuild its column model on
+  // every poll tick.
+  const buildRowFixUrl = useCallback(
+    (record: BulkBatchRecordSummary): string | null => {
+      if (batchId_ === undefined || batchConnectionId === undefined) return null;
+      const target = resolveBatchFixTarget([record]);
+      if (target.blocker !== null) return null;
+      return buildBatchFixUrl({
+        productIds: target.productIds,
+        variantIds: target.variantIds,
+        connectionId: batchConnectionId,
+        batchId: batchId_,
+      });
+    },
+    [batchId_, batchConnectionId],
+  );
 
   const inProgress = useMemo(() => {
     if (!query.data) return 0;
@@ -161,7 +203,13 @@ export function BulkBatchProgressPage(): ReactElement {
         <MetricCard
           label={`Failed · ${failedPct.toString()}%`}
           value={batch.failedCount.toLocaleString()}
-          description={batch.failedCount > 0 ? 'Retry available below' : 'No failures'}
+          description={
+            batch.failedCount === 0
+              ? 'No failures'
+              : write.visible
+                ? 'Recovery available below'
+                : 'Recovery needs write access'
+          }
           tone={batch.failedCount > 0 ? 'error' : 'neutral'}
         />
         <MetricCard
@@ -178,27 +226,73 @@ export function BulkBatchProgressPage(): ReactElement {
         </Alert>
       ) : null}
 
-      {batch.status === 'partially-failed' && batch.failedCount > 0 ? (
+      {/* Recovery bar (#2234). Gated on the terminal-with-failures state, not
+          on `partially-failed` alone - a batch where everything failed used to
+          render no recovery control at all while the Failed metric card still
+          read "Retry available below". The two actions are ranked rather than
+          equivalent: a payload the platform rejected cannot be healed by
+          re-sending it, so the data fix leads and retry stays one click away
+          for the transient case. */}
+      {isTerminal && batch.failedCount > 0 && write.visible ? (
         <Alert tone="warning">
-          <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--space-3)' }}>
-            <div style={{ flex: 1 }}>
-              <strong>Batch ended with {batch.failedCount.toLocaleString()} {batch.failedCount === 1 ? 'failure' : 'failures'}.</strong>{' '}
-              You can retry all of them in one click — successful offers won't be touched.
+          <div className="bulk-batch__recovery">
+            <div className="bulk-batch__recovery-copy">
+              <strong>
+                {batch.succeededCount === 0
+                  ? `${batch.failedCount.toLocaleString()} ${batch.failedCount === 1 ? 'variant' : 'variants'} failed. Nothing went live.`
+                  : `${batch.failedCount.toLocaleString()} of ${batch.totalCount.toLocaleString()} variants failed. ${batch.succeededCount.toLocaleString()} ${batch.succeededCount === 1 ? 'offer is' : 'offers are'} live.`}
+              </strong>{' '}
+              Reopen the wizard with the failed variants already selected, or re-run the
+              batch exactly as saved.
+              {fixTarget.blocker !== null ? (
+                <div className="bulk-batch__recovery-reason">
+                  {describeBatchFixBlocker(fixTarget.blocker)}
+                </div>
+              ) : null}
             </div>
-            <Button
-              tone="primary"
-              onClick={() => { void handleRetryAll(); }}
-              disabled={retryMutation.isPending}
-            >
-              {retryMutation.isPending
-                ? 'Retrying…'
-                : `Retry all failed (${batch.failedCount.toLocaleString()})`}
-            </Button>
+            <div className="bulk-batch__recovery-actions">
+              <ReadOnlyLock active={write.demoReadOnly} message={DEMO_LOCK_MESSAGE}>
+                <Button
+                  tone="secondary"
+                  onClick={() => { void handleRetryAll(); }}
+                  disabled={!write.canWrite || retryMutation.isPending}
+                >
+                  {retryMutation.isPending
+                    ? 'Retrying…'
+                    : `Retry unchanged (${batch.failedCount.toLocaleString()})`}
+                </Button>
+              </ReadOnlyLock>
+              {fixTarget.blocker === null && write.canWrite ? (
+                <Link
+                  className="button button--primary"
+                  to={buildBatchFixUrl({
+                    productIds: fixTarget.productIds,
+                    variantIds: fixTarget.variantIds,
+                    connectionId: batch.connectionId,
+                    batchId: batch.id,
+                  })}
+                >
+                  Fix and resubmit ({failedRecords.length.toLocaleString()}) →
+                </Link>
+              ) : (
+                <ReadOnlyLock
+                  active={write.demoReadOnly}
+                  message={DEMO_LOCK_MESSAGE}
+                >
+                  <Button tone="primary" disabled>
+                    Fix and resubmit ({failedRecords.length.toLocaleString()}) →
+                  </Button>
+                </ReadOnlyLock>
+              )}
+            </div>
           </div>
         </Alert>
       ) : null}
 
-      <BulkBatchProgressTable records={batch.records} />
+      <BulkBatchProgressTable
+        records={batch.records}
+        buildFixUrl={write.canWrite ? buildRowFixUrl : undefined}
+      />
 
       {isTerminal ? (
         <div className="bulk-batch__summary">

--- a/apps/web/src/pages/listings/bulk-create-wizard-page.tsx
+++ b/apps/web/src/pages/listings/bulk-create-wizard-page.tsx
@@ -11,6 +11,10 @@
  * render:
  *   - empty productIds  → redirect back to /products
  *   - >100 productIds   → redirect back to /products with an alert
+ *
+ * An optional `?fromBatch=` param (#2234) marks the load as a recovery of a
+ * failed bulk batch; it is forwarded to the wizard for its resuming banner and
+ * is never read by the submit path.
  *   - loading           → LoadingState
  *   - product-fetch errors → ErrorState with retry
  *
@@ -24,11 +28,17 @@ import {
   LoadingState,
 } from '../../shared/ui';
 import { BulkWizard } from '../../features/listings/components/bulk/bulk-wizard';
+import { MAX_WIZARD_PRODUCTS } from '../../features/listings/lib/batch-recovery';
 import { useConnectionsQuery } from '../../features/connections';
 import { useProductsBatchQuery } from '../../features/products';
 import type { Product } from '../../features/products';
 
-const MAX_PRODUCTS = 100;
+/**
+ * Shared with the batch-recovery helpers (#2234) so the failed-batch "Fix and
+ * resubmit" action disables itself at the same cap this route enforces,
+ * instead of routing into a redirect.
+ */
+const MAX_PRODUCTS = MAX_WIZARD_PRODUCTS;
 
 export function BulkCreateWizardPage(): ReactElement {
   const [searchParams] = useSearchParams();
@@ -127,6 +137,7 @@ export function BulkCreateWizardPage(): ReactElement {
       products={products}
       preSelectedVariantIds={selectedVariantIds}
       preselectedConnectionId={searchParams.get('connectionId') ?? undefined}
+      resumedFromBatchId={searchParams.get('fromBatch') ?? undefined}
       resolveConnectionName={(connectionId) =>
         connectionsQuery.data?.find((c) => c.id === connectionId)?.name ??
         connectionId

--- a/libs/core/src/listings/application/services/__tests__/bulk-listing-submit.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/bulk-listing-submit.service.spec.ts
@@ -40,7 +40,9 @@ describe('BulkListingSubmitService', () => {
   let offerMappings: jest.Mocked<Pick<OfferMappingRepositoryPort, 'countByConnectionAndVariants'>>;
   let enqueueService: jest.Mocked<IOfferCreationEnqueueService>;
   let integrations: jest.Mocked<IIntegrationsService>;
-  let products: jest.Mocked<Pick<IProductsService, 'getVariant' | 'getVariantsByProductId'>>;
+  let products: jest.Mocked<
+    Pick<IProductsService, 'getVariant' | 'getVariantsByProductId' | 'getVariantsByIds'>
+  >;
   let inventoryQuery: jest.Mocked<Pick<IInventoryQueryService, 'getAvailabilityByVariantIds'>>;
 
   const connectionId = 'conn-1';
@@ -156,6 +158,7 @@ describe('BulkListingSubmitService', () => {
     products = {
       getVariant: jest.fn().mockResolvedValue(null),
       getVariantsByProductId: jest.fn().mockResolvedValue([]),
+      getVariantsByIds: jest.fn().mockResolvedValue([]),
     };
     inventoryQuery = {
       getAvailabilityByVariantIds: jest.fn().mockResolvedValue([]),
@@ -1326,13 +1329,57 @@ describe('BulkListingSubmitService', () => {
     it('returns batch + per-product records when found', async () => {
       const batch = makeBatch();
       bulkBatchRepo.findById.mockResolvedValue(batch);
-      const records = [{ id: 'r-1' } as unknown as OfferCreationRecord];
+      const records = [
+        { id: 'r-1', internalVariantId: 'v-a' } as unknown as OfferCreationRecord,
+      ];
       offerCreationRecords.findByBulkBatchId.mockResolvedValue(records);
 
       const result = await service.getBatch('batch-1');
 
-      expect(result).toEqual({ batch, records });
+      expect(result).toEqual({ batch, records, productIdByVariantId: {} });
       expect(offerCreationRecords.findByBulkBatchId).toHaveBeenCalledWith('batch-1');
+    });
+
+    it('resolves each record variant to its owning product in one batched lookup (#2234)', async () => {
+      bulkBatchRepo.findById.mockResolvedValue(makeBatch());
+      offerCreationRecords.findByBulkBatchId.mockResolvedValue([
+        { id: 'r-1', internalVariantId: 'v-a' } as unknown as OfferCreationRecord,
+        { id: 'r-2', internalVariantId: 'v-b' } as unknown as OfferCreationRecord,
+        // Same variant twice: the lookup must be deduped.
+        { id: 'r-3', internalVariantId: 'v-a' } as unknown as OfferCreationRecord,
+      ]);
+      products.getVariantsByIds.mockResolvedValue([
+        { id: 'v-a', productId: 'p-1' } as unknown as ProductVariant,
+        { id: 'v-b', productId: 'p-2' } as unknown as ProductVariant,
+      ]);
+
+      const result = await service.getBatch('batch-1');
+
+      expect(products.getVariantsByIds).toHaveBeenCalledTimes(1);
+      expect(products.getVariantsByIds).toHaveBeenCalledWith(['v-a', 'v-b']);
+      expect(result?.productIdByVariantId).toEqual({ 'v-a': 'p-1', 'v-b': 'p-2' });
+    });
+
+    it('omits a variant that no longer resolves rather than defaulting it (#2234)', async () => {
+      bulkBatchRepo.findById.mockResolvedValue(makeBatch());
+      offerCreationRecords.findByBulkBatchId.mockResolvedValue([
+        { id: 'r-1', internalVariantId: 'v-gone' } as unknown as OfferCreationRecord,
+      ]);
+      products.getVariantsByIds.mockResolvedValue([]);
+
+      const result = await service.getBatch('batch-1');
+
+      expect(result?.productIdByVariantId).toEqual({});
+    });
+
+    it('skips the variant lookup for a batch with no records (#2234)', async () => {
+      bulkBatchRepo.findById.mockResolvedValue(makeBatch());
+      offerCreationRecords.findByBulkBatchId.mockResolvedValue([]);
+
+      const result = await service.getBatch('batch-1');
+
+      expect(products.getVariantsByIds).not.toHaveBeenCalled();
+      expect(result?.productIdByVariantId).toEqual({});
     });
   });
 });

--- a/libs/core/src/listings/application/services/bulk-listing-submit.service.ts
+++ b/libs/core/src/listings/application/services/bulk-listing-submit.service.ts
@@ -46,6 +46,7 @@ import type {
   BulkBatchStatus,
   BulkListingBatch,
   CreateOfferOverrides,
+  OfferCreationRecord,
   OfferManagerPort,
 } from '@openlinker/core/listings';
 import {
@@ -323,7 +324,33 @@ export class BulkListingSubmitService implements IBulkListingSubmitService {
       return null;
     }
     const records = await this.offerCreationRecords.findByBulkBatchId(batchId);
-    return { batch, records };
+    return {
+      batch,
+      records,
+      productIdByVariantId: await this.resolveProductIds(records),
+    };
+  }
+
+  /**
+   * Map each record's variant id to its owning product id (#2234). The FE
+   * needs product ids to reopen the bulk wizard on a failed batch's variants,
+   * and neither `OfferCreationRecord` nor its request snapshot carries one.
+   * One batched lookup per page load; a variant that no longer resolves is
+   * omitted rather than defaulted, so the caller can tell "no product link"
+   * apart from a wrong one.
+   */
+  private async resolveProductIds(
+    records: readonly OfferCreationRecord[]
+  ): Promise<Record<string, string>> {
+    const variantIds = [...new Set(records.map((record) => record.internalVariantId))];
+    if (variantIds.length === 0) return {};
+
+    const variants = await this.productsService.getVariantsByIds(variantIds);
+    const productIdByVariantId: Record<string, string> = {};
+    for (const variant of variants) {
+      productIdByVariantId[variant.id] = variant.productId;
+    }
+    return productIdByVariantId;
   }
 
   /**

--- a/libs/core/src/listings/application/types/bulk-listing-submit.types.ts
+++ b/libs/core/src/listings/application/types/bulk-listing-submit.types.ts
@@ -177,4 +177,12 @@ export interface BulkBatchSummary {
    * review table renders rows in submission order even after retries.
    */
   records: OfferCreationRecord[];
+  /**
+   * Owning product id per record variant id (#2234). Resolved with one batched
+   * variant lookup rather than a per-record fan-out, and carried beside
+   * `records` so `OfferCreationRecord` (which has no product column, nor one on
+   * its request snapshot) stays untouched. A variant that no longer resolves is
+   * simply absent from the map.
+   */
+  productIdByVariantId: Record<string, string>;
 }

--- a/libs/core/src/products/application/services/products.service.interface.ts
+++ b/libs/core/src/products/application/services/products.service.interface.ts
@@ -79,6 +79,14 @@ export interface IProductsService {
   getVariantsBySkus(skus: string[]): Promise<ProductVariant[]>;
 
   /**
+   * Variant lookup by internal variant id list. Batched counterpart to
+   * `getVariant`, for callers holding a set of variant ids that need each
+   * one's owning product without a per-id fan-out (#2234). Empty input
+   * returns `[]` without a DB round-trip; unknown ids are omitted.
+   */
+  getVariantsByIds(ids: readonly string[]): Promise<ProductVariant[]>;
+
+  /**
    * Variant lookup by EAN or GTIN list, scoped to a master-catalog
    * connection. The connection scope ensures variants on a different
    * master tenant don't collide on the same barcode. Empty input returns

--- a/libs/core/src/products/application/services/products.service.spec.ts
+++ b/libs/core/src/products/application/services/products.service.spec.ts
@@ -60,6 +60,7 @@ describe('ProductsService', () => {
     countByProductIds: jest.fn(),
     findBySku: jest.fn(),
     findBySkuIn: jest.fn(),
+    findByIdIn: jest.fn(),
     findByEanOrGtinIn: jest.fn(),
     upsert: jest.fn(),
     upsertMany: jest.fn(),

--- a/libs/core/src/products/application/services/products.service.ts
+++ b/libs/core/src/products/application/services/products.service.ts
@@ -91,6 +91,11 @@ export class ProductsService implements IProductsService {
     return this.variantRepository.findBySkuIn(skus);
   }
 
+  async getVariantsByIds(ids: readonly string[]): Promise<ProductVariant[]> {
+    if (ids.length === 0) return [];
+    return this.variantRepository.findByIdIn(ids);
+  }
+
   async getVariantsByBarcodes(
     connectionId: string,
     values: string[],

--- a/libs/core/src/products/domain/ports/product-variant-repository.port.ts
+++ b/libs/core/src/products/domain/ports/product-variant-repository.port.ts
@@ -67,6 +67,18 @@ export interface ProductVariantRepositoryPort {
   findBySkuIn(skus: string[]): Promise<ProductVariant[]>;
 
   /**
+   * Find variants by internal variant id list
+   *
+   * Batched counterpart to `findById`. Used where a caller holds a set of
+   * variant ids and needs their owning products in one query rather than a
+   * per-id fan-out (e.g. the bulk-batch summary projection, #2234).
+   *
+   * @param ids - Array of internal OpenLinker variant IDs
+   * @returns Array of product variant domain entities (missing ids are omitted)
+   */
+  findByIdIn(ids: readonly string[]): Promise<ProductVariant[]>;
+
+  /**
    * Find variants by EAN or GTIN list, scoped to master catalog connection
    *
    * @param connectionId - Master catalog connection ID

--- a/libs/core/src/products/infrastructure/persistence/repositories/product-variant.repository.ts
+++ b/libs/core/src/products/infrastructure/persistence/repositories/product-variant.repository.ts
@@ -97,6 +97,18 @@ export class ProductVariantRepository implements ProductVariantRepositoryPort {
     return entities.map((entity) => this.toDomain(entity));
   }
 
+  async findByIdIn(ids: readonly string[]): Promise<ProductVariant[]> {
+    if (ids.length === 0) {
+      return [];
+    }
+
+    const entities = await this.repository.find({
+      where: { id: In([...ids]) },
+    });
+
+    return entities.map((entity) => this.toDomain(entity));
+  }
+
   async findByEanOrGtinIn(
     connectionId: string,
     values: string[],


### PR DESCRIPTION
**Design artifact:** https://claude.ai/code/artifact/d834c30d-bbae-4fcb-9d55-ba85decfb6f2

Closes #2234

## What this changes

A bulk batch that failed on bad data was a dead end. The progress page offered one control - re-run the identical payload - while the table's own copy already promised the other road: *"a data fix is a new batch excluding the already-live siblings."* That road had no control, so changing a rejected category, EAN or title meant leaving the page, re-finding every product under `/products` and rebuilding the batch by hand.

Two defects close here.

### 1. No route back to the data

The recovery bar now carries two ranked actions:

| Action | Behaviour |
|---|---|
| **Fix and resubmit (N) →** (primary) | Deep-links to the bulk wizard with the failed variants, their products and the same connection already selected. |
| **Retry unchanged (N)** (secondary) | The existing re-run, unchanged behaviour, clearer label. |

The fix leads because a payload the platform rejected cannot be healed by re-sending it; retry stays one click away for the transient case, which the operator identifies from the reason column. Failed rows also carry a per-row **"Fix this one"**, so a mixed batch can be repaired one variant at a time.

### 2. A fully failed batch rendered no recovery control at all

The banner was gated on `batch.status === 'partially-failed'`, so a batch where *everything* failed showed the failure, the reason, and nothing to press - while the Failed metric card still read "Retry available below". The bar now keys on `isTerminal && failedCount > 0`.

## How

No new endpoint. `bulk-create-wizard-page.tsx` already reads `productIds`, `variantIds` and `connectionId` from the query string. It gains an optional `fromBatch`, read **only** to render a "Resuming from batch …" banner so the pre-filled selection reads as intentional; nothing in the submit path consumes it.

The one backend addition is the product link the fix path needs. `OfferCreationRecord` has no product column and neither does its `request` snapshot, so `BulkListingSubmitService.getBatch` resolves it from the variants in one batched lookup (`IProductsService.getVariantsByIds` → `ProductVariantRepositoryPort.findByIdIn`) and returns it beside the records as `productIdByVariantId`; the controller folds it into each record DTO as `productId`. The FE type already declared that field optional against this exact follow-up (`bulk-listings.types.ts`).

Guard rails:

- A variant that no longer resolves stays `null` rather than being defaulted. The fix action then disables itself with the reason stated inline (`"…needs the product link, which this batch did not record. Retry is unaffected."`) instead of routing into a wizard that would bounce back to `/products`. Same treatment above the wizard's 100-product cap, which is now a shared constant so the two cannot drift.
- Both actions sit behind `listings:write`, matching the wizard's own submit gate - a demo viewer sees them disabled rather than missing, and the Failed card no longer claims recovery is available to a session that cannot use it.

## Out of scope

Carrying the operator's per-variant edits from the original batch into the reopened wizard. The wizard rehydrates each product from the catalogue, so the prefill restores *which* variants and *which* connection, not the per-row overrides typed the first time. Reading those back from the persisted request snapshot is a separate, backend-shaped change.

## Testing

- `apps/web/src/features/listings/lib/batch-recovery.test.ts` - new: product-id dedup, the two blockers, records with a partial product link, URL shape.
- `bulk-batch-progress-page.test.tsx` - bar on a fully failed batch, the built wizard URL, the disabled+reason path, hidden without `listings:write`.
- `bulk-batch-progress-table.test.tsx` - per-row action present / absent.
- `bulk-listing-submit.service.spec.ts` - `getBatch` deduped batched lookup, unresolved variant omitted, no lookup for an empty batch.
- `bulk-listing.controller.spec.ts` - `productId` in the DTO projection.

`pnpm lint` and `pnpm type-check` pass clean; the touched suites pass (web via vitest, core + api via jest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
