### PR TITLE
docs(oms): Wave-2 + returns product specs, backlog overview, decision-surface mockup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ Before writing or modifying code, read the relevant doc(s):
 | Implementation plan process | `docs/implementation-plan-generator-guide.md` |
 | Recurring gotchas / regression ledger | `docs/lessons.md` |
 | Analytics metric definitions and formulas | `docs/specs/metrics-analytics-dashboard.md` |
+| OMS programme wave map and backlog navigation | `docs/plans/oms-backlog-overview.md` |
 
 Architecture docs define **intent and direction**, not every implementation detail. You may infer missing layers or patterns if they clearly align — but always justify them explicitly.
 

--- a/docs/plans/mockups/mockup-who-decides-what.html
+++ b/docs/plans/mockups/mockup-who-decides-what.html
@@ -1,0 +1,252 @@
+<title>Who Decides What</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;500&family=IBM+Plex+Sans:wght@400;500;600&display=swap" rel="stylesheet">
+<style>
+:root {
+  --font-sans: 'IBM Plex Sans', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif;
+  --font-mono: 'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  --bg-canvas: oklch(99% 0.003 80);
+  --bg-surface: #ffffff;
+  --bg-muted: oklch(96% 0.005 80);
+  --border-subtle: oklch(93.5% 0.006 80);
+  --border-default: oklch(88% 0.008 80);
+  --text-primary: oklch(20% 0.012 80);
+  --text-secondary: oklch(38% 0.010 80);
+  --text-muted: oklch(52% 0.008 80);
+  --accent-primary: oklch(68% 0.18 50);
+  --accent-primary-soft: oklch(96% 0.04 60);
+  --accent-primary-border: oklch(85% 0.10 55);
+  --accent-primary-strong: oklch(40% 0.16 50);
+  --status-error-soft: oklch(96% 0.04 25); --status-error-border: oklch(85% 0.10 25); --status-error-fg: oklch(42% 0.16 25);
+  --status-warning-soft: oklch(96% 0.05 85); --status-warning-border: oklch(85% 0.10 85); --status-warning-fg: oklch(42% 0.12 80);
+  --status-info-soft: oklch(96% 0.03 245); --status-info-border: oklch(85% 0.08 245); --status-info-fg: oklch(40% 0.12 245);
+  --status-disabled-soft: oklch(95% 0.005 80); --status-disabled-border: oklch(85% 0.008 80); --status-disabled-fg: oklch(38% 0.010 80);
+  --shadow-soft: 0 1px 2px rgb(15 18 26 / 0.04), 0 6px 16px rgb(15 18 26 / 0.06);
+  --radius: 8px;
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --bg-canvas: oklch(17% 0.008 80); --bg-surface: oklch(21% 0.009 80); --bg-muted: oklch(25% 0.009 80);
+    --border-subtle: oklch(28% 0.010 80); --border-default: oklch(34% 0.012 80);
+    --text-primary: oklch(95% 0.005 80); --text-secondary: oklch(78% 0.008 80); --text-muted: oklch(62% 0.008 80);
+    --accent-primary-soft: oklch(30% 0.07 55); --accent-primary-border: oklch(45% 0.12 55); --accent-primary-strong: oklch(85% 0.10 55);
+    --status-error-soft: oklch(28% 0.07 25); --status-error-border: oklch(42% 0.11 25); --status-error-fg: oklch(85% 0.10 25);
+    --status-warning-soft: oklch(28% 0.06 85); --status-warning-border: oklch(42% 0.10 85); --status-warning-fg: oklch(88% 0.10 85);
+    --status-info-soft: oklch(27% 0.05 245); --status-info-border: oklch(40% 0.09 245); --status-info-fg: oklch(86% 0.08 245);
+    --status-disabled-soft: oklch(25% 0.006 80); --status-disabled-border: oklch(34% 0.008 80); --status-disabled-fg: oklch(72% 0.006 80);
+  }
+}
+:root[data-theme="dark"] {
+  --bg-canvas: oklch(17% 0.008 80); --bg-surface: oklch(21% 0.009 80); --bg-muted: oklch(25% 0.009 80);
+  --border-subtle: oklch(28% 0.010 80); --border-default: oklch(34% 0.012 80);
+  --text-primary: oklch(95% 0.005 80); --text-secondary: oklch(78% 0.008 80); --text-muted: oklch(62% 0.008 80);
+  --accent-primary-soft: oklch(30% 0.07 55); --accent-primary-border: oklch(45% 0.12 55); --accent-primary-strong: oklch(85% 0.10 55);
+  --status-error-soft: oklch(28% 0.07 25); --status-error-border: oklch(42% 0.11 25); --status-error-fg: oklch(85% 0.10 25);
+  --status-warning-soft: oklch(28% 0.06 85); --status-warning-border: oklch(42% 0.10 85); --status-warning-fg: oklch(88% 0.10 85);
+  --status-info-soft: oklch(27% 0.05 245); --status-info-border: oklch(40% 0.09 245); --status-info-fg: oklch(86% 0.08 245);
+  --status-disabled-soft: oklch(25% 0.006 80); --status-disabled-border: oklch(34% 0.008 80); --status-disabled-fg: oklch(72% 0.006 80);
+}
+body { margin:0; background:var(--bg-canvas); color:var(--text-primary); font-family:var(--font-sans); font-size:14px; line-height:1.5; }
+.wrap { max-width:1040px; margin:0 auto; padding:32px 20px 80px; }
+.eyebrow { font-size:11px; letter-spacing:.08em; text-transform:uppercase; color:var(--text-muted); font-weight:600; margin:0 0 4px; }
+h1 { font-size:24px; margin:0 0 6px; letter-spacing:-.01em; }
+h2 { font-size:16px; margin:0; letter-spacing:-.005em; }
+.lede { color:var(--text-secondary); margin:0 0 28px; max-width:64ch; }
+.panel { background:var(--bg-surface); border:1px solid var(--border-subtle); border-radius:var(--radius); box-shadow:var(--shadow-soft); padding:20px; margin-bottom:24px; }
+.panel__header { display:flex; justify-content:space-between; align-items:flex-start; gap:16px; margin-bottom:16px; }
+.cards { display:grid; grid-template-columns:repeat(auto-fit,minmax(268px,1fr)); gap:12px; }
+.card { border:1px solid var(--border-default); border-radius:var(--radius); padding:14px; background:var(--bg-surface); display:flex; flex-direction:column; gap:8px; }
+.card--on { border-color:var(--accent-primary-border); background:var(--accent-primary-soft); }
+.card--off { opacity:.62; }
+.card h3 { margin:0; font-size:14px; display:flex; align-items:center; gap:8px; }
+.card p { margin:0; font-size:13px; color:var(--text-secondary); }
+.card .best { font-size:12px; color:var(--text-muted); font-style:italic; }
+.card .effect { font-size:12px; color:var(--text-secondary); border-top:1px dashed var(--border-subtle); padding-top:8px; }
+.radio { width:14px; height:14px; border-radius:50%; border:2px solid var(--border-strong,var(--border-default)); flex:0 0 auto; }
+.radio--on { border-color:var(--accent-primary); background:radial-gradient(circle,var(--accent-primary) 0 42%, transparent 44%); }
+.badge { display:inline-block; font-size:11px; font-weight:600; padding:2px 8px; border-radius:999px; border:1px solid; white-space:nowrap; }
+.b-neutral { background:var(--status-disabled-soft); border-color:var(--status-disabled-border); color:var(--status-disabled-fg); }
+.b-info { background:var(--status-info-soft); border-color:var(--status-info-border); color:var(--status-info-fg); }
+.b-warn { background:var(--status-warning-soft); border-color:var(--status-warning-border); color:var(--status-warning-fg); }
+.b-err  { background:var(--status-error-soft); border-color:var(--status-error-border); color:var(--status-error-fg); }
+.b-acc  { background:var(--accent-primary-soft); border-color:var(--accent-primary-border); color:var(--accent-primary-strong); }
+.tablewrap { overflow-x:auto; }
+table { width:100%; border-collapse:collapse; min-width:640px; }
+th { text-align:left; font-size:11px; letter-spacing:.06em; text-transform:uppercase; color:var(--text-muted); font-weight:600; padding:8px 10px; border-bottom:1px solid var(--border-default); }
+td { padding:11px 10px; border-bottom:1px solid var(--border-subtle); vertical-align:top; }
+tr:last-child td { border-bottom:none; }
+.q { font-weight:600; }
+.why { display:block; font-size:12px; color:var(--text-muted); margin-top:3px; max-width:46ch; }
+.note { font-size:12.5px; color:var(--text-secondary); background:var(--bg-muted); border:1px solid var(--border-subtle); border-radius:var(--radius); padding:10px 12px; margin-top:16px; }
+.att-row { display:flex; gap:12px; align-items:flex-start; padding:12px 0; border-bottom:1px solid var(--border-subtle); }
+.att-row:last-child { border-bottom:none; }
+.att-body { flex:1; min-width:0; }
+.att-title { font-weight:600; font-size:13.5px; }
+.att-text { font-size:12.5px; color:var(--text-secondary); margin-top:2px; }
+.att-fix { font-size:12px; margin-top:4px; }
+a { color:var(--text-link,var(--accent-primary-strong)); }
+.link { color:var(--accent-primary-strong); text-decoration:underline; text-underline-offset:2px; cursor:pointer; }
+.callout { font-size:12.5px; color:var(--text-secondary); }
+.mono { font-family:var(--font-mono); font-size:12px; }
+.foot { font-size:12px; color:var(--text-muted); border-top:1px solid var(--border-subtle); margin-top:32px; padding-top:14px; }
+</style>
+
+<div class="wrap">
+  <p class="eyebrow">Settings</p>
+  <h1>Who decides what</h1>
+  <p class="lede">OpenLinker, your shop, your marketplaces and your warehouse each get to decide
+  different things. This page shows who decides what right now, and lets you hand some of those
+  decisions to OpenLinker — or keep them where they are.</p>
+
+  <!-- ── PRESETS ────────────────────────────────────────────── -->
+  <section class="panel">
+    <div class="panel__header">
+      <div>
+        <p class="eyebrow">Choose an arrangement</p>
+        <h2>How should this work?</h2>
+      </div>
+    </div>
+
+    <div class="cards">
+      <div class="card card--on">
+        <h3><span class="radio radio--on"></span> Leave things as they are <span class="badge b-acc">Current</span></h3>
+        <p>Your shop and your marketplaces keep making every decision, exactly as they do now.
+        OpenLinker connects them, publishes your stock and offers, files your invoices, and stays
+        out of the way.</p>
+        <span class="best">Best if: one shop, one warehouse, and nothing about your current setup is annoying you.</span>
+        <span class="effect"><strong>Nothing changes when you pick this.</strong> It is what OpenLinker already does.</span>
+      </div>
+
+      <div class="card">
+        <h3><span class="radio"></span> Let OpenLinker decide</h3>
+        <p>OpenLinker becomes the place where decisions get made: it works out how much stock you
+        can safely promise, holds orders that shouldn’t go out yet, and decides what happens to
+        goods that come back. Your shop and your carriers still do the physical work.</p>
+        <span class="best">Best if: you sell the same stock on more than one channel, or you keep finding orders you wish had been stopped before they shipped.</span>
+        <span class="effect"><strong>What this changes:</strong> OpenLinker starts subtracting orders it has seen from the stock numbers it publishes, and can hold an order so it never reaches your shop. Your existing stock, order and invoice flows are untouched.</span>
+      </div>
+
+      <div class="card card--off">
+        <h3><span class="radio"></span> Keep my other system in charge <span class="badge b-neutral">Not available yet</span></h3>
+        <p>Your existing warehouse or order system keeps deciding. OpenLinker gives it marketplace
+        connectivity — offers, stock publication, order feed, status relay — and files your Polish
+        invoices and receipts, which it can’t.</p>
+        <span class="best">Best if: you already run a warehouse or ERP system that you trust and don’t want to replace.</span>
+        <span class="effect">Needs a system that can take over. <span class="link">Connect one first.</span></span>
+      </div>
+    </div>
+
+    <p class="note">Changing this only affects what happens <strong>from now on</strong>. Anything
+    already in progress — an order already sent to your shop, a label already bought — keeps its
+    current arrangement until it finishes.</p>
+  </section>
+
+  <!-- ── WHO DECIDES TABLE ──────────────────────────────────── -->
+  <section class="panel">
+    <div class="panel__header">
+      <div>
+        <p class="eyebrow">Right now</p>
+        <h2>Who decides what</h2>
+      </div>
+      <span class="callout">7 decisions</span>
+    </div>
+
+    <div class="tablewrap">
+      <table>
+        <thead><tr><th style="width:52%">Question</th><th style="width:30%">Decided by</th><th>State</th></tr></thead>
+        <tbody>
+          <tr>
+            <td><span class="q">How much stock can we promise?</span>
+              <span class="why">Worked out from your stock master, minus your safety buffer. Nobody else has claimed it.</span></td>
+            <td>OpenLinker</td><td><span class="badge b-neutral">Default</span></td>
+          </tr>
+          <tr>
+            <td><span class="q">Where does an order ship from?</span>
+              <span class="why">You sell from one place, so there is nothing to choose between.</span></td>
+            <td>Each shop decides</td><td><span class="badge b-neutral">Nothing to route</span></td>
+          </tr>
+          <tr>
+            <td><span class="q">Who picks and ships?</span>
+              <span class="why">Marketplace-fulfilled orders are picked and shipped by the marketplace. Everything else lands with your shop.</span></td>
+            <td>My shop · Allegro</td><td><span class="badge b-neutral">Default</span></td>
+          </tr>
+          <tr>
+            <td><span class="q">What state is an order in?</span>
+              <span class="why">OpenLinker works it out from what it can see — the shipment, the invoice, any hold you placed.</span></td>
+            <td>OpenLinker</td><td><span class="badge b-neutral">Default</span></td>
+          </tr>
+          <tr>
+            <td><span class="q">What happens to returned goods?</span>
+              <span class="why">Two systems are set up to decide, so OpenLinker is doing neither. Returns are still being recorded, but nothing is being restocked or scrapped automatically.</span></td>
+            <td>OpenLinker can’t tell</td><td><span class="badge b-err">Nothing is deciding</span></td>
+          </tr>
+          <tr>
+            <td><span class="q">Who issues refunds?</span>
+              <span class="why">Only OpenLinker holds the payment credentials, so only OpenLinker can do it. This one can’t be handed over.</span></td>
+            <td>OpenLinker</td><td><span class="badge b-info">Always</span></td>
+          </tr>
+          <tr>
+            <td><span class="q">Who issues invoices and receipts?</span>
+              <span class="why">Configured per country under Sales documents.</span></td>
+            <td><span class="link">Set up under Sales documents →</span></td><td><span class="badge b-neutral">Elsewhere</span></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <!-- ── NEEDS ATTENTION ────────────────────────────────────── -->
+  <section class="panel">
+    <div class="panel__header">
+      <div>
+        <p class="eyebrow">Not working</p>
+        <h2>Needs attention <span class="badge b-err">4</span></h2>
+      </div>
+      <span class="callout">Only things that are stopping something. Defaults are never listed here.</span>
+    </div>
+
+    <div class="att-row">
+      <span class="badge b-err">Stopped</span>
+      <div class="att-body">
+        <div class="att-title">Nothing is deciding what happens to returns from Allegro</div>
+        <div class="att-text">Two systems are set up to decide, so OpenLinker is doing neither. Returns are still being recorded, but nothing is being restocked or scrapped automatically.</div>
+        <div class="att-fix"><span class="link">Subiekt nexo</span> · <span class="link">Warehouse OMS</span> — turn one of them off.</div>
+      </div>
+    </div>
+
+    <div class="att-row">
+      <span class="badge b-warn">At risk</span>
+      <div class="att-body">
+        <div class="att-title">Order <span class="mono">OL-2026-0184</span> is short 2 × <span class="mono">SKU-4471</span></div>
+        <div class="att-text">Your stock master dropped below what this order was promised. Nothing was silently reduced — this order is the one at risk.</div>
+        <div class="att-fix"><span class="link">Open order</span> · <span class="link">Open product</span></div>
+      </div>
+    </div>
+
+    <div class="att-row">
+      <span class="badge b-err">Stopped</span>
+      <div class="att-body">
+        <div class="att-title">Couldn’t buy the label for order <span class="mono">OL-2026-0191</span></div>
+        <div class="att-text">The automation “Packed → label → tell Allegro” tried and DPD said: <em>no service available for this postcode</em>. Nothing else in that automation ran, so Allegro has not been told. The order is waiting for you.</div>
+        <div class="att-fix"><span class="link">Open order</span> · <span class="link">Open automation</span> · <span class="link">Try again</span></div>
+      </div>
+    </div>
+
+    <div class="att-row">
+      <span class="badge b-err">Blocked</span>
+      <div class="att-body">
+        <div class="att-title">Stock was not added</div>
+        <div class="att-text">OpenLinker recorded the disposition, but <strong>PrestaShop</strong> does not accept stock adjustments from OpenLinker, so <strong>your stock has not changed</strong>. Add 1 × <span class="mono">SKU-1180</span> in PrestaShop yourself, then mark this handled.</div>
+        <div class="att-fix"><span class="link">Open return</span> · <span class="link">Open PrestaShop</span></div>
+      </div>
+    </div>
+  </section>
+
+  <p class="foot">Mockup for the Wave-2 operator-experience product spec. Layout is indicative; every
+  string on this page is verbatim from the spec, which is the record — page furniture and badge
+  vocabulary from §3.2/§3.3, attention copy from §4.2. The two states owned by the returns spec
+  (<em>Stock was not added</em>, orphan returns) carry that spec’s §5.4/§5.5 strings, imported rather
+  than restated. No model vocabulary (“authority”, “posture”, “FulfillmentWork”) appears anywhere on
+  this page — by rule.</p>
+</div>

--- a/docs/plans/oms-backlog-overview.md
+++ b/docs/plans/oms-backlog-overview.md
@@ -1,0 +1,231 @@
+# OMS Programme — Backlog Overview
+
+The map of the OMS authority-model programme: what each wave is for, what gates it, and where the
+long chains run. It is a **navigation document**, not a source of truth — the decisions live in
+[`analysis/DESIGN-oms-authority-model.md`](./analysis/DESIGN-oms-authority-model.md) and
+[`analysis/REVIEW-oms-authority-model.md`](./analysis/REVIEW-oms-authority-model.md), and the
+architectural commitments in [ADRs 052–062](../architecture/adrs/) (merged in PR #2281).
+
+Two product specs cover the operator-facing half of Wave 2:
+
+- [`../specs/product-spec-oms-wave2-operator-experience.md`](../specs/product-spec-oms-wave2-operator-experience.md)
+  — order holds, the authority surface and presets, automation v1.
+- [`../specs/product-spec-oms-returns-operator-ux.md`](../specs/product-spec-oms-returns-operator-ux.md)
+  — returns custody, disposition, money and the commission-refund flow.
+
+The authority surface's shape is prototyped in
+[`mockups/mockup-who-decides-what.html`](./mockups/mockup-who-decides-what.html).
+
+## Reading the slugs
+
+Backlog issues are referenced here by **W-slug** (`W1a-3`, `W2-14`, `W3a-19`, `W4-7`). GitHub
+numbers are assigned at filing time; every issue in the programme carries the **`oms`** label, so
+`label:oms` is the durable way to find them. Wave 0 is the exception — it is already filed and is
+referenced by its real numbers.
+
+Streams used throughout: **S1** = core inventory/fulfillment BE · **S2** = orders/returns BE ·
+**S3** = product/FE. Sizes: **S** ≤2d · **M** ≤5d · **L** ≤10d.
+
+---
+
+## Wave structure at a glance
+
+| Wave | Subject | Children | Status |
+|---|---|---|---|
+| **0** | Preconditions and correctness fixes | 8 | **Filed** — #2282–#2289 |
+| **1a** | Vocabulary leaves + derived order lifecycle phase | 8 | To file |
+| **1b** | Inventory foundations: locations, provenance, availability seam | 11 | To file (+1 unscheduled, Wave 1d) |
+| **1c** | Returns, observed | 10 filed / 9 active | To file (scope fork on #2289) |
+| **2** | The majority's OMS value | 51 | To file |
+| **3a** | Fulfilment routing, work objects, desktop worklist | 22 | To file |
+| **3b** | Store-associate scan/pick surface | 8 | To file |
+| **4** | Third-party OMS, posture B, port hardening | 11 | To file |
+
+Both demand gates have **fired**: a live multi-location routing pain case exists (Wave 3) and
+third-party OMS/3PL demand exists (Wave 4). Only `W4-9` — the vendor adapter — stays parameterized,
+because no vendor is named yet.
+
+---
+
+## Wave 0 — preconditions (filed: #2282–#2289)
+
+The correctness work that later waves name as preconditions rather than assume. `persistOrder`
+source-attribution immutability (#2282, also ADR-057's stated precondition), the ingestion line-diff
+and `amended` fact (#2283), the `WHERE cancelledAt IS NULL` provisioning predicate (#2284, an
+ADR-059 named precondition), the quantity-derived `inv:{hash}` idempotency-key swap (#2285, which
+must be gone before propagation behaviour changes or the corrective write dedups against the stale
+key), `never`-default exhaustiveness on the five `OrderLifecycleEvent` consumers (#2286), `packedAt`
+BE/FE (#2287/#2288 — automation trigger T5's backing fact), and the Allegro customer-returns feed
+spike (#2289, which sets Wave 1c's scope fork). #2296/#2297 (CI) are done; #2298 is the
+design-freshness reconciliation.
+
+## Wave 1a — vocabulary leaves + derived lifecycle phase (8 children)
+
+The only genuinely zero-behaviour wave in the programme — the delivery panel split the original
+Wave 1 into 1a/1b/1c/1d precisely because the "zero behaviour" label was false of the other three.
+It lands the two vocabulary leaf contexts every later wave imports (fulfillment-authority,
+order-lifecycle) plus the one operator-facing read that pays for itself immediately: the derived
+`OrderLifecyclePhase`. `order_records` already carries six quasi-status axes and `OrderHealth`
+answers *sync* health; nothing answers "what is this order waiting on, and who holds it up". ADR-059
+supersedes the reverted ADR-043 by persisting facts and deriving the phase — no new persisted
+column, no write-path change. `W1a-8` also owns the `architecture-overview.md` pointer lines for
+ADRs 052, 053 and 059; the other eight ADRs in the block are assigned to the wave that first
+implements them.
+
+**Gated on:** #2284, #2286, #2283 merged; the ADR 052–062 block merged; #2298 resolved.
+
+## Wave 1b — inventory foundations (11 children)
+
+`inventory_items` is nominally location-aware and behaviourally single-location: one line in
+`inventory.service.ts` disables propagation outright for a non-null `locationId`, the row carries no
+connection provenance (which is why the #1904 rival-master guard is detect-and-withhold rather than
+attributable), both partial unique indexes include the nullable `locationId` so duplicate
+locationless positions are permitted and silently summed, and no `inventory_locations` table exists.
+Wave 1b ships steps (i) and (ii) of ADR-058's three-step ladder — nullable `sourceConnectionId` plus
+a `'legacy'` sentinel backfill — the locations table and CRUD, provenance-scoped lookup and
+per-source pruning, and the `IAvailabilityService` computed seam that every publishing site is then
+rewired onto. **Not zero-behaviour**, and it carries the programme's one declared plugin-breaking
+change (retiring the `locationId` propagation skip). Step (iii) is filed as Wave 1d, unscheduled —
+migrations run in one transaction, so `CREATE INDEX CONCURRENTLY` is unavailable and index
+recreation would hold `ACCESS EXCLUSIVE` on the live oversell table.
+
+**Gated on:** #2285 merged; ADR-058 merged; `W1a-8` landed.
+
+## Wave 1c — returns, observed (10 filed / 9 active)
+
+OL has no returns model; `libs/core/src/returns/` does not exist and the only adjacent persistence
+is the capture-only `RefundRecord` (#2036). ADR-060 keeps ANALYSIS-1032's source-shape findings
+wholesale (verbatim `rawStatus`, nullable `resolvedOrderLineId` by design) and puts an OL-owned
+aggregate above the projection. This wave **observes** only: the aggregate, the orphan bucket,
+ingestion, the read API, list and detail, and the single source write `return.decline`. Nothing here
+writes stock, money or an invoice correction.
+
+Scope forks on **#2289**: if the Allegro feed is cursor- or watermark-shaped, returns get their own
+poll/sync jobs through a `ReturnSourceReader` sub-capability (`W1c-4A`); if the kill condition
+fires, they land as projection-only observations off order sync (`W1c-4B`). Exactly one of the two
+is filed — everything else in the epic is identical either way, because the aggregate, orphan
+bucket, read API and FE do not depend on how the observation arrived.
+
+**Gated on:** #2289 resolved with the fork decided; Wave 1a landed; ADR-060 merged.
+
+## Wave 2 — the majority's OMS value (51 children)
+
+Waves 1a–1c land vocabulary, a derived phase, inventory foundations and an observed returns record.
+None of them change what an operator can **do**. Wave 2 is the first wave with operator value on the
+majority topology — the single-location, self-shipping seller — and the roadmap names it as part of
+the minimal coherent V1. Five bodies of work share one epic because they share the attention surface
+and the authority read:
+
+1. **Order holds** (5 children) — the first OL-owned lifecycle write.
+2. **The reservation ledger** (8) — the only thing in the programme that makes an ingested order
+   reduce what channels may promise.
+3. **The authority surface + presets** (7) — shipping *together with* the first operator-settable
+   authority flag; the design forbids shipping the flag without the surface.
+4. **Automation v1** (12) — 8 triggers × 6 actions over a closed legality matrix, plus its
+   operational half: every firing recorded, landed on the acted-on order's timeline, and a failed
+   action raised as its own attention state (AF-X). Automation that spends real money without
+   leaving a trace where the operator looks is a configuration surface, not an operational one.
+5. **Returns custody, disposition, money and the Allegro commission refund** (17, incl. one spike) —
+   plus the `InventoryMasterPort.adjustInventory` amendment, without which `restock_blocked` is the
+   *default* outcome on the most common OL master.
+
+Two DX gates close the wave (`W2-46a` vocabulary, `W2-46b` responsive audit). **`W2-50`** (Allegro
+commission-claim spike) and **`W2-46a`** are scheduled first: both are dependency-free, and their
+answers constrain later work.
+
+**Gated on:** Wave 1a in full; `W1b-6`, `W1b-7`, `W1b-9`, `W1b-11`; #2283, #2287/#2288 merged; Wave
+1c landed with its fork decided; `W1c-6` (`order_changes` — reused, never rebuilt); and both product
+specs signed off including spec §8 Q1. A `no` on Q1 deletes `W2-21`…`W2-29` and nothing else.
+
+## Wave 3a — routing, work objects, desktop worklist (22 children)
+
+OL can route nothing today: `OrderIngestionService` goes `persistOrder` → `syncOrder`, fanning every
+order out to every destination. A seller with two locations, a 3PL, or a no-shop topology cannot say
+which lines are fulfilled where, cannot dry-run that decision, and has no object to hang progress
+on. Because `identifier_mappings` is a bijection per connection (ADR-044), the order itself can
+never be split — the *work* must be. Wave 3a lands the router seam, the `routing_decisions` intent
+row, the `FulfillmentWork` aggregate with its two orthogonal state axes, the executor handshake,
+core-side progress ingress, the OL-OMS plugin at `libs/oms/`, and a **desktop** worklist with manual
+mark-picked / mark-shipped. Per REVIEW D10 the cut sits *before* the floor UI — 3a lights the 3PL
+story without it. A router-less install must run byte-identically to today, pinned by a
+characterisation test.
+
+**Gated on:** Wave 1b locations (with `countryIso2`/`postcode`/optional geo — the `country-served`
+and `nearest` rules are unimplementable without them) and the availability seam; Wave 1a's leaves
+and conformance checklist; Wave 2's holds, reservation ledger and authority surface; #2282. Only
+`W3a-1` (package scaffold) is startable immediately.
+
+## Wave 3b — the store-associate scan surface (8 children)
+
+3a's desktop worklist is enough for a 3PL, not for a human on a floor with a scanner. REVIEW D10
+sizes this honestly as its own wizard-scale FE epic (~30 files / ~10k lines) and refuses to hide it
+inside 3a. Design §5.4's `short_picked` + `releaseShortfall` semantics are only exercisable once
+something on the floor can report a shortfall, so the re-sourcing logic ships here too.
+
+**Gated on:** Wave 3a merged — specifically `W3a-11` (progress ingress), `W3a-18` (OL executor) and
+`W3a-19` (read model); and **#2080** (pack-station principal ADR) decided and merged. A shared floor
+terminal is not an ordinary logged-in admin session; this epic consumes #2080's answer and does not
+re-open it.
+
+## Wave 4 — third-party OMS, posture B, port hardening (11 children)
+
+The plugin-contracts panel's verdict was blunt: *"a competent third party cannot ship an adapter
+against this contract as it stands"* — nine referenced I/O types undefined, no per-port error
+taxonomy or timeout budget, a synchronous `route()` where a DOMS is not, no batch caps. `W4-1`…`W4-5`
+close that and are **binding blockers**: no out-of-tree or vendor port-implementation issue may start
+until all five are merged. The wave also lands the posture-B seam (an external OMS owning the order
+and pushing it in — substantially just an `OrderSource`, blocked on the ADR-057 predicate), ADR-062
+trust activation, one vendor-parameterized adapter, and the two scale features the design defers
+here (location networks, returns disposition routing).
+
+**Gated on:** Wave 3a merged; #2282; and, for `W4-9` alone, a named vendor. Waving and
+`ReturnReceiver` are deferred by the design and not filed.
+
+---
+
+## Cross-wave critical paths
+
+Three long chains run through the programme. They are largely independent, which is what makes
+three streams worth staffing.
+
+**1. Lifecycle / orders (S2).**
+`#2286 → W1a-2 → W1a-3 (+#2284) → W1a-4 → W1a-5 → W1a-6` → Wave 2 holds
+(`W2-1 → W2-2 → W2-3/W2-4 → W2-5`) → automation, which converges late:
+`W2-23` (trigger emission) sits downstream of *both* the returns disposition writes (`W2-33`) and
+the shortfall episode (`W2-12`), not parallel to them. It is the wave's real convergence point and
+the piece most likely to slip; if S2 is one person, run returns before automation — returns has more
+downstream FE and unblocks `W2-23` besides.
+
+**2. Inventory / fulfilment (S1) — the longest chain in Wave 1.**
+`#2285 → W1b-3 → W1b-4 → W1b-5 → W1b-6 → W1b-7 → W1b-8`, feeding the Wave-2 reservation ledger
+(`W2-6 → W2-7 → W2-8/W2-9/W2-10 → W2-11/W2-12 → W2-13`), which in turn is a Wave-3a entry criterion.
+From there:
+`W3a-1 → W3a-2 → W3a-3 → W3a-6 → W3a-7 → (W3a-10 / W3a-11) → W3a-19 → W3a-20`, then into Wave 3b
+(`W3b-1 → W3b-3 → W3b-4 → W3b-5/W3b-6/W3b-7 → W3b-8`) and Wave 4's blockers
+(`W4-1 → W4-2 → W4-3 → W4-9`).
+
+**3. Returns (S2 → S3).**
+`#2289 → W1c-1 → W1c-2 → W1c-4A → W1c-6 → W1c-9`, continuing into Wave 2 custody and money
+(`W2-30/W2-31 → W2-32/W2-33 → W2-34/W2-35/W2-38 → W2-37 → W2-39 → W2-42/W2-44`) and terminating in
+Wave 4's returns disposition routing (`W4-11`), which additionally needs the Wave-2 reservation
+ledger.
+
+---
+
+## Standing rules
+
+Two directives bind every issue in the programme and are restated in each epic rather than assumed.
+
+**UI naming (REVIEW P9).** The words *authority*, *posture* and *FulfillmentWork* never reach the
+UI. Operator-facing copy uses "Who decides X?", "fulfilment task", and outcome-named presets. The
+`W2-46a` vocabulary gate enforces this and must land before any Wave-2 copy is written.
+
+**Boundary (ADR-053 no-injection invariant).** The `fulfillment` context injects **no** `orders` or
+`inventory` service. Order data enters as arguments; type needs go through
+`@openlinker/core/orders/types`. A boot integration test pins the one-way edge, following the
+ADR-041 F3 precedent.
+
+**Frontend (S3).** Every Zod schema mirroring a backend projection uses `.nullish()`, never
+`.optional()` — OL serialises an absent optional as JSON `null`, and under `.optional()` one `null`
+sub-field drops the whole section (#939). Each new feature folder ships its public `index.ts` barrel
+and registers its slug in both `.eslintrc.js` `no-restricted-imports` pattern groups.

--- a/docs/plans/oms-backlog-overview.md
+++ b/docs/plans/oms-backlog-overview.md
@@ -18,10 +18,11 @@ The authority surface's shape is prototyped in
 
 ## Reading the slugs
 
-Backlog issues are referenced here by **W-slug** (`W1a-3`, `W2-14`, `W3a-19`, `W4-7`). GitHub
-numbers are assigned at filing time; every issue in the programme carries the **`oms`** label, so
-`label:oms` is the durable way to find them. Wave 0 is the exception — it is already filed and is
-referenced by its real numbers.
+Backlog issues are referenced here by **W-slug** (`W1a-3`, `W2-14`, `W3a-19`, `W4-7`). The full
+backlog is **filed** — each wave's epic carries a number-mapped checklist resolving every slug to
+its GitHub number, so the epic is the place to go from a slug to an issue. Every issue in the
+programme carries the **`oms`** label, so `label:oms` is the durable way to find them. Wave 0 is
+the exception — it has no epic and is referenced here by its real numbers.
 
 Streams used throughout: **S1** = core inventory/fulfillment BE · **S2** = orders/returns BE ·
 **S3** = product/FE. Sizes: **S** ≤2d · **M** ≤5d · **L** ≤10d.
@@ -33,13 +34,13 @@ Streams used throughout: **S1** = core inventory/fulfillment BE · **S2** = orde
 | Wave | Subject | Children | Status |
 |---|---|---|---|
 | **0** | Preconditions and correctness fixes | 8 | **Filed** — #2282–#2289 |
-| **1a** | Vocabulary leaves + derived order lifecycle phase | 8 | To file |
-| **1b** | Inventory foundations: locations, provenance, availability seam | 11 | To file (+1 unscheduled, Wave 1d) |
-| **1c** | Returns, observed | 10 filed / 9 active | To file (scope fork on #2289) |
-| **2** | The majority's OMS value | 51 | To file |
-| **3a** | Fulfilment routing, work objects, desktop worklist | 22 | To file |
-| **3b** | Store-associate scan/pick surface | 8 | To file |
-| **4** | Third-party OMS, posture B, port hardening | 11 | To file |
+| **1a** | Vocabulary leaves + derived order lifecycle phase | 8 | **Filed** — epic #2312 |
+| **1b** | Inventory foundations: locations, provenance, availability seam | 11 | **Filed** — epic #2326 (+ #2325, Wave 1d, unscheduled) |
+| **1c** | Returns, observed | 10 filed / 9 active | **Filed** — epic #2337 (scope fork on #2289) |
+| **2** | The majority's OMS value | 51 | **Filed** — epic #2389 |
+| **3a** | Fulfilment routing, work objects, desktop worklist | 22 | **Filed** — epic #2412 |
+| **3b** | Store-associate scan/pick surface | 8 | **Filed** — epic #2422 |
+| **4** | Third-party OMS, posture B, port hardening | 11 | **Filed** — epic #2434 |
 
 Both demand gates have **fired**: a live multi-location routing pain case exists (Wave 3) and
 third-party OMS/3PL demand exists (Wave 4). Only `W4-9` — the vendor adapter — stays parameterized,
@@ -59,7 +60,7 @@ BE/FE (#2287/#2288 — automation trigger T5's backing fact), and the Allegro cu
 spike (#2289, which sets Wave 1c's scope fork). #2296/#2297 (CI) are done; #2298 is the
 design-freshness reconciliation.
 
-## Wave 1a — vocabulary leaves + derived lifecycle phase (8 children)
+## Wave 1a — vocabulary leaves + derived lifecycle phase (8 children, epic #2312)
 
 The only genuinely zero-behaviour wave in the programme — the delivery panel split the original
 Wave 1 into 1a/1b/1c/1d precisely because the "zero behaviour" label was false of the other three.
@@ -74,7 +75,7 @@ implements them.
 
 **Gated on:** #2284, #2286, #2283 merged; the ADR 052–062 block merged; #2298 resolved.
 
-## Wave 1b — inventory foundations (11 children)
+## Wave 1b — inventory foundations (11 children, epic #2326)
 
 `inventory_items` is nominally location-aware and behaviourally single-location: one line in
 `inventory.service.ts` disables propagation outright for a non-null `locationId`, the row carries no
@@ -91,7 +92,7 @@ recreation would hold `ACCESS EXCLUSIVE` on the live oversell table.
 
 **Gated on:** #2285 merged; ADR-058 merged; `W1a-8` landed.
 
-## Wave 1c — returns, observed (10 filed / 9 active)
+## Wave 1c — returns, observed (10 filed / 9 active, epic #2337)
 
 OL has no returns model; `libs/core/src/returns/` does not exist and the only adjacent persistence
 is the capture-only `RefundRecord` (#2036). ADR-060 keeps ANALYSIS-1032's source-shape findings
@@ -108,7 +109,7 @@ bucket, read API and FE do not depend on how the observation arrived.
 
 **Gated on:** #2289 resolved with the fork decided; Wave 1a landed; ADR-060 merged.
 
-## Wave 2 — the majority's OMS value (51 children)
+## Wave 2 — the majority's OMS value (51 children, epic #2389)
 
 Waves 1a–1c land vocabulary, a derived phase, inventory foundations and an observed returns record.
 None of them change what an operator can **do**. Wave 2 is the first wave with operator value on the
@@ -137,7 +138,7 @@ answers constrain later work.
 1c landed with its fork decided; `W1c-6` (`order_changes` — reused, never rebuilt); and both product
 specs signed off including spec §8 Q1. A `no` on Q1 deletes `W2-21`…`W2-29` and nothing else.
 
-## Wave 3a — routing, work objects, desktop worklist (22 children)
+## Wave 3a — routing, work objects, desktop worklist (22 children, epic #2412)
 
 OL can route nothing today: `OrderIngestionService` goes `persistOrder` → `syncOrder`, fanning every
 order out to every destination. A seller with two locations, a 3PL, or a no-shop topology cannot say
@@ -155,7 +156,7 @@ and `nearest` rules are unimplementable without them) and the availability seam;
 and conformance checklist; Wave 2's holds, reservation ledger and authority surface; #2282. Only
 `W3a-1` (package scaffold) is startable immediately.
 
-## Wave 3b — the store-associate scan surface (8 children)
+## Wave 3b — the store-associate scan surface (8 children, epic #2422)
 
 3a's desktop worklist is enough for a 3PL, not for a human on a floor with a scanner. REVIEW D10
 sizes this honestly as its own wizard-scale FE epic (~30 files / ~10k lines) and refuses to hide it
@@ -167,7 +168,7 @@ something on the floor can report a shortfall, so the re-sourcing logic ships he
 terminal is not an ordinary logged-in admin session; this epic consumes #2080's answer and does not
 re-open it.
 
-## Wave 4 — third-party OMS, posture B, port hardening (11 children)
+## Wave 4 — third-party OMS, posture B, port hardening (11 children, epic #2434)
 
 The plugin-contracts panel's verdict was blunt: *"a competent third party cannot ship an adapter
 against this contract as it stands"* — nine referenced I/O types undefined, no per-port error

--- a/docs/specs/product-spec-oms-returns-operator-ux.md
+++ b/docs/specs/product-spec-oms-returns-operator-ux.md
@@ -1,0 +1,811 @@
+# Product Spec — OMS Returns: the operator's day (Waves 1c–2)
+
+**Status:** Draft for review — **product/UX specification only**. The domain model is decided and out
+of scope for re-litigation: `docs/plans/analysis/DESIGN-oms-authority-model.md` §7,
+`docs/architecture/adrs/060-returns-aggregate-above-source-projection.md`, and the R1 REVIEW record.
+Source-shape constraints are absorbed verbatim from `ANALYSIS-1032-oms-module.md` § Wave 4.
+**Parent design stories:** T1–T7, T10 (§14). **Waves:** 1c (observe) + 2 (custody, money, corrections).
+**Started:** 2026-08-22
+
+> **What this document is.** ADR-060 decided *what a return is*. Nobody has designed *the operator's
+> day*: the screen a warehouse user opens when a parcel lands on the bench, the moment an operator
+> learns a restock silently refused, the paragraph an accountant reads before issuing a credit note
+> against a legal document that cannot be retracted. That is this spec. Every screen below is
+> constrained by one rule the model already committed to: **OL displays what it observed and what its
+> operator did, and never a state it inferred.**
+
+---
+
+## 1. Problem
+
+OL persists refunds (`RefundRecord`, #2036) with **no frontend at all** — verified: the only `refund`
+token in `apps/web/src` is a payment badge label. Returns exist nowhere. So today the operator's
+return workflow is: read the marketplace's own panel, count the parcel on the bench, type the stock
+correction into PrestaShop by hand, remember to issue the credit note, and remember — separately, and
+most sellers do not — to claim the Allegro commission back.
+
+Four distinct failures live in that gap:
+
+1. **No single place.** Returns are opened on the marketplace the buyer bought from. A three-channel
+   seller checks three panels, on three cadences, with three vocabularies.
+2. **The physical fact has nowhere to land.** "Two of the three advised units arrived, one is
+   scuffed" is an event in the operator's own building with **no source counterpart to contradict it**
+   — and no field anywhere in OL to hold it.
+3. **Restock is the silent one.** `PrestashopInventoryMasterAdapter.adjustInventory` **rejects**
+   (`PrestashopNotSupportedException`). A returns feature that reports "restocked" against that
+   adapter would be lying to an operator about their own stock. ADR-060's answer — `restock_blocked`,
+   operator-visible — only works if a screen surfaces it with something the operator can *do*.
+4. **The money is two flows, not one.** The buyer refund and (on Allegro) the **commission refund**
+   are separate claims with separate outcomes. Exactly one competitor covers the second. Sellers who
+   do not claim it lose the fee on every return, permanently and invisibly.
+
+### Why this is a UX problem and not a data problem
+
+The model is deliberately honest in ways that are *hostile to a naive screen*: `rawStatus` is verbatim
+and uninterpreted (Allegro's 11 values interleave four axes; the spec itself calls it a "timeline"),
+`resolvedOrderLineId` is **nullable by design**, custody and money are **two machines that never
+collapse**, and lines carry **counters, not statuses**. A screen that renders any of that as a single
+green pill has re-introduced the inference the model refused. The design work here is showing three
+partial truths at once without making the operator feel they are looking at a broken page.
+
+---
+
+## 2. Affected personas
+
+| | Persona | What they do here | Their screen |
+|---|---|---|---|
+| **P1** | **The operator** (multi-channel seller, non-technical, runs the OL admin) | Triage the day's returns, decline what's declinable, drive money and paperwork | Returns list, return detail money side |
+| **P2** | **The warehouse user** (may be the same human wearing a different hat; on a bench, possibly a tablet) | Open the parcel, record what actually arrived per line, dispose restock/scrap | Return detail custody side, mobile/tablet-first |
+| **P3** | **The accountant** (often external, low OL familiarity, opens OL for one task) | Confirm a credit-note proposal against the original invoice | Correction-proposal review |
+
+P2 is why the detail page is **tablet-first, not desktop-only** — the receiving flow is the one OL
+surface a user reaches with a parcel in one hand. The responsive rule (mobile ≤767, tablet 768–1023
+first-class) is binding here rather than nominal.
+
+---
+
+## 3. Decisions this spec owns
+
+### 3.1 `inspected` — **collapsed into `received` for v1** (design §12.7, delegated)
+
+**Decision: ship custody as `advised → in_transit → received → disposed | not_returned`. `inspected`
+is deleted from v1.**
+
+Reasoning, in the order that decided it:
+
+1. **The fact `inspected` would carry is a fact OL already ruled out.** The only thing inspection
+   produces that receipt does not is *condition* — and `damagedQuantity` was cut as unobservable from
+   every source in scope, operator-typed-only, and **grading returned goods is a declared permanent
+   non-goal** ("warehouse mechanics", ANALYSIS §1). A state whose payload does not exist is a label.
+2. **It has no distinct action and no distinct decision.** `received` is entered by the operator
+   recording quantities; `disposed` is entered by the operator choosing restock or scrap. **The
+   disposition choice *is* the inspection outcome.** There is no third form, no third button, and
+   nothing downstream branches on the difference — which is precisely the condition ADR-060 and design
+   §12.7 set for deleting it ("delete before it enters a downstream `switch`").
+3. **The operator need it appears to serve is already served.** "Arrived, not yet decided" is exactly
+   `received` with `quantityRestocked + quantityScrapped < quantityReceived` — visible in the
+   counters, which are the model's chosen expression of partial progress. Adding a state to say what
+   a counter already says is double-encoding, and it makes `received` ambiguous.
+4. **The cost of being wrong is asymmetric and small.** Adding a state later is additive (one enum
+   value, one timestamp, one step in the custody rail). Shipping one nobody enters means every return
+   sits in `received` forever while a timeline step renders permanently grey — and the operator learns
+   to distrust the timeline, which is the one component whose entire value is trust.
+
+**Reversal gate (explicit, so a later wave does not re-argue from scratch):** `inspected` re-enters the
+moment **receipt and disposition are performed by different actors** — i.e. when `ReturnReceiver`
+(T8, deferred with its narrowing base unnamed) or any 3PL receiving integration ships, because then
+"received by the 3PL, not yet adjudicated by the authority" is a real hand-off with a real waiting
+party. It must be added **before** any downstream consumer branches on custody, never after.
+
+**Consequence for this spec:** every AC, rail and filter below uses the four-state custody machine. The
+persisted `receivedAt` / `disposedAt` timestamps carry the whole story; a free-text **note** is offered
+per disposition line (§5.3) and is explicitly *not* a graded vocabulary.
+
+### 3.2 The rollup labels are derived from counters, and say so
+
+The list needs one glanceable signal per row, but the model forbids a status. So the row renders a
+**derived operator stage** computed *purely from counters and timestamps* — `Awaiting parcel`,
+`Partially received`, `Received — awaiting disposition`, `Disposed`, `Not returned`, `Declined` — with
+the counters themselves adjacent (`3 of 5 received`). It is a **presentation projection, never a
+persisted column**, mirrored FE/SQL and pinned by a mirror test, following the #2100
+`invoicingBlockedBadge` precedent exactly (`satisfies Record<…>` exhaustiveness + table-driven test +
+a `scripts/check-*-mirror.mjs` invariant). If a future wave wants to persist it, that is a model change
+and needs its own ADR — this spec does not create one by the back door.
+
+### 3.3 `rawStatus` is shown, attributed, and never translated
+
+The source status renders as a neutral chip carrying **the verbatim string**, always prefixed by the
+source (`Allegro: COMMISSION_REFUND_CLAIMED`), with hover/press copy: *"Reported by Allegro. OpenLinker
+does not interpret this value."* No mapping table, no traffic-light tone, no sorting by it. It is
+evidence, not state.
+
+---
+
+## 4. Screen 1 — the Returns list (`/returns`)
+
+Route module `src/app/routes/returns.route.tsx` (lazy; bump `EXPECTED_LAZY_ROUTE_COUNT`), page
+`src/pages/returns/returns-list-page.tsx`, feature `src/features/returns/`. Breadcrumb handle
+`{ crumb: { group: 'Operations', title: 'Returns' } }`.
+
+### 4.1 Segments (MetricCard strip, clickable → filter)
+
+Mirrors the orders-list `HEALTH_SEGMENTS` pattern. **Ordered by what stops the operator's day:**
+
+| Segment | Tone | Means |
+|---|---|---|
+| **Needs receiving** | warning | custody `advised` / `in_transit`, or `received` with `quantityReceived < quantityAdvised` |
+| **Needs disposition** | warning | `quantityReceived > quantityRestocked + quantityScrapped` |
+| **Restock blocked** | error | any line with `restock_blocked` |
+| **Money pending** | warning | money `pending` or **`in_doubt`** on any line |
+| **Orphans** | error | `internalOrderId IS NULL` |
+| **All open** | neutral | every return still needing something: custody is `advised`, `in_transit`, or `received` with units not yet disposed — **or** custody is finished (`disposed` / `not_returned` / declined) but money is still `pending` or `in_doubt`. A return leaves this segment only when custody **and** money are both finished |
+
+**`Restock blocked` and `Orphans` are the two attention-worthy segments** (the #2100
+attention-worthy/routine split): they alone may render a non-zero count in red on a healthy install,
+because both mean *OL did something the operator has not been told about anywhere else*. `Money
+pending` is routine on any active seller and is never red.
+
+**Orphans, said plainly.** Copy on the segment and its empty state: *"Returns for orders OpenLinker has
+never seen. They are kept, but nothing is triggered from them — no stock change, no refund, no credit
+note — until they are matched to an order."* This is T2's whole point and must not be softened into
+"unmatched".
+
+### 4.2 Columns (desktop table)
+
+| Column | Content | Sort |
+|---|---|---|
+| **Return** | source platform badge + `externalReturnId` (or OL id) + `Recorded by you` chip when `origin = operator_authored` | — |
+| **Order** | `Link to={/orders/:id#returns}` with buyer name; **orphan** → red `Orphan` badge + `Match to order` affordance | — |
+| **Opened** | `TimeDisplay` relative, absolute on hover | ✅ default desc |
+| **Stage** | derived stage label (§3.2) + the counter line `3 of 5 received` | — |
+| **Money** | money rollup chip: `Not refundable` / `Refund pending` / **`Refund in doubt`** / `Refund triggered` / `Refunded` / `Denied`; plus a small second chip when an Allegro **commission** flow is live | — |
+| **Source status** | verbatim `rawStatus` chip, source-prefixed (§3.3) | — |
+| **Attention** | `Restock blocked` / `Authority ambiguous` badges — independent parts, never a ternary | — |
+
+**Three independent parts, never one ternary.** The #2100 post-mortem is explicit that folding an
+invoice pill, a block badge and a CTA into a three-way ternary made the badge unreachable behind any
+record. Money chip, attention badge and the primary action are siblings here for the same reason.
+
+### 4.3 Filters (all URL params; any change resets `offset`)
+
+`stage`, `attention=restock_blocked`, `orphan=true`, `money` (incl. `money=in_doubt`),
+`sourceConnectionId`, `reason` (reuses `RefundReasonValues` verbatim — so returns-by-reason and
+refunds-by-reason report on one axis by construction), `openedFrom` / `openedTo`. `FILTER_PARAMS` const
++ `hasActiveFilters` + one-call `clearAllFilters`, per the orders-list convention. Raw params narrowed
+by type guards against `as const` arrays; an unrecognised value is ignored, never thrown.
+
+### 4.4 Mobile / tablet
+
+One `DataTable` with `cardView` using **the same cell renderers** as the desktop columns (#2091 — the
+two must not be able to drift). Card: title = return + source badge; subtitle = order link or orphan
+badge; body `dl` = Stage + counters, Money, Source status; meta = opened. Segment strip 1×6 → 2-col →
+6-col. No horizontal scrolling outside `.data-table__container`.
+
+### 4.5 Empty / loading / error
+
+- **Loading:** `DataTableSkeleton columns={columns}`.
+- **Error:** `ErrorState`, naming the failing scope, with Retry.
+- **Empty, filtered:** "No returns match these filters" + `Clear filters`.
+- **Empty, unfiltered, healthy:** "No open returns." plus a line stating *when OL last checked* and
+  *how* (§7 — this line is the fork's most visible artefact).
+- **Empty, no returns-capable connection at all:** an informational card — *"None of your connected
+  channels report returns to OpenLinker yet. You can still record a return yourself."* + the
+  operator-authored action. Never an error state: it is a configuration fact, not a failure.
+
+---
+
+## 5. Screen 2 — the Return detail (`/returns/:id`)
+
+Stacked panel column, no tabs — matching `order-detail-page.tsx`. Hash anchors `#custody`, `#money`,
+`#correction` for deep links from the list, the order panel and toasts.
+
+Panel order, chosen so the page answers questions in the order they are asked:
+
+1. `ReturnDetailHeader` — return id, source badge, origin, order link (or orphan banner), opened-at,
+   primary actions.
+2. `ReturnOrphanBanner` *(conditional, error tone, top of page)* — §5.5.
+3. `ReturnCustodyPanel` (`#custody`) — the custody rail + the per-line receive/dispose flow.
+4. `ReturnMoneyPanel` (`#money`) — the money rail, refund trigger, commission refund.
+5. `ReturnCorrectionPanel` (`#correction`) — the credit-note proposal.
+6. `ReturnSourceObservationPanel` — verbatim `rawStatus`, source-reported dates, `rawPayload` in a
+   `RawPayloadPanel`.
+7. `ReturnActivityTimeline` — the merged audit narrative (who did what, when).
+
+### 5.1 The two timelines, side by side and labelled as two
+
+Custody and money render as **two separate rails**, stacked vertically on mobile, each with its own
+heading and a one-line explainer:
+
+- **Custody — where the goods are.** `Advised → In transit → Received → Disposed` (or `Not returned`).
+- **Money — where the refund is.** `Pending → Triggered → Refunded` (or `Denied` / `Not refundable`).
+
+Under both, one standing sentence, always visible, never a tooltip:
+
+> *These move independently. A marketplace often refunds the buyer before the parcel reaches you.*
+
+That sentence exists because the single most likely support ticket this feature generates is "why does
+it say refunded when I haven't got the item back". Answering it pre-emptively on the page is cheaper
+than answering it in a mailbox.
+
+**`in_doubt` is a first-class rail step, not an error.** Warning tone, labelled **"Refund — outcome
+unconfirmed"**, body: *"OpenLinker asked the provider to refund and did not get a confirmed answer.
+Nothing further will be triggered from this return until a confirmed outcome arrives. Do not refund
+again from the marketplace panel."* — the ADR-042 discipline in operator language. It blocks like
+`pending` and clears only on a terminal observation; the copy must say so, because the operator's
+instinct is to retry.
+
+### 5.2 The receive flow (P2, tablet-first)
+
+Per-line table. Columns: product (name + sku + variant), **Advised**, **Received**, **Restocked**,
+**Scrapped**, **Line status**, action. The invariant `advised ≥ received ≥ restocked + scrapped` is
+enforced client-side *and* server-side; a client-side violation is a field error, never a
+disabled-with-no-explanation input.
+
+**Receiving is an inline expansion, not a modal** — following `generate-label-form.tsx` (RHF +
+zodResolver, `<fieldset disabled>` while pending, `FormErrorSummary` / `FieldError` / `FormField`).
+A modal on a tablet with a parcel in one hand is the wrong ergonomics, and the operator needs the
+advised quantities visible while typing.
+
+**Declared departure from the style guide.** `docs/frontend-ui-style-guide.md` puts complex data
+editors behind an *"open on desktop"* hint at tablet width. The receive and dispose forms
+deliberately **do not** carry that hint and stay fully interactive at 768 px. This is a declared
+departure in the same shape as the bulk product picker (#1754/#1779), and it is declared rather than
+silently taken:
+
+- **The rule being departed from:** complex editors degrade to a desktop hint below the desktop
+  breakpoint.
+- **Why:** the tablet *is* the primary device for this task. The user is at a bench with a parcel in
+  one hand; the desktop they would be redirected to is in another room. A hint here does not move
+  the work to a better device, it moves it to a paper note and a later re-entry — which is exactly
+  the double-handling this screen exists to remove.
+- **What is guaranteed instead:** every control is fully interactive at 768 px, touch targets are
+  ≥44 px, the advised quantities stay visible while typing, no horizontal scrolling occurs outside
+  `.data-table__container`, and no *"open on desktop"* affordance is rendered at any width.
+- **Scope of the departure:** the receive and dispose forms only. The credit-note proposal (§5.8) is
+  an accountant's desktop task and keeps the standard treatment.
+
+Fields per line: **quantity received** (number, defaults to the remaining advised quantity — the common
+case is one press), optional **note**. Bulk affordance: **`Receive all as advised`** at the table head,
+which pre-fills every line and still requires an explicit confirm. That is the single most common real
+interaction, and it decides whether this screen is used or bypassed.
+
+**Partial and over-receipt.**
+- Received < advised → the line stays `received` with the shortfall visible; a `Mark remainder not
+  returned` action moves the shortfall to `not_returned`. This is the only way a line reaches
+  `not_returned`, and it is always an operator act, never a timeout.
+- Received > advised → **blocked**, with an actionable message: *"You've recorded more units than the
+  buyer advised. Record what arrived up to the advised quantity, and open a separate return for the
+  rest."* OL does not silently widen a marketplace's own claim.
+
+### 5.3 The dispose flow
+
+Available per line once `quantityReceived > quantityRestocked + quantityScrapped`. Inline, same
+pattern. Fields: **quantity**, **disposition** (`Restock` | `Scrap` — a two-option segmented control,
+not a dropdown, because there will never be a third in this wave), optional **note** (free text; this
+is where "scuffed box" goes, and it is deliberately not a graded vocabulary — §3.1).
+
+Copy on the control, resolving the one thing an operator will get wrong:
+
+- **Restock** — *"Adds the units back to your stock, in the system that owns your stock."*
+- **Scrap** — *"Writes the units off. Stock is not changed."*
+
+**Where the stock actually goes is named, not implied.** Under the Restock option, when an
+`InventoryMaster` connection resolves: *"Stock will be added in **{connection name}**."* That is the
+difference between an operator trusting the number and going to check it by hand.
+
+### 5.4 `restock_blocked` — the surfacing that justifies the feature
+
+> **This section is the canonical copy source for `restock_blocked`.** The Wave-2 operator-experience
+> spec's attention state **RB-L** imports these strings rather than restating them, and the copy
+> mirror check that the Wave-2 spec's S2-1 mandates covers **both** feature folders. Where any other
+> document disagrees with the strings below, this section wins.
+
+When the master's `adjustInventory` refuses (PrestaShop today), the line records `restock_blocked` and
+the units stay in `quantityReceived`, **not** in `quantityRestocked`. Three surfaces, all required:
+
+1. **List row** — `Restock blocked` error badge, and the `Restock blocked` segment counts it.
+2. **Line row** — a persistent inline error row under the line, not a toast:
+
+   > **Stock was not added.** OpenLinker recorded the disposition, but **{connection name}** does not
+   > accept stock adjustments from OpenLinker, so **your stock has not changed**. Add {n} × {sku} in
+   > {connection name} yourself, then mark this handled.
+   >
+   > `[Mark stock handled manually]`  `[Open {connection name}]`  `[Why did this happen?]`
+
+3. **Order-detail returns panel** — the same badge, so an operator who reached the order first is not
+   told a different story.
+
+**`[Why did this happen?]` — the explainer, specified.** It expands inline (a disclosure, not a
+modal, not a link out) and says exactly this:
+
+> **OpenLinker can publish your stock, but it can't always change it.**
+> Adding stock back needs a write into the system that owns your stock. **{connection name}** accepts
+> stock *readings* from OpenLinker but not stock *adjustments*, so OpenLinker recorded what you
+> decided and stopped there rather than telling you it had done something it hadn't.
+> Nothing is lost: the units are still counted as received on this return, and this message stays
+> until you say you've handled it.
+
+No blame, no jargon, and no promise of a fix date — the real remedy (implementing `adjustInventory`
+on that master) is a scheduling decision (R2), not something to hint at in a disclosure.
+
+**`Mark stock handled manually` — what it does, and what it leaves behind.** It records an operator
+attestation (who, when) and moves the units into `quantityRestocked` with
+`restockedBy: 'operator_out_of_band'` — the same honesty device the refund trigger uses. It **never**
+claims OL wrote the stock. Gated by the standard write posture (§9). Its post-state is specified,
+because a resolution that leaves the alarm ringing trains the operator to ignore the alarm:
+
+| Surface | Before | After the attestation |
+|---|---|---|
+| Line row | red inline error block, three actions | a neutral (not success, not error) row: *"Stock added manually by {user} on {date}. OpenLinker did not change your stock."* — no actions |
+| Line counters | units in `quantityReceived` | units in `quantityRestocked`, `restockedBy: 'operator_out_of_band'` |
+| List `Attention` badge | `Restock blocked` | **cleared**, if no other line on the return is still unhandled |
+| `Restock blocked` segment | counts this return | **no longer counts it** — the segment counts *unhandled* blocks only |
+| Order-detail returns panel | `Restock blocked` badge | badge cleared, on the same rule as the list |
+| Timeline | *"Restock blocked"* | plus *"Stock handled manually"*, `by` = the operator, never removed |
+
+**The segment counts unhandled blocks, not historical ones.** An operator who resolves twelve blocked
+lines and still reads `Restock blocked 12` learns that the number is decoration — which is R2's
+learned-ignored risk arriving by a different door. The attestation is permanent in the timeline and
+on the line; only the *attention* clears, which is the same distinction the whole spec draws between
+a record and an alarm.
+
+**A toast is not sufficient and must not be the only signal.** A restock that silently no-ops is worse
+than none; a restock whose failure lives in a toast the operator dismissed while looking at a parcel is
+the same failure with extra steps.
+
+### 5.5 Orphan returns
+
+> **This section is the canonical copy source for the orphan-return state.** The Wave-2
+> operator-experience spec's attention state **OR-P** imports these strings rather than restating
+> them, under the same both-folders mirror check as §5.4.
+
+Red banner at the top of the detail, and the row badge on the list:
+
+> **This return is not matched to an order.** OpenLinker received it from {source} but has no matching
+> order. It is safe here, and nothing will be triggered from it — no stock change, no refund, no credit
+> note — until it is matched.
+>
+> `[Match to an order]`
+
+Every action on the page that would move goods, money or paperwork is **visible and disabled**, with
+the banner as its explanation — never hidden, because hiding makes the operator think the feature is
+broken. A background reconcile may match it later; when it does, the timeline records *"Matched to
+order {n} automatically"* with a timestamp, because an operator who finds actions unlocked overnight
+needs to know why.
+
+### 5.6 Decline / authorize (T3)
+
+Two actions, deliberately asymmetric, and the asymmetry is stated rather than hidden:
+
+- **Decline** — visible only where the source connection supports the write (Allegro). Confirm dialog:
+  *"Declining tells {source} you are refusing this return. {source} decides what happens next —
+  OpenLinker records the outcome it reports."* On success the return shows **`Decline sent`** until the
+  source confirms; a confirmed decline is a *source observation*, never assumed from a 2xx.
+- **Authorize** — visible **only for `operator_authored` returns**. On a source-ingested return the
+  action is absent, with a one-line explainer in the header: *"{source} decides whether this return is
+  accepted. OpenLinker records their decision."* This is the model's "OL must not pretend to decide
+  what the marketplace already decided" rendered as an absence *plus a sentence* — an unexplained
+  absence reads as a missing feature.
+
+### 5.7 Money: the refund trigger and the commission refund (T6, T10)
+
+**Buyer refund.** Primary action `Confirm refund` — the label is deliberately not "Refund": *"OpenLinker
+does not move money. Confirm that you have refunded the buyer, and OpenLinker will record it against
+this return and this order."* Fields: amount (pre-filled from the received/disposed lines, editable),
+currency (locked to the order's — the existing refund-currency-mismatch guard), reason
+(`RefundReasonValues`), note. Writes the linked `RefundRecord` with
+`executedBy: 'operator_out_of_band'`, and the money rail moves to `triggered`. **`refunded` is only ever
+entered on observation** — no button in the UI sets it, and the rail step carries *"Confirmed by
+{source}"* when it lands.
+
+When a `RefundExecutor` capability is present (no shipped adapter today), the same button becomes
+*"Refund the buyer"* and the copy drops the out-of-band sentence. The seam exists; the label is the
+whole difference the operator sees.
+
+**Commission refund (Allegro) — a separate money flow, surfaced separately.** A distinct block inside
+the money panel, never merged into the refund rail:
+
+> **Allegro commission** — When a return completes, Allegro can refund the sales commission you paid on
+> the order. **This is your money coming back from Allegro, and it is separate from the refund you give
+> the buyer.**
+> Status: `Not claimed` / `Claim filed` / `Refunded by Allegro` / `Refused`
+
+Status is read from the observed `rawStatus` timeline (`COMMISSION_REFUND_CLAIMED` /
+`COMMISSION_REFUNDED`) — **observation, not inference**, and the block says so. It appears only on
+Allegro-sourced returns; on every other source the block is absent, not empty. The moment it earns its
+keep is the one where an operator who has run returns for years learns OL is claiming something they
+never did — so the copy leads with *"your money"*, not with *"commission"*.
+
+**The action under the block has two specified branches, and a spike decides which ships (§14 Q2).**
+Nothing yet verifies that Allegro exposes a commission-refund *claim write* — the status above is a
+read of observed values, which is a different thing. The house rule is to verify Allegro field shapes
+before designing to them, so both branches are specified now and the block is built once the spike
+answers. **Everything above this line is identical in both branches**; only the action differs.
+
+*Branch A — the API permits claiming.* The block carries a real action:
+
+> `[Claim commission refund]`
+
+which calls the Allegro write and moves the status to `Claim filed` **only on Allegro's own
+observation**, never on a 2xx — the same discipline §5.6's `Decline sent` uses. A failure surfaces
+Allegro's own message verbatim and attributed, and the button stays available.
+
+*Branch B — claiming is seller-panel-only.* The block carries a deep link and an attestation instead,
+and says so plainly rather than pretending:
+
+> Allegro does not let OpenLinker file this claim for you — it has to be done in the Allegro seller
+> panel. **It is still your money**, and OpenLinker will show you when Allegro refunds it.
+>
+> `[Claim this on Allegro ↗]`   `[I've claimed this]`
+
+`Claim this on Allegro` deep-links to the order's commission page in the seller panel. `I've claimed
+this` records an operator attestation (who, when) and moves the block to `Claim filed`, marked as
+*"You told OpenLinker you filed this"* — never as *"Filed"*, because OL did not file it. The
+`Refunded by Allegro` step still arrives as an observation in both branches, which is the point: even
+in Branch B the block does the thing the operator cannot do for themselves, which is **notice** the
+refund landing.
+
+**The block is worth building in either branch.** Branch B is not a degraded version — a seller who
+has never claimed a commission refund is losing the money because nobody told them it was claimable,
+not because filing was hard. The prompt is the product; the write is a convenience.
+
+### 5.8 The credit-note proposal (T7, P3)
+
+**A proposal, never an issue.** The panel leads with what is at stake:
+
+> **Credit note proposal.** OpenLinker has matched these returned lines to lines on invoice
+> **{invoiceNumber}**. Check the match before issuing — **a correction to a document already sent to
+> {authority} cannot be withdrawn.**
+
+Table: returned line → proposed original invoice line (name, quantity, unit price gross, tax rate),
+with a per-row **confidence**:
+
+- **Matched** — one candidate, unambiguous.
+- **⚠ Ambiguous** — *"Invoice {n} has {k} identical lines for this product. OpenLinker cannot tell which
+  one this return refers to; the correction amount is the same either way **unless these lines were
+  priced differently**."* All candidates are listed and the operator picks one. This is the positional
+  line-identity problem *shown rather than resolved*, exactly as ANALYSIS-1032 requires.
+- **⚠ No match** — no proposal for that line; the operator is told it is excluded, and why.
+
+Auto-issue is **not offered**, and its absence is explained once in the panel footer: *"OpenLinker will
+not issue corrections automatically until invoice lines carry a stable reference."* Every issue goes
+through the existing `CorrectionIssuer` review flow with the operator's confirmed mapping.
+
+**Hard AC:** a fully `Matched` proposal and one with a single `Ambiguous` line must be visibly different
+**before** the operator reaches the confirm button — not in a dialog after it.
+
+### 5.9 Loading / empty / error, detail
+
+Skeleton panels rather than a full-page spinner (the header resolves first and orients the operator).
+A failed sub-read degrades that panel to a scoped `ErrorState` with Retry; it never blanks the page.
+Every mutation: success toast + explicit query invalidation, no optimistic updates.
+
+---
+
+## 6. Screen 3 — the order-detail Returns panel
+
+`<div id="returns" tabIndex={-1}><OrderReturnsPanel order={order} /></div>`, after the shipment and
+sales-document pair, before `OrderCustomerCard`. Compact: one row per return (return id, source badge,
+opened, stage + counters, money chip, attention badge) linking to the detail. Plus:
+
+- **`Record a return`** (write posture, §9) — the operator-authored path, and on shop orders and in the
+  projection-only fork (§7B) the *only* path.
+- A **Returns group in `OrderActivityTimeline`**, using its existing
+  `TimelineEvent {id,timestamp,title,by,description,tone,footer}` shape: return opened, declined,
+  received, disposed, restock blocked, refund confirmed, credit note issued. `by` carries the operator
+  for OL-owned events and the source name for observations — the distinction the whole model rests on,
+  made visible in one field.
+- **Empty state:** "No returns against this order." — routine, neutral, no call to action beyond the
+  record action.
+
+---
+
+## 7. The spike fork (#2289 — Allegro customer-returns feed shape)
+
+The Wave-0 spike's kill condition: *if the feed is neither cursor- nor watermark-shaped, returns
+ingestion shrinks to a projection off order sync.* Both branches ship the same aggregate, the same
+detail page and the same custody / money / correction flows — **the fork changes discovery, freshness
+and the orphan bucket, and nothing else.** That containment is deliberate: it is what lets the FE work
+start before the spike lands.
+
+### Branch A — the feed is pollable (cursor or watermark)
+
+- `marketplace.returns.poll` + `marketplace.return.sync` run on their own cadence.
+- **The orphan bucket is live** — a return can arrive for an order OL never ingested. The `Orphans`
+  segment is a real, non-zero-capable red counter and §5.5 is fully exercised.
+- List freshness line: *"Channels last checked {relative}."* per source connection, with a `Check now`
+  action (write posture, §9) for when the operator expects something that has not landed.
+- Decline follow-up rides the returns feed, so the `Decline sent` interim state typically resolves
+  within one poll.
+- The list is a **primary navigation item** under Operations.
+
+### Branch B — projection-only fallback (returns ride order sync)
+
+- No returns poll. A return becomes visible only when its **order** re-syncs.
+- **The orphan bucket ships but is structurally near-empty** — a return discovered through an order is
+  by construction attached to one. It renders as a segment with its own empty explanation rather than
+  being deleted: an operator-authored return against a later-deleted order, or a reconcile race, can
+  still produce one, and deleting the bucket would leave those rows nowhere to appear. Copy: *"Orphan
+  returns are rare on your channels, because OpenLinker discovers returns through orders."*
+- **Freshness is stated prominently, per source**, because it is now the operator's main surprise:
+  *"OpenLinker discovers Allegro returns when it re-checks the order — usually within {order poll
+  cadence}. A return may exist on Allegro before it appears here."* This sits on the list header **and**
+  on the order returns panel. Understating it produces exactly the "OL is missing my return" ticket the
+  line prevents.
+- `Check now` on the order returns panel triggers an **order** re-sync and says so: *"Re-check this
+  order on {source}"* — never "check for returns", which would promise a capability that does not exist.
+- Decline stays available (it is a write, independent of feed shape), but confirmation waits for the next
+  order sync, so `Decline sent` is longer-lived and the copy says *"{source} will confirm the next time
+  OpenLinker checks this order."*
+- The **operator-authored return is promoted**: it is the primary way a return OL has not yet observed
+  gets worked today. The unfiltered empty state leads with it.
+- The list page still ships and is still primary navigation — it reads OL's own aggregate, which exists
+  in both branches. Only the inflow differs.
+
+**Degradation rule.** Nothing in Branch B renders an error, a warning tone, or a "limited mode" banner.
+It is a slower discovery path, not a broken one; presenting it as degraded teaches operators to distrust
+a working feature.
+
+---
+
+## 8. Authority ambiguity (P4's operator-facing form)
+
+A second enabled `ReturnsAuthority` connection resolves `ambiguous`: **no automated disposition, reason
+persisted, inert**. Operator surface: an `Authority ambiguous` badge on the row, and an informational
+(not error) banner on the detail:
+
+> **Two systems are configured to decide dispositions for this channel.** OpenLinker will not decide
+> automatically while that is true — you can still receive and dispose by hand.
+> `[Review returns authority]`
+
+Inert and reported, per the matrix rule. The banner links to the Wave-2 authority-status surface; it
+does not attempt to resolve the conflict inline.
+
+---
+
+## 9. Access
+
+**v1 introduces no new permission names.** Returns reuses the existing operator/admin posture
+exactly as every other operations surface does:
+
+- **Reads** — list, detail, the order-detail panel, the correction proposal — are available to any
+  signed-in user who can already see orders. Returns are order data; a separate read permission
+  would let a deployment produce a user who can see an order but not the return against it, which
+  is a state nobody asked for.
+- **Writes** — receive, dispose, mark stock handled manually, record an operator-authored return,
+  match an orphan, decline, authorize, confirm a refund, claim a commission refund, confirm and
+  issue a credit-note correction — are gated by the standard write posture: `useWriteAccess` +
+  `ReadOnlyLock` (visible-but-disabled, carrying the demo message) for actions, `AccessGate`
+  (hidden, demo-unaware) for informational content. Never an inline `session.user.role` compare.
+- **No `scripts/check-permission-mirror.mjs` change**, no new `ROLE_PERMISSIONS` entry, no new
+  `session.types.ts` value.
+
+**Why no returns-specific tier.** A finer split — warehouse-records-goods versus operator-moves-money
+— is only meaningful where those are **different humans**, and no current deployment is known to have
+a distinct warehouse persona. A permission name is close to unremovable once shipped: every
+deployment that granted it must be migrated, and every issue that gated on it must be re-litigated.
+Shipping one ahead of the human it describes is the wrong direction of risk, and the write posture
+already stops a read-only user from doing any of it.
+
+**Reversal gate.** Introduce returns-specific permissions when either (a) a deployment presents a
+distinct warehouse persona who must record physical arrival without being able to move money, or
+(b) `ReturnReceiver` / 3PL arrival lands, which introduces a second receiving actor by construction.
+Either is a real second principal; until then there is one.
+
+---
+
+## 10. User stories & acceptance criteria
+
+**US-1 — One place for every return.** *(T1)*
+*As the operator, I want every return from every channel in one list, so I stop checking three
+marketplace panels.*
+- The list shows returns from every returns-capable connection plus operator-authored ones.
+- Each row states its source, and the source's own status verbatim and attributed.
+- The list renders loading, error, filtered-empty and unfiltered-empty states distinctly.
+- With no returns-capable connection, the operator sees an explanation and the record-a-return action —
+  never an error.
+
+**US-2 — Orphans are kept, visible, and inert.** *(T2)*
+*As the operator, I want returns for orders OL never saw to be safe and obviously blocked.*
+- An orphan return persists and appears in its own attention-worthy segment.
+- Its detail page states, in one sentence, that nothing will be triggered from it and why.
+- Every goods / money / paperwork action is **visible and disabled**, not hidden, with the banner as its
+  explanation.
+- Automatic matching is narrated in the timeline with its timestamp.
+
+**US-3 — Decline where the platform allows; authorize only what I authored.** *(T3)*
+*As the operator, I never want OL to pretend it decided something the marketplace decided.*
+- `Decline` appears only where the source supports the write; elsewhere it is absent with a one-line
+  explanation of who decides.
+- `Authorize` appears only on `operator_authored` returns.
+- A successful decline shows `Decline sent` until the source confirms. **A 2xx alone never displays as
+  "declined by {source}".**
+
+**US-4 — Record what physically arrived.** *(T4)*
+*As the warehouse user, I want to record per line and quantity, on a tablet, with a parcel in my hand.*
+- Per-line receive is an inline form, usable at tablet width, with ≥44 px targets.
+- `Receive all as advised` pre-fills every line and requires one explicit confirm.
+- Receiving more than advised is blocked with an actionable message.
+- A shortfall stays visible; `not_returned` is only ever entered by an explicit operator action.
+- `advised ≥ received ≥ restocked + scrapped` holds at every intermediate state, and a violation is a
+  field error, never a silently disabled control.
+
+**US-5 — Dispose, and know where the stock went.** *(T5)*
+*As the operator, I want restock to land in the authoritative stock book, or to fail loudly.*
+- Disposition is `Restock` or `Scrap` only; the restock control names the connection stock will land in.
+- On refusal the line records `restock_blocked` and the units stay in `received` — never in `restocked`.
+- `restock_blocked` surfaces in **three** places: list badge + segment, the line row, and the order
+  returns panel — with a persistent inline message, not only a toast.
+- The remediation message names the quantity, the sku and the connection, and offers `Mark stock handled
+  manually`, which records an operator attestation and never claims OL wrote the stock.
+- **After the attestation the alarm clears and the record does not**: the line row becomes the neutral
+  *"Stock added manually by {user} on {date}. OpenLinker did not change your stock."*, the list badge
+  and the order-panel badge clear (when no other line is still unhandled), the `Restock blocked`
+  segment stops counting the return, and the timeline keeps both the block and the attestation
+  permanently. A segment that keeps counting resolved work is a number the operator learns to ignore.
+- `[Why did this happen?]` expands inline to the explainer specified in §5.4 — never a link out, never
+  a modal, and never a promise that OpenLinker will fix it soon.
+- **No screen ever shows "restocked" for units whose master write refused.** This is the
+  highest-severity AC in this spec.
+
+**US-6 — Refunds described honestly.** *(T6)*
+*As the operator, I want OL to record who actually moved the money.*
+- The buyer-refund action is labelled `Confirm refund` and states that OL does not move money.
+- Confirming writes a `RefundRecord` linked to the return with `executedBy: 'operator_out_of_band'`,
+  reusing `RefundReasonValues`.
+- No UI path sets `refunded`; it is entered only on observation and rendered as "Confirmed by {source}".
+- `in_doubt` renders as a named rail step in warning tone, tells the operator **not** to refund again,
+  and blocks downstream triggers exactly as `pending` does.
+- Custody and money are visibly two rails, with the "these move independently" sentence always visible.
+
+**US-7 — A credit note I can trust.** *(T7)*
+*As the accountant, I want the ambiguity shown before I issue, not after.*
+- The proposal names the original invoice and states that a transmitted correction cannot be withdrawn.
+- Each line is `Matched`, `Ambiguous` (all candidates listed, operator picks) or `No match` (excluded,
+  with the reason).
+- An ambiguous proposal is visually distinct from a fully matched one **before** the confirm button.
+- Nothing is auto-issued; the absence is explained once, in the panel.
+
+**US-8 — The commission comes back.** *(T10)*
+*As a PL seller, I want the Allegro commission refund claimed, and to understand it is not the buyer's
+refund.*
+- The commission block is separate from the refund rail and leads with "your money coming back".
+- Its status is read from observed source values, never inferred, and the panel says so.
+- It appears only on Allegro-sourced returns; it is absent, not empty, elsewhere.
+
+**US-9 — The return reaches me from the order too.**
+*As the operator, I want to see returns where I already am.*
+- The order detail carries a `#returns` panel with one row per return and a record-a-return action.
+- Return events appear in the order activity timeline, with `by` distinguishing operator acts from
+  source observations.
+
+**US-10 — I can tell how fresh this is.** *(the fork's story)*
+- In both branches the list states when and how OL last learned about returns, per source.
+- In the projection-only branch the discovery latency is stated on the list header and on the order
+  panel, and the manual action is honestly labelled as re-checking the **order**.
+- Neither branch presents itself as degraded or limited.
+
+---
+
+## 11. Non-goals
+
+Stated because silence reads as oversight.
+
+1. **Exchanges / replacements.** No entity, no flow, no partial credit. A later wave, and it needs an
+   order relationship OL does not have.
+2. **Scan-driven receiving** (barcode / handheld). Wave 3b, behind the demand gate, with the pick/pack
+   surface whose mechanics it shares.
+3. **Disposition routing / receive-node selection.** Wave 4. `ReverseFulfillmentWork` does not exist and
+   this spec must not imply a receiving-location choice.
+4. **Condition grading, `refurbish`, RTV, quarantine.** Permanent non-goal at this level — warehouse
+   mechanics. A free-text note is the whole affordance (§3.1).
+5. **`inspected` as a state.** Decided out for v1 (§3.1), with a named reversal gate.
+6. **3PL receiving (T8).** Deferred with `ReturnReceiver`; its narrowing base must be named before any
+   screen assumes a second actor.
+7. **Buyer-facing return portal / self-serve label generation.** OL is the seller's tool. Return labels
+   exist as inbound `Shipment` rows; the buyer never sees an OL screen.
+8. **Fiscal-receipt corrections.** ADR-042 defers them; only invoice corrections are proposed here.
+9. **A returns-rate analytics dashboard.** The reason axis is deliberately shared with refunds so this is
+   cheap later; it is not this wave.
+10. **Automatic disposition, automatic correction issuance, automatic refund execution.** Each is gated
+    on something that does not exist (an authority adapter, a stable invoice-line reference, a
+    `RefundExecutor` implementation). Returns automation triggers belong to Wave 2's automation layer,
+    not here.
+11. **Replacing the marketplace's own returns panel.** OL surfaces and orchestrates; the platform still
+    decides acceptance on source-ingested returns.
+
+---
+
+## 12. Definition of done
+
+Split deliberately. The first list can be checked on the day the wave ships; the second is what we
+watch for afterwards. An item that can only be evaluated months later, or that asserts an absence over
+unbounded time, is a **signal**, not a gate — filing it as a gate teaches the reader to skim the list.
+
+**Ship gates (checkable at ship):**
+
+- **No screen ever shows "restocked" for units whose master write refused.** Proven by a test against
+  a PrestaShop master with `adjustInventory` refusing: the line, the list, the order panel and the
+  timeline all report `restock_blocked`, and no counter reads `restocked`. **Hard bar, highest
+  severity in this spec.**
+- A warehouse user completes a full receive-and-dispose on a tablet at 768 px without pinch-zooming,
+  without horizontal scrolling outside `.data-table__container`, and without meeting any *"open on
+  desktop"* affordance (§5.2's declared departure).
+- **A 5-person unmoderated test in which ≥4 correctly answer, from the return detail alone,** whether
+  the buyer has been refunded and whether the goods have arrived — the two-rails design's actual
+  claim, testable, replacing *"no support question of the form…"* which asserted an absence over
+  unbounded time.
+- An accountant states, from the proposal alone and with no help, whether each line match is certain;
+  a fully-`Matched` proposal and one with a single `Ambiguous` line are visibly different **before**
+  the confirm button.
+- The commission block renders with a **live claim status on a real Allegro return in staging**, in
+  whichever §5.7 branch the spike selected. (This replaces *"at least one PL seller claims a
+  commission refund they would not otherwise have claimed"*, which is a counterfactual nobody can
+  measure.)
+- Every state in §5.4's post-attestation table is reachable and renders as specified — in particular
+  the `Restock blocked` segment count drops when the last blocked line is attested.
+- Both spike branches' copy exists and the shipped one is reachable; the list and the order panel both
+  state freshness per source (§7).
+
+**Post-launch success signals (watched, not gates):**
+
+- An operator working a day of returns does not open a marketplace panel to answer *"what arrived,
+  what did I do with it, where is the money"*.
+- Support conversations do not contain *"why does it say refunded when I haven't received the item"* —
+  the standing two-rails sentence is what is being tested, and its failure mode is visible in the
+  first month.
+- Operators do not describe the shipped spike branch as "missing" returns — i.e. the freshness copy
+  (§7) is doing its job rather than the fork being invisible.
+- PL sellers claim commission refunds they were previously unaware of. Not measurable as a
+  counterfactual; measurable as *"the commission block's claim action is used at all"*.
+
+---
+
+## 13. Risks
+
+| | Risk | Mitigation in this spec |
+|---|---|---|
+| R1 | Operators read the derived stage as a persisted status and ask to filter or automate on it | Counters shown adjacent everywhere; stage is presentation-only and mirror-tested; no API field |
+| R2 | `restock_blocked` becomes normal noise on a PrestaShop-master install and is learned-ignored | The real fix is implementing `adjustInventory` on PrestaShop — a **prerequisite worth scheduling with this wave**, not a returns line item. Until then the badge is per-line and actionable, never a global banner |
+| R3 | The commission block reads as "OL refunded me" | Copy leads with "your money coming back from Allegro"; status is explicitly an observation |
+| R4 | Ambiguous credit-note lines get click-through-confirmed | Ambiguity is visible before the confirm button and each candidate must be actively picked; no bulk confirm |
+| R5 | Branch B's latency generates "OL is broken" tickets | Freshness stated in two places, honest manual action label, no degraded framing |
+| R6 | `in_doubt` prompts a double refund from the marketplace panel | Explicit "do not refund again" copy on the rail step |
+| R7 | A future returns-specific permission split blocks the common path (one person, both hats) | v1 ships none (§9); the reversal gate is a real second principal, not a hypothetical one |
+
+---
+
+## 14. Open questions
+
+1. **How is an orphan matched to an order?** Search-and-pick is assumed; whether an operator can
+   realistically identify the right order from a marketplace return payload is unverified.
+2. **Does the Allegro API permit *claiming* a commission refund, or is it panel-only?** This is a
+   **spike**, not a product question — it is the one thing in §5.7 designed against an unverified API
+   shape, and the house rule is to verify Allegro field shapes before designing to them. Both
+   branches are specified in §5.7 and neither blocks the rest of the wave; the spike decides which
+   one ships. It must land before the commission block is built.
+
+Three earlier entries here — the permission split, the nav placement, and whether the commission
+refund is a button or a rule — were **settled** and now appear in the Decision log rather than being
+re-opened.
+
+---
+
+## Decision log
+
+| Date | Decision | Rationale |
+|---|---|---|
+| 2026-08-22 | **`inspected` collapsed into `received` for v1** | No distinct payload (condition is a non-goal), no distinct action, no downstream branch; counters already express partial progress. Reversal gate: a second receiving actor (`ReturnReceiver` / 3PL) |
+| 2026-08-22 | Derived stage labels are presentation-only and mirror-tested | The model says counters, not statuses; a persisted rollup is a model change needing its own ADR |
+| 2026-08-22 | `rawStatus` shown verbatim, source-attributed, never toned or sorted | It is a timeline across four axes; toning it would be the inference the model refused |
+| 2026-08-22 | Receiving is inline and tablet-first, not a modal | The user has a parcel in one hand and needs advised quantities visible |
+| 2026-08-22 | `restock_blocked` surfaces in three places, persistently | A toast dismissed at a bench is indistinguishable from a silent no-op |
+| 2026-08-22 | **No new permission names in v1**; returns reuses the existing operator/admin write posture (`useWriteAccess` + `ReadOnlyLock`), and `check-permission-mirror.mjs` is untouched | A permission is near-unremovable once shipped, and the finer split is only meaningful where the warehouse user is a *different human* — which no current deployment presents. Reversal gate: a distinct warehouse persona, or `ReturnReceiver` / 3PL arrival introducing a second receiving actor |
+| 2026-08-22 | **Returns is a top-level `Operations` nav entry**, not a tab under Orders | Returns have their own cadence, their own attention states and their own two attention-worthy segments; a tab would make them visible only to someone already looking at an order |
+| 2026-08-22 | **The Allegro commission refund is a button, not an automation** | It is a claim against a third party with money attached and no idempotency guarantee OL controls; automating it is a Wave-2 automation-layer question, and the operator's own confirmation costs one click |
+| 2026-08-22 | **Both commission-claim branches are specified now; a spike picks one** | The claim *write* is unverified against Allegro's API, and the house rule is to verify Allegro shapes before designing to them. Neither branch blocks the wave, and Branch B is not a degraded version — the prompt is the product |
+| 2026-08-22 | **`restock_blocked` and orphan copy is owned by this spec**; the Wave-2 spec imports it | One copy source with identical titles in both places is a Wave-2 AC (S2-1); two specs authoring the same string ships a violation of it on day one. The mirror check covers both feature folders |
+| 2026-08-22 | **`Mark stock handled manually` clears the attention, never the record** | A segment that keeps counting resolved work becomes decoration; the attestation stays permanently in the timeline and on the line |
+| 2026-08-22 | **The tablet-first receive/dispose forms are a declared departure from the style guide** | The tablet is the primary device for this task; a desktop hint moves the work to a paper note, not to a better device. Declared in §5.2 in the shape of the #1754/#1779 picker precedent |
+| 2026-08-22 | **`All open` is defined positively** (custody unfinished, or money still `pending`/`in_doubt`) | The original negation did not parse — a reader could not tell whether `declined` had to be money-terminal too |
+| 2026-08-22 | Branch B ships the orphan segment and the list page unchanged | The aggregate exists in both branches; only inflow differs, and a "limited mode" framing teaches distrust |

--- a/docs/specs/product-spec-oms-wave2-operator-experience.md
+++ b/docs/specs/product-spec-oms-wave2-operator-experience.md
@@ -1,0 +1,1090 @@
+# Product Spec — OMS Wave 2 operator experience (presets, authority status, automation v1)
+
+**Status:** Draft for owner review. Discharges the standing directive in
+[`REVIEW-oms-authority-model.md`](../plans/analysis/REVIEW-oms-authority-model.md) §7 —
+*"product-spec before Wave 2 (presets UX, automation triggers/actions, authority-status page)"*.
+Wave 2 engineering issues must not be filed ahead of a Gate on this document.
+
+**Design of record:** [`DESIGN-oms-authority-model.md`](../plans/analysis/DESIGN-oms-authority-model.md)
+(§2 authority matrix, §6 lifecycle/holds, §10 Wave 2, §14 stories P2/P8/L4/R2/R4/R10/I6/T4–T7).
+**ADRs:** [052](../architecture/adrs/052-independently-assignable-fulfillment-authorities.md),
+[053](../architecture/adrs/053-fulfillment-authority-vocabulary-leaf.md),
+[061](../architecture/adrs/061-advisory-reservations-and-availability-authority.md);
+integrated by reference: [041](../architecture/adrs/041-sales-document-routing-policy.md) (+ #2047, #2100, #2170).
+**House precedent this spec is answerable to:** the shipped #2161/#2170 sales-documents rule engine
+and its composer.
+**Workflow:** [`refinement-workflow.md`](../contributors/refinement-workflow.md) — this is a Tier-1
+product spec; engineering plans are Tier-2 and downstream.
+
+---
+
+## 0. Scope of this document
+
+Three operator surfaces, and nothing else:
+
+| # | Surface | Design story | Ships with |
+|---|---|---|---|
+| S1 | **Who decides what** — the two presets + the authority answers they write | P2 (re-scoped from Wave 4 to Wave 2), P1 | The first operator-settable authority flag |
+| S2 | **Authority status** — what is currently inert, and why | P4 (invariant → its operator-facing form), I6, R10, L4 | S1 |
+| S3 | **Automation v1** — a closed trigger × action matrix | P8 | Wave 2's holds + reservation ledger + returns custody |
+
+**Not in this document:** the router/worklist UI (Wave 3, its own spec per the same directive), the
+scan/pick surface (Wave 3b), posture-B read-only surfaces (Wave 4, story L8), routing-rule storage
+(**owned by #2298** — see §7.4), and any backend contract already fixed by ADR-052/053/061.
+
+---
+
+## 1. Problem & operator context
+
+### 1.1 What the operator has today
+
+An OpenLinker operator today configures **integrations**, not **decisions**. Every screen in
+`/connections` answers "what is this system, and does it work?"; nothing answers "and what does it
+get to decide?" That was fine while the answer was always the same — the shop decided everything,
+OpenLinker moved data between it and the marketplaces.
+
+Wave 2 breaks that for the first time. It ships the first authority flag an operator can actually
+set, plus three new classes of decision OpenLinker makes on its own (hold an order, promise stock
+against a reservation, dispose a returned line). The moment a decision has more than one possible
+holder, three operator problems appear at once, and none of them has a home:
+
+1. **"What did I just turn on?"** A per-authority checkbox grid is the obvious build and the wrong
+   one. Six authorities × three candidate holders is a configuration surface no solo operator will
+   ever read, and every combination it permits is a combination we must then support. The design
+   answers this with **presets, and explicitly no per-authority override in v1** — *a needed
+   override is a missing third preset* (§10 Wave 2). This spec holds that line.
+2. **"Why did nothing happen?"** Every authority conflict in this model is **inert and reported**
+   (§2, and the shipped #2047 shape). Inert-and-reported is only half a product: #2100 already
+   taught us that a block which exists only in a log line is indistinguishable from a bug, and the
+   fix was to persist it and put it on the row. Wave 2 adds five new inert states
+   (§4.2) and they need the same treatment on day one, not in a follow-up.
+3. **"Can I make it do the boring part?"** The derived phase (Wave 1a), holds (Wave 2) and the
+   reservation ledger (Wave 2) are plumbing. The design is blunt about it: *"The automation layer is
+   the sellable product layer above the phase; the phase is plumbing."* An operator does not buy a
+   phase. They buy "chase the marketplace deadline for me" and "email the buyer when I hold their
+   order".
+
+### 1.2 Persona
+
+**P-A, the solo/small-team operator** — the actual majority the R1 roadmap inverted around:
+single location, self-shipping or marketplace-fulfilled, 1–3 marketplaces, 1 shop, Polish market,
+no WMS, no 3PL. They are the *only* persona this spec designs for. Two consequences:
+
+- Every surface must be **legible without the design document**. The words "authority", "posture"
+  and "FulfillmentWork" are forbidden in the UI (design P9, and §2.1 below) because P-A has never
+  read the model and never will.
+- Every surface must be **useful with one connection**. A who-decides page that only makes sense
+  once you have a 3PL is a page P-A never opens, which means the inert states never get seen,
+  which loses the whole point of S2.
+
+P-B (multi-location) and P-C (gateway/integrator) are served by the *same* surfaces later; they
+drive no v1 requirement here.
+
+### 1.3 The bet, stated honestly
+
+S1 and S2 are **cost of shipping Wave 2 safely** — without them the first authority flag is a
+silent foot-gun. S3 is the part with commercial upside, and it is a **strategic bet**: no named
+seller has asked for an automation builder. BaseLinker's automation layer is the single most-cited
+reason sellers stay on it, which is the market signal; it is not demand from a named OpenLinker
+user. Gate this document on whether the owner accepts that.
+
+---
+
+## 2. Cross-cutting rules
+
+### 2.1 UI naming (design P9 — binding)
+
+`authority`, `posture`, `FulfillmentWork`, `AvailabilityAuthority`, `atpEffect`, `phase`,
+`Orchestrator`, `Gateway` **never render**. The domain vocabulary stays in the code, the API and
+this document.
+
+| Model term | Renders as |
+|---|---|
+| authority / holder | *"who decides"*, *"decided by"* |
+| A1 availability authority | *"how much stock we can promise"* |
+| A2 sourcing/routing | *"where an order ships from"* |
+| A3 fulfillment execution | *"who picks and ships"* |
+| A4 order lifecycle | *"what state an order is in"* |
+| A5 returns disposition | *"what happens to returned goods"* |
+| A6 refund trigger | *"who issues refunds"* |
+| A7 invoicing/fiscalization | *"who issues invoices and receipts"* |
+| posture A / posture B preset | see the two preset names, §3.2 |
+| `FulfillmentWork` | *"job"* (Wave 3 only; unused in Wave 2) |
+| `ambiguous` | *"OpenLinker can't tell which one"* |
+| `inert` / blocked | *"nothing happens until you fix this"* |
+| `OrderLifecyclePhase` | *"status"* (the existing word; the phase is what feeds it) |
+
+A copy-lint script (`scripts/check-ui-vocabulary.mjs`, §7.5) fails the build on any of the banned
+words appearing in a `.tsx` string literal or a user-facing `*.copy.ts` under the three feature
+folders. This is the same shape as the existing `check-sales-document-reason-mirror.mjs` gate.
+
+**The banned list is closed and is exactly this table — nine terms, no "and other internal terms".**
+A lint script cannot implement an open list, and an open list is how a gate becomes advisory:
+
+| # | Banned term | Matched as |
+|---|---|---|
+| 1 | `authority` | case-insensitive word match |
+| 2 | `posture` | case-insensitive word match |
+| 3 | `FulfillmentWork` | exact, and the spaced form *"fulfillment work"* |
+| 4 | `AvailabilityAuthority` | exact |
+| 5 | `atpEffect` | exact, and the spaced form *"ATP"* |
+| 6 | `phase` | case-insensitive word match |
+| 7 | `Orchestrator` | case-insensitive word match |
+| 8 | `Gateway` | case-insensitive word match |
+| 9 | `holder` | case-insensitive word match |
+
+Adding a tenth term is an edit to this table and to the script in the same commit; the seed issue
+and this table are one list, mirror-checked against each other like every other pinned pair in the
+repo.
+
+### 2.2 Attention-worthy vs routine (#2100, binding)
+
+Every state in S2 is classified **attention-worthy** or **routine**, and only attention-worthy
+states are counted, badged red, or filterable. #2100's lesson applies verbatim: `trigger-model-manual`
+is a *default*, so counting it puts a red "4,312 blocked" on a healthy install. The classification
+table is §4.3, and it is a data table read by both the count query and the badge renderer — never
+two independent lists.
+
+### 2.3 Zero-config visibility
+
+An operator who has set nothing must still be able to open S1 and read a complete, correct answer
+("OpenLinker, by default" on every row). The page is **never gated on having configured anything**,
+and never renders an empty state. This is the operator-facing form of the matrix's third
+load-bearing property (every default is today's shipped behaviour).
+
+---
+
+## 3. Surface S1 — "Who decides what"
+
+### 3.1 Placement
+
+New route **`/settings/who-decides`**, reached from a new `SettingsPage` tile ("Who decides what").
+Rationale for settings rather than a top-level nav item:
+
+- It is read-rarely, changed-rarely, and admin-only — the exact profile of the existing
+  `/settings/sales-documents` page (#2187), which this page is a sibling of and links to for A7.
+- The left nav's `Operations` group is for daily work. A configuration page there competes with
+  Orders for the operator's attention every day, forever, to be opened twice a year.
+- The nav registry already reserves a **`Planned → Automations`** slot. S3 claims that slot (§5.1);
+  S1 does not need one.
+
+Admin-only (`@Roles('admin')` on the write endpoints; the read is available to `operator` so a
+non-admin can *see* who decides what without being able to change it — matching the read-only-role
+posture established in #1124/#1357).
+
+### 3.2 Page copy and the two presets (exact operator-facing copy)
+
+**Page furniture (verbatim; the mockup renders exactly these strings).**
+
+| Slot | Copy |
+|---|---|
+| Eyebrow | `Settings` |
+| Title | `Who decides what` |
+| Lede | *OpenLinker, your shop, your marketplaces and your warehouse each get to decide different things. This page shows who decides what right now, and lets you hand some of those decisions to OpenLinker — or keep them where they are.* |
+| Preset section eyebrow / heading | `Choose an arrangement` / `How should this work?` |
+| Table section eyebrow / heading | `Right now` / `Who decides what` |
+| Table section counter | `7 decisions` |
+| Attention section eyebrow / heading | `Not working` / `Needs attention {N}` |
+| Attention section subhead | *Only things that are stopping something. Defaults are never listed here.* |
+
+The attention subhead is not decoration: it is §4.3's classification rule stated to the operator on
+the page, which is what stops "why isn't my default listed here?" arriving as a ticket.
+
+Rendered as three cards in a single-select radio group. The **third card is the current default and
+is not a preset** — it is the pre-preset state, shown so that "I haven't chosen" is a visible,
+named position rather than an absence.
+
+---
+
+> **Card 1 — Leave things as they are** &nbsp;·&nbsp; *badge:* `Current` (shown only while selected)
+>
+> Your shop and your marketplaces keep making every decision, exactly as they do now.
+> OpenLinker connects them, publishes your stock and offers, files your invoices, and stays out of
+> the way.
+>
+> *Best if:* one shop, one warehouse, and nothing about your current setup is annoying you.
+>
+> **Nothing changes when you pick this.** It is what OpenLinker already does.
+
+---
+
+> **Card 2 — Let OpenLinker decide**
+>
+> OpenLinker becomes the place where decisions get made: it works out how much stock you can
+> safely promise, holds orders that shouldn't go out yet, and decides what happens to goods that
+> come back. Your shop and your carriers still do the physical work.
+>
+> *Best if:* you sell the same stock on more than one channel, or you keep finding orders you
+> wish had been stopped before they shipped.
+>
+> **What this changes:** OpenLinker starts subtracting orders it has seen from the stock numbers it
+> publishes, and can hold an order so it never reaches your shop. Your existing stock, order and
+> invoice flows are untouched.
+
+---
+
+> **Card 3 — Keep my other system in charge** &nbsp;·&nbsp; *badge:* `Not available yet`
+>
+> Your existing warehouse or order system keeps deciding. OpenLinker gives it marketplace
+> connectivity — offers, stock publication, order feed, status relay — and files your Polish
+> invoices and receipts, which it can't.
+>
+> *Best if:* you already run a warehouse or ERP system that you trust and don't want to replace.
+>
+> **What this changes:** OpenLinker stops working out your promisable stock itself and publishes
+> what your system tells it. Refunds and fiscal documents stay with OpenLinker either way — only
+> OpenLinker holds the credentials that can issue them.
+
+---
+
+Below the cards, a persistent line, always visible, never a tooltip:
+
+> Changing this only affects what happens **from now on**. Anything already in progress — an order
+> already sent to your shop, a label already bought — keeps its current arrangement until it
+> finishes.
+
+(That is the operator-facing rendering of prospective-only revocation, invariant P7.)
+
+**Card 3 is disabled, badged `Not available yet`, with an inline reason until Wave 4** — *"Needs a
+system that can take over. Connect one first."* — because the fact-producer seam it depends on is Wave-4 gated. Showing it
+disabled rather than hiding it is deliberate: it tells the operator the shape of the choice, and it
+is the same discipline as the composer's disabled tax-ID checkbox in #2170.
+
+### 3.3 The "Who decides X?" table (exact copy)
+
+Below the preset cards, always rendered, read-only in v1 (no per-authority override — §1.1). Each
+row shows the **question**, the **current answer**, **why** that is the answer, and a state badge.
+
+| Question | Answer values it can show | "Why" line when unset |
+|---|---|---|
+| **How much stock can we promise?** | `OpenLinker` · `My warehouse system` · `My 3PL` · `OpenLinker can't tell` | *Worked out from your stock master, minus your safety buffer. Nobody else has claimed it.* |
+| **Where does an order ship from?** | `Each shop decides (nothing to route)` · `OpenLinker` · `My other system` · `OpenLinker can't tell` | *You sell from one place, so there is nothing to choose between.* |
+| **Who picks and ships?** | `My shop` · `My marketplace` · `OpenLinker` · `My 3PL` · **a compound of any of these** · `OpenLinker can't tell` | *Whoever the order lands with, as it works today.* |
+| **What state is an order in?** | `OpenLinker` · `My other system` · `OpenLinker can't tell` | *OpenLinker works it out from what it can see — the shipment, the invoice, any hold you placed.* |
+| **What happens to returned goods?** | `OpenLinker` · `The marketplace` · `My other system` · `OpenLinker can't tell` | *Nothing decides yet — you handle returns by hand.* (until returns ship) |
+| **Who issues refunds?** | `OpenLinker` — **always** | *Only OpenLinker holds the payment credentials, so only OpenLinker can do it. This one can't be handed over.* |
+| **Who issues invoices and receipts?** | *(link)* `Set up under Sales documents →` | *Configured per country under Sales documents.* |
+
+Notes that are load-bearing rather than cosmetic:
+
+- **The refund row is rendered locked, not hidden.** A6's non-assignability is a statement of
+  physical fact (§2, ADR-052) and reads as a reassurance to the operator, not a restriction. Hiding
+  it would invite the question in a support ticket instead.
+- **The invoicing row delegates rather than duplicates.** A7 is already fully specified and shipped
+  by ADR-041/#2170; restating its answer here would create a second surface that can disagree with
+  `/settings/sales-documents`. One link, no mirrored state.
+- **The "why" line is the whole point of the table.** A per-row answer with no reason is a
+  configuration dump. With the reason, the table doubles as the explanation of what the default
+  *is*, which is what makes §2.3 (zero-config visibility) worth building.
+
+**Compound answers (the "who picks and ships" case).** On the persona this spec designs for — one
+shop plus one or two marketplaces — the truthful answer to *"who picks and ships?"* is per-order,
+not a single holder. The answer is therefore a **list of holders with a scope**, rendered as a
+middle dot join in the order the operator meets them (their own shop first, then each marketplace
+alphabetically), with a scoped why-line. Exact copy for the 1-shop + Allegro case:
+
+> **Answer:** `My shop · Allegro`
+> **Why:** *Marketplace-fulfilled orders are picked and shipped by the marketplace. Everything else
+> lands with your shop.*
+
+The same rendering applies wherever a row resolves to more than one holder. A compound is a
+**routine** answer, never attention-worthy — it is the correct description of a normal setup, not a
+conflict. It is distinct from `OpenLinker can't tell`, which means two systems claim the *same*
+scope and is attention-worthy (§4.2).
+
+**`OpenLinker can't tell` is a value on every assignable row, and it swaps the why-line.** When a row
+resolves ambiguous, the row renders the answer `OpenLinker can't tell` and its why-line is
+**replaced by the §4.2 body copy for the matching state** (A1-U, A2-A, A3-X, A5-A) rather than the
+default why-line. That is a rule, not a rendering accident: the operator reading the row is asking
+exactly the question §4.2 answers, and a stale default why-line under an ambiguous answer would be a
+false statement. The refund row (A6) and the invoicing row (A7) never take this value — the first
+cannot be assigned, the second is answered elsewhere.
+
+**State badge vocabulary (closed).** Every row carries exactly one badge from this list, and nothing
+else:
+
+| Badge | Tone | Means | Attention-worthy? |
+|---|---|---|---|
+| `Default` | neutral | Nobody has claimed this; OpenLinker's shipped behaviour answers it | No |
+| `Nothing to route` | neutral | The question does not arise on this topology (A2 resolving `none`) | No |
+| `Always` | info | Cannot be handed over (A6 refunds) | No |
+| `Elsewhere` | neutral | Answered on another page (A7 sales documents) | No |
+| `Chosen` | accent | The operator has picked a holder for this row | No |
+| `Nothing is deciding` | error | Ambiguous — two systems claim it, so OpenLinker does neither | **Yes** |
+
+`Nothing is deciding` is the only badge that is ever red, and its presence on a row implies a
+matching §4.2 row in `Needs attention` — one fact, two renderings, from one source (§4.3).
+
+### 3.4 Stories & acceptance criteria
+
+**S1-1 — I can see who decides what, without configuring anything** *(P2, P1)*
+- Given a fresh install with one shop connection and no OMS configuration,
+- When I open `/settings/who-decides`,
+- Then every row renders a concrete answer and a "why" line; no row is blank, "unknown", or an
+  empty state; and the page never asks me to add something before it will show me anything.
+
+**S1-2 — I pick a preset and understand what changed** *(P2)*
+- Given I select **Let OpenLinker decide** and confirm,
+- Then the confirm dialog lists, in plain sentences, exactly which rows changed answer and what the
+  new behaviour is — generated from the diff, not from static copy;
+- And after saving, the changed rows show a `Changed just now` marker and the page states that
+- in-progress work is unaffected.
+
+**S1-3 — I can go back** *(P7)*
+- Given I have selected a preset,
+- When I select **Leave things as they are** and confirm,
+- Then every row returns to its default answer, and the confirm dialog says explicitly that orders
+  already held, reservations already taken, and jobs already accepted are **not** reversed by this
+  — with a link to the affected orders where any exist.
+
+**S1-4 — I can't half-configure my way into an inert state** *(P4)*
+- Given a preset selection would result in any authority resolving `ambiguous` (e.g. a second
+  connection already claims the same thing),
+- Then the confirm dialog blocks the save, names the conflicting connection, and states what would
+  stop working — rather than saving and reporting the problem afterwards on S2.
+- *(This is the one place the model's "inert and reported" is pre-empted rather than reported: at
+  save time OpenLinker has both candidates in hand and the operator is present.)*
+
+---
+
+## 4. Surface S2 — Authority status
+
+### 4.1 Shape and placement
+
+**The same page**, below the who-decides table — not a separate route. Rationale: an operator who
+opens the configuration page and an operator who needs to know why nothing happened are the same
+person with the same question five seconds apart. Two pages guarantee one of them is stale.
+
+The section renders as `Needs attention (N)` — a count badge in the page header, a table below,
+and nothing at all when N = 0 beyond a single line: *"Everything that should be deciding something
+is deciding it."*
+
+**Second surface, always:** every attention-worthy state also renders **where the operator already
+is** — a badge on the affected `/orders` row, `/products` row, or connection card, following #2100's
+own treatment of `salesDocumentBlockReason` exactly. A state that only exists on a settings page is
+a state nobody sees.
+
+### 4.2 The inert states (complete for Wave 2)
+
+Nine states. Each carries a **badge** — the short label rendered on the affected `/orders`,
+`/products`, `/returns` or connection row, drawn from a closed four-value vocabulary
+(`Stopped` / `At risk` / `Blocked` / `Not matched`) so a row badge is scannable without reading the
+title.
+
+| # | State | Badge | Where it comes from | Operator-facing title | Body copy | Fix |
+|---|---|---|---|---|---|---|
+| A1-U | **Stock we can promise is unknown** | `Stopped` | Two connections claim the same stock, or the claiming system errored | *"We don't know how much stock to publish"* | Two of your systems both say they're in charge of your stock, so OpenLinker won't guess. Publishing for these products is paused. | Name both connections; link to each; state that publishing stays paused |
+| A2-A | **Two systems want to route the same orders** | `Stopped` | Two enabled routers on one source | *"Nothing is deciding where {channel} orders ship from"* | Two systems are set up to decide, so OpenLinker is doing neither. Orders are going out the way they did before. | Name both; link to each |
+| A3-X | **Nobody accepted the job** | `Stopped` | Every candidate rejected or timed out | *"No one took the job for order {ref}"* | Every place that could have shipped it said no. It's waiting for you. | Link to order; show each rejection reason |
+| UF-L | **Line can't be fulfilled** | `At risk` | `RoutingPlan.unfulfillable[]` | *"{n} line(s) on order {ref} can't be shipped from anywhere"* | There isn't stock for it in any place that can ship to this buyer. This is a refund or return decision, not something OpenLinker can fix. | Link to order; offer the refund/return action |
+| RS-S | **We promised more than we have** | `At risk` | Reservation shortfall (I6) | *"Order {ref} is short {n} × {sku}"* | Your stock master dropped below what this order was promised. Nothing was silently reduced — this order is the one at risk. | Link to order; link to the product |
+| A5-A | **Two systems want to decide returns** | `Stopped` | Two enabled returns authorities | *"Nothing is deciding what happens to returns from {channel}"* | Two systems are set up to decide, so OpenLinker is doing neither. Returns are still being recorded, but nothing is being restocked or scrapped automatically. | Name both |
+| RB-L | **Restock was refused** | `Blocked` | `restock_blocked` (T5) | **Copy owned by the returns spec §5.4** — imported, never restated (see below) | | Link to the return; name the system |
+| OR-P | **Return with no order** | `Not matched` | Orphan return (T2) | **Copy owned by the returns spec §5.5** — imported, never restated (see below) | | Link to the return |
+| **AF-X** | **An automation couldn't finish** | `Stopped` | An automation step returned a failure (§5.3, §5.6) | *"Couldn't buy the label for order {ref}"* — one title per action, the action's own verb | The automation '{rule name}' tried and {reason from the underlying operation}. Nothing else in that automation ran, so {source} has not been told. The order is waiting for you. | Link to the order; link to the rule; `Try again` |
+
+**AF-X is the automation-failure state, and it is not optional.** §1.1 and S2-1 commit to *"nothing
+ever fails silently"*, and an automation is the one place in Wave 2 that spends money without an
+operator present. A failed action landing only in a per-rule log — inside a page nobody has open —
+is the same silent decline the #2100 lineage exists to forbid, one surface down. The multi-step
+"stop on first failure" rule makes it sharper: when step 1 fails, step 2 (*"tell the marketplace"*)
+never runs, so the marketplace still shows the order unshipped and the operator has **no** signal at
+all unless this state exists. Rules:
+
+- One AF-X row per failed **firing**, not per rule and not per step; the body names the step that
+  failed and states which later steps were skipped.
+- The title is the action's own verb — *"Couldn't buy the label for order {ref}"*, *"Couldn't issue
+  the invoice for order {ref}"*, *"Couldn't tell {source} about order {ref}"*, *"Couldn't send the
+  email for order {ref}"*, *"Couldn't put order {ref} on hold"*, *"Couldn't lift the hold on order
+  {ref}"* — because "an automation failed" tells the operator nothing about what to do next.
+- The reason is **the underlying operation's own reason**, passed through verbatim and attributed
+  (*"Allegro said: …"*, *"DPD said: …"*), never a re-worded summary. The same discipline as the
+  returns spec's `rawStatus` treatment.
+- It clears when the firing is retried successfully, or when the operator dismisses it with an
+  explicit *"I handled this myself"* — never on a timer, and never because a later, unrelated firing
+  of the same rule succeeded.
+
+**RB-L and OR-P copy is imported, not restated (canonical owner: the returns spec).** Both states are
+owned end-to-end by the returns feature, and S2-1 requires *one* copy source with the same title in
+both places. The canonical strings live in the **returns product spec §5.4 (`restock_blocked`) and
+§5.5 (orphan)**, and this surface imports them from the returns copy module rather than keeping its
+own variant. The mirror check that S2-1 mandates covers **both** feature folders, so a divergence
+fails the build rather than shipping as two truths. For the reader's convenience, the imported
+titles are *"Stock was not added."* (RB-L) and *"This return is not matched to an order."* (OR-P) —
+but the returns spec is the record, and if this line ever disagrees with it, the returns spec wins.
+
+**No state is written around `{location}`.** §1.2 designs for a single-location seller, for whom a
+location name is a concept that does not exist and would render as an id or an empty string. A1-U's
+copy is therefore written around the **systems** that disagree, which is the fact the operator can
+act on. Where a deployment genuinely has more than one location, the location name is appended to
+the body as a trailing clause (*"… in charge of your stock at {location}"*) — additive, never the
+subject of the sentence.
+
+### 4.3 Attention-worthy vs routine classification
+
+**Attention-worthy** (counted, badged `danger`/`warning`, filterable): every row in §4.2, AF-X
+included. A failed automation action is attention-worthy by the same rule that makes a blocked
+sales document attention-worthy — OpenLinker was asked to do something, did not do it, and no other
+surface says so.
+
+**Routine** (rendered on the row it applies to, never counted, never red, never filterable):
+
+- *"OpenLinker decides this, by default"* — the zero-config answer on every who-decides row.
+- *"Nothing to route — you ship from one place"* — A2 resolving `none` on a single-location install.
+- *"Waiting for the marketplace to ship it"* — observation-only work on `omp_fulfilled` (R10).
+- *"You handle this by hand"* — any decision the operator has deliberately left with a manual
+  trigger model.
+- *"{system A} · {system B}"* — a compound answer on a who-decides row (§3.3). Two systems handling
+  *different* orders is a description of a normal setup; only two systems claiming the *same* scope
+  is a problem.
+- An automation that ran and **did nothing because no rule matched**. Not-firing is the normal case,
+  and counting it would put a number on every install with a narrow rule.
+
+The #2100 precedent is exact and this is where it bites hardest: **A2 `none` is the default on the
+majority topology.** Counting it would put a permanent red number on every single-location install
+on the day Wave 2 ships. It is not a problem; it is the correct answer to a question that doesn't
+arise.
+
+**One table, two readers.** The classification above, the §4.2 badge column and the §3.3 state-badge
+vocabulary are read by the count query, the settings-page renderer and the row-badge renderer from
+**one** declared data table. Three independent lists is how a state ends up counted in one place and
+invisible in another.
+
+### 4.4 Stories & acceptance criteria
+
+**S2-1 — Nothing ever fails silently** *(P4)*
+- Given any of the nine states in §4.2 exists,
+- Then it appears in `Needs attention` **and** as a badge on the affected order/product/connection
+  row, with the same title text in both places (one copy source, mirror-checked like #2100's
+  reason mirror).
+
+**S2-2 — The healthy install stays quiet** *(#2100)*
+- Given a single-location install with no OMS configuration and 4,000 orders,
+- Then `Needs attention` shows 0, no red badge appears on any order row, and the who-decides table
+  renders every row with a neutral tone.
+
+**S2-3 — I can tell "not set up" from "broken"**
+- Given a state is routine,
+- Then it never contributes to the attention count and never uses the `danger` or `warning` tone;
+- Given a state is attention-worthy,
+- Then its copy states what is *not happening as a result*, in a sentence, before offering a fix.
+
+**S2-4 — Every attention row names a next action**
+- Given any row in §4.2,
+- Then it links to the object it is about, and states either the exact fix or, where OpenLinker
+  cannot fix it (RB-L, UF-L), where the operator must go instead.
+
+**S2-6 — A failed automation is visible where the operator already is** *(AF-X)*
+- Given an automation step fails,
+- Then an AF-X row appears in `Needs attention`, a `Stopped` badge appears on the affected order
+  row, and the order's activity timeline (§5.6) names the rule, the step, the failure reason and
+  the steps that were skipped;
+- And the automation's own rule page shows the same firing with the same reason — one record, three
+  renderings, never three independent writes.
+
+**S2-5 — An unrecognised state degrades safely**
+- Given a persisted reason this build's UI does not recognise,
+- Then it renders neutrally with its raw value and is **not** counted — the #2100 `IN`-list
+  behaviour, restated as a requirement rather than inherited by accident.
+
+---
+
+## 5. Surface S3 — Automation v1
+
+### 5.1 Placement
+
+Claims the reserved **`Planned → Automations`** nav slot (`nav-registry.ts`), promoting it to a real
+route **`/automations`** in the `Operations` group. This is a daily-relevance surface (the operator
+will check "did my rules fire?"), unlike S1, which is why it earns nav space where S1 doesn't.
+
+**First run — the zero-rules state (exact copy).** On a fresh install the index would otherwise
+render eight triggers with `0 rules` each: technically complete, and useless as a starting point.
+Instead the page leads with a single card above the trigger index:
+
+> **You have no automations yet.**
+> Most sellers start with this one:
+>
+> **When an order is marked packed → buy the shipping label → tell the marketplace.**
+> One click at the packing bench instead of three, and the marketplace hears about it straight away.
+>
+> `[Set this up]`   `[Start from scratch]`
+
+`Set this up` opens the composer **pre-filled** with T5 → A2 → A3, no conditions, inactive, and
+still subject to the §5.7 S3-2 arming gate — the operator reviews and arms it, exactly as if they
+had built it. It is a suggestion, never a rule that exists before the operator saved it: nothing is
+created by opening the page.
+
+Exactly **one** suggestion is offered, deliberately. A gallery of prebuilt recipes is a content
+surface with its own maintenance cost, and §5.4 already names T5→A2→A3 as *"the automation that
+justifies the wave"* — so the honest first-run page recommends that one and gets out of the way.
+The card disappears permanently once any rule exists (active or not); it never returns after the
+operator deletes their last rule, because at that point they know what the page is for.
+
+### 5.2 The v1 trigger set (exactly 8)
+
+**Admission rule:** a trigger is admissible only if it names a fact OpenLinker **persists**, at a
+grain OpenLinker **writes**, in a wave that has **already shipped** by Wave 2. No derived-with-a-clock
+facts, no facts produced by a gated wave.
+
+| # | Trigger | Operator-facing name | Backing persisted fact | Fires | Available from | Parameters |
+|---|---|---|---|---|---|---|
+| T1 | `order.hold.placed` | *"An order is put on hold"* | `order_holds` insert (Wave 2, L4) | `edge` | Wave 2 | hold reason (any / specific) |
+| T2 | `order.hold.released` | *"A hold is lifted"* | `order_holds.releasedAt` (Wave 2) | `edge` | Wave 2 | hold reason |
+| T3 | `order.on_hold_for` | *"An order has been on hold for too long"* | `order_holds.placedAt`, open row | `deadline sweep` | Wave 2 | N (hours/days) |
+| T4 | `order.dispatch_deadline_near` | *"A marketplace dispatch deadline is close"* | `order_records.dispatchByAt` (**persisted today**, inert; L9) | `deadline sweep` | Wave 1a | X (hours before) |
+| T5 | `order.packed` | *"An order is marked packed"* | `order_records.packedAt` (Wave 0, L0 — the only demand-backed ask on record) | `edge` | Wave 0 | — |
+| T6 | `return.received` | *"Returned goods arrive"* | `ReturnLine.quantityReceived` > 0 (Wave 2, T4) | `edge` | Wave 2 | — |
+| T7 | `return.disposed` | *"A return is restocked or scrapped"* | disposition recorded (Wave 2, T5) | `edge` | Wave 2 | disposition (any / restock / scrap) |
+| T8 | `inventory.reservation_shortfall` | *"We've promised more of something than we have"* | shortfall fact on a named order (Wave 2, I6) | `edge` | Wave 2 | — |
+
+**Firing semantics — the two kinds, stated per trigger.** Without this, a *standing condition* like
+T8 (a shortfall is true until somebody fixes it) is a level-triggered fact that a naive
+implementation re-evaluates every recompute and emails about hourly, forever.
+
+**`edge` — fires on the transition, once per transition.** T1, T2, T5, T6, T7, T8. The firing is
+caused by the *write* that creates the fact, so re-reading, re-ingesting or re-computing the same
+fact fires nothing. Concretely:
+
+- **T1 / T2** fire per `order_holds` row, so hold → release → hold **does** fire T1 twice: those are
+  two distinct holds and the second one is a real new fact.
+- **T5** fires on the transition of `packedAt` from null to a value. Re-writing `packedAt` (a
+  correction to the timestamp, or a re-pack) does **not** re-fire — the fact "this order got packed"
+  happened once, and re-buying a label because someone fixed a typo is exactly the failure mode this
+  rule prevents.
+- **T6 / T7** fire per receive/dispose *act*, so a return received in three parcels fires T6 three
+  times. That is intended: each is a real arrival.
+- **T8** fires on the transition into shortfall for a given (order, sku) — **not** on every
+  recompute while the shortfall persists. It re-fires only if the shortfall clears and then recurs.
+
+**`deadline sweep` — fires when a clock crosses a persisted timestamp.** T3 and T4 only. There is no
+event to hang these on: the fact is "time has passed", so a periodic evaluator is required. Rules:
+
+- **Cadence: every 15 minutes**, one bounded, resumable sweep per rule set, sharing the shape of the
+  existing bounded sweeps rather than inventing a scheduler.
+- **At most once per (rule, order), ever.** The firing is recorded, and the recorded firing is what
+  makes the next sweep skip that pair. A duration trigger whose condition stays true for three days
+  must not fire 288 times.
+- The parameter is a **threshold**, not a schedule. *"On hold for more than 48 hours"* fires once,
+  the first time a sweep observes an open hold older than 48 hours. It does not fire again at 72.
+- A rule edited to a **shorter** threshold may fire for orders that already passed the old one; a
+  rule edited to a **longer** one never un-fires. Editing a rule does not erase its firing record.
+
+**Rules are never retroactive.** A rule created today acts only on facts that occur after it was
+saved — a new rule does not fire against the 40 orders already on hold, and a `deadline sweep` rule
+does not fire for a pair whose deadline was crossed before the rule existed. This is stated to the
+operator in the composer, not only here (§5.5):
+
+> *An automation only acts on things that happen after you save it.*
+
+That sentence is load-bearing: the opposite expectation ("I'll set this up and it'll clean up my
+backlog") is the single most likely first-use surprise, and it would surprise them by spending
+money on 40 labels.
+
+**Pruned, with reasons** (recorded so the next reader doesn't re-propose them):
+
+- **`work.short_picked`** *(named in the design's own Wave-2 sketch)* — **cut.** `FulfillmentWork`
+  does not exist until Wave 3, and Wave 3 is demand-gated. A trigger whose backing object may never
+  ship would be dead configuration in the composer's dropdown from day one, and would have to be
+  rendered disabled-with-a-caveat forever. Re-admit it with Wave 3a.
+- **`order.phase_held_for_N_days`** *(the design's phrasing)* — **narrowed to T3.** The derived phase
+  carries **no clock and no entered-at timestamp** by construction (§6.3: *"a phase fed by `now` is
+  uninvalidatable"*), so "the phase has been X for N days" is not computable from anything persisted.
+  `order_holds.placedAt` **is** persisted, and "on hold for N days" is what the operator actually
+  meant. This is a correctness prune, not a scope prune — the original phrasing describes a fact OL
+  does not have.
+- **`order.routed`** — Wave 3, same reason as `work.short_picked`.
+- **`order.status_changed`** *(the obvious BaseLinker-shaped trigger)* — **cut from v1.** Source
+  status is a pass-through string that re-arrives on every poll; a trigger on it fires on
+  re-ingestion noise, and the deduplication story is a wave of its own. The derived phase is the
+  right basis and it needs an entered-at fact OL has decided not to persist (§10, Decision log).
+
+### 5.3 The v1 action set (exactly 6)
+
+**Admission rule:** an action is admissible only if it invokes an operation OpenLinker **already
+ships end-to-end**, with its own idempotency and failure handling already solved.
+
+| # | Action | Operator-facing name | Underlying shipped operation | Reversible? |
+|---|---|---|---|---|
+| A1 | `issue-sales-document` | *"Issue the invoice or receipt"* | ADR-041 routing + `InvoiceService.issueInvoice` / fiscalization; #2047 one-document guard applies unchanged | **No** — fiscal |
+| A2 | `dispatch-shipment` | *"Buy the shipping label"* | `ShipmentDispatchService` (ADR-012) | **No** — money + carrier |
+| A3 | `relay-status-to-source` | *"Tell the marketplace"* | `OrderStatusWriteback` relay (#1157/ADR-027) | No (but harmless to repeat) |
+| A4 | `send-email` | *"Send an email"* | existing `MailerPort` + a template; recipient = **buyer** or **a fixed address you enter** | No (but recoverable) |
+| A5 | `place-hold` | *"Put the order on hold"* | `order_holds` (Wave 2); reason required | **Yes** |
+| A6 | `release-hold` | *"Lift the hold"* | `order_holds.releasedAt` (Wave 2); note required | **Yes** |
+
+**Pruned, with reasons:**
+
+- **`mark-packed`** *(listed in the brief)* — **cut, on principle.** `packedAt` + `packedByUserId`
+  record that **a named human packed a physical box**. An automation writing it would put a user id
+  (or a null) against an event that did not happen, and the column's entire value is that it is
+  trustworthy. Automating an assertion about the physical world is the one thing this layer must
+  never do.
+- **`propose-credit-note`** — **deferred to v1.1.** The correction proposal (T7) is real Wave-2
+  functionality, but the design is explicit that it must render its positional ambiguity for
+  operator confirmation and must never auto-issue. An automation that creates confirmable proposals
+  is defensible; it needs the proposal inbox UI first, which is not in Wave 2's scope.
+- **`adjust-stock` / `restock`** — **cut.** Restock is already the automatic consequence of
+  disposition (T5); a second path to the same write is how double-restock bugs get built.
+- **`call-a-webhook`** — cut, see §6 non-goals.
+
+### 5.3b Action parameters (exact controls, defaults and copy)
+
+Every action needs configuration, and none of it can be guessed at runtime — `ShipmentDispatchService`
+does not pick a carrier for you. This is the largest copy surface in S3 and it renders inside the
+composer where `( action parameters render here )` appears.
+
+**A1 — *"Issue the invoice or receipt"***
+
+| Parameter | Control | Default | Copy |
+|---|---|---|---|
+| — | none | — | *"Which document gets issued, and by which provider, is decided by your Sales documents rules. This automation only decides **when**."* + link to `/settings/sales-documents` |
+
+A1 deliberately takes **no** parameters. ADR-041 routing already owns document-kind selection, and a
+second place to choose it is a second answer that can disagree with the first.
+
+**A2 — *"Buy the shipping label"***
+
+| Parameter | Control | Default | Copy |
+|---|---|---|---|
+| Carrier | select, from the connection's configured carriers | none — **required** | *"Which carrier account to buy from."* |
+| Service | select, from that carrier's services | the carrier's own default service where it declares one, else required | *"The service level. If your carrier only offers one, this is filled in for you."* |
+| Package | select from saved package presets, or *"Use the order's own weight and size"* | *"Use the order's own weight and size"* | *"What to declare to the carrier. If the order has no weight, buying the label will fail — pick a preset instead."* |
+| Cash on delivery | checkbox, disabled with a reason unless the carrier supports it | off | *"Collect the order total from the buyer on delivery."* |
+
+A2 is the money-spending action; its parameter block carries a standing line: *"Every time this
+runs, it buys a label and you are charged for it."*
+
+**A3 — *"Tell the marketplace"***
+
+| Parameter | Control | Default | Copy |
+|---|---|---|---|
+| What to tell them | fixed: *"that the order has shipped, with the tracking number if there is one"* | — | *"OpenLinker relays what it knows. If no label has been bought yet, the marketplace is told the order shipped without a tracking number."* |
+
+No selectable status vocabulary: the relay is the shipped `OrderStatusWriteback` path, and inventing
+a status picker would be the "states yes" boundary this design refuses.
+
+**A4 — *"Send an email"***
+
+| Parameter | Control | Default | Copy |
+|---|---|---|---|
+| To | radio: *"The buyer"* / *"A fixed address"* (+ text input) | *"A fixed address"* | *"Emails to the buyer are sent from your configured sender address."* |
+| Subject | text, merge fields allowed | *"Order {order.reference}"* | — |
+| Body | textarea, merge fields allowed, plain text | empty — **required** | *"Use the fields below to drop in order details. Anything else is sent exactly as you type it."* |
+
+**Merge fields — a closed list of nine, and nothing else.** An open templating surface is a scripting
+language, which §6 refuses. An unrecognised `{…}` is rendered **verbatim** as typed, never blanked —
+blanking silently produces an email that reads as broken, and a visible `{ordr.reference}` is a typo
+the operator can see and fix.
+
+| Field | Renders |
+|---|---|
+| `{order.reference}` | the order's operator-facing reference |
+| `{order.source}` | the channel name (*"Allegro"*) |
+| `{order.total}` | the gross total with its currency |
+| `{order.placedAt}` | the order date, in the operator's locale |
+| `{order.dispatchBy}` | the marketplace dispatch deadline, or *"no deadline"* |
+| `{buyer.name}` | the buyer's name as the source reported it |
+| `{shipment.tracking}` | the tracking number, or *"not yet"* |
+| `{hold.reason}` | the current hold's reason, or *"no hold"* |
+| `{rule.name}` | the automation's own name |
+
+**A5 — *"Put the order on hold"***
+
+| Parameter | Control | Default | Copy |
+|---|---|---|---|
+| Reason | select, from the closed hold-reason union (§7.4) — **the only source** | none — **required** | *"Why it's being held. The operator who finds it sees this."* |
+| Note | text, merge fields allowed | *"Placed by the automation '{rule.name}'."* | *"Added to the hold record."* |
+
+The reason list is the design's merged union verbatim. The composer cannot add a reason, and an
+operator who needs one that does not exist is asking for a design change (§7.4).
+
+**A6 — *"Lift the hold"***
+
+| Parameter | Control | Default | Copy |
+|---|---|---|---|
+| Which hold | select: *"Any hold"* / a specific reason | *"Any hold"* | *"Which hold to lift, if the order has more than one."* |
+| Note | text, merge fields allowed, **required** (mirrors the manual release) | empty | *"Why it's being lifted. Required, the same as when you lift a hold by hand."* |
+
+### 5.4 The legality matrix (which action may follow which trigger)
+
+Not every pair is meaningful, and offering a meaningless pair is how an operator builds a rule that
+silently never fires. The composer offers **only legal pairs**, from one declared table:
+
+| | A1 invoice | A2 label | A3 relay | A4 email | A5 hold | A6 release |
+|---|---|---|---|---|---|---|
+| T1 hold placed | — | — | — | ✓ | — | — |
+| T2 hold released | ✓ | ✓ | ✓ | ✓ | — | — |
+| T3 on hold too long | — | — | — | ✓ | — | ✓ |
+| T4 deadline near | — | ✓ | — | ✓ | — | — |
+| T5 packed | ✓ | ✓ | ✓ | ✓ | — | — |
+| T6 return received | — | — | — | ✓ | — | — |
+| T7 return disposed | — | — | ✓ | ✓ | — | — |
+| T8 shortfall | — | — | — | ✓ | ✓ | — |
+
+Two of these are the load-bearing ones, and both should be read as the product:
+
+- **T5 packed → A2 label → A3 relay** is "I packed it, buy the label and tell Allegro" — one click
+  becomes zero. This is the automation that justifies the wave.
+- **T4 deadline near → A4 email(operator)** is the marketplace-penalty story (L9), and it works on
+  data OpenLinker has persisted and left inert for a year.
+
+### 5.5 Composer UX — **mirror #2161**, with three declared divergences
+
+The #2161/#2170 composer is the house pattern and this design adopts it: a **scope index table** →
+per-scope dialog → **rule composer dialog** with an AND-ed list of closed-vocabulary conditions, a
+declared outcome, effective-from/to dates, and a save-time conflict guard over a canonicalized
+conditions hash. Concretely reused, not re-invented:
+
+- The **condition shape**: a discriminated union on `field`, each field carrying exactly the
+  comparison shape it needs; a runtime `is*Condition` narrower that treats a malformed persisted
+  condition as *never matches* rather than throwing; `canonicalize*` + `compute*ConditionsHash`
+  for the save-time duplicate guard.
+- **No priority number.** #2170 deliberately removed it, and the reasoning transfers: a priority
+  field is a silent tie-break, and a silent tie-break on an action that spends money is exactly what
+  the #2047 lineage exists to prevent.
+- **AND-only conditions**, with the shipped footer sentence used **verbatim** — *"Every added
+  condition must ALL be true for this rule to match (AND)."* (`sales-document-rule-composer-dialog.tsx:246`,
+  minus its trailing sentence about the cross-country `field` vocabulary, which is specific to the
+  sales-documents matrix and has no counterpart here). No OR, no grouping, no negation. This is the
+  one string a spec claiming to mirror #2161 must copy exactly rather than paraphrase, and it is the
+  same string in the prose here and in the skeleton below.
+- **Effective from / to** on every rule, filtered against an explicitly-supplied `now`.
+- The **index-table shape** of `sales-document-country-index.tsx`: scannable, one status badge per
+  row, a `Configure` action reaching one callback, and an add-row that costs the same number of
+  clicks for a new scope as for an existing one.
+
+**Divergence 1 — the scope axis is the trigger, not the country.** #2161 indexes by country because
+the law is the scoping axis. Here the operator's mental model is *"when X happens, do Y"*, so the
+index lists the **8 triggers**, each row showing rule count / last fired / status, and `Configure`
+opens that trigger's rule list. A country index would be a category error.
+
+**Divergence 2 — the condition vocabulary is different, and carries inline values.** v1 fields:
+
+| Field | Op | Value |
+|---|---|---|
+| `sourceConnection` | `eq` | a connection (select) |
+| `orderCountry` | `eq` | ISO-3166-1 alpha-2 (typed) |
+| `orderTotalGross` | `gte` \| `lt` | **inline amount + currency** |
+| `holdReason` | `eq` | one of the closed hold-reason values *(only offered for T1/T2/T3)* |
+
+`orderTotalGross` carries an **inline literal**, where #2161 structurally forbids one and forces a
+`thresholdRef`. That is not sloppiness: #2161's threshold indirection exists so a **legal** amount
+can version independently of the rules citing it. An automation threshold ("email me about orders
+over 2,000 PLN") has no legal-matrix versioning concern, and forcing the operator through a
+separate thresholds table to author one would be ceremony imported from a constraint that doesn't
+apply here. **Currency mismatch resolves the same way it does in #2161**: no conversion, ever — the
+rule simply does not match, and the operator is told why on the rule row. (The ADR-040 FX stamp is
+analytics-only and must not be reached for; the fact that automation is not a fiscal path does not
+make a silently-converted comparison acceptable.)
+
+**Divergence 3 — multiple rules may fire, *except* for irreversible actions.** #2161 resolves
+at-most-one and reports `unresolved` on two matches, because two fiscal documents for one sale is
+an unrecoverable legal event. Automation is asymmetric: sending two emails is recoverable; buying
+two labels is not. So:
+
+- For **reversible/repeatable actions** (A3, A4, A5, A6): every matching rule fires. Two rules that
+  both send an email send two emails, which is what the operator asked for.
+- For **irreversible actions** (A1 `issue-sales-document`, A2 `dispatch-shipment`): the #2047 rule
+  applies **verbatim** — at most one may resolve; two matching rules resolve `ambiguous`, **nothing
+  fires**, and the reason is persisted on the order and surfaced on S2. The save-time guard warns at
+  authoring time where it can see the overlap; the runtime guard is the authority.
+
+This split is the single most important design decision in S3, and it is a direct application of
+the model's own rule: *an unrouted order is recoverable, a double-shipped one is not.*
+
+**Composer copy skeleton** (dialog title *"Add automation"*):
+
+```
+When   [ An order is marked packed              ▾ ]
+       ( trigger parameters render here, if any )
+
+Only if  [ Marketplace is        ▾ ] [ Allegro          ▾ ]   [× ]
+         [ Order country is      ▾ ] [ PL               ]     [× ]
+         + Add condition
+         Every added condition must ALL be true for this rule to match (AND).
+
+Then   [ Buy the shipping label   ▾ ]
+       ( action parameters render here )
+       + Add step        ← max 3 steps, run in order, stop on first failure
+
+Active from [ 2026-09-01 ]   until [           ] (optional)
+       An automation only acts on things that happen after you save it.
+
+                                        [ Cancel ]  [ Save automation ]
+```
+
+**Multi-step is capped at 3 and stops on first failure.** The T5→A2→A3 story needs two steps; three
+is one step of headroom. Unbounded chaining is a scripting language with extra clicks.
+
+### 5.6 Dry run, and automation history (three surfaces)
+
+An operator who discovers a wrong outcome starts **from the order**, not from a rule they do not yet
+suspect. A per-rule log is the only surface that assumes the operator already knows which rule to
+blame — which is precisely the thing they are trying to find out. Automation history therefore lands
+in three places, from one record.
+
+**(a) "Test on a recent order" — before it is armed.**
+Pick any order from the last 30 days, and the composer shows whether each condition matched and
+whether the rule would have fired, without doing anything. This is the same instinct as the router's
+`evaluate()` dry-run being called OL's differentiator (§5.3), applied at the layer the operator
+actually touches. An automation that spends money and cannot be tested before it is armed will not
+be armed. (The gate itself, and its fallback where no order matches, is S3-2 in §5.7.)
+
+**(b) The order activity timeline — where the operator actually looks.**
+**Every** automation firing writes an event to the affected order's `OrderActivityTimeline`, using
+its existing `TimelineEvent {id, timestamp, title, by, description, tone, footer}` shape — the same
+device the returns spec uses to make `by` carry the difference between an operator act and an
+observation. One event per **step**, so a two-step rule writes two events in order.
+
+| Field | Value |
+|---|---|
+| `by` | `Automation · {rule name}` — the rule name is a link to the rule |
+| `title` | The action's own past-tense verb: *"Bought the shipping label"* · *"Issued the invoice"* · *"Told Allegro the order shipped"* · *"Sent an email"* · *"Put the order on hold"* · *"Lifted the hold"* |
+| `description` | What the step actually produced, in operator vocabulary: *"DPD, tracking 000340512..."*, *"To warehouse@example.com"*, *"Reason: awaiting payment"* |
+| `footer` | *"Ran because: {trigger, in the operator-facing name from §5.2}"* — e.g. *"Ran because: an order was marked packed"* |
+| `tone` | neutral on success; **error** on a failed step, whose `title` becomes the AF-X title (§4.2) and whose `description` carries the underlying reason verbatim, attributed |
+
+A failed step also writes one further event stating what did **not** run — *"Skipped: tell the
+marketplace"*, footer *"The automation stopped after the step that failed."* — because a silently
+missing step is indistinguishable from a step that was never configured.
+
+Timeline events are written for **firings only**. A rule that evaluated and did not match writes
+nothing: an order that matched no rule would otherwise accumulate one line per rule per event,
+forever, and drown the timeline the feature exists to make readable.
+
+**(c) `/automations/activity` — the global run log.**
+The cross-rule counterpart to `/sync/jobs`, and the answer to *"what has been happening?"* when the
+operator does not have a specific order in hand. Reached from `/automations` (a `Run log` action in
+the page header) and from every rule page (`See all runs for this rule →`, which opens it
+pre-filtered).
+
+- **Placement:** a child route of `/automations`, in the `Operations` group; not a nav entry of its
+  own (the parent already has one).
+- **Columns:** `When` (`TimeDisplay`, relative with absolute on hover — default sort, descending) ·
+  `Automation` (rule name, links to the rule) · `Trigger` (operator-facing name) · `Order / Return`
+  (links to the object) · `What it did` (one line per step, in order, each with a tick or a cross) ·
+  `Outcome` (`Done` / `Failed` / `Nothing to do` / `Blocked`).
+- **Filters, all URL params:** `ruleId`, `trigger`, `outcome`, `from` / `to`, `orderId`. Same
+  `FILTER_PARAMS` + `hasActiveFilters` + one-call `clearAllFilters` convention as the orders list;
+  an unrecognised param value is ignored, never thrown.
+- **A run row links to three things**: the order or return it acted on, the rule that fired, and —
+  where the step dispatched a job — the `sync_jobs` row, so the existing job detail remains the
+  place technical failure detail lives rather than being re-rendered here.
+- **Outcome vocabulary is closed and honest.** `Blocked` is the #2047 two-money-rules case (§5.5
+  divergence 3) — nothing ran, and the row says which rules collided. `Nothing to do` is a rule that
+  fired and found the work already done (the label already bought). Neither is `Failed`, and neither
+  is attention-worthy.
+- **Retention:** runs are kept for 90 days, stated on the page footer (*"Runs older than 90 days are
+  removed."*), so an empty older window is a known fact and not a suspected data loss.
+
+**Per-rule fired log.** Each rule page keeps its last-50 view — the same records, pre-filtered — and
+a deactivated rule keeps it (S3-6). Backed by `sync_jobs` where the action dispatches a job
+(A1/A2/A3) and by the `automation_runs` table otherwise (§7.2); the run row is written **either
+way**, so the log is complete rather than complete-for-some-actions.
+
+**One record, four readings.** The timeline event, the run-log row, the per-rule log and the AF-X
+attention state (§4.2) are renderings of **one** persisted run record. They cannot be four writes:
+that is how a firing shows as succeeded in one place and failed in another.
+
+### 5.7 Stories & acceptance criteria
+
+**S3-1 — Label-and-tell** *(P8)*
+- Given I create: **when** an order is marked packed, **only if** marketplace is Allegro, **then**
+  buy the shipping label **and** tell the marketplace,
+- When I mark an Allegro order packed,
+- Then a label is bought and the marketplace is notified, and both appear in the rule's fired log
+  linked to that order.
+
+**S3-2 — I can test before I arm it, and I am never locked out of arming it**
+- Given a draft automation whose action spends money (A1, A2), **and at least one order from the
+  last 30 days matches its conditions**,
+- Then the composer requires me to run a test against one of those orders before `Save` is enabled,
+  and shows me the result of every condition;
+- Given **no** order from the last 30 days matches its conditions (a new install, or a marketplace
+  with no recent orders),
+- Then the gate becomes an explicit acknowledgement instead of a test — the composer states:
+  *"No order from the last 30 days matches these conditions, so this can't be tested yet. This
+  automation will buy labels with real money the first time it matches."* — with a required
+  checkbox, *"I understand this will spend money without having been tested"*, and `Save` enabled
+  only once it is ticked;
+- And the acknowledgement is recorded on the rule (who, when) and shown on the rule row until the
+  rule's first successful firing, so an untested money rule is visible rather than
+  indistinguishable from a tested one.
+- *(Without this fallback the gate is unsatisfiable forever on exactly the installs that most need
+  the automation — which would make the safety device a lock-out.)*
+
+**S3-3 — Two money rules never both fire** *(#2047)*
+- Given two active automations that would both buy a label for the same order,
+- Then neither fires, an attention-worthy state appears on the order and on S2 naming both rules,
+  and the label is not bought.
+
+**S3-4 — Two emails do both fire**
+- Given two active automations that would both email the buyer,
+- Then both send, and neither is reported as a conflict.
+
+**S3-5 — A rule that can never match says so**
+- Given a rule whose threshold currency does not match any order in the selected marketplace's
+  currency, or whose conditions are impossible,
+- Then the rule row renders a warning stating that it has never matched an order, with the reason —
+  following the #2170 composer's disabled-with-a-caveat precedent for `buyerHasTaxId`.
+
+**S3-6 — Disarming is one click**
+- Given any active automation,
+- Then I can deactivate it from the list without deleting it, and a deactivated rule keeps its
+  fired log.
+
+**S3-7 — A failed action is never silent** *(AF-X, §4.2)*
+- Given an automation step fails,
+- Then an AF-X attention row exists, a `Stopped` badge appears on the affected order row, the order
+  timeline carries an error-toned event naming the step, the reason (verbatim from the underlying
+  operation, attributed) and the steps that were skipped, and the run appears in
+  `/automations/activity` with outcome `Failed`;
+- And the AF-X row offers `Try again` and a link to the rule;
+- And nothing about the failure is discoverable **only** inside the rule page.
+
+**S3-8 — I can find the automation from the order** *(journey: an automation did something wrong)*
+- Given an order that an automation acted on,
+- When I open the order,
+- Then its timeline names the rule, the trigger, the timestamp and the outcome of each step, and
+  links to the rule — so that turning the rule off (S3-6) is reachable from the order without
+  knowing which rule to suspect first.
+
+**S3-9 — A new rule does not act on my backlog** *(§5.2)*
+- Given 40 orders already on hold and a rule created now on T3 (*"an order has been on hold for too
+  long"*),
+- Then no firing occurs for any hold placed before the rule was saved, the composer stated this
+  before I saved, and `/automations/activity` is empty for that rule.
+
+---
+
+## 6. Non-goals (explicit, so silence isn't read as oversight)
+
+**Hard non-goals — recommend never:**
+
+- **Free-form conditions or scripting.** No expression language, no JS, no templating beyond
+  named merge fields in the email body. The condition vocabulary is closed and every value is
+  either a select or a typed literal against a declared type. This is the *"actions yes, states
+  no"* boundary from ANALYSIS-1032, applied one layer up.
+- **Automating an assertion about the physical world.** `mark-packed`, `mark-received`,
+  `mark-inspected` — anything whose value is that a named human did it. (§5.3.)
+- **An automation that can issue a second fiscal document.** A1 runs *through* ADR-041 routing and
+  the #2047 guard, never around them.
+- **Cross-order triggers.** "When 5 orders are held", "when a product runs out across all orders" —
+  aggregate triggers need a windowing model, a debounce model and an "is it still true?" re-check,
+  none of which exist. Every v1 trigger fires on exactly one order or one return.
+- **External webhooks / HTTP-call actions.** An outbound call to an operator-supplied URL is a new
+  egress surface with its own auth, retry, secret-storage and SSRF story. It is also the single
+  most-requested automation feature everywhere it exists, so this needs to be a deliberate
+  refusal-for-now with a named prerequisite (a credential store for operator-supplied endpoints),
+  not an omission.
+
+**Gated / deferred:**
+
+- Per-authority override on S1 — **only** when a real operator need cannot be expressed as a third
+  preset (the design's own rule; §1.1).
+- `work.short_picked` and `order.routed` triggers — with Wave 3a.
+- `propose-credit-note` action — v1.1, after the proposal inbox.
+- **Calendar / time-of-day schedules** ("every morning at 8", "every Monday") — a different
+  scheduler shape, and a different mental model: a schedule runs whether or not anything happened.
+  Not v1. This is **not** a refusal of the `deadline sweep` mechanism (§5.2), which fires against a
+  persisted per-order timestamp and is what T3 and T4 are built on.
+- Bulk preset switching across many connections at once (open question 1 in the design).
+
+---
+
+## 7. Boundaries with other work
+
+1. **Routing rules are plugin-owned; this spec neither stores nor edits them.** S1 renders *which*
+   system routes; it never renders or edits the router's filter/sort list. Routing-rule storage
+   lives in `@openlinker/oms` per design §5.3 / REVIEW H7 (the Wave-3a work), **not** with #2298 —
+   #2298 is a docs-reconciliation task whose only bearing here is whether the merged #2161
+   rule-engine *shape* is reused for those rules. Where this spec meets that work: S1's A2 row must
+   be able to read a resolved answer shaped `{ holder, reason }` from the routing layer, and
+   **that read is an obligation this spec places on Wave 3a's routing work** — it is named in
+   §3.3's A2 row, and an issue must carry it, or the row silently degrades to `OpenLinker can't
+   tell` on every install that configures a router.
+2. **Automation storage is proposed here, and should mirror #2161's table shape**: an
+   `automation_rules` table with `trigger`, `conditions jsonb`, `actions jsonb`, `conditionsHash`,
+   `effectiveFrom/To`, `active`, plus an `automation_runs` log (one row per firing, carrying the
+   per-step outcomes) that is the single record behind all four history renderings in §5.6, and a
+   small `automation_trigger_firings` record making the §5.2 at-most-once-per-(rule, order) rule
+   for `deadline sweep` triggers enforceable rather than aspirational. Same canonicalize+hash
+   duplicate guard, same "malformed row never matches" narrowing. **Flagged as a proposal** — the
+   Wave-2 engineering agent owns the final schema.
+3. **A7 stays with sales-documents.** One link, no mirrored state (§3.3).
+4. **The hold vocabulary is the design's merged union** (adjudication #4) and this spec adds no
+   value to it. If the composer needs a hold reason not in the union, that is a design change, not
+   a UI change.
+5. **The copy-lint gate** (§2.1) is a new `check:invariants` entry and needs an issue of its own.
+
+---
+
+## 8. Open product questions (for the owner)
+
+1. **Is the automation bet accepted?** (§1.3.) S1 and S2 are cost-of-shipping-Wave-2 and need no
+   demand justification. S3 is a strategic bet on market signal, not on a named seller. If the
+   answer is no, Wave 2 still ships coherently — S3 drops out cleanly and the phase stays plumbing,
+   which is the honest cost of saying no.
+
+That is the only question still open for the owner. Two earlier entries here — *"do we persist a
+phase-entered timestamp?"* and *"card 3 disabled, or absent?"* — were **settled** and are now
+recorded in the Decision log (§10) rather than re-opened; the body of this spec already implements
+both answers.
+
+---
+
+## 9. Definition of done
+
+Split deliberately: the first list is checkable on the day the wave ships, the second is what we
+watch for afterwards. An unmeasurable item in a DoD list is not a gate, it is a wish, and mixing the
+two teaches the reader to skim both.
+
+**Ship gates (checkable at ship):**
+
+- **A 5-person unmoderated test** in which **≥4 correctly answer "who decides how much stock we
+  publish?"** from `/settings/who-decides` alone, with no documentation and no configuration, on a
+  fresh single-shop install. (This replaces *"without reading any documentation"*, which named no
+  protocol and so could not be failed.)
+- No banned vocabulary word (§2.1) appears in any shipped string; the lint gate proves it, and the
+  banned list is the closed nine-term table in §2.1.
+- **All nine** inert states (§4.2), AF-X included, are reachable in a test environment and render in
+  both places (settings + the affected row) with identical copy, proven by the copy mirror check.
+- A healthy install — single location, no OMS configuration, 4,000 orders — shows an attention count
+  of exactly 0 and no red badge on any order row.
+- The T5→A2→A3 automation can be built, tested against a real past order, armed, and fired; its
+  result is visible in **all three** history surfaces (§5.6) — the order timeline, the run log, and
+  the rule's own log.
+- Two overlapping money-spending automations demonstrably fire nothing, write a `Blocked` run row
+  naming both rules, and report why on the order.
+- A deliberately-broken money action (an invalid carrier account) produces an AF-X row, a `Stopped`
+  order badge, an error-toned timeline event naming the skipped step, and a `Failed` run row — all
+  from one firing.
+- A rule created against a backlog of 40 held orders fires nothing (§5.7 S3-9).
+
+**Post-launch success signals (watched, not gates):**
+
+- Operators diagnose an automation misfire from the **order** rather than by opening rules one at a
+  time — measured as: support conversations about a wrong automated outcome reference the order
+  timeline or the run log, not "which rule did this?".
+- The first-run suggestion (§5.1) is armed on a majority of installs that create any rule at all —
+  if it is not, the suggestion is the wrong one, not the operator.
+- `Needs attention` counts stay near zero on healthy installs over the first quarter; a drifting
+  count means a state was classified attention-worthy that should be routine (§4.3).
+
+---
+
+## 10. Decision log
+
+| Date | Decision | Rationale |
+|---|---|---|
+| 2026-08-22 | **Three cards, not two presets** — "leave things as they are" is a named, selectable position | "I haven't chosen" is a real state and the majority one; leaving it as an absence makes the page a configuration dump that cannot describe the install it is running on |
+| 2026-08-22 | **Card 3 ships disabled, badged `Not available yet`, with an inline reason** — not hidden | Hiding it means the page silently changes shape at Wave 4; showing it disabled tells the operator the shape of the choice, matching the #2170 disabled tax-ID checkbox precedent. (Was §8.3's open question; settled.) |
+| 2026-08-22 | **No `phaseEnteredAt` in v1**; the duration trigger is *"on hold for N"*, read off `order_holds.placedAt` | A phase fed by `now` is uninvalidatable, and a materialised entered-at column carries a five-context invalidation surface — the objection ADR-043 already sustained. `order_holds.placedAt` is persisted and is what the operator actually meant. (Was §8.2's open question; settled.) |
+| 2026-08-22 | **`mark-packed` is refused as an automation action, on principle** | `packedAt` + `packedByUserId` assert that a named human packed a physical box; automating it writes a user id against an event that did not happen, and destroys the column's only value |
+| 2026-08-22 | **Reversible actions all fire; irreversible actions obey #2047 exactly-one** | Two emails are recoverable, two labels are not — the split is the model's own "an unrouted order is recoverable, a double-shipped one is not", applied to automation |
+| 2026-08-22 | **`order.status_changed` cut from v1** | Source status is a pass-through string that re-arrives on every poll; a trigger on it fires on re-ingestion noise, and the dedup story is a wave of its own |
+| 2026-08-22 | **Automation history writes to the order timeline and a global run log, not only to a per-rule log** | The operator starts from the order, not from a rule they do not yet suspect; a per-rule-only log makes diagnosis require knowing the answer first |
+| 2026-08-22 | **A failed automation step is attention-worthy (AF-X), never log-only** | The same §54/#2100 principle the rest of the document is built on; "stop on first failure" otherwise leaves the marketplace untold with no signal anywhere |
+| 2026-08-22 | **Rules are never retroactive, and the composer says so** | The opposite expectation would spend money on a backlog the operator was only intending to describe |
+| 2026-08-22 | **`restock_blocked` and orphan copy is owned by the returns spec and imported here** | S2-1 requires one copy source with identical titles in both places; two specs authoring the same string ships a violation of that AC on day one |
+| 2026-08-22 | **Routing-rule storage is plugin-owned (`@openlinker/oms`), not #2298's** | #2298 is a docs reconciliation; it decides only whether the #2161 rule-engine shape is reused |


### PR DESCRIPTION
Follows merged PR #2281, which landed ADRs 052–062 plus `DESIGN-oms-authority-model.md` and `REVIEW-oms-authority-model.md`. This PR adds the **product and planning layer** above that design. Docs only — no code, no ADRs, no schema.

## What this adds

**`docs/specs/product-spec-oms-wave2-operator-experience.md`** — the operator-facing spec for Wave 2's non-returns half: order holds, the "Who decides what" authority surface and its two presets, and automation v1 (8 triggers × 6 actions over a closed legality matrix, including the operational half — run records, order-timeline rendering, and a failed action as its own attention state).

**`docs/specs/product-spec-oms-returns-operator-ux.md`** — the returns spec: custody and disposition per line, the money machine, `restock_blocked` surfacing and remediation, and the Allegro commission-refund flow.

**`docs/plans/oms-backlog-overview.md`** — a new ~200-line navigation document synthesized from the epic bodies of the filing-ready issue sets. It carries the wave structure (Wave 0 already filed as #2282–#2289; then 1a/1b/1c at 8/11/10, Wave 2 at 51, 3a/3b at 22/8, Wave 4 at 11), a one-paragraph purpose per wave, the entry/gating criteria summary, the three cross-wave critical paths, and the three standing directives (UI naming, the ADR-053 no-injection boundary, and the `.nullish()` FE rule). It links the two specs, the design and review docs, and ADRs 052–062.

**`docs/plans/mockups/mockup-who-decides-what.html`** — the authority-surface prototype the Wave-2 spec references.

## On the backlog issues

The overview references issues by **W-slug** (`W1a-3`, `W2-14`, `W3a-19`, `W4-7`) rather than by number: the backlog is being filed now, and GitHub numbers are assigned at filing time. Every issue in the programme carries the **`oms`** label, so `label:oms` is the durable way to find them. Wave 0 is the exception and is referenced by its real numbers, since it is already filed.

Deliberately no `Closes #N` — this PR closes nothing.

## Checks

`node scripts/check-architecture-gates.mjs` passes (no ADRs added). CI's `dorny/paths-filter` excludes `docs/**` from the `code` filter, so the lint/type-check/test/integration jobs skip for a docs-only change; the pre-commit hook ran the full gate locally regardless and was green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)