### PR TITLE
fix(ci): make the docs-only path gate actually fire (predicate-quantifier)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,15 +21,41 @@ concurrency:
 
 jobs:
   # Cheap path gate. Runs on GitHub-hosted runners so it never consumes a
-  # self-hosted slot. The four non-required heavy jobs (lint/test/integration/
-  # build) gate on `code == 'true'`; `Type Check` (the only required check) is
-  # intentionally NOT gated so it always reports — a docs-only or draft PR then
-  # spends 1 self-hosted slot instead of 5.
+  # self-hosted slot. The four self-hosted heavy jobs (lint/test/integration/
+  # build) gate on `code == 'true'`; `Type Check` is intentionally NOT gated so
+  # it always reports — a docs-only or draft PR then spends 1 self-hosted slot
+  # instead of 5. (Which checks are *required* is branch-protection state, not
+  # readable from this file — see GOVERNANCE.md § Who can merge. It is asserted
+  # here deliberately no longer, because ci.yml and GOVERNANCE.md disagreed and
+  # neither can be verified from the tree.)
   #
   # `code` matches any changed file EXCEPT pure docs / markdown / the dev-stack
   # compose file (none of which any CI job consumes — integration tests use
   # Testcontainers, not docker-compose.yml). Dockerfile is deliberately NOT
   # ignored: it feeds the future image build once CD is enabled.
+  #
+  # `predicate-quantifier: 'every'` is LOAD-BEARING, not decoration (#2296).
+  # The pattern list below is an include-everything-then-negate list, and it
+  # only subtracts anything under `every`, where a file must satisfy ALL four
+  # predicates (matches `**` AND not-docs AND not-md AND not-compose). Under
+  # the action's DEFAULT quantifier (`some`) a file matches if it satisfies
+  # ANY pattern — every file matches `'**'`, so the negations subtract nothing
+  # and `code` is `true` for literally any change. That was the state from
+  # this job's introduction until #2296: the gate never once fired.
+  #
+  # Two traps when editing this list:
+  #   1. It is an AND. Adding a pattern meaning "also match X" NARROWS the
+  #      filter to near-nothing instead of widening it — and removing the
+  #      quantifier restores the original inert-gate bug, silently.
+  #   2. `paths-filter` FAILS the step on an unrecognised quantifier value,
+  #      and every gated job below is `needs: changes` with no `always()`, so
+  #      a failed step SKIPS them all. On a code PR that reads as five skips
+  #      plus two green checks — indistinguishable from a healthy docs PR.
+  #      `Type Check` staying ungated is what bounds that.
+  #
+  # Five jobs gate on `code`; only FOUR of them are self-hosted
+  # (`docker-build-smoke` is `ubuntu-latest`), which is why the slot
+  # arithmetic above says 4-of-5 rather than 5.
   changes:
     name: Detect changed paths
     runs-on: ubuntu-latest
@@ -40,6 +66,7 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: filter
         with:
+          predicate-quantifier: 'every'
           filters: |
             code:
               - '**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,13 +21,19 @@ concurrency:
 
 jobs:
   # Cheap path gate. Runs on GitHub-hosted runners so it never consumes a
-  # self-hosted slot. The four self-hosted heavy jobs (lint/test/integration/
-  # build) gate on `code == 'true'`; `Type Check` is intentionally NOT gated so
-  # it always reports — a docs-only or draft PR then spends 1 self-hosted slot
-  # instead of 5. (Which checks are *required* is branch-protection state, not
-  # readable from this file — see GOVERNANCE.md § Who can merge. It is asserted
-  # here deliberately no longer, because ci.yml and GOVERNANCE.md disagreed and
-  # neither can be verified from the tree.)
+  # self-hosted slot.
+  #
+  # FIVE jobs gate on `code == 'true'` — lint / test / integration / build /
+  # docker-build-smoke — but only the first FOUR are self-hosted
+  # (`docker-build-smoke` is `ubuntu-latest`). `Type Check` is self-hosted and
+  # intentionally NOT gated, so it always reports. That is where the slot
+  # arithmetic comes from: five self-hosted jobs exist, four of them gate away,
+  # so a docs-only or draft PR spends 1 self-hosted slot instead of 5.
+  #
+  # Which checks are *required* is branch-protection state and is not readable
+  # from this file. This comment used to claim `Type Check` was the only one;
+  # GOVERNANCE.md § Who can merge says otherwise, and neither can be verified
+  # from the tree, so the claim is deliberately no longer made here.
   #
   # `code` matches any changed file EXCEPT pure docs / markdown / the dev-stack
   # compose file (none of which any CI job consumes — integration tests use
@@ -43,19 +49,15 @@ jobs:
   # and `code` is `true` for literally any change. That was the state from
   # this job's introduction until #2296: the gate never once fired.
   #
-  # Two traps when editing this list:
+  # Two ways to silently re-break this:
   #   1. It is an AND. Adding a pattern meaning "also match X" NARROWS the
   #      filter to near-nothing instead of widening it — and removing the
-  #      quantifier restores the original inert-gate bug, silently.
+  #      quantifier restores the original inert-gate bug, with no symptom.
   #   2. `paths-filter` FAILS the step on an unrecognised quantifier value,
   #      and every gated job below is `needs: changes` with no `always()`, so
   #      a failed step SKIPS them all. On a code PR that reads as five skips
   #      plus two green checks — indistinguishable from a healthy docs PR.
   #      `Type Check` staying ungated is what bounds that.
-  #
-  # Five jobs gate on `code`; only FOUR of them are self-hosted
-  # (`docker-build-smoke` is `ubuntu-latest`), which is why the slot
-  # arithmetic above says 4-of-5 rather than 5.
   changes:
     name: Detect changed paths
     runs-on: ubuntu-latest

--- a/docs/plans/analysis/ANALYSIS-ci-paths-filter-quantifier.md
+++ b/docs/plans/analysis/ANALYSIS-ci-paths-filter-quantifier.md
@@ -1,0 +1,68 @@
+# Pre-implement gate — `implementation-plan-ci-paths-filter-quantifier.md` (#2296)
+
+**Verdict: READY** — with one Warning that must be resolved *while* implementing Step 2, not after.
+
+No Critical findings. No reuse collision. No contract surface in the usual sense is touched.
+
+## Scope note — why the standard fan-out was not run
+
+The gate's reuse audit is defined over ports, services, DI tokens, ORM entities and capabilities. This plan creates **none** of those: it adds one key to a third-party action's `with:` block in `.github/workflows/ci.yml` and rewrites an adjacent comment. Fanning `Explore` agents over `libs/core/**/domain/ports/**` for a plan that declares no port would produce five confident "confirmed absent" rows carrying no information.
+
+The audit was instead run against the collision classes that *do* apply to a CI-config change: duplicate uses of the same idiom, other consumers of the changed output, competing skip mechanisms, and documentation that describes the behaviour being changed.
+
+## Reuse findings
+
+| Plan artifact | Classification | Evidence |
+|---|---|---|
+| `predicate-quantifier: 'every'` on the `changes` job | **NEW (confirmed absent)** | `grep -rn "predicate-quantifier" .github/` → no hits |
+| The `paths-filter` idiom itself | **ALREADY EXISTS — single instance** | `ci.yml` is the only consumer of `dorny/paths-filter`; no sibling workflow carries the same latent bug, so this fix needs no companion |
+| Per-job path gating | **PARTIAL — a different, correct mechanism exists** | `scaffold-smoke.yml` uses native `on.pull_request.paths` with `!` negations. That is GitHub's own filter engine, not picomatch, and it handles negation correctly. It is **not** an alternative here: `paths:` is workflow-level, so it cannot gate individual jobs inside `ci.yml`. `paths-filter` remains the right tool. |
+
+**Consumers of the changed output — exhaustive.** Five `if:` conditions read `needs.changes.outputs.code`, all identical: `lint` (58), `test` (117), `test-integration` (149), `build` (337), `docker-build-smoke` (362). Ungated: `type-check`, `test-php`, `changes`. The issue's assumption is **confirmed**.
+
+**Adjacent workflows unaffected.** `e2e.yml` is `workflow_dispatch`-only (dormant). `cd.yml`, `staging.yml`, `release-please.yml` do not run on `pull_request` path filters. `scaffold-smoke.yml` filters independently.
+
+**No live documentation describes the skip behaviour.** Every `grep` hit for "docs-only" / "Detect changed paths" outside `ci.yml` is a historical `docs/plans/implementation-plan-*.md`. Nothing in `docs/` (user- or contributor-facing) goes stale.
+
+## Backward-compatibility findings
+
+| Surface | Result |
+|---|---|
+| Top-level barrels | n/a — no TypeScript touched |
+| Port signatures | n/a |
+| DTO shapes | n/a |
+| Symbol tokens | n/a |
+| ORM schema / migration | n/a — no ORM entity, so `docs/migrations.md` does not engage |
+| `check:invariants` | **Unaffected.** No script in the chain reads `.github/**`. Verified against the 22-check chain in `package.json`. |
+
+### ⚠️ Warning — the plan restates a required-check claim that another document contradicts
+
+Plan §2.5 concludes the existing comment is accurate and instructs the implementer **not** to change its arithmetic. That conclusion is right about the *slot counting* (5 gated, 4 self-hosted, 1 ungated self-hosted — verified). But the same comment also asserts:
+
+> `Type Check` (**the only required check**)
+
+and `GOVERNANCE.md:53-55` documents the intended branch protection as:
+
+> `Require status checks to pass before merging` — **on** for `lint`, `type-check`, `test`, and integration-test workflows once those workflows can run reliably on fork PRs (tracked in #662)
+
+So one of the two is wrong, or `GOVERNANCE.md` is aspirational and not yet applied. **The gate cannot resolve this** — branch-protection settings are not readable from the repository tree, and no PR to date has exercised the skip path (the gate has never fired), so there is no observational evidence either.
+
+**Why it matters for this plan specifically.** Step 2 rewrites that exact comment block. Restating "the only required check" while a governance document says otherwise would launder an unverified claim into the file that the next person treats as authoritative.
+
+**Why it is a Warning and not Critical.** The mechanism is safe in the direction that matters: a job skipped by a job-level `if:` still reports a check run with conclusion `skipped`, which GitHub counts as passing for a required status check. The dangerous shape — a required check that *never reports* and pins the PR at "Expected — waiting for status" — arises when the whole *workflow* is filtered out, which is not what this change does (`changes` always runs). So the expected outcome is safe; it is the *verification* that is missing.
+
+**Required resolution during implementation** — either:
+
+1. Drop the parenthetical from the rewritten comment and state only what is verifiable from the tree (which jobs are gated, which are self-hosted), leaving required-check status to `GOVERNANCE.md`; **or**
+2. Confirm the actual protection setting and make `ci.yml` and `GOVERNANCE.md` agree, in this PR or a follow-up.
+
+Option 1 is the smaller, safer move and keeps this PR's scope honest. Either way, **the plan's AC1 verification (a throwaway docs-only PR) is no longer optional** — it is the only available empirical test that a skipped gated job does not block a PR, and it costs one throwaway PR to run.
+
+## Open questions
+
+1. **Is `lint`/`test`/`test-integration` actually a required status check on `main` today?** Not answerable from the tree. Settles the `ci.yml` ↔ `GOVERNANCE.md` contradiction above. The docs-only test PR answers it observationally.
+2. **Does #662 (fork-PR reliability) change the answer later?** If required checks are widened per `GOVERNANCE.md` after this ships, the skip path gets its first real exercise at that moment. Worth a line in the comment so the two changes are linked.
+
+## Verdict rationale
+
+No Critical ⇒ not `NEEDS-REVISION`. The single Warning is actionable inside Step 2 rather than requiring a plan rewrite, and the plan's own §5 already nominates the verification that resolves it. **READY.**

--- a/docs/plans/implementation-plan-ci-paths-filter-quantifier.md
+++ b/docs/plans/implementation-plan-ci-paths-filter-quantifier.md
@@ -1,0 +1,159 @@
+# Implementation plan — CI paths-filter negations need `predicate-quantifier: 'every'` (#2296)
+
+## 1. Understand the task
+
+**Goal.** Make `ci.yml`'s `changes` job actually skip the heavy jobs on a docs-only PR, which is what it was written to do and has never done.
+
+**Layer.** DX / Infrastructure (CI). No application layer is touched — `.github/workflows/ci.yml` only. No CORE, no Integration, no Interface, no Frontend. No migration, no ORM entity, no port, no DTO, no Symbol token, no barrel.
+
+**Non-goals** (explicit):
+
+- Changing *which* jobs are gated. The five gated jobs and the deliberately-ungated `Type Check` / `PHP Unit Tests` stay exactly as they are.
+- Changing the filter's pattern list. The four patterns are correct; only their combining rule is wrong.
+- Fixing the Lint failure seen on run `32520492989` — the issue states, and this plan accepts, that it was a separate runner-side flake.
+- Touching `concurrency`, runner labels, or the draft-PR condition.
+
+## 2. Research — findings that shape the change
+
+### 2.1 The symptom is reproduced
+
+Run `32520492989` (PR #2281, branch `docs/oms-authority-model-design`, a pure-docs change) ran `Lint`, `Test`, `Integration Tests`, `Build` **and** `Docker Build Smoke Test`. `Detect changed paths` reported `code == 'true'`.
+
+### 2.2 The mechanism, from the action's source (not inferred)
+
+`dorny/paths-filter@v3`, `src/filter.ts`:
+
+```ts
+const MatchOptions = { dot: true }
+…
+if (this.filterConfig?.predicateQuantifier === 'every') {
+  return patterns.every(aPredicate)
+} else {
+  return patterns.some(aPredicate)   // default
+}
+```
+
+Under the default `some`, a changed file matches the `code` rule if it matches **any** listed pattern. Every file matches `'**'`, so the three `!` negations subtract nothing and `code` is `true` whenever the PR changes at least one file of any kind. The gate has been inert since it was added.
+
+**The evidence is tag-relative.** The workflow pins `dorny/paths-filter@v3`, a moving major tag, so the two behaviours above describe `v3` as it stands today, not a fixed commit. Pinning to a SHA would make them permanent, but every other action here (`actions/checkout@v4`, `actions/setup-node@v4`, `pnpm/action-setup@v2`) uses the same moving-tag convention — changing it for this one action alone would be inconsistent, so pinning belongs to its own repo-wide decision rather than this fix.
+
+### 2.3 `dot: true` — consequence for verification
+
+Because picomatch is configured with `dot: true`, `'**'` matches dotfile paths including `.github/**`. Therefore a PR that changes only `.github/workflows/ci.yml` is still `code: true` and runs every job.
+
+This is both **correct behaviour** (a CI change should exercise CI) and **useful**: the PR implementing this plan verifies AC2 on itself, with no contrived second change needed.
+
+### 2.4 Consumers of `outputs.code` — exhaustive
+
+`grep -n "needs.changes.outputs" .github/workflows/ci.yml` yields exactly five, all the same expression:
+
+| Line | Job | `runs-on` |
+|---|---|---|
+| 58 | `lint` | self-hosted |
+| 117 | `test` | self-hosted |
+| 149 | `test-integration` | self-hosted |
+| 337 | `build` | self-hosted |
+| 362 | `docker-build-smoke` | ubuntu-latest |
+
+Ungated: `type-check` (self-hosted, the only required check), `test-php` (ubuntu-latest), `changes` itself (ubuntu-latest).
+
+The issue's assumption "no job other than the five gated ones reads `outputs.code`" is **confirmed**.
+
+### 2.5 The existing comment's arithmetic is correct — do not "correct" it
+
+The comment says *"a docs-only or draft PR then spends 1 self-hosted slot instead of 5"* and names *"the four non-required heavy jobs (lint/test/integration/build)"*.
+
+Both are right, and the reason is non-obvious enough to be worth recording: there are **five** gated jobs but only **four self-hosted** ones — `docker-build-smoke` is gated *and* GitHub-hosted, so it does not enter the self-hosted-slot arithmetic. Five self-hosted jobs exist in total; gating four away leaves `type-check` = 1.
+
+A reviewer counting gated jobs will get 5 and may try to "fix" the 4. The revised comment should make the two counts distinguishable.
+
+**Superseded in part by the pre-implement gate.** The conclusion above is right about the *slot arithmetic* and must not be read as validating the whole comment. The same block also asserts `Type Check` is *"the only required check"*, which `GOVERNANCE.md:53-55` contradicts (it documents the intended required set as `lint`, `type-check`, `test`, and integration-test workflows). Branch-protection settings are not readable from the tree, so neither claim can be settled here. Step 2 therefore **drops the required-check parenthetical** rather than restating it — see `docs/plans/analysis/ANALYSIS-ci-paths-filter-quantifier.md` § Warning.
+
+## 3. Design
+
+One key, one comment. No new file, no new pattern.
+
+```yaml
+- uses: dorny/paths-filter@v3
+  id: filter
+  with:
+    predicate-quantifier: 'every'
+    filters: |
+      code:
+        - '**'
+        - '!docs/**'
+        - '!**/*.md'
+        - '!docker-compose.yml'
+```
+
+**Semantics after the change.** A changed file counts toward `code` only if it satisfies *all four* predicates: matches `'**'` AND is not under `docs/` AND is not `*.md` AND is not `docker-compose.yml`. The rule is per-file; `code` is `true` if **any** changed file qualifies, which is what makes a mixed docs+code PR run everything (AC3).
+
+**Worked cases:**
+
+| Changed file | `**` | `!docs/**` | `!**/*.md` | `!docker-compose.yml` | `code` |
+|---|---|---|---|---|---|
+| `libs/core/src/x.ts` | ✓ | ✓ | ✓ | ✓ | **true** |
+| `docs/adr/052.md` | ✓ | ✗ | ✗ | ✓ | false |
+| `README.md` | ✓ | ✓ | ✗ | ✓ | false |
+| `docs/img/diagram.png` | ✓ | ✗ | ✓ | ✓ | false |
+| `docker-compose.yml` | ✓ | ✓ | ✓ | ✗ | false |
+| `Dockerfile` | ✓ | ✓ | ✓ | ✓ | **true** |
+| `.github/workflows/ci.yml` | ✓ (`dot: true`) | ✓ | ✓ | ✓ | **true** |
+
+`Dockerfile` staying `true` matches the existing comment's stated intent ("deliberately NOT ignored: it feeds the future image build once CD is enabled").
+
+## 4. Steps
+
+### Step 1 — add the quantifier
+
+**File**: `.github/workflows/ci.yml` (`changes` job, `paths-filter` step).
+
+Add `predicate-quantifier: 'every'` as a sibling of `filters:` under `with:`.
+
+**Acceptance**: the key is present; YAML still parses; no other key in the step changes.
+
+### Step 2 — record why the quantifier is load-bearing
+
+**File**: `.github/workflows/ci.yml` (comment block above `changes`).
+
+The comment must state:
+
+1. that the pattern list is combined with **AND**, not OR, because of the quantifier;
+2. the refactor trap that follows — adding a pattern intending *"also match X"* silently **narrows** the filter to near-nothing rather than widening it, and adding it without the quantifier restores the original inert-gate bug;
+3. the 5-gated / 4-self-hosted distinction from §2.5, so the slot arithmetic reads as deliberate.
+
+**Acceptance**: a reader who has never seen `predicate-quantifier` can tell from the comment alone why it is there and what breaks without it.
+
+## 5. Validation
+
+**Architecture compliance**: n/a — no application code. No hexagonal boundary, port, adapter, DI token, barrel, ORM entity or migration is involved.
+
+**`check:invariants`**: unaffected. No script in the chain reads `.github/**`.
+
+**Testing strategy**: this change has no unit-testable surface — the behaviour under change belongs to a third-party action evaluated by GitHub. It is verified by observation, and the observation has a trap that must be avoided.
+
+**The gating condition is a conjunction, and only one conjunct is under test.** Every gated job reads:
+
+```yaml
+if: ${{ github.event_name == 'push' || (github.event.pull_request.draft == false && needs.changes.outputs.code == 'true') }}
+```
+
+`draft == false` is **ANDed** with the path gate, so a **draft** PR skips all five heavy jobs *regardless of paths* — the same observable outcome AC1 predicts. Verifying AC1 with a draft PR is therefore a **false pass**: the jobs skip for the wrong reason. Likewise the `push` arm means everything runs on `main` regardless, so AC1 is a statement about **pull requests only**.
+
+Verification, in two observations, **both on non-draft PRs**:
+
+- **AC2 (non-docs PR runs everything)** — verified by *this PR*, which touches only `.github/workflows/ci.yml` and, per §2.3, must show all jobs running. This is also the control: it proves the skip in AC1 is caused by the path filter and not by a broken `changes` job.
+- **AC1 (docs-only PR skips the heavy jobs)** — cannot be observed from this PR, which is not docs-only. Verified by a throwaway docs-only PR opened against this branch — **marked ready for review, never draft** — whose job list is recorded in the PR before it is closed.
+- **AC3 (mixed PR runs everything)** — follows from the per-file rule in §3: the filter evaluates per changed file and `code` is `true` if *any* file qualifies, which is the identical mechanism AC2 exercises. No separate run is needed, but the reasoning is recorded on the issue when the checkbox is ticked rather than left to look untested.
+
+**Security**: none. No secret, credential, permission or runner-label change. `predicate-quantifier` is an input to an already-trusted action at the same major version.
+
+**Risk**: low, but **not one-directional** — the plausible failure is precisely "jobs wrongly skipped", and it is silent.
+
+`dorny/paths-filter` validates `predicate-quantifier` and **fails the step** on an unrecognised value. All five gated jobs declare `needs: changes` and **none** carries `always()`, so a failed `changes` job causes GitHub to *skip* every dependent job. On a code PR that means `Lint`, `Test`, `Integration Tests`, `Build` and `Docker Build Smoke Test` all skip — and because `type-check` and `test-php` carry no `needs: changes`, they still run and go green. The PR then shows two green checks plus five skips: indistinguishable at a glance from a healthy docs-only PR.
+
+What actually bounds the damage is not the direction of the failure but the fact that **`Type Check` stays ungated** — it runs on every PR whatever the filter says or does. That is the safety property worth preserving; the quantifier's own failure mode deserves no benefit of the doubt.
+
+## 6. Open questions
+
+None blocking. One decision recorded for the reviewer: AC1's verification is by observation on a throwaway PR rather than by an automated assertion, because there is no mechanism in this repo to unit-test a GitHub Actions path filter.


### PR DESCRIPTION
## The bug

`ci.yml`'s `changes` job exists so a docs-only PR spends 1 self-hosted slot instead of 5. **It never has.**

`dorny/paths-filter`'s default `predicate-quantifier` is `some` — a changed file matches the `code` rule if it matches **any** listed pattern. Every file matches `'**'`, so the three `!` negations subtracted nothing and `code` was `true` for literally any change.

Confirmed on [run 32520492989](https://github.com/openlinker-project/openlinker/actions/runs/32520492989): PR #2281, 26 files all under `docs/**`, ran Lint, Test, Integration Tests, Build **and** Docker Build Smoke Test.

## The fix

`predicate-quantifier: 'every'` makes the list an AND, which is what an include-everything-then-negate list needs. The rule stays per-file, so a mixed docs+code PR still runs everything.

Verified against the action's **own source** rather than inferred (`dorny/paths-filter@v3`, `src/filter.ts`):

```ts
const MatchOptions = { dot: true }
…
if (this.filterConfig?.predicateQuantifier === 'every') {
  return patterns.every(aPredicate)
} else {
  return patterns.some(aPredicate)   // default
}
```

`dot: true` matters for a second reason: `'**'` matches `.github/**`, so **this PR is itself `code: true` and runs every job** — which makes it the control observation for the fix rather than needing a contrived second change.

## Verification — and the trap in it

The gating condition is a **conjunction**:

```yaml
if: ${{ github.event_name == 'push' || (github.event.pull_request.draft == false && needs.changes.outputs.code == 'true') }}
```

`draft == false` is ANDed with the path gate, so a **draft** docs-only PR skips the heavy jobs *regardless of paths* — the same observable outcome AC1 predicts, i.e. a **false pass**. The verification PR must be non-draft. (The `push` arm likewise means AC1 is a statement about pull requests only.)

| AC | How |
|---|---|
| **AC2** — non-docs PR runs everything | **This PR** (touches only `.github/**`, so `code: true`). Also the control: proves any skip in AC1 comes from the filter, not a broken `changes` job. |
| **AC1** — docs-only PR skips the heavy jobs | Throwaway docs-only PR against this branch, **non-draft**, job list recorded before closing. Not observable from this PR. |
| **AC3** — mixed PR runs everything | Follows from the per-file rule: `code` is `true` if *any* changed file qualifies — the identical mechanism AC2 exercises. Reasoning recorded rather than left looking untested. |
| **AC4** — comment updated | Done, and expanded — see below. |

## What the comment block now records

Each of these is a way to silently re-break this:

1. **The list is an AND.** Adding a pattern meaning "also match X" *narrows* the filter to near-nothing instead of widening it; dropping the quantifier restores the original inert gate with no visible symptom.
2. **`paths-filter` fails its step on an unrecognised quantifier**, and all five gated jobs are `needs: changes` with no `always()` — so a failed step **skips them all**. On a code PR that reads as five skips plus two green checks, indistinguishable from a healthy docs PR. `Type Check` staying ungated is what bounds it. *(This corrects the plan's original claim that the risk was "one-directional" — it isn't, and the dangerous direction is the silent one.)*
3. **Five jobs gate on `code` but only four are self-hosted** (`docker-build-smoke` is `ubuntu-latest`), which is why the slot arithmetic reads 4-of-5 rather than 5. A reviewer counting gated jobs gets 5 and may try to "correct" the 4.

## One thing removed

The comment's **"(the only required check)"** claim about `Type Check` is dropped. `GOVERNANCE.md` § Who can merge documents the intended required set as `lint`, `type-check`, `test` and integration-test workflows — so the two documents disagreed, and branch-protection state is not readable from the tree. Asserting either in the file a reader treats as authoritative is worse than asserting neither.

Worth settling separately: **is `lint`/`test`/`test-integration` actually a required check on `main` today?** The docs-only verification PR answers it observationally, since it is the first PR that will ever exercise the skip path. (A job skipped by a job-level `if:` reports conclusion `skipped`, which counts as passing for a required check — the dangerous shape is a check that *never reports*, which needs a whole workflow to be filtered out and is not what this does.)

## Process

- Plan: `docs/plans/implementation-plan-ci-paths-filter-quantifier.md`
- Gate: `docs/plans/analysis/ANALYSIS-ci-paths-filter-quantifier.md` — **READY**, one Warning (the required-check contradiction above), applied.
- Deep `/tech-review` on the plan found 2 IMPORTANT + 2 SUGGESTION, all applied before implementing: the draft-PR false pass, the mis-stated risk direction, the moving-`@v3`-tag caveat, and the AC3 reasoning.

`pnpm lint` (22 checks + 13 self-checks) and `pnpm type-check` green; full pre-commit gate passed.

Closes #2296

🤖 Generated with [Claude Code](https://claude.com/claude-code)