### PR TITLE
fix(products): surface isStale/staleAt on variant response DTOs

### DIFF
--- a/apps/api/src/products/http/dto/product-variant-response.dto.ts
+++ b/apps/api/src/products/http/dto/product-variant-response.dto.ts
@@ -67,6 +67,18 @@ export class ProductVariantResponseDto {
   @ApiProperty({ description: 'Last update timestamp (ISO 8601)' })
   updatedAt!: string;
 
+  @ApiProperty({
+    description:
+      'Whether this variant was deleted at the master (absent from the master catalog, or the product 404s). Its offers are auto-paused.',
+  })
+  isStale!: boolean;
+
+  @ApiPropertyOptional({
+    nullable: true,
+    description: 'Timestamp of the most recent stale-marking; null while the variant is live.',
+  })
+  staleAt!: string | null;
+
   @ApiPropertyOptional({ type: [ExternalIdMappingDto], description: 'External platform identifiers' })
   externalIds?: ExternalIdMappingDto[];
 }

--- a/apps/api/src/products/http/dto/product-variant-summary-response.dto.ts
+++ b/apps/api/src/products/http/dto/product-variant-summary-response.dto.ts
@@ -30,4 +30,16 @@ export class ProductVariantSummaryResponseDto {
     description: 'Display label assembled from variant attributes (e.g. "Red / 42")',
   })
   name?: string;
+
+  @ApiProperty({
+    description:
+      'Whether this variant was deleted at the master (absent from the master catalog, or the product 404s). Its offers are auto-paused.',
+  })
+  isStale!: boolean;
+
+  @ApiPropertyOptional({
+    nullable: true,
+    description: 'Timestamp of the most recent stale-marking; null while the variant is live.',
+  })
+  staleAt!: string | null;
 }

--- a/apps/api/src/products/http/products.controller.spec.ts
+++ b/apps/api/src/products/http/products.controller.spec.ts
@@ -52,6 +52,8 @@ function makeVariant(overrides: Partial<ProductVariant> = {}): ProductVariant {
     price: overrides.price,
     createdAt: overrides.createdAt ?? new Date('2026-01-01T00:00:00Z'),
     updatedAt: overrides.updatedAt ?? new Date('2026-01-01T00:00:00Z'),
+    isStale: overrides.isStale,
+    staleAt: overrides.staleAt,
   };
 }
 
@@ -433,6 +435,32 @@ describe('ProductsController', () => {
       expect(result.variants![0].price).toBe(19.99);
     });
 
+    it('should surface isStale/staleAt when the master deleted the variant (#2446)', async () => {
+      const staleAt = new Date('2026-03-01T00:00:00Z');
+      productsService.getProduct.mockResolvedValue(makeProduct());
+      productsService.listVariants.mockResolvedValue({
+        items: [makeVariant({ isStale: true, staleAt })],
+        total: 1,
+      });
+      identifierMapping.getExternalIds.mockResolvedValue([]);
+
+      const result = await controller.getProduct('ol_product_1');
+
+      expect(result.variants![0].isStale).toBe(true);
+      expect(result.variants![0].staleAt).toBe(staleAt.toISOString());
+    });
+
+    it('should default isStale to false and staleAt to null for a live variant', async () => {
+      productsService.getProduct.mockResolvedValue(makeProduct());
+      productsService.listVariants.mockResolvedValue({ items: [makeVariant()], total: 1 });
+      identifierMapping.getExternalIds.mockResolvedValue([]);
+
+      const result = await controller.getProduct('ol_product_1');
+
+      expect(result.variants![0].isStale).toBe(false);
+      expect(result.variants![0].staleAt).toBeNull();
+    });
+
     it('should surface currency when the domain entity carries one', async () => {
       productsService.getProduct.mockResolvedValue(makeProduct({ currency: 'PLN' }));
       productsService.listVariants.mockResolvedValue({ items: [], total: 0 });
@@ -502,8 +530,22 @@ describe('ProductsController', () => {
         sku: 'SKU-RED-42',
         ean: '5901234123457',
         name: 'Red / 42',
+        isStale: false,
+        staleAt: null,
       });
       expect(productsService.getVariant).toHaveBeenCalledWith('ol_variant_42');
+    });
+
+    it('should surface isStale/staleAt when the master deleted the variant (#2446)', async () => {
+      const staleAt = new Date('2026-03-01T00:00:00Z');
+      productsService.getVariant.mockResolvedValue(
+        makeVariant({ id: 'ol_variant_44', isStale: true, staleAt })
+      );
+
+      const result = await controller.getVariantSummary('ol_variant_44');
+
+      expect(result.isStale).toBe(true);
+      expect(result.staleAt).toBe(staleAt.toISOString());
     });
 
     it('should leave name undefined when the variant has no string attributes', async () => {

--- a/apps/api/src/products/http/products.controller.ts
+++ b/apps/api/src/products/http/products.controller.ts
@@ -106,6 +106,8 @@ function variantToDto(variant: ProductVariant): ProductVariantResponseDto {
     taxRateUnknownReason: variant.taxRateUnknownReason ?? null,
     createdAt: variant.createdAt!.toISOString(),
     updatedAt: variant.updatedAt!.toISOString(),
+    isStale: variant.isStale ?? false,
+    staleAt: variant.staleAt?.toISOString() ?? null,
   };
 }
 
@@ -467,6 +469,8 @@ export class ProductsController {
       sku: variant.sku,
       ean: variant.ean ?? null,
       name: attributeValues.length > 0 ? attributeValues.join(' / ') : undefined,
+      isStale: variant.isStale ?? false,
+      staleAt: variant.staleAt?.toISOString() ?? null,
     };
   }
 


### PR DESCRIPTION
## Summary
- `ProductVariant`'s domain entity, ORM entity, and repository mapping already carried `isStale`/`staleAt` (#1599), but `ProductVariantResponseDto` and `ProductVariantSummaryResponseDto` dropped both fields before they reached a consumer.
- A variant deleted at the master was therefore indistinguishable from a normal one over the API — including to the frontend that #2447 will use to render a "deleted at source" badge.
- Adds both fields to both DTOs and populates them in the shared `variantToDto` mapper and `toVariantSummaryDto`.

## Test plan
- [x] Unit tests added for both mappers covering a stale variant (`isStale: true`, `staleAt` as ISO string) and a live variant (`isStale: false`, `staleAt: null`)
- [x] `pnpm --filter @openlinker/api test -- products.controller.spec.ts` passes (32/32)
- [x] `pnpm --filter @openlinker/api type-check` clean
- [x] `pnpm --filter @openlinker/api lint` — 0 errors
- [x] `pnpm check:invariants` — all checks pass

Closes #2446