### PR TITLE
feat(orders,analytics): Phase 2 — display-currency read model (no persistence writes)

### DIFF
--- a/apps/api/src/analytics/http/dto/sales-analytics-query.dto.spec.ts
+++ b/apps/api/src/analytics/http/dto/sales-analytics-query.dto.spec.ts
@@ -1,0 +1,76 @@
+/**
+ * Sales Analytics Query DTO — validation spec (#2459)
+ *
+ * Exercises the `displayCurrency` / `rateBasis` class-validator constraints
+ * added on top of the pre-existing `from`/`to`/`sourceConnectionId` shape —
+ * see `record-refund-request.dto.spec.ts` for the same `validate` +
+ * `plainToInstance` pattern.
+ *
+ * @module apps/api/src/analytics/http/dto
+ */
+import { validate } from 'class-validator';
+import { plainToInstance } from 'class-transformer';
+
+import { SalesAnalyticsQueryDto } from './sales-analytics-query.dto';
+
+function buildDto(payload: Record<string, unknown>): SalesAnalyticsQueryDto {
+  return plainToInstance(SalesAnalyticsQueryDto, payload);
+}
+
+const validBase = { from: '2026-08-01T00:00:00.000Z', to: '2026-08-08T00:00:00.000Z' };
+
+describe('SalesAnalyticsQueryDto', () => {
+  it('should pass validation with only the required from/to range (displayCurrency/rateBasis omitted)', async () => {
+    const errors = await validate(buildDto(validBase));
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should accept a displayCurrency in SUPPORTED_REPORTING_CURRENCIES', async () => {
+    const errors = await validate(buildDto({ ...validBase, displayCurrency: 'PLN' }));
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should accept every SUPPORTED_REPORTING_CURRENCIES entry (EUR)', async () => {
+    const errors = await validate(buildDto({ ...validBase, displayCurrency: 'EUR' }));
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should reject a displayCurrency outside SUPPORTED_REPORTING_CURRENCIES (well-formed ISO-4217 shape, unsupported code)', async () => {
+    const errors = await validate(buildDto({ ...validBase, displayCurrency: 'USD' }));
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].property).toBe('displayCurrency');
+    expect(errors[0].constraints).toHaveProperty('isIn');
+  });
+
+  it('should reject a malformed (non-ISO-4217-shaped) displayCurrency', async () => {
+    const errors = await validate(buildDto({ ...validBase, displayCurrency: 'pl' }));
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].property).toBe('displayCurrency');
+    expect(errors[0].constraints).toHaveProperty('isIn');
+  });
+
+  it('should accept rateBasis "current-rate"', async () => {
+    const errors = await validate(buildDto({ ...validBase, displayCurrency: 'PLN', rateBasis: 'current-rate' }));
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should accept rateBasis "order-date"', async () => {
+    const errors = await validate(buildDto({ ...validBase, displayCurrency: 'PLN', rateBasis: 'order-date' }));
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it('should reject a rateBasis outside DISPLAY_CURRENCY_RATE_BASIS_VALUES', async () => {
+    const errors = await validate(buildDto({ ...validBase, displayCurrency: 'PLN', rateBasis: 'live' }));
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].property).toBe('rateBasis');
+    expect(errors[0].constraints).toHaveProperty('isIn');
+  });
+});

--- a/apps/api/src/analytics/http/dto/sales-analytics-query.dto.ts
+++ b/apps/api/src/analytics/http/dto/sales-analytics-query.dto.ts
@@ -6,7 +6,7 @@
  * **required** here — a sales query without a range is not a meaningful
  * request.
  *
- * `displayCurrency` / `rateBasis` (#2459, ADR-064) are the display-currency
+ * `displayCurrency` / `rateBasis` (#2459, ADR-064, pending in PR #2485) are the display-currency
  * override axis: both optional, and omitting `displayCurrency` leaves the
  * response byte-identical to the pre-#2459 shape — the controller never even
  * calls `IDisplayCurrencyConversionService` when it's absent. Unlike
@@ -58,9 +58,9 @@ export class SalesAnalyticsQueryDto {
   @ApiPropertyOptional({
     description:
       "Conversion rate basis, only meaningful when displayCurrency is set. 'current-rate' " +
-      "(default) groups each native-currency bucket already read by the aggregation and " +
+      '(default) groups each native-currency bucket already read by the aggregation and ' +
       "converts each group at today's rate. 'order-date' instead takes the already-stamped " +
-      "reporting-currency total and applies a single current rate to the whole figure.",
+      'reporting-currency total and applies a single current rate to the whole figure.',
     enum: DISPLAY_CURRENCY_RATE_BASIS_VALUES,
     default: 'current-rate',
   })

--- a/apps/api/src/analytics/http/dto/sales-analytics-query.dto.ts
+++ b/apps/api/src/analytics/http/dto/sales-analytics-query.dto.ts
@@ -6,10 +6,26 @@
  * **required** here — a sales query without a range is not a meaningful
  * request.
  *
+ * `displayCurrency` / `rateBasis` (#2459, ADR-064) are the display-currency
+ * override axis: both optional, and omitting `displayCurrency` leaves the
+ * response byte-identical to the pre-#2459 shape — the controller never even
+ * calls `IDisplayCurrencyConversionService` when it's absent. Unlike
+ * `SetReportingCurrencyDto.reportingCurrency` (which deliberately stays a bare
+ * `@IsString()` because ITS selectable set is narrowed at runtime by which
+ * providers are registered), `displayCurrency` is validated directly against
+ * `SUPPORTED_REPORTING_CURRENCIES` at the DTO layer — a display override has
+ * no such runtime narrowing, so the class-validator decorator IS the whole
+ * gate (400 on violation, never a deeper 422).
+ *
  * @module apps/api/src/analytics/http/dto
  */
-import { IsDateString, IsNotEmpty, IsOptional, IsUUID } from 'class-validator';
+import { IsDateString, IsIn, IsNotEmpty, IsOptional, IsUUID } from 'class-validator';
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { SUPPORTED_REPORTING_CURRENCIES } from '@openlinker/core/currency';
+import {
+  DISPLAY_CURRENCY_RATE_BASIS_VALUES,
+  type DisplayCurrencyRateBasis,
+} from '@openlinker/core/orders';
 
 export class SalesAnalyticsQueryDto {
   @ApiProperty({ description: 'Range start, inclusive (ISO 8601). Bucketed by placedAt.' })
@@ -26,4 +42,29 @@ export class SalesAnalyticsQueryDto {
   @IsOptional()
   @IsUUID()
   sourceConnectionId?: string;
+
+  @ApiPropertyOptional({
+    description:
+      `Convert headline/channel revenue into this ISO-4217 currency instead of the ` +
+      `stamped reporting currency. Restricted to ${SUPPORTED_REPORTING_CURRENCIES.join(', ')} ` +
+      `— the currencies OpenLinker can report in today. Omit for the pre-#2459 response shape.`,
+    enum: SUPPORTED_REPORTING_CURRENCIES,
+    example: 'PLN',
+  })
+  @IsOptional()
+  @IsIn(SUPPORTED_REPORTING_CURRENCIES)
+  displayCurrency?: string;
+
+  @ApiPropertyOptional({
+    description:
+      "Conversion rate basis, only meaningful when displayCurrency is set. 'current-rate' " +
+      "(default) groups each native-currency bucket already read by the aggregation and " +
+      "converts each group at today's rate. 'order-date' instead takes the already-stamped " +
+      "reporting-currency total and applies a single current rate to the whole figure.",
+    enum: DISPLAY_CURRENCY_RATE_BASIS_VALUES,
+    default: 'current-rate',
+  })
+  @IsOptional()
+  @IsIn(DISPLAY_CURRENCY_RATE_BASIS_VALUES)
+  rateBasis?: DisplayCurrencyRateBasis;
 }

--- a/apps/api/src/analytics/http/dto/sales-analytics-response.dto.ts
+++ b/apps/api/src/analytics/http/dto/sales-analytics-response.dto.ts
@@ -14,15 +14,82 @@
  * Gross/net tax-treatment normalization remains a separate, not-yet-scoped
  * effort.
  *
+ * Display-currency conversion (#2459, ADR-064): `displayCurrencyConversion` is
+ * `undefined` unless the request carried `displayCurrency` — that's the
+ * regression guard for every pre-#2459 caller. When present, it's populated
+ * on the headline and on every channel row, using whichever of the two
+ * `IDisplayCurrencyConversionService` modes the request's `rateBasis` named.
+ *
  * @module apps/api/src/analytics/http/dto
  */
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import {
+  DisplayCurrencyRateBasis} from '@openlinker/core/orders';
 import type {
   ChannelSalesAnalytics,
+  CurrentRateConversionResult,
   DailyTrendPoint,
+  OrderDateConversionResult,
   SalesAnalyticsHeadline,
   SalesAndChannelAnalytics,
 } from '@openlinker/core/orders';
+
+/**
+ * The uniform shape both `IDisplayCurrencyConversionService` modes project
+ * into. `unresolvedNativeCurrencies` is always an array — for `order-date`
+ * (whose domain result carries a single `unresolved` boolean plus one
+ * `sourceCurrency`) that's normalised to a 0- or 1-element list, so a caller
+ * reads one field regardless of which `rateBasis` was requested.
+ */
+export class DisplayCurrencyConversionDto {
+  @ApiProperty({ description: 'The requested target currency (ISO-4217).' })
+  displayCurrency!: string;
+
+  @ApiProperty({ description: 'Which conversion mode produced this result.' })
+  rateBasis!: DisplayCurrencyRateBasis;
+
+  @ApiProperty({
+    type: Number,
+    nullable: true,
+    description:
+      "The converted revenue figure, or null when there was nothing to convert " +
+      "('order-date' with no stamped order in range yet).",
+  })
+  convertedRevenue!: number | null;
+
+  @ApiProperty({
+    type: [String],
+    description:
+      'Native currencies that could not be converted (no resolvable rate) and were excluded ' +
+      'from convertedRevenue — never guessed at. Empty when every bucket converted cleanly.',
+  })
+  unresolvedNativeCurrencies!: string[];
+
+  static fromCurrentRateResult(
+    result: CurrentRateConversionResult,
+    rateBasis: DisplayCurrencyRateBasis
+  ): DisplayCurrencyConversionDto {
+    const dto = new DisplayCurrencyConversionDto();
+    dto.displayCurrency = result.displayCurrency;
+    dto.rateBasis = rateBasis;
+    dto.convertedRevenue = result.convertedTotal;
+    dto.unresolvedNativeCurrencies = [...result.unresolvedNativeCurrencies];
+    return dto;
+  }
+
+  static fromOrderDateResult(
+    result: OrderDateConversionResult,
+    rateBasis: DisplayCurrencyRateBasis
+  ): DisplayCurrencyConversionDto {
+    const dto = new DisplayCurrencyConversionDto();
+    dto.displayCurrency = result.displayCurrency;
+    dto.rateBasis = rateBasis;
+    dto.convertedRevenue = result.convertedTotal;
+    dto.unresolvedNativeCurrencies =
+      result.unresolved && result.sourceCurrency !== null ? [result.sourceCurrency] : [];
+    return dto;
+  }
+}
 
 export class DailyTrendPointDto {
   @ApiProperty({ description: 'yyyy-mm-dd' })
@@ -144,6 +211,15 @@ export class SalesAnalyticsHeadlineDto {
   })
   netExcludedValue!: number;
 
+  @ApiPropertyOptional({
+    type: DisplayCurrencyConversionDto,
+    description:
+      'Present only when the request carried displayCurrency (#2459). Absent — never null — ' +
+      'when the request omitted it, which is what keeps the response byte-identical to a ' +
+      'pre-#2459 caller.',
+  })
+  displayCurrencyConversion?: DisplayCurrencyConversionDto;
+
   static fromDomain(headline: SalesAnalyticsHeadline): SalesAnalyticsHeadlineDto {
     const dto = new SalesAnalyticsHeadlineDto();
     dto.revenue = headline.revenue;
@@ -258,6 +334,12 @@ export class ChannelSalesAnalyticsDto {
     description: 'Same meaning as the headline netExcludedValue field, scoped to this channel.',
   })
   netExcludedValue!: number;
+
+  @ApiPropertyOptional({
+    type: DisplayCurrencyConversionDto,
+    description: 'Same meaning as the headline displayCurrencyConversion field, scoped to this channel.',
+  })
+  displayCurrencyConversion?: DisplayCurrencyConversionDto;
 
   static fromDomain(channel: ChannelSalesAnalytics): ChannelSalesAnalyticsDto {
     const dto = new ChannelSalesAnalyticsDto();

--- a/apps/api/src/analytics/http/dto/sales-analytics-response.dto.ts
+++ b/apps/api/src/analytics/http/dto/sales-analytics-response.dto.ts
@@ -14,7 +14,7 @@
  * Gross/net tax-treatment normalization remains a separate, not-yet-scoped
  * effort.
  *
- * Display-currency conversion (#2459, ADR-064): `displayCurrencyConversion` is
+ * Display-currency conversion (#2459, ADR-064, pending in PR #2485): `displayCurrencyConversion` is
  * `undefined` unless the request carried `displayCurrency` — that's the
  * regression guard for every pre-#2459 caller. When present, it's populated
  * on the headline and on every channel row, using whichever of the two
@@ -23,8 +23,7 @@
  * @module apps/api/src/analytics/http/dto
  */
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import {
-  DisplayCurrencyRateBasis} from '@openlinker/core/orders';
+import { DisplayCurrencyRateBasis } from '@openlinker/core/orders';
 import type {
   ChannelSalesAnalytics,
   CurrentRateConversionResult,
@@ -52,7 +51,7 @@ export class DisplayCurrencyConversionDto {
     type: Number,
     nullable: true,
     description:
-      "The converted revenue figure, or null when there was nothing to convert " +
+      'The converted revenue figure, or null when there was nothing to convert ' +
       "('order-date' with no stamped order in range yet).",
   })
   convertedRevenue!: number | null;
@@ -61,7 +60,10 @@ export class DisplayCurrencyConversionDto {
     type: [String],
     description:
       'Native currencies that could not be converted (no resolvable rate) and were excluded ' +
-      'from convertedRevenue — never guessed at. Empty when every bucket converted cleanly.',
+      "from convertedRevenue — never guessed at. May also contain the literal 'mixed-currencies' " +
+      'when the still-unconverted bucket itself spans more than one native currency — that money ' +
+      'is real and non-zero but this read model has no single ISO code to label it with, so it is ' +
+      'reported here rather than silently dropped. Empty when every bucket converted cleanly.',
   })
   unresolvedNativeCurrencies!: string[];
 
@@ -138,7 +140,8 @@ export class SalesAnalyticsHeadlineDto {
   unitsSold!: number;
 
   @ApiProperty({
-    description: 'Units sold on unconvertedCount orders — the unitsSold companion to unconvertedValue.',
+    description:
+      'Units sold on unconvertedCount orders — the unitsSold companion to unconvertedValue.',
   })
   unconvertedUnitsSold!: number;
 
@@ -158,7 +161,7 @@ export class SalesAnalyticsHeadlineDto {
 
   @ApiProperty({
     description:
-      "Non-cancelled orders in range with no reporting-currency stamp yet — not reflected in revenue.",
+      'Non-cancelled orders in range with no reporting-currency stamp yet — not reflected in revenue.',
   })
   unconvertedCount!: number;
 
@@ -196,7 +199,8 @@ export class SalesAnalyticsHeadlineDto {
   @ApiProperty({
     type: Number,
     nullable: true,
-    description: 'VAT-exclusive counterpart of medianOrderValue. null when no net-eligible order matches the range.',
+    description:
+      'VAT-exclusive counterpart of medianOrderValue. null when no net-eligible order matches the range.',
   })
   netMedianOrderValue!: number | null;
 
@@ -207,7 +211,8 @@ export class SalesAnalyticsHeadlineDto {
   netExcludedCount!: number;
 
   @ApiProperty({
-    description: 'Native-currency sum for netExcludedCount — informational only, may mix currencies.',
+    description:
+      'Native-currency sum for netExcludedCount — informational only, may mix currencies.',
   })
   netExcludedValue!: number;
 
@@ -257,7 +262,8 @@ export class ChannelSalesAnalyticsDto {
   @ApiProperty({
     type: Number,
     nullable: true,
-    description: 'Same meaning as the headline averageOrderValue field — null when orderCount is 0.',
+    description:
+      'Same meaning as the headline averageOrderValue field — null when orderCount is 0.',
   })
   averageOrderValue!: number | null;
 
@@ -315,7 +321,9 @@ export class ChannelSalesAnalyticsDto {
   })
   coverageComplete!: boolean;
 
-  @ApiProperty({ description: 'Same meaning as the headline netRevenue field, scoped to this channel.' })
+  @ApiProperty({
+    description: 'Same meaning as the headline netRevenue field, scoped to this channel.',
+  })
   netRevenue!: number;
 
   @ApiProperty({
@@ -337,7 +345,8 @@ export class ChannelSalesAnalyticsDto {
 
   @ApiPropertyOptional({
     type: DisplayCurrencyConversionDto,
-    description: 'Same meaning as the headline displayCurrencyConversion field, scoped to this channel.',
+    description:
+      'Same meaning as the headline displayCurrencyConversion field, scoped to this channel.',
   })
   displayCurrencyConversion?: DisplayCurrencyConversionDto;
 
@@ -376,7 +385,9 @@ export class SalesAnalyticsResponseDto {
   static fromDomain(analytics: SalesAndChannelAnalytics): SalesAnalyticsResponseDto {
     const dto = new SalesAnalyticsResponseDto();
     dto.headline = SalesAnalyticsHeadlineDto.fromDomain(analytics.headline);
-    dto.channels = analytics.channels.map((channel) => ChannelSalesAnalyticsDto.fromDomain(channel));
+    dto.channels = analytics.channels.map((channel) =>
+      ChannelSalesAnalyticsDto.fromDomain(channel)
+    );
     return dto;
   }
 }

--- a/apps/api/src/analytics/http/sales-analytics.controller.spec.ts
+++ b/apps/api/src/analytics/http/sales-analytics.controller.spec.ts
@@ -1,8 +1,14 @@
 /**
- * Sales Analytics Controller — Unit Tests (#1987)
+ * Sales Analytics Controller — Unit Tests (#1987, display-currency #2459)
  */
 import { BadRequestException } from '@nestjs/common';
-import type { IOrderRecordService, SalesAndChannelAnalytics } from '@openlinker/core/orders';
+import type {
+  CurrentRateConversionResult,
+  IDisplayCurrencyConversionService,
+  IOrderRecordService,
+  OrderDateConversionResult,
+  SalesAndChannelAnalytics,
+} from '@openlinker/core/orders';
 import { SalesAnalyticsController } from './sales-analytics.controller';
 
 describe('SalesAnalyticsController', () => {
@@ -52,14 +58,31 @@ describe('SalesAnalyticsController', () => {
     ],
   };
 
-  const createService = (): jest.Mocked<Pick<IOrderRecordService, 'getSalesAndChannelAnalytics'>> => ({
+  const createOrderRecordService = (): jest.Mocked<
+    Pick<IOrderRecordService, 'getSalesAndChannelAnalytics'>
+  > => ({
     getSalesAndChannelAnalytics: jest.fn(),
   });
 
+  const createDisplayCurrencyConversionService = (): jest.Mocked<IDisplayCurrencyConversionService> => ({
+    convertAtCurrentRate: jest.fn(),
+    convertAtOrderDate: jest.fn(),
+  });
+
+  const createController = (
+    orderRecordService: jest.Mocked<Pick<IOrderRecordService, 'getSalesAndChannelAnalytics'>>,
+    displayCurrencyConversionService: jest.Mocked<IDisplayCurrencyConversionService>
+  ): SalesAnalyticsController =>
+    new SalesAnalyticsController(
+      orderRecordService as unknown as IOrderRecordService,
+      displayCurrencyConversionService
+    );
+
   it('maps the query params to filters and projects the domain result into the response DTO', async () => {
-    const service = createService();
-    service.getSalesAndChannelAnalytics.mockResolvedValue(analytics);
-    const controller = new SalesAnalyticsController(service as unknown as IOrderRecordService);
+    const orderRecordService = createOrderRecordService();
+    orderRecordService.getSalesAndChannelAnalytics.mockResolvedValue(analytics);
+    const displayCurrencyConversionService = createDisplayCurrencyConversionService();
+    const controller = createController(orderRecordService, displayCurrencyConversionService);
 
     const result = await controller.getSalesAnalytics({
       from: '2026-08-01T00:00:00.000Z',
@@ -67,7 +90,7 @@ describe('SalesAnalyticsController', () => {
       sourceConnectionId: 'conn-a',
     });
 
-    expect(service.getSalesAndChannelAnalytics).toHaveBeenCalledWith({
+    expect(orderRecordService.getSalesAndChannelAnalytics).toHaveBeenCalledWith({
       from: new Date('2026-08-01T00:00:00.000Z'),
       to: new Date('2026-08-08T00:00:00.000Z'),
       sourceConnectionId: 'conn-a',
@@ -90,8 +113,8 @@ describe('SalesAnalyticsController', () => {
   });
 
   it('throws BadRequestException when to <= from', async () => {
-    const service = createService();
-    const controller = new SalesAnalyticsController(service as unknown as IOrderRecordService);
+    const orderRecordService = createOrderRecordService();
+    const controller = createController(orderRecordService, createDisplayCurrencyConversionService());
 
     await expect(
       controller.getSalesAnalytics({
@@ -99,12 +122,12 @@ describe('SalesAnalyticsController', () => {
         to: '2026-08-01T00:00:00.000Z',
       })
     ).rejects.toThrow(BadRequestException);
-    expect(service.getSalesAndChannelAnalytics).not.toHaveBeenCalled();
+    expect(orderRecordService.getSalesAndChannelAnalytics).not.toHaveBeenCalled();
   });
 
   it('throws BadRequestException when to === from', async () => {
-    const service = createService();
-    const controller = new SalesAnalyticsController(service as unknown as IOrderRecordService);
+    const orderRecordService = createOrderRecordService();
+    const controller = createController(orderRecordService, createDisplayCurrencyConversionService());
 
     await expect(
       controller.getSalesAnalytics({
@@ -115,8 +138,8 @@ describe('SalesAnalyticsController', () => {
   });
 
   it('throws BadRequestException when the range exceeds the max window (#1987 review, suggestion 3)', async () => {
-    const service = createService();
-    const controller = new SalesAnalyticsController(service as unknown as IOrderRecordService);
+    const orderRecordService = createOrderRecordService();
+    const controller = createController(orderRecordService, createDisplayCurrencyConversionService());
 
     await expect(
       controller.getSalesAnalytics({
@@ -124,6 +147,165 @@ describe('SalesAnalyticsController', () => {
         to: '2100-01-01T00:00:00.000Z',
       })
     ).rejects.toThrow(BadRequestException);
-    expect(service.getSalesAndChannelAnalytics).not.toHaveBeenCalled();
+    expect(orderRecordService.getSalesAndChannelAnalytics).not.toHaveBeenCalled();
+  });
+
+  describe('display-currency conversion (#2459)', () => {
+    it('never calls IDisplayCurrencyConversionService and leaves displayCurrencyConversion unset when displayCurrency is omitted (regression guard)', async () => {
+      const orderRecordService = createOrderRecordService();
+      orderRecordService.getSalesAndChannelAnalytics.mockResolvedValue(analytics);
+      const displayCurrencyConversionService = createDisplayCurrencyConversionService();
+      const controller = createController(orderRecordService, displayCurrencyConversionService);
+
+      const result = await controller.getSalesAnalytics({
+        from: '2026-08-01T00:00:00.000Z',
+        to: '2026-08-08T00:00:00.000Z',
+      });
+
+      expect(displayCurrencyConversionService.convertAtCurrentRate).not.toHaveBeenCalled();
+      expect(displayCurrencyConversionService.convertAtOrderDate).not.toHaveBeenCalled();
+      expect(result.headline.displayCurrencyConversion).toBeUndefined();
+      expect(result.channels[0].displayCurrencyConversion).toBeUndefined();
+    });
+
+    it("converts headline and channel revenue via convertAtCurrentRate when rateBasis defaults to 'current-rate'", async () => {
+      const orderRecordService = createOrderRecordService();
+      orderRecordService.getSalesAndChannelAnalytics.mockResolvedValue(analytics);
+      const displayCurrencyConversionService = createDisplayCurrencyConversionService();
+      const headlineResult: CurrentRateConversionResult = {
+        displayCurrency: 'PLN',
+        convertedTotal: 82000,
+        breakdown: [
+          { currency: 'EUR', orderCount: 140, nativeTotal: 18420.5, convertedTotal: 79200 },
+          { currency: 'PLN', orderCount: 2, nativeTotal: 145, convertedTotal: null },
+        ],
+        unresolvedNativeCurrencies: ['XXX'],
+      };
+      const channelResult: CurrentRateConversionResult = {
+        displayCurrency: 'PLN',
+        convertedTotal: 52000,
+        breakdown: [{ currency: 'EUR', orderCount: 90, nativeTotal: 11980, convertedTotal: 52000 }],
+        unresolvedNativeCurrencies: [],
+      };
+      displayCurrencyConversionService.convertAtCurrentRate
+        .mockResolvedValueOnce(headlineResult)
+        .mockResolvedValueOnce(channelResult);
+      const controller = createController(orderRecordService, displayCurrencyConversionService);
+
+      const result = await controller.getSalesAnalytics({
+        from: '2026-08-01T00:00:00.000Z',
+        to: '2026-08-08T00:00:00.000Z',
+        displayCurrency: 'PLN',
+      });
+
+      expect(displayCurrencyConversionService.convertAtOrderDate).not.toHaveBeenCalled();
+      expect(displayCurrencyConversionService.convertAtCurrentRate).toHaveBeenNthCalledWith(1, {
+        amounts: [
+          { currency: 'EUR', amount: 18420.5 },
+          { currency: 'PLN', amount: 145 },
+        ],
+        displayCurrency: 'PLN',
+      });
+      expect(displayCurrencyConversionService.convertAtCurrentRate).toHaveBeenNthCalledWith(2, {
+        amounts: [
+          { currency: 'EUR', amount: 11980 },
+          { currency: 'PLN', amount: 60 },
+        ],
+        displayCurrency: 'PLN',
+      });
+      expect(result.headline.displayCurrencyConversion).toEqual({
+        displayCurrency: 'PLN',
+        rateBasis: 'current-rate',
+        convertedRevenue: 82000,
+        unresolvedNativeCurrencies: ['XXX'],
+      });
+      expect(result.channels[0].displayCurrencyConversion).toEqual({
+        displayCurrency: 'PLN',
+        rateBasis: 'current-rate',
+        convertedRevenue: 52000,
+        unresolvedNativeCurrencies: [],
+      });
+    });
+
+    it("converts headline and channel revenue via convertAtOrderDate when rateBasis is 'order-date', normalising a resolved rate to an empty unresolvedNativeCurrencies list", async () => {
+      const orderRecordService = createOrderRecordService();
+      orderRecordService.getSalesAndChannelAnalytics.mockResolvedValue(analytics);
+      const displayCurrencyConversionService = createDisplayCurrencyConversionService();
+      const headlineResult: OrderDateConversionResult = {
+        displayCurrency: 'PLN',
+        convertedTotal: 79200,
+        sourceCurrency: 'EUR',
+        unresolved: false,
+      };
+      const channelResult: OrderDateConversionResult = {
+        displayCurrency: 'PLN',
+        convertedTotal: 51500,
+        sourceCurrency: 'EUR',
+        unresolved: false,
+      };
+      displayCurrencyConversionService.convertAtOrderDate
+        .mockResolvedValueOnce(headlineResult)
+        .mockResolvedValueOnce(channelResult);
+      const controller = createController(orderRecordService, displayCurrencyConversionService);
+
+      const result = await controller.getSalesAnalytics({
+        from: '2026-08-01T00:00:00.000Z',
+        to: '2026-08-08T00:00:00.000Z',
+        displayCurrency: 'PLN',
+        rateBasis: 'order-date',
+      });
+
+      expect(displayCurrencyConversionService.convertAtCurrentRate).not.toHaveBeenCalled();
+      expect(displayCurrencyConversionService.convertAtOrderDate).toHaveBeenNthCalledWith(1, {
+        reportingTotal: 18420.5,
+        reportingCurrency: 'EUR',
+        displayCurrency: 'PLN',
+      });
+      expect(displayCurrencyConversionService.convertAtOrderDate).toHaveBeenNthCalledWith(2, {
+        reportingTotal: 11980,
+        reportingCurrency: 'EUR',
+        displayCurrency: 'PLN',
+      });
+      expect(result.headline.displayCurrencyConversion).toEqual({
+        displayCurrency: 'PLN',
+        rateBasis: 'order-date',
+        convertedRevenue: 79200,
+        unresolvedNativeCurrencies: [],
+      });
+      expect(result.channels[0].displayCurrencyConversion).toEqual({
+        displayCurrency: 'PLN',
+        rateBasis: 'order-date',
+        convertedRevenue: 51500,
+        unresolvedNativeCurrencies: [],
+      });
+    });
+
+    it("normalises an unresolved convertAtOrderDate outcome into a one-element unresolvedNativeCurrencies list", async () => {
+      const orderRecordService = createOrderRecordService();
+      orderRecordService.getSalesAndChannelAnalytics.mockResolvedValue(analytics);
+      const displayCurrencyConversionService = createDisplayCurrencyConversionService();
+      const unresolvedResult: OrderDateConversionResult = {
+        displayCurrency: 'PLN',
+        convertedTotal: null,
+        sourceCurrency: 'EUR',
+        unresolved: true,
+      };
+      displayCurrencyConversionService.convertAtOrderDate.mockResolvedValue(unresolvedResult);
+      const controller = createController(orderRecordService, displayCurrencyConversionService);
+
+      const result = await controller.getSalesAnalytics({
+        from: '2026-08-01T00:00:00.000Z',
+        to: '2026-08-08T00:00:00.000Z',
+        displayCurrency: 'PLN',
+        rateBasis: 'order-date',
+      });
+
+      expect(result.headline.displayCurrencyConversion).toEqual({
+        displayCurrency: 'PLN',
+        rateBasis: 'order-date',
+        convertedRevenue: null,
+        unresolvedNativeCurrencies: ['EUR'],
+      });
+    });
   });
 });

--- a/apps/api/src/analytics/http/sales-analytics.controller.spec.ts
+++ b/apps/api/src/analytics/http/sales-analytics.controller.spec.ts
@@ -2,6 +2,7 @@
  * Sales Analytics Controller — Unit Tests (#1987, display-currency #2459)
  */
 import { BadRequestException } from '@nestjs/common';
+import { MIXED_NATIVE_CURRENCIES_LABEL } from '@openlinker/core/orders';
 import type {
   CurrentRateConversionResult,
   IDisplayCurrencyConversionService,
@@ -64,10 +65,11 @@ describe('SalesAnalyticsController', () => {
     getSalesAndChannelAnalytics: jest.fn(),
   });
 
-  const createDisplayCurrencyConversionService = (): jest.Mocked<IDisplayCurrencyConversionService> => ({
-    convertAtCurrentRate: jest.fn(),
-    convertAtOrderDate: jest.fn(),
-  });
+  const createDisplayCurrencyConversionService =
+    (): jest.Mocked<IDisplayCurrencyConversionService> => ({
+      convertAtCurrentRate: jest.fn(),
+      convertAtOrderDate: jest.fn(),
+    });
 
   const createController = (
     orderRecordService: jest.Mocked<Pick<IOrderRecordService, 'getSalesAndChannelAnalytics'>>,
@@ -114,7 +116,10 @@ describe('SalesAnalyticsController', () => {
 
   it('throws BadRequestException when to <= from', async () => {
     const orderRecordService = createOrderRecordService();
-    const controller = createController(orderRecordService, createDisplayCurrencyConversionService());
+    const controller = createController(
+      orderRecordService,
+      createDisplayCurrencyConversionService()
+    );
 
     await expect(
       controller.getSalesAnalytics({
@@ -127,7 +132,10 @@ describe('SalesAnalyticsController', () => {
 
   it('throws BadRequestException when to === from', async () => {
     const orderRecordService = createOrderRecordService();
-    const controller = createController(orderRecordService, createDisplayCurrencyConversionService());
+    const controller = createController(
+      orderRecordService,
+      createDisplayCurrencyConversionService()
+    );
 
     await expect(
       controller.getSalesAnalytics({
@@ -139,7 +147,10 @@ describe('SalesAnalyticsController', () => {
 
   it('throws BadRequestException when the range exceeds the max window (#1987 review, suggestion 3)', async () => {
     const orderRecordService = createOrderRecordService();
-    const controller = createController(orderRecordService, createDisplayCurrencyConversionService());
+    const controller = createController(
+      orderRecordService,
+      createDisplayCurrencyConversionService()
+    );
 
     await expect(
       controller.getSalesAnalytics({
@@ -199,17 +210,20 @@ describe('SalesAnalyticsController', () => {
       });
 
       expect(displayCurrencyConversionService.convertAtOrderDate).not.toHaveBeenCalled();
+      // count carries the REAL order count for each bucket (#2488 review,
+      // IMPORTANT 1) — headline.orderCount / unconvertedCount, never a flat
+      // "1 bucket = 1 order".
       expect(displayCurrencyConversionService.convertAtCurrentRate).toHaveBeenNthCalledWith(1, {
         amounts: [
-          { currency: 'EUR', amount: 18420.5 },
-          { currency: 'PLN', amount: 145 },
+          { currency: 'EUR', amount: 18420.5, count: 142 },
+          { currency: 'PLN', amount: 145, count: 2 },
         ],
         displayCurrency: 'PLN',
       });
       expect(displayCurrencyConversionService.convertAtCurrentRate).toHaveBeenNthCalledWith(2, {
         amounts: [
-          { currency: 'EUR', amount: 11980 },
-          { currency: 'PLN', amount: 60 },
+          { currency: 'EUR', amount: 11980, count: 90 },
+          { currency: 'PLN', amount: 60, count: 1 },
         ],
         displayCurrency: 'PLN',
       });
@@ -280,7 +294,43 @@ describe('SalesAnalyticsController', () => {
       });
     });
 
-    it("normalises an unresolved convertAtOrderDate outcome into a one-element unresolvedNativeCurrencies list", async () => {
+    it('labels a mixed-currency unconverted bucket with the mixed-currencies sentinel rather than dropping it (#2488 review, IMPORTANT 2)', async () => {
+      const mixedAnalytics: SalesAndChannelAnalytics = {
+        ...analytics,
+        headline: {
+          ...analytics.headline,
+          unconvertedCount: 3,
+          unconvertedValue: 210,
+          unconvertedCurrency: null,
+        },
+      };
+      const orderRecordService = createOrderRecordService();
+      orderRecordService.getSalesAndChannelAnalytics.mockResolvedValue(mixedAnalytics);
+      const displayCurrencyConversionService = createDisplayCurrencyConversionService();
+      displayCurrencyConversionService.convertAtCurrentRate.mockResolvedValue({
+        displayCurrency: 'PLN',
+        convertedTotal: 79200,
+        breakdown: [],
+        unresolvedNativeCurrencies: [],
+      });
+      const controller = createController(orderRecordService, displayCurrencyConversionService);
+
+      await controller.getSalesAnalytics({
+        from: '2026-08-01T00:00:00.000Z',
+        to: '2026-08-08T00:00:00.000Z',
+        displayCurrency: 'PLN',
+      });
+
+      expect(displayCurrencyConversionService.convertAtCurrentRate).toHaveBeenNthCalledWith(1, {
+        amounts: [
+          { currency: 'EUR', amount: 18420.5, count: 142 },
+          { currency: MIXED_NATIVE_CURRENCIES_LABEL, amount: 210, count: 3 },
+        ],
+        displayCurrency: 'PLN',
+      });
+    });
+
+    it('normalises an unresolved convertAtOrderDate outcome into a one-element unresolvedNativeCurrencies list', async () => {
       const orderRecordService = createOrderRecordService();
       orderRecordService.getSalesAndChannelAnalytics.mockResolvedValue(analytics);
       const displayCurrencyConversionService = createDisplayCurrencyConversionService();

--- a/apps/api/src/analytics/http/sales-analytics.controller.ts
+++ b/apps/api/src/analytics/http/sales-analytics.controller.ts
@@ -31,6 +31,7 @@ import { BadRequestException, Controller, Get, Inject, Query } from '@nestjs/com
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import {
   DISPLAY_CURRENCY_CONVERSION_SERVICE_TOKEN,
+  MIXED_NATIVE_CURRENCIES_LABEL,
   ORDER_RECORD_SERVICE_TOKEN,
   type ChannelSalesAnalytics,
   type DisplayCurrencyRateBasis,
@@ -49,8 +50,10 @@ import {
 interface CurrencyBucketRow {
   readonly currency: string | null;
   readonly revenue: number;
+  readonly orderCount: number;
   readonly unconvertedCurrency: string | null;
   readonly unconvertedValue: number;
+  readonly unconvertedCount: number;
 }
 
 /**
@@ -155,18 +158,39 @@ export class SalesAnalyticsController {
 
   /**
    * The two native-currency buckets a headline/channel row actually tracks:
-   * the reporting-currency-stamped bucket (`currency`/`revenue`) and, when
-   * present, the still-unconverted bucket (`unconvertedCurrency`/
-   * `unconvertedValue`). This is the finest native-currency granularity
-   * available at this read model — not a per-order breakdown.
+   * the reporting-currency-stamped bucket (`currency`/`revenue`/`orderCount`)
+   * and, when present, the still-unconverted bucket (`unconvertedCurrency`/
+   * `unconvertedValue`/`unconvertedCount`). This is the finest native-currency
+   * granularity available at this read model — not a per-order breakdown.
+   * Each bucket's real order count is threaded through via
+   * `NativeCurrencyAmount.count` (#2488 review, IMPORTANT 1) so
+   * `NativeCurrencyBreakdown.orderCount` reports true per-currency order
+   * counts rather than "1 bucket = 1 order".
+   *
+   * When the unconverted set spans more than one native currency
+   * (`unconvertedCurrency === null` with `unconvertedCount > 0` — #2488
+   * review, IMPORTANT 2), that money is still reported, labelled with
+   * {@link MIXED_NATIVE_CURRENCIES_LABEL} rather than silently dropped: this
+   * read model doesn't retain which individual currencies made up that sum,
+   * but it can and must still surface that unresolved money exists.
    */
   private buildNativeCurrencyAmounts(row: CurrencyBucketRow): NativeCurrencyAmount[] {
     const amounts: NativeCurrencyAmount[] = [];
     if (row.currency !== null) {
-      amounts.push({ currency: row.currency, amount: row.revenue });
+      amounts.push({ currency: row.currency, amount: row.revenue, count: row.orderCount });
     }
     if (row.unconvertedCurrency !== null) {
-      amounts.push({ currency: row.unconvertedCurrency, amount: row.unconvertedValue });
+      amounts.push({
+        currency: row.unconvertedCurrency,
+        amount: row.unconvertedValue,
+        count: row.unconvertedCount,
+      });
+    } else if (row.unconvertedCount > 0) {
+      amounts.push({
+        currency: MIXED_NATIVE_CURRENCIES_LABEL,
+        amount: row.unconvertedValue,
+        count: row.unconvertedCount,
+      });
     }
     return amounts;
   }

--- a/apps/api/src/analytics/http/sales-analytics.controller.ts
+++ b/apps/api/src/analytics/http/sales-analytics.controller.ts
@@ -6,15 +6,52 @@
  * Single-context read (entirely inside `orders`), so this injects
  * `IOrderRecordService` directly rather than introducing an apps/api-layer
  * composition service (unlike `NeedsAttentionService`, which exists
- * specifically to fan out across two core contexts).
+ * specifically to fan out across two core contexts). `IDisplayCurrencyConversionService`
+ * (#2458) is the same-context sibling this controller wires in for #2459 —
+ * still no cross-context composition service needed.
+ *
+ * Display-currency conversion (#2459) is called ONLY when `query.displayCurrency`
+ * is present — an absent value takes zero extra code paths, which is the
+ * regression guard for every existing caller. `rateBasis` selects which of
+ * the two `IDisplayCurrencyConversionService` modes runs:
+ *
+ *  - `'current-rate'` (default): groups the two native-currency buckets this
+ *    read model already tracks per row — the reporting-currency-stamped
+ *    revenue bucket and, when present, the still-unconverted bucket — and
+ *    converts each at today's rate. This is the finest native-currency
+ *    breakdown available at THIS read model's granularity; a full per-order
+ *    breakdown would need a new query and is out of scope here.
+ *  - `'order-date'`: converts the already-aggregated revenue total in one
+ *    shot, per `OrderDateConversionInput`'s own doc comment (which names
+ *    `SalesAnalyticsHeadline.revenue` as its intended input).
  *
  * @module apps/api/src/analytics/http
  */
 import { BadRequestException, Controller, Get, Inject, Query } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
-import { ORDER_RECORD_SERVICE_TOKEN, type IOrderRecordService } from '@openlinker/core/orders';
+import {
+  DISPLAY_CURRENCY_CONVERSION_SERVICE_TOKEN,
+  ORDER_RECORD_SERVICE_TOKEN,
+  type ChannelSalesAnalytics,
+  type DisplayCurrencyRateBasis,
+  type IDisplayCurrencyConversionService,
+  type IOrderRecordService,
+  type NativeCurrencyAmount,
+  type SalesAnalyticsHeadline,
+} from '@openlinker/core/orders';
 import { SalesAnalyticsQueryDto } from './dto/sales-analytics-query.dto';
-import { SalesAnalyticsResponseDto } from './dto/sales-analytics-response.dto';
+import {
+  DisplayCurrencyConversionDto,
+  SalesAnalyticsResponseDto,
+} from './dto/sales-analytics-response.dto';
+
+/** Shared shape of a headline/channel row's currency-bucket fields — the input to `buildDisplayCurrencyConversion`. */
+interface CurrencyBucketRow {
+  readonly currency: string | null;
+  readonly revenue: number;
+  readonly unconvertedCurrency: string | null;
+  readonly unconvertedValue: number;
+}
 
 /**
  * Upper bound on a requested range (#1987 review, suggestion 3). Unbounded,
@@ -32,7 +69,9 @@ const MAX_SALES_ANALYTICS_RANGE_DAYS = 400;
 export class SalesAnalyticsController {
   constructor(
     @Inject(ORDER_RECORD_SERVICE_TOKEN)
-    private readonly orderRecordService: IOrderRecordService
+    private readonly orderRecordService: IOrderRecordService,
+    @Inject(DISPLAY_CURRENCY_CONVERSION_SERVICE_TOKEN)
+    private readonly displayCurrencyConversionService: IDisplayCurrencyConversionService
   ) {}
 
   @Get('sales')
@@ -62,6 +101,73 @@ export class SalesAnalyticsController {
       sourceConnectionId: query.sourceConnectionId,
     });
 
-    return SalesAnalyticsResponseDto.fromDomain(analytics);
+    const dto = SalesAnalyticsResponseDto.fromDomain(analytics);
+
+    // #2459: only touched when displayCurrency is present — an absent value
+    // never reaches this branch, which is the byte-identical regression
+    // guard for every pre-#2459 caller.
+    if (query.displayCurrency !== undefined) {
+      const rateBasis: DisplayCurrencyRateBasis = query.rateBasis ?? 'current-rate';
+      dto.headline.displayCurrencyConversion = await this.buildDisplayCurrencyConversion(
+        analytics.headline,
+        query.displayCurrency,
+        rateBasis
+      );
+      for (let i = 0; i < dto.channels.length; i += 1) {
+        dto.channels[i].displayCurrencyConversion = await this.buildDisplayCurrencyConversion(
+          analytics.channels[i],
+          query.displayCurrency,
+          rateBasis
+        );
+      }
+    }
+
+    return dto;
+  }
+
+  /**
+   * Dispatches to whichever `IDisplayCurrencyConversionService` mode
+   * `rateBasis` names, over one row's currency-bucket fields — shared between
+   * the headline and every channel row (`SalesAnalyticsHeadline` and
+   * `ChannelSalesAnalytics` carry the same four fields this reads).
+   */
+  private async buildDisplayCurrencyConversion(
+    row: SalesAnalyticsHeadline | ChannelSalesAnalytics,
+    displayCurrency: string,
+    rateBasis: DisplayCurrencyRateBasis
+  ): Promise<DisplayCurrencyConversionDto> {
+    if (rateBasis === 'order-date') {
+      const result = await this.displayCurrencyConversionService.convertAtOrderDate({
+        reportingTotal: row.revenue,
+        reportingCurrency: row.currency,
+        displayCurrency,
+      });
+      return DisplayCurrencyConversionDto.fromOrderDateResult(result, rateBasis);
+    }
+
+    const amounts: NativeCurrencyAmount[] = this.buildNativeCurrencyAmounts(row);
+    const result = await this.displayCurrencyConversionService.convertAtCurrentRate({
+      amounts,
+      displayCurrency,
+    });
+    return DisplayCurrencyConversionDto.fromCurrentRateResult(result, rateBasis);
+  }
+
+  /**
+   * The two native-currency buckets a headline/channel row actually tracks:
+   * the reporting-currency-stamped bucket (`currency`/`revenue`) and, when
+   * present, the still-unconverted bucket (`unconvertedCurrency`/
+   * `unconvertedValue`). This is the finest native-currency granularity
+   * available at this read model — not a per-order breakdown.
+   */
+  private buildNativeCurrencyAmounts(row: CurrencyBucketRow): NativeCurrencyAmount[] {
+    const amounts: NativeCurrencyAmount[] = [];
+    if (row.currency !== null) {
+      amounts.push({ currency: row.currency, amount: row.revenue });
+    }
+    if (row.unconvertedCurrency !== null) {
+      amounts.push({ currency: row.unconvertedCurrency, amount: row.unconvertedValue });
+    }
+    return amounts;
   }
 }

--- a/libs/core/src/orders/application/interfaces/display-currency-conversion.service.interface.ts
+++ b/libs/core/src/orders/application/interfaces/display-currency-conversion.service.interface.ts
@@ -2,7 +2,7 @@
  * Display Currency Conversion Service Interface
  *
  * The read-only, request-scoped display-currency transform behind the
- * `/analytics` display-currency picker (#2458, ADR-064). See the interface
+ * `/analytics` display-currency picker (#2458, ADR-064, pending in PR #2485). See the interface
  * methods' own doc comments for the two conversion modes.
  *
  * @module libs/core/src/orders/application/interfaces

--- a/libs/core/src/orders/application/interfaces/display-currency-conversion.service.interface.ts
+++ b/libs/core/src/orders/application/interfaces/display-currency-conversion.service.interface.ts
@@ -1,0 +1,33 @@
+/**
+ * Display Currency Conversion Service Interface
+ *
+ * The read-only, request-scoped display-currency transform behind the
+ * `/analytics` display-currency picker (#2458, ADR-064). See the interface
+ * methods' own doc comments for the two conversion modes.
+ *
+ * @module libs/core/src/orders/application/interfaces
+ */
+import type {
+  CurrentRateConversionInput,
+  CurrentRateConversionResult,
+  OrderDateConversionInput,
+  OrderDateConversionResult,
+} from '../../domain/types/display-currency.types';
+
+export interface IDisplayCurrencyConversionService {
+  /**
+   * Group `input.amounts` by distinct native currency and convert each group
+   * to `input.displayCurrency` at today's rate. A currency with no resolvable
+   * rate is reported in the result's `unresolvedNativeCurrencies` — never
+   * thrown — and excluded from `convertedTotal`.
+   */
+  convertAtCurrentRate(input: CurrentRateConversionInput): Promise<CurrentRateConversionResult>;
+
+  /**
+   * Convert an already-computed reporting-currency total to
+   * `input.displayCurrency`. Zero I/O when the two currencies already match;
+   * otherwise resolves exactly one current rate and multiplies the whole
+   * total once — never once per order.
+   */
+  convertAtOrderDate(input: OrderDateConversionInput): Promise<OrderDateConversionResult>;
+}

--- a/libs/core/src/orders/application/services/__tests__/display-currency-conversion.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/display-currency-conversion.service.spec.ts
@@ -1,10 +1,11 @@
 /**
- * Display Currency Conversion Service Spec (#2458, ADR-064)
+ * Display Currency Conversion Service Spec (#2458, ADR-064, pending in PR #2485)
  *
  * @module libs/core/src/orders/application/services/__tests__
  */
 import { RateUnsupportedPairError } from '@openlinker/core/currency';
 import type { ICurrencyRateService } from '@openlinker/core/currency';
+import { MIXED_NATIVE_CURRENCIES_LABEL } from '../../../domain/types/display-currency.types';
 import { DisplayCurrencyConversionService } from '../display-currency-conversion.service';
 
 // A fixed instant well clear of any provider-calendar edge case — the exact
@@ -38,8 +39,8 @@ describe('DisplayCurrencyConversionService', () => {
       const result = await service.convertAtCurrentRate(
         {
           amounts: [
-            { currency: 'PLN', amount: 100 },
-            { currency: 'XXX', amount: 50 },
+            { currency: 'PLN', amount: 100, count: 1 },
+            { currency: 'XXX', amount: 50, count: 1 },
           ],
           displayCurrency: 'EUR',
         },
@@ -62,8 +63,8 @@ describe('DisplayCurrencyConversionService', () => {
       const result = await service.convertAtCurrentRate(
         {
           amounts: [
-            { currency: 'PLN', amount: 100 },
-            { currency: 'PLN', amount: 200 },
+            { currency: 'PLN', amount: 100, count: 1 },
+            { currency: 'PLN', amount: 200, count: 1 },
           ],
           displayCurrency: 'EUR',
         },
@@ -81,7 +82,7 @@ describe('DisplayCurrencyConversionService', () => {
     it('should convert a currency matching the display currency with zero calls', async () => {
       const result = await service.convertAtCurrentRate(
         {
-          amounts: [{ currency: 'EUR', amount: 100 }],
+          amounts: [{ currency: 'EUR', amount: 100, count: 1 }],
           displayCurrency: 'EUR',
         },
         NOW
@@ -90,6 +91,76 @@ describe('DisplayCurrencyConversionService', () => {
       expect(rates.getRateFor).not.toHaveBeenCalled();
       expect(result.convertedTotal).toBe(100);
       expect(result.unresolvedNativeCurrencies).toEqual([]);
+    });
+
+    it("should sum each amount's own count rather than counting array entries (#2488 review, IMPORTANT 1)", async () => {
+      // Mirrors the real controller path: one pre-aggregated bucket per
+      // native currency, carrying the TRUE order count for that bucket —
+      // not one array entry per order.
+      rates.getRateFor.mockResolvedValue({ id: 'rate_1', rate: '0.25' } as never);
+
+      const result = await service.convertAtCurrentRate(
+        {
+          amounts: [{ currency: 'PLN', amount: 14000, count: 140 }],
+          displayCurrency: 'EUR',
+        },
+        NOW
+      );
+
+      expect(result.breakdown).toEqual([
+        { currency: 'PLN', orderCount: 140, nativeTotal: 14000, convertedTotal: 3500 },
+      ]);
+    });
+
+    it('should merge counts across multiple entries for the same currency', async () => {
+      rates.getRateFor.mockResolvedValue({ id: 'rate_1', rate: '0.25' } as never);
+
+      const result = await service.convertAtCurrentRate(
+        {
+          amounts: [
+            { currency: 'PLN', amount: 100, count: 3 },
+            { currency: 'PLN', amount: 200, count: 5 },
+          ],
+          displayCurrency: 'EUR',
+        },
+        NOW
+      );
+
+      expect(result.breakdown).toEqual([
+        { currency: 'PLN', orderCount: 8, nativeTotal: 300, convertedTotal: 75 },
+      ]);
+    });
+
+    it('should report a mixed-currency bucket as unresolved without calling the rate provider (#2488 review, IMPORTANT 2)', async () => {
+      rates.getRateFor.mockResolvedValue({ id: 'rate_1', rate: '0.25' } as never);
+
+      const result = await service.convertAtCurrentRate(
+        {
+          amounts: [
+            { currency: 'PLN', amount: 100, count: 1 },
+            { currency: MIXED_NATIVE_CURRENCIES_LABEL, amount: 75, count: 2 },
+          ],
+          displayCurrency: 'EUR',
+        },
+        NOW
+      );
+
+      expect(result.unresolvedNativeCurrencies).toEqual([MIXED_NATIVE_CURRENCIES_LABEL]);
+      // The mixed bucket's 75 is excluded from convertedTotal (unresolved,
+      // never guessed at) but is NOT silently dropped — it's reported via
+      // unresolvedNativeCurrencies/breakdown above.
+      expect(result.convertedTotal).toBe(25);
+      expect(result.breakdown).toContainEqual({
+        currency: MIXED_NATIVE_CURRENCIES_LABEL,
+        orderCount: 2,
+        nativeTotal: 75,
+        convertedTotal: null,
+      });
+      // Never sent to the rate provider — there is no single currency to
+      // resolve a rate for.
+      expect(rates.getRateFor).not.toHaveBeenCalledWith(
+        expect.objectContaining({ from: MIXED_NATIVE_CURRENCIES_LABEL })
+      );
     });
   });
 

--- a/libs/core/src/orders/application/services/__tests__/display-currency-conversion.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/display-currency-conversion.service.spec.ts
@@ -1,0 +1,179 @@
+/**
+ * Display Currency Conversion Service Spec (#2458, ADR-064)
+ *
+ * @module libs/core/src/orders/application/services/__tests__
+ */
+import { RateUnsupportedPairError } from '@openlinker/core/currency';
+import type { ICurrencyRateService } from '@openlinker/core/currency';
+import { DisplayCurrencyConversionService } from '../display-currency-conversion.service';
+
+// A fixed instant well clear of any provider-calendar edge case — the exact
+// candidate day this resolves to is irrelevant to these tests, which only
+// assert on `from`/`to` and call counts, never on the date string itself.
+const NOW = new Date('2026-06-10T09:00:00.000Z');
+
+describe('DisplayCurrencyConversionService', () => {
+  let rates: jest.Mocked<ICurrencyRateService>;
+  let service: DisplayCurrencyConversionService;
+
+  beforeEach(() => {
+    rates = {
+      getRateFor: jest.fn(),
+    } as unknown as jest.Mocked<ICurrencyRateService>;
+
+    service = new DisplayCurrencyConversionService(rates);
+  });
+
+  describe('convertAtCurrentRate', () => {
+    it('should exclude an unresolvable native currency from the converted total and report it', async () => {
+      rates.getRateFor.mockImplementation(({ from }) => {
+        if (from === 'PLN') {
+          return Promise.resolve({ id: 'rate_1', rate: '0.25' } as never);
+        }
+        return Promise.reject(
+          new RateUnsupportedPairError('ecb', from, 'EUR', '2026-06-09', 'unsupported pair')
+        );
+      });
+
+      const result = await service.convertAtCurrentRate(
+        {
+          amounts: [
+            { currency: 'PLN', amount: 100 },
+            { currency: 'XXX', amount: 50 },
+          ],
+          displayCurrency: 'EUR',
+        },
+        NOW
+      );
+
+      expect(result.unresolvedNativeCurrencies).toEqual(['XXX']);
+      // Only the resolved PLN group (100 * 0.25 = 25) contributes — the
+      // unresolvable XXX group is excluded entirely, never guessed at.
+      expect(result.convertedTotal).toBe(25);
+      expect(result.breakdown).toEqual([
+        { currency: 'PLN', orderCount: 1, nativeTotal: 100, convertedTotal: 25 },
+        { currency: 'XXX', orderCount: 1, nativeTotal: 50, convertedTotal: null },
+      ]);
+    });
+
+    it('should group multiple orders sharing a native currency into one rate lookup', async () => {
+      rates.getRateFor.mockResolvedValue({ id: 'rate_1', rate: '0.25' } as never);
+
+      const result = await service.convertAtCurrentRate(
+        {
+          amounts: [
+            { currency: 'PLN', amount: 100 },
+            { currency: 'PLN', amount: 200 },
+          ],
+          displayCurrency: 'EUR',
+        },
+        NOW
+      );
+
+      expect(rates.getRateFor).toHaveBeenCalledTimes(1);
+      expect(result.unresolvedNativeCurrencies).toEqual([]);
+      expect(result.convertedTotal).toBe(75); // 300 * 0.25
+      expect(result.breakdown).toEqual([
+        { currency: 'PLN', orderCount: 2, nativeTotal: 300, convertedTotal: 75 },
+      ]);
+    });
+
+    it('should convert a currency matching the display currency with zero calls', async () => {
+      const result = await service.convertAtCurrentRate(
+        {
+          amounts: [{ currency: 'EUR', amount: 100 }],
+          displayCurrency: 'EUR',
+        },
+        NOW
+      );
+
+      expect(rates.getRateFor).not.toHaveBeenCalled();
+      expect(result.convertedTotal).toBe(100);
+      expect(result.unresolvedNativeCurrencies).toEqual([]);
+    });
+  });
+
+  describe('convertAtOrderDate', () => {
+    it('should make zero calls when the display currency equals the reporting currency', async () => {
+      const result = await service.convertAtOrderDate(
+        { reportingTotal: 500, reportingCurrency: 'EUR', displayCurrency: 'EUR' },
+        NOW
+      );
+
+      expect(rates.getRateFor).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        displayCurrency: 'EUR',
+        convertedTotal: 500,
+        sourceCurrency: 'EUR',
+        unresolved: false,
+      });
+    });
+
+    it('should make exactly one call and multiply the whole total once for a different display currency', async () => {
+      rates.getRateFor.mockResolvedValue({ id: 'rate_1', rate: '4.2' } as never);
+
+      const result = await service.convertAtOrderDate(
+        { reportingTotal: 500, reportingCurrency: 'EUR', displayCurrency: 'PLN' },
+        NOW
+      );
+
+      expect(rates.getRateFor).toHaveBeenCalledTimes(1);
+      expect(rates.getRateFor).toHaveBeenCalledWith(
+        expect.objectContaining({ source: 'nbp', from: 'EUR', to: 'PLN' })
+      );
+      expect(result).toEqual({
+        displayCurrency: 'PLN',
+        convertedTotal: 2100,
+        sourceCurrency: 'EUR',
+        unresolved: false,
+      });
+    });
+
+    it('should call exactly once regardless of how many orders fed the aggregate total', async () => {
+      // The service never sees individual orders in this mode — it receives
+      // one already-summed total — so "exactly one call regardless of order
+      // count" is inherent to the shape rather than something to loop over.
+      rates.getRateFor.mockResolvedValue({ id: 'rate_1', rate: '4.2' } as never);
+
+      await service.convertAtOrderDate(
+        { reportingTotal: 123456.78, reportingCurrency: 'EUR', displayCurrency: 'PLN' },
+        NOW
+      );
+
+      expect(rates.getRateFor).toHaveBeenCalledTimes(1);
+    });
+
+    it('should report unresolved without throwing when the rate cannot be resolved', async () => {
+      rates.getRateFor.mockRejectedValue(
+        new RateUnsupportedPairError('nbp', 'EUR', 'PLN', '2026-06-09', 'unsupported pair')
+      );
+
+      const result = await service.convertAtOrderDate(
+        { reportingTotal: 500, reportingCurrency: 'EUR', displayCurrency: 'PLN' },
+        NOW
+      );
+
+      expect(result).toEqual({
+        displayCurrency: 'PLN',
+        convertedTotal: null,
+        sourceCurrency: 'EUR',
+        unresolved: true,
+      });
+    });
+
+    it('should report nothing to convert when no order in range has been stamped yet', async () => {
+      const result = await service.convertAtOrderDate(
+        { reportingTotal: 0, reportingCurrency: null, displayCurrency: 'PLN' },
+        NOW
+      );
+
+      expect(rates.getRateFor).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        displayCurrency: 'PLN',
+        convertedTotal: null,
+        sourceCurrency: null,
+        unresolved: false,
+      });
+    });
+  });
+});

--- a/libs/core/src/orders/application/services/display-currency-conversion.service.ts
+++ b/libs/core/src/orders/application/services/display-currency-conversion.service.ts
@@ -1,0 +1,230 @@
+/**
+ * Display Currency Conversion Service
+ *
+ * The read-only display-currency transform behind the `/analytics`
+ * display-currency picker (#2458, ADR-064). Both modes are plain synchronous
+ * application-layer code — no `SyncJobPort`, no `sync_jobs` row, no polling
+ * endpoint — and neither reads nor writes `order_records.reportingCurrency` /
+ * `reportingTotalAmount` (the ADR-040 write-once stamp). This is a SECOND,
+ * read-only inbound edge from `orders` into the `currency` leaf context,
+ * alongside the ADR-040 stamp's own edge — see
+ * `docs/architecture-overview.md § 18. Currency`.
+ *
+ * `current-rate` groups raw native `currency`/`totalAmount` figures by
+ * distinct native currency and resolves one rate per distinct currency —
+ * cheap regardless of order volume, because the number of distinct native
+ * currencies in any real dataset is small. `order-date` takes the
+ * already-computed reporting-currency total and applies at most one rate to
+ * the whole figure.
+ *
+ * Neither mode throws on a rate-resolution failure: a currency (or the whole
+ * order-date total) that cannot be converted is reported back as an explicit
+ * unresolved outcome — this backs the mockup's `unavailable` state — rather
+ * than aborting the read or silently defaulting to a guessed figure.
+ *
+ * @module libs/core/src/orders/application/services
+ * @implements {IDisplayCurrencyConversionService}
+ */
+import { Inject, Injectable } from '@nestjs/common';
+import { Logger } from '@openlinker/shared/logging';
+import {
+  CURRENCY_RATE_SERVICE_TOKEN,
+  DEFAULT_FX_RATE_RULE,
+  ICurrencyRateService,
+  resolveRateDate,
+  resolveRateSource,
+} from '@openlinker/core/currency';
+import type {
+  CurrentRateConversionInput,
+  CurrentRateConversionResult,
+  NativeCurrencyBreakdown,
+  OrderDateConversionInput,
+  OrderDateConversionResult,
+} from '../../domain/types/display-currency.types';
+import type { IDisplayCurrencyConversionService } from '../interfaces/display-currency-conversion.service.interface';
+
+/**
+ * Money is kept to 2 decimal places, mirroring `OrderFxStampService`'s own
+ * `round2` (module-private there too — this is a display transform, not a
+ * shared pricing rule, so a third copy of a two-line helper is cheaper than a
+ * shared export).
+ */
+function round2(value: number): number {
+  return Math.round((value + Number.EPSILON) * 100) / 100;
+}
+
+interface CurrencyGroup {
+  count: number;
+  total: number;
+}
+
+/** Group native-currency amounts by currency code, preserving input order for the first-seen currency. */
+function groupByCurrency(
+  amounts: readonly { readonly currency: string; readonly amount: number }[]
+): Map<string, CurrencyGroup> {
+  const grouped = new Map<string, CurrencyGroup>();
+  for (const item of amounts) {
+    const existing = grouped.get(item.currency);
+    if (existing) {
+      existing.count += 1;
+      existing.total += item.amount;
+    } else {
+      grouped.set(item.currency, { count: 1, total: item.amount });
+    }
+  }
+  return grouped;
+}
+
+@Injectable()
+export class DisplayCurrencyConversionService implements IDisplayCurrencyConversionService {
+  private readonly logger = new Logger(DisplayCurrencyConversionService.name);
+
+  constructor(
+    @Inject(CURRENCY_RATE_SERVICE_TOKEN)
+    private readonly rates: ICurrencyRateService
+  ) {}
+
+  async convertAtCurrentRate(
+    input: CurrentRateConversionInput,
+    now: Date = new Date()
+  ): Promise<CurrentRateConversionResult> {
+    const grouped = groupByCurrency(input.amounts);
+    const rateDate = this.resolveCurrentRateDate(now);
+
+    const breakdown: NativeCurrencyBreakdown[] = [];
+    const unresolvedNativeCurrencies: string[] = [];
+    let convertedTotal = 0;
+
+    // Sequential, not `Promise.all` — mirrors `OrderFxStampService.sweep`'s
+    // own reasoning: a handful of distinct currencies is a handful of
+    // provider calls, and there is no latency anyone is waiting on that
+    // fanning them out would improve.
+    for (const [currency, group] of grouped) {
+      if (currency === input.displayCurrency) {
+        const nativeTotal = round2(group.total);
+        breakdown.push({
+          currency,
+          orderCount: group.count,
+          nativeTotal,
+          convertedTotal: nativeTotal,
+        });
+        convertedTotal += nativeTotal;
+        continue;
+      }
+
+      const rate =
+        rateDate === null ? null : await this.resolveRate(currency, input.displayCurrency, rateDate);
+
+      if (rate === null) {
+        unresolvedNativeCurrencies.push(currency);
+        breakdown.push({
+          currency,
+          orderCount: group.count,
+          nativeTotal: round2(group.total),
+          convertedTotal: null,
+        });
+        continue;
+      }
+
+      const converted = round2(group.total * rate);
+      breakdown.push({
+        currency,
+        orderCount: group.count,
+        nativeTotal: round2(group.total),
+        convertedTotal: converted,
+      });
+      convertedTotal += converted;
+    }
+
+    return {
+      displayCurrency: input.displayCurrency,
+      convertedTotal: round2(convertedTotal),
+      breakdown,
+      unresolvedNativeCurrencies,
+    };
+  }
+
+  async convertAtOrderDate(
+    input: OrderDateConversionInput,
+    now: Date = new Date()
+  ): Promise<OrderDateConversionResult> {
+    // Nothing stamped in range — there is no reporting-currency figure to
+    // convert at all. Not the same as "unresolved": no conversion was even
+    // attempted.
+    if (input.reportingCurrency === null) {
+      return {
+        displayCurrency: input.displayCurrency,
+        convertedTotal: null,
+        sourceCurrency: null,
+        unresolved: false,
+      };
+    }
+
+    // Zero I/O — the whole point of this mode's "stable" framing. Never
+    // calls `ICurrencyRateService`.
+    if (input.reportingCurrency === input.displayCurrency) {
+      return {
+        displayCurrency: input.displayCurrency,
+        convertedTotal: round2(input.reportingTotal),
+        sourceCurrency: input.reportingCurrency,
+        unresolved: false,
+      };
+    }
+
+    const rateDate = this.resolveCurrentRateDate(now);
+    const rate =
+      rateDate === null
+        ? null
+        : await this.resolveRate(input.reportingCurrency, input.displayCurrency, rateDate);
+
+    if (rate === null) {
+      return {
+        displayCurrency: input.displayCurrency,
+        convertedTotal: null,
+        sourceCurrency: input.reportingCurrency,
+        unresolved: true,
+      };
+    }
+
+    return {
+      displayCurrency: input.displayCurrency,
+      convertedTotal: round2(input.reportingTotal * rate),
+      sourceCurrency: input.reportingCurrency,
+      unresolved: false,
+    };
+  }
+
+  /**
+   * The most recently published rate day as of `now`, via the same pure
+   * `resolveRateDate` the ADR-040 stamp uses — passing `now` as both the
+   * anchor and the clamp yields "yesterday in Warsaw" under the shipped
+   * `prev-business-day` rule, which each provider adapter then resolves onto
+   * a day it actually published on. `null` is unreachable in practice (`now`
+   * is always a valid `Date`), but is handled rather than asserted away.
+   */
+  private resolveCurrentRateDate(now: Date): string | null {
+    return resolveRateDate(now, DEFAULT_FX_RATE_RULE, now);
+  }
+
+  /**
+   * Resolve one `to` unit's worth of `from`, or `null` on any failure —
+   * an unsupported display currency (`resolveRateSource` throws for a
+   * currency no publisher quotes), an unsupported pair, a transient provider
+   * failure, anything. This service never retries and never throws past
+   * itself: a failed lookup for one currency must not abort the batch for
+   * every other currency, nor the whole request.
+   */
+  private async resolveRate(from: string, to: string, rateDate: string): Promise<number | null> {
+    try {
+      const source = resolveRateSource(to);
+      const rate = await this.rates.getRateFor({ source, from, to, rateDate });
+      return Number(rate.rate);
+    } catch (error) {
+      this.logger.warn(
+        `Display-currency rate ${from}->${to} on ${rateDate} could not be resolved: ` +
+          (error instanceof Error ? error.message : String(error))
+      );
+      return null;
+    }
+  }
+}

--- a/libs/core/src/orders/application/services/display-currency-conversion.service.ts
+++ b/libs/core/src/orders/application/services/display-currency-conversion.service.ts
@@ -2,7 +2,7 @@
  * Display Currency Conversion Service
  *
  * The read-only display-currency transform behind the `/analytics`
- * display-currency picker (#2458, ADR-064). Both modes are plain synchronous
+ * display-currency picker (#2458, ADR-064, pending in PR #2485). Both modes are plain synchronous
  * application-layer code — no `SyncJobPort`, no `sync_jobs` row, no polling
  * endpoint — and neither reads nor writes `order_records.reportingCurrency` /
  * `reportingTotalAmount` (the ADR-040 write-once stamp). This is a SECOND,
@@ -34,12 +34,13 @@ import {
   resolveRateDate,
   resolveRateSource,
 } from '@openlinker/core/currency';
-import type {
-  CurrentRateConversionInput,
-  CurrentRateConversionResult,
-  NativeCurrencyBreakdown,
-  OrderDateConversionInput,
-  OrderDateConversionResult,
+import {
+  MIXED_NATIVE_CURRENCIES_LABEL,
+  type CurrentRateConversionInput,
+  type CurrentRateConversionResult,
+  type NativeCurrencyBreakdown,
+  type OrderDateConversionInput,
+  type OrderDateConversionResult,
 } from '../../domain/types/display-currency.types';
 import type { IDisplayCurrencyConversionService } from '../interfaces/display-currency-conversion.service.interface';
 
@@ -58,18 +59,25 @@ interface CurrencyGroup {
   total: number;
 }
 
-/** Group native-currency amounts by currency code, preserving input order for the first-seen currency. */
+/**
+ * Group native-currency amounts by currency code, preserving input order for
+ * the first-seen currency. `count` is SUMMED from each item's own `count`
+ * (#2488 review, IMPORTANT 1) rather than incremented once per array entry —
+ * a caller that pre-aggregates several orders into one bucket (e.g. the
+ * controller's per-currency revenue bucket) reports the real order count via
+ * `item.count`, not the number of buckets it happened to push.
+ */
 function groupByCurrency(
-  amounts: readonly { readonly currency: string; readonly amount: number }[]
+  amounts: readonly { readonly currency: string; readonly amount: number; readonly count: number }[]
 ): Map<string, CurrencyGroup> {
   const grouped = new Map<string, CurrencyGroup>();
   for (const item of amounts) {
     const existing = grouped.get(item.currency);
     if (existing) {
-      existing.count += 1;
+      existing.count += item.count;
       existing.total += item.amount;
     } else {
-      grouped.set(item.currency, { count: 1, total: item.amount });
+      grouped.set(item.currency, { count: item.count, total: item.amount });
     }
   }
   return grouped;
@@ -100,6 +108,22 @@ export class DisplayCurrencyConversionService implements IDisplayCurrencyConvers
     // provider calls, and there is no latency anyone is waiting on that
     // fanning them out would improve.
     for (const [currency, group] of grouped) {
+      // A bucket with no single native currency (#2488 review, IMPORTANT 2)
+      // has no rate to resolve — report it as unresolved unconditionally
+      // rather than spending a provider call that could only ever fail, and
+      // rather than silently excluding this real money from the result with
+      // no trace at all.
+      if (currency === MIXED_NATIVE_CURRENCIES_LABEL) {
+        unresolvedNativeCurrencies.push(currency);
+        breakdown.push({
+          currency,
+          orderCount: group.count,
+          nativeTotal: round2(group.total),
+          convertedTotal: null,
+        });
+        continue;
+      }
+
       if (currency === input.displayCurrency) {
         const nativeTotal = round2(group.total);
         breakdown.push({
@@ -113,7 +137,9 @@ export class DisplayCurrencyConversionService implements IDisplayCurrencyConvers
       }
 
       const rate =
-        rateDate === null ? null : await this.resolveRate(currency, input.displayCurrency, rateDate);
+        rateDate === null
+          ? null
+          : await this.resolveRate(currency, input.displayCurrency, rateDate);
 
       if (rate === null) {
         unresolvedNativeCurrencies.push(currency);

--- a/libs/core/src/orders/domain/types/display-currency.types.ts
+++ b/libs/core/src/orders/domain/types/display-currency.types.ts
@@ -1,0 +1,117 @@
+/**
+ * Display Currency Conversion Types
+ *
+ * Shapes for the `/analytics` display-currency read model (#2458, ADR-064).
+ * Two conversion modes back the operator-facing display-currency picker:
+ *
+ *  - `current-rate`: groups the RAW native `currency`/`totalAmount` figures
+ *    the aggregation already reads by distinct native currency and converts
+ *    each group at today's rate — never the ADR-040 stamp.
+ *  - `order-date`: takes the already-computed `SalesAnalyticsHeadline.revenue`
+ *    (in the system's stamped reporting currency) and applies a single
+ *    current rate to the whole total.
+ *
+ * Neither mode reads or writes `order_records.reportingCurrency` /
+ * `reportingTotalAmount` — that column is written exactly once, by the
+ * ADR-040 stamp service, and this is a read-only display transform layered
+ * on top of it, never a second writer.
+ *
+ * @module libs/core/src/orders/domain/types
+ */
+
+/**
+ * The two display-currency conversion modes a caller can request. Kept as an
+ * open-ended `as const` union, mirroring `FxRateRule`, so a future mode is one
+ * array entry away with no schema change on whatever persists the operator's
+ * choice.
+ */
+export const DISPLAY_CURRENCY_RATE_BASIS_VALUES = ['current-rate', 'order-date'] as const;
+
+export type DisplayCurrencyRateBasis = (typeof DISPLAY_CURRENCY_RATE_BASIS_VALUES)[number];
+
+/** Runtime narrowing for a value read back out of a query param or a settings row. */
+export function isDisplayCurrencyRateBasis(value: string): value is DisplayCurrencyRateBasis {
+  return (DISPLAY_CURRENCY_RATE_BASIS_VALUES as readonly string[]).includes(value);
+}
+
+/**
+ * One native-currency amount to fold into a `current-rate` conversion — one
+ * entry per order, or one entry per daily-row native-currency bucket. The
+ * aggregation's own day/connection grouping is irrelevant here; only the
+ * `(currency, amount)` pair is read.
+ */
+export interface NativeCurrencyAmount {
+  readonly currency: string;
+  readonly amount: number;
+}
+
+/** Input to {@link IDisplayCurrencyConversionService.convertAtCurrentRate}. */
+export interface CurrentRateConversionInput {
+  readonly amounts: readonly NativeCurrencyAmount[];
+  readonly displayCurrency: string;
+}
+
+/**
+ * Per-native-currency subtotal within a `current-rate` conversion result —
+ * backs the mockup's "Summed by each order's own currency: {n} orders in
+ * {currency}, …" banner.
+ */
+export interface NativeCurrencyBreakdown {
+  readonly currency: string;
+  readonly orderCount: number;
+  /** `SUM(amount)` for this currency, in its own native currency — never converted. */
+  readonly nativeTotal: number;
+  /**
+   * `nativeTotal` converted to the requested display currency, or `null` when
+   * no rate could be resolved for this currency — the row this currency
+   * contributes to {@link CurrentRateConversionResult.unresolvedNativeCurrencies}.
+   */
+  readonly convertedTotal: number | null;
+}
+
+/**
+ * Output of a `current-rate` conversion. `unresolvedNativeCurrencies` backs
+ * the mockup's `unavailable` state — a currency with no resolvable rate is
+ * reported here, never thrown and never silently dropped or defaulted.
+ */
+export interface CurrentRateConversionResult {
+  readonly displayCurrency: string;
+  /**
+   * Sum of every RESOLVED breakdown row's `convertedTotal`. A native currency
+   * in `unresolvedNativeCurrencies` contributes nothing to this figure — the
+   * total is honest about only what it could actually convert.
+   */
+  readonly convertedTotal: number;
+  readonly breakdown: readonly NativeCurrencyBreakdown[];
+  readonly unresolvedNativeCurrencies: readonly string[];
+}
+
+/** Input to {@link IDisplayCurrencyConversionService.convertAtOrderDate}. */
+export interface OrderDateConversionInput {
+  /** The already-computed aggregate figure, in `reportingCurrency` — e.g. `SalesAnalyticsHeadline.revenue`. */
+  readonly reportingTotal: number;
+  /**
+   * `SalesAnalyticsHeadline.currency` (or the per-channel equivalent) —
+   * `null` when nothing in range has been stamped yet, in which case there is
+   * nothing to convert.
+   */
+  readonly reportingCurrency: string | null;
+  readonly displayCurrency: string;
+}
+
+/**
+ * Output of an `order-date` conversion.
+ *
+ * `convertedTotal` is `null` in exactly two cases: `reportingCurrency` was
+ * `null` (nothing stamped in range to convert), or a conversion was
+ * attempted and no rate could be resolved (`unresolved: true`) — the mockup's
+ * `unavailable` state for this mode.
+ */
+export interface OrderDateConversionResult {
+  readonly displayCurrency: string;
+  readonly convertedTotal: number | null;
+  /** The currency `reportingTotal` was expressed in before conversion, or `null` when `reportingCurrency` was `null`. */
+  readonly sourceCurrency: string | null;
+  /** `true` only when a rate lookup was attempted and failed — never `true` merely because there was nothing to convert. */
+  readonly unresolved: boolean;
+}

--- a/libs/core/src/orders/domain/types/display-currency.types.ts
+++ b/libs/core/src/orders/domain/types/display-currency.types.ts
@@ -1,7 +1,7 @@
 /**
  * Display Currency Conversion Types
  *
- * Shapes for the `/analytics` display-currency read model (#2458, ADR-064).
+ * Shapes for the `/analytics` display-currency read model (#2458, ADR-064, pending in PR #2485).
  * Two conversion modes back the operator-facing display-currency picker:
  *
  *  - `current-rate`: groups the RAW native `currency`/`totalAmount` figures
@@ -35,14 +35,39 @@ export function isDisplayCurrencyRateBasis(value: string): value is DisplayCurre
 }
 
 /**
+ * Sentinel `currency` value for a `NativeCurrencyAmount` bucket that sums
+ * orders spanning more than one native currency with no single ISO code to
+ * label them (`SalesAnalyticsHeadline.unconvertedCurrency === null` while
+ * `unconvertedCount > 0`, i.e. real, non-zero money whose currencies the
+ * `#1987` read model didn't keep separately). `groupByCurrency` never sends
+ * this value to a rate provider — a currency-less bucket has no rate to
+ * resolve — and it is unconditionally reported in
+ * `CurrentRateConversionResult.unresolvedNativeCurrencies` rather than being
+ * silently excluded from `convertedTotal` with no trace at all.
+ */
+export const MIXED_NATIVE_CURRENCIES_LABEL = 'mixed-currencies';
+
+/**
  * One native-currency amount to fold into a `current-rate` conversion — one
  * entry per order, or one entry per daily-row native-currency bucket. The
  * aggregation's own day/connection grouping is irrelevant here; only the
- * `(currency, amount)` pair is read.
+ * `(currency, amount, count)` triple is read. `currency` may be
+ * {@link MIXED_NATIVE_CURRENCIES_LABEL} when the caller cannot label a bucket
+ * with one ISO code.
  */
 export interface NativeCurrencyAmount {
   readonly currency: string;
   readonly amount: number;
+  /**
+   * How many orders this amount represents (#2488 review, IMPORTANT 1) — a
+   * caller aggregating several orders into one pre-summed bucket (e.g. the
+   * controller's per-currency revenue bucket) passes the real order count
+   * here, not one entry per order. `groupByCurrency` sums this field rather
+   * than counting array entries, so `NativeCurrencyBreakdown.orderCount`
+   * reflects true order counts regardless of how coarsely the caller batched
+   * its input.
+   */
+  readonly count: number;
 }
 
 /** Input to {@link IDisplayCurrencyConversionService.convertAtCurrentRate}. */
@@ -72,7 +97,10 @@ export interface NativeCurrencyBreakdown {
 /**
  * Output of a `current-rate` conversion. `unresolvedNativeCurrencies` backs
  * the mockup's `unavailable` state — a currency with no resolvable rate is
- * reported here, never thrown and never silently dropped or defaulted.
+ * reported here, never thrown and never silently dropped or defaulted. It may
+ * also contain {@link MIXED_NATIVE_CURRENCIES_LABEL}: real, non-zero money
+ * from a bucket that spans more than one native currency is reported as
+ * unresolved rather than being excluded from `convertedTotal` with no trace.
  */
 export interface CurrentRateConversionResult {
   readonly displayCurrency: string;

--- a/libs/core/src/orders/index.ts
+++ b/libs/core/src/orders/index.ts
@@ -164,9 +164,10 @@ export {
   CreateRefundRecordInput,
 } from './domain/types/refund-record.types';
 
-// Analytics display-currency conversion read model (#2458, ADR-064).
+// Analytics display-currency conversion read model (#2458, ADR-064, pending in PR #2485).
 export {
   DISPLAY_CURRENCY_RATE_BASIS_VALUES,
+  MIXED_NATIVE_CURRENCIES_LABEL,
   isDisplayCurrencyRateBasis,
 } from './domain/types/display-currency.types';
 export type {
@@ -180,7 +181,11 @@ export type {
 } from './domain/types/display-currency.types';
 
 // Services
-export { IOrderSyncService, OrderSyncRequest, OrderSyncResult } from './application/interfaces/order-sync.service.interface';
+export {
+  IOrderSyncService,
+  OrderSyncRequest,
+  OrderSyncResult,
+} from './application/interfaces/order-sync.service.interface';
 export {
   IOrderIngestionService,
   OrderIngestionOptions,
@@ -248,7 +253,3 @@ export { OrderRecordRepositoryPort } from './domain/ports/order-record-repositor
 
 // Module
 export { OrdersModule } from './orders.module';
-
-
-
-

--- a/libs/core/src/orders/index.ts
+++ b/libs/core/src/orders/index.ts
@@ -164,6 +164,21 @@ export {
   CreateRefundRecordInput,
 } from './domain/types/refund-record.types';
 
+// Analytics display-currency conversion read model (#2458, ADR-064).
+export {
+  DISPLAY_CURRENCY_RATE_BASIS_VALUES,
+  isDisplayCurrencyRateBasis,
+} from './domain/types/display-currency.types';
+export type {
+  DisplayCurrencyRateBasis,
+  NativeCurrencyAmount,
+  CurrentRateConversionInput,
+  NativeCurrencyBreakdown,
+  CurrentRateConversionResult,
+  OrderDateConversionInput,
+  OrderDateConversionResult,
+} from './domain/types/display-currency.types';
+
 // Services
 export { IOrderSyncService, OrderSyncRequest, OrderSyncResult } from './application/interfaces/order-sync.service.interface';
 export {
@@ -194,6 +209,7 @@ export type {
   TaxRateBackfillPageInput,
   TaxRateBackfillPageResult,
 } from './application/services/tax-rate-backfill.service.interface';
+export type { IDisplayCurrencyConversionService } from './application/interfaces/display-currency-conversion.service.interface';
 export * from './orders.tokens';
 
 // Domain entities

--- a/libs/core/src/orders/orders.module.ts
+++ b/libs/core/src/orders/orders.module.ts
@@ -24,6 +24,7 @@ import { RefundRecordRepository } from './infrastructure/persistence/repositorie
 import { RefundRecordOrmEntity } from './infrastructure/persistence/entities/refund-record.orm-entity';
 import { OrderLineItemOrmEntity } from './infrastructure/persistence/entities/order-line-item.orm-entity';
 import { TaxRateBackfillService } from './application/services/tax-rate-backfill.service';
+import { DisplayCurrencyConversionService } from './application/services/display-currency-conversion.service';
 import {
   ORDER_SYNC_SERVICE_TOKEN,
   ORDER_INGESTION_SERVICE_TOKEN,
@@ -38,6 +39,7 @@ import {
   ORDER_FX_READ_SERVICE_TOKEN,
   ORDER_LINE_ITEM_REPOSITORY_TOKEN,
   TAX_RATE_BACKFILL_SERVICE_TOKEN,
+  DISPLAY_CURRENCY_CONVERSION_SERVICE_TOKEN,
 } from './orders.tokens';
 import { IntegrationsModule } from '@openlinker/core/integrations';
 import { IdentifierMappingModule } from '@openlinker/core/identifier-mapping';
@@ -87,6 +89,7 @@ export { ORDER_SYNC_SERVICE_TOKEN } from './orders.tokens';
     RefundRecordRepository,
     OrderLineItemRepository,
     TaxRateBackfillService,
+    DisplayCurrencyConversionService,
     // Then provide token bindings using useExisting
     {
       provide: ORDER_SYNC_SERVICE_TOKEN,
@@ -140,6 +143,10 @@ export { ORDER_SYNC_SERVICE_TOKEN } from './orders.tokens';
       provide: TAX_RATE_BACKFILL_SERVICE_TOKEN,
       useExisting: TaxRateBackfillService,
     },
+    {
+      provide: DISPLAY_CURRENCY_CONVERSION_SERVICE_TOKEN,
+      useExisting: DisplayCurrencyConversionService,
+    },
   ],
   exports: [
     OrderRecordService, // Export service class for direct injection
@@ -158,6 +165,9 @@ export { ORDER_SYNC_SERVICE_TOKEN } from './orders.tokens';
     // Exported so the worker's `orders.taxRate.backfill` handler can inject
     // the backfill seam (#2440).
     TAX_RATE_BACKFILL_SERVICE_TOKEN,
+    // Exported so the `/analytics` display-currency read surface (a later
+    // phase of #2452) can inject this seam (#2458, ADR-064).
+    DISPLAY_CURRENCY_CONVERSION_SERVICE_TOKEN,
   ],
 })
 export class OrdersModule {}

--- a/libs/core/src/orders/orders.module.ts
+++ b/libs/core/src/orders/orders.module.ts
@@ -166,9 +166,8 @@ export { ORDER_SYNC_SERVICE_TOKEN } from './orders.tokens';
     // the backfill seam (#2440).
     TAX_RATE_BACKFILL_SERVICE_TOKEN,
     // Exported so the `/analytics` display-currency read surface (a later
-    // phase of #2452) can inject this seam (#2458, ADR-064).
+    // phase of #2452) can inject this seam (#2458, ADR-064, pending in PR #2485).
     DISPLAY_CURRENCY_CONVERSION_SERVICE_TOKEN,
   ],
 })
 export class OrdersModule {}
-

--- a/libs/core/src/orders/orders.tokens.ts
+++ b/libs/core/src/orders/orders.tokens.ts
@@ -26,6 +26,10 @@ export const ORDER_REFUND_SERVICE_TOKEN = Symbol('IOrderRefundService');
 export const ORDER_LINE_ITEM_REPOSITORY_TOKEN = Symbol('OrderLineItemRepositoryPort');
 // Tax-rate backfill sweep for pre-#2245 lines (#2440).
 export const TAX_RATE_BACKFILL_SERVICE_TOKEN = Symbol('ITaxRateBackfillService');
+// Analytics display-currency conversion read model (#2458, ADR-064).
+export const DISPLAY_CURRENCY_CONVERSION_SERVICE_TOKEN = Symbol(
+  'IDisplayCurrencyConversionService'
+);
 
 
 

--- a/libs/core/src/orders/orders.tokens.ts
+++ b/libs/core/src/orders/orders.tokens.ts
@@ -26,10 +26,7 @@ export const ORDER_REFUND_SERVICE_TOKEN = Symbol('IOrderRefundService');
 export const ORDER_LINE_ITEM_REPOSITORY_TOKEN = Symbol('OrderLineItemRepositoryPort');
 // Tax-rate backfill sweep for pre-#2245 lines (#2440).
 export const TAX_RATE_BACKFILL_SERVICE_TOKEN = Symbol('ITaxRateBackfillService');
-// Analytics display-currency conversion read model (#2458, ADR-064).
+// Analytics display-currency conversion read model (#2458, ADR-064, pending in PR #2485).
 export const DISPLAY_CURRENCY_CONVERSION_SERVICE_TOKEN = Symbol(
   'IDisplayCurrencyConversionService'
 );
-
-
-


### PR DESCRIPTION
## Summary

Phase 2 of epic #2452 — read-only, synchronous display-currency conversion for `/analytics/sales`. No writes to `order_records`.

## Status

- [x] Task #2458 — CORE `DisplayCurrencyConversionService` (both modes, synchronous) — landed
- [ ] Task #2459 — Interface `GET /analytics/sales` query param + response DTO — in progress

Opened as **draft** so progress is visible; will move to ready-for-review once #2459 lands, then go through the standard /pr-review fix loop.

Part of #2457, #2452.
Closes #2458
Closes #2459