### PR TITLE
fix(ksef): surface session-crypto failures on Test connection instead of a generic message

### DIFF
--- a/libs/integrations/ksef/src/infrastructure/adapters/__tests__/ksef-connection-tester.adapter.spec.ts
+++ b/libs/integrations/ksef/src/infrastructure/adapters/__tests__/ksef-connection-tester.adapter.spec.ts
@@ -16,6 +16,7 @@ import type { HttpTransportFactoryPort } from '@openlinker/shared/http';
 import { KsefConnectionTesterAdapter } from '../ksef-connection-tester.adapter';
 import { KsefAuthenticationException } from '../../../domain/exceptions/ksef-authentication.exception';
 import { KsefConfigException } from '../../../domain/exceptions/ksef-config.exception';
+import { KsefSessionCryptoException } from '../../../domain/exceptions/ksef-session-crypto.exception';
 import * as httpClientFactory from '../../http/ksef-http-client.factory';
 
 jest.mock('../../http/ksef-http-client.factory');
@@ -238,6 +239,30 @@ describe('KsefConnectionTesterAdapter', () => {
     expect(result).toMatchObject({
       success: false,
       message: 'KSeF auth handshake used before wiring completed',
+    });
+  });
+
+  it('should surface a session-crypto failure (cert fetch/validation, RSA wrap) instead of the generic fallback', async () => {
+    const authenticate = jest
+      .fn()
+      .mockRejectedValue(
+        new KsefSessionCryptoException('No valid MF public-key certificate for usage KsefTokenEncryption', 'CERT_NOT_FOUND'),
+      );
+    createKsefHttpClientMock.mockReturnValue({
+      httpClient: {} as never,
+      publicKeyCache: {} as never,
+      handshake: { authenticate } as never,
+    });
+
+    const adapter = new KsefConnectionTesterAdapter(http);
+    const result = await adapter.test(
+      connection(),
+      resolver({ 'ref:ksef': { authType: 'ksef-token', secret: 'tok' } }),
+    );
+
+    expect(result).toMatchObject({
+      success: false,
+      message: 'No valid MF public-key certificate for usage KsefTokenEncryption',
     });
   });
 });

--- a/libs/integrations/ksef/src/infrastructure/adapters/ksef-connection-tester.adapter.ts
+++ b/libs/integrations/ksef/src/infrastructure/adapters/ksef-connection-tester.adapter.ts
@@ -38,6 +38,7 @@ import { createKsefHttpClient } from '../http/ksef-http-client.factory';
 import { KsefApiException } from '../../domain/exceptions/ksef-api.exception';
 import { KsefAuthenticationException } from '../../domain/exceptions/ksef-authentication.exception';
 import { KsefConfigException } from '../../domain/exceptions/ksef-config.exception';
+import { KsefSessionCryptoException } from '../../domain/exceptions/ksef-session-crypto.exception';
 import { KsefEnvironmentValues } from '../../domain/types/ksef-connection.types';
 import type { KsefConnectionConfig, KsefCredentials } from '../../domain/types/ksef-connection.types';
 
@@ -125,7 +126,8 @@ export class KsefConnectionTesterAdapter implements ConnectionTesterPort {
     if (
       error instanceof KsefAuthenticationException ||
       error instanceof KsefApiException ||
-      error instanceof KsefConfigException
+      error instanceof KsefConfigException ||
+      error instanceof KsefSessionCryptoException
     ) {
       const status =
         error instanceof KsefAuthenticationException || error instanceof KsefApiException


### PR DESCRIPTION
## Summary
- `KsefConnectionTesterAdapter.toFailure()` only handled `KsefAuthenticationException` / `KsefApiException` / `KsefConfigException`, so any `KsefSessionCryptoException` (MF public-key cert fetch/validation failure, RSA-OAEP wrap failure) fell through to a generic "KSeF connection test failed" message.
- Added the missing branch so the real reason (cert usage mismatch, expired/not-yet-valid cert, RSA wrap failure) reaches the operator-facing toast.
- Added a unit test covering the new branch.

## Test plan
- [x] `pnpm --filter @openlinker/integrations-ksef test -- ksef-connection-tester.adapter.spec.ts` — 11/11 passing
- [x] `pnpm --filter @openlinker/integrations-ksef lint` — clean (0 errors)
- [x] `pnpm --filter @openlinker/integrations-ksef type-check` — clean

Closes #2443