### PR TITLE
fix(dx): unbreak main — register the sales-document routing knob, retire the superseded one

### DIFF
--- a/scripts/check-architecture-gates.mjs
+++ b/scripts/check-architecture-gates.mjs
@@ -275,6 +275,29 @@ function checkConfigKnobs() {
     }
   }
 
+  // NON_KNOBS gets the same staleness treatment as KNOWN_CONFIG_KNOBS above.
+  // A suppression that outlives the thing it suppresses is invisible — nothing
+  // else in this rule would ever mention the entry again — and this matters
+  // most for exactly the case that motivated the first entry: a superseded
+  // helper suppressed here, then deleted, leaves a dead exemption that the
+  // next reader has to disprove by hand.
+  for (const [rel, reason] of NON_KNOBS) {
+    const abs = join(REPO_ROOT, rel);
+    if (!existsSync(abs)) {
+      failures.push(
+        `stale NON_KNOBS entry: ${rel} ("${reason}") no longer exists — remove it from ` +
+          `NON_KNOBS in scripts/check-architecture-gates.mjs.`
+      );
+      continue;
+    }
+    if (!isKnobCandidate(readFileSync(abs, 'utf8'))) {
+      failures.push(
+        `stale NON_KNOBS entry: ${rel} ("${reason}") no longer matches the knob pattern, so the ` +
+          `exemption is doing nothing — remove it from NON_KNOBS.`
+      );
+    }
+  }
+
   for (const abs of walkTypesFiles(join(REPO_ROOT, CORE_SRC))) {
     const rel = abs.slice(REPO_ROOT.length + 1);
     if (KNOWN_CONFIG_KNOBS.has(rel) || NON_KNOBS.has(rel)) continue;
@@ -333,6 +356,16 @@ function checkLadderRungs() {
     if (!existsSync(join(dirAbs, rung))) {
       failures.push(
         `stale registry entry: ${RUNG_DIR}/${rung} no longer exists — remove it from KNOWN_RUNGS.`
+      );
+    }
+  }
+  // Symmetric with the NON_KNOBS staleness check in rule 2: an exemption that
+  // outlives its file is a silent one. NON_RUNGS is empty today, so this guard
+  // exists before the first entry rather than after the first rot.
+  for (const rung of NON_RUNGS) {
+    if (!existsSync(join(dirAbs, rung))) {
+      failures.push(
+        `stale NON_RUNGS entry: ${RUNG_DIR}/${rung} no longer exists — remove it from NON_RUNGS.`
       );
     }
   }

--- a/scripts/check-architecture-gates.mjs
+++ b/scripts/check-architecture-gates.mjs
@@ -90,10 +90,6 @@ const KNOWN_CONFIG_KNOBS = new Map([
     { helper: 'parseTriggerModel', key: 'config.invoicing.triggerModel' },
   ],
   [
-    'libs/core/src/invoicing/domain/types/invoicing-primary.types.ts',
-    { helper: 'parseIsPrimaryInvoicing', key: 'config.invoicing.isPrimary' },
-  ],
-  [
     'libs/core/src/identifier-mapping/domain/types/stock-safety-buffer.types.ts',
     { helper: 'readStockSafetyBuffer', key: 'config.stockSafetyBuffer' },
   ],
@@ -101,14 +97,36 @@ const KNOWN_CONFIG_KNOBS = new Map([
     'libs/core/src/identifier-mapping/domain/types/pricing-rule.types.ts',
     { helper: 'readPricingRule', key: 'config.pricingRule' },
   ],
+  [
+    'libs/core/src/sales-documents/domain/types/sales-document-kind.types.ts',
+    {
+      helper: 'readSalesDocumentRouting',
+      key: 'config.invoicing.isPrimary + config.salesDocument.documentKind',
+    },
+  ],
 ]);
 
 /**
  * Files that match the discovery conjunction but are deliberately NOT knobs.
- * Empty today: the conjunction (breadcrumb AND an exported read/parse fn) already
- * excludes the known near-misses. An entry here must say why it is not a knob.
+ * An entry here must say why it is not a knob.
  */
-const NON_KNOBS = new Map([]);
+const NON_KNOBS = new Map([
+  [
+    'libs/core/src/invoicing/domain/types/invoicing-primary.types.ts',
+    // SUPERSEDED, not a second knob. #2161 (ADR-041 decision 4) moved the live
+    // read of `config.invoicing.isPrimary` into `readSalesDocumentRouting`,
+    // registered above — its own docblock says it reads "the EXACT shape #2047
+    // already writes (decision 4 fixes that shape, it does not introduce a
+    // second one)". `parseIsPrimaryInvoicing` has no production caller left
+    // (only its definition and the `@openlinker/core/invoicing` barrel
+    // re-export), so counting it would report five knobs where four keys are
+    // actually coerced, and would trip KNOB_THRESHOLD on a helper nothing
+    // calls. Deleting it — and `selectPrimaryInvoicingConnection` beside it,
+    // likewise superseded by `resolveSalesDocumentRouting` — is a public-barrel
+    // change that belongs in its own reviewed PR, tracked separately.
+    'superseded by readSalesDocumentRouting (#2161); dead export pending removal',
+  ],
+]);
 
 /**
  * At the fifth knob, the shared-rules-model conversation the #1032 cut named


### PR DESCRIPTION
## `main` is red

The Lint job on `6a335fd` ([run 32501838234](https://github.com/openlinker-project/openlinker/actions/runs/32501838234/job/96833207594)) fails `check:invariants`:

```
✖ [config-knobs] libs/core/src/sales-documents/domain/types/sales-document-kind.types.ts
  — looks like a new per-connection config-coercion knob
```

## Why it wasn't caught pre-merge

Nothing is wrong with either change that produced it. This is a **semantic merge conflict** — two PRs, each green, neither visible to the other:

| PR | Merged | Added | Its Lint base |
|---|---|---|---|
| **#2161** | `e089363` | `readSalesDocumentRouting` (a `Connection.config` coercion helper) | no `check-architecture-gates.mjs` yet → green |
| **#2291** | `a46c1b4` | `check-architecture-gates.mjs`, whose `config-knobs` rule fails on any unregistered knob | no `sales-document-kind.types.ts` yet → green, reported `4/5 knobs` |

Merge both and the gate finds an unregistered knob. `#2290` landed on top and its `push: main` run is simply the first to surface it — post-merge runs report, they don't gate.

The gate is working exactly as designed. It just met new code that arrived beside it.

## Commit 1 — the fix is a swap, not an addition

`readSalesDocumentRouting` did **not** introduce a fifth config key. It took over `config.invoicing.isPrimary` from `parseIsPrimaryInvoicing` — its own docblock says so:

> `isPrimary` reads `config.invoicing.isPrimary` — the EXACT shape #2047 already writes (decision 4 fixes that shape, it does not introduce a second one)

— and added `config.salesDocument.documentKind` alongside it.

So registering it while leaving the superseded helper counted would report **five knobs where four keys are coerced**, and would trip `KNOB_THRESHOLD` on a helper nothing calls — forcing the #1032 rules-engine conversation on a false count. That is the one outcome worse than the red build: a real architectural gate firing on a bookkeeping artefact, which is how gates get raised until they mean nothing.

So:

- `readSalesDocumentRouting` → `KNOWN_CONFIG_KNOBS` (it is the live knob),
- `parseIsPrimaryInvoicing` → `NON_KNOBS`, with its reason.

Count stays **4/5** and now reflects reality.

## Commit 2 — from self-review: the exemption lists were never verified

`KNOWN_CONFIG_KNOBS` and `KNOWN_RUNGS` are each checked for staleness (file exists, still matches the pattern, still exports the named helper). `NON_KNOBS` and `NON_RUNGS` were only read through `.has()`. Both were empty until this branch, so nothing had exercised the gap.

It bites precisely on the follow-up below: delete `parseIsPrimaryInvoicing` and its `NON_KNOBS` entry keeps suppressing a file that is gone, with nothing in the rule ever mentioning it again. A suppression that outlives the thing it suppresses is the same silent failure this gate exists to prevent, one level up.

`NON_KNOBS` is now checked on both arms (file exists; still matches the knob pattern, or the exemption is doing nothing). `NON_RUNGS` gets the file-exists check for symmetry — still empty, so the guard lands before the first entry rather than after the first rot.

## Follow-up this surfaced (not fixed here)

`parseIsPrimaryInvoicing` has **no production caller left** — only its own definition and the `@openlinker/core/invoicing` barrel re-export. `selectPrimaryInvoicingConnection` beside it is likewise superseded by `resolveSalesDocumentRouting`, which reimplemented its single-candidate / primary-tiebreak rule (and says so in its own docblock).

Deleting both is a public-barrel change and belongs in its own reviewed PR. The `NON_KNOBS` entry records why they are still here so the next reader doesn't "correct" the count back — and, as of commit 2, the entry now fails the build if it outlives them.

## Verification

- `pnpm check:invariants` — green; `check-architecture-gates: … 4/5 config knobs, 1/3 ladder rungs`
- `check-architecture-gates --self-check` — 13/13
- Both new guards exercised in both directions: temporarily deleting the exempted file fires the missing-file arm; stripping its `Connection.config` breadcrumb fires the no-longer-matches arm; clean tree green before and after, exit `1`/`0` as appropriate
- Full pre-commit gate (lint + type-check + smart-test) passed on both commits
- The ESLint half of `pnpm lint` cannot be affected — no package's lint glob covers `scripts/`

*(Correction: an earlier revision of this description and of commit 1's message said `check:invariants` runs "34 checks". It runs **22 checks plus 13 self-checks**.)*

## Worth considering separately

`main` does not require **"Require branches to be up to date before merging."** Every PR in the current queue is `behind`, and this failure mode — a new lint rule meeting new code that violates it — is invisible to a textual merge. Given how much this repo now leans on `check:invariants`, that setting is the structural fix; this PR is only the symptom.

## Note on conventions

No `Closes #N` — there is no issue for this, since it is an unbreak-main fix found from the failing run. The branch is `worktree-fix-config-knob-registry` rather than the repo's `{issue}-{description}` shape for the same reason; happy to rename or file a tracking issue if you'd prefer it match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)