### PR TITLE
feat(invoicing): carry the tax rate onto the document and hold when it is absent

### DIFF
--- a/apps/api/src/invoicing/http/invoicing.controller.ts
+++ b/apps/api/src/invoicing/http/invoicing.controller.ts
@@ -71,6 +71,7 @@ import {
   InvalidInvoiceLineError,
   UnsupportedPriceTreatmentError,
   DuplicateInvoiceRecordException,
+  MissingTaxRateException,
   OrderAlreadyInvoicedException,
   InvoiceIssueContendedException,
   InvoiceRecordNotFoundException,
@@ -717,6 +718,17 @@ export class InvoicingController {
           reason:
             `An invoice for this order already exists on connection ${error.issuingConnectionId} ` +
             `(invoice ${error.blockingInvoiceId}, status ${error.blockingStatus}).`,
+        };
+      }
+      if (error instanceof MissingTaxRateException) {
+        // #2248: a NAMED ineligibility, not a batch failure. The order cannot be
+        // invoiced by anyone until the rate is added in the shop, so pointing an
+        // operator at "retry" or at manual review would waste the click - the
+        // pattern bulk dispatch already uses for `source_deleted`.
+        return {
+          orderId,
+          outcome: 'skipped',
+          reason: error.message,
         };
       }
       if (error instanceof InvoiceIssueContendedException) {
@@ -1383,6 +1395,23 @@ export class InvoicingController {
         message: error.message,
         error: 'InvoiceIssueContendedException',
         retryable: true,
+      });
+    }
+    // #2248 (ADR-052 § 6): the order carries a line with no tax rate, so no
+    // document can state what tax was charged. 422 rather than 400 - the request
+    // is well formed, the DATA it names is not yet issuable - and rather than 409,
+    // which would say a document already exists. `retryable: false` distinguishes
+    // it from the contended 409 above: retrying changes nothing until the rate is
+    // added in the shop, which is what the body's ids point the operator at.
+    if (error instanceof MissingTaxRateException) {
+      return new UnprocessableEntityException({
+        message: error.message,
+        error: 'MissingTaxRateException',
+        reason: 'missing-tax-rate',
+        retryable: false,
+        lineCount: error.finding.lineCount,
+        totalLines: error.finding.totalLines,
+        firstProductId: error.finding.firstProductId,
       });
     }
     if (

--- a/apps/api/src/migrations/1837000000001-add-order-record-sales-document-block-instants.ts
+++ b/apps/api/src/migrations/1837000000001-add-order-record-sales-document-block-instants.ts
@@ -1,0 +1,52 @@
+/**
+ * Record WHEN a sales-document hold started and ended (#2248, #2245 F4).
+ *
+ * `salesDocumentBlockReason` is level-triggered: the gate re-decides on every
+ * order transition and the writer stores the answer including `null`. That is
+ * what makes a reason self-heal, but it also means nothing records that the
+ * order was ever held once the hold clears - so the operator-facing age has no
+ * clock, and the "the rate arrived, the invoice issued" timeline entry has no
+ * instant to hang on (the shipped timeline builds its block entry with
+ * `timestamp: null` for exactly this reason).
+ *
+ * Both columns are additive, nullable and NOT backfilled. Stamping a synthetic
+ * "held since" onto history would put an invented age on an operator screen -
+ * the same class of invention this epic exists to remove. Orders held before
+ * this migration simply have no start instant until their next transition.
+ *
+ * Written only by `OrderRecordRepository.updateSalesDocumentBlock`, in the same
+ * statement that sets the reason, because the transition is the only place both
+ * the old and the new value are known.
+ */
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddOrderRecordSalesDocumentBlockInstants1837000000001 implements MigrationInterface {
+  name = 'AddOrderRecordSalesDocumentBlockInstants1837000000001';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "order_records" ADD COLUMN IF NOT EXISTS "salesDocumentBlockedAt" TIMESTAMP WITH TIME ZONE`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "order_records" ADD COLUMN IF NOT EXISTS "salesDocumentBlockReleasedAt" TIMESTAMP WITH TIME ZONE`
+    );
+    // The age query is "oldest held order first", so the index covers the
+    // held population only - a partial index, matching the shape of the
+    // reason column's own filter.
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_order_records_sales_document_blocked_at"
+        ON "order_records" ("salesDocumentBlockedAt")
+        WHERE "salesDocumentBlockReason" IS NOT NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_order_records_sales_document_blocked_at"`);
+    await queryRunner.query(
+      `ALTER TABLE "order_records" DROP COLUMN IF EXISTS "salesDocumentBlockReleasedAt"`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "order_records" DROP COLUMN IF EXISTS "salesDocumentBlockedAt"`
+    );
+  }
+}

--- a/apps/api/src/orders/http/dto/order-record-response.dto.ts
+++ b/apps/api/src/orders/http/dto/order-record-response.dto.ts
@@ -111,6 +111,26 @@ export class OrderRecordResponseDto {
   })
   salesDocumentBlockDetail!: string | null;
 
+  @ApiPropertyOptional({
+    nullable: true,
+    description:
+      'When the CURRENT sales-document hold started (ISO 8601), or null when the order is not ' +
+      'held and never has been (#2248). The reason column is level-triggered and nulled the ' +
+      'moment it clears, so this is the only clock an operator-facing age can run on. Stamped ' +
+      'on the none-to-blocked transition only, so a change of reason inside one episode does ' +
+      'not reset it.',
+  })
+  salesDocumentBlockedAt!: string | null;
+
+  @ApiPropertyOptional({
+    nullable: true,
+    description:
+      'When the current hold ended (ISO 8601), cleared whenever a new one starts, so the pair ' +
+      'with salesDocumentBlockedAt always describes one episode. It is what lets the timeline ' +
+      'say the order was held and then released — the reason itself is gone by then.',
+  })
+  salesDocumentBlockReleasedAt!: string | null;
+
   @ApiProperty({ description: 'Order last-update timestamp (ISO 8601)' })
   updatedAt!: string;
 

--- a/apps/api/src/orders/http/orders.controller.ts
+++ b/apps/api/src/orders/http/orders.controller.ts
@@ -326,6 +326,8 @@ export class OrdersController {
       salesDocumentBlockReason: order.salesDocumentBlockReason,
       salesDocumentUnresolvedReason: order.salesDocumentUnresolvedReason,
       salesDocumentBlockDetail: order.salesDocumentBlockDetail,
+      salesDocumentBlockedAt: order.salesDocumentBlockedAt?.toISOString() ?? null,
+      salesDocumentBlockReleasedAt: order.salesDocumentBlockReleasedAt?.toISOString() ?? null,
       createdAt: order.createdAt instanceof Date ? order.createdAt.toISOString() : order.createdAt,
       updatedAt: order.updatedAt instanceof Date ? order.updatedAt.toISOString() : order.updatedAt,
       dispatchByAt: order.dispatchByAt ? order.dispatchByAt.toISOString() : null,

--- a/apps/web/src/features/orders/api/orders.types.ts
+++ b/apps/web/src/features/orders/api/orders.types.ts
@@ -81,6 +81,7 @@ export type SlaStateValue = (typeof SlaStateValues)[number];
 export const SalesDocumentGateBlockReasonValues = [
   'unresolved-routing',
   'missing-required-tax-id',
+  'missing-tax-rate',
   'tax-rate-conflict',
   'trigger-model-manual',
   'trigger-model-batched',

--- a/apps/web/src/features/orders/lib/order-row.ts
+++ b/apps/web/src/features/orders/lib/order-row.ts
@@ -227,7 +227,22 @@ const BADGE_BY_REASON = {
     hint: 'This order needs a buyer tax ID before it can be invoiced.',
     keepIssueAction: false,
   },
-  // Declared but never written today — blocked on #2057.
+  // #2248 (ADR-052). The one reason where `keepIssueAction: false` means the
+  // action is genuinely unavailable rather than merely unhelpful: issuing by
+  // hand would make a provider guess a rate onto a real fiscal document, so the
+  // backend refuses the manual paths too. Every other `false` above is a
+  // presentation choice; this one matches a server-side refusal.
+  'missing-tax-rate': {
+    label: 'No tax rate',
+    tone: 'error',
+    hint: 'A product on this order has no tax rate, so no document can state the tax charged.',
+    keepIssueAction: false,
+  },
+  // Declared but never written today, and it stays that way: a shop-versus-channel
+  // disagreement does not block (#2245 F1). It surfaces on its own field with its
+  // own resolver, because a badge routed through here would never render - the
+  // resolver below suppresses one whenever an invoice exists, and a non-blocking
+  // conflict always has one.
   'tax-rate-conflict': {
     label: 'Tax rate conflict',
     tone: 'error',

--- a/libs/core/src/invoicing/application/mappers/order-to-issue-invoice-command.mapper.ts
+++ b/libs/core/src/invoicing/application/mappers/order-to-issue-invoice-command.mapper.ts
@@ -22,6 +22,7 @@ import type {
 import { InvalidBuyerProfileError } from './errors/invalid-buyer-profile.error';
 import { InvalidInvoiceLineError } from './errors/invalid-invoice-line.error';
 import { UnsupportedPriceTreatmentError } from './errors/unsupported-price-treatment.error';
+import { splitShippingAcrossRates } from '../../domain/types/shipping-tax-split.types';
 
 /**
  * Default carrier-neutral label for the shipping invoice line (#1517). Core is
@@ -93,10 +94,7 @@ export function toIssueInvoiceCommand(
   // order total, #1517). Emit it as a normal gross line so the provider adapter
   // resolves its tax rate the same way it does for product lines; core never
   // names a tax rate. Skipped when shipping is 0 (no phantom line).
-  const shippingLine = toShippingLine(order.totals.shipping, shippingLineName);
-  if (shippingLine) {
-    lines.push(shippingLine);
-  }
+  lines.push(...toShippingLines(order.totals.shipping, order.items, shippingLineName));
 
   const command: IssueInvoiceCommand = {
     connectionId,
@@ -206,9 +204,14 @@ function toBuyerAddress(address: Address): BuyerAddress {
 /**
  * Map an {@link OrderItem} onto an {@link InvoiceLine}. `unitPriceGross` is the
  * line price (gross — see treatment guard above). `name` falls back to
- * `sku` then `productId` when the source omitted a label. `taxRate` is left
- * empty here — the provider adapter resolves the regime rate; core never names
- * a tax rate on the order contract.
+ * `sku` then `productId` when the source omitted a label.
+ *
+ * `taxRate` now carries the rate the order line was settled with (#2248,
+ * ADR-052) instead of the empty string it used to emit. It stays a passthrough:
+ * the code was resolved once at ingestion, and this mapper neither derives one
+ * nor substitutes a default. An empty value still reaches the adapter unchanged
+ * — the gate is what refuses such an order, not this function, because a mapper
+ * that threw would turn an operator-fixable data gap into a failed job.
  *
  * Throws {@link InvalidInvoiceLineError} (PII-clean, cites only `orderId`) when
  * the quantity is not a positive finite number - a malformed order snapshot
@@ -225,27 +228,56 @@ function toInvoiceLine(item: OrderItem, orderId: string): InvoiceLine {
     name: item.name?.trim() || item.sku || item.productId,
     quantity: item.quantity,
     unitPriceGross: item.price,
-    taxRate: '',
+    taxRate: item.taxRate?.trim() ?? '',
   };
 }
 
 /**
- * Compose the shipping {@link InvoiceLine} from the order's gross shipping cost,
- * or `null` when there is nothing to bill (#1517). A single unit priced at the
- * gross shipping amount; `taxRate` is left empty (provider adapter resolves the
- * regime rate, mirroring {@link toInvoiceLine}). Non-positive or non-finite
- * shipping (0, negative, NaN) yields no line — no phantom shipping line. `name`
- * defaults to the neutral {@link SHIPPING_LINE_NAME} when the caller supplies no
- * (locale-specific) override.
+ * Compose the shipping {@link InvoiceLine}s from the order's gross shipping
+ * cost (#1517, extended by #2248).
+ *
+ * Shipping inherits the basket's tax treatment, so a single-rate basket yields
+ * ONE line at that rate — the ordinary case, unchanged in shape from before.
+ * A mixed-rate basket yields N lines whose amounts sum exactly to the shipping
+ * the buyer paid, split in proportion to what was bought at each rate.
+ *
+ * Non-positive or non-finite shipping (0, negative, NaN) yields no line — no
+ * phantom shipping line. `name` defaults to the neutral
+ * {@link SHIPPING_LINE_NAME} when the caller supplies no (locale-specific)
+ * override; a split line carries the same name, since the rate is what
+ * distinguishes the parts and inventing "Shipping (23%)" would put regime
+ * vocabulary in core.
+ *
+ * When the split is uncomputable — some line has no rate — a single line with
+ * an EMPTY rate is returned rather than nothing. Dropping the shipping would
+ * understate the document total; the gate refuses the order before it reaches
+ * a provider.
  */
-function toShippingLine(shipping: number, name?: string): InvoiceLine | null {
+function toShippingLines(
+  shipping: number,
+  items: readonly OrderItem[],
+  name?: string
+): InvoiceLine[] {
   if (!Number.isFinite(shipping) || shipping <= 0) {
-    return null;
+    return [];
   }
-  return {
-    name: name?.trim() || SHIPPING_LINE_NAME,
+  const label = name?.trim() || SHIPPING_LINE_NAME;
+  const parts = splitShippingAcrossRates(
+    shipping,
+    items.map((item) => ({
+      taxRate: item.taxRate?.trim() ?? null,
+      gross: item.price * item.quantity,
+    }))
+  );
+
+  if (parts === null) {
+    return [{ name: label, quantity: 1, unitPriceGross: shipping, taxRate: '' }];
+  }
+
+  return parts.map((part) => ({
+    name: label,
     quantity: 1,
-    unitPriceGross: shipping,
-    taxRate: '',
-  };
+    unitPriceGross: part.amount,
+    taxRate: part.taxRate,
+  }));
 }

--- a/libs/core/src/invoicing/application/services/auto-issue-trigger.service.ts
+++ b/libs/core/src/invoicing/application/services/auto-issue-trigger.service.ts
@@ -81,6 +81,10 @@ import type {
   SalesDocumentBlockOutcome,
 } from '@openlinker/core/sales-documents';
 import { Logger } from '@openlinker/shared/logging';
+import {
+  describeMissingTaxRate,
+  findMissingTaxRate,
+} from '../../domain/types/order-tax-rate-gate.types';
 
 import type { IAutoIssueTriggerService } from './auto-issue-trigger.service.interface';
 import type {
@@ -314,6 +318,23 @@ export class AutoIssueTriggerService implements IAutoIssueTriggerService {
     try {
       const triggerModel = parseTriggerModel(connection.config.invoicing?.triggerModel);
       this.warnOnceIfManualPrimaryDisablesInstall(triggerModel, connection.id, connections.length);
+
+      // #2248 (ADR-052 § 6): a line with no tax rate is checked BEFORE the
+      // trigger-model gate, and deliberately so. On a `manual` connection both
+      // would apply, and the two say different things - `trigger-model-manual`
+      // means "waiting for a human", which is a workflow state with a working
+      // CTA, while this one means "no human can issue it either". Reporting the
+      // weaker reason would leave an operator clicking a button that refuses.
+      const missingRate = findMissingTaxRate(order.items);
+      if (missingRate) {
+        return await this.reportBlock(
+          {
+            reason: 'missing-tax-rate',
+            detail: describeMissingTaxRate(missingRate),
+          },
+          order.id,
+        );
+      }
 
       const gate = this.evaluateGate(order, triggerModel, connection.id);
       if (gate.kind === 'waiting') {

--- a/libs/core/src/invoicing/application/services/invoice.service.ts
+++ b/libs/core/src/invoicing/application/services/invoice.service.ts
@@ -51,6 +51,8 @@ import {
 } from './invoice-issue-lock';
 import { MissingNumberingSeriesException } from '../../domain/exceptions/missing-numbering-series.exception';
 import { taxRatePercentToFraction } from '../../domain/types/tax-rate-notation.types';
+import { findMissingTaxRate } from '../../domain/types/order-tax-rate-gate.types';
+import { MissingTaxRateException } from '../../domain/exceptions/missing-tax-rate.exception';
 import { CapabilityNotSupportedException } from '@openlinker/core/integrations';
 // Published so an adapter spec can pin its own pre-call refusal message against
 // the very markers this service matches on (#2103 review) — see the constant's doc.
@@ -256,6 +258,18 @@ export class InvoiceService implements IInvoiceService {
    * enforce.
    */
   async issueInvoice(cmd: IssueInvoiceCommand): Promise<InvoiceRecord> {
+    // #2248 (ADR-052 § 6): refuse before the lock and before any persisted
+    // state is touched. This is the write-path half of the gate, and it is what
+    // closes the MANUAL routes - `POST /invoices`, the panel button, bulk issue
+    // - which every other block reason deliberately leaves open. A command
+    // whose lines carry no rate can only be issued by a provider guessing one
+    // onto a real fiscal document.
+    //
+    // Checked on the COMMAND rather than on the order, so no caller can bypass
+    // it by composing lines itself, and so the correction path (which composes
+    // its own lines from an already-issued document) is unaffected.
+    this.assertEveryLineHasATaxRate(cmd);
+
     const lockKey = invoiceIssueLockKey(cmd.orderId);
     const token = await this.issueLock.acquire(lockKey, INVOICE_ISSUE_LOCK_TTL_MS);
 
@@ -276,6 +290,22 @@ export class InvoiceService implements IInvoiceService {
             `${releaseError instanceof Error ? releaseError.message : String(releaseError)}`,
         );
       }
+    }
+  }
+
+  /**
+   * Refuse an issuance whose lines do not all name a tax rate (#2248).
+   *
+   * `'0'` passes: a zero rate is an answer, not a gap. A blank one does not -
+   * that is what the mapper emits when nothing established the rate, and the
+   * three shipped providers each substitute a different default for it.
+   */
+  private assertEveryLineHasATaxRate(cmd: IssueInvoiceCommand): void {
+    const finding = findMissingTaxRate(
+      cmd.lines.map((line) => ({ productId: line.name, taxRate: line.taxRate })),
+    );
+    if (finding) {
+      throw new MissingTaxRateException(cmd.orderId, finding);
     }
   }
 

--- a/libs/core/src/invoicing/domain/exceptions/missing-tax-rate.exception.ts
+++ b/libs/core/src/invoicing/domain/exceptions/missing-tax-rate.exception.ts
@@ -1,0 +1,36 @@
+/**
+ * Missing Tax Rate Exception (#2248, ADR-052 § 6)
+ *
+ * Raised when issuance is attempted for an order whose lines do not all carry
+ * a tax rate.
+ *
+ * This is the one refusal that also closes the MANUAL paths. Every other
+ * sales-document block means "auto-issue did not happen", and issuing by hand
+ * past those is a legitimate operator action; this one means "this cannot be
+ * issued", because the only way past it is a provider substituting a guessed
+ * rate onto a real fiscal document. The remedy is in the shop's catalogue, not
+ * in OpenLinker - which is why the message names the product rather than
+ * offering an override.
+ *
+ * PII-clean by construction: it carries the order id, a count and an internal
+ * product id. No buyer data, no line names.
+ *
+ * @module libs/core/src/invoicing/domain/exceptions
+ */
+import type { MissingTaxRateFinding } from '../types/order-tax-rate-gate.types';
+import { describeMissingTaxRate } from '../types/order-tax-rate-gate.types';
+
+export class MissingTaxRateException extends Error {
+  constructor(
+    public readonly orderId: string,
+    public readonly finding: MissingTaxRateFinding
+  ) {
+    super(
+      `Order ${orderId} cannot be invoiced: ${describeMissingTaxRate(finding)}. ` +
+        `Add the rate in the shop's catalogue and re-sync the product; OpenLinker ` +
+        `does not substitute one.`
+    );
+    this.name = 'MissingTaxRateException';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}

--- a/libs/core/src/invoicing/domain/types/order-tax-rate-gate.types.spec.ts
+++ b/libs/core/src/invoicing/domain/types/order-tax-rate-gate.types.spec.ts
@@ -1,0 +1,66 @@
+/**
+ * Order Tax-Rate Gate Tests (#2248, ADR-052 § 6)
+ *
+ * @module libs/core/src/invoicing/domain/types
+ */
+import { describeMissingTaxRate, findMissingTaxRate } from './order-tax-rate-gate.types';
+
+describe('findMissingTaxRate', () => {
+  it('should report nothing when every line carries a rate', () => {
+    expect(
+      findMissingTaxRate([
+        { productId: 'ol_product_a', taxRate: '23' },
+        { productId: 'ol_product_b', taxRate: 'zw' },
+      ])
+    ).toBeNull();
+  });
+
+  it('should treat a zero rate as an answer, not a gap', () => {
+    // Export, intra-EU and exempt goods are legitimately zero. Blocking here
+    // would hold documents for a correctly configured catalogue.
+    expect(findMissingTaxRate([{ productId: 'ol_product_a', taxRate: '0' }])).toBeNull();
+  });
+
+  it('should report a line whose rate is absent', () => {
+    expect(
+      findMissingTaxRate([
+        { productId: 'ol_product_a', taxRate: '23' },
+        { productId: 'ol_product_b' },
+      ])
+    ).toEqual({ lineCount: 1, totalLines: 2, firstProductId: 'ol_product_b' });
+  });
+
+  it('should report a line whose rate is blank', () => {
+    // The empty string is what the mapper emitted before this epic.
+    expect(findMissingTaxRate([{ productId: 'ol_product_a', taxRate: '  ' }])?.lineCount).toBe(1);
+  });
+
+  it('should report nothing for an order with no lines', () => {
+    // There is nothing to state a rate for, and a tax complaint would displace
+    // whatever the real problem with an empty order is.
+    expect(findMissingTaxRate([])).toBeNull();
+  });
+
+  it('should name the first offending product so the remedy points at one thing', () => {
+    const finding = findMissingTaxRate([
+      { productId: 'ol_product_a' },
+      { productId: 'ol_product_b' },
+    ]);
+    expect(finding?.firstProductId).toBe('ol_product_a');
+    expect(finding?.lineCount).toBe(2);
+  });
+});
+
+describe('describeMissingTaxRate', () => {
+  it('should state the scope and name the first product', () => {
+    expect(
+      describeMissingTaxRate({ lineCount: 1, totalLines: 3, firstProductId: 'ol_product_a' })
+    ).toBe('1 of 3 lines carry no tax rate; first: ol_product_a');
+  });
+
+  it('should omit the product clause when there is no id to name', () => {
+    expect(describeMissingTaxRate({ lineCount: 2, totalLines: 2, firstProductId: null })).toBe(
+      '2 of 2 lines carry no tax rate'
+    );
+  });
+});

--- a/libs/core/src/invoicing/domain/types/order-tax-rate-gate.types.ts
+++ b/libs/core/src/invoicing/domain/types/order-tax-rate-gate.types.ts
@@ -1,0 +1,69 @@
+/**
+ * Order Tax-Rate Gate (#2248, ADR-052 § 6)
+ *
+ * The one predicate that answers "can a document state what tax was charged on
+ * this order?". A line with no rate means no, and the document is held rather
+ * than issued with a rate some adapter guessed.
+ *
+ * Pure and dependency-free - it takes the minimal line shape rather than an
+ * `Order`, so it can be called from the gate, from the write path, and from a
+ * bulk eligibility pass without any of them dragging the orders context in.
+ *
+ * @module libs/core/src/invoicing/domain/types
+ */
+
+/** The two fields the gate reads off an order line. */
+export interface TaxRateGateLine {
+  /** Internal product id - an OL identifier, never buyer data. */
+  productId: string;
+  /** The settled rate code, or absent when none was ever established. */
+  taxRate?: string;
+}
+
+/** What is missing, in terms an operator screen can render verbatim. */
+export interface MissingTaxRateFinding {
+  /** How many lines have no rate. */
+  lineCount: number;
+  /** Total lines on the order, so "3 of 4" is expressible. */
+  totalLines: number;
+  /**
+   * The internal product id of the first line with no rate, so the remedy can
+   * name one thing to fix. An OL id, deliberately - a product NAME would be
+   * shop-authored free text on an operator screen that also renders to logs.
+   */
+  firstProductId: string | null;
+}
+
+/**
+ * Report the lines with no tax rate, or `null` when every line has one.
+ *
+ * A blank string counts as missing: that is what the mapper emitted before
+ * #2248 and what a source with no rate still produces. `'0'` does NOT count -
+ * a zero rate is an answer (export, intra-EU, exempt goods), and treating it
+ * as a gap would hold documents for a correctly configured catalogue.
+ *
+ * An order with no lines at all reports `null`. There is nothing to state a
+ * rate for, and refusing it here would substitute a tax complaint for whatever
+ * the real problem with an empty order is.
+ */
+export function findMissingTaxRate(
+  lines: readonly TaxRateGateLine[]
+): MissingTaxRateFinding | null {
+  if (lines.length === 0) return null;
+  const missing = lines.filter((line) => (line.taxRate ?? '').trim() === '');
+  if (missing.length === 0) return null;
+  return {
+    lineCount: missing.length,
+    totalLines: lines.length,
+    firstProductId: missing[0]?.productId ?? null,
+  };
+}
+
+/**
+ * PII-free block detail. Ids and counts only - it reaches an operator screen
+ * verbatim and is logged beside a PII-safe envelope.
+ */
+export function describeMissingTaxRate(finding: MissingTaxRateFinding): string {
+  const scope = `${String(finding.lineCount)} of ${String(finding.totalLines)} lines carry no tax rate`;
+  return finding.firstProductId ? `${scope}; first: ${finding.firstProductId}` : scope;
+}

--- a/libs/core/src/invoicing/domain/types/shipping-tax-split.types.spec.ts
+++ b/libs/core/src/invoicing/domain/types/shipping-tax-split.types.spec.ts
@@ -1,0 +1,114 @@
+/**
+ * Shipping Tax Split Tests (#2248, ADR-052 § 5)
+ *
+ * The property that matters is arithmetic: however the parts fall, they add
+ * back up to the shipping the buyer actually paid. Everything else is about
+ * refusing to guess when the basket's rate mix is unknown.
+ *
+ * @module libs/core/src/invoicing/domain/types
+ */
+import { splitShippingAcrossRates } from './shipping-tax-split.types';
+import type { ShippingSplitLine } from './shipping-tax-split.types';
+
+function line(taxRate: string | null, gross: number): ShippingSplitLine {
+  return { taxRate, gross };
+}
+
+function sum(parts: { amount: number }[]): number {
+  return Math.round(parts.reduce((total, part) => total + part.amount, 0) * 100) / 100;
+}
+
+describe('splitShippingAcrossRates', () => {
+  describe('nothing to bill', () => {
+    it('should produce no line when shipping is zero', () => {
+      expect(splitShippingAcrossRates(0, [line('23', 100)])).toEqual([]);
+    });
+
+    it('should produce no line when shipping is negative or not a number', () => {
+      expect(splitShippingAcrossRates(-5, [line('23', 100)])).toEqual([]);
+      expect(splitShippingAcrossRates(Number.NaN, [line('23', 100)])).toEqual([]);
+    });
+  });
+
+  describe('uncomputable', () => {
+    it('should refuse when any line carries no rate', () => {
+      // The unknown line's share cannot be attributed to somebody else's rate.
+      expect(splitShippingAcrossRates(10, [line('23', 100), line(null, 50)])).toBeNull();
+      expect(splitShippingAcrossRates(10, [line('23', 100), line('  ', 50)])).toBeNull();
+    });
+
+    it('should refuse when there are no lines to be proportional to', () => {
+      expect(splitShippingAcrossRates(10, [])).toBeNull();
+    });
+
+    it('should refuse when every line gross is zero', () => {
+      expect(splitShippingAcrossRates(10, [line('23', 0), line('8', 0)])).toBeNull();
+    });
+  });
+
+  describe('single rate', () => {
+    it('should produce one part carrying the whole shipping amount', () => {
+      expect(splitShippingAcrossRates(12.34, [line('23', 100), line('23', 50)])).toEqual([
+        { taxRate: '23', amount: 12.34 },
+      ]);
+    });
+  });
+
+  describe('mixed rates', () => {
+    it('should split in proportion to line gross', () => {
+      const parts = splitShippingAcrossRates(30, [line('23', 200), line('8', 100)]);
+      expect(parts).toEqual([
+        { taxRate: '23', amount: 20 },
+        { taxRate: '8', amount: 10 },
+      ]);
+    });
+
+    it('should sum exactly to the shipping paid when the split does not divide evenly', () => {
+      // 10.00 across 1:1:1 is 3.3333 each; the remainder has to land somewhere.
+      const parts = splitShippingAcrossRates(10, [line('23', 100), line('8', 100), line('5', 100)]);
+      expect(parts).not.toBeNull();
+      expect(sum(parts!)).toBe(10);
+    });
+
+    it('should put the rounding remainder on the largest part', () => {
+      const parts = splitShippingAcrossRates(10, [line('23', 100), line('8', 100), line('5', 100)]);
+      // Equal grosses tie, so ordering falls to the rate code; whichever part
+      // sorts first absorbs the cent.
+      expect(parts?.[0].amount).toBeGreaterThanOrEqual(parts?.[1].amount ?? 0);
+    });
+
+    it('should handle three or more rate buckets and still sum exactly', () => {
+      const parts = splitShippingAcrossRates(19.99, [
+        line('23', 349.99),
+        line('8', 17.5),
+        line('5', 3.33),
+        line('0', 120),
+      ]);
+      expect(parts).toHaveLength(4);
+      expect(sum(parts!)).toBe(19.99);
+    });
+
+    it('should group several lines that share a rate into one part', () => {
+      const parts = splitShippingAcrossRates(20, [
+        line('23', 100),
+        line('23', 100),
+        line('8', 200),
+      ]);
+      expect(parts).toHaveLength(2);
+      expect(parts?.find((p) => p.taxRate === '23')?.amount).toBe(10);
+    });
+
+    it('should treat a zero rate as a rate rather than as a gap', () => {
+      const parts = splitShippingAcrossRates(10, [line('0', 100), line('23', 100)]);
+      expect(parts?.map((p) => p.taxRate).sort()).toEqual(['0', '23']);
+    });
+
+    it('should drop a part that rounds away to nothing', () => {
+      // A 0.01 shipping charge cannot be meaningfully split; a 0.00 line would
+      // state that nothing was charged at a rate, which is noise.
+      const parts = splitShippingAcrossRates(0.01, [line('23', 100000), line('8', 1)]);
+      expect(parts?.every((p) => p.amount !== 0)).toBe(true);
+      expect(sum(parts!)).toBe(0.01);
+    });
+  });
+});

--- a/libs/core/src/invoicing/domain/types/shipping-tax-split.types.ts
+++ b/libs/core/src/invoicing/domain/types/shipping-tax-split.types.ts
@@ -1,0 +1,108 @@
+/**
+ * Shipping Tax Split (#2248, ADR-052 § 5)
+ *
+ * A basket can carry several tax rates. The shipping the buyer paid is one
+ * amount, and a document has to state which rate applies to it - so on a
+ * mixed-rate basket it is split across the rates present, in proportion to
+ * what was actually bought at each.
+ *
+ * **This is division, not tax computation.** Core groups an amount it was given
+ * and cuts it into parts that sum back to it; it never derives a tax figure and
+ * never rounds a tax value. The rounding rule for a rate stays in the provider
+ * adapter, which is what ADR-052 § 5 reserves to it. The rounding that happens
+ * here is on the *split*, and its only obligation is that the parts add up
+ * exactly to the amount paid.
+ *
+ * Pure and dependency-free: no I/O, no framework, no regime knowledge.
+ *
+ * @module libs/core/src/invoicing/domain/types
+ */
+
+/** One product line's contribution to the basket, as the split sees it. */
+export interface ShippingSplitLine {
+  /** The neutral rate code this line carries, or `null` when it has none. */
+  taxRate: string | null;
+  /** The line's gross total (unit price times quantity). */
+  gross: number;
+}
+
+/** One shipping part: an amount charged at one rate. */
+export interface ShippingSplitPart {
+  taxRate: string;
+  amount: number;
+}
+
+/**
+ * Split `shipping` across the rates present in `lines`.
+ *
+ * Returns `null` when the split is **uncomputable**, which is a different thing
+ * from an empty result:
+ *
+ * - any line carries no rate - the basket's rate mix is unknown, so no
+ *   proportion can be stated, and the whole document waits;
+ * - `lines` is empty, or every line's gross is zero or unusable - there is
+ *   nothing to be proportional to.
+ *
+ * Returns `[]` when there is simply nothing to bill (non-positive or non-finite
+ * shipping). That is a successful answer: no phantom shipping line.
+ *
+ * One rate in the basket gives one part at that rate - the ordinary case, and
+ * it never touches the proportional arithmetic.
+ *
+ * **The remainder goes to the largest part.** Rounding each share to the
+ * currency's minor unit leaves up to a few units unaccounted for; parking them
+ * on the biggest share keeps the parts summing exactly to what the buyer paid,
+ * which is the only property a document reader can check. Ordering is
+ * deterministic (descending gross, then rate code) so the same basket always
+ * produces the same split.
+ */
+export function splitShippingAcrossRates(
+  shipping: number,
+  lines: readonly ShippingSplitLine[]
+): ShippingSplitPart[] | null {
+  if (!Number.isFinite(shipping) || shipping <= 0) return [];
+  if (lines.length === 0) return null;
+  // A single unknown rate makes the mix unknowable. Splitting across the rates
+  // we happen to know would silently attribute the unknown line's share to
+  // somebody else's rate.
+  if (lines.some((line) => line.taxRate === null || line.taxRate.trim() === '')) return null;
+
+  const grossByRate = new Map<string, number>();
+  for (const line of lines) {
+    const rate = (line.taxRate as string).trim();
+    const gross = Number.isFinite(line.gross) && line.gross > 0 ? line.gross : 0;
+    grossByRate.set(rate, (grossByRate.get(rate) ?? 0) + gross);
+  }
+
+  const totalGross = [...grossByRate.values()].reduce((sum, gross) => sum + gross, 0);
+  if (totalGross <= 0) return null;
+
+  const rates = [...grossByRate.entries()].sort(
+    (a, b) => b[1] - a[1] || (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0)
+  );
+
+  if (rates.length === 1) {
+    return [{ taxRate: rates[0][0], amount: round2(shipping) }];
+  }
+
+  const parts: ShippingSplitPart[] = rates.map(([taxRate, gross]) => ({
+    taxRate,
+    amount: round2((shipping * gross) / totalGross),
+  }));
+
+  const allocated = round2(parts.reduce((sum, part) => sum + part.amount, 0));
+  const remainder = round2(round2(shipping) - allocated);
+  if (remainder !== 0) {
+    // `rates` is sorted by descending gross, so index 0 is the largest part.
+    parts[0].amount = round2(parts[0].amount + remainder);
+  }
+
+  // A part that rounds to zero would be a document line stating that zero was
+  // charged at a rate, which is noise rather than information.
+  return parts.filter((part) => part.amount !== 0);
+}
+
+/** Two decimal places - the minor unit of every ISO-4217 currency used here. */
+function round2(value: number): number {
+  return Math.round((value + Number.EPSILON) * 100) / 100;
+}

--- a/libs/core/src/invoicing/index.ts
+++ b/libs/core/src/invoicing/index.ts
@@ -33,6 +33,22 @@ export type {
   InvoicingConnectionSelection,
 } from './domain/types/invoicing-primary.types';
 export { normalizeShippingLineName } from './domain/types/shipping-line-label.types';
+// Proportional shipping split across the rates in a mixed-rate basket (#2248).
+export { splitShippingAcrossRates } from './domain/types/shipping-tax-split.types';
+// A missing per-line tax rate holds the document (#2248, ADR-052 § 6).
+export {
+  describeMissingTaxRate,
+  findMissingTaxRate,
+} from './domain/types/order-tax-rate-gate.types';
+export type {
+  MissingTaxRateFinding,
+  TaxRateGateLine,
+} from './domain/types/order-tax-rate-gate.types';
+export { MissingTaxRateException } from './domain/exceptions/missing-tax-rate.exception';
+export type {
+  ShippingSplitLine,
+  ShippingSplitPart,
+} from './domain/types/shipping-tax-split.types';
 // Canonical percent-as-string tax-rate notation (#2247).
 export {
   FractionalTaxRateNotationError,

--- a/libs/core/src/orders/domain/entities/order-record.entity.ts
+++ b/libs/core/src/orders/domain/entities/order-record.entity.ts
@@ -154,7 +154,28 @@ export class OrderRecord {
      * lookup — so a retry or the sweep stamps against the same currency the
      * inline attempt resolved even if the system setting changed in between.
      */
-    public readonly fxIntendedCurrency: string | null = null
+    public readonly fxIntendedCurrency: string | null = null,
+    /**
+     * When the current sales-document hold started (#2248 / #2245 F4), or
+     * `null` when the order has never been held.
+     *
+     * Appended at the END of the parameter list rather than beside the three
+     * `salesDocument*` fields above: this is a positional constructor, and
+     * inserting mid-list would silently shift every argument after it at each
+     * of its call sites.
+     *
+     * Written only by `updateSalesDocumentBlock`, like the reason columns it
+     * belongs with, and stamped on the `none -> blocked` transition alone so it
+     * measures the whole episode rather than the latest reason within it.
+     */
+    public readonly salesDocumentBlockedAt: Date | null = null,
+    /**
+     * When the current hold ended, cleared whenever a new one starts. The pair
+     * with `salesDocumentBlockedAt` always describes one episode, which is what
+     * lets a timeline say the order was held and then released - the reason
+     * itself is gone by then.
+     */
+    public readonly salesDocumentBlockReleasedAt: Date | null = null
   ) {}
 
   /**

--- a/libs/core/src/orders/infrastructure/persistence/entities/order-record.orm-entity.ts
+++ b/libs/core/src/orders/infrastructure/persistence/entities/order-record.orm-entity.ts
@@ -170,6 +170,30 @@ export class OrderRecordOrmEntity {
   salesDocumentBlockDetail!: string | null;
 
   /**
+   * When the CURRENT hold started (#2248 / #2245 F4).
+   *
+   * The reason column is level-triggered and nulled the moment it clears, so
+   * without an instant there is no clock for the operator-facing age and no
+   * "held since" to render. Stamped on the `none -> blocked` transition only,
+   * so a change of reason inside one episode does not reset an age somebody is
+   * watching, and written exclusively by `updateSalesDocumentBlock` - never by
+   * the ingestion upsert.
+   */
+  @Column({ type: 'timestamptz', nullable: true })
+  salesDocumentBlockedAt!: Date | null;
+
+  /**
+   * When the current hold ENDED. Stamped on `blocked -> none` and cleared
+   * whenever a new block starts, so the pair always describes one episode.
+   *
+   * It is what makes the "the rate arrived, the invoice issued" timeline entry
+   * possible: the reason itself is gone by then, so nothing else records that
+   * the order was ever held.
+   */
+  @Column({ type: 'timestamptz', nullable: true })
+  salesDocumentBlockReleasedAt!: Date | null;
+
+  /**
    * Per-order reporting-currency snapshot (#2124, ADR-040) — six columns
    * written ONLY by the two narrow, conditional UPDATEs on the repository
    * (`claimFxIntentIfAbsent`, `stampFxIfAbsent`). The ingestion upsert

--- a/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
@@ -719,11 +719,33 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
     // `IS DISTINCT FROM` is NULL-safe, so this is exact for the clear case too, and
     // it keeps the `@UpdateDateColumn` bump off the overwhelmingly common
     // `null -> null` path without giving up last-write-wins.
+    // The two instants (#2248 / #2245 F4) are derived from the TRANSITION, in the
+    // same statement, because they are facts about when the reason column changed
+    // and only this UPDATE knows both the old and the new value. Computing them
+    // caller-side would need a read first, which is exactly the race the no-op
+    // guard below exists to avoid.
+    //
+    // `blockedAt` is stamped only on none -> blocked, so it survives a change of
+    // reason and keeps measuring how long the order has actually been held. A
+    // reason that changes (manual, then missing-tax-rate) is the same episode from
+    // the operator's point of view; restamping would reset an age they are
+    // watching. `releasedAt` is stamped on blocked -> none and cleared whenever a
+    // block starts, so the pair always describes the CURRENT episode rather than
+    // an arbitrary mix of two.
     await this.repository.query(
       `UPDATE "order_records"
           SET "salesDocumentBlockReason" = $1,
               "salesDocumentUnresolvedReason" = $2,
               "salesDocumentBlockDetail" = $3,
+              "salesDocumentBlockedAt" = CASE
+                WHEN $1 IS NOT NULL AND "salesDocumentBlockReason" IS NULL THEN now()
+                ELSE "salesDocumentBlockedAt"
+              END,
+              "salesDocumentBlockReleasedAt" = CASE
+                WHEN $1 IS NULL AND "salesDocumentBlockReason" IS NOT NULL THEN now()
+                WHEN $1 IS NOT NULL THEN NULL
+                ELSE "salesDocumentBlockReleasedAt"
+              END,
               "updatedAt" = now()
         WHERE "internalOrderId" = $4
           AND ("salesDocumentBlockReason" IS DISTINCT FROM $1
@@ -1091,7 +1113,9 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
       entity.exchangeRateId ?? null,
       entity.fxRule ?? null,
       entity.fxStampedAt ?? null,
-      entity.fxIntendedCurrency ?? null
+      entity.fxIntendedCurrency ?? null,
+      entity.salesDocumentBlockedAt ?? null,
+      entity.salesDocumentBlockReleasedAt ?? null
     );
   }
 

--- a/libs/core/src/sales-documents/domain/types/sales-document-reason.types.ts
+++ b/libs/core/src/sales-documents/domain/types/sales-document-reason.types.ts
@@ -57,18 +57,32 @@ export type SalesDocumentUnresolvedReason = (typeof SalesDocumentUnresolvedReaso
  * and `'trigger-model-batched'` — the three reachable non-issuing exits of
  * `AutoIssueTriggerService.onOrderTransition`.
  *
+ * ALSO WRITTEN (#2248, ADR-052): `'missing-tax-rate'` — a line carries no tax
+ * rate, so no document can state what tax was charged.
+ *
+ * **It is the first reason for which "this cannot be issued" is literally true.**
+ * Every other value means "auto-issue did not happen", and ADR-041 says so
+ * explicitly; a manual issue past those is a legitimate operator action. This
+ * one is not: issuing anyway means a provider substituting a guessed rate onto
+ * a real fiscal document. So it closes the manual paths too — the invoice
+ * panel's issue button, the receipt's register button, and bulk issue — which
+ * no other reason does.
+ *
  * DECLARED BUT NEVER WRITTEN, each blocked on a prerequisite ADR-041 names:
  *   - `'missing-required-tax-id'` — needs a buyer tax id on the order contract;
  *     no such field exists on `Order` today.
- *   - `'tax-rate-conflict'`       — needs #2057. An unknown tax rate is currently
- *     indistinguishable from a resolved zero (a failed read returns the number
- *     `0`, which is also a legitimate exemption), so "a channel-reported rate
- *     diverging from the master's" is not computable and the gate would read
- *     "no conflict" on precisely the unknown-rate orders it exists to catch.
+ *   - `'tax-rate-conflict'`       — and it stays unwritten even after #2245.
+ *     A shop-versus-channel disagreement does NOT block (epic F1): the shop
+ *     wins, the document issues, and the mismatch is surfaced on its own
+ *     projection field with its own resolver. Writing it here would make its
+ *     badge unreachable — `invoicingBlockedBadge` suppresses the badge whenever
+ *     an invoice exists, and a non-blocking conflict always has one — and would
+ *     additionally double-count it inside `salesDocumentBlocked`.
  */
 export const SalesDocumentGateBlockReasonValues = [
   'unresolved-routing',
   'missing-required-tax-id',
+  'missing-tax-rate',
   'tax-rate-conflict',
   'trigger-model-manual',
   'trigger-model-batched',


### PR DESCRIPTION
Turns the rate #2054 puts on the order into a document, and refuses to issue when it is absent.

## Filling the rate

`toInvoiceLine` stops emitting `taxRate: ''` and carries the code the order line was settled with. It stays a **passthrough** - no derivation, no default - and an empty value still reaches the adapter unchanged, because a mapper that threw would turn an operator-fixable data gap into a failed job. The gate is what refuses.

## The gate

`missing-tax-rate` joins `SalesDocumentGateBlockReasonValues` on **both** sides of the mirror (the invariant script fails the build otherwise), plus a badge entry, since `BADGE_BY_REASON` is `satisfies Record<…>` and compile-forces one.

**It is the first reason for which "this cannot be issued" is literally true.** Every other reason means "auto-issue did not happen" - ADR-041 says so explicitly - and issuing by hand past those is a legitimate operator action. Issuing past this one means a provider substituting a guessed rate onto a real fiscal document. So it closes the manual paths too (#2245 F2):

| Path | Behaviour |
|---|---|
| Auto-issue gate | reports `missing-tax-rate`, with a PII-free detail naming the count and the first product id |
| `InvoiceService.issueInvoice` | refuses **before the lock** and before any persisted state is touched |
| `POST /invoices` | 422 with `reason: 'missing-tax-rate'`, `retryable: false`, and the ids to act on |
| `POST /invoices/bulk-issue` | a named `skipped` ineligibility, the pattern bulk dispatch uses for `source_deleted` |

Two placement decisions:

- The check runs on the **command**, not on the order, so no caller can bypass it by composing lines itself - and the correction path, which composes its lines from an already-issued document, is unaffected.
- It runs **before** the trigger-model gate. On a `manual` connection both apply, and reporting `trigger-model-manual` would leave an operator clicking a CTA that then refuses.

A zero rate passes everywhere. Export, intra-EU and exempt goods are legitimately zero.

`tax-rate-conflict` stays declared-but-never-written, and the doc comment now says why it stays that way rather than "blocked on #2057": a shop-versus-channel disagreement does not block (#2245 F1).

## Shipping split

A mixed-rate basket yields N shipping lines, split by line gross, remainder on the largest part so the parts sum **exactly** to the shipping paid. A single-rate basket still yields one line, unchanged in shape.

This is division, not tax computation - core groups an amount it was given and cuts it into parts that add back up to it (ADR-052 § 5). A single line with no rate makes the mix unknowable, so the split returns `null` and the whole document waits; the shipping line is still emitted (with an empty rate) rather than dropped, because dropping it would understate the total, and the gate refuses the order before it reaches a provider.

Covered by tests including three and four rate buckets, ties, and a part that rounds away to nothing.

## The persisted block instant (F4)

`salesDocumentBlockedAt` / `salesDocumentBlockReleasedAt`, derived from the **transition** inside the same `UPDATE` - only that statement knows both the old and the new value, and computing them caller-side would need a read first, which is the race the existing no-op guard exists to avoid.

`blockedAt` is stamped on `none -> blocked` only, so a change of reason inside one episode does not reset an age somebody is watching. `releasedAt` is stamped on `blocked -> none` and cleared when a new block starts, so the pair always describes one episode. Additive, nullable, no backfill - a synthetic "held since" would put an invented age on an operator screen.

Closes #2248
Refs #2245

🤖 Generated with [Claude Code](https://claude.com/claude-code)