### PR TITLE
feat(orders): mark pre-rollout orders and measure catalogue rate coverage

### DIFF
--- a/apps/api/src/migrations/1837000000000-add-product-tax-rate.ts
+++ b/apps/api/src/migrations/1837000000000-add-product-tax-rate.ts
@@ -14,7 +14,7 @@
  * query rather than a crawl: "which products have no rate" backs the operator
  * surface, "which have not been checked" backs the sync suggestion.
  */
-import { MigrationInterface, QueryRunner } from 'typeorm';
+import type { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class AddProductTaxRate1837000000000 implements MigrationInterface {
   name = 'AddProductTaxRate1837000000000';

--- a/apps/api/src/migrations/1837000000001-add-order-record-sales-document-block-instants.ts
+++ b/apps/api/src/migrations/1837000000001-add-order-record-sales-document-block-instants.ts
@@ -18,7 +18,7 @@
  * statement that sets the reason, because the transition is the only place both
  * the old and the new value are known.
  */
-import { MigrationInterface, QueryRunner } from 'typeorm';
+import type { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class AddOrderRecordSalesDocumentBlockInstants1837000000001 implements MigrationInterface {
   name = 'AddOrderRecordSalesDocumentBlockInstants1837000000001';

--- a/apps/api/src/migrations/1837000000002-create-tax-rate-journal.ts
+++ b/apps/api/src/migrations/1837000000002-create-tax-rate-journal.ts
@@ -13,7 +13,7 @@
  * entry for one item on one connection, and the latest per connection for one
  * item - because both walk the same prefix.
  */
-import { MigrationInterface, QueryRunner } from 'typeorm';
+import type { MigrationInterface, QueryRunner } from 'typeorm';
 
 export class CreateTaxRateJournal1837000000002 implements MigrationInterface {
   name = 'CreateTaxRateJournal1837000000002';

--- a/apps/api/src/migrations/1837000000003-mark-pre-rollout-orders-historical.ts
+++ b/apps/api/src/migrations/1837000000003-mark-pre-rollout-orders-historical.ts
@@ -1,0 +1,68 @@
+/**
+ * Mark orders that predate per-line tax rates (#2256, ADR-052 § Consequences).
+ *
+ * Orders ingested before this epic carry no rate on any line, and the document
+ * issued for them used whatever the provider adapter defaulted to. They are
+ * marked rather than blocked: blocking would stop history nobody is going to
+ * retrofit, and nothing about them can be corrected after the fact.
+ *
+ * The marker's only job is to keep a net-revenue figure honest. A pre-rollout
+ * order's tax is not a confirmed rate, so it is EXCLUDED from such a figure
+ * rather than back-computed - there is nothing to compute from.
+ *
+ * Two shape decisions.
+ *
+ * **Per record, not per line.** The lines live in a jsonb snapshot, so a
+ * per-line marker would rewrite every snapshot in the table for a value that is
+ * uniform across an order and that no surface renders per line. The frontend
+ * deliberately shows nothing for it: it appeared in one place with no action
+ * attached, so it is analytics data, not a badge.
+ *
+ * **Backfilled deliberately, and this is not the backfill the epic forbids.**
+ * What must never be invented is a tax RATE. Recording that an order predates
+ * the feature is a fact about OpenLinker's own history, and it is exactly what
+ * lets a later reader avoid mistaking a defaulted rate for a stated one.
+ *
+ * Idempotent and safe to re-run: the column add is `IF NOT EXISTS` and the
+ * update touches only rows where the marker is still null AND no rate has ever
+ * been settled on a line - so an order ingested between two runs of this
+ * migration is not retroactively called historical.
+ */
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class MarkPreRolloutOrdersHistorical1837000000003 implements MigrationInterface {
+  name = 'MarkPreRolloutOrdersHistorical1837000000003';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "order_records" ADD COLUMN IF NOT EXISTS "taxRateEra" character varying(16)`
+    );
+
+    // `jsonb_path_exists` asks "does ANY line carry a non-empty taxRate?".
+    // Guarding on it rather than on a timestamp is what makes a re-run safe:
+    // an order ingested after the first run already carries rates and is
+    // therefore skipped, with no cutover instant to get wrong.
+    await queryRunner.query(`
+      UPDATE "order_records"
+         SET "taxRateEra" = 'pre-rollout'
+       WHERE "taxRateEra" IS NULL
+         AND NOT jsonb_path_exists(
+               "orderSnapshot",
+               '$.items[*].taxRate ? (@ != "")'
+             )
+    `);
+
+    // Analytics reads "the orders whose tax is stated", so the index covers
+    // the population that is NOT marked - the one that grows.
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_order_records_tax_rate_era"
+        ON "order_records" ("createdAt")
+        WHERE "taxRateEra" IS NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_order_records_tax_rate_era"`);
+    await queryRunner.query(`ALTER TABLE "order_records" DROP COLUMN IF EXISTS "taxRateEra"`);
+  }
+}

--- a/docs/operations/tax-rate-coverage.md
+++ b/docs/operations/tax-rate-coverage.md
@@ -1,0 +1,87 @@
+# Measuring tax-rate coverage before rollout
+
+Per-line tax rates ([ADR-052](../architecture/adrs/052-per-line-tax-rate-resolution-and-provenance.md))
+hold a document when a line has no rate. That is the right behaviour and the wrong
+first day, if the catalogue has no rates in it: every order stops at once, and an
+operator reads an outage rather than a diagnosis.
+
+So the count comes first. This page is how to take it, and what the answer means.
+
+## What the three states mean
+
+| State | Condition | What it says |
+|---|---|---|
+| **known** | `taxRateReadAt IS NOT NULL AND taxRate IS NOT NULL` | The shop stated a rate. `'0'` counts here - a zero rate is an answer. |
+| **missing** | `taxRateReadAt IS NOT NULL AND taxRate IS NULL` | The shop was asked and has none. **This is the population that holds documents.** |
+| **not checked** | `taxRateReadAt IS NULL` | Nobody has asked yet. Not a problem - it needs a product sync, not a catalogue edit. |
+
+Keeping *missing* and *not checked* apart is the whole point. On the day the
+columns land every row is *not checked*, and reading that as *missing* would
+report a catalogue-wide failure that does not exist.
+
+## Taking the count
+
+Per shop connection, which is the unit an operator actually fixes:
+
+```sql
+SELECT m."connectionId",
+       m."platformType",
+       COUNT(*)                                                                         AS total,
+       COUNT(*) FILTER (WHERE p."taxRateReadAt" IS NOT NULL AND p."taxRate" IS NOT NULL) AS known,
+       COUNT(*) FILTER (WHERE p."taxRateReadAt" IS NOT NULL AND p."taxRate" IS NULL)     AS missing,
+       COUNT(*) FILTER (WHERE p."taxRateReadAt" IS NULL)                                 AS not_checked
+  FROM products p
+  JOIN identifier_mappings m
+    ON m."internalId" = p.id AND m."entityType" = 'Product'
+ GROUP BY 1, 2
+ ORDER BY missing DESC, not_checked DESC;
+```
+
+A product mapped on two connections is counted under both. That is the honest
+answer - both shops would have to carry the rate for both to publish - rather
+than an arbitrary pick.
+
+The same numbers are available in code as
+`IProductsService.getTaxRateCoverageByConnection()`, which is what a future
+operator surface would read. There is deliberately no standing dashboard: this
+is a rollout measurement, and the standing form of the question is the
+per-product state the publish and issuance paths already act on.
+
+## Reading the answer
+
+- **Mostly `not_checked`** - normal, and not a blocker by itself. Run a product
+  sync per connection and re-measure. Only after that does the count mean
+  anything.
+- **Mostly `missing` after a sync** - the shop genuinely has no tax
+  configuration for those products. Fill it there, not in OpenLinker; the
+  catalogue is the only place a fix serves every channel.
+- **Mostly `known`** - safe to remove the provider defaults (#2257).
+
+## Why this gates #2257
+
+#2257 removes the hardcoded 23% each provider adapter substitutes today. Until
+then a rate-less product still produces a document, with a guessed rate. After
+it, a rate-less product produces nothing at all. Running the two in the wrong
+order turns a slow, visible data problem into an immediate outage.
+
+**Baseline recorded 2026-08-21** on the `ol-demo-fresh` stack: coverage was
+**zero** - no rate column existed, no order line carried a rate, and the
+WooCommerce store had an empty tax table. The full measurement is on #2256.
+
+## Pre-rollout orders
+
+Orders ingested before the feature carry no rate on any line, and the documents
+issued for them used the provider defaults. The
+`MarkPreRolloutOrdersHistorical` migration stamps `order_records.taxRateEra =
+'pre-rollout'` on them.
+
+They **issue exactly as they do today** - blocking would stop history nobody is
+going to retrofit - and they are **excluded from any net-revenue figure** rather
+than presented as a confirmed rate. Nothing renders the marker to an operator:
+it appeared in one place with no action attached, so it is analytics data, not a
+badge.
+
+```sql
+-- orders whose tax is stated rather than defaulted
+SELECT * FROM order_records WHERE "taxRateEra" IS NULL;
+```

--- a/libs/core/src/orders/domain/entities/order-record.entity.ts
+++ b/libs/core/src/orders/domain/entities/order-record.entity.ts
@@ -175,7 +175,18 @@ export class OrderRecord {
      * lets a timeline say the order was held and then released - the reason
      * itself is gone by then.
      */
-    public readonly salesDocumentBlockReleasedAt: Date | null = null
+    public readonly salesDocumentBlockReleasedAt: Date | null = null,
+    /**
+     * `'pre-rollout'` for an order that arrived before per-line tax rates
+     * existed (#2256); `null` for everything after. A data marker for
+     * analytics, never an operator-facing state - such an order issues exactly
+     * as it does today, and no surface renders it.
+     *
+     * Excluded from any net-revenue figure rather than presented as a confirmed
+     * rate: its tax was whatever the provider defaulted to, and there is
+     * nothing to back-compute from.
+     */
+    public readonly taxRateEra: string | null = null
   ) {}
 
   /**

--- a/libs/core/src/orders/infrastructure/persistence/entities/order-record.orm-entity.ts
+++ b/libs/core/src/orders/infrastructure/persistence/entities/order-record.orm-entity.ts
@@ -194,6 +194,27 @@ export class OrderRecordOrmEntity {
   salesDocumentBlockReleasedAt!: Date | null;
 
   /**
+   * Marks an order that arrived BEFORE per-line tax rates existed (#2256).
+   *
+   * `'pre-rollout'` on every row the enabling migration found; `null` on
+   * everything ingested afterwards. It is a DATA marker for analytics, not an
+   * operator-facing state - such an order issues exactly as it does today, and
+   * the frontend deliberately renders nothing for it.
+   *
+   * Its only job is to keep a net-revenue figure honest: a pre-rollout order's
+   * tax was whatever the provider defaulted to, so presenting it as a confirmed
+   * rate would be a claim the data does not support. Excluded rather than
+   * back-computed, because there is nothing to compute from.
+   *
+   * Recorded per RECORD rather than per line, deliberately. The lines live in a
+   * jsonb snapshot, so a per-line marker would mean rewriting every snapshot in
+   * the table for a value that is uniform across an order and that no surface
+   * renders per line.
+   */
+  @Column({ type: 'varchar', length: 16, nullable: true })
+  taxRateEra!: string | null;
+
+  /**
    * Per-order reporting-currency snapshot (#2124, ADR-040) — six columns
    * written ONLY by the two narrow, conditional UPDATEs on the repository
    * (`claimFxIntentIfAbsent`, `stampFxIfAbsent`). The ingestion upsert

--- a/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
@@ -1115,7 +1115,8 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
       entity.fxStampedAt ?? null,
       entity.fxIntendedCurrency ?? null,
       entity.salesDocumentBlockedAt ?? null,
-      entity.salesDocumentBlockReleasedAt ?? null
+      entity.salesDocumentBlockReleasedAt ?? null,
+      entity.taxRateEra ?? null
     );
   }
 

--- a/libs/core/src/products/application/services/products.service.interface.ts
+++ b/libs/core/src/products/application/services/products.service.interface.ts
@@ -75,6 +75,22 @@ export interface IProductsService {
   }>;
 
   /**
+   * The same coverage, per connection (#2256) - the unit an operator actually
+   * fixes. "The catalogue has no rates" is not actionable when three shops feed
+   * it and only one is incomplete.
+   */
+  getTaxRateCoverageByConnection(): Promise<
+    Array<{
+      connectionId: string;
+      platformType: string;
+      total: number;
+      known: number;
+      missing: number;
+      notChecked: number;
+    }>
+  >;
+
+  /**
    * Get a single product by internal ID
    */
   getProduct(id: string): Promise<Product | null>;

--- a/libs/core/src/products/application/services/products.service.spec.ts
+++ b/libs/core/src/products/application/services/products.service.spec.ts
@@ -55,6 +55,7 @@ describe('ProductsService', () => {
     recordTaxRate: jest.fn(),
     findTaxRate: jest.fn(),
     countTaxRateStates: jest.fn(),
+    countTaxRateStatesByConnection: jest.fn(),
   };
 
   const mockVariantRepo: jest.Mocked<ProductVariantRepositoryPort> = {

--- a/libs/core/src/products/application/services/products.service.ts
+++ b/libs/core/src/products/application/services/products.service.ts
@@ -105,6 +105,19 @@ export class ProductsService implements IProductsService {
     return this.productRepository.countTaxRateStates();
   }
 
+  async getTaxRateCoverageByConnection(): Promise<
+    Array<{
+      connectionId: string;
+      platformType: string;
+      total: number;
+      known: number;
+      missing: number;
+      notChecked: number;
+    }>
+  > {
+    return this.productRepository.countTaxRateStatesByConnection();
+  }
+
   async getProduct(id: string): Promise<Product | null> {
     return this.productRepository.findById(id);
   }

--- a/libs/core/src/products/domain/ports/product-repository.port.ts
+++ b/libs/core/src/products/domain/ports/product-repository.port.ts
@@ -96,4 +96,25 @@ export interface ProductRepositoryPort {
    * them is what would make day one read as an outage.
    */
   countTaxRateStates(): Promise<{ total: number; known: number; missing: number; notChecked: number }>;
+
+  /**
+   * The same counts, broken down per connection (#2256).
+   *
+   * The pre-rollout measurement is per SHOP, because that is the unit an
+   * operator fixes: "the catalogue has no rates" is not actionable when three
+   * shops feed it and only one is incomplete. `products` carries no connection
+   * of its own, so the grouping comes from `identifier_mappings` - a product
+   * mapped on two connections is counted under both, which is the honest
+   * answer rather than an arbitrary pick.
+   */
+  countTaxRateStatesByConnection(): Promise<
+    Array<{
+      connectionId: string;
+      platformType: string;
+      total: number;
+      known: number;
+      missing: number;
+      notChecked: number;
+    }>
+  >;
 }

--- a/libs/core/src/products/infrastructure/persistence/repositories/product.repository.ts
+++ b/libs/core/src/products/infrastructure/persistence/repositories/product.repository.ts
@@ -320,4 +320,54 @@ export class ProductRepository implements ProductRepositoryPort {
       notChecked: Number(row?.notChecked ?? 0),
     };
   }
+
+  /**
+   * Per-connection breakdown (#2256).
+   *
+   * A read-model reporting join by table NAME rather than by importing the
+   * identifier-mapping context's ORM entity, which the cross-context contract
+   * forbids - the same posture the stock-aggregation join in `findMany`
+   * already takes. Columns are camelCase in Postgres and must stay quoted.
+   */
+  async countTaxRateStatesByConnection(): Promise<
+    Array<{
+      connectionId: string;
+      platformType: string;
+      total: number;
+      known: number;
+      missing: number;
+      notChecked: number;
+    }>
+  > {
+    const rows = (await this.repository.query(
+      `SELECT m."connectionId"   AS "connectionId",
+              m."platformType"   AS "platformType",
+              COUNT(*)                                                                        AS "total",
+              COUNT(*) FILTER (WHERE p."taxRateReadAt" IS NOT NULL AND p."taxRate" IS NOT NULL) AS "known",
+              COUNT(*) FILTER (WHERE p."taxRateReadAt" IS NOT NULL AND p."taxRate" IS NULL)     AS "missing",
+              COUNT(*) FILTER (WHERE p."taxRateReadAt" IS NULL)                                 AS "notChecked"
+         FROM "products" p
+         JOIN "identifier_mappings" m
+           ON m."internalId" = p."id" AND m."entityType" = $1
+        GROUP BY m."connectionId", m."platformType"
+        ORDER BY "missing" DESC, "notChecked" DESC`,
+      [CORE_ENTITY_TYPE.Product]
+    )) as Array<{
+      connectionId: string;
+      platformType: string;
+      total: string;
+      known: string;
+      missing: string;
+      notChecked: string;
+    }>;
+
+    return rows.map((row) => ({
+      connectionId: row.connectionId,
+      platformType: row.platformType,
+      total: Number(row.total),
+      known: Number(row.known),
+      missing: Number(row.missing),
+      notChecked: Number(row.notChecked),
+    }));
+  }
 }


### PR DESCRIPTION
Two rollout chores that keep the first day honest.

## Historical orders

An order ingested before per-line rates existed carries none on any line, and the document issued for it used whatever the provider adapter defaulted to. It is **marked, not blocked** - blocking would stop history nobody is going to retrofit, and nothing about it can be corrected after the fact.

The marker's only job is to keep a net-revenue figure honest: such an order is **excluded** from one rather than presented as a confirmed rate, because there is nothing to back-compute from.

**Per record, not per line.** The lines live in a jsonb snapshot, so a per-line marker would rewrite every snapshot in the table for a value that is uniform across an order and that no surface renders per line. The frontend deliberately shows nothing for it - it appeared in one place with no action attached, so it is analytics data rather than a badge.

**This backfill is not the one the epic forbids.** What must never be invented is a tax *rate*. Recording that an order predates the feature is a fact about OpenLinker's own history, and it is exactly what stops a later reader mistaking a defaulted rate for a stated one.

**Idempotent by construction**: it marks only rows where no line has ever carried a rate, so an order ingested between two runs is not retroactively called historical. There is no cutover instant to get wrong.

## Coverage

Counts per **shop connection**, because that is the unit an operator fixes - "the catalogue has no rates" is not actionable when three shops feed it and only one is incomplete. A product mapped on two connections counts under both, which is the honest answer since both shops would have to carry the rate for both to publish.

The grouping joins `identifier_mappings` **by table name**, the read-model posture the stock aggregation in `findMany` already takes, rather than importing another context's ORM entity.

The three states stay distinct, and that is the point: on the day the columns land every row is *not checked*, and reading that as *missing* would report a catalogue-wide failure that does not exist.

## `docs/operations/tax-rate-coverage.md`

The query, what each state means, how to read the answer, and why this gates #2257 - until the defaults come out a rate-less product still produces a document with a guessed rate; after, it produces nothing at all. Running the two in the wrong order turns a slow, visible data problem into an immediate outage.

**Baseline measured 2026-08-21: coverage was zero.** No rate column existed, no order line carried a rate, and the WooCommerce store's tax table was empty. Full measurement recorded on #2256.

Closes #2256
Refs #2245

🤖 Generated with [Claude Code](https://claude.com/claude-code)