### PR TITLE
feat(web): show the destination integration + step-1 config on every bulk wizard step

### DIFF
--- a/apps/web/src/features/listings/components/bulk/bulk-config-summary.test.ts
+++ b/apps/web/src/features/listings/components/bulk/bulk-config-summary.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Bulk config summary tests (#2227)
+ *
+ * Pins the policy descriptions, the changed-from-default list (an all-defaults
+ * batch must produce NO entries, since that is what suppresses the bar's chip),
+ * and the open-world `platformParams` formatting.
+ */
+import { describe, expect, it } from 'vitest';
+import {
+  buildBulkConfigRows,
+  collectBulkConfigChanges,
+  describePricingPolicy,
+  describeStockPolicy,
+  formatPlatformParamValue,
+  humanizeParamKey,
+  readConnectionEnvironment,
+} from './bulk-config-summary';
+import type { BulkWizardConfig } from './bulk-wizard.types';
+
+function makeConfig(over: Partial<BulkWizardConfig> = {}): BulkWizardConfig {
+  return {
+    connectionId: 'conn-1',
+    platformParams: {},
+    currency: 'PLN',
+    pricingPolicy: { mode: 'use-master' },
+    stockPolicy: { mode: 'use-master' },
+    publishImmediately: true,
+    generateDescription: false,
+    ...over,
+  };
+}
+
+describe('readConnectionEnvironment', () => {
+  it('should return the environment when the config carries a known value', () => {
+    expect(readConnectionEnvironment({ environment: 'sandbox' })).toBe('sandbox');
+    expect(readConnectionEnvironment({ environment: 'production' })).toBe('production');
+  });
+
+  it('should return null when the environment is absent, unknown or not a string', () => {
+    expect(readConnectionEnvironment({})).toBeNull();
+    expect(readConnectionEnvironment(undefined)).toBeNull();
+    expect(readConnectionEnvironment({ environment: 'staging' })).toBeNull();
+    expect(readConnectionEnvironment({ environment: 1 })).toBeNull();
+  });
+});
+
+describe('describePricingPolicy', () => {
+  it('should describe every pricing mode', () => {
+    expect(describePricingPolicy({ mode: 'use-master' }, 'PLN')).toBe('Master price');
+    expect(describePricingPolicy({ mode: 'markup', percent: 12 }, 'PLN')).toBe('Master price +12%');
+    expect(describePricingPolicy({ mode: 'flat', amount: 39 }, 'PLN')).toBe('Flat 39.00 PLN');
+  });
+
+  it('should not print a double sign when the markup is negative', () => {
+    expect(describePricingPolicy({ mode: 'markup', percent: -5 }, 'PLN')).toBe('Master price -5%');
+  });
+});
+
+describe('describeStockPolicy', () => {
+  it('should describe every stock mode', () => {
+    expect(describeStockPolicy({ mode: 'use-master' })).toBe('Master stock');
+    expect(describeStockPolicy({ mode: 'cap', value: 20 })).toBe('Master stock, capped at 20');
+    expect(describeStockPolicy({ mode: 'flat', value: 5 })).toBe('Flat 5');
+  });
+});
+
+describe('collectBulkConfigChanges', () => {
+  it('should report no changes when the batch runs entirely on defaults', () => {
+    expect(collectBulkConfigChanges(makeConfig())).toEqual([]);
+  });
+
+  it('should report a single change when only the price policy moved', () => {
+    expect(collectBulkConfigChanges(makeConfig({ pricingPolicy: { mode: 'markup', percent: 12 } }))).toEqual([
+      { label: 'Price', value: 'Master price +12%' },
+    ]);
+  });
+
+  it('should report every changed setting when several moved', () => {
+    const changes = collectBulkConfigChanges(
+      makeConfig({
+        pricingPolicy: { mode: 'flat', amount: 39 },
+        stockPolicy: { mode: 'cap', value: 20 },
+        publishImmediately: false,
+        generateDescription: true,
+      }),
+    );
+    expect(changes.map((c) => c.label)).toEqual(['Price', 'Stock', 'On create', 'Description']);
+  });
+});
+
+describe('formatPlatformParamValue', () => {
+  it('should render every value shape readably', () => {
+    expect(formatPlatformParamValue('Standard 24h')).toBe('Standard 24h');
+    expect(formatPlatformParamValue(24)).toBe('24');
+    expect(formatPlatformParamValue(true)).toBe('true');
+    expect(formatPlatformParamValue(['a', 'b'])).toBe('a, b');
+  });
+
+  it('should report an absent value instead of an empty cell', () => {
+    expect(formatPlatformParamValue(null)).toBe('Not set');
+    expect(formatPlatformParamValue(undefined)).toBe('Not set');
+    expect(formatPlatformParamValue('')).toBe('Not set');
+    expect(formatPlatformParamValue([])).toBe('Not set');
+  });
+
+  it('should never surface an object as [object Object]', () => {
+    expect(formatPlatformParamValue({ id: 7 })).toBe('{"id":7}');
+  });
+});
+
+describe('humanizeParamKey', () => {
+  it('should turn an open-world param key into a label', () => {
+    expect(humanizeParamKey('deliveryPolicyId')).toBe('Delivery policy id');
+    expect(humanizeParamKey('dispatch_time')).toBe('Dispatch time');
+  });
+});
+
+describe('buildBulkConfigRows', () => {
+  it('should list the whole config, ending with the integration and connection id', () => {
+    const rows = buildBulkConfigRows({
+      config: makeConfig({ platformParams: { deliveryPolicyId: 'Standard 24h' } }),
+      platformLabel: 'Allegro',
+      platformType: 'allegro',
+      connectionIdLabel: 'conn…-1',
+    });
+
+    expect(rows.map((r) => r.id)).toEqual([
+      'currency',
+      'price',
+      'stock',
+      'on-create',
+      'description',
+      'param-deliveryPolicyId',
+      'platform',
+      'connection-id',
+    ]);
+    expect(rows.find((r) => r.id === 'platform')?.value).toBe('Allegro (allegro)');
+    expect(rows.find((r) => r.id === 'connection-id')?.mono).toBe(true);
+  });
+
+  it('should say where the description comes from in both directions', () => {
+    const base = { platformLabel: 'Allegro', platformType: 'allegro', connectionIdLabel: 'c' };
+    const fromMaster = buildBulkConfigRows({ config: makeConfig(), ...base });
+    const fromAi = buildBulkConfigRows({ config: makeConfig({ generateDescription: true }), ...base });
+
+    expect(fromMaster.find((r) => r.id === 'description')?.value).toBe('From the master catalogue');
+    expect(fromAi.find((r) => r.id === 'description')?.value).toBe('Written by AI');
+  });
+});

--- a/apps/web/src/features/listings/components/bulk/bulk-config-summary.test.ts
+++ b/apps/web/src/features/listings/components/bulk/bulk-config-summary.test.ts
@@ -13,6 +13,7 @@ import {
   describeStockPolicy,
   formatPlatformParamValue,
   humanizeParamKey,
+  looksLikeIdentifier,
   readConnectionEnvironment,
 } from './bulk-config-summary';
 import type { BulkWizardConfig } from './bulk-wizard.types';
@@ -110,8 +111,30 @@ describe('formatPlatformParamValue', () => {
 
 describe('humanizeParamKey', () => {
   it('should turn an open-world param key into a label', () => {
-    expect(humanizeParamKey('deliveryPolicyId')).toBe('Delivery policy id');
     expect(humanizeParamKey('dispatch_time')).toBe('Dispatch time');
+    expect(humanizeParamKey('handlingTime')).toBe('Handling time');
+  });
+
+  it('should drop an Id suffix, which names the value shape rather than the setting', () => {
+    expect(humanizeParamKey('deliveryPolicyId')).toBe('Delivery policy');
+    expect(humanizeParamKey('return_policy_id')).toBe('Return policy');
+  });
+
+  it('should keep a key that is nothing but an id', () => {
+    expect(humanizeParamKey('id')).toBe('Id');
+  });
+});
+
+describe('looksLikeIdentifier', () => {
+  it('should recognise a value the operator cannot read as words', () => {
+    expect(looksLikeIdentifier('2012d84a-8c28-441c-b6cc-27e4bcbf8113')).toBe(true);
+    expect(looksLikeIdentifier('ol_variant_e4b98e91340a44ed')).toBe(true);
+  });
+
+  it('should leave a human value alone', () => {
+    expect(looksLikeIdentifier('Standard 24h')).toBe(false);
+    expect(looksLikeIdentifier('24 h')).toBe(false);
+    expect(looksLikeIdentifier('PLN')).toBe(false);
   });
 });
 

--- a/apps/web/src/features/listings/components/bulk/bulk-config-summary.ts
+++ b/apps/web/src/features/listings/components/bulk/bulk-config-summary.ts
@@ -90,13 +90,29 @@ export function collectBulkConfigChanges(config: BulkWizardConfig): BulkConfigCh
   return changes;
 }
 
-/** `deliveryPolicyId` -> `Delivery policy id`, so an open-world param key reads as a label. */
+/**
+ * `deliveryPolicyId` -> `Delivery policy`, so an open-world param key reads as a
+ * label. The `Id` suffix is dropped: it names the shape of the value, which the
+ * operator can already see, and every param key in the repo that carries it is
+ * a reference to something the label already names.
+ */
 export function humanizeParamKey(key: string): string {
-  const spaced = key
+  const withoutIdSuffix = key.replace(/[_-]?(?:Id|ID|id)$/, '');
+  const spaced = (withoutIdSuffix === '' ? key : withoutIdSuffix)
     .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
     .replace(/[_-]+/g, ' ')
     .trim();
   return spaced.charAt(0).toUpperCase() + spaced.slice(1).toLowerCase();
+}
+
+/**
+ * A value the operator cannot read as words - a uuid, an internal id, an opaque
+ * token. Rendered mono so it reads as a reference to quote in a ticket rather
+ * than as a name.
+ */
+export function looksLikeIdentifier(value: string): boolean {
+  if (/\s/.test(value)) return false;
+  return /^ol_/.test(value) || /^[0-9a-f]{8}-[0-9a-f]{4}-/i.test(value) || value.length >= 20;
 }
 
 /**
@@ -147,10 +163,12 @@ export function buildBulkConfigRows({
   ];
 
   for (const [key, value] of Object.entries(config.platformParams)) {
+    const formatted = formatPlatformParamValue(value);
     rows.push({
       id: `param-${key}`,
       label: humanizeParamKey(key),
-      value: formatPlatformParamValue(value),
+      value: formatted,
+      ...(looksLikeIdentifier(formatted) ? { mono: true } : {}),
     });
   }
 

--- a/apps/web/src/features/listings/components/bulk/bulk-config-summary.ts
+++ b/apps/web/src/features/listings/components/bulk/bulk-config-summary.ts
@@ -1,0 +1,161 @@
+/**
+ * Bulk wizard config summary (#2227)
+ *
+ * Pure formatters that turn a committed `BulkWizardConfig` into (a) the list of
+ * settings the operator moved away from their defaults - the only config the
+ * destination bar shows without being asked - and (b) the full label/value rows
+ * behind its disclosure.
+ *
+ * Kept React-free so the branches can be pinned by a plain unit test.
+ *
+ * @module apps/web/src/features/listings/components/bulk
+ */
+import type { BulkWizardConfig, PricingPolicy, StockPolicy } from './bulk-wizard.types';
+
+/** One label/value row rendered by `KeyValueList` in the bar's settings panel. */
+export interface BulkConfigRow {
+  id: string;
+  label: string;
+  value: string;
+  mono?: boolean;
+}
+
+/** A setting the operator changed away from its default. */
+export interface BulkConfigChange {
+  label: string;
+  value: string;
+}
+
+export type ConnectionEnvironment = 'sandbox' | 'production';
+
+/**
+ * `Connection.config` is an untyped `Record<string, unknown>`, so the
+ * environment is narrowed rather than cast - and an absent or unrecognised
+ * value returns `null` so the bar can omit the badge instead of guessing an
+ * environment the operator would act on.
+ */
+export function readConnectionEnvironment(
+  config: Record<string, unknown> | undefined,
+): ConnectionEnvironment | null {
+  const value = config?.environment;
+  return value === 'sandbox' || value === 'production' ? value : null;
+}
+
+/** Signed percent, so a negative markup reads as a discount rather than `+-5%`. */
+function formatPercent(percent: number): string {
+  return `${percent > 0 ? '+' : ''}${percent}%`;
+}
+
+export function describePricingPolicy(policy: PricingPolicy, currency: string): string {
+  switch (policy.mode) {
+    case 'markup':
+      return `Master price ${formatPercent(policy.percent)}`;
+    case 'flat':
+      return `Flat ${policy.amount.toFixed(2)} ${currency}`;
+    default:
+      return 'Master price';
+  }
+}
+
+export function describeStockPolicy(policy: StockPolicy): string {
+  switch (policy.mode) {
+    case 'cap':
+      return `Master stock, capped at ${policy.value}`;
+    case 'flat':
+      return `Flat ${policy.value}`;
+    default:
+      return 'Master stock';
+  }
+}
+
+/**
+ * Everything the operator moved off its default. An all-defaults batch returns
+ * an empty list, which is what lets the bar render no chip at all rather than a
+ * chip saying nothing changed.
+ */
+export function collectBulkConfigChanges(config: BulkWizardConfig): BulkConfigChange[] {
+  const changes: BulkConfigChange[] = [];
+  if (config.pricingPolicy.mode !== 'use-master') {
+    changes.push({ label: 'Price', value: describePricingPolicy(config.pricingPolicy, config.currency) });
+  }
+  if (config.stockPolicy.mode !== 'use-master') {
+    changes.push({ label: 'Stock', value: describeStockPolicy(config.stockPolicy) });
+  }
+  if (!config.publishImmediately) {
+    changes.push({ label: 'On create', value: 'Save as draft' });
+  }
+  if (config.generateDescription) {
+    changes.push({ label: 'Description', value: 'Written by AI' });
+  }
+  return changes;
+}
+
+/** `deliveryPolicyId` -> `Delivery policy id`, so an open-world param key reads as a label. */
+export function humanizeParamKey(key: string): string {
+  const spaced = key
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/[_-]+/g, ' ')
+    .trim();
+  return spaced.charAt(0).toUpperCase() + spaced.slice(1).toLowerCase();
+}
+
+/**
+ * `platformParams` is open-world (`Record<string, unknown>`), so every value
+ * shape gets a readable form - an object must never reach the operator as
+ * `[object Object]`.
+ */
+export function formatPlatformParamValue(value: unknown): string {
+  if (value === null || value === undefined || value === '') return 'Not set';
+  if (typeof value === 'string') return value;
+  if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+  if (Array.isArray(value)) {
+    return value.length === 0 ? 'Not set' : value.map((entry) => formatPlatformParamValue(entry)).join(', ');
+  }
+  return JSON.stringify(value);
+}
+
+export interface BulkConfigRowsInput {
+  config: BulkWizardConfig;
+  /** Registry-resolved platform display name (`resolvePlatformLabel`). */
+  platformLabel: string;
+  platformType: string;
+  /** Already-shortened connection id (`shortenId`). */
+  connectionIdLabel: string;
+}
+
+/** The full step-1 config, in the order an operator reads it. */
+export function buildBulkConfigRows({
+  config,
+  platformLabel,
+  platformType,
+  connectionIdLabel,
+}: BulkConfigRowsInput): BulkConfigRow[] {
+  const rows: BulkConfigRow[] = [
+    { id: 'currency', label: 'Listing currency', value: config.currency },
+    { id: 'price', label: 'Price', value: describePricingPolicy(config.pricingPolicy, config.currency) },
+    { id: 'stock', label: 'Stock', value: describeStockPolicy(config.stockPolicy) },
+    {
+      id: 'on-create',
+      label: 'On create',
+      value: config.publishImmediately ? 'Publish immediately' : 'Save as draft',
+    },
+    {
+      id: 'description',
+      label: 'Description',
+      value: config.generateDescription ? 'Written by AI' : 'From the master catalogue',
+    },
+  ];
+
+  for (const [key, value] of Object.entries(config.platformParams)) {
+    rows.push({
+      id: `param-${key}`,
+      label: humanizeParamKey(key),
+      value: formatPlatformParamValue(value),
+    });
+  }
+
+  rows.push({ id: 'platform', label: 'Integration', value: `${platformLabel} (${platformType})` });
+  rows.push({ id: 'connection-id', label: 'Connection id', value: connectionIdLabel, mono: true });
+
+  return rows;
+}

--- a/apps/web/src/features/listings/components/bulk/bulk-destination-bar.test.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-destination-bar.test.tsx
@@ -104,6 +104,21 @@ describe('BulkDestinationBar', () => {
     });
   });
 
+  it('should announce the destination once, not twice', () => {
+    renderBar();
+
+    // ConnectionDot carries the name in an sr-only span; the bar renders it
+    // visibly right beside the disc, so the disc is hidden from assistive tech.
+    const bar = screen.getByTestId('bulk-destination-bar');
+    const announced = Array.from(bar.querySelectorAll('*')).filter(
+      (el) =>
+        el.textContent === 'Allegro — Sklep główny' &&
+        el.closest('[aria-hidden="true"]') === null &&
+        el.children.length === 0,
+    );
+    expect(announced).toHaveLength(1);
+  });
+
   it('should flag a sandbox connection on the badge and on the bar itself', () => {
     renderBar({ connection: makeConnection({ config: { environment: 'sandbox' } }) });
 
@@ -173,7 +188,7 @@ describe('BulkDestinationBar', () => {
     expect(screen.getByText('PLN')).toBeInTheDocument();
     expect(screen.getByText('Master stock')).toBeInTheDocument();
     expect(screen.getByText('Publish immediately')).toBeInTheDocument();
-    expect(screen.getByText('Delivery policy id')).toBeInTheDocument();
+    expect(screen.getByText('Delivery policy')).toBeInTheDocument();
     expect(screen.getByText('Standard 24h')).toBeInTheDocument();
   });
 

--- a/apps/web/src/features/listings/components/bulk/bulk-destination-bar.test.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-destination-bar.test.tsx
@@ -1,0 +1,182 @@
+/**
+ * BulkDestinationBar tests (#2227)
+ *
+ * The bar exists so a screenshot of a wizard step names its destination, so the
+ * assertions are about what is legible without interaction: the connection, its
+ * environment, its health when it is not active, and one chip for settings moved
+ * off the defaults. Also pins the two states the design deliberately renders as
+ * "nothing": no environment key (badge omitted rather than guessed) and an
+ * all-defaults batch (no chip).
+ */
+import { fireEvent, screen, cleanup, within } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../../test/test-utils';
+import { BulkDestinationBar } from './bulk-destination-bar';
+import type { Connection } from '../../../connections';
+import type { BulkWizardConfig } from './bulk-wizard.types';
+
+function makeConnection(over: Partial<Connection> = {}): Connection {
+  return {
+    id: 'ol_conn_1234567890',
+    name: 'Allegro — Sklep główny',
+    platformType: 'allegro',
+    status: 'active',
+    config: { environment: 'production' },
+    credentialsBacked: true,
+    enabledCapabilities: ['OfferManager'],
+    supportedCapabilities: ['OfferManager', 'OfferCreator'],
+    createdAt: '2026-08-01T00:00:00.000Z',
+    updatedAt: '2026-08-01T00:00:00.000Z',
+    ...over,
+  } as Connection;
+}
+
+function makeConfig(over: Partial<BulkWizardConfig> = {}): BulkWizardConfig {
+  return {
+    connectionId: 'ol_conn_1234567890',
+    platformParams: {},
+    currency: 'PLN',
+    pricingPolicy: { mode: 'use-master' },
+    stockPolicy: { mode: 'use-master' },
+    publishImmediately: true,
+    generateDescription: false,
+    ...over,
+  };
+}
+
+function renderBar(over: {
+  connection?: Connection;
+  config?: BulkWizardConfig | null;
+  settingsOpen?: boolean;
+  onToggleSettings?: () => void;
+  onChangeDestination?: () => void;
+} = {}) {
+  const onToggleSettings = over.onToggleSettings ?? vi.fn();
+  const onChangeDestination = over.onChangeDestination ?? vi.fn();
+  renderWithProviders(
+    <BulkDestinationBar
+      connection={over.connection ?? makeConnection()}
+      config={over.config === undefined ? makeConfig() : over.config}
+      settingsOpen={over.settingsOpen ?? false}
+      onToggleSettings={onToggleSettings}
+      onChangeDestination={onChangeDestination}
+    />,
+  );
+  return { onToggleSettings, onChangeDestination };
+}
+
+afterEach(() => {
+  cleanup();
+});
+
+/**
+ * `ConnectionDot` also renders the name in an `sr-only` span, and the settings
+ * panel repeats every value the chip can show - so "visible on the bar" has to
+ * be queried inside the bar's own regions, not globally.
+ */
+function barName(): HTMLElement {
+  return screen.getByText('Allegro — Sklep główny', { selector: '.bulk-destbar__name' });
+}
+
+function badges(): HTMLElement {
+  const region = screen.getByTestId('bulk-destination-bar').querySelector('.bulk-destbar__badges');
+  if (region === null) throw new Error('badges region not rendered');
+  return region as HTMLElement;
+}
+
+describe('BulkDestinationBar', () => {
+  it('should name the connection and its environment when the batch targets production', () => {
+    renderBar();
+
+    expect(barName()).toBeInTheDocument();
+    expect(within(badges()).getByText('Production')).toBeInTheDocument();
+    expect(screen.queryByText('Sandbox')).not.toBeInTheDocument();
+  });
+
+  it('should flag a sandbox connection on the badge and on the bar itself', () => {
+    renderBar({ connection: makeConnection({ config: { environment: 'sandbox' } }) });
+
+    expect(screen.getByText('Sandbox')).toBeInTheDocument();
+    expect(screen.getByTestId('bulk-destination-bar')).toHaveAttribute('data-environment', 'sandbox');
+  });
+
+  it('should omit the environment badge when the connection config carries no environment', () => {
+    renderBar({ connection: makeConnection({ config: {} }) });
+
+    expect(screen.queryByText('Production')).not.toBeInTheDocument();
+    expect(screen.queryByText('Sandbox')).not.toBeInTheDocument();
+    expect(screen.getByTestId('bulk-destination-bar')).not.toHaveAttribute('data-environment');
+  });
+
+  it('should surface a connection that needs re-auth', () => {
+    renderBar({ connection: makeConnection({ status: 'needs_reauth' }) });
+
+    expect(screen.getByText('Needs re-auth')).toBeInTheDocument();
+  });
+
+  it('should render no changed-settings chip when the batch runs on defaults', () => {
+    renderBar();
+
+    expect(screen.queryByText(/settings changed/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Master price \+/)).not.toBeInTheDocument();
+  });
+
+  it('should name the single changed setting rather than counting it', () => {
+    renderBar({ config: makeConfig({ pricingPolicy: { mode: 'markup', percent: 12 } }) });
+
+    expect(within(badges()).getByText('Master price +12%')).toBeInTheDocument();
+    expect(screen.queryByText(/settings changed/)).not.toBeInTheDocument();
+  });
+
+  it('should count the changed settings when more than one moved', () => {
+    renderBar({
+      config: makeConfig({
+        pricingPolicy: { mode: 'flat', amount: 39 },
+        stockPolicy: { mode: 'cap', value: 20 },
+        publishImmediately: false,
+      }),
+    });
+
+    expect(screen.getByText('3 settings changed')).toBeInTheDocument();
+  });
+
+  it('should keep the settings panel hidden until it is opened', () => {
+    const { onToggleSettings } = renderBar();
+
+    const toggle = screen.getByRole('button', { name: 'Show settings' });
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.getByText('Listing currency').closest('.bulk-destbar__panel')).toHaveAttribute('hidden');
+
+    fireEvent.click(toggle);
+    expect(onToggleSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it('should show the whole step-1 config once open, including platform params', () => {
+    renderBar({
+      settingsOpen: true,
+      config: makeConfig({ platformParams: { deliveryPolicyId: 'Standard 24h' } }),
+    });
+
+    expect(screen.getByRole('button', { name: 'Hide settings' })).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText('Listing currency').closest('.bulk-destbar__panel')).not.toHaveAttribute('hidden');
+    expect(screen.getByText('PLN')).toBeInTheDocument();
+    expect(screen.getByText('Master stock')).toBeInTheDocument();
+    expect(screen.getByText('Publish immediately')).toBeInTheDocument();
+    expect(screen.getByText('Delivery policy id')).toBeInTheDocument();
+    expect(screen.getByText('Standard 24h')).toBeInTheDocument();
+  });
+
+  it('should ask the wizard to change destination rather than navigating itself', () => {
+    const { onChangeDestination } = renderBar({ settingsOpen: true });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Change destination' }));
+    expect(onChangeDestination).toHaveBeenCalledTimes(1);
+  });
+
+  it('should show identity only, with no settings toggle, before the config is committed', () => {
+    renderBar({ config: null });
+
+    expect(barName()).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /settings/ })).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/listings/components/bulk/bulk-destination-bar.test.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-destination-bar.test.tsx
@@ -44,13 +44,20 @@ function makeConfig(over: Partial<BulkWizardConfig> = {}): BulkWizardConfig {
   };
 }
 
-function renderBar(over: {
+interface RenderBarOverrides {
   connection?: Connection;
   config?: BulkWizardConfig | null;
   settingsOpen?: boolean;
   onToggleSettings?: () => void;
   onChangeDestination?: () => void;
-} = {}) {
+}
+
+interface RenderBarResult {
+  onToggleSettings: () => void;
+  onChangeDestination: () => void;
+}
+
+function renderBar(over: RenderBarOverrides = {}): RenderBarResult {
   const onToggleSettings = over.onToggleSettings ?? vi.fn();
   const onChangeDestination = over.onChangeDestination ?? vi.fn();
   renderWithProviders(
@@ -91,6 +98,10 @@ describe('BulkDestinationBar', () => {
     expect(barName()).toBeInTheDocument();
     expect(within(badges()).getByText('Production')).toBeInTheDocument();
     expect(screen.queryByText('Sandbox')).not.toBeInTheDocument();
+    // The disc is the batch's identity anchor here, so it is raised off the 14 px default.
+    expect(screen.getByTestId('bulk-destination-bar').querySelector('.conn-dot')).toHaveStyle({
+      '--conn-size': '26px',
+    });
   });
 
   it('should flag a sandbox connection on the badge and on the bar itself', () => {

--- a/apps/web/src/features/listings/components/bulk/bulk-destination-bar.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-destination-bar.tsx
@@ -84,7 +84,9 @@ export function BulkDestinationBar({
     >
       <div className="bulk-destbar__main">
         <span className="bulk-destbar__id">
-          <ConnectionDot name={connection.name} platformType={connection.platformType} />
+          {/* Larger than the 14 px default: here the disc is the identity
+              anchor for the whole batch, not a marker beside other text. */}
+          <ConnectionDot name={connection.name} platformType={connection.platformType} size={26} />
           <span className="bulk-destbar__name" title={connection.name}>
             {connection.name}
           </span>

--- a/apps/web/src/features/listings/components/bulk/bulk-destination-bar.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-destination-bar.tsx
@@ -85,8 +85,13 @@ export function BulkDestinationBar({
       <div className="bulk-destbar__main">
         <span className="bulk-destbar__id">
           {/* Larger than the 14 px default: here the disc is the identity
-              anchor for the whole batch, not a marker beside other text. */}
-          <ConnectionDot name={connection.name} platformType={connection.platformType} size={26} />
+              anchor for the whole batch, not a marker beside other text.
+              Hidden from assistive tech because the name it carries in its
+              `sr-only` span is rendered visibly right beside it - without this
+              the destination is announced twice. */}
+          <span aria-hidden="true">
+            <ConnectionDot name={connection.name} platformType={connection.platformType} size={26} />
+          </span>
           <span className="bulk-destbar__name" title={connection.name}>
             {connection.name}
           </span>

--- a/apps/web/src/features/listings/components/bulk/bulk-destination-bar.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-destination-bar.tsx
@@ -1,0 +1,146 @@
+/**
+ * Bulk wizard destination context bar (#2227)
+ *
+ * Keeps the destination on screen for every wizard step after Config, so a
+ * screenshot of Resolving / Review / Confirm says which integration the batch
+ * is going to - previously those steps rendered identically for Allegro
+ * production, Allegro sandbox, Erli and a WooCommerce shop.
+ *
+ * Only what an operator would act on stays visible: the connection, its
+ * environment, a health badge when the connection is not active, and one chip
+ * naming what was changed away from the step-1 defaults. The full config sits
+ * behind the disclosure, together with `Change destination` - the one action
+ * here that discards work, so it is kept away from the toggle.
+ *
+ * Presentational: the disclosure's open state is owned by the wizard, because
+ * the wizard re-renders its body on every step change and the panel must not
+ * snap shut.
+ *
+ * @module apps/web/src/features/listings/components/bulk
+ */
+import { useId, type ReactElement } from 'react';
+import { KeyValueList, StatusBadge, shortenId, type StatusBadgeTone } from '../../../../shared/ui';
+// The tooltip compound is not on the `shared/ui` barrel; the sibling
+// `bulk-confirm-modal.tsx` imports it from the module directly for the same reason.
+import { Tooltip, TooltipContent, TooltipTrigger } from '../../../../shared/ui/tooltip';
+import { ConnectionDot } from '../../../orders';
+import { resolvePlatformLabel } from '../../../mappings';
+import { usePlatforms } from '../../../../shared/plugins';
+import type { Connection, ConnectionStatus } from '../../../connections';
+import type { BulkWizardConfig } from './bulk-wizard.types';
+import {
+  buildBulkConfigRows,
+  collectBulkConfigChanges,
+  readConnectionEnvironment,
+} from './bulk-config-summary';
+
+interface BulkDestinationBarProps {
+  /** The destination the batch is going to, resolved by the wizard. */
+  connection: Connection;
+  /** Committed step-1 config; null before Config is left. */
+  config: BulkWizardConfig | null;
+  /** Disclosure state - owned by the wizard so it survives a step change. */
+  settingsOpen: boolean;
+  onToggleSettings: () => void;
+  /** Opens the wizard's confirm dialog; never navigates on its own. */
+  onChangeDestination: () => void;
+}
+
+const STATUS_COPY: Record<Exclude<ConnectionStatus, 'active'>, { label: string; tone: StatusBadgeTone }> = {
+  needs_reauth: { label: 'Needs re-auth', tone: 'error' },
+  error: { label: 'Connection error', tone: 'error' },
+  disabled: { label: 'Disabled', tone: 'neutral' },
+};
+
+export function BulkDestinationBar({
+  connection,
+  config,
+  settingsOpen,
+  onToggleSettings,
+  onChangeDestination,
+}: BulkDestinationBarProps): ReactElement {
+  const platforms = usePlatforms();
+  const panelId = useId();
+
+  const environment = readConnectionEnvironment(connection.config);
+  const health = connection.status === 'active' ? null : STATUS_COPY[connection.status];
+  const changes = config ? collectBulkConfigChanges(config) : [];
+  const platformLabel = resolvePlatformLabel(platforms, connection);
+
+  const rows = config
+    ? buildBulkConfigRows({
+        config,
+        platformLabel,
+        platformType: connection.platformType,
+        connectionIdLabel: shortenId(connection.id),
+      })
+    : [];
+
+  return (
+    <div
+      className="bulk-destbar"
+      data-environment={environment ?? undefined}
+      data-testid="bulk-destination-bar"
+    >
+      <div className="bulk-destbar__main">
+        <span className="bulk-destbar__id">
+          <ConnectionDot name={connection.name} platformType={connection.platformType} />
+          <span className="bulk-destbar__name" title={connection.name}>
+            {connection.name}
+          </span>
+        </span>
+
+        <span className="bulk-destbar__badges">
+          {environment !== null && (
+            <StatusBadge tone={environment === 'sandbox' ? 'warning' : 'success'} withDot compact>
+              {environment === 'sandbox' ? 'Sandbox' : 'Production'}
+            </StatusBadge>
+          )}
+          {health !== null && (
+            <StatusBadge tone={health.tone} withDot compact>
+              {health.label}
+            </StatusBadge>
+          )}
+          {changes.length === 1 && (
+            <StatusBadge tone="review" compact>
+              {changes[0].value}
+            </StatusBadge>
+          )}
+          {changes.length > 1 && (
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="bulk-destbar__changes">
+                  <StatusBadge tone="review" compact>
+                    {changes.length} settings changed
+                  </StatusBadge>
+                </span>
+              </TooltipTrigger>
+              <TooltipContent>
+                {changes.map((change) => `${change.label}: ${change.value}`).join(' · ')}
+              </TooltipContent>
+            </Tooltip>
+          )}
+        </span>
+
+        {config !== null && (
+          <button
+            type="button"
+            className="bulk-destbar__toggle"
+            aria-expanded={settingsOpen}
+            aria-controls={panelId}
+            onClick={onToggleSettings}
+          >
+            {settingsOpen ? 'Hide settings' : 'Show settings'}
+          </button>
+        )}
+      </div>
+
+      <div className="bulk-destbar__panel" id={panelId} hidden={!settingsOpen || config === null}>
+        <KeyValueList items={rows} />
+        <button type="button" className="bulk-destbar__change" onClick={onChangeDestination}>
+          Change destination
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/features/listings/components/bulk/bulk-wizard.test.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-wizard.test.tsx
@@ -233,6 +233,62 @@ describe('BulkWizard — demo instrumentation (#1788)', () => {
   }, 15000);
 });
 
+describe('BulkWizard — destination context (#2227)', () => {
+  afterEach(cleanup);
+
+  it('should name the destination in the heading and show the context bar once Config is left', async () => {
+    const connection = {
+      id: 'conn-1',
+      name: 'My Allegro',
+      status: 'active',
+      platformType: 'allegro',
+      supportedCapabilities: ['OfferManager', 'OfferCreator'],
+      config: { environment: 'sandbox', masterCatalogConnectionId: 'conn-master' },
+    } as unknown as Connection;
+    const apiClient = createMockApiClient({
+      connections: { list: vi.fn().mockResolvedValue([connection]) },
+      listings: {
+        getSellerPolicies: vi.fn().mockResolvedValue({
+          deliveryPolicies: [{ id: 'dp1', name: 'Courier 24h' }],
+        }),
+      },
+    });
+    const products: Product[] = [
+      { id: 'prod_1', name: 'P', currency: 'PLN' } as unknown as Product,
+    ];
+
+    renderWithProviders(
+      <BulkWizard
+        products={products}
+        resolveConnectionName={() => 'My Allegro'}
+        preselectedConnectionId="conn-1"
+      />,
+      { apiClient },
+    );
+
+    // Config IS the destination form: plain heading, no bar repeating the picker.
+    expect(
+      await screen.findByRole('heading', { name: 'Bulk marketplace offer creation' }),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('bulk-destination-bar')).not.toBeInTheDocument();
+
+    await screen.findByRole('option', { name: 'Courier 24h' }, { timeout: 5000 });
+    fireEvent.change(screen.getByRole('combobox', { name: 'Shipping rate package' }), {
+      target: { value: 'dp1' },
+    });
+    const proceed = screen.getByRole('button', { name: /Proceed/ });
+    await waitFor(() => expect(proceed).toBeEnabled(), { timeout: 5000 });
+    fireEvent.click(proceed);
+
+    expect(
+      await screen.findByRole('heading', { name: 'Create offers on My Allegro' }),
+    ).toBeInTheDocument();
+    const bar = screen.getByTestId('bulk-destination-bar');
+    expect(bar).toHaveAttribute('data-environment', 'sandbox');
+    expect(document.title).toBe('Bulk offers · My Allegro');
+  }, 15000);
+});
+
 describe('seedRows (#1754 pre-selected variants)', () => {
   function makeProduct(id: string, variantIds: string[]): Product {
     return {

--- a/apps/web/src/features/listings/components/bulk/bulk-wizard.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-wizard.tsx
@@ -15,7 +15,7 @@
  */
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Alert, Button, PageLayout, SetupStepper } from '../../../../shared/ui';
+import { Alert, Button, ConfirmDialog, PageLayout, SetupStepper } from '../../../../shared/ui';
 import { useToast } from '../../../../shared/ui/toast-provider';
 import { usePlatforms, type OfferRowValidationInput } from '../../../../shared/plugins';
 import { resolvePlatformLabel } from '../../../mappings';
@@ -36,6 +36,7 @@ import type {
 import type { BulkShopPublishItemRequest } from '../../api/listings.types';
 import type { Product, ProductVariant } from '../../../products';
 import { BulkConfigStep } from './bulk-config-step';
+import { BulkDestinationBar } from './bulk-destination-bar';
 import {
   BulkResolveStep,
   type BulkResolveCompletion,
@@ -154,6 +155,19 @@ export function BulkWizard({
   const isShop = activeConnection ? publishDestinationKind(activeConnection) === 'shop' : false;
   const wizardSteps = isShop ? SHOP_WIZARD_STEPS : WIZARD_STEPS;
 
+  // #2227: name the destination in the browser tab too, so a screenshot that
+  // includes browser chrome identifies the batch. Deliberately a local effect -
+  // `apps/web` has no document-title convention, and one surface does not yet
+  // justify introducing a shared hook.
+  useEffect(() => {
+    if (!activeConnection) return;
+    const previousTitle = document.title;
+    document.title = `${isShop ? 'Bulk publish' : 'Bulk offers'} · ${activeConnection.name}`;
+    return () => {
+      document.title = previousTitle;
+    };
+  }, [activeConnection, isShop]);
+
   // #1837 duplicate guard: soft-warn when included variants are already
   // published on the destination (a duplicate offer on a marketplace, an
   // upsert on a shop). Never blocks - surfaced as a chip + a confirm before the
@@ -163,6 +177,13 @@ export function BulkWizard({
     items: BulkShopPublishItemRequest[];
     status: ShopPublishVisibility;
   } | null>(null);
+
+  // #2227 destination context bar. Both pieces of state live here rather than in
+  // the bar: the wizard re-renders its body on every step change, so a
+  // bar-owned disclosure would snap shut, and the confirm dialog has to outlive
+  // the bar it was opened from (confirming unmounts it by returning to Config).
+  const [destSettingsOpen, setDestSettingsOpen] = useState(false);
+  const [changeDestOpen, setChangeDestOpen] = useState(false);
 
   // Sync row state when the products list changes (dedup by product id so a
   // product surfaced twice yields one row / one fan-out, mirroring the BE seen
@@ -638,6 +659,22 @@ export function BulkWizard({
       }
     >
       <div className="bulk-wizard">
+        {/* #2227: every step but Config, which IS the destination form. Also
+            not once a shop batch has submitted - `step` still reads 'review'
+            there while the body is the publish tracker, and offering
+            `Change destination` on an already-submitted batch is a false
+            affordance. Post-submit identity is the tracker's + the batch
+            progress page's job. */}
+        {step !== 'config' && shopBatchId === null && activeConnection ? (
+          <BulkDestinationBar
+            connection={activeConnection}
+            config={config}
+            settingsOpen={destSettingsOpen}
+            onToggleSettings={() => setDestSettingsOpen((open) => !open)}
+            onChangeDestination={() => setChangeDestOpen(true)}
+          />
+        ) : null}
+
         <div className="bulk-wizard__stepper">
           <SetupStepper
             steps={wizardSteps.map((s) => s.label)}
@@ -758,6 +795,24 @@ export function BulkWizard({
             }}
           />
         ) : null}
+
+        <ConfirmDialog
+          open={changeDestOpen}
+          onOpenChange={setChangeDestOpen}
+          title="Change destination?"
+          description={
+            activeConnection
+              ? `This batch has matched categories and row edits that only apply to ${activeConnection.name}. Going back to step 1 discards them.`
+              : 'Going back to step 1 discards the matched categories and row edits for this batch.'
+          }
+          confirmLabel="Change destination"
+          cancelLabel="Keep this batch"
+          tone="danger"
+          onConfirm={() => {
+            setChangeDestOpen(false);
+            setStep('config');
+          }}
+        />
 
         {config ? (
           <DuplicateGuardModal

--- a/apps/web/src/features/listings/components/bulk/bulk-wizard.tsx
+++ b/apps/web/src/features/listings/components/bulk/bulk-wizard.tsx
@@ -648,10 +648,21 @@ export function BulkWizard({
   );
   const stepperCurrent = shopBatchId !== null ? wizardSteps.length : currentStepIndex;
 
+  // #2227: name the destination in the heading, so even a screenshot cropped to
+  // the top of the page identifies the batch. Only after Config - on Config the
+  // destination is still being chosen, and the picker itself carries the name.
+  // The action verb matches the step's primary button ("Create offers" /
+  // "Publish"), so the flow keeps one vocabulary.
+  const baseTitle = isShop ? 'Bulk shop product publishing' : 'Bulk marketplace offer creation';
+  const pageTitle =
+    step !== 'config' && activeConnection !== null
+      ? `${isShop ? 'Publish products to' : 'Create offers on'} ${activeConnection.name}`
+      : baseTitle;
+
   return (
     <PageLayout
       eyebrow="Operations · Listings"
-      title={isShop ? 'Bulk shop product publishing' : 'Bulk marketplace offer creation'}
+      title={pageTitle}
       description={
         isShop
           ? `Publishing ${rows.length} ${rows.length === 1 ? 'product' : 'products'} · ${counts.totalVariants} variants to a shop.`

--- a/apps/web/src/features/orders/components/connection-dot.tsx
+++ b/apps/web/src/features/orders/components/connection-dot.tsx
@@ -22,6 +22,13 @@ interface ConnectionDotProps {
   platformType?: string | null;
   /** Only affects the generic (name === null) glyph. */
   variant?: 'shop' | 'carrier';
+  /**
+   * Disc diameter in px (default 14). The glyph is an SVG with a `viewBox`, so
+   * the initial scales with the disc. Raised where the dot is the primary
+   * identity anchor rather than a marker beside other text - the bulk wizard's
+   * destination bar (#2227) uses 26.
+   */
+  size?: number;
 }
 
 /** Deterministic 0–359 hue from a seed so a connection always gets the same colour. */
@@ -56,15 +63,17 @@ export function ConnectionDot({
   name,
   platformType = null,
   variant = 'shop',
+  size,
 }: ConnectionDotProps): ReactElement {
   const isGeneric = name === null;
   const fullName = name ?? (variant === 'carrier' ? 'a carrier' : 'the destination shop');
   const initial = computeInitial(name, platformType, variant);
   // Generic dots ignore the hash (muted grey via the modifier class); named/known
   // dots carry a stable hue seeded on platformType (falling back to the name).
-  const style: CSSProperties | undefined = isGeneric
-    ? undefined
-    : ({ '--conn-hue': stableHue(platformType ?? name ?? '') } as CSSProperties);
+  const style: CSSProperties = {
+    ...(isGeneric ? {} : { '--conn-hue': stableHue(platformType ?? name ?? '') }),
+    ...(size === undefined ? {} : { '--conn-size': `${size}px` }),
+  } as CSSProperties;
 
   return (
     <span className={cx('conn-dot', isGeneric && 'conn-dot--generic')} style={style} title={fullName}>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -332,16 +332,14 @@
   --button-primary-bg-hover: oklch(62% 0.19 50);
 
   /* ── Spacing scale (strict 4px grid) ─────────────────────────────── */
-  /* ── Layout offsets (#2227) ────────────────────────────────────────
-   * Sticky sub-headers need to know what is already pinned above them. The
-   * topbar is always there; the demo banner sits under it only in demo mode,
-   * so `.shell-main:has(.demo-banner)` raises `--layout-sticky-top` instead of
-   * every sticky element hardcoding a guess. Height, not padding, so the token
-   * stays true: `.demo-banner` carries a matching `min-height`.
+  /* ── Layout heights (#2227) ────────────────────────────────────────
+   * The two pinned strips at the top of the shell, named once instead of
+   * repeated as a literal `52px` in `.shell-topbar` and `.demo-banner`. Height,
+   * not padding, so the value stays true: the banner carries a matching
+   * `min-height`.
    */
   --shell-topbar-height: 52px;
   --demo-banner-height: 48px;
-  --layout-sticky-top: var(--shell-topbar-height);
 
   --space-1: 0.25rem; /* 4px */
   --space-2: 0.5rem; /* 8px */
@@ -1308,13 +1306,6 @@ textarea,
   :root {
     --demo-banner-height: 32px;
   }
-}
-
-/* Only demo mode renders a second pinned strip, so only then does a sticky
-   sub-header have to clear it. `:has()` keeps the knowledge in CSS instead of
-   threading a flag through AppShell into every sticky consumer. */
-.shell-main:has(.demo-banner) {
-  --layout-sticky-top: calc(var(--shell-topbar-height) + var(--demo-banner-height));
 }
 
 .shell-topbar {
@@ -10818,11 +10809,12 @@ input.bulk-dispatch__num--wide {
  * the accent, re-tinted to the warning tone for a sandbox connection - the
  * state that is most expensive to miss in a screenshot.
  */
+/* Deliberately NOT sticky: `main.shell-content` declares `overflow-y: auto`, so
+   it is the scroll container a sticky descendant resolves against - but the
+   document scrolls instead of it, so the offset never engages and the element
+   just scrolls away. Pinning this bar needs that shell-wide scroll model fixed
+   first (it also disables DataTable's sticky headers today). */
 .bulk-destbar {
-  position: sticky;
-  top: var(--layout-sticky-top);
-  /* Above scrolled content, below the demo banner (9) and the topbar (10). */
-  z-index: 3;
   background: var(--bg-surface);
   border: 1px solid var(--border-default);
   border-left: 3px solid var(--accent-primary);
@@ -10913,11 +10905,6 @@ input.bulk-dispatch__num--wide {
   display: none;
 }
 
-/* Expanded, the bar is a panel rather than a marker - pinning it would cover
-   the rows it describes, so it scrolls away until it is collapsed again. */
-.bulk-destbar:has(.bulk-destbar__panel:not([hidden])) {
-  position: static;
-}
 
 /* KeyValueList owns its own responsive dt/dd grid - only the width is ours. */
 .bulk-destbar__panel .key-value-list {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -10785,6 +10785,107 @@ input.bulk-dispatch__num--wide {
   flex: 1;
 }
 
+/* ── Bulk wizard destination context bar (#2227) ─────────────────────
+ * Sits above the stepper on every step after Config. The left edge carries
+ * the accent, re-tinted to the warning tone for a sandbox connection - the
+ * state that is most expensive to miss in a screenshot.
+ */
+.bulk-destbar {
+  background: var(--bg-surface);
+  border: 1px solid var(--border-default);
+  border-left: 3px solid var(--accent-primary);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+}
+
+.bulk-destbar[data-environment='sandbox'] {
+  border-left-color: var(--status-warning-strong);
+}
+
+.bulk-destbar__main {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2) var(--space-3);
+  padding: var(--space-2) var(--space-3);
+}
+
+.bulk-destbar__id {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+/* `display: block` is load-bearing: an inline span ignores text-overflow, so
+   a long connection name would set its own min-content width and push the
+   badges onto their own rows at 320 px. */
+.bulk-destbar__name {
+  display: block;
+  max-width: 26ch;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: var(--tracking-tight);
+  color: var(--text-primary);
+}
+
+.bulk-destbar__badges {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-2);
+  min-width: 0;
+}
+
+.bulk-destbar__changes {
+  display: inline-flex;
+}
+
+.bulk-destbar__toggle,
+.bulk-destbar__change {
+  font-family: var(--font-sans);
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  background: var(--bg-surface-muted);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  padding: 9px var(--space-3);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.bulk-destbar__toggle {
+  margin-left: auto;
+}
+
+.bulk-destbar__toggle:hover,
+.bulk-destbar__change:hover {
+  background: var(--bg-surface-hover);
+  color: var(--text-primary);
+}
+
+.bulk-destbar__panel {
+  border-top: 1px dashed var(--border-default);
+  padding: var(--space-3);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: var(--space-3);
+}
+
+.bulk-destbar__panel[hidden] {
+  display: none;
+}
+
+/* KeyValueList owns its own responsive dt/dd grid - only the width is ours. */
+.bulk-destbar__panel .key-value-list {
+  width: 100%;
+}
+
 /* ── Bulk shop-publish review step (#1829) ──────────────────────────── */
 .bulk-shop-review {
   display: flex;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -332,6 +332,17 @@
   --button-primary-bg-hover: oklch(62% 0.19 50);
 
   /* ── Spacing scale (strict 4px grid) ─────────────────────────────── */
+  /* ── Layout offsets (#2227) ────────────────────────────────────────
+   * Sticky sub-headers need to know what is already pinned above them. The
+   * topbar is always there; the demo banner sits under it only in demo mode,
+   * so `.shell-main:has(.demo-banner)` raises `--layout-sticky-top` instead of
+   * every sticky element hardcoding a guess. Height, not padding, so the token
+   * stays true: `.demo-banner` carries a matching `min-height`.
+   */
+  --shell-topbar-height: 52px;
+  --demo-banner-height: 48px;
+  --layout-sticky-top: var(--shell-topbar-height);
+
   --space-1: 0.25rem; /* 4px */
   --space-2: 0.5rem; /* 8px */
   --space-3: 0.75rem; /* 12px */
@@ -1291,6 +1302,21 @@ textarea,
   flex-direction: column;
 }
 
+/* The demo banner wraps to two lines on narrow viewports; from tablet up it is
+   one line, so the offset a sticky sub-header must clear gets smaller (#2227). */
+@media (min-width: 768px) {
+  :root {
+    --demo-banner-height: 32px;
+  }
+}
+
+/* Only demo mode renders a second pinned strip, so only then does a sticky
+   sub-header have to clear it. `:has()` keeps the knowledge in CSS instead of
+   threading a flag through AppShell into every sticky consumer. */
+.shell-main:has(.demo-banner) {
+  --layout-sticky-top: calc(var(--shell-topbar-height) + var(--demo-banner-height));
+}
+
 .shell-topbar {
   position: sticky;
   top: 0;
@@ -1298,7 +1324,7 @@ textarea,
   display: flex;
   align-items: center;
   gap: 12px;
-  height: 52px;
+  height: var(--shell-topbar-height);
   padding: 0 16px;
   background: var(--bg-shell);
   border-bottom: 1px solid var(--border-subtle);
@@ -2437,8 +2463,10 @@ textarea,
    initial + visually-hidden full name carry the signal. */
 .conn-dot {
   display: inline-block;
-  width: 14px;
-  height: 14px;
+  /* `--conn-size` is set inline by connection-dot.tsx only where the dot is the
+     primary identity anchor (the bulk wizard destination bar, #2227). */
+  width: var(--conn-size, 14px);
+  height: var(--conn-size, 14px);
   border-radius: 50%;
   flex: 0 0 auto;
   vertical-align: -2px;
@@ -2449,8 +2477,8 @@ textarea,
    so it needs no line-box gymnastics - just fill the disc. */
 .conn-dot__glyph {
   display: block;
-  width: 14px;
-  height: 14px;
+  width: var(--conn-size, 14px);
+  height: var(--conn-size, 14px);
 }
 
 .conn-dot__glyph text {
@@ -10791,6 +10819,10 @@ input.bulk-dispatch__num--wide {
  * state that is most expensive to miss in a screenshot.
  */
 .bulk-destbar {
+  position: sticky;
+  top: var(--layout-sticky-top);
+  /* Above scrolled content, below the demo banner (9) and the topbar (10). */
+  z-index: 3;
   background: var(--bg-surface);
   border: 1px solid var(--border-default);
   border-left: 3px solid var(--accent-primary);
@@ -10879,6 +10911,12 @@ input.bulk-dispatch__num--wide {
 
 .bulk-destbar__panel[hidden] {
   display: none;
+}
+
+/* Expanded, the bar is a panel rather than a marker - pinning it would cover
+   the rows it describes, so it scrolls away until it is collapsed again. */
+.bulk-destbar:has(.bulk-destbar__panel:not([hidden])) {
+  position: static;
 }
 
 /* KeyValueList owns its own responsive dt/dd grid - only the width is ours. */
@@ -14951,7 +14989,8 @@ textarea.bulk-editor__input { resize: vertical; min-height: 66px; font-family: i
      scrolled .shell-content but below the topbar (z-index: 10) so the two
      header blocks never overlap. */
   position: sticky;
-  top: 52px;
+  top: var(--shell-topbar-height);
+  min-height: var(--demo-banner-height);
   z-index: 9;
 }
 

--- a/apps/web/src/shared/theme/tokens.ts
+++ b/apps/web/src/shared/theme/tokens.ts
@@ -41,12 +41,10 @@ export const tokens = {
   'space-7': 'var(--space-7)',
   'space-8': 'var(--space-8)',
 
-  // ── Layout offsets (#2227) ──────────────────────────────────────
-  // What is already pinned above a sticky sub-header. `layout-sticky-top` is
-  // the one to stick to: it accounts for the demo banner when it is present.
+  // ── Layout heights (#2227) ──────────────────────────────────────
+  // The two pinned strips at the top of the shell.
   'shell-topbar-height': 'var(--shell-topbar-height)',
   'demo-banner-height': 'var(--demo-banner-height)',
-  'layout-sticky-top': 'var(--layout-sticky-top)',
 
   // ── Radii ───────────────────────────────────────────────────────
   'radius-xs': 'var(--radius-xs)',

--- a/apps/web/src/shared/theme/tokens.ts
+++ b/apps/web/src/shared/theme/tokens.ts
@@ -41,6 +41,13 @@ export const tokens = {
   'space-7': 'var(--space-7)',
   'space-8': 'var(--space-8)',
 
+  // ── Layout offsets (#2227) ──────────────────────────────────────
+  // What is already pinned above a sticky sub-header. `layout-sticky-top` is
+  // the one to stick to: it accounts for the demo banner when it is present.
+  'shell-topbar-height': 'var(--shell-topbar-height)',
+  'demo-banner-height': 'var(--demo-banner-height)',
+  'layout-sticky-top': 'var(--layout-sticky-top)',
+
   // ── Radii ───────────────────────────────────────────────────────
   'radius-xs': 'var(--radius-xs)',
   'radius-sm': 'var(--radius-sm)',

--- a/docs/plans/implementation-plan-bulk-wizard-destination-bar.md
+++ b/docs/plans/implementation-plan-bulk-wizard-destination-bar.md
@@ -23,8 +23,9 @@ away.* A dense strip of settings reads as noise and gets ignored, which defeats 
 - No change to `BulkWizardConfig`, the submit payload, or any BE contract.
 - No redesign of the step bodies, the Review table, or the Edit modal.
 - No change to the single-product publish flows outside the bulk wizard.
-- No new shared primitive, no new design token.
-- **Sticky-on-scroll is deferred** — see §5 *Deliberate deferrals*.
+- No new shared primitive, and no new colour token - the only tokens added are the three layout
+  offsets the sticky bar needs (§6.1).
+- No change to the shell's own layout beyond those offsets.
 - **Batch progress page is already done** — `bulk-batch-progress-page.tsx:139` already renders
   `connectionName` in its description, so nothing to add there.
 
@@ -155,14 +156,27 @@ which is what made the 320 px layout blow up in the mockup). Badges wrap; the le
 - **Security.** The panel shows a shortened connection id via the existing `shortenId`; no
   credentials, no `config` blob dump — only the known keys plus `platformParams`.
 
-**Deliberate deferrals** (stated rather than silently dropped):
+## 6. Decisions taken after the first pass
 
-- **Sticky-on-scroll.** `.demo-banner` is itself `position: sticky; top: 52px` in the same scroll
-  container, and there is no layout token for "topbar + banner height". A sticky bar at `top: 52px`
-  would sit under the banner in demo mode. Doing it correctly needs a shared offset token, which is a
-  layout change beyond this issue. The bar sits directly under the page title, which is where a
-  screenshot of a wizard step is normally framed. Follow-up if it turns out to matter.
+Three things the operator asked for once the first implementation was reviewable:
 
-**Open question for the user:** `ConnectionDot` is a fixed 14 px disc. The mockup drew a 26 px disc,
-which reads better as an identity anchor. Reuse the 14 px component as-is (no shared-component
-change), or give it an optional `size` prop? Plan assumes reuse as-is.
+1. **Sticky-on-scroll shipped**, and it needed the shared offset token the first pass tried to avoid.
+   `.demo-banner` is itself `position: sticky; top: 52px` in the same scroll container, so a bar
+   pinned at a hardcoded `52px` would sit *under* it in demo mode. Three tokens now carry the fact -
+   `--shell-topbar-height` (which `.shell-topbar` and `.demo-banner` both consume instead of
+   repeating `52px`), `--demo-banner-height` (with a matching `min-height` on the banner so the token
+   stays true, wrapped on mobile and one line from 768 px up), and `--layout-sticky-top`, raised by
+   `.shell-main:has(.demo-banner)`. `:has()` keeps the knowledge in CSS rather than threading a flag
+   through `AppShell` into every future sticky consumer. The bar stops pinning while its settings
+   panel is open (`:has(.bulk-destbar__panel:not([hidden]))`) - expanded, it would cover the rows it
+   describes.
+2. **`ConnectionDot` gained an optional `size`** (default 14). The glyph is an SVG with a `viewBox`,
+   so the initial scales with the disc; `.conn-dot` reads `var(--conn-size, 14px)`. The bar passes
+   26, where the disc is the identity anchor for the whole batch rather than a marker beside other
+   text. Every existing call site is untouched.
+3. **The destination is in the heading after all** - `Create offers on {name}` /
+   `Publish products to {name}`, with the action verb matching the step's primary button so the flow
+   keeps one vocabulary. Only after Config: on Config the destination is still being chosen, the
+   picker already carries the name, and the e2e page object asserts that exact heading
+   (`apps/e2e/src/pages/bulk-offer-wizard.page.ts:63`, anchored `^...$`) - so the base title stays
+   byte-identical there.

--- a/docs/plans/implementation-plan-bulk-wizard-destination-bar.md
+++ b/docs/plans/implementation-plan-bulk-wizard-destination-bar.md
@@ -160,16 +160,21 @@ which is what made the 320 px layout blow up in the mockup). Badges wrap; the le
 
 Three things the operator asked for once the first implementation was reviewable:
 
-1. **Sticky-on-scroll shipped**, and it needed the shared offset token the first pass tried to avoid.
-   `.demo-banner` is itself `position: sticky; top: 52px` in the same scroll container, so a bar
-   pinned at a hardcoded `52px` would sit *under* it in demo mode. Three tokens now carry the fact -
-   `--shell-topbar-height` (which `.shell-topbar` and `.demo-banner` both consume instead of
-   repeating `52px`), `--demo-banner-height` (with a matching `min-height` on the banner so the token
-   stays true, wrapped on mobile and one line from 768 px up), and `--layout-sticky-top`, raised by
-   `.shell-main:has(.demo-banner)`. `:has()` keeps the knowledge in CSS rather than threading a flag
-   through `AppShell` into every future sticky consumer. The bar stops pinning while its settings
-   panel is open (`:has(.bulk-destbar__panel:not([hidden]))`) - expanded, it would cover the rows it
-   describes.
+1. **Sticky-on-scroll was attempted, verified against the running app, and withdrawn** - it cannot
+   work today, and the reason is a shell-wide defect rather than anything about this bar.
+   `main.shell-content` declares `overflow-y: auto`, which makes it the scroll container any sticky
+   descendant resolves against; but the shell never constrains its height, so the **document**
+   scrolls and `.shell-content` itself never does (measured live: `html.scrollTopMax = 222`,
+   `.shell-content.scrollTopMax = 0`). A sticky descendant therefore never engages and simply scrolls
+   away - confirmed on the real page: computed `position: sticky; top: 52px`, and the bar still moved
+   from `y = 138` to `y = -36` under a 222 px scroll. **The same defect silently disables every other
+   sticky element inside the content area, including `DataTable`'s sticky table headers and
+   `.bulk-action-bar`.** Fixing it means changing where the app scrolls, which is a shell-wide change
+   affecting every page - out of scope here and worth its own issue. What survives from the attempt:
+   `--shell-topbar-height` and `--demo-banner-height`, which replace the literal `52px` repeated in
+   `.shell-topbar` and `.demo-banner` (the banner gained a matching `min-height` so the value stays
+   true). `--layout-sticky-top` and the `:has()` rule that raised it were dropped rather than left as
+   dead tokens.
 2. **`ConnectionDot` gained an optional `size`** (default 14). The glyph is an SVG with a `viewBox`,
    so the initial scales with the disc; `.conn-dot` reads `var(--conn-size, 14px)`. The bar passes
    26, where the disc is the identity anchor for the whole batch rather than a marker beside other

--- a/docs/plans/implementation-plan-bulk-wizard-destination-bar.md
+++ b/docs/plans/implementation-plan-bulk-wizard-destination-bar.md
@@ -1,0 +1,168 @@
+# Implementation plan — Bulk wizard destination context bar (#2227)
+
+## 1. Understand the task
+
+**Goal.** The bulk offer-creation wizard asks for the destination connection on step 1 and then never
+shows it again. Steps 2-4 render identically for Allegro production, Allegro sandbox, Erli and a
+WooCommerce shop, so a client screenshot of step 3 cannot be diagnosed, and the batch settings
+committed on step 1 (currency, price rule, stock rule, publish mode, AI description, platform
+params) are invisible from step 2 onward.
+
+Render a destination context bar from step 2 onward that carries the connection identity + the
+environment always, and the full step-1 config behind a disclosure.
+
+**Layer.** Frontend only (`apps/web`). No CORE, no integration, no interface-layer change, no
+migration. Every value the bar shows is already in `BulkWizard`'s own state (`activeConnection`,
+`config`, `platforms`).
+
+**Design source.** Issue #2227 plus the interactive mockup linked there. The governing rule from the
+mockup review: *only what an operator would act on stays visible; everything else is one click
+away.* A dense strip of settings reads as noise and gets ignored, which defeats the purpose.
+
+**Non-goals.**
+- No change to `BulkWizardConfig`, the submit payload, or any BE contract.
+- No redesign of the step bodies, the Review table, or the Edit modal.
+- No change to the single-product publish flows outside the bulk wizard.
+- No new shared primitive, no new design token.
+- **Sticky-on-scroll is deferred** — see §5 *Deliberate deferrals*.
+- **Batch progress page is already done** — `bulk-batch-progress-page.tsx:139` already renders
+  `connectionName` in its description, so nothing to add there.
+
+## 2. Research — what already exists
+
+| Need | Existing thing | Notes |
+|---|---|---|
+| Connection identity disc | `ConnectionDot` (`features/orders`, exported from that barrel) | Props `name`, `platformType`, `variant`. Fixed 14 px. Cross-feature import must go through the barrel (`.eslintrc.js` bans `**/orders/components/**`); precedent: `features/shipments/hooks/use-notify-dispatched-mutation.ts:16`. |
+| Badges | `StatusBadge` | Label is `children`, tones `error/info/neutral/review/success/warning`, `withDot`. |
+| Settings panel | `KeyValueList` | `KeyValueItem { id, label: ReactNode, value: ReactNode, mono? }`. |
+| Confirm dialog | `ConfirmDialog` | `open` / `onOpenChange` / `title` / `description` / `confirmLabel` / `cancelLabel` / `tone` / `onConfirm`. Escape + focus trap handled by the Radix `Dialog` underneath. Exact precedent: `connection-mappings-page.tsx:709` ("Discard unsaved changes?"). |
+| Tooltip | `Tooltip` / `TooltipTrigger asChild` / `TooltipContent` | Already used inside this folder (`bulk-confirm-modal.tsx:105`). |
+| Destination kind | `publishDestinationKind(connection)` | `'marketplace' \| 'shop' \| null`. Already computed in the wizard as `isShop`. |
+| Platform label | `resolvePlatformLabel(platforms, connection)` | Wizard already holds `platforms` and calls this at line 527. |
+| Environment | nothing | `Connection.config` is `Record<string, unknown>`; `config.environment` is untyped. Established read pattern is a local narrowing guard (`readInfaktEnvironment` / `readInpostEnvironment` in `EditConnectionForm.tsx`, `sync-job-detail-page.tsx:174`). |
+| Chip styling | `.context-chip` (`index.css:1612`) via `EnvironmentBadge` | That badge is the **app** environment (`VITE_APP_ENV`), not a connection's. Not reusable as logic; reusable as a styling precedent. |
+
+**Two findings that shape the design:**
+
+1. `InlineDisclosure` is a native uncontrolled `<details>` with a fixed `label / value / "Change →"`
+   summary. The bar needs a *controlled* disclosure (open state must survive the wizard re-rendering
+   its body on every step change) and a different summary. Modifying a shared primitive is out of
+   scope, so the bar uses a plain `<button aria-expanded aria-controls>` + panel. **`InlineDisclosure`
+   drops off the reuse list** stated in the issue.
+2. A connection-scoped environment chip does not exist anywhere in `apps/web`. This is the first one.
+
+## 3. Design
+
+New component, one file, no state of its own:
+
+```
+apps/web/src/features/listings/components/bulk/
+  bulk-destination-bar.tsx        # presentational; open state is a prop
+  bulk-config-summary.ts          # pure: BulkWizardConfig -> summary rows + changed-from-default list
+  bulk-config-summary.test.ts
+  bulk-destination-bar.test.tsx
+```
+
+`BulkDestinationBar` props:
+
+```ts
+interface BulkDestinationBarProps {
+  connection: Connection;               // resolved by the wizard (activeConnection)
+  config: BulkWizardConfig | null;      // null before commit; bar then shows identity only
+  settingsOpen: boolean;                // owned by the wizard, survives step changes
+  onToggleSettings: () => void;
+  onChangeDestination: () => void;      // wizard opens the ConfirmDialog
+}
+```
+
+**Always visible:** `ConnectionDot` + `connection.name`, environment `StatusBadge`
+(`Sandbox` warning / `Production` success / omitted when `config.environment` is absent — never
+guessed), a health `StatusBadge` only when `connection.status !== 'active'`, one changed-settings
+chip, and the `Show settings` / `Hide settings` toggle.
+
+**Changed-settings chip** — from `bulk-config-summary.ts`:
+
+```ts
+export interface BulkConfigChange { label: string; value: string }
+export function collectBulkConfigChanges(config: BulkWizardConfig): BulkConfigChange[]
+export function buildBulkConfigRows(config, connection, platformLabel): KeyValueItem[]
+```
+
+A change is anything off the defaults: `pricingPolicy.mode !== 'use-master'`,
+`stockPolicy.mode !== 'use-master'`, `publishImmediately === false`, `generateDescription === true`.
+Zero changes → **no chip at all**. One change → that change (`markup +12%`). More → `N settings
+changed`, with the list in a `Tooltip`.
+
+**Behind the disclosure:** `KeyValueList` with listing currency, price rule, stock rule, on-create
+(with the AI-description state under it), platform label + slug + shortened connection id
+(`shortenId`), and every `config.platformParams` entry as its own row. Plus the `Change destination`
+button — it is the one action that throws work away, so it does not sit next to a disclosure toggle.
+
+**Wizard wiring** (`bulk-wizard.tsx`, inside the existing `<div className="bulk-wizard">`, directly
+above `.bulk-wizard__stepper`):
+
+```tsx
+{step !== 'config' && activeConnection && (
+  <BulkDestinationBar … />
+)}
+```
+
+Two new pieces of wizard state: `settingsOpen` and `changeDestOpen`. `onChangeDestination` opens a
+`ConfirmDialog` (`tone="danger"`, title `Change destination?`, description naming the connection and
+what is discarded, `confirmLabel="Change destination"`, `cancelLabel="Keep this batch"`); confirming
+calls `setStep('config')`.
+
+**Browser tab title.** No `document.title` pattern exists anywhere in `apps/web` (zero runtime hits).
+Rather than introduce a shared hook, the wizard sets it in one local `useEffect` and restores the
+previous value on unmount. Scoped to this file; if a second surface needs it, that is when a shared
+hook earns its place.
+
+**CSS.** One block in `apps/web/src/index.css` next to the existing `/* ── Bulk listing wizard ── */`
+section, classes `.bulk-destbar`, `__id`, `__name`, `__badges`, `__actions`, `__panel`, following the
+`.bulk-wizard__*` naming already there and using only existing tokens. `.bulk-destbar__name` needs
+`display: block; max-width: 26ch; text-overflow: ellipsis` (an inline span ignores `text-overflow`,
+which is what made the 320 px layout blow up in the mockup). Badges wrap; the left accent edge is
+`--accent-primary`, re-tinted to `--status-warning-strong` on `[data-environment='sandbox']`.
+
+## 4. Steps
+
+1. **`bulk-config-summary.ts`** — pure module: `readConnectionEnvironment(config)` narrowing guard,
+   `collectBulkConfigChanges`, `describePricingPolicy`, `describeStockPolicy`, `buildBulkConfigRows`.
+   No React import. AC: every branch of `PricingPolicy` / `StockPolicy` renders a human string; an
+   unknown `platformParams` value type is stringified, never `[object Object]`.
+2. **`bulk-config-summary.test.ts`** — table-driven over the policy unions + the changes list
+   (all-defaults ⇒ `[]`, one change ⇒ one entry, three changes ⇒ three).
+3. **`bulk-destination-bar.tsx`** — presentational component per §3. AC: no `useState`, no data
+   fetching, no `any`, file header comment per engineering standards.
+4. **CSS block** in `index.css`. AC: tokens only; holds at 320 px; no new token.
+5. **Wire into `bulk-wizard.tsx`** — render above the stepper for every non-Config step (marketplace
+   and shop paths alike), add `settingsOpen` + `changeDestOpen` state, the `ConfirmDialog`, and the
+   `document.title` effect. AC: Config step renders no bar; confirming the dialog lands on Config.
+6. **`bulk-destination-bar.test.tsx`** — marketplace vs shop, sandbox vs production, absent
+   `config.environment` (no badge), `status: 'needs_reauth'` (health badge), all-defaults (no chip),
+   one change (named), three changes (`3 settings changed`), disclosure toggle calls the callback,
+   `Change destination` calls its callback.
+7. **Quality gate** — `pnpm lint`, `pnpm type-check`, and the `apps/web` vitest suite.
+
+## 5. Validation
+
+- **Architecture.** Frontend-only; `features → shared` respected; the one cross-feature import
+  (`ConnectionDot`) goes through the `features/orders` barrel, which `.eslintrc.js` allows.
+- **Capability-driven.** Destination kind comes from `publishDestinationKind`, platform naming from
+  the plugin registry via `resolvePlatformLabel`. No `platformType` literal anywhere in the bar.
+- **Naming.** `PascalCase.tsx` component, `*.test.tsx` test, pure helpers in a `*.ts` sibling.
+- **Types.** `config.environment` narrowed by a guard, never cast. No `any`.
+- **Security.** The panel shows a shortened connection id via the existing `shortenId`; no
+  credentials, no `config` blob dump — only the known keys plus `platformParams`.
+
+**Deliberate deferrals** (stated rather than silently dropped):
+
+- **Sticky-on-scroll.** `.demo-banner` is itself `position: sticky; top: 52px` in the same scroll
+  container, and there is no layout token for "topbar + banner height". A sticky bar at `top: 52px`
+  would sit under the banner in demo mode. Doing it correctly needs a shared offset token, which is a
+  layout change beyond this issue. The bar sits directly under the page title, which is where a
+  screenshot of a wizard step is normally framed. Follow-up if it turns out to matter.
+
+**Open question for the user:** `ConnectionDot` is a fixed 14 px disc. The mockup drew a 26 px disc,
+which reads better as an identity anchor. Reuse the 14 px component as-is (no shared-component
+change), or give it an optional `size` prop? Plan assumes reuse as-is.


### PR DESCRIPTION
## Why

The bulk offer-creation wizard asked for the destination connection on step 1 and then dropped it, so
Resolving / Review / Confirm rendered identically for Allegro production, Allegro sandbox, Erli and a
WooCommerce shop. A client screenshot of step 3 could not be diagnosed without asking which
integration they were on, and the batch settings committed on step 1 were invisible from step 2
onward - an operator reviewing a row price of `39.00 PLN` could not tell whether it came from master,
a markup or a flat price.

Design + interactive mockup (dark theme, real tokens):
https://claude.ai/code/artifact/bc021a1d-12ec-42c8-8a1d-d0148ebb116a

## What

A destination context bar above the stepper on every step after Config (Config *is* the destination
form, so a bar there would only repeat the picker).

**Visible without asking - only what an operator would act on:**

- connection name + the existing `ConnectionDot`, at 26 px
- environment badge: `Sandbox` in warning tone plus a re-tinted left edge, `Production` in success
  tone. Omitted entirely when `config.environment` is absent, rather than guessing an environment the
  operator would act on
- connection health, only when the connection is not `active` (e.g. `Needs re-auth`)
- **one** chip naming what was changed away from the step-1 defaults: the single change when there is
  one (`Master price +12%`), otherwise `N settings changed` with the list in a tooltip. An
  all-defaults batch shows no chip at all

**Behind `Show settings`:** the whole config - currency, price rule, stock rule, on-create,
description source, every `platformParams` entry, the integration and the shortened connection id.
`Change destination` lives there too, since it is the one action that discards work, and it opens a
`ConfirmDialog` naming what is lost before anything is lost.

The heading becomes `Create offers on {name}` / `Publish products to {name}` after Config, and the
destination goes into `document.title`, so a cropped screenshot still identifies the batch.

Frontend only. No BE contract change, no change to `BulkWizardConfig` or the submit payload.

## Decisions worth reviewing

- **`InlineDisclosure` deliberately not reused.** It is an uncontrolled `<details>` with a fixed
  `label / value / "Change →"` summary. The open state has to live in the wizard or it snaps shut on
  every step change, so the bar uses a plain `<button aria-expanded aria-controls>`. Modifying the
  shared primitive was out of scope.
- **Sticky-on-scroll was attempted and withdrawn - and the reason is a shell-wide defect worth its
  own issue.** `main.shell-content` declares `overflow-y: auto`, which makes it the scroll container
  a sticky descendant resolves against; but the shell never constrains its height, so the *document*
  scrolls and `.shell-content` never does. Measured on the running app: computed
  `position: sticky; top: 52px`, `.shell-content` `scrollTopMax = 0`, `html` `scrollTopMax = 222`,
  and the bar still travelled from `y = 138` to `y = -36` under a 222 px scroll. **The same defect
  silently disables every other sticky element in the content area, including `DataTable`'s sticky
  headers and `.bulk-action-bar`.** Fixing it changes where the whole app scrolls, so it is not this
  PR's business. What survives: `--shell-topbar-height` and `--demo-banner-height`, which
  de-duplicate the literal `52px` that `.shell-topbar` and `.demo-banner` both carried.
- **The bar is suppressed once a shop batch has submitted.** `step` still reads `'review'` there
  while the body is the publish tracker, and offering `Change destination` on a submitted batch is a
  false affordance. Post-submit identity is the tracker's and the batch progress page's job (that page
  already renders the connection name).
- **`ConnectionDot` gained an optional `size`,** default 14, so every existing call site is
  byte-identical. The glyph is an SVG with a `viewBox`, so the initial scales with the disc.
- **The Config heading is unchanged on purpose** - `apps/e2e/src/pages/bulk-offer-wizard.page.ts:63`
  asserts it anchored `^...$`, and on Config the destination is still being chosen.

## Verified on the running demo stack

Driven through both destination paths with Playwright (worktree vite against the demo API), every
step screenshotted:

**https://claude.ai/code/artifact/0a888c37-33bd-4e7b-8706-9df36bbd7ee8**

That run caught two defects no unit test could see - a platform param rendering as
`DELIVERY POLICY ID - 2012d84a-8c28-441c-...`, and the destination being announced twice to a screen
reader (the `ConnectionDot`'s `sr-only` name plus the visible name beside it). Both fixed in
`6a3ce44`, with tests.

## Tests

- `bulk-config-summary.test.ts` - every pricing/stock branch, the changed-from-default list
  (all-defaults ⇒ empty, which is what suppresses the chip), and open-world `platformParams`
  formatting including "never `[object Object]`".
- `bulk-destination-bar.test.tsx` - marketplace vs shop, sandbox vs production, absent
  `config.environment` (no badge), `needs_reauth`, all-defaults (no chip), one change named, three
  changes counted, the disclosure's aria state, and `Change destination` delegating to the wizard.
- `bulk-wizard.test.tsx` - Config shows the plain heading and no bar; proceeding past it yields the
  destination heading, the bar with its sandbox marker, and the document title.

`pnpm lint` (0 errors), `pnpm type-check` and the `apps/web` suite all pass.

## Deferred

Nothing from the issue. One follow-up this PR surfaced and did not fix: sticky positioning is
globally inert inside `main.shell-content` (see above), which affects `DataTable`'s sticky headers
and `.bulk-action-bar` today, not just this bar.

Closes #2227

🤖 Generated with [Claude Code](https://claude.com/claude-code)
