### PR TITLE
feat(oms): Wave 0 — preconditions and correctness fixes (#2282–#2289)

### DIFF
--- a/apps/api/src/migrations/1840000000000-add-order-record-packed.ts
+++ b/apps/api/src/migrations/1840000000000-add-order-record-packed.ts
@@ -1,0 +1,55 @@
+/**
+ * Add order_records packed columns
+ *
+ * Two nullable columns recording the plain operator fact "this order is packed"
+ * and who marked it (#2287). Deliberately a FACT, not a state: nothing here
+ * touches `recordStatus`, `fulfillmentState` or the SLA/health derivations, and
+ * no policy is gated on it (ADR-045), so it is meaningful for every order —
+ * including `omp_fulfilled` ones OpenLinker never dispatches.
+ *
+ * `packedAt` is indexed because "is it packed" is an operator-facing scan axis,
+ * mirroring `cancelledAt`. The index is plain rather than partial: an operator
+ * filters both ways ("show me what still needs packing" and "show me what is
+ * packed"), so a `WHERE "packedAt" IS NOT NULL` index would serve only half the
+ * queries. `packedByUserId` is left unindexed — it is display + attribution
+ * only and is never filtered on.
+ *
+ * The index is named to this table's camelCase convention rather than
+ * `migration:generate`'s snake_case, matching its siblings.
+ *
+ * No FK to `users`: `order_records` FKs across no context today, and a deleted
+ * user leaving a dangling id is the honest outcome for an audit fact — the
+ * alternative would either block the delete or silently erase who packed it.
+ *
+ * **No backfill.** Unlike `cancelledAt` (#1984, which could proxy off
+ * `updatedAt`), nothing in the existing schema stands in for "was this packed",
+ * so every historical row correctly starts unpacked; inventing a proxy would
+ * badge history wrongly.
+ *
+ * @module apps/api/src/migrations
+ */
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddOrderRecordPacked1840000000000 implements MigrationInterface {
+  name = 'AddOrderRecordPacked1840000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "order_records" ADD COLUMN IF NOT EXISTS "packedAt" TIMESTAMP WITH TIME ZONE`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "order_records" ADD COLUMN IF NOT EXISTS "packedByUserId" uuid`
+    );
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_order_records_packedAt" ON "order_records" ("packedAt")`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_order_records_packedAt"`);
+    await queryRunner.query(
+      `ALTER TABLE "order_records" DROP COLUMN IF EXISTS "packedByUserId"`
+    );
+    await queryRunner.query(`ALTER TABLE "order_records" DROP COLUMN IF EXISTS "packedAt"`);
+  }
+}

--- a/apps/api/src/migrations/1841000000000-add-order-record-amendment.ts
+++ b/apps/api/src/migrations/1841000000000-add-order-record-amendment.ts
@@ -1,0 +1,54 @@
+/**
+ * Add order_records amendment columns
+ *
+ * Two nullable columns recording OpenLinker's own observation that the SOURCE
+ * amended an order after it was already ingested (#2283) — a line removed,
+ * added or re-quantified, or the shipping address edited.
+ *
+ * An internal FACT, not a lifecycle state: nothing here touches `recordStatus`,
+ * `fulfillmentState`, the SLA/health derivations or any status union, and no
+ * policy is gated on it. It exists because ingestion overwrites `orderSnapshot`
+ * wholesale, so before this the amendment left no trace whatsoever — not even
+ * for a shipment left dangling against a line that no longer exists.
+ *
+ * `lastAmendedAt` is indexed because "which orders did the source change under
+ * us" is an operator-facing scan axis, and the index is what makes the deferred
+ * list badge/filter cheap. Plain rather than partial, mirroring `packedAt`
+ * (#2287): an operator filters both ways. `lastAmendmentChanges` is unindexed —
+ * it is rendered, never queried inside.
+ *
+ * The index is named to this table's camelCase convention rather than
+ * `migration:generate`'s snake_case, matching its siblings.
+ *
+ * **No backfill.** The historical diff is unknowable: the prior snapshot each
+ * past amendment overwrote is gone, so there is nothing to reconstruct one from.
+ * Inventing a proxy would badge orders as amended on evidence that does not
+ * exist — the #2100 / #2287 precedent.
+ *
+ * @module apps/api/src/migrations
+ */
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddOrderRecordAmendment1841000000000 implements MigrationInterface {
+  name = 'AddOrderRecordAmendment1841000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "order_records" ADD COLUMN IF NOT EXISTS "lastAmendedAt" TIMESTAMP WITH TIME ZONE`
+    );
+    await queryRunner.query(
+      `ALTER TABLE "order_records" ADD COLUMN IF NOT EXISTS "lastAmendmentChanges" jsonb`
+    );
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "IDX_order_records_lastAmendedAt" ON "order_records" ("lastAmendedAt")`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_order_records_lastAmendedAt"`);
+    await queryRunner.query(
+      `ALTER TABLE "order_records" DROP COLUMN IF EXISTS "lastAmendmentChanges"`
+    );
+    await queryRunner.query(`ALTER TABLE "order_records" DROP COLUMN IF EXISTS "lastAmendedAt"`);
+  }
+}

--- a/apps/api/src/migrations/1842000000000-add-order-record-packed.ts
+++ b/apps/api/src/migrations/1842000000000-add-order-record-packed.ts
@@ -30,8 +30,8 @@
  */
 import type { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class AddOrderRecordPacked1840000000000 implements MigrationInterface {
-  name = 'AddOrderRecordPacked1840000000000';
+export class AddOrderRecordPacked1842000000000 implements MigrationInterface {
+  name = 'AddOrderRecordPacked1842000000000';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(

--- a/apps/api/src/migrations/1845000000000-add-order-record-amendment.ts
+++ b/apps/api/src/migrations/1845000000000-add-order-record-amendment.ts
@@ -29,8 +29,8 @@
  */
 import type { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class AddOrderRecordAmendment1841000000000 implements MigrationInterface {
-  name = 'AddOrderRecordAmendment1841000000000';
+export class AddOrderRecordAmendment1845000000000 implements MigrationInterface {
+  name = 'AddOrderRecordAmendment1845000000000';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(

--- a/apps/api/src/orders/http/dto/order-amendment-change.dto.ts
+++ b/apps/api/src/orders/http/dto/order-amendment-change.dto.ts
@@ -1,0 +1,42 @@
+/**
+ * Order Amendment Change DTO
+ *
+ * One source-side amendment OpenLinker observed on a re-ingestion (#2283).
+ *
+ * PII-free by construction, and that is the contract rather than an
+ * implementation detail: line ids, SKUs and quantities are carried verbatim
+ * (none is personal data), while an address change contributes only the NAMES of
+ * the fields that moved. A before/after address would put buyer PII on a wire
+ * shape with none of the `OL_STORE_PII` discipline the order snapshot has.
+ *
+ * @module apps/api/src/orders/http/dto
+ */
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  OrderAmendmentChangeKindValues,
+  type OrderAmendmentChangeKind,
+} from '@openlinker/core/orders';
+
+export class OrderAmendmentChangeDto {
+  @ApiProperty({ enum: OrderAmendmentChangeKindValues })
+  kind!: OrderAmendmentChangeKind;
+
+  @ApiPropertyOptional({ description: 'Source-native line id, for the line-grained kinds.' })
+  lineId?: string;
+
+  @ApiPropertyOptional({ description: 'Source-native SKU, when the source reported one.' })
+  sku?: string;
+
+  @ApiPropertyOptional({ description: 'Quantity before the amendment.' })
+  fromQuantity?: number;
+
+  @ApiPropertyOptional({ description: 'Quantity after the amendment.' })
+  toQuantity?: number;
+
+  @ApiPropertyOptional({
+    type: [String],
+    description:
+      'Names of the address fields that changed. Names only — the values are deliberately absent.',
+  })
+  fields?: string[];
+}

--- a/apps/api/src/orders/http/dto/order-record-response.dto.ts
+++ b/apps/api/src/orders/http/dto/order-record-response.dto.ts
@@ -131,6 +131,23 @@ export class OrderRecordResponseDto {
   })
   cancelledAt!: string | null;
 
+  @ApiPropertyOptional({
+    nullable: true,
+    description:
+      'Instant an operator marked this order packed (ISO 8601, #2287). null = not packed. ' +
+      'A fact, not a state: independent of recordStatus / fulfillmentState / slaState, and it gates nothing. ' +
+      'Set once — a repeat mark replays the original stamp rather than re-stamping.',
+  })
+  packedAt!: string | null;
+
+  @ApiPropertyOptional({
+    nullable: true,
+    description:
+      'OL user id of whoever marked this order packed (#2287). null when not packed. ' +
+      'Moves as one group with packedAt, so the FIRST actor is never overwritten.',
+  })
+  packedByUserId!: string | null;
+
   @ApiProperty({
     description:
       'True when `dispatchByAt` is an OL-side ESTIMATE rather than a marketplace-authoritative ' +

--- a/apps/api/src/orders/http/dto/order-record-response.dto.ts
+++ b/apps/api/src/orders/http/dto/order-record-response.dto.ts
@@ -22,6 +22,7 @@ import type {
   SalesDocumentGateBlockReason,
   SalesDocumentUnresolvedReason,
 } from '@openlinker/core/sales-documents';
+import { OrderAmendmentChangeDto } from './order-amendment-change.dto';
 import { OrderSyncStatusResponseDto } from './order-sync-status-response.dto';
 import { SyncAttemptResponseDto } from './sync-attempt-response.dto';
 import type { OrderInvoiceProjectionDto } from './order-invoice-projection.dto';
@@ -147,6 +148,25 @@ export class OrderRecordResponseDto {
       'Moves as one group with packedAt, so the FIRST actor is never overwritten.',
   })
   packedByUserId!: string | null;
+
+  @ApiPropertyOptional({
+    nullable: true,
+    description:
+      'Instant OpenLinker last observed the SOURCE amend this order after ingestion (ISO 8601, #2283) — ' +
+      'a line removed, added or re-quantified, or the shipping address edited. null = never observed amended. ' +
+      'An internal fact: it moves no status and gates nothing.',
+  })
+  lastAmendedAt!: string | null;
+
+  @ApiPropertyOptional({
+    nullable: true,
+    type: [OrderAmendmentChangeDto],
+    description:
+      'What changed at lastAmendedAt (#2283) — the most recent observation only, not a history. ' +
+      'PII-free by construction: line ids, SKUs and quantities verbatim, and for an address change only ' +
+      'the NAMES of the fields that moved, never their values.',
+  })
+  lastAmendmentChanges!: OrderAmendmentChangeDto[] | null;
 
   @ApiProperty({
     description:

--- a/apps/api/src/orders/http/orders.controller.spec.ts
+++ b/apps/api/src/orders/http/orders.controller.spec.ts
@@ -10,6 +10,7 @@ import { OrdersController } from './orders.controller';
 import {
   ORDER_RECORD_REPOSITORY_TOKEN,
   ORDER_DESTINATION_RETRY_SERVICE_TOKEN,
+  ORDER_RECORD_SERVICE_TOKEN,
   OrderRecord,
   OrderRecordNotFoundException,
   OrderDestinationNotFoundException,
@@ -19,6 +20,7 @@ import {
 import type {
   OrderRecordRepositoryPort,
   IOrderDestinationRetryService,
+  IOrderRecordService,
 } from '@openlinker/core/orders';
 import { INVOICE_SERVICE_TOKEN } from '@openlinker/core/invoicing';
 import type { IInvoiceService } from '@openlinker/core/invoicing';
@@ -35,6 +37,7 @@ import type {
 describe('OrdersController', () => {
   let controller: OrdersController;
   let repository: jest.Mocked<OrderRecordRepositoryPort>;
+  let orderRecordService: jest.Mocked<IOrderRecordService>;
   let retryService: jest.Mocked<IOrderDestinationRetryService>;
   let invoiceService: jest.Mocked<IInvoiceService>;
   let fulfillmentRouting: jest.Mocked<IFulfillmentRoutingService>;
@@ -80,7 +83,14 @@ describe('OrdersController', () => {
       findUnstampedFxOrderIds: jest.fn(),
       listDistinctNativeCurrencies: jest.fn(),
       countStampedByReportingCurrency: jest.fn(),
+      markPacked: jest.fn(),
+      clearPacked: jest.fn(),
     };
+
+    const mockOrderRecordService = {
+      markPacked: jest.fn(),
+      clearPacked: jest.fn(),
+    } as unknown as jest.Mocked<IOrderRecordService>;
 
     const mockRetryService: jest.Mocked<IOrderDestinationRetryService> = {
       retry: jest.fn(),
@@ -126,6 +136,10 @@ describe('OrdersController', () => {
           useValue: mockRepository,
         },
         {
+          provide: ORDER_RECORD_SERVICE_TOKEN,
+          useValue: mockOrderRecordService,
+        },
+        {
           provide: ORDER_DESTINATION_RETRY_SERVICE_TOKEN,
           useValue: mockRetryService,
         },
@@ -146,6 +160,7 @@ describe('OrdersController', () => {
 
     controller = module.get<OrdersController>(OrdersController);
     repository = module.get(ORDER_RECORD_REPOSITORY_TOKEN);
+    orderRecordService = module.get(ORDER_RECORD_SERVICE_TOKEN);
     retryService = module.get(ORDER_DESTINATION_RETRY_SERVICE_TOKEN);
     invoiceService = module.get(INVOICE_SERVICE_TOKEN);
     fulfillmentRouting = module.get(FULFILLMENT_ROUTING_SERVICE_TOKEN);
@@ -796,6 +811,81 @@ describe('OrdersController', () => {
       await expect(
         controller.retryDestination(internalOrderId, connectionId)
       ).rejects.toBeInstanceOf(InternalServerErrorException);
+    });
+  });
+  describe('packed (#2287)', () => {
+    const actor = {
+      id: 'user-op-001',
+      email: 'op@example.com',
+      role: 'operator',
+    } as unknown as Parameters<typeof controller.markPacked>[1];
+
+    const packedOrder = new OrderRecord(
+      'ol_order_001',
+      'ol_customer_001',
+      'conn-source-001',
+      'event-001',
+      { externalOrderId: 'EXT-123', items: [] },
+      [],
+      'ready',
+      new Date('2026-04-01T00:00:00Z'),
+      new Date('2026-04-01T12:00:00Z'),
+      [],
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null,
+      new Date('2026-04-02T09:30:00Z'),
+      'user-op-001'
+    );
+
+    it('should pass the acting user id when marking packed', async () => {
+      orderRecordService.markPacked.mockResolvedValue(packedOrder);
+
+      const result = await controller.markPacked('ol_order_001', actor);
+
+      expect(orderRecordService.markPacked).toHaveBeenCalledWith('ol_order_001', 'user-op-001');
+      expect(result.packedAt).toBe('2026-04-02T09:30:00.000Z');
+      expect(result.packedByUserId).toBe('user-op-001');
+    });
+
+    it('should project null packed fields for an unpacked order', async () => {
+      orderRecordService.clearPacked.mockResolvedValue(mockOrder);
+
+      const result = await controller.clearPacked('ol_order_001');
+
+      expect(orderRecordService.clearPacked).toHaveBeenCalledWith('ol_order_001');
+      expect(result.packedAt).toBeNull();
+      expect(result.packedByUserId).toBeNull();
+    });
+
+    it('should map OrderRecordNotFoundException to NotFoundException when marking', async () => {
+      orderRecordService.markPacked.mockRejectedValue(
+        new OrderRecordNotFoundException('ol_order_missing')
+      );
+
+      await expect(controller.markPacked('ol_order_missing', actor)).rejects.toBeInstanceOf(
+        NotFoundException
+      );
+    });
+
+    it('should map OrderRecordNotFoundException to NotFoundException when clearing', async () => {
+      orderRecordService.clearPacked.mockRejectedValue(
+        new OrderRecordNotFoundException('ol_order_missing')
+      );
+
+      await expect(controller.clearPacked('ol_order_missing')).rejects.toBeInstanceOf(
+        NotFoundException
+      );
     });
   });
 });

--- a/apps/api/src/orders/http/orders.controller.spec.ts
+++ b/apps/api/src/orders/http/orders.controller.spec.ts
@@ -85,11 +85,13 @@ describe('OrdersController', () => {
       countStampedByReportingCurrency: jest.fn(),
       markPacked: jest.fn(),
       clearPacked: jest.fn(),
+      recordAmendment: jest.fn(),
     };
 
     const mockOrderRecordService = {
       markPacked: jest.fn(),
       clearPacked: jest.fn(),
+      recordAmendment: jest.fn(),
     } as unknown as jest.Mocked<IOrderRecordService>;
 
     const mockRetryService: jest.Mocked<IOrderDestinationRetryService> = {

--- a/apps/api/src/orders/http/orders.controller.ts
+++ b/apps/api/src/orders/http/orders.controller.ts
@@ -10,6 +10,7 @@ import {
   Controller,
   Get,
   Post,
+  Delete,
   Query,
   Param,
   HttpCode,
@@ -22,10 +23,14 @@ import {
 } from '@nestjs/common';
 import { ApiBearerAuth, ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
 import { Roles } from '../../auth/decorators/roles.decorator';
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+import { AuthenticatedUser } from '../../auth/auth.types';
 import {
   OrderRecordRepositoryPort,
   ORDER_RECORD_REPOSITORY_TOKEN,
   ORDER_DESTINATION_RETRY_SERVICE_TOKEN,
+  ORDER_RECORD_SERVICE_TOKEN,
+  IOrderRecordService,
   OrderRecordNotFoundException,
   OrderDestinationNotFoundException,
   OrderDestinationNotRetryableException,
@@ -74,6 +79,13 @@ export class OrdersController {
   constructor(
     @Inject(ORDER_RECORD_REPOSITORY_TOKEN)
     private readonly orderRecordRepository: OrderRecordRepositoryPort,
+    // #2287: the packed writes go through the SERVICE, not the repository port
+    // this controller injects for its reads. The two guarded statements plus
+    // the re-read that tells "already packed" from "no such order" are one
+    // policy, and it belongs in the application layer where the other writers
+    // (`markCancelled`, `markSalesDocumentBlock`) already live.
+    @Inject(ORDER_RECORD_SERVICE_TOKEN)
+    private readonly orderRecordService: IOrderRecordService,
     @Inject(ORDER_DESTINATION_RETRY_SERVICE_TOKEN)
     private readonly destinationRetryService: IOrderDestinationRetryService,
     @Inject(INVOICE_SERVICE_TOKEN)
@@ -311,6 +323,57 @@ export class OrdersController {
     }
   }
 
+  @Roles('admin', 'operator')
+  @Post(':internalOrderId/packed')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Mark an order packed',
+    description:
+      'Records the plain operator fact that this order is packed, stamping the instant (server-side) and the acting user. ' +
+      'It is a fact, not a state: recordStatus, fulfillmentState, slaState and the order-health buckets are untouched, and nothing is gated on it. ' +
+      'Idempotent — a repeat call returns the EXISTING stamp and actor rather than re-stamping, which is why it answers 200 and not 201.',
+  })
+  @ApiResponse({ status: 200, description: 'Order is packed', type: OrderRecordResponseDto })
+  @ApiResponse({ status: 404, description: 'Order not found' })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async markPacked(
+    @Param('internalOrderId') internalOrderId: string,
+    @CurrentUser() user: AuthenticatedUser
+  ): Promise<OrderRecordResponseDto> {
+    try {
+      return this.toDto(await this.orderRecordService.markPacked(internalOrderId, user.id));
+    } catch (error) {
+      if (error instanceof OrderRecordNotFoundException) {
+        throw new NotFoundException(error.message);
+      }
+      throw error;
+    }
+  }
+
+  @Roles('admin', 'operator')
+  @Delete(':internalOrderId/packed')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Clear an order’s packed mark',
+    description:
+      'Clears both packed fields together. Clearing an order that is not packed is a no-op that returns the record unchanged.',
+  })
+  @ApiResponse({ status: 200, description: 'Order is not packed', type: OrderRecordResponseDto })
+  @ApiResponse({ status: 404, description: 'Order not found' })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async clearPacked(
+    @Param('internalOrderId') internalOrderId: string
+  ): Promise<OrderRecordResponseDto> {
+    try {
+      return this.toDto(await this.orderRecordService.clearPacked(internalOrderId));
+    } catch (error) {
+      if (error instanceof OrderRecordNotFoundException) {
+        throw new NotFoundException(error.message);
+      }
+      throw error;
+    }
+  }
+
   private toDto(order: OrderRecord): OrderRecordResponseDto {
     const fulfillmentState = order.fulfillmentState ?? 'not-shipped';
     return {
@@ -330,6 +393,10 @@ export class OrdersController {
       updatedAt: order.updatedAt instanceof Date ? order.updatedAt.toISOString() : order.updatedAt,
       dispatchByAt: order.dispatchByAt ? order.dispatchByAt.toISOString() : null,
       cancelledAt: order.cancelledAt ? order.cancelledAt.toISOString() : null,
+      // Operator packed fact (#2287). Projected on the SHARED toDto, so it
+      // reaches the list and the detail response from one place.
+      packedAt: order.packedAt ? order.packedAt.toISOString() : null,
+      packedByUserId: order.packedByUserId,
       // Ship-by estimate flag (#1776): a typed, fail-safe read off the snapshot's
       // dispatch window. Erli marks its derived window `estimated: true`; Allegro
       // leaves it absent (authoritative). Narrowing lives on the entity getter.

--- a/apps/api/src/orders/http/orders.controller.ts
+++ b/apps/api/src/orders/http/orders.controller.ts
@@ -397,6 +397,11 @@ export class OrdersController {
       // reaches the list and the detail response from one place.
       packedAt: order.packedAt ? order.packedAt.toISOString() : null,
       packedByUserId: order.packedByUserId,
+      // Source-amendment fact (#2283). On the SHARED toDto for the same reason
+      // as `packedAt`: one projection reaches both the list and the detail
+      // response, so a follow-up list badge needs no second wiring.
+      lastAmendedAt: order.lastAmendedAt ? order.lastAmendedAt.toISOString() : null,
+      lastAmendmentChanges: order.lastAmendmentChanges,
       // Ship-by estimate flag (#1776): a typed, fail-safe read off the snapshot's
       // dispatch window. Erli marks its derived window `estimated: true`; Allegro
       // leaves it absent (authoritative). Narrowing lives on the entity getter.

--- a/apps/api/src/orders/http/refunds.controller.spec.ts
+++ b/apps/api/src/orders/http/refunds.controller.spec.ts
@@ -48,6 +48,7 @@ describe('RefundsController', () => {
       getFailedSyncValueSummary: jest.fn(),
       markPacked: jest.fn(),
       clearPacked: jest.fn(),
+      recordAmendment: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({

--- a/apps/api/src/orders/http/refunds.controller.spec.ts
+++ b/apps/api/src/orders/http/refunds.controller.spec.ts
@@ -46,6 +46,8 @@ describe('RefundsController', () => {
       markSalesDocumentBlock: jest.fn(),
       markItemResolutionFailure: jest.fn(),
       getFailedSyncValueSummary: jest.fn(),
+      markPacked: jest.fn(),
+      clearPacked: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({

--- a/apps/api/src/shipping/http/shipment.controller.spec.ts
+++ b/apps/api/src/shipping/http/shipment.controller.spec.ts
@@ -133,6 +133,7 @@ describe('ShipmentController', () => {
       markSalesDocumentBlock: jest.fn(),
       markPacked: jest.fn(),
       clearPacked: jest.fn(),
+      recordAmendment: jest.fn(),
     };
     controller = new ShipmentController(
       query,

--- a/apps/api/src/shipping/http/shipment.controller.spec.ts
+++ b/apps/api/src/shipping/http/shipment.controller.spec.ts
@@ -131,6 +131,8 @@ describe('ShipmentController', () => {
       getFailedSyncValueSummary: jest.fn(),
       markCancelled: jest.fn(),
       markSalesDocumentBlock: jest.fn(),
+      markPacked: jest.fn(),
+      clearPacked: jest.fn(),
     };
     controller = new ShipmentController(
       query,

--- a/apps/api/test/integration/orders/order-amendment-fact.int-spec.ts
+++ b/apps/api/test/integration/orders/order-amendment-fact.int-spec.ts
@@ -1,0 +1,257 @@
+/**
+ * Order source-amendment fact Int-Spec (#2283)
+ *
+ * The value here is the DB-level guarantee, not mock choreography. Every
+ * property under test is a property of the STATEMENT Postgres runs, or of the
+ * ingestion upsert running against a real row, and none is observable against a
+ * mocked repository:
+ *
+ *  - the `IS DISTINCT FROM` no-op guard, and specifically that it compares ONLY
+ *    `lastAmendmentChanges` — a guard that also compared `lastAmendedAt` would
+ *    be defeated by the fresh timestamp every call carries and would bump
+ *    `updatedAt` on writes that changed nothing,
+ *  - the `toOrm` exclusion, provable only by writing the fact out of band and
+ *    then re-running the ingestion upsert against a real row. That is the
+ *    highest-risk regression shape here: #2140 / #2101 / #1984 / #2100 / #2124 /
+ *    #2287 each had to remove a column an earlier issue re-admitted, and this
+ *    column is the sharpest case — the write is TRIGGERED by an ingestion, so a
+ *    re-admitted mapping would have the detecting poll erase its own finding,
+ *  - and the PII discipline: the persisted jsonb must carry no raw address value
+ *    under `OL_STORE_PII=false`.
+ *
+ * Records are read through `IOrderRecordService` and the ORM entity, never a
+ * `*RepositoryPort` — importing one from `apps/api` is a deny shape in
+ * `scripts/check-cross-context-imports.mjs`.
+ *
+ * @module apps/api/test/integration/orders
+ */
+import {
+  ORDER_RECORD_SERVICE_TOKEN,
+  diffOrderAmendment,
+  type IOrderRecordService,
+  type IncomingOrder,
+  type Order,
+} from '@openlinker/core/orders';
+import { OrderRecordOrmEntity } from '@openlinker/core/orders/orm-entities';
+import {
+  getTestHarness,
+  resetTestHarness,
+  teardownTestHarness,
+  type IntegrationTestHarness,
+} from '../setup';
+import { createTestConnection } from '../helpers/test-connection.helper';
+
+const ORDER_ID = 'ol_order_amend_test';
+
+function makeOrder(overrides: Partial<Order> = {}): Order {
+  return {
+    id: ORDER_ID,
+    orderNumber: 'ORD-AMEND-1',
+    status: 'pending',
+    customerId: null,
+    items: [
+      {
+        id: 'l1',
+        productId: 'ol_product_1',
+        variantId: 'ol_variant_1',
+        quantity: 2,
+        price: 10,
+        sku: 'SKU-1',
+      },
+    ],
+    totals: { subtotal: 20, tax: 0, shipping: 0, total: 20, currency: 'PLN' },
+    shippingAddress: {
+      firstName: 'Anna',
+      lastName: 'Nowak',
+      address1: 'ul. Kwiatowa 1',
+      city: 'Warszawa',
+      postalCode: '00-001',
+      country: 'PL',
+    },
+    createdAt: new Date('2026-08-01T00:00:00Z'),
+    updatedAt: new Date('2026-08-01T00:00:00Z'),
+    ...overrides,
+  } as Order;
+}
+
+function makeIncoming(overrides: Partial<IncomingOrder> = {}): IncomingOrder {
+  return {
+    externalOrderId: 'EXT-AMEND-1',
+    orderNumber: 'ORD-AMEND-1',
+    status: 'pending',
+    items: [
+      {
+        id: 'l1',
+        productRef: { type: 'offer', externalId: 'offer-l1' },
+        quantity: 1,
+        price: 10,
+        sku: 'SKU-1',
+      },
+    ],
+    totals: { subtotal: 10, tax: 0, shipping: 0, total: 10, currency: 'PLN' },
+    createdAt: '2026-08-02T00:00:00Z',
+    updatedAt: '2026-08-02T00:00:00Z',
+    ...overrides,
+  } as IncomingOrder;
+}
+
+describe('Order source-amendment fact (#2283)', () => {
+  let harness: IntegrationTestHarness;
+  let orderRecordService: IOrderRecordService;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+    orderRecordService = harness.getApp().get<IOrderRecordService>(ORDER_RECORD_SERVICE_TOKEN);
+  });
+
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  function recordRepo() {
+    return harness.getDataSource().getRepository(OrderRecordOrmEntity);
+  }
+
+  async function seedOrder(): Promise<string> {
+    const source = await createTestConnection(harness.getDataSource(), {
+      platformType: 'allegro',
+      name: 'Allegro source',
+      adapterKey: 'allegro.test.unused',
+    });
+    await orderRecordService.persistOrder(makeOrder(), source.id, 'evt-1');
+    return source.id;
+  }
+
+  async function readRow(): Promise<OrderRecordOrmEntity> {
+    const row = await recordRepo().findOne({ where: { internalOrderId: ORDER_ID } });
+    expect(row).not.toBeNull();
+    return row as OrderRecordOrmEntity;
+  }
+
+  it('writes the quantity change a re-ingestion diff observes, and suppresses an identical re-write', async () => {
+    await seedOrder();
+
+    const stored = await readRow();
+    const changes = diffOrderAmendment(stored.orderSnapshot, makeIncoming(), { storePii: true });
+    expect(changes).toEqual([
+      {
+        kind: 'line-quantity-changed',
+        lineId: 'l1',
+        sku: 'SKU-1',
+        fromQuantity: 2,
+        toQuantity: 1,
+      },
+    ]);
+
+    await orderRecordService.recordAmendment(
+      ORDER_ID,
+      new Date('2026-08-02T09:00:00Z'),
+      changes,
+    );
+
+    const afterFirst = await readRow();
+    expect(afterFirst.lastAmendedAt).toEqual(new Date('2026-08-02T09:00:00Z'));
+    expect(afterFirst.lastAmendmentChanges).toEqual(changes);
+
+    // The no-op guard: an identical re-write must touch nothing — neither the
+    // instant nor `updatedAt`. A guard that also compared `lastAmendedAt` would
+    // fail here, because the second call carries a later instant.
+    await orderRecordService.recordAmendment(
+      ORDER_ID,
+      new Date('2026-08-02T10:00:00Z'),
+      changes,
+    );
+
+    const afterSecond = await readRow();
+    expect(afterSecond.lastAmendedAt).toEqual(afterFirst.lastAmendedAt);
+    expect(afterSecond.updatedAt).toEqual(afterFirst.updatedAt);
+
+    // A genuinely different change list IS last-write-wins.
+    const removal = [{ kind: 'line-removed' as const, lineId: 'l1', fromQuantity: 1 }];
+    await orderRecordService.recordAmendment(
+      ORDER_ID,
+      new Date('2026-08-02T11:00:00Z'),
+      removal,
+    );
+    const afterThird = await readRow();
+    expect(afterThird.lastAmendedAt).toEqual(new Date('2026-08-02T11:00:00Z'));
+    expect(afterThird.lastAmendmentChanges).toEqual(removal);
+  });
+
+  it('survives the ingestion upsert — the re-poll that detects the amendment cannot erase it', async () => {
+    const sourceId = await seedOrder();
+    const changes = [
+      { kind: 'line-quantity-changed' as const, lineId: 'l1', fromQuantity: 2, toQuantity: 1 },
+    ];
+    await orderRecordService.recordAmendment(
+      ORDER_ID,
+      new Date('2026-08-02T09:00:00Z'),
+      changes,
+    );
+
+    // Exactly what the ingestion path does next, on the same tick.
+    await orderRecordService.persistIncomingSnapshot(makeIncoming(), ORDER_ID, null, sourceId, 'evt-2');
+    await orderRecordService.persistOrder(makeOrder({ status: 'processing' }), sourceId, 'evt-2');
+
+    const row = await readRow();
+    expect(row.lastAmendedAt).toEqual(new Date('2026-08-02T09:00:00Z'));
+    expect(row.lastAmendmentChanges).toEqual(changes);
+  });
+
+  it('is a silent no-op for an order that does not exist', async () => {
+    await expect(
+      orderRecordService.recordAmendment('ol_order_missing', new Date(), [
+        { kind: 'line-removed', lineId: 'l1' },
+      ]),
+    ).resolves.toBeUndefined();
+  });
+
+  it('stores no raw address value when PII storage is off', async () => {
+    const previous = process.env.OL_STORE_PII;
+    process.env.OL_STORE_PII = 'false';
+    try {
+      const sourceId = await seedOrder();
+      const stored = await readRow();
+
+      const amendedIncoming = makeIncoming({
+        shippingAddress: {
+          firstName: 'Anna',
+          lastName: 'Nowak',
+          address1: 'ul. Kwiatowa 1',
+          city: 'Warszawa',
+          postalCode: '00-001',
+          country: 'DE',
+        },
+      });
+      const changes = diffOrderAmendment(stored.orderSnapshot, amendedIncoming, {
+        storePii: false,
+      });
+
+      // Only the country is observable in hash-only mode — the documented cost
+      // of comparing like with like rather than raw-against-redacted.
+      expect(changes).toContainEqual({
+        kind: 'shipping-address-changed',
+        fields: ['country'],
+      });
+
+      await orderRecordService.recordAmendment(ORDER_ID, new Date(), changes);
+
+      const row = await readRow();
+      const persisted = JSON.stringify(row.lastAmendmentChanges);
+      for (const value of ['Anna', 'Nowak', 'Kwiatowa', 'Warszawa', '00-001']) {
+        expect(persisted).not.toContain(value);
+      }
+      expect(sourceId).toBeTruthy();
+    } finally {
+      if (previous === undefined) {
+        delete process.env.OL_STORE_PII;
+      } else {
+        process.env.OL_STORE_PII = previous;
+      }
+    }
+  });
+});

--- a/apps/api/test/integration/orders/order-record-packed.int-spec.ts
+++ b/apps/api/test/integration/orders/order-record-packed.int-spec.ts
@@ -1,0 +1,188 @@
+/**
+ * Order packed-fact Int-Spec (#2287)
+ *
+ * The value here is the DB-level guarantee, not mock choreography. Three of the
+ * four properties under test are properties of the STATEMENT Postgres runs and
+ * cannot be observed against a mocked repository:
+ *
+ *  - the `packedAt IS NULL` guard, which is what makes a repeat mark preserve
+ *    the ORIGINAL actor rather than overwriting it,
+ *  - the `packedAt IS NOT NULL` guard on the clear,
+ *  - and the `toOrm` exclusion, provable only by writing the packed fact out of
+ *    band and then re-running the ingestion upsert against a real row. That is
+ *    the highest-risk regression shape in this change: #2140 / #2101 / #1984 /
+ *    #2100 / #2124 each had to remove a column an earlier issue re-admitted.
+ *
+ * Records are read through `IOrderRecordService` and the ORM entity, never a
+ * `*RepositoryPort` — importing one from `apps/api` is a deny shape in
+ * `scripts/check-cross-context-imports.mjs`.
+ *
+ * @module apps/api/test/integration/orders
+ */
+import {
+  ORDER_RECORD_SERVICE_TOKEN,
+  type IOrderRecordService,
+  type Order,
+} from '@openlinker/core/orders';
+import { OrderRecordOrmEntity } from '@openlinker/core/orders/orm-entities';
+import {
+  getTestHarness,
+  resetTestHarness,
+  teardownTestHarness,
+  type IntegrationTestHarness,
+} from '../setup';
+import { createTestConnection } from '../helpers/test-connection.helper';
+import { loginAsAdmin } from '../helpers/test-auth.helper';
+
+const ORDER_ID = 'ol_order_packed_test';
+
+function makeOrder(overrides: Partial<Order> = {}): Order {
+  return {
+    id: ORDER_ID,
+    orderNumber: 'ORD-PACK-1',
+    status: 'pending',
+    customerId: null,
+    items: [],
+    totals: { subtotal: 10, tax: 0, shipping: 0, total: 10, currency: 'PLN' },
+    createdAt: new Date('2026-08-01T00:00:00Z'),
+    updatedAt: new Date('2026-08-01T00:00:00Z'),
+    ...overrides,
+  } as Order;
+}
+
+describe('Order packed fact (#2287)', () => {
+  let harness: IntegrationTestHarness;
+  let orderRecordService: IOrderRecordService;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+    orderRecordService = harness.getApp().get<IOrderRecordService>(ORDER_RECORD_SERVICE_TOKEN);
+  });
+
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  function recordRepo() {
+    return harness.getDataSource().getRepository(OrderRecordOrmEntity);
+  }
+
+  async function seedOrder(): Promise<string> {
+    const source = await createTestConnection(harness.getDataSource(), {
+      platformType: 'allegro',
+      name: 'Allegro source',
+      adapterKey: 'allegro.test.unused',
+    });
+    await orderRecordService.persistOrder(makeOrder(), source.id, 'evt-1');
+    return source.id;
+  }
+
+  it('marks an order packed, clears it, and 404s an unknown order over HTTP', async () => {
+    await seedOrder();
+    const http = harness.getHttp();
+    // loginAsAdmin plain-INSERTs a fixed admin user — call it at most once per test.
+    const token = await loginAsAdmin(http, harness.getDataSource());
+
+    const marked = await http
+      .post(`/v1/orders/${ORDER_ID}/packed`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    expect(marked.body.packedAt).toEqual(expect.any(String));
+    expect(marked.body.packedByUserId).toEqual(expect.any(String));
+
+    const firstActor = marked.body.packedByUserId as string;
+    const firstStamp = marked.body.packedAt as string;
+
+    // Both columns are really on the row, not merely on the projection.
+    const rowAfterMark = await recordRepo().findOne({ where: { internalOrderId: ORDER_ID } });
+    expect(rowAfterMark!.packedAt).toBeInstanceOf(Date);
+    expect(rowAfterMark!.packedByUserId).toBe(firstActor);
+
+    // A repeat mark is an idempotent replay: still 200, and the FIRST stamp and
+    // actor survive (the `packedAt IS NULL` guard, not a COALESCE).
+    const replay = await http
+      .post(`/v1/orders/${ORDER_ID}/packed`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    expect(replay.body.packedAt).toBe(firstStamp);
+    expect(replay.body.packedByUserId).toBe(firstActor);
+
+    // The fact reaches the LIST read too — one shared `toDto`.
+    const list = await http
+      .get('/v1/orders')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    expect(list.body.items[0].packedAt).toBe(firstStamp);
+    expect(list.body.items[0].packedByUserId).toBe(firstActor);
+
+    // Unmark nulls BOTH columns together.
+    const cleared = await http
+      .delete(`/v1/orders/${ORDER_ID}/packed`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+    expect(cleared.body.packedAt).toBeNull();
+    expect(cleared.body.packedByUserId).toBeNull();
+
+    const rowAfterClear = await recordRepo().findOne({ where: { internalOrderId: ORDER_ID } });
+    expect(rowAfterClear!.packedAt).toBeNull();
+    expect(rowAfterClear!.packedByUserId).toBeNull();
+
+    // Clearing an already-unpacked order is a no-op, not an error.
+    await http
+      .delete(`/v1/orders/${ORDER_ID}/packed`)
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    // An unknown order is a 404 on both routes.
+    await http
+      .post('/v1/orders/ol_order_does_not_exist/packed')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(404);
+    await http
+      .delete('/v1/orders/ol_order_does_not_exist/packed')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(404);
+  });
+
+  it('preserves the packed fact across a re-ingestion (toOrm exclusion)', async () => {
+    const sourceId = await seedOrder();
+
+    // Seed the packed fact out of band — this is what the ingestion upsert must
+    // not be able to reach.
+    const stamp = new Date('2026-08-05T10:15:00Z');
+    await recordRepo().update(
+      { internalOrderId: ORDER_ID },
+      { packedAt: stamp, packedByUserId: '11111111-1111-1111-1111-111111111111' }
+    );
+
+    // Re-ingest the same order with a changed snapshot. The ingestion path's
+    // in-memory OrderRecord carries `packedAt: null`, so if either column were
+    // mapped in `toOrm` (or added to the upsert statement) this would silently
+    // un-pack the order.
+    const saved = await orderRecordService.persistOrder(
+      makeOrder({ orderNumber: 'ORD-PACK-2', status: 'processing' }),
+      sourceId,
+      'evt-2'
+    );
+
+    // The upsert's documented contract: out-of-band columns read empty on the
+    // RETURNING projection, whatever the row holds.
+    expect(saved.packedAt).toBeNull();
+    expect(saved.packedByUserId).toBeNull();
+    expect(saved.orderSnapshot.orderNumber).toBe('ORD-PACK-2');
+
+    // The ROW is what matters, and it is untouched.
+    const row = await recordRepo().findOne({ where: { internalOrderId: ORDER_ID } });
+    expect(row!.packedAt).toEqual(stamp);
+    expect(row!.packedByUserId).toBe('11111111-1111-1111-1111-111111111111');
+
+    // A fresh read through the service reports the true value.
+    const reread = await orderRecordService.getOrderRecord(ORDER_ID);
+    expect(reread!.packedAt).toEqual(stamp);
+    expect(reread!.packedByUserId).toBe('11111111-1111-1111-1111-111111111111');
+  });
+});

--- a/apps/api/test/integration/orders/order-source-attribution-immutability.int-spec.ts
+++ b/apps/api/test/integration/orders/order-source-attribution-immutability.int-spec.ts
@@ -1,0 +1,274 @@
+/**
+ * Order Source-Attribution Immutability Int-Spec (#2282, ADR-057)
+ *
+ * `persistOrder` / `persistIncomingSnapshot` used to write the row through a
+ * full-object TypeORM `save()`, so a re-ingestion rewrote `sourceConnectionId`
+ * and `sourceEventId` along with the snapshot. The only protection was the
+ * ADR-017 caller-side guard in `OrderIngestionService`; any other caller
+ * reaching the write path clobbered attribution (the #940 defect class).
+ *
+ * The invariant now lives in the statement the repository emits, which is
+ * exactly why this coverage has to be an integration test: a mocked repository
+ * can only assert what was handed to it, whereas the whole point is what
+ * Postgres does with `INSERT ... ON CONFLICT DO UPDATE`. The suite bypasses the
+ * ADR-017 guard on purpose by calling the record service directly.
+ *
+ * The excluded-column regression block is the highest-risk part of the change:
+ * swapping `save()` for raw SQL is exactly the shape that silently re-admits a
+ * column an earlier issue removed (#2140 / #2101 / #1984 / #2100 / #2124).
+ *
+ * Records are read through `IOrderRecordService` and the ORM entity, never a
+ * `*RepositoryPort` - importing one from `apps/api` is a deny shape in
+ * `scripts/check-cross-context-imports.mjs`.
+ *
+ * @module apps/api/test/integration/orders
+ */
+import {
+  ORDER_RECORD_SERVICE_TOKEN,
+  type IOrderRecordService,
+  type IncomingOrder,
+  type Order,
+} from '@openlinker/core/orders';
+import { OrderRecordOrmEntity } from '@openlinker/core/orders/orm-entities';
+import {
+  getTestHarness,
+  resetTestHarness,
+  teardownTestHarness,
+  type IntegrationTestHarness,
+} from '../setup';
+import { createTestConnection } from '../helpers/test-connection.helper';
+
+const ORDER_ID = 'ol_order_attribution_test';
+
+function makeOrder(overrides: Partial<Order> = {}): Order {
+  return {
+    id: ORDER_ID,
+    orderNumber: 'ORD-ATTR-1',
+    status: 'pending',
+    customerId: null,
+    items: [],
+    totals: { subtotal: 10, tax: 0, shipping: 0, total: 10, currency: 'PLN' },
+    createdAt: new Date('2026-08-01T00:00:00Z'),
+    updatedAt: new Date('2026-08-01T00:00:00Z'),
+    ...overrides,
+  } as Order;
+}
+
+function makeIncoming(overrides: Partial<IncomingOrder> = {}): IncomingOrder {
+  return {
+    externalOrderId: 'ext-attr-1',
+    status: 'pending',
+    items: [],
+    totals: { subtotal: 10, tax: 0, shipping: 0, total: 10, currency: 'PLN' },
+    createdAt: new Date('2026-08-01T00:00:00Z').toISOString(),
+    updatedAt: new Date('2026-08-01T00:00:00Z').toISOString(),
+    ...overrides,
+  } as IncomingOrder;
+}
+
+describe('Order source attribution is immutable at the write path (#2282)', () => {
+  let harness: IntegrationTestHarness;
+  let orderRecordService: IOrderRecordService;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+    orderRecordService = harness.getApp().get<IOrderRecordService>(ORDER_RECORD_SERVICE_TOKEN);
+  });
+
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  async function seedConnections(): Promise<{ sourceId: string; otherId: string }> {
+    const dataSource = harness.getDataSource();
+    const source = await createTestConnection(dataSource, {
+      platformType: 'allegro',
+      name: 'Allegro source',
+      adapterKey: 'allegro.test.unused',
+    });
+    const other = await createTestConnection(dataSource, {
+      platformType: 'prestashop',
+      name: 'PrestaShop destination',
+    });
+    return { sourceId: source.id, otherId: other.id };
+  }
+
+  function recordRepo() {
+    return harness.getDataSource().getRepository(OrderRecordOrmEntity);
+  }
+
+  it('records the supplied attribution on the first insert', async () => {
+    const { sourceId } = await seedConnections();
+
+    const saved = await orderRecordService.persistOrder(makeOrder(), sourceId, 'evt-1');
+
+    expect(saved.sourceConnectionId).toBe(sourceId);
+    expect(saved.sourceEventId).toBe('evt-1');
+
+    const row = await recordRepo().findOne({ where: { internalOrderId: ORDER_ID } });
+    expect(row!.sourceConnectionId).toBe(sourceId);
+    expect(row!.sourceEventId).toBe('evt-1');
+  });
+
+  it('refreshes the snapshot and advances sourceEventId on a same-source re-ingestion', async () => {
+    const { sourceId } = await seedConnections();
+
+    await orderRecordService.persistOrder(makeOrder(), sourceId, 'evt-1');
+    const saved = await orderRecordService.persistOrder(
+      makeOrder({ orderNumber: 'ORD-ATTR-2', status: 'processing' }),
+      sourceId,
+      'evt-2',
+    );
+
+    expect(saved.sourceConnectionId).toBe(sourceId);
+    // Same-source may advance: byte-identical to the pre-#2282 behaviour.
+    expect(saved.sourceEventId).toBe('evt-2');
+    expect(saved.orderSnapshot.orderNumber).toBe('ORD-ATTR-2');
+    expect(saved.orderSnapshot.status).toBe('processing');
+
+    const row = await recordRepo().findOne({ where: { internalOrderId: ORDER_ID } });
+    expect(row!.sourceEventId).toBe('evt-2');
+    // The jsonb column round-trips as a document, not as a string.
+    expect(row!.orderSnapshot).toEqual(saved.orderSnapshot);
+    expect(row!.orderSnapshot).toMatchObject({
+      orderNumber: 'ORD-ATTR-2',
+      status: 'processing',
+      totals: { subtotal: 10, tax: 0, shipping: 0, total: 10, currency: 'PLN' },
+    });
+  });
+
+  it('refuses a cross-source attribution change on persistOrder, ADR-017 guard bypassed', async () => {
+    const { sourceId, otherId } = await seedConnections();
+
+    await orderRecordService.persistOrder(makeOrder(), sourceId, 'evt-1');
+    const saved = await orderRecordService.persistOrder(
+      makeOrder({ orderNumber: 'ORD-ECHO' }),
+      otherId,
+      'echo-evt',
+    );
+
+    // Both attribution fields frozen; the returned record reports the ORIGINAL
+    // source, which is what lets the service warn without a second read.
+    expect(saved.sourceConnectionId).toBe(sourceId);
+    expect(saved.sourceEventId).toBe('evt-1');
+
+    const row = await recordRepo().findOne({ where: { internalOrderId: ORDER_ID } });
+    expect(row!.sourceConnectionId).toBe(sourceId);
+    expect(row!.sourceEventId).toBe('evt-1');
+  });
+
+  it('refuses a cross-source attribution change on persistIncomingSnapshot too', async () => {
+    const { sourceId, otherId } = await seedConnections();
+
+    await orderRecordService.persistIncomingSnapshot(
+      makeIncoming(),
+      ORDER_ID,
+      null,
+      sourceId,
+      'evt-1',
+    );
+    const saved = await orderRecordService.persistIncomingSnapshot(
+      makeIncoming({ externalOrderId: 'ext-echo' }),
+      ORDER_ID,
+      null,
+      otherId,
+      'echo-evt',
+    );
+
+    expect(saved.sourceConnectionId).toBe(sourceId);
+    expect(saved.sourceEventId).toBe('evt-1');
+
+    const row = await recordRepo().findOne({ where: { internalOrderId: ORDER_ID } });
+    expect(row!.sourceConnectionId).toBe(sourceId);
+    expect(row!.sourceEventId).toBe('evt-1');
+  });
+
+  it('does not move createdAt on a re-ingestion, but does move updatedAt', async () => {
+    const { sourceId } = await seedConnections();
+
+    await orderRecordService.persistOrder(makeOrder(), sourceId, 'evt-1');
+    const first = await recordRepo().findOne({ where: { internalOrderId: ORDER_ID } });
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    await orderRecordService.persistOrder(makeOrder({ status: 'processing' }), sourceId, 'evt-2');
+    const second = await recordRepo().findOne({ where: { internalOrderId: ORDER_ID } });
+
+    expect(second!.createdAt.getTime()).toBe(first!.createdAt.getTime());
+    expect(second!.updatedAt.getTime()).toBeGreaterThan(first!.updatedAt.getTime());
+  });
+
+  it('leaves every out-of-band column untouched by a re-ingestion (#2140/#2101/#1984/#2100/#2124)', async () => {
+    const { sourceId } = await seedConnections();
+
+    await orderRecordService.persistOrder(makeOrder(), sourceId, 'evt-1');
+
+    // Seed the excluded columns out of band, exactly as their narrow writers do.
+    const cancelledAt = new Date('2026-08-02T10:00:00Z');
+    const fxStampedAt = new Date('2026-08-02T11:00:00Z');
+    await recordRepo().update(
+      { internalOrderId: ORDER_ID },
+      {
+        syncStatus: [
+          {
+            destinationConnectionId: '22222222-2222-4222-8222-222222222222',
+            status: 'synced',
+            externalOrderId: 'dest-1',
+          },
+        ],
+        syncAttempts: [
+          {
+            destinationConnectionId: '22222222-2222-4222-8222-222222222222',
+            status: 'synced',
+            attemptedAt: cancelledAt.toISOString(),
+          },
+        ],
+        fulfillmentState: 'dispatched',
+        cancelledAt,
+        salesDocumentBlockReason: 'trigger-model-manual',
+        salesDocumentUnresolvedReason: 'no-configuration-for-country',
+        salesDocumentBlockDetail: 'seeded detail',
+        reportingCurrency: 'EUR',
+        reportingTotalAmount: 42.5,
+        exchangeRateId: '33333333-3333-4333-8333-333333333333',
+        fxRule: 'prev-business-day',
+        fxStampedAt,
+        fxIntendedCurrency: 'EUR',
+      },
+    );
+
+    // Re-ingest. Every column above must survive the raw-SQL upsert.
+    await orderRecordService.persistOrder(
+      makeOrder({ status: 'processing' }),
+      sourceId,
+      'evt-2',
+    );
+
+    const row = await recordRepo().findOne({ where: { internalOrderId: ORDER_ID } });
+    expect(row!.syncStatus).toHaveLength(1);
+    expect(row!.syncStatus[0].externalOrderId).toBe('dest-1');
+    expect(row!.syncAttempts).toHaveLength(1);
+    expect(row!.fulfillmentState).toBe('dispatched');
+    expect(row!.cancelledAt!.getTime()).toBe(cancelledAt.getTime());
+    expect(row!.salesDocumentBlockReason).toBe('trigger-model-manual');
+    expect(row!.salesDocumentUnresolvedReason).toBe('no-configuration-for-country');
+    expect(row!.salesDocumentBlockDetail).toBe('seeded detail');
+    expect(row!.reportingCurrency).toBe('EUR');
+    expect(Number(row!.reportingTotalAmount)).toBe(42.5);
+    expect(row!.exchangeRateId).toBe('33333333-3333-4333-8333-333333333333');
+    expect(row!.fxRule).toBe('prev-business-day');
+    expect(row!.fxStampedAt!.getTime()).toBe(fxStampedAt.getTime());
+    expect(row!.fxIntendedCurrency).toBe('EUR');
+    // The write set itself still landed.
+    expect(row!.orderSnapshot.status).toBe('processing');
+
+    // The other half of the contract - that `upsert()`'s OWN return reports
+    // these columns empty despite `RETURNING *` carrying them - is asserted in
+    // `order-record.repository.spec.ts`, not here: `persistOrder` may hand back
+    // a `findById` re-read instead of the upsert return (#2125), so what this
+    // path returns is deliberately not a statement about the write contract.
+  });
+});

--- a/apps/web/src/features/orders/api/orders.api.test.ts
+++ b/apps/web/src/features/orders/api/orders.api.test.ts
@@ -91,3 +91,36 @@ describe('orders api — buildQuery', () => {
     expect(paths[0]).not.toContain('salesDocumentBlocked');
   });
 });
+
+
+describe('orders api — packed writes (#2288)', () => {
+  function recordingApiWithInit(): {
+    api: ReturnType<typeof createOrdersApi>;
+    calls: { path: string; init?: RequestInit }[];
+  } {
+    const calls: { path: string; init?: RequestInit }[] = [];
+    const request = vi.fn(async (path: string, init?: RequestInit) => {
+      calls.push({ path, init });
+      return {} as never;
+    });
+    return { api: createOrdersApi(request), calls };
+  }
+
+  it('POSTs to the packed sub-resource and encodes the order id', async () => {
+    const { api, calls } = recordingApiWithInit();
+
+    await api.markPacked('ol/order 1');
+
+    expect(calls[0].path).toBe('/orders/ol%2Forder%201/packed');
+    expect(calls[0].init?.method).toBe('POST');
+  });
+
+  it('DELETEs the same path to clear the mark', async () => {
+    const { api, calls } = recordingApiWithInit();
+
+    await api.unmarkPacked('ol_order_1');
+
+    expect(calls[0].path).toBe('/orders/ol_order_1/packed');
+    expect(calls[0].init?.method).toBe('DELETE');
+  });
+});

--- a/apps/web/src/features/orders/api/orders.api.ts
+++ b/apps/web/src/features/orders/api/orders.api.ts
@@ -26,6 +26,14 @@ export interface OrdersApi {
     internalOrderId: string,
     destinationConnectionId: string,
   ) => Promise<RetryOrderDestinationResult>;
+  /**
+   * Mark the order packed (#2287). Returns the updated record, and returns 200
+   * on an idempotent replay too — marking an already-packed order keeps the
+   * FIRST actor and instant rather than restamping them.
+   */
+  markPacked: (internalOrderId: string) => Promise<OrderRecord>;
+  /** Clear the packed mark (#2287). Clearing an unpacked order is a no-op 200. */
+  unmarkPacked: (internalOrderId: string) => Promise<OrderRecord>;
 }
 
 interface ApiRequest {
@@ -86,6 +94,16 @@ export function createOrdersApi(request: ApiRequest): OrdersApi {
         `/orders/${encodeURIComponent(internalOrderId)}/destinations/${encodeURIComponent(destinationConnectionId)}/retry`,
         { method: 'POST' },
       );
+    },
+    markPacked(internalOrderId): Promise<OrderRecord> {
+      return request<OrderRecord>(`/orders/${encodeURIComponent(internalOrderId)}/packed`, {
+        method: 'POST',
+      });
+    },
+    unmarkPacked(internalOrderId): Promise<OrderRecord> {
+      return request<OrderRecord>(`/orders/${encodeURIComponent(internalOrderId)}/packed`, {
+        method: 'DELETE',
+      });
     },
   };
 }

--- a/apps/web/src/features/orders/api/orders.types.ts
+++ b/apps/web/src/features/orders/api/orders.types.ts
@@ -8,7 +8,21 @@
  * @module apps/web/src/features/orders/api
  */
 
-export const OrderSyncStatusValues = ['pending', 'syncing', 'synced', 'failed'] as const;
+/**
+ * Mirrors CORE `OrderSyncStatusFilterValues` (`order-record.types.ts`).
+ *
+ * `'skipped_cancelled'` (#2284) is terminal and is NOT a failure: the source
+ * cancelled the order before any destination order existed, so provisioning was
+ * deliberately withheld. It must never borrow an error colour and is never
+ * retryable.
+ */
+export const OrderSyncStatusValues = [
+  'pending',
+  'syncing',
+  'synced',
+  'failed',
+  'skipped_cancelled',
+] as const;
 export type OrderSyncStatusValue = (typeof OrderSyncStatusValues)[number];
 
 export interface OrderSyncStatus {

--- a/apps/web/src/features/orders/api/orders.types.ts
+++ b/apps/web/src/features/orders/api/orders.types.ts
@@ -282,6 +282,19 @@ export interface OrderRecord {
    * never their values, so this is safe to render verbatim.
    */
   lastAmendmentChanges?: OrderAmendmentChange[] | null;
+  /**
+   * Instant an operator marked this order packed (#2287/#2288). `null`/absent =
+   * not packed. A plain operator fact: it moves no status, gates nothing and is
+   * owned by neither the source nor a destination — which is why the list shows
+   * it as a tick rather than a badge, and the detail page (not the row) acts.
+   * Optional for graceful degradation on a pre-#2287 payload.
+   */
+  packedAt?: string | null;
+  /**
+   * OL user id of whoever marked it packed (#2287). Moves as one group with
+   * `packedAt`, so it is non-null exactly when `packedAt` is.
+   */
+  packedByUserId?: string | null;
 }
 
 // Result ordering for the orders list (#927, extended #944). Mirrors

--- a/apps/web/src/features/orders/api/orders.types.ts
+++ b/apps/web/src/features/orders/api/orders.types.ts
@@ -170,6 +170,31 @@ export interface OrderDeliveryRider {
   candidateCarrier?: DeliveryRiderCandidateCarrier;
 }
 
+// Source-side amendment kinds (#2283). Hand-mirrored from
+// `OrderAmendmentChangeKindValues` in `@openlinker/core/orders` per the FE-001
+// contract strategy — keep in sync.
+export const OrderAmendmentChangeKindValues = [
+  'line-removed',
+  'line-added',
+  'line-quantity-changed',
+  'shipping-address-changed',
+] as const;
+export type OrderAmendmentChangeKindValue = (typeof OrderAmendmentChangeKindValues)[number];
+
+/**
+ * One observed source amendment. PII-free by backend contract: ids, SKUs and
+ * quantities verbatim, and for an address change only the NAMES of the fields
+ * that moved.
+ */
+export interface OrderAmendmentChange {
+  kind: OrderAmendmentChangeKindValue;
+  lineId?: string;
+  sku?: string;
+  fromQuantity?: number;
+  toQuantity?: number;
+  fields?: string[];
+}
+
 export interface OrderRecord {
   internalOrderId: string;
   customerId: string | null;
@@ -243,6 +268,20 @@ export interface OrderRecord {
   salesDocumentUnresolvedReason?: SalesDocumentUnresolvedReasonValue | null;
   /** PII-free elaboration of the block reason (ids and counts only). */
   salesDocumentBlockDetail?: string | null;
+  /**
+   * Instant OpenLinker last observed the SOURCE amend this order after it was
+   * already ingested (#2283) — a line removed, added or re-quantified, or the
+   * shipping address edited. `null`/absent = never observed amended. An internal
+   * fact: it moves no status and gates nothing, so it is rendered as one more
+   * timeline entry rather than a state.
+   */
+  lastAmendedAt?: string | null;
+  /**
+   * What changed at `lastAmendedAt` (#2283) — most recent observation only.
+   * PII-free by contract: an address change names the FIELDS that moved and
+   * never their values, so this is safe to render verbatim.
+   */
+  lastAmendmentChanges?: OrderAmendmentChange[] | null;
 }
 
 // Result ordering for the orders list (#927, extended #944). Mirrors

--- a/apps/web/src/features/orders/components/order-activity-timeline.test.tsx
+++ b/apps/web/src/features/orders/components/order-activity-timeline.test.tsx
@@ -239,4 +239,61 @@ describe('OrderActivityTimeline', () => {
       expect(screen.queryByText('No invoice issued')).toBeNull();
     });
   });
+
+  describe('source amendment (#2283)', () => {
+    it('renders a dated warning entry naming the lines that changed', () => {
+      renderTimeline({
+        createdAt: '2026-04-20T10:00:00.000Z',
+        recordStatus: 'ready',
+        syncAttempts: [],
+        sourceConnectionId: SOURCE_CONNECTION_ID,
+        lastAmendedAt: '2026-04-21T08:15:00.000Z',
+        lastAmendmentChanges: [
+          { kind: 'line-removed', lineId: 'l2', sku: 'SKU-2', fromQuantity: 1 },
+          { kind: 'line-quantity-changed', lineId: 'l1', sku: 'SKU-1', fromQuantity: 2, toQuantity: 1 },
+        ],
+      });
+
+      const entry = screen.getByText('Order changed at the source').closest('li');
+      expect(entry).not.toBeNull();
+      // Dated, unlike the #2100 block entry: a real instant is persisted.
+      expect(entry?.querySelector('time')?.getAttribute('dateTime')).toBe(
+        '2026-04-21T08:15:00.000Z',
+      );
+      expect(entry?.querySelector('.order-activity__dot--warning')).not.toBeNull();
+      expect(within(entry as HTMLElement).getByText(/line SKU-2 removed/)).toBeTruthy();
+      expect(within(entry as HTMLElement).getByText(/line SKU-1 quantity 2 → 1/)).toBeTruthy();
+    });
+
+    it('names the address fields that changed and shows no address values', () => {
+      renderTimeline({
+        createdAt: '2026-04-20T10:00:00.000Z',
+        recordStatus: 'ready',
+        syncAttempts: [],
+        sourceConnectionId: SOURCE_CONNECTION_ID,
+        lastAmendedAt: '2026-04-21T08:15:00.000Z',
+        lastAmendmentChanges: [
+          { kind: 'shipping-address-changed', fields: ['city', 'postalCode'] },
+        ],
+      });
+
+      const entry = screen.getByText('Order changed at the source').closest('li');
+      expect(
+        within(entry as HTMLElement).getByText(/shipping address changed \(city, postalCode\)/),
+      ).toBeTruthy();
+    });
+
+    it('renders no amendment entry when the order was never amended', () => {
+      renderTimeline({
+        createdAt: '2026-04-20T10:00:00.000Z',
+        recordStatus: 'ready',
+        syncAttempts: [],
+        sourceConnectionId: SOURCE_CONNECTION_ID,
+        lastAmendedAt: null,
+        lastAmendmentChanges: null,
+      });
+
+      expect(screen.queryByText('Order changed at the source')).toBeNull();
+    });
+  });
 });

--- a/apps/web/src/features/orders/components/order-activity-timeline.test.tsx
+++ b/apps/web/src/features/orders/components/order-activity-timeline.test.tsx
@@ -296,4 +296,59 @@ describe('OrderActivityTimeline', () => {
       expect(screen.queryByText('Order changed at the source')).toBeNull();
     });
   });
+
+  describe('packed (#2288)', () => {
+    it('renders a DATED packed entry naming the operator', () => {
+      renderTimeline({
+        createdAt: '2026-04-20T10:00:00.000Z',
+        recordStatus: 'ready',
+        syncAttempts: [],
+        sourceConnectionId: SOURCE_CONNECTION_ID,
+        packedAt: '2026-04-21T09:00:00.000Z',
+        packedByUserId: 'user_7',
+      });
+
+      const entry = screen.getByText('Order packed').closest('li');
+      expect(within(entry as HTMLElement).getByText(/Marked packed by user_7\./)).toBeTruthy();
+      // A real instant is persisted, so the entry carries a <time> — unlike the
+      // deliberately undated invoicing-block entry.
+      expect(
+        (entry as HTMLElement).querySelector('time[datetime="2026-04-21T09:00:00.000Z"]'),
+      ).toBeTruthy();
+    });
+
+    it('renders no packed entry when the order was never packed', () => {
+      renderTimeline({
+        createdAt: '2026-04-20T10:00:00.000Z',
+        recordStatus: 'ready',
+        syncAttempts: [],
+        sourceConnectionId: SOURCE_CONNECTION_ID,
+        packedAt: null,
+        packedByUserId: null,
+      });
+
+      expect(screen.queryByText('Order packed')).toBeNull();
+    });
+
+    it('places the packed entry BEFORE the undated invoicing-block entry', () => {
+      renderTimeline({
+        createdAt: '2026-04-20T10:00:00.000Z',
+        recordStatus: 'ready',
+        syncAttempts: [],
+        sourceConnectionId: SOURCE_CONNECTION_ID,
+        packedAt: '2026-04-21T09:00:00.000Z',
+        packedByUserId: 'user_7',
+        salesDocumentBlockReason: 'trigger-model-manual',
+      });
+
+      const titles = Array.from(document.querySelectorAll('.order-activity__item')).map(
+        (li) => li.textContent ?? '',
+      );
+      const packedIndex = titles.findIndex((t) => t.includes('Order packed'));
+      const blockedIndex = titles.findIndex((t) => t.includes('No invoice issued'));
+
+      expect(packedIndex).toBeGreaterThanOrEqual(0);
+      expect(blockedIndex).toBeGreaterThan(packedIndex);
+    });
+  });
 });

--- a/apps/web/src/features/orders/components/order-activity-timeline.tsx
+++ b/apps/web/src/features/orders/components/order-activity-timeline.tsx
@@ -84,6 +84,14 @@ interface OrderActivityTimelineProps {
   lastAmendedAt?: string | null;
   /** What changed then (#2283) — PII-free by backend contract. */
   lastAmendmentChanges?: OrderAmendmentChange[] | null;
+  /**
+   * Instant an operator marked this order packed (#2288). DATED, like the
+   * #2283 amendment entry and unlike the #2100 invoicing block: a real instant
+   * is persisted, so it belongs in the history rather than beside it.
+   */
+  packedAt?: string | null;
+  /** OL user id of whoever marked it packed (#2288) — rendered as the actor. */
+  packedByUserId?: string | null;
 }
 
 const STATUS_PAST_TENSE: Record<OrderSyncStatusValue, string> = {
@@ -162,6 +170,8 @@ function buildEvents(
   invoice?: ParsedOrderInvoice | null,
   lastAmendedAt?: string | null,
   lastAmendmentChanges?: OrderAmendmentChange[] | null,
+  packedAt?: string | null,
+  packedByUserId?: string | null,
 ): TimelineEvent[] {
   const events: TimelineEvent[] = [];
 
@@ -287,6 +297,23 @@ function buildEvents(
     });
   }
 
+  // #2288 — an operator marked this order packed. DATED for the same reason the
+  // amendment entry above is: a real instant is persisted. `success` because it
+  // is progress through the workflow, not outstanding work. Pushed BEFORE the
+  // undated entry below so the current-state row stays last.
+  if (packedAt) {
+    events.push({
+      id: 'packed',
+      timestamp: packedAt,
+      title: 'Order packed',
+      by: 'operator',
+      description: packedByUserId
+        ? `Marked packed by ${packedByUserId}.`
+        : 'Marked packed by an operator.',
+      tone: 'success',
+    });
+  }
+
   // #2100 — appended last and DELIBERATELY UNDATED (`timestamp: null`): the block
   // is a current-state fact re-decided on every transition, not a historical
   // event, and no instant is persisted for it. Dating it with `createdAt` or
@@ -334,6 +361,8 @@ export function OrderActivityTimeline({
   invoice,
   lastAmendedAt,
   lastAmendmentChanges,
+  packedAt,
+  packedByUserId,
 }: OrderActivityTimelineProps): ReactElement {
   const events = useMemo(
     () =>
@@ -349,6 +378,8 @@ export function OrderActivityTimeline({
         invoice,
         lastAmendedAt,
         lastAmendmentChanges,
+        packedAt,
+        packedByUserId,
       ),
     [
       createdAt,
@@ -362,6 +393,8 @@ export function OrderActivityTimeline({
       invoice,
       lastAmendedAt,
       lastAmendmentChanges,
+      packedAt,
+      packedByUserId,
     ],
   );
 

--- a/apps/web/src/features/orders/components/order-activity-timeline.tsx
+++ b/apps/web/src/features/orders/components/order-activity-timeline.tsx
@@ -20,6 +20,7 @@ import {
   type SyncAttempt,
   type SalesDocumentGateBlockReasonValue,
   type SalesDocumentUnresolvedReasonValue,
+  type OrderAmendmentChange,
 } from '../api/orders.types';
 import type { StatusBadgeTone } from '../../../shared/ui/status-badge';
 import type { ParsedOrderInvoice } from '../api/order-snapshot.schema';
@@ -75,6 +76,14 @@ interface OrderActivityTimelineProps {
    * see the shared rule on `invoicingBlockedBadge`.
    */
   invoice?: ParsedOrderInvoice | null;
+  /**
+   * Instant the source last amended this order after ingestion (#2283). Unlike
+   * the #2100 invoicing block, a real instant IS persisted here, so the entry is
+   * DATED and sorts into place with the rest of the history.
+   */
+  lastAmendedAt?: string | null;
+  /** What changed then (#2283) — PII-free by backend contract. */
+  lastAmendmentChanges?: OrderAmendmentChange[] | null;
 }
 
 const STATUS_PAST_TENSE: Record<OrderSyncStatusValue, string> = {
@@ -110,6 +119,37 @@ const TONE_FOR_STATUS: Record<OrderSyncStatusValue, TimelineEvent['tone']> = {
   skipped_cancelled: 'default',
 };
 
+/**
+ * Operator-facing sentence for a change list (#2283).
+ *
+ * Renders only what the backend sent: an address change names the FIELDS that
+ * moved and never their values, because the values are deliberately not on the
+ * wire. An unrecognised `kind` from a newer backend degrades to the raw value
+ * rather than vanishing — a change the operator cannot see is worse than one
+ * labelled awkwardly.
+ */
+function describeAmendment(changes?: OrderAmendmentChange[] | null): string {
+  const parts = (changes ?? []).map((change) => {
+    const line = change.sku ?? change.lineId ?? 'a line';
+    switch (change.kind) {
+      case 'line-removed':
+        return `line ${line} removed`;
+      case 'line-added':
+        return `line ${line} added`;
+      case 'line-quantity-changed':
+        return `line ${line} quantity ${change.fromQuantity} \u2192 ${change.toQuantity}`;
+      case 'shipping-address-changed':
+        return `shipping address changed (${(change.fields ?? []).join(', ')})`;
+      default:
+        return change.kind;
+    }
+  });
+
+  return parts.length > 0
+    ? `The source changed this order after ingestion: ${parts.join('; ')}.`
+    : 'The source changed this order after ingestion.';
+}
+
 function buildEvents(
   createdAt: string,
   recordStatus: string,
@@ -120,6 +160,8 @@ function buildEvents(
   salesDocumentUnresolvedReason?: SalesDocumentUnresolvedReasonValue | null,
   salesDocumentBlockDetail?: string | null,
   invoice?: ParsedOrderInvoice | null,
+  lastAmendedAt?: string | null,
+  lastAmendmentChanges?: OrderAmendmentChange[] | null,
 ): TimelineEvent[] {
   const events: TimelineEvent[] = [];
 
@@ -229,6 +271,22 @@ function buildEvents(
     });
   });
 
+  // #2283 — the source amended this order after we ingested it. DATED, unlike
+  // the #2100 entry below: a real instant is persisted for it, so it belongs in
+  // the history rather than beside it. Pushed BEFORE that entry so the undated
+  // current-state row stays last, and `warning` because it is outstanding work —
+  // a shipment may already reference a line the source removed.
+  if (lastAmendedAt) {
+    events.push({
+      id: 'source-amended',
+      timestamp: lastAmendedAt,
+      title: 'Order changed at the source',
+      by: 'system · ingest',
+      description: describeAmendment(lastAmendmentChanges),
+      tone: 'warning',
+    });
+  }
+
   // #2100 — appended last and DELIBERATELY UNDATED (`timestamp: null`): the block
   // is a current-state fact re-decided on every transition, not a historical
   // event, and no instant is persisted for it. Dating it with `createdAt` or
@@ -274,6 +332,8 @@ export function OrderActivityTimeline({
   salesDocumentUnresolvedReason,
   salesDocumentBlockDetail,
   invoice,
+  lastAmendedAt,
+  lastAmendmentChanges,
 }: OrderActivityTimelineProps): ReactElement {
   const events = useMemo(
     () =>
@@ -287,6 +347,8 @@ export function OrderActivityTimeline({
         salesDocumentUnresolvedReason,
         salesDocumentBlockDetail,
         invoice,
+        lastAmendedAt,
+        lastAmendmentChanges,
       ),
     [
       createdAt,
@@ -298,6 +360,8 @@ export function OrderActivityTimeline({
       salesDocumentUnresolvedReason,
       salesDocumentBlockDetail,
       invoice,
+      lastAmendedAt,
+      lastAmendmentChanges,
     ],
   );
 

--- a/apps/web/src/features/orders/components/order-activity-timeline.tsx
+++ b/apps/web/src/features/orders/components/order-activity-timeline.tsx
@@ -82,6 +82,7 @@ const STATUS_PAST_TENSE: Record<OrderSyncStatusValue, string> = {
   syncing: 'syncing to',
   synced: 'synced to',
   failed: 'failed to sync to',
+  skipped_cancelled: 'skipped (cancelled at source) for',
 };
 
 /**
@@ -105,6 +106,8 @@ const TONE_FOR_STATUS: Record<OrderSyncStatusValue, TimelineEvent['tone']> = {
   syncing: 'default',
   synced: 'success',
   failed: 'error',
+  // Terminal, and not a failure — a deliberate withholding reads neutral (#2284).
+  skipped_cancelled: 'default',
 };
 
 function buildEvents(

--- a/apps/web/src/features/orders/components/order-packed-control.test.tsx
+++ b/apps/web/src/features/orders/components/order-packed-control.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * `OrderPackedControl` unit tests (#2288).
+ *
+ * The four states the acceptance criteria name are all reachable here without
+ * mounting the whole detail page: unpacked → mark, packed → attribution + undo,
+ * viewer → no affordance at all, demo viewer → visible but locked.
+ */
+import { cleanup, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { OrderPackedControl } from './order-packed-control';
+import {
+  createAuthenticatedSessionAdapter,
+  createMockApiClient,
+  renderWithProviders,
+} from '../../../test/test-utils';
+import type { SessionUser } from '../../../shared/auth/session.types';
+
+const ORDER_ID = 'ol_order_1';
+const PACKED_AT = '2026-04-20T10:00:00.000Z';
+
+/** A viewer: authenticated, but without `orders:write`. */
+const VIEWER: SessionUser = {
+  id: 'user_2',
+  username: 'viewer',
+  email: 'viewer@example.com',
+  role: 'viewer',
+  permissions: ['orders:read'],
+  analyticsConsent: true,
+};
+
+function renderControl(
+  props: Partial<React.ComponentProps<typeof OrderPackedControl>> = {},
+  opts: { user?: SessionUser; demoMode?: boolean } = {},
+) {
+  const orders = {
+    markPacked: vi.fn().mockResolvedValue({ internalOrderId: ORDER_ID, packedAt: PACKED_AT }),
+    unmarkPacked: vi.fn().mockResolvedValue({ internalOrderId: ORDER_ID, packedAt: null }),
+  };
+  const api = createMockApiClient({
+    orders,
+    system: { getConfig: vi.fn().mockResolvedValue({ demoMode: opts.demoMode ?? false }) },
+  });
+
+  renderWithProviders(
+    <OrderPackedControl
+      internalOrderId={ORDER_ID}
+      packedAt={null}
+      packedByUserId={null}
+      {...props}
+    />,
+    {
+      apiClient: api,
+      sessionAdapter: createAuthenticatedSessionAdapter(opts.user),
+    },
+  );
+
+  return orders;
+}
+
+afterEach(cleanup);
+
+describe('OrderPackedControl (#2288)', () => {
+  it('offers "Mark packed" for an unpacked order and calls the write', async () => {
+    const orders = renderControl();
+    const user = userEvent.setup();
+
+    expect(screen.getByText('Not packed yet.')).toBeInTheDocument();
+    const button = await screen.findByRole('button', { name: 'Mark packed' });
+    await user.click(button);
+
+    await waitFor(() => {
+      expect(orders.markPacked).toHaveBeenCalledWith(ORDER_ID);
+    });
+    expect(orders.unmarkPacked).not.toHaveBeenCalled();
+  });
+
+  it('shows the attribution and an Undo for a packed order', async () => {
+    const orders = renderControl({ packedAt: PACKED_AT, packedByUserId: 'user_7' });
+    const user = userEvent.setup();
+
+    expect(screen.getByText('user_7')).toBeInTheDocument();
+    const undo = await screen.findByRole('button', { name: 'Undo' });
+    await user.click(undo);
+
+    await waitFor(() => {
+      expect(orders.unmarkPacked).toHaveBeenCalledWith(ORDER_ID);
+    });
+    expect(orders.markPacked).not.toHaveBeenCalled();
+  });
+
+  it('hides the affordance from a viewer but still states the fact', async () => {
+    renderControl({ packedAt: PACKED_AT, packedByUserId: 'user_7' }, { user: VIEWER });
+
+    // The packed FACT is read-only information — a viewer sees it.
+    expect(screen.getByText('user_7')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    });
+  });
+
+  it('renders the affordance visible-but-disabled for a demo viewer', async () => {
+    renderControl({}, { user: VIEWER, demoMode: true });
+
+    // A demo visitor should SEE that the action exists — the #1615 treatment
+    // the orders list already applies to its per-row Retry.
+    const button = await screen.findByRole('button', { name: 'Mark packed' });
+    expect(button).toBeDisabled();
+  });
+});

--- a/apps/web/src/features/orders/components/order-packed-control.tsx
+++ b/apps/web/src/features/orders/components/order-packed-control.tsx
@@ -1,0 +1,116 @@
+/**
+ * Order Packed Control
+ *
+ * The mark/unmark affordance for the operator "packed" fact (#2288). The list
+ * displays and the DETAIL page acts (#2081 rule 3), so this is the only place
+ * the fact is written.
+ *
+ * It deliberately does NOT live in `OrderShipmentPanel`: that panel renders only
+ * when a connection declares `ShippingProviderManager`, and packing is a fact
+ * about every order — including one the shop fulfils itself. Hosting it there
+ * would have hidden the control for exactly the orders whose packing nobody else
+ * tracks. Staying out of that panel also leaves its #1615/#1826
+ * `usePermission('shipments:write')` doctrine untouched.
+ *
+ * Gating mirrors the orders list's per-row Retry (`orders-list-page.tsx`):
+ * `useWriteAccess` hides the affordance from a viewer entirely, and renders it
+ * visible-but-disabled under a `ReadOnlyLock` tooltip for a demo viewer — a demo
+ * visitor should see that the action exists, a viewer should not be shown one
+ * they can never use. The packed FACT is read-only information, so it renders
+ * for everyone; only the button is gated.
+ *
+ * @module apps/web/src/features/orders/components
+ */
+import type { ReactElement } from 'react';
+import { Button } from '../../../shared/ui/button';
+import { ReadOnlyLock } from '../../../shared/ui/read-only-lock';
+import { TimeDisplay } from '../../../shared/ui/time-display';
+import { useToast } from '../../../shared/ui/toast-provider';
+import { useWriteAccess } from '../../../shared/auth/use-permission';
+import { DEMO_READ_ONLY_ACTION_MESSAGE } from '../../../shared/config/demo-mode';
+import { useDemoMode } from '../../system';
+import { useMarkPackedMutation } from '../hooks/use-mark-packed-mutation';
+
+export interface OrderPackedControlProps {
+  internalOrderId: string;
+  packedAt: string | null | undefined;
+  packedByUserId: string | null | undefined;
+}
+
+export function OrderPackedControl({
+  internalOrderId,
+  packedAt,
+  packedByUserId,
+}: OrderPackedControlProps): ReactElement {
+  const { showToast } = useToast();
+  const demoMode = useDemoMode();
+  const packWrite = useWriteAccess('orders:write', demoMode);
+  const markPacked = useMarkPackedMutation();
+
+  const packed = Boolean(packedAt);
+
+  const handleToggle = (): void => {
+    markPacked.mutate(
+      { internalOrderId, packed: !packed },
+      {
+        onSuccess: () => {
+          showToast({
+            tone: 'success',
+            description: packed ? 'Packed mark cleared.' : 'Order marked packed.',
+          });
+        },
+        onError: (error: Error) => {
+          showToast({
+            tone: 'error',
+            description: error.message || 'Could not update the packed mark.',
+          });
+        },
+      },
+    );
+  };
+
+  const buttonLabel = markPacked.isPending
+    ? packed
+      ? 'Clearing…'
+      : 'Marking…'
+    : packed
+      ? 'Undo'
+      : 'Mark packed';
+
+  return (
+    <section className="detail-section">
+      <h3 className="detail-section__title">Packing</h3>
+      <div className="ds-row order-packed-control">
+        {packedAt ? (
+          <span className="orders-packed-state">
+            {/* Glyph + word, never colour alone (#2081). */}
+            <span className="orders-packed-tick__mark" aria-hidden="true">
+              ✓
+            </span>{' '}
+            Packed <TimeDisplay iso={packedAt} format="relative" />
+            {packedByUserId ? (
+              <>
+                {' '}
+                by <span className="mono-text">{packedByUserId}</span>
+              </>
+            ) : null}
+          </span>
+        ) : (
+          <span className="text-muted">Not packed yet.</span>
+        )}
+        {packWrite.visible ? (
+          <ReadOnlyLock active={packWrite.demoReadOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
+            <Button
+              tone={packed ? 'ghost' : 'primary'}
+              className="button--sm"
+              disabled={markPacked.isPending || packWrite.demoReadOnly}
+              onClick={handleToggle}
+            >
+              {buttonLabel}
+            </Button>
+          </ReadOnlyLock>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/features/orders/components/order-packed-tick.test.tsx
+++ b/apps/web/src/features/orders/components/order-packed-tick.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * `OrderPackedTick` unit tests (#2288).
+ *
+ * The component is one shared cell rendered by two surfaces with different
+ * empty semantics — the desktop stack shows nothing for the ordinary unpacked
+ * row, the mobile `<dd>` must never be empty — so both layouts are driven here
+ * rather than through `OrdersListPage`, which would cost a mock API client and
+ * a viewport mock per case.
+ */
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { OrderPackedTick } from './order-packed-tick';
+
+const PACKED_AT = '2026-04-20T10:00:00.000Z';
+
+afterEach(cleanup);
+
+describe('OrderPackedTick (#2288)', () => {
+  describe('not packed', () => {
+    it('renders the empty fallback when packedAt is null', () => {
+      render(<OrderPackedTick packedAt={null} layout="row" emptyFallback="—" />);
+
+      expect(screen.getByText('—')).toBeInTheDocument();
+      expect(screen.queryByLabelText(/^Packed /)).not.toBeInTheDocument();
+    });
+
+    it('renders nothing at all when the desktop stack passes a null fallback', () => {
+      // The common row: a marker on every unpacked row would be noise.
+      const { container } = render(
+        <OrderPackedTick packedAt={null} layout="stack" emptyFallback={null} />,
+      );
+
+      expect(container).toBeEmptyDOMElement();
+    });
+
+    it('treats an absent field (pre-#2287 payload) exactly like null', () => {
+      render(<OrderPackedTick packedAt={undefined} layout="row" emptyFallback="—" />);
+
+      expect(screen.getByText('—')).toBeInTheDocument();
+    });
+  });
+
+  describe('packed', () => {
+    it.each(['stack', 'row'] as const)(
+      'states the fact in text and carries an absolute accessible name (%s layout)',
+      (layout) => {
+        render(<OrderPackedTick packedAt={PACKED_AT} layout={layout} emptyFallback="—" />);
+
+        // Colour is never the only signal: the word is in the DOM either way.
+        expect(screen.getByText('Packed')).toBeInTheDocument();
+        // `aria-label` alongside `title` — a title alone is unreachable by
+        // keyboard and absent on touch.
+        const marker = screen.getByLabelText(/^Packed /);
+        expect(marker).toHaveAttribute('title', marker.getAttribute('aria-label'));
+        expect(screen.queryByText('—')).not.toBeInTheDocument();
+      },
+    );
+
+    it('exposes the instant as a machine-readable <time>', () => {
+      const { container } = render(
+        <OrderPackedTick packedAt={PACKED_AT} layout="stack" emptyFallback={null} />,
+      );
+
+      expect(container.querySelector('time')).toHaveAttribute('datetime', PACKED_AT);
+    });
+  });
+});

--- a/apps/web/src/features/orders/components/order-packed-tick.tsx
+++ b/apps/web/src/features/orders/components/order-packed-tick.tsx
@@ -1,0 +1,71 @@
+/**
+ * Order Packed Tick
+ *
+ * The operator "packed" fact on one order row, rendered identically by the
+ * desktop shipment cell and the mobile card — the shape `OrderInvoicingCell`
+ * established after the hand-duplicated desktop/mobile ternaries drifted apart.
+ *
+ * It is a TICK, not a badge (#2081): the row already carries four badge
+ * vocabularies (fulfillment, SLA, payment, invoicing) and packed is a position
+ * in a workflow rather than a state anyone reconciles against. For the same
+ * reason colour is never the only signal — the glyph and a text label carry it,
+ * so the fact survives a monochrome or colour-blind reading.
+ *
+ * Unpacked renders `emptyFallback`, which the desktop stack passes as `null`:
+ * not-yet-packed is the ordinary row, and a placeholder on every one of them
+ * would be noise. The mobile fact list passes "—" instead, because a labelled
+ * `<dd>` may not be empty.
+ *
+ * @module apps/web/src/features/orders/components
+ */
+import type { ReactNode } from 'react';
+import { TimeDisplay } from '../../../shared/ui/time-display';
+import { formatDateTime } from '../../../shared/format/format-date';
+
+export interface OrderPackedTickProps {
+  /** `undefined` (older payload) and `null` (never packed) mean the same here. */
+  packedAt: string | null | undefined;
+  /**
+   * `stack` lets the parent's `orders-cell-stack` lay the tick out vertically
+   * (desktop); `row` wraps it so a `<dd>` still receives a single child
+   * (mobile). Layout only — the content is identical.
+   */
+  layout: 'stack' | 'row';
+  /** Rendered when the order is not packed. */
+  emptyFallback: ReactNode;
+}
+
+export function OrderPackedTick({
+  packedAt,
+  layout,
+  emptyFallback,
+}: OrderPackedTickProps): ReactNode {
+  if (!packedAt) return emptyFallback;
+
+  // `aria-label` alongside `title` (the #2100 pairing): `title` alone is
+  // unreachable by keyboard, unreliable in screen readers on a role-less span,
+  // and absent on touch — so the absolute instant is stated both ways. The
+  // relative time beside it is decorative duplication for a screen reader,
+  // hence `aria-hidden`.
+  const absolute = formatDateTime(packedAt);
+  const content = (
+    <span
+      className="orders-packed-tick"
+      title={`Packed ${absolute}`}
+      aria-label={`Packed ${absolute}`}
+    >
+      <span className="orders-packed-tick__mark" aria-hidden="true">
+        ✓
+      </span>{' '}
+      <span className="orders-packed-tick__label">Packed</span>{' '}
+      <TimeDisplay
+        className="text-muted orders-cell-sub"
+        iso={packedAt}
+        format="relative"
+        aria-hidden="true"
+      />
+    </span>
+  );
+
+  return layout === 'row' ? <span className="ds-row">{content}</span> : content;
+}

--- a/apps/web/src/features/orders/hooks/use-mark-packed-mutation.test.tsx
+++ b/apps/web/src/features/orders/hooks/use-mark-packed-mutation.test.tsx
@@ -1,0 +1,67 @@
+/**
+ * `useMarkPackedMutation` unit tests (#2288).
+ *
+ * The hook's contract is two facts: the boolean picks the verb, and BOTH verbs
+ * invalidate the whole orders domain. The second is what keeps the row tick, the
+ * detail control and the timeline entry from disagreeing, so it is asserted for
+ * each direction rather than once.
+ */
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { useMarkPackedMutation } from './use-mark-packed-mutation';
+import { ApiClientProvider } from '../../../app/api/api-client-provider';
+import { createMockApiClient } from '../../../test/test-utils';
+import { ordersQueryKeys } from '../api/orders.query-keys';
+
+const ORDER_ID = 'ol_order_1';
+
+function setup() {
+  const orders = {
+    markPacked: vi.fn().mockResolvedValue({ internalOrderId: ORDER_ID }),
+    unmarkPacked: vi.fn().mockResolvedValue({ internalOrderId: ORDER_ID }),
+  };
+  const apiClient = createMockApiClient({ orders });
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <ApiClientProvider client={apiClient}>{children}</ApiClientProvider>
+    </QueryClientProvider>
+  );
+
+  const { result } = renderHook(() => useMarkPackedMutation(), { wrapper });
+  return { orders, invalidateSpy, result };
+}
+
+describe('useMarkPackedMutation (#2288)', () => {
+  it('marks packed and invalidates the whole orders domain', async () => {
+    const { orders, invalidateSpy, result } = setup();
+
+    result.current.mutate({ internalOrderId: ORDER_ID, packed: true });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(orders.markPacked).toHaveBeenCalledWith(ORDER_ID);
+    expect(orders.unmarkPacked).not.toHaveBeenCalled();
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ordersQueryKeys.all });
+  });
+
+  it('clears the mark and invalidates the same domain', async () => {
+    const { orders, invalidateSpy, result } = setup();
+
+    result.current.mutate({ internalOrderId: ORDER_ID, packed: false });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+    expect(orders.unmarkPacked).toHaveBeenCalledWith(ORDER_ID);
+    expect(orders.markPacked).not.toHaveBeenCalled();
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ordersQueryKeys.all });
+  });
+});

--- a/apps/web/src/features/orders/hooks/use-mark-packed-mutation.ts
+++ b/apps/web/src/features/orders/hooks/use-mark-packed-mutation.ts
@@ -1,0 +1,41 @@
+/**
+ * Mark Packed Mutation Hook
+ *
+ * Sets or clears the operator "packed" fact on one order (#2288, over #2287's
+ * POST/DELETE pair). ONE hook takes the desired state rather than two hooks per
+ * verb: both directions invalidate exactly the same thing, and a second hook
+ * would be an identical invalidation waiting to drift out of step with this one.
+ *
+ * Invalidates the whole orders domain on success — like the retry-destination
+ * hook — so the detail control, the row tick and the timeline entry can never
+ * disagree about whether the order is packed. No optimistic update: the packed
+ * instant is stamped server-side, so an optimistic row would have to invent a
+ * timestamp it does not know.
+ *
+ * @module apps/web/src/features/orders/hooks
+ */
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { ordersQueryKeys } from '../api/orders.query-keys';
+import type { OrderRecord } from '../api/orders.types';
+
+export interface MarkPackedInput {
+  internalOrderId: string;
+  /** `true` marks packed, `false` clears the mark. */
+  packed: boolean;
+}
+
+export function useMarkPackedMutation(): UseMutationResult<OrderRecord, Error, MarkPackedInput> {
+  const apiClient = useApiClient();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ internalOrderId, packed }) =>
+      packed
+        ? apiClient.orders.markPacked(internalOrderId)
+        : apiClient.orders.unmarkPacked(internalOrderId),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ordersQueryKeys.all });
+    },
+  });
+}

--- a/apps/web/src/features/orders/lib/order-health.test.ts
+++ b/apps/web/src/features/orders/lib/order-health.test.ts
@@ -156,7 +156,16 @@ describe('rollupSyncStatus', () => {
       status({ status: 'pending' }),
       status({ status: 'syncing' }),
     ]);
-    expect(rollup).toEqual({ total: 4, failed: 1, synced: 1, pending: 2 });
+    expect(rollup).toEqual({ total: 4, failed: 1, synced: 1, pending: 2, skipped: 0 });
+  });
+
+  // #2284 — terminal, and neither failed nor pending.
+  it('counts skipped_cancelled in its own bucket', () => {
+    const rollup = rollupSyncStatus([
+      status({ status: 'skipped_cancelled' }),
+      status({ status: 'synced' }),
+    ]);
+    expect(rollup).toEqual({ total: 2, failed: 0, synced: 1, pending: 0, skipped: 1 });
   });
 });
 
@@ -177,6 +186,12 @@ describe('deriveHealthLevel + healthLabel', () => {
     expect(deriveHealthLevel(rollupSyncStatus([status({ status: 'syncing' })]))).toBe('pending');
   });
 
+  it('does not read a skipped_cancelled destination as pending or attention', () => {
+    expect(deriveHealthLevel(rollupSyncStatus([status({ status: 'skipped_cancelled' })]))).toBe(
+      'healthy',
+    );
+  });
+
   it('reports healthy when all synced', () => {
     const level = deriveHealthLevel(rollupSyncStatus([status({ status: 'synced' })]));
     expect(level).toBe('healthy');
@@ -192,6 +207,13 @@ describe('syncCellLabel', () => {
     expect(syncCellLabel(rollupSyncStatus([status({ status: 'synced' }), status({ status: 'syncing' })]))).toBe(
       '1 of 2 synced',
     );
+  });
+  it('surfaces the skipped count alongside the synced count', () => {
+    expect(
+      syncCellLabel(
+        rollupSyncStatus([status({ status: 'synced' }), status({ status: 'skipped_cancelled' })]),
+      ),
+    ).toBe('1 of 2 synced (1 skipped)');
   });
   it('handles no destinations', () => {
     expect(syncCellLabel(rollupSyncStatus([]))).toBe('No destinations');

--- a/apps/web/src/features/orders/lib/order-health.ts
+++ b/apps/web/src/features/orders/lib/order-health.ts
@@ -102,23 +102,42 @@ export interface SyncRollup {
   synced: number;
   /** pending + syncing — anything not yet terminal. */
   pending: number;
+  /**
+   * `skipped_cancelled` (#2284) — terminal, and neither a failure nor
+   * outstanding work: the source cancelled the order before any destination
+   * order existed, so provisioning was deliberately withheld. Counted on its own
+   * so it can never inflate `failed` (it is not an error) or `pending` (it would
+   * leave the order reading as stuck forever).
+   */
+  skipped: number;
 }
 
 export function rollupSyncStatus(syncStatus: readonly OrderSyncStatus[]): SyncRollup {
   let failed = 0;
   let synced = 0;
   let pending = 0;
+  let skipped = 0;
   for (const s of syncStatus) {
     if (s.status === 'failed') failed += 1;
     else if (s.status === 'synced') synced += 1;
+    // Explicit branch on purpose: the catch-all `else` below is not
+    // compiler-guarded, so a widened union would silently land here and be
+    // counted as pending.
+    else if (s.status === 'skipped_cancelled') skipped += 1;
     else pending += 1;
   }
-  return { total: syncStatus.length, failed, synced, pending };
+  return { total: syncStatus.length, failed, synced, pending, skipped };
 }
 
 export const OrderHealthLevelValues = ['attention', 'pending', 'healthy', 'unknown'] as const;
 export type OrderHealthLevel = (typeof OrderHealthLevelValues)[number];
 
+/**
+ * A `skipped_cancelled`-only order resolves to `'healthy'`: it is terminal with
+ * no outstanding work and nothing failed (#2284). The health PARTITION is
+ * deliberately unchanged — a dedicated bucket would need the SQL twin plus the
+ * list KPI cards, which is out of scope.
+ */
 export function deriveHealthLevel(rollup: SyncRollup): OrderHealthLevel {
   if (rollup.total === 0) return 'unknown';
   if (rollup.failed > 0) return 'attention';
@@ -143,6 +162,8 @@ export function healthLabel(level: OrderHealthLevel): string {
 export function syncCellLabel(rollup: SyncRollup): string {
   if (rollup.total === 0) return 'No destinations';
   if (rollup.failed > 0) return `${rollup.failed} of ${rollup.total} failed`;
+  if (rollup.skipped > 0)
+    return `${rollup.synced} of ${rollup.total} synced (${rollup.skipped} skipped)`;
   return `${rollup.synced} of ${rollup.total} synced`;
 }
 

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -9093,6 +9093,15 @@ a.kpi-card:focus-visible {
 .orders-shipby-row { display: inline-flex; align-items: center; gap: 6px; }
 .orders-carrier { max-width: 200px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 
+/* Packed tick (#2288). A workflow POSITION, so it reads as a tick rather than
+   one more badge — the row already carries four badge vocabularies. Colour is
+   never the only signal: the glyph and the word carry the fact on their own. */
+.orders-packed-tick { display: inline-flex; align-items: center; gap: 4px; font-size: 0.75rem; }
+.orders-packed-tick__mark { color: var(--status-success-fg); font-weight: 600; }
+.orders-packed-tick__label { color: var(--text-muted); }
+.orders-packed-control { gap: var(--space-3); }
+.orders-packed-state { display: inline-flex; align-items: center; gap: 4px; }
+
 /* Channel folds under the order name below the Channel column's 1024px hide
    breakpoint — hidden on wide screens where the standalone column shows. */
 .orders-order-channel { display: none; align-items: center; gap: 6px; }

--- a/apps/web/src/pages/customers/customer-detail-page.tsx
+++ b/apps/web/src/pages/customers/customer-detail-page.tsx
@@ -68,6 +68,8 @@ const SYNC_STATUS_TONES: Record<OrderSyncStatusValue, StatusBadgeTone> = {
   syncing: 'warning',
   synced: 'success',
   failed: 'error',
+  // #2284 — provisioning withheld because the source cancelled; never an error.
+  skipped_cancelled: 'neutral',
 };
 
 const CUSTOMER_ORDER_COLUMNS: DataTableColumn<OrderRecord>[] = [

--- a/apps/web/src/pages/orders/order-detail-page.tsx
+++ b/apps/web/src/pages/orders/order-detail-page.tsx
@@ -466,6 +466,8 @@ export function OrderDetailPage(): ReactElement {
           salesDocumentUnresolvedReason={order.salesDocumentUnresolvedReason}
           salesDocumentBlockDetail={order.salesDocumentBlockDetail}
           invoice={snapshot.invoice}
+          lastAmendedAt={order.lastAmendedAt}
+          lastAmendmentChanges={order.lastAmendmentChanges}
         />
       </section>
 

--- a/apps/web/src/pages/orders/order-detail-page.tsx
+++ b/apps/web/src/pages/orders/order-detail-page.tsx
@@ -35,6 +35,7 @@ import {
 } from '../../features/shipments';
 import { OrderCustomerCard } from '../../features/orders/components/order-customer-card';
 import { OrderActivityTimeline } from '../../features/orders/components/order-activity-timeline';
+import { OrderPackedControl } from '../../features/orders/components/order-packed-control';
 import { OrderShipmentPanel } from '../../features/orders/components/order-shipment-panel';
 import { SalesDocumentPanel } from '../../features/orders/components/sales-document-panel';
 import { OrderDetailHeader } from '../../features/orders/components/order-detail-header';
@@ -374,6 +375,16 @@ export function OrderDetailPage(): ReactElement {
             <KeyValueList items={summaryItems} />
           </section>
 
+          {/* Packing is a fact about EVERY order, so this sits in the always
+              rendered left stack rather than inside the capability-gated
+              shipment panel — an order with no shipping-capable connection
+              still gets packed. */}
+          <OrderPackedControl
+            internalOrderId={order.internalOrderId}
+            packedAt={order.packedAt}
+            packedByUserId={order.packedByUserId}
+          />
+
           <section className="detail-section">
             <h3 className="detail-section__title">
               Sync status{order.syncStatus.length > 0 ? ` (${order.syncStatus.length})` : ''}
@@ -468,6 +479,8 @@ export function OrderDetailPage(): ReactElement {
           invoice={snapshot.invoice}
           lastAmendedAt={order.lastAmendedAt}
           lastAmendmentChanges={order.lastAmendmentChanges}
+          packedAt={order.packedAt}
+          packedByUserId={order.packedByUserId}
         />
       </section>
 

--- a/apps/web/src/pages/orders/order-detail-page.tsx
+++ b/apps/web/src/pages/orders/order-detail-page.tsx
@@ -54,6 +54,8 @@ const SYNC_STATUS_TONES: Record<OrderSyncStatusValue, StatusBadgeTone> = {
   syncing: 'warning',
   synced: 'success',
   failed: 'error',
+  // #2284 — provisioning withheld because the source cancelled; never an error.
+  skipped_cancelled: 'neutral',
 };
 
 /** Ship-by urgency level (#927) → StatusBadge tone. */

--- a/apps/web/src/pages/orders/orders-list-page.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.tsx
@@ -57,6 +57,7 @@ import { deriveOrderHealth, slaBadge, fulfillmentBadge } from '../../features/or
 import { paymentBadge } from '../../features/orders/lib/order-row';
 import { OrderIdentityCell } from '../../features/orders';
 import { OrderInvoicingCell } from '../../features/orders/components/order-invoicing-cell';
+import { OrderPackedTick } from '../../features/orders/components/order-packed-tick';
 import { deriveDeliveryOutcome, hasLiveOlCarrierRoute } from '../../features/orders/lib/delivery-outcome';
 import { DeliveryOutcomeChip } from '../../features/orders/components/delivery-chip';
 import { resolveDeliveryOwner } from '../../features/orders/lib/delivery-owner';
@@ -859,6 +860,11 @@ export function OrdersListPage(): ReactElement {
             hasLiveOlCarrierRoute(order.deliveryResolution);
           return (
             <span className="orders-cell-stack">
+              {/* Packed sits FIRST: the shipment cell reads as time (packed →
+                  shipped → due → carrier), and packing precedes everything else
+                  in it. It is also the one slot that never depends on a sibling —
+                  the fulfillment badge below is conditional. */}
+              <OrderPackedTick packedAt={order.packedAt} layout="stack" emptyFallback={null} />
               {/* When the row offers "Generate label" the CTA is deferred to sit
                   directly under the Awaiting-label delivery chip (the state it
                   resolves), so the top slot only carries the passive fulfillment
@@ -1569,6 +1575,20 @@ export function OrdersListPage(): ReactElement {
                       <div>
                         <dt>Customer</dt>
                         <dd>{cust ?? '—'}</dd>
+                      </div>
+                      <div>
+                        <dt>Packed</dt>
+                        <dd>
+                          {/* SAME component as the desktop cell. On a narrow
+                              viewport the desktop tick becomes a labelled fact,
+                              so the empty case needs a dash rather than nothing —
+                              a <dd> may not be empty. */}
+                          <OrderPackedTick
+                            packedAt={order.packedAt}
+                            layout="row"
+                            emptyFallback="—"
+                          />
+                        </dd>
                       </div>
                       <div className="orders-card-facts__wide">
                         <dt>Shipment</dt>

--- a/apps/worker/src/sync/handlers/marketplace-offer-quantity-update.handler.spec.ts
+++ b/apps/worker/src/sync/handlers/marketplace-offer-quantity-update.handler.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * Marketplace Offer Quantity Update Handler Tests
+ *
+ * Covers the payload contract for the observation token threaded into the derived
+ * idempotency key (#2285) — accepted only as a string, never fatal when absent or
+ * malformed, since V1 payloads in flight predate the field.
+ *
+ * @module apps/worker/src/sync/handlers
+ */
+
+import { MarketplaceOfferQuantityUpdateHandler } from './marketplace-offer-quantity-update.handler';
+import type { IInventorySyncService } from '@openlinker/core/inventory';
+import type { SyncJob } from '@openlinker/core/sync';
+
+describe('MarketplaceOfferQuantityUpdateHandler', () => {
+  let handler: MarketplaceOfferQuantityUpdateHandler;
+  let inventorySync: jest.Mocked<IInventorySyncService>;
+
+  const job = (payload: Record<string, unknown>): SyncJob =>
+    ({
+      id: 'job-1',
+      jobType: 'marketplace.offerQuantity.update',
+      connectionId: 'conn-1',
+      payload,
+    }) as unknown as SyncJob;
+
+  beforeEach(() => {
+    inventorySync = {
+      updateOfferQuantity: jest.fn().mockResolvedValue({ succeeded: ['o1'], failed: [] }),
+      updateOfferQuantities: jest.fn(),
+    } as unknown as jest.Mocked<IInventorySyncService>;
+
+    handler = new MarketplaceOfferQuantityUpdateHandler(inventorySync);
+  });
+
+  it('should thread a string observedAt from the payload into the core command', async () => {
+    const result = await handler.execute(
+      job({
+        schemaVersion: 1,
+        offerId: 'o1',
+        quantity: 0,
+        observedAt: '2026-08-01T00:00:00.000Z',
+      })
+    );
+
+    expect(inventorySync.updateOfferQuantity).toHaveBeenCalledWith(
+      'conn-1',
+      expect.objectContaining({ observedAt: '2026-08-01T00:00:00.000Z' })
+    );
+    expect(result).toEqual({ outcome: 'ok' });
+  });
+
+  it('should execute a payload carrying no observedAt', async () => {
+    const result = await handler.execute(job({ schemaVersion: 1, offerId: 'o1', quantity: 4 }));
+
+    expect(inventorySync.updateOfferQuantity).toHaveBeenCalledWith(
+      'conn-1',
+      expect.objectContaining({ offerId: 'o1', quantity: 4, observedAt: undefined })
+    );
+    expect(result).toEqual({ outcome: 'ok' });
+  });
+
+  it.each([[null], [12345], [{ at: 'x' }]])(
+    'should coerce a non-string observedAt (%p) to absent rather than fail the job',
+    async (observedAt) => {
+      const result = await handler.execute(
+        job({ schemaVersion: 1, offerId: 'o1', quantity: 4, observedAt })
+      );
+
+      expect(inventorySync.updateOfferQuantity).toHaveBeenCalledWith(
+        'conn-1',
+        expect.objectContaining({ observedAt: undefined })
+      );
+      expect(result).toEqual({ outcome: 'ok' });
+    }
+  );
+});

--- a/apps/worker/src/sync/handlers/marketplace-offer-quantity-update.handler.ts
+++ b/apps/worker/src/sync/handlers/marketplace-offer-quantity-update.handler.ts
@@ -42,6 +42,7 @@ export class MarketplaceOfferQuantityUpdateHandler implements SyncJobHandler {
         offerId: payload.offerId,
         quantity: payload.quantity,
         idempotencyKey: payload.idempotencyKey,
+        observedAt: payload.observedAt,
       });
 
       if (result.failed.length > 0) {
@@ -100,11 +101,24 @@ export class MarketplaceOfferQuantityUpdateHandler implements SyncJobHandler {
         job.connectionId
       );
     }
+    // #2285 — `observedAt` is an optional versioning hint, not a requirement: a
+    // payload enqueued before it existed carries none, so ANY non-string value
+    // (including null) coerces to absent with one warn. Never fail the job on it.
+    let observedAt: string | undefined;
+    if (typeof payload.observedAt === 'string') {
+      observedAt = payload.observedAt;
+    } else if (payload.observedAt !== undefined) {
+      this.logger.warn(
+        `Ignoring non-string observedAt in payload for job ${job.id} (offerId=${payload.offerId}); the derived idempotency key will be unversioned`
+      );
+    }
+
     return {
       schemaVersion: 1,
       offerId: payload.offerId,
       quantity: payload.quantity,
       idempotencyKey: payload.idempotencyKey,
+      observedAt,
     };
   }
 }

--- a/apps/worker/test/integration/allegro-order-sync-e2e.int-spec.ts
+++ b/apps/worker/test/integration/allegro-order-sync-e2e.int-spec.ts
@@ -33,6 +33,8 @@ import {
   IDENTIFIER_MAPPING_SERVICE_TOKEN,
 } from '@openlinker/core/identifier-mapping';
 import { ProductOrmEntity, ProductVariantOrmEntity } from '@openlinker/core/products/orm-entities';
+import { OrderRecordOrmEntity } from '@openlinker/core/orders/orm-entities';
+import { CORE_ENTITY_TYPE } from '@openlinker/core/identifier-mapping';
 import { DataSource } from 'typeorm';
 import { randomUUID } from 'crypto';
 
@@ -223,6 +225,89 @@ describe('Allegro Order Sync End-to-End Integration', () => {
       const cursor = await cursorRepository.get(connection.id, 'allegro.orders.lastEventId');
       expect(cursor).toBeDefined();
       expect(cursor).not.toBeNull();
+    });
+
+    // #2284 — AC 4: a cancellation landing between ingestion and the sync job
+    // must withhold destination provisioning entirely.
+    it('should not create a destination order when the source cancelled it first', async () => {
+      const connection = await createTestConnection(dataSource, {
+        platformType: 'allegro',
+        status: 'active',
+        credentialsRef: 'test-credentials-ref',
+        adapterKey: 'allegro.publicapi.v1',
+      });
+
+      const product = new ProductOrmEntity();
+      product.id = 'ol_product_cancel_1';
+      product.name = 'Test Product';
+      await dataSource.getRepository(ProductOrmEntity).save(product);
+
+      const variant = new ProductVariantOrmEntity();
+      variant.id = 'ol_variant_cancel_1';
+      variant.productId = product.id;
+      await dataSource.getRepository(ProductVariantOrmEntity).save(variant);
+
+      await identifierMapping.createMapping('Offer', 'offer-1', connection.id, variant.id);
+
+      // Pre-resolve the internal order id the ingestion path will land on, then
+      // seed a record already cancelled at source — the window this closes.
+      const internalOrderId = await identifierMapping.getOrCreateInternalId(
+        CORE_ENTITY_TYPE.Order,
+        'checkout-form-001',
+        connection.id
+      );
+
+      const cancelledAt = new Date('2026-08-01T10:00:00.000Z');
+      const recordRepo = dataSource.getRepository(OrderRecordOrmEntity);
+      const record = recordRepo.create({
+        internalOrderId,
+        customerId: null,
+        sourceConnectionId: connection.id,
+        sourceEventId: null,
+        orderSnapshot: {},
+        syncStatus: [],
+        syncAttempts: [],
+        recordStatus: 'ready',
+        cancelledAt,
+      });
+      await recordRepo.save(record);
+
+      const orderSyncPersisted = await jobRepository.createIfNotExistsByIdempotencyKey({
+        jobType: 'marketplace.order.sync',
+        connectionId: connection.id,
+        payload: {
+          schemaVersion: 1,
+          externalOrderId: 'checkout-form-001',
+          sourceEventId: 'event-001',
+        },
+        idempotencyKey: `test-order-sync-cancelled-${randomUUID()}`,
+        maxAttempts: 10,
+      });
+
+      const {
+        MarketplaceOrderSyncHandler,
+      } = require('../../src/sync/handlers/marketplace-order-sync.handler');
+      const orderSyncHandler = harness.get(MarketplaceOrderSyncHandler);
+      await orderSyncHandler.execute(orderSyncPersisted);
+
+      // No destination order was created, and no destination mapping was written.
+      expect(mockOrderProcessor.createOrder).not.toHaveBeenCalled();
+      const orderMappings = await identifierMapping.getExternalIds(
+        CORE_ENTITY_TYPE.Order,
+        internalOrderId
+      );
+      expect(orderMappings.some((m) => m.connectionId === 'dest-prestashop-1')).toBe(false);
+
+      // The skip is visible per destination, terminal, and carries its reason.
+      const persisted = await recordRepo.findOne({ where: { internalOrderId } });
+      expect(persisted?.cancelledAt).not.toBeNull();
+      expect(persisted?.syncStatus).toEqual([
+        expect.objectContaining({
+          destinationConnectionId: 'dest-prestashop-1',
+          status: 'skipped_cancelled',
+          error: 'Order cancelled at source before destination create',
+        }),
+      ]);
     });
 
     it('should handle cursor persistence correctly', async () => {

--- a/docs/architecture/adrs/052-independently-assignable-fulfillment-authorities.md
+++ b/docs/architecture/adrs/052-independently-assignable-fulfillment-authorities.md
@@ -22,7 +22,11 @@ handshake — never "who owns the Order".
 location), sourcing/routing (per order, configured per channel), fulfillment execution (per work
 object, by handshake), order lifecycle (per order, as fact producer), returns disposition (per
 return), refund trigger (per payment instrument, **never assignable away from OL**) — with
-invoicing/fiscalization integrated as already resolved by [ADR-041](./041-sales-document-routing-policy.md).
+invoicing/fiscalization integrated as already resolved by [ADR-041](./041-sales-document-routing-policy.md),
+whose router is shipped code, not a proposal: `AutoIssueTriggerService` consults the
+`evaluateSalesDocumentRules` rule engine first and falls back to `resolveSalesDocumentRouting`
+(which carries #2047's single-candidate and operator-primary rules) only where no country
+configuration exists.
 Each authority's default holder is **today's shipped behaviour, reachable with zero config**; each
 conflict resolves to **inert-and-reported ambiguity** (the #2047 rule: an unrouted order is
 recoverable, a double-shipped one is not). The two postures ship as two named **presets** writing
@@ -59,6 +63,6 @@ at all — re-opens the matrix decision.
 
 ## References
 
-- Related issues: #1032, #2047
+- Related issues: #1032, #2047, #2161 (ADR-041's router shipped — A7 is built, not proposed)
 - Related ADRs: [ADR-041](./041-sales-document-routing-policy.md), [ADR-044](./044-order-changeset-proposed-then-confirmed.md), [ADR-053](./053-fulfillment-authority-vocabulary-leaf.md), [ADR-057](./057-adr-017-authoritative-reingestion-amendment.md)
 - Design doc: [DESIGN-oms-authority-model](../../plans/analysis/DESIGN-oms-authority-model.md)

--- a/docs/architecture/adrs/054-fulfillment-work-unit-of-assignment.md
+++ b/docs/architecture/adrs/054-fulfillment-work-unit-of-assignment.md
@@ -47,25 +47,25 @@ named routing filters/sorts and their coercer are **owned by the OL-OMS plugin**
 only `RoutingInput`/`RoutingPlan` (with a `pending {decisionId}` arm for async DOMS sourcing) /
 `RoutingExplanationStep` with opaque rule names.
 
-> **PROPOSED AMENDMENT — routing-rule storage shape (#2298; PENDING ORCHESTRATOR ADJUDICATION,
-> not adopted).** This ADR and the design (§5.3(c)) assume the ordered filter/sort list is
+> **AMENDMENT (ADOPTED 2026-08-23, #2298 adjudication) — routing-rule storage shape.** This ADR and the design (§5.3(c)) assume the ordered filter/sort list is
 > operator-authored into `Connection.config.routing` jsonb on the `stockSafetyBuffer` precedent
 > (#1844). #2161/#2170 have since shipped a closer precedent — the `sales-documents` rule engine:
 > a closed condition vocabulary, a pure caller-fed evaluator, and **rows** in
 > `sales_document_rules` / `sales_document_thresholds` / `sales_document_country_defaults` with
 > per-row effective dating and an application-computed `conditionsHash` behind a unique index.
-> The amendment would store routing rules as rows too — in the plugin's own `oms_routing_rules`
-> table, never core — for three reasons: a `RoutingExplanationStep` persisted on a
+> Routing rules **are** stored as rows too — in the plugin's own `oms_routing_rules`
+> table, never core — superseding the `Connection.config.routing` sentence in the Decision above,
+> for three reasons: a `RoutingExplanationStep` persisted on a
 > `routing_decisions` row needs a **stable rule id** to remain readable after the operator edits
 > the list; per-rule effective dating and duplicate detection already exist in the newer precedent
 > and have no jsonb equivalent; and moving to rows changes only *placement*, so H7's ruling that
 > the named filters/sorts and their coercer are owned by `@openlinker/oms` is untouched (the
 > coercer narrows an untrusted persisted `conditions` column instead of a config blob — what
-> `isSalesDocumentCondition` does today). Were it adopted it would carry its own
+> `isSalesDocumentCondition` does today). This amendment carries its own
 > *Reversal gate (prose-only):* an
 > operator-authored routing list that never needs to be cited by a persisted explanation and never
 > needs per-rule dating would return the decision to jsonb. Nothing binds until Wave 3's demand
-> gate fires; until adjudicated, the `Connection.config.routing` shape above stands as written.
+> gate fires.
 
 ## Alternatives considered
 

--- a/docs/architecture/adrs/054-fulfillment-work-unit-of-assignment.md
+++ b/docs/architecture/adrs/054-fulfillment-work-unit-of-assignment.md
@@ -47,6 +47,26 @@ named routing filters/sorts and their coercer are **owned by the OL-OMS plugin**
 only `RoutingInput`/`RoutingPlan` (with a `pending {decisionId}` arm for async DOMS sourcing) /
 `RoutingExplanationStep` with opaque rule names.
 
+> **PROPOSED AMENDMENT — routing-rule storage shape (#2298; PENDING ORCHESTRATOR ADJUDICATION,
+> not adopted).** This ADR and the design (§5.3(c)) assume the ordered filter/sort list is
+> operator-authored into `Connection.config.routing` jsonb on the `stockSafetyBuffer` precedent
+> (#1844). #2161/#2170 have since shipped a closer precedent — the `sales-documents` rule engine:
+> a closed condition vocabulary, a pure caller-fed evaluator, and **rows** in
+> `sales_document_rules` / `sales_document_thresholds` / `sales_document_country_defaults` with
+> per-row effective dating and an application-computed `conditionsHash` behind a unique index.
+> The amendment would store routing rules as rows too — in the plugin's own `oms_routing_rules`
+> table, never core — for three reasons: a `RoutingExplanationStep` persisted on a
+> `routing_decisions` row needs a **stable rule id** to remain readable after the operator edits
+> the list; per-rule effective dating and duplicate detection already exist in the newer precedent
+> and have no jsonb equivalent; and moving to rows changes only *placement*, so H7's ruling that
+> the named filters/sorts and their coercer are owned by `@openlinker/oms` is untouched (the
+> coercer narrows an untrusted persisted `conditions` column instead of a config blob — what
+> `isSalesDocumentCondition` does today). Were it adopted it would carry its own
+> *Reversal gate (prose-only):* an
+> operator-authored routing list that never needs to be cited by a persisted explanation and never
+> needs per-rule dating would return the decision to jsonb. Nothing binds until Wave 3's demand
+> gate fires; until adjudicated, the `Connection.config.routing` shape above stands as written.
+
 ## Alternatives considered
 
 - **Split the order**: structurally impossible (bijection) and manufactures a
@@ -78,6 +98,6 @@ executor needing batching re-opens the `awaiting_wave` deferral.
 
 ## References
 
-- Related issues: #1032, #1917
+- Related issues: #1032, #1917, #2170/#2298 (the proposed storage-shape amendment above)
 - Related ADRs: [ADR-007](./007-syncjob-status-vs-outcome-split.md), [ADR-012](./012-branch-1-fulfillment-modeling.md), [ADR-020](./020-neutral-delivery-intent-shipping-dispatch.md), [ADR-027](./027-order-status-writeback-capability-and-relay.md), [ADR-044](./044-order-changeset-proposed-then-confirmed.md)
 - Design doc: [DESIGN-oms-authority-model](../../plans/analysis/DESIGN-oms-authority-model.md) §5

--- a/docs/architecture/adrs/056-refund-and-fiscal-authority-never-leave-ol.md
+++ b/docs/architecture/adrs/056-refund-and-fiscal-authority-never-leave-ol.md
@@ -28,7 +28,11 @@ blocking like `pending` and cleared only by a terminal observation, so a crash b
 marketplace's 200 and the predicate write cannot double-refund; and order transitions that feed
 ADR-041's
 `AutoIssueTriggerService` exactly as OL's own ingestion does — its inputs change in posture B, its
-authority does not, and since it already reports rather than persists, no new DI edge appears.
+authority does not, and since it reports a `SalesDocumentBlockOutcome` for the caller in `orders`
+to persist rather than writing one itself, **no new `orders` edge** appears. That is the property
+`invoicing-auto-issue-boot.int-spec.ts` pins, and it survived #2156/#2173 giving that service
+three unrelated new dependencies (`integrations`, the `sales-documents` rule service, a lazy
+`ModuleRef` resolve of `IFiscalRegistrationService`).
 Where no refund executor exists (true of every shipped adapter today), the trigger confirms to
 `executedBy: 'operator_out_of_band'` — an honest description of who moves money.
 
@@ -60,6 +64,6 @@ weaker, re-opens this ADR.
 
 ## References
 
-- Related issues: #2047
+- Related issues: #2047, #2156/#2173 (the gate's new dependencies; the `orders` edge still absent)
 - Related ADRs: [ADR-041](./041-sales-document-routing-policy.md), [ADR-042](./042-fiscalization-capability.md), [ADR-052](./052-independently-assignable-fulfillment-authorities.md)
 - Design doc: [DESIGN-oms-authority-model](../../plans/analysis/DESIGN-oms-authority-model.md) §8

--- a/docs/plans/analysis/DESIGN-oms-authority-model.md
+++ b/docs/plans/analysis/DESIGN-oms-authority-model.md
@@ -15,8 +15,8 @@ the revised, demand-gated roadmap; §14 reflects the panel's story additions and
 while #2161 was an open PR; it has since merged, shipping ADR-041's router, its rule engine and
 its persistence as real code. A7's matrix row, §2.1, §5.3(c), §8, §10's automation-layer spec and
 ADRs 052/054/056 now describe that code as shipped rather than proposed, and §5.3(c) carries a
-storage-shape **recommendation** (rows over `Connection.config.routing` jsonb) whose flagged ADR
-amendment sits in ADR-054, pending adjudication. The authority matrix is unchanged: #2161
+storage-shape **decision** (rows over `Connection.config.routing` jsonb), adopted at orchestrator
+adjudication on 2026-08-23 and amending ADR-054. The authority matrix is unchanged: #2161
 implements A7's "already specified" cell.
 
 **The ask**: OpenLinker gets a state-of-the-art full OMS — multi-location inventory + ATP,
@@ -493,7 +493,7 @@ conflict and not a coin flip), **rows in dedicated tables** (`sales_document_rul
 closed vocabulary, pure evaluator, rows, composer — and `RoutingExplanationStep` is the routing
 counterpart of the engine's reported `unresolved` reason.
 
-**RECOMMENDATION (adopt/differ, pending adjudication) — storage shape: rows, not
+**DECISION (adopted 2026-08-23, #2298 adjudication) — storage shape: rows, not
 `Connection.config.routing` jsonb; in the plugin's own table, not core.** The design previously argued jsonb from the `stockSafetyBuffer` precedent
 (#1844); the newer precedent is the closer analogue and supersedes it, because `stockSafetyBuffer`
 is a single scalar while a routing ruleset is an ordered, individually-addressable, individually-
@@ -512,9 +512,9 @@ coercer leave core survives intact, and core still keeps only `RoutingInput` / `
 narrowing an untrusted persisted `conditions` column, which is what
 `isSalesDocumentCondition` does today.
 
-*This is a **recommendation pending orchestrator adjudication**, not an applied change*: it
-touches ADR-054's reversal
-gate, and the flagged amendment paragraph lives there. Nothing binds until Wave 3's demand gate
+*Adopted at orchestrator adjudication (2026-08-23)*: the amendment it flagged on ADR-054 —
+which supersedes that ADR's `Connection.config.routing` sentence and carries its own active
+reversal gate — is adopted there. Nothing binds until Wave 3's demand gate
 fires (§10).
 
 **Exactly one router per order** — the #2047 four-part copy, verbatim shape: pure

--- a/docs/plans/analysis/DESIGN-oms-authority-model.md
+++ b/docs/plans/analysis/DESIGN-oms-authority-model.md
@@ -11,6 +11,14 @@ conformance, distributed correctness, product value, plugin contracts, delivery 
 adjudication record is [REVIEW-oms-authority-model.md](./REVIEW-oms-authority-model.md). §10 is
 the revised, demand-gated roadmap; §14 reflects the panel's story additions and cuts.
 
+**Revision R2 (2026-08-23, #2298)**: freshness pass only — no architectural change. R1 was written
+while #2161 was an open PR; it has since merged, shipping ADR-041's router, its rule engine and
+its persistence as real code. A7's matrix row, §2.1, §5.3(c), §8, §10's automation-layer spec and
+ADRs 052/054/056 now describe that code as shipped rather than proposed, and §5.3(c) carries a
+storage-shape **recommendation** (rows over `Connection.config.routing` jsonb) whose flagged ADR
+amendment sits in ADR-054, pending adjudication. The authority matrix is unchanged: #2161
+implements A7's "already specified" cell.
+
 **The ask**: OpenLinker gets a state-of-the-art full OMS — multi-location inventory + ATP,
 sourcing/routing + fulfillment execution, an OL-owned order lifecycle, returns/RMA — implemented as
 a **first-party plugin** behind neutral capability ports, so that a **third-party OMS** can plug
@@ -96,7 +104,7 @@ reuses the four separable parts of the shipped #2047 shape:
 | A4 | **Order lifecycle** | per **order**, by fact class | OL derives (default); external OMS as **fact producer** | OL derives from its own persisted facts | Facts are recorded at their own grain with their producer; conflicting facts are **both kept**, the projection resolves by precedence, disagreement is displayed | (4) only |
 | A5 | **Returns disposition** | per **return**, configured per **channel** | OL-OMS, external OMS, the marketplace itself (Allegro decides, OL records) | OL's own `ReturnDispositionService` (once returns exist; today: none) | One per return; a second enabled `ReturnsAuthority` connection is `ambiguous` → no automated disposition, reason persisted on the return and surfaced — inert, per the matrix rule (R1: boot-failure clause retired) | (1)+(4) |
 | A6 | **Refund trigger** | per **payment instrument** = per source connection | **OL only** | OL, manual | **Never assignable away** — the OMS *requests*, OL executes or refuses with a persisted reason | (3) — per-order lock + attempted-predicate, the `blocksIssuanceElsewhere` shape |
-| A7 | **Invoicing / fiscalization** | per order, one originating document | ADR-041's resolved connection | #2047 selection, unchanged | Already specified | (1)(2)(3)(4) — the source of the shape |
+| A7 | **Invoicing / fiscalization** | per order, one originating document | ADR-041's resolved connection | Shipped and unchanged by this design (#2161): the rule engine (`evaluateSalesDocumentRules`) first, `resolveSalesDocumentRouting` — carrying #2047's single-candidate/operator-primary rules — as the fallback | Already specified | (1)(2)(3)(4) — the source of the shape |
 
 Three properties are load-bearing:
 
@@ -120,8 +128,9 @@ sibling-context value edges**, not framework-freedom — see ADR-053), pinned by
 spec. It publishes `AuthorityKind`, `AuthorityScope` (discriminated
 union: global / location / channel / order / work), `AuthorityAssignment`, the generic
 `selectAuthorityHolder()` (the pure generalisation of `selectPrimaryInvoicingConnection`, including
-its single-candidate rule), `parseAuthorityConfig()`, and `FulfillmentAuthorityBlockOutcome` with
-its reason unions.
+its single-candidate rule — a rule the shipped `resolveSalesDocumentRouting` already mirrors
+verbatim, so the generalisation has two consumers to keep honest, not one), `parseAuthorityConfig()`,
+and `FulfillmentAuthorityBlockOutcome` with its reason unions.
 
 **Resolution lives where the write lives** — A1 in `inventory`, A2/A3 in the new `fulfillment`
 context, A4 in the projection itself, A5 in `returns`, A6 in `orders`. A single `oms-policy`
@@ -206,7 +215,10 @@ diverged, these rulings apply throughout this document:
    routing-rule rows, pick-list state, wave state later).
 7. **Two vocabulary leaves, not one.** `fulfillment-authority` (authority vocabulary) and
    `order-lifecycle` (phase/hold/amendment vocabulary) are separate concerns, each following the
-   `sales-documents` leaf pattern. Merging them would couple two unrelated release cadences.
+   `sales-documents` leaf pattern — in its post-#2170 reading (ADR-053): what each leaf copies is
+   the **zero sibling-context value edge**, not framework-freedom, which `sales-documents` itself
+   gave up when the rule engine landed it a module, repositories and a tokens file. Merging them
+   would couple two unrelated release cadences.
 8. **Returns' restock into an OL-owned book routes through the OMS plugin's own
    `InventoryMaster` `adjustInventory` implementation** — the QC bucket flow
    (`received → quality_control → available`) is deferred with the `inspected` custody state; v1/v2
@@ -456,15 +468,54 @@ records that nothing planned produces a dry-run; `evaluate()` closes that, and
 here" answer commercial DOMSes rarely show. It never mints an internal id (operates on ingested
 orders only). **(c) Rules are a closed set of named filters + sorts, not a rules engine** —
 `method-capable`, `in-stock`, `country-served`, `not-blocked-by-reject`; sorts `priority`,
-`nearest`, `most-complete`, `least-splits`; sequenced by an operator-authored ordered list in
-`Connection.config.routing` (pure coercer, the `stockSafetyBuffer` precedent), with `afterAction:
+`nearest`, `most-complete`, `least-splits`; sequenced by an operator-authored ordered list (storage
+shape: see the rule-engine precedent below), with `afterAction:
 line-split | quantity-split | no-split` declared on the rule. **The named filters/sorts and
 their coercer are owned by `@openlinker/oms`** — they configure OL's own router and
 bind no vendor; core keeps only what crosses the port (`RoutingInput`, `RoutingPlan`,
 `RoutingExplanationStep`, whose rule names are opaque strings with display labels so a vendor's
 own names render). `RoutingPlan` carries a third arm, `pending {decisionId}`, for genuinely
-asynchronous DOMS sourcing (R1). ANALYSIS-1032 cut Wave 3's rules
-engine on evidence; filters+sorts is the smaller true shape.
+asynchronous DOMS sourcing (R1). ANALYSIS-1032 cut Wave 3's *routing* rules
+engine on evidence; filters+sorts is the smaller true shape — a cut about
+routing's decision vocabulary, not about rule layers in general, which is why the shipped
+sales-document engine below is precedent for the *mechanics* without reopening it.
+
+**The house pattern for an operator-authored rule layer now exists in shipped code, and this
+design mirrors it (#2161/#2170).** The `sales-documents` rule engine is the repo's one worked
+example of exactly this problem: a **closed** condition vocabulary
+(`SalesDocumentConditionFieldValues`, a discriminated union per field, no arbitrary predicates and
+no country literals), a **pure evaluator** with the caller loading every fact it needs
+(`evaluateSalesDocumentRules` — no I/O, `now` passed in, ambiguity resolving `unresolved` rather
+than to a silent winner, and *no priority field*, so two rules matching one order is a reported
+conflict and not a coin flip), **rows in dedicated tables** (`sales_document_rules` +
+`sales_document_thresholds` + `sales_document_country_defaults`), and a **FE composer dialog**
+(`SalesDocumentRuleComposerDialog`) over that shape. Routing's filters+sorts should copy all four —
+closed vocabulary, pure evaluator, rows, composer — and `RoutingExplanationStep` is the routing
+counterpart of the engine's reported `unresolved` reason.
+
+**RECOMMENDATION (adopt/differ, pending adjudication) — storage shape: rows, not
+`Connection.config.routing` jsonb; in the plugin's own table, not core.** The design previously argued jsonb from the `stockSafetyBuffer` precedent
+(#1844); the newer precedent is the closer analogue and supersedes it, because `stockSafetyBuffer`
+is a single scalar while a routing ruleset is an ordered, individually-addressable, individually-
+dated collection. Three reasons decide it. (1) **Rule identity has to be citable.** The
+`routing_decisions` intent row and its `RoutingExplanationStep[]` persist *why* an order went where
+it did; an array inside a config blob has no stable id, so an explanation written today becomes
+unreadable the moment the operator reorders or edits the list — `sales_document_rules` carries a
+uuid PK for precisely this. (2) **Effective dating and conflict detection are already solved
+once.** #2170 ships per-row `effectiveFrom`/`effectiveTo` filtering and an application-computed
+`conditionsHash` behind a unique index; `Connection.config` jsonb has neither history nor any
+uniqueness surface to guard a duplicate rule with. (3) **This changes placement, not ownership.**
+Adjudication #6 already assigns the plugin's private working state to `oms_*` tables, so the table
+is `oms_routing_rules` in `@openlinker/oms` — H7's ruling that the named filters/sorts and their
+coercer leave core survives intact, and core still keeps only `RoutingInput` / `RoutingPlan` /
+`RoutingExplanationStep`. The coercer does not disappear: it moves from parsing a config blob to
+narrowing an untrusted persisted `conditions` column, which is what
+`isSalesDocumentCondition` does today.
+
+*This is a **recommendation pending orchestrator adjudication**, not an applied change*: it
+touches ADR-054's reversal
+gate, and the flagged amendment paragraph lives there. Nothing binds until Wave 3's demand gate
+fires (§10).
 
 **Exactly one router per order** — the #2047 four-part copy, verbatim shape: pure
 `selectPrimaryFulfillmentRouter` (`none` = run today's path; `ambiguous` does nothing and persists
@@ -573,8 +624,10 @@ authors and derives the phase, which is the distinction the revert was reaching 
 
 ### 6.2 Vocabulary (the revert's second demand, supplied)
 
-In a new dependency-free leaf `libs/core/src/order-lifecycle/` (the `sales-documents` pattern:
-types + pure guards, zero outbound imports, no tokens file, pinned by barrel-purity):
+In a new dependency-free leaf `libs/core/src/order-lifecycle/` (the `sales-documents` pattern in
+its post-#2170 reading, ADR-053: types + pure guards, zero outbound sibling-context value edges,
+pinned by barrel-purity — the no-tokens-file posture is the *starting* one and ends the day the
+concern needs a binding, exactly as `sales-documents`' did):
 
 **`OrderLifecyclePhase`** — nine values, derived, precedence highest-wins, mirrored FE + SQL with a
 mirror-check script: `cancelled` (1: cancel wins over everything, a cancel-after-dispatch shows the
@@ -813,8 +866,10 @@ OL's A6 guard executes or refuses with a persisted reason — the attempted-pred
 boundary (R1: the ordering that makes the invoicing guard safe, restated rather than inherited by
 analogy), so a crash cannot double-refund (unexecuted is recoverable; a double refund is not) —
 and order transitions that feed ADR-041's `AutoIssueTriggerService` exactly as OL's own
-ingestion does today (its inputs change; its authority does not; it already reports rather than
-persists, so no new DI edge). The problem with no vendor precedent has a clean answer under the
+ingestion does today (its inputs change; its authority does not; it reports a
+`SalesDocumentBlockOutcome` and the caller in `orders` persists it, so **no new `orders` edge**
+appears — the precise property `invoicing-auto-issue-boot.int-spec.ts` pins, and the one that
+survived #2156/#2173 adding this service three unrelated dependencies). The problem with no vendor precedent has a clean answer under the
 matrix and none under any order-ownership model — the strongest single piece of evidence for the
 design.
 
@@ -996,8 +1051,12 @@ claim, shortfall surfacing, ADR-028 ordering); returns custody + the `adjustInve
 flow from the buyer refund, and the PL-specific story that makes the returns module read as
 complete); **automation layer v1** — a small **closed** set of triggers OL already owns (phase
 held N days, hold placed, work short-picked, dispatch deadline within X) × actions OL already
-ships (issue invoice, dispatch label, relay status, email buyer). The automation layer is the
-sellable product layer above the phase; the phase is plumbing.
+ships (issue invoice, dispatch label, relay status, email buyer), built on the **shipped
+`sales-documents` rule engine as the house pattern** (#2161/#2170 — closed condition vocabulary,
+pure evaluator with caller-loaded facts and no priority tie-break, rows in dedicated tables, a
+composer dialog over them; see §5.3(c) for the four properties and the storage-shape decision that
+follows from them). The automation layer is the sellable product layer above the phase; the phase
+is plumbing.
 
 **Wave 3 — routing + execution + the OL-OMS plugin** — **GATED on a fired demand trigger** (a
 live 2+-location deployment in pain; a no-shop/WMS seller; a late-penalty case): 3a — router +

--- a/docs/plans/analysis/REVIEW-oms-authority-model.md
+++ b/docs/plans/analysis/REVIEW-oms-authority-model.md
@@ -8,6 +8,18 @@ adjudicated by the orchestrating reviewer. This file is the adjudication record;
 ADRs have been amended per the ACCEPT verdicts below (Revision R1), with the larger restructurings
 recorded as directives in §6.
 
+**Post-merge verification (2026-08-23, #2298).** This record was produced while #2161 was an open
+PR. Every code claim in it was re-checked against the merged tree and stands: H8b's count is
+verified again (`CoreCapabilityValues` in `libs/core/src/integrations/domain/types/adapter.types.ts`
+has **9** members, so the design's 9→13 holds), and the #2047 precedent both the hexagonal and
+correctness panels lean on survives — `selectPrimaryInvoicingConnection` still exists in
+`invoicing`, and the shipped `resolveSalesDocumentRouting` mirrors its single-candidate and
+operator-primary rules rather than replacing them. This record carries no `file:line` citations by
+construction (symbol and path references only), so nothing here needed re-pointing. One panel
+finding gains shipped precedent rather than changing verdict: **P1**'s closed trigger×action
+automation layer now has a house pattern to copy in the `sales-documents` rule engine (#2170) —
+recorded in the design at §5.3(c) and §10, not re-adjudicated here.
+
 ---
 
 ## 1. Panel verdicts, and the synthesis

--- a/docs/plans/analysis/SPIKE-2289-allegro-returns-feed.md
+++ b/docs/plans/analysis/SPIKE-2289-allegro-returns-feed.md
@@ -1,0 +1,158 @@
+# Spike #2289 — Allegro customer-returns: is the feed cursor/watermark-pollable?
+
+Desk research only. Sources of record: the official OpenAPI spec at
+`https://developer.allegro.pl/swagger.yaml` (fetched 2026-08-22; paths `/order/customer-returns`,
+`/order/customer-returns/{customerReturnId}`), the order-handling tutorial, and one Allegro-staff
+answer on `allegro/allegro-api`.
+
+## Verdict — 4A, qualified
+
+The kill condition for 4A is "the feed is neither cursor- nor watermark-pollable with acceptable
+stability". It is not met. `GET /order/customer-returns` ships a first-class, vendor-documented
+cursor — `from`, "The ID of the last seen customer return. Customer returns created after the given
+customer return will be returned" ([swagger.yaml](https://developer.allegro.pl/swagger.yaml)) — and
+Allegro staff state that returns are held in indexing order, that remembering the last id and
+passing it as `from` is the intended way to synchronise a local copy, and that under that usage
+"there is no risk that any returns will be missed"
+([allegro/allegro-api#5550](https://github.com/allegro/allegro-api/issues/5550)). That is the same
+shape `AllegroOrderSourceAdapter` already uses for `/order/events`, so it maps onto the existing
+poll/sync job model without inventing a mechanism. A `createdAt.gte`/`createdAt.lte` date watermark
+exists alongside it as a repair axis.
+
+The qualification is load-bearing and must reach the issue, not just this file: the cursor covers
+DISCOVERY, not LIFECYCLE. `CustomerReturn` carries `createdAt` and no `updatedAt`, and `from` is
+defined over creation, so a return that moves `CREATED -> DELIVERED -> FINISHED` after the cursor
+passed it is invisible to the cursor forever. There is also no returns entry in the order event
+journal — `/order/events` `type` is exactly `BOUGHT | FILLED_IN | READY_FOR_PROCESSING |
+BUYER_CANCELLED | FULFILLMENT_STATUS_CHANGED | AUTO_CANCELLED` — which independently kills 4B as a
+SOURCE: an order-sync projection cannot observe an Allegro return at all. So 4A is the only path
+that yields data, and it needs two passes: a cursor sweep for new returns plus a bounded re-read of
+non-terminal ones for status.
+
+## Evidence
+
+Unless noted, the source is the official spec, [developer.allegro.pl/swagger.yaml](https://developer.allegro.pl/swagger.yaml).
+
+| # | Fact | Source |
+|---|---|---|
+| E1 | `GET /order/customer-returns` exists, marked `[BETA]`, media type `application/vnd.allegro.beta.v1+json`, scope `allegro:api:orders:read` | swagger.yaml |
+| E2 | `from` = "The ID of the last seen customer return. Customer returns created after the given customer return will be returned." | swagger.yaml |
+| E3 | Returns are stored in indexing order (usually == buyer creation order); `from`-based sync is the documented incremental method and misses nothing | [allegro-api#5550](https://github.com/allegro/allegro-api/issues/5550) |
+| E4 | `createdAt.gte` / `createdAt.lte` ISO-8601 filters exist — a date watermark is available as a fallback/repair axis | swagger.yaml |
+| E5 | `limit` 1..1000 (default 100), `offset` >= 0 (default 0); response is `{count, customerReturns[]}` | swagger.yaml |
+| E6 | Deep offsets are unsafe in practice: `offset=20000&limit=1000` returned HTTP 504; the same reporter saw creation dates out of sequence across pages | [allegro-api#5550](https://github.com/allegro/allegro-api/issues/5550) |
+| E7 | No `updatedAt` / `modifiedAt` anywhere on `CustomerReturn` | swagger.yaml |
+| E8 | `/order/events` carries no return event type | swagger.yaml |
+| E9 | Rate limit stated in the endpoint description: 25 req/s per user, 50 req/s per clientId | swagger.yaml |
+| E10 | `GET /order/customer-returns/{customerReturnId}` exists (single read by id) | swagger.yaml |
+| E11 | `status` is filterable as a query param, same 11-value vocabulary as the payload | swagger.yaml |
+| E12 | `status` was added to the payload after the resource shipped; the announcement gives no change-detection guidance | [news: status zwrotu](https://developer.allegro.pl/news/zwroty-klienckie-dodalismy-informacje-o-statusie-zwrotu-9gzwkO7ebuk) |
+| E13 | Return REASON vocabulary is still being extended by Allegro (new reasons announced for 04 Nov 2025) — treat as open-world | [news: nowe powody zwrotu](https://developer.allegro.pl/news/zwroty-klienckie-4-listopada-2025-dodamy-nowe-powody-zwrotu-k1bKmlMWkIy) |
+| E14 | Tutorial section "how to retrieve customer returns list" documents `from` as "the identifier of the most recently retrieved return" and states no ordering guarantee of its own | [process-orders tutorial](https://developer.allegro.pl/tutorials/process-orders-PgPMlWDr8Cv) |
+
+## API surface summary
+
+**List** — `GET /order/customer-returns`
+Accept `application/vnd.allegro.beta.v1+json`; scope `allegro:api:orders:read`.
+
+Query params (all optional; `string` unless noted):
+`customerReturnId`, `orderId`, `buyer.email`, `buyer.login`, `items.offerId`, `items.name`,
+`parcels.waybill`, `parcels.transportingWaybill`, `parcels.carrierId`,
+`parcels.transportingCarrierId`, `parcels.sender.phoneNumber`, `referenceNumber`,
+**`from`** (cursor — last seen return id), **`createdAt.gte`**, **`createdAt.lte`**,
+`marketplaceId`, `status`, `limit` (int 1-1000, default 100), `offset` (int, default 0);
+header `Accept-Language`.
+
+**Single** — `GET /order/customer-returns/{customerReturnId}`
+**Write** — `POST /order/customer-returns/{customerReturnId}/rejection` (reject refund; out of scope here)
+
+Payload sketch (`CustomerReturn`):
+
+```
+id                string (uuid)          # this is the value passed to `from`
+orderId           string (uuid)          # == checkout-form id -> joins OL's Order mapping
+referenceNumber   string                 # e.g. '1234/Z04A'
+createdAt         date-time              # the ONLY timestamp on the aggregate
+status            CREATED | DISPATCHED | IN_TRANSIT | DELIVERED | FINISHED | FINISHED_APT
+                  | REJECTED | COMMISSION_REFUND_CLAIMED | COMMISSION_REFUNDED
+                  | WAREHOUSE_DELIVERED | WAREHOUSE_VERIFICATION
+isFulfillment     boolean                # handled by One Fulfillment
+marketplaceId     string                 # e.g. 'allegro-pl'
+buyer             { email, login }
+items[]           { offerId, quantity:int64, name, price, url,
+                    reason:{ type, userComment }, serialNumbers[] }
+refund            { bankAccount }        # present only for COD / transfer / Allegro Pay
+parcels[]         { createdAt, waybill, transportingWaybill?, carrierId,
+                    transportingCarrierId?, sender }
+rejection         { code, reason, createdAt }
+                  # code in REFUND_REJECTED | NEW_ITEM_SENT | ITEM_FIXED | MISSING_PART_SENT
+                  #         | ITEM_MISMATCH | BUSINESS_PURCHASE | NO_RETURN_RIGHT
+```
+
+Two shape notes that bear on the neutral contract:
+
+- **Line items key on `offerId`** — not on an order-line id, not on a barcode/SKU, and with no
+  reference back to a specific order line. Attributing a returned quantity to an OL
+  `ProductVariant` therefore goes `offerId -> Offer mapping -> variant`. A multi-variant
+  auto-grouped listing (#824) puts one `offerId` per variant, so that resolves; an unmapped offer
+  yields an ORPHANED return, which 4A must handle just as 4B was scoped to.
+- **`items[].reason.type` is prose, not an OpenAPI `enum`** (E13 shows the list is still growing).
+  Model it open-world (raw string passthrough), never a closed union.
+
+## Open risks — flagged, not guessed
+
+1. **`from` + filter composition is undocumented.** Whether `from` may be combined with `status` or
+   `createdAt.gte` in one request — and if so whether the cursor applies before or after the filter
+   — is stated nowhere. Must be settled live before a `status=`-filtered sweep is designed.
+2. **`from` is defined over CREATION, but staff describe INDEXING order,** and say the two "usually"
+   coincide (E2 vs E3) — an explicit hedge. Whether a late-indexed old return can be stepped over by
+   a cursor already past its creation position is unresolved. The `createdAt.gte` repair sweep below
+   exists for exactly this.
+3. **No documented total-order guarantee, plus one field report of out-of-sequence pages (E6).** The
+   report is offset-paged, so it may be an artefact of `offset` rather than of `from`. Unverified.
+4. **Deep `offset` is a live 504 risk (E6)** and bootstrapping a large seller's history is precisely
+   the deep-offset case.
+5. **Status transitions have no watermark at all (E7/E8).** The cost of the re-read sweep is a
+   function of open-return count, which the docs cannot bound.
+6. **Sandbox coverage unverified.** The spec is environment-neutral and nothing states whether
+   `[BETA]` returns are populated in `sandbox.allegro.pl`. Creating a BUYER-initiated return in
+   sandbox may not be possible at all — the single biggest risk to writing integration tests for
+   4A, and not answerable from docs.
+7. **`[BETA]` media type** `application/vnd.allegro.beta.v1+json` may change without the usual
+   deprecation ladder. Acceptable, but the shape must not be treated as frozen.
+8. **`count` semantics unstated** (total matching vs. page size). Do not drive termination off it;
+   terminate on an empty `customerReturns[]`.
+
+## Recommended cursor semantics (4A)
+
+Two passes, two cursors, deliberately separate — the split OL already draws between
+`master.product.syncAll` (enumeration) and `master.product.reconcile` (state re-check).
+
+**Pass 1 — discovery** (`marketplace.returns.poll`)
+- Cursor key `allegro.customerReturns.lastReturnId`, per connection; value = `CustomerReturn.id` of
+  the last item of the last FULLY-processed page. Scalar and opaque — the shape
+  `OrderSourcePort.listOrderFeed` already uses.
+- Request `GET /order/customer-returns?from={cursor}&limit=100`, paging until the array is empty.
+- **Advance only after every item on the page was persisted/enqueued** (the #2218 rule): a partial
+  failure holds the cursor and retries the page. Re-reading is free because the downstream write is
+  an idempotent upsert keyed on `CustomerReturn.id`.
+- A missing cursor means FIRST RUN, never "since the epoch" via a bare unbounded call.
+
+**Bootstrap / repair.** Walk `createdAt.gte` + `createdAt.lte` windows oldest-first (7-day windows,
+`limit=1000`), never deep `offset` (risk 4). The same mechanism is the repair path for risk 2: a
+periodic overlapped re-sweep at `createdAt.gte = now - 7d` catches anything the id cursor stepped
+over. **Overlap window 7 days, configurable** — deliberately generous, because a missed return is an
+unrefunded buyer while an overlap is an idempotent no-op upsert.
+
+**Pass 2 — lifecycle** (`marketplace.returns.statusSync`), the counterpart to
+`marketplace.offer.statusSync` (#816) and for the same reason: no change feed exists, so OL must
+re-read. Enumerate OL's own return records whose status is NOT terminal — treat `FINISHED`,
+`FINISHED_APT`, `REJECTED`, `COMMISSION_REFUNDED` as terminal and everything else as open — budgeted
+and rolling-scan-cursored via `runBoundedSweep`, re-reading each through
+`GET /order/customer-returns/{id}` (E10). Prefer that over a `status=`-filtered list until risk 1 is
+settled live. Budget against 25 req/s per user (E9), which is generous; the binding constraint is
+OL's own lane accounting (ADR-050), not Allegro's quota.
+
+**Verify live before implementation** (one ~30-minute spike): risks 1, 3 and 6. If 6 comes back
+negative, 4A still stands but its test strategy becomes fixture-driven against recorded production
+payloads — which should be said in the issue rather than discovered mid-wave.

--- a/docs/plans/oms-progress-ledger.md
+++ b/docs/plans/oms-progress-ledger.md
@@ -37,12 +37,12 @@ Legend: ☐ not started · ◐ plan in review · ◑ implementing · ◕ diff in
 | Issue | Subject | Status |
 |---|---|---|
 | #2282 | persistOrder source-attribution immutability | ☑ merged b91088599 (commit a5f59a370; reviewed, approved) |
-| #2283 | ingestion line-diff + `amended` fact | ◐ plan agent running (lands AFTER #2286-style case arms; both prerequisites merged) |
+| #2283 | ingestion line-diff + `amended` fact | ◑ implementing (READY; ANALYSIS-2283; scope = internal fact only, no union member; migration 1841000000000) |
 | #2284 | `WHERE cancelledAt IS NULL` provisioning predicate | ☑ merged 4587122c9 (commit 99ab27462; reviewed, approved) |
-| #2285 | `inv:{hash}` idempotency-key swap | ◕ diff in review (gates green, committing) |
+| #2285 | `inv:{hash}` idempotency-key swap | ☑ merged 641e07bad (commit 97dfdf1d0; reviewed, approved) |
 | #2286 | `never`-default exhaustiveness (5 consumers) | ☑ merged 9b48585b4 (commit 885b63f9e; reviewed, approved) |
-| #2287 | `packedAt` BE | ◑ implementing (READY; ANALYSIS-2287; migration 1840000000000 reserved) |
-| #2288 | `packedAt` FE | ◐ planned (plan-2288; audit running; blocked on #2287) |
+| #2287 | `packedAt` BE | ☑ merged b6b06df76 (commit 943e0fa91; reviewed, approved) |
+| #2288 | `packedAt` FE | ⛔ gate-cleared (ANALYSIS-2288: control OUT of capability-gated panel, orders:write); queued behind #2283 merge (shared timeline files) |
 | #2289 | Allegro returns-feed spike → 1c fork | ☑ verdict 4A (two-pass); findings on branch + issue comment |
 
 ### Wave 1a (epic #2312) — gated on #2284 #2286 #2283 merged; #2298 resolved

--- a/docs/plans/oms-progress-ledger.md
+++ b/docs/plans/oms-progress-ledger.md
@@ -7,10 +7,14 @@ and commit it with the work.
 
 ## Owner decisions (2026-08-22, binding)
 
-1. **Integration model**: one long-lived feature branch; per-issue work happens on short issue
-   branches off it; the orchestrator merges them back after review. At each wave boundary run
-   `/pr-review` over the wave's accumulated diff, apply all findings, then continue. PRs to `main`
-   at wave boundaries; owner merges those.
+1. **Integration model (amended 2026-08-23 — stacked waves)**: per-issue work happens on short
+   issue branches off the current wave branch; the orchestrator merges them back after review. At
+   each wave boundary run `/pr-review` over the wave's accumulated diff, apply all findings, open
+   the wave PR to `main` (owner merges) — and IMMEDIATELY branch the next wave's long-lived branch
+   off the reviewed wave tip (`oms-programme-waves-0-2` carries Wave 0; then `oms-programme-wave-1`
+   off it; then `oms-programme-wave-2` off Wave 1) and continue the loop there without waiting for
+   the PR merge. When an earlier wave's PR merges to main, merge `origin/main` forward into the
+   active wave branch.
 2. **Spec §8 Q1 = YES** — automation v1 is in scope (W2-21…W2-29 stay).
 3. **Severity rule (spec §4.3 ambiguity)**: decision-table row carries the fact's severity (red
    where nothing decides); the attention card is **always amber** (it is a to-do list). Fold into
@@ -42,10 +46,12 @@ Legend: ☐ not started · ◐ plan in review · ◑ implementing · ◕ diff in
 | #2285 | `inv:{hash}` idempotency-key swap | ☑ merged 641e07bad (commit 97dfdf1d0; reviewed, approved) |
 | #2286 | `never`-default exhaustiveness (5 consumers) | ☑ merged 9b48585b4 (commit 885b63f9e; reviewed, approved) |
 | #2287 | `packedAt` BE | ☑ merged b6b06df76 (commit 943e0fa91; reviewed, approved) |
-| #2288 | `packedAt` FE | ⛔ gate-cleared (ANALYSIS-2288: control OUT of capability-gated panel, orders:write); queued behind #2283 merge (shared timeline files) |
+| #2288 | `packedAt` FE | ☑ committed 8a2567199 directly on the wave branch (reviewed, approved; agent lost worktree isolation across sleep-resumes — work verified additive + green) |
+
+**WAVE 0 COMPLETE (8/8).** Boundary: /pr-review sweep → findings applied → PR to main → `oms-programme-wave-1` branched off the reviewed tip (owner decision 1, amended).
 | #2289 | Allegro returns-feed spike → 1c fork | ☑ verdict 4A (two-pass); findings on branch + issue comment |
 
-### Wave 1a (epic #2312) — gated on #2284 #2286 #2283 merged; #2298 resolved
+### Wave 1a (epic #2312) — gated on #2284 #2286 #2283 merged (✓ all on branch); #2298 resolved (✓ merged 1373784cd: R2 freshness pass + ADOPTED ADR-054 storage amendment — routing rules are ROWS in the plugin's `oms_routing_rules`, never `Connection.config.routing` jsonb; design artifact re-synced)
 ### Wave 1b (epic #2326) — gated on #2285 merged; W1a-8 (#2308)
 ### Wave 1c (epic #2337) — gated on #2289 fork decided; Wave 1a
 ### Wave 2 (epic #2389) — gated per its epic body; §8 Q1 = YES (decision 2 above)

--- a/docs/plans/oms-progress-ledger.md
+++ b/docs/plans/oms-progress-ledger.md
@@ -1,0 +1,67 @@
+# OMS Programme Execution Ledger — Waves 0 → 2
+
+**Branch**: `oms-programme-waves-0-2` (worktree `.claude/worktrees/oms-wave2-programme`).
+**This file is the resume point.** A session continuing the programme reads this first, then the
+wave epics (#2312 #2326 #2337 #2389) for per-issue detail. Update it after every issue completes
+and commit it with the work.
+
+## Owner decisions (2026-08-22, binding)
+
+1. **Integration model**: one long-lived feature branch; per-issue work happens on short issue
+   branches off it; the orchestrator merges them back after review. At each wave boundary run
+   `/pr-review` over the wave's accumulated diff, apply all findings, then continue. PRs to `main`
+   at wave boundaries; owner merges those.
+2. **Spec §8 Q1 = YES** — automation v1 is in scope (W2-21…W2-29 stay).
+3. **Severity rule (spec §4.3 ambiguity)**: decision-table row carries the fact's severity (red
+   where nothing decides); the attention card is **always amber** (it is a to-do list). Fold into
+   the spec when Wave-2 FE copy is first touched.
+4. **#2289 spike method**: desk research against developer.allegro.pl (no sandbox credentials).
+5. **Wave-2 FE pre-work**: #2435 (FormField single-child), #2436 (index.css token defects),
+   #2299 (Dialog barrel) are scheduled before the Wave-2 FE children that hit them.
+
+## Per-issue process (non-negotiable)
+
+read spec/design refs → `/pre-implement` → plan (Opus) → `/tech-review` plan, apply ALL findings →
+implement (Opus, on an issue branch off this branch) → quality gate (`pnpm lint && pnpm type-check
+&& pnpm test`; `test:integration` when the slice warrants; `migration:show` on schema changes) →
+`/tech-review` the diff, apply ALL findings → iterate until clean → orchestrator merges the issue
+branch here → tick this ledger + the epic checklist. Fable orchestrates/reviews only; Opus produces
+every line. Commits: `git commit -s`, `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+Migration-bearing issues use synthetic-sequential timestamps (docs/migrations.md rule 3).
+
+## Status
+
+Legend: ☐ not started · ◐ plan in review · ◑ implementing · ◕ diff in review · ☑ merged to branch · ⛔ blocked
+
+### Wave 0 (no epic)
+| Issue | Subject | Status |
+|---|---|---|
+| #2282 | persistOrder source-attribution immutability | ☐ |
+| #2283 | ingestion line-diff + `amended` fact | ☐ (after #2282 — same files) |
+| #2284 | `WHERE cancelledAt IS NULL` provisioning predicate | ◐ plan agent running |
+| #2285 | `inv:{hash}` idempotency-key swap | ◐ plan agent running |
+| #2286 | `never`-default exhaustiveness (5 consumers) | ◐ plan agent running |
+| #2287 | `packedAt` BE | ☐ |
+| #2288 | `packedAt` FE | ☐ (after #2287) |
+| #2289 | Allegro returns-feed spike → 1c fork | ◐ desk-research agent running |
+
+### Wave 1a (epic #2312) — gated on #2284 #2286 #2283 merged; #2298 resolved
+### Wave 1b (epic #2326) — gated on #2285 merged; W1a-8 (#2308)
+### Wave 1c (epic #2337) — gated on #2289 fork decided; Wave 1a
+### Wave 2 (epic #2389) — gated per its epic body; §8 Q1 = YES (decision 2 above)
+
+(Fill per-issue tables for each wave when its frontier opens; until then the epic checklist is the list.)
+
+## Wave boundaries completed
+
+(none yet)
+
+## Resume instructions
+
+1. `cd .claude/worktrees/oms-wave2-programme` (or EnterWorktree with that path); `git fetch origin`.
+2. Read this ledger + `git log --oneline origin/main..HEAD` to see what landed.
+3. If `node_modules` is missing: `pnpm install`, then `pnpm -r --filter "./libs/**" build`.
+4. Continue the frontier: unblocked ☐ issues first, honoring the chains in
+   `docs/plans/oms-backlog-overview.md` § Cross-wave critical paths.
+5. At a wave boundary: `/pr-review` the wave diff, apply findings, merge `origin/main` in, open the
+   wave PR to `main`, ask the owner to merge, and record it here.

--- a/docs/plans/oms-progress-ledger.md
+++ b/docs/plans/oms-progress-ledger.md
@@ -36,14 +36,14 @@ Legend: ☐ not started · ◐ plan in review · ◑ implementing · ◕ diff in
 ### Wave 0 (no epic)
 | Issue | Subject | Status |
 |---|---|---|
-| #2282 | persistOrder source-attribution immutability | ☐ |
-| #2283 | ingestion line-diff + `amended` fact | ☐ (after #2282 — same files) |
-| #2284 | `WHERE cancelledAt IS NULL` provisioning predicate | ◐ plan agent running |
-| #2285 | `inv:{hash}` idempotency-key swap | ◐ plan agent running |
-| #2286 | `never`-default exhaustiveness (5 consumers) | ◐ plan agent running |
-| #2287 | `packedAt` BE | ☐ |
-| #2288 | `packedAt` FE | ☐ (after #2287) |
-| #2289 | Allegro returns-feed spike → 1c fork | ◐ desk-research agent running |
+| #2282 | persistOrder source-attribution immutability | ☑ merged b91088599 (commit a5f59a370; reviewed, approved) |
+| #2283 | ingestion line-diff + `amended` fact | ◐ plan agent running (lands AFTER #2286-style case arms; both prerequisites merged) |
+| #2284 | `WHERE cancelledAt IS NULL` provisioning predicate | ☑ merged 4587122c9 (commit 99ab27462; reviewed, approved) |
+| #2285 | `inv:{hash}` idempotency-key swap | ◕ diff in review (gates green, committing) |
+| #2286 | `never`-default exhaustiveness (5 consumers) | ☑ merged 9b48585b4 (commit 885b63f9e; reviewed, approved) |
+| #2287 | `packedAt` BE | ◑ implementing (READY; ANALYSIS-2287; migration 1840000000000 reserved) |
+| #2288 | `packedAt` FE | ◐ planned (plan-2288; audit running; blocked on #2287) |
+| #2289 | Allegro returns-feed spike → 1c fork | ☑ verdict 4A (two-pass); findings on branch + issue comment |
 
 ### Wave 1a (epic #2312) — gated on #2284 #2286 #2283 merged; #2298 resolved
 ### Wave 1b (epic #2326) — gated on #2285 merged; W1a-8 (#2308)

--- a/libs/core/src/inventory/application/services/__tests__/inventory-sync.service.spec.ts
+++ b/libs/core/src/inventory/application/services/__tests__/inventory-sync.service.spec.ts
@@ -139,7 +139,8 @@ describe('InventorySyncService', () => {
   it('should auto-generate a deterministic idempotency key when an item omits one', async () => {
     // Single-item path (length === 1) forces per-item loop, which lets us inspect the
     // normalized item passed to updateOfferQuantity. The key is a SHA-256 truncation
-    // of (connectionId, offerId, quantity) — same tuple → same key, distinct tuple → distinct key.
+    // of (connectionId, offerId, quantity, observedAt) — same tuple → same key,
+    // distinct tuple → distinct key (#2285).
     marketplace.updateOfferQuantity.mockResolvedValue(undefined);
 
     await service.updateOfferQuantities(connectionId, {
@@ -164,6 +165,103 @@ describe('InventorySyncService', () => {
     const thirdCallArg = marketplace.updateOfferQuantity.mock.calls[2][0];
     expect(thirdCallArg.idempotencyKey).toMatch(/^inv:[a-f0-9]{16}$/);
     expect(thirdCallArg.idempotencyKey).not.toBe(firstCallArg.idempotencyKey);
+  });
+
+  describe('observation-token idempotency key (#2285)', () => {
+    const keyOf = (call: number): string | undefined =>
+      marketplace.updateOfferQuantity.mock.calls[call][0].idempotencyKey;
+
+    beforeEach(() => {
+      marketplace.updateOfferQuantity.mockResolvedValue(undefined);
+    });
+
+    it('should derive different keys when the quantity is identical but the observation differs', async () => {
+      await service.updateOfferQuantity(connectionId, {
+        offerId: 'o1',
+        quantity: 0,
+        observedAt: '2026-08-01T00:00:00.000Z',
+      });
+      await service.updateOfferQuantity(connectionId, {
+        offerId: 'o1',
+        quantity: 0,
+        observedAt: '2026-08-02T00:00:00.000Z',
+      });
+
+      expect(keyOf(0)).toMatch(/^inv:[a-f0-9]{16}$/);
+      expect(keyOf(1)).toMatch(/^inv:[a-f0-9]{16}$/);
+      expect(keyOf(1)).not.toBe(keyOf(0));
+    });
+
+    it('should derive the same key when the observation is the same', async () => {
+      const observedAt = '2026-08-01T00:00:00.000Z';
+      await service.updateOfferQuantity(connectionId, { offerId: 'o1', quantity: 3, observedAt });
+      await service.updateOfferQuantity(connectionId, { offerId: 'o1', quantity: 3, observedAt });
+
+      expect(keyOf(1)).toBe(keyOf(0));
+    });
+
+    it('should keep an explicit idempotency key ahead of the derived one', async () => {
+      await service.updateOfferQuantity(connectionId, {
+        offerId: 'o1',
+        quantity: 3,
+        idempotencyKey: 'caller-key',
+        observedAt: '2026-08-01T00:00:00.000Z',
+      });
+
+      expect(keyOf(0)).toBe('caller-key');
+    });
+
+    it('should fall back to an unversioned key and warn when no observation is supplied', async () => {
+      const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+
+      await service.updateOfferQuantity(connectionId, { offerId: 'o1', quantity: 3 });
+
+      expect(keyOf(0)).toMatch(/^inv:[a-f0-9]{16}$/);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('inventory_quantity_key_unversioned')
+      );
+      warnSpy.mockRestore();
+    });
+
+    it('should mint three distinct keys for a restock-to-the-same-quantity sequence', async () => {
+      // qty 5 @ t0 -> qty 0 @ t1 -> qty 5 @ t2. Pre-#2285 the third write reused the
+      // first write's key and was swallowed by the destination's command-id dedup,
+      // leaving the offer selling at a quantity it no longer had.
+      await service.updateOfferQuantity(connectionId, {
+        offerId: 'o1',
+        quantity: 5,
+        observedAt: '2026-08-01T00:00:00.000Z',
+      });
+      await service.updateOfferQuantity(connectionId, {
+        offerId: 'o1',
+        quantity: 0,
+        observedAt: '2026-08-02T00:00:00.000Z',
+      });
+      await service.updateOfferQuantity(connectionId, {
+        offerId: 'o1',
+        quantity: 5,
+        observedAt: '2026-08-03T00:00:00.000Z',
+      });
+
+      expect(marketplace.updateOfferQuantity).toHaveBeenCalledTimes(3);
+      expect(new Set([keyOf(0), keyOf(1), keyOf(2)]).size).toBe(3);
+    });
+
+    it('should never derive the key from wall-clock time', async () => {
+      const input = {
+        offerId: 'o1',
+        quantity: 5,
+        observedAt: '2026-08-01T00:00:00.000Z',
+      };
+
+      jest.useFakeTimers().setSystemTime(new Date('2026-08-10T00:00:00.000Z'));
+      await service.updateOfferQuantity(connectionId, input);
+      jest.setSystemTime(new Date('2027-01-01T00:00:00.000Z'));
+      await service.updateOfferQuantity(connectionId, input);
+      jest.useRealTimers();
+
+      expect(keyOf(1)).toBe(keyOf(0));
+    });
   });
 
   describe('stock safety buffer (#1844)', () => {
@@ -224,7 +322,9 @@ describe('InventorySyncService', () => {
 
       await service.updateOfferQuantity(connectionId, { offerId: 'o1', quantity: 10 });
 
-      expect(warnSpy).not.toHaveBeenCalled();
+      // Scoped to the buffer warn: an item with no observation token separately warns
+      // about its unversioned idempotency key (#2285).
+      expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('present but invalid'));
       warnSpy.mockRestore();
     });
 

--- a/libs/core/src/inventory/application/services/inventory-sync.service.ts
+++ b/libs/core/src/inventory/application/services/inventory-sync.service.ts
@@ -74,11 +74,21 @@ export class InventorySyncService implements IInventorySyncService {
       idempotencyKey: cmd.idempotencyKey,
       items: cmd.items.map((i) => {
         const quantity = applyStockSafetyBuffer(i.quantity, reserve);
+        if (!i.idempotencyKey && !i.observedAt) {
+          // #2285 — a quantity-only key cannot distinguish two writes of the same
+          // value, so a corrective write is swallowed by the destination's command-id
+          // dedup. Keep the legacy key (nothing else to derive from) but make the
+          // degradation observable rather than silent.
+          this.logger.warn(
+            `inventory_quantity_key_unversioned connection=${connectionId} offer=${i.offerId} quantity=${quantity}`
+          );
+        }
         return {
           ...i,
           quantity,
           idempotencyKey:
-            i.idempotencyKey ?? this.buildIdempotencyKey(connectionId, i.offerId, quantity),
+            i.idempotencyKey ??
+            this.buildIdempotencyKey(connectionId, i.offerId, quantity, i.observedAt),
         };
       }),
     };
@@ -113,9 +123,22 @@ export class InventorySyncService implements IInventorySyncService {
     return result;
   }
 
-  private buildIdempotencyKey(connectionId: string, offerId: string, quantity: number): string {
+  /**
+   * Deterministic, compact idempotency key over the 4-tuple
+   * `(connectionId, offerId, quantity, observedAt)`. The observation token is what
+   * lets two writes of the same quantity be told apart (#2285); with no token the
+   * key degrades to the pre-#2285 quantity-only form, marked `unversioned`.
+   *
+   * Never derives from wall-clock time — see `UpdateOfferQuantityCommand.observedAt`.
+   */
+  private buildIdempotencyKey(
+    connectionId: string,
+    offerId: string,
+    quantity: number,
+    observedAt?: string
+  ): string {
     // Deterministic, compact idempotency key (avoid long hashes).
-    const raw = `inventory:${connectionId}:${offerId}:${quantity}`;
+    const raw = `inventory:${connectionId}:${offerId}:${quantity}:${observedAt ?? 'unversioned'}`;
     const digest = createHash('sha256').update(raw).digest('hex').slice(0, 16);
     return `inv:${digest}`;
   }

--- a/libs/core/src/listings/application/services/__tests__/stale-offer-pause.service.spec.ts
+++ b/libs/core/src/listings/application/services/__tests__/stale-offer-pause.service.spec.ts
@@ -131,6 +131,25 @@ describe('StaleOfferPauseService', () => {
       });
     });
 
+    it('stamps the variant staleAt as the payload observedAt (#2285)', async () => {
+      identifierMapping.getExternalIds.mockResolvedValueOnce([
+        mapping({ connectionId: 'conn-1', externalId: 'offer-1' }),
+      ]);
+
+      await service.pauseOffersForVariants({
+        variantIds: ['ol_variant_a'],
+        correlationId: 'corr-1',
+      });
+
+      expect(jobQueue.enqueue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          payload: expect.objectContaining({
+            observedAt: '2026-07-01T00:00:00.000Z',
+          }),
+        })
+      );
+    });
+
     it('composes the dedupe key from connectionId, externalOfferId, and staleAt', async () => {
       identifierMapping.getExternalIds.mockResolvedValueOnce([
         mapping({ connectionId: 'conn-1', externalId: 'offer-1' }),

--- a/libs/core/src/listings/application/services/stale-offer-pause.service.ts
+++ b/libs/core/src/listings/application/services/stale-offer-pause.service.ts
@@ -173,6 +173,10 @@ export class StaleOfferPauseService implements IStaleOfferPauseService {
           schemaVersion: 1,
           offerId: target.externalOfferId,
           quantity: 0,
+          // #2285 — the stale transition IS the observation this write expresses, so
+          // a re-pause after a restock derives a fresh key instead of reusing a dead
+          // command id and leaving the offer selling.
+          observedAt: target.staleAt.toISOString(),
         },
         options: { dedupeKey },
       });

--- a/libs/core/src/listings/domain/types/offer-quantity-update.types.ts
+++ b/libs/core/src/listings/domain/types/offer-quantity-update.types.ts
@@ -20,6 +20,22 @@ export interface UpdateOfferQuantityCommand {
    * Optional idempotency key. If absent, core orchestration should generate one deterministically.
    */
   idempotencyKey?: string;
+
+  /**
+   * ISO-8601 stamp of the OBSERVATION this write expresses — the inventory position
+   * row's `updatedAt`, or the equivalent state-transition time (e.g. a variant's
+   * `staleAt`). It is what makes the derived idempotency key distinguish two writes
+   * that carry the same quantity, so a corrective write returning an offer to a
+   * previously-written value is not silently swallowed by the destination's
+   * command-id dedup.
+   *
+   * MUST NOT be wall-clock `now()`. A wall-clock value collapses dedup to zero and
+   * turns every tick into a marketplace write; a value that is stable per observation
+   * preserves dedup exactly where it is wanted.
+   *
+   * Adapters never read this field — it feeds key derivation in core only.
+   */
+  observedAt?: string;
 }
 
 /**

--- a/libs/core/src/orders/application/interfaces/order-lifecycle-relay.service.interface.ts
+++ b/libs/core/src/orders/application/interfaces/order-lifecycle-relay.service.interface.ts
@@ -11,8 +11,26 @@
  * @module libs/core/src/orders/application/interfaces
  * @see {@link OrderStatusWriteback} for the per-participant writeback contract
  */
-import type { DispatchCarrierHint } from '../../domain/types/dispatch-carrier-hint.types';
-import type { OrderWritebackOutcome } from '../../domain/types/order-lifecycle-event.types';
+import type {
+  OrderLifecycleEvent,
+  OrderWritebackOutcome,
+} from '../../domain/types/order-lifecycle-event.types';
+
+/**
+ * The relay-facing projection of {@link OrderLifecycleEvent}: the same union,
+ * minus the per-participant `externalOrderId` the relay resolves itself.
+ *
+ * **Derived, never restated (#2286).** This union used to be hand-written, so a
+ * new `OrderLifecycleEvent` member did not widen the relay input and the relay's
+ * own branch kept compiling — defeating the exhaustiveness guard everywhere else.
+ * The distribution over the union (rather than a plain `Omit`) is what preserves
+ * the discriminated shape: a non-distributed `Omit` would collapse the members
+ * into one object with optional fields, which narrows on `type` but no longer
+ * fails to compile when a member is added.
+ */
+export type OrderLifecycleRelayEvent<E = OrderLifecycleEvent> = E extends unknown
+  ? Omit<E, 'externalOrderId'>
+  : never;
 
 /**
  * A lifecycle event to relay, keyed on the internal order. The relay resolves
@@ -23,9 +41,7 @@ export interface OrderLifecycleRelayInput {
   internalOrderId: string;
   /** The participant that authored the event — excluded from the targets (self-echo suppression at the participant level). */
   originConnectionId: string;
-  event:
-    | { type: 'dispatched'; trackingNumber?: string; carrier?: DispatchCarrierHint }
-    | { type: 'cancelled'; reason?: string };
+  event: OrderLifecycleRelayEvent;
 }
 
 /**

--- a/libs/core/src/orders/application/interfaces/order-record.service.interface.ts
+++ b/libs/core/src/orders/application/interfaces/order-record.service.interface.ts
@@ -180,4 +180,26 @@ export interface IOrderRecordService {
     internalOrderId: string,
     block: SalesDocumentBlock | null
   ): Promise<void>;
+
+  /**
+   * Mark this order packed (#2287), stamping the instant and the acting
+   * operator. A plain fact — it touches no state column (`recordStatus`,
+   * `fulfillmentState`, `slaState`, `OrderHealth` are all untouched) and gates
+   * nothing, so it applies to every order including `omp_fulfilled` ones OL
+   * never dispatches.
+   *
+   * Idempotent: a repeat call is a replay that returns the EXISTING stamp and
+   * actor rather than re-stamping. Throws `OrderRecordNotFoundException` when
+   * no record exists for `internalOrderId` — a missing row is a caller error
+   * here (an operator acting on an order), unlike the residual-race tolerance
+   * the event-driven writers carry.
+   */
+  markPacked(internalOrderId: string, packedByUserId: string): Promise<OrderRecord>;
+
+  /**
+   * Clear this order's packed fact (#2287), nulling both columns together.
+   * Clearing an already-unpacked order is a no-op that returns the record
+   * unchanged; an unknown order throws `OrderRecordNotFoundException`.
+   */
+  clearPacked(internalOrderId: string): Promise<OrderRecord>;
 }

--- a/libs/core/src/orders/application/interfaces/order-record.service.interface.ts
+++ b/libs/core/src/orders/application/interfaces/order-record.service.interface.ts
@@ -20,6 +20,7 @@ import type {
 } from '../../domain/types/order-record.types';
 import type { FulfillmentRollupState } from '../../domain/types/order-fulfillment.types';
 import type { SalesDocumentBlock } from '@openlinker/core/sales-documents';
+import type { OrderAmendmentChange } from '../../domain/order-amendment-diff';
 
 export interface IOrderRecordService {
   /**
@@ -202,4 +203,27 @@ export interface IOrderRecordService {
    * unchanged; an unknown order throws `OrderRecordNotFoundException`.
    */
   clearPacked(internalOrderId: string): Promise<OrderRecord>;
+
+  /**
+   * Record that the source amended this order after it was already ingested
+   * (#2283) — a line removed, added or re-quantified, or the shipping address
+   * edited. An internal FACT: it moves no status, fires no relay event and gates
+   * nothing; it exists because ingestion overwrites the snapshot wholesale and
+   * the change would otherwise leave no trace.
+   *
+   * Callers pass a non-empty change list — an empty one has nothing to record
+   * and must not reach here. Last-write-wins (the newest observation is the
+   * truthful one) and a re-observation of the SAME change list is suppressed at
+   * the write, so it neither bumps `updatedAt` nor re-dates the fact.
+   *
+   * No-op (no throw) when no record exists for `internalOrderId`: this is
+   * event-driven, so it carries the residual-race tolerance the other
+   * ingestion-path writers carry rather than the operator-error posture of
+   * {@link markPacked}.
+   */
+  recordAmendment(
+    internalOrderId: string,
+    observedAt: Date,
+    changes: OrderAmendmentChange[]
+  ): Promise<void>;
 }

--- a/libs/core/src/orders/application/interfaces/order-sync.service.interface.ts
+++ b/libs/core/src/orders/application/interfaces/order-sync.service.interface.ts
@@ -38,6 +38,10 @@ export interface OrderSyncRequest {
  * destination processor. `status: 'success'` carries the destination order
  * reference; `status: 'failed'` carries the error message so callers can
  * surface partial failures without losing track of successful destinations.
+ *
+ * `status: 'skipped_cancelled'` (#2284) is a THIRD, terminal arm rather than a
+ * `'failed'` with a code: nothing went wrong, and a distinct arm is what stops
+ * any consumer routing the skip into a retry.
  */
 export type OrderSyncResult =
   | {
@@ -55,6 +59,12 @@ export type OrderSyncResult =
         message: string;
         code?: string;
       };
+    }
+  | {
+      destinationConnectionId: string;
+      status: 'skipped_cancelled';
+      /** When the source cancellation was first recorded (first-write-wins). */
+      cancelledAt: Date;
     };
 
 /**

--- a/libs/core/src/orders/application/services/__tests__/order-destination-retry.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-destination-retry.service.spec.ts
@@ -158,7 +158,9 @@ describe('OrderDestinationRetryService', () => {
       expect(jobEnqueue.enqueueJob).not.toHaveBeenCalled();
     });
 
-    it.each(['pending', 'syncing', 'synced'] as const)(
+    // `'skipped_cancelled'` (#2284) is terminal: the source cancelled the order,
+    // so a retry must never re-attempt provisioning.
+    it.each(['pending', 'syncing', 'synced', 'skipped_cancelled'] as const)(
       'should throw OrderDestinationNotRetryableException when status is %s',
       async (status) => {
         orderRepo.findById.mockResolvedValue(

--- a/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
@@ -519,6 +519,27 @@ describe('OrderIngestionService', () => {
       );
     });
 
+    it('should call updateSyncStatus with skipped_cancelled when the order was cancelled at source', async () => {
+      orderSyncService.syncOrder.mockResolvedValue([
+        {
+          status: 'skipped_cancelled',
+          destinationConnectionId: 'dest-conn-1',
+          cancelledAt: new Date('2026-08-01T10:00:00.000Z'),
+        },
+      ]);
+
+      await service.syncOrderFromSource(connectionId, externalOrderId);
+
+      expect(orderRecordService.updateSyncStatus).toHaveBeenCalledWith(
+        'ol_order_test',
+        'dest-conn-1',
+        expect.objectContaining({
+          status: 'skipped_cancelled',
+          error: 'Order cancelled at source before destination create',
+        })
+      );
+    });
+
     it('should persist snapshot and order even when syncOrder throws', async () => {
       orderSyncService.syncOrder.mockRejectedValue(new Error('no destinations'));
 

--- a/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
@@ -106,6 +106,7 @@ describe('OrderIngestionService', () => {
       markItemResolutionFailure: jest.fn().mockResolvedValue(undefined),
       markCancelled: jest.fn().mockResolvedValue(undefined),
       markSalesDocumentBlock: jest.fn().mockResolvedValue(undefined),
+      recordAmendment: jest.fn().mockResolvedValue(undefined),
     } as unknown as jest.Mocked<IOrderRecordService>;
 
     customerIdentityResolver = {
@@ -1312,6 +1313,139 @@ describe('OrderIngestionService', () => {
       });
       expect(errorSpy).toHaveBeenCalledWith(
         expect.stringContaining('Failed to record cancellation'),
+        expect.anything()
+      );
+    });
+  });
+
+  describe('source-amendment fact (#2283)', () => {
+    const externalOrderId = 'amend-1';
+    const internalOrderId = 'ol_order_amend';
+
+    const incoming = {
+      externalOrderId,
+      orderNumber: externalOrderId,
+      status: 'BOUGHT',
+      items: [
+        {
+          id: 'l1',
+          productRef: { type: 'offer' as const, externalId: 'offer-l1' },
+          quantity: 1,
+          price: 10,
+          sku: 'SKU-l1',
+        },
+      ],
+      totals: { subtotal: 10, tax: 0, shipping: 0, total: 10, currency: 'PLN' },
+      createdAt: '2026-08-01T00:00:00Z',
+      updatedAt: '2026-08-01T00:00:00Z',
+    };
+
+    beforeEach(() => {
+      identifierMapping.getOrCreateInternalId.mockResolvedValue(internalOrderId);
+      orderSource.getOrder.mockResolvedValue(incoming);
+      integrationsService.getCapabilityAdapter.mockResolvedValue(orderSource);
+      orderSyncService.syncOrder.mockResolvedValue([]);
+      orderItemRefResolver.tryResolve.mockResolvedValue({
+        resolved: true,
+        internalProductId: 'ol_product_1',
+        internalVariantId: 'ol_variant_1',
+      });
+    });
+
+    const priorWithQuantity = (quantity: number): OrderRecord =>
+      ({
+        sourceConnectionId: connectionId,
+        orderSnapshot: { status: 'BOUGHT', items: [{ id: 'l1', quantity, sku: 'SKU-l1' }] },
+      }) as unknown as OrderRecord;
+
+    it('should record the fact once with the observed changes when the source amended the order', async () => {
+      orderRecordService.getOrderRecord.mockResolvedValue(priorWithQuantity(3));
+
+      await service.syncOrderFromSource(connectionId, externalOrderId);
+
+      expect(orderRecordService.recordAmendment).toHaveBeenCalledTimes(1);
+      expect(orderRecordService.recordAmendment).toHaveBeenCalledWith(
+        internalOrderId,
+        expect.any(Date),
+        [
+          {
+            kind: 'line-quantity-changed',
+            lineId: 'l1',
+            sku: 'SKU-l1',
+            fromQuantity: 3,
+            toQuantity: 1,
+          },
+        ]
+      );
+    });
+
+    it('should record the fact BEFORE the snapshot write that would destroy the evidence', async () => {
+      orderRecordService.getOrderRecord.mockResolvedValue(priorWithQuantity(3));
+
+      await service.syncOrderFromSource(connectionId, externalOrderId);
+
+      expect(orderRecordService.recordAmendment.mock.invocationCallOrder[0]).toBeLessThan(
+        orderRecordService.persistIncomingSnapshot.mock.invocationCallOrder[0]
+      );
+    });
+
+    it('should not record anything on an identical re-poll', async () => {
+      orderRecordService.getOrderRecord.mockResolvedValue(priorWithQuantity(1));
+
+      await service.syncOrderFromSource(connectionId, externalOrderId);
+
+      expect(orderRecordService.recordAmendment).not.toHaveBeenCalled();
+    });
+
+    it('should not record anything on a first ingestion', async () => {
+      orderRecordService.getOrderRecord.mockResolvedValue(null);
+
+      await service.syncOrderFromSource(connectionId, externalOrderId);
+
+      expect(orderRecordService.recordAmendment).not.toHaveBeenCalled();
+    });
+
+    it('should not record anything on the destination-echo skip', async () => {
+      orderRecordService.getOrderRecord.mockResolvedValue({
+        sourceConnectionId: 'some-other-connection',
+        orderSnapshot: { items: [{ id: 'l1', quantity: 99 }] },
+      } as unknown as OrderRecord);
+
+      await service.syncOrderFromSource(connectionId, externalOrderId);
+
+      expect(orderRecordService.recordAmendment).not.toHaveBeenCalled();
+    });
+
+    it('should still record the fact when item resolution later throws', async () => {
+      orderRecordService.getOrderRecord.mockResolvedValue(priorWithQuantity(3));
+      orderItemRefResolver.tryResolve.mockResolvedValue({
+        resolved: false,
+        productRef: { type: 'offer', externalId: 'unmapped' },
+        reason: 'no mapping',
+        kind: 'missing_mapping' as const,
+      });
+
+      await expect(
+        service.syncOrderFromSource(connectionId, externalOrderId)
+      ).rejects.toBeInstanceOf(MissingOrderItemMappingError);
+
+      expect(orderRecordService.recordAmendment).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not fail the ingestion when recording the fact throws', async () => {
+      orderRecordService.getOrderRecord.mockResolvedValue(priorWithQuantity(3));
+      orderRecordService.recordAmendment.mockRejectedValueOnce(new Error('db down'));
+      const errorSpy = jest
+        .spyOn((service as unknown as { logger: { error: jest.Mock } }).logger, 'error')
+        .mockImplementation(() => undefined);
+
+      await expect(service.syncOrderFromSource(connectionId, externalOrderId)).resolves.toEqual(
+        []
+      );
+
+      expect(orderRecordService.persistOrder).toHaveBeenCalled();
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Failed to record source amendment'),
         expect.anything()
       );
     });

--- a/libs/core/src/orders/application/services/__tests__/order-lifecycle-relay.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-lifecycle-relay.service.spec.ts
@@ -6,6 +6,7 @@
 import { OrderLifecycleRelayService } from '../order-lifecycle-relay.service';
 import { CapabilityNotSupportedException, type IIntegrationsService } from '@openlinker/core/integrations';
 import type { IIdentifierMappingService } from '@openlinker/core/identifier-mapping';
+import type { OrderLifecycleRelayInput } from '../../interfaces/order-lifecycle-relay.service.interface';
 
 const origin = 'allegro-conn';
 
@@ -228,6 +229,32 @@ describe('OrderLifecycleRelayService', () => {
       // able to tell this apart from a structural capability gap, or it records
       // a delivery that never happened.
       unsupportedReason: 'adapter-unresolved',
+    });
+  });
+
+  // #2286 — the runtime half of the exhaustiveness guard. The relay's default
+  // arm THROWS (unlike the adapters', which degrade to `unsupported`): a member
+  // core itself cannot map is an in-tree defect, and the pre-#2286 ternary
+  // stamped `type: 'cancelled'` onto anything that was not `dispatched` — i.e.
+  // it would have pushed a cancellation to every participant of the order.
+  describe('unknown member (never-default, #2286)', () => {
+    it('throws and writes to no participant, rather than relaying it as a cancellation', async () => {
+      identifierMapping.getExternalIds.mockResolvedValue([
+        mapping(origin, 'allegro-1'),
+        mapping('ps-conn', 'ps-7'),
+      ]);
+      const adapter = { write: jest.fn().mockResolvedValue({ outcome: 'applied' }) };
+      integrations.getCapabilityAdapter.mockResolvedValue(adapter);
+
+      await expect(
+        service.relay({
+          internalOrderId: 'ol_order_1',
+          originConnectionId: origin,
+          event: { type: 'amended' } as unknown as OrderLifecycleRelayInput['event'],
+        })
+      ).rejects.toThrow(/Unhandled union member.*amended/);
+
+      expect(adapter.write).not.toHaveBeenCalled();
     });
   });
 });

--- a/libs/core/src/orders/application/services/__tests__/order-sync.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-sync.service.spec.ts
@@ -17,6 +17,8 @@ import { NoOrderDestinationsAvailableException } from '../../../domain/exception
 import { OrderCreateContendedException } from '../../../domain/exceptions/order-create-contended.exception';
 import type { SyncLockPort } from '@openlinker/core/sync';
 import type { IIdentifierMappingService } from '@openlinker/core/identifier-mapping';
+import type { IOrderRecordService } from '../../interfaces/order-record.service.interface';
+import type { OrderRecord } from '../../../domain/entities/order-record.entity';
 import {
   DuplicateIdentifierMappingError,
   MappingAlreadyExistsError,
@@ -28,6 +30,7 @@ describe('OrderSyncService', () => {
   let mappingConfigService: jest.Mocked<IMappingConfigService>;
   let syncLock: jest.Mocked<SyncLockPort>;
   let identifierMapping: jest.Mocked<IIdentifierMappingService>;
+  let orderRecordService: jest.Mocked<IOrderRecordService>;
 
   const makeAdapter = (orderRef: OrderRef = { orderId: 'dest_order' }) =>
     ({
@@ -119,11 +122,16 @@ describe('OrderSyncService', () => {
       batchGetOrCreateInternalIds: jest.fn(),
     } as unknown as jest.Mocked<IIdentifierMappingService>;
 
+    orderRecordService = {
+      getOrderRecord: jest.fn().mockResolvedValue(null),
+    } as unknown as jest.Mocked<IOrderRecordService>;
+
     service = new OrderSyncService(
       integrationsService,
       mappingConfigService,
       syncLock,
-      identifierMapping
+      identifierMapping,
+      orderRecordService
     );
   });
 
@@ -575,6 +583,92 @@ describe('OrderSyncService', () => {
         status: 'success',
         orderRef: { orderId: 'PS-555' },
       });
+    });
+  });
+
+  // #2284 — the `WHERE cancelledAt IS NULL` provisioning predicate.
+  describe('source-cancelled orders', () => {
+    const cancelledAt = new Date('2026-08-01T10:00:00.000Z');
+    const cancelledRecord = { isCancelled: true, cancelledAt } as unknown as OrderRecord;
+
+    it('should skip destination provisioning when the order was cancelled at source', async () => {
+      const adapterA = makeAdapter();
+      const adapterB = makeAdapter();
+      registerDestinations([
+        { connectionId: 'dest-a', adapter: adapterA },
+        { connectionId: 'dest-b', adapter: adapterB },
+      ]);
+      orderRecordService.getOrderRecord.mockResolvedValue(cancelledRecord);
+
+      const results = await service.syncOrder({
+        order: createOrder(),
+        sourceConnectionId: 'source-1',
+      });
+
+      expect(results).toEqual([
+        { destinationConnectionId: 'dest-a', status: 'skipped_cancelled', cancelledAt },
+        { destinationConnectionId: 'dest-b', status: 'skipped_cancelled', cancelledAt },
+      ]);
+      expect(adapterA.createOrder).not.toHaveBeenCalled();
+      expect(adapterB.createOrder).not.toHaveBeenCalled();
+      expect(syncLock.acquire).not.toHaveBeenCalled();
+      expect(identifierMapping.createMapping).not.toHaveBeenCalled();
+    });
+
+    it('should provision normally when the order record reports no cancellation', async () => {
+      const adapter = makeAdapter({ orderId: 'dest_order_1' });
+      registerDestinations([{ connectionId: 'dest-a', adapter }]);
+      orderRecordService.getOrderRecord.mockResolvedValue({
+        isCancelled: false,
+        cancelledAt: null,
+      } as unknown as OrderRecord);
+
+      const results = await service.syncOrder({
+        order: createOrder(),
+        sourceConnectionId: 'source-1',
+      });
+
+      expect(results[0]).toMatchObject({ status: 'success' });
+      expect(adapter.createOrder).toHaveBeenCalledTimes(1);
+    });
+
+    it('should provision when no order record exists (absence is not cancellation)', async () => {
+      const adapter = makeAdapter({ orderId: 'dest_order_1' });
+      registerDestinations([{ connectionId: 'dest-a', adapter }]);
+      orderRecordService.getOrderRecord.mockResolvedValue(null);
+
+      const results = await service.syncOrder({
+        order: createOrder(),
+        sourceConnectionId: 'source-1',
+      });
+
+      expect(results[0]).toMatchObject({ status: 'success' });
+      expect(adapter.createOrder).toHaveBeenCalledTimes(1);
+    });
+
+    // A read failure must never fall through into a create: provisioning a
+    // possibly-cancelled order is the worse outcome, so the throw propagates
+    // and the sync job retries.
+    it('should propagate a record-read failure instead of provisioning', async () => {
+      const adapter = makeAdapter();
+      registerDestinations([{ connectionId: 'dest-a', adapter }]);
+      orderRecordService.getOrderRecord.mockRejectedValue(new Error('db down'));
+
+      await expect(
+        service.syncOrder({ order: createOrder(), sourceConnectionId: 'source-1' })
+      ).rejects.toThrow('db down');
+      expect(adapter.createOrder).not.toHaveBeenCalled();
+    });
+
+    // The guard sits AFTER the no-destinations throw, so a cancelled order with
+    // no destinations still reports the configuration problem.
+    it('should still throw NoOrderDestinationsAvailableException with zero destinations', async () => {
+      registerDestinations([]);
+      orderRecordService.getOrderRecord.mockResolvedValue(cancelledRecord);
+
+      await expect(
+        service.syncOrder({ order: createOrder(), sourceConnectionId: 'source-1' })
+      ).rejects.toThrow(NoOrderDestinationsAvailableException);
     });
   });
 });

--- a/libs/core/src/orders/application/services/order-ingestion.service.ts
+++ b/libs/core/src/orders/application/services/order-ingestion.service.ts
@@ -231,6 +231,11 @@ export class OrderIngestionService implements IOrderIngestionService {
     // history — so skip. The real source stays authoritative; destination-side
     // fulfillment flows through the dedicated *.statusSync jobs (which key on
     // destinationConnectionId, not the source) and is unaffected.
+    //
+    // Since #2282 the write path enforces the attribution half of this itself
+    // (`sourceConnectionId` is insert-only in the upsert statement), so this
+    // guard is defence in depth. It is still load-bearing: only skipping here
+    // also spares the SNAPSHOT, which the write path does still overwrite.
     const existing = await this.orderRecordService.getOrderRecord(internalOrderId);
     if (existing && existing.sourceConnectionId !== connectionId) {
       // `debug` not `log`: this is an expected, per-order steady-state skip that

--- a/libs/core/src/orders/application/services/order-ingestion.service.ts
+++ b/libs/core/src/orders/application/services/order-ingestion.service.ts
@@ -57,7 +57,9 @@ import type { OrderRecord } from '../../domain/entities/order-record.entity';
 import type { SalesDocumentBlockOutcome } from '@openlinker/core/sales-documents';
 import type { OrderRecordStatus } from '../../domain/types/order-record.types';
 import type { ItemResolutionFailureKind } from './order-item-ref-resolver.types';
+import { getEnvBoolean } from '@openlinker/shared/config';
 import { Logger } from '@openlinker/shared/logging';
+import { diffOrderAmendment } from '../../domain/order-amendment-diff';
 import { MissingOrderItemMappingError } from '../../domain/exceptions/missing-order-item-mapping.error';
 
 @Injectable()
@@ -256,6 +258,20 @@ export class OrderIngestionService implements IOrderIngestionService {
     // fire once on a first-seen already-cancelled order — the restore is a
     // harmless absolute-set).
     const priorStatus = this.readSnapshotStatus(existing);
+
+    // Source-amendment diff (#2283) — taken HERE, against the already-loaded
+    // prior record, and deliberately BEFORE `persistIncomingSnapshot` below.
+    // Two properties depend on the placement:
+    //   - `persistIncomingSnapshot` overwrites `orderSnapshot`, so after it the
+    //     prior state this diff needs no longer exists anywhere;
+    //   - Step 4 throws `MissingOrderItemMappingError` before `persistOrder` is
+    //     ever reached, so writing the fact later would lose it permanently on
+    //     exactly the orders most likely to have been amended (a line the source
+    //     changed is a line whose mapping may well have gone with it).
+    // The fact is an observation about the SOURCE and is true whether or not
+    // item resolution subsequently succeeds. The destination-echo early return
+    // above is untouched: an echo is not an amendment.
+    await this.recordSourceAmendment(existing, incoming, internalOrderId, connectionId);
 
     const internalCustomerId = await this.resolveCustomerId(
       incoming,
@@ -640,6 +656,54 @@ export class OrderIngestionService implements IOrderIngestionService {
    * value isn't a string — both treated as non-cancelled by the caller. Pure
    * read; binds only to the snapshot's `status` key, not its full JSON layout.
    */
+  /**
+   * Diff the stored snapshot against the incoming order and persist the fact
+   * when something moved (#2283).
+   *
+   * Best-effort throughout: an ingestion must never fail because an
+   * observability fact could not be written, so a repository error is logged and
+   * swallowed. The `changes.length > 0` gate is the primary suppressor — on a
+   * steady-state poll nothing changed and no statement is issued at all.
+   *
+   * The log line is PII-free (ids, change kinds and line ids only) and is `warn`
+   * rather than `log` on purpose: an adapter with UNSTABLE line ids would report
+   * every poll as a removal plus an addition, and that noise must be immediately
+   * visible rather than accumulating silently in the column.
+   */
+  private async recordSourceAmendment(
+    existing: OrderRecord | null,
+    incoming: IncomingOrder,
+    internalOrderId: string,
+    connectionId: string
+  ): Promise<void> {
+    try {
+      // `getEnvBoolean` rather than `getPiiConfig()`: the diff needs the FLAG,
+      // not the hash salt, and `getPiiConfig` throws when `OL_PII_HASH_SALT` is
+      // unset. Reading it here would put an unrelated configuration failure on
+      // the ingestion path — swallowed by the catch below, so the fact would go
+      // silently unrecorded. The default matches `getPiiConfig`'s own.
+      const changes = diffOrderAmendment(existing?.orderSnapshot ?? null, incoming, {
+        storePii: getEnvBoolean('OL_STORE_PII', true),
+      });
+      if (changes.length === 0) {
+        return;
+      }
+
+      this.logger.warn(
+        `Source amended order ${internalOrderId} on connection ${connectionId} after ingestion: ` +
+          changes
+            .map((c) => (c.lineId ? `${c.kind}(${c.lineId})` : `${c.kind}(${(c.fields ?? []).join(',')})`))
+            .join('; ')
+      );
+      await this.orderRecordService.recordAmendment(internalOrderId, new Date(), changes);
+    } catch (error) {
+      this.logger.error(
+        `Failed to record source amendment for order ${internalOrderId}`,
+        (error as Error).stack
+      );
+    }
+  }
+
   private readSnapshotStatus(existing: OrderRecord | null): string | undefined {
     const value = existing?.orderSnapshot?.status;
     return typeof value === 'string' ? value : undefined;

--- a/libs/core/src/orders/application/services/order-ingestion.service.ts
+++ b/libs/core/src/orders/application/services/order-ingestion.service.ts
@@ -431,6 +431,20 @@ export class OrderIngestionService implements IOrderIngestionService {
               externalOrderNumber: result.orderRef.orderNumber,
             }
           );
+        } else if (result.status === 'skipped_cancelled') {
+          // #2284 — terminal, and NOT a failure: the source cancelled before the
+          // destination create ran, so provisioning was withheld. `error` carries
+          // the human reason (no new column); the same string lands on the
+          // append-only attempt entry so the timeline narrates the skip.
+          return this.orderRecordService.updateSyncStatus(
+            order.id,
+            result.destinationConnectionId,
+            {
+              destinationConnectionId: result.destinationConnectionId,
+              status: 'skipped_cancelled',
+              error: 'Order cancelled at source before destination create',
+            }
+          );
         } else {
           return this.orderRecordService.updateSyncStatus(
             order.id,

--- a/libs/core/src/orders/application/services/order-lifecycle-relay.service.ts
+++ b/libs/core/src/orders/application/services/order-lifecycle-relay.service.ts
@@ -30,6 +30,7 @@ import {
   CORE_ENTITY_TYPE,
 } from '@openlinker/core/identifier-mapping';
 import { Logger } from '@openlinker/shared/logging';
+import { assertNever } from '@openlinker/shared/types';
 import {
   isOrderStatusWriteback,
   type OrderStatusWriteback,
@@ -119,15 +120,27 @@ export class OrderLifecycleRelayService implements IOrderLifecycleRelayService {
     }
     const { adapter, capability } = resolved;
 
-    const event: OrderLifecycleEvent =
-      input.event.type === 'dispatched'
-        ? {
+    // Switch (not a ternary) over a narrowed local, so that adding an
+    // `OrderLifecycleEvent` member is a compile error here rather than a silent
+    // relay of the new event as a cancellation (#2286). The default throws: a
+    // member core itself cannot map is an in-tree defect, and stamping some
+    // other `type` onto it would push a wrong fact to every participant.
+    const relayEvent = input.event;
+    const event: OrderLifecycleEvent = ((): OrderLifecycleEvent => {
+      switch (relayEvent.type) {
+        case 'dispatched':
+          return {
             type: 'dispatched',
             externalOrderId,
-            trackingNumber: input.event.trackingNumber,
-            carrier: input.event.carrier,
-          }
-        : { type: 'cancelled', externalOrderId, reason: input.event.reason };
+            trackingNumber: relayEvent.trackingNumber,
+            carrier: relayEvent.carrier,
+          };
+        case 'cancelled':
+          return { type: 'cancelled', externalOrderId, reason: relayEvent.reason };
+        default:
+          return assertNever(relayEvent, 'OrderLifecycleRelayInput.event');
+      }
+    })();
 
     try {
       const result = await adapter.write(event);

--- a/libs/core/src/orders/application/services/order-record-packed.service.spec.ts
+++ b/libs/core/src/orders/application/services/order-record-packed.service.spec.ts
@@ -1,0 +1,150 @@
+/**
+ * OrderRecordService packed-fact unit tests (#2287)
+ *
+ * Covers the one piece of policy the service owns: the guarded repository
+ * write reports `false` both for an idempotent replay and for a missing row,
+ * and only the re-read tells them apart.
+ *
+ * @module application/services
+ */
+import { OrderRecordService } from './order-record.service';
+import type { OrderRecordRepositoryPort } from '../../domain/ports/order-record-repository.port';
+import { OrderRecord } from '../../domain/entities/order-record.entity';
+import { OrderRecordNotFoundException } from '../../domain/exceptions/order-record-not-found.exception';
+import type { IOrderFxStampService } from '../interfaces/order-fx-stamp.service.interface';
+
+const ORDER_ID = 'ol_order_packed_001';
+
+function buildRecord(packedAt: Date | null, packedByUserId: string | null): OrderRecord {
+  return new OrderRecord(
+    ORDER_ID,
+    'ol_customer_001',
+    'conn-source-001',
+    'event-001',
+    {},
+    [],
+    'ready',
+    new Date('2026-04-01T00:00:00Z'),
+    new Date('2026-04-01T00:00:00Z'),
+    [],
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    null,
+    packedAt,
+    packedByUserId
+  );
+}
+
+describe('OrderRecordService — packed fact (#2287)', () => {
+  let repository: jest.Mocked<Pick<OrderRecordRepositoryPort, 'markPacked' | 'clearPacked' | 'findById'>>;
+  let service: OrderRecordService;
+
+  beforeEach(() => {
+    repository = {
+      markPacked: jest.fn(),
+      clearPacked: jest.fn(),
+      findById: jest.fn(),
+    };
+
+    const fxStamp = {
+      stampOnIngestion: jest.fn(),
+    } as unknown as IOrderFxStampService;
+
+    service = new OrderRecordService(
+      repository as unknown as OrderRecordRepositoryPort,
+      fxStamp
+    );
+  });
+
+  describe('markPacked', () => {
+    it('should stamp the actor and return the re-read record when the order was unpacked', async () => {
+      const stamped = buildRecord(new Date('2026-04-02T09:30:00Z'), 'user-op-001');
+      repository.markPacked.mockResolvedValue(true);
+      repository.findById.mockResolvedValue(stamped);
+
+      const result = await service.markPacked(ORDER_ID, 'user-op-001');
+
+      expect(repository.markPacked).toHaveBeenCalledWith(
+        ORDER_ID,
+        expect.any(Date),
+        'user-op-001'
+      );
+      expect(result).toBe(stamped);
+    });
+
+    it('should stamp the instant itself rather than accept one from the caller', async () => {
+      // The signature carries no timestamp at all — an operator action is OL's
+      // own observation, so an audit fact can never be backdated by a client.
+      repository.markPacked.mockResolvedValue(true);
+      repository.findById.mockResolvedValue(buildRecord(new Date(), 'user-op-001'));
+
+      const before = Date.now();
+      await service.markPacked(ORDER_ID, 'user-op-001');
+
+      const stampedAt = repository.markPacked.mock.calls[0][1];
+      expect(stampedAt.getTime()).toBeGreaterThanOrEqual(before);
+      expect(stampedAt.getTime()).toBeLessThanOrEqual(Date.now());
+    });
+
+    it('should return the ORIGINAL stamp and actor on a repeat mark', async () => {
+      const original = buildRecord(new Date('2026-04-02T09:30:00Z'), 'user-op-001');
+      repository.markPacked.mockResolvedValue(false);
+      repository.findById.mockResolvedValue(original);
+
+      const result = await service.markPacked(ORDER_ID, 'user-op-002');
+
+      expect(result.packedByUserId).toBe('user-op-001');
+      expect(result.packedAt).toEqual(new Date('2026-04-02T09:30:00Z'));
+    });
+
+    it('should throw OrderRecordNotFoundException when no such order exists', async () => {
+      repository.markPacked.mockResolvedValue(false);
+      repository.findById.mockResolvedValue(null);
+
+      await expect(service.markPacked(ORDER_ID, 'user-op-001')).rejects.toBeInstanceOf(
+        OrderRecordNotFoundException
+      );
+    });
+  });
+
+  describe('clearPacked', () => {
+    it('should return the cleared record', async () => {
+      const cleared = buildRecord(null, null);
+      repository.clearPacked.mockResolvedValue(true);
+      repository.findById.mockResolvedValue(cleared);
+
+      const result = await service.clearPacked(ORDER_ID);
+
+      expect(repository.clearPacked).toHaveBeenCalledWith(ORDER_ID);
+      expect(result.packedAt).toBeNull();
+      expect(result.packedByUserId).toBeNull();
+    });
+
+    it('should be a no-op returning the record when the order is already unpacked', async () => {
+      const unpacked = buildRecord(null, null);
+      repository.clearPacked.mockResolvedValue(false);
+      repository.findById.mockResolvedValue(unpacked);
+
+      await expect(service.clearPacked(ORDER_ID)).resolves.toBe(unpacked);
+    });
+
+    it('should throw OrderRecordNotFoundException when no such order exists', async () => {
+      repository.clearPacked.mockResolvedValue(false);
+      repository.findById.mockResolvedValue(null);
+
+      await expect(service.clearPacked(ORDER_ID)).rejects.toBeInstanceOf(
+        OrderRecordNotFoundException
+      );
+    });
+  });
+});

--- a/libs/core/src/orders/application/services/order-record.service.ts
+++ b/libs/core/src/orders/application/services/order-record.service.ts
@@ -156,6 +156,7 @@ export class OrderRecordService implements IOrderRecordService {
     );
 
     const saved = await this.repository.upsert(orderRecord);
+    this.warnOnAttributionDivergence(orderRecord, saved);
 
     // Two post-upsert writers, ONE refresh (#2125). Both write columns that
     // `upsert()` deliberately excludes from its statement, so `saved` cannot
@@ -279,6 +280,7 @@ export class OrderRecordService implements IOrderRecordService {
     );
 
     const saved = await this.repository.upsert(orderRecord);
+    this.warnOnAttributionDivergence(orderRecord, saved);
 
     // No FX stamp on this path, deliberately: an `awaiting_mapping` snapshot is
     // overwritten by `persistOrder` as soon as item resolution succeeds, so
@@ -292,6 +294,32 @@ export class OrderRecordService implements IOrderRecordService {
     );
 
     return cancellationWrote ? (await this.repository.findById(internalOrderId)) ?? saved : saved;
+  }
+
+  /**
+   * Report - never refuse - an attempted change of an order's source
+   * attribution (#2282).
+   *
+   * The write path itself is the enforcement point: `upsert` establishes
+   * `sourceConnectionId` on the first write and cannot move it afterwards, so
+   * the returned record carries the row's TRUE origin. When that differs from
+   * what this call asked for, the caller reached the write path for an order
+   * that belongs to another source - the #940 destination-echo shape, which the
+   * ADR-017 guard in `OrderIngestionService` normally catches upstream. Silently
+   * preserving and warn-logging is deliberate: throwing would turn a benign,
+   * already-correct outcome into a failed ingestion job.
+   */
+  private warnOnAttributionDivergence(requested: OrderRecord, saved: OrderRecord): void {
+    if (saved.sourceConnectionId === requested.sourceConnectionId) {
+      return;
+    }
+
+    this.logger.warn(
+      `Source attribution change refused for order ${requested.internalOrderId}: ` +
+        `write from connection ${requested.sourceConnectionId} left the record ` +
+        `attributed to its original source ${saved.sourceConnectionId} ` +
+        `(source attribution is immutable after the first write)`
+    );
   }
 
   /**

--- a/libs/core/src/orders/application/services/order-record.service.ts
+++ b/libs/core/src/orders/application/services/order-record.service.ts
@@ -15,6 +15,7 @@ import { OrderRecord } from '../../domain/entities/order-record.entity';
 import type { OrderSyncStatus, SyncAttempt } from '../../domain/types/order-sync.types';
 import type { IOrderRecordService } from '../interfaces/order-record.service.interface';
 import type { IncomingOrder } from '../../domain/types/incoming-order.types';
+import { OrderRecordNotFoundException } from '../../domain/exceptions/order-record-not-found.exception';
 import type {
   FailedSyncValueSummary,
   OrderHealthSummaryFilters,
@@ -486,6 +487,43 @@ export class OrderRecordService implements IOrderRecordService {
     block: SalesDocumentBlock | null
   ): Promise<void> {
     await this.repository.updateSalesDocumentBlock(internalOrderId, block);
+  }
+
+  /**
+   * Mark this order packed (#2287). The instant is stamped HERE rather than
+   * taken from the caller: unlike `markCancelled`, which relays an instant an
+   * external cancel event carries, "packed" is OpenLinker's own observation of
+   * an operator action, so accepting a caller-supplied timestamp would let a
+   * client backdate an audit fact.
+   *
+   * The repository write is guarded (`packedAt IS NULL`), so `false` means one
+   * of exactly two things and they must be told apart: the order is already
+   * packed (the idempotent replay — return the existing stamp untouched) or no
+   * such order exists (throw). Only the re-read can distinguish them, and it is
+   * also what makes the returned record authoritative on the winner's stamp
+   * rather than on this call's discarded one.
+   */
+  async markPacked(internalOrderId: string, packedByUserId: string): Promise<OrderRecord> {
+    await this.repository.markPacked(internalOrderId, new Date(), packedByUserId);
+    const record = await this.repository.findById(internalOrderId);
+    if (!record) {
+      throw new OrderRecordNotFoundException(internalOrderId);
+    }
+    return record;
+  }
+
+  /**
+   * Clear this order's packed fact (#2287). Same missing-row disambiguation as
+   * {@link markPacked}: the guarded write reports `false` both for an already-
+   * unpacked order and for an absent one, so the re-read decides.
+   */
+  async clearPacked(internalOrderId: string): Promise<OrderRecord> {
+    await this.repository.clearPacked(internalOrderId);
+    const record = await this.repository.findById(internalOrderId);
+    if (!record) {
+      throw new OrderRecordNotFoundException(internalOrderId);
+    }
+    return record;
   }
 
   /**

--- a/libs/core/src/orders/application/services/order-record.service.ts
+++ b/libs/core/src/orders/application/services/order-record.service.ts
@@ -26,6 +26,8 @@ import type {
 } from '../../domain/types/order-record.types';
 import type { FulfillmentRollupState } from '../../domain/types/order-fulfillment.types';
 import type { SalesDocumentBlock } from '@openlinker/core/sales-documents';
+import { redactAddress } from '../../domain/order-address-redaction';
+import type { OrderAmendmentChange } from '../../domain/order-amendment-diff';
 import { getPiiConfig } from '@openlinker/shared/config';
 import { Logger } from '@openlinker/shared/logging';
 import { IOrderFxStampService } from '../interfaces/order-fx-stamp.service.interface';
@@ -85,12 +87,12 @@ export class OrderRecordService implements IOrderRecordService {
       totals: order.totals,
       shippingAddress: piiConfig.storePii
         ? order.shippingAddress
-        : this.sanitizeAddress(order.shippingAddress),
+        : redactAddress(order.shippingAddress),
       billingAddress: piiConfig.storePii
         ? order.billingAddress
-        : this.sanitizeAddress(order.billingAddress),
+        : redactAddress(order.billingAddress),
       // Buyer email (#948) — PII-gated + present-only. Unlike addresses (which
-      // get a `[REDACTED]` placeholder via sanitizeAddress), email is omitted
+      // get a `[REDACTED]` placeholder via redactAddress), email is omitted
       // entirely under hash-only mode: there's no meaningful redaction of an
       // atomic identifier, and the privacy model keeps only `emailHash` on the
       // customer projection. Needed for the Generate-Label recipient.
@@ -233,10 +235,10 @@ export class OrderRecordService implements IOrderRecordService {
       totals: incoming.totals,
       shippingAddress: piiConfig.storePii
         ? incoming.shippingAddress
-        : this.sanitizeAddress(incoming.shippingAddress),
+        : redactAddress(incoming.shippingAddress),
       billingAddress: piiConfig.storePii
         ? incoming.billingAddress
-        : this.sanitizeAddress(incoming.billingAddress),
+        : redactAddress(incoming.billingAddress),
       // Buyer email (#948) — PII-gated + present-only; see persistOrder for the
       // omit-vs-redact rationale. For "ready" orders this awaiting_mapping
       // snapshot is overwritten by persistOrder, so this write is for
@@ -527,26 +529,17 @@ export class OrderRecordService implements IOrderRecordService {
   }
 
   /**
-   * Sanitize address by removing PII fields
-   *
-   * When PII storage is disabled, removes sensitive fields from addresses
-   * while keeping structural information (hash can be computed separately).
+   * Record a source-side amendment (#2283). A thin pass-through: the diff that
+   * produced `changes` is pure and lives in the domain, the no-op suppression
+   * lives in the repository's WHERE clause, and there is no re-read — unlike
+   * {@link markPacked}, no caller needs the resulting record, and this runs on
+   * the hot ingestion path where a second query would buy nothing.
    */
-  private sanitizeAddress(
-    address:
-      | { address1?: string; city?: string; postalCode?: string; country?: string }
-      | null
-      | undefined
-  ): { address1: string; city: string; postalCode: string; country: string } | undefined {
-    if (!address) {
-      return undefined;
-    }
-
-    return {
-      address1: '[REDACTED]',
-      city: '[REDACTED]',
-      postalCode: '[REDACTED]',
-      country: address.country ?? '', // Country code is not PII
-    };
+  async recordAmendment(
+    internalOrderId: string,
+    observedAt: Date,
+    changes: OrderAmendmentChange[]
+  ): Promise<void> {
+    await this.repository.recordAmendment(internalOrderId, observedAt, changes);
   }
 }

--- a/libs/core/src/orders/application/services/order-sync.service.ts
+++ b/libs/core/src/orders/application/services/order-sync.service.ts
@@ -35,6 +35,8 @@ import { Logger } from '@openlinker/shared/logging';
 import { NoOrderDestinationsAvailableException } from '../../domain/exceptions/no-order-destinations-available.exception';
 import { OrderCreateContendedException } from '../../domain/exceptions/order-create-contended.exception';
 import { ORDER_CREATE_LOCK_TTL_MS, orderCreateLockKey } from './order-create-lock';
+import { IOrderRecordService } from '../interfaces/order-record.service.interface';
+import { ORDER_RECORD_SERVICE_TOKEN } from '../../orders.tokens';
 
 @Injectable()
 export class OrderSyncService implements IOrderSyncService {
@@ -48,7 +50,9 @@ export class OrderSyncService implements IOrderSyncService {
     @Inject(SYNC_LOCK_TOKEN)
     private readonly syncLock: SyncLockPort,
     @Inject(IDENTIFIER_MAPPING_SERVICE_TOKEN)
-    private readonly identifierMapping: IIdentifierMappingService
+    private readonly identifierMapping: IIdentifierMappingService,
+    @Inject(ORDER_RECORD_SERVICE_TOKEN)
+    private readonly orderRecordService: IOrderRecordService
   ) {}
 
   async syncOrder(request: OrderSyncRequest): Promise<OrderSyncResult[]> {
@@ -62,6 +66,30 @@ export class OrderSyncService implements IOrderSyncService {
 
     if (destinations.length === 0) {
       throw new NoOrderDestinationsAvailableException(order.id, sourceConnectionId);
+    }
+
+    // #2284 — the `WHERE cancelledAt IS NULL` provisioning predicate. A source
+    // cancellation is an observation, never gated (DESIGN-oms-authority-model
+    // § 6.4), so a create/update job enqueued before the cancel — or an operator
+    // retry afterwards — would otherwise still create the order in every
+    // destination. Withhold instead: no lock, no `createOrder`, no mapping write.
+    //
+    // Deliberately RE-READ rather than threaded from ingestion: ingestion's own
+    // snapshot is taken before item resolution and persist, so it is stale in
+    // exactly the race this closes. A missing record means "nothing known", which
+    // is not "cancelled" — proceed. A read failure PROPAGATES: provisioning a
+    // possibly-cancelled order because a read blipped is the worse outcome.
+    const record = await this.orderRecordService.getOrderRecord(order.id);
+    if (record?.isCancelled) {
+      const cancelledAt = record.cancelledAt as Date;
+      this.logger.warn(
+        `Order ${order.id} was cancelled at source (${cancelledAt.toISOString()}); skipping destination provisioning for ${destinations.length} destination(s)`
+      );
+      return destinations.map(({ connectionId }) => ({
+        destinationConnectionId: connectionId,
+        status: 'skipped_cancelled' as const,
+        cancelledAt,
+      }));
     }
 
     // Resolve status mapping once — identical across all destinations

--- a/libs/core/src/orders/domain/entities/order-record.entity.ts
+++ b/libs/core/src/orders/domain/entities/order-record.entity.ts
@@ -14,6 +14,7 @@ import type { PaymentStatus } from '../types/payment-status.types';
 import type { CodToCollect } from '../types/cod-to-collect.types';
 import type { FulfillmentRollupState } from '../types/order-fulfillment.types';
 import type { OrderDispatchWindow } from '../types/order.types';
+import type { OrderAmendmentChange } from '../order-amendment-diff';
 import type {
   SalesDocumentGateBlockReason,
   SalesDocumentUnresolvedReason,
@@ -174,7 +175,33 @@ export class OrderRecord {
      * actor is preserved. No FK to `users`: a deleted user leaving a dangling
      * id the UI renders raw is the honest outcome for an audit fact.
      */
-    public readonly packedByUserId: string | null = null
+    public readonly packedByUserId: string | null = null,
+    /**
+     * Instant OpenLinker last observed the SOURCE amend this order after it was
+     * already ingested (#2283) — a line removed, added or re-quantified, or the
+     * shipping address edited. `null` = never observed amended.
+     *
+     * An internal FACT, not a lifecycle state: it appears in no status union, no
+     * relay event and no health bucket, and nothing is gated on it. It exists
+     * because ingestion overwrites `orderSnapshot` wholesale, so before this the
+     * amendment left no trace whatsoever.
+     *
+     * Single-writer, like `cancelledAt` / `packedAt` / the FX columns: only the
+     * narrow `recordAmendment` statement writes it, and the ingestion upsert
+     * excludes it, so the re-poll that DETECTS the amendment cannot also erase it.
+     */
+    public readonly lastAmendedAt: Date | null = null,
+    /**
+     * What changed at that instant (#2283) — the most recent observation only,
+     * not a history. Moves as one group with `lastAmendedAt`.
+     *
+     * PII-free by construction: line ids, SKUs and quantities verbatim, and for
+     * an address change only the NAMES of the fields that moved. It is persisted
+     * and rendered to operators, so carrying address values would put buyer PII
+     * into a second store with none of the `OL_STORE_PII` discipline the snapshot
+     * itself has.
+     */
+    public readonly lastAmendmentChanges: OrderAmendmentChange[] | null = null
   ) {}
 
   /**

--- a/libs/core/src/orders/domain/entities/order-record.entity.ts
+++ b/libs/core/src/orders/domain/entities/order-record.entity.ts
@@ -154,7 +154,27 @@ export class OrderRecord {
      * lookup — so a retry or the sweep stamps against the same currency the
      * inline attempt resolved even if the system setting changed in between.
      */
-    public readonly fxIntendedCurrency: string | null = null
+    public readonly fxIntendedCurrency: string | null = null,
+    /**
+     * Instant an operator marked this order packed (#2287). A plain operator
+     * FACT, not a state: it is deliberately independent of `recordStatus`,
+     * `fulfillmentState`, `slaState` and `OrderHealth`, and carries no pack
+     * policy (no scan verification, no dispatch gating) per ADR-045. It is
+     * therefore meaningful for 100% of orders, including `omp_fulfilled` ones
+     * OpenLinker never dispatches. `null` = not packed.
+     *
+     * Single-writer, like `cancelledAt` and the FX columns: only the guarded
+     * `markPacked` / `clearPacked` statements write it, and the ingestion
+     * upsert excludes it entirely, so a re-poll can never reset it.
+     */
+    public readonly packedAt: Date | null = null,
+    /**
+     * The OL user id of whoever marked this order packed (#2287). Moves as one
+     * group with `packedAt` — a repeat mark is a no-op replay, so the FIRST
+     * actor is preserved. No FK to `users`: a deleted user leaving a dangling
+     * id the UI renders raw is the honest outcome for an audit fact.
+     */
+    public readonly packedByUserId: string | null = null
   ) {}
 
   /**

--- a/libs/core/src/orders/domain/order-address-redaction.ts
+++ b/libs/core/src/orders/domain/order-address-redaction.ts
@@ -1,0 +1,64 @@
+/**
+ * Order Address Redaction
+ *
+ * The single implementation of OpenLinker's PII redaction rule for an order
+ * address, shared by every consumer that must agree on it (#2283).
+ *
+ * It has two callers with two different jobs, and they MUST use one rule.
+ * `OrderRecordService` applies it on the way into the snapshot under
+ * `OL_STORE_PII=false`; the ingestion amendment diff applies it to the INCOMING
+ * address before comparing against a stored one. If the two ever diverged, every
+ * poll of every order would compare a raw address against a redacted one and
+ * report a shipping-address change that did not happen — a permanent
+ * false-positive storm rather than a subtle drift. Reimplementing the rule twice
+ * is what makes that divergence possible, so there is one function.
+ *
+ * Domain-only: pure, no framework dependencies, no I/O.
+ *
+ * @module libs/core/src/orders/domain
+ */
+
+/** Placeholder written in place of a PII field under `OL_STORE_PII=false`. */
+export const REDACTED_PLACEHOLDER = '[REDACTED]';
+
+/** The structural subset of an address this rule reads. */
+export interface RedactableAddress {
+  address1?: string;
+  city?: string;
+  postalCode?: string;
+  country?: string;
+}
+
+/** What survives redaction: placeholders plus the (non-PII) country code. */
+export interface RedactedAddress {
+  address1: string;
+  city: string;
+  postalCode: string;
+  country: string;
+}
+
+/**
+ * Reduce an address to its non-PII residue.
+ *
+ * Structure is preserved (so downstream shape checks still hold) while every
+ * identifying value becomes {@link REDACTED_PLACEHOLDER}. `country` is kept
+ * verbatim — a country code is not personal data, and it is the one field that
+ * stays meaningfully comparable in hash-only mode.
+ *
+ * Returns `undefined` for an absent address, so an order with no address keeps
+ * an absent key rather than gaining a wholly-redacted phantom one.
+ */
+export function redactAddress(
+  address: RedactableAddress | null | undefined
+): RedactedAddress | undefined {
+  if (!address) {
+    return undefined;
+  }
+
+  return {
+    address1: REDACTED_PLACEHOLDER,
+    city: REDACTED_PLACEHOLDER,
+    postalCode: REDACTED_PLACEHOLDER,
+    country: address.country ?? '',
+  };
+}

--- a/libs/core/src/orders/domain/order-amendment-diff.spec.ts
+++ b/libs/core/src/orders/domain/order-amendment-diff.spec.ts
@@ -1,0 +1,255 @@
+/**
+ * Order Amendment Diff — unit tests
+ *
+ * @module libs/core/src/orders/domain
+ */
+import { diffOrderAmendment } from './order-amendment-diff';
+import type { IncomingOrder } from './types/incoming-order.types';
+
+function incomingOrder(overrides: Partial<IncomingOrder> = {}): IncomingOrder {
+  return {
+    externalOrderId: 'EXT-1',
+    status: 'new',
+    items: [
+      { id: 'line-1', productRef: { type: 'product', externalId: 'p1' }, quantity: 2, price: 10, sku: 'SKU-1' },
+    ],
+    totals: { subtotal: 20, tax: 0, shipping: 0, total: 20, currency: 'PLN' },
+    createdAt: '2026-08-01T10:00:00.000Z',
+    updatedAt: '2026-08-01T10:00:00.000Z',
+    ...overrides,
+  } as IncomingOrder;
+}
+
+const address = {
+  firstName: 'Anna',
+  lastName: 'Nowak',
+  address1: 'ul. Kwiatowa 1',
+  city: 'Warszawa',
+  postalCode: '00-001',
+  country: 'PL',
+};
+
+const PII_ON = { storePii: true };
+const PII_OFF = { storePii: false };
+
+describe('diffOrderAmendment', () => {
+  describe('lines', () => {
+    it('should report nothing when the incoming order matches the stored snapshot', () => {
+      const prior = { items: [{ id: 'line-1', quantity: 2, sku: 'SKU-1' }] };
+      expect(diffOrderAmendment(prior, incomingOrder(), PII_ON)).toEqual([]);
+    });
+
+    it('should report a removed line when the source dropped it', () => {
+      const prior = {
+        items: [
+          { id: 'line-1', quantity: 2, sku: 'SKU-1' },
+          { id: 'line-2', quantity: 5, sku: 'SKU-2' },
+        ],
+      };
+      expect(diffOrderAmendment(prior, incomingOrder(), PII_ON)).toEqual([
+        { kind: 'line-removed', lineId: 'line-2', sku: 'SKU-2', fromQuantity: 5 },
+      ]);
+    });
+
+    it('should report an added line when the source introduced one', () => {
+      const prior = { items: [{ id: 'line-1', quantity: 2, sku: 'SKU-1' }] };
+      const incoming = incomingOrder({
+        items: [
+          { id: 'line-1', productRef: { type: 'product', externalId: 'p1' }, quantity: 2, price: 10, sku: 'SKU-1' },
+          { id: 'line-9', productRef: { type: 'product', externalId: 'p9' }, quantity: 1, price: 5, sku: 'SKU-9' },
+        ],
+      });
+
+      expect(diffOrderAmendment(prior, incoming, PII_ON)).toEqual([
+        { kind: 'line-added', lineId: 'line-9', sku: 'SKU-9', toQuantity: 1 },
+      ]);
+    });
+
+    it('should report a quantity change with both quantities', () => {
+      const prior = { items: [{ id: 'line-1', quantity: 5, sku: 'SKU-1' }] };
+      expect(diffOrderAmendment(prior, incomingOrder(), PII_ON)).toEqual([
+        {
+          kind: 'line-quantity-changed',
+          lineId: 'line-1',
+          sku: 'SKU-1',
+          fromQuantity: 5,
+          toQuantity: 2,
+        },
+      ]);
+    });
+
+    it('should ignore a price change, which is ordinary churn rather than an amendment', () => {
+      const prior = { items: [{ id: 'line-1', quantity: 2, sku: 'SKU-1', price: 999 }] };
+      expect(diffOrderAmendment(prior, incomingOrder(), PII_ON)).toEqual([]);
+    });
+
+    it('should key on line id rather than position, so a reordered feed reports nothing', () => {
+      const prior = {
+        items: [
+          { id: 'line-2', quantity: 1 },
+          { id: 'line-1', quantity: 2 },
+        ],
+      };
+      const incoming = incomingOrder({
+        items: [
+          { id: 'line-1', productRef: { type: 'product', externalId: 'p1' }, quantity: 2, price: 10 },
+          { id: 'line-2', productRef: { type: 'product', externalId: 'p2' }, quantity: 1, price: 3 },
+        ],
+      });
+      expect(diffOrderAmendment(prior, incoming, PII_ON)).toEqual([]);
+    });
+
+    it('should diff a ready-path snapshot the same way as a raw-path one', () => {
+      // Ready path carries internalised productId/variantId beside the same
+      // source-native `id` — the diff key must be unaffected.
+      const readyPrior = {
+        items: [
+          { id: 'line-1', productId: 'ol_product_x', variantId: 'ol_variant_y', quantity: 7, sku: 'SKU-1' },
+        ],
+      };
+      expect(diffOrderAmendment(readyPrior, incomingOrder(), PII_ON)).toEqual([
+        {
+          kind: 'line-quantity-changed',
+          lineId: 'line-1',
+          sku: 'SKU-1',
+          fromQuantity: 7,
+          toQuantity: 2,
+        },
+      ]);
+    });
+  });
+
+  describe('defensive reads', () => {
+    it('should report nothing on a first ingestion (null prior)', () => {
+      expect(diffOrderAmendment(null, incomingOrder(), PII_ON)).toEqual([]);
+      expect(diffOrderAmendment(undefined, incomingOrder(), PII_ON)).toEqual([]);
+    });
+
+    it('should report nothing when the prior snapshot carries no usable items array', () => {
+      expect(diffOrderAmendment({}, incomingOrder(), PII_ON)).toEqual([]);
+      expect(diffOrderAmendment({ items: 'not-an-array' }, incomingOrder(), PII_ON)).toEqual([]);
+      expect(diffOrderAmendment({ items: null }, incomingOrder(), PII_ON)).toEqual([]);
+    });
+
+    it('should not throw on malformed line entries and should skip them individually', () => {
+      const prior = {
+        items: [null, 'nope', { quantity: 3 }, { id: 'line-1', quantity: 'two' }, { id: 'line-1', quantity: 2 }],
+      };
+      expect(() => diffOrderAmendment(prior, incomingOrder(), PII_ON)).not.toThrow();
+      expect(diffOrderAmendment(prior, incomingOrder(), PII_ON)).toEqual([]);
+    });
+  });
+
+  describe('shipping address', () => {
+    it('should report the changed field names and never their values', () => {
+      const prior = { items: [{ id: 'line-1', quantity: 2 }], shippingAddress: address };
+      const incoming = incomingOrder({
+        shippingAddress: { ...address, city: 'Kraków', postalCode: '30-001' },
+      });
+
+      const changes = diffOrderAmendment(prior, incoming, PII_ON);
+      expect(changes).toEqual([
+        { kind: 'shipping-address-changed', fields: ['city', 'postalCode'] },
+      ]);
+      expect(JSON.stringify(changes)).not.toContain('Kraków');
+      expect(JSON.stringify(changes)).not.toContain('30-001');
+    });
+
+    it('should treat absent, null and blank address fields as one value', () => {
+      const prior = {
+        items: [{ id: 'line-1', quantity: 2 }],
+        shippingAddress: { ...address, address2: null, company: '' },
+      };
+      const incoming = incomingOrder({ shippingAddress: { ...address } });
+      expect(diffOrderAmendment(prior, incoming, PII_ON)).toEqual([]);
+    });
+
+    it('should report nothing when only one side carries an address', () => {
+      const prior = { items: [{ id: 'line-1', quantity: 2 }], shippingAddress: address };
+      expect(diffOrderAmendment(prior, incomingOrder(), PII_ON)).toEqual([]);
+
+      const noAddressPrior = { items: [{ id: 'line-1', quantity: 2 }] };
+      expect(
+        diffOrderAmendment(noAddressPrior, incomingOrder({ shippingAddress: address }), PII_ON)
+      ).toEqual([]);
+    });
+
+    it('should not report a change against a redacted prior in hash-only mode', () => {
+      // The false-positive guard: without projecting the incoming address
+      // through the same redaction rule, EVERY poll of EVERY order would report
+      // a shipping-address change forever.
+      const redactedPrior = {
+        items: [{ id: 'line-1', quantity: 2 }],
+        shippingAddress: {
+          address1: '[REDACTED]',
+          city: '[REDACTED]',
+          postalCode: '[REDACTED]',
+          country: 'PL',
+        },
+      };
+      expect(
+        diffOrderAmendment(redactedPrior, incomingOrder({ shippingAddress: address }), PII_OFF)
+      ).toEqual([]);
+    });
+
+    it('should still detect a country change in hash-only mode', () => {
+      const redactedPrior = {
+        items: [{ id: 'line-1', quantity: 2 }],
+        shippingAddress: {
+          address1: '[REDACTED]',
+          city: '[REDACTED]',
+          postalCode: '[REDACTED]',
+          country: 'PL',
+        },
+      };
+      expect(
+        diffOrderAmendment(
+          redactedPrior,
+          incomingOrder({ shippingAddress: { ...address, country: 'DE' } }),
+          PII_OFF
+        )
+      ).toEqual([{ kind: 'shipping-address-changed', fields: ['country'] }]);
+    });
+
+    it('should store no raw address value in hash-only mode even when a change is reported', () => {
+      const redactedPrior = {
+        items: [{ id: 'line-1', quantity: 2 }],
+        shippingAddress: {
+          address1: '[REDACTED]',
+          city: '[REDACTED]',
+          postalCode: '[REDACTED]',
+          country: 'PL',
+        },
+      };
+      const serialised = JSON.stringify(
+        diffOrderAmendment(
+          redactedPrior,
+          incomingOrder({ shippingAddress: { ...address, country: 'DE' } }),
+          PII_OFF
+        )
+      );
+      for (const value of ['Anna', 'Nowak', 'Kwiatowa', 'Warszawa', '00-001']) {
+        expect(serialised).not.toContain(value);
+      }
+    });
+  });
+
+  it('should report line and address changes together', () => {
+    const prior = {
+      items: [{ id: 'line-1', quantity: 9, sku: 'SKU-1' }],
+      shippingAddress: address,
+    };
+    const incoming = incomingOrder({ shippingAddress: { ...address, city: 'Gdańsk' } });
+
+    expect(diffOrderAmendment(prior, incoming, PII_ON)).toEqual([
+      {
+        kind: 'line-quantity-changed',
+        lineId: 'line-1',
+        sku: 'SKU-1',
+        fromQuantity: 9,
+        toQuantity: 2,
+      },
+      { kind: 'shipping-address-changed', fields: ['city'] },
+    ]);
+  });
+});

--- a/libs/core/src/orders/domain/order-amendment-diff.ts
+++ b/libs/core/src/orders/domain/order-amendment-diff.ts
@@ -1,0 +1,267 @@
+/**
+ * Order Amendment Diff
+ *
+ * Pure comparison of an order's ALREADY-STORED snapshot against the order the
+ * source just reported, producing the list of changes that a re-ingestion is
+ * about to silently absorb (#2283).
+ *
+ * The problem it exists for: ingestion overwrites `orderSnapshot` wholesale, so
+ * a line that shrank, vanished or changed quantity — or a shipping address the
+ * buyer edited — left no trace at all. No fact, no operator surface, and any
+ * shipment already referencing the removed line dangles with nothing explaining
+ * why. This module names what changed; persisting and surfacing it is the
+ * caller's job.
+ *
+ * ## What is compared, and why only this
+ *
+ * Lines are keyed by `items[].id` and compared on `quantity` alone. The key is
+ * safe across BOTH snapshot shapes: the raw path stores `incoming.items`
+ * verbatim, and the ready path sets `id: item.id` — the source's own line id in
+ * both cases (only `productId` / `variantId` are internalised). Price, name and
+ * image are deliberately ignored: price churn is ordinary and would drown the
+ * signal, and neither dangles a shipment.
+ *
+ * The shipping address is compared field-by-field, and only FIELD NAMES ever
+ * leave this module. A change list is persisted and rendered to operators, so
+ * carrying before/after address values would put buyer PII into a second store
+ * with none of the `OL_STORE_PII` discipline the snapshot itself has.
+ *
+ * ## Hash-only mode
+ *
+ * Under `OL_STORE_PII=false` the stored address is already redacted, so the
+ * incoming one is passed through the SAME rule ({@link redactAddress}) before
+ * comparison. Without that, every poll would compare a raw address against a
+ * redacted one and report a change on every order forever. The documented cost:
+ * in hash-only mode only a `country` change is detectable at all. That is a real
+ * blind spot, stated rather than hidden — the alternative is a false-positive
+ * storm or storing the PII this deployment explicitly opted out of.
+ *
+ * Domain-only: pure, no framework dependencies, no I/O. Every read of the prior
+ * snapshot is defensive (it is an untyped `Record<string, unknown>` that may
+ * predate any of these keys); a malformed or absent prior yields no changes
+ * rather than throwing, mirroring `OrderIngestionService.readSnapshotStatus`.
+ *
+ * @module libs/core/src/orders/domain
+ */
+import type { IncomingOrder } from './types/incoming-order.types';
+import { redactAddress, type RedactableAddress } from './order-address-redaction';
+
+/** The kinds of source-side amendment this diff can observe. */
+export const OrderAmendmentChangeKindValues = [
+  'line-removed',
+  'line-added',
+  'line-quantity-changed',
+  'shipping-address-changed',
+] as const;
+
+export type OrderAmendmentChangeKind = (typeof OrderAmendmentChangeKindValues)[number];
+
+/**
+ * One observed change. PII-free by construction: ids, SKUs and quantities are
+ * carried verbatim (none is personal data), while an address contributes only
+ * the NAMES of the fields that moved.
+ */
+export interface OrderAmendmentChange {
+  kind: OrderAmendmentChangeKind;
+  /** Source-native line id, for the line-grained kinds. */
+  lineId?: string;
+  /** Source-native SKU when the source reported one, for operator legibility. */
+  sku?: string;
+  fromQuantity?: number;
+  toQuantity?: number;
+  /**
+   * Address-grain only: the names of the fields that differ. NEVER values —
+   * see the module header.
+   */
+  fields?: string[];
+}
+
+export interface OrderAmendmentDiffOptions {
+  /** The deployment's `OL_STORE_PII` setting, as the snapshot writers saw it. */
+  storePii: boolean;
+}
+
+/**
+ * The address fields worth reporting on. Fixed rather than derived from the
+ * objects, so a source that starts emitting an extra key cannot silently widen
+ * what OpenLinker reports — and so the two snapshot shapes (`Address` on the
+ * ready path, `IncomingOrderAddress` on the raw path) compare on their common
+ * ground.
+ */
+const COMPARED_ADDRESS_FIELDS = [
+  'firstName',
+  'lastName',
+  'company',
+  'address1',
+  'address2',
+  'city',
+  'state',
+  'postalCode',
+  'country',
+  'phone',
+] as const;
+
+interface PriorLine {
+  quantity: number;
+  sku?: string;
+}
+
+/**
+ * Compare a stored snapshot against the incoming order.
+ *
+ * Returns `[]` — never throws — for a first ingestion (`null` prior), a prior
+ * that carries no usable `items` array, and an unchanged re-poll. An empty
+ * result means "no fact to record", which is the overwhelmingly common case on
+ * a steady-state poll.
+ */
+export function diffOrderAmendment(
+  priorSnapshot: Record<string, unknown> | null | undefined,
+  incoming: IncomingOrder,
+  options: OrderAmendmentDiffOptions
+): OrderAmendmentChange[] {
+  if (!priorSnapshot) {
+    return [];
+  }
+
+  const changes: OrderAmendmentChange[] = [];
+  changes.push(...diffLines(priorSnapshot, incoming));
+
+  const addressFields = diffShippingAddress(priorSnapshot, incoming, options.storePii);
+  if (addressFields.length > 0) {
+    changes.push({ kind: 'shipping-address-changed', fields: addressFields });
+  }
+
+  return changes;
+}
+
+function diffLines(
+  priorSnapshot: Record<string, unknown>,
+  incoming: IncomingOrder
+): OrderAmendmentChange[] {
+  const prior = readPriorLines(priorSnapshot);
+  // An absent/garbled prior `items` is indistinguishable from "we never stored
+  // lines", so reporting every incoming line as ADDED would manufacture an
+  // amendment out of a storage gap. Report nothing.
+  if (prior === null) {
+    return [];
+  }
+
+  const changes: OrderAmendmentChange[] = [];
+  const seen = new Set<string>();
+
+  for (const item of incoming.items ?? []) {
+    const lineId = item?.id;
+    if (typeof lineId !== 'string' || lineId.length === 0) {
+      continue;
+    }
+    seen.add(lineId);
+
+    const before = prior.get(lineId);
+    const toQuantity = item.quantity;
+    if (!before) {
+      changes.push({
+        kind: 'line-added',
+        lineId,
+        ...(item.sku !== undefined && { sku: item.sku }),
+        toQuantity,
+      });
+      continue;
+    }
+    if (before.quantity !== toQuantity) {
+      changes.push({
+        kind: 'line-quantity-changed',
+        lineId,
+        ...(item.sku !== undefined && { sku: item.sku }),
+        fromQuantity: before.quantity,
+        toQuantity,
+      });
+    }
+  }
+
+  for (const [lineId, before] of prior) {
+    if (!seen.has(lineId)) {
+      changes.push({
+        kind: 'line-removed',
+        lineId,
+        ...(before.sku !== undefined && { sku: before.sku }),
+        fromQuantity: before.quantity,
+      });
+    }
+  }
+
+  return changes;
+}
+
+/**
+ * Read the prior snapshot's lines into a quantity-by-id map, or `null` when the
+ * snapshot carries nothing usable. A line whose `id` or `quantity` is malformed
+ * is dropped individually rather than failing the whole read.
+ */
+function readPriorLines(priorSnapshot: Record<string, unknown>): Map<string, PriorLine> | null {
+  const raw = priorSnapshot.items;
+  if (!Array.isArray(raw)) {
+    return null;
+  }
+
+  const lines = new Map<string, PriorLine>();
+  for (const entry of raw) {
+    if (typeof entry !== 'object' || entry === null) {
+      continue;
+    }
+    const { id, quantity, sku } = entry as Record<string, unknown>;
+    if (typeof id !== 'string' || id.length === 0 || typeof quantity !== 'number') {
+      continue;
+    }
+    lines.set(id, {
+      quantity,
+      ...(typeof sku === 'string' && { sku }),
+    });
+  }
+  return lines;
+}
+
+function diffShippingAddress(
+  priorSnapshot: Record<string, unknown>,
+  incoming: IncomingOrder,
+  storePii: boolean
+): string[] {
+  const priorRaw = priorSnapshot.shippingAddress;
+  const priorAddress =
+    typeof priorRaw === 'object' && priorRaw !== null
+      ? (priorRaw as Record<string, unknown>)
+      : undefined;
+
+  // Project the incoming address through the SAME rule the snapshot writers
+  // applied, so like is compared with like. See the module header.
+  const incomingProjected = storePii
+    ? (incoming.shippingAddress as Record<string, unknown> | undefined)
+    : (redactAddress(incoming.shippingAddress as RedactableAddress | undefined) as
+        | Record<string, unknown>
+        | undefined);
+
+  // Absence on either side is not a field-level change: an order that never had
+  // an address, or a source that stopped reporting one, is not a buyer edit and
+  // naming every field would be noise. Only a present-vs-present pair is diffed.
+  if (!priorAddress || !incomingProjected) {
+    return [];
+  }
+
+  const fields: string[] = [];
+  for (const field of COMPARED_ADDRESS_FIELDS) {
+    const before = normaliseAddressField(priorAddress[field]);
+    const after = normaliseAddressField(incomingProjected[field]);
+    if (before !== after) {
+      fields.push(field);
+    }
+  }
+  return fields;
+}
+
+/**
+ * Treat an absent, null and empty-string field as one value. Adapters and JSON
+ * round-trips disagree on which of the three an unset field becomes, and a
+ * change between two spellings of "nothing" is not an amendment.
+ */
+function normaliseAddressField(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}

--- a/libs/core/src/orders/domain/order-from-ready-snapshot.ts
+++ b/libs/core/src/orders/domain/order-from-ready-snapshot.ts
@@ -22,9 +22,14 @@
 import type { OrderRecord } from './entities/order-record.entity';
 import type { Address, Order, OrderItem, OrderTotals } from './types/order.types';
 import { OrderSnapshotUnavailableError } from './exceptions/order-snapshot-unavailable.error';
+import { REDACTED_PLACEHOLDER } from './order-address-redaction';
 
-/** The `OrderRecordService.sanitizeAddress` placeholder for a PII-redacted field. */
-const REDACTED = '[REDACTED]';
+/**
+ * The placeholder `redactAddress` writes for a PII-redacted field. Imported
+ * from the one implementation (#2283) rather than re-declared, so a change to
+ * the redaction rule cannot leave this reader silently matching the old token.
+ */
+const REDACTED = REDACTED_PLACEHOLDER;
 
 /** Caller-declared expectations of the rehydrated order. */
 export interface OrderFromReadySnapshotOptions {

--- a/libs/core/src/orders/domain/ports/order-record-repository.port.ts
+++ b/libs/core/src/orders/domain/ports/order-record-repository.port.ts
@@ -53,7 +53,8 @@ export interface OrderRecordRepositoryPort {
    * {@link updateFulfillmentState}), `cancelledAt` (#1984,
    * {@link markCancelled}), the three `salesDocument*` columns (#2100,
    * {@link updateSalesDocumentBlock}) and the six FX snapshot columns (#2124,
-   * {@link claimFxIntentIfAbsent} / {@link stampFxIfAbsent}) - are NOT part of
+   * {@link claimFxIntentIfAbsent} / {@link stampFxIfAbsent}) and the two packed
+   * columns (#2287, {@link markPacked} / {@link clearPacked}) - are NOT part of
    * the write set, so a re-ingestion of the same order cannot reset them. The
    * returned record therefore reports all of them as empty (`[]` / `null`)
    * whatever the row holds; re-read via {@link findById} when their live value
@@ -202,6 +203,38 @@ export interface OrderRecordRepositoryPort {
    * NULL by definition.
    */
   claimFxIntentIfAbsent(internalOrderId: string, intent: OrderFxIntent): Promise<boolean>;
+
+  /**
+   * Mark this order packed (#2287) — writes `packedAt` + `packedByUserId` and
+   * nothing else, guarded on `packedAt IS NULL` so the FIRST mark wins.
+   *
+   * Both columns move in ONE guarded statement rather than via a per-column
+   * `COALESCE`: they are one fact, and a `COALESCE` on `packedAt` alone would
+   * preserve the original instant while letting a second caller overwrite
+   * `packedByUserId` — "who packed it first is never overwritten" is the
+   * explicit requirement.
+   *
+   * Returns `true` when this call wrote and `false` when it did not — either
+   * because the order is already packed (an idempotent replay) or because no
+   * row matches the id at all. It never throws, so a caller that must tell
+   * those two apart re-reads via {@link findById}.
+   */
+  markPacked(
+    internalOrderId: string,
+    packedAt: Date,
+    packedByUserId: string
+  ): Promise<boolean>;
+
+  /**
+   * Clear this order's packed fact (#2287) — nulls `packedAt` +
+   * `packedByUserId` together, guarded on `packedAt IS NOT NULL` so unmarking
+   * an already-unpacked order affects no row and does not bump `updatedAt`.
+   *
+   * Returns `true` when this call cleared, `false` otherwise (already unpacked,
+   * or no row matched). Never throws — same disambiguation rule as
+   * {@link markPacked}.
+   */
+  clearPacked(internalOrderId: string): Promise<boolean>;
 
   /**
    * Stamp the order's reporting-currency figures at most once (#2124) — one

--- a/libs/core/src/orders/domain/ports/order-record-repository.port.ts
+++ b/libs/core/src/orders/domain/ports/order-record-repository.port.ts
@@ -58,6 +58,16 @@ export interface OrderRecordRepositoryPort {
    * returned record therefore reports all of them as empty (`[]` / `null`)
    * whatever the row holds; re-read via {@link findById} when their live value
    * matters.
+   *
+   * Source attribution is immutable at this write path (#2282, ADR-057). The
+   * rule is: *same-source may advance, cross-source frozen*. `sourceConnectionId`
+   * is established by the first write and can never be changed by a later one;
+   * `sourceEventId` is refreshed only when the write arrives from the row's own
+   * `sourceConnectionId`, and is left as committed otherwise. An implementation
+   * MUST enforce this in the statement itself, so the invariant holds for every
+   * caller and not only for the ADR-017 destination-echo guard in
+   * `OrderIngestionService`. The returned record therefore reports the row's
+   * true, possibly pre-existing attribution rather than what was requested.
    */
   upsert(orderRecord: OrderRecord): Promise<OrderRecord>;
 

--- a/libs/core/src/orders/domain/ports/order-record-repository.port.ts
+++ b/libs/core/src/orders/domain/ports/order-record-repository.port.ts
@@ -23,6 +23,7 @@ import type { SyncAttempt } from '../types/order-sync.types';
 import type { SalesDocumentBlock } from '@openlinker/core/sales-documents';
 import type { OrderFxIntent, OrderFxStamp } from '../types/order-fx.types';
 import type { StampedReportingCurrencyCount } from '../types/order-fx-read.types';
+import type { OrderAmendmentChange } from '../order-amendment-diff';
 
 export interface OrderRecordRepositoryPort {
   /**
@@ -235,6 +236,30 @@ export interface OrderRecordRepositoryPort {
    * {@link markPacked}.
    */
   clearPacked(internalOrderId: string): Promise<boolean>;
+
+  /**
+   * Record that the source amended this order after ingestion (#2283) — writes
+   * `lastAmendedAt` + `lastAmendmentChanges` together and nothing else.
+   *
+   * Last-write-wins, like {@link updateSalesDocumentBlock} and unlike
+   * {@link markCancelled}: an amendment is always NEWER information about the
+   * source, so the freshest observation is the truthful one. Only the most
+   * recent observation is kept — this is a fact, not a history.
+   *
+   * The implementation MUST suppress a no-op write, and MUST compare only
+   * `lastAmendmentChanges` when doing so. Comparing the timestamp too would
+   * defeat the guard entirely: every call carries a fresh instant, so the row
+   * would always look changed and `updatedAt` would be bumped on writes that
+   * changed nothing.
+   *
+   * No-op (no throw) when the order row doesn't exist, mirroring
+   * {@link updateFulfillmentState}'s residual-race tolerance.
+   */
+  recordAmendment(
+    internalOrderId: string,
+    observedAt: Date,
+    changes: OrderAmendmentChange[]
+  ): Promise<void>;
 
   /**
    * Stamp the order's reporting-currency figures at most once (#2124) — one

--- a/libs/core/src/orders/domain/types/order-lifecycle-event.types.ts
+++ b/libs/core/src/orders/domain/types/order-lifecycle-event.types.ts
@@ -28,6 +28,27 @@ export type OrderLifecycleEventType = (typeof OrderLifecycleEventTypeValues)[num
  * A lifecycle event targeted at a single participant. `externalOrderId` is the
  * participant's own external order id, resolved upstream by the relay (the
  * adapter performs no identifier mapping).
+ *
+ * **Exhaustiveness discipline (#2286).** Adding a member here is a breaking
+ * change for every in-tree consumer, and that is deliberate: each one branches
+ * with `switch (event.type)` over a `default:` arm that binds the narrowed value
+ * to `never`, so an unhandled member is a **compile** error rather than a
+ * runtime fall-through into whichever arm happened to be last. Before #2286 the
+ * consumers used two-arm `if/else`, so a third member would have compiled
+ * cleanly and been relayed to every participant *as a cancellation*.
+ *
+ * A new member therefore requires updating, in the same change: the relay
+ * (`OrderLifecycleRelayService`) and the four `OrderStatusWriteback` adapters
+ * (Allegro, Erli, PrestaShop, WooCommerce). `OrderLifecycleRelayInput.event` is
+ * derived from this union rather than restated, so the widening reaches the
+ * relay too.
+ *
+ * **Port-boundary exception (ADR-055 forward-compat).** The adapters' `default:`
+ * arms keep the `never` binding for the compile break but still *return*
+ * `{ outcome: 'unsupported' }` instead of throwing — an out-of-tree adapter
+ * compiled against an older copy of this union must degrade to a surfaced no-op,
+ * never take down a relay fan-out. The relay's own default throws (`assertNever`),
+ * because a member it cannot map is an in-tree defect, not a third-party one.
  */
 export type OrderLifecycleEvent =
   | {

--- a/libs/core/src/orders/domain/types/order-record.types.ts
+++ b/libs/core/src/orders/domain/types/order-record.types.ts
@@ -11,9 +11,32 @@ import type { SlaState } from './order-sla.types';
 import type { FulfillmentRollupState } from './order-fulfillment.types';
 
 /**
- * Sync status filter values for order queries
+ * Per-destination sync status values (#2284).
+ *
+ * The single source of truth for the vocabulary: the persisted jsonb payload
+ * (`OrderSyncStatus` / `SyncAttempt`, `OrderSyncStatusJson` / `SyncAttemptJson`),
+ * the `/orders` query filter, and the response DTO all type off this one const —
+ * so the persisted set and the queryable set can never drift.
+ *
+ * `'skipped_cancelled'` (#2284) is **terminal**: the source cancelled the order
+ * before any destination order existed, so provisioning was deliberately
+ * withheld. It is never retried (`OrderDestinationRetryService` retries only
+ * `'failed'`) and must never read as a failure — nothing went wrong. Two
+ * consequences of typing the query filter off the same const, both intended:
+ * the response DTO widens with no edit, and `GET /orders?syncStatus=…`
+ * legitimately accepts the new value.
+ *
+ * Health partitioning is deliberately unchanged: a cancelled-and-skipped order
+ * falls into the residual `awaiting_dispatch` bucket. A dedicated bucket needs
+ * the SQL twin plus the FE KPI cards and is out of scope for #2284.
  */
-export const OrderSyncStatusFilterValues = ['pending', 'syncing', 'synced', 'failed'] as const;
+export const OrderSyncStatusFilterValues = [
+  'pending',
+  'syncing',
+  'synced',
+  'failed',
+  'skipped_cancelled',
+] as const;
 
 /**
  * Sync status filter type

--- a/libs/core/src/orders/domain/types/order-sync.types.ts
+++ b/libs/core/src/orders/domain/types/order-sync.types.ts
@@ -9,6 +9,7 @@
  *
  * @module domain/types
  */
+import type { OrderSyncStatusFilter } from './order-record.types';
 
 /**
  * Current sync state for one destination connection.
@@ -19,8 +20,12 @@
 export interface OrderSyncStatus {
   /** Destination connection ID */
   destinationConnectionId: string;
-  /** Sync status: pending, syncing, synced, or failed */
-  status: 'pending' | 'syncing' | 'synced' | 'failed';
+  /**
+   * Sync status. `'skipped_cancelled'` is terminal — the source cancelled the
+   * order before the destination create ran, so provisioning was withheld
+   * (#2284); the reason rides in `error`.
+   */
+  status: OrderSyncStatusFilter;
   /** Timestamp when sync completed (for synced status) */
   syncedAt?: Date;
   /** External order ID in destination system */
@@ -42,7 +47,7 @@ export interface OrderSyncStatus {
  */
 export interface SyncAttempt {
   destinationConnectionId: string;
-  status: 'pending' | 'syncing' | 'synced' | 'failed';
+  status: OrderSyncStatusFilter;
   attemptedAt: Date;
   error?: string;
   externalOrderId?: string;

--- a/libs/core/src/orders/index.ts
+++ b/libs/core/src/orders/index.ts
@@ -197,6 +197,15 @@ export { orderFromReadySnapshot } from './domain/order-from-ready-snapshot';
 export type { OrderFromReadySnapshotOptions } from './domain/order-from-ready-snapshot';
 
 // Order-identity list projection for Shipments/Invoices (#1995).
+export { diffOrderAmendment, OrderAmendmentChangeKindValues } from './domain/order-amendment-diff';
+export type {
+  OrderAmendmentChange,
+  OrderAmendmentChangeKind,
+  OrderAmendmentDiffOptions,
+} from './domain/order-amendment-diff';
+export { redactAddress, REDACTED_PLACEHOLDER } from './domain/order-address-redaction';
+export type { RedactableAddress, RedactedAddress } from './domain/order-address-redaction';
+
 export { buildOrderSummary } from './domain/order-summary-projection';
 export type { OrderSummary } from './domain/order-summary-projection';
 

--- a/libs/core/src/orders/infrastructure/persistence/entities/order-record.orm-entity.ts
+++ b/libs/core/src/orders/infrastructure/persistence/entities/order-record.orm-entity.ts
@@ -235,6 +235,25 @@ export class OrderRecordOrmEntity {
   @Column({ type: 'varchar', length: 3, nullable: true })
   fxIntendedCurrency!: string | null;
 
+  /**
+   * Instant an operator marked this order packed (#2287). `null` = not packed.
+   * A fact, not a state — independent of `recordStatus` / `fulfillmentState` /
+   * `slaState`. Indexed because "is it packed" is an operator-facing scan axis,
+   * mirroring `cancelledAt`.
+   */
+  @Column({ type: 'timestamptz', nullable: true })
+  @Index()
+  packedAt!: Date | null;
+
+  /**
+   * OL user id of whoever marked this order packed (#2287). Deliberately
+   * unindexed: it is display + attribution only and is never filtered on. No FK
+   * to `users` — this table FKs across no context, and a dangling id from a
+   * deleted user is the honest outcome for an audit fact.
+   */
+  @Column({ type: 'uuid', nullable: true })
+  packedByUserId!: string | null;
+
   @CreateDateColumn()
   createdAt!: Date;
 

--- a/libs/core/src/orders/infrastructure/persistence/entities/order-record.orm-entity.ts
+++ b/libs/core/src/orders/infrastructure/persistence/entities/order-record.orm-entity.ts
@@ -9,6 +9,7 @@
  */
 import { Entity, PrimaryColumn, Column, CreateDateColumn, UpdateDateColumn, Index } from 'typeorm';
 import type { OrderSyncStatusFilter } from '../../../domain/types/order-record.types';
+import type { OrderAmendmentChange } from '../../../domain/order-amendment-diff';
 
 /**
  * Sync status JSONB structure
@@ -253,6 +254,26 @@ export class OrderRecordOrmEntity {
    */
   @Column({ type: 'uuid', nullable: true })
   packedByUserId!: string | null;
+
+  /**
+   * Instant OpenLinker last observed the source amend this order after ingestion
+   * (#2283). `null` = never observed amended. Indexed because "which orders did
+   * the source change under us" is an operator-facing scan axis, and it is the
+   * index that makes a follow-up list badge/filter cheap. Plain rather than
+   * partial, mirroring `packedAt`: an operator filters both ways.
+   */
+  @Column({ type: 'timestamptz', nullable: true })
+  @Index()
+  lastAmendedAt!: Date | null;
+
+  /**
+   * The change list observed at `lastAmendedAt` (#2283) — most recent
+   * observation only, not a history. `jsonb` because the shape is a small
+   * open-ended list the FE renders; nothing queries inside it. PII-free by
+   * construction (ids, SKUs, quantities and address FIELD NAMES only).
+   */
+  @Column({ type: 'jsonb', nullable: true })
+  lastAmendmentChanges!: OrderAmendmentChange[] | null;
 
   @CreateDateColumn()
   createdAt!: Date;

--- a/libs/core/src/orders/infrastructure/persistence/entities/order-record.orm-entity.ts
+++ b/libs/core/src/orders/infrastructure/persistence/entities/order-record.orm-entity.ts
@@ -8,13 +8,14 @@
  * @module libs/core/src/orders/infrastructure/persistence/entities
  */
 import { Entity, PrimaryColumn, Column, CreateDateColumn, UpdateDateColumn, Index } from 'typeorm';
+import type { OrderSyncStatusFilter } from '../../../domain/types/order-record.types';
 
 /**
  * Sync status JSONB structure
  */
 export interface OrderSyncStatusJson {
   destinationConnectionId: string;
-  status: 'pending' | 'syncing' | 'synced' | 'failed';
+  status: OrderSyncStatusFilter;
   syncedAt?: string;
   externalOrderId?: string;
   externalOrderNumber?: string;
@@ -27,7 +28,7 @@ export interface OrderSyncStatusJson {
  */
 export interface SyncAttemptJson {
   destinationConnectionId: string;
-  status: 'pending' | 'syncing' | 'synced' | 'failed';
+  status: OrderSyncStatusFilter;
   attemptedAt: string;
   error?: string;
   externalOrderId?: string;

--- a/libs/core/src/orders/infrastructure/persistence/repositories/__tests__/order-record.repository.spec.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/__tests__/order-record.repository.spec.ts
@@ -176,36 +176,63 @@ describe('OrderRecordRepository', () => {
     });
   });
 
+  /**
+   * Since #2282 `upsert()` is a raw `INSERT ... ON CONFLICT DO UPDATE` with
+   * `RETURNING *`, not a `save()`. The write set is still defined by `toOrm`,
+   * but a column is now excluded by never being NAMED in the statement - so
+   * that is what these tests assert, instead of an unset entity property.
+   */
+  function mockUpsertReturning(entity: OrderRecordOrmEntity): void {
+    (ormRepository.query as jest.Mock).mockResolvedValue([entity]);
+  }
+
+  function upsertCall(): [string, unknown[]] {
+    const calls = (ormRepository.query as jest.Mock).mock.calls as unknown[][];
+    return calls[0] as [string, unknown[]];
+  }
+
+  function upsertSql(): string {
+    return upsertCall()[0];
+  }
+
+  function upsertParams(): unknown[] {
+    return upsertCall()[1];
+  }
+
+  function expectColumnAbsentFromUpsert(column: string): void {
+    expect(upsertSql()).not.toContain(`"${column}"`);
+  }
+
   describe('upsert', () => {
     it('should create new order record', async () => {
       const domainEntity = createDomainEntity();
       const savedEntity = createOrmEntity();
-      ormRepository.save.mockResolvedValue(savedEntity);
+      mockUpsertReturning(savedEntity);
 
       const result = await repository.upsert(domainEntity);
 
       expect(result).toBeDefined();
       expect(result.internalOrderId).toBe('order-123');
-      expect(ormRepository.save).toHaveBeenCalledTimes(1);
+      expect(ormRepository.query).toHaveBeenCalledTimes(1);
     });
 
     it('should update existing order record', async () => {
       const domainEntity = createDomainEntity();
       const existingEntity = createOrmEntity();
       existingEntity.updatedAt = new Date('2025-01-02T10:00:00Z');
-      ormRepository.save.mockResolvedValue(existingEntity);
+      mockUpsertReturning(existingEntity);
 
       const result = await repository.upsert(domainEntity);
 
       expect(result).toBeDefined();
-      expect(ormRepository.save).toHaveBeenCalledTimes(1);
+      expect(ormRepository.query).toHaveBeenCalledTimes(1);
     });
 
     it('should NOT write syncStatus even when the domain record carries one (#2140)', async () => {
       // Guards against a future caller reintroducing the clobber by passing
       // destination sync state through the ingestion path. updateSyncStatus is
-      // the sole writer; a full-object save() that carries this column resets
-      // the per-destination rows it committed.
+      // the sole writer; a statement that carries this column resets the
+      // per-destination rows it committed.
       const syncStatus: OrderSyncStatus[] = [
         {
           destinationConnectionId: 'dest-connection-789',
@@ -231,12 +258,11 @@ describe('OrderRecordRepository', () => {
         new Date('2025-01-01T10:00:00Z')
       );
       const savedEntity = createOrmEntity();
-      ormRepository.save.mockResolvedValue(savedEntity);
+      mockUpsertReturning(savedEntity);
 
       await repository.upsert(domainEntity);
 
-      const callArg = ormRepository.save.mock.calls[0][0] as OrderRecordOrmEntity;
-      expect(callArg.syncStatus).toBeUndefined();
+      expectColumnAbsentFromUpsert('syncStatus');
     });
 
     it('should map recordStatus to ORM entity on toOrm path', async () => {
@@ -252,51 +278,51 @@ describe('OrderRecordRepository', () => {
         new Date()
       );
       const savedEntity = createOrmEntity();
-      ormRepository.save.mockResolvedValue(savedEntity);
+      mockUpsertReturning(savedEntity);
 
       await repository.upsert(domainEntity);
 
-      const callArg = ormRepository.save.mock.calls[0][0] as OrderRecordOrmEntity;
-      expect(callArg.recordStatus).toBe('awaiting_mapping');
+      // `recordStatus` IS in the write set - the 6th bound parameter.
+      expect(upsertParams()[5]).toBe('awaiting_mapping');
     });
 
-    it('should read cancelledAt back via toDomain when present on the ORM row', async () => {
-      const cancelledAt = new Date('2026-08-01T12:00:00Z');
+    it('should report cancelledAt as null even though RETURNING carries it (#2282)', async () => {
+      // The pre-#2282 mock handed back whatever `save()` was given, so this
+      // read-back could not happen in production either - the docblock has
+      // always promised the excluded columns read empty. `RETURNING *` now
+      // really does carry the row's value, so `fromRawRow` has to reset it or
+      // both `OrderRecordService` call sites silently change behaviour.
       const savedEntity = createOrmEntity();
-      savedEntity.cancelledAt = cancelledAt;
-      ormRepository.save.mockResolvedValue(savedEntity);
+      savedEntity.cancelledAt = new Date('2026-08-01T12:00:00Z');
+      mockUpsertReturning(savedEntity);
 
       const result = await repository.upsert(createDomainEntity());
 
-      expect(result.cancelledAt).toBe(cancelledAt);
+      expect(result.cancelledAt).toBeNull();
     });
 
-    it('should NOT include cancelledAt in the entity passed to save() (#1984)', async () => {
-      // upsert() is a full-object save() with no per-order lock around it, so
-      // writing cancelledAt here would race with the atomic, COALESCE-based
-      // markCancelled() a concurrent cancel-event call may commit at the same
-      // time. Leaving the property unset lets TypeORM omit the column from
-      // the generated UPDATE entirely — markCancelled is the sole writer.
+    it('should NOT include cancelledAt in the upsert statement (#1984)', async () => {
+      // upsert() has no per-order lock around it, so writing cancelledAt here
+      // would race with the atomic, COALESCE-based markCancelled() a concurrent
+      // cancel-event call may commit at the same time. Never naming the column
+      // in the statement is what keeps markCancelled its sole writer.
       const domainEntity = createDomainEntity();
-      ormRepository.save.mockResolvedValue(createOrmEntity());
+      mockUpsertReturning(createOrmEntity());
 
       await repository.upsert(domainEntity);
 
-      const callArg = ormRepository.save.mock.calls[0][0] as OrderRecordOrmEntity;
-      expect(callArg.cancelledAt).toBeUndefined();
+      expectColumnAbsentFromUpsert('cancelledAt');
     });
 
-    it('should NOT include fulfillmentState in the entity passed to save() (#2101)', async () => {
+    it('should NOT include fulfillmentState in the upsert statement (#2101)', async () => {
       // The ingestion path never carries a fulfillment rollup, so writing the
       // column here reset a `'dispatched'` order to NULL on every re-poll.
-      // Leaving the property unset lets TypeORM omit the column from the
-      // generated UPDATE - updateFulfillmentState is the sole writer.
-      ormRepository.save.mockResolvedValue(createOrmEntity());
+      // Absent from the statement - updateFulfillmentState is the sole writer.
+      mockUpsertReturning(createOrmEntity());
 
       await repository.upsert(createDomainEntity());
 
-      const callArg = ormRepository.save.mock.calls[0][0] as OrderRecordOrmEntity;
-      expect(callArg.fulfillmentState).toBeUndefined();
+      expectColumnAbsentFromUpsert('fulfillmentState');
     });
 
     it('should NOT write fulfillmentState even when the domain record carries one', async () => {
@@ -316,38 +342,72 @@ describe('OrderRecordRepository', () => {
         null,
         'dispatched'
       );
-      ormRepository.save.mockResolvedValue(createOrmEntity());
+      mockUpsertReturning(createOrmEntity());
 
       await repository.upsert(domainEntity);
 
-      const callArg = ormRepository.save.mock.calls[0][0] as OrderRecordOrmEntity;
-      expect(callArg.fulfillmentState).toBeUndefined();
+      expectColumnAbsentFromUpsert('fulfillmentState');
     });
 
-    it('should read fulfillmentState back via toDomain when present on the ORM row', async () => {
+    it('should report every excluded column empty even though RETURNING carries them (#2282)', async () => {
+      // The load-bearing half of the save() -> raw-SQL swap: the return
+      // contract stays byte-identical, so callers still re-read via findById.
       const savedEntity = createOrmEntity();
       savedEntity.fulfillmentState = 'dispatched';
-      ormRepository.save.mockResolvedValue(savedEntity);
+      savedEntity.syncStatus = [
+        { destinationConnectionId: 'dest-connection-789', status: 'synced' },
+      ];
+      savedEntity.syncAttempts = [
+        {
+          destinationConnectionId: 'dest-connection-789',
+          status: 'synced',
+          attemptedAt: '2026-08-01T12:00:00Z',
+        },
+      ];
+      savedEntity.cancelledAt = new Date('2026-08-01T12:00:00Z');
+      savedEntity.salesDocumentBlockReason = 'trigger-model-manual';
+      savedEntity.salesDocumentUnresolvedReason = 'no-configuration-for-country';
+      savedEntity.salesDocumentBlockDetail = 'seeded';
+      savedEntity.reportingCurrency = 'EUR';
+      savedEntity.reportingTotalAmount = 425;
+      savedEntity.exchangeRateId = 'e1f0c0de-0000-4000-8000-000000000001';
+      savedEntity.fxRule = 'prev-business-day';
+      savedEntity.fxStampedAt = new Date('2026-08-14T09:00:00Z');
+      savedEntity.fxIntendedCurrency = 'EUR';
+      mockUpsertReturning(savedEntity);
 
       const result = await repository.upsert(createDomainEntity());
 
-      expect(result.fulfillmentState).toBe('dispatched');
+      expect(result.syncStatus).toEqual([]);
+      expect(result.syncAttempts).toEqual([]);
+      expect(result.fulfillmentState).toBeNull();
+      expect(result.cancelledAt).toBeNull();
+      expect(result.salesDocumentBlockReason).toBeNull();
+      expect(result.salesDocumentUnresolvedReason).toBeNull();
+      expect(result.salesDocumentBlockDetail).toBeNull();
+      expect(result.reportingCurrency).toBeNull();
+      expect(result.reportingTotalAmount).toBeNull();
+      expect(result.exchangeRateId).toBeNull();
+      expect(result.fxRule).toBeNull();
+      expect(result.fxStampedAt).toBeNull();
+      expect(result.fxIntendedCurrency).toBeNull();
+      // The ingestion-owned columns still come back.
+      expect(result.internalOrderId).toBe('order-123');
+      expect(result.recordStatus).toBe('ready');
     });
 
-    it('should NOT include syncStatus or syncAttempts in the entity passed to save() (#2140)', async () => {
+    it('should NOT include syncStatus or syncAttempts in the upsert statement (#2140)', async () => {
       // The ingestion path never carries destination sync state, so writing
       // these columns wiped the per-destination rows and the whole attempt
-      // history on every re-poll. Leaving the properties unset lets TypeORM omit
-      // both columns from the generated statement - updateSyncStatus is the sole
-      // writer, and Postgres fills an omitted column on INSERT from its
-      // `DEFAULT '[]'`.
-      ormRepository.save.mockResolvedValue(createOrmEntity());
+      // history on every re-poll. Naming neither column in either half of the
+      // statement keeps updateSyncStatus the sole writer, and Postgres fills an
+      // omitted column on INSERT from its `DEFAULT '[]'`.
+      mockUpsertReturning(createOrmEntity());
 
       await repository.upsert(createDomainEntity());
 
-      const callArg = ormRepository.save.mock.calls[0][0] as OrderRecordOrmEntity;
-      expect(callArg.syncStatus).toBeUndefined();
-      expect(callArg.syncAttempts).toBeUndefined();
+      expectColumnAbsentFromUpsert('syncStatus');
+      expectColumnAbsentFromUpsert('syncAttempts');
     });
 
     it('should NOT write syncAttempts even when the domain record carries history', async () => {
@@ -371,27 +431,58 @@ describe('OrderRecordRepository', () => {
         new Date('2025-01-01T10:00:00Z'),
         attempts
       );
-      ormRepository.save.mockResolvedValue(createOrmEntity());
+      mockUpsertReturning(createOrmEntity());
 
       await repository.upsert(domainEntity);
 
-      const callArg = ormRepository.save.mock.calls[0][0] as OrderRecordOrmEntity;
-      expect(callArg.syncAttempts).toBeUndefined();
+      expectColumnAbsentFromUpsert('syncAttempts');
     });
 
-    it('should report both columns empty when save() hands back the entity it was given', async () => {
-      // The update path has no RETURNING clause, so the entity TypeORM returns
-      // still carries the unset properties. toDomain must read that as "not part
-      // of this statement" rather than throwing on `undefined.map`.
+    it('should report both columns empty when the returned row omits them', async () => {
+      // toDomain must read an absent property as "not part of this statement"
+      // rather than throwing on `undefined.map`.
       const unsetEntity = createOrmEntity();
       delete (unsetEntity as Partial<OrderRecordOrmEntity>).syncStatus;
       delete (unsetEntity as Partial<OrderRecordOrmEntity>).syncAttempts;
-      ormRepository.save.mockResolvedValue(unsetEntity);
+      mockUpsertReturning(unsetEntity);
 
       const result = await repository.upsert(createDomainEntity());
 
       expect(result.syncStatus).toEqual([]);
       expect(result.syncAttempts).toEqual([]);
+    });
+
+    it('should keep sourceConnectionId and createdAt out of the DO UPDATE set (#2282)', async () => {
+      mockUpsertReturning(createOrmEntity());
+
+      await repository.upsert(createDomainEntity());
+
+      const doUpdate = upsertSql().slice(upsertSql().indexOf('DO UPDATE'));
+      // Matched at the start of a SET line, so the CASE's comparison against
+      // EXCLUDED."sourceConnectionId" is not mistaken for an assignment.
+      expect(doUpdate).not.toMatch(/^\s*"sourceConnectionId" =/m);
+      expect(doUpdate).not.toMatch(/^\s*"createdAt" =/m);
+      // save() auto-bumped @UpdateDateColumn; the raw statement must not lose that.
+      expect(doUpdate).toContain('"updatedAt" = EXCLUDED."updatedAt"');
+      // Same-source may advance, cross-source frozen.
+      expect(doUpdate).toContain('"sourceEventId" = CASE');
+    });
+
+    it('should bind every value as a parameter and serialize the jsonb snapshot (#2282)', async () => {
+      mockUpsertReturning(createOrmEntity());
+
+      await repository.upsert(createDomainEntity());
+
+      // No interpolation: the connection id reaches Postgres as a bound param.
+      expect(upsertSql()).not.toContain('source-connection-123');
+      expect(upsertParams()).toHaveLength(10);
+      expect(upsertParams()[2]).toBe('source-connection-123');
+      expect(typeof upsertParams()[4]).toBe('string');
+      expect(JSON.parse(upsertParams()[4] as string)).toEqual({
+        id: 'order-123',
+        orderNumber: 'ORD-001',
+        status: 'pending',
+      });
     });
   });
 
@@ -770,23 +861,22 @@ describe('OrderRecordRepository', () => {
     });
 
     describe('toOrm', () => {
-      it('should NOT include any of the six FX columns in the entity passed to save()', async () => {
-        // upsert() is a full-row save() on an update-or-create ingestion path,
-        // so mapping these columns would let a re-poll of an already-stamped
-        // order write `null` over a reported financial figure. Leaving the
-        // properties unset makes TypeORM omit the columns from the UPDATE —
-        // claimFxIntentIfAbsent / stampFxIfAbsent are their only writers.
-        ormRepository.save.mockResolvedValue(createOrmEntity());
+      it('should NOT include any of the six FX columns in the upsert statement', async () => {
+        // upsert() is an update-or-create on the ingestion path, so naming
+        // these columns would let a re-poll of an already-stamped order write
+        // `null` over a reported financial figure. They appear in neither half
+        // of the statement — claimFxIntentIfAbsent / stampFxIfAbsent are their
+        // only writers.
+        mockUpsertReturning(createOrmEntity());
 
         await repository.upsert(createDomainEntity());
 
-        const callArg = ormRepository.save.mock.calls[0][0] as OrderRecordOrmEntity;
-        expect(callArg.reportingCurrency).toBeUndefined();
-        expect(callArg.reportingTotalAmount).toBeUndefined();
-        expect(callArg.exchangeRateId).toBeUndefined();
-        expect(callArg.fxRule).toBeUndefined();
-        expect(callArg.fxStampedAt).toBeUndefined();
-        expect(callArg.fxIntendedCurrency).toBeUndefined();
+        expectColumnAbsentFromUpsert('reportingCurrency');
+        expectColumnAbsentFromUpsert('reportingTotalAmount');
+        expectColumnAbsentFromUpsert('exchangeRateId');
+        expectColumnAbsentFromUpsert('fxRule');
+        expectColumnAbsentFromUpsert('fxStampedAt');
+        expectColumnAbsentFromUpsert('fxIntendedCurrency');
       });
 
       it('should NOT write the FX columns even when the domain record carries a stamp', async () => {
@@ -817,17 +907,16 @@ describe('OrderRecordRepository', () => {
           new Date('2026-08-14T09:00:00Z'),
           'EUR'
         );
-        ormRepository.save.mockResolvedValue(createOrmEntity());
+        mockUpsertReturning(createOrmEntity());
 
         await repository.upsert(stamped);
 
-        const callArg = ormRepository.save.mock.calls[0][0] as OrderRecordOrmEntity;
-        expect(callArg.reportingCurrency).toBeUndefined();
-        expect(callArg.reportingTotalAmount).toBeUndefined();
-        expect(callArg.exchangeRateId).toBeUndefined();
-        expect(callArg.fxRule).toBeUndefined();
-        expect(callArg.fxStampedAt).toBeUndefined();
-        expect(callArg.fxIntendedCurrency).toBeUndefined();
+        expectColumnAbsentFromUpsert('reportingCurrency');
+        expectColumnAbsentFromUpsert('reportingTotalAmount');
+        expectColumnAbsentFromUpsert('exchangeRateId');
+        expectColumnAbsentFromUpsert('fxRule');
+        expectColumnAbsentFromUpsert('fxStampedAt');
+        expectColumnAbsentFromUpsert('fxIntendedCurrency');
       });
     });
 

--- a/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
@@ -999,7 +999,8 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
    *
    * `syncStatus` / `syncAttempts` (#2140), `fulfillmentState` (#2101),
    * `cancelledAt` (#1984), the three `salesDocument*` columns (#2100), the six
-   * FX snapshot columns (#2124) and the two packed columns (#2287) are
+   * FX snapshot columns (#2124), the two packed columns (#2287) and the two
+   * amendment columns `lastAmendedAt` / `lastAmendmentChanges` (#2283) are
    * deliberately outside the write set - see the {@link toOrm} comments. A
    * consequence is that the returned record reports all of them as empty (`[]` / `null`) regardless of what the row
    * holds, because none of those columns was part of the statement; callers
@@ -1034,7 +1035,8 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
     // `cancelledAt` (#1984), the three `salesDocument*` columns (#2100) and the
     // six FX snapshot columns `reportingCurrency` / `reportingTotalAmount` /
     // `exchangeRateId` / `fxRule` / `fxStampedAt` / `fxIntendedCurrency`
-    // (#2124), and `packedAt` / `packedByUserId` (#2287). Do not add one of
+    // (#2124), `packedAt` / `packedByUserId` (#2287), and `lastAmendedAt` /
+    // `lastAmendmentChanges` (#2283). Do not add one of
     // them to either half of this statement - each has a narrow, atomic
     // out-of-band writer that owns it.
     const entity = this.toOrm(orderRecord);
@@ -1301,7 +1303,7 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
    * property unset makes TypeORM omit the column from the generated statement
    * entirely, so the row's committed value survives untouched.
    *
-   * This is not optional tidiness. `upsert()` is a full-object `save()` with no
+   * This is not optional tidiness. `upsert()` is a single statement with no
    * per-order lock around it (webhook + reconciliation poll legitimately race
    * for the same order, per `docs/architecture-overview.md` § "Webhook =
    * trigger, poll = reconciliation backstop"), so mapping any of them lets the

--- a/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
@@ -933,12 +933,114 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
    * reports all of them as empty (`[]` / `null`) regardless of what the row
    * holds, because none of those columns was part of the statement; callers
    * needing their true value re-read via {@link findById}.
+   *
+   * ## Source attribution is immutable at the write path (#2282, ADR-057)
+   *
+   * `sourceConnectionId` is INSERT-ONLY: it is absent from the `DO UPDATE` set,
+   * so the first write establishes the order's origin and no later re-ingestion
+   * can move it. `sourceEventId` follows the rule *same-source may advance,
+   * cross-source frozen*: a write arriving from the row's own source still
+   * refreshes it to the latest event id (byte-identical to the pre-#2282
+   * behaviour), while a write arriving from any other connection leaves it as
+   * committed.
+   *
+   * This is why the statement is raw SQL rather than the previous full-object
+   * `save()`. `sourceConnectionId` is `uuid NOT NULL` with no DB default, so it
+   * MUST be on the INSERT half and MUST NOT be on the UPDATE half - a shape
+   * `save()` cannot express, and one a read-before-write cannot emulate safely
+   * (see the race doctrine in {@link toOrm}). The `markCancelled` COALESCE
+   * statement is the same precedent.
+   *
+   * The caller-side ADR-017 destination-echo guard in `OrderIngestionService`
+   * stays in place as defence in depth; this makes the invariant hold for every
+   * caller of the write path, not just that one.
    */
   async upsert(orderRecord: OrderRecord): Promise<OrderRecord> {
+    // The write set is defined once, by `toOrm` - the parameter tuple below is
+    // built from it so the two cannot drift. Every column NOT named here keeps
+    // its committed value (on conflict) or its DB default (on insert):
+    // `syncStatus`, `syncAttempts` (#2140), `fulfillmentState` (#2101),
+    // `cancelledAt` (#1984), the three `salesDocument*` columns (#2100) and the
+    // six FX snapshot columns `reportingCurrency` / `reportingTotalAmount` /
+    // `exchangeRateId` / `fxRule` / `fxStampedAt` / `fxIntendedCurrency`
+    // (#2124). Do not add one of them to either half of this statement - each
+    // has a narrow, atomic out-of-band writer that owns it.
     const entity = this.toOrm(orderRecord);
-    // TypeORM save() performs upsert on primary key (internalOrderId)
-    const saved = await this.repository.save(entity);
-    return this.toDomain(saved);
+
+    const rows = (await this.repository.query(
+      `INSERT INTO "order_records" (
+         "internalOrderId", "customerId", "sourceConnectionId", "sourceEventId",
+         "orderSnapshot", "recordStatus", "mappingFailureReason", "dispatchByAt",
+         "createdAt", "updatedAt"
+       ) VALUES ($1, $2, $3, $4, $5::jsonb, $6, $7, $8, $9, $10)
+       ON CONFLICT ("internalOrderId") DO UPDATE SET
+         "customerId" = EXCLUDED."customerId",
+         -- Source attribution (#2282): "sourceConnectionId" is absent from this
+         -- SET list on purpose. "sourceEventId" advances only when the write
+         -- comes from the row's own source.
+         "sourceEventId" = CASE
+           WHEN "order_records"."sourceConnectionId" = EXCLUDED."sourceConnectionId"
+             THEN EXCLUDED."sourceEventId"
+           ELSE "order_records"."sourceEventId"
+         END,
+         "orderSnapshot" = EXCLUDED."orderSnapshot",
+         "recordStatus" = EXCLUDED."recordStatus",
+         "mappingFailureReason" = EXCLUDED."mappingFailureReason",
+         "dispatchByAt" = EXCLUDED."dispatchByAt",
+         -- "createdAt" is deliberately NOT updated: it records the first write.
+         "updatedAt" = EXCLUDED."updatedAt"
+       RETURNING *`,
+      [
+        entity.internalOrderId,
+        entity.customerId,
+        entity.sourceConnectionId,
+        entity.sourceEventId,
+        // Serialized explicitly rather than relying on the driver's object
+        // handling, so the jsonb column receives a document in every case.
+        JSON.stringify(entity.orderSnapshot ?? {}),
+        entity.recordStatus,
+        entity.mappingFailureReason,
+        entity.dispatchByAt,
+        entity.createdAt,
+        entity.updatedAt,
+      ]
+    )) as unknown;
+
+    if (!Array.isArray(rows) || rows.length === 0) {
+      // Unreachable: `ON CONFLICT ... DO UPDATE` always produces a row.
+      throw new OrderRecordNotFoundException(orderRecord.internalOrderId);
+    }
+
+    return this.toDomain(this.fromRawRow(rows[0] as Record<string, unknown>));
+  }
+
+  /**
+   * Project a `RETURNING *` row onto an {@link OrderRecordOrmEntity}, resetting
+   * every column outside the upsert's write set to its empty default.
+   *
+   * The reset is the point, not tidiness. `RETURNING *` carries the row's TRUE
+   * values for the out-of-band columns, whereas the pre-#2282 `save()` returned
+   * only what it wrote - and {@link upsert}'s contract (repeated on the port)
+   * promises callers that those columns read empty and must be re-read via
+   * {@link findById}. Passing the true values through would silently change
+   * what both `OrderRecordService` call sites return.
+   */
+  private fromRawRow(row: Record<string, unknown>): OrderRecordOrmEntity {
+    const entity = Object.assign(new OrderRecordOrmEntity(), row);
+    entity.syncStatus = [];
+    entity.syncAttempts = [];
+    entity.fulfillmentState = null;
+    entity.cancelledAt = null;
+    entity.salesDocumentBlockReason = null;
+    entity.salesDocumentUnresolvedReason = null;
+    entity.salesDocumentBlockDetail = null;
+    entity.reportingCurrency = null;
+    entity.reportingTotalAmount = null;
+    entity.exchangeRateId = null;
+    entity.fxRule = null;
+    entity.fxStampedAt = null;
+    entity.fxIntendedCurrency = null;
+    return entity;
   }
 
   /**
@@ -1138,6 +1240,14 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
    *   + `stampFxIfAbsent` (both guarded, both single-statement). Mapping them
    *   here would let a re-poll of an already-stamped order overwrite a
    *   REPORTED FINANCIAL FIGURE with the ingestion path's in-memory `null`.
+   *
+   * ## The insert-only column
+   *
+   * `sourceConnectionId` IS assigned here, but it is insert-only at the
+   * statement level (#2282): {@link upsert} places it on the INSERT half and
+   * omits it from `DO UPDATE`. It cannot simply be left unset like the columns
+   * above, because it is `uuid NOT NULL` with no DB default and so must be
+   * present on a first write.
    *
    * Before adding an assignment here, ask which out-of-band writer owns that
    * column: #2101 excluded only `fulfillmentState` and left the two columns

--- a/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
@@ -11,7 +11,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import type { SelectQueryBuilder } from 'typeorm';
-import { In, IsNull, LessThan, MoreThanOrEqual, Repository } from 'typeorm';
+import { In, IsNull, LessThan, MoreThanOrEqual, Not, Repository } from 'typeorm';
 import type { OrderSyncStatusJson, SyncAttemptJson } from '../entities/order-record.orm-entity';
 import { OrderRecordOrmEntity } from '../entities/order-record.orm-entity';
 import type { OrderRecordRepositoryPort } from '../../../domain/ports/order-record-repository.port';
@@ -779,6 +779,44 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
   }
 
   /**
+   * Mark this order packed (#2287). Conditional write in the
+   * `claimFxIntentIfAbsent` / `ShipmentRepository.claimWaybillRelay` shape:
+   * `packedAt: IsNull()` in the WHERE is what makes the first mark win, so a
+   * second POST (double-click, retry, a second operator) affects zero rows and
+   * leaves the original instant AND the original actor intact.
+   *
+   * Both columns move in the same statement deliberately. A `markCancelled`-style
+   * `COALESCE("packedAt", $1)` would keep the timestamp but still overwrite
+   * `packedByUserId` — the two are one fact and must move together.
+   */
+  async markPacked(
+    internalOrderId: string,
+    packedAt: Date,
+    packedByUserId: string
+  ): Promise<boolean> {
+    const result = await this.repository.update(
+      { internalOrderId, packedAt: IsNull() },
+      { packedAt, packedByUserId, updatedAt: new Date() }
+    );
+    return (result.affected ?? 0) > 0;
+  }
+
+  /**
+   * Clear this order's packed fact (#2287). The `Not(IsNull())` guard is the
+   * no-op idea `updateSalesDocumentBlock` puts in its WHERE: unmarking an
+   * already-unpacked order affects no row, so it neither bumps `updatedAt` nor
+   * is distinguishable from a missing row without a re-read (the service does
+   * that re-read).
+   */
+  async clearPacked(internalOrderId: string): Promise<boolean> {
+    const result = await this.repository.update(
+      { internalOrderId, packedAt: Not(IsNull()) },
+      { packedAt: null, packedByUserId: null, updatedAt: new Date() }
+    );
+    return (result.affected ?? 0) > 0;
+  }
+
+  /**
    * Distinct order-native currencies already ingested (#2124), for the
    * reporting-currency coverage advisory.
    *
@@ -927,10 +965,10 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
    * Full-row upsert of the ingestion-owned columns, keyed on the primary key.
    *
    * `syncStatus` / `syncAttempts` (#2140), `fulfillmentState` (#2101),
-   * `cancelledAt` (#1984), the three `salesDocument*` columns (#2100) and the
-   * six FX snapshot columns (#2124) are deliberately outside the write set -
-   * see the {@link toOrm} comments. A consequence is that the returned record
-   * reports all of them as empty (`[]` / `null`) regardless of what the row
+   * `cancelledAt` (#1984), the three `salesDocument*` columns (#2100), the six
+   * FX snapshot columns (#2124) and the two packed columns (#2287) are
+   * deliberately outside the write set - see the {@link toOrm} comments. A
+   * consequence is that the returned record reports all of them as empty (`[]` / `null`) regardless of what the row
    * holds, because none of those columns was part of the statement; callers
    * needing their true value re-read via {@link findById}.
    *
@@ -963,8 +1001,9 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
     // `cancelledAt` (#1984), the three `salesDocument*` columns (#2100) and the
     // six FX snapshot columns `reportingCurrency` / `reportingTotalAmount` /
     // `exchangeRateId` / `fxRule` / `fxStampedAt` / `fxIntendedCurrency`
-    // (#2124). Do not add one of them to either half of this statement - each
-    // has a narrow, atomic out-of-band writer that owns it.
+    // (#2124), and `packedAt` / `packedByUserId` (#2287). Do not add one of
+    // them to either half of this statement - each has a narrow, atomic
+    // out-of-band writer that owns it.
     const entity = this.toOrm(orderRecord);
 
     const rows = (await this.repository.query(
@@ -1040,6 +1079,14 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
     entity.fxRule = null;
     entity.fxStampedAt = null;
     entity.fxIntendedCurrency = null;
+    // #2287: reset like every other out-of-band column. `RETURNING *` DOES
+    // carry the row's true packed fact, but surfacing it here would make
+    // `upsert`'s return value inconsistent with its documented contract - and
+    // inconsistently so, since the pre-#2282 `save()` path could not have
+    // reported it. The row itself is untouched; callers needing the live value
+    // re-read via `findById`.
+    entity.packedAt = null;
+    entity.packedByUserId = null;
     return entity;
   }
 
@@ -1193,7 +1240,9 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
       entity.exchangeRateId ?? null,
       entity.fxRule ?? null,
       entity.fxStampedAt ?? null,
-      entity.fxIntendedCurrency ?? null
+      entity.fxIntendedCurrency ?? null,
+      entity.packedAt ?? null,
+      entity.packedByUserId ?? null
     );
   }
 
@@ -1240,6 +1289,12 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
    *   + `stampFxIfAbsent` (both guarded, both single-statement). Mapping them
    *   here would let a re-poll of an already-stamped order overwrite a
    *   REPORTED FINANCIAL FIGURE with the ingestion path's in-memory `null`.
+   * - `packedAt` / `packedByUserId` (#2287) - sole writers {@link markPacked} +
+   *   {@link clearPacked} (both guarded, both single-statement). No order source
+   *   reports whether an operator packed a box, so the ingestion path's value is
+   *   always `null`; mapping them here would silently un-pack an order on every
+   *   re-poll, and the operator would have no way to tell the un-pack from a
+   *   colleague's deliberate one.
    *
    * ## The insert-only column
    *

--- a/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
@@ -42,6 +42,7 @@ import {
 } from '@openlinker/core/sales-documents';
 import type { OrderFxIntent, OrderFxStamp } from '../../../domain/types/order-fx.types';
 import type { StampedReportingCurrencyCount } from '../../../domain/types/order-fx-read.types';
+import type { OrderAmendmentChange } from '../../../domain/order-amendment-diff';
 
 @Injectable()
 export class OrderRecordRepository implements OrderRecordRepositoryPort {
@@ -817,6 +818,38 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
   }
 
   /**
+   * Record a source-side amendment (#2283). Narrow absolute-set on the two
+   * amendment columns only, in `updateSalesDocumentBlock`'s shape: raw
+   * parameterized statement, no read-modify-write, last-write-wins.
+   *
+   * The `IS DISTINCT FROM` guard compares ONLY `lastAmendmentChanges`, never
+   * `lastAmendedAt`. Every call carries a fresh instant, so including the
+   * timestamp in the comparison would make the row always look changed and the
+   * guard would suppress nothing — the caller's `changes.length > 0` gate is the
+   * primary suppressor, and this is the second line of defence against a source
+   * that re-reports the SAME amendment on every poll (which is the steady state
+   * for as long as the amended snapshot is what we hold).
+   *
+   * `$1::jsonb` is explicit because the binder cannot infer the type of a
+   * parameter that appears only inside `IS DISTINCT FROM`.
+   */
+  async recordAmendment(
+    internalOrderId: string,
+    observedAt: Date,
+    changes: OrderAmendmentChange[]
+  ): Promise<void> {
+    await this.repository.query(
+      `UPDATE "order_records"
+          SET "lastAmendmentChanges" = $1::jsonb,
+              "lastAmendedAt" = $2,
+              "updatedAt" = now()
+        WHERE "internalOrderId" = $3
+          AND "lastAmendmentChanges" IS DISTINCT FROM $1::jsonb`,
+      [JSON.stringify(changes), observedAt, internalOrderId]
+    );
+  }
+
+  /**
    * Distinct order-native currencies already ingested (#2124), for the
    * reporting-currency coverage advisory.
    *
@@ -1087,6 +1120,11 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
     // re-read via `findById`.
     entity.packedAt = null;
     entity.packedByUserId = null;
+    // #2283: same reset, same reason. `recordAmendment` owns both columns; the
+    // upsert never writes them, so reporting the row's true values here would
+    // break `upsert`'s documented all-out-of-band-columns-read-empty contract.
+    entity.lastAmendedAt = null;
+    entity.lastAmendmentChanges = null;
     return entity;
   }
 
@@ -1242,7 +1280,13 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
       entity.fxStampedAt ?? null,
       entity.fxIntendedCurrency ?? null,
       entity.packedAt ?? null,
-      entity.packedByUserId ?? null
+      entity.packedByUserId ?? null,
+      entity.lastAmendedAt ?? null,
+      // The jsonb column is written only by `recordAmendment`, which always
+      // stores an array; `?? null` covers the never-amended row and a hand-edited
+      // value is passed through rather than coerced - the FE renders what it
+      // recognises and a change kind from a newer release must not vanish.
+      entity.lastAmendmentChanges ?? null
     );
   }
 
@@ -1295,6 +1339,13 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
    *   always `null`; mapping them here would silently un-pack an order on every
    *   re-poll, and the operator would have no way to tell the un-pack from a
    *   colleague's deliberate one.
+   *
+   * - `lastAmendedAt` / `lastAmendmentChanges` (#2283) - sole writer
+   *   {@link recordAmendment}. The sharpest case of the shared reason: the write
+   *   is triggered BY an ingestion, from a diff taken against the snapshot this
+   *   very upsert is about to overwrite, so mapping them here would have the
+   *   detecting re-poll erase its own finding. No source payload carries them
+   *   either - they are OpenLinker's observation, not the source's report.
    *
    * ## The insert-only column
    *

--- a/libs/core/src/shipping/application/services/fulfillment-status-sync.service.spec.ts
+++ b/libs/core/src/shipping/application/services/fulfillment-status-sync.service.spec.ts
@@ -104,6 +104,8 @@ describe('FulfillmentStatusSyncService', () => {
       getFailedSyncValueSummary: jest.fn(),
       markCancelled: jest.fn(),
       markSalesDocumentBlock: jest.fn(),
+      markPacked: jest.fn(),
+      clearPacked: jest.fn(),
     };
 
     routing = {

--- a/libs/core/src/shipping/application/services/fulfillment-status-sync.service.spec.ts
+++ b/libs/core/src/shipping/application/services/fulfillment-status-sync.service.spec.ts
@@ -106,6 +106,7 @@ describe('FulfillmentStatusSyncService', () => {
       markSalesDocumentBlock: jest.fn(),
       markPacked: jest.fn(),
       clearPacked: jest.fn(),
+      recordAmendment: jest.fn(),
     };
 
     routing = {

--- a/libs/core/src/shipping/application/services/shipment-dispatch-notification.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-dispatch-notification.service.spec.ts
@@ -104,6 +104,7 @@ describe('ShipmentDispatchNotificationService', () => {
       markSalesDocumentBlock: jest.fn(),
       markPacked: jest.fn(),
       clearPacked: jest.fn(),
+      recordAmendment: jest.fn(),
     };
 
     integrations = {

--- a/libs/core/src/shipping/application/services/shipment-dispatch-notification.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-dispatch-notification.service.spec.ts
@@ -102,6 +102,8 @@ describe('ShipmentDispatchNotificationService', () => {
       getFailedSyncValueSummary: jest.fn(),
       markCancelled: jest.fn(),
       markSalesDocumentBlock: jest.fn(),
+      markPacked: jest.fn(),
+      clearPacked: jest.fn(),
     };
 
     integrations = {

--- a/libs/core/src/shipping/application/services/shipment-dispatch.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-dispatch.service.spec.ts
@@ -169,6 +169,8 @@ describe('ShipmentDispatchService', () => {
       getFailedSyncValueSummary: jest.fn(),
       markCancelled: jest.fn(),
       markSalesDocumentBlock: jest.fn(),
+      markPacked: jest.fn(),
+      clearPacked: jest.fn(),
     };
     const fulfillmentProjection = { recompute: jest.fn() };
     // Uncontended by default (#1917): every pre-existing test asserts the

--- a/libs/core/src/shipping/application/services/shipment-dispatch.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-dispatch.service.spec.ts
@@ -171,6 +171,7 @@ describe('ShipmentDispatchService', () => {
       markSalesDocumentBlock: jest.fn(),
       markPacked: jest.fn(),
       clearPacked: jest.fn(),
+      recordAmendment: jest.fn(),
     };
     const fulfillmentProjection = { recompute: jest.fn() };
     // Uncontended by default (#1917): every pre-existing test asserts the

--- a/libs/core/src/sync/domain/types/marketplace-job-payloads.types.ts
+++ b/libs/core/src/sync/domain/types/marketplace-job-payloads.types.ts
@@ -88,6 +88,11 @@ export interface MarketplaceOfferQuantityUpdatePayloadV1 {
   offerId: string;
   quantity: number;
   idempotencyKey?: string;
+  /**
+   * ISO-8601 observation token for the state this write expresses (#2285) — never
+   * wall-clock `now()`. Optional, so payloads enqueued before #2285 stay valid.
+   */
+  observedAt?: string;
 }
 
 export interface MarketplaceOfferFieldUpdatePayloadV1 {

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-order-source.adapter.spec.ts
@@ -16,6 +16,7 @@ import type {
   AllegroOrderEventsResponse,
 } from '../../../domain/types/allegro-api.types';
 import { AllegroApiException } from '../../../domain/exceptions/allegro-api.exception';
+import type { OrderLifecycleEvent } from '@openlinker/core/orders';
 
 describe('AllegroOrderSourceAdapter', () => {
   let adapter: AllegroOrderSourceAdapter;
@@ -163,6 +164,22 @@ describe('AllegroOrderSourceAdapter', () => {
       const result = await adapter.write({ type: 'cancelled', externalOrderId: 'cf-1' });
       expect(result.outcome).toBe('rejected');
       expect(result.detail).toContain('conflict');
+    });
+
+    // #2286 — the runtime half of the exhaustiveness guard. Before the switch
+    // conversion an unrecognised member fell through to the cancel path and was
+    // reported `applied`; the regression to defend against is someone "fixing"
+    // the default arm back into that branch.
+    it('unknown member: returns unsupported without writing anything (never-default, #2286)', async () => {
+      const result = await adapter.write({
+        type: 'amended',
+        externalOrderId: 'cf-1',
+      } as unknown as OrderLifecycleEvent);
+
+      expect(result.outcome).toBe('unsupported');
+      expect(result.detail).toContain('amended');
+      expect(httpClient.put).not.toHaveBeenCalled();
+      expect(httpClient.post).not.toHaveBeenCalled();
     });
   });
 

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-order-source.adapter.ts
@@ -103,14 +103,28 @@ export class AllegroOrderSourceAdapter
    */
   async write(event: OrderLifecycleEvent): Promise<OrderWritebackResult> {
     try {
-      if (event.type === 'dispatched') {
-        await this.markSent(event.externalOrderId, event.trackingNumber, event.carrier);
-        return { outcome: 'applied' };
+      switch (event.type) {
+        case 'dispatched': {
+          await this.markSent(event.externalOrderId, event.trackingNumber, event.carrier);
+          return { outcome: 'applied' };
+        }
+        case 'cancelled': {
+          await this.putFulfillment(event.externalOrderId, ALLEGRO_FULFILLMENT_STATUS_CANCELLED);
+          return { outcome: 'applied' };
+        }
+        default: {
+          // Unreachable in-tree: the binding is the compile break when an
+          // `OrderLifecycleEvent` member is added without an arm here (#2286).
+          // It still degrades rather than throwing, so a caller compiled against
+          // a widened union gets a surfaced no-op, not a `rejected` from the
+          // enclosing catch (ADR-055 forward-compat).
+          const unhandled: never = event;
+          return {
+            outcome: 'unsupported',
+            detail: `unsupported order lifecycle event: ${JSON.stringify(unhandled)}`,
+          };
+        }
       }
-
-      // event.type === 'cancelled'
-      await this.putFulfillment(event.externalOrderId, ALLEGRO_FULFILLMENT_STATUS_CANCELLED);
-      return { outcome: 'applied' };
     } catch (error) {
       const detail = error instanceof Error ? error.message : String(error);
       this.logger.warn(

--- a/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-order-source.adapter.spec.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/__tests__/erli-order-source.adapter.spec.ts
@@ -15,7 +15,11 @@
  *
  * @module libs/integrations/erli/src/infrastructure/adapters/__tests__
  */
-import { isOrderStatusWriteback, type OrderFeedInput } from '@openlinker/core/orders';
+import {
+  isOrderStatusWriteback,
+  type OrderFeedInput,
+  type OrderLifecycleEvent,
+} from '@openlinker/core/orders';
 import type { IInventoryQueryService } from '@openlinker/core/inventory';
 import type { OfferManagerPort, OfferStockRestorer } from '@openlinker/core/listings';
 import { ErliApiException } from '../../../domain/exceptions/erli-api.exception';
@@ -657,6 +661,21 @@ describe('ErliOrderSourceAdapter', () => {
 
     it('is narrowed by isOrderStatusWriteback', () => {
       expect(isOrderStatusWriteback(adapter)).toBe(true);
+    });
+
+    // #2286 — the runtime half of the exhaustiveness guard. Erli's branch order
+    // is inverted (`cancelled` first, `dispatched` as the remainder), so before
+    // the switch conversion an unrecognised member ran the dispatch writeback.
+    it('unknown member: returns unsupported without writing anything (never-default, #2286)', async () => {
+      const result = await adapter.write({
+        type: 'amended',
+        externalOrderId: ORDER_ID,
+      } as unknown as OrderLifecycleEvent);
+
+      expect(result.outcome).toBe('unsupported');
+      expect(result.detail).toContain('amended');
+      expect(client.patch).not.toHaveBeenCalled();
+      expect(client.post).not.toHaveBeenCalled();
     });
 
     // #1198: `cancelled` now triggers stock-restore instead of unconditional

--- a/libs/integrations/erli/src/infrastructure/adapters/erli-order-source.adapter.ts
+++ b/libs/integrations/erli/src/infrastructure/adapters/erli-order-source.adapter.ts
@@ -523,55 +523,75 @@ export class ErliOrderSourceAdapter
    * at info/warn (waybill = PII); error wrapping is message-only.
    */
   async write(event: OrderLifecycleEvent): Promise<OrderWritebackResult> {
-    if (event.type === 'cancelled') {
-      if (!this.offerManager || !this.inventoryQuery) {
+    switch (event.type) {
+      case 'cancelled': {
+        if (!this.offerManager || !this.inventoryQuery) {
+          return {
+            outcome: 'unsupported',
+            detail:
+              'Erli cancelled stock-restore is not wired: offerManager or inventoryQuery is absent.',
+          };
+        }
+        try {
+          await this.restockOnCancellation(
+            event.externalOrderId,
+            this.offerManager,
+            this.inventoryQuery,
+          );
+          return { outcome: 'applied' };
+        } catch (error) {
+          const detail = error instanceof Error ? error.message : String(error);
+          this.logger.warn(
+            `OrderStatusWriteback 'cancelled' (stock-restore) rejected for Erli order ` +
+              `(connection: ${this.connectionId}): ${detail}`,
+          );
+          return { outcome: 'rejected', detail };
+        }
+      }
+
+      case 'dispatched': {
+        // #992 release gate (#1086 review): the writeback wire shapes
+        // (PATCH /orders/{id}/status {status:'sent'} + POST /shipping/external) are
+        // PROVISIONAL until the #992 sandbox confirms them. Default OFF so OL never
+        // writes to an unconfirmed endpoint on a LIVE order; opt in only once #992
+        // lands (mirrors the offer-status-sync opt-in posture, #1063). Reporting
+        // `unsupported` (not `applied`) surfaces the skip to the operator.
+        if (process.env.OL_ERLI_DISPATCH_WRITEBACK_ENABLED !== 'true') {
+          this.logger.warn(
+            `Erli dispatch writeback skipped — gated OFF until #992 ` +
+              `(set OL_ERLI_DISPATCH_WRITEBACK_ENABLED=true to enable) [connectionId=${this.connectionId}]`,
+          );
+          return {
+            outcome: 'unsupported',
+            detail:
+              'Erli dispatch writeback is gated OFF until #992 (OL_ERLI_DISPATCH_WRITEBACK_ENABLED).',
+          };
+        }
+
+        try {
+          await this.markDispatched(event.externalOrderId, event.trackingNumber, event.carrier);
+          return { outcome: 'applied' };
+        } catch (error) {
+          const detail = error instanceof Error ? error.message : String(error);
+          // No PII: connectionId only, never order id / waybill.
+          this.logger.warn(
+            `OrderStatusWriteback 'dispatched' rejected for Erli order (connection: ${this.connectionId}): ${detail}`,
+          );
+          return { outcome: 'rejected', detail };
+        }
+      }
+
+      default: {
+        // Unreachable in-tree: the binding is the compile break when an
+        // `OrderLifecycleEvent` member is added without an arm here (#2286);
+        // the return keeps an out-of-tree caller on a surfaced no-op
+        // (ADR-055 forward-compat).
+        const unhandled: never = event;
         return {
           outcome: 'unsupported',
-          detail:
-            'Erli cancelled stock-restore is not wired: offerManager or inventoryQuery is absent.',
+          detail: `unsupported order lifecycle event: ${JSON.stringify(unhandled)}`,
         };
       }
-      try {
-        await this.restockOnCancellation(event.externalOrderId, this.offerManager, this.inventoryQuery);
-        return { outcome: 'applied' };
-      } catch (error) {
-        const detail = error instanceof Error ? error.message : String(error);
-        this.logger.warn(
-          `OrderStatusWriteback 'cancelled' (stock-restore) rejected for Erli order ` +
-            `(connection: ${this.connectionId}): ${detail}`,
-        );
-        return { outcome: 'rejected', detail };
-      }
-    }
-
-    // event.type === 'dispatched'
-    // #992 release gate (#1086 review): the writeback wire shapes
-    // (PATCH /orders/{id}/status {status:'sent'} + POST /shipping/external) are
-    // PROVISIONAL until the #992 sandbox confirms them. Default OFF so OL never
-    // writes to an unconfirmed endpoint on a LIVE order; opt in only once #992
-    // lands (mirrors the offer-status-sync opt-in posture, #1063). Reporting
-    // `unsupported` (not `applied`) surfaces the skip to the operator.
-    if (process.env.OL_ERLI_DISPATCH_WRITEBACK_ENABLED !== 'true') {
-      this.logger.warn(
-        `Erli dispatch writeback skipped — gated OFF until #992 ` +
-          `(set OL_ERLI_DISPATCH_WRITEBACK_ENABLED=true to enable) [connectionId=${this.connectionId}]`,
-      );
-      return {
-        outcome: 'unsupported',
-        detail: 'Erli dispatch writeback is gated OFF until #992 (OL_ERLI_DISPATCH_WRITEBACK_ENABLED).',
-      };
-    }
-
-    try {
-      await this.markDispatched(event.externalOrderId, event.trackingNumber, event.carrier);
-      return { outcome: 'applied' };
-    } catch (error) {
-      const detail = error instanceof Error ? error.message : String(error);
-      // No PII: connectionId only, never order id / waybill.
-      this.logger.warn(
-        `OrderStatusWriteback 'dispatched' rejected for Erli order (connection: ${this.connectionId}): ${detail}`,
-      );
-      return { outcome: 'rejected', detail };
     }
   }
 

--- a/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-order-processor-manager.status-writeback.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-order-processor-manager.status-writeback.spec.ts
@@ -11,6 +11,7 @@ import {
   createOrderProcessorManagerHarness,
   type OrderProcessorHarness,
 } from '../../../__tests__/mocks/prestashop-order-processor-manager.factory';
+import type { OrderLifecycleEvent } from '@openlinker/core/orders';
 
 const STATE_ID: Record<string, number> = { shipped: 4, delivered: 5, cancelled: 6 };
 
@@ -99,6 +100,25 @@ describe('PrestashopOrderProcessorManagerAdapter — OrderStatusWriteback.write'
         expect.anything(),
         expect.anything()
       );
+    });
+  });
+
+  // #2286 — the runtime half of the exhaustiveness guard. Before the switch
+  // conversion an unrecognised member fell into the cancel branch and could
+  // transition a live shop order to `cancelled`.
+  describe('unknown member (never-default, #2286)', () => {
+    it('returns unsupported without reading or writing the order', async () => {
+      mockHttpClient.getResource = jest.fn();
+
+      const result = await adapter.write({
+        type: 'amended',
+        externalOrderId: PS_ORDER_ID,
+      } as unknown as OrderLifecycleEvent);
+
+      expect(result.outcome).toBe('unsupported');
+      expect(result.detail).toContain('amended');
+      expect(mockHttpClient.getResource).not.toHaveBeenCalled();
+      expect(mockHttpClient.createResource).not.toHaveBeenCalled();
     });
   });
 });

--- a/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-processor-manager.adapter.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-order-processor-manager.adapter.ts
@@ -920,43 +920,60 @@ export class PrestashopOrderProcessorManagerAdapter
    */
   async write(event: OrderLifecycleEvent): Promise<OrderWritebackResult> {
     try {
-      if (event.type === 'dispatched') {
-        await this.updateFulfillment({
-          externalOrderId: event.externalOrderId,
-          status: 'shipped',
-          trackingNumber: event.trackingNumber,
-        });
-        return { outcome: 'applied' };
-      }
+      switch (event.type) {
+        case 'dispatched': {
+          await this.updateFulfillment({
+            externalOrderId: event.externalOrderId,
+            status: 'shipped',
+            trackingNumber: event.trackingNumber,
+          });
+          return { outcome: 'applied' };
+        }
 
-      // event.type === 'cancelled' — refuse if the shop already shipped/delivered.
-      // One read here; the cancel carries no tracking, so we reuse the fetched
-      // state for the transition instead of re-reading via updateFulfillment.
-      const order = await this.httpClient.getResource<PrestashopOrder>(
-        'orders',
-        event.externalOrderId
-      );
-      const currentStateId = Number(order.current_state);
-      const [shippedStateId, deliveredStateId, cancelledStateId] = await Promise.all([
-        this.resolveStateId('shipped'),
-        this.resolveStateId('delivered'),
-        this.resolveStateId('cancelled'),
-      ]);
-      if (currentStateId === shippedStateId || currentStateId === deliveredStateId) {
-        this.logger.warn(
-          `PrestaShop order ${event.externalOrderId} already in state ${currentStateId} ` +
-            `(shipped/delivered) — refusing cancel writeback (connection: ${this.connection.id})`
-        );
-        return { outcome: 'rejected', detail: 'order already shipped' };
-      }
+        case 'cancelled': {
+          // Refuse if the shop already shipped/delivered. One read here; the
+          // cancel carries no tracking, so we reuse the fetched state for the
+          // transition instead of re-reading via updateFulfillment.
+          const order = await this.httpClient.getResource<PrestashopOrder>(
+            'orders',
+            event.externalOrderId
+          );
+          const currentStateId = Number(order.current_state);
+          const [shippedStateId, deliveredStateId, cancelledStateId] = await Promise.all([
+            this.resolveStateId('shipped'),
+            this.resolveStateId('delivered'),
+            this.resolveStateId('cancelled'),
+          ]);
+          if (currentStateId === shippedStateId || currentStateId === deliveredStateId) {
+            this.logger.warn(
+              `PrestaShop order ${event.externalOrderId} already in state ${currentStateId} ` +
+                `(shipped/delivered) — refusing cancel writeback (connection: ${this.connection.id})`
+            );
+            return { outcome: 'rejected', detail: 'order already shipped' };
+          }
 
-      await this.applyOrderStateTransition(
-        event.externalOrderId,
-        currentStateId,
-        cancelledStateId,
-        'cancelled'
-      );
-      return { outcome: 'applied' };
+          await this.applyOrderStateTransition(
+            event.externalOrderId,
+            currentStateId,
+            cancelledStateId,
+            'cancelled'
+          );
+          return { outcome: 'applied' };
+        }
+
+        default: {
+          // Unreachable in-tree: the binding is the compile break when an
+          // `OrderLifecycleEvent` member is added without an arm here (#2286).
+          // It returns rather than throwing so a caller compiled against a
+          // widened union gets a surfaced no-op, not a `rejected` from the
+          // enclosing catch (ADR-055 forward-compat).
+          const unhandled: never = event;
+          return {
+            outcome: 'unsupported',
+            detail: `unsupported order lifecycle event: ${JSON.stringify(unhandled)}`,
+          };
+        }
+      }
     } catch (error) {
       const detail = error instanceof Error ? error.message : String(error);
       this.logger.error(

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/__tests__/woocommerce-order-processor.adapter.spec.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/__tests__/woocommerce-order-processor.adapter.spec.ts
@@ -19,7 +19,12 @@ import { WC_ORDER_STATUS_LABELS } from '../woocommerce-options.types';
 import type { IWooCommerceHttpClient } from '../../../http/woocommerce-http-client.interface';
 import type { IdentifierMappingPort, Connection } from '@openlinker/core/identifier-mapping';
 import { CORE_ENTITY_TYPE, DuplicateIdentifierMappingError } from '@openlinker/core/identifier-mapping';
-import type { OrderCreate, OrderItem, OrderStatus } from '@openlinker/core/orders';
+import type {
+  OrderCreate,
+  OrderItem,
+  OrderStatus,
+  OrderLifecycleEvent,
+} from '@openlinker/core/orders';
 import type { CustomerProjectionRepositoryPort } from '@openlinker/core/customers';
 import { DestinationAddressMapping } from '@openlinker/core/customers';
 import type { SyncLockPort } from '@openlinker/core/sync';
@@ -1004,6 +1009,25 @@ describe('WooCommerceOrderProcessorAdapter — OrderStatusWriteback', () => {
 
     expect(result.outcome).toBe('rejected');
     expect(result.detail).toBeDefined();
+  });
+
+  // ── unknown member (never-default, #2286) ──
+  //
+  // Before the switch conversion an unrecognised member fell into the cancel
+  // branch and could PUT `cancelled` onto a live shop order.
+  it('should return unsupported for an unknown member without reading or writing', async () => {
+    const httpClient = makeHttpClient();
+    const adapter = makeAdapter(httpClient, makeIdentifierMapping());
+
+    const result = await adapter.write({
+      type: 'amended',
+      externalOrderId: '55',
+    } as unknown as OrderLifecycleEvent);
+
+    expect(result.outcome).toBe('unsupported');
+    expect(result.detail).toContain('amended');
+    expect(httpClient.get).not.toHaveBeenCalled();
+    expect(httpClient.put).not.toHaveBeenCalled();
   });
 });
 

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/woocommerce-order-processor.adapter.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/order-processor/woocommerce-order-processor.adapter.ts
@@ -287,44 +287,61 @@ export class WooCommerceOrderProcessorAdapter
         };
       }
 
-      if (event.type === 'dispatched') {
-        await this.updateFulfillment({
-          externalOrderId: event.externalOrderId,
-          status: 'shipped',
-          trackingNumber: event.trackingNumber,
-        });
-        return { outcome: 'applied' };
+      switch (event.type) {
+        case 'dispatched': {
+          await this.updateFulfillment({
+            externalOrderId: event.externalOrderId,
+            status: 'shipped',
+            trackingNumber: event.trackingNumber,
+          });
+          return { outcome: 'applied' };
+        }
+
+        case 'cancelled': {
+          // One read to honour the shop's authoritative live state before
+          // forcing a regressive transition.
+          const order = await this.httpClient.get<WooCommerceOrderResponse>(
+            `/wp-json/wc/v3/orders/${event.externalOrderId}`,
+          );
+          const currentStatus = order.status;
+
+          if (currentStatus === 'completed' || currentStatus === 'refunded') {
+            this.logger.warn(
+              `WooCommerce order ${event.externalOrderId} already in terminal state ` +
+                `'${currentStatus}' — refusing cancel writeback (connection: ${this.connection.id})`,
+            );
+            return { outcome: 'rejected', detail: `order already ${currentStatus}` };
+          }
+
+          if (currentStatus === 'cancelled') {
+            this.logger.debug(
+              `WooCommerce order ${event.externalOrderId} already cancelled — cancel writeback is a no-op ` +
+                `(connection: ${this.connection.id})`,
+            );
+            return { outcome: 'applied' };
+          }
+
+          const wcStatus = WC_ORDER_STATUS_MAP.cancelled;
+          await this.httpClient.put<WooCommerceOrderUpdateRequest>(
+            `/wp-json/wc/v3/orders/${event.externalOrderId}`,
+            { status: wcStatus } satisfies WooCommerceOrderUpdateRequest,
+          );
+          return { outcome: 'applied' };
+        }
+
+        default: {
+          // Unreachable in-tree: the binding is the compile break when an
+          // `OrderLifecycleEvent` member is added without an arm here (#2286).
+          // It returns rather than throwing so a caller compiled against a
+          // widened union gets a surfaced no-op, not a `rejected` from the
+          // enclosing catch (ADR-055 forward-compat).
+          const unhandled: never = event;
+          return {
+            outcome: 'unsupported',
+            detail: `unsupported order lifecycle event: ${JSON.stringify(unhandled)}`,
+          };
+        }
       }
-
-      // event.type === 'cancelled' — one read to honour the shop's authoritative
-      // live state before forcing a regressive transition.
-      const order = await this.httpClient.get<WooCommerceOrderResponse>(
-        `/wp-json/wc/v3/orders/${event.externalOrderId}`,
-      );
-      const currentStatus = order.status;
-
-      if (currentStatus === 'completed' || currentStatus === 'refunded') {
-        this.logger.warn(
-          `WooCommerce order ${event.externalOrderId} already in terminal state ` +
-            `'${currentStatus}' — refusing cancel writeback (connection: ${this.connection.id})`,
-        );
-        return { outcome: 'rejected', detail: `order already ${currentStatus}` };
-      }
-
-      if (currentStatus === 'cancelled') {
-        this.logger.debug(
-          `WooCommerce order ${event.externalOrderId} already cancelled — cancel writeback is a no-op ` +
-            `(connection: ${this.connection.id})`,
-        );
-        return { outcome: 'applied' };
-      }
-
-      const wcStatus = WC_ORDER_STATUS_MAP.cancelled;
-      await this.httpClient.put<WooCommerceOrderUpdateRequest>(
-        `/wp-json/wc/v3/orders/${event.externalOrderId}`,
-        { status: wcStatus } satisfies WooCommerceOrderUpdateRequest,
-      );
-      return { outcome: 'applied' };
     } catch (error) {
       const detail = error instanceof Error ? error.message : String(error);
       this.logger.error(

--- a/libs/shared/src/types/__tests__/exhaustive.types.spec.ts
+++ b/libs/shared/src/types/__tests__/exhaustive.types.spec.ts
@@ -1,0 +1,40 @@
+/**
+ * Exhaustiveness Assertion — unit tests (#2286)
+ *
+ * `assertNever`'s primary contract is compile-time and therefore untestable at
+ * runtime. What is testable is the fallback: the throw a widened union produces
+ * when it reaches a default arm from outside the type system, and the message
+ * that identifies which value and which site.
+ *
+ * @module libs/shared/src/types/__tests__
+ */
+import { assertNever } from '../exhaustive.types';
+
+describe('assertNever', () => {
+  const unhandled = { type: 'amended' } as unknown as never;
+
+  it('throws, naming the unhandled value', () => {
+    expect(() => assertNever(unhandled)).toThrow(/Unhandled union member: .*amended/);
+  });
+
+  it('includes the caller-supplied context so the site is identifiable without a stack trace', () => {
+    expect(() => assertNever(unhandled, 'OrderLifecycleEvent')).toThrow(
+      /Unhandled union member in OrderLifecycleEvent: .*amended/
+    );
+  });
+
+  it('still throws for a value JSON.stringify cannot render', () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+
+    expect(() => assertNever(circular as unknown as never, 'circular')).toThrow(
+      /Unhandled union member in circular:/
+    );
+  });
+
+  it('renders an undefined value rather than throwing on the render itself', () => {
+    expect(() => assertNever(undefined as unknown as never)).toThrow(
+      'Unhandled union member: undefined'
+    );
+  });
+});

--- a/libs/shared/src/types/exhaustive.types.ts
+++ b/libs/shared/src/types/exhaustive.types.ts
@@ -1,0 +1,44 @@
+/**
+ * Exhaustiveness Assertion
+ *
+ * The shared form of the repo's inline `const _exhaustive: never = value;`
+ * idiom: a compile-time proof that a discriminated-union `switch` handles every
+ * member, plus a runtime throw for the case where a widened union reaches the
+ * default arm from outside the type system (an out-of-tree plugin compiled
+ * against an older contract, or a persisted value read back).
+ *
+ * Home rationale — `engineering-standards.md § The pure-rule exception to
+ * "types only"`: this is a pure function (no I/O, no injected dependency, no
+ * framework import, no argument mutation), and it *is* the narrowing rule for
+ * the `never` type it sits with. Note that this barrel previously exported type
+ * aliases only; `assertNever` is its first runtime export, admitted under that
+ * exception rather than as a precedent for general helpers.
+ *
+ * @module libs/shared/src/types
+ */
+
+/**
+ * Assert that `value` is `never` — i.e. that every member of the union it came
+ * from has already been handled by an earlier branch.
+ *
+ * Adding a member to the union makes every call site that does not handle it a
+ * **compile** error, which is the point: the alternative is a `default:` arm
+ * that silently absorbs the new member at runtime.
+ *
+ * @param value the supposedly-impossible value (must narrow to `never`)
+ * @param context optional caller-supplied label naming the union being switched
+ *   on, so the thrown message identifies the site without a stack trace
+ * @throws {Error} always
+ */
+export function assertNever(value: never, context?: string): never {
+  const rendered = ((): string => {
+    try {
+      return JSON.stringify(value) ?? String(value);
+    } catch {
+      return String(value);
+    }
+  })();
+  throw new Error(
+    `Unhandled union member${context ? ` in ${context}` : ''}: ${rendered}`
+  );
+}

--- a/libs/shared/src/types/index.ts
+++ b/libs/shared/src/types/index.ts
@@ -10,3 +10,5 @@ export type Nullable<T> = T | null;
 export type Optional<T> = T | undefined;
 export type Maybe<T> = T | null | undefined;
 
+export * from './exhaustive.types';
+


### PR DESCRIPTION
Wave 0 of the OMS programme (backlog overview: `docs/plans/oms-backlog-overview.md`; execution ledger on the branch at `docs/plans/oms-progress-ledger.md`). Eight issues, each through the full per-issue process (plan → `/pre-implement` live-tree audit → plan review with all findings applied → Opus implementation → quality gate → diff review → merge), plus a wave-boundary consistency sweep over the seams between them, whose findings are applied in the closing commit.

## What ships

- **#2282** — `persistOrder` source attribution is immutable at the write path: `upsert()` swaps full-object `save()` for parameterized `INSERT … ON CONFLICT` — `sourceConnectionId` insert-only, `sourceEventId` *same-source may advance, cross-source frozen* (CASE), return contract preserved via `fromRawRow` resets. ADR-057's stated precondition.
- **#2283** — re-ingestion line-diff records the internal **amended fact**: pure `diffOrderAmendment` keyed on `items[].id`+quantity, run pre-persist off the already-loaded record (survives item-resolution failure); `lastAmendedAt`/`lastAmendmentChanges` columns (single-writer, `IS DISTINCT FROM` no-op guard comparing changes only); PII-free by construction with one shared `redactAddress` rule; dated timeline entry. **No** `amended` union member yet — that lands with its consumer wave, enforced by #2286's compile break.
- **#2284** — source-cancelled orders are never provisioned: re-read guard before the destination fan-out; new terminal `skipped_cancelled` status (widening the existing `OrderSyncStatusFilterValues`, not a new const), structurally un-retryable; FE renders it neutral everywhere incl. the un-compiler-guarded `order-health` rollup.
- **#2285** — offer-quantity idempotency keys carry an **observation token** (`observedAt`, never wall-clock): closes the pause→restock→re-pause dedup swallow at Allegro's command-id layer; stale-offer-pause stamps `staleAt`; disjoint keyspaces across the deploy boundary.
- **#2286** — `never`-default exhaustiveness on all five `OrderLifecycleEvent` consumers + shared `assertNever` (`@openlinker/shared/types`); the relay input union is now **derived** from `OrderLifecycleEvent` (the sixth, undocumented restatement that would have defeated the guard). Adapters keep ADR-055 forward-compat (`unsupported` return + used `never` binding).
- **#2287** — `packedAt`/`packedByUserId` (migration `1840000000000`): first-write-wins conditional-UPDATE writers, POST/DELETE `/orders/:id/packed` (`@Roles('admin','operator')`, 200 on idempotent replay), shared `toDto` projection.
- **#2288** — the FE half: packed tick in the Shipment stack (first, chronological, tick-not-badge per #2081), always-rendered detail control (`useWriteAccess('orders:write', …)`, deliberately **not** in the capability-gated shipment panel), dated timeline entry.
- **#2289** — Allegro customer-returns spike: **verdict 4A** with the two-pass qualification (creation-cursor discovery + bounded re-read of non-terminal returns, since `CustomerReturn` has no `updatedAt`). Findings at `docs/plans/analysis/SPIKE-2289-allegro-returns-feed.md`; verdict comment on the issue.
- **#2298** — design freshness pass (R2): six wrong-about-shipped-code statements fixed across DESIGN + ADRs 052/054/056; **adopted amendment to ADR-054** — routing rules are rows in the plugin's own `oms_routing_rules` table, superseding `Connection.config.routing` jsonb; design artifact re-synced.

## Numbers

83+ files, ~4.9k insertions / ~290 deletions before the boundary commit; 2 migrations (`1840000000000`, `1841000000000` — synthetic-sequential, verified by `check-migration-timestamps`); every gate green per issue (core 247/3057, api 106/1392, web 355/3651+1s at final state) plus per-issue int-specs (cancelled-skip e2e, packed 5-case, amendment 4-case, attribution immutability).

## Wave gates this unlocks

Wave 1a's entry criteria (#2284/#2286/#2283 merged; #2298 resolved) are all satisfied by this PR. Per the stacked-wave model, `oms-programme-wave-1` continues from this branch's tip; merging this PR then folds `main` forward.

Closes #2282
Closes #2283
Closes #2284
Closes #2285
Closes #2286
Closes #2287
Closes #2288
Closes #2289
Closes #2298

🤖 Generated with [Claude Code](https://claude.com/claude-code)