### PR TITLE
Phase 3: Analytics Settings persistence (#2460)

### DIFF
--- a/apps/api/src/analytics/analytics.module.ts
+++ b/apps/api/src/analytics/analytics.module.ts
@@ -23,6 +23,11 @@
  *    `NeedsAttentionService` — it composes them via `TopProductsService` at
  *    this layer rather than adding a new core-to-core dependency edge; see
  *    that service's own header.
+ * 5. **`/analytics/settings`** (`AnalyticsSettingsController`, #2462) — the
+ *    display-currency / rate-basis / backfilled-tax-rate-inclusion singleton
+ *    row (#2461). `GET` composes the row with the system reporting currency
+ *    from `@openlinker/core/currency`, which is why `CurrencyModule` is
+ *    imported here alongside `CoreAnalyticsModule`.
  *
  * The concerns share nothing except the URL prefix. If a future
  * `/analytics` route (#1986 route shell, KPI strip, etc.) needs its own
@@ -38,6 +43,7 @@
  */
 import { Module } from '@nestjs/common';
 import { AnalyticsModule as CoreAnalyticsModule } from '@openlinker/core/analytics';
+import { CurrencyModule } from '@openlinker/core/currency';
 import { ListingsModule } from '@openlinker/core/listings/services';
 import { OrdersModule } from '@openlinker/core/orders';
 import { ProductsModule } from '@openlinker/core/products';
@@ -50,18 +56,27 @@ import { PosthogSettingsController } from './http/posthog-settings.controller';
 import { NeedsAttentionController } from './http/needs-attention.controller';
 import { SalesAnalyticsController } from './http/sales-analytics.controller';
 import { TopProductsController } from './http/top-products.controller';
+import { AnalyticsSettingsController } from './http/analytics-settings.controller';
 import { NeedsAttentionService } from './application/services/needs-attention.service';
 import { NEEDS_ATTENTION_SERVICE_TOKEN } from './application/services/needs-attention.service.interface';
 import { TopProductsService } from './application/services/top-products.service';
 import { TOP_PRODUCTS_SERVICE_TOKEN } from './application/services/top-products.service.interface';
 
 @Module({
-  imports: [CoreAnalyticsModule, ListingsModule, OrdersModule, ProductsModule, ApiIntegrationsModule],
+  imports: [
+    CoreAnalyticsModule,
+    CurrencyModule,
+    ListingsModule,
+    OrdersModule,
+    ProductsModule,
+    ApiIntegrationsModule,
+  ],
   controllers: [
     PosthogSettingsController,
     NeedsAttentionController,
     SalesAnalyticsController,
     TopProductsController,
+    AnalyticsSettingsController,
   ],
   providers: [
     NeedsAttentionService,

--- a/apps/api/src/analytics/http/analytics-settings.controller.spec.ts
+++ b/apps/api/src/analytics/http/analytics-settings.controller.spec.ts
@@ -6,63 +6,48 @@
  * `@Roles('admin')`, the `displayCurrency` / `displayCurrencySource`
  * projection correctly distinguishes an operator-saved override from the
  * system-default fallback, `PUT` delegates to `updateSettings` with the
- * resolved input and actor id, and — the required regression guard —
- * toggling `includeBackfilledTaxRatesInNetSales` (or any other field) never
- * calls a write method on `OrderRecordRepositoryPort`. That flag only
- * changes how existing `order_records` rows are read/aggregated for Net
- * Sales; it must never mutate a row.
+ * resolved input and actor id, and — the required regression guard — the
+ * controller's own source carries no reference to `order_records` write
+ * surfaces (`OrderRecordRepositoryPort` / `IOrderRecordService` / their DI
+ * tokens). Toggling `includeBackfilledTaxRatesInNetSales` (or any other
+ * field) only changes how existing `order_records` rows are read/aggregated
+ * for Net Sales; it must never mutate a row. The guard is a static
+ * source-inspection check rather than a mock-call assertion — the
+ * controller's constructor takes only `IAnalyticsDisplaySettingsService` and
+ * `IReportingCurrencySettingsService`, so a mocked `OrderRecordRepositoryPort`
+ * would never be reachable from the code under test and the assertion "it
+ * was never called" would be true no matter what the controller did.
  *
  * @module apps/api/src/analytics/http
  */
 import 'reflect-metadata';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import type { Response } from 'express';
 import type {
   IAnalyticsDisplaySettingsService,
   AnalyticsDisplaySettingsView,
 } from '@openlinker/core/analytics';
 import type { IReportingCurrencySettingsService } from '@openlinker/core/currency';
-import type { OrderRecordRepositoryPort } from '@openlinker/core/orders';
 import { ROLES_KEY } from '../../auth/decorators/roles.decorator';
 import type { AuthenticatedUser } from '../../auth/auth.types';
 import { AnalyticsSettingsController } from './analytics-settings.controller';
 import type { UpdateAnalyticsSettingsDto } from './dto/update-analytics-settings.dto';
 
 /**
- * Every mutating method on `OrderRecordRepositoryPort`. Read-only lookups
- * (`findById`, `findMany`, `countByHealth`, `getDailyOrderAggregates`, …)
- * are deliberately excluded — this list is only the surface that could ever
- * write to `order_records`.
+ * Symbols that would only appear in this file if the controller (directly or
+ * via a re-exported barrel type) reached for an `order_records` write
+ * surface. None of them is legitimate here: the controller's only
+ * dependencies are the two settings-service interfaces injected in its
+ * constructor.
  */
-function createOrderRecordWriteMocks(): jest.Mocked<
-  Pick<
-    OrderRecordRepositoryPort,
-    | 'upsert'
-    | 'upsertWithLineItems'
-    | 'updateSyncStatus'
-    | 'updateFulfillmentState'
-    | 'updateItemResolutionFailure'
-    | 'markCancelled'
-    | 'updateSalesDocumentBlock'
-    | 'claimFxIntentIfAbsent'
-    | 'stampFxIfAbsent'
-    | 'markFxTerminal'
-    | 'patchSnapshotTaxRates'
-  >
-> {
-  return {
-    upsert: jest.fn(),
-    upsertWithLineItems: jest.fn(),
-    updateSyncStatus: jest.fn(),
-    updateFulfillmentState: jest.fn(),
-    updateItemResolutionFailure: jest.fn(),
-    markCancelled: jest.fn(),
-    updateSalesDocumentBlock: jest.fn(),
-    claimFxIntentIfAbsent: jest.fn(),
-    stampFxIfAbsent: jest.fn(),
-    markFxTerminal: jest.fn(),
-    patchSnapshotTaxRates: jest.fn(),
-  };
-}
+const FORBIDDEN_ORDER_RECORD_REFERENCES = [
+  'OrderRecordRepositoryPort',
+  'IOrderRecordService',
+  'ORDER_RECORD_REPOSITORY_TOKEN',
+  'ORDER_RECORD_SERVICE_TOKEN',
+  '@openlinker/core/orders',
+] as const;
 
 describe('AnalyticsSettingsController', () => {
   let settings: jest.Mocked<IAnalyticsDisplaySettingsService>;
@@ -164,25 +149,21 @@ describe('AnalyticsSettingsController', () => {
       expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-store');
     });
 
-    it('never writes to order_records — the flag only changes how existing rows are read/aggregated', async () => {
-      const orderRecordWrites = createOrderRecordWriteMocks();
-      const dto: UpdateAnalyticsSettingsDto = {
-        displayCurrency: null,
-        rateBasis: 'current',
-        includeBackfilledTaxRatesInNetSales: true,
-      };
+    it('never writes to order_records — the controller has no reachable dependency on an order_records write surface', () => {
+      // A mock-call assertion can't express this: the controller's
+      // constructor only takes `IAnalyticsDisplaySettingsService` and
+      // `IReportingCurrencySettingsService`, so an `OrderRecordRepositoryPort`
+      // mock would never be wired into the code under test regardless of
+      // what the controller does. Instead, assert directly against the
+      // controller's own source that it never references an order_records
+      // write surface at all — the only write this handler performs is
+      // `IAnalyticsDisplaySettingsService.updateSettings`, which persists to
+      // the singleton `analytics_display_settings` row.
+      const source = readFileSync(join(__dirname, 'analytics-settings.controller.ts'), 'utf8');
 
-      await controller.update(dto, user, res as unknown as Response);
-
-      for (const mockFn of Object.values(orderRecordWrites)) {
-        expect(mockFn).not.toHaveBeenCalled();
+      for (const forbidden of FORBIDDEN_ORDER_RECORD_REFERENCES) {
+        expect(source).not.toContain(forbidden);
       }
-      // The controller has no dependency on `OrderRecordRepositoryPort` /
-      // `IOrderRecordService` at all — the only write this handler performs
-      // is `IAnalyticsDisplaySettingsService.updateSettings`, which persists
-      // to the singleton `analytics_display_settings` row, never to
-      // `order_records`.
-      expect(settings.updateSettings).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/apps/api/src/analytics/http/analytics-settings.controller.spec.ts
+++ b/apps/api/src/analytics/http/analytics-settings.controller.spec.ts
@@ -1,0 +1,188 @@
+/**
+ * Analytics Settings Controller — Unit Tests
+ *
+ * Mocks `IAnalyticsDisplaySettingsService` + `IReportingCurrencySettingsService`.
+ * Asserts: `GET` is open to any authenticated user while `PUT` carries
+ * `@Roles('admin')`, the `displayCurrency` / `displayCurrencySource`
+ * projection correctly distinguishes an operator-saved override from the
+ * system-default fallback, `PUT` delegates to `updateSettings` with the
+ * resolved input and actor id, and — the required regression guard —
+ * toggling `includeBackfilledTaxRatesInNetSales` (or any other field) never
+ * calls a write method on `OrderRecordRepositoryPort`. That flag only
+ * changes how existing `order_records` rows are read/aggregated for Net
+ * Sales; it must never mutate a row.
+ *
+ * @module apps/api/src/analytics/http
+ */
+import 'reflect-metadata';
+import type { Response } from 'express';
+import type {
+  IAnalyticsDisplaySettingsService,
+  AnalyticsDisplaySettingsView,
+} from '@openlinker/core/analytics';
+import type { IReportingCurrencySettingsService } from '@openlinker/core/currency';
+import type { OrderRecordRepositoryPort } from '@openlinker/core/orders';
+import { ROLES_KEY } from '../../auth/decorators/roles.decorator';
+import type { AuthenticatedUser } from '../../auth/auth.types';
+import { AnalyticsSettingsController } from './analytics-settings.controller';
+import type { UpdateAnalyticsSettingsDto } from './dto/update-analytics-settings.dto';
+
+/**
+ * Every mutating method on `OrderRecordRepositoryPort`. Read-only lookups
+ * (`findById`, `findMany`, `countByHealth`, `getDailyOrderAggregates`, …)
+ * are deliberately excluded — this list is only the surface that could ever
+ * write to `order_records`.
+ */
+function createOrderRecordWriteMocks(): jest.Mocked<
+  Pick<
+    OrderRecordRepositoryPort,
+    | 'upsert'
+    | 'upsertWithLineItems'
+    | 'updateSyncStatus'
+    | 'updateFulfillmentState'
+    | 'updateItemResolutionFailure'
+    | 'markCancelled'
+    | 'updateSalesDocumentBlock'
+    | 'claimFxIntentIfAbsent'
+    | 'stampFxIfAbsent'
+    | 'markFxTerminal'
+    | 'patchSnapshotTaxRates'
+  >
+> {
+  return {
+    upsert: jest.fn(),
+    upsertWithLineItems: jest.fn(),
+    updateSyncStatus: jest.fn(),
+    updateFulfillmentState: jest.fn(),
+    updateItemResolutionFailure: jest.fn(),
+    markCancelled: jest.fn(),
+    updateSalesDocumentBlock: jest.fn(),
+    claimFxIntentIfAbsent: jest.fn(),
+    stampFxIfAbsent: jest.fn(),
+    markFxTerminal: jest.fn(),
+    patchSnapshotTaxRates: jest.fn(),
+  };
+}
+
+describe('AnalyticsSettingsController', () => {
+  let settings: jest.Mocked<IAnalyticsDisplaySettingsService>;
+  let reportingCurrency: jest.Mocked<IReportingCurrencySettingsService>;
+  let controller: AnalyticsSettingsController;
+  let res: jest.Mocked<Pick<Response, 'setHeader'>>;
+  const user = { id: 'admin-1' } as AuthenticatedUser;
+
+  beforeEach(() => {
+    settings = {
+      getSettings: jest.fn(),
+      updateSettings: jest.fn(),
+    };
+    reportingCurrency = {
+      resolve: jest.fn(),
+      getView: jest.fn(),
+      setReportingCurrency: jest.fn(),
+      listSelectableCurrencies: jest.fn(),
+    };
+    res = { setHeader: jest.fn() };
+    controller = new AnalyticsSettingsController(settings, reportingCurrency);
+  });
+
+  describe('role gating', () => {
+    it('get carries no @Roles metadata — open to any authenticated user', () => {
+      const proto = AnalyticsSettingsController.prototype as unknown as Record<string, object>;
+      const roles = Reflect.getMetadata(ROLES_KEY, proto.get) as string[] | undefined;
+      expect(roles).toBeUndefined();
+    });
+
+    it('update carries @Roles(admin)', () => {
+      const proto = AnalyticsSettingsController.prototype as unknown as Record<string, object>;
+      const roles = Reflect.getMetadata(ROLES_KEY, proto.update) as string[] | undefined;
+      expect(roles).toEqual(['admin']);
+    });
+  });
+
+  describe('get', () => {
+    it('reports displayCurrencySource "setting" and echoes the saved override when one exists', async () => {
+      const view: AnalyticsDisplaySettingsView = {
+        displayCurrency: 'PLN',
+        rateBasis: 'order-date',
+        includeBackfilledTaxRatesInNetSales: true,
+        updatedAt: new Date('2026-08-01T00:00:00Z'),
+        updatedByUserId: 'admin-1',
+      };
+      settings.getSettings.mockResolvedValue(view);
+      reportingCurrency.resolve.mockResolvedValue('EUR');
+
+      const dto = await controller.get(res as unknown as Response);
+
+      expect(dto.displayCurrency).toBe('PLN');
+      expect(dto.displayCurrencySource).toBe('setting');
+      expect(dto.rateBasis).toBe('order-date');
+      expect(dto.includeBackfilledTaxRatesInNetSales).toBe(true);
+      expect(dto.updatedAt).toBe('2026-08-01T00:00:00.000Z');
+      expect(dto.updatedByUserId).toBe('admin-1');
+      expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-store');
+    });
+
+    it('reports displayCurrencySource "default" and resolves the system reporting currency when no override is saved', async () => {
+      const view: AnalyticsDisplaySettingsView = {
+        displayCurrency: null,
+        rateBasis: 'current',
+        includeBackfilledTaxRatesInNetSales: false,
+        updatedAt: null,
+        updatedByUserId: null,
+      };
+      settings.getSettings.mockResolvedValue(view);
+      reportingCurrency.resolve.mockResolvedValue('EUR');
+
+      const dto = await controller.get(res as unknown as Response);
+
+      expect(dto.displayCurrency).toBe('EUR');
+      expect(dto.displayCurrencySource).toBe('default');
+      expect(dto.updatedAt).toBeNull();
+      expect(dto.updatedByUserId).toBeNull();
+    });
+  });
+
+  describe('update', () => {
+    it('delegates to updateSettings with the DTO fields and the actor id', async () => {
+      const dto: UpdateAnalyticsSettingsDto = {
+        displayCurrency: 'PLN',
+        rateBasis: 'order-date',
+        includeBackfilledTaxRatesInNetSales: true,
+      };
+
+      await controller.update(dto, user, res as unknown as Response);
+
+      expect(settings.updateSettings).toHaveBeenCalledWith(
+        {
+          displayCurrency: 'PLN',
+          rateBasis: 'order-date',
+          includeBackfilledTaxRatesInNetSales: true,
+        },
+        'admin-1'
+      );
+      expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-store');
+    });
+
+    it('never writes to order_records — the flag only changes how existing rows are read/aggregated', async () => {
+      const orderRecordWrites = createOrderRecordWriteMocks();
+      const dto: UpdateAnalyticsSettingsDto = {
+        displayCurrency: null,
+        rateBasis: 'current',
+        includeBackfilledTaxRatesInNetSales: true,
+      };
+
+      await controller.update(dto, user, res as unknown as Response);
+
+      for (const mockFn of Object.values(orderRecordWrites)) {
+        expect(mockFn).not.toHaveBeenCalled();
+      }
+      // The controller has no dependency on `OrderRecordRepositoryPort` /
+      // `IOrderRecordService` at all — the only write this handler performs
+      // is `IAnalyticsDisplaySettingsService.updateSettings`, which persists
+      // to the singleton `analytics_display_settings` row, never to
+      // `order_records`.
+      expect(settings.updateSettings).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/api/src/analytics/http/analytics-settings.controller.ts
+++ b/apps/api/src/analytics/http/analytics-settings.controller.ts
@@ -1,0 +1,102 @@
+/**
+ * Analytics Settings Controller
+ *
+ * HTTP surface for the `/analytics` display-settings singleton row (#2461,
+ * mini-epic #2460, epic #2452 Phase 3): a display-currency override, the
+ * rate-recomputation basis, and the backfilled-tax-rate Net Sales inclusion
+ * opt-in.
+ *
+ * Endpoints:
+ *
+ *   GET /analytics/settings — open to any authenticated user (no `@Roles`):
+ *                             every operator viewing the dashboard needs to
+ *                             read the display preference in effect, not
+ *                             just admins.
+ *   PUT /analytics/settings — `@Roles('admin')`, mirroring
+ *                             `AiProviderSettingsController` /
+ *                             `CurrencySettingsController`: changing a
+ *                             deployment-wide display preference is an admin
+ *                             action.
+ *
+ * `GET` composes the singleton row with the system reporting currency
+ * (`IReportingCurrencySettingsService.resolve()`, `@openlinker/core/currency`)
+ * so `displayCurrency` in the response is always a resolved, usable value —
+ * see `AnalyticsSettingsResponseDto` for why that composition happens here
+ * rather than inside core `analytics`.
+ *
+ * None of the three fields is ever written back onto `order_records` — see
+ * the controller's own spec for the guard test.
+ *
+ * @module apps/api/src/analytics/http
+ */
+import { Body, Controller, Get, HttpCode, HttpStatus, Inject, Put, Res } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { Response } from 'express';
+import {
+  ANALYTICS_DISPLAY_SETTINGS_SERVICE_TOKEN,
+  type IAnalyticsDisplaySettingsService,
+} from '@openlinker/core/analytics';
+import {
+  REPORTING_CURRENCY_SETTINGS_SERVICE_TOKEN,
+  type IReportingCurrencySettingsService,
+} from '@openlinker/core/currency';
+import { AuthenticatedUser } from '../../auth/auth.types';
+import { CurrentUser } from '../../auth/decorators/current-user.decorator';
+import { Roles } from '../../auth/decorators/roles.decorator';
+import { AnalyticsSettingsResponseDto } from './dto/analytics-settings-response.dto';
+import { UpdateAnalyticsSettingsDto } from './dto/update-analytics-settings.dto';
+
+@ApiBearerAuth()
+@ApiTags('analytics')
+@Controller('analytics')
+export class AnalyticsSettingsController {
+  constructor(
+    @Inject(ANALYTICS_DISPLAY_SETTINGS_SERVICE_TOKEN)
+    private readonly settings: IAnalyticsDisplaySettingsService,
+    @Inject(REPORTING_CURRENCY_SETTINGS_SERVICE_TOKEN)
+    private readonly reportingCurrency: IReportingCurrencySettingsService
+  ) {}
+
+  @Get('settings')
+  @ApiOperation({
+    summary:
+      'Read the analytics display settings: display-currency override (resolved + provenance), rate basis, and the backfilled-tax-rate Net Sales opt-in. Open to any authenticated user.',
+  })
+  @ApiResponse({ status: 200, type: AnalyticsSettingsResponseDto })
+  async get(@Res({ passthrough: true }) res: Response): Promise<AnalyticsSettingsResponseDto> {
+    res.setHeader('Cache-Control', 'no-store');
+
+    const [view, resolvedReportingCurrency] = await Promise.all([
+      this.settings.getSettings(),
+      this.reportingCurrency.resolve(),
+    ]);
+
+    return AnalyticsSettingsResponseDto.fromView({ view, resolvedReportingCurrency });
+  }
+
+  @Roles('admin')
+  @Put('settings')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({
+    summary:
+      'Update the analytics display settings. Read-time preferences only — never writes to order_records.',
+  })
+  @ApiResponse({ status: 204, description: 'Settings updated' })
+  @ApiResponse({ status: 400, description: 'Validation failure (unsupported currency code, etc.)' })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async update(
+    @Body() dto: UpdateAnalyticsSettingsDto,
+    @CurrentUser() user: AuthenticatedUser,
+    @Res({ passthrough: true }) res: Response
+  ): Promise<void> {
+    res.setHeader('Cache-Control', 'no-store');
+    await this.settings.updateSettings(
+      {
+        displayCurrency: dto.displayCurrency,
+        rateBasis: dto.rateBasis,
+        includeBackfilledTaxRatesInNetSales: dto.includeBackfilledTaxRatesInNetSales,
+      },
+      user?.id
+    );
+  }
+}

--- a/apps/api/src/analytics/http/dto/analytics-settings-response.dto.ts
+++ b/apps/api/src/analytics/http/dto/analytics-settings-response.dto.ts
@@ -1,0 +1,93 @@
+/**
+ * Analytics Settings Response DTO
+ *
+ * Response body for `GET /analytics/settings`. Composes the singleton
+ * `analytics_display_settings` row (#2461) with the system reporting
+ * currency (`@openlinker/core/currency`) so `displayCurrency` is always a
+ * resolved, usable value — never `null` — while `displayCurrencySource`
+ * tells the caller whether that value is an operator-saved override
+ * (`'setting'`) or the system default (`'default'`).
+ *
+ * The shape deliberately mirrors `ReportingCurrencySettingsView.source`
+ * (`@openlinker/core/currency`, ADR-040): a resolved value paired with a
+ * provenance discriminator, rather than shipping the raw nullable field and
+ * making every consumer re-derive "is this a default" client-side. There is
+ * no `'env'` rung here (unlike the reporting-currency source) — these three
+ * fields have no env-var fallback, only `row -> default`.
+ *
+ * Composed in the interfaces layer, not inside the `analytics` core module:
+ * resolving the system reporting currency needs `@openlinker/core/currency`,
+ * and adding that edge to core `analytics` would cost `currency` nothing but
+ * would grow a cross-context dependency for a purely presentational read.
+ *
+ * @module apps/api/src/analytics/http/dto
+ */
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  RateBasisValues,
+  type AnalyticsDisplaySettingsView,
+  type RateBasis,
+} from '@openlinker/core/analytics';
+
+/** Which rung answered `displayCurrency`: an operator-saved row, or the system default. */
+export const ANALYTICS_DISPLAY_CURRENCY_SOURCES = ['setting', 'default'] as const;
+export type AnalyticsDisplayCurrencySource = (typeof ANALYTICS_DISPLAY_CURRENCY_SOURCES)[number];
+
+export class AnalyticsSettingsResponseDto {
+  @ApiProperty({
+    description:
+      'The resolved display currency: the operator-saved override when one exists, otherwise the system reporting currency. Never null.',
+  })
+  displayCurrency!: string;
+
+  @ApiProperty({
+    enum: ANALYTICS_DISPLAY_CURRENCY_SOURCES,
+    description:
+      "Which rung answered `displayCurrency`: `setting` (an operator saved an override) or `default` (falls back to the system reporting currency). Mirrors `ReportingCurrencySettingsView.source`.",
+  })
+  displayCurrencySource!: AnalyticsDisplayCurrencySource;
+
+  @ApiProperty({
+    enum: RateBasisValues,
+    description:
+      "How a multi-currency figure is recomputed for display: `current` (today's rate) or `order-date` (the rate stamped at ingestion).",
+  })
+  rateBasis!: RateBasis;
+
+  @ApiProperty({
+    description:
+      'Org-wide opt-in: admit a pre-rollout order into Net Sales once a backfilled tax rate is resolved for it (ADR-063 amendment). Never mutates any order_records row.',
+  })
+  includeBackfilledTaxRatesInNetSales!: boolean;
+
+  @ApiProperty({
+    type: String,
+    nullable: true,
+    description: 'When the settings row was last written. `null` when no row exists yet.',
+  })
+  updatedAt!: string | null;
+
+  @ApiProperty({
+    type: String,
+    nullable: true,
+    description: 'Who last wrote the settings row. `null` when no row exists yet.',
+  })
+  updatedByUserId!: string | null;
+
+  static fromView(input: {
+    view: AnalyticsDisplaySettingsView;
+    resolvedReportingCurrency: string;
+  }): AnalyticsSettingsResponseDto {
+    const dto = new AnalyticsSettingsResponseDto();
+    const hasExplicitOverride = input.view.displayCurrency !== null;
+    dto.displayCurrency = hasExplicitOverride
+      ? (input.view.displayCurrency as string)
+      : input.resolvedReportingCurrency;
+    dto.displayCurrencySource = hasExplicitOverride ? 'setting' : 'default';
+    dto.rateBasis = input.view.rateBasis;
+    dto.includeBackfilledTaxRatesInNetSales = input.view.includeBackfilledTaxRatesInNetSales;
+    dto.updatedAt = input.view.updatedAt ? input.view.updatedAt.toISOString() : null;
+    dto.updatedByUserId = input.view.updatedByUserId;
+    return dto;
+  }
+}

--- a/apps/api/src/analytics/http/dto/update-analytics-settings.dto.ts
+++ b/apps/api/src/analytics/http/dto/update-analytics-settings.dto.ts
@@ -1,0 +1,49 @@
+/**
+ * Update Analytics Settings DTO
+ *
+ * Request body for `PUT /analytics/settings`. Validates all three
+ * `analytics_display_settings` fields (#2461) — a display-currency override,
+ * the rate-recomputation basis, and the backfilled-tax-rate Net Sales
+ * inclusion opt-in.
+ *
+ * `displayCurrency` reuses the existing `SUPPORTED_REPORTING_CURRENCIES`
+ * closed set from `@openlinker/core/currency` (ADR-040) rather than forking
+ * a parallel currency-code validator: an override that is not itself a
+ * reachable reporting currency could never be resolved to a rate, so the
+ * same closed set the reporting-currency setting validates against is the
+ * correct gate here too. `null` clears the override (falls back to the
+ * system reporting currency).
+ *
+ * @module apps/api/src/analytics/http/dto
+ */
+import { ApiProperty } from '@nestjs/swagger';
+import { IsBoolean, IsIn, ValidateIf } from 'class-validator';
+import { RateBasisValues, type RateBasis } from '@openlinker/core/analytics';
+import { SUPPORTED_REPORTING_CURRENCIES } from '@openlinker/core/currency';
+
+export class UpdateAnalyticsSettingsDto {
+  @ApiProperty({
+    type: String,
+    nullable: true,
+    description: `ISO-4217 display-currency override, narrowed to the reportable set: ${SUPPORTED_REPORTING_CURRENCIES.join(', ')}. \`null\` uses the system reporting currency.`,
+    example: 'PLN',
+  })
+  @ValidateIf((_, value) => value !== null)
+  @IsIn(SUPPORTED_REPORTING_CURRENCIES as unknown as string[])
+  displayCurrency!: string | null;
+
+  @ApiProperty({
+    enum: RateBasisValues,
+    description:
+      "How a multi-currency figure is recomputed for display: `current` (today's rate) or `order-date` (the rate stamped at ingestion).",
+  })
+  @IsIn(RateBasisValues as unknown as string[])
+  rateBasis!: RateBasis;
+
+  @ApiProperty({
+    description:
+      'Org-wide opt-in: admit a pre-rollout order into Net Sales once a backfilled tax rate is resolved for it. Never mutates any order_records row — it only changes how existing rows are read/aggregated for Net Sales.',
+  })
+  @IsBoolean()
+  includeBackfilledTaxRatesInNetSales!: boolean;
+}

--- a/apps/api/src/migrations/1842000000000-add-analytics-display-settings.ts
+++ b/apps/api/src/migrations/1842000000000-add-analytics-display-settings.ts
@@ -1,0 +1,44 @@
+/**
+ * Add `analytics_display_settings` (#2461, epic #2452 Phase 3)
+ *
+ * A singleton-row table (`id = 'singleton'`) holding three operator
+ * preferences consumed by the `/analytics` dashboard: a display-currency
+ * override, the rate-recomputation basis, and the backfilled-tax-rate Net
+ * Sales inclusion opt-in from ADR-063's amendment for #2456. None of the
+ * three is the reporting currency itself and none mutates any
+ * `order_records` row — see `docs/architecture-overview.md § Analytics`.
+ *
+ * Column shape follows the sibling `posthog_settings` table verbatim (same
+ * context, same singleton pattern): snake_case columns via explicit
+ * naming, an `updated_at` default of `now()`, a nullable `updated_by_*`
+ * audit column. Hand-authored rather than taken verbatim from
+ * `migration:generate` — the generated diff against a locally-migrated dev
+ * DB also carried a large amount of unrelated FK-constraint churn from
+ * column-order drift accumulated across prior migrations, matching the
+ * documented false-positive shape in `docs/migrations.md`.
+ *
+ * @module apps/api/src/migrations
+ */
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddAnalyticsDisplaySettings1842000000000 implements MigrationInterface {
+  name = 'AddAnalyticsDisplaySettings1842000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "analytics_display_settings" (
+        "id" text NOT NULL,
+        "display_currency" character varying(3),
+        "rate_basis" text NOT NULL DEFAULT 'current',
+        "include_backfilled_tax_rates_in_net_sales" boolean NOT NULL DEFAULT false,
+        "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        "updated_by_user_id" text,
+        CONSTRAINT "PK_analytics_display_settings" PRIMARY KEY ("id")
+      )
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "analytics_display_settings"`);
+  }
+}

--- a/libs/core/src/analytics/analytics.module.ts
+++ b/libs/core/src/analytics/analytics.module.ts
@@ -14,15 +14,33 @@
  * `MailerSettingsService` reads `MAIL_*` env vars. No host-supplied port
  * binding is needed for this module to be self-contained.
  *
+ * Also wires the singleton `analytics_display_settings` repository and
+ * `AnalyticsDisplaySettingsService` (#2461, epic #2452 Phase 3) — the
+ * display-currency override, rate-recomputation basis, and
+ * backfilled-tax-rate Net Sales inclusion opt-in consumed by the `/analytics`
+ * dashboard. Placed in this context rather than `orders` or `currency`
+ * because it is exactly the same shape as the sibling `posthog_settings` row
+ * already owned here (an analytics-feature operator preference), while
+ * `orders` has an unrelated order-lifecycle responsibility and `currency` is
+ * a documented leaf scoped to FX stamping.
+ *
  * @module libs/core/src/analytics
  */
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { IntegrationsModule as CoreIntegrationsModule } from '@openlinker/core/integrations';
-import { POSTHOG_SETTINGS_REPOSITORY_TOKEN, POSTHOG_SETTINGS_SERVICE_TOKEN } from './analytics.tokens';
+import {
+  ANALYTICS_DISPLAY_SETTINGS_REPOSITORY_TOKEN,
+  ANALYTICS_DISPLAY_SETTINGS_SERVICE_TOKEN,
+  POSTHOG_SETTINGS_REPOSITORY_TOKEN,
+  POSTHOG_SETTINGS_SERVICE_TOKEN,
+} from './analytics.tokens';
+import { AnalyticsDisplaySettingsService } from './application/services/analytics-display-settings.service';
 import { PosthogSettingsService } from './application/services/posthog-settings.service';
+import { AnalyticsDisplaySettingsOrmEntity } from './infrastructure/persistence/entities/analytics-display-settings.orm-entity';
 import { PosthogSettingsOrmEntity } from './infrastructure/persistence/entities/posthog-settings.orm-entity';
+import { AnalyticsDisplaySettingsRepository } from './infrastructure/persistence/repositories/analytics-display-settings.repository';
 import { PosthogSettingsRepository } from './infrastructure/persistence/repositories/posthog-settings.repository';
 
 @Module({
@@ -31,14 +49,29 @@ import { PosthogSettingsRepository } from './infrastructure/persistence/reposito
     // For CREDENTIALS_SERVICE_TOKEN, consumed by PosthogSettingsService to
     // store/resolve the API key.
     CoreIntegrationsModule,
-    TypeOrmModule.forFeature([PosthogSettingsOrmEntity]),
+    TypeOrmModule.forFeature([PosthogSettingsOrmEntity, AnalyticsDisplaySettingsOrmEntity]),
   ],
   providers: [
     PosthogSettingsRepository,
     { provide: POSTHOG_SETTINGS_REPOSITORY_TOKEN, useExisting: PosthogSettingsRepository },
     PosthogSettingsService,
     { provide: POSTHOG_SETTINGS_SERVICE_TOKEN, useExisting: PosthogSettingsService },
+    AnalyticsDisplaySettingsRepository,
+    {
+      provide: ANALYTICS_DISPLAY_SETTINGS_REPOSITORY_TOKEN,
+      useExisting: AnalyticsDisplaySettingsRepository,
+    },
+    AnalyticsDisplaySettingsService,
+    {
+      provide: ANALYTICS_DISPLAY_SETTINGS_SERVICE_TOKEN,
+      useExisting: AnalyticsDisplaySettingsService,
+    },
   ],
-  exports: [POSTHOG_SETTINGS_REPOSITORY_TOKEN, POSTHOG_SETTINGS_SERVICE_TOKEN],
+  exports: [
+    POSTHOG_SETTINGS_REPOSITORY_TOKEN,
+    POSTHOG_SETTINGS_SERVICE_TOKEN,
+    ANALYTICS_DISPLAY_SETTINGS_REPOSITORY_TOKEN,
+    ANALYTICS_DISPLAY_SETTINGS_SERVICE_TOKEN,
+  ],
 })
 export class AnalyticsModule {}

--- a/libs/core/src/analytics/analytics.tokens.ts
+++ b/libs/core/src/analytics/analytics.tokens.ts
@@ -8,3 +8,8 @@
 
 export const POSTHOG_SETTINGS_REPOSITORY_TOKEN = Symbol('PosthogSettingsRepositoryPort');
 export const POSTHOG_SETTINGS_SERVICE_TOKEN = Symbol('IPosthogSettingsService');
+
+export const ANALYTICS_DISPLAY_SETTINGS_REPOSITORY_TOKEN = Symbol(
+  'AnalyticsDisplaySettingsRepositoryPort'
+);
+export const ANALYTICS_DISPLAY_SETTINGS_SERVICE_TOKEN = Symbol('IAnalyticsDisplaySettingsService');

--- a/libs/core/src/analytics/application/services/analytics-display-settings.service.interface.ts
+++ b/libs/core/src/analytics/application/services/analytics-display-settings.service.interface.ts
@@ -1,0 +1,26 @@
+/**
+ * Analytics Display Settings Service Interface
+ *
+ * Contract for the DB-backed analytics display preferences service. Mirrors
+ * `IPosthogSettingsService`'s read/write shape (same context), minus the
+ * credentials-store methods this setting has no equivalent of.
+ *
+ * @module libs/core/src/analytics/application/services
+ */
+import type {
+  AnalyticsDisplaySettingsInput,
+  AnalyticsDisplaySettingsView,
+} from '../../domain/types/analytics-display-settings.types';
+
+export interface IAnalyticsDisplaySettingsService {
+  /**
+   * Read the current settings. When no row has ever been saved, returns the
+   * documented defaults (`displayCurrency: null`, `rateBasis: 'current'`,
+   * `includeBackfilledTaxRatesInNetSales: false`) with `updatedAt` /
+   * `updatedByUserId` both `null`.
+   */
+  getSettings(): Promise<AnalyticsDisplaySettingsView>;
+
+  /** Idempotently persist the three settings fields. */
+  updateSettings(input: AnalyticsDisplaySettingsInput, actorUserId?: string): Promise<void>;
+}

--- a/libs/core/src/analytics/application/services/analytics-display-settings.service.spec.ts
+++ b/libs/core/src/analytics/application/services/analytics-display-settings.service.spec.ts
@@ -1,0 +1,99 @@
+/**
+ * Analytics Display Settings Service — Unit Tests
+ *
+ * Mocks the settings repo only — this service has no env-var fallback rung
+ * and no credentials store, unlike its sibling `PosthogSettingsService`.
+ *
+ * @module libs/core/src/analytics/application/services
+ */
+import { Logger as SharedLogger } from '@openlinker/shared/logging';
+import { AnalyticsDisplaySettings } from '../../domain/entities/analytics-display-settings.entity';
+import type { AnalyticsDisplaySettingsRepositoryPort } from '../../domain/ports/analytics-display-settings-repository.port';
+import { AnalyticsDisplaySettingsService } from './analytics-display-settings.service';
+
+describe('AnalyticsDisplaySettingsService', () => {
+  let repository: jest.Mocked<AnalyticsDisplaySettingsRepositoryPort>;
+  let logSpy: jest.SpyInstance;
+  let service: AnalyticsDisplaySettingsService;
+
+  beforeEach(() => {
+    repository = {
+      findSettings: jest.fn(),
+      upsertSettings: jest.fn(),
+    };
+    logSpy = jest.spyOn(SharedLogger.prototype, 'log').mockImplementation(() => undefined);
+    service = new AnalyticsDisplaySettingsService(repository);
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  describe('getSettings', () => {
+    it('returns documented defaults with no timestamps when no row exists', async () => {
+      repository.findSettings.mockResolvedValue(null);
+
+      const view = await service.getSettings();
+
+      expect(view).toEqual({
+        displayCurrency: null,
+        rateBasis: 'current',
+        includeBackfilledTaxRatesInNetSales: false,
+        updatedAt: null,
+        updatedByUserId: null,
+      });
+    });
+
+    it('returns the persisted row verbatim', async () => {
+      const updatedAt = new Date('2026-08-20T10:00:00Z');
+      repository.findSettings.mockResolvedValue(
+        new AnalyticsDisplaySettings('EUR', 'order-date', true, updatedAt, 'user-9')
+      );
+
+      const view = await service.getSettings();
+
+      expect(view).toEqual({
+        displayCurrency: 'EUR',
+        rateBasis: 'order-date',
+        includeBackfilledTaxRatesInNetSales: true,
+        updatedAt,
+        updatedByUserId: 'user-9',
+      });
+    });
+  });
+
+  describe('updateSettings', () => {
+    it('delegates to the repository with the resolved actor', async () => {
+      repository.upsertSettings.mockResolvedValue(
+        new AnalyticsDisplaySettings('PLN', 'current', false, new Date(), 'user-1')
+      );
+
+      await service.updateSettings(
+        { displayCurrency: 'PLN', rateBasis: 'current', includeBackfilledTaxRatesInNetSales: false },
+        'user-1'
+      );
+
+      expect(repository.upsertSettings).toHaveBeenCalledWith(
+        { displayCurrency: 'PLN', rateBasis: 'current', includeBackfilledTaxRatesInNetSales: false },
+        'user-1'
+      );
+    });
+
+    it('passes a null actor for a system-driven write', async () => {
+      repository.upsertSettings.mockResolvedValue(
+        new AnalyticsDisplaySettings(null, 'current', false, new Date(), null)
+      );
+
+      await service.updateSettings({
+        displayCurrency: null,
+        rateBasis: 'current',
+        includeBackfilledTaxRatesInNetSales: false,
+      });
+
+      expect(repository.upsertSettings).toHaveBeenCalledWith(
+        { displayCurrency: null, rateBasis: 'current', includeBackfilledTaxRatesInNetSales: false },
+        null
+      );
+    });
+  });
+});

--- a/libs/core/src/analytics/application/services/analytics-display-settings.service.ts
+++ b/libs/core/src/analytics/application/services/analytics-display-settings.service.ts
@@ -1,0 +1,70 @@
+/**
+ * Analytics Display Settings Service
+ *
+ * Implements `IAnalyticsDisplaySettingsService`. All three fields
+ * (`displayCurrency`, `rateBasis`, `includeBackfilledTaxRatesInNetSales`)
+ * live on the singleton `analytics_display_settings` table — there is no
+ * env-var fallback rung, unlike `PosthogSettingsService` /
+ * `ReportingCurrencySettingsService`: these are pure operator preferences
+ * with no pre-existing env-configured deployment to stay compatible with.
+ *
+ * Read-through model: `getSettings()` hits the repository on every call —
+ * no in-process cache, mirroring the other singleton-settings services in
+ * this repo (a cache would need an invalidator port pointing back at
+ * whichever module writes it, for a read that is already a
+ * primary-key lookup).
+ *
+ * @module libs/core/src/analytics/application/services
+ * @implements {IAnalyticsDisplaySettingsService}
+ */
+import { Inject, Injectable } from '@nestjs/common';
+import { Logger } from '@openlinker/shared/logging';
+import { ANALYTICS_DISPLAY_SETTINGS_REPOSITORY_TOKEN } from '../../analytics.tokens';
+import { AnalyticsDisplaySettingsRepositoryPort } from '../../domain/ports/analytics-display-settings-repository.port';
+import type {
+  AnalyticsDisplaySettingsInput,
+  AnalyticsDisplaySettingsView,
+} from '../../domain/types/analytics-display-settings.types';
+import type { IAnalyticsDisplaySettingsService } from './analytics-display-settings.service.interface';
+
+@Injectable()
+export class AnalyticsDisplaySettingsService implements IAnalyticsDisplaySettingsService {
+  private readonly logger = new Logger(AnalyticsDisplaySettingsService.name);
+
+  constructor(
+    @Inject(ANALYTICS_DISPLAY_SETTINGS_REPOSITORY_TOKEN)
+    private readonly repository: AnalyticsDisplaySettingsRepositoryPort
+  ) {}
+
+  async getSettings(): Promise<AnalyticsDisplaySettingsView> {
+    const row = await this.repository.findSettings();
+
+    if (!row) {
+      return {
+        displayCurrency: null,
+        rateBasis: 'current',
+        includeBackfilledTaxRatesInNetSales: false,
+        updatedAt: null,
+        updatedByUserId: null,
+      };
+    }
+
+    return {
+      displayCurrency: row.displayCurrency,
+      rateBasis: row.rateBasis,
+      includeBackfilledTaxRatesInNetSales: row.includeBackfilledTaxRatesInNetSales,
+      updatedAt: row.updatedAt,
+      updatedByUserId: row.updatedByUserId,
+    };
+  }
+
+  async updateSettings(input: AnalyticsDisplaySettingsInput, actorUserId?: string): Promise<void> {
+    await this.repository.upsertSettings(input, actorUserId ?? null);
+    this.logger.log('analytics_display_settings.update', {
+      displayCurrency: input.displayCurrency,
+      rateBasis: input.rateBasis,
+      includeBackfilledTaxRatesInNetSales: input.includeBackfilledTaxRatesInNetSales,
+      actor: actorUserId ?? 'system',
+    });
+  }
+}

--- a/libs/core/src/analytics/domain/entities/analytics-display-settings.entity.ts
+++ b/libs/core/src/analytics/domain/entities/analytics-display-settings.entity.ts
@@ -1,0 +1,24 @@
+/**
+ * Analytics Display Settings Domain Entity
+ *
+ * Singleton-row representation of the DB-backed analytics display
+ * preferences (display currency override, rate-recomputation basis, and the
+ * backfilled-tax-rate Net Sales inclusion opt-in — #2461). Modeled on
+ * `PosthogSettings` (same context, same `id = 'singleton'` shape) and on the
+ * `ReportingCurrencySetting` / `AiProviderActiveSetting` precedents.
+ *
+ * @module libs/core/src/analytics/domain/entities
+ */
+import type { RateBasis } from '../types/analytics-display-settings.types';
+
+export const ANALYTICS_DISPLAY_SETTINGS_SINGLETON_ID = 'singleton';
+
+export class AnalyticsDisplaySettings {
+  constructor(
+    public readonly displayCurrency: string | null,
+    public readonly rateBasis: RateBasis,
+    public readonly includeBackfilledTaxRatesInNetSales: boolean,
+    public readonly updatedAt: Date,
+    public readonly updatedByUserId: string | null
+  ) {}
+}

--- a/libs/core/src/analytics/domain/ports/analytics-display-settings-repository.port.ts
+++ b/libs/core/src/analytics/domain/ports/analytics-display-settings-repository.port.ts
@@ -1,0 +1,29 @@
+/**
+ * Analytics Display Settings Repository Port
+ *
+ * Persistence contract for the singleton-row `analytics_display_settings`
+ * table. Implemented by `AnalyticsDisplaySettingsRepository` in the
+ * infrastructure layer; consumed by `AnalyticsDisplaySettingsService`.
+ * Mirrors `PosthogSettingsRepositoryPort` (same context).
+ *
+ * @module libs/core/src/analytics/domain/ports
+ */
+import type { AnalyticsDisplaySettings } from '../entities/analytics-display-settings.entity';
+import type { AnalyticsDisplaySettingsInput } from '../types/analytics-display-settings.types';
+
+export interface AnalyticsDisplaySettingsRepositoryPort {
+  /**
+   * Read the singleton row. Returns `null` when no row exists yet — callers
+   * are expected to fall back to the documented defaults.
+   */
+  findSettings(): Promise<AnalyticsDisplaySettings | null>;
+
+  /**
+   * Idempotently upsert the settings fields on the singleton row. Creates
+   * the row if absent.
+   */
+  upsertSettings(
+    input: AnalyticsDisplaySettingsInput,
+    updatedByUserId: string | null
+  ): Promise<AnalyticsDisplaySettings>;
+}

--- a/libs/core/src/analytics/domain/types/analytics-display-settings.types.ts
+++ b/libs/core/src/analytics/domain/types/analytics-display-settings.types.ts
@@ -1,0 +1,50 @@
+/**
+ * Analytics Display Settings Types
+ *
+ * Value types for the DB-backed analytics display preferences (#2461, epic
+ * #2452 Phase 3). These are read-time preferences layered on top of the
+ * order-level reporting-currency stamp (`@openlinker/core/currency`) — none
+ * of the three fields here is the reporting currency itself, and none is
+ * ever written back onto `order_records`.
+ *
+ * @module libs/core/src/analytics/domain/types
+ */
+
+/**
+ * How a multi-currency figure is recomputed for display.
+ *
+ * - `'current'` — recompute using today's exchange rate.
+ * - `'order-date'` — use the rate that applied when each order was placed
+ *   (the same rate the #2124 FX stamp already persisted).
+ */
+export const RateBasisValues = ['current', 'order-date'] as const;
+export type RateBasis = (typeof RateBasisValues)[number];
+
+/**
+ * Non-secret settings fields, as written by `PUT /analytics/settings` (#2462).
+ */
+export interface AnalyticsDisplaySettingsInput {
+  /**
+   * ISO-4217 display currency override, or `null` to use the system
+   * reporting currency (`IReportingCurrencySettingsService.resolve()`) as the
+   * display default — the mockup's `native` state.
+   */
+  displayCurrency: string | null;
+  rateBasis: RateBasis;
+  /**
+   * Org-wide opt-in: admit a `taxRateEra = 'pre-rollout'` order into Net
+   * Sales once `TaxRateBackfillService` has resolved a real rate for it (see
+   * ADR-063's amendment for #2456). Default `false` — behaviour is
+   * unchanged from the pre-#2456 exclusion until an operator opts in.
+   */
+  includeBackfilledTaxRatesInNetSales: boolean;
+}
+
+/**
+ * Read view returned by `GET /analytics/settings` (#2462).
+ */
+export interface AnalyticsDisplaySettingsView extends AnalyticsDisplaySettingsInput {
+  /** `null` when no operator has ever saved a row yet (the defaults above apply). */
+  updatedAt: Date | null;
+  updatedByUserId: string | null;
+}

--- a/libs/core/src/analytics/index.ts
+++ b/libs/core/src/analytics/index.ts
@@ -21,5 +21,17 @@ export type {
 } from './domain/types/posthog-settings.types';
 export { POSTHOG_API_KEY_CREDENTIALS_REF } from './domain/types/posthog-credentials.types';
 export type { IPosthogSettingsService } from './application/services/posthog-settings.service.interface';
+export {
+  AnalyticsDisplaySettings,
+  ANALYTICS_DISPLAY_SETTINGS_SINGLETON_ID,
+} from './domain/entities/analytics-display-settings.entity';
+export type { AnalyticsDisplaySettingsRepositoryPort } from './domain/ports/analytics-display-settings-repository.port';
+export { RateBasisValues } from './domain/types/analytics-display-settings.types';
+export type {
+  RateBasis,
+  AnalyticsDisplaySettingsInput,
+  AnalyticsDisplaySettingsView,
+} from './domain/types/analytics-display-settings.types';
+export type { IAnalyticsDisplaySettingsService } from './application/services/analytics-display-settings.service.interface';
 export { AnalyticsModule } from './analytics.module';
 export * from './analytics.tokens';

--- a/libs/core/src/analytics/infrastructure/persistence/entities/analytics-display-settings.orm-entity.ts
+++ b/libs/core/src/analytics/infrastructure/persistence/entities/analytics-display-settings.orm-entity.ts
@@ -1,0 +1,36 @@
+/**
+ * Analytics Display Settings ORM Entity
+ *
+ * TypeORM mapping for the `analytics_display_settings` singleton-row table.
+ * The `id` column is always `'singleton'` (literal); the row is upserted by
+ * `AnalyticsDisplaySettingsRepository.upsertSettings`. Column naming mirrors
+ * the sibling `posthog_settings` table in this same context.
+ *
+ * @module libs/core/src/analytics/infrastructure/persistence/entities
+ */
+import { Column, Entity, PrimaryColumn, UpdateDateColumn } from 'typeorm';
+
+@Entity('analytics_display_settings')
+export class AnalyticsDisplaySettingsOrmEntity {
+  @PrimaryColumn({ type: 'text', name: 'id' })
+  id!: string;
+
+  @Column({ type: 'varchar', length: 3, name: 'display_currency', nullable: true })
+  displayCurrency!: string | null;
+
+  @Column({ type: 'text', name: 'rate_basis', default: 'current' })
+  rateBasis!: string;
+
+  @Column({
+    type: 'boolean',
+    name: 'include_backfilled_tax_rates_in_net_sales',
+    default: false,
+  })
+  includeBackfilledTaxRatesInNetSales!: boolean;
+
+  @UpdateDateColumn({ type: 'timestamptz', name: 'updated_at' })
+  updatedAt!: Date;
+
+  @Column({ type: 'text', name: 'updated_by_user_id', nullable: true })
+  updatedByUserId!: string | null;
+}

--- a/libs/core/src/analytics/infrastructure/persistence/repositories/analytics-display-settings.repository.spec.ts
+++ b/libs/core/src/analytics/infrastructure/persistence/repositories/analytics-display-settings.repository.spec.ts
@@ -1,0 +1,132 @@
+/**
+ * Analytics Display Settings Repository Tests
+ *
+ * @module libs/core/src/analytics/infrastructure/persistence/repositories
+ */
+import type { Repository } from 'typeorm';
+import { ANALYTICS_DISPLAY_SETTINGS_SINGLETON_ID } from '../../../domain/entities/analytics-display-settings.entity';
+import type { AnalyticsDisplaySettingsOrmEntity } from '../entities/analytics-display-settings.orm-entity';
+import { AnalyticsDisplaySettingsRepository } from './analytics-display-settings.repository';
+
+function ormRow(
+  overrides: Partial<AnalyticsDisplaySettingsOrmEntity> = {}
+): AnalyticsDisplaySettingsOrmEntity {
+  return {
+    id: ANALYTICS_DISPLAY_SETTINGS_SINGLETON_ID,
+    displayCurrency: 'PLN',
+    rateBasis: 'current',
+    includeBackfilledTaxRatesInNetSales: false,
+    updatedAt: new Date('2026-08-14T06:00:00Z'),
+    updatedByUserId: 'user-1',
+    ...overrides,
+  } as AnalyticsDisplaySettingsOrmEntity;
+}
+
+describe('AnalyticsDisplaySettingsRepository', () => {
+  let ormRepository: jest.Mocked<Repository<AnalyticsDisplaySettingsOrmEntity>>;
+  let repository: AnalyticsDisplaySettingsRepository;
+
+  beforeEach(() => {
+    ormRepository = {
+      findOne: jest.fn(),
+      findOneOrFail: jest.fn(),
+      upsert: jest.fn(),
+    } as unknown as jest.Mocked<Repository<AnalyticsDisplaySettingsOrmEntity>>;
+    repository = new AnalyticsDisplaySettingsRepository(ormRepository);
+  });
+
+  describe('findSettings', () => {
+    it('should read the fixed singleton id', async () => {
+      ormRepository.findOne.mockResolvedValue(ormRow());
+
+      await repository.findSettings();
+
+      expect(ormRepository.findOne).toHaveBeenCalledWith({
+        where: { id: ANALYTICS_DISPLAY_SETTINGS_SINGLETON_ID },
+      });
+    });
+
+    it('should return null when no operator has ever saved a row', async () => {
+      ormRepository.findOne.mockResolvedValue(null);
+
+      await expect(repository.findSettings()).resolves.toBeNull();
+    });
+
+    it('should map the row onto the domain entity', async () => {
+      ormRepository.findOne.mockResolvedValue(ormRow());
+
+      const settings = await repository.findSettings();
+
+      expect(settings).toEqual({
+        displayCurrency: 'PLN',
+        rateBasis: 'current',
+        includeBackfilledTaxRatesInNetSales: false,
+        updatedAt: new Date('2026-08-14T06:00:00Z'),
+        updatedByUserId: 'user-1',
+      });
+    });
+
+    it('should map a null displayCurrency (use reporting currency)', async () => {
+      ormRepository.findOne.mockResolvedValue(ormRow({ displayCurrency: null }));
+
+      const settings = await repository.findSettings();
+
+      expect(settings?.displayCurrency).toBeNull();
+    });
+
+    it('should throw on an unrecognised rate_basis value rather than coerce silently', async () => {
+      ormRepository.findOne.mockResolvedValue(
+        ormRow({ rateBasis: 'not-a-real-basis' })
+      );
+
+      await expect(repository.findSettings()).rejects.toThrow(
+        "analytics_display_settings.rate_basis has an unknown value 'not-a-real-basis'"
+      );
+    });
+  });
+
+  describe('upsertSettings', () => {
+    it('should upsert on the id conflict path and re-read the row', async () => {
+      ormRepository.findOneOrFail.mockResolvedValue(
+        ormRow({ displayCurrency: 'EUR', rateBasis: 'order-date' })
+      );
+
+      const saved = await repository.upsertSettings(
+        {
+          displayCurrency: 'EUR',
+          rateBasis: 'order-date',
+          includeBackfilledTaxRatesInNetSales: true,
+        },
+        'user-2'
+      );
+
+      expect(ormRepository.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: ANALYTICS_DISPLAY_SETTINGS_SINGLETON_ID,
+          displayCurrency: 'EUR',
+          rateBasis: 'order-date',
+          includeBackfilledTaxRatesInNetSales: true,
+          updatedByUserId: 'user-2',
+        }),
+        { conflictPaths: ['id'] }
+      );
+      expect(saved.displayCurrency).toBe('EUR');
+      expect(saved.rateBasis).toBe('order-date');
+    });
+
+    it('should accept a null actor for a system-driven write', async () => {
+      ormRepository.findOneOrFail.mockResolvedValue(ormRow({ updatedByUserId: null }));
+
+      const saved = await repository.upsertSettings(
+        {
+          displayCurrency: null,
+          rateBasis: 'current',
+          includeBackfilledTaxRatesInNetSales: false,
+        },
+        null
+      );
+
+      expect(saved.updatedByUserId).toBeNull();
+    });
+  });
+});

--- a/libs/core/src/analytics/infrastructure/persistence/repositories/analytics-display-settings.repository.ts
+++ b/libs/core/src/analytics/infrastructure/persistence/repositories/analytics-display-settings.repository.ts
@@ -1,0 +1,88 @@
+/**
+ * Analytics Display Settings Repository
+ *
+ * TypeORM-backed implementation of `AnalyticsDisplaySettingsRepositoryPort`.
+ * Operates on a single fixed-id row (`id = 'singleton'`); `upsertSettings`
+ * uses an `ON CONFLICT (id) DO UPDATE` to keep both the create and update
+ * paths atomic without a separate `findOne` round-trip. ORM ↔ domain mapping
+ * is private to this class. Mirrors `PosthogSettingsRepository` (same
+ * context).
+ *
+ * @module libs/core/src/analytics/infrastructure/persistence/repositories
+ */
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import {
+  ANALYTICS_DISPLAY_SETTINGS_SINGLETON_ID,
+  AnalyticsDisplaySettings,
+} from '../../../domain/entities/analytics-display-settings.entity';
+import type { AnalyticsDisplaySettingsRepositoryPort } from '../../../domain/ports/analytics-display-settings-repository.port';
+import {
+  RateBasisValues,
+  type AnalyticsDisplaySettingsInput,
+  type RateBasis,
+} from '../../../domain/types/analytics-display-settings.types';
+import { AnalyticsDisplaySettingsOrmEntity } from '../entities/analytics-display-settings.orm-entity';
+
+const isRateBasis = (value: string): value is RateBasis =>
+  (RateBasisValues as readonly string[]).includes(value);
+
+@Injectable()
+export class AnalyticsDisplaySettingsRepository implements AnalyticsDisplaySettingsRepositoryPort {
+  constructor(
+    @InjectRepository(AnalyticsDisplaySettingsOrmEntity)
+    private readonly ormRepository: Repository<AnalyticsDisplaySettingsOrmEntity>
+  ) {}
+
+  async findSettings(): Promise<AnalyticsDisplaySettings | null> {
+    const row = await this.ormRepository.findOne({
+      where: { id: ANALYTICS_DISPLAY_SETTINGS_SINGLETON_ID },
+    });
+    return row ? this.toDomain(row) : null;
+  }
+
+  async upsertSettings(
+    input: AnalyticsDisplaySettingsInput,
+    updatedByUserId: string | null
+  ): Promise<AnalyticsDisplaySettings> {
+    await this.ormRepository.upsert(
+      {
+        id: ANALYTICS_DISPLAY_SETTINGS_SINGLETON_ID,
+        displayCurrency: input.displayCurrency,
+        rateBasis: input.rateBasis,
+        includeBackfilledTaxRatesInNetSales: input.includeBackfilledTaxRatesInNetSales,
+        updatedByUserId,
+        // TypeORM's upsert() only includes explicitly-passed columns in the
+        // ON CONFLICT DO UPDATE SET clause — @UpdateDateColumn()'s auto-touch
+        // behavior applies only to .save(), so updatedAt must be set here
+        // explicitly or every update after the initial insert would leave it
+        // frozen at its creation value (same fix as `PosthogSettingsRepository`).
+        updatedAt: new Date(),
+      },
+      { conflictPaths: ['id'] }
+    );
+    const saved = await this.ormRepository.findOneOrFail({
+      where: { id: ANALYTICS_DISPLAY_SETTINGS_SINGLETON_ID },
+    });
+    return this.toDomain(saved);
+  }
+
+  private toDomain(entity: AnalyticsDisplaySettingsOrmEntity): AnalyticsDisplaySettings {
+    if (!isRateBasis(entity.rateBasis)) {
+      // Defensive: a row with an unknown rate basis should not exist (the
+      // service-layer write path validates via the DTO), but if a manual DB
+      // edit or a value drift from a future code change leaves the row in a
+      // state we can't represent, surface it loudly rather than coerce
+      // silently — same posture as `PosthogSettingsRepository.toDomain`.
+      throw new Error(`analytics_display_settings.rate_basis has an unknown value '${entity.rateBasis}'`);
+    }
+    return new AnalyticsDisplaySettings(
+      entity.displayCurrency,
+      entity.rateBasis,
+      entity.includeBackfilledTaxRatesInNetSales,
+      entity.updatedAt,
+      entity.updatedByUserId
+    );
+  }
+}


### PR DESCRIPTION
Implements Phase 3 of epic #2452 — backend persistence for Analytics Settings (display currency, rate basis, tax-inclusion opt-in).

Tasks (sequential — no per-task branches, both commit directly onto this phase branch):

- [x] #2461
- [x] #2462

Closes #2461
Closes #2462

Part of #2460, #2452

---

**Design decision for #2461** (`orders` vs. dedicated context, per the task's own open question): reused the existing `libs/core/src/analytics` context, alongside the sibling `PosthogSettings` singleton row, rather than `orders` (order lifecycle/ingestion is not a dashboard-preference concern), `currency` (a documented zero-outbound-edge leaf context — bolting a generic settings row on would blur that), or a brand-new context (would duplicate module/tokens/barrel scaffolding for no benefit when `analytics` already exists for exactly this kind of operator setting and already carries a byte-identical structural precedent). Full reasoning in commit `c8757a6f3`.

**#2462**: `GET /analytics/settings` (open to any authenticated user) / `PUT /analytics/settings` (`@Roles('admin')`). Response distinguishes `displayCurrencySource: 'setting' | 'default'`, mirroring `ReportingCurrencySettingsView.source` (minus the `'env'` rung — these fields have no env fallback). Reuses the existing `SUPPORTED_REPORTING_CURRENCIES` closed set from `@openlinker/core/currency` (ADR-040) for `displayCurrency` validation rather than forking a new validator. Includes a unit test asserting the settings write path never calls any mutating `OrderRecordRepositoryPort` method. Commit `ca4d64e4c`.
