### PR TITLE
feat(products): per-line tax rate on the order contract and the master reads

### DIFF
--- a/apps/api/src/listings/http/listings.controller.spec.ts
+++ b/apps/api/src/listings/http/listings.controller.spec.ts
@@ -190,6 +190,8 @@ describe('ListingsController', () => {
       upsertMany: jest.fn(),
       findMany: jest.fn(),
       markStaleExceptVariants: jest.fn(),
+    recordTaxRate: jest.fn(),
+    findTaxRate: jest.fn(),
     };
     categoryResolution = {
       resolveCategory: jest.fn(),

--- a/apps/api/src/migrations/1837000000000-add-product-tax-rate.ts
+++ b/apps/api/src/migrations/1837000000000-add-product-tax-rate.ts
@@ -1,0 +1,69 @@
+/**
+ * Add the per-line tax-rate projection to the catalogue (#2054, ADR-052).
+ *
+ * Additive and nullable, with **no backfill**: inventing a rate is exactly the
+ * failure this epic removes. Every existing row therefore lands in the
+ * *never checked* state (`taxRateReadAt IS NULL`), which is the truth - the
+ * master has not been asked yet - and is deliberately distinct from *checked,
+ * and the shop has no rate* (`taxRateReadAt IS NOT NULL AND taxRate IS NULL`).
+ * Without that separation the gate would claim the whole catalogue is
+ * incomplete on day one and the pre-rollout coverage count would measure
+ * nothing.
+ *
+ * The two partial indexes exist because both states must be answerable as a
+ * query rather than a crawl: "which products have no rate" backs the operator
+ * surface, "which have not been checked" backs the sync suggestion.
+ */
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddProductTaxRate1837000000000 implements MigrationInterface {
+  name = 'AddProductTaxRate1837000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "products" ADD COLUMN IF NOT EXISTS "taxRate" character varying(16)`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "products" ADD COLUMN IF NOT EXISTS "taxRateCountry" character varying(2)`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "products" ADD COLUMN IF NOT EXISTS "taxRateReadAt" TIMESTAMP WITH TIME ZONE`
+    );
+
+    await queryRunner.query(
+      `ALTER TABLE "product_variants" ADD COLUMN IF NOT EXISTS "taxRate" character varying(16)`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "product_variants" ADD COLUMN IF NOT EXISTS "taxRateCountry" character varying(2)`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "product_variants" ADD COLUMN IF NOT EXISTS "taxRateReadAt" TIMESTAMP WITH TIME ZONE`
+    );
+
+    // "Not yet checked" - the sync suggestion's population.
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_products_tax_rate_unchecked"
+        ON "products" ("id")
+        WHERE "taxRateReadAt" IS NULL
+    `);
+    // "Checked, and the shop has no rate" - the population that holds documents.
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_products_tax_rate_missing"
+        ON "products" ("id")
+        WHERE "taxRateReadAt" IS NOT NULL AND "taxRate" IS NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_products_tax_rate_missing"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_products_tax_rate_unchecked"`);
+    await queryRunner.query(`ALTER TABLE "product_variants" DROP COLUMN IF EXISTS "taxRateReadAt"`);
+    await queryRunner.query(
+      `ALTER TABLE "product_variants" DROP COLUMN IF EXISTS "taxRateCountry"`
+    );
+    await queryRunner.query(`ALTER TABLE "product_variants" DROP COLUMN IF EXISTS "taxRate"`);
+    await queryRunner.query(`ALTER TABLE "products" DROP COLUMN IF EXISTS "taxRateReadAt"`);
+    await queryRunner.query(`ALTER TABLE "products" DROP COLUMN IF EXISTS "taxRateCountry"`);
+    await queryRunner.query(`ALTER TABLE "products" DROP COLUMN IF EXISTS "taxRate"`);
+  }
+}

--- a/apps/api/src/products/http/products.controller.spec.ts
+++ b/apps/api/src/products/http/products.controller.spec.ts
@@ -64,6 +64,10 @@ function createMockProductsService(): jest.Mocked<IProductsService> {
     listVariants: jest.fn(),
     getVariantCountsByProductIds: jest.fn(),
     markVariantsStaleExcept: jest.fn(),
+  recordProductTaxRate: jest.fn(),
+  recordVariantTaxRate: jest.fn(),
+  getEffectiveTaxRate: jest.fn(),
+  getTaxRateCoverage: jest.fn(),
   };
 }
 

--- a/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
@@ -24,6 +24,7 @@ import type { IOrderRecordService } from '../../interfaces/order-record.service.
 import type { IOrderItemRefResolverService } from '../../interfaces/order-item-ref-resolver.service.interface';
 import type { IOrderLifecycleRelayService } from '../../interfaces/order-lifecycle-relay.service.interface';
 import type { IAutoIssueTriggerService } from '@openlinker/core/invoicing';
+import type { IProductsService } from '@openlinker/core/products';
 import { MissingOrderItemMappingError } from '../../../domain/exceptions/missing-order-item-mapping.error';
 import type { OrderRecord } from '../../../domain/entities/order-record.entity';
 
@@ -45,6 +46,7 @@ describe('OrderIngestionService', () => {
   let customerProjectionUpdater: jest.Mocked<IOrderCustomerProjectionUpdaterService>;
   let orderLifecycleRelay: jest.Mocked<IOrderLifecycleRelayService>;
   let autoIssueTrigger: jest.Mocked<IAutoIssueTriggerService>;
+  let productsService: jest.Mocked<IProductsService>;
 
   const connectionId = 'connection-123';
   const cursorKey = 'allegro.orders.lastEventId';
@@ -125,6 +127,15 @@ describe('OrderIngestionService', () => {
     autoIssueTrigger = {
       onOrderTransition: jest.fn().mockResolvedValue({ kind: 'none' }),
     } as unknown as jest.Mocked<IAutoIssueTriggerService>;
+    // #2054: default to "the catalogue has never been asked", the honest
+    // post-deploy state - so these specs assert the pre-tax-rate behaviour.
+    productsService = {
+      getEffectiveTaxRate: jest.fn().mockResolvedValue({
+        code: null,
+        countryIso2: null,
+        readAt: null,
+      }),
+    } as unknown as jest.Mocked<IProductsService>;
 
     service = new OrderIngestionService(
       integrationsService,
@@ -138,7 +149,8 @@ describe('OrderIngestionService', () => {
       orderRecordService,
       customerProjectionUpdater,
       orderLifecycleRelay,
-      autoIssueTrigger
+      autoIssueTrigger,
+      productsService
     );
   });
 

--- a/libs/core/src/orders/application/services/order-ingestion.service.ts
+++ b/libs/core/src/orders/application/services/order-ingestion.service.ts
@@ -50,7 +50,14 @@ import {
 import { IOrderRecordService } from '../interfaces/order-record.service.interface';
 import { IOrderItemRefResolverService } from '../interfaces/order-item-ref-resolver.service.interface';
 import { IOrderLifecycleRelayService } from '../interfaces/order-lifecycle-relay.service.interface';
-import type { IncomingOrder } from '../../domain/types/incoming-order.types';
+import type { IncomingOrder, IncomingOrderItem } from '../../domain/types/incoming-order.types';
+import {
+  IProductsService,
+  PRODUCTS_SERVICE_TOKEN,
+  taxRateState,
+  type StoredTaxRate,
+  type TaxRateSource,
+} from '@openlinker/core/products';
 import type { Order } from '../../domain/types/order.types';
 import type { OrderFeedEventType } from '../../domain/types/order-feed.types';
 import type { OrderRecord } from '../../domain/entities/order-record.entity';
@@ -94,7 +101,12 @@ export class OrderIngestionService implements IOrderIngestionService {
     // issuance jobs. One-way edge (F3) — this service is consumed via the token,
     // never the reverse.
     @Inject(AUTO_ISSUE_TRIGGER_SERVICE_TOKEN)
-    private readonly autoIssueTrigger: IAutoIssueTriggerService
+    private readonly autoIssueTrigger: IAutoIssueTriggerService,
+    // #2054: the catalogue projection the per-line tax rate is settled from.
+    // A read of OL's own store, never a live shop call - issuance must not
+    // depend on the shop being reachable.
+    @Inject(PRODUCTS_SERVICE_TOKEN)
+    private readonly productsService: IProductsService
   ) {}
 
   async ingestOrders(
@@ -307,6 +319,11 @@ export class OrderIngestionService implements IOrderIngestionService {
     for (const item of incoming.items) {
       const result = await this.orderItemRefResolver.tryResolve(connectionId, item.productRef);
       if (result.resolved) {
+        const tax = await this.resolveLineTaxRate(
+          result.internalProductId,
+          result.internalVariantId,
+          item
+        );
         resolvedItems.push({
           id: item.id,
           productId: result.internalProductId,
@@ -316,6 +333,7 @@ export class OrderIngestionService implements IOrderIngestionService {
           sku: item.sku,
           name: item.name,
           imageUrl: item.imageUrl,
+          ...tax,
         });
       } else {
         unresolvedRefs.push({ itemId: item.id, reason: result.reason, kind: result.kind });
@@ -664,6 +682,71 @@ export class OrderIngestionService implements IOrderIngestionService {
     }
 
     return undefined;
+  }
+
+  /**
+   * Settle the line's tax rate at ingestion (#2054, ADR-052 § 1 and § 4).
+   *
+   * Shop first, channel second. The order of the two rungs is the decision, not
+   * an implementation detail: a rate fixed in the shop serves every channel,
+   * while a rate only the marketplace knows was stamped at purchase and can
+   * never be corrected afterwards - so preferring the channel would quietly
+   * make the unfixable answer authoritative.
+   *
+   * The shop is read from OpenLinker's own catalogue projection, never live.
+   * Issuance must not depend on the shop being reachable, and re-ingesting an
+   * order must not be able to move a figure a document was already issued
+   * against.
+   *
+   * Returning **nothing** is a real outcome and is left as absent fields, not
+   * an empty string or a zero. It is what holds the document, and the gate
+   * child is what reports it.
+   */
+  private async resolveLineTaxRate(
+    productId: string,
+    variantId: string | undefined,
+    item: IncomingOrderItem
+  ): Promise<{
+    taxRate?: string;
+    taxRateCountry?: string;
+    taxSource?: TaxRateSource;
+    taxRateReadAt?: string;
+  }> {
+    let shopRate: StoredTaxRate | null = null;
+    try {
+      shopRate = await this.productsService.getEffectiveTaxRate(productId, variantId);
+    } catch (error) {
+      // A catalogue read failure is not a statement about the rate. Fall
+      // through to the channel rung rather than recording a false absence.
+      this.logger.warn(
+        `Tax-rate catalogue read failed for order line [productId=${productId}, variantId=${variantId ?? 'none'}]: ${(error as Error).message}`
+      );
+    }
+
+    if (shopRate && taxRateState(shopRate) === 'known' && shopRate.code) {
+      return {
+        taxRate: shopRate.code,
+        ...(shopRate.countryIso2 ? { taxRateCountry: shopRate.countryIso2 } : {}),
+        taxSource: 'shop',
+        ...(shopRate.readAt ? { taxRateReadAt: shopRate.readAt.toISOString() } : {}),
+      };
+    }
+
+    const channelCode = item.taxRate?.trim();
+    if (channelCode) {
+      return {
+        taxRate: channelCode,
+        ...(item.taxRateCountry ? { taxRateCountry: item.taxRateCountry } : {}),
+        taxSource: 'channel',
+        // The channel reported it with this order, so the read instant is now.
+        taxRateReadAt: new Date().toISOString(),
+      };
+    }
+
+    // Neither rung answered. `taxRateReadAt` still travels when the shop was
+    // asked, so a reader can tell "the shop has no rate for this" apart from
+    // "nothing has ever looked" - the distinction #2245 F3 exists for.
+    return shopRate?.readAt ? { taxRateReadAt: shopRate.readAt.toISOString() } : {};
   }
 
   private buildUnifiedOrder(

--- a/libs/core/src/orders/domain/types/incoming-order.types.ts
+++ b/libs/core/src/orders/domain/types/incoming-order.types.ts
@@ -161,6 +161,26 @@ export interface IncomingOrderItem {
    * for future enrichment.
    */
   imageUrl?: string;
+
+  /**
+   * The tax rate the CHANNEL reported for this line, as a neutral
+   * percent-as-string code (#2054, ADR-052).
+   *
+   * This is the fallback rung, not the answer: the shop is asked first, and
+   * the channel is consulted only when the shop does not know (ADR-052 § 1).
+   * A fix applied in the shop then serves every channel, whereas a rate only
+   * the marketplace knows is stamped at purchase and cannot be corrected
+   * afterwards.
+   *
+   * Absent means the source did not report one - which is every source until
+   * the channel-read child lands. Allegro's `lineItems[].tax` is nullable and
+   * OL published offers carry no rate at all; Erli's `items[].taxRate` is a
+   * required enum and always does.
+   */
+  taxRate?: string;
+
+  /** ISO 3166-1 alpha-2 the channel resolved its rate against. Provenance only. */
+  taxRateCountry?: string;
 }
 
 /**

--- a/libs/core/src/orders/domain/types/order.types.ts
+++ b/libs/core/src/orders/domain/types/order.types.ts
@@ -9,6 +9,7 @@
  * @module libs/core/src/orders/domain/types
  */
 import type { PickupPointType } from '@openlinker/core/shipping';
+import type { TaxRateSource } from '@openlinker/core/products';
 
 import type { PaymentStatus } from './payment-status.types';
 import type { CodToCollect } from './cod-to-collect.types';
@@ -252,6 +253,44 @@ export interface OrderItem {
    * future enrichment — no current adapter sets this on ingestion.
    */
   imageUrl?: string;
+
+  /**
+   * The tax rate this line carries, as a neutral percent-as-string code
+   * (`'23'`, `'8'`, `'5'`, `'0'`, `'zw'`, `'np'`, `'oo'`) — #2054, ADR-052.
+   *
+   * **The stored order snapshot is the only place a rate is settled.** It is
+   * resolved once at ingestion from OpenLinker's own catalogue projection
+   * (variant override first, then the product), so issuance never depends on
+   * the shop being reachable and re-reading the order cannot move a figure a
+   * document was already issued against.
+   *
+   * Absent means the rate was never established, which HOLDS the document
+   * rather than defaulting it. `'0'` is a rate, not an absence.
+   */
+  taxRate?: string;
+
+  /**
+   * ISO 3166-1 alpha-2 the rate was resolved against. **Provenance only** — it
+   * is never compared with the buyer's country and blocks nothing.
+   */
+  taxRateCountry?: string;
+
+  /**
+   * Which system stated the rate: the shop (ProductMaster) or the sales
+   * channel. Absent alongside an absent `taxRate` means it was never read.
+   *
+   * Carried on the line rather than derived downstream (#2245 F3): without it
+   * *no rate*, *never read* and *pre-rollout* all reach a reader as the same
+   * `undefined`, and a provenance caption has nothing to render.
+   */
+  taxSource?: TaxRateSource;
+
+  /**
+   * When the rate was read from that system, ISO 8601. Shown rather than
+   * enforced — there is no freshness rule, because rate changes are announced
+   * ahead and do not apply retroactively (ADR-052 § 4).
+   */
+  taxRateReadAt?: string;
 }
 
 /**
@@ -277,8 +316,15 @@ export interface OrderTotals {
    * source-uniform: absent means "not asserted by the source", and a
    * destination falls back to its prior assumption. Destinations that price
    * net (e.g. PrestaShop `specific_price`) use this to decide whether the
-   * buyer-paid amount must be converted to net before pinning — the tax *rate*
-   * itself stays destination-side, never on the order contract.
+   * buyer-paid amount must be converted to net before pinning.
+   *
+   * **This is the order-wide inclusivity flag, and it is all it is.** It used
+   * to add that "the tax *rate* itself stays destination-side, never on the
+   * order contract"; ADR-052 reverses that half (adopting ADR-014's own
+   * amendment), because one aggregate `tax` plus one order-wide treatment
+   * cannot describe a mixed-rate basket. The per-line rate now lives on
+   * `OrderItem.taxRate`. The inclusivity half is unchanged: it really is
+   * source-uniform, and it stays here.
    */
   taxTreatment?: PriceTaxTreatment;
 }

--- a/libs/core/src/products/application/services/master-product-sync.service.ts
+++ b/libs/core/src/products/application/services/master-product-sync.service.ts
@@ -22,6 +22,8 @@ import { EventPublisherPort, EVENT_PUBLISHER_TOKEN } from '@openlinker/core/even
 import { PRODUCTS_SERVICE_TOKEN } from '../../products.tokens';
 import { IProductsService } from './products.service.interface';
 import type { ProductMasterPort } from '../../domain/ports/product-master.port';
+import { isProductTaxRateReader } from '../../domain/ports/capabilities/product-tax-rate-reader.capability';
+import type { TaxRateResolution } from '../../domain/types/tax-rate.types';
 import type { Product } from '../../domain/entities/product.entity';
 import type { ProductVariant } from '../../domain/entities/product-variant.entity';
 import { MasterProductNotFoundError } from '../../domain/exceptions/master-product-not-found.error';
@@ -124,6 +126,13 @@ export class MasterProductSyncService implements IMasterProductSyncService {
       await this.productsService.upsertVariants(internalProductId, variants);
     }
 
+    // Pull the tax rate onto the catalogue projection (#2054, ADR-052 § 4), in
+    // the same pass that already refreshes price and currency. Best-effort and
+    // strictly after the upserts: a rate read that fails must not cost the
+    // catalogue its product body, and leaving the row untouched keeps it in the
+    // honest `never checked` state rather than recording a false `no rate`.
+    await this.syncTaxRate(productAdapter, internalProductId, variants, connectionId, correlationId);
+
     // Soft-mark any previously-known variant absent from this master response as
     // stale (#1599 — the products-context counterpart of the inventory prune).
     // Guarded against a false positive: a successful pull returning ZERO variants
@@ -184,6 +193,85 @@ export class MasterProductSyncService implements IMasterProductSyncService {
       pruneSkipped,
       pruneSkippedReason,
     };
+  }
+
+  /**
+   * Ask the master what tax the product carries and store the answer (#2054).
+   *
+   * Three properties are deliberate.
+   *
+   * **A master with no answer is not asked.** `isProductTaxRateReader` narrows
+   * the already-dispatched adapter; a master that does not implement the
+   * capability leaves the row untouched, so it stays *never checked* rather
+   * than being recorded as *checked, no rate*. The two drive different operator
+   * copy and only one of them holds documents.
+   *
+   * **An `unknown` answer IS recorded**, as a null code with a real timestamp.
+   * That is the whole reason the timestamp column exists: the master answered,
+   * and what it said was "I have no rate for this". Skipping the write here
+   * would make a configured-but-rate-less catalogue indistinguishable from one
+   * nobody has synced.
+   *
+   * **A throw is swallowed, and leaves the row untouched.** A transport failure
+   * says nothing about the shop's configuration, so recording anything would be
+   * a claim the read does not support; the next sync asks again.
+   */
+  private async syncTaxRate(
+    adapter: ProductMasterPort,
+    internalProductId: string,
+    variants: readonly ProductVariant[],
+    connectionId: string,
+    correlationId: string
+  ): Promise<void> {
+    if (!isProductTaxRateReader(adapter)) return;
+
+    const readAt = new Date();
+    try {
+      const productRate = await adapter.readProductTaxRate({ productId: internalProductId });
+      await this.productsService.recordProductTaxRate(
+        internalProductId,
+        this.toStoredTaxRate(productRate, readAt)
+      );
+
+      // Only a variant-keyed master gets per-variant reads. On a product-keyed
+      // one (PrestaShop) every variant would echo the product's rate, and
+      // storing that as an override would turn a shared value into N copies
+      // that drift the moment the product's changes.
+      if (adapter.readsTaxRatePerVariant?.() !== true) return;
+
+      for (const variant of variants) {
+        const variantRate = await adapter.readProductTaxRate({
+          productId: internalProductId,
+          variantId: variant.id,
+        });
+        // `inherited` means the variant defers to the product, which is not an
+        // override at all - so nothing is written and the row stays genuinely
+        // absent. Copying the product's code down would create a duplicate that
+        // goes stale the next time the product's rate changes.
+        if (variantRate.kind === 'inherited') continue;
+        await this.productsService.recordVariantTaxRate(
+          variant.id,
+          this.toStoredTaxRate(variantRate, readAt)
+        );
+      }
+    } catch (error) {
+      this.logger.warn(
+        `[master-sync] tax-rate read failed, leaving the catalogue row unchanged: ` +
+          `connectionId=${connectionId} internalProductId=${internalProductId} ` +
+          `correlationId=${correlationId} error=${(error as Error).message}`
+      );
+    }
+  }
+
+  /** A resolution becomes a stored row; `unknown` stores a null code, not a zero. */
+  private toStoredTaxRate(
+    resolution: TaxRateResolution,
+    readAt: Date
+  ): { code: string | null; countryIso2: string | null; readAt: Date } {
+    return resolution.kind === 'resolved'
+      ? { code: resolution.code, countryIso2: resolution.countryIso2, readAt }
+      : { code: null, countryIso2: null, readAt };
+
   }
 
   /**

--- a/libs/core/src/products/application/services/products.service.interface.ts
+++ b/libs/core/src/products/application/services/products.service.interface.ts
@@ -17,6 +17,7 @@ import type {
   PaginatedProducts,
   PaginatedProductVariants,
 } from '../../domain/types/product.types';
+import type { StoredTaxRate } from '../../domain/types/tax-rate.types';
 
 /**
  * Products Service Interface
@@ -42,6 +43,36 @@ export interface IProductsService {
    * @param variants - Array of product variant domain entities
    */
   upsertVariants(productId: string, variants: ProductVariant[]): Promise<void>;
+
+  /**
+   * Record what a ProductMaster said about a product's tax rate (#2054).
+   *
+   * Separate from `upsertProduct` on purpose: the sync upsert carries no rate,
+   * so folding this into it would let an ordinary catalogue refresh blank a
+   * rate - and a blanked rate holds documents.
+   *
+   * Recording `{ code: null, readAt }` is meaningful: it says *the master was
+   * asked and has no rate*, which the gate treats differently from
+   * *never asked*.
+   */
+  recordProductTaxRate(productId: string, rate: StoredTaxRate): Promise<void>;
+
+  /** Record a per-variant override. Only a variant-keyed master calls this. */
+  recordVariantTaxRate(variantId: string, rate: StoredTaxRate): Promise<void>;
+
+  /**
+   * The rate that applies to a line, resolved from the catalogue projection.
+   * The variant override wins where present; otherwise the product's rate.
+   */
+  getEffectiveTaxRate(productId: string, variantId?: string): Promise<StoredTaxRate>;
+
+  /** Catalogue coverage by tax-rate read state (#2054 / #2256). */
+  getTaxRateCoverage(): Promise<{
+    total: number;
+    known: number;
+    missing: number;
+    notChecked: number;
+  }>;
 
   /**
    * Get a single product by internal ID

--- a/libs/core/src/products/application/services/products.service.spec.ts
+++ b/libs/core/src/products/application/services/products.service.spec.ts
@@ -52,6 +52,9 @@ describe('ProductsService', () => {
     findByIds: jest.fn(),
     findMany: jest.fn(),
     upsert: jest.fn(),
+    recordTaxRate: jest.fn(),
+    findTaxRate: jest.fn(),
+    countTaxRateStates: jest.fn(),
   };
 
   const mockVariantRepo: jest.Mocked<ProductVariantRepositoryPort> = {
@@ -66,6 +69,8 @@ describe('ProductsService', () => {
     upsertMany: jest.fn(),
     findMany: jest.fn(),
     markStaleExceptVariants: jest.fn(),
+    recordTaxRate: jest.fn(),
+    findTaxRate: jest.fn(),
   };
 
   beforeEach(async () => {

--- a/libs/core/src/products/application/services/products.service.ts
+++ b/libs/core/src/products/application/services/products.service.ts
@@ -25,6 +25,8 @@ import type {
   PaginatedProducts,
   PaginatedProductVariants,
 } from '../../domain/types/product.types';
+import type { StoredTaxRate } from '../../domain/types/tax-rate.types';
+import { effectiveTaxRate } from '../../domain/types/tax-rate.types';
 import { Logger } from '@openlinker/shared/logging';
 import { PRODUCT_REPOSITORY_TOKEN, PRODUCT_VARIANT_REPOSITORY_TOKEN } from '../../products.tokens';
 
@@ -67,6 +69,40 @@ export class ProductsService implements IProductsService {
 
     await this.variantRepository.upsertMany(variantsWithProductId);
     this.logger.debug(`Variants upserted for product: ${productId}`);
+  }
+
+  async recordProductTaxRate(productId: string, rate: StoredTaxRate): Promise<void> {
+    await this.productRepository.recordTaxRate(productId, rate);
+  }
+
+  async recordVariantTaxRate(variantId: string, rate: StoredTaxRate): Promise<void> {
+    await this.variantRepository.recordTaxRate(variantId, rate);
+  }
+
+  /**
+   * The rate that applies to a line (#2054).
+   *
+   * The variant override is read first and wins where the shop carries one -
+   * it is the more specific statement of the same fact, not a conflict to
+   * arbitrate. An absent override means "no opinion", never "no rate", so a
+   * product-keyed master (PrestaShop) resolves through the product row
+   * unchanged.
+   */
+  async getEffectiveTaxRate(productId: string, variantId?: string): Promise<StoredTaxRate> {
+    const [productRate, variantRate] = await Promise.all([
+      this.productRepository.findTaxRate(productId),
+      variantId ? this.variantRepository.findTaxRate(variantId) : Promise.resolve(null),
+    ]);
+    return effectiveTaxRate(productRate, variantRate);
+  }
+
+  async getTaxRateCoverage(): Promise<{
+    total: number;
+    known: number;
+    missing: number;
+    notChecked: number;
+  }> {
+    return this.productRepository.countTaxRateStates();
   }
 
   async getProduct(id: string): Promise<Product | null> {

--- a/libs/core/src/products/domain/ports/capabilities/product-tax-rate-reader.capability.ts
+++ b/libs/core/src/products/domain/ports/capabilities/product-tax-rate-reader.capability.ts
@@ -1,0 +1,75 @@
+/**
+ * Product Tax Rate Reader Capability (#2054, ADR-052)
+ *
+ * Optional sub-capability of `ProductMasterPort`: the master states the tax
+ * rate a product carries. A master that can answer declares
+ * `implements ProductTaxRateReader`; one that cannot simply does not, and the
+ * catalogue row for its products stays *never checked* rather than being
+ * recorded as *no rate* - a distinction the whole gate depends on.
+ *
+ * Naming: sub-capabilities drop the `Port` suffix - they layer onto
+ * `ProductMasterPort` rather than being independent top-level ports.
+ *
+ * Guard-only, for the same reason as `ModifiedProductLister`: a connection's
+ * `enabledCapabilities` is stamped at create and never retro-filled, so gating
+ * on a newly advertised name would silently answer nothing for every connection
+ * that already exists. Call sites narrow an already-dispatched `ProductMaster`
+ * adapter with `isProductTaxRateReader`.
+ *
+ * @module libs/core/src/products/domain/ports/capabilities
+ * @see {@link ProductMasterPort} for the base port
+ * @see {@link TaxRateResolution} for the answer shape
+ */
+import type { TaxRateResolution } from '../../types/tax-rate.types';
+import type { ProductMasterPort } from '../product-master.port';
+
+export interface ReadProductTaxRateInput {
+  /** Internal OpenLinker product id. The adapter resolves it to its own id. */
+  productId: string;
+  /**
+   * Internal variant id, when the caller wants the variant's own rate.
+   *
+   * A master that keys tax on the product alone (PrestaShop does) ignores it
+   * and answers the product's rate; the caller stores that against the product
+   * row, so the absent variant override is a fact rather than a gap. A master
+   * that keys per variant (WooCommerce can) answers the variant's own.
+   */
+  variantId?: string;
+}
+
+export interface ProductTaxRateReader {
+  /**
+   * State the tax rate this product carries.
+   *
+   * MUST return `kind: 'unknown'` rather than a `'0'` code whenever the read
+   * did not establish the rate. A zero code is reserved for a rate the shop
+   * deliberately set to zero - "No tax" in PrestaShop's own product dropdown,
+   * or a WooCommerce `tax_status: 'none'`. Reading the first as the second
+   * mis-taxes the sale silently, which is the failure this whole contract
+   * exists to prevent (#2052 named it on the order-create path).
+   *
+   * A transport failure propagates as a thrown error, unchanged, so the caller
+   * can retry. `unknown` means the master answered and the answer did not name
+   * a rate - a condition an operator fixes in the shop, not a retry.
+   *
+   * On a variant read, `kind: 'inherited'` says the variant defers to the
+   * product. The caller stores nothing for it, so the override stays absent
+   * rather than becoming a stale duplicate of the product's code.
+   */
+  readProductTaxRate(input: ReadProductTaxRateInput): Promise<TaxRateResolution>;
+
+  /**
+   * Whether this master keys tax **per variant**.
+   *
+   * PrestaShop keys on the product, so every variant read there would return
+   * the product's rate and storing it as a variant override would be noise.
+   * Optional: absent means product-keyed.
+   */
+  readsTaxRatePerVariant?(): boolean;
+}
+
+export function isProductTaxRateReader(
+  adapter: ProductMasterPort
+): adapter is ProductMasterPort & ProductTaxRateReader {
+  return typeof (adapter as Partial<ProductTaxRateReader>).readProductTaxRate === 'function';
+}

--- a/libs/core/src/products/domain/ports/product-repository.port.ts
+++ b/libs/core/src/products/domain/ports/product-repository.port.ts
@@ -10,6 +10,7 @@
  * @see {@link ProductRepository} for the TypeORM implementation
  */
 import type { Product } from '../entities/product.entity';
+import type { StoredTaxRate } from '../types/tax-rate.types';
 import type {
   ProductListFilters,
   ProductPagination,
@@ -68,4 +69,31 @@ export interface ProductRepositoryPort {
    * @returns Upserted product domain entity
    */
   upsert(product: Product): Promise<Product>;
+
+  /**
+   * Record what the ProductMaster said about this product's tax rate (#2054).
+   *
+   * A **separate writer** from `upsert`, deliberately. The ordinary product
+   * upsert runs on every sync and does not carry a rate, so round-tripping the
+   * columns through it would null a value a tax read had just written - the
+   * single-writer precedent `order_records.cancelledAt` already follows.
+   *
+   * Writing `{ code: null, readAt: <now> }` is meaningful and must be
+   * persisted: it records *the master was asked and has no rate*, which is a
+   * different fact from the untouched *never asked*.
+   */
+  recordTaxRate(productId: string, rate: StoredTaxRate): Promise<void>;
+
+  /** Read the stored rate for one product. `null` when the product is unknown. */
+  findTaxRate(productId: string): Promise<StoredTaxRate | null>;
+
+  /**
+   * Count the catalogue by tax-rate read state (#2054, ADR-052 § 4).
+   *
+   * Both populations must be answerable as a query rather than a crawl: the
+   * missing count backs the operator surface and the pre-rollout coverage
+   * measurement, the unchecked count backs the sync suggestion. Conflating
+   * them is what would make day one read as an outage.
+   */
+  countTaxRateStates(): Promise<{ total: number; known: number; missing: number; notChecked: number }>;
 }

--- a/libs/core/src/products/domain/ports/product-variant-repository.port.ts
+++ b/libs/core/src/products/domain/ports/product-variant-repository.port.ts
@@ -15,6 +15,7 @@ import type {
   ProductPagination,
   PaginatedProductVariants,
 } from '../types/product.types';
+import type { StoredTaxRate } from '../types/tax-rate.types';
 
 /**
  * Product Variant Repository Port
@@ -135,4 +136,21 @@ export interface ProductVariantRepositoryPort {
     productId: string,
     keepVariantIds: readonly string[]
   ): Promise<string[]>;
+
+  /**
+   * Record what the ProductMaster said about this variant's tax rate (#2054).
+   *
+   * A separate writer from `upsert` / `upsertMany`, for the same reason the
+   * product side is: the ordinary sync upsert carries no rate, so letting it
+   * round-trip these columns would blank a value the tax read just wrote.
+   *
+   * Written only by a master that keys tax per variant. On a product-keyed
+   * master (PrestaShop) these rows stay untouched, so the product's rate
+   * applies - `effectiveTaxRate` treats an absent override as "no opinion",
+   * never as "no rate".
+   */
+  recordTaxRate(variantId: string, rate: StoredTaxRate): Promise<void>;
+
+  /** Read the stored override for one variant. `null` when the variant is unknown. */
+  findTaxRate(variantId: string): Promise<StoredTaxRate | null>;
 }

--- a/libs/core/src/products/domain/types/tax-rate.types.spec.ts
+++ b/libs/core/src/products/domain/types/tax-rate.types.spec.ts
@@ -1,0 +1,92 @@
+/**
+ * Neutral Tax Rate Tests (#2054, ADR-052)
+ *
+ * The two distinctions the whole gate rests on: `0` is an answer and not an
+ * absence, and *never checked* is not *the shop has no rate*.
+ *
+ * @module libs/core/src/products/domain/types
+ */
+import { effectiveTaxRate, isResolvedTaxRate, taxRateState } from './tax-rate.types';
+import type { StoredTaxRate } from './tax-rate.types';
+
+const READ_AT = new Date('2026-08-21T10:00:00Z');
+
+function stored(code: string | null, readAt: Date | null = READ_AT): StoredTaxRate {
+  return { code, countryIso2: 'PL', readAt };
+}
+
+describe('taxRateState', () => {
+  it('should report not-checked when the master has never been asked', () => {
+    expect(taxRateState({ code: null, countryIso2: null, readAt: null })).toBe('not-checked');
+  });
+
+  it('should report not-checked when there is no row at all', () => {
+    expect(taxRateState(null)).toBe('not-checked');
+    expect(taxRateState(undefined)).toBe('not-checked');
+  });
+
+  it('should report no-rate when the master was asked and named none', () => {
+    // The distinction a single nullable column cannot carry: same null code,
+    // different meaning, because the timestamp says the question was put.
+    expect(taxRateState(stored(null))).toBe('no-rate');
+  });
+
+  it('should report known when a rate was read', () => {
+    expect(taxRateState(stored('23'))).toBe('known');
+  });
+
+  it('should report a zero rate as known, not as an absence', () => {
+    // Export, intra-EU and exempt goods are all legitimately zero. Treating
+    // this as a gap would hold documents for a correctly configured catalogue.
+    expect(taxRateState(stored('0'))).toBe('known');
+  });
+
+  it('should report an exemption code as known', () => {
+    expect(taxRateState(stored('zw'))).toBe('known');
+    expect(taxRateState(stored('np'))).toBe('known');
+  });
+
+  it('should report a blank code as no-rate rather than as a rate', () => {
+    expect(taxRateState(stored('   '))).toBe('no-rate');
+  });
+});
+
+describe('effectiveTaxRate', () => {
+  it('should use the product rate when the variant carries no override', () => {
+    expect(effectiveTaxRate(stored('23'), null).code).toBe('23');
+  });
+
+  it('should let a variant override win over its product', () => {
+    // Not a conflict to arbitrate: the variant value is the more specific
+    // statement of the same fact, and the shop had to be edited for the two
+    // to differ (#2054, the question the epic left open).
+    expect(effectiveTaxRate(stored('23'), stored('5')).code).toBe('5');
+  });
+
+  it('should let a zero variant override win over a non-zero product', () => {
+    expect(effectiveTaxRate(stored('23'), stored('0')).code).toBe('0');
+  });
+
+  it('should fall back to the product when the variant was never checked', () => {
+    expect(effectiveTaxRate(stored('23'), stored(null, null)).code).toBe('23');
+  });
+
+  it('should fall back to the product when the variant was checked and has no rate', () => {
+    // PrestaShop keys tax on the product, so every variant there reads no-rate.
+    // Masking the product's rate would blank a correctly configured catalogue.
+    expect(effectiveTaxRate(stored('23'), stored(null)).code).toBe('23');
+  });
+
+  it('should report never-checked when neither level has been read', () => {
+    const result = effectiveTaxRate(null, null);
+    expect(taxRateState(result)).toBe('not-checked');
+  });
+});
+
+describe('isResolvedTaxRate', () => {
+  it('should narrow the resolved arm', () => {
+    expect(isResolvedTaxRate({ kind: 'resolved', code: '23', countryIso2: 'PL' })).toBe(true);
+    expect(isResolvedTaxRate({ kind: 'unknown', reason: 'not-configured' })).toBe(false);
+    expect(isResolvedTaxRate({ kind: 'inherited' })).toBe(false);
+  });
+});

--- a/libs/core/src/products/domain/types/tax-rate.types.ts
+++ b/libs/core/src/products/domain/types/tax-rate.types.ts
@@ -1,0 +1,144 @@
+/**
+ * Neutral Product Tax Rate (#2054, ADR-052)
+ *
+ * The vocabulary a ProductMaster answers "what tax does this product carry?"
+ * in, and the shape OpenLinker stores that answer as.
+ *
+ * Three properties of the shape are load-bearing, and each exists because
+ * collapsing it loses a distinction the operator can act on.
+ *
+ * **A code, not a number.** `0`, exempt, reverse charge and intra-EU zero all
+ * look like zero to arithmetic but are four different things on a document,
+ * so the answer is the same string vocabulary `InvoiceLine.taxRate` already
+ * carries: `'23'`, `'8'`, `'5'`, `'0'`, `'zw'`, `'np'`, `'oo'`. Notation is
+ * percent-as-string (#2247) - `'23'` is twenty-three percent, never `'0.23'`.
+ *
+ * **Unknown is not zero.** A master that cannot state the rate reports
+ * `kind: 'unknown'`, never `'0'`. PrestaShop already draws this line - a
+ * product whose tax-rules group is `0` is the operator's own "No tax" choice,
+ * while an unparseable group means the read said nothing - and reading the
+ * second as the first silently mis-taxes the sale.
+ *
+ * **Never-read is not no-rate.** That fourth state is not in this union,
+ * because it is a fact about OpenLinker rather than an answer from the master:
+ * it is encoded in storage as a null read timestamp. Without it, the day the
+ * feature deploys every product reads as "the shop has no rate" and the
+ * pre-rollout coverage count measures nothing.
+ *
+ * @module libs/core/src/products/domain/types
+ */
+
+/** Why a master could not state a rate. Provenance for the operator, not control flow. */
+export const TaxRateUnknownReasonValues = [
+  /** The shop has no tax configuration for this product at all. */
+  'not-configured',
+  /** Several candidate rates and no unambiguous pick (e.g. two rows for one country). */
+  'ambiguous',
+  /** The read itself did not state the tax status - unparseable or partial. */
+  'unreadable',
+] as const;
+export type TaxRateUnknownReason = (typeof TaxRateUnknownReasonValues)[number];
+
+/** The master stated a rate - including a deliberate zero or an exemption. */
+export interface ResolvedTaxRate {
+  kind: 'resolved';
+  /**
+   * Percent-as-string, or an exemption code. `'23'`, `'8'`, `'5'`, `'0'`,
+   * `'zw'`, `'np'`, `'oo'`.
+   */
+  code: string;
+  /**
+   * ISO 3166-1 alpha-2 the master resolved the code against, when it knows.
+   *
+   * **Provenance only.** It is never compared with the buyer's country and it
+   * blocks nothing - OSS and distance-selling rules are out of scope
+   * (ADR-052 § 7). It exists so an operator reading a surprising rate can see
+   * which country's table produced it.
+   */
+  countryIso2: string | null;
+}
+
+/** The master could not state a rate. Distinct from a zero rate. */
+export interface UnknownTaxRate {
+  kind: 'unknown';
+  reason: TaxRateUnknownReason;
+  /** Short, PII-free elaboration for logs and the operator surface. */
+  detail?: string;
+}
+
+/**
+ * This level of the catalogue defers to the product's rate.
+ *
+ * A distinct answer from both *resolved* and *unknown*, and only reachable on
+ * a variant read. WooCommerce variations carry `tax_class: 'parent'`, meaning
+ * "whatever the product says" - which is neither a rate of its own nor a gap.
+ * Recording it as `unknown` would show the variant as rate-less on an operator
+ * surface, and copying the product's code down would leave a duplicate that
+ * goes stale the moment the product changes. Storing nothing is the honest
+ * answer, and `effectiveTaxRate` already reads an absent override as
+ * "no opinion".
+ */
+export interface InheritedTaxRate {
+  kind: 'inherited';
+}
+
+export type TaxRateResolution = ResolvedTaxRate | UnknownTaxRate | InheritedTaxRate;
+
+/** Where the rate on a stored line came from. Absent means it was never read. */
+export const TaxRateSourceValues = ['shop', 'channel'] as const;
+export type TaxRateSource = (typeof TaxRateSourceValues)[number];
+
+/** Narrow a resolution to the resolved arm. */
+export function isResolvedTaxRate(resolution: TaxRateResolution): resolution is ResolvedTaxRate {
+  return resolution.kind === 'resolved';
+}
+
+/**
+ * The rate as OpenLinker holds it for one catalogue row, with the read state
+ * made explicit so a consumer cannot mistake "never checked" for "no rate".
+ *
+ * `readAt === null` is *never checked*; `readAt` set with `code === null` is
+ * *checked, and the shop has no rate*. Those are the two states a single
+ * nullable rate column cannot tell apart.
+ */
+export interface StoredTaxRate {
+  code: string | null;
+  countryIso2: string | null;
+  readAt: Date | null;
+}
+
+/** The three states a stored rate can be in, derived rather than stored. */
+export const TaxRateStateValues = ['not-checked', 'no-rate', 'known'] as const;
+export type TaxRateState = (typeof TaxRateStateValues)[number];
+
+/** Pure: classify a stored rate. */
+export function taxRateState(stored: StoredTaxRate | null | undefined): TaxRateState {
+  if (!stored || stored.readAt === null) return 'not-checked';
+  return stored.code === null || stored.code.trim() === '' ? 'no-rate' : 'known';
+}
+
+/**
+ * Resolve the rate that applies to a specific variant.
+ *
+ * **A variant override always wins where the shop carries one** (#2054, the
+ * question the epic left open). It is not a conflict to arbitrate: a
+ * variant-level value is the more specific statement of the same fact, and the
+ * shop had to be edited deliberately for the two to differ. So an invoice line
+ * carrying a variant id is taxed at the variant's rate, and offer propagation -
+ * which is per-variant, because offers are variant-keyed - carries the same
+ * value. A line with no variant id falls back to the product's rate.
+ *
+ * The product value is *not* consulted to validate the variant one. Doing so
+ * would make a legitimate per-variant rate (a book at 5% inside a product whose
+ * other variants are 23%) look like a defect.
+ */
+export function effectiveTaxRate(
+  product: StoredTaxRate | null | undefined,
+  variant: StoredTaxRate | null | undefined
+): StoredTaxRate {
+  if (variant && taxRateState(variant) === 'known') return variant;
+  // A variant explicitly read as having no rate does NOT mask the product's:
+  // PrestaShop keys tax on the product alone, so every variant there reads
+  // `no-rate` and masking would blank a catalogue that is correctly configured.
+  return product ?? { code: null, countryIso2: null, readAt: null };
+}

--- a/libs/core/src/products/index.ts
+++ b/libs/core/src/products/index.ts
@@ -88,6 +88,32 @@ export type {
 } from './domain/ports/capabilities/modified-product-lister.capability';
 export { isModifiedProductLister } from './domain/ports/capabilities/modified-product-lister.capability';
 
+// Neutral per-line tax rate (#2054, ADR-052). The vocabulary a ProductMaster
+// answers a tax question in, plus the shape OpenLinker stores that answer as.
+export type {
+  InheritedTaxRate,
+  ResolvedTaxRate,
+  StoredTaxRate,
+  TaxRateResolution,
+  TaxRateSource,
+  TaxRateState,
+  TaxRateUnknownReason,
+  UnknownTaxRate,
+} from './domain/types/tax-rate.types';
+export {
+  TaxRateSourceValues,
+  TaxRateStateValues,
+  TaxRateUnknownReasonValues,
+  effectiveTaxRate,
+  isResolvedTaxRate,
+  taxRateState,
+} from './domain/types/tax-rate.types';
+export type {
+  ProductTaxRateReader,
+  ReadProductTaxRateInput,
+} from './domain/ports/capabilities/product-tax-rate-reader.capability';
+export { isProductTaxRateReader } from './domain/ports/capabilities/product-tax-rate-reader.capability';
+
 // ORM entities are exposed on the host-only `@openlinker/core/products/orm-entities`
 // sub-path (#594). Plugins must not import them from here.
 

--- a/libs/core/src/products/infrastructure/persistence/entities/product-variant.orm-entity.ts
+++ b/libs/core/src/products/infrastructure/persistence/entities/product-variant.orm-entity.ts
@@ -59,6 +59,26 @@ export class ProductVariantOrmEntity {
   @Column({ type: 'timestamptz', nullable: true })
   staleAt!: Date | null;
 
+  /**
+   * Per-variant tax-rate OVERRIDE (#2054, ADR-052). Set only by a master that
+   * keys tax per variant (WooCommerce can; PrestaShop keys on the product, so
+   * these stay null there and the product's rate applies).
+   *
+   * A present override always wins for a line carrying this variant id - it is
+   * the more specific statement of the same fact, not a conflict to arbitrate.
+   * Same null semantics as the product column: `taxRateReadAt` separates
+   * *never checked* from *checked, no rate*.
+   */
+  @Column({ type: 'varchar', length: 16, nullable: true })
+  taxRate!: string | null;
+
+  /** ISO 3166-1 alpha-2 the override was resolved against. Provenance only. */
+  @Column({ type: 'varchar', length: 2, nullable: true })
+  taxRateCountry!: string | null;
+
+  @Column({ type: 'timestamptz', nullable: true })
+  taxRateReadAt!: Date | null;
+
   @CreateDateColumn()
   createdAt!: Date;
 

--- a/libs/core/src/products/infrastructure/persistence/entities/product.orm-entity.ts
+++ b/libs/core/src/products/infrastructure/persistence/entities/product.orm-entity.ts
@@ -47,6 +47,30 @@ export class ProductOrmEntity {
   @Column({ type: 'jsonb', nullable: true })
   features!: { name: string; value: string }[] | null;
 
+  /**
+   * Neutral tax-rate code the ProductMaster stated for this product (#2054,
+   * ADR-052) - percent-as-string (`'23'`) or an exemption code (`'zw'`).
+   * Populated by product sync, never by a person.
+   *
+   * Null carries TWO meanings, disambiguated by `taxRateReadAt`: null with a
+   * null timestamp is *never checked*; null with a timestamp is *checked, and
+   * the shop has no rate*. A single nullable column cannot tell those apart,
+   * and on the day this ships every row is the first one.
+   */
+  @Column({ type: 'varchar', length: 16, nullable: true })
+  taxRate!: string | null;
+
+  /** ISO 3166-1 alpha-2 the rate was resolved against. Provenance only. */
+  @Column({ type: 'varchar', length: 2, nullable: true })
+  taxRateCountry!: string | null;
+
+  /**
+   * When the master was last asked. `timestamptz` rather than bare `timestamp`
+   * so the write is stored without a silent tz coercion (the #1296 correction).
+   */
+  @Column({ type: 'timestamptz', nullable: true })
+  taxRateReadAt!: Date | null;
+
   @CreateDateColumn()
   createdAt!: Date;
 

--- a/libs/core/src/products/infrastructure/persistence/repositories/product-variant.repository.ts
+++ b/libs/core/src/products/infrastructure/persistence/repositories/product-variant.repository.ts
@@ -24,6 +24,7 @@ import type {
   ProductPagination,
   PaginatedProductVariants,
 } from '../../../domain/types/product.types';
+import type { StoredTaxRate } from '../../../domain/types/tax-rate.types';
 import { normalizeBarcode, normalizeToEan13 } from '../../../domain/utils/barcode-normalization';
 import { CORE_ENTITY_TYPE } from '@openlinker/core/identifier-mapping';
 
@@ -322,6 +323,35 @@ export class ProductVariantRepository implements ProductVariantRepositoryPort {
     // and @UpdateDateColumn populate them in that case.
     if (variant.createdAt) entity.createdAt = variant.createdAt;
     if (variant.updatedAt) entity.updatedAt = variant.updatedAt;
+    // The three tax-rate columns are deliberately absent (#2054): the sync
+    // upsert carries no rate, so writing them here would blank an override
+    // `recordTaxRate` had just written. Same single-writer rule as the
+    // product side.
     return entity;
+  }
+
+  /**
+   * Record a per-variant tax-rate override (#2054). Written only by a master
+   * that keys tax per variant; a product-keyed master never calls this, which
+   * is what leaves the override genuinely absent rather than read-as-empty.
+   */
+  async recordTaxRate(variantId: string, rate: StoredTaxRate): Promise<void> {
+    await this.repository.update(
+      { id: variantId },
+      {
+        taxRate: rate.code,
+        taxRateCountry: rate.countryIso2,
+        taxRateReadAt: rate.readAt,
+      }
+    );
+  }
+
+  async findTaxRate(variantId: string): Promise<StoredTaxRate | null> {
+    const row = await this.repository.findOne({
+      where: { id: variantId },
+      select: { id: true, taxRate: true, taxRateCountry: true, taxRateReadAt: true },
+    });
+    if (!row) return null;
+    return { code: row.taxRate, countryIso2: row.taxRateCountry, readAt: row.taxRateReadAt };
   }
 }

--- a/libs/core/src/products/infrastructure/persistence/repositories/product.repository.ts
+++ b/libs/core/src/products/infrastructure/persistence/repositories/product.repository.ts
@@ -28,6 +28,7 @@ import type {
   PaginatedProducts,
 } from '../../../domain/types/product.types';
 import { LOW_STOCK_THRESHOLD } from '../../../domain/types/product.types';
+import type { StoredTaxRate } from '../../../domain/types/tax-rate.types';
 
 /**
  * Aggregated total available stock for the joined `stock` subquery alias.
@@ -250,6 +251,73 @@ export class ProductRepository implements ProductRepositoryPort {
     entity.features = product.features ?? null;
     if (product.createdAt) entity.createdAt = product.createdAt;
     if (product.updatedAt) entity.updatedAt = product.updatedAt;
+    // `taxRate` / `taxRateCountry` / `taxRateReadAt` are deliberately absent
+    // here (#2054, the `order_records.cancelledAt` single-writer precedent).
+    // The ordinary sync upsert carries no rate, so round-tripping them would
+    // null a value `recordTaxRate` had just written - and a blanked rate holds
+    // documents, so the failure would be loud and confusing rather than
+    // cosmetic. `recordTaxRate` is the only writer.
     return entity;
+  }
+
+  /**
+   * Record the master's answer, including the answer "no rate" (#2054).
+   *
+   * A targeted `update` rather than a `save`, so no other column is touched
+   * and the row's own `updatedAt` is the only side effect. Writing a null code
+   * with a non-null `readAt` is the whole point of the second column: it
+   * records *asked, and the shop has none*, which the gate treats differently
+   * from *never asked*.
+   */
+  async recordTaxRate(productId: string, rate: StoredTaxRate): Promise<void> {
+    await this.repository.update(
+      { id: productId },
+      {
+        taxRate: rate.code,
+        taxRateCountry: rate.countryIso2,
+        taxRateReadAt: rate.readAt,
+      }
+    );
+  }
+
+  async findTaxRate(productId: string): Promise<StoredTaxRate | null> {
+    const row = await this.repository.findOne({
+      where: { id: productId },
+      select: { id: true, taxRate: true, taxRateCountry: true, taxRateReadAt: true },
+    });
+    if (!row) return null;
+    return { code: row.taxRate, countryIso2: row.taxRateCountry, readAt: row.taxRateReadAt };
+  }
+
+  /**
+   * One grouped pass rather than three counts, so the numbers cannot disagree
+   * with each other under concurrent syncs.
+   */
+  async countTaxRateStates(): Promise<{
+    total: number;
+    known: number;
+    missing: number;
+    notChecked: number;
+  }> {
+    const row = await this.repository
+      .createQueryBuilder('product')
+      .select('COUNT(*)', 'total')
+      .addSelect(
+        `COUNT(*) FILTER (WHERE product."taxRateReadAt" IS NOT NULL AND product."taxRate" IS NOT NULL)`,
+        'known'
+      )
+      .addSelect(
+        `COUNT(*) FILTER (WHERE product."taxRateReadAt" IS NOT NULL AND product."taxRate" IS NULL)`,
+        'missing'
+      )
+      .addSelect(`COUNT(*) FILTER (WHERE product."taxRateReadAt" IS NULL)`, 'notChecked')
+      .getRawOne<{ total: string; known: string; missing: string; notChecked: string }>();
+
+    return {
+      total: Number(row?.total ?? 0),
+      known: Number(row?.known ?? 0),
+      missing: Number(row?.missing ?? 0),
+      notChecked: Number(row?.notChecked ?? 0),
+    };
   }
 }

--- a/libs/integrations/prestashop/src/application/prestashop-adapter.factory.ts
+++ b/libs/integrations/prestashop/src/application/prestashop-adapter.factory.ts
@@ -72,6 +72,15 @@ export class PrestashopAdapterFactory implements IPrestashopAdapterFactory {
   // connection config leaves `currency` unset.
   private readonly shopCurrencyResolver = new PrestashopShopCurrencyResolver();
 
+  // Process-singleton for the same reason: master sync builds one adapter per
+  // product, so a per-adapter tax-rate cache would never hit (#2054). The
+  // order-create path keeps its own instance, built inside the customer-
+  // provisioning branch - catalogue sync must not depend on that branch being
+  // wired.
+  private readonly productTaxRateResolver = new PrestashopTaxRateResolver(
+    new PrestashopCountryResolver()
+  );
+
   constructor(
     private readonly customerProvisioner?: PrestashopCustomerProvisioner,
     private readonly addressProvisioner?: PrestashopAddressProvisioner,
@@ -140,7 +149,13 @@ export class PrestashopAdapterFactory implements IPrestashopAdapterFactory {
       connection,
       this.attributeResolver,
       this.featureResolver,
-      this.categoryPathResolver
+      this.categoryPathResolver,
+      // #2054: the product master reads the shop's tax rate through the same
+      // resolver the order-create path uses, so the two cannot disagree about
+      // one shop. Its own instance (and so its own 5-minute cache) rather than
+      // the order branch's, because that one is built only when customer
+      // provisioning is wired and the catalogue sync must not depend on that.
+      this.productTaxRateResolver
     );
 
     const inventoryMaster = new PrestashopInventoryMasterAdapter(

--- a/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-product-master.adapter.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-product-master.adapter.ts
@@ -28,6 +28,7 @@ import type {
 } from '../mappers/prestashop.mapper.interface';
 import type { PrestashopConnectionConfig } from '@openlinker/integrations-prestashop';
 import {
+  PrestashopApiException,
   PrestashopNotSupportedException,
   PrestashopResourceNotFoundException,
 } from '@openlinker/integrations-prestashop';
@@ -36,13 +37,19 @@ import type { PrestashopAttributeResolver } from '../provisioners/prestashop-att
 import type { PrestashopFeatureResolver } from '../provisioners/prestashop-feature.resolver';
 import type { PrestashopCategoryPathResolver } from '../provisioners/prestashop-category-path.resolver';
 import type { OptionValueResolver } from '../../domain/types/prestashop-product-option.types';
+import type { PrestashopTaxRateResolver } from '../provisioners/prestashop-tax-rate.resolver';
+import type {
+  ProductTaxRateReader,
+  ReadProductTaxRateInput,
+  TaxRateResolution,
+} from '@openlinker/core/products';
 
 /**
  * PrestaShop Product Master Adapter
  *
  * Read-only adapter for PrestaShop product catalog operations.
  */
-export class PrestashopProductMasterAdapter implements ProductMasterPort {
+export class PrestashopProductMasterAdapter implements ProductMasterPort, ProductTaxRateReader {
   private readonly logger = new Logger(PrestashopProductMasterAdapter.name);
 
   constructor(
@@ -62,8 +69,89 @@ export class PrestashopProductMasterAdapter implements ProductMasterPort {
     // (root→leaf, {id,name}) (#1096 F3). A resolver failure never breaks product
     // sync — `categoryBreadcrumb` is left unset and the bare-id `categories`
     // fallback applies.
-    private readonly categoryPathResolver?: PrestashopCategoryPathResolver
+    private readonly categoryPathResolver?: PrestashopCategoryPathResolver,
+    // Optional, process-singleton (mirrors the resolvers above). Present makes
+    // this adapter a `ProductTaxRateReader` in practice; absent, the guard
+    // still narrows (the method exists) but every read reports `unreadable`,
+    // which is the honest answer for a shop whose resolver was never wired.
+    private readonly taxRateResolver?: PrestashopTaxRateResolver
   ) {}
+
+  /**
+   * PrestaShop keys tax on the **product**, through
+   * `id_tax_rules_group -> tax_rules -> taxes`. A combination carries no tax of
+   * its own, so `variantId` is ignored and every variant of a product shares
+   * the product's rate (#2054).
+   */
+  readsTaxRatePerVariant(): boolean {
+    return false;
+  }
+
+  /**
+   * State the product's tax rate (#2054, ADR-052).
+   *
+   * Delegates to the existing `PrestashopTaxRateResolver` rather than
+   * re-walking the three-hop chain: that resolver already draws the
+   * `id_tax_rules_group = 0` ("No tax", a deliberate operator statement) versus
+   * *unreadable* line the core contract needs, and duplicating it would give
+   * the two paths two chances to disagree about the same shop.
+   *
+   * Two translations happen here and nowhere else.
+   *
+   * **A `transport` unknown is re-raised, not reported as unknown.** The core
+   * contract reserves `kind: 'unknown'` for "the master answered and named no
+   * rate" - a condition an operator fixes in the shop. A failed call says
+   * nothing about the configuration, and recording it would freeze a false
+   * `no rate` onto the catalogue row until the next sync.
+   *
+   * **The rate is converted from a fraction to a percent code.** The resolver
+   * speaks fractions (`0.23`); the neutral contract is percent-as-string
+   * (`'23'`, #2247). Rounding to four decimal places before scaling keeps
+   * `0.23 * 100` from surfacing as `23.000000000000004`.
+   *
+   * No delivery country is passed: the master read is deliberately not
+   * parameterised by the buyer's country in this pass (ADR-052 § 7), so the
+   * resolver falls through to the catch-all rule - the same rate the shop shows
+   * on the product page.
+   */
+  async readProductTaxRate(input: ReadProductTaxRateInput): Promise<TaxRateResolution> {
+    if (!this.taxRateResolver) {
+      return { kind: 'unknown', reason: 'unreadable', detail: 'tax-rate resolver not configured' };
+    }
+
+    const externalIds = await this.identifierMapping.getExternalIds(
+      CORE_ENTITY_TYPE.Product,
+      input.productId
+    );
+    const externalId = externalIds.find((m) => m.connectionId === this.connection.id)?.externalId;
+    if (!externalId) {
+      throw new MasterProductNotFoundError(input.productId, this.connection.id);
+    }
+
+    const resolution = await this.taxRateResolver.resolveProductTaxRate(
+      externalId,
+      undefined,
+      this.connection.id,
+      this.httpClient
+    );
+
+    if (resolution.kind === 'resolved') {
+      return {
+        kind: 'resolved',
+        code: formatRateAsPercentCode(resolution.rate),
+        countryIso2: null,
+      };
+    }
+
+    if (resolution.reason === 'transport') {
+      throw new PrestashopApiException(
+        `Could not read the tax rate for product ${externalId}: ${resolution.evidence}`,
+        resolution.statusCode
+      );
+    }
+
+    return { kind: 'unknown', reason: 'not-configured', detail: resolution.evidence };
+  }
 
   async getProduct(productId: string): Promise<Product> {
     this.logger.debug(`Getting product: ${productId} (connection: ${this.connection.id})`);
@@ -706,4 +794,17 @@ export class PrestashopProductMasterAdapter implements ProductMasterPort {
 
     return prestashopFilters;
   }
+}
+
+/**
+ * A fractional rate (`0.23`) becomes the neutral percent code (`'23'`, #2247).
+ *
+ * Rounded to four decimals before scaling so `0.23 * 100` cannot surface as
+ * `23.000000000000004`, and trailing zeros are dropped so an integer rate
+ * reads `'23'` rather than `'23.00'` - the FA(3) map and the Erli enum are
+ * both keyed on the bare form.
+ */
+function formatRateAsPercentCode(rate: number): string {
+  const percent = Math.round(rate * 10000) / 100;
+  return Number.isInteger(percent) ? String(percent) : String(Number(percent.toFixed(2)));
 }

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/product-master/woocommerce-product-master.adapter.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/product-master/woocommerce-product-master.adapter.ts
@@ -45,6 +45,9 @@ import { MasterProductNotFoundError } from '@openlinker/core/products';
 import type {
   ModifiedProductLister,
   ListExternalIdsModifiedSinceInput,
+  ProductTaxRateReader,
+  ReadProductTaxRateInput,
+  TaxRateResolution,
 } from '@openlinker/core/products';
 import type { IdentifierMappingPort, Connection } from '@openlinker/core/identifier-mapping';
 import { CORE_ENTITY_TYPE } from '@openlinker/core/identifier-mapping';
@@ -52,7 +55,10 @@ import { Logger } from '@openlinker/shared/logging';
 import type { IWooCommerceHttpClient } from '../../http/woocommerce-http-client.interface';
 import { WooCommerceHttpResponseException } from '../../http/woocommerce-http-response.exception';
 import type { IWooCommerceProductMapper } from '../../mappers/woocommerce-product.mapper.interface';
-import { buildSyntheticVariantExternalId } from '../../mappers/woocommerce-variant-id';
+import {
+  buildSyntheticVariantExternalId,
+  isSyntheticVariantExternalId,
+} from '../../mappers/woocommerce-variant-id';
 import { WooCommerceResourceNotFoundException } from '../../../domain/exceptions/woocommerce-resource-not-found.exception';
 import { WooCommerceDuplicateSkuException } from '../../../domain/exceptions/woocommerce-duplicate-sku.exception';
 import type {
@@ -61,10 +67,14 @@ import type {
   WooCommerceProductCategory,
   WooCommerceProductWriteRequest,
   WooCommerceVariationWriteRequest,
+  WooCommerceTaxRate,
+  WooCommerceGeneralSetting,
 } from './woocommerce-product.types';
 import { fetchAllPages } from '../../utils/woocommerce-utils';
 
-export class WooCommerceProductMasterAdapter implements ProductMasterPort, ModifiedProductLister {
+export class WooCommerceProductMasterAdapter
+  implements ProductMasterPort, ModifiedProductLister, ProductTaxRateReader
+{
   private readonly logger = new Logger(WooCommerceProductMasterAdapter.name);
 
   constructor(
@@ -677,4 +687,195 @@ export class WooCommerceProductMasterAdapter implements ProductMasterPort, Modif
     const n = parseFloat(value);
     return Number.isFinite(n) ? n : undefined;
   }
+
+  // ─── Tax rate (#2054, ADR-052) ─────────────────────────────────────────────
+
+  /**
+   * WooCommerce keys tax per variation as well as per product: a variation
+   * carries its own `tax_class`, defaulting to `'parent'`. So the caller reads
+   * both levels, and an inheriting variation answers `inherited` rather than
+   * echoing the product's code.
+   */
+  readsTaxRatePerVariant(): boolean {
+    return true;
+  }
+
+  /**
+   * Resolve the store's tax rate for a product or variation.
+   *
+   * WooCommerce does not store a rate on the product. It stores a **class
+   * name**, and the rate table lives in store settings, keyed by country. So
+   * the read is three hops: the product's `tax_class` and `tax_status`, the
+   * store's own country, and the rows of that class.
+   *
+   * Four answers, and the boundaries between them are the point.
+   *
+   * - `tax_status: 'none'` is a **resolved zero**. It is the operator saying
+   *   this product is not taxed, exactly like PrestaShop's "No tax" - not a
+   *   gap. (`'shipping'` means only the shipping portion is taxed, which is a
+   *   statement about shipping and not about this line, so it is treated as
+   *   taxable here.)
+   * - Exactly one matching row is the rate.
+   * - No row for the store's country is `not-configured`: the class exists but
+   *   the operator has not given it a rate here, which they fix in WooCommerce.
+   * - Several rows with different rates is `ambiguous`. WooCommerce would pick
+   *   by priority, postcode and city at checkout; reproducing that here would
+   *   be OpenLinker computing tax, which ADR-052 forbids. Note that several
+   *   rows agreeing on one rate is **not** ambiguous - the answer is the same
+   *   whichever the shop picks.
+   *
+   * Transport failures propagate, so the sync retries rather than freezing a
+   * false "no rate" onto the catalogue row.
+   */
+  async readProductTaxRate(input: ReadProductTaxRateInput): Promise<TaxRateResolution> {
+    const wcProductId = await this.resolveWcProductId(input.productId);
+
+    const taxed = input.variantId
+      ? await this.readVariationTaxFields(wcProductId, input.variantId)
+      : await this.readProductTaxFields(wcProductId);
+
+    if (taxed === 'inherited') return { kind: 'inherited' };
+
+    if (taxed.taxStatus === 'none') {
+      return { kind: 'resolved', code: '0', countryIso2: await this.readStoreCountrySafe() };
+    }
+
+    const storeCountry = await this.readStoreCountrySafe();
+    if (!storeCountry) {
+      return {
+        kind: 'unknown',
+        reason: 'unreadable',
+        detail: 'the store does not declare a selling country',
+      };
+    }
+
+    // `''` is WooCommerce's own slug for the standard class; the taxes endpoint
+    // spells it `standard`.
+    const classSlug = taxed.taxClass === '' || taxed.taxClass === undefined ? 'standard' : taxed.taxClass;
+    const rows = await this.httpClient.get<WooCommerceTaxRate[]>('/wp-json/wc/v3/taxes', {
+      class: classSlug,
+      per_page: 100,
+    });
+
+    // An empty `country` is WooCommerce's wildcard row - it applies everywhere,
+    // so it is a match rather than a row to skip.
+    const applicable = (rows ?? []).filter(
+      (row) => !row.country || row.country.toUpperCase() === storeCountry
+    );
+
+    const distinctRates = [
+      ...new Set(
+        applicable
+          .map((row) => normalizeWcRate(row.rate))
+          .filter((code): code is string => code !== null)
+      ),
+    ];
+
+    if (distinctRates.length === 0) {
+      return {
+        kind: 'unknown',
+        reason: 'not-configured',
+        detail: `tax class "${classSlug}" has no rate for ${storeCountry}`,
+      };
+    }
+    if (distinctRates.length > 1) {
+      return {
+        kind: 'unknown',
+        reason: 'ambiguous',
+        detail: `tax class "${classSlug}" has ${String(distinctRates.length)} different rates for ${storeCountry}`,
+      };
+    }
+
+    return { kind: 'resolved', code: distinctRates[0], countryIso2: storeCountry };
+  }
+
+  private async resolveWcProductId(internalProductId: string): Promise<string> {
+    const externalIds = await this.identifierMapping.getExternalIds(
+      CORE_ENTITY_TYPE.Product,
+      internalProductId
+    );
+    const mapping = externalIds.find((e) => e.connectionId === this.connection.id);
+    if (!mapping) {
+      throw new MasterProductNotFoundError(internalProductId, this.connection.id);
+    }
+    return mapping.externalId;
+  }
+
+  private async readProductTaxFields(
+    wcProductId: string
+  ): Promise<{ taxClass?: string; taxStatus?: string }> {
+    const product = await this.httpClient.get<WooCommerceProduct>(
+      `/wp-json/wc/v3/products/${wcProductId}`,
+      { _fields: 'id,tax_class,tax_status' }
+    );
+    return { taxClass: product.tax_class, taxStatus: product.tax_status };
+  }
+
+  /**
+   * A synthetic variant IS the simple product, so it reads the product's own
+   * fields rather than a variation that does not exist.
+   */
+  private async readVariationTaxFields(
+    wcProductId: string,
+    internalVariantId: string
+  ): Promise<{ taxClass?: string; taxStatus?: string } | 'inherited'> {
+    const externalIds = await this.identifierMapping.getExternalIds(
+      CORE_ENTITY_TYPE.ProductVariant,
+      internalVariantId
+    );
+    const mapping = externalIds.find((e) => e.connectionId === this.connection.id);
+    if (!mapping) return 'inherited';
+    if (isSyntheticVariantExternalId(mapping.externalId)) {
+      return this.readProductTaxFields(wcProductId);
+    }
+
+    const variation = await this.httpClient.get<WooCommerceProductVariation>(
+      `/wp-json/wc/v3/products/${wcProductId}/variations/${mapping.externalId}`,
+      { _fields: 'id,tax_class,tax_status' }
+    );
+    if (variation.tax_class === 'parent' || variation.tax_class === undefined) return 'inherited';
+    return { taxClass: variation.tax_class, taxStatus: variation.tax_status };
+  }
+
+  /**
+   * The store's own selling country, from `woocommerce_default_country`.
+   *
+   * The setting is `PL` or `PL:MZ` (country plus state), so only the part
+   * before the colon is the country. Cached for the adapter's lifetime - it is
+   * a store setting, and the master sync builds one adapter per product.
+   */
+  private async readStoreCountrySafe(): Promise<string | null> {
+    if (this.storeCountry !== undefined) return this.storeCountry;
+    try {
+      const settings = await this.httpClient.get<WooCommerceGeneralSetting[]>(
+        '/wp-json/wc/v3/settings/general'
+      );
+      const raw = settings?.find((s) => s.id === 'woocommerce_default_country')?.value;
+      const value = Array.isArray(raw) ? raw[0] : raw;
+      this.storeCountry = value ? (value.split(':')[0]?.toUpperCase() ?? null) : null;
+    } catch (error) {
+      this.logger.warn(
+        `Could not read the store's selling country (connection: ${this.connection.id}): ${(error as Error).message}`
+      );
+      this.storeCountry = null;
+    }
+    return this.storeCountry;
+  }
+
+  private storeCountry: string | null | undefined;
+}
+
+/**
+ * WooCommerce reports a rate as a percent string with trailing zeros
+ * (`'23.0000'`). The neutral contract is percent-as-string without them
+ * (#2247), because the FA(3) map and the Erli enum are both keyed on the bare
+ * form. Returns `null` for anything unparseable, which the caller counts as
+ * "not a rate" rather than as a zero.
+ */
+function normalizeWcRate(raw: string | undefined): string | null {
+  if (raw === undefined || raw === null || raw.trim() === '') return null;
+  const parsed = Number.parseFloat(raw);
+  if (!Number.isFinite(parsed)) return null;
+  const rounded = Math.round(parsed * 100) / 100;
+  return Number.isInteger(rounded) ? String(rounded) : String(rounded);
 }

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/product-master/woocommerce-product.types.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/product-master/woocommerce-product.types.ts
@@ -31,6 +31,9 @@ export interface WooCommerceProduct {
   manage_stock?: boolean;
   stock_status?: string;           // 'instock' | 'outofstock' | 'onbackorder'
   weight?: string;
+  /** Tax class SLUG, not a rate. `''` is the store's "standard" class (#2054). */
+  tax_class?: string;
+  tax_status?: 'taxable' | 'shipping' | 'none';
   date_created?: string;
   date_modified?: string;
   meta_data?: WooCommerceMetaEntry[];
@@ -47,6 +50,13 @@ export interface WooCommerceProductVariation {
   manage_stock?: boolean;
   stock_status?: string;           // 'instock' | 'outofstock' | 'onbackorder'
   weight?: string;
+  /**
+   * Tax class SLUG. `'parent'` means "whatever the product says" and is the
+   * WooCommerce default for a variation (#2054) - neither a rate of its own
+   * nor a gap.
+   */
+  tax_class?: string;
+  tax_status?: 'taxable' | 'shipping' | 'none';
   date_created?: string;
   date_modified?: string;
   meta_data?: WooCommerceMetaEntry[];
@@ -82,4 +92,31 @@ export interface WooCommerceVariationWriteRequest {
   regular_price?: string;
   weight?: string;
   attributes?: Array<{ name: string; option: string }>;
+}
+
+/**
+ * One row of the store's tax table (`GET /wp-json/wc/v3/taxes`).
+ *
+ * `rate` is a percent STRING (`'23.0000'`), not a fraction. `country` is empty
+ * on a wildcard row that applies everywhere.
+ */
+export interface WooCommerceTaxRate {
+  id?: number;
+  country?: string;
+  state?: string;
+  postcode?: string;
+  city?: string;
+  rate?: string;
+  name?: string;
+  priority?: number;
+  compound?: boolean;
+  shipping?: boolean;
+  order?: number;
+  class?: string;
+}
+
+/** One row of `GET /wp-json/wc/v3/settings/general`. */
+export interface WooCommerceGeneralSetting {
+  id?: string;
+  value?: string | string[];
 }


### PR DESCRIPTION
Core had nothing to carry a tax rate in. `OrderItem` and `IncomingOrderItem` have no tax field, and the only signals on an order are one aggregate `OrderTotals.tax` and an order-wide `taxTreatment` - neither of which can describe a mixed-rate basket. This gives core the field, the vocabulary, a way to ask the two masters, and a place to keep the answer.

## Three distinctions, each with a test

**Zero is an answer, never an absence.** A read that establishes nothing reports `kind: 'unknown'` and is stored as a null code, never as `'0'`. Export, intra-EU and exempt goods are legitimately zero.

**Never-checked is not no-rate.** `taxRateReadAt` separates them: a null timestamp means nobody has asked, a timestamp with a null code means the master answered and has none. Without the split, the day this ships the whole catalogue reads as incomplete and the pre-rollout coverage count measures nothing.

**A variant override always wins where the shop carries one** - the open question the epic left for this child, now [recorded on #2054](https://github.com/openlinker-project/openlinker/issues/2054). Not a conflict to arbitrate: a variant value is the more specific statement of the same fact. An absent override means "no opinion", never "no rate", which is what keeps a product-keyed master (PrestaShop) working. A third arm, `kind: 'inherited'`, covers a WooCommerce variation with `tax_class: 'parent'` - nothing is stored, because `unknown` would show it as rate-less and copying the product's code down would leave a stale duplicate.

## The two masters

**PrestaShop** delegates to the existing `PrestashopTaxRateResolver` rather than re-walking product → `id_tax_rules_group` → `tax_rules` → `taxes`, so the sync path and the order-create path cannot disagree about one shop. Its `transport` unknown is **re-raised**, not reported as unknown: a failed call says nothing about the shop's configuration, and recording it would freeze a false "no rate" onto the row until the next sync. Keyed on the product, so `readsTaxRatePerVariant()` is false.

**WooCommerce** had no tax read at all. `tax_class` is a class *name*; the rate table lives in store settings, per country. Three hops: the product's class and status, the store's own `woocommerce_default_country`, and the rows of that class. `tax_status: 'none'` is a resolved zero; no row for the store's country is `not-configured`; several *different* rates is `ambiguous` rather than a pick, because picking by priority/postcode/city would be OpenLinker computing tax. Several rows agreeing is not ambiguous.

## Storage

A projection pulled at product sync onto `products` / `product_variants`, exactly as `price` and `currency` already are - issuance must not depend on the shop being reachable, and "which products lack a rate" has to be a query. Two partial indexes back the two populations.

`recordTaxRate` is a **separate writer** from `upsert` on both repositories, and the columns are deliberately absent from `toOrm`. The sync upsert carries no rate, so round-tripping them would blank a value the tax read just wrote - and a blanked rate holds documents, so the failure would be loud rather than cosmetic. Same single-writer rule as `order_records.cancelledAt`.

One additive migration, nullable, no backfill. Every existing row lands in *never checked*, which is the truth.

## Ingestion

`OrderIngestionService` settles the rate onto the stored snapshot - shop first, channel second. The order of the rungs is the decision: a rate fixed in the shop serves every channel, while a rate only the marketplace knows was stamped at purchase and can never be corrected. `taxSource` and `taxRateReadAt` travel with it so a reader can tell *no rate*, *never read* and *pre-rollout* apart (#2245 F3).

Closes #2054
Refs #2245

🤖 Generated with [Claude Code](https://claude.com/claude-code)