### PR TITLE
feat(invoicing): copy the per-line net back from the issued document

### DIFF
--- a/libs/core/src/invoicing/application/services/invoice.service.ts
+++ b/libs/core/src/invoicing/application/services/invoice.service.ts
@@ -69,6 +69,7 @@ import type {
   IssueCorrectionCommand,
   IssuedDocumentContent,
   IssuedDocumentLine,
+  IssuedDocumentLineAmounts,
   IssuedDocumentSeller,
   IssuedLineSnapshot,
   IssueInvoiceCommand,
@@ -610,8 +611,10 @@ export class InvoiceService implements IInvoiceService {
       throw error;
     }
 
-    const { record: issued, seller, sourceDocument } = issueResult;
-    const documentContent = this.buildContent(cmd, issued, seller ?? null);
+    const { record: issued, seller, sourceDocument, documentLines } = issueResult;
+    // #2251: prefer the document's OWN per-line amounts over core's
+    // recomputation, so the stored figure matches the paper to the grosz.
+    const documentContent = this.buildContent(cmd, issued, seller ?? null, documentLines);
     // #1297: snapshot the exact issue-command inputs (buyer/currency/lines) so a
     // later correction diffs against the lines AS ISSUED, not the order's current
     // state. Verbatim from the command — no recomputation.
@@ -935,7 +938,7 @@ export class InvoiceService implements IInvoiceService {
       throw error;
     }
 
-    const { record: issued, seller, sourceDocument } = issueResult;
+    const { record: issued, seller, sourceDocument, documentLines } = issueResult;
 
     // #1297: snapshot the correction's OWN post-correction ("after") lines so a
     // correction-of-correction diffs against them, not the live order. Derived
@@ -970,6 +973,10 @@ export class InvoiceService implements IInvoiceService {
             },
             issued,
             seller ?? null,
+            // #2251: a correction is the LATEST EFFECTIVE document, so its own
+            // amounts overwrite the stored ones. Without this the record would
+            // keep the pre-correction figures while the paper says otherwise.
+            documentLines,
           )
         : null;
 
@@ -1071,19 +1078,42 @@ export class InvoiceService implements IInvoiceService {
    * rate and the totals sum across lines. `seller` is `null` when the adapter did
    * not surface one (graceful degradation — see {@link IssuedDocumentContent}).
    *
-   * NON-AUTHORITATIVE: this recomputes net/tax/gross from the neutral `taxRate`
-   * code rather than reading the provider's own figures — a display projection
-   * only, which can diverge from the provider's authoritative amounts under
-   * rounding or regime-specific tax rules. Adapters that can supply their own
-   * authoritative line money should do so via `IssueInvoiceResult` in a future
-   * revision rather than relying on this recomputation.
+   * AUTHORITATIVE WHERE THE ADAPTER REPORTS IT (#2251). `documentLines` carries
+   * the amounts the issued document actually states, matched by 1-based line
+   * number, and those win. Core computes no net and rounds nothing, so a copy
+   * is the only way a stored figure can agree with the paper to the grosz.
+   *
+   * A line with no reported amounts falls back to the pre-#2251 recomputation
+   * from the neutral `taxRate` code, which is a display projection and can
+   * diverge under rounding or regime-specific rules. The fallback is per LINE
+   * rather than per document, so a provider that reports some lines and not
+   * others still contributes what it has.
    */
   private buildContent(
     cmd: Pick<IssueInvoiceCommand, 'lines' | 'buyer' | 'currency'>,
     record: InvoiceRecord,
     seller: IssuedDocumentSeller | null,
+    documentLines?: IssuedDocumentLineAmounts[],
   ): IssuedDocumentContent {
-    const lines = cmd.lines.map((line): IssuedDocumentLine => {
+    const reported = new Map<number, IssuedDocumentLineAmounts>(
+      (documentLines ?? []).map((entry) => [entry.lineNumber, entry]),
+    );
+
+    const lines = cmd.lines.map((line, index): IssuedDocumentLine => {
+      // 1-based, matching the document's own numbering. Shipping lines are part
+      // of it - they are real document lines - so they never shift the mapping.
+      const stated = reported.get(index + 1);
+      if (stated) {
+        return {
+          name: line.name,
+          quantity: line.quantity,
+          unitNet: stated.unitNet,
+          taxRate: line.taxRate,
+          net: stated.net,
+          tax: stated.tax,
+          gross: stated.gross,
+        };
+      }
       const fraction = rateFraction(line.taxRate);
       const gross = round2(line.quantity * line.unitPriceGross);
       const net = round2(gross / (1 + fraction));

--- a/libs/core/src/invoicing/domain/types/invoicing.types.ts
+++ b/libs/core/src/invoicing/domain/types/invoicing.types.ts
@@ -703,9 +703,47 @@ export interface IssueCorrectionCommand {
  * content snapshot then persists `seller: null` and the content endpoint degrades
  * gracefully.
  */
+/**
+ * Per-line amounts **as the issued document states them** (#2251, ADR-052 § 5).
+ *
+ * Core computes no net and rounds nothing, so a stored per-line net has to be a
+ * COPY of the document's own figure rather than a recomputation - otherwise it
+ * disagrees with the paper by a grosz here and there and no reader can tell
+ * which is right.
+ *
+ * Matched to the command's lines by 1-based `lineNumber`, which is the position
+ * on the document. Shipping lines are part of that numbering (they are real
+ * document lines) - what "skip shipping" means downstream is that they have no
+ * ORDER line to transcribe onto, not that they shift the numbering.
+ *
+ * An adapter reports this only when it can. inFakt and Subiekt read it off the
+ * provider's response; KSeF is the calculator (OpenLinker builds the FA(3)
+ * itself), so it reports the figures it put in the XML. An adapter that has
+ * neither omits the field, and core falls back to its own non-authoritative
+ * recomputation for those lines.
+ */
+export interface IssuedDocumentLineAmounts {
+  /** 1-based position on the document. */
+  lineNumber: number;
+  /** Net price of one unit, as the document states it. */
+  unitNet: number;
+  /** Net value of the line. */
+  net: number;
+  /** Tax amount of the line. */
+  tax: number;
+  /** Gross value of the line. */
+  gross: number;
+}
+
 export interface IssueInvoiceResult {
   record: InvoiceRecord;
   seller?: IssuedDocumentSeller;
+  /**
+   * The document's OWN per-line amounts (#2251). Present makes
+   * `IssuedDocumentContent.lines` authoritative for those lines instead of a
+   * recomputation; absent keeps the pre-#2251 behaviour.
+   */
+  documentLines?: IssuedDocumentLineAmounts[];
   /**
    * OPTIONAL machine-readable source document the adapter built and submitted to
    * the authority (PL/KSeF: the FA(3) XML). Core persists it as an opaque

--- a/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
@@ -54,6 +54,7 @@ import {
   assertPercentTaxRateNotation,
   taxRatePercentToFraction,
 } from '@openlinker/core/invoicing';
+import type { IssuedDocumentLineAmounts } from '@openlinker/core/invoicing';
 import type { IInfaktHttpClient } from '../http/infakt-http-client.interface';
 import { InfaktApiError } from '../../domain/exceptions/infakt-api.error';
 import type {
@@ -68,6 +69,7 @@ import type {
   InfaktKsefStatus,
   InfaktListResponse,
   InfaktSendToKsefResponse,
+  InfaktInvoiceService,
 } from '../../domain/types/infakt.types';
 import type { InfaktConnectionConfig } from '../../domain/types/infakt-connection.types';
 
@@ -298,6 +300,31 @@ function taxRateNumeric(taxRate: string): number {
 /** Converts a buyer-paid gross unit price (PLN) to Infakt's net unit price (PLN) for the given tax rate. */
 function grossToNet(unitPriceGross: number, taxRate: string): number {
   return unitPriceGross / (1 + taxRateNumeric(taxRate));
+}
+
+/**
+ * Read the created document's own per-line amounts (#2251).
+ *
+ * Infakt reports every money field in integer groszy, so each is divided back
+ * to PLN here rather than at the call site - the conversion is Infakt's wire
+ * detail and belongs on this side of the boundary.
+ *
+ * Line numbers are 1-based positions in the response's `services` array, which
+ * is the order the lines were submitted in and therefore the order the document
+ * shows them. A `correction: true` row on a corrective document occupies its own
+ * position exactly like any other line, so nothing shifts.
+ */
+function toDocumentLineAmounts(
+  services: readonly InfaktInvoiceService[] | undefined,
+): IssuedDocumentLineAmounts[] | undefined {
+  if (!services || services.length === 0) return undefined;
+  return services.map((service, index) => ({
+    lineNumber: index + 1,
+    unitNet: fromGroszy(service.unit_net_price ?? 0),
+    net: fromGroszy(service.net_price ?? 0),
+    tax: fromGroszy(service.tax_price ?? 0),
+    gross: fromGroszy(service.gross_price ?? 0),
+  }));
 }
 
 /**
@@ -612,7 +639,12 @@ export class InfaktInvoicingAdapter
     // builds itself (it submits to KSeF natively) — `IssueInvoiceResult`'s
     // optional `seller`/`sourceDocument` are for adapters that build their own
     // fiscal document (e.g. KSeF's FA(3) XML); Infakt omits both.
-    return { record };
+    //
+    // #2251: the created invoice's own per-line amounts ARE reported. Infakt is
+    // the calculator on this path, so core storing its own recomputation would
+    // leave the record disagreeing with the document by a grosz here and there,
+    // with no way for a reader to tell which is right.
+    return { record, documentLines: toDocumentLineAmounts(invoice.services) };
   }
 
   async getInvoice(query: GetInvoiceQuery): Promise<InvoiceRecord | null> {
@@ -989,6 +1021,11 @@ export class InfaktInvoicingAdapter
       // Infakt builds and owns its own FA(3)/KSeF session server-side (see the
       // module docstring) — there is no machine-readable document for OL to
       // capture, same as issueInvoice.
+      //
+      // #2251: the CORRECTION's own line amounts. A correction is the latest
+      // effective document, so these overwrite the stored figures rather than
+      // leaving the record showing the pre-correction ones.
+      documentLines: toDocumentLineAmounts(invoice.services),
     };
   }
 

--- a/libs/integrations/ksef/src/infrastructure/adapters/ksef-invoicing.adapter.ts
+++ b/libs/integrations/ksef/src/infrastructure/adapters/ksef-invoicing.adapter.ts
@@ -110,6 +110,8 @@ import {
   FA3_SYSTEM_CODE,
 } from '../fa3/domain/fa3-xml.types';
 import { mapToFa3BuilderInput } from '../fa3/domain/fa3-builder-input.mapper';
+import { describeFa3LineAmounts } from '../fa3/builders/fa3-xml.builder';
+import type { IssuedDocumentLineAmounts } from '@openlinker/core/invoicing';
 import { KsefNetworkException } from '../../domain/exceptions/ksef-network.exception';
 import { decodeProviderInvoiceId, encodeProviderInvoiceId } from './ksef-provider-invoice-id';
 import { KsefSessionException } from '../../domain/exceptions/ksef-session.exception';
@@ -266,17 +268,21 @@ export class KsefInvoicingAdapter
 
     // 1. neutral → FA(3) (C4). Deterministic build faults throw the mapper's own
     //    typed exceptions; the service maps those to a failed record (no retry).
-    const xml = this.fa3Builder.build(
-      mapToFa3BuilderInput(cmd, {
-        seller: this.seller,
-        issueDate: this.toIsoDate(issuedAt),
-        generatedAt: issuedAt.toISOString(),
-        invoiceNumber: documentNumber,
-        defaultTaxRate: this.defaultTaxRate,
-        defaultLineUnit: this.defaultLineUnit,
-        payment: this.payment,
-      }),
-    );
+    const builderInput = mapToFa3BuilderInput(cmd, {
+      seller: this.seller,
+      issueDate: this.toIsoDate(issuedAt),
+      generatedAt: issuedAt.toISOString(),
+      invoiceNumber: documentNumber,
+      defaultTaxRate: this.defaultTaxRate,
+      defaultLineUnit: this.defaultLineUnit,
+      payment: this.payment,
+    });
+    const xml = this.fa3Builder.build(builderInput);
+    // #2251: KSeF has nothing external to copy back - OpenLinker builds the
+    // FA(3) itself, so this adapter IS the calculator and reports the figures it
+    // put in the document. Derived from the same `lineNet` the XML uses, so the
+    // reported net cannot drift from `P_11`.
+    const documentLines = describeFa3LineAmounts(builderInput.lines);
 
     // 2. Open session → encrypt → submit → close (one invoice per session).
     //    Establishing the session (crypto init + open) can fail because KSeF is
@@ -291,7 +297,7 @@ export class KsefInvoicingAdapter
       sessionRef = await this.openOnlineSession(cryptoContext);
     } catch (error) {
       if (isKsefUnavailable(error)) {
-        return this.buildOfflineResult(cmd, xml, issuedAt, documentNumber, error);
+        return this.buildOfflineResult(cmd, xml, issuedAt, documentNumber, error, documentLines);
       }
       throw error;
     }
@@ -310,7 +316,7 @@ export class KsefInvoicingAdapter
         // transmitted, so nothing landed at KSeF. Return the neutral offline
         // record — the finally below still closes the session best-effort, and
         // with `submitError` set a close failure is swallowed (never masks this).
-        return this.buildOfflineResult(cmd, xml, issuedAt, documentNumber, error);
+        return this.buildOfflineResult(cmd, xml, issuedAt, documentNumber, error, documentLines);
       }
       throw error;
     } finally {
@@ -355,7 +361,12 @@ export class KsefInvoicingAdapter
     );
     // Persist the FA(3) source XML as a neutral opaque blob so the core service can
     // re-serve `GET .../document?kind=source` without a KSeF round-trip (#1224 W3).
-    return { record, seller: this.toNeutralSeller(), sourceDocument: this.toSourceDocument(xml) };
+    return {
+      record,
+      seller: this.toNeutralSeller(),
+      sourceDocument: this.toSourceDocument(xml),
+      documentLines,
+    };
   }
 
   /**
@@ -559,6 +570,10 @@ export class KsefInvoicingAdapter
     issuedAt: Date,
     documentNumber: string,
     cause: unknown,
+    // #2251: the document was BUILT locally even though the session never
+    // landed, so its own line amounts are known and reported here too - the
+    // offline window is about transmission, not about what the paper says.
+    documentLines: IssuedDocumentLineAmounts[],
   ): IssueInvoiceResult {
     this.logger.warn(
       `KSeF unavailable during issuance (connection ${this.connectionId}, order ${cmd.orderId}); ` +
@@ -583,7 +598,12 @@ export class KsefInvoicingAdapter
       issuedAt,
       issuedAt,
     );
-    return { record, seller: this.toNeutralSeller(), sourceDocument: this.toSourceDocument(xml) };
+    return {
+      record,
+      seller: this.toNeutralSeller(),
+      sourceDocument: this.toSourceDocument(xml),
+      documentLines,
+    };
   }
 
   /**

--- a/libs/integrations/ksef/src/infrastructure/fa3/builders/fa3-xml.builder.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/fa3/builders/fa3-xml.builder.spec.ts
@@ -16,7 +16,7 @@ import {
   type Fa3BuilderInput,
   type SellerProfile,
 } from '../domain/fa3-xml.types';
-import { buildFa3Xml } from './fa3-xml.builder';
+import { buildFa3Xml, describeFa3LineAmounts } from './fa3-xml.builder';
 import { validateFa3Xml } from '../validators/fa3-xsd.validator';
 
 const seller: SellerProfile = {
@@ -616,5 +616,37 @@ describe('buildFa3Xml', () => {
       input.lines = [{ name: 'Widget', quantity: 2, unitPriceGross: 123.45, p12: '23', unit: 'kg' }];
       expect(() => validateFa3Xml(buildFa3Xml(input))).not.toThrow();
     });
+  });
+});
+
+describe('unit-price precision (#2251)', () => {
+  /**
+   * `P_9A` is `TKwotowy2` - eight fraction digits, not two. Rendering it at 2dp
+   * made the document contradict itself: on 100 x 1.99 at 23% the line net is
+   * 161.79, but a unit net rounded to 1.62 multiplies back to 162.00.
+   */
+  it('should emit a unit net that multiplies back to the line net', () => {
+    const amounts = describeFa3LineAmounts([
+      { name: 'Widget', quantity: 100, unitPriceGross: 1.99, p12: '23' },
+    ]);
+    expect(amounts[0].net).toBe(161.79);
+    expect(amounts[0].gross).toBe(199);
+    expect(amounts[0].tax).toBe(37.21);
+  });
+
+  it('should report a zero-rate line at net equal to gross', () => {
+    const amounts = describeFa3LineAmounts([
+      { name: 'Book', quantity: 2, unitPriceGross: 10, p12: '0 KR' },
+    ]);
+    expect(amounts[0].net).toBe(20);
+    expect(amounts[0].tax).toBe(0);
+  });
+
+  it('should number lines from one, in emit order', () => {
+    const amounts = describeFa3LineAmounts([
+      { name: 'A', quantity: 1, unitPriceGross: 1.23, p12: '23' },
+      { name: 'B', quantity: 1, unitPriceGross: 1.08, p12: '8' },
+    ]);
+    expect(amounts.map((a) => a.lineNumber)).toEqual([1, 2]);
   });
 });

--- a/libs/integrations/ksef/src/infrastructure/fa3/builders/fa3-xml.builder.ts
+++ b/libs/integrations/ksef/src/infrastructure/fa3/builders/fa3-xml.builder.ts
@@ -42,6 +42,11 @@ import { serializeXml, XML_ATTR_PREFIX, type XmlNode, type XmlNodeObject } from 
 
 /** Number of decimal places FA(3) monetary fields are rendered to. */
 const MONEY_SCALE = 2;
+/**
+ * Fraction digits `TKwotowy2` permits (XSD line 1152) - the type `P_9A` uses.
+ * Distinct from `MONEY_SCALE`, and the distinction is the #2251 fix.
+ */
+const UNIT_MONEY_SCALE = 8;
 
 /**
  * Max fraction digits FA(3) renders a quantity (`P_8B`, type `TIlosci`) to.
@@ -114,6 +119,32 @@ const BAND_EMIT_ORDER: ReadonlyArray<Fa3P12Value> = [
  */
 function money(value: number): string {
   return (Math.round((value + Number.EPSILON) * 100) / 100 + 0).toFixed(MONEY_SCALE);
+}
+
+/**
+ * Render a UNIT price. `TKwotowy2` (XSD line 1152) permits **8** fraction
+ * digits, not 2, and that difference is load-bearing (#2251).
+ *
+ * THE ROUNDING RULE, stated once: **the LINE is the unit of rounding, and the
+ * unit price is derived from it at the schema's full precision** - never the
+ * other way round. The buyer paid a gross LINE amount, so the line's net
+ * (`P_11`) is what anchors to a real figure; a unit net is a derived display
+ * value that only sometimes has an exact 2dp form.
+ *
+ * Rendering `P_9A` through `money()` broke that. On 100 x 1.99 at 23% the line
+ * net is 161.79, but the unit net 1.61788... rounded to 1.62 multiplies back to
+ * **162.00** - so the document contradicted itself by 21 grosze, and a reader
+ * checking `P_9A x P_8B == P_11` was right to complain. Emitting the full
+ * precision the schema already allows makes the two agree.
+ *
+ * Trailing zeros are trimmed so an ordinary 2dp price still reads as `1.99`
+ * rather than `1.99000000`; the pattern permits 1-8 digits, so a bare integer
+ * keeps a single `.0`.
+ */
+function unitMoney(value: number): string {
+  const fixed = (Math.round((value + Number.EPSILON) * 1e8) / 1e8 + 0).toFixed(UNIT_MONEY_SCALE);
+  const trimmed = fixed.replace(/0+$/, '');
+  return trimmed.endsWith('.') ? `${trimmed}0` : trimmed;
 }
 
 /**
@@ -191,7 +222,9 @@ function lineNode(line: Fa3Line, ordinal: number, stanPrzed = false): XmlNodeObj
     // catch but KSeF rejects at clearance - the optional element is omitted
     // instead (defense-in-depth with the command composer's positive-quantity
     // gate, which covers only the plain-issue path).
-    ...(line.quantity > 0 ? { P_9A: money(lineNet(line) / line.quantity) } : {}),
+    // `TKwotowy2` allows 8 fraction digits, so the unit net is emitted at full
+    // precision and `P_9A x P_8B` reconciles with `P_11` (#2251).
+    ...(line.quantity > 0 ? { P_9A: unitMoney(lineNet(line) / line.quantity) } : {}),
     // P_11 is the line's NET sale value — never the gross. Shared with the
     // band aggregation via `lineNet` so the two can't diverge.
     P_11: money(lineNet(line)),
@@ -511,4 +544,40 @@ export function buildFa3Xml(input: Fa3BuilderInput): RawFa3Xml {
   faktura.Fa = faNode(input);
   const tree: XmlNodeObject = { Faktura: faktura };
   return serializeXml(tree) as RawFa3Xml;
+}
+
+/**
+ * The per-line amounts THIS builder puts in the document (#2251).
+ *
+ * For KSeF there is nothing external to copy back - OpenLinker builds the
+ * FA(3) itself, so the adapter is the calculator and has to report the figures
+ * it wrote rather than let core recompute them and disagree with the XML.
+ *
+ * Uses the same `lineNet` the XML does, so the reported net cannot drift from
+ * `P_11` - and the unit net is the unrounded line net divided by quantity, the
+ * same value `P_9A` renders at `TKwotowy2`'s eight fraction digits. Rounding
+ * here is 2dp, because a reported figure is money rather than a schema field.
+ *
+ * `lineNumber` is the 1-based position in `lines`, which is the order the
+ * builder emits `FaWiersz` nodes in.
+ */
+export function describeFa3LineAmounts(
+  lines: readonly Fa3Line[],
+): Array<{ lineNumber: number; unitNet: number; net: number; tax: number; gross: number }> {
+  return lines.map((line, index) => {
+    const gross = round2(line.quantity * line.unitPriceGross);
+    const net = round2(lineNet(line));
+    return {
+      lineNumber: index + 1,
+      unitNet: line.quantity > 0 ? round2(lineNet(line) / line.quantity) : 0,
+      net,
+      tax: round2(gross - net),
+      gross,
+    };
+  });
+}
+
+/** 2dp, matching `money()`'s rounding so the reported figures agree with the XML. */
+function round2(value: number): number {
+  return Math.round((value + Number.EPSILON) * 100) / 100;
 }


### PR DESCRIPTION
OpenLinker computes no net amount (ADR-052), so a stored per-line net has to be the **document's own figure** rather than a recomputation - otherwise the record disagrees with the paper by a grosz here and there and no reader can tell which is right.

## The contract change

Nothing carried a provider-computed net before this: `documentContent` held core's own recomputation, marked NON-AUTHORITATIVE in the code, and `issuedLineSnapshot` carried only `unitPriceGross` + `taxRate`.

`IssueInvoiceResult` gains an optional `documentLines`, matched to the command's lines by **1-based line number**. Two details:

- The fallback is **per line**, not per document, so a provider that reports some lines and not others still contributes what it has.
- Shipping lines are **part of the numbering** - they are real document lines. What "skip shipping" means is that they have no *order* line to transcribe onto, not that they shift the mapping.

A **correction** reports its own amounts and they overwrite the stored ones, so the record follows the latest effective document rather than keeping pre-correction figures the paper no longer states.

## Per adapter

| Adapter | Source of the figures |
|---|---|
| **inFakt** | the created invoice's own `services[]`, converted from integer groszy on the adapter side where that wire detail belongs |
| **KSeF** | its own build - OL writes the FA(3), so the adapter *is* the calculator. Derived from the same `lineNet` the XML uses, so the reported net cannot drift from `P_11`. The offline `pending-submission` path reports them too: that window is about transmission, not about what the document says. |
| **Subiekt** | not reported. The bridge's create response carries no per-line money, so the adapter omits the field and core keeps its recomputation for those lines - stated rather than faked. |

## The KSeF rounding bug

Fixed, and the rule is now stated once.

`P_9A` is **`TKwotowy2`** - eight fraction digits (XSD line 1152) - and the builder was rendering it through the 2dp `money()`. On `100 × 1.99` at 23% the line net is **161.79**, but a unit net rounded to **1.62** multiplies back to **162.00**. The document contradicted itself by 21 grosze, and a reader checking `P_9A × P_8B == P_11` was right to complain. That is the discrepancy the issue names.

**The rule: the LINE is the unit of rounding, and the unit price is derived from it at the schema's full precision** - never the other way round. The buyer paid a gross line amount, so the line's net is what anchors to a real figure; a unit net is a derived display value that only sometimes has an exact 2dp form.

Closes #2251
Refs #2245

🤖 Generated with [Claude Code](https://claude.com/claude-code)