### PR TITLE
feat(integrations): read the channel's tax rate and propagate the shop's onto offers

### DIFF
--- a/libs/core/src/listings/application/services/offer-builder.service.ts
+++ b/libs/core/src/listings/application/services/offer-builder.service.ts
@@ -284,6 +284,21 @@ export class OfferBuilderService implements IOfferBuilderService {
       productCardId: input.overrides?.productCardId ?? null,
     };
 
+    // #2249 (ADR-052) — propagate the shop's rate onto the offer, in the same
+    // pass that already carries price and stock. Read from OL's own catalogue
+    // projection, so publishing does not depend on the shop being reachable and
+    // the offer carries the same rate an invoice for it would.
+    //
+    // Set only when the shop actually has one: an absent rate must reach the
+    // adapter as absent, so it can refuse rather than publish an offer with no
+    // tax settings. Publishing rate-less is exactly what produced the offers
+    // whose orders report `tax: null` today.
+    const taxRate = await this.resolveTaxRate(product.id, input.internalVariantId);
+    if (taxRate.code) {
+      command.taxRate = taxRate.code;
+      if (taxRate.countryIso2) command.taxRateCountry = taxRate.countryIso2;
+    }
+
     // #1065 — only set when populated, keeping the command shape tidy (mirrors
     // the `?? null` / cleanedOverrides posture above).
     if (variantGroup) {
@@ -563,6 +578,29 @@ export class OfferBuilderService implements IOfferBuilderService {
       );
     }
     return readStockSafetyBuffer(config);
+  }
+
+  /**
+   * The catalogue's rate for this variant (#2249).
+   *
+   * Best-effort: a read failure degrades to "no rate", which the adapter then
+   * refuses on - the same outcome as a genuinely rate-less product, and a
+   * safer one than publishing an offer whose tax nobody stated. The gate on the
+   * invoicing side is what makes that visible.
+   */
+  private async resolveTaxRate(
+    productId: string,
+    variantId: string
+  ): Promise<{ code: string | null; countryIso2: string | null }> {
+    try {
+      const stored = await this.productsService.getEffectiveTaxRate(productId, variantId);
+      return { code: stored.code, countryIso2: stored.countryIso2 };
+    } catch (error) {
+      this.logger.warn(
+        `Could not read the catalogue tax rate for variant ${variantId}: ${(error as Error).message}`
+      );
+      return { code: null, countryIso2: null };
+    }
   }
 }
 

--- a/libs/core/src/listings/domain/types/offer-create.types.ts
+++ b/libs/core/src/listings/domain/types/offer-create.types.ts
@@ -248,6 +248,29 @@ export interface CreateOfferCommand {
    * product carried no features.
    */
   sourceAttributes?: SourceAttribute[];
+  /**
+   * The shop's tax rate for this variant, as the neutral percent-as-string
+   * code (#2249, ADR-052) - `'23'`, `'8'`, `'5'`, `'0'`, `'zw'`, `'np'`, `'oo'`.
+   *
+   * Propagated exactly as price and stock already are, at create and at every
+   * update. **There is no OpenLinker-side rate field to type into**: a rate
+   * entered here would be a fourth source no master or channel could be
+   * corrected from, and the whole chain exists so a fix lands where the
+   * catalogue lives.
+   *
+   * Absent means the shop has no rate for the variant. An adapter MUST NOT
+   * publish with the rate silently omitted in that case - that is how the
+   * rate-less offers this epic exists to fix were produced. It either refuses,
+   * or (where the platform genuinely has no such field) ignores the value.
+   */
+  taxRate?: string;
+  /**
+   * ISO 3166-1 alpha-2 the rate was resolved against - provenance for the
+   * platforms whose tax settings are country-keyed (Allegro's
+   * `OfferTaxSettings.rates[] = {rate, countryCode}`). Never compared with a
+   * buyer's country; OSS is out of scope (ADR-052 § 7).
+   */
+  taxRateCountry?: string;
 }
 
 /**

--- a/libs/core/src/listings/domain/types/offer-update.types.ts
+++ b/libs/core/src/listings/domain/types/offer-update.types.ts
@@ -33,4 +33,16 @@ export interface OfferFieldUpdate {
   price?: OfferPriceUpdate;
   title?: string;
   description?: OfferDescriptionUpdate;
+  /**
+   * The shop's tax rate, as the neutral percent-as-string code (#2249,
+   * ADR-052). Propagated on an update the same way it is on a create, so an
+   * offer's rate follows the catalogue rather than freezing at whatever it was
+   * when the offer was first published.
+   *
+   * Optional and never inferred: absent means "this update does not touch the
+   * rate", which is different from "the product has no rate" - an update path
+   * must not be able to blank a rate an offer already carries. An adapter whose
+   * platform marks the field as seller-frozen skips the write.
+   */
+  taxRate?: string;
 }

--- a/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
+++ b/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
@@ -77,6 +77,25 @@ export interface AllegroCheckoutForm {
       currency: string;
     };
     boughtAt?: string;
+    /**
+     * Per-line tax as Allegro reports it (live since 28 Mar 2024, #2249).
+     *
+     * EVERY field is nullable, including the object itself, and a null must
+     * stay a null: an offer published without tax settings reports nothing
+     * here, and reading that as `0` would state a zero-rated sale that never
+     * happened. Offers OpenLinker itself published before this epic carry no
+     * rate at all - verified on the live sandbox, 24 lines across 11 offers all
+     * returned `tax: null`.
+     *
+     * `rate` is a percent string (`"23.00"`). `subject` and `exemption` are
+     * Allegro's own vocabulary for a non-percentage regime and are read only as
+     * provenance - core never learns them.
+     */
+    tax?: {
+      rate?: string | null;
+      subject?: string | null;
+      exemption?: string | null;
+    } | null;
   }>;
   summary: {
     totalToPay: {
@@ -516,6 +535,14 @@ export interface AllegroCategoryParametersResponse {
  */
 export interface AllegroOfferFieldsPatchBody extends Record<string, unknown> {
   name?: string;
+  /**
+   * Per-country tax rates (#2249). Patched so an offer's rate follows the
+   * catalogue instead of freezing at whatever it was when the offer was first
+   * published - the same reason price and stock are propagated.
+   */
+  taxSettings?: {
+    rates: Array<{ rate: number; countryCode: string }>;
+  };
   sellingMode?: {
     price?: {
       amount: string;
@@ -610,6 +637,22 @@ export interface AllegroProductOfferCreateRequest extends Record<string, unknown
     warranty?: { id: string };
   };
   payments?: { invoice?: 'VAT' | 'NO_INVOICE' | 'VAT_MARGIN' };
+  /**
+   * Per-country tax rates for the offer (#2249, ADR-052).
+   *
+   * OpenLinker wrote nothing here before this epic, which is why every offer it
+   * published reported `tax: null` on the resulting order lines - verified on
+   * the live sandbox: 24 lines across 11 offers, and a `PATCH` setting this
+   * field made the next purchase report `tax: {"rate": "23.00"}`.
+   *
+   * `rate` is a percent NUMBER (Allegro's own shape), not the neutral
+   * percent-as-string code; the adapter converts. Which rates a category allows
+   * is Allegro's own rule, readable at
+   * `GET /sale/tax-settings?category.id=&countryCode=`.
+   */
+  taxSettings?: {
+    rates: Array<{ rate: number; countryCode: string }>;
+  };
   publication?: { status: 'INACTIVE' | 'ACTIVE' };
   external?: { id: string };
   /**
@@ -845,5 +888,16 @@ export interface AllegroSmartOfferClassificationReport {
     name: string;
     description: string;
     fulfilled: boolean;
+  }>;
+}
+
+/**
+ * `GET /sale/tax-settings?category.id=&countryCode=` (#2249) - what tax rates a
+ * category permits in a country. Read only to turn an Allegro rejection into an
+ * actionable OpenLinker error naming the permitted values.
+ */
+export interface AllegroTaxSettingsResponse {
+  taxSettings?: Array<{
+    rates?: Array<{ rate: number | string; countryCode?: string }>;
   }>;
 }

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
@@ -102,6 +102,7 @@ import type {
   AllegroOfferEventsResponse,
   AllegroOfferFieldsPatchBody,
   AllegroProductOfferCreateRequest,
+  AllegroTaxSettingsResponse,
   AllegroProductOfferCreateResponse,
   AllegroProductSetEntry,
   AllegroValidationError,
@@ -118,6 +119,15 @@ import { AllegroApiException } from '../../domain/exceptions/allegro-api.excepti
 import { Logger, formatBodyForLog } from '@openlinker/shared/logging';
 import { createHash } from 'crypto';
 import { sanitizeAllegroName } from '../util/sanitize-allegro-name';
+import { toAllegroRate } from './allegro-tax-rate.mapper';
+
+/**
+ * Country the offer's tax settings are written for when the catalogue rate
+ * carries no provenance country (#2249). Allegro's marketplace is PL-first and
+ * `taxSettings.rates[]` requires a country, so a default is unavoidable; it is
+ * a named constant rather than an inline literal so the assumption is visible.
+ */
+const DEFAULT_ALLEGRO_TAX_COUNTRY = 'PL';
 import { uploadImagesViaAllegro } from '../util/upload-images-via-allegro';
 import { uploadSafetyAttachmentViaAllegro } from '../util/upload-safety-attachment-via-allegro';
 import type { AllegroQuantityCommandRepositoryPort } from '../../index';
@@ -1362,6 +1372,29 @@ export class AllegroOfferManagerAdapter
       callerBody.name = sanitized;
     }
 
+    // #2249 — propagate a rate change onto the live offer. An unmappable code is
+    // DROPPED rather than raising, unlike on the create path: a create that
+    // cannot state its tax must not happen at all, while an update that cannot
+    // is a partial update of an offer that already exists and already sells, and
+    // raising would take a title or price fix down with it. The category's
+    // permitted-values check is not repeated here - Allegro validates the PATCH
+    // itself, and a second discovery call per update would double the request
+    // count on the hot path.
+    if (cmd.fields.taxRate !== undefined) {
+      const rate = toAllegroRate(cmd.fields.taxRate);
+      if (rate === null) {
+        this.logger.warn(
+          `Allegro offer tax settings carry a numeric rate, so "${cmd.fields.taxRate}" cannot be ` +
+            `patched; leaving the offer's rate unchanged: offerId=${cmd.externalOfferId} ` +
+            `connection=${this.connectionId}`
+        );
+      } else {
+        callerBody.taxSettings = {
+          rates: [{ rate, countryCode: DEFAULT_ALLEGRO_TAX_COUNTRY }],
+        };
+      }
+    }
+
     if (cmd.fields.description !== undefined) {
       callerBody.description = {
         sections: cmd.fields.description.sections.map((section) => ({
@@ -1550,6 +1583,13 @@ export class AllegroOfferManagerAdapter
       ]);
     }
 
+    // #2249 (ADR-052) — preflight the tax rate BEFORE anything is created.
+    // Allegro's own tax settings are what make an order line report a rate at
+    // all: OL wrote nothing here until this epic, so every offer it published
+    // produced `tax: null` on purchase. Resolved up front so a refusal costs no
+    // image upload and no product card.
+    const taxSettings = await this.resolveTaxSettings(cmd);
+
     // #431 — smart-link pre-step. Compute once at the top so the body
     // builder + platform-params applier stay synchronous (their current
     // contract). On `unique`, `productSet[0]` becomes a card-link reference
@@ -1558,6 +1598,9 @@ export class AllegroOfferManagerAdapter
     const cardLinkResult = await this.maybeResolveProductCard(cmd);
 
     const body = this.buildCreateOfferRequest(cmd, cardLinkResult);
+    if (taxSettings) {
+      body.taxSettings = taxSettings;
+    }
 
     // Pre-step: re-host any operator image URLs onto Allegro's CDN. Allegro
     // resolves URLs in `images[]` server-side and rejects offer creation when
@@ -1870,6 +1913,108 @@ export class AllegroOfferManagerAdapter
     this.applyPlatformParams(body, platformParams, cmd.parameters, cardLinkResult, cmd.condition);
 
     return body;
+  }
+
+  /**
+   * Resolve the offer's `taxSettings` from the neutral command rate (#2249).
+   *
+   * Three refusals, and each names what the operator can act on. Nothing is
+   * ever published with the rate silently omitted - that is precisely how the
+   * rate-less offers this epic exists to fix were produced, and the failure it
+   * causes surfaces months later on somebody's invoice rather than here.
+   *
+   * - **No rate at all.** The shop does not know, and Allegro is not going to
+   *   invent one either. The remedy is in the shop's catalogue.
+   * - **An exemption code.** `taxSettings.rates[]` carries numbers, so `zw` /
+   *   `np` / `oo` cannot be expressed. Publishing without them would list a
+   *   product at the category's default rate, which is a different sale.
+   * - **A rate the category refuses.** `GET /sale/tax-settings` lists what the
+   *   category allows; when OpenLinker's value is not among them the shop
+   *   record is almost certainly the wrong one, so the error names the
+   *   permitted values rather than picking one.
+   *
+   * The permitted-values read is best-effort: a failure to LIST is not a
+   * failure to publish, so it warns and proceeds with the value the shop gave.
+   * Allegro validates the body itself, and refusing a publish because a
+   * secondary discovery call was unavailable would be worse than the check.
+   */
+  private async resolveTaxSettings(
+    cmd: CreateOfferCommand,
+  ): Promise<{ rates: Array<{ rate: number; countryCode: string }> } | undefined> {
+    const categoryId = cmd.overrides?.categoryId;
+    const countryCode = cmd.taxRateCountry ?? DEFAULT_ALLEGRO_TAX_COUNTRY;
+
+    if (!cmd.taxRate) {
+      throw new OfferCreateRejectedException(ALLEGRO_ADAPTER_KEY, 0, [
+        {
+          field: 'taxRate',
+          code: 'TAX_RATE_MISSING',
+          message:
+            `No tax rate is known for this product, so the offer cannot state what tax it ` +
+            `charges. Add the rate in the shop's catalogue and re-sync the product; ` +
+            `OpenLinker does not substitute one.`,
+        },
+      ]);
+    }
+
+    const rate = toAllegroRate(cmd.taxRate);
+    if (rate === null) {
+      throw new OfferCreateRejectedException(ALLEGRO_ADAPTER_KEY, 0, [
+        {
+          field: 'taxRate',
+          code: 'TAX_RATE_NOT_EXPRESSIBLE',
+          message:
+            `Allegro offer tax settings carry a numeric rate, so the exemption code ` +
+            `"${cmd.taxRate}" cannot be published. Set a numeric rate on the product in the ` +
+            `shop, or list it on a channel that supports the exemption.`,
+        },
+      ]);
+    }
+
+    const permitted = await this.fetchPermittedTaxRates(categoryId, countryCode);
+    if (permitted !== null && permitted.length > 0 && !permitted.includes(rate)) {
+      throw new OfferCreateRejectedException(ALLEGRO_ADAPTER_KEY, 0, [
+        {
+          field: 'taxRate',
+          code: 'TAX_RATE_NOT_ALLOWED_IN_CATEGORY',
+          message:
+            `This Allegro category does not allow a ${String(rate)}% rate in ${countryCode}. ` +
+            `Allowed: ${permitted.map((value) => `${String(value)}%`).join(', ')}. ` +
+            `The shop's rate for this product is most likely the one to correct.`,
+        },
+      ]);
+    }
+
+    return { rates: [{ rate, countryCode }] };
+  }
+
+  /**
+   * What rates the category allows, or `null` when the listing could not be
+   * read. `null` is deliberately distinct from `[]`: an empty list means
+   * Allegro answered and named none, which is not a reason to block.
+   */
+  private async fetchPermittedTaxRates(
+    categoryId: string | undefined,
+    countryCode: string,
+  ): Promise<number[] | null> {
+    if (!categoryId) return null;
+    try {
+      const response = await this.httpClient.get<AllegroTaxSettingsResponse>(
+        '/sale/tax-settings',
+        { queryParams: { 'category.id': categoryId, countryCode } },
+      );
+      const rates = response.data.taxSettings?.flatMap((setting) => setting.rates ?? []) ?? [];
+      return rates
+        .map((entry) => Number.parseFloat(String(entry.rate)))
+        .filter((value) => Number.isFinite(value));
+    } catch (error) {
+      this.logger.warn(
+        `Could not read Allegro tax settings for category ${categoryId} (${countryCode}); ` +
+          `publishing with the shop's rate and letting Allegro validate: ` +
+          `${(error as Error).message}`,
+      );
+      return null;
+    }
   }
 
   /**

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts
@@ -53,6 +53,7 @@ import {
 import { AllegroApiException } from '../../domain/exceptions/allegro-api.exception';
 import { AllegroOrderDispatchRejectedException } from '../../domain/exceptions/allegro-order-dispatch-rejected.exception';
 import { deriveAllegroPaymentStatus } from './allegro-payment-status';
+import { toNeutralTaxRate } from './allegro-tax-rate.mapper';
 
 type OrderFeedItem = OrderFeedOutput['items'][number];
 
@@ -388,17 +389,26 @@ export class AllegroOrderSourceAdapter
         status,
         customerExternalId: checkoutForm.buyer.id,
         customerEmail: checkoutForm.buyer.email,
-        items: checkoutForm.lineItems.map((lineItem) => ({
-          id: lineItem.id,
-          productRef: { type: 'offer', externalId: lineItem.offer.id },
-          quantity: lineItem.quantity,
-          price: Number.parseFloat(lineItem.price.amount),
-          sku: lineItem.offer.id,
-          name: lineItem.offer.name,
-          // imageUrl intentionally omitted — Allegro's checkout-form endpoint
-          // does not expose a product image URL. Future enrichment from the
-          // internal product catalog is tracked as a separate follow-up.
-        })),
+        items: checkoutForm.lineItems.map((lineItem) => {
+          // #2249: Allegro's per-line tax, read as the CHANNEL rung of the
+          // resolution chain. Nullable throughout, and a null stays absent -
+          // never `0`, which would state a zero-rated sale. Offers OL published
+          // before this epic report nothing here at all, which is exactly the
+          // gap the propagation half closes.
+          const neutralTaxRate = toNeutralTaxRate(lineItem.tax);
+          return {
+            id: lineItem.id,
+            productRef: { type: 'offer' as const, externalId: lineItem.offer.id },
+            quantity: lineItem.quantity,
+            price: Number.parseFloat(lineItem.price.amount),
+            sku: lineItem.offer.id,
+            name: lineItem.offer.name,
+            ...(neutralTaxRate ? { taxRate: neutralTaxRate } : {}),
+            // imageUrl intentionally omitted — Allegro's checkout-form endpoint
+            // does not expose a product image URL. Future enrichment from the
+            // internal product catalog is tracked as a separate follow-up.
+          };
+        }),
         totals: {
           subtotal: roundCurrency(subtotal),
           tax: 0,

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-tax-rate.mapper.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-tax-rate.mapper.spec.ts
@@ -1,0 +1,59 @@
+/**
+ * Allegro Tax-Rate Mapper Tests (#2249)
+ *
+ * The rule under test is that a null stays a null. Allegro reports every field
+ * of `lineItems[].tax` as nullable, and reading an absent one as `0` would
+ * state a zero-rated sale that never happened.
+ *
+ * @module libs/integrations/allegro/src/infrastructure/adapters
+ */
+import { toAllegroRate, toNeutralTaxRate } from './allegro-tax-rate.mapper';
+
+describe('Allegro tax-rate mapping', () => {
+  describe('toNeutralTaxRate', () => {
+    it('should normalise a percent string to the bare neutral code', () => {
+      // Allegro reports "23.00"; the FA(3) map and the Erli enum are both keyed
+      // on the bare form (#2247).
+      expect(toNeutralTaxRate({ rate: '23.00' })).toBe('23');
+      expect(toNeutralTaxRate({ rate: '8.0' })).toBe('8');
+    });
+
+    it('should keep a genuine zero rate as a rate', () => {
+      expect(toNeutralTaxRate({ rate: '0.00' })).toBe('0');
+    });
+
+    it('should report an absent tax object as null, never as zero', () => {
+      expect(toNeutralTaxRate(null)).toBeNull();
+      expect(toNeutralTaxRate(undefined)).toBeNull();
+      expect(toNeutralTaxRate({})).toBeNull();
+      expect(toNeutralTaxRate({ rate: null })).toBeNull();
+    });
+
+    it('should read an exemption when no rate is given', () => {
+      expect(toNeutralTaxRate({ rate: null, exemption: 'ZW' })).toBe('zw');
+      expect(toNeutralTaxRate({ exemption: 'np' })).toBe('np');
+    });
+
+    it('should report an unrecognised exemption as null rather than guessing', () => {
+      expect(toNeutralTaxRate({ exemption: 'SOMETHING_ELSE' })).toBeNull();
+    });
+  });
+
+  describe('toAllegroRate', () => {
+    it('should express a numeric code as a number', () => {
+      expect(toAllegroRate('23')).toBe(23);
+      expect(toAllegroRate('0')).toBe(0);
+    });
+
+    it('should refuse an exemption code, which has no place in a numeric rates array', () => {
+      expect(toAllegroRate('zw')).toBeNull();
+      expect(toAllegroRate('np')).toBeNull();
+      expect(toAllegroRate('oo')).toBeNull();
+    });
+
+    it('should refuse an absent code', () => {
+      expect(toAllegroRate(undefined)).toBeNull();
+      expect(toAllegroRate('')).toBeNull();
+    });
+  });
+});

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-tax-rate.mapper.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-tax-rate.mapper.ts
@@ -1,0 +1,64 @@
+/**
+ * Allegro Tax-Rate Mapper (#2249, ADR-052)
+ *
+ * Translates Allegro's per-line `tax` object and its offer tax settings to and
+ * from OpenLinker's neutral percent-as-string code. The platform vocabulary
+ * stays here, in the adapter (ADR-026).
+ *
+ * The one rule that matters: **a null stays a null**. Allegro reports every
+ * field of `lineItems[].tax` as nullable, and an offer published without tax
+ * settings reports nothing at all. Reading that as `'0'` would state a
+ * zero-rated sale that never happened.
+ *
+ * @module libs/integrations/allegro/src/infrastructure/adapters
+ */
+
+/** The `tax` object as Allegro reports it on an order line. */
+export interface AllegroLineTax {
+  rate?: string | null;
+  subject?: string | null;
+  exemption?: string | null;
+}
+
+/**
+ * Read Allegro's per-line tax as a neutral code, or `null` when it reported
+ * none.
+ *
+ * A numeric `rate` is normalised from Allegro's `"23.00"` to the bare `'23'`
+ * the neutral contract uses (#2247) - the FA(3) map and the Erli enum are both
+ * keyed on the bare form. An `exemption` with no rate is passed through
+ * lower-cased, which covers Allegro's `zw` / `np` tokens; anything else is
+ * `null` rather than a guess.
+ */
+export function toNeutralTaxRate(tax: AllegroLineTax | null | undefined): string | null {
+  if (!tax) return null;
+
+  const rate = tax.rate?.trim();
+  if (rate) {
+    const parsed = Number.parseFloat(rate);
+    if (Number.isFinite(parsed)) {
+      const rounded = Math.round(parsed * 100) / 100;
+      return String(rounded);
+    }
+  }
+
+  const exemption = tax.exemption?.trim().toLowerCase();
+  if (exemption === 'zw' || exemption === 'np' || exemption === 'oo') return exemption;
+
+  return null;
+}
+
+/**
+ * Express a neutral code as the numeric rate Allegro's `OfferTaxSettings`
+ * expects.
+ *
+ * Returns `null` for an exemption code: `rates[]` carries numbers, so `zw` /
+ * `np` / `oo` have no place in it. The caller must treat that as "cannot
+ * publish this rate" rather than as "publish without one" - omitting the
+ * setting is what produced the rate-less offers this epic exists to fix.
+ */
+export function toAllegroRate(neutralTaxRate: string | undefined | null): number | null {
+  if (!neutralTaxRate) return null;
+  const parsed = Number.parseFloat(neutralTaxRate.trim());
+  return Number.isFinite(parsed) ? parsed : null;
+}

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-offer-manager.adapter.ts
@@ -129,6 +129,7 @@ import {
   type UpdateOfferFieldsCommand,
   type UpdateOfferQuantityCommand,
 } from '@openlinker/core/listings';
+import { supportedErliTaxRates, toErliTaxRate } from './erli-tax-rate.mapper';
 
 import { ERLI_DESCRIPTION_FORMAT } from './erli-description-format';
 import type { CachePort } from '@openlinker/shared';
@@ -174,6 +175,11 @@ const PATCH_KEY_TO_ERLI_FROZEN_NAME: Partial<Record<keyof ErliProductPatchBody, 
   price: 'price',
   name: 'name',
   description: 'description',
+  // #2249: Erli sets `frozen.taxRate` the moment the seller edits the field in
+  // their panel. That is the signal a PERSON chose the value, so OL skips the
+  // write - and `force` stays deliberately unused, because overriding a
+  // deliberate human tax decision is the one write worth getting wrong least.
+  taxRate: 'taxRate',
 };
 
 /**
@@ -237,6 +243,13 @@ export class ErliOfferManagerAdapter
     ResponsibleProducerReader,
     DeliveryPriceListReader
 {
+  /**
+   * Connections already told that their Erli tax rate is seller-frozen (#2249).
+   * A module-level `Set` on the instance rather than a per-call log, so one
+   * deliberate seller decision is reported once instead of on every propagation.
+   */
+  private readonly frozenTaxRateReported = new Set<string>();
+
   private readonly logger = new Logger(ErliOfferManagerAdapter.name);
 
   /**
@@ -677,9 +690,25 @@ export class ErliOfferManagerAdapter
     for (const key of Object.keys(result) as (keyof ErliProductPatchBody)[]) {
       const erliName = PATCH_KEY_TO_ERLI_FROZEN_NAME[key];
       if (erliName !== undefined && frozen[erliName] === true) {
-        this.logger.debug(
-          `Skipping frozen Erli field "${erliName}" on field-update [connectionId=${this.connectionId}]`,
-        );
+        if (key === 'taxRate') {
+          // #2249: a frozen tax rate is INFORMATION, not an error - the seller
+          // set it in their panel deliberately, and that is exactly the signal
+          // that makes a later shop-versus-channel disagreement attributable to
+          // a person. Logged once per connection so a nightly propagation pass
+          // does not turn one deliberate decision into a recurring complaint,
+          // and `force` is never sent.
+          if (!this.frozenTaxRateReported.has(this.connectionId)) {
+            this.frozenTaxRateReported.add(this.connectionId);
+            this.logger.log(
+              `Erli tax rate is seller-frozen on this connection; OpenLinker will not overwrite it ` +
+                `[connectionId=${this.connectionId}]`,
+            );
+          }
+        } else {
+          this.logger.debug(
+            `Skipping frozen Erli field "${erliName}" on field-update [connectionId=${this.connectionId}]`,
+          );
+        }
         delete result[key];
       }
     }
@@ -844,6 +873,43 @@ export class ErliOfferManagerAdapter
     return erliProductPath(rawId);
   }
 
+  /**
+   * The Erli enum value for the command's neutral rate (#2249).
+   *
+   * Refuses rather than omitting, in both failure directions, because an
+   * omitted rate is the worse outcome on this platform: Erli publishes the
+   * product and then marks it not-buyable with `missingTaxRate`, which nobody
+   * sees until an operator wonders why the listing gets no orders.
+   */
+  private resolveErliTaxRate(cmd: CreateOfferCommand): string {
+    if (!cmd.taxRate) {
+      throw new OfferCreateRejectedException(this.adapterKey, 0, [
+        {
+          field: 'taxRate',
+          code: 'TAX_RATE_MISSING',
+          message:
+            `No tax rate is known for this product, and Erli blocks a product without one ` +
+            `("missingTaxRate"). Add the rate in the shop's catalogue and re-sync the product; ` +
+            `OpenLinker does not substitute one.`,
+        },
+      ]);
+    }
+    const erliTaxRate = toErliTaxRate(cmd.taxRate);
+    if (erliTaxRate === null) {
+      throw new OfferCreateRejectedException(this.adapterKey, 0, [
+        {
+          field: 'taxRate',
+          code: 'TAX_RATE_NOT_EXPRESSIBLE',
+          message:
+            `Erli has no tax value for "${cmd.taxRate}". Supported: ` +
+            `${supportedErliTaxRates().join(', ')}. Set one of those on the product in the shop, ` +
+            `or list it on a channel that supports the code.`,
+        },
+      ]);
+    }
+    return erliTaxRate;
+  }
+
   private buildCreateBody(cmd: CreateOfferCommand): ErliProductCreateBody {
     // Erli requires name, images, price, stock, dispatchTime on create. Fail
     // CLOSED locally on every required field (same posture as dispatchTime) so a
@@ -880,6 +946,13 @@ export class ErliOfferManagerAdapter
     if (cmd.variantBarcode != null) {
       body.ean = cmd.variantBarcode;
     }
+    // #2249 (ADR-052) — the shop's rate, propagated onto the Erli product.
+    // Refused rather than omitted: Erli's own `buyableProblems.missingTaxRate`
+    // blocks a rate-less product server-side, so omitting it trades an
+    // actionable error here for a silently not-buyable listing an operator has
+    // to go and discover. `oo` has no Erli equivalent and is refused for the
+    // same reason - a nearest-looking token would be a real sale taxed wrongly.
+    body.taxRate = this.resolveErliTaxRate(cmd);
     // Taxonomy (#985 / #1096): prefer the resolved Allegro id, else the master
     // shop's own categories (`source:"shop"`), else omit — Erli's API makes
     // category optional, so an uncategorised offer is valid rather than a hard
@@ -990,6 +1063,22 @@ export class ErliOfferManagerAdapter
     }
     if (fields.description !== undefined) {
       body.description = flattenDescription(fields.description);
+    }
+    // #2249: propagate a rate change onto the live product. An unmappable code
+    // is DROPPED rather than throwing, unlike on the create path: a create that
+    // cannot state its tax must not happen at all, while an update that cannot
+    // is a partial update of an offer that already exists and already sells.
+    // Throwing here would take a title or price fix down with it.
+    if (fields.taxRate !== undefined) {
+      const erliTaxRate = toErliTaxRate(fields.taxRate);
+      if (erliTaxRate === null) {
+        this.logger.warn(
+          `Erli has no tax value for "${fields.taxRate}"; leaving the offer's rate unchanged ` +
+            `[connectionId=${this.connectionId}]`,
+        );
+      } else {
+        body.taxRate = erliTaxRate;
+      }
     }
     return body;
   }

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-order.mapper.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-order.mapper.ts
@@ -56,6 +56,7 @@ import type {
   ErliOrderPickupPlace,
   ErliOrderStatus,
 } from './erli-order.types';
+import { toNeutralTaxRate } from './erli-tax-rate.mapper';
 
 /** Erli prices are integer minor units (grosze); the neutral DTO is decimal PLN. */
 function toMajorUnits(minor: number | undefined): number {
@@ -154,6 +155,16 @@ function derivePaymentStatus(status: ErliOrderStatus, cod: boolean): PaymentStat
  * `price` is the per-unit amount in decimal PLN.
  */
 function mapItem(item: ErliOrderItem): IncomingOrderItem {
+  // #2249: Erli reports a REQUIRED per-line tax rate and OL used to discard it.
+  // It is the channel rung of the resolution chain (ADR-052 § 1) - consulted
+  // only when the shop does not know, but the only rate that exists at all for
+  // a product that lives solely as an Erli offer.
+  //
+  // An unrecognised value maps to `undefined`, never to `'0'`: Erli's enum is
+  // category-dependent and may gain values, and reading an unknown token as a
+  // zero-rated sale is exactly the conflation this epic removes. The line then
+  // simply carries no channel rate, and the gate treats it as unresolved.
+  const neutralTaxRate = toNeutralTaxRate(item.taxRate);
   return {
     id: String(item.id),
     productRef: { type: 'offer', externalId: item.externalId },
@@ -161,6 +172,7 @@ function mapItem(item: ErliOrderItem): IncomingOrderItem {
     price: toMajorUnits(item.unitPrice),
     sku: item.sku,
     name: item.name,
+    ...(neutralTaxRate ? { taxRate: neutralTaxRate, taxRateCountry: 'PL' } : {}),
   };
 }
 

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-product.types.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-product.types.ts
@@ -152,6 +152,19 @@ export interface ErliProductCreateBody {
    * rejects one).
    */
   externalVariantGroup?: ErliVariantGroupRef;
+  /**
+   * VAT rate, as Erli's own enum (`TAX_0` / `TAX_5` / `TAX_8` / `TAX_23` /
+   * `NP` / `ZW` / `TAX_7` / `TAX_19`) - #2249, ADR-052.
+   *
+   * Erli treats it as required in practice: `buyableProblems` carries
+   * `missingTaxRate`, so a product published without one is blocked
+   * server-side. OpenLinker therefore refuses to publish rather than omitting
+   * it, which turns a silent not-buyable product into an actionable error.
+   *
+   * Which values a category allows is Erli's own rule and is not predicted
+   * here; Erli rejects a disallowed value itself.
+   */
+  taxRate?: string;
 }
 
 /**
@@ -164,7 +177,7 @@ export interface ErliProductCreateBody {
  */
 export type ErliProductPatchBody = Pick<
   ErliProductCreateBody,
-  'name' | 'price' | 'stock' | 'description'
+  'name' | 'price' | 'stock' | 'description' | 'taxRate'
 >;
 
 /**

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-tax-rate.mapper.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-tax-rate.mapper.spec.ts
@@ -1,0 +1,75 @@
+/**
+ * Erli Tax-Rate Mapper Tests (#2249)
+ *
+ * Both directions, because the platform vocabulary and the neutral code have
+ * to round-trip for the same sale to be taxed the same way on the offer and on
+ * the invoice.
+ *
+ * @module libs/integrations/erli/src/infrastructure/adapters
+ */
+import { supportedErliTaxRates, toErliTaxRate, toNeutralTaxRate } from './erli-tax-rate.mapper';
+
+describe('Erli tax-rate mapping', () => {
+  describe('toNeutralTaxRate', () => {
+    it.each([
+      ['TAX_23', '23'],
+      ['TAX_8', '8'],
+      ['TAX_5', '5'],
+      ['TAX_0', '0'],
+      ['TAX_7', '7'],
+      ['TAX_19', '19'],
+      ['NP', 'np'],
+      ['ZW', 'zw'],
+    ])('should read %s as the neutral code %s', (erli, neutral) => {
+      expect(toNeutralTaxRate(erli)).toBe(neutral);
+    });
+
+    it('should accept a lower-case or padded value', () => {
+      expect(toNeutralTaxRate(' tax_23 ')).toBe('23');
+    });
+
+    it('should report an absent value as null rather than as a zero rate', () => {
+      // A rate OL cannot read is not a zero-rated sale. Conflating the two is
+      // the failure this epic exists to remove.
+      expect(toNeutralTaxRate(undefined)).toBeNull();
+      expect(toNeutralTaxRate(null)).toBeNull();
+      expect(toNeutralTaxRate('')).toBeNull();
+    });
+
+    it('should report an unrecognised value as null', () => {
+      // Erli's enum is category-dependent and may gain values.
+      expect(toNeutralTaxRate('TAX_42')).toBeNull();
+    });
+  });
+
+  describe('toErliTaxRate', () => {
+    it.each([
+      ['23', 'TAX_23'],
+      ['8', 'TAX_8'],
+      ['0', 'TAX_0'],
+      ['zw', 'ZW'],
+      ['np', 'NP'],
+    ])('should express the neutral code %s as %s', (neutral, erli) => {
+      expect(toErliTaxRate(neutral)).toBe(erli);
+    });
+
+    it('should refuse reverse charge, which Erli cannot express', () => {
+      // `oo` has no Erli value. Returning the nearest-looking token would be a
+      // real sale taxed wrongly, so the caller has to refuse the publish.
+      expect(toErliTaxRate('oo')).toBeNull();
+    });
+
+    it('should refuse an absent code', () => {
+      expect(toErliTaxRate(undefined)).toBeNull();
+      expect(toErliTaxRate('')).toBeNull();
+    });
+  });
+
+  it('should round-trip every value it claims to support', () => {
+    for (const neutral of supportedErliTaxRates()) {
+      const erli = toErliTaxRate(neutral);
+      expect(erli).not.toBeNull();
+      expect(toNeutralTaxRate(erli)).toBe(neutral);
+    }
+  });
+});

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-tax-rate.mapper.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-tax-rate.mapper.ts
@@ -1,0 +1,70 @@
+/**
+ * Erli Tax-Rate Mapper (#2249, ADR-052)
+ *
+ * Translates between Erli's PL-specific tax-rate enum and OpenLinker's neutral
+ * percent-as-string code. The mapping lives here, in the adapter, because the
+ * enum is Erli's own vocabulary and core must never learn it (ADR-026).
+ *
+ * Two asymmetries are deliberate rather than oversights.
+ *
+ * **`oo` (reverse charge) has no Erli value.** Erli's enum stops at `NP`, so a
+ * product OpenLinker holds at `oo` cannot be expressed and the write is refused
+ * rather than downgraded to the nearest-looking token - a wrong tax token on a
+ * live offer is a real sale taxed wrongly.
+ *
+ * **Which values a category actually allows is Erli's own rule** and is not
+ * modelled here. Erli rejects a disallowed value itself, and its
+ * `buyableProblems.missingTaxRate` blocks a rate-less product server-side, so
+ * OpenLinker does not attempt to predict the answer.
+ *
+ * @module libs/integrations/erli/src/infrastructure/adapters
+ */
+
+/** Erli enum -> neutral code. Erli's `TAX_7` / `TAX_19` are historical PL rates. */
+const NEUTRAL_BY_ERLI: Readonly<Record<string, string>> = {
+  TAX_0: '0',
+  TAX_5: '5',
+  TAX_7: '7',
+  TAX_8: '8',
+  TAX_19: '19',
+  TAX_23: '23',
+  NP: 'np',
+  ZW: 'zw',
+};
+
+/**
+ * Neutral -> Erli. Derived from the table above so the two can never disagree
+ * about a value one of them knows.
+ */
+const ERLI_BY_NEUTRAL: Readonly<Record<string, string>> = Object.fromEntries(
+  Object.entries(NEUTRAL_BY_ERLI).map(([erli, neutral]) => [neutral, erli])
+);
+
+/**
+ * Read an Erli rate as a neutral code.
+ *
+ * Returns `null` for an absent or unrecognised value - never a `'0'`. A rate
+ * OpenLinker cannot read is not a zero-rated sale, and conflating the two is
+ * the failure the whole epic exists to remove.
+ */
+export function toNeutralTaxRate(erliTaxRate: string | undefined | null): string | null {
+  if (!erliTaxRate) return null;
+  return NEUTRAL_BY_ERLI[erliTaxRate.trim().toUpperCase()] ?? null;
+}
+
+/**
+ * Express a neutral code as an Erli enum value.
+ *
+ * Returns `null` when Erli has no equivalent (today: `oo`), which the caller
+ * must treat as "cannot publish this rate" rather than as "publish without
+ * one".
+ */
+export function toErliTaxRate(neutralTaxRate: string | undefined | null): string | null {
+  if (!neutralTaxRate) return null;
+  return ERLI_BY_NEUTRAL[neutralTaxRate.trim().toLowerCase()] ?? null;
+}
+
+/** Every neutral code Erli can express - for an operator-facing error message. */
+export function supportedErliTaxRates(): string[] {
+  return Object.keys(ERLI_BY_NEUTRAL);
+}


### PR DESCRIPTION
The channel half of the resolution chain, and the write back to the channel.

## Reads

**Erli** reports a **required** per-line `taxRate` on every order line. OL's own type already modelled it and the mapper discarded it; it now reaches the order contract.

**Allegro**'s `lineItems[].tax` has been live since March 2024 and the OL type had **no field for it at all**. Modelled and read.

Both map their platform vocabulary to the neutral code **inside the adapter**, tested in both directions, with a round-trip test over every value the Erli mapper claims to support.

An unreadable value maps to **absent, never `'0'`**. A rate OL cannot read is not a zero-rated sale, and Erli's enum is category-dependent and may gain values.

## Writes

`OfferBuilderService` stamps the shop's rate onto `CreateOfferCommand` in the same pass that already carries price and stock, read from OL's own catalogue projection - so publishing does not depend on the shop being reachable, and the offer carries the same rate an invoice for it would.

**There is no OL-side rate field to type into**, deliberately: a rate entered in OL would be a fourth source no master or channel could be corrected from, and the whole chain exists so a fix lands where the catalogue lives.

**Nothing is published with the rate omitted.** That is precisely how the rate-less offers this epic exists to fix were produced, and the failure surfaces months later on somebody's invoice rather than at publish time.

| Platform | Refuses when | Message names |
|---|---|---|
| Allegro | no rate | the shop catalogue as the remedy |
| Allegro | an exemption code | that `taxSettings.rates[]` carries numbers |
| Allegro | the category disallows the rate | the permitted values |
| Erli | no rate | that Erli itself blocks with `missingTaxRate` |
| Erli | `oo` | the codes Erli does support |

The permitted-values read (`GET /sale/tax-settings`) is **best-effort**: a failure to *list* is not a failure to publish, so it warns and proceeds with the shop's value. Allegro validates the body itself, and refusing a publish because a secondary discovery call was unavailable would be worse than the check. `null` (unreadable) is deliberately distinct from `[]` (Allegro answered and named none).

## Updates

`OfferFieldUpdate` gains an optional `taxRate` and both adapters patch it, so an offer's rate follows the catalogue instead of freezing at first publish. There an unmappable code is **dropped rather than raised**: an update that cannot state its tax is a partial update of an offer that already exists and already sells, and raising would take a title or price fix down with it. Absent means "this update does not touch the rate" - an update path must never be able to blank a rate an offer already carries.

## Frozen fields

`taxRate` joins `PATCH_KEY_TO_ERLI_FROZEN_NAME`, so the existing #988/#1737 machinery skips it. `force` is never sent. It is reported **once per connection at info level** rather than as a recurring publish error: a seller freezing the field is a deliberate decision, and it is exactly the signal that makes a later shop-versus-channel disagreement attributable to a person.

Closes #2249
Refs #2245

🤖 Generated with [Claude Code](https://claude.com/claude-code)