### PR TITLE
feat(integrations): remove the hardcoded tax-rate defaults from the providers

### DIFF
--- a/libs/core/src/invoicing/application/mappers/order-to-issue-invoice-command.mapper.spec.ts
+++ b/libs/core/src/invoicing/application/mappers/order-to-issue-invoice-command.mapper.spec.ts
@@ -102,6 +102,9 @@ describe('toIssueInvoiceCommand', () => {
 
     expect(cmd.currency).toBe('EUR');
     expect(cmd.lines).toHaveLength(3);
+    // An empty rate here is the honest passthrough of an order line that never
+    // got one, NOT a default (#2257): the mapper names no rate of its own, and
+    // the gate refuses such an order before it reaches a provider.
     expect(cmd.lines[0]).toEqual({ name: 'Named', quantity: 2, unitPriceGross: 10, taxRate: '' });
     expect(cmd.lines[1].name).toBe('SKU-9');
     expect(cmd.lines[2].name).toBe('PID-5');
@@ -296,7 +299,11 @@ describe('toIssueInvoiceCommand', () => {
     expect(gross).toBeCloseTo(order.totals.total, 2);
   });
 
-  it('shipping: taxRate left empty on the shipping line (provider adapter resolves the regime rate)', () => {
+  it('shipping: an empty line rate leaves the shipping rate empty rather than guessing (#2257)', () => {
+    // Reworded, not relaxed. It used to read "the provider adapter resolves the
+    // regime rate", which is no longer true - no adapter substitutes one. The
+    // shipping line is still EMITTED (dropping it would understate the total)
+    // and still carries an empty rate, and the gate refuses the whole document.
     const order = makeOrder({
       totals: { subtotal: 100, tax: 0, shipping: 15, total: 115, currency: 'PLN', taxTreatment: 'inclusive' },
     });
@@ -306,6 +313,20 @@ describe('toIssueInvoiceCommand', () => {
     const shippingLine = cmd.lines.find((l) => l.name === 'Shipping');
     expect(shippingLine).toBeDefined();
     expect(shippingLine?.taxRate).toBe('');
+  });
+
+  it('shipping: inherits the basket rate when every line carries the same one (#2248)', () => {
+    const order = makeOrder({
+      items: [
+        { id: 'i1', productId: 'p1', quantity: 1, price: 100, taxRate: '23' },
+      ],
+      totals: { subtotal: 100, tax: 0, shipping: 15, total: 115, currency: 'PLN', taxTreatment: 'inclusive' },
+    });
+
+    const cmd = toIssueInvoiceCommand({ order, connectionId: 'conn-1' });
+
+    const shippingLine = cmd.lines.find((l) => l.name === 'Shipping');
+    expect(shippingLine?.taxRate).toBe('23');
   });
 
   it.each([

--- a/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-invoicing.adapter.spec.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-invoicing.adapter.spec.ts
@@ -23,6 +23,7 @@ import {
   BuyerProfile,
   CURRENCY_REJECTION_MARKERS,
   FractionalTaxRateNotationError,
+  MissingTaxRateException,
   InvoiceRecord,
   UnsupportedRegulatoryDocumentKindError,
 } from '@openlinker/core/invoicing';
@@ -573,26 +574,32 @@ describe('InfaktInvoicingAdapter', () => {
       expect(CURRENCY_REJECTION_MARKERS.some((marker) => haystack.includes(marker))).toBe(true);
     });
 
-    it('should default an empty taxRate to the Polish standard VAT rate (regime-rate fallback)', async () => {
-      // Core always leaves InvoiceLine.taxRate empty (documented contract:
-      // "the provider adapter resolves the regime rate"). Verified live
-      // (2026-07-01): an empty tax_symbol cascades into services.gross /
-      // value.tax_values rejections too — every real order line hit this.
+    it('should refuse an empty taxRate rather than defaulting it (#2257)', async () => {
+      // INVERTED deliberately. This test used to lock the 23% fallback in place;
+      // that fallback is the thing #2245 exists to remove. A silent 23% is
+      // indistinguishable from a confirmed 23% on the issued document, and the
+      // whole cost of being wrong lands on the seller.
+      //
+      // The old live finding still holds and is why nothing is lost: an empty
+      // tax_symbol cascades into services.gross / value.tax_values rejections
+      // (verified 2026-07-01), so a rate-less line was never going to produce a
+      // document anyway. It now fails naming the product instead of a wire field.
       http.seed('POST', 'invoices.json', invoiceFixture());
 
-      await adapter.issueInvoice({ ...baseCmd, lines: [{ name: 'Widget', quantity: 1, unitPriceGross: 123, taxRate: '' }] });
+      await expect(
+        adapter.issueInvoice({
+          ...baseCmd,
+          lines: [{ name: 'Widget', quantity: 1, unitPriceGross: 123, taxRate: '' }],
+        }),
+      ).rejects.toBeInstanceOf(MissingTaxRateException);
 
-      const invoiceCall = http.calls.find((c) => c.method === 'POST' && c.path === 'invoices.json');
-      const services = (invoiceCall?.body as { invoice: { services: Array<{ tax_symbol: string; unit_net_price: number }> } })
-        .invoice.services;
-      expect(services[0].tax_symbol).toBe('23');
-      expect(services[0].unit_net_price).toBe(10000);
+      // And nothing was sent: the refusal is local, so no draft is left behind.
+      expect(http.calls.find((c) => c.method === 'POST' && c.path === 'invoices.json')).toBeUndefined();
     });
 
     it('should read "23" as twenty-three percent when splitting gross into net (#2247)', async () => {
       // Percent-as-string is the neutral contract. 123 gross at 23% is 100.00
-      // net, i.e. 10000 groszy - the same figure the empty-rate fallback
-      // produces, which is what makes the two readings comparable at all.
+      // net, i.e. 10000 groszy.
       http.seed('POST', 'invoices.json', invoiceFixture());
 
       await adapter.issueInvoice({

--- a/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
@@ -55,6 +55,7 @@ import {
   taxRatePercentToFraction,
 } from '@openlinker/core/invoicing';
 import type { IssuedDocumentLineAmounts } from '@openlinker/core/invoicing';
+import { MissingTaxRateException, findMissingTaxRate } from '@openlinker/core/invoicing';
 import type { IInfaktHttpClient } from '../http/infakt-http-client.interface';
 import { InfaktApiError } from '../../domain/exceptions/infakt-api.error';
 import type {
@@ -235,16 +236,24 @@ function toInfaktEmailLocale(locale: InvoiceEmailLocale | undefined): string | u
 }
 
 /**
- * Poland's standard VAT rate — the "regime rate" the adapter is documented
- * (`order-to-issue-invoice-command.mapper.ts`) to resolve when core leaves
- * `InvoiceLine.taxRate` empty, which it always does today (core never names
- * a tax rate on the order contract). Verified live (2026-07-01): an empty
- * `tax_symbol` doesn't just get rejected on its own field — Infakt cascades
- * it into `services.gross` / `value.tax_values` errors too, so EVERY line on
- * EVERY invoice 422'd before this fallback existed.
+ * There is no default any more (#2257).
+ *
+ * This adapter used to substitute Poland's standard 23% whenever core left
+ * `InvoiceLine.taxRate` empty - which it always did, because core had no
+ * per-line rate to give. That guess is what the whole #2245 epic exists to
+ * remove: a silent 23% is indistinguishable from a confirmed 23% on the issued
+ * document, and the entire cost of being wrong lands on the seller.
+ *
+ * Core now refuses an issuance whose lines do not all name a rate, so an empty
+ * value should never reach here. The guard below is defence in depth, and it
+ * FAILS rather than filling the gap.
+ *
+ * The historical note is worth keeping: an empty `tax_symbol` does not merely
+ * get rejected on its own field - inFakt cascades it into `services.gross` /
+ * `value.tax_values` errors too (verified live, 2026-07-01), so a rate-less
+ * line was never going to produce a document either way. The difference is that
+ * the failure now names the product instead of a wire field.
  */
-const DEFAULT_PL_VAT_SYMBOL = '23';
-const DEFAULT_PL_VAT_RATE = 0.23;
 
 /**
  * Maps a neutral taxRate string to an Infakt `tax_symbol`.
@@ -276,7 +285,7 @@ function toInfaktTaxSymbol(taxRate: string): string {
     case 'oo':
       return 'np';
     default:
-      return code === '' ? DEFAULT_PL_VAT_SYMBOL : code;
+      return code;
   }
 }
 
@@ -288,12 +297,11 @@ function toInfaktTaxSymbol(taxRate: string): string {
  * 100 and throws on fractional input. The old `n > 1` heuristic that lived here
  * accepted both spellings and, as a side effect, read a genuine 1% rate as 100%.
  *
- * Must stay consistent with `toInfaktTaxSymbol`'s empty-string fallback — a
- * mismatched net/gross split for the declared tax_symbol is itself rejected
- * by Infakt as an invalid `value.tax_values`.
+ * An empty rate no longer resolves to anything (#2257) - the caller refuses such
+ * a command before reaching this function, so there is nothing left to be
+ * consistent with.
  */
 function taxRateNumeric(taxRate: string): number {
-  if (taxRate.trim() === '') return DEFAULT_PL_VAT_RATE;
   return taxRatePercentToFraction(taxRate) ?? 0;
 }
 
@@ -544,6 +552,11 @@ export class InfaktInvoicingAdapter
   }
 
   async issueInvoice(cmd: IssueInvoiceCommand): Promise<IssueInvoiceResult> {
+    // #2257 — defence in depth. Core refuses a rate-less command before the
+    // adapter is reached, so this should be unreachable; it exists because the
+    // alternative to failing here is silently substituting a rate onto a real
+    // fiscal document, which is exactly what this change removes.
+    assertEveryLineHasATaxRate(cmd);
     const { lines, documentType, idempotencyKey, orderId } = cmd;
     // Resolved BEFORE the client upsert so a malformed currency costs no
     // provider round-trip and cannot leave a freshly-created client behind.
@@ -1349,4 +1362,19 @@ export class InfaktInvoicingAdapter
   private sleep(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
   }
+}
+
+/**
+ * Refuse a command whose lines do not all name a tax rate (#2257).
+ *
+ * The provider defaults are gone, so a rate-less line has nowhere to resolve
+ * to. Raising the same neutral exception core does keeps the failure legible at
+ * every layer - and keeps its existing 422 mapping - rather than surfacing as an
+ * inFakt wire-field rejection nobody can act on.
+ */
+function assertEveryLineHasATaxRate(cmd: IssueInvoiceCommand): void {
+  const finding = findMissingTaxRate(
+    cmd.lines.map((line) => ({ productId: line.name, taxRate: line.taxRate })),
+  );
+  if (finding) throw new MissingTaxRateException(cmd.orderId, finding);
 }

--- a/libs/integrations/ksef/README.md
+++ b/libs/integrations/ksef/README.md
@@ -65,7 +65,7 @@ never echoed back.
 | Field | Values | Notes |
 |---|---|---|
 | `env` | `"test"` \| `"demo"` \| `"prod"` | `test` → `api-test.ksef.mf.gov.pl/v2`; `demo` → `api-demo.ksef.mf.gov.pl/v2`; `prod` → `api.ksef.mf.gov.pl/v2` |
-| `seller` | Object | Seller identity (`Podmiot1`) stamped on every FA(3): `nip`, `name`, `address { line1, line2?, city, postalCode, countryIso2 }`, optional `defaultTaxRate`. Optional at create time, required before the connection can issue |
+| `seller` | Object | Seller identity (`Podmiot1`) stamped on every FA(3): `nip`, `name`, `address { line1, line2?, city, postalCode, countryIso2 }`. Optional at create time, required before the connection can issue. (`defaultTaxRate` was retired in #2257 — the rate comes from the ProductMaster and no adapter substitutes one; a leftover value is ignored.) |
 | `payment` | Object (optional) | Default payment details emitted as the FA(3) `Platnosc` block: `formaPlatnosci`, `paymentTermDays`, `bankAccount { nrRb, bankName?, swift? }`, `skonto { amount, conditions }`. See [docs/setup-guide.md](./docs/setup-guide.md) |
 
 ## Documentation

--- a/libs/integrations/ksef/src/application/factories/ksef-adapter.factory.ts
+++ b/libs/integrations/ksef/src/application/factories/ksef-adapter.factory.ts
@@ -32,7 +32,6 @@ import { KsefInvoicingAdapter } from '../../infrastructure/adapters/ksef-invoici
 import { createKsefHttpClient } from '../../infrastructure/http/ksef-http-client.factory';
 import { KsefSessionCryptoService } from '../../infrastructure/crypto/ksef-session-crypto.service';
 import { Fa3WithValidationBuilder } from '../../infrastructure/fa3/builders/fa3-with-validation.builder';
-import { DEFAULT_FA3_TAX_RATE } from '../../infrastructure/fa3/domain/fa3-tax-rate.mapper';
 import type { Fa3PaymentInput, SellerProfile } from '../../infrastructure/fa3/domain/fa3-xml.types';
 import type { KsefTokenAuthMaterial } from '../../infrastructure/http/auth/ksef-auth-handshake.service';
 import type {
@@ -62,7 +61,6 @@ export class KsefAdapterFactory implements IKsefAdapterFactory {
     const authMaterial = this.resolveAuthMaterial(connection, credentials);
 
     const seller = this.resolveSeller(connection);
-    const defaultTaxRate = this.resolveDefaultTaxRate(connection);
     const payment = this.resolvePayment(connection);
     const defaultLineUnit = this.resolveDefaultLineUnit(connection);
     const numberingTimeZone = this.resolveNumberingTimeZone(connection);
@@ -87,7 +85,6 @@ export class KsefAdapterFactory implements IKsefAdapterFactory {
         sessionCrypto,
         fa3Builder,
         seller,
-        defaultTaxRate,
         { payment, defaultLineUnit, numberingTimeZone },
       ),
     };
@@ -144,18 +141,6 @@ export class KsefAdapterFactory implements IKsefAdapterFactory {
     };
   }
 
-  /**
-   * Resolve the connection-level fallback `P_12` neutral code (adapter-scoped
-   * issuance policy, not seller identity — see `Fa3MappingContext.defaultTaxRate`).
-   * The `.trim() ||` fallback is defensive for configs saved before the
-   * `ksef.publicapi.v2` shape validator started rejecting a whitespace-only
-   * `seller.defaultTaxRate` (#1291) — a post-validation config can never
-   * actually hit the empty branch, but a pre-existing row could.
-   */
-  private resolveDefaultTaxRate(connection: Connection): string {
-    const config = connection.config as Partial<KsefConnectionConfig> | undefined;
-    return config?.seller?.defaultTaxRate?.trim() || DEFAULT_FA3_TAX_RATE;
-  }
 
   /**
    * Resolve the connection-level default unit of measure (`P_8A`, #1525) from

--- a/libs/integrations/ksef/src/domain/types/ksef-connection.types.ts
+++ b/libs/integrations/ksef/src/domain/types/ksef-connection.types.ts
@@ -47,11 +47,19 @@ export interface KsefSellerConfig {
     countryIso2: string;
   };
   /**
-   * Neutral tax-rate code (an `FA3_TAX_RATE_MAP` key, e.g. `'23'`) applied to
-   * any invoice line whose neutral `taxRate` is empty — core has no per-line
-   * tax rate to give (ADR-026), so this is the connection's flat fallback.
-   * Optional; falls back to the PL standard rate (`DEFAULT_FA3_TAX_RATE`)
-   * when absent.
+   * RETIRED (#2257). This was the connection's flat fallback for a line whose
+   * neutral `taxRate` was empty - which was every line, because core had no
+   * per-line rate to give.
+   *
+   * It is no longer read anywhere. Core now refuses an issuance whose lines do
+   * not all name a rate, and no adapter substitutes one, so a value left in an
+   * existing connection's config is inert: it is neither used nor validated,
+   * and it can be removed at leisure. It is deliberately NOT deleted from
+   * stored configs by a migration - an unread key is harmless, whereas a
+   * migration touching every KSeF connection's credentials blob to remove one
+   * is not.
+   *
+   * @deprecated Ignored since #2257. The rate comes from the ProductMaster.
    */
   defaultTaxRate?: string;
 }

--- a/libs/integrations/ksef/src/infrastructure/adapters/__tests__/ksef-connection-config-shape-validator.adapter.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/adapters/__tests__/ksef-connection-config-shape-validator.adapter.spec.ts
@@ -2,7 +2,7 @@
  * KSeF Connection Config Shape Validator — unit tests
  *
  * Verifies the required `env` enum check (test/demo/prod), the optional
- * `seller.defaultTaxRate` check against `FA3_TAX_RATE_MAP` (#1291), and the
+ * The `seller.defaultTaxRate` check was retired with the setting (#2257), and the
  * flat-issue rejection payload, with neutral error messaging (#1144).
  *
  * @module libs/integrations/ksef/src/infrastructure/adapters/__tests__
@@ -60,65 +60,15 @@ describe('KsefConnectionConfigShapeValidatorAdapter', () => {
     });
   });
 
-  describe('seller.defaultTaxRate', () => {
-    it('should resolve when seller.defaultTaxRate is a known FA3_TAX_RATE_MAP key', async () => {
+  describe('seller.defaultTaxRate (retired, #2257)', () => {
+    it('should accept a leftover value without validating it, since nothing reads it', async () => {
+      // The setting is gone, not the data. Validating a key nothing reads would
+      // tell an operator their value is accepted when it is simply ignored; and
+      // REJECTING it would fail a connection save over a dead key. Inert is the
+      // only honest treatment.
       await expect(
-        validator.validate({ env: 'test', seller: { defaultTaxRate: '23' } }),
+        validator.validate({ env: 'test', seller: { defaultTaxRate: 'not-a-rate' } }),
       ).resolves.toBeUndefined();
-    });
-
-    it('should resolve when seller.defaultTaxRate is absent', async () => {
-      await expect(
-        validator.validate({ env: 'test', seller: { nip: '1234567890' } }),
-      ).resolves.toBeUndefined();
-    });
-
-    it('should resolve when seller is absent entirely', async () => {
-      await expect(validator.validate({ env: 'test' })).resolves.toBeUndefined();
-    });
-
-    it('should reject when seller.defaultTaxRate is not a known FA3_TAX_RATE_MAP key', async () => {
-      await expect(
-        validator.validate({ env: 'test', seller: { defaultTaxRate: '23%' } }),
-      ).rejects.toBeInstanceOf(InvalidConnectionConfigException);
-    });
-
-    it('should reject when seller.defaultTaxRate is an empty string', async () => {
-      await expect(
-        validator.validate({ env: 'test', seller: { defaultTaxRate: '' } }),
-      ).rejects.toBeInstanceOf(InvalidConnectionConfigException);
-    });
-
-    it('should reject when seller.defaultTaxRate is whitespace-only', async () => {
-      await expect(
-        validator.validate({ env: 'test', seller: { defaultTaxRate: '   ' } }),
-      ).rejects.toBeInstanceOf(InvalidConnectionConfigException);
-    });
-
-    it('should reject when seller.defaultTaxRate is not a string', async () => {
-      await expect(
-        validator.validate({ env: 'test', seller: { defaultTaxRate: 23 } }),
-      ).rejects.toBeInstanceOf(InvalidConnectionConfigException);
-    });
-
-    it.each(['constructor', 'toString', 'valueOf', 'hasOwnProperty', '__proto__'])(
-      'should reject the inherited-prototype key %s (not a real FA3_TAX_RATE_MAP entry)',
-      async (protoKey) => {
-        await expect(
-          validator.validate({ env: 'test', seller: { defaultTaxRate: protoKey } }),
-        ).rejects.toBeInstanceOf(InvalidConnectionConfigException);
-      },
-    );
-
-    it('should carry a flat { path, message } issue for seller.defaultTaxRate', async () => {
-      await expect(
-        validator.validate({ env: 'test', seller: { defaultTaxRate: '23%' } }),
-      ).rejects.toMatchObject({
-        pluginName: 'KSeF',
-        errors: [
-          { path: 'seller.defaultTaxRate', message: expect.stringContaining('must be one of') },
-        ],
-      });
     });
   });
 

--- a/libs/integrations/ksef/src/infrastructure/adapters/__tests__/ksef-invoicing.adapter.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/adapters/__tests__/ksef-invoicing.adapter.spec.ts
@@ -54,7 +54,6 @@ const SELLER: SellerProfile = {
   },
 };
 
-const DEFAULT_TAX_RATE = '23';
 
 const SESSION_REF = 'SESSION-REF-001';
 const INVOICE_REF = 'INVOICE-REF-001';
@@ -199,7 +198,6 @@ function adapter(
     fakeCrypto(),
     builder,
     SELLER,
-    DEFAULT_TAX_RATE,
     { payment, now: () => new Date('2026-06-23T10:00:00.000Z') },
   );
 }
@@ -1099,7 +1097,7 @@ describe('KsefInvoicingAdapter', () => {
       seedHappyPath(http);
       const now = new Date('2026-06-23T10:00:00.000Z');
       const crypto = fakeCrypto();
-      const ad = new KsefInvoicingAdapter('conn-1', http, crypto, fakeBuilder, SELLER, DEFAULT_TAX_RATE, {
+      const ad = new KsefInvoicingAdapter('conn-1', http, crypto, fakeBuilder, SELLER, {
         now: () => now,
       });
 

--- a/libs/integrations/ksef/src/infrastructure/adapters/ksef-connection-config-shape-validator.adapter.ts
+++ b/libs/integrations/ksef/src/infrastructure/adapters/ksef-connection-config-shape-validator.adapter.ts
@@ -3,7 +3,7 @@
  *
  * Validates the non-secret config for a KSeF connection: a required `env`
  * selecting the target environment (`test` | `demo` | `prod`), an optional
- * `seller.defaultTaxRate` check (must be a known `FA3_TAX_RATE_MAP` key when
+ * The `seller.defaultTaxRate` check was retired with the setting (#2257).
  * present, #1291) so a mistyped rate is rejected at connection-save time
  * instead of surfacing as `UnmappedTaxRateException` at issuance, and an
  * optional `payment` check (#1311): `payment`, `payment.bankAccount` and
@@ -38,7 +38,6 @@ import {
   InvalidConnectionConfigException,
 } from '@openlinker/core/integrations';
 import { KsefEnvironmentValues, KsefFormaPlatnosciValues } from '../../domain/types/ksef-connection.types';
-import { FA3_TAX_RATE_MAP } from '../fa3/domain/fa3-tax-rate.mapper';
 
 export class KsefConnectionConfigShapeValidatorAdapter
   implements ConnectionConfigShapeValidatorPort
@@ -58,23 +57,12 @@ export class KsefConnectionConfigShapeValidatorAdapter
       });
     }
 
-    const seller = config.seller;
-    if (seller !== undefined && seller !== null && typeof seller === 'object') {
-      const defaultTaxRate = (seller as Record<string, unknown>).defaultTaxRate;
-      if (defaultTaxRate !== undefined) {
-        if (typeof defaultTaxRate !== 'string' || defaultTaxRate.trim().length === 0) {
-          issues.push({
-            path: 'seller.defaultTaxRate',
-            message: 'must be a non-empty string',
-          });
-        } else if (!Object.prototype.hasOwnProperty.call(FA3_TAX_RATE_MAP, defaultTaxRate)) {
-          issues.push({
-            path: 'seller.defaultTaxRate',
-            message: `must be one of: ${Object.keys(FA3_TAX_RATE_MAP).join(', ')}`,
-          });
-        }
-      }
-    }
+    // #2257 — the `seller.defaultTaxRate` check is gone with the setting it
+    // guarded. Validating a key nothing reads would tell an operator their value
+    // is accepted, which is now the opposite of true: it is ignored. A value
+    // left behind in an existing config is inert and is deliberately not
+    // rejected either - failing a connection save over a dead key would be a
+    // gratuitous break for something that does nothing.
 
     const payment = config.payment;
     // A wrong-typed `payment` (or sub-object below) is rejected here rather

--- a/libs/integrations/ksef/src/infrastructure/adapters/ksef-invoicing.adapter.ts
+++ b/libs/integrations/ksef/src/infrastructure/adapters/ksef-invoicing.adapter.ts
@@ -218,11 +218,6 @@ export class KsefInvoicingAdapter
     private readonly fa3Builder: IFa3XmlBuilder,
     private readonly seller: SellerProfile,
     /**
-     * Connection-resolved fallback `P_12` neutral code applied to any line
-     * whose neutral `taxRate` arrives empty (see `Fa3MappingContext.defaultTaxRate`).
-     */
-    private readonly defaultTaxRate: string,
-    /**
      * Trailing optional inputs (payment defaults #1311, injected clock) ride
      * in an options bag so a future addition never shifts positional call
      * sites (PR #1317 review).
@@ -264,7 +259,6 @@ export class KsefInvoicingAdapter
     this.logger.log(
       `Issuing KSeF document (connection ${this.connectionId}, order ${cmd.orderId}, lines ${cmd.lines.length})`,
     );
-    this.warnOnEmptyTaxRateFallback(cmd);
 
     // 1. neutral → FA(3) (C4). Deterministic build faults throw the mapper's own
     //    typed exceptions; the service maps those to a failed record (no retry).
@@ -273,7 +267,6 @@ export class KsefInvoicingAdapter
       issueDate: this.toIsoDate(issuedAt),
       generatedAt: issuedAt.toISOString(),
       invoiceNumber: documentNumber,
-      defaultTaxRate: this.defaultTaxRate,
       defaultLineUnit: this.defaultLineUnit,
       payment: this.payment,
     });
@@ -1188,24 +1181,6 @@ export class KsefInvoicingAdapter
     }
   }
 
-  /**
-   * The pure `mapToFa3BuilderInput` mapper cannot log, so the audit trail for
-   * the empty-`taxRate` → connection-`defaultTaxRate` substitution (#1290,
-   * #1291) lives here instead — a WARN per issuance whose command carries at
-   * least one line (plain or correction) with an empty neutral `taxRate`.
-   */
-  private warnOnEmptyTaxRateFallback(cmd: IssueInvoiceCommand): void {
-    const emptyLineCount =
-      cmd.lines.filter((line) => !line.taxRate).length +
-      (cmd.correction?.correctedLines.filter((line) => !line.taxRate).length ?? 0);
-    if (emptyLineCount > 0) {
-      this.logger.warn(
-        `KSeF document (connection ${this.connectionId}, order ${cmd.orderId}) has ` +
-          `${emptyLineCount} line(s) with an empty neutral taxRate — falling back to the ` +
-          `connection default (${this.defaultTaxRate}).`,
-      );
-    }
-  }
 
   private resolveDocumentType(documentType?: string): string {
     // Validated by assertDocumentTypeSupported at the top of issueInvoice; an

--- a/libs/integrations/ksef/src/infrastructure/fa3/domain/fa3-builder-input.mapper.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/fa3/domain/fa3-builder-input.mapper.spec.ts
@@ -1,7 +1,7 @@
 /**
  * Neutral → FA(3) Builder-Input Mapper — Unit Specs
  *
- * Pins the empty-`taxRate` → connection-`defaultTaxRate` fallback (#1290):
+ * Pins the REMOVAL of the empty-`taxRate` fallback (#1290, removed in #2257):
  * an empty neutral rate resolves via the context's connection default; a
  * non-empty rate is never overridden (including a genuinely unmapped one,
  * which still throws); the same fallback applies to correction lines.
@@ -27,7 +27,6 @@ const CONTEXT: Fa3MappingContext = {
   issueDate: '2026-07-01',
   generatedAt: '2026-07-01T00:00:00.000Z',
   invoiceNumber: 'ol_order_test_001',
-  defaultTaxRate: '8',
 };
 
 function baseCommand(taxRate: string): IssueInvoiceCommand {
@@ -46,9 +45,15 @@ function baseCommand(taxRate: string): IssueInvoiceCommand {
 }
 
 describe('mapToFa3BuilderInput — tax-rate fallback', () => {
-  it('should resolve an empty neutral taxRate to the seller defaultTaxRate', () => {
-    const result = mapToFa3BuilderInput(baseCommand(''), CONTEXT);
-    expect(result.lines[0].p12).toBe('8');
+  it('should refuse an empty neutral taxRate rather than defaulting it (#2257)', () => {
+    // INVERTED deliberately. The connection default this used to assert is what
+    // #2245 removes: it put a flat rate on every line of every document, and on
+    // the paper a guessed 23% is indistinguishable from a confirmed one.
+    // `resolveP12('')` throwing IS the correct outcome now - and core refuses
+    // such a command before the builder is reached at all.
+    expect(() => mapToFa3BuilderInput(baseCommand(''), CONTEXT)).toThrow(
+      UnmappedTaxRateException,
+    );
   });
 
   it('should not override an explicit, mapped neutral taxRate with the default', () => {

--- a/libs/integrations/ksef/src/infrastructure/fa3/domain/fa3-builder-input.mapper.ts
+++ b/libs/integrations/ksef/src/infrastructure/fa3/domain/fa3-builder-input.mapper.ts
@@ -58,7 +58,6 @@ export interface Fa3MappingContext {
    * not belong on `SellerProfile` (which mirrors `Podmiot1` XML fields only)
    * even though both are resolved from the same connection config.
    */
-  defaultTaxRate: string;
   /**
    * Connection-resolved fallback unit of measure (`P_8A`, #1525) applied to any
    * line whose neutral `unit` is absent/empty. `undefined` when the connection
@@ -110,7 +109,7 @@ export function mapToFa3BuilderInput(
 /**
  * Map one neutral line to a fully-mapped FA(3) line (applies the P_12 mapper).
  * An empty neutral `taxRate` (core has no per-line rate to give — ADR-026)
- * falls back to the connection's `defaultTaxRate` before resolution; a
+ * no longer falls back to any connection default (#2257); a
  * non-empty rate is never overridden, so a genuine unmapped/mis-keyed code
  * still surfaces loudly via `resolveP12`'s throw.
  */
@@ -135,7 +134,10 @@ function mapLine(line: InvoiceLine, context: Fa3MappingContext): Fa3Line {
     name: line.name,
     quantity: line.quantity,
     unitPriceGross: line.unitPriceGross,
-    p12: resolveP12(line.taxRate || context.defaultTaxRate),
+    // #2257 — no fallback. `resolveP12('')` throws UnmappedTaxRateException,
+    // which is the correct outcome: OpenLinker never invents a rate for a
+    // fiscal document, and core refuses such a command before this runs.
+    p12: resolveP12(line.taxRate),
     ...(unit !== undefined ? { unit } : {}),
   };
 }

--- a/libs/integrations/subiekt/src/infrastructure/mappers/subiekt-line.mapper.spec.ts
+++ b/libs/integrations/subiekt/src/infrastructure/mappers/subiekt-line.mapper.spec.ts
@@ -9,7 +9,7 @@
  * @module libs/integrations/subiekt/src/infrastructure/mappers
  */
 import type { InvoiceLine } from '@openlinker/core/invoicing';
-import { FractionalTaxRateNotationError } from '@openlinker/core/invoicing';
+import { FractionalTaxRateNotationError, MissingTaxRateException } from '@openlinker/core/invoicing';
 import { toBridgeLines } from './subiekt-line.mapper';
 
 function line(taxRate: string): InvoiceLine {
@@ -29,10 +29,12 @@ describe('toBridgeLines', () => {
     expect(toBridgeLines([line('zw')])[0]?.stawkaVAT).toBe('zw');
   });
 
-  it('should fall back to the Polish standard rate when the neutral code is empty', () => {
-    // Unchanged pre-rollout behaviour; #2257 removes this default.
-    expect(toBridgeLines([line('')])[0]?.stawkaVAT).toBe('23');
-    expect(toBridgeLines([line('   ')])[0]?.stawkaVAT).toBe('23');
+  it('should refuse an empty rate rather than defaulting it (#2257)', () => {
+    // INVERTED deliberately: the 23% default this used to assert is what the
+    // epic removes. The bridge would reject the line anyway ("StawkaVAT jest
+    // wymagana"); the difference is that the failure now names the product.
+    expect(() => toBridgeLines([line('')])).toThrow(MissingTaxRateException);
+    expect(() => toBridgeLines([line('   ')])).toThrow(MissingTaxRateException);
   });
 
   it('should reject a fractional-looking rate rather than forwarding it', () => {

--- a/libs/integrations/subiekt/src/infrastructure/mappers/subiekt-line.mapper.ts
+++ b/libs/integrations/subiekt/src/infrastructure/mappers/subiekt-line.mapper.ts
@@ -9,34 +9,45 @@
  *   - `unitPriceGross` -> `cenaBrutto`
  *   - `taxRate`        -> `stawkaVAT`
  *
- * TAX-REGIME DEFAULT (Subiekt-specific): the neutral core `InvoiceLine` leaves
- * `taxRate` empty by design — core never names a tax rate on the order contract
- * ("the provider adapter resolves the regime rate", see the core line mapper).
- * The Subiekt bridge REQUIRES a non-empty `stawkaVAT` ("StawkaVAT jest wymagana")
- * and parses Polish rate symbols ("23","8","5","0","zw","np") in percent-as-string
- * notation (#2247). When the neutral
- * line carries no rate we therefore default to the Polish standard rate "23".
- * A rate the source DID supply passes through verbatim.
+ * NO TAX-REGIME DEFAULT (#2257). This mapper used to substitute the Polish
+ * standard "23" whenever the neutral line carried no rate - which was always,
+ * because core had no per-line rate to give. That guess is what #2245 removes:
+ * on the issued document a silent 23% is indistinguishable from a confirmed
+ * one, and the seller carries the whole cost of it being wrong.
+ *
+ * Core now refuses a rate-less command before any adapter runs, so the guard
+ * here is defence in depth. The Subiekt bridge would reject the line anyway
+ * ("StawkaVAT jest wymagana"); the difference is that the failure now names the
+ * product rather than a bridge field. The bridge parses Polish rate symbols
+ * ("23","8","5","0","zw","np") in percent-as-string notation (#2247), and a
+ * rate the source supplied passes through verbatim.
  *
  * @module libs/integrations/subiekt/src/infrastructure/mappers
  */
 import type { CorrectionLine, InvoiceLine } from '@openlinker/core/invoicing';
-import { assertPercentTaxRateNotation } from '@openlinker/core/invoicing';
+import { MissingTaxRateException, assertPercentTaxRateNotation } from '@openlinker/core/invoicing';
 import type { BridgeKorektaLine, BridgeLine } from '../../bridge/subiekt-bridge.types';
-
-/** Polish standard VAT rate — used when the neutral line carries no rate. */
-const DEFAULT_PL_VAT_RATE = '23';
 
 /**
  * The bridge parses the neutral code as a Polish rate symbol, so it is passed
  * through verbatim - but the notation is still part of the contract (#2247).
- * `assertPercentTaxRateNotation` rejects a fractional spelling here rather than
+ * `assertPercentTaxRateNotation` rejects a fractional spelling rather than
  * letting `'0.23'` reach Subiekt, where it is neither a known symbol nor a rate
  * anyone declared.
+ *
+ * An empty code now raises (#2257) instead of resolving to "23". Nothing here
+ * is allowed to invent a rate for a fiscal document.
  */
-function toStawkaVat(taxRate: string): string {
+function toStawkaVat(taxRate: string, lineName: string): string {
   const code = assertPercentTaxRateNotation(taxRate);
-  return code.length > 0 ? code : DEFAULT_PL_VAT_RATE;
+  if (code.length === 0) {
+    throw new MissingTaxRateException(lineName, {
+      lineCount: 1,
+      totalLines: 1,
+      firstProductId: lineName,
+    });
+  }
+  return code;
 }
 
 export function toBridgeLines(lines: InvoiceLine[]): BridgeLine[] {
@@ -44,7 +55,7 @@ export function toBridgeLines(lines: InvoiceLine[]): BridgeLine[] {
     name: line.name,
     ilosc: line.quantity,
     cenaBrutto: line.unitPriceGross,
-    stawkaVAT: toStawkaVat(line.taxRate),
+    stawkaVAT: toStawkaVat(line.taxRate, line.name),
   }));
 }
 


### PR DESCRIPTION
The last child. Delete the guesses this epic exists to replace.

| Adapter | Was | Now |
|---|---|---|
| inFakt | substituted 23% on an empty rate | refuses, naming the product |
| Subiekt | substituted `"23"` in the line mapper | refuses, naming the product |
| KSeF | fell back to a per-connection `defaultTaxRate` defaulting to `'23'` | setting retired; `resolveP12('')` throws |

On the issued document a silent 23% is indistinguishable from a confirmed 23%, and the whole cost of being wrong lands on the seller.

## Failing here loses nothing

A rate-less line was never going to produce a document anyway: inFakt cascades an empty `tax_symbol` into `services.gross` / `value.tax_values` rejections (live-verified 2026-07-01), the Subiekt bridge answers *"StawkaVAT jest wymagana"*, and `resolveP12('')` throws. **The difference is that the failure now names the product an operator can fix instead of a wire field they cannot.**

Each adapter raises the same neutral `MissingTaxRateException` core does, so the failure reads the same at every layer and keeps its existing 422 mapping. These guards are **defence in depth**: core refuses a rate-less command before any adapter runs (#2248), and the receipt path does the same (#2252).

## The KSeF setting

Unread by the adapter, unwired in the factory, no longer validated on save. **There is no frontend control to retire** - the field was config-only, edited through the raw connection config. Worth stating, because the issue expected one.

**No migration touches stored configs.** A leftover value is inert, and the validator now accepts it *without checking it*: validating a key nothing reads would tell an operator their value is accepted when it is ignored, and rejecting it would fail a connection save over a dead key.

`warnOnEmptyTaxRateFallback` (#2053's instrumentation) is removed rather than left reporting a substitution that no longer happens.

## The four tests

Inverted deliberately, each saying why in place rather than being quietly deleted:

- `order-to-issue-invoice-command.mapper.spec.ts` - the empty shipping rate is **reworded**, not relaxed: the line is still emitted (dropping it would understate the total), it simply carries no rate and the gate refuses the document. Gains the single-rate inheritance case.
- `infakt-invoicing.adapter.spec.ts` - now asserts a refusal, **and** that nothing was POSTed, so no draft is left behind.
- `subiekt-line.mapper.spec.ts` - asserts a refusal.
- `fa3-builder-input.mapper.spec.ts` - asserts `UnmappedTaxRateException`.

## Prerequisites, all met

#2248, #2251 and #2252 are merged into the epic branch, and the coverage count is recorded on #2256 (it measured **zero**, which is why this child is last and why `docs/operations/tax-rate-coverage.md` gates enabling it on a real catalogue).

Closes #2257
Refs #2245

🤖 Generated with [Claude Code](https://claude.com/claude-code)