### PR TITLE
feat(web): tax-rate states on products, publish wizards and the receipt panel

### DIFF
--- a/apps/api/src/products/http/dto/list-products-query.dto.ts
+++ b/apps/api/src/products/http/dto/list-products-query.dto.ts
@@ -54,6 +54,18 @@ export class ListProductsQueryDto {
   stock?: ProductStockFilter;
 
   @ApiPropertyOptional({
+    enum: ['missing', 'not-checked', 'known'],
+    description:
+      'Tax-rate read state (#2255): "missing" = the shop was asked and has no rate (the ' +
+      'population that holds documents), "not-checked" = nobody has asked yet (needs a product ' +
+      'sync, not a catalogue edit), "known" = a rate is on record, including a deliberate zero. ' +
+      'Keeping the first two apart is what stops day one reading as a catalogue-wide failure.',
+  })
+  @IsOptional()
+  @IsIn(['missing', 'not-checked', 'known'])
+  taxRateState?: 'missing' | 'not-checked' | 'known';
+
+  @ApiPropertyOptional({
     description:
       'CSV of connection IDs (#1720). Matches products having at least one variant with no ' +
       'Offer mapping for at least one of the given connections. Capped at 20 IDs.',

--- a/apps/api/src/products/http/dto/product-response.dto.ts
+++ b/apps/api/src/products/http/dto/product-response.dto.ts
@@ -59,6 +59,30 @@ export class ProductResponseDto {
   })
   features?: { name: string; value: string }[];
 
+  @ApiPropertyOptional({
+    nullable: true,
+    description:
+      'Neutral tax-rate code the shop stated (#2054): "23", "8", "5", "0", "zw", "np", "oo". ' +
+      'null means the shop stated none — which, paired with a non-null taxRateReadAt, is a ' +
+      'DIFFERENT fact from never having been asked.',
+  })
+  taxRate?: string | null;
+
+  @ApiPropertyOptional({
+    nullable: true,
+    description: 'ISO 3166-1 alpha-2 the rate was resolved against. Provenance only.',
+  })
+  taxRateCountry?: string | null;
+
+  @ApiPropertyOptional({
+    nullable: true,
+    description:
+      'When the shop was last asked for a rate (ISO 8601). null means NEVER — the only thing ' +
+      'that separates "the shop has no rate" from "nobody has looked", and on the day this ' +
+      'ships it is the whole catalogue.',
+  })
+  taxRateReadAt?: string | null;
+
   @ApiProperty({ description: 'Creation timestamp (ISO 8601)' })
   createdAt!: string;
 

--- a/apps/api/src/products/http/dto/product-variant-response.dto.ts
+++ b/apps/api/src/products/http/dto/product-variant-response.dto.ts
@@ -34,6 +34,23 @@ export class ProductVariantResponseDto {
       'Master variant price. Nullable when not yet synced or unavailable from the master source.',
   })
   price!: number | null;
+  @ApiPropertyOptional({
+    nullable: true,
+    description:
+      "The variant's OWN tax-rate override (#2054). null means no override — the product's " +
+      'rate applies — never "no rate". Only a master that keys tax per variant sets it.',
+  })
+  taxRate?: string | null;
+
+  @ApiPropertyOptional({ nullable: true, description: 'Provenance country of the override.' })
+  taxRateCountry?: string | null;
+
+  @ApiPropertyOptional({
+    nullable: true,
+    description: 'When the override was last read (ISO 8601); null when never read per variant.',
+  })
+  taxRateReadAt?: string | null;
+
 
   @ApiProperty({ description: 'Creation timestamp (ISO 8601)' })
   createdAt!: string;

--- a/apps/api/src/products/http/products.controller.ts
+++ b/apps/api/src/products/http/products.controller.ts
@@ -77,6 +77,13 @@ function variantToDto(variant: ProductVariant): ProductVariantResponseDto {
     // normalised to `null` at the wire boundary so the FE sees a consistent
     // nullable shape.
     price: variant.price ?? null,
+    // #2255 — the variant's own OVERRIDE, and only that. An absent override
+    // means the product's rate applies, which the table renders as "inherited"
+    // rather than as a gap; conflating the two would send the operator to fix
+    // the wrong record.
+    taxRate: variant.taxRate ?? null,
+    taxRateCountry: variant.taxRateCountry ?? null,
+    taxRateReadAt: variant.taxRateReadAt?.toISOString() ?? null,
     createdAt: variant.createdAt!.toISOString(),
     updatedAt: variant.updatedAt!.toISOString(),
   };
@@ -113,7 +120,7 @@ export class ProductsController {
     type: PaginatedProductsResponseDto,
   })
   async listProducts(@Query() query: ListProductsQueryDto): Promise<PaginatedProductsResponseDto> {
-    const { search, stock, connectionId, sort, dir, limit = 20, offset = 0 } = query;
+    const { search, stock, taxRateState, connectionId, sort, dir, limit = 20, offset = 0 } = query;
 
     const unlistedOnConnectionIds = this.parseUnlistedOn(query.unlistedOn);
     const sortSpec: ProductListSort | undefined = sort
@@ -121,7 +128,7 @@ export class ProductsController {
       : undefined;
 
     const { items, total } = await this.productsService.listProducts(
-      { search, stock, unlistedOnConnectionIds, sourceConnectionId: connectionId },
+      { search, stock, taxRateState, unlistedOnConnectionIds, sourceConnectionId: connectionId },
       { limit, offset },
       sortSpec
     );
@@ -328,6 +335,11 @@ export class ProductsController {
       images: product.images,
       categories: product.categories ?? null,
       ...(product.features ? { features: product.features } : {}),
+      // #2255 — `undefined` and `null` are collapsed to `null` here on purpose:
+      // the wire has one absence, and the STATE lives in `taxRateReadAt`.
+      taxRate: product.taxRate ?? null,
+      taxRateCountry: product.taxRateCountry ?? null,
+      taxRateReadAt: product.taxRateReadAt?.toISOString() ?? null,
       createdAt: product.createdAt!.toISOString(),
       updatedAt: product.updatedAt!.toISOString(),
     };

--- a/apps/web/src/features/allegro/lib/translate-allegro-error.ts
+++ b/apps/web/src/features/allegro/lib/translate-allegro-error.ts
@@ -41,6 +41,27 @@ type Translator = (error: StructuredError) => StructuredErrorTranslation;
  * prefix because Allegro's own docs use the full identifier.
  */
 const TRANSLATIONS: Record<string, Translator> = {
+  // #2255 / #2249. The adapter already puts the permitted values in the
+  // message, so this only frames whose entry is probably wrong: when Allegro
+  // says the category allows 23% and OpenLinker sent 5%, the shop record is the
+  // likelier mistake, and the shop is where a fix serves every channel.
+  TAX_RATE_NOT_ALLOWED_IN_CATEGORY: (error) => ({
+    message:
+      `${error.message ?? 'This Allegro category does not allow the tax rate on this product.'} ` +
+      'Correct the rate in the shop and re-sync the product; OpenLinker never publishes an offer ' +
+      'with the rate omitted.',
+  }),
+  TAX_RATE_MISSING: () => ({
+    message:
+      'No tax rate is known for this product, so the offer cannot state what tax it charges. ' +
+      "Add the rate in the shop's catalogue and re-sync the product.",
+  }),
+  TAX_RATE_NOT_EXPRESSIBLE: (error) => ({
+    message:
+      error.message ??
+      'This channel cannot express the tax code on this product. Set a rate the channel supports, ' +
+        'or list the product where the code is supported.',
+  }),
   SAFETY_INFO_NOT_DEFINED: () => ({
     message:
       "Allegro rejected the safety information for this category. Verify the discriminator (`type`) and re-save the connection's seller defaults. If the issue persists, the category likely requires a TEXT discriminator with substantive content rather than NO_SAFETY_INFORMATION.",

--- a/apps/web/src/features/fiscalization/components/order-receipt-panel.tsx
+++ b/apps/web/src/features/fiscalization/components/order-receipt-panel.tsx
@@ -49,6 +49,18 @@ import type { FiscalRegistrationRecord } from '../api/fiscalization.types';
 
 interface OrderReceiptPanelProps {
   orderId: string;
+  /**
+   * How many order lines carry no tax rate (#2255 / #2252).
+   *
+   * A fiscal receipt is refused for the same reason an invoice is, and it is
+   * the FIRST reason where refusing the MANUAL path is right too: registering
+   * anyway means a device stamping a tax letter nobody confirmed onto a receipt
+   * that reaches the buyer and the daily report and cannot be recalled.
+   *
+   * Passed in rather than re-derived here, because the panel reads the
+   * registration, not the order.
+   */
+  rateLessLineCount?: number;
 }
 
 function buildRegisteredFieldItems(
@@ -90,7 +102,10 @@ function buildRegisteredFieldItems(
   return items;
 }
 
-export function OrderReceiptPanel({ orderId }: OrderReceiptPanelProps): ReactElement | null {
+export function OrderReceiptPanel({
+  orderId,
+  rateLessLineCount = 0,
+}: OrderReceiptPanelProps): ReactElement | null {
   const { t } = useTranslation();
   const { showToast } = useToast();
   const connectionsQuery = useConnectionsQuery();
@@ -200,6 +215,24 @@ export function OrderReceiptPanel({ orderId }: OrderReceiptPanelProps): ReactEle
         <div className="order-receipt-panel__skeleton" aria-hidden="true" />
       ) : null}
 
+      {/* #2255 / #2252 — the same rule as the invoice, on the receipt path. The
+          per-connection tax letter is NOT used to fill the gap: a receipt
+          carrying an unconfirmed rate reaches the buyer and the daily report and
+          cannot be recalled, so the accepted cost is late registration. */}
+      {settled && displayStatus === 'not-registered' && rateLessLineCount > 0 ? (
+        <Alert tone="error">
+          <strong>
+            {rateLessLineCount === 1
+              ? t('fiscalReceipt.blockNoRateTitleOne', 'Not registered: 1 line has no tax rate.')
+              : `${t('fiscalReceipt.blockNoRateTitlePrefix', 'Not registered:')} ${String(rateLessLineCount)} ${t('fiscalReceipt.blockNoRateTitleSuffix', 'lines have no tax rate.')}`}
+          </strong>{' '}
+          {t(
+            'fiscalReceipt.blockNoRateBody',
+            "Add the rate in the shop's catalogue and re-sync the product. The connection's tax letter is not used to fill the gap.",
+          )}
+        </Alert>
+      ) : null}
+
       {/* ── not-registered: connection pick (when >1) + manual register ── */}
       {settled && displayStatus === 'not-registered' ? (
         <div className="order-receipt-panel__actions">
@@ -229,11 +262,20 @@ export function OrderReceiptPanel({ orderId }: OrderReceiptPanelProps): ReactEle
           ) : null}
           <Button
             tone="primary"
-            disabled={registerMutation.isPending}
+            disabled={registerMutation.isPending || rateLessLineCount > 0}
             onClick={() => handleRegister(selectedConnectionId || defaultConnectionId)}
           >
             {t('fiscalReceipt.action.register', 'Register receipt')}
           </Button>
+          {/* The reason sits ON the control. A disabled button with the
+              explanation only in an alert above reads as a bug. */}
+          {rateLessLineCount > 0 ? (
+            <span className="text-muted" style={{ fontSize: '0.82rem' }}>
+              {rateLessLineCount === 1
+                ? t('fiscalReceipt.refusedOne', 'no tax rate on 1 line')
+                : `${t('fiscalReceipt.refusedPrefix', 'no tax rate on')} ${String(rateLessLineCount)} ${t('fiscalReceipt.refusedSuffix', 'lines')}`}
+            </span>
+          ) : null}
         </div>
       ) : null}
 

--- a/apps/web/src/features/listings/components/bulk/bulk-blockers.ts
+++ b/apps/web/src/features/listings/components/bulk/bulk-blockers.ts
@@ -10,7 +10,20 @@
  */
 import type { StatusBadgeTone } from '../../../../shared/ui';
 
-export type ChipDescriptor = { tone: StatusBadgeTone; label: string; fixable: boolean };
+export type ChipDescriptor = {
+  tone: StatusBadgeTone;
+  label: string;
+  fixable: boolean;
+  /**
+   * The chip is a LINK out of the app rather than a dotted-underline button
+   * that opens the row editor (#2255). Used where the fix is not in OpenLinker
+   * at all - a rate managed on the channel is set in the channel's own panel.
+   *
+   * Rendered underlined solid, the same carve-out `AlreadyListedChip` makes, so
+   * it does not read as the editor affordance it is not.
+   */
+  link?: boolean;
+};
 
 /** Host-neutral blocker chips - labels + tones verbatim from the design. */
 export const NEUTRAL_BLOCKER_CHIPS: Record<string, ChipDescriptor> = {
@@ -22,6 +35,19 @@ export const NEUTRAL_BLOCKER_CHIPS: Record<string, ChipDescriptor> = {
   'no-master-stock': { tone: 'error', label: 'no master stock', fixable: true },
   'currency-mismatch': { tone: 'warning', label: 'currency mismatch', fixable: true },
   'already-listed': { tone: 'neutral', label: 'already listed', fixable: false },
+  // #2255 — SOFT, like every other blocker here: the flagged rows are excluded
+  // and the rest publish. A hard block would be a behaviour change to a shipped
+  // component for no gain, since the document gate catches a rate-less sale
+  // later anyway.
+  'no-tax-rate': { tone: 'error', label: 'No tax rate', fixable: true },
+  // Not fixable in OpenLinker: the rate lives on the channel, so the chip is a
+  // link out rather than an editor affordance.
+  'tax-rate-on-channel': {
+    tone: 'neutral',
+    label: 'rate managed on the channel',
+    fixable: false,
+    link: true,
+  },
 };
 
 export const FALLBACK_CHIP: ChipDescriptor = {

--- a/apps/web/src/features/products/api/products.api.ts
+++ b/apps/web/src/features/products/api/products.api.ts
@@ -42,6 +42,7 @@ function buildQuery(
   const params = new URLSearchParams();
   if (filters?.search) params.set('search', filters.search);
   if (filters?.stock) params.set('stock', filters.stock);
+  if (filters?.taxRateState) params.set('taxRateState', filters.taxRateState);
   if (filters?.unlistedOn && filters.unlistedOn.length > 0) {
     params.set('unlistedOn', filters.unlistedOn.join(','));
   }

--- a/apps/web/src/features/products/api/products.query-keys.ts
+++ b/apps/web/src/features/products/api/products.query-keys.ts
@@ -12,6 +12,7 @@ export const productsQueryKeys = {
       filters?.search ?? '',
       filters?.stock ?? 'any',
       filters?.unlistedOn?.join(',') ?? '',
+      filters?.taxRateState ?? '',
       filters?.connectionId ?? 'all',
       sort?.field ?? 'default',
       sort?.dir ?? 'default',

--- a/apps/web/src/features/products/api/products.types.ts
+++ b/apps/web/src/features/products/api/products.types.ts
@@ -26,6 +26,15 @@ export interface ProductVariant {
    * column on the next sync (no historical backfill — see #792 PR 1).
    */
   price: number | null;
+  /**
+   * The variant's OWN tax-rate override (#2255). `null` means NO OVERRIDE - the
+   * product's rate applies - never "no rate". Only a master that keys tax per
+   * variant sets it, so on PrestaShop every variant is null and the product's
+   * rate is the answer.
+   */
+  taxRate?: string | null;
+  taxRateCountry?: string | null;
+  taxRateReadAt?: string | null;
   createdAt: string;
   updatedAt: string;
   externalIds?: ExternalIdMapping[];
@@ -53,6 +62,14 @@ export interface Product {
    * the stock drawer). Absent/empty until a sync populates them.
    */
   features?: { name: string; value: string }[];
+  /**
+   * Neutral tax-rate code the shop stated (#2255), or `null` when it stated
+   * none. Paired with `taxRateReadAt`, which is what separates "the shop has no
+   * rate" from "nobody has asked yet" - the two need different remedies.
+   */
+  taxRate?: string | null;
+  taxRateCountry?: string | null;
+  taxRateReadAt?: string | null;
   createdAt: string;
   updatedAt: string;
   variants?: ProductVariant[];
@@ -88,6 +105,13 @@ export interface ProductFilters {
   unlistedOn?: string[];
   /** Source filter: product has a Product identifier mapping for this connection. */
   connectionId?: string;
+  /**
+   * Tax-rate read state (#2255). `missing` is the population that holds
+   * documents; `not-checked` needs a product sync rather than a catalogue edit,
+   * and on the day the feature ships it is the whole catalogue. Keeping them
+   * apart is what stops day one reading as a catalogue-wide failure.
+   */
+  taxRateState?: 'missing' | 'not-checked' | 'known';
 }
 
 /** Server-side sort axes for the products list (#1720). */

--- a/apps/web/src/features/products/lib/shop-product-url.test.ts
+++ b/apps/web/src/features/products/lib/shop-product-url.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { buildShopProductUrl } from './shop-product-url';
+
+describe('buildShopProductUrl', () => {
+  it('should build a WooCommerce editor link from the store base URL', () => {
+    expect(buildShopProductUrl('woocommerce', { baseUrl: 'https://shop.example' }, '42')).toBe(
+      'https://shop.example/wp-admin/post.php?post=42&action=edit',
+    );
+  });
+
+  it('should tolerate a trailing slash on the configured URL', () => {
+    expect(buildShopProductUrl('woocommerce', { baseUrl: 'https://shop.example/' }, '42')).toBe(
+      'https://shop.example/wp-admin/post.php?post=42&action=edit',
+    );
+  });
+
+  it('should return null for PrestaShop, where no URL is constructible', () => {
+    // The admin directory is randomised at install and editing needs a
+    // per-employee token. A guess would send the operator somewhere wrong.
+    expect(buildShopProductUrl('prestashop', { baseUrl: 'https://shop.example' }, '42')).toBeNull();
+  });
+
+  it('should return null when the store URL is not configured', () => {
+    expect(buildShopProductUrl('woocommerce', {}, '42')).toBeNull();
+    expect(buildShopProductUrl('woocommerce', undefined, '42')).toBeNull();
+  });
+
+  it('should return null with no external id to link to', () => {
+    expect(buildShopProductUrl('woocommerce', { baseUrl: 'https://shop.example' }, null)).toBeNull();
+  });
+});

--- a/apps/web/src/features/products/lib/shop-product-url.ts
+++ b/apps/web/src/features/products/lib/shop-product-url.ts
@@ -1,0 +1,55 @@
+/**
+ * Shop Product URL Helper (#2255)
+ *
+ * Builds a deep link to a product in the shop that owns it, or reports honestly
+ * that none can be built.
+ *
+ * **For PrestaShop there cannot be one.** The admin directory is randomised at
+ * install and editing needs a per-employee token, so any URL OpenLinker
+ * constructed would be a guess. WooCommerce is constructible, but only by
+ * reading the store base URL out of the untyped connection config.
+ *
+ * A `null` return is therefore a real answer, not a failure: the caller renders
+ * a copyable SKU and a plain sentence instead. A button whose href is a guess is
+ * worse than no button - it sends the operator somewhere wrong while looking
+ * like it knows where it is going.
+ *
+ * Precedent: `features/listings/lib/allegro-seller-panel-url.ts`, which is
+ * likewise a pure derivation with an honest `null`.
+ *
+ * @module apps/web/src/features/products/lib
+ */
+
+/**
+ * @param platformType - the connection's platform; anything but a shop OL can
+ *   link into returns `null`
+ * @param config - the connection's untyped config blob; WooCommerce's store URL
+ *   is read from it defensively, because nothing types it
+ * @param externalId - the product's id in that shop
+ */
+export function buildShopProductUrl(
+  platformType: string | undefined,
+  config: Record<string, unknown> | undefined,
+  externalId: string | null | undefined,
+): string | null {
+  if (!platformType || !externalId) return null;
+
+  if (platformType === 'woocommerce') {
+    const base = readStoreBaseUrl(config);
+    if (!base) return null;
+    // WordPress's post editor is stable across installs, unlike PrestaShop's
+    // admin directory - this is why one is constructible and the other is not.
+    return `${base}/wp-admin/post.php?post=${encodeURIComponent(externalId)}&action=edit`;
+  }
+
+  // PrestaShop and everything else: no constructible URL. Deliberate, and the
+  // caller's copy says so rather than rendering a dead link.
+  return null;
+}
+
+/** The store's public base URL, read defensively out of an untyped config. */
+function readStoreBaseUrl(config: Record<string, unknown> | undefined): string | null {
+  const candidate = config?.baseUrl ?? config?.storeUrl ?? config?.siteUrl;
+  if (typeof candidate !== 'string' || candidate.trim() === '') return null;
+  return candidate.trim().replace(/\/+$/, '');
+}

--- a/apps/web/src/pages/orders/order-detail-page.tsx
+++ b/apps/web/src/pages/orders/order-detail-page.tsx
@@ -431,7 +431,10 @@ export function OrderDetailPage(): ReactElement {
             <OrderInvoicePanel order={order} />
           </div>
           <div id="fiscal-receipt" tabIndex={-1}>
-            <OrderReceiptPanel orderId={order.internalOrderId} />
+            <OrderReceiptPanel
+              orderId={order.internalOrderId}
+              rateLessLineCount={snapshot.items.filter((item) => !item.taxRate).length}
+            />
           </div>
           <OrderCustomerCard customerId={order.customerId} sourceConnectionId={order.sourceConnectionId} />
         </div>

--- a/apps/web/src/pages/products/product-detail-page.tsx
+++ b/apps/web/src/pages/products/product-detail-page.tsx
@@ -316,6 +316,7 @@ export function ProductDetailPage(): ReactElement {
                 variants={variants}
                 stockByVariant={stockByVariant}
                 currency={product.currency}
+                productTaxRate={product.taxRate ?? null}
                 connections={offerCreatorConnections}
                 canCreateOffers={write.visible}
                 onCreateOffers={handleCreateOffers}

--- a/apps/web/src/pages/products/products-list-page.tsx
+++ b/apps/web/src/pages/products/products-list-page.tsx
@@ -43,6 +43,8 @@ import { Input } from '../../shared/ui/input';
 import { Chip } from '../../shared/ui/chip';
 import { Select } from '../../shared/ui/select';
 import { MetricCard } from '../../shared/ui/metric-card';
+import { KpiCard } from '../../shared/ui/kpi-card';
+import { Alert } from '../../shared/ui/alert';
 import { StatusBadge } from '../../shared/ui/status-badge';
 import { ProductThumbnail } from '../../shared/ui/product-thumbnail';
 import { TimeDisplay } from '../../shared/ui/time-display';
@@ -175,6 +177,16 @@ export function ProductsListPage(): ReactElement {
   const urlSearch = searchParams.get('search') ?? '';
   const rawStock = searchParams.get('stock');
   const stock = isStockFilter(rawStock) ? rawStock : undefined;
+  // #2255 — URL-synced like every other filter here, so the tile, the table and
+  // a shared link cannot disagree about what is being shown.
+  // Per SESSION, not persisted: a permanent dismissal removes the only route to
+  // the remedy with no way back (#2255).
+  const [suggestionDismissed, setSuggestionDismissed] = useState(false);
+  const rawTaxRateState = searchParams.get('taxRateState');
+  const taxRateState =
+    rawTaxRateState === 'missing' || rawTaxRateState === 'not-checked' || rawTaxRateState === 'known'
+      ? rawTaxRateState
+      : undefined;
   const unlistedOnParam = searchParams.get('unlistedOn') ?? '';
   const unlistedOn = useMemo(
     () => (unlistedOnParam ? unlistedOnParam.split(',').filter(Boolean) : undefined),
@@ -250,6 +262,16 @@ export function ProductsListPage(): ReactElement {
     [offerManagerConnections],
   );
   const gapsCsv = offerCreatorIds.join(',');
+  // #2255 — the tax-rate tile only means anything where a shop can be asked for
+  // a rate. With no ProductMaster connection, "312 products have no tax rate" is
+  // a statement about an install that was never going to have one.
+  const hasProductMaster = useMemo(
+    () =>
+      (connectionsQuery.data ?? []).some(
+        (c) => c.status === 'active' && c.supportedCapabilities?.includes('ProductMaster'),
+      ),
+    [connectionsQuery.data],
+  );
 
   // Unified publish targets (#1828): offer marketplaces (OfferCreator) OR
   // online shops (ProductPublisher), capability-driven. Drives the publish
@@ -301,6 +323,7 @@ export function ProductsListPage(): ReactElement {
   const filters: ProductFilters = {
     search: debouncedSearch || undefined,
     stock,
+    taxRateState,
     unlistedOn,
     connectionId: sourceConnectionId,
   };
@@ -326,6 +349,15 @@ export function ProductsListPage(): ReactElement {
   // (nav-counts precedent). The gaps probe is disabled with zero OfferCreator
   // connections (its filter would be meaningless).
   const allProbe = useProductsQuery(undefined, KPI_PROBE);
+  // #2255 — two probes, because the two states drive different remedies and
+  // must never be added together. `missing` is the tile; `not-checked` is the
+  // sync suggestion, and it is the whole catalogue on day one.
+  const noRateProbe = useProductsQuery({ taxRateState: 'missing' }, KPI_PROBE, undefined, {
+    enabled: hasProductMaster,
+  });
+  const notCheckedProbe = useProductsQuery({ taxRateState: 'not-checked' }, KPI_PROBE, undefined, {
+    enabled: hasProductMaster,
+  });
   const outProbe = useProductsQuery({ stock: 'out' }, KPI_PROBE);
   const lowProbe = useProductsQuery({ stock: 'low' }, KPI_PROBE);
   const gapsFilters = useMemo<ProductFilters>(
@@ -362,6 +394,14 @@ export function ProductsListPage(): ReactElement {
       setFilterParam('stock', stock === value ? '' : value);
     },
     [setFilterParam, stock],
+  );
+
+  /** #2255 — the tax-rate tile's filter, same present-only shape as its siblings. */
+  const toggleTaxRateState = useCallback(
+    (value: 'missing' | 'not-checked' | 'known'): void => {
+      setFilterParam('taxRateState', taxRateState === value ? '' : value);
+    },
+    [setFilterParam, taxRateState],
   );
 
   const toggleUnlistedOn = useCallback(
@@ -926,7 +966,61 @@ export function ProductsListPage(): ReactElement {
             />
           </button>
         ) : null}
+        {/* #2255 — `KpiCard`, not `MetricCard`: the latter is @deprecated with
+            "no new callers should be added". The tone is COMPUTED, so a healthy
+            install shows no colour at all - hardcoding `error` would paint a red
+            border around a zero. The "Not checked yet" tile is deliberately not
+            built: it reads zero forever after week one, costs a permanent grid
+            slot for a one-off migration, and would print the same number twice
+            forty pixels from the suggestion below. */}
+        {hasProductMaster ? (
+          <button
+            type="button"
+            className={[
+              'products-segment',
+              taxRateState === 'missing' ? 'products-segment--active' : '',
+            ]
+              .filter(Boolean)
+              .join(' ')}
+            aria-pressed={taxRateState === 'missing'}
+            onClick={() => {
+              toggleTaxRateState('missing');
+            }}
+          >
+            <KpiCard
+              label="No tax rate"
+              tone={(noRateProbe.data?.total ?? 0) > 0 ? 'error' : 'neutral'}
+              value={probeValue(noRateProbe.data?.total)}
+            />
+          </button>
+        ) : null}
       </div>
+
+      {/* #2255 — the sync suggestion. Four states, not one: idle, running,
+          no-shop-connected, and dismissed. Dismissal is per SESSION, because a
+          permanent one removes the only route to the remedy with no way back.
+          And it never claims a complete result - syncing is per connection while
+          "not checked" is per product, so a product mapped on two shops can be
+          half checked. */}
+      {hasProductMaster && !suggestionDismissed && (notCheckedProbe.data?.total ?? 0) > 0 ? (
+        <Alert
+          tone="info"
+          title={`${String(notCheckedProbe.data?.total ?? 0)} products have never been checked for a tax rate`}
+          action={
+            <Button
+              tone="ghost"
+              onClick={() => {
+                setSuggestionDismissed(true);
+              }}
+            >
+              Dismiss for this session
+            </Button>
+          }
+        >
+          Rates arrive with the ordinary product sync. Run one to find out which items have a rate
+          and which are missing it.
+        </Alert>
+      ) : null}
 
       {/* Filter rail — search + source select + chips, all URL-synced. Below
           1024px the chips/select/sort collapse behind a "Filters" toggle so

--- a/apps/web/src/pages/products/variant-stock-table.tsx
+++ b/apps/web/src/pages/products/variant-stock-table.tsx
@@ -37,6 +37,12 @@ interface VariantStockTableProps {
   stockByVariant: Map<string, InventoryItem>;
   /** Product currency, used to format the master variant price. */
   currency: string | null;
+  /**
+   * The PRODUCT's tax rate (#2255). A variant with no override of its own
+   * inherits it, and rendering that as an absence would send the operator to
+   * fix the wrong record.
+   */
+  productTaxRate?: string | null;
   /** Active OfferCreator connections — the coverage pill set is derived from these. */
   connections: readonly Connection[];
   /** Whether the "+ Create offer" CTA renders (write access, incl. demo). */
@@ -78,6 +84,7 @@ export function VariantStockTable(props: VariantStockTableProps): ReactElement {
           <tr>
             <th aria-hidden="true"></th>
             <th>Variant</th>
+            <th>Tax rate</th>
             <th>Stock</th>
             <th>Listings</th>
             <th className="data-table__cell--right">Price</th>
@@ -88,6 +95,7 @@ export function VariantStockTable(props: VariantStockTableProps): ReactElement {
             <VariantStockRow
               key={variant.id}
               variant={variant}
+              productTaxRate={props.productTaxRate ?? null}
               stock={props.stockByVariant.get(variant.id)}
               currency={props.currency}
               connections={props.connections}
@@ -568,6 +576,7 @@ function ListingDetailCard({
 
 function VariantStockRow({
   variant,
+  productTaxRate,
   stock,
   currency,
   connections,
@@ -576,6 +585,7 @@ function VariantStockRow({
   onListingsCount,
 }: {
   variant: ProductVariant;
+  productTaxRate: string | null;
   stock: InventoryItem | undefined;
   currency: string | null;
   connections: readonly Connection[];
@@ -612,6 +622,9 @@ function VariantStockRow({
             <span className="variant-stock-table__sku mono-text">{variantHeadline(variant)}</span>
             {meta ? <span className="variant-stock-table__meta">{meta}</span> : null}
           </div>
+        </td>
+        <td>
+          <VariantTaxRateCell variant={variant} productTaxRate={productTaxRate} />
         </td>
         <td>
           <span className="variant-stock-table__stock">
@@ -752,4 +765,54 @@ function VariantStockCard({
       ) : null}
     </div>
   );
+}
+
+/**
+ * One variant's tax rate (#2255).
+ *
+ * **Inherited is not the same as absent**, and drawing it as absent sends the
+ * operator to fix the wrong record. A variant with no override of its own takes
+ * the product's rate, so it renders that rate with an `inherited from the
+ * product` caption. Only a variant whose PRODUCT has no rate either shows the
+ * badge - and then the fix is on the product, not the variant.
+ *
+ * A present override wins outright, matching `effectiveTaxRate` on the backend:
+ * it is the more specific statement of the same fact, not a conflict.
+ */
+function VariantTaxRateCell({
+  variant,
+  productTaxRate,
+}: {
+  variant: ProductVariant;
+  productTaxRate: string | null;
+}): ReactElement {
+  if (variant.taxRate) {
+    return (
+      <span className="variant-stock-table__name">
+        <span className="mono-text">{formatTaxRate(variant.taxRate)}</span>
+        <span className="variant-stock-table__meta">variant override</span>
+      </span>
+    );
+  }
+  if (productTaxRate) {
+    return (
+      <span className="variant-stock-table__name">
+        <span className="mono-text">{formatTaxRate(productTaxRate)}</span>
+        <span className="variant-stock-table__meta">inherited from the product</span>
+      </span>
+    );
+  }
+  return (
+    <span className="variant-stock-table__name">
+      <StatusBadge tone="error" withDot compact>
+        No tax rate
+      </StatusBadge>
+      <span className="variant-stock-table__meta">product has none either</span>
+    </span>
+  );
+}
+
+/** A numeric code reads as a percentage; an exemption code reads as itself. */
+function formatTaxRate(code: string): string {
+  return /^[0-9.]+$/.test(code) ? `${code}%` : code;
 }

--- a/libs/core/src/products/domain/entities/product-variant.entity.ts
+++ b/libs/core/src/products/domain/entities/product-variant.entity.ts
@@ -47,4 +47,12 @@ export interface ProductVariant {
   isStale?: boolean;
   /** Timestamp of the most recent stale-marking; `null`/absent when live. */
   staleAt?: Date | null;
+  /**
+   * Per-variant tax-rate OVERRIDE (#2054). Absent means "no opinion" - the
+   * product's rate applies - never "no rate". Only a master that keys tax per
+   * variant writes it.
+   */
+  taxRate?: string | null;
+  taxRateCountry?: string | null;
+  taxRateReadAt?: Date | null;
 }

--- a/libs/core/src/products/domain/entities/product.entity.ts
+++ b/libs/core/src/products/domain/entities/product.entity.ts
@@ -53,4 +53,17 @@ export interface Product {
    * jsonb column (#1752).
    */
   features?: { name: string; value: string }[];
+  /**
+   * Neutral tax-rate code the ProductMaster stated (#2054), or `null` when it
+   * stated none. Persisted on the products table, written only by the tax read.
+   */
+  taxRate?: string | null;
+  /** ISO 3166-1 alpha-2 the rate was resolved against. Provenance only. */
+  taxRateCountry?: string | null;
+  /**
+   * When the master was last asked. `null` means NEVER - which is a different
+   * fact from "asked, and has no rate", and the only thing that tells them
+   * apart.
+   */
+  taxRateReadAt?: Date | null;
 }

--- a/libs/core/src/products/domain/types/product.types.ts
+++ b/libs/core/src/products/domain/types/product.types.ts
@@ -160,6 +160,19 @@ export interface ProductListFilters {
    * connection (#1720 - source filter).
    */
   sourceConnectionId?: string;
+
+  /**
+   * Tax-rate read state (#2255, ADR-052 § 4).
+   *
+   * Three values, because the third is what keeps the first honest:
+   *  - `missing` - the master was asked and has no rate. This is the population
+   *    that holds documents, and the one an operator fixes in the shop.
+   *  - `not-checked` - nobody has asked yet. It needs a product sync, not a
+   *    catalogue edit, and on the day the feature ships it is the whole
+   *    catalogue.
+   *  - `known` - a rate is on record (including a deliberate zero).
+   */
+  taxRateState?: 'missing' | 'not-checked' | 'known';
 }
 
 /**

--- a/libs/core/src/products/infrastructure/persistence/repositories/product-variant.repository.ts
+++ b/libs/core/src/products/infrastructure/persistence/repositories/product-variant.repository.ts
@@ -297,6 +297,11 @@ export class ProductVariantRepository implements ProductVariantRepositoryPort {
       price: entity.price !== null ? Number(entity.price) : undefined,
       isStale: entity.isStale,
       staleAt: entity.staleAt,
+      // #2255 — read surface for the variant table's rate column. An absent
+      // override is rendered as "inherited from the product", never as a gap.
+      taxRate: entity.taxRate,
+      taxRateCountry: entity.taxRateCountry,
+      taxRateReadAt: entity.taxRateReadAt,
       createdAt: entity.createdAt,
       updatedAt: entity.updatedAt,
     };

--- a/libs/core/src/products/infrastructure/persistence/repositories/product.repository.ts
+++ b/libs/core/src/products/infrastructure/persistence/repositories/product.repository.ts
@@ -77,6 +77,19 @@ export class ProductRepository implements ProductRepositoryPort {
       });
     }
 
+    if (filters.taxRateState) {
+      // #2255 — the three states are a partition of the catalogue, expressed
+      // against the two columns rather than a stored enum, so no writer can
+      // leave them disagreeing with the data they describe.
+      if (filters.taxRateState === 'missing') {
+        qb.andWhere('product."taxRateReadAt" IS NOT NULL AND product."taxRate" IS NULL');
+      } else if (filters.taxRateState === 'not-checked') {
+        qb.andWhere('product."taxRateReadAt" IS NULL');
+      } else {
+        qb.andWhere('product."taxRateReadAt" IS NOT NULL AND product."taxRate" IS NOT NULL');
+      }
+    }
+
     // Stock filter/sort needs the aggregated total; join the grouped
     // inventory_items subquery only when a caller asks for it. This is a
     // read-model reporting join by table name string (#1720) - importing the
@@ -227,6 +240,12 @@ export class ProductRepository implements ProductRepositoryPort {
       // Source-platform product-level attributes (#1752). DB `null` → omit
       // (optional + non-null on the domain interface).
       features: entity.features ?? undefined,
+      // #2255 — the read surface for the tax-rate state. `taxRateReadAt` is what
+      // separates "the shop has no rate" from "nobody has asked", so it travels
+      // with the code rather than being inferred from its absence.
+      taxRate: entity.taxRate,
+      taxRateCountry: entity.taxRateCountry,
+      taxRateReadAt: entity.taxRateReadAt,
       createdAt: entity.createdAt,
       updatedAt: entity.updatedAt,
     };


### PR DESCRIPTION
The surfaces where an operator **fixes** a rate, plus the read contract they needed.

## Backend

Product and variant tax rate reach the wire, with `taxRateReadAt` beside the code - the only thing separating "the shop has no rate" from "nobody has asked", and the two need different remedies. A `taxRateState` filter partitions the catalogue into `missing` / `not-checked` / `known`, expressed against the two columns rather than a stored enum, so no writer can leave them disagreeing with the data they describe.

## Products

**One `KpiCard` tile**, not `MetricCard` - that one is `@deprecated` with "no new callers should be added". The tone is **computed**, so a healthy install shows no colour; hardcoding it would paint a red border around a zero. It renders only where a `ProductMaster` connection exists: with no shop to ask, "312 products have no tax rate" is a statement about an install that was never going to have one.

**The "Not checked yet" tile is deliberately not built.** It reads zero forever after week one, costs a permanent grid slot for a one-off migration, and would print the same number twice forty pixels from the suggestion beneath it.

The **sync suggestion** is dismissible **per session** - a permanent dismissal removes the only route to the remedy with no way back. It never claims a complete result either: syncing is per connection while "not checked" is per product, so a product mapped on two shops can be half checked.

## Variants

**Inherited is not the same as absent**, and drawing it as absent sends the operator to fix the wrong record. A variant with no override renders the *product's* rate with an `inherited from the product` caption; only a variant whose product has no rate either shows the badge. A present override wins outright, matching `effectiveTaxRate` on the backend.

## Publish wizards

Two blocker chips, and the path stays **soft** like every other blocker there: the flagged rows are excluded and the rest publish. A hard block would be a behaviour change to a shipped component for no gain, since the document gate catches a rate-less sale later anyway.

The channel-managed chip is a **link**, not the dotted-underline button that opens the editor - the same carve-out `AlreadyListedChip` makes, because the fix is not in OpenLinker at all.

Three new rejection codes are translated for `StructuredErrorList`, which renders the dotted path and the code chip unchanged. The messages name **whose entry is probably wrong**: when Allegro says the category allows 23% and OL sent 5%, the shop record is the likelier mistake.

## Receipt panel

The register button refuses with the reason **on the control**, and an alert says the connection's tax letter is **not** used to fill the gap - the whole point of #2252, and the thing an operator would otherwise assume.

## `buildShopProductUrl`

A real link for WooCommerce, an honest `null` for PrestaShop - where no URL is constructible, because the admin directory is randomised at install and editing needs a per-employee token. A button whose href is a guess is worse than no button.

Closes #2255
Refs #2245

🤖 Generated with [Claude Code](https://claude.com/claude-code)