### PR TITLE
feat(web): shared-UI primitives for the tax-rate states

### DIFF
--- a/apps/web/src/features/invoicing/lib/sales-document-block-copy.ts
+++ b/apps/web/src/features/invoicing/lib/sales-document-block-copy.ts
@@ -13,7 +13,11 @@ import type { OrderRecord } from '../../orders';
 
 /** One rendered explanation of why this order carries no fiscal document (#2100). */
 export interface SalesDocumentBlockCopy {
-  tone: 'warning' | 'error' | 'info';
+  /**
+   * Passed straight into `<Alert>`, so it must stay a subset of `AlertTone`.
+   * `'conflict'` (#2253) is available for a non-blocking source disagreement.
+   */
+  tone: 'conflict' | 'warning' | 'error' | 'info';
   title: string;
   body: string;
   /** PII-free elaboration the backend supplied, if any. */

--- a/apps/web/src/features/orders/components/delivery-chip.tsx
+++ b/apps/web/src/features/orders/components/delivery-chip.tsx
@@ -17,8 +17,8 @@
  * Colours reuse the design tokens via `StatusBadge`: green (`success`) =
  * resolved, blue (`info`) = awaiting-label, grey (`neutral`, dashed) = no
  * method / shop-fulfilled, amber (`warning`) = unmapped, semantic conflict
- * orange (`--status-conflict`, via a className override — distinct from the
- * brand accent) = not-connected. Colour is never the only signal — every
+ * orange (the shared `conflict` tone — distinct from the brand accent) =
+ * not-connected. Colour is never the only signal — every
  * chip carries its text label + tone dot.
  *
  * @module apps/web/src/features/orders/components
@@ -164,15 +164,18 @@ export function DeliveryRiderChip({
   if (!isActionableRider(rider)) {
     return null;
   }
+  // `not-connected` / `disabled` read as the shared `conflict` tone (#2253).
+  // The className that used to carry those colours is kept as a hook for
+  // layout and for the tests that assert on it, but it no longer paints.
+  const needsConnection = rider.rider === 'not-connected' || rider.rider === 'disabled';
   return (
     <StatusBadge
-      tone="warning"
+      tone={needsConnection ? 'conflict' : 'warning'}
       withDot
       compact
       className={cx(
         'delivery-rider-chip',
-        rider.rider === 'not-connected' && 'delivery-rider-chip--not-connected',
-        rider.rider === 'disabled' && 'delivery-rider-chip--not-connected',
+        needsConnection && 'delivery-rider-chip--not-connected',
         className,
       )}
     >

--- a/apps/web/src/features/orders/components/order-activity-timeline.tsx
+++ b/apps/web/src/features/orders/components/order-activity-timeline.tsx
@@ -32,7 +32,7 @@ interface TimelineEvent {
   /** Actor eyebrow (e.g. "system · ingest", "system · attempt 2"). */
   by?: string;
   description?: ReactElement | string;
-  tone: 'default' | 'success' | 'error' | 'warning';
+  tone: 'default' | 'success' | 'error' | 'warning' | 'conflict';
   /**
    * Footer rendered below the row body — used to attach the "view all
    * attempts" deep link to the **last** attempt of a capped destination.
@@ -95,6 +95,7 @@ const BLOCK_TONE_FOR_BADGE: Record<StatusBadgeTone, TimelineEvent['tone']> = {
   error: 'error',
   warning: 'warning',
   success: 'success',
+  conflict: 'conflict',
   neutral: 'default',
   info: 'default',
   review: 'default',
@@ -259,6 +260,7 @@ const TONE_CLASS: Record<TimelineEvent['tone'], string> = {
   success: 'order-activity__dot--success',
   error: 'order-activity__dot--error',
   warning: 'order-activity__dot--warning',
+  conflict: 'order-activity__dot--conflict',
 };
 
 export function OrderActivityTimeline({

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1808,6 +1808,12 @@ textarea,
   box-shadow: inset 3px 0 0 var(--status-warning);
 }
 
+.alert--conflict {
+  border-color: var(--status-conflict-border);
+  background: var(--status-conflict-soft);
+  box-shadow: inset 3px 0 0 var(--status-conflict);
+}
+
 .alert--error {
   border-color: var(--status-error-border);
   background: var(--status-error-soft);
@@ -2357,6 +2363,18 @@ textarea,
   color: var(--status-review-fg);
 }
 
+/*
+ * The conflict family has no `-fg` member, so text reads from `-strong`.
+ * The ramp base gives roughly 2.5:1 here and fails contrast; the token
+ * checker is one-directional and would not catch a missing `-fg`, it would
+ * simply resolve to nothing.
+ */
+.status-badge--conflict {
+  border-color: var(--status-conflict-border);
+  background: var(--status-conflict-soft);
+  color: var(--status-conflict-strong);
+}
+
 .status-badge--info {
   border-color: var(--status-info-border);
   background: var(--status-info-soft);
@@ -2491,12 +2509,6 @@ html[data-theme='dark'] .conn-dot--generic {
   margin-left: 4px;
   opacity: 0.55;
   font-weight: 600;
-}
-
-.status-badge.delivery-rider-chip--not-connected {
-  border-color: var(--status-conflict-border);
-  background: var(--status-conflict-soft);
-  color: var(--status-conflict-strong);
 }
 
 .delivery-rider-banner {
@@ -8154,6 +8166,10 @@ a.kpi-card:focus-visible {
 
 .order-activity__dot--warning {
   background: var(--status-warning);
+}
+
+.order-activity__dot--conflict {
+  background: var(--status-conflict);
 }
 
 .order-activity__body {

--- a/apps/web/src/pages/listings/listings-list-page.tsx
+++ b/apps/web/src/pages/listings/listings-list-page.tsx
@@ -24,6 +24,7 @@ import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
 import { ErrorState, EmptyState } from '../../shared/ui/feedback-state';
 import { DataTableSkeleton } from '../../shared/ui/data-table-skeleton';
 import { Button } from '../../shared/ui/button';
+import { AbsentValue } from '../../shared/ui/absent-value';
 import { EmptyValue } from '../../shared/ui/empty-value';
 import { Input } from '../../shared/ui/input';
 import { Select } from '../../shared/ui/select';
@@ -161,21 +162,6 @@ function ColumnHead({
       {label}
       <span className="listings-col-head__note">{note}</span>
     </span>
-  );
-}
-
-/**
- * `EmptyValue` names itself with `aria-label` on a bare `<span>` - a generic
- * element ARIA prohibits naming, which screen readers commonly drop. The
- * never-read-versus-zero distinction is the whole point of this page's
- * commercial columns, so the wording is also carried visually-hidden.
- */
-function AbsentValue({ label }: { label: string }): ReactElement {
-  return (
-    <>
-      <EmptyValue label={label} />
-      <span className="sr-only">{label}</span>
-    </>
   );
 }
 

--- a/apps/web/src/shared/ui/absent-value.test.tsx
+++ b/apps/web/src/shared/ui/absent-value.test.tsx
@@ -1,0 +1,26 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { AbsentValue } from './absent-value';
+
+describe('AbsentValue', () => {
+  afterEach(cleanup);
+
+  it('should render a visible dash when the value is absent', () => {
+    const { container } = render(<AbsentValue label="No rate read yet" />);
+    expect(container.textContent).toContain('—');
+  });
+
+  it('should carry the wording visually hidden, not only as an aria-label', () => {
+    // aria-label on a bare <span> is prohibited and commonly dropped, which is
+    // why absence-versus-zero cannot rely on it (#2253).
+    const { container } = render(<AbsentValue label="No rate read yet" />);
+    const hidden = container.querySelector('.sr-only');
+    expect(hidden).not.toBeNull();
+    expect(hidden).toHaveTextContent('No rate read yet');
+  });
+
+  it('should still expose the label to the accessibility tree', () => {
+    render(<AbsentValue label="Price not reported by the channel" />);
+    expect(screen.getByLabelText('Price not reported by the channel')).toHaveTextContent('—');
+  });
+});

--- a/apps/web/src/shared/ui/absent-value.tsx
+++ b/apps/web/src/shared/ui/absent-value.tsx
@@ -1,0 +1,41 @@
+/**
+ * Absent Value (#2253)
+ *
+ * The one renderer for "this value is absent", as distinct from "this value is
+ * zero". A visible em-dash carries the distinction for a sighted reader; the
+ * wording carries it for everyone else.
+ *
+ * The wording is rendered **visually hidden** rather than as an `aria-label`.
+ * `EmptyValue` names itself with `aria-label` on a bare `<span>`, a generic
+ * element ARIA prohibits naming, and screen readers commonly drop it - so on
+ * the surfaces where absence-versus-zero is the actual claim, the label is not
+ * reliably announced at all.
+ *
+ * Promoted out of `pages/listings/listings-list-page.tsx`, where it was
+ * file-local. Absence versus zero is the central claim of the per-line
+ * tax-rate work (#2245): a rate of `0` is a real answer - export, intra-EU,
+ * exempt goods - and "we have no rate" is a different fact that holds the
+ * document. Two implementations of that distinction would eventually disagree.
+ *
+ * `EmptyValue` stays as-is for the ordinary "nothing here" cell, where the
+ * absent-versus-zero question does not arise.
+ *
+ * @module apps/web/src/shared/ui
+ */
+import type { ReactElement } from 'react';
+
+import { EmptyValue } from './empty-value';
+
+interface AbsentValueProps {
+  /** What is absent, in words. Announced; also carried on the dash. */
+  label: string;
+}
+
+export function AbsentValue({ label }: AbsentValueProps): ReactElement {
+  return (
+    <>
+      <EmptyValue label={label} />
+      <span className="sr-only">{label}</span>
+    </>
+  );
+}

--- a/apps/web/src/shared/ui/alert.tsx
+++ b/apps/web/src/shared/ui/alert.tsx
@@ -1,6 +1,13 @@
 import type { ReactElement, ReactNode } from 'react';
 
-export type AlertTone = 'error' | 'info' | 'success' | 'warning';
+/**
+ * `conflict` (#2253) reports two sources disagreeing about the same fact. It
+ * is deliberately **not** `error`: the work still completed, so the alert
+ * lands on `role="status"` below rather than interrupting a screen reader
+ * mid-task. That is the correct politeness level for a non-blocking advisory,
+ * and it follows from the tone rather than being chosen per call site.
+ */
+export type AlertTone = 'conflict' | 'error' | 'info' | 'success' | 'warning';
 
 interface AlertProps {
   action?: ReactNode;

--- a/apps/web/src/shared/ui/index.ts
+++ b/apps/web/src/shared/ui/index.ts
@@ -19,6 +19,7 @@
  */
 
 // ── Feedback / status ──────────────────────────────────────────────
+export { AbsentValue } from './absent-value';
 export { Alert } from './alert';
 export type { AlertTone } from './alert';
 export { StatusBadge } from './status-badge';

--- a/apps/web/src/shared/ui/status-badge.tsx
+++ b/apps/web/src/shared/ui/status-badge.tsx
@@ -1,6 +1,19 @@
 import type { ReactElement, ReactNode } from 'react';
 
-export type StatusBadgeTone = 'error' | 'info' | 'neutral' | 'review' | 'success' | 'warning';
+/**
+ * `conflict` (#2253) is for two sources disagreeing about the same fact - a
+ * state that needs attention but is not an error, because the document still
+ * issued. Its family has no `-fg` member, so the CSS rule reads
+ * `--status-conflict-strong`.
+ */
+export type StatusBadgeTone =
+  | 'conflict'
+  | 'error'
+  | 'info'
+  | 'neutral'
+  | 'review'
+  | 'success'
+  | 'warning';
 
 interface StatusBadgeProps {
   children: ReactNode;


### PR DESCRIPTION
Three shared-UI additions the per-line tax-rate surfaces need, and nothing else. Everything the reviews rejected stays rejected.

## `StatusBadgeTone += 'conflict'`

Two sources disagreeing about the same fact - needs attention, but not an error, because the document still issued.

Two details that were easy to get wrong, and both are handled:

- The family has **no `-fg` member**, so the rule reads `--status-conflict-strong`. The ramp base gives roughly 2.5:1 and fails contrast, and nothing would have caught it - `check-design-tokens.mjs` is one-directional, so a rule reading a token that does not exist resolves to nothing silently.
- The family **already had a consumer** through a className override (`.status-badge.delivery-rider-chip--not-connected`). That override is migrated onto the tone here rather than left as a second owner with a second text token. The className survives as a layout hook, so the existing `delivery-chip.test.tsx` assertions still hold.

Adding the member compile-forced both of the timeline's exhaustive records (`BLOCK_TONE_FOR_BADGE`, `TONE_CLASS`); both gain it along with the `TimelineEvent` tone member and `.order-activity__dot--conflict`.

## `AlertTone += 'conflict'`

`Alert` picks `role="alert"` only for `error`, so a conflict alert lands on `role="status"` - the correct politeness level for a non-blocking advisory, now following from the tone rather than from a per-call-site choice. `SalesDocumentBlockCopy['tone']` widens to match, since its value is passed straight into `<Alert>`.

## One exported absence primitive

`AbsentValue` moves from `pages/listings/listings-list-page.tsx` into `shared/ui`, with a test. Absence versus zero is this epic's central claim - a rate of `0` is a real answer, and "no rate" holds the document - so it needs one implementation. It renders the wording visually hidden rather than as an `aria-label`, because `aria-label` on a bare `<span>` is prohibited and commonly dropped.

`EmptyValue` is left alone: it has 39 callers, and folding the hidden wording into it would change what every empty cell in the app announces.

## Not done, deliberately

`ChipTone += 'conflict'` (`.chip--active` overrides every tone, so an inactive conflict chip reads as pressed), extracting the timeline into `shared/ui`, extending the bulk editor's provenance union, and any new `MetricCard` caller.

Closes #2253
Refs #2245

🤖 Generated with [Claude Code](https://claude.com/claude-code)