### PR TITLE
fix(invoicing): settle the tax-rate notation on percent-as-string

### DIFF
--- a/libs/core/src/invoicing/application/services/invoice.service.ts
+++ b/libs/core/src/invoicing/application/services/invoice.service.ts
@@ -50,6 +50,7 @@ import {
   invoiceIssueLockKey,
 } from './invoice-issue-lock';
 import { MissingNumberingSeriesException } from '../../domain/exceptions/missing-numbering-series.exception';
+import { taxRatePercentToFraction } from '../../domain/types/tax-rate-notation.types';
 import { CapabilityNotSupportedException } from '@openlinker/core/integrations';
 // Published so an adapter spec can pin its own pre-call refusal message against
 // the very markers this service matches on (#2103 review) — see the constant's doc.
@@ -173,10 +174,12 @@ function round2(value: number): number {
  * (`'23'`, `'8'`, `'0'`) are read as a percentage; non-numeric exemption codes
  * (`zw`/`np`/…) carry no tax (0). The adapter owns the authoritative regime
  * mapping; this is only for the non-authoritative content projection.
+ *
+ * Notation is settled once, in `taxRatePercentToFraction` (#2247) - fractional
+ * input throws there rather than being read as a hundredth of itself here.
  */
 function rateFraction(taxRate: string): number {
-  const parsed = Number.parseFloat(taxRate);
-  return Number.isFinite(parsed) ? parsed / 100 : 0;
+  return taxRatePercentToFraction(taxRate) ?? 0;
 }
 
 /**

--- a/libs/core/src/invoicing/domain/types/invoicing.types.ts
+++ b/libs/core/src/invoicing/domain/types/invoicing.types.ts
@@ -313,6 +313,14 @@ export interface BuyerAddress {
  * One invoice line. `unitPriceGross` is numeric (matches core's `number` money
  * idiom); `taxRate` is a neutral string code the provider resolves to its
  * regime (a PL adapter maps `zw`/`np` onto UNCL 5305 `E`/`O`).
+ *
+ * **`taxRate` notation is percent-as-string (#2247):** `'23'` means twenty-three
+ * percent, `'0'` means a zero rate, and a non-numeric code (`zw`, `np`, `oo`)
+ * names an exemption that carries no percentage. Fractional notation (`'0.23'`)
+ * is **not** an alternative spelling - it is rejected, because read as a
+ * percentage it means 0.23% and nothing in the value says which was intended.
+ * Every reader goes through `parseTaxRatePercent` / `taxRatePercentToFraction`
+ * (`./tax-rate-notation.types`) rather than parsing the string itself.
  */
 export interface InvoiceLine {
   name: string;

--- a/libs/core/src/invoicing/domain/types/tax-rate-notation.types.spec.ts
+++ b/libs/core/src/invoicing/domain/types/tax-rate-notation.types.spec.ts
@@ -1,0 +1,101 @@
+/**
+ * Tax-Rate Notation Tests (#2247)
+ *
+ * Pins the one canonical reading of `InvoiceLine.taxRate`: percent-as-string.
+ * The cases that matter are the ambiguous ones - a fractional spelling must
+ * raise rather than resolve, and a genuine sub-10% rate must not be mistaken
+ * for one.
+ *
+ * @module libs/core/src/invoicing/domain/types
+ */
+import {
+  FractionalTaxRateNotationError,
+  assertPercentTaxRateNotation,
+  isFractionalTaxRateNotation,
+  parseTaxRatePercent,
+  taxRatePercentToFraction,
+} from './tax-rate-notation.types';
+
+describe('tax-rate notation', () => {
+  describe('parseTaxRatePercent', () => {
+    it('should read a numeric code as a percentage when the code is well formed', () => {
+      expect(parseTaxRatePercent('23')).toBe(23);
+      expect(parseTaxRatePercent('8')).toBe(8);
+      expect(parseTaxRatePercent('5')).toBe(5);
+    });
+
+    it('should treat zero as an answer rather than an absence when the code is "0"', () => {
+      expect(parseTaxRatePercent('0')).toBe(0);
+    });
+
+    it('should read a one-percent rate as one percent when the code is "1"', () => {
+      // The pre-#2247 inFakt heuristic (`n > 1 ? n / 100 : n`) read this as 100%.
+      expect(parseTaxRatePercent('1')).toBe(1);
+      expect(taxRatePercentToFraction('1')).toBeCloseTo(0.01, 10);
+    });
+
+    it('should return null when the code names an exemption rather than a percentage', () => {
+      expect(parseTaxRatePercent('zw')).toBeNull();
+      expect(parseTaxRatePercent('np')).toBeNull();
+      expect(parseTaxRatePercent('oo')).toBeNull();
+    });
+
+    it('should return null when the code is empty, preserving the pre-rollout path', () => {
+      expect(parseTaxRatePercent('')).toBeNull();
+      expect(parseTaxRatePercent('   ')).toBeNull();
+    });
+
+    it('should throw when the code is written as a fraction', () => {
+      expect(() => parseTaxRatePercent('0.23')).toThrow(FractionalTaxRateNotationError);
+      expect(() => parseTaxRatePercent('0.08')).toThrow(FractionalTaxRateNotationError);
+      expect(() => parseTaxRatePercent('0.05')).toThrow(FractionalTaxRateNotationError);
+    });
+
+    it('should name the offending value when it throws', () => {
+      expect(() => parseTaxRatePercent('0.23')).toThrow(/"0\.23"/);
+    });
+  });
+
+  describe('taxRatePercentToFraction', () => {
+    it('should divide by one hundred when the code is numeric', () => {
+      expect(taxRatePercentToFraction('23')).toBeCloseTo(0.23, 10);
+      expect(taxRatePercentToFraction('0')).toBe(0);
+    });
+
+    it('should return null when the code carries no percentage', () => {
+      expect(taxRatePercentToFraction('zw')).toBeNull();
+      expect(taxRatePercentToFraction('')).toBeNull();
+    });
+  });
+
+  describe('isFractionalTaxRateNotation', () => {
+    it('should report a value strictly between zero and one as fractional', () => {
+      expect(isFractionalTaxRateNotation('0.23')).toBe(true);
+      expect(isFractionalTaxRateNotation('0.5')).toBe(true);
+    });
+
+    it('should not report zero as fractional, since a zero rate is a real answer', () => {
+      expect(isFractionalTaxRateNotation('0')).toBe(false);
+      expect(isFractionalTaxRateNotation('0.00')).toBe(false);
+    });
+
+    it('should not report a whole percentage or an exemption code as fractional', () => {
+      expect(isFractionalTaxRateNotation('1')).toBe(false);
+      expect(isFractionalTaxRateNotation('23')).toBe(false);
+      expect(isFractionalTaxRateNotation('zw')).toBe(false);
+      expect(isFractionalTaxRateNotation('')).toBe(false);
+    });
+  });
+
+  describe('assertPercentTaxRateNotation', () => {
+    it('should return the trimmed code when the notation is valid', () => {
+      expect(assertPercentTaxRateNotation(' 23 ')).toBe('23');
+      expect(assertPercentTaxRateNotation('zw')).toBe('zw');
+      expect(assertPercentTaxRateNotation('')).toBe('');
+    });
+
+    it('should throw when the notation is fractional', () => {
+      expect(() => assertPercentTaxRateNotation('0.23')).toThrow(FractionalTaxRateNotationError);
+    });
+  });
+});

--- a/libs/core/src/invoicing/domain/types/tax-rate-notation.types.ts
+++ b/libs/core/src/invoicing/domain/types/tax-rate-notation.types.ts
@@ -1,0 +1,93 @@
+/**
+ * Neutral Tax-Rate Notation (#2247)
+ *
+ * One canonical reading of `InvoiceLine.taxRate` shared by core and by every
+ * provider adapter. The code is **percent-as-string**: `'23'` is twenty-three
+ * percent. It is never a fraction, so `'0.23'` is not another way of writing
+ * the same thing - read as a percentage it means 0.23%, and on a 123 PLN
+ * invoice the two readings diverge by 22.72 PLN.
+ *
+ * Before this module each reader guessed. Core divided by 100 unconditionally;
+ * the inFakt adapter switched on `n > 1`, so `'23'` and `'0.23'` both resolved
+ * to 23% while a genuine 1% rate resolved to 100%. A guess is the wrong shape
+ * for this field: the writer knows which notation it used, so an ambiguous
+ * value is a defect upstream and must surface rather than be reinterpreted.
+ *
+ * Pure and dependency-free: no I/O, no framework, no regime knowledge. The
+ * mapping from a code to a national tax symbol stays in the provider adapter
+ * (ADR-026); this module only settles how the digits are read.
+ *
+ * @module libs/core/src/invoicing/domain/types
+ * @see {@link InvoiceLine.taxRate}
+ */
+
+/**
+ * Raised when a tax-rate code is written in fractional notation (a numeric
+ * value strictly between 0 and 1, e.g. `'0.23'`). Rejected rather than
+ * normalised: `'0.23'` is indistinguishable from a genuine 0.23% rate, so
+ * silently multiplying by 100 would invent a value the writer never stated.
+ */
+export class FractionalTaxRateNotationError extends Error {
+  constructor(public readonly taxRate: string) {
+    super(
+      `Tax rate "${taxRate}" is written as a fraction. The neutral contract is ` +
+        `percent-as-string, so twenty-three percent is "23", not "0.23".`
+    );
+    this.name = 'FractionalTaxRateNotationError';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}
+
+/**
+ * True when the code is written as a fraction - numeric and strictly between
+ * 0 and 1. `'0'` is excluded because a zero rate is a legitimate answer
+ * (export, intra-EU, exempt goods) and carries no notation ambiguity.
+ */
+export function isFractionalTaxRateNotation(taxRate: string): boolean {
+  const parsed = Number.parseFloat(taxRate.trim());
+  return Number.isFinite(parsed) && parsed > 0 && parsed < 1;
+}
+
+/**
+ * Read a numeric tax-rate code as a **percentage**.
+ *
+ * Returns `null` for anything that is not a number - an empty string, or an
+ * exemption code such as `zw` / `np` / `oo`, which carry no percentage at all.
+ * A caller that needs a number for those must decide what they mean; this
+ * function refuses to guess.
+ *
+ * @throws {FractionalTaxRateNotationError} on fractional notation.
+ */
+export function parseTaxRatePercent(taxRate: string): number | null {
+  const trimmed = taxRate.trim();
+  if (trimmed === '') return null;
+  const parsed = Number.parseFloat(trimmed);
+  if (!Number.isFinite(parsed)) return null;
+  if (parsed > 0 && parsed < 1) throw new FractionalTaxRateNotationError(taxRate);
+  return parsed;
+}
+
+/**
+ * Read a numeric tax-rate code as a **fraction of one** (`'23'` -> `0.23`),
+ * the form an arithmetic caller wants. Non-numeric codes return `null`, for
+ * the same reason `parseTaxRatePercent` does.
+ *
+ * @throws {FractionalTaxRateNotationError} on fractional notation.
+ */
+export function taxRatePercentToFraction(taxRate: string): number | null {
+  const percent = parseTaxRatePercent(taxRate);
+  return percent === null ? null : percent / 100;
+}
+
+/**
+ * Throw if the code uses fractional notation; otherwise return it trimmed.
+ * For writers that pass a code straight through to a provider without doing
+ * arithmetic on it, where the notation is still part of the contract.
+ *
+ * @throws {FractionalTaxRateNotationError} on fractional notation.
+ */
+export function assertPercentTaxRateNotation(taxRate: string): string {
+  const trimmed = taxRate.trim();
+  if (isFractionalTaxRateNotation(trimmed)) throw new FractionalTaxRateNotationError(taxRate);
+  return trimmed;
+}

--- a/libs/core/src/invoicing/index.ts
+++ b/libs/core/src/invoicing/index.ts
@@ -33,6 +33,14 @@ export type {
   InvoicingConnectionSelection,
 } from './domain/types/invoicing-primary.types';
 export { normalizeShippingLineName } from './domain/types/shipping-line-label.types';
+// Canonical percent-as-string tax-rate notation (#2247).
+export {
+  FractionalTaxRateNotationError,
+  isFractionalTaxRateNotation,
+  parseTaxRatePercent,
+  taxRatePercentToFraction,
+  assertPercentTaxRateNotation,
+} from './domain/types/tax-rate-notation.types';
 export * from './domain/entities/buyer-profile.entity';
 export * from './domain/entities/invoice-record.entity';
 export * from './domain/entities/invoice-numbering-series.entity';

--- a/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-invoicing.adapter.spec.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-invoicing.adapter.spec.ts
@@ -22,6 +22,7 @@ import type { LoggerPort } from '@openlinker/shared/logging';
 import {
   BuyerProfile,
   CURRENCY_REJECTION_MARKERS,
+  FractionalTaxRateNotationError,
   InvoiceRecord,
   UnsupportedRegulatoryDocumentKindError,
 } from '@openlinker/core/invoicing';
@@ -586,6 +587,54 @@ describe('InfaktInvoicingAdapter', () => {
         .invoice.services;
       expect(services[0].tax_symbol).toBe('23');
       expect(services[0].unit_net_price).toBe(10000);
+    });
+
+    it('should read "23" as twenty-three percent when splitting gross into net (#2247)', async () => {
+      // Percent-as-string is the neutral contract. 123 gross at 23% is 100.00
+      // net, i.e. 10000 groszy - the same figure the empty-rate fallback
+      // produces, which is what makes the two readings comparable at all.
+      http.seed('POST', 'invoices.json', invoiceFixture());
+
+      await adapter.issueInvoice({
+        ...baseCmd,
+        lines: [{ name: 'Widget', quantity: 1, unitPriceGross: 123, taxRate: '23' }],
+      });
+
+      const invoiceCall = http.calls.find((c) => c.method === 'POST' && c.path === 'invoices.json');
+      const services = (
+        invoiceCall?.body as { invoice: { services: Array<{ tax_symbol: string; unit_net_price: number }> } }
+      ).invoice.services;
+      expect(services[0].tax_symbol).toBe('23');
+      expect(services[0].unit_net_price).toBe(10000);
+    });
+
+    it('should read "1" as one percent rather than one hundred percent (#2247)', async () => {
+      // The pre-#2247 `n > 1` heuristic read this as a fraction, so a 1% line
+      // was split as if it carried 100% tax - 61.50 net instead of 121.78.
+      http.seed('POST', 'invoices.json', invoiceFixture());
+
+      await adapter.issueInvoice({
+        ...baseCmd,
+        lines: [{ name: 'Widget', quantity: 1, unitPriceGross: 123, taxRate: '1' }],
+      });
+
+      const invoiceCall = http.calls.find((c) => c.method === 'POST' && c.path === 'invoices.json');
+      const services = (invoiceCall?.body as { invoice: { services: Array<{ unit_net_price: number }> } })
+        .invoice.services;
+      expect(services[0].unit_net_price).toBe(12178);
+    });
+
+    it('should reject a fractional-looking taxRate rather than reinterpreting it (#2247)', async () => {
+      // "0.23" read as a percentage is 0.23%, read as a fraction it is 23%.
+      // Nothing in the value says which, so it is refused before any request.
+      http.seed('POST', 'invoices.json', invoiceFixture());
+
+      await expect(
+        adapter.issueInvoice({
+          ...baseCmd,
+          lines: [{ name: 'Widget', quantity: 1, unitPriceGross: 123, taxRate: '0.23' }],
+        }),
+      ).rejects.toBeInstanceOf(FractionalTaxRateNotationError);
     });
 
     it('should propagate a 422 InfaktApiError with failureMode: rejected (error path)', async () => {

--- a/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
@@ -50,6 +50,10 @@ import type {
   UpsertCustomerResult,
 } from '@openlinker/core/invoicing';
 import { InvoiceRecord, UnsupportedRegulatoryDocumentKindError } from '@openlinker/core/invoicing';
+import {
+  assertPercentTaxRateNotation,
+  taxRatePercentToFraction,
+} from '@openlinker/core/invoicing';
 import type { IInfaktHttpClient } from '../http/infakt-http-client.interface';
 import { InfaktApiError } from '../../domain/exceptions/infakt-api.error';
 import type {
@@ -240,21 +244,29 @@ function toInfaktEmailLocale(locale: InvoiceEmailLocale | undefined): string | u
 const DEFAULT_PL_VAT_SYMBOL = '23';
 const DEFAULT_PL_VAT_RATE = 0.23;
 
-/** Maps neutral taxRate string to Infakt tax_symbol. */
+/**
+ * Maps a neutral taxRate string to an Infakt `tax_symbol`.
+ *
+ * The neutral code is percent-as-string (#2247), so the fractional spellings
+ * this switch used to accept (`'0.23'`, `'0.08'`, `'0.05'`) are gone -
+ * `assertPercentTaxRateNotation` rejects them instead of quietly treating
+ * `'0.23'` as 23%, which is the reading that made a genuine 1% rate resolve
+ * to 100%.
+ *
+ * `'0'` maps to `zw`, which is a deliberate PL-regime choice rather than a
+ * notation one: Infakt has no numeric zero symbol, so a zero-rated line is
+ * declared exempt. That mapping is the adapter's to own (ADR-026).
+ */
 function toInfaktTaxSymbol(taxRate: string): string {
-  // Common neutral→Infakt mapping; adapter owns this PL logic
-  switch (taxRate) {
+  const code = assertPercentTaxRateNotation(taxRate);
+  switch (code) {
     case '23':
-    case '0.23':
       return '23';
     case '8':
-    case '0.08':
       return '8';
     case '5':
-    case '0.05':
       return '5';
     case '0':
-    case '0.00':
     case 'zw':
     case 'exempt':
       return 'zw';
@@ -262,13 +274,17 @@ function toInfaktTaxSymbol(taxRate: string): string {
     case 'oo':
       return 'np';
     default:
-      return taxRate.trim() === '' ? DEFAULT_PL_VAT_SYMBOL : taxRate;
+      return code === '' ? DEFAULT_PL_VAT_SYMBOL : code;
   }
 }
 
 /**
- * Parses a tax-rate string (neutral `'23'`/`'0.23'` or Infakt `tax_symbol`
- * `'zw'`/`'np'`) to a decimal fraction.
+ * Parses a tax-rate string (a neutral percent-as-string code such as `'23'`,
+ * or an Infakt `tax_symbol` like `'zw'`/`'np'`) to a decimal fraction.
+ *
+ * Notation is settled centrally (#2247): `taxRatePercentToFraction` divides by
+ * 100 and throws on fractional input. The old `n > 1` heuristic that lived here
+ * accepted both spellings and, as a side effect, read a genuine 1% rate as 100%.
  *
  * Must stay consistent with `toInfaktTaxSymbol`'s empty-string fallback — a
  * mismatched net/gross split for the declared tax_symbol is itself rejected
@@ -276,10 +292,7 @@ function toInfaktTaxSymbol(taxRate: string): string {
  */
 function taxRateNumeric(taxRate: string): number {
   if (taxRate.trim() === '') return DEFAULT_PL_VAT_RATE;
-  const n = parseFloat(taxRate);
-  if (!isNaN(n) && n > 1) return n / 100;
-  if (!isNaN(n)) return n;
-  return 0;
+  return taxRatePercentToFraction(taxRate) ?? 0;
 }
 
 /** Converts a buyer-paid gross unit price (PLN) to Infakt's net unit price (PLN) for the given tax rate. */

--- a/libs/integrations/ksef/src/infrastructure/fa3/domain/fa3-tax-rate.mapper.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/fa3/domain/fa3-tax-rate.mapper.spec.ts
@@ -36,6 +36,15 @@ describe('resolveP12', () => {
     expect(() => resolveP12('')).toThrow(UnmappedTaxRateException);
   });
 
+  it.each(['0.23', '0.08', '0.05'])(
+    'should reject the fractional spelling %s rather than reading it as a percentage (#2247)',
+    (fractional) => {
+      // Neutral notation is percent-as-string. A fractional code is not an
+      // alternative spelling of the same rate, so it must never map to a P_12.
+      expect(() => resolveP12(fractional)).toThrow(UnmappedTaxRateException);
+    },
+  );
+
   it.each(['constructor', 'toString', 'valueOf', 'hasOwnProperty', '__proto__'])(
     'should throw UnmappedTaxRateException on the inherited-prototype key %s (#1291)',
     (protoKey) => {

--- a/libs/integrations/subiekt/src/infrastructure/mappers/subiekt-line.mapper.spec.ts
+++ b/libs/integrations/subiekt/src/infrastructure/mappers/subiekt-line.mapper.spec.ts
@@ -1,0 +1,50 @@
+/**
+ * Subiekt Line Mapper Tests — tax-rate notation (#2247)
+ *
+ * The bridge takes the neutral code through as a Polish rate symbol, so the
+ * only thing that can go wrong here is notation. A fractional spelling must
+ * not reach Subiekt, where `'0.23'` is neither a symbol it knows nor a rate
+ * anyone declared.
+ *
+ * @module libs/integrations/subiekt/src/infrastructure/mappers
+ */
+import type { InvoiceLine } from '@openlinker/core/invoicing';
+import { FractionalTaxRateNotationError } from '@openlinker/core/invoicing';
+import { toBridgeLines } from './subiekt-line.mapper';
+
+function line(taxRate: string): InvoiceLine {
+  return { name: 'Widget', quantity: 1, unitPriceGross: 123, taxRate };
+}
+
+describe('toBridgeLines', () => {
+  it('should send 23 as the rate symbol when the neutral code is "23"', () => {
+    expect(toBridgeLines([line('23')])[0]?.stawkaVAT).toBe('23');
+  });
+
+  it('should pass a zero rate through rather than defaulting it', () => {
+    expect(toBridgeLines([line('0')])[0]?.stawkaVAT).toBe('0');
+  });
+
+  it('should pass an exemption code through unchanged', () => {
+    expect(toBridgeLines([line('zw')])[0]?.stawkaVAT).toBe('zw');
+  });
+
+  it('should fall back to the Polish standard rate when the neutral code is empty', () => {
+    // Unchanged pre-rollout behaviour; #2257 removes this default.
+    expect(toBridgeLines([line('')])[0]?.stawkaVAT).toBe('23');
+    expect(toBridgeLines([line('   ')])[0]?.stawkaVAT).toBe('23');
+  });
+
+  it('should reject a fractional-looking rate rather than forwarding it', () => {
+    expect(() => toBridgeLines([line('0.23')])).toThrow(FractionalTaxRateNotationError);
+  });
+
+  it('should carry the line name, quantity and gross unit price through unchanged', () => {
+    expect(toBridgeLines([line('23')])[0]).toEqual({
+      name: 'Widget',
+      ilosc: 1,
+      cenaBrutto: 123,
+      stawkaVAT: '23',
+    });
+  });
+});

--- a/libs/integrations/subiekt/src/infrastructure/mappers/subiekt-line.mapper.ts
+++ b/libs/integrations/subiekt/src/infrastructure/mappers/subiekt-line.mapper.ts
@@ -13,24 +13,38 @@
  * `taxRate` empty by design — core never names a tax rate on the order contract
  * ("the provider adapter resolves the regime rate", see the core line mapper).
  * The Subiekt bridge REQUIRES a non-empty `stawkaVAT` ("StawkaVAT jest wymagana")
- * and parses Polish rate symbols ("23","8","5","0","zw","np"). When the neutral
+ * and parses Polish rate symbols ("23","8","5","0","zw","np") in percent-as-string
+ * notation (#2247). When the neutral
  * line carries no rate we therefore default to the Polish standard rate "23".
  * A rate the source DID supply passes through verbatim.
  *
  * @module libs/integrations/subiekt/src/infrastructure/mappers
  */
 import type { CorrectionLine, InvoiceLine } from '@openlinker/core/invoicing';
+import { assertPercentTaxRateNotation } from '@openlinker/core/invoicing';
 import type { BridgeKorektaLine, BridgeLine } from '../../bridge/subiekt-bridge.types';
 
 /** Polish standard VAT rate — used when the neutral line carries no rate. */
 const DEFAULT_PL_VAT_RATE = '23';
+
+/**
+ * The bridge parses the neutral code as a Polish rate symbol, so it is passed
+ * through verbatim - but the notation is still part of the contract (#2247).
+ * `assertPercentTaxRateNotation` rejects a fractional spelling here rather than
+ * letting `'0.23'` reach Subiekt, where it is neither a known symbol nor a rate
+ * anyone declared.
+ */
+function toStawkaVat(taxRate: string): string {
+  const code = assertPercentTaxRateNotation(taxRate);
+  return code.length > 0 ? code : DEFAULT_PL_VAT_RATE;
+}
 
 export function toBridgeLines(lines: InvoiceLine[]): BridgeLine[] {
   return lines.map((line) => ({
     name: line.name,
     ilosc: line.quantity,
     cenaBrutto: line.unitPriceGross,
-    stawkaVAT: line.taxRate.trim().length > 0 ? line.taxRate.trim() : DEFAULT_PL_VAT_RATE,
+    stawkaVAT: toStawkaVat(line.taxRate),
   }));
 }
 


### PR DESCRIPTION
`InvoiceLine.taxRate` had no single reading.

- Core divided by 100 unconditionally, so `'0.23'` meant 0.23%.
- The inFakt adapter switched on `n > 1`, so `'23'` and `'0.23'` both resolved to 23% - and a genuine **1% rate resolved to 100%**.

On a 123 PLN invoice the two readings diverge by 22.72 PLN. The blast radius is narrow only because the mapper still emits an empty rate and each adapter substitutes its own default; once #2054 lands, every line travels through this field.

## The fix

A guess is the wrong shape here: the writer knows which notation it used, so an ambiguous value is a defect upstream and must surface.

A new pure module, `tax-rate-notation.types`, states the contract once and every reader goes through it. Fractional notation - numeric, strictly between 0 and 1 - raises `FractionalTaxRateNotationError` rather than being multiplied by 100, because `'0.23'` is indistinguishable from a genuine 0.23% rate and normalising it would invent a value nobody stated.

`'0'` is deliberately **not** fractional. A zero rate is a real answer, and PrestaShop already distinguishes it from unknown - that distinction is the whole point of the epic.

## Readers aligned

| Reader | Before | After |
|---|---|---|
| core `rateFraction` | `parseFloat / 100` unconditionally | `taxRatePercentToFraction` |
| inFakt `taxRateNumeric` | `n > 1 ? n / 100 : n` | `taxRatePercentToFraction`, empty-string default kept |
| inFakt `toInfaktTaxSymbol` | accepted `'0.23'` / `'0.08'` / `'0.05'` | fractional spellings rejected |
| Subiekt `stawkaVAT` | raw passthrough | notation-guarded passthrough |
| KSeF `resolveP12` | already rejected (no such map key) | unchanged, now pinned by a test |

The empty-string path is untouched on every adapter; #2257 removes those defaults.

Closes #2247
Refs #2245

🤖 Generated with [Claude Code](https://claude.com/claude-code)