### PR TITLE
feat(products): append-only tax-rate provenance journal

### DIFF
--- a/apps/api/src/migrations/1837000000002-create-tax-rate-journal.ts
+++ b/apps/api/src/migrations/1837000000002-create-tax-rate-journal.ts
@@ -1,0 +1,46 @@
+/**
+ * Append-only tax-rate provenance journal (#2250, ADR-052 § 4).
+ *
+ * One row per CHANGE in an observed rate, never one per read. A mutable
+ * "source" field can only say how things stand now; it cannot answer when the
+ * shop changed the rate, what OpenLinker last wrote onto a channel, or whether
+ * somebody overwrote it afterwards - and the last of those is what makes a
+ * shop-versus-channel disagreement attributable rather than mysterious.
+ *
+ * No unique constraint: rows are meant to repeat over time, and the "write only
+ * on a change" rule is a service-level dedup against the latest row rather than
+ * a constraint. The single index serves both reads the model has - the latest
+ * entry for one item on one connection, and the latest per connection for one
+ * item - because both walk the same prefix.
+ */
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateTaxRateJournal1837000000002 implements MigrationInterface {
+  name = 'CreateTaxRateJournal1837000000002';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "tax_rate_journal" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "productId" text NOT NULL,
+        "variantId" text,
+        "connectionId" uuid NOT NULL,
+        "origin" character varying(32) NOT NULL,
+        "taxRate" character varying(16),
+        "frozen" boolean NOT NULL DEFAULT false,
+        "observedAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+        "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_tax_rate_journal" PRIMARY KEY ("id")
+      )
+    `);
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_tax_rate_journal_latest"
+        ON "tax_rate_journal" ("productId", "variantId", "connectionId", "observedAt" DESC)
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_tax_rate_journal_latest"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "tax_rate_journal"`);
+  }
+}

--- a/libs/core/src/products/application/services/__tests__/master-product-sync.service.spec.ts
+++ b/libs/core/src/products/application/services/__tests__/master-product-sync.service.spec.ts
@@ -20,6 +20,7 @@ import {
 } from '../../../domain/types/master-deletion-events.types';
 import type { IProductsService } from '../products.service.interface';
 import type { IEntityClaimService, IIntegrationsService } from '@openlinker/core/integrations';
+import type { ITaxRateJournalService } from '../tax-rate-journal.service.interface';
 import type { IIdentifierMappingService } from '@openlinker/core/identifier-mapping';
 import type { EventPublisherPort } from '@openlinker/core/events';
 import type { Product } from '../../../domain/entities/product.entity';
@@ -46,6 +47,7 @@ describe('MasterProductSyncService', () => {
   >;
   let eventPublisher: jest.Mocked<EventPublisherPort>;
   let entityClaims: jest.Mocked<IEntityClaimService>;
+  let taxRateJournal: jest.Mocked<ITaxRateJournalService>;
   let adapter: jest.Mocked<Pick<ProductMasterPort, 'getProduct' | 'getProductVariants'>>;
   let service: MasterProductSyncService;
 
@@ -79,12 +81,21 @@ describe('MasterProductSyncService', () => {
       findRivalClaimants: jest.fn().mockResolvedValue([]),
     } as unknown as jest.Mocked<IEntityClaimService>;
 
+
+    // #2250: the journal is provenance only, so these specs assert the sync's
+    // own behaviour with a no-op recorder.
+    taxRateJournal = {
+      record: jest.fn().mockResolvedValue(null),
+      getLatestPerConnection: jest.fn().mockResolvedValue([]),
+    } as unknown as jest.Mocked<ITaxRateJournalService>;
+
     service = new MasterProductSyncService(
       integrationsService,
       identifierMapping,
       productsService as unknown as IProductsService,
       eventPublisher,
-      entityClaims
+      entityClaims,
+      taxRateJournal
     );
   });
 

--- a/libs/core/src/products/application/services/master-product-sync.service.ts
+++ b/libs/core/src/products/application/services/master-product-sync.service.ts
@@ -19,7 +19,8 @@ import {
 } from '@openlinker/core/integrations';
 import { IIdentifierMappingService, IDENTIFIER_MAPPING_SERVICE_TOKEN, CORE_ENTITY_TYPE } from '@openlinker/core/identifier-mapping';
 import { EventPublisherPort, EVENT_PUBLISHER_TOKEN } from '@openlinker/core/events';
-import { PRODUCTS_SERVICE_TOKEN } from '../../products.tokens';
+import { PRODUCTS_SERVICE_TOKEN, TAX_RATE_JOURNAL_SERVICE_TOKEN } from '../../products.tokens';
+import type { ITaxRateJournalService } from './tax-rate-journal.service.interface';
 import { IProductsService } from './products.service.interface';
 import type { ProductMasterPort } from '../../domain/ports/product-master.port';
 import { isProductTaxRateReader } from '../../domain/ports/capabilities/product-tax-rate-reader.capability';
@@ -55,7 +56,11 @@ export class MasterProductSyncService implements IMasterProductSyncService {
     @Inject(EVENT_PUBLISHER_TOKEN)
     private readonly eventPublisher: EventPublisherPort,
     @Inject(ENTITY_CLAIM_SERVICE_TOKEN)
-    private readonly entityClaims: IEntityClaimService
+    private readonly entityClaims: IEntityClaimService,
+    // #2250: provenance for every rate this sync observes. Append-only and
+    // change-only, so an unchanged catalogue writes nothing.
+    @Inject(TAX_RATE_JOURNAL_SERVICE_TOKEN)
+    private readonly taxRateJournal: ITaxRateJournalService
   ) {}
 
   async syncFromMasterByExternalId(
@@ -228,9 +233,14 @@ export class MasterProductSyncService implements IMasterProductSyncService {
     const readAt = new Date();
     try {
       const productRate = await adapter.readProductTaxRate({ productId: internalProductId });
-      await this.productsService.recordProductTaxRate(
+      const storedProductRate = this.toStoredTaxRate(productRate, readAt);
+      await this.productsService.recordProductTaxRate(internalProductId, storedProductRate);
+      await this.journalObservation(
         internalProductId,
-        this.toStoredTaxRate(productRate, readAt)
+        null,
+        connectionId,
+        storedProductRate.code,
+        readAt
       );
 
       // Only a variant-keyed master gets per-variant reads. On a product-keyed
@@ -249,9 +259,14 @@ export class MasterProductSyncService implements IMasterProductSyncService {
         // absent. Copying the product's code down would create a duplicate that
         // goes stale the next time the product's rate changes.
         if (variantRate.kind === 'inherited') continue;
-        await this.productsService.recordVariantTaxRate(
+        const storedVariantRate = this.toStoredTaxRate(variantRate, readAt);
+        await this.productsService.recordVariantTaxRate(variant.id, storedVariantRate);
+        await this.journalObservation(
+          internalProductId,
           variant.id,
-          this.toStoredTaxRate(variantRate, readAt)
+          connectionId,
+          storedVariantRate.code,
+          readAt
         );
       }
     } catch (error) {
@@ -259,6 +274,38 @@ export class MasterProductSyncService implements IMasterProductSyncService {
         `[master-sync] tax-rate read failed, leaving the catalogue row unchanged: ` +
           `connectionId=${connectionId} internalProductId=${internalProductId} ` +
           `correlationId=${correlationId} error=${(error as Error).message}`
+      );
+    }
+  }
+
+  /**
+   * Journal what the shop said (#2250).
+   *
+   * Best-effort and separate from the catalogue write: the journal is
+   * provenance, so losing an entry costs an audit trail rather than a rate, and
+   * failing the sync over it would trade the thing that matters for the thing
+   * that explains it.
+   */
+  private async journalObservation(
+    productId: string,
+    variantId: string | null,
+    connectionId: string,
+    taxRate: string | null,
+    observedAt: Date
+  ): Promise<void> {
+    try {
+      await this.taxRateJournal.record({
+        productId,
+        variantId,
+        connectionId,
+        origin: 'shop',
+        taxRate,
+        observedAt,
+      });
+    } catch (error) {
+      this.logger.warn(
+        `[master-sync] tax-rate journal write failed (provenance only, catalogue is unaffected): ` +
+          `productId=${productId} variantId=${variantId ?? 'none'} error=${(error as Error).message}`
       );
     }
   }

--- a/libs/core/src/products/application/services/tax-rate-journal.service.interface.ts
+++ b/libs/core/src/products/application/services/tax-rate-journal.service.interface.ts
@@ -1,0 +1,29 @@
+/**
+ * Tax-Rate Journal Service Interface (#2250)
+ *
+ * @module libs/core/src/products/application/services
+ * @see {@link TaxRateJournalService} for the implementation
+ */
+import type {
+  TaxRateJournalEntry,
+  TaxRateObservation,
+} from '../../domain/types/tax-rate-journal.types';
+
+export interface ITaxRateJournalService {
+  /**
+   * Record an observation, but only when it CHANGES what the journal last held
+   * for the same item and connection.
+   *
+   * Returns the row when one was written and `null` when the observation was a
+   * repeat. The catalogue sweep runs every twenty minutes and most products'
+   * rates never move, so writing unconditionally would grow the table by the
+   * size of the catalogue per tick and bury the handful of rows that matter.
+   */
+  record(observation: TaxRateObservation): Promise<TaxRateJournalEntry | null>;
+
+  /** The latest entry per connection for one item - the disagreement surface's read. */
+  getLatestPerConnection(
+    productId: string,
+    variantId?: string | null
+  ): Promise<TaxRateJournalEntry[]>;
+}

--- a/libs/core/src/products/application/services/tax-rate-journal.service.ts
+++ b/libs/core/src/products/application/services/tax-rate-journal.service.ts
@@ -1,0 +1,57 @@
+/**
+ * Tax-Rate Journal Service (#2250, ADR-052 § 4)
+ *
+ * Owns the one rule that keeps the journal a record of CHANGES rather than a
+ * log of reads.
+ *
+ * @module libs/core/src/products/application/services
+ * @implements {ITaxRateJournalService}
+ */
+import { Inject, Injectable } from '@nestjs/common';
+import { Logger } from '@openlinker/shared/logging';
+import type { ITaxRateJournalService } from './tax-rate-journal.service.interface';
+import { TAX_RATE_JOURNAL_REPOSITORY_TOKEN } from '../../products.tokens';
+import { TaxRateJournalRepositoryPort } from '../../domain/ports/tax-rate-journal-repository.port';
+import type {
+  TaxRateJournalEntry,
+  TaxRateObservation,
+} from '../../domain/types/tax-rate-journal.types';
+import { isNewTaxRateObservation } from '../../domain/types/tax-rate-journal.types';
+
+@Injectable()
+export class TaxRateJournalService implements ITaxRateJournalService {
+  private readonly logger = new Logger(TaxRateJournalService.name);
+
+  constructor(
+    @Inject(TAX_RATE_JOURNAL_REPOSITORY_TOKEN)
+    private readonly repository: TaxRateJournalRepositoryPort
+  ) {}
+
+  async record(observation: TaxRateObservation): Promise<TaxRateJournalEntry | null> {
+    const latest = await this.repository.findLatest(
+      observation.productId,
+      observation.variantId,
+      observation.connectionId
+    );
+    if (!isNewTaxRateObservation(latest, observation)) return null;
+
+    const entry = await this.repository.append({
+      ...observation,
+      observedAt: observation.observedAt ?? new Date(),
+    });
+    this.logger.debug(
+      `Tax-rate journal entry: productId=${observation.productId} ` +
+        `variantId=${observation.variantId ?? 'none'} connectionId=${observation.connectionId} ` +
+        `origin=${observation.origin} rate=${observation.taxRate ?? 'none'} ` +
+        `frozen=${String(observation.frozen ?? false)}`
+    );
+    return entry;
+  }
+
+  async getLatestPerConnection(
+    productId: string,
+    variantId: string | null = null
+  ): Promise<TaxRateJournalEntry[]> {
+    return this.repository.findLatestPerConnection(productId, variantId);
+  }
+}

--- a/libs/core/src/products/domain/ports/tax-rate-journal-repository.port.ts
+++ b/libs/core/src/products/domain/ports/tax-rate-journal-repository.port.ts
@@ -1,0 +1,37 @@
+/**
+ * Tax-Rate Journal Repository Port (#2250)
+ *
+ * Append-only by construction: the interface declares no update, no upsert and
+ * no delete. A journal whose rows can be edited after the fact cannot answer
+ * the question it exists for - "did the value change, and when?" - so adding a
+ * mutating method here is not a refactor, it changes what an entry means. Same
+ * discipline as `ExchangeRateRepositoryPort` (ADR-040).
+ *
+ * @module libs/core/src/products/domain/ports
+ */
+import type { TaxRateJournalEntry, TaxRateObservation } from '../types/tax-rate-journal.types';
+
+export interface TaxRateJournalRepositoryPort {
+  /** Insert one row. Callers dedup first; this method always writes. */
+  append(observation: TaxRateObservation & { observedAt: Date }): Promise<TaxRateJournalEntry>;
+
+  /**
+   * The most recent entry for one item on one connection, or `null` when the
+   * journal has never held one. One indexed read.
+   */
+  findLatest(
+    productId: string,
+    variantId: string | null,
+    connectionId: string
+  ): Promise<TaxRateJournalEntry | null>;
+
+  /**
+   * The most recent entry per connection for one item, across every connection
+   * the journal knows about - what the disagreement surface reads to compare
+   * the shop's value against each channel's.
+   */
+  findLatestPerConnection(
+    productId: string,
+    variantId: string | null
+  ): Promise<TaxRateJournalEntry[]>;
+}

--- a/libs/core/src/products/domain/types/tax-rate-journal.types.spec.ts
+++ b/libs/core/src/products/domain/types/tax-rate-journal.types.spec.ts
@@ -1,0 +1,71 @@
+/**
+ * Tax-Rate Journal Dedup Tests (#2250)
+ *
+ * The dedup rule is the whole reason a twenty-minute catalogue sweep can feed
+ * this table without it growing by the size of the catalogue per tick.
+ *
+ * @module libs/core/src/products/domain/types
+ */
+import { isNewTaxRateObservation } from './tax-rate-journal.types';
+import type { TaxRateJournalEntry, TaxRateObservation } from './tax-rate-journal.types';
+
+const OBSERVED_AT = new Date('2026-08-21T10:00:00Z');
+
+function observation(over: Partial<TaxRateObservation> = {}): TaxRateObservation {
+  return {
+    productId: 'ol_product_a',
+    variantId: null,
+    connectionId: 'conn-1',
+    origin: 'shop',
+    taxRate: '23',
+    ...over,
+  };
+}
+
+function entry(over: Partial<TaxRateJournalEntry> = {}): TaxRateJournalEntry {
+  return {
+    id: 'row-1',
+    observedAt: OBSERVED_AT,
+    createdAt: OBSERVED_AT,
+    ...observation(),
+    ...over,
+  };
+}
+
+describe('isNewTaxRateObservation', () => {
+  it('should be new when the journal holds nothing for the pair', () => {
+    expect(isNewTaxRateObservation(null, observation())).toBe(true);
+  });
+
+  it('should not be new when the value, origin and frozen flag all match', () => {
+    // The ordinary case: an unchanged catalogue re-synced every twenty minutes.
+    expect(isNewTaxRateObservation(entry(), observation())).toBe(false);
+  });
+
+  it('should be new when the rate changed', () => {
+    expect(isNewTaxRateObservation(entry(), observation({ taxRate: '8' }))).toBe(true);
+  });
+
+  it('should be new when a rate disappeared', () => {
+    expect(isNewTaxRateObservation(entry(), observation({ taxRate: null }))).toBe(true);
+  });
+
+  it('should be new when the same value now comes from a different origin', () => {
+    // The shop and the channel agreeing is not the same fact as only the shop
+    // having been asked.
+    expect(isNewTaxRateObservation(entry(), observation({ origin: 'channel' }))).toBe(true);
+  });
+
+  it('should be new when the channel froze a field whose value did not change', () => {
+    // A seller freezing the field is a real change in what the value MEANS -
+    // it is now something a person set. Losing it would leave the disagreement
+    // surface unable to say so.
+    expect(isNewTaxRateObservation(entry({ frozen: false }), observation({ frozen: true }))).toBe(
+      true
+    );
+  });
+
+  it('should treat an absent frozen flag as not frozen', () => {
+    expect(isNewTaxRateObservation(entry({ frozen: false }), observation())).toBe(false);
+  });
+});

--- a/libs/core/src/products/domain/types/tax-rate-journal.types.ts
+++ b/libs/core/src/products/domain/types/tax-rate-journal.types.ts
@@ -1,0 +1,91 @@
+/**
+ * Tax-Rate Journal Types (#2250, ADR-052 § 4)
+ *
+ * A mutable "rate source" field only says how things stand now. It cannot
+ * answer *when* the shop changed the rate, *what* OpenLinker last wrote onto a
+ * channel, or *whether somebody overwrote it afterwards* - and that last
+ * question is what makes a shop-versus-channel disagreement attributable
+ * rather than mysterious.
+ *
+ * So the provenance is a journal: one row per **change**, never per read. An
+ * identical repeat writes nothing, which is what keeps a table fed by an
+ * every-20-minute catalogue sweep from growing without bound.
+ *
+ * @module libs/core/src/products/domain/types
+ */
+
+/**
+ * Where an observed rate came from.
+ *
+ * The three are not interchangeable, and the third is the reason the journal
+ * exists at all: `written-by-us` records OpenLinker's own write onto a channel,
+ * so a later `channel` observation carrying a different value proves somebody
+ * changed it after we did.
+ */
+export const TaxRateJournalOriginValues = [
+  /** Read from the ProductMaster - the shop's own catalogue. */
+  'shop',
+  /** Read back from a sales channel (a marketplace offer or order line). */
+  'channel',
+  /** Written BY OpenLinker onto a channel. Not an observation - an action. */
+  'written-by-us',
+] as const;
+export type TaxRateJournalOrigin = (typeof TaxRateJournalOriginValues)[number];
+
+/** One observation, as a caller reports it. */
+export interface TaxRateObservation {
+  /** Internal product id. Always present - the journal is product-scoped. */
+  productId: string;
+  /** Internal variant id when the observation is variant-specific. */
+  variantId: string | null;
+  /**
+   * The connection the observation is about: the master connection for a
+   * `shop` read, the marketplace connection for the other two. Never null -
+   * an observation with no connection has no channel to be attributed to.
+   */
+  connectionId: string;
+  origin: TaxRateJournalOrigin;
+  /** The neutral rate code observed, or `null` when the source named none. */
+  taxRate: string | null;
+  /**
+   * The channel reports this field as frozen by the seller.
+   *
+   * Recorded because it changes what a disagreement MEANS: a frozen value is
+   * one a person set deliberately (Erli sets `frozen.taxRate` when the seller
+   * edits it in their panel), so the surface can say so instead of implying
+   * OpenLinker failed to write. Absent on a `shop` observation, which has no
+   * such concept.
+   */
+  frozen?: boolean;
+  /** When the observation was made. Defaults to now at the write site. */
+  observedAt?: Date;
+}
+
+/** One persisted journal row. */
+export interface TaxRateJournalEntry extends TaxRateObservation {
+  id: string;
+  observedAt: Date;
+  createdAt: Date;
+}
+
+/**
+ * Whether an observation differs from what the journal last holds for the same
+ * item and connection.
+ *
+ * Pure, so the dedup rule has one definition rather than one per call site.
+ * The comparison covers the value, the origin AND the frozen flag: a seller
+ * freezing a field without changing its value is a real change in what the
+ * value means, and losing it would leave the disagreement surface unable to
+ * say a person set it.
+ */
+export function isNewTaxRateObservation(
+  latest: TaxRateJournalEntry | null,
+  observation: TaxRateObservation
+): boolean {
+  if (latest === null) return true;
+  return (
+    latest.taxRate !== observation.taxRate ||
+    latest.origin !== observation.origin ||
+    (latest.frozen ?? false) !== (observation.frozen ?? false)
+  );
+}

--- a/libs/core/src/products/index.ts
+++ b/libs/core/src/products/index.ts
@@ -114,6 +114,19 @@ export type {
 } from './domain/ports/capabilities/product-tax-rate-reader.capability';
 export { isProductTaxRateReader } from './domain/ports/capabilities/product-tax-rate-reader.capability';
 
+// Append-only tax-rate provenance journal (#2250, ADR-052 § 4).
+export type {
+  TaxRateJournalEntry,
+  TaxRateJournalOrigin,
+  TaxRateObservation,
+} from './domain/types/tax-rate-journal.types';
+export {
+  TaxRateJournalOriginValues,
+  isNewTaxRateObservation,
+} from './domain/types/tax-rate-journal.types';
+export type { TaxRateJournalRepositoryPort } from './domain/ports/tax-rate-journal-repository.port';
+export type { ITaxRateJournalService } from './application/services/tax-rate-journal.service.interface';
+
 // ORM entities are exposed on the host-only `@openlinker/core/products/orm-entities`
 // sub-path (#594). Plugins must not import them from here.
 

--- a/libs/core/src/products/infrastructure/persistence/entities/tax-rate-journal.orm-entity.ts
+++ b/libs/core/src/products/infrastructure/persistence/entities/tax-rate-journal.orm-entity.ts
@@ -1,0 +1,54 @@
+/**
+ * Tax-Rate Journal ORM Entity (#2250)
+ *
+ * TypeORM entity for the `tax_rate_journal` table - one row per CHANGE in an
+ * observed tax rate, never one per read.
+ *
+ * @module libs/core/src/products/infrastructure/persistence/entities
+ */
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity('tax_rate_journal')
+// "The latest entry for this item on this connection" is the read every
+// consumer makes, so it is one indexed lookup rather than a scan.
+@Index('IDX_tax_rate_journal_latest', ['productId', 'variantId', 'connectionId', 'observedAt'])
+export class TaxRateJournalOrmEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'text' })
+  productId!: string;
+
+  /** Null when the observation is about the product rather than one variant. */
+  @Column({ type: 'text', nullable: true })
+  variantId!: string | null;
+
+  @Column({ type: 'uuid' })
+  connectionId!: string;
+
+  /** `shop` | `channel` | `written-by-us`. Kept as varchar: the union is core's. */
+  @Column({ type: 'varchar', length: 32 })
+  origin!: string;
+
+  /** The observed code, or null when the source named no rate. */
+  @Column({ type: 'varchar', length: 16, nullable: true })
+  taxRate!: string | null;
+
+  /**
+   * The channel reported the field as frozen by the seller. Defaults false so
+   * a shop observation - which has no such concept - reads as not-frozen
+   * rather than as unknown.
+   */
+  @Column({ type: 'boolean', default: false })
+  frozen!: boolean;
+
+  /**
+   * When the observation was made, as distinct from when the row was written.
+   * `timestamptz` so the value is stored without a silent tz coercion.
+   */
+  @Column({ type: 'timestamptz' })
+  observedAt!: Date;
+
+  @CreateDateColumn({ type: 'timestamptz' })
+  createdAt!: Date;
+}

--- a/libs/core/src/products/infrastructure/persistence/repositories/tax-rate-journal.repository.ts
+++ b/libs/core/src/products/infrastructure/persistence/repositories/tax-rate-journal.repository.ts
@@ -1,0 +1,96 @@
+/**
+ * Tax-Rate Journal Repository (#2250)
+ *
+ * @module libs/core/src/products/infrastructure/persistence/repositories
+ * @implements {TaxRateJournalRepositoryPort}
+ */
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { IsNull, Repository } from 'typeorm';
+import { TaxRateJournalOrmEntity } from '../entities/tax-rate-journal.orm-entity';
+import type { TaxRateJournalRepositoryPort } from '../../../domain/ports/tax-rate-journal-repository.port';
+import type {
+  TaxRateJournalEntry,
+  TaxRateJournalOrigin,
+  TaxRateObservation,
+} from '../../../domain/types/tax-rate-journal.types';
+
+@Injectable()
+export class TaxRateJournalRepository implements TaxRateJournalRepositoryPort {
+  constructor(
+    @InjectRepository(TaxRateJournalOrmEntity)
+    private readonly repository: Repository<TaxRateJournalOrmEntity>
+  ) {}
+
+  async append(
+    observation: TaxRateObservation & { observedAt: Date }
+  ): Promise<TaxRateJournalEntry> {
+    const entity = this.repository.create({
+      productId: observation.productId,
+      variantId: observation.variantId,
+      connectionId: observation.connectionId,
+      origin: observation.origin,
+      taxRate: observation.taxRate,
+      frozen: observation.frozen ?? false,
+      observedAt: observation.observedAt,
+    });
+    return this.toDomain(await this.repository.save(entity));
+  }
+
+  async findLatest(
+    productId: string,
+    variantId: string | null,
+    connectionId: string
+  ): Promise<TaxRateJournalEntry | null> {
+    const row = await this.repository.findOne({
+      where: {
+        productId,
+        // `IsNull()` rather than `null`: TypeORM renders a bare null as
+        // `= NULL`, which matches nothing, so a product-level entry would
+        // never be found and every sync would append a duplicate.
+        variantId: variantId === null ? IsNull() : variantId,
+        connectionId,
+      },
+      order: { observedAt: 'DESC', createdAt: 'DESC' },
+    });
+    return row ? this.toDomain(row) : null;
+  }
+
+  /**
+   * One row per connection, newest first.
+   *
+   * `DISTINCT ON` rather than a window function: it is the Postgres idiom for
+   * "the latest per group" and reads straight off the same index the single
+   * lookup uses.
+   */
+  async findLatestPerConnection(
+    productId: string,
+    variantId: string | null
+  ): Promise<TaxRateJournalEntry[]> {
+    // `query` is untyped by TypeORM, so the cast is the boundary where the raw
+    // row shape is asserted once rather than at each field read below.
+    const rows = (await this.repository.query(
+      `SELECT DISTINCT ON ("connectionId") *
+         FROM "tax_rate_journal"
+        WHERE "productId" = $1
+          AND "variantId" IS NOT DISTINCT FROM $2
+        ORDER BY "connectionId", "observedAt" DESC, "createdAt" DESC`,
+      [productId, variantId]
+    )) as TaxRateJournalOrmEntity[];
+    return rows.map((row) => this.toDomain(row));
+  }
+
+  private toDomain(entity: TaxRateJournalOrmEntity): TaxRateJournalEntry {
+    return {
+      id: entity.id,
+      productId: entity.productId,
+      variantId: entity.variantId,
+      connectionId: entity.connectionId,
+      origin: entity.origin as TaxRateJournalOrigin,
+      taxRate: entity.taxRate,
+      frozen: entity.frozen,
+      observedAt: entity.observedAt,
+      createdAt: entity.createdAt,
+    };
+  }
+}

--- a/libs/core/src/products/orm-entities.ts
+++ b/libs/core/src/products/orm-entities.ts
@@ -19,3 +19,4 @@
  */
 export { ProductOrmEntity } from './infrastructure/persistence/entities/product.orm-entity';
 export { ProductVariantOrmEntity } from './infrastructure/persistence/entities/product-variant.orm-entity';
+export { TaxRateJournalOrmEntity } from './infrastructure/persistence/entities/tax-rate-journal.orm-entity';

--- a/libs/core/src/products/products.module.ts
+++ b/libs/core/src/products/products.module.ts
@@ -16,12 +16,17 @@ import { ProductVariantRepository } from './infrastructure/persistence/repositor
 import { ProductsService } from './application/services/products.service';
 import { MasterProductSyncService } from './application/services/master-product-sync.service';
 import { AutoMatchVariantOffersService } from './application/services/auto-match-variant-offers.service';
+import { TaxRateJournalOrmEntity } from './infrastructure/persistence/entities/tax-rate-journal.orm-entity';
+import { TaxRateJournalRepository } from './infrastructure/persistence/repositories/tax-rate-journal.repository';
+import { TaxRateJournalService } from './application/services/tax-rate-journal.service';
 import {
   PRODUCT_REPOSITORY_TOKEN,
   PRODUCT_VARIANT_REPOSITORY_TOKEN,
   PRODUCTS_SERVICE_TOKEN,
   MASTER_PRODUCT_SYNC_SERVICE_TOKEN,
   AUTO_MATCH_VARIANT_OFFERS_SERVICE_TOKEN,
+  TAX_RATE_JOURNAL_REPOSITORY_TOKEN,
+  TAX_RATE_JOURNAL_SERVICE_TOKEN,
 } from './products.tokens';
 import { IntegrationsModule } from '@openlinker/core/integrations';
 import { IdentifierMappingModule } from '@openlinker/core/identifier-mapping';
@@ -37,7 +42,7 @@ export {
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([ProductOrmEntity, ProductVariantOrmEntity]),
+    TypeOrmModule.forFeature([ProductOrmEntity, ProductVariantOrmEntity, TaxRateJournalOrmEntity]),
     IntegrationsModule,
     IdentifierMappingModule,
     EventsModule,
@@ -49,6 +54,8 @@ export {
     ProductsService,
     MasterProductSyncService,
     AutoMatchVariantOffersService,
+    TaxRateJournalRepository,
+    TaxRateJournalService,
     // Then provide token bindings using useExisting
     {
       provide: PRODUCT_REPOSITORY_TOKEN,
@@ -70,6 +77,14 @@ export {
       provide: AUTO_MATCH_VARIANT_OFFERS_SERVICE_TOKEN,
       useExisting: AutoMatchVariantOffersService,
     },
+    {
+      provide: TAX_RATE_JOURNAL_REPOSITORY_TOKEN,
+      useExisting: TaxRateJournalRepository,
+    },
+    {
+      provide: TAX_RATE_JOURNAL_SERVICE_TOKEN,
+      useExisting: TaxRateJournalService,
+    },
   ],
   exports: [
     PRODUCT_REPOSITORY_TOKEN,
@@ -77,6 +92,8 @@ export {
     PRODUCTS_SERVICE_TOKEN,
     MASTER_PRODUCT_SYNC_SERVICE_TOKEN,
     AUTO_MATCH_VARIANT_OFFERS_SERVICE_TOKEN,
+    TAX_RATE_JOURNAL_SERVICE_TOKEN,
+    TAX_RATE_JOURNAL_REPOSITORY_TOKEN,
   ],
 })
 export class ProductsModule {}

--- a/libs/core/src/products/products.tokens.ts
+++ b/libs/core/src/products/products.tokens.ts
@@ -14,4 +14,6 @@ export const PRODUCT_VARIANT_REPOSITORY_TOKEN = Symbol('ProductVariantRepository
 export const PRODUCTS_SERVICE_TOKEN = Symbol('IProductsService');
 export const MASTER_PRODUCT_SYNC_SERVICE_TOKEN = Symbol('IMasterProductSyncService');
 export const AUTO_MATCH_VARIANT_OFFERS_SERVICE_TOKEN = Symbol('IAutoMatchVariantOffersService');
+export const TAX_RATE_JOURNAL_REPOSITORY_TOKEN = Symbol('TaxRateJournalRepositoryPort');
+export const TAX_RATE_JOURNAL_SERVICE_TOKEN = Symbol('ITaxRateJournalService');
 


### PR DESCRIPTION
A mutable "rate source" field only says how things stand now. It cannot answer *when* the shop changed the rate, *what* OpenLinker last wrote onto a channel, or *whether somebody overwrote it afterwards* - and the last of those is what makes a shop-versus-channel disagreement attributable rather than mysterious.

## One row per change, not per read

The catalogue sweep runs every twenty minutes and most rates never move. Writing unconditionally would grow the table by the size of the catalogue per tick and bury the handful of rows that matter. `isNewTaxRateObservation` owns that rule in one pure place, with its own spec.

The comparison covers the value, the origin **and** the frozen flag. A seller freezing a field without changing its value is a real change in what the value means - it is now something a person set - and losing it would leave the disagreement surface unable to say so (Erli sets `frozen.taxRate` when the seller edits it in their panel).

## Append-only by construction

The port declares `append`, `findLatest` and `findLatestPerConnection`, and **no** update, upsert or delete. A journal whose rows can be edited after the fact cannot answer the question it exists for, so adding a mutating method is not a refactor - it changes what an entry means. Same discipline as `ExchangeRateRepositoryPort` (ADR-040).

No unique constraint either: rows are meant to repeat over time, and "write only on a change" is a service-level dedup against the latest row.

## Origin

`shop` | `channel` | `written-by-us`. The third is the reason the journal exists at all - it records OpenLinker's own write onto a channel, so a later `channel` observation carrying a different value proves somebody changed it after we did.

## Wiring

Master product sync records every rate it observes. The write is **best-effort and separate** from the catalogue write: the journal is provenance, so losing an entry costs an audit trail rather than a rate, and failing the sync over it would trade the thing that matters for the thing that explains it.

One index serves both reads - the latest for one connection and the latest per connection both walk the same prefix.

## Scope note

`taxSource` and `taxRateReadAt` already reach the **order snapshot** line (#2054, epic F3). The `order_line_items` half of this issue is **not** implemented here: that table does not exist on `main`. It is defined in #2014, which is still open, and transcribing onto a table that does not exist is not something this branch can do.

Closes #2250
Refs #2245

🤖 Generated with [Claude Code](https://claude.com/claude-code)