### PR TITLE
feat(web): tax-rate states on the orders list, order detail and invoice panel

### DIFF
--- a/apps/api/src/orders/http/dto/list-orders-query.dto.ts
+++ b/apps/api/src/orders/http/dto/list-orders-query.dto.ts
@@ -158,6 +158,19 @@ export class ListOrdersQueryDto {
   @IsBoolean()
   salesDocumentBlocked?: boolean;
 
+  @ApiPropertyOptional({
+    type: Boolean,
+    description:
+      'Tax-rate conflict filter (#2254): true keeps only orders where the shop and the channel ' +
+      'named DIFFERENT rates, false keeps only the rest, omitted does not filter. A SEPARATE ' +
+      'axis from salesDocumentBlocked, and it has to be — a conflict does not stop the invoice, ' +
+      'so the rows it finds are usually already invoiced and are invisible in every other view.',
+  })
+  @IsOptional()
+  @Transform(({ value }): unknown => (value === 'true' ? true : value === 'false' ? false : value))
+  @IsBoolean()
+  taxRateConflict?: boolean;
+
   @ApiPropertyOptional({ default: 0, minimum: 0, description: 'Number of items to skip' })
   @IsOptional()
   @Type(() => Number)

--- a/apps/api/src/orders/http/dto/order-health-summary-response.dto.ts
+++ b/apps/api/src/orders/http/dto/order-health-summary-response.dto.ts
@@ -43,4 +43,22 @@ export class OrderHealthSummaryResponseDto {
       'often "synced"), so this number must never be added to their sum.',
   })
   salesDocumentBlocked!: number;
+
+  @ApiProperty({
+    description:
+      'Orders where the shop and the channel named DIFFERENT tax rates (#2254). Its OWN count, ' +
+      'never part of salesDocumentBlocked: a conflict does not stop the invoice, so an order can ' +
+      'be in conflict and perfectly healthy, and folding it in would print one number twice on ' +
+      'the same screen.',
+  })
+  taxRateConflict!: number;
+
+  @ApiProperty({
+    nullable: true,
+    description:
+      'When the OLDEST still-held order was held (ISO 8601), or null when nothing is held ' +
+      '(#2254). Lets the blocked chip carry an age inside its label rather than adding a third ' +
+      'dotted badge to a row that already has two SLA badges.',
+  })
+  salesDocumentBlockedOldestAt!: string | null;
 }

--- a/apps/api/src/orders/http/orders.controller.spec.ts
+++ b/apps/api/src/orders/http/orders.controller.spec.ts
@@ -511,7 +511,7 @@ describe('OrdersController', () => {
         needsAttention: 1,
         synced: 1,
         awaitingDispatch: 9,
-        salesDocumentBlocked: 0,
+        salesDocumentBlocked: 0, taxRateConflict: 0, salesDocumentBlockedOldestAt: null,
       });
 
       const result = await controller.statusSummary({});
@@ -529,7 +529,7 @@ describe('OrdersController', () => {
         needsAttention: 0,
         synced: 0,
         awaitingDispatch: 0,
-        salesDocumentBlocked: 0,
+        salesDocumentBlocked: 0, taxRateConflict: 0, salesDocumentBlockedOldestAt: null,
       });
 
       await controller.statusSummary({

--- a/apps/api/src/orders/http/orders.controller.ts
+++ b/apps/api/src/orders/http/orders.controller.ts
@@ -112,6 +112,7 @@ export class OrdersController {
       slaState,
       fulfillmentState,
       salesDocumentBlocked,
+      taxRateConflict,
       limit = 20,
       offset = 0,
     } = query;
@@ -131,6 +132,7 @@ export class OrdersController {
         slaState,
         fulfillmentState,
         salesDocumentBlocked,
+        taxRateConflict,
       },
       { limit, offset }
     );
@@ -189,12 +191,17 @@ export class OrdersController {
     @Query() query: OrderHealthSummaryQueryDto
   ): Promise<OrderHealthSummaryResponseDto> {
     const { sourceConnectionId, customerId, createdFrom, createdTo } = query;
-    return this.orderRecordRepository.countByHealth({
+    const summary = await this.orderRecordRepository.countByHealth({
       sourceConnectionId,
       customerId,
       createdFrom: createdFrom ? new Date(createdFrom) : undefined,
       createdTo: createdTo ? new Date(createdTo) : undefined,
     });
+    // The wire carries an ISO string; the domain summary carries a Date (#2254).
+    return {
+      ...summary,
+      salesDocumentBlockedOldestAt: summary.salesDocumentBlockedOldestAt?.toISOString() ?? null,
+    };
   }
 
   @Get('sla-summary')

--- a/apps/web/src/features/invoicing/components/order-invoice-panel.tsx
+++ b/apps/web/src/features/invoicing/components/order-invoice-panel.tsx
@@ -63,7 +63,9 @@ import { useWriteAccess } from '../../../shared/auth/use-permission';
 import { DEMO_READ_ONLY_ACTION_MESSAGE } from '../../../shared/config/demo-mode';
 import { useDemoMode } from '../../system';
 
-import type { OrderRecord } from '../../orders';
+import type { OrderRecord, ParsedOrderItem } from '../../orders';
+import { parseOrderSnapshot } from '../../orders';
+import type { RateLessLine } from '../lib/sales-document-block-copy';
 import type { InvoiceRecord } from '../api/invoicing.types';
 import { useOrderInvoiceQuery } from '../hooks/use-order-invoice-query';
 import { useIssueInvoiceMutation } from '../hooks/use-issue-invoice-mutation';
@@ -270,10 +272,36 @@ export function OrderInvoicePanel({ order }: OrderInvoicePanelProps): ReactEleme
   // failure — which may have produced a document — suppresses. Same rule as
   // `invoiceSupersedesBlock` on the row and as the backend gate; they have to
   // agree, or the aggregate counts blocks no surface can explain.
+  // #2254 — the rate-less lines, read from the order's own snapshot. The remedy
+  // depends on WHY a rate is absent, and only the lines say which case this is.
+  const snapshotItems = parseOrderSnapshot(order.orderSnapshot).items;
+  const rateLessLines = collectRateLessLines(snapshotItems);
+  const conflictLines = snapshotItems.filter((item) => Boolean(item.taxRateChannel));
   const blockCopy =
     invoice && !canRetryInvoice(invoice)
       ? null
-      : resolveSalesDocumentBlockCopy(order, requiresConnectionPick, t);
+      : resolveSalesDocumentBlockCopy(order, requiresConnectionPick, t, rateLessLines);
+  // #2254 (epic F2) — the FIRST reason where the manual path must close too.
+  // Every other block reason means "auto-issue did not happen" and issuing by
+  // hand is a legitimate action; this one means "this cannot be issued", and the
+  // backend refuses it with a 422. A live button above a red "will not be
+  // issued" alert would be an invitation to a failure OL already knows about.
+  const missingRateReason = order.salesDocumentBlockReason === 'missing-tax-rate';
+  // #2254 — what the document's shipping line(s) will say. A mixed-rate basket
+  // splits shipping proportionally, so the operator can see the shape of the
+  // document before it exists; one unknown line rate makes the proportion
+  // uncomputable, so the whole preview collapses to a single waiting row rather
+  // than showing a split OL cannot stand behind.
+  const shippingSplitPreview = renderShippingSplitPreview(
+    snapshotItems,
+    order.orderSnapshot,
+    t,
+  );
+  const issueRefusal = missingRateReason
+    ? rateLessLines.length === 1
+      ? t('invoice.panel.issueRefusedOne', 'no tax rate on 1 line')
+      : `${t('invoice.panel.issueRefusedPrefix', 'no tax rate on')} ${String(Math.max(rateLessLines.length, 1))} ${t('invoice.panel.issueRefusedSuffix', 'lines')}`
+    : null;
   // "Set a primary" follows the BACKEND's reason when it has one, so the button
   // appears for the state the gate actually recorded rather than for the state the
   // browser guessed.
@@ -399,6 +427,58 @@ export function OrderInvoicePanel({ order }: OrderInvoicePanelProps): ReactEleme
           </Alert>
         </div>
       ) : null}
+
+      {/* #2254 (epic F6) — the return path. Every remedy in this epic leaves the
+          app, is applied in a system OpenLinker does not read live, and returns
+          the operator to a screen that still says the old thing. Without naming
+          the latency, a correct fix looks like it did nothing and the operator
+          concludes the product is broken.
+
+          It links to the products list rather than opening a sync dialog here:
+          the connection to sync is the SHOP that owns the product, which this
+          panel does not know - it knows invoicing connections. A control that
+          synced the wrong connection would be worse than a link to the one
+          screen that does know. */}
+      {missingRateReason ? (
+        <div className="order-invoice-panel__body">
+          <p className="order-invoice-panel__notice">
+            {t(
+              'invoice.panel.fixAndRecheck',
+              'Rates are read during product sync, so a fix in the shop shows up on the next one.',
+            )}{' '}
+            <Link to="/products?taxRate=missing">
+              {t('invoice.panel.fixAndRecheckAction', 'Fix and re-check')}
+            </Link>
+          </p>
+        </div>
+      ) : null}
+
+      {/* #2254 — the conflict is INFORMATIONAL, never a block. The invoice
+          exists; the two systems simply disagree about the rate, and the shop's
+          won. `Alert` gives a non-error tone `role="status"`, which is the right
+          politeness level for an advisory nobody has to act on immediately. */}
+      {conflictLines.length > 0 ? (
+        <div className="order-invoice-panel__body">
+          <Alert tone="conflict">
+            <strong>
+              {t('invoice.panel.conflictTitle', "Invoiced on the shop's rate. The channel disagrees.")}
+            </strong>{' '}
+            {conflictLines
+              .map(
+                (line) =>
+                  `${line.name ?? line.sku ?? line.id}: shop ${String(line.taxRate)}, channel ${String(line.taxRateChannel)}`,
+              )
+              .join('; ')}
+            .
+          </Alert>
+        </div>
+      ) : null}
+
+      {/* #2254 — the shipping split preview lives HERE, not on the line-items
+          panel, because shipping has no order line: it is composed when the
+          document is. A single `waiting` row while any line rate is unknown,
+          since one unknown makes the proportion uncomputable. */}
+      {shippingSplitPreview}
 
       {/* The lock warning is about the pick, not about the primary — it must
           also show once the operator has picked on an install with NO primary,
@@ -768,14 +848,107 @@ export function OrderInvoicePanel({ order }: OrderInvoicePanelProps): ReactEleme
               tone="primary"
               onClick={handleIssue}
               disabled={
-                issueMutation.isPending || write.demoReadOnly || invoicingConnection === null
+                issueMutation.isPending ||
+                write.demoReadOnly ||
+                invoicingConnection === null ||
+                issueRefusal !== null
               }
             >
               {t('invoice.action.issue', 'Issue invoice')}
             </Button>
           </ReadOnlyLock>
+          {/* The reason sits ON the control, not only in the alert above: a
+              disabled button with no explanation beside it reads as a bug. */}
+          {issueRefusal ? (
+            <span className="text-muted" style={{ fontSize: '0.82rem' }}>
+              {issueRefusal}
+            </span>
+          ) : null}
         </div>
       ) : null}
     </section>
+  );
+}
+
+/**
+ * The lines with no tax rate, shaped for the remedy branches (#2254).
+ *
+ * "In the catalogue" is read off `productId`: a line OpenLinker resolved to an
+ * internal product can be fixed in the shop that owns it, while a line that
+ * resolved to none exists only as a marketplace offer - and fixing that offer
+ * cannot release THIS order, because the marketplace stamped the rate at
+ * purchase. Those are different instructions, so they cannot share a sentence.
+ */
+function collectRateLessLines(items: readonly ParsedOrderItem[]): RateLessLine[] {
+  return items
+    .filter((item) => !item.taxRate)
+    .map((item) => ({
+      name: item.name ?? item.sku ?? item.productId ?? item.id,
+      inCatalogue: Boolean(item.productId),
+      // The shop answered and its answer was ambiguous - distinguishable only
+      // because the read WAS made, which `taxSource` records.
+      ambiguousTaxClass: item.taxSource === 'shop',
+    }));
+}
+
+/**
+ * The shipping line(s) the document will carry (#2254).
+ *
+ * Rendered on the invoice panel rather than beside the order's line items,
+ * because shipping has no order line: it exists only once a document is being
+ * composed. One rate in the basket means one shipping line at that rate; a
+ * mixed basket means several, split in proportion to line gross.
+ *
+ * A single unknown line rate collapses the whole thing to one `waiting` row.
+ * Showing a partial split would state a proportion OpenLinker cannot compute,
+ * and the document is held anyway.
+ */
+function renderShippingSplitPreview(
+  items: readonly ParsedOrderItem[],
+  snapshot: Record<string, unknown>,
+  t: (key: string, fallback: string) => string,
+): ReactElement | null {
+  const totals = snapshot.totals as { shipping?: number; currency?: string } | undefined;
+  const shipping = totals?.shipping ?? 0;
+  if (!Number.isFinite(shipping) || shipping <= 0 || items.length === 0) return null;
+
+  const anyUnknown = items.some((item) => !item.taxRate);
+  if (anyUnknown) {
+    return (
+      <div className="order-invoice-panel__body">
+        <p className="order-invoice-panel__notice">
+          {t(
+            'invoice.panel.shippingSplitWaiting',
+            'Shipping is waiting with the document: it is split across the rates in the basket, and one line has no rate yet.',
+          )}
+        </p>
+      </div>
+    );
+  }
+
+  const grossByRate = new Map<string, number>();
+  for (const item of items) {
+    const rate = String(item.taxRate);
+    grossByRate.set(rate, (grossByRate.get(rate) ?? 0) + item.price * item.quantity);
+  }
+  if (grossByRate.size <= 1) return null;
+
+  const totalGross = [...grossByRate.values()].reduce((sum, gross) => sum + gross, 0);
+  if (totalGross <= 0) return null;
+
+  const parts = [...grossByRate.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .map(([rate, gross]) => ({
+      rate,
+      amount: Math.round(((shipping * gross) / totalGross) * 100) / 100,
+    }));
+
+  return (
+    <div className="order-invoice-panel__body">
+      <p className="order-invoice-panel__notice">
+        {t('invoice.panel.shippingSplit', 'Shipping is split across the rates in this basket:')}{' '}
+        {parts.map((part) => `${part.amount.toFixed(2)} at ${part.rate}%`).join(', ')}.
+      </p>
+    </div>
   );
 }

--- a/apps/web/src/features/invoicing/lib/sales-document-block-copy.ts
+++ b/apps/web/src/features/invoicing/lib/sales-document-block-copy.ts
@@ -49,6 +49,13 @@ export function resolveSalesDocumentBlockCopy(
   order: OrderRecord,
   derivedAmbiguity: boolean,
   t: (key: string, fallback: string) => string,
+  /**
+   * The rate-less lines, when the reason is `missing-tax-rate` (#2254).
+   *
+   * Passed in rather than re-derived, because the remedy depends on WHY a rate
+   * is absent and only the lines say which case this is. Omitted elsewhere.
+   */
+  rateLines: RateLessLine[] = [],
 ): SalesDocumentBlockCopy | null {
   const reason = order.salesDocumentBlockReason ?? null;
   const detail = order.salesDocumentBlockDetail ?? null;
@@ -137,9 +144,16 @@ export function resolveSalesDocumentBlockCopy(
     };
   }
 
+  if (reason === 'missing-tax-rate') {
+    return resolveMissingTaxRateCopy(rateLines, detail, t);
+  }
+
   if (reason === 'tax-rate-conflict') {
+    // Declared in the union but never written (#2245 F1): a shop-versus-channel
+    // disagreement does NOT block, so this arm only guards against a newer
+    // backend. Kept honest rather than deleted.
     return {
-      tone: 'error',
+      tone: 'conflict',
       title: t('invoice.panel.blockTaxRateTitle', 'Not invoiced: the tax rates disagree.'),
       body: t(
         'invoice.panel.blockTaxRateBody',
@@ -160,6 +174,99 @@ export function resolveSalesDocumentBlockCopy(
       'invoice.panel.blockUnknownBody',
       'OpenLinker declined to issue a document for this order. Issue it by hand if it should be invoiced.',
     ),
+    detail,
+    offerSetPrimary: false,
+  };
+}
+
+/**
+ * One line with no tax rate, as the panel knows it (#2254).
+ *
+ * `inCatalogue` is what separates the two hardest remedies: a product OL has
+ * mapped can be fixed in its shop, while an item that exists only as a
+ * marketplace offer cannot be released by fixing that offer at all - the
+ * marketplace stamped the rate at purchase.
+ */
+export interface RateLessLine {
+  name: string;
+  inCatalogue: boolean;
+  /** The shop answered, and its answer was ambiguous (several candidate rates). */
+  ambiguousTaxClass?: boolean;
+}
+
+/**
+ * The three remedy branches for a missing rate (#2254).
+ *
+ * One sentence would be wrong here, because the REASON a rate is absent decides
+ * the remedy and the three are not interchangeable:
+ *
+ *  1. blank on a mapped product - set it in the shop, and the fix releases this
+ *     order on the next sync;
+ *  2. the item is in no catalogue - fixing the offer will NOT release this
+ *     order, because the marketplace stamped the rate at purchase; the only
+ *     route is adding the item to a shop;
+ *  3. the shop's tax class is ambiguous - the rate table for the shop's own
+ *     country is what needs fixing, not the product.
+ *
+ * Plural-safe with a count, deliberately: a forty-line B2B order with six
+ * rate-less lines cannot be told about one product, and every other branch in
+ * this file is order-scoped and singular by nature.
+ */
+function resolveMissingTaxRateCopy(
+  lines: RateLessLine[],
+  detail: string | null,
+  t: (key: string, fallback: string) => string,
+): SalesDocumentBlockCopy {
+  const names = lines.map((line) => line.name).filter(Boolean);
+  const count = Math.max(names.length, 1);
+  const list = names.length > 0 ? names.join(', ') : t('invoice.panel.someLines', 'Some lines');
+
+  const uncatalogued = lines.filter((line) => !line.inCatalogue);
+  if (uncatalogued.length > 0 && uncatalogued.length === lines.length) {
+    const subject = uncatalogued.map((line) => line.name).join(', ');
+    return {
+      tone: 'error',
+      title:
+        uncatalogued.length === 1
+          ? `${t('invoice.panel.blockNoRateUncataloguedTitle', 'Not invoiced:')} ${subject} ${t('invoice.panel.blockNoRateUncataloguedTitleTail', 'is not in your catalogue.')}`
+          : `${t('invoice.panel.blockNoRateUncataloguedTitlePlural', 'Not invoiced:')} ${String(uncatalogued.length)} ${t('invoice.panel.blockNoRateUncataloguedTitlePluralTail', 'items are not in your catalogue.')}`,
+      body: t(
+        'invoice.panel.blockNoRateUncataloguedBody',
+        'The channel reported no rate at purchase, and fixing the offer now will not release this order. Add the item to a shop to release it.',
+      ),
+      detail,
+      offerSetPrimary: false,
+    };
+  }
+
+  if (lines.length > 0 && lines.every((line) => line.ambiguousTaxClass === true)) {
+    return {
+      tone: 'error',
+      title: `${t('invoice.panel.blockNoRateAmbiguousTitle', 'Not invoiced:')} ${String(count)} ${
+        count === 1
+          ? t('invoice.panel.blockNoRateAmbiguousTitleTail', 'line has an ambiguous tax class.')
+          : t('invoice.panel.blockNoRateAmbiguousTitleTailPlural', 'lines have an ambiguous tax class.')
+      }`,
+      body: t(
+        'invoice.panel.blockNoRateAmbiguousBody',
+        "The shop's tax class matches several rates for its own country, so OpenLinker cannot tell which one applies. Fix the rate table in the shop, not the product.",
+      ),
+      detail,
+      offerSetPrimary: false,
+    };
+  }
+
+  return {
+    tone: 'error',
+    title: `${t('invoice.panel.blockNoRateTitle', 'Not invoiced:')} ${String(count)} ${
+      count === 1
+        ? t('invoice.panel.blockNoRateTitleTail', 'line has no tax rate.')
+        : t('invoice.panel.blockNoRateTitleTailPlural', 'lines have no tax rate.')
+    }`,
+    body: `${list} ${t(
+      'invoice.panel.blockNoRateBody',
+      'have no rate in the shop, and the channel did not report one. Rates arrive with the product sync.',
+    )}`,
     detail,
     offerSetPrimary: false,
   };

--- a/apps/web/src/features/orders/api/order-snapshot.schema.ts
+++ b/apps/web/src/features/orders/api/order-snapshot.schema.ts
@@ -40,6 +40,24 @@ const orderItemSchema = z.object({
   sku: z.string().nullish(),
   name: z.string().nullish(),
   imageUrl: z.string().nullish(),
+  /**
+   * Per-line tax (#2054 / #2254). The neutral percent-as-string code, plus the
+   * provenance the column's caption needs.
+   *
+   * `taxSource` and `taxRateReadAt` are on the SNAPSHOT line rather than only on
+   * a line-item table, and that is what makes the column buildable: without
+   * them, *no rate*, *never read* and *pre-rollout* all arrive as the same
+   * `null` and a caption has no source to name.
+   *
+   * `taxRateChannel` is written only when the channel disagreed with the shop,
+   * so its presence IS the conflict - no client-side comparison, and nothing to
+   * get wrong when only one side answered.
+   */
+  taxRate: z.string().nullish(),
+  taxRateCountry: z.string().nullish(),
+  taxSource: z.enum(['shop', 'channel']).nullish(),
+  taxRateReadAt: z.string().nullish(),
+  taxRateChannel: z.string().nullish(),
 });
 
 /**

--- a/apps/web/src/features/orders/api/orders.types.ts
+++ b/apps/web/src/features/orders/api/orders.types.ts
@@ -226,6 +226,14 @@ export interface OrderRecord {
   salesDocumentUnresolvedReason?: SalesDocumentUnresolvedReasonValue | null;
   /** PII-free elaboration of the block reason (ids and counts only). */
   salesDocumentBlockDetail?: string | null;
+  /**
+   * When the current sales-document hold started (ISO 8601), or null (#2248).
+   * The only clock an operator-facing age can run on: the reason itself is
+   * level-triggered and nulled the moment it clears.
+   */
+  salesDocumentBlockedAt?: string | null;
+  /** When the current hold ended (ISO 8601), cleared when a new one starts. */
+  salesDocumentBlockReleasedAt?: string | null;
 }
 
 // Result ordering for the orders list (#927, extended #944). Mirrors
@@ -280,6 +288,20 @@ export interface OrderHealthSummary {
    * Optional for graceful degradation against an older API.
    */
   salesDocumentBlocked?: number;
+  /**
+   * Orders where the shop and the channel named DIFFERENT tax rates (#2254).
+   * Its OWN count, never inside `salesDocumentBlocked` — a conflict does not
+   * stop the invoice, so an order can be in conflict and perfectly healthy.
+   * Optional for graceful degradation against an older API.
+   */
+  taxRateConflict?: number;
+  /**
+   * When the oldest still-held order was held (ISO 8601), or `null`/absent when
+   * nothing is held (#2254). The blocked chip folds an age into its own label
+   * from this, rather than adding a third dotted badge to a row that already
+   * carries two SLA badges.
+   */
+  salesDocumentBlockedOldestAt?: string | null;
 }
 
 export interface OrderFilters {
@@ -306,6 +328,12 @@ export interface OrderFilters {
    * `health` — "synced AND invoicing blocked" is the common shape of the problem.
    */
   salesDocumentBlocked?: boolean;
+  /**
+   * Tax-rate conflict filter (#2254). A separate axis, and it has to be: the
+   * rows it finds are usually already invoiced, which is exactly why they are
+   * invisible in every other view.
+   */
+  taxRateConflict?: boolean;
 }
 
 /**

--- a/apps/web/src/features/orders/components/order-activity-timeline.tsx
+++ b/apps/web/src/features/orders/components/order-activity-timeline.tsx
@@ -75,6 +75,17 @@ interface OrderActivityTimelineProps {
    * see the shared rule on `invoicingBlockedBadge`.
    */
   invoice?: ParsedOrderInvoice | null;
+  /**
+   * When the current hold started (#2248). Dates the block entry, which was
+   * previously undated because no instant was persisted for it.
+   */
+  salesDocumentBlockedAt?: string | null;
+  /**
+   * When the hold ended. The release entry can only exist because of it: by the
+   * time an order is released the reason is gone, so nothing else records that
+   * it was ever held.
+   */
+  salesDocumentBlockReleasedAt?: string | null;
 }
 
 const STATUS_PAST_TENSE: Record<OrderSyncStatusValue, string> = {
@@ -118,6 +129,8 @@ function buildEvents(
   salesDocumentUnresolvedReason?: SalesDocumentUnresolvedReasonValue | null,
   salesDocumentBlockDetail?: string | null,
   invoice?: ParsedOrderInvoice | null,
+  salesDocumentBlockedAt?: string | null,
+  salesDocumentBlockReleasedAt?: string | null,
 ): TimelineEvent[] {
   const events: TimelineEvent[] = [];
 
@@ -227,10 +240,14 @@ function buildEvents(
     });
   });
 
-  // #2100 — appended last and DELIBERATELY UNDATED (`timestamp: null`): the block
-  // is a current-state fact re-decided on every transition, not a historical
-  // event, and no instant is persisted for it. Dating it with `createdAt` or
-  // `updatedAt` would assert a moment the data does not support.
+  // #2100 — appended last. It used to be DELIBERATELY UNDATED, because the block
+  // is a current-state fact re-decided on every transition and no instant was
+  // persisted for it; dating it with `createdAt` or `updatedAt` would have
+  // asserted a moment the data did not support.
+  //
+  // #2248 persists that instant, so the entry is dated when one exists and stays
+  // undated when it does not (an order held before the columns landed). The
+  // fallback is still `null` rather than a guess, for the original reason.
   // `invoice` is passed so the shared suppression rule applies here too: without
   // it this entry claimed "No invoice issued" directly under the panel showing the
   // issued invoice (#2100 review).
@@ -242,13 +259,33 @@ function buildEvents(
   if (blocked) {
     events.push({
       id: 'invoicing-blocked',
-      timestamp: null,
+      timestamp: salesDocumentBlockedAt ?? null,
       title: 'No invoice issued',
       by: 'system · invoicing',
       description: `${blocked.hint}${
         salesDocumentBlockDetail ? ` (${salesDocumentBlockDetail})` : ''
       }`,
       tone: BLOCK_TONE_FOR_BADGE[blocked.tone],
+    });
+  }
+
+  // #2254 — the RELEASE entry, which can only exist because the instant is
+  // persisted: by the time an order is released the reason itself is gone, so
+  // nothing else records that it was ever held. It is what answers "why did this
+  // suddenly issue".
+  //
+  // Rendered only when the hold has actually ended and nothing is blocking now -
+  // a released instant alongside a live block would be describing a previous
+  // episode, and the pair is cleared on each new one precisely so it cannot.
+  if (!blocked && salesDocumentBlockReleasedAt) {
+    events.push({
+      id: 'invoicing-released',
+      timestamp: salesDocumentBlockReleasedAt,
+      title: 'Rates arrived, invoice released',
+      by: 'system · invoicing',
+      description:
+        'The tax rate this order was waiting on is now known, so OpenLinker stopped holding the document.',
+      tone: 'success',
     });
   }
 
@@ -273,6 +310,8 @@ export function OrderActivityTimeline({
   salesDocumentUnresolvedReason,
   salesDocumentBlockDetail,
   invoice,
+  salesDocumentBlockedAt,
+  salesDocumentBlockReleasedAt,
 }: OrderActivityTimelineProps): ReactElement {
   const events = useMemo(
     () =>
@@ -286,6 +325,8 @@ export function OrderActivityTimeline({
         salesDocumentUnresolvedReason,
         salesDocumentBlockDetail,
         invoice,
+        salesDocumentBlockedAt,
+        salesDocumentBlockReleasedAt,
       ),
     [
       createdAt,
@@ -297,6 +338,8 @@ export function OrderActivityTimeline({
       salesDocumentUnresolvedReason,
       salesDocumentBlockDetail,
       invoice,
+      salesDocumentBlockedAt,
+      salesDocumentBlockReleasedAt,
     ],
   );
 

--- a/apps/web/src/features/orders/components/order-invoicing-cell.tsx
+++ b/apps/web/src/features/orders/components/order-invoicing-cell.tsx
@@ -27,7 +27,7 @@
 import type { ReactNode } from 'react';
 import { Link } from 'react-router-dom';
 import { StatusBadge } from '../../../shared/ui/status-badge';
-import { invoiceBadge, invoicingBlockedBadge } from '../lib/order-row';
+import { invoiceBadge, invoicingBlockedBadge, taxRateConflictBadge } from '../lib/order-row';
 import type { ParsedOrderInvoice } from '../api/order-snapshot.schema';
 import type {
   SalesDocumentGateBlockReasonValue,
@@ -48,6 +48,14 @@ export interface OrderInvoicingCellProps {
    * (mobile). Layout only — the parts and their conditions are identical.
    */
   layout: 'stack' | 'row';
+  /**
+   * The shop and the channel named different rates on at least one line
+   * (#2254). A FOURTH independent part, not a variant of the block badge:
+   * `invoicingBlockedBadge` suppresses itself whenever an invoice plausibly
+   * exists, and a conflict does not stop the invoice, so routing this through
+   * it would make it unrenderable on exactly the rows it describes.
+   */
+  hasTaxRateConflict?: boolean;
   /** Rendered when there is nothing at all to say. */
   emptyFallback: ReactNode;
 }
@@ -58,18 +66,20 @@ export function OrderInvoicingCell({
   blockReason,
   unresolvedReason,
   hasInvoicingCapability,
+  hasTaxRateConflict = false,
   layout,
   emptyFallback,
 }: OrderInvoicingCellProps): ReactNode {
   const inv = invoice ? invoiceBadge(invoice) : null;
   const blocked = invoicingBlockedBadge(blockReason, unresolvedReason, invoice);
+  const conflict = hasTaxRateConflict ? taxRateConflictBadge() : null;
 
   // An existing record — even a failed one — means the next step is Retry in the
   // invoice panel, not a fresh issue; so the CTA never sits beside an invoice
   // pill. `keepIssueAction` is true only for `trigger-model-manual`.
   const showCta = hasInvoicingCapability && !inv && (!blocked || blocked.keepIssueAction);
 
-  if (!inv && !blocked && !showCta) return emptyFallback;
+  if (!inv && !blocked && !conflict && !showCta) return emptyFallback;
 
   const cta = (
     <Link className="orders-row-cta" to={`/orders/${internalOrderId}#invoicing`}>
@@ -97,6 +107,22 @@ export function OrderInvoicingCell({
           <StatusBadge tone={blocked.tone} withDot compact>
             {blocked.label}
           </StatusBadge>
+        </span>
+      ) : null}
+      {conflict ? (
+        // Same shape as the block badge's, and for the same reason: this hint is
+        // the only statement of the fact on the list. Visible label plus the
+        // wording repeated in a visually-hidden span (the listings page's
+        // `RowBadge` pattern) - `aria-label` on a bare span is prohibited and
+        // commonly dropped, and `title` alone is unreachable by keyboard and
+        // absent on touch.
+        <span title={conflict.hint}>
+          <StatusBadge tone="conflict" withDot compact>
+            {conflict.label}
+          </StatusBadge>
+          <span className="sr-only">
+            {conflict.label}: {conflict.hint}
+          </span>
         </span>
       ) : null}
       {showCta ? cta : null}

--- a/apps/web/src/features/orders/components/order-line-items-panel.tsx
+++ b/apps/web/src/features/orders/components/order-line-items-panel.tsx
@@ -2,15 +2,31 @@
  * Order Line Items Panel
  *
  * Renders an order's parsed line items as a DataTable (product thumbnail +
- * name/SKU, qty, unit price, line total). The financial rollup lives in a
- * sibling `OrderTotalsPanel` (split in #382) so the summary stays visible
+ * name/SKU, tax rate, qty, unit price, line total). The financial rollup lives
+ * in a sibling `OrderTotalsPanel` (split in #382) so the summary stays visible
  * when items fail to parse.
+ *
+ * The tax-rate column (#2254) follows one rule: **an answer is text, only an
+ * exception is a badge.** A known rate, a zero and an exemption are all
+ * answers, so they read the way the money beside them reads - monospace,
+ * tabular, quiet - with a provenance caption underneath. Only *no rate* and
+ * *rate conflict* get colour. A green pill on every known rate would put three
+ * badges on every line of every order and spend attention on the base case,
+ * which is the opposite of what the badge is for.
+ *
+ * The column carries **no `hideBelow`**. This panel passes no `cardView`, so
+ * there is no card to keep four facts in - the class would simply delete the
+ * blocking state on a phone, on the one screen that diagnoses it.
  */
+import { useMemo, useRef, useState } from 'react';
 import type { ReactElement } from 'react';
 import { DataTable, type DataTableColumn } from '../../../shared/ui/data-table';
 import { EmptyState } from '../../../shared/ui/feedback-state';
 import { ProductThumbnail } from '../../../shared/ui/product-thumbnail';
 import { formatAmount } from '../../../shared/format/format-amount';
+import { AbsentValue } from '../../../shared/ui/absent-value';
+import { Button } from '../../../shared/ui/button';
+import { StatusBadge } from '../../../shared/ui/status-badge';
 import type { ParsedOrderItem, ParsedOrderTotals } from '../api/order-snapshot.schema';
 
 interface OrderLineItemsPanelProps {
@@ -24,6 +40,26 @@ interface OrderLineItemsPanelProps {
 
 export function OrderLineItemsPanel({ items, totals }: OrderLineItemsPanelProps): ReactElement {
   const currency = totals?.currency;
+  // Borrowed from the bulk review step rather than invented: a 200-line order
+  // gets an alert naming the offending lines and then leaves the operator to
+  // find them. Same two controls, same behaviour.
+  const [onlyFlagged, setOnlyFlagged] = useState(false);
+  const flaggedCursor = useRef(0);
+  const tableRef = useRef<HTMLDivElement>(null);
+
+  const flagged = useMemo(() => items.filter(isFlaggedLine), [items]);
+  const rows = onlyFlagged ? flagged : items;
+
+  function jumpToNextFlagged(): void {
+    if (flagged.length === 0) return;
+    const next = flagged[flaggedCursor.current % flagged.length];
+    flaggedCursor.current += 1;
+    const target = tableRef.current?.querySelector<HTMLElement>(
+      `[data-line-id="${CSS.escape(next.id)}"]`,
+    );
+    target?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    target?.focus?.();
+  }
 
   const columns: DataTableColumn<ParsedOrderItem>[] = [
     {
@@ -50,6 +86,11 @@ export function OrderLineItemsPanel({ items, totals }: OrderLineItemsPanelProps)
           </span>
         </span>
       ),
+    },
+    {
+      id: 'taxRate',
+      header: 'Tax rate',
+      cell: (item) => <TaxRateCell item={item} />,
     },
     {
       id: 'qty',
@@ -86,13 +127,102 @@ export function OrderLineItemsPanel({ items, totals }: OrderLineItemsPanelProps)
   }
 
   return (
-    <div className="order-line-items">
+    <div className="order-line-items" ref={tableRef}>
+      {flagged.length > 0 ? (
+        <div className="ds-row" style={{ gap: 'var(--space-2)', marginBottom: 'var(--space-2)' }}>
+          <Button
+            tone="secondary"
+            aria-pressed={onlyFlagged}
+            onClick={() => { setOnlyFlagged((v) => !v); }}
+          >
+            Only flagged
+          </Button>
+          <Button tone="ghost" onClick={jumpToNextFlagged}>
+            Jump to next flagged
+          </Button>
+        </div>
+      ) : null}
       <DataTable
         caption="Order line items"
         columns={columns}
-        rows={items}
+        rows={rows}
         rowKey={(item) => item.id}
       />
     </div>
   );
+}
+
+/** A line an operator has to act on: no rate at all, or two systems disagreeing. */
+function isFlaggedLine(item: ParsedOrderItem): boolean {
+  return !item.taxRate || Boolean(item.taxRateChannel);
+}
+
+/**
+ * One line's tax rate.
+ *
+ * Four renderings, and the split between them is the epic's central claim:
+ * a rate, a zero and an exemption are ANSWERS and read as text; only an absence
+ * and a disagreement are exceptions and get a badge.
+ */
+function TaxRateCell({ item }: { item: ParsedOrderItem }): ReactElement {
+  if (!item.taxRate) {
+    return (
+      <span className="order-line-item__product-info" data-line-id={item.id} tabIndex={-1}>
+        <StatusBadge tone="error" withDot compact>
+          No tax rate
+        </StatusBadge>
+        <span className="order-line-item__sku text-muted">set it in the shop</span>
+      </span>
+    );
+  }
+
+  if (item.taxRateChannel) {
+    return (
+      <span className="order-line-item__product-info" data-line-id={item.id} tabIndex={-1}>
+        <span className="mono-text">{formatRate(item.taxRate)}</span>
+        <StatusBadge tone="conflict" withDot compact>
+          Rate conflict
+        </StatusBadge>
+        <span className="order-line-item__sku text-muted">
+          shop {formatRate(item.taxRate)}, channel {formatRate(item.taxRateChannel)}
+        </span>
+      </span>
+    );
+  }
+
+  return (
+    <span className="order-line-item__product-info">
+      <span className="mono-text">{formatRate(item.taxRate)}</span>
+      <span className="order-line-item__sku text-muted">{provenanceCaption(item)}</span>
+    </span>
+  );
+}
+
+/**
+ * A numeric code reads as a percentage; an exemption code reads as itself.
+ * `'0'` renders as `0%` rather than as a dash - it is a rate, and the dash is
+ * reserved for absence (`AbsentValue`).
+ */
+function formatRate(code: string): string {
+  return /^[0-9.]+$/.test(code) ? `${code}%` : code;
+}
+
+/**
+ * Where the rate came from and when it was read. Shown rather than enforced:
+ * there is no freshness rule, because rate changes are announced ahead and do
+ * not apply retroactively.
+ */
+function provenanceCaption(item: ParsedOrderItem): ReactElement | string {
+  const from =
+    item.taxSource === 'shop'
+      ? 'from the shop'
+      : item.taxSource === 'channel'
+        ? 'from the channel'
+        : null;
+  if (!from) return <AbsentValue label="source not recorded" />;
+  if (!item.taxRateReadAt) return from;
+  const readAt = new Date(item.taxRateReadAt);
+  if (!Number.isFinite(readAt.getTime())) return from;
+  const days = Math.floor((Date.now() - readAt.getTime()) / 86_400_000);
+  return days >= 1 ? `${from} \u00b7 read ${String(days)} d ago` : `${from} \u00b7 read today`;
 }

--- a/apps/web/src/features/orders/components/order-totals-panel.tsx
+++ b/apps/web/src/features/orders/components/order-totals-panel.tsx
@@ -30,7 +30,17 @@ export function OrderTotalsPanel({ totals }: OrderTotalsPanelProps): ReactElemen
       ) : null}
       {totals.tax > 0 ? (
         <div className="order-totals__row">
-          <dt>Tax</dt>
+          {/* #2254 — this number is the CHANNEL's, and it will visibly disagree
+              with the per-line rates: Allegro and Erli report zero here, so a 5%
+              line rate can sit beside a tax total of 0.00. Nothing here computes
+              a replacement, so the row keeps its snapshot value and says whose
+              number it is rather than letting the reader assume it is OL's. */}
+          <dt>
+            Tax{' '}
+            <span className="text-muted" style={{ fontWeight: 400 }}>
+              as reported by the channel
+            </span>
+          </dt>
           <dd className="mono-text">{formatAmount(totals.tax, currency)}</dd>
         </div>
       ) : null}

--- a/apps/web/src/features/orders/index.ts
+++ b/apps/web/src/features/orders/index.ts
@@ -22,6 +22,10 @@
  * the feature that owns what an order identity looks like (#1996).
  */
 export { ordersQueryKeys } from './api/orders.query-keys';
+// #2254 — the invoice panel needs the parsed lines to decide WHICH remedy a
+// missing rate calls for; the reason alone cannot say.
+export { parseOrderSnapshot } from './api/order-snapshot.schema';
+export type { ParsedOrderItem } from './api/order-snapshot.schema';
 export type {
   OrderRecord,
   OrderFilters,

--- a/apps/web/src/features/orders/lib/order-row.ts
+++ b/apps/web/src/features/orders/lib/order-row.ts
@@ -250,3 +250,23 @@ const BADGE_BY_REASON = {
     keepIssueAction: false,
   },
 } satisfies Record<SalesDocumentGateBlockReasonValue, InvoicingBlockedBadge>;
+
+/**
+ * The rate-conflict badge (#2254, epic F1).
+ *
+ * Its OWN resolver, deliberately separate from `invoicingBlockedBadge`. That
+ * one returns `null` whenever `invoiceSupersedesBlock` holds - which it does for
+ * any invoice that plausibly exists - and a conflict does not stop the invoice,
+ * so the invoice always exists and the badge would never render. Routing this
+ * through the gate machinery would also double-count it inside
+ * `salesDocumentBlocked`, against its own chip.
+ *
+ * It takes no invoice argument at all, which is the point: an issued invoice is
+ * the ordinary case here, not a reason to suppress.
+ */
+export function taxRateConflictBadge(): { label: string; hint: string } {
+  return {
+    label: 'Rate conflict',
+    hint: "The invoice used the shop's rate; the channel reported a different one.",
+  };
+}

--- a/apps/web/src/pages/orders/order-detail-page.tsx
+++ b/apps/web/src/pages/orders/order-detail-page.tsx
@@ -462,6 +462,8 @@ export function OrderDetailPage(): ReactElement {
           salesDocumentUnresolvedReason={order.salesDocumentUnresolvedReason}
           salesDocumentBlockDetail={order.salesDocumentBlockDetail}
           invoice={snapshot.invoice}
+          salesDocumentBlockedAt={order.salesDocumentBlockedAt}
+          salesDocumentBlockReleasedAt={order.salesDocumentBlockReleasedAt}
         />
       </section>
 

--- a/apps/web/src/pages/orders/orders-list-page.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.tsx
@@ -260,6 +260,7 @@ const NARROWING_FILTER_URL_PARAM: Record<NarrowingOrderFilterKey, string> = {
   slaState: 'slaState',
   fulfillmentState: 'fulfillmentState',
   salesDocumentBlocked: 'invoicing',
+  taxRateConflict: 'taxRate',
 };
 
 /** Every URL param that narrows the result set — derived, not hand-maintained (#2148). */
@@ -274,6 +275,39 @@ const FILTER_PARAMS: readonly string[] = Object.values(NARROWING_FILTER_URL_PARA
  * all orders" button that cleared filters one at a time would leave all but the last one
  * applied.
  */
+/**
+ * The age clause the blocked chip folds into its own label (#2254).
+ *
+ * An age rather than only a count, because the cost of a held document is
+ * lateness and a bare "42" does not say whether that started this morning or a
+ * fortnight ago. It rides INSIDE the label rather than as a third dotted badge:
+ * this row already carries two SLA badges, and a third would compete with them
+ * for exactly the attention the SLA ones are for.
+ *
+ * Returns an empty string when nothing is held or the instant is unreadable -
+ * an absent age says less than a wrong one.
+ */
+/**
+ * Does any line record a channel rate that disagreed with the shop's (#2254)?
+ *
+ * `taxRateChannel` is written ONLY on disagreement, so its presence is the
+ * conflict - there is nothing to compare here, and nothing to get wrong when
+ * only one of the two systems answered.
+ */
+function hasTaxRateConflict(parsed: ReturnType<typeof parseOrderSnapshot>): boolean {
+  return parsed.items.some((item) => Boolean(item.taxRateChannel));
+}
+
+function blockedAgeSuffix(oldestAt: string | null | undefined): string {
+  if (!oldestAt) return '';
+  const heldSince = new Date(oldestAt).getTime();
+  if (!Number.isFinite(heldSince)) return '';
+  const days = Math.floor((Date.now() - heldSince) / 86_400_000);
+  if (days >= 1) return ` \u00b7 oldest ${String(days)} d`;
+  const hours = Math.floor((Date.now() - heldSince) / 3_600_000);
+  return hours >= 1 ? ` \u00b7 oldest ${String(hours)} h` : '';
+}
+
 function clearAllFilters(setSearchParams: SetURLSearchParams): void {
   setSearchParams((prev) => {
     const p = new URLSearchParams(prev);
@@ -315,6 +349,10 @@ export function OrdersListPage(): ReactElement {
   // `health` rather than replacing it. Present-only toggle: the URL never carries
   // `invoicing=false`, so the filter is either "blocked only" or absent.
   const invoicingBlocked = searchParams.get('invoicing') === 'blocked';
+  // #2254 — a THIRD axis, in its own param for the same reason: the rows it
+  // finds are usually already invoiced, so it composes with the other two
+  // rather than replacing either. Present-only, like its neighbour.
+  const rateConflict = searchParams.get('taxRate') === 'conflict';
   const offset = Number(searchParams.get('offset') ?? '0');
 
   // "Breaching soon / overdue" cutoff — stable per toggle (not recomputed each
@@ -340,6 +378,7 @@ export function OrdersListPage(): ReactElement {
     // never `false`, which would mean "hide blocked orders" and is not something
     // the UI offers.
     salesDocumentBlocked: invoicingBlocked ? true : undefined,
+    taxRateConflict: rateConflict ? true : undefined,
   };
   const pagination = { limit: PAGE_SIZE, offset };
 
@@ -958,6 +997,7 @@ export function OrdersListPage(): ReactElement {
                 blockReason={order.salesDocumentBlockReason}
                 unresolvedReason={order.salesDocumentUnresolvedReason}
                 hasInvoicingCapability={hasInvoicingCapability}
+                hasTaxRateConflict={hasTaxRateConflict(parsed)}
                 layout="stack"
                 emptyFallback={<span className="text-muted">—</span>}
               />
@@ -1067,6 +1107,24 @@ export function OrdersListPage(): ReactElement {
 
   /** Is the current view narrowed at all? Drives the empty-state copy (#2148). */
   const hasActiveFilters = FILTER_PARAMS.some((key) => searchParams.get(key) !== null);
+
+  /** #2254 — the conflict axis, same present-only shape as its two neighbours. */
+  function toggleRateConflict(): void {
+    captureDemoEvent('demo_orders_filtered', {
+      filter: 'tax_rate_conflict',
+      value: String(!rateConflict),
+    });
+    setSearchParams((prev) => {
+      const p = new URLSearchParams(prev);
+      if (rateConflict) {
+        p.delete('taxRate');
+      } else {
+        p.set('taxRate', 'conflict');
+      }
+      p.delete('offset');
+      return p;
+    });
+  }
 
   /** #2100 — mirrors `toggleBreaching`: an independent, present-only chip filter. */
   function toggleInvoicingBlocked(): void {
@@ -1276,7 +1334,23 @@ export function OrdersListPage(): ReactElement {
             Invoicing blocked
             {summary?.salesDocumentBlocked === undefined
               ? ''
-              : ` ${summary.salesDocumentBlocked}`}
+              : ` ${summary.salesDocumentBlocked}${blockedAgeSuffix(
+                  summary.salesDocumentBlockedOldestAt,
+                )}`}
+          </Chip>
+        ) : null}
+        {/* #2254 — its own count, and it mounts on `filterActive || count` for
+            the same nine-line reason the chip above does: gating on the count
+            alone unmounts the only way to clear the filter the moment
+            remediation succeeds. No tone: `.chip.chip--active` overrides every
+            `.chip--{tone}`, so an inactive `conflict` chip (96% lightness, hue
+            45) would read as pressed next to an active accent chip (96%, hue
+            60). The label and `aria-pressed` carry the state; the row badge
+            carries the semantics. */}
+        {rateConflict || summary?.taxRateConflict ? (
+          <Chip active={rateConflict} onClick={toggleRateConflict}>
+            Rate conflict
+            {summary?.taxRateConflict === undefined ? '' : ` ${summary.taxRateConflict}`}
           </Chip>
         ) : null}
         {/* SLA KPI affordance (#1108) — at-a-glance overdue / at-risk counts. */}
@@ -1319,6 +1393,28 @@ export function OrdersListPage(): ReactElement {
             action={
               <Button onClick={() => { clearAllFilters(setSearchParams); }}>
                 View all orders
+              </Button>
+            }
+          />
+        ) : rateConflict ? (
+          /*
+            #2254 — sits ABOVE both single-filter arms, because two of them can be
+            active at once. With the conflict filter and the invoicing filter both
+            on and no rows, an arm claiming "nothing is blocked from invoicing"
+            would be a statement about a set the other filter narrowed. So this
+            one says "in this view" and offers to clear.
+
+            `liveRegion` stays at the default `polite`, not `off`: like the
+            `hasActiveFilters` arm it sits beside, it is reached by a transition
+            from a loaded table rather than from the operator's own click on a
+            segment that already announced itself.
+          */
+          <EmptyState
+            title="No rate conflicts in this view"
+            message="The other filters are still applied. Clear them to check the whole list."
+            action={
+              <Button onClick={() => { clearAllFilters(setSearchParams); }}>
+                Clear filters
               </Button>
             }
           />
@@ -1561,6 +1657,7 @@ export function OrdersListPage(): ReactElement {
                             blockReason={order.salesDocumentBlockReason}
                             unresolvedReason={order.salesDocumentUnresolvedReason}
                             hasInvoicingCapability={hasInvoicingCapability}
+                            hasTaxRateConflict={hasTaxRateConflict(parsed)}
                             layout="row"
                             emptyFallback="—"
                           />

--- a/libs/core/src/orders/application/services/order-ingestion.service.ts
+++ b/libs/core/src/orders/application/services/order-ingestion.service.ts
@@ -711,6 +711,7 @@ export class OrderIngestionService implements IOrderIngestionService {
     taxRateCountry?: string;
     taxSource?: TaxRateSource;
     taxRateReadAt?: string;
+    taxRateChannel?: string;
   }> {
     let shopRate: StoredTaxRate | null = null;
     try {
@@ -724,11 +725,19 @@ export class OrderIngestionService implements IOrderIngestionService {
     }
 
     if (shopRate && taxRateState(shopRate) === 'known' && shopRate.code) {
+      // #2254 (epic F1): when the channel ALSO reported a rate and it differs,
+      // record the other number. The shop still wins and the document still
+      // issues - this is the evidence for a non-blocking conflict, not a veto.
+      // Recorded only on disagreement, so its presence IS the conflict and no
+      // reader has to compare two fields to find out.
+      const channelCode = item.taxRate?.trim();
+      const conflicts = Boolean(channelCode) && channelCode !== shopRate.code;
       return {
         taxRate: shopRate.code,
         ...(shopRate.countryIso2 ? { taxRateCountry: shopRate.countryIso2 } : {}),
         taxSource: 'shop',
         ...(shopRate.readAt ? { taxRateReadAt: shopRate.readAt.toISOString() } : {}),
+        ...(conflicts ? { taxRateChannel: channelCode } : {}),
       };
     }
 

--- a/libs/core/src/orders/domain/types/order-record.types.ts
+++ b/libs/core/src/orders/domain/types/order-record.types.ts
@@ -100,6 +100,21 @@ export interface OrderHealthSummary {
    * failure behind an invoicing one.
    */
   salesDocumentBlocked: number;
+  /**
+   * Orders where the shop and the channel named DIFFERENT tax rates (#2254).
+   *
+   * Its OWN count, not part of `salesDocumentBlocked`. A conflict does not stop
+   * the invoice, so an order can be in conflict and perfectly healthy - and
+   * folding it into the blocked count would print one number twice on the same
+   * screen while making its badge unreachable (epic F1).
+   */
+  taxRateConflict: number;
+  /**
+   * When the OLDEST still-held order was held (#2254), or `null` when nothing
+   * is held. Lets the blocked chip carry an age inside its label rather than
+   * adding a third dotted badge to a row that already has two SLA badges.
+   */
+  salesDocumentBlockedOldestAt: Date | null;
 }
 
 /**
@@ -207,6 +222,15 @@ export interface OrderRecordFilters {
    * blocked", which is the most common shape of the problem).
    */
   salesDocumentBlocked?: boolean;
+  /**
+   * Restrict to orders where the shop and the channel named different tax rates
+   * (#2254). `undefined` means "don't filter".
+   *
+   * A separate axis from `salesDocumentBlocked`, and it has to be: the rows it
+   * finds are usually INVOICED, which is exactly why they are invisible in
+   * every other view.
+   */
+  taxRateConflict?: boolean;
   /**
    * Result ordering (#927/#944/#1108). Maps to a SQL `ORDER BY` by
    * `OrderRecordRepository.applySort`. `dispatchBy` (ship-by deadline, NULLs

--- a/libs/core/src/orders/domain/types/order.types.ts
+++ b/libs/core/src/orders/domain/types/order.types.ts
@@ -291,6 +291,22 @@ export interface OrderItem {
    * ahead and do not apply retroactively (ADR-052 § 4).
    */
   taxRateReadAt?: string;
+
+  /**
+   * The rate the CHANNEL reported, recorded ONLY when it disagreed with the
+   * shop's (#2254, epic F1).
+   *
+   * Present means a conflict: the shop won, the document was issued on its
+   * rate, and this is the other number so the operator can see both and decide
+   * which system to correct. Absent means the two agreed, or only one of them
+   * answered - neither of which is a conflict.
+   *
+   * It is deliberately NOT a gate reason. `invoicingBlockedBadge` suppresses a
+   * badge whenever an invoice exists, and a non-blocking conflict always has
+   * one, so routing this through the block machinery would make it unrenderable
+   * on the very rows it describes.
+   */
+  taxRateChannel?: string;
 }
 
 /**

--- a/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
@@ -175,6 +175,17 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
       );
     }
 
+    if (filters.taxRateConflict !== undefined) {
+      // #2254 — its own axis, ANDed with the others exactly like
+      // `salesDocumentBlocked`: "issued AND the rates disagree" is the shape
+      // this filter exists to find, and it is invisible in every other view.
+      qb.andWhere(
+        filters.taxRateConflict
+          ? OrderRecordRepository.HAS_TAX_RATE_CONFLICT
+          : `NOT (${OrderRecordRepository.HAS_TAX_RATE_CONFLICT})`,
+      );
+    }
+
     this.applySort(qb, filters.sort, filters.dir);
 
     const [entities, total] = await qb.getManyAndCount();
@@ -229,6 +240,21 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
       .addSelect(
         `COUNT(*) FILTER (WHERE ${OrderRecordRepository.IS_SALES_DOCUMENT_BLOCKED})`,
         'sales_document_blocked'
+      )
+      // #2254 — its own count, so it is never inside `sales_document_blocked`.
+      // The two populations overlap freely: an order can be both blocked and in
+      // conflict, and printing one number twice is what the separate field
+      // avoids.
+      .addSelect(
+        `COUNT(*) FILTER (WHERE ${OrderRecordRepository.HAS_TAX_RATE_CONFLICT})`,
+        'tax_rate_conflict'
+      )
+      // #2254 — the oldest still-held order, so the chip label can carry an age
+      // rather than a bare count. MIN over the held population only; NULL when
+      // nothing is held, which the caller renders as no age clause at all.
+      .addSelect(
+        `MIN(rec."salesDocumentBlockedAt") FILTER (WHERE ${OrderRecordRepository.IS_SALES_DOCUMENT_BLOCKED})`,
+        'sales_document_blocked_oldest_at'
       );
 
     if (filters.sourceConnectionId) {
@@ -254,6 +280,8 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
       synced: string;
       awaiting_dispatch: string;
       sales_document_blocked: string;
+      tax_rate_conflict: string;
+      sales_document_blocked_oldest_at: Date | null;
     }>();
 
     return {
@@ -264,6 +292,8 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
       synced: Number(raw?.synced ?? 0),
       awaitingDispatch: Number(raw?.awaiting_dispatch ?? 0),
       salesDocumentBlocked: Number(raw?.sales_document_blocked ?? 0),
+      taxRateConflict: Number(raw?.tax_rate_conflict ?? 0),
+      salesDocumentBlockedOldestAt: raw?.sales_document_blocked_oldest_at ?? null,
     };
   }
 
@@ -369,6 +399,20 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
    * the IN-list replaced it. Coalescing to the empty string (never a valid reason)
    * keeps both directions two-valued.
    */
+  /**
+   * A line where the shop and the channel named DIFFERENT rates (#2254).
+   *
+   * `taxRateChannel` is written on a line only when the two disagreed, so its
+   * mere presence is the conflict - no comparison is needed here, and none is
+   * possible in SQL against a jsonb array without a lateral join.
+   *
+   * Deliberately NOT part of the block predicate: a conflict does not stop the
+   * invoice, so folding it in would both double-count it inside
+   * `salesDocumentBlocked` and route its badge through a resolver that
+   * suppresses itself whenever an invoice exists (epic F1).
+   */
+  private static readonly HAS_TAX_RATE_CONFLICT = `jsonb_path_exists(rec."orderSnapshot", '$.items[*].taxRateChannel')`;
+
   private static readonly IS_SALES_DOCUMENT_BLOCKED = `COALESCE(rec."salesDocumentBlockReason", '') IN (${SalesDocumentAttentionReasonValues.map(
     (reason) => `'${reason}'`,
   ).join(', ')})`;


### PR DESCRIPTION
Every tax-rate state on the orders surfaces, plus the backend contract two of them needed.

## Backend: the conflict gets its own field (epic F1)

Not a gate reason. `invoicingBlockedBadge` returns `null` whenever an invoice plausibly exists, and a conflict does not stop the invoice - so routing it through the block machinery would make the badge unreachable on exactly the rows it describes, and `SalesDocumentAttentionReasonValues` would have counted it inside `salesDocumentBlocked`, against its own chip.

The evidence is `taxRateChannel` on the order line, written **only** when the channel disagreed with the shop. Its presence *is* the conflict - no reader compares two fields, and nothing goes wrong when only one system answered. The summary also reports `salesDocumentBlockedOldestAt`, so the blocked chip can carry an age.

## Orders list

- A `Rate conflict` chip on its own count, mounting on `filterActive || count` for the nine-line reason the invoicing chip already documents.
- **No tone on it**: `.chip.chip--active` overrides every `.chip--{tone}`, so an inactive conflict chip would read as pressed beside an active accent one.
- The age folds **into the blocked chip's label** (`Invoicing blocked 42 · oldest 12 d`) rather than becoming a third dotted badge in a row that already carries two SLA badges.
- The conflict badge uses the listings page's `RowBadge` shape - visible label plus the wording in a visually-hidden span - because the hint is the only statement of the fact here.
- A new empty arm **above both single-filter arms**: with two filters active and no rows, "nothing is blocked from invoicing" would be a statement about a set the other filter narrowed. `liveRegion` stays `polite`.

## Order detail

A tax-rate column following the epic's central claim: **an answer is text, only an exception is a badge.** A rate, a zero and an exemption read the way the money beside them reads, with a provenance caption; only *no rate* and *conflict* get colour.

**No `hideBelow`** - this panel passes no `cardView`, so the class would simply delete the blocking state on a phone, on the one screen that diagnoses it. `Only flagged` and `Jump to next flagged` are borrowed from the bulk review step.

The totals panel's `Tax` row keeps its snapshot value and gains a caption naming whose number it is, because Allegro and Erli report zero there and it will visibly disagree with the line rates.

## Invoice panel

**Three remedy branches**, plural-safe with a count: a blank rate on a mapped product; an item in no catalogue (fixing the offer will *not* release this order - the marketplace stamped the rate at purchase); an ambiguous shop tax class (fix the rate table, not the product).

**The `Issue invoice` button is disabled with the reason on the control** (epic F2). It renders on `invoiceSettled && not-issued` independently of the block copy, so until now a red "will not be issued" alert sat above a live button that issues it - and the backend now answers 422.

The conflict alert is informational, landing on `role="status"` via the `conflict` tone. The shipping split preview lives here rather than beside the line items, because shipping has no order line; one unknown line rate collapses it to a single `waiting` row rather than showing a proportion OL cannot compute.

`Fix and re-check` names the latency and links to the products list rather than opening a sync dialog here: the connection to sync is the **shop** that owns the product, which this panel does not know.

## Timeline

The block entry is dated from the persisted instant instead of `timestamp: null`, and a **release** entry exists at all - by the time an order is released the reason is gone, so nothing else records that it was ever held.

Closes #2254
Refs #2245

🤖 Generated with [Claude Code](https://claude.com/claude-code)