### PR TITLE
Phase 4: Backend — data-coverage detection (epic #2452)

### DIFF
--- a/apps/api/src/analytics/analytics.module.ts
+++ b/apps/api/src/analytics/analytics.module.ts
@@ -28,6 +28,13 @@
  *    row (#2461). `GET` composes the row with the system reporting currency
  *    from `@openlinker/core/currency`, which is why `CurrencyModule` is
  *    imported here alongside `CoreAnalyticsModule`.
+ * 6. **`/analytics/coverage`** (`AnalyticsCoverageController`, #2466) — the
+ *    Data Coverage panel aggregate: one row per category (currency, tax
+ *    A/B/C, product-matching), elevating #2464/#2465's detectors plus the
+ *    new product-matching-error detector. Single-context read (`orders`),
+ *    same reasoning as `SalesAnalyticsController` — no new composition
+ *    service. Reuses `CurrencyModule` (already imported above) for its one
+ *    cross-context dependency, `IReportingCurrencySettingsService`.
  *
  * The concerns share nothing except the URL prefix. If a future
  * `/analytics` route (#1986 route shell, KPI strip, etc.) needs its own
@@ -57,6 +64,7 @@ import { NeedsAttentionController } from './http/needs-attention.controller';
 import { SalesAnalyticsController } from './http/sales-analytics.controller';
 import { TopProductsController } from './http/top-products.controller';
 import { AnalyticsSettingsController } from './http/analytics-settings.controller';
+import { AnalyticsCoverageController } from './http/analytics-coverage.controller';
 import { NeedsAttentionService } from './application/services/needs-attention.service';
 import { NEEDS_ATTENTION_SERVICE_TOKEN } from './application/services/needs-attention.service.interface';
 import { TopProductsService } from './application/services/top-products.service';
@@ -77,6 +85,7 @@ import { TOP_PRODUCTS_SERVICE_TOKEN } from './application/services/top-products.
     SalesAnalyticsController,
     TopProductsController,
     AnalyticsSettingsController,
+    AnalyticsCoverageController,
   ],
   providers: [
     NeedsAttentionService,

--- a/apps/api/src/analytics/http/analytics-coverage.controller.spec.ts
+++ b/apps/api/src/analytics/http/analytics-coverage.controller.spec.ts
@@ -1,0 +1,204 @@
+/**
+ * Analytics Coverage Controller — Unit Tests (#2466)
+ *
+ * @module apps/api/src/analytics/http
+ */
+import { BadRequestException } from '@nestjs/common';
+import type {
+  IOrderRecordService,
+  ITaxCoverageDetectionService,
+  PaginatedCurrencyMismatchOrders,
+  PaginatedProductMatchingErrorOrders,
+  PaginatedTaxCoverageOrders,
+  TaxCoverageCategory,
+} from '@openlinker/core/orders';
+import type { IReportingCurrencySettingsService } from '@openlinker/core/currency';
+import { AnalyticsCoverageController } from './analytics-coverage.controller';
+import type { AnalyticsCoverageQueryDto } from './dto/analytics-coverage-query.dto';
+
+describe('AnalyticsCoverageController (#2466)', () => {
+  const createOrderRecordService = (): jest.Mocked<
+    Pick<IOrderRecordService, 'getCurrencyMismatchOrders' | 'getProductMatchingErrorOrders'>
+  > => ({
+    getCurrencyMismatchOrders: jest.fn(),
+    getProductMatchingErrorOrders: jest.fn(),
+  });
+
+  const createTaxCoverageDetectionService = (): jest.Mocked<
+    Pick<ITaxCoverageDetectionService, 'getAllCategoryPages'>
+  > => ({
+    getAllCategoryPages: jest.fn(),
+  });
+
+  const createReportingCurrencySettings = (): jest.Mocked<
+    Pick<IReportingCurrencySettingsService, 'resolve'>
+  > => ({
+    resolve: jest.fn(),
+  });
+
+  const emptyPage = { items: [], total: 0 };
+
+  const emptyTaxPages = (): Record<TaxCoverageCategory, PaginatedTaxCoverageOrders> => ({
+    'tax-a': { items: [], total: 0 },
+    'tax-b': { items: [], total: 0 },
+    'tax-c': { items: [], total: 0 },
+  });
+
+  function buildController(
+    orderRecordService = createOrderRecordService(),
+    taxCoverageDetectionService = createTaxCoverageDetectionService(),
+    reportingCurrencySettings = createReportingCurrencySettings()
+  ): {
+    controller: AnalyticsCoverageController;
+    orderRecordService: ReturnType<typeof createOrderRecordService>;
+    taxCoverageDetectionService: ReturnType<typeof createTaxCoverageDetectionService>;
+    reportingCurrencySettings: ReturnType<typeof createReportingCurrencySettings>;
+  } {
+    const controller = new AnalyticsCoverageController(
+      orderRecordService as unknown as IOrderRecordService,
+      taxCoverageDetectionService as unknown as ITaxCoverageDetectionService,
+      reportingCurrencySettings as unknown as IReportingCurrencySettingsService
+    );
+    return {
+      controller,
+      orderRecordService,
+      taxCoverageDetectionService,
+      reportingCurrencySettings,
+    };
+  }
+
+  const query: AnalyticsCoverageQueryDto = {
+    from: '2026-08-01T00:00:00.000Z',
+    to: '2026-08-08T00:00:00.000Z',
+  };
+
+  it('reports all-clear (every category affectedCount: 0) when every detector is empty', async () => {
+    const { controller, orderRecordService, taxCoverageDetectionService, reportingCurrencySettings } =
+      buildController();
+    reportingCurrencySettings.resolve.mockResolvedValue('EUR');
+    orderRecordService.getCurrencyMismatchOrders.mockResolvedValue(
+      emptyPage as PaginatedCurrencyMismatchOrders
+    );
+    orderRecordService.getProductMatchingErrorOrders.mockResolvedValue(
+      emptyPage as PaginatedProductMatchingErrorOrders
+    );
+    taxCoverageDetectionService.getAllCategoryPages.mockResolvedValue(emptyTaxPages());
+
+    const result = await controller.getCoverage(query);
+
+    expect(result.categories).toHaveLength(5);
+    expect(result.categories.map((c) => c.category).sort()).toEqual(
+      ['currency', 'product-matching', 'tax-a', 'tax-b', 'tax-c'].sort()
+    );
+    for (const row of result.categories) {
+      expect(row.affectedCount).toBe(0);
+      expect(row.sampleOrderIds).toEqual([]);
+      expect(row.status).toBe('open');
+    }
+  });
+
+  it('resolves the current reporting currency ONCE and threads it into both currency and tax reads', async () => {
+    const { controller, orderRecordService, taxCoverageDetectionService, reportingCurrencySettings } =
+      buildController();
+    reportingCurrencySettings.resolve.mockResolvedValue('PLN');
+    orderRecordService.getCurrencyMismatchOrders.mockResolvedValue(
+      emptyPage as PaginatedCurrencyMismatchOrders
+    );
+    orderRecordService.getProductMatchingErrorOrders.mockResolvedValue(
+      emptyPage as PaginatedProductMatchingErrorOrders
+    );
+    taxCoverageDetectionService.getAllCategoryPages.mockResolvedValue(emptyTaxPages());
+
+    await controller.getCoverage(query);
+
+    expect(reportingCurrencySettings.resolve).toHaveBeenCalledTimes(1);
+    expect(orderRecordService.getCurrencyMismatchOrders).toHaveBeenCalledWith(
+      expect.anything(),
+      'PLN',
+      expect.anything()
+    );
+    expect(taxCoverageDetectionService.getAllCategoryPages).toHaveBeenCalledWith(
+      expect.anything(),
+      'PLN',
+      expect.anything()
+    );
+  });
+
+  it('maps affectedCount + sampleOrderIds from each detector, including all three tax sub-categories', async () => {
+    const { controller, orderRecordService, taxCoverageDetectionService, reportingCurrencySettings } =
+      buildController();
+    reportingCurrencySettings.resolve.mockResolvedValue('EUR');
+    orderRecordService.getCurrencyMismatchOrders.mockResolvedValue({
+      items: [
+        {
+          internalOrderId: 'order-currency-1',
+          sourceConnectionId: 'conn-a',
+          nativeCurrency: 'PLN',
+          stampedCurrency: null,
+          stampedAt: null,
+        },
+      ],
+      total: 4,
+    });
+    orderRecordService.getProductMatchingErrorOrders.mockResolvedValue({
+      items: [
+        {
+          internalOrderId: 'order-mapping-1',
+          sourceConnectionId: 'conn-a',
+          recordStatus: 'awaiting_mapping',
+          mappingFailureReason: 'no variant mapping',
+          createdAt: new Date('2026-08-02T00:00:00Z'),
+        },
+      ],
+      total: 7,
+    });
+    taxCoverageDetectionService.getAllCategoryPages.mockResolvedValue({
+      'tax-a': {
+        items: [{ internalOrderId: 'order-tax-a-1', sourceConnectionId: 'conn-a', placedAt: null }],
+        total: 1,
+      },
+      'tax-b': { items: [], total: 0 },
+      'tax-c': {
+        items: [{ internalOrderId: 'order-tax-c-1', sourceConnectionId: 'conn-a', placedAt: null }],
+        total: 2,
+      },
+    });
+
+    const result = await controller.getCoverage(query);
+
+    const byCategory = new Map(result.categories.map((row) => [row.category, row]));
+    expect(byCategory.get('currency')).toMatchObject({
+      affectedCount: 4,
+      sampleOrderIds: ['order-currency-1'],
+    });
+    expect(byCategory.get('product-matching')).toMatchObject({
+      affectedCount: 7,
+      sampleOrderIds: ['order-mapping-1'],
+    });
+    expect(byCategory.get('tax-a')).toMatchObject({
+      affectedCount: 1,
+      sampleOrderIds: ['order-tax-a-1'],
+    });
+    expect(byCategory.get('tax-b')).toMatchObject({ affectedCount: 0, sampleOrderIds: [] });
+    expect(byCategory.get('tax-c')).toMatchObject({
+      affectedCount: 2,
+      sampleOrderIds: ['order-tax-c-1'],
+    });
+  });
+
+  it('throws BadRequestException when to is not after from', async () => {
+    const { controller } = buildController();
+
+    await expect(
+      controller.getCoverage({ from: '2026-08-08T00:00:00.000Z', to: '2026-08-01T00:00:00.000Z' })
+    ).rejects.toThrow(BadRequestException);
+  });
+
+  it('throws BadRequestException when the range exceeds the max window', async () => {
+    const { controller } = buildController();
+
+    await expect(
+      controller.getCoverage({ from: '2020-01-01T00:00:00.000Z', to: '2026-08-08T00:00:00.000Z' })
+    ).rejects.toThrow(BadRequestException);
+  });
+});

--- a/apps/api/src/analytics/http/analytics-coverage.controller.ts
+++ b/apps/api/src/analytics/http/analytics-coverage.controller.ts
@@ -1,0 +1,133 @@
+/**
+ * Analytics Coverage Controller
+ *
+ * HTTP surface for the `/analytics` Data Coverage panel (#2466, epic #2452
+ * mini-epic #2463): `GET /analytics/coverage` elevates the currency
+ * mismatch drill-down (#2464), the tax A/B/C split (#2465), and the new
+ * product-matching-error detector into one response, one row per category.
+ *
+ * Single-context read — every detector lives in `orders` — so this injects
+ * `IOrderRecordService` + `ITaxCoverageDetectionService` directly, mirroring
+ * `SalesAnalyticsController`'s own reasoning (see its header) rather than
+ * introducing an apps/api-layer composition service. The one cross-context
+ * dependency, `IReportingCurrencySettingsService` (`@openlinker/core/currency`,
+ * a leaf context), is resolved ONCE per request and threaded into both the
+ * currency and tax reads so they can never straddle a setting change
+ * mid-request — the same reasoning `OrderRecordService.
+ * getSalesAndChannelAnalytics` documents for its own single resolve.
+ *
+ * @module apps/api/src/analytics/http
+ */
+import { BadRequestException, Controller, Get, Inject, Query } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import {
+  ORDER_RECORD_SERVICE_TOKEN,
+  TAX_COVERAGE_DETECTION_SERVICE_TOKEN,
+  TaxCoverageCategoryValues,
+  type IOrderRecordService,
+  type ITaxCoverageDetectionService,
+} from '@openlinker/core/orders';
+import {
+  REPORTING_CURRENCY_SETTINGS_SERVICE_TOKEN,
+  type IReportingCurrencySettingsService,
+} from '@openlinker/core/currency';
+import { AnalyticsCoverageQueryDto } from './dto/analytics-coverage-query.dto';
+import {
+  AnalyticsCoverageResponseDto,
+  CoverageCategoryRowDto,
+} from './dto/analytics-coverage-response.dto';
+
+/**
+ * Sample size for `sampleOrderIds` — deliberately small. This endpoint's job
+ * is to answer "is anything open, and roughly how much", not to serve a
+ * paginated drill-down list — a future dedicated per-category endpoint is
+ * the place for that, per the currency/tax detectors' own paginated reads.
+ */
+const COVERAGE_SAMPLE_SIZE = 10;
+
+/** Mirrors `SalesAnalyticsController`'s own bound — see that controller for the rationale. */
+const MAX_COVERAGE_RANGE_DAYS = 400;
+
+@ApiBearerAuth()
+@ApiTags('analytics')
+@Controller('analytics')
+export class AnalyticsCoverageController {
+  constructor(
+    @Inject(ORDER_RECORD_SERVICE_TOKEN)
+    private readonly orderRecordService: IOrderRecordService,
+    @Inject(TAX_COVERAGE_DETECTION_SERVICE_TOKEN)
+    private readonly taxCoverageDetectionService: ITaxCoverageDetectionService,
+    @Inject(REPORTING_CURRENCY_SETTINGS_SERVICE_TOKEN)
+    private readonly reportingCurrencySettings: IReportingCurrencySettingsService
+  ) {}
+
+  @Get('coverage')
+  @ApiOperation({
+    summary:
+      'Data Coverage panel aggregate — one row per category (currency, tax A/B/C, product-matching)',
+  })
+  @ApiResponse({ status: 200, type: AnalyticsCoverageResponseDto })
+  async getCoverage(
+    @Query() query: AnalyticsCoverageQueryDto
+  ): Promise<AnalyticsCoverageResponseDto> {
+    const from = new Date(query.from);
+    const to = new Date(query.to);
+    if (to.getTime() <= from.getTime()) {
+      throw new BadRequestException('to must be after from');
+    }
+    const rangeDays = (to.getTime() - from.getTime()) / (24 * 60 * 60 * 1000);
+    if (rangeDays > MAX_COVERAGE_RANGE_DAYS) {
+      throw new BadRequestException(
+        `Range too wide: ${Math.ceil(rangeDays)} days exceeds the ${MAX_COVERAGE_RANGE_DAYS}-day limit`
+      );
+    }
+
+    const salesFilters = { from, to, sourceConnectionId: query.sourceConnectionId };
+    const healthFilters = {
+      createdFrom: from,
+      createdTo: to,
+      sourceConnectionId: query.sourceConnectionId,
+    };
+    const pagination = { limit: COVERAGE_SAMPLE_SIZE, offset: 0 };
+
+    const currentReportingCurrency = await this.reportingCurrencySettings.resolve();
+
+    const [currencyPage, taxPages, productMatchingPage] = await Promise.all([
+      this.orderRecordService.getCurrencyMismatchOrders(
+        salesFilters,
+        currentReportingCurrency,
+        pagination
+      ),
+      this.taxCoverageDetectionService.getAllCategoryPages(
+        salesFilters,
+        currentReportingCurrency,
+        pagination
+      ),
+      this.orderRecordService.getProductMatchingErrorOrders(healthFilters, pagination),
+    ]);
+
+    const categories: CoverageCategoryRowDto[] = [
+      CoverageCategoryRowDto.of(
+        'currency',
+        currencyPage.total,
+        currencyPage.items.map((item) => item.internalOrderId)
+      ),
+      ...TaxCoverageCategoryValues.map((category) =>
+        CoverageCategoryRowDto.of(
+          category,
+          taxPages[category].total,
+          taxPages[category].items.map((item) => item.internalOrderId)
+        )
+      ),
+      CoverageCategoryRowDto.of(
+        'product-matching',
+        productMatchingPage.total,
+        productMatchingPage.items.map((item) => item.internalOrderId)
+      ),
+    ];
+
+    const response = new AnalyticsCoverageResponseDto();
+    response.categories = categories;
+    return response;
+  }
+}

--- a/apps/api/src/analytics/http/dto/analytics-coverage-query.dto.ts
+++ b/apps/api/src/analytics/http/dto/analytics-coverage-query.dto.ts
@@ -1,0 +1,45 @@
+/**
+ * Analytics Coverage Query DTO
+ *
+ * Query parameters for `GET /analytics/coverage` (#2466). `from`/`to` are
+ * required, mirroring `SalesAnalyticsQueryDto` — a coverage query without a
+ * range is not meaningful, since every detector (currency, tax A/B/C,
+ * product-matching) is scoped to a date window.
+ *
+ * The window means two different things per category, and that split is
+ * deliberate rather than an oversight: the currency and tax detectors
+ * bucket by `placedAt` (mirroring `SalesAnalyticsFilters`, since they read
+ * the SAME `netExcludedCount`/`unconvertedCount` population
+ * `getDailyOrderAggregates` computes), while the product-matching detector
+ * buckets by `createdAt` (mirroring `OrderHealthSummaryFilters`) — an
+ * `awaiting_mapping`/`source_deleted` order has no resolved `placedAt` yet
+ * (#1985 populates it only for `recordStatus = 'ready'` records), so a
+ * `placedAt` filter would silently exclude every product-matching row.
+ *
+ * @module apps/api/src/analytics/http/dto
+ */
+import { IsDateString, IsNotEmpty, IsOptional, IsUUID } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class AnalyticsCoverageQueryDto {
+  @ApiProperty({
+    description:
+      'Range start, inclusive (ISO 8601). Bucketed by placedAt (currency/tax) or createdAt (product-matching).',
+  })
+  @IsNotEmpty()
+  @IsDateString()
+  from!: string;
+
+  @ApiProperty({
+    description:
+      'Range end, exclusive (ISO 8601). Bucketed by placedAt (currency/tax) or createdAt (product-matching) — see class doc.',
+  })
+  @IsNotEmpty()
+  @IsDateString()
+  to!: string;
+
+  @ApiPropertyOptional({ description: 'Narrow to a single source connection (UUID)' })
+  @IsOptional()
+  @IsUUID()
+  sourceConnectionId?: string;
+}

--- a/apps/api/src/analytics/http/dto/analytics-coverage-response.dto.ts
+++ b/apps/api/src/analytics/http/dto/analytics-coverage-response.dto.ts
@@ -1,0 +1,59 @@
+/**
+ * Analytics Coverage Response DTO
+ *
+ * Response body for `GET /analytics/coverage` (#2466, epic #2452 mini-epic
+ * #2463) — one row per Data Coverage category, elevating the currency
+ * (#2464) and tax A/B/C (#2465) exclusion counts plus the new
+ * product-matching-error detector into the mockup's `all-clear` /
+ * `detail-*` states.
+ *
+ * `status` is hardcoded `'open'` for every row today — a later phase of
+ * this epic is the only intended writer of `'in-progress'` /
+ * `'resolved'` / `'failed'`, and only for the `'currency'` category (per
+ * the Phase 1 decision doc's scoping note). This DTO does not invent a
+ * status this build cannot produce.
+ *
+ * @module apps/api/src/analytics/http/dto
+ */
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  CoverageCategoryValues,
+  CoverageResolutionStatusValues,
+  type CoverageCategory,
+  type CoverageResolutionStatus,
+} from '@openlinker/core/orders';
+
+export class CoverageCategoryRowDto {
+  @ApiProperty({ enum: CoverageCategoryValues })
+  category!: CoverageCategory;
+
+  @ApiProperty({ enum: CoverageResolutionStatusValues })
+  status!: CoverageResolutionStatus;
+
+  @ApiProperty({ description: 'Total orders in this category for the requested range.' })
+  affectedCount!: number;
+
+  @ApiProperty({
+    description: 'A small sample of affected internal order ids, newest-first.',
+    type: [String],
+  })
+  sampleOrderIds!: string[];
+
+  static of(
+    category: CoverageCategory,
+    affectedCount: number,
+    sampleOrderIds: string[]
+  ): CoverageCategoryRowDto {
+    const dto = new CoverageCategoryRowDto();
+    dto.category = category;
+    dto.status = 'open';
+    dto.affectedCount = affectedCount;
+    dto.sampleOrderIds = sampleOrderIds;
+    return dto;
+  }
+}
+
+export class AnalyticsCoverageResponseDto {
+  @ApiProperty({ type: [CoverageCategoryRowDto] })
+  categories!: CoverageCategoryRowDto[];
+}

--- a/apps/api/src/orders/http/orders.controller.spec.ts
+++ b/apps/api/src/orders/http/orders.controller.spec.ts
@@ -87,6 +87,7 @@ describe('OrdersController', () => {
       patchSnapshotTaxRates: jest.fn(),
       getNetMedianOrderValue: jest.fn(),
       findCurrencyMismatchOrders: jest.fn(),
+      findNetExcludedOrderCandidates: jest.fn(),
     };
 
     const mockRetryService: jest.Mocked<IOrderDestinationRetryService> = {

--- a/apps/api/src/orders/http/orders.controller.spec.ts
+++ b/apps/api/src/orders/http/orders.controller.spec.ts
@@ -88,6 +88,7 @@ describe('OrdersController', () => {
       getNetMedianOrderValue: jest.fn(),
       findCurrencyMismatchOrders: jest.fn(),
       findNetExcludedOrderCandidates: jest.fn(),
+      findProductMatchingErrorOrders: jest.fn(),
     };
 
     const mockRetryService: jest.Mocked<IOrderDestinationRetryService> = {

--- a/apps/api/src/orders/http/orders.controller.spec.ts
+++ b/apps/api/src/orders/http/orders.controller.spec.ts
@@ -86,6 +86,7 @@ describe('OrdersController', () => {
       getMedianOrderValue: jest.fn(),
       patchSnapshotTaxRates: jest.fn(),
       getNetMedianOrderValue: jest.fn(),
+      findCurrencyMismatchOrders: jest.fn(),
     };
 
     const mockRetryService: jest.Mocked<IOrderDestinationRetryService> = {

--- a/apps/api/src/orders/http/refunds.controller.spec.ts
+++ b/apps/api/src/orders/http/refunds.controller.spec.ts
@@ -49,6 +49,8 @@ describe('RefundsController', () => {
       getFailedSyncValueSummary: jest.fn(),
       getSalesAndChannelAnalytics: jest.fn(),
       getTopProducts: jest.fn(),
+      getCurrencyMismatchOrders: jest.fn(),
+      getProductMatchingErrorOrders: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({

--- a/apps/api/src/shipping/http/shipment.controller.spec.ts
+++ b/apps/api/src/shipping/http/shipment.controller.spec.ts
@@ -134,6 +134,8 @@ describe('ShipmentController', () => {
       getEarliestOrderDateByConnection: jest.fn(),
       getSalesAndChannelAnalytics: jest.fn(),
       getTopProducts: jest.fn(),
+      getCurrencyMismatchOrders: jest.fn(),
+      getProductMatchingErrorOrders: jest.fn(),
     };
     controller = new ShipmentController(
       query,

--- a/apps/api/test/integration/orders/tax-coverage-net-excluded.int-spec.ts
+++ b/apps/api/test/integration/orders/tax-coverage-net-excluded.int-spec.ts
@@ -1,0 +1,191 @@
+/**
+ * Tax Coverage — Net-Excluded Candidates Int-Spec (#2465)
+ *
+ * Exercises `OrderRecordRepository.findNetExcludedOrderCandidates` against
+ * real Testcontainers Postgres. The unit specs mock the query builder, so
+ * the `netSalesOrderNetEligibleSql` `EXISTS`/`FILTER (WHERE ...)` SQL never
+ * actually runs against a server there — this proves two things no mocked
+ * spec can:
+ *
+ * 1. `candidates.length` is EXACTLY `getDailyOrderAggregates`'
+ *    `netExcludedCount` summed over the same filters/currency (the #2465
+ *    regression guard) — the two reads share the same predicate fragment
+ *    by construction, but only a real query proves they stay in sync.
+ * 2. A pre-rollout order with an unresolved line (no rate, catalogue never
+ *    checked) is correctly reported as a candidate carrying `taxRateEra:
+ *    'pre-rollout'` — the live-demo defect this detector exists to surface.
+ *
+ * @module apps/api/test/integration/orders
+ */
+import {
+  ORDER_RECORD_REPOSITORY_TOKEN,
+  type OrderRecordRepositoryPort,
+} from '@openlinker/core/orders';
+import { OrderLineItemOrmEntity } from '@openlinker/core/orders/orm-entities';
+import {
+  getTestHarness,
+  resetTestHarness,
+  teardownTestHarness,
+  type IntegrationTestHarness,
+} from '../setup';
+import { createTestOrderRecord } from '../fixtures/order.fixtures';
+
+describe('Tax coverage — net-excluded candidates against real Postgres (#2465)', () => {
+  let harness: IntegrationTestHarness;
+  let repository: OrderRecordRepositoryPort;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+    repository = harness.getApp().get<OrderRecordRepositoryPort>(ORDER_RECORD_REPOSITORY_TOKEN);
+  });
+
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  const filters = {
+    from: new Date('2026-08-01T00:00:00.000Z'),
+    to: new Date('2026-08-08T00:00:00.000Z'),
+  };
+
+  async function seedLineItem(overrides: Partial<OrderLineItemOrmEntity>): Promise<void> {
+    const repo = harness.getDataSource().getRepository(OrderLineItemOrmEntity);
+    await repo.save(
+      repo.create({
+        orderRecordId: 'ol_order_placeholder',
+        lineNumber: 0,
+        productId: 'ol_product_placeholder',
+        variantId: null,
+        quantity: 1,
+        unitPrice: 100,
+        sourceConnectionId: '11111111-1111-4111-8111-111111111111',
+        placedAt: new Date('2026-08-02T00:00:00.000Z'),
+        taxRate: null,
+        ...overrides,
+      })
+    );
+  }
+
+  it(
+    'reports the SAME count as getDailyOrderAggregates.netExcludedCount for a mix of eligible, ' +
+      'pre-rollout, and unresolved-rate orders (regression guard)',
+    async () => {
+      const dataSource = harness.getDataSource();
+
+      // Net-eligible: exclusive pricing, no rate needed.
+      const eligible = await createTestOrderRecord(dataSource, {
+        placedAt: new Date('2026-08-02T00:00:00.000Z'),
+        totalAmount: 100,
+        currency: 'EUR',
+        reportingCurrency: 'EUR',
+        reportingTotalAmount: 100,
+        recordStatus: 'ready',
+        taxTreatment: 'exclusive',
+        taxRateEra: null,
+      });
+      await seedLineItem({
+        orderRecordId: eligible.internalOrderId,
+        unitPrice: 100,
+      });
+
+      // Excluded: pre-rollout era (blanket exclusion regardless of line state).
+      const preRollout = await createTestOrderRecord(dataSource, {
+        placedAt: new Date('2026-08-03T00:00:00.000Z'),
+        totalAmount: 50,
+        currency: 'EUR',
+        reportingCurrency: 'EUR',
+        reportingTotalAmount: 50,
+        recordStatus: 'ready',
+        taxTreatment: 'inclusive',
+        taxRateEra: 'pre-rollout',
+      });
+      await seedLineItem({
+        orderRecordId: preRollout.internalOrderId,
+        unitPrice: 50,
+        taxRate: null,
+      });
+
+      // Excluded: post-rollout order with a genuinely unresolved line rate.
+      const unresolved = await createTestOrderRecord(dataSource, {
+        placedAt: new Date('2026-08-04T00:00:00.000Z'),
+        totalAmount: 75,
+        currency: 'EUR',
+        reportingCurrency: 'EUR',
+        reportingTotalAmount: 75,
+        recordStatus: 'ready',
+        taxTreatment: 'inclusive',
+        taxRateEra: null,
+      });
+      await seedLineItem({
+        orderRecordId: unresolved.internalOrderId,
+        unitPrice: 75,
+        taxRate: null,
+      });
+
+      const [aggregateRows, candidates] = await Promise.all([
+        repository.getDailyOrderAggregates(filters, 'EUR'),
+        repository.findNetExcludedOrderCandidates(filters, 'EUR'),
+      ]);
+
+      const netExcludedCount = aggregateRows.reduce((sum, row) => sum + row.netExcludedCount, 0);
+
+      expect(netExcludedCount).toBe(2);
+      expect(candidates).toHaveLength(netExcludedCount);
+
+      const candidateIds = candidates.map((c) => c.internalOrderId).sort();
+      expect(candidateIds).toEqual(
+        [preRollout.internalOrderId, unresolved.internalOrderId].sort()
+      );
+
+      const preRolloutCandidate = candidates.find(
+        (c) => c.internalOrderId === preRollout.internalOrderId
+      );
+      expect(preRolloutCandidate?.taxRateEra).toBe('pre-rollout');
+
+      const unresolvedCandidate = candidates.find(
+        (c) => c.internalOrderId === unresolved.internalOrderId
+      );
+      expect(unresolvedCandidate?.taxRateEra).toBeNull();
+    }
+  );
+
+  it('excludes cancelled orders and orders stamped in a prior reporting-currency era', async () => {
+    const dataSource = harness.getDataSource();
+
+    const cancelled = await createTestOrderRecord(dataSource, {
+      placedAt: new Date('2026-08-02T00:00:00.000Z'),
+      totalAmount: 10,
+      currency: 'EUR',
+      reportingCurrency: 'EUR',
+      reportingTotalAmount: 10,
+      recordStatus: 'ready',
+      taxTreatment: 'inclusive',
+      taxRateEra: 'pre-rollout',
+      cancelledAt: new Date('2026-08-02T01:00:00.000Z'),
+    });
+    await seedLineItem({ orderRecordId: cancelled.internalOrderId, unitPrice: 10, taxRate: null });
+
+    const priorEra = await createTestOrderRecord(dataSource, {
+      placedAt: new Date('2026-08-02T00:00:00.000Z'),
+      totalAmount: 10,
+      currency: 'EUR',
+      // Stamped under a DIFFERENT reporting-currency era than what this
+      // read is asked about below.
+      reportingCurrency: 'PLN',
+      reportingTotalAmount: 40,
+      recordStatus: 'ready',
+      taxTreatment: 'inclusive',
+      taxRateEra: 'pre-rollout',
+    });
+    await seedLineItem({ orderRecordId: priorEra.internalOrderId, unitPrice: 10, taxRate: null });
+
+    const candidates = await repository.findNetExcludedOrderCandidates(filters, 'EUR');
+
+    expect(candidates.map((c) => c.internalOrderId)).not.toContain(cancelled.internalOrderId);
+    expect(candidates.map((c) => c.internalOrderId)).not.toContain(priorEra.internalOrderId);
+  });
+});

--- a/apps/api/test/integration/sales-analytics-aggregates.int-spec.ts
+++ b/apps/api/test/integration/sales-analytics-aggregates.int-spec.ts
@@ -410,4 +410,71 @@ describe('Sales analytics daily aggregates (integration, #1987)', () => {
       expect(secondPage.items[0].nativeCurrency).toBe('PLN');
     });
   });
+
+  describe('findProductMatchingErrorOrders (#2466)', () => {
+    it(
+      'reports the SAME total as countByHealth.sourceDeleted + awaitingMapping, mapping both ' +
+        'statuses to the row shape (regression guard)',
+      async () => {
+        await seedStampedOrder({
+          recordStatus: 'awaiting_mapping',
+          mappingFailureReason: 'no variant mapping for SKU-123',
+          placedAt: null,
+          totalAmount: null,
+          reportingCurrency: null,
+        });
+        await seedStampedOrder({
+          recordStatus: 'source_deleted',
+          mappingFailureReason: 'variant deleted at master',
+          placedAt: null,
+          totalAmount: null,
+          reportingCurrency: null,
+        });
+        // A healthy, ready order — must NOT appear in the product-matching page.
+        await seedStampedOrder({
+          recordStatus: 'ready',
+          placedAt: new Date('2026-08-02T00:00:00.000Z'),
+          totalAmount: 20,
+          reportingCurrency: 'EUR',
+          reportingTotalAmount: 20,
+        });
+
+        const [health, page] = await Promise.all([
+          repository.countByHealth({}),
+          repository.findProductMatchingErrorOrders({}, { limit: 20, offset: 0 }),
+        ]);
+
+        const expectedCount = health.sourceDeleted + health.awaitingMapping;
+        expect(expectedCount).toBe(2);
+        expect(page.total).toBe(expectedCount);
+
+        const reasons = page.items.map((item) => item.mappingFailureReason).sort();
+        expect(reasons).toEqual(['no variant mapping for SKU-123', 'variant deleted at master']);
+        const statuses = page.items.map((item) => item.recordStatus).sort();
+        expect(statuses).toEqual(['awaiting_mapping', 'source_deleted']);
+      }
+    );
+
+    it('scopes by createdFrom/createdTo, and reports an empty page when nothing matches', async () => {
+      const filters = {
+        createdFrom: new Date(Date.now() + 60_000),
+        createdTo: new Date(Date.now() + 120_000),
+      };
+
+      await seedStampedOrder({
+        recordStatus: 'awaiting_mapping',
+        mappingFailureReason: 'no variant mapping',
+        placedAt: null,
+        totalAmount: null,
+        reportingCurrency: null,
+      });
+
+      const page = await repository.findProductMatchingErrorOrders(filters, {
+        limit: 20,
+        offset: 0,
+      });
+
+      expect(page).toEqual({ items: [], total: 0 });
+    });
+  });
 });

--- a/apps/api/test/integration/sales-analytics-aggregates.int-spec.ts
+++ b/apps/api/test/integration/sales-analytics-aggregates.int-spec.ts
@@ -215,4 +215,199 @@ describe('Sales analytics daily aggregates (integration, #1987)', () => {
 
     expect(median).toBe(20);
   });
+
+  describe('findCurrencyMismatchOrders (#2464)', () => {
+    it('flags a never-stamped order (reportingCurrency IS NULL)', async () => {
+      await seedStampedOrder({
+        placedAt: new Date('2026-08-02T10:00:00.000Z'),
+        currency: 'PLN',
+        totalAmount: 100,
+        reportingCurrency: null,
+        reportingTotalAmount: null,
+        fxStampedAt: null,
+      });
+
+      const result = await repository.findCurrencyMismatchOrders(
+        {
+          from: new Date('2026-08-01T00:00:00.000Z'),
+          to: new Date('2026-08-08T00:00:00.000Z'),
+        },
+        'EUR',
+        { limit: 20, offset: 0 }
+      );
+
+      expect(result.total).toBe(1);
+      expect(result.items).toHaveLength(1);
+      expect(result.items[0].nativeCurrency).toBe('PLN');
+      expect(result.items[0].stampedCurrency).toBeNull();
+      expect(result.items[0].stampedAt).toBeNull();
+    });
+
+    it('flags the demo-DB same-currency-code stale-stamp shape (reportingCurrency present but not the CURRENT setting)', async () => {
+      // Exactly the shape #2464's issue calls out as manually fixed on the
+      // demo DB: a real stamp exists (fxStampedAt is set, the order is NOT
+      // "never stamped"), but it was taken while the operator's reporting
+      // setting held a different value than it holds now.
+      const stampedAt = new Date('2026-06-01T09:00:00.000Z');
+      await seedStampedOrder({
+        placedAt: new Date('2026-08-03T10:00:00.000Z'),
+        currency: 'PLN',
+        totalAmount: 100,
+        reportingCurrency: 'EUR',
+        reportingTotalAmount: 23,
+        fxStampedAt: stampedAt,
+      });
+
+      const result = await repository.findCurrencyMismatchOrders(
+        {
+          from: new Date('2026-08-01T00:00:00.000Z'),
+          to: new Date('2026-08-08T00:00:00.000Z'),
+        },
+        // The CURRENT setting has since moved to PLN — the EUR stamp above
+        // is now a prior-era, stale stamp, not a fresh one.
+        'PLN',
+        { limit: 20, offset: 0 }
+      );
+
+      expect(result.total).toBe(1);
+      expect(result.items[0].nativeCurrency).toBe('PLN');
+      expect(result.items[0].stampedCurrency).toBe('EUR');
+      expect(result.items[0].stampedAt?.toISOString()).toBe(stampedAt.toISOString());
+    });
+
+    it('combines both populations into one total that matches getDailyOrderAggregates.unconvertedCount exactly (regression guard)', async () => {
+      const day = new Date('2026-08-04T10:00:00.000Z');
+      // Never-stamped.
+      await seedStampedOrder({
+        placedAt: day,
+        currency: 'PLN',
+        totalAmount: 10,
+        reportingCurrency: null,
+        reportingTotalAmount: null,
+        fxStampedAt: null,
+      });
+      // Stale-stamp, cross-currency.
+      await seedStampedOrder({
+        placedAt: day,
+        currency: 'USD',
+        totalAmount: 20,
+        reportingCurrency: 'EUR',
+        reportingTotalAmount: 18,
+        fxStampedAt: new Date('2026-05-01T00:00:00.000Z'),
+      });
+      // Stale-stamp, same-currency-code shape from the issue.
+      await seedStampedOrder({
+        placedAt: day,
+        currency: 'PLN',
+        totalAmount: 30,
+        reportingCurrency: 'EUR',
+        reportingTotalAmount: 7,
+        fxStampedAt: new Date('2026-05-02T00:00:00.000Z'),
+      });
+      // Current-era stamped — must NOT be counted as a mismatch.
+      await seedStampedOrder({
+        placedAt: day,
+        currency: 'PLN',
+        totalAmount: 40,
+        reportingCurrency: 'PLN',
+        reportingTotalAmount: 40,
+        fxStampedAt: new Date('2026-08-04T00:00:00.000Z'),
+      });
+      // Cancelled — excluded from both reads identically.
+      await seedStampedOrder({
+        placedAt: day,
+        currency: 'PLN',
+        totalAmount: 999,
+        reportingCurrency: null,
+        reportingTotalAmount: null,
+        fxStampedAt: null,
+        cancelledAt: new Date('2026-08-04T12:00:00.000Z'),
+      });
+
+      const filters = {
+        from: new Date('2026-08-01T00:00:00.000Z'),
+        to: new Date('2026-08-08T00:00:00.000Z'),
+      };
+
+      const [dailyRows, mismatchPage] = await Promise.all([
+        repository.getDailyOrderAggregates(filters, 'PLN'),
+        repository.findCurrencyMismatchOrders(filters, 'PLN', { limit: 20, offset: 0 }),
+      ]);
+
+      const unconvertedCount = dailyRows.reduce((sum, row) => sum + row.unconvertedCount, 0);
+
+      expect(unconvertedCount).toBe(3);
+      expect(mismatchPage.total).toBe(unconvertedCount);
+      expect(mismatchPage.items).toHaveLength(3);
+    });
+
+    it('reports a zero-mismatch page when every order is current-era stamped (backs the all-clear mockup state)', async () => {
+      const day = new Date('2026-08-05T10:00:00.000Z');
+      await seedStampedOrder({
+        placedAt: day,
+        currency: 'EUR',
+        totalAmount: 50,
+        reportingCurrency: 'EUR',
+        reportingTotalAmount: 50,
+        fxStampedAt: new Date('2026-08-05T00:00:00.000Z'),
+      });
+
+      const filters = {
+        from: new Date('2026-08-01T00:00:00.000Z'),
+        to: new Date('2026-08-08T00:00:00.000Z'),
+      };
+
+      const [dailyRows, mismatchPage] = await Promise.all([
+        repository.getDailyOrderAggregates(filters, 'EUR'),
+        repository.findCurrencyMismatchOrders(filters, 'EUR', { limit: 20, offset: 0 }),
+      ]);
+
+      const unconvertedCount = dailyRows.reduce((sum, row) => sum + row.unconvertedCount, 0);
+
+      expect(unconvertedCount).toBe(0);
+      expect(mismatchPage).toEqual({ items: [], total: 0 });
+    });
+
+    it('paginates via limit/offset, newest-first', async () => {
+      // Distinct native currencies so the two pages are distinguishable —
+      // the row shape carries no `placedAt`, so ordering is asserted via
+      // which order lands on which page rather than a raw date comparison.
+      await seedStampedOrder({
+        placedAt: new Date('2026-08-02T10:00:00.000Z'),
+        currency: 'PLN',
+        totalAmount: 10,
+        reportingCurrency: null,
+        fxStampedAt: null,
+      });
+      await seedStampedOrder({
+        placedAt: new Date('2026-08-03T10:00:00.000Z'),
+        currency: 'USD',
+        totalAmount: 20,
+        reportingCurrency: null,
+        fxStampedAt: null,
+      });
+
+      const filters = {
+        from: new Date('2026-08-01T00:00:00.000Z'),
+        to: new Date('2026-08-08T00:00:00.000Z'),
+      };
+
+      const firstPage = await repository.findCurrencyMismatchOrders(filters, 'EUR', {
+        limit: 1,
+        offset: 0,
+      });
+      const secondPage = await repository.findCurrencyMismatchOrders(filters, 'EUR', {
+        limit: 1,
+        offset: 1,
+      });
+
+      expect(firstPage.total).toBe(2);
+      expect(secondPage.total).toBe(2);
+      // 2026-08-03 (USD) is the newer of the two — must land on page 1.
+      expect(firstPage.items).toHaveLength(1);
+      expect(firstPage.items[0].nativeCurrency).toBe('USD');
+      expect(secondPage.items).toHaveLength(1);
+      expect(secondPage.items[0].nativeCurrency).toBe('PLN');
+    });
+  });
 });

--- a/docs/plans/notes/phase-2452-p4-kickoff.md
+++ b/docs/plans/notes/phase-2452-p4-kickoff.md
@@ -1,0 +1,8 @@
+# Phase 4 kickoff — epic #2452
+
+Branch `phase/2452-p4-coverage-detection`, cut from `epic/2452-analytics-currency-coverage`.
+
+Tracks mini-epic #2463 (Backend: data-coverage detection). Real work lands in
+follow-up commits from tasks #2464, #2465, #2466. This file exists only to give
+the branch an initial diff so the draft PR against the epic branch is not
+rejected as zero-diff.

--- a/libs/core/src/orders/application/interfaces/order-record.service.interface.ts
+++ b/libs/core/src/orders/application/interfaces/order-record.service.interface.ts
@@ -25,6 +25,11 @@ import type {
   SalesAndChannelAnalytics,
 } from '../../domain/types/order-sales-analytics.types';
 import type { TopProductFilters, TopProductsResult } from '../../domain/types/top-products.types';
+import type {
+  CoverageDetectionPagination,
+  PaginatedCurrencyMismatchOrders,
+  PaginatedProductMatchingErrorOrders,
+} from '../../domain/types/coverage-detection.types';
 
 export interface IOrderRecordService {
   /**
@@ -228,4 +233,34 @@ export interface IOrderRecordService {
    * separate, not-yet-scoped read (spec row C3).
    */
   getTopProducts(filters: TopProductFilters): Promise<TopProductsResult>;
+
+  /**
+   * Data Coverage `'currency'` category drill-down (#2464/#2466) — the
+   * cross-context surface `AnalyticsCoverageController`'s
+   * `GET /analytics/coverage` uses. Repository ports are forbidden across
+   * context boundaries (`docs/architecture-overview.md § Cross-context
+   * dependencies in core`), so this thin pass-through to {@link
+   * OrderRecordRepositoryPort.findCurrencyMismatchOrders} is the seam.
+   * `currentReportingCurrency` is an explicit caller-supplied param rather
+   * than resolved internally (unlike {@link getSalesAndChannelAnalytics}),
+   * because the same request also threads it into
+   * `ITaxCoverageDetectionService`'s call — resolving it twice per request
+   * risks the two reads straddling a setting change mid-request.
+   */
+  getCurrencyMismatchOrders(
+    filters: SalesAnalyticsFilters,
+    currentReportingCurrency: string,
+    pagination: CoverageDetectionPagination
+  ): Promise<PaginatedCurrencyMismatchOrders>;
+
+  /**
+   * Data Coverage `'product-matching'` category drill-down (#2466) — thin
+   * pass-through to {@link
+   * OrderRecordRepositoryPort.findProductMatchingErrorOrders}, for the same
+   * cross-context-boundary reason as {@link getCurrencyMismatchOrders}.
+   */
+  getProductMatchingErrorOrders(
+    filters: OrderHealthSummaryFilters,
+    pagination: CoverageDetectionPagination
+  ): Promise<PaginatedProductMatchingErrorOrders>;
 }

--- a/libs/core/src/orders/application/services/__tests__/order-record.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-record.service.spec.ts
@@ -49,6 +49,8 @@ describe('OrderRecordService', () => {
       getDailyOrderAggregates: jest.fn(),
       getMedianOrderValue: jest.fn(),
       getNetMedianOrderValue: jest.fn(),
+      findCurrencyMismatchOrders: jest.fn(),
+      findProductMatchingErrorOrders: jest.fn(),
     } as unknown as jest.Mocked<OrderRecordRepositoryPort>;
 
     // Defaults to `deferred`, which is the outcome that owes NO refresh - so
@@ -1350,6 +1352,42 @@ describe('OrderRecordService', () => {
         filters,
         'EUR'
       );
+    });
+  });
+
+  describe('getCurrencyMismatchOrders (#2466)', () => {
+    it('is a thin pass-through to the repository read, forwarding args verbatim', async () => {
+      const salesFilters = {
+        from: new Date('2026-08-01T00:00:00.000Z'),
+        to: new Date('2026-08-08T00:00:00.000Z'),
+      };
+      const pagination = { limit: 10, offset: 0 };
+      repository.findCurrencyMismatchOrders.mockResolvedValue({ items: [], total: 0 });
+
+      const result = await service.getCurrencyMismatchOrders(salesFilters, 'EUR', pagination);
+
+      expect(repository.findCurrencyMismatchOrders).toHaveBeenCalledWith(
+        salesFilters,
+        'EUR',
+        pagination
+      );
+      expect(result).toEqual({ items: [], total: 0 });
+    });
+  });
+
+  describe('getProductMatchingErrorOrders (#2466)', () => {
+    it('is a thin pass-through to the repository read, forwarding args verbatim', async () => {
+      const healthFilters = { sourceConnectionId: 'conn-a' };
+      const pagination = { limit: 10, offset: 0 };
+      repository.findProductMatchingErrorOrders.mockResolvedValue({ items: [], total: 0 });
+
+      const result = await service.getProductMatchingErrorOrders(healthFilters, pagination);
+
+      expect(repository.findProductMatchingErrorOrders).toHaveBeenCalledWith(
+        healthFilters,
+        pagination
+      );
+      expect(result).toEqual({ items: [], total: 0 });
     });
   });
 });

--- a/libs/core/src/orders/application/services/order-record.service.ts
+++ b/libs/core/src/orders/application/services/order-record.service.ts
@@ -46,6 +46,11 @@ import { deriveOrderAnalyticsScalars, deriveOrderLineItems } from '../../domain/
 import { buildSalesAndChannelAnalytics } from '../../domain/order-sales-aggregation';
 import { buildTopProducts } from '../../domain/top-products-aggregation';
 import type { TopProductFilters, TopProductsResult } from '../../domain/types/top-products.types';
+import type {
+  CoverageDetectionPagination,
+  PaginatedCurrencyMismatchOrders,
+  PaginatedProductMatchingErrorOrders,
+} from '../../domain/types/coverage-detection.types';
 
 @Injectable()
 export class OrderRecordService implements IOrderRecordService {
@@ -561,6 +566,35 @@ export class OrderRecordService implements IOrderRecordService {
     );
 
     return buildTopProducts({ ranking, total, breakdown });
+  }
+
+  /**
+   * Data Coverage `'currency'` category drill-down (#2464/#2466) — thin
+   * pass-through to {@link OrderRecordRepositoryPort.findCurrencyMismatchOrders},
+   * the cross-context seam `AnalyticsCoverageController` uses.
+   */
+  async getCurrencyMismatchOrders(
+    filters: SalesAnalyticsFilters,
+    currentReportingCurrency: string,
+    pagination: CoverageDetectionPagination
+  ): Promise<PaginatedCurrencyMismatchOrders> {
+    return this.repository.findCurrencyMismatchOrders(
+      filters,
+      currentReportingCurrency,
+      pagination
+    );
+  }
+
+  /**
+   * Data Coverage `'product-matching'` category drill-down (#2466) — thin
+   * pass-through to {@link
+   * OrderRecordRepositoryPort.findProductMatchingErrorOrders}.
+   */
+  async getProductMatchingErrorOrders(
+    filters: OrderHealthSummaryFilters,
+    pagination: CoverageDetectionPagination
+  ): Promise<PaginatedProductMatchingErrorOrders> {
+    return this.repository.findProductMatchingErrorOrders(filters, pagination);
   }
 
   /**

--- a/libs/core/src/orders/application/services/tax-coverage-detection.service.interface.ts
+++ b/libs/core/src/orders/application/services/tax-coverage-detection.service.interface.ts
@@ -51,4 +51,17 @@ export interface ITaxCoverageDetectionService {
     filters: SalesAnalyticsFilters,
     currentReportingCurrency: string
   ): Promise<Record<TaxCoverageCategory, number>>;
+
+  /**
+   * All three categories' drill-down pages in ONE {@link classify} pass
+   * (#2466) — `AnalyticsCoverageController` needs `tax-a`/`tax-b`/`tax-c`
+   * together for a single `GET /analytics/coverage` request, and calling
+   * {@link getCategoryPage} three times would re-run the live-catalogue
+   * classification pass three times over the SAME candidate population.
+   */
+  getAllCategoryPages(
+    filters: SalesAnalyticsFilters,
+    currentReportingCurrency: string,
+    pagination: CoverageDetectionPagination
+  ): Promise<Record<TaxCoverageCategory, PaginatedTaxCoverageOrders>>;
 }

--- a/libs/core/src/orders/application/services/tax-coverage-detection.service.interface.ts
+++ b/libs/core/src/orders/application/services/tax-coverage-detection.service.interface.ts
@@ -1,0 +1,54 @@
+/**
+ * Tax Coverage Detection Service Interface
+ *
+ * Contract for the Data Coverage panel's tax A/B/C detector (#2465) — see
+ * `TaxCoverageDetectionService`'s doc comment for the full classification
+ * rule and rationale.
+ *
+ * @module libs/core/src/orders/application/services
+ */
+import type { SalesAnalyticsFilters } from '../../domain/types/order-sales-analytics.types';
+import type {
+  CoverageDetectionPagination,
+  PaginatedTaxCoverageOrders,
+  TaxCoverageCategory,
+  TaxCoverageClassification,
+} from '../../domain/types/coverage-detection.types';
+
+export interface ITaxCoverageDetectionService {
+  /**
+   * Classify every `netExcludedCount` candidate order (for the given
+   * filters/currency) into its `'tax-a'` / `'tax-b'` / `'tax-c'` bucket.
+   * The three returned arrays are a complete, non-overlapping partition of
+   * the candidate population — their combined length always equals
+   * `netExcludedCount` for the same filters/currency.
+   */
+  classify(
+    filters: SalesAnalyticsFilters,
+    currentReportingCurrency: string
+  ): Promise<TaxCoverageClassification>;
+
+  /**
+   * One category's drill-down page (mockup states `detail-tax` /
+   * `detail-novat` / `detail-postrollout`), sliced from the same
+   * classification pass {@link classify} runs. Pagination is applied
+   * in-memory over the classified result — see the class doc comment for
+   * why this cannot be pushed into SQL.
+   */
+  getCategoryPage(
+    category: TaxCoverageCategory,
+    filters: SalesAnalyticsFilters,
+    currentReportingCurrency: string,
+    pagination: CoverageDetectionPagination
+  ): Promise<PaginatedTaxCoverageOrders>;
+
+  /**
+   * Per-category counts, for the `GET /analytics/coverage` aggregate row
+   * (#2466) — `affectedCount` per category without a caller needing to
+   * fetch and slice a full page.
+   */
+  getCategoryCounts(
+    filters: SalesAnalyticsFilters,
+    currentReportingCurrency: string
+  ): Promise<Record<TaxCoverageCategory, number>>;
+}

--- a/libs/core/src/orders/application/services/tax-coverage-detection.service.spec.ts
+++ b/libs/core/src/orders/application/services/tax-coverage-detection.service.spec.ts
@@ -232,4 +232,53 @@ describe('TaxCoverageDetectionService (#2465)', () => {
       expect(counts).toEqual({ 'tax-a': 0, 'tax-b': 1, 'tax-c': 0 });
     });
   });
+
+  describe('getAllCategoryPages (#2466)', () => {
+    it('returns all three categories from ONE classification pass', async () => {
+      const candidates = [
+        candidate({ internalOrderId: 'order-1', taxRateEra: null }),
+        candidate({ internalOrderId: 'order-2', taxRateEra: 'pre-rollout' }),
+      ];
+      recordRepository.findNetExcludedOrderCandidates.mockResolvedValue(candidates);
+      lineItemRepository.findByOrderId.mockResolvedValue([
+        makeLine({ orderRecordId: 'order-2', taxRate: '23' }),
+      ]);
+
+      const pages = await service.getAllCategoryPages(baseFilters, 'EUR', {
+        limit: 10,
+        offset: 0,
+      });
+
+      expect(recordRepository.findNetExcludedOrderCandidates).toHaveBeenCalledTimes(1);
+      expect(pages['tax-a']).toEqual({
+        items: [
+          { internalOrderId: 'order-2', sourceConnectionId: 'conn-1', placedAt: expect.any(Date) },
+        ],
+        total: 1,
+      });
+      expect(pages['tax-b']).toEqual({
+        items: [
+          { internalOrderId: 'order-1', sourceConnectionId: 'conn-1', placedAt: expect.any(Date) },
+        ],
+        total: 1,
+      });
+      expect(pages['tax-c']).toEqual({ items: [], total: 0 });
+    });
+
+    it('slices each category page in-memory by the requested pagination', async () => {
+      const candidates = Array.from({ length: 5 }, (_, i) =>
+        candidate({ internalOrderId: `order-${i}`, taxRateEra: null })
+      );
+      recordRepository.findNetExcludedOrderCandidates.mockResolvedValue(candidates);
+
+      const pages = await service.getAllCategoryPages(baseFilters, 'EUR', {
+        limit: 2,
+        offset: 2,
+      });
+
+      expect(pages['tax-b'].total).toBe(5);
+      expect(pages['tax-b'].items).toHaveLength(2);
+      expect(pages['tax-b'].items[0].internalOrderId).toBe('order-2');
+    });
+  });
 });

--- a/libs/core/src/orders/application/services/tax-coverage-detection.service.spec.ts
+++ b/libs/core/src/orders/application/services/tax-coverage-detection.service.spec.ts
@@ -1,0 +1,235 @@
+import type { IProductsService } from '@openlinker/core/products';
+import type { StoredTaxRate } from '@openlinker/core/products';
+
+import { OrderLineItem } from '../../domain/entities/order-line-item.entity';
+import type { OrderLineItemRepositoryPort } from '../../domain/ports/order-line-item-repository.port';
+import type { OrderRecordRepositoryPort } from '../../domain/ports/order-record-repository.port';
+import type { NetExcludedOrderCandidate } from '../../domain/types/coverage-detection.types';
+import { TaxCoverageDetectionService } from './tax-coverage-detection.service';
+
+describe('TaxCoverageDetectionService (#2465)', () => {
+  let service: TaxCoverageDetectionService;
+  let recordRepository: jest.Mocked<
+    Pick<OrderRecordRepositoryPort, 'findNetExcludedOrderCandidates'>
+  >;
+  let lineItemRepository: jest.Mocked<Pick<OrderLineItemRepositoryPort, 'findByOrderId'>>;
+  let productsService: jest.Mocked<Pick<IProductsService, 'getEffectiveTaxRate'>>;
+
+  const baseFilters = {
+    from: new Date('2026-08-01T00:00:00.000Z'),
+    to: new Date('2026-08-08T00:00:00.000Z'),
+  };
+
+  const candidate = (overrides: Partial<NetExcludedOrderCandidate>): NetExcludedOrderCandidate => ({
+    internalOrderId: 'ol_order_1',
+    sourceConnectionId: 'conn-1',
+    placedAt: new Date('2026-08-02T00:00:00Z'),
+    taxRateEra: null,
+    ...overrides,
+  });
+
+  const makeLine = (overrides: Partial<OrderLineItem> = {}): OrderLineItem =>
+    new OrderLineItem(
+      overrides.id ?? 'line-1',
+      overrides.orderRecordId ?? 'ol_order_1',
+      overrides.lineNumber ?? 0,
+      overrides.productId ?? 'ol_product_1',
+      overrides.variantId ?? null,
+      overrides.quantity ?? 1,
+      overrides.unitPrice ?? 100,
+      overrides.sourceConnectionId ?? 'conn-1',
+      overrides.placedAt ?? new Date('2026-08-02T00:00:00Z'),
+      overrides.createdAt ?? new Date('2026-08-02T00:00:00Z'),
+      overrides.taxRate ?? null,
+      overrides.taxSource ?? null,
+      overrides.taxRateReadAt ?? null
+    );
+
+  const known = (code: string): StoredTaxRate => ({
+    code,
+    countryIso2: 'PL',
+    readAt: new Date('2026-08-24T00:00:00Z'),
+  });
+  const noRate: StoredTaxRate = { code: null, countryIso2: 'PL', readAt: new Date('2026-08-24T00:00:00Z') };
+  const notChecked: StoredTaxRate = { code: null, countryIso2: null, readAt: null };
+
+  beforeEach(() => {
+    recordRepository = { findNetExcludedOrderCandidates: jest.fn() };
+    lineItemRepository = { findByOrderId: jest.fn() };
+    productsService = { getEffectiveTaxRate: jest.fn() };
+
+    service = new TaxCoverageDetectionService(
+      recordRepository as unknown as OrderRecordRepositoryPort,
+      lineItemRepository as unknown as OrderLineItemRepositoryPort,
+      productsService as unknown as IProductsService
+    );
+  });
+
+  describe('classify', () => {
+    it('reports tax-b for a non-pre-rollout candidate without touching line items or the catalogue', async () => {
+      recordRepository.findNetExcludedOrderCandidates.mockResolvedValue([
+        candidate({ internalOrderId: 'order-post-rollout', taxRateEra: null }),
+      ]);
+
+      const result = await service.classify(baseFilters, 'EUR');
+
+      expect(result['tax-b']).toHaveLength(1);
+      expect(result['tax-b'][0].internalOrderId).toBe('order-post-rollout');
+      expect(result['tax-a']).toHaveLength(0);
+      expect(result['tax-c']).toHaveLength(0);
+      expect(lineItemRepository.findByOrderId).not.toHaveBeenCalled();
+    });
+
+    it('reports tax-a when a pre-rollout order already has every line resolved (backfill already ran)', async () => {
+      recordRepository.findNetExcludedOrderCandidates.mockResolvedValue([
+        candidate({ internalOrderId: 'order-a', taxRateEra: 'pre-rollout' }),
+      ]);
+      lineItemRepository.findByOrderId.mockResolvedValue([
+        makeLine({ orderRecordId: 'order-a', taxRate: '23' }),
+      ]);
+
+      const result = await service.classify(baseFilters, 'EUR');
+
+      expect(result['tax-a']).toHaveLength(1);
+      expect(result['tax-a'][0].internalOrderId).toBe('order-a');
+      expect(productsService.getEffectiveTaxRate).not.toHaveBeenCalled();
+    });
+
+    it('reports tax-a when a pre-rollout order has an unresolved line that resolves live via the catalogue (the 31-row demo case)', async () => {
+      recordRepository.findNetExcludedOrderCandidates.mockResolvedValue([
+        candidate({ internalOrderId: 'order-a', taxRateEra: 'pre-rollout' }),
+      ]);
+      lineItemRepository.findByOrderId.mockResolvedValue([
+        makeLine({ orderRecordId: 'order-a', productId: 'ol_product_x', taxRate: null }),
+      ]);
+      productsService.getEffectiveTaxRate.mockResolvedValue(known('23'));
+
+      const result = await service.classify(baseFilters, 'EUR');
+
+      expect(result['tax-a']).toHaveLength(1);
+      expect(result['tax-b']).toHaveLength(0);
+      expect(result['tax-c']).toHaveLength(0);
+      expect(productsService.getEffectiveTaxRate).toHaveBeenCalledWith('ol_product_x', undefined);
+    });
+
+    it('reports tax-b when a pre-rollout order has an unresolved line the catalogue confirms carries no rate', async () => {
+      recordRepository.findNetExcludedOrderCandidates.mockResolvedValue([
+        candidate({ internalOrderId: 'order-b', taxRateEra: 'pre-rollout' }),
+      ]);
+      lineItemRepository.findByOrderId.mockResolvedValue([
+        makeLine({ orderRecordId: 'order-b', taxRate: null }),
+      ]);
+      productsService.getEffectiveTaxRate.mockResolvedValue(noRate);
+
+      const result = await service.classify(baseFilters, 'EUR');
+
+      expect(result['tax-b']).toHaveLength(1);
+      expect(result['tax-a']).toHaveLength(0);
+      expect(result['tax-c']).toHaveLength(0);
+    });
+
+    it('reports tax-c when a pre-rollout order has an unresolved line the catalogue has never checked', async () => {
+      recordRepository.findNetExcludedOrderCandidates.mockResolvedValue([
+        candidate({ internalOrderId: 'order-c', taxRateEra: 'pre-rollout' }),
+      ]);
+      lineItemRepository.findByOrderId.mockResolvedValue([
+        makeLine({ orderRecordId: 'order-c', taxRate: null }),
+      ]);
+      productsService.getEffectiveTaxRate.mockResolvedValue(notChecked);
+
+      const result = await service.classify(baseFilters, 'EUR');
+
+      expect(result['tax-c']).toHaveLength(1);
+      expect(result['tax-a']).toHaveLength(0);
+      expect(result['tax-b']).toHaveLength(0);
+    });
+
+    it('prefers tax-b over tax-c when a pre-rollout order mixes a confirmed-no-rate line with a not-checked line', async () => {
+      recordRepository.findNetExcludedOrderCandidates.mockResolvedValue([
+        candidate({ internalOrderId: 'order-mixed', taxRateEra: 'pre-rollout' }),
+      ]);
+      lineItemRepository.findByOrderId.mockResolvedValue([
+        makeLine({ id: 'line-1', lineNumber: 0, productId: 'p1', taxRate: null }),
+        makeLine({ id: 'line-2', lineNumber: 1, productId: 'p2', taxRate: null }),
+      ]);
+      productsService.getEffectiveTaxRate
+        .mockResolvedValueOnce(noRate)
+        .mockResolvedValueOnce(notChecked);
+
+      const result = await service.classify(baseFilters, 'EUR');
+
+      expect(result['tax-b']).toHaveLength(1);
+      expect(result['tax-c']).toHaveLength(0);
+    });
+
+    it('treats a catalogue read failure like not-checked rather than a confirmed no-rate', async () => {
+      recordRepository.findNetExcludedOrderCandidates.mockResolvedValue([
+        candidate({ internalOrderId: 'order-fail', taxRateEra: 'pre-rollout' }),
+      ]);
+      lineItemRepository.findByOrderId.mockResolvedValue([
+        makeLine({ orderRecordId: 'order-fail', taxRate: null }),
+      ]);
+      productsService.getEffectiveTaxRate.mockRejectedValue(new Error('catalogue unavailable'));
+
+      const result = await service.classify(baseFilters, 'EUR');
+
+      expect(result['tax-c']).toHaveLength(1);
+      expect(result['tax-b']).toHaveLength(0);
+    });
+
+    it('partitions a mixed candidate set with categories summing to the full candidate count (regression guard)', async () => {
+      const candidates = [
+        candidate({ internalOrderId: 'order-1', taxRateEra: null }),
+        candidate({ internalOrderId: 'order-2', taxRateEra: 'pre-rollout' }),
+        candidate({ internalOrderId: 'order-3', taxRateEra: 'pre-rollout' }),
+      ];
+      recordRepository.findNetExcludedOrderCandidates.mockResolvedValue(candidates);
+      lineItemRepository.findByOrderId.mockImplementation((orderRecordId: string) => {
+        if (orderRecordId === 'order-2') {
+          return Promise.resolve([makeLine({ orderRecordId, taxRate: '23' })]);
+        }
+        return Promise.resolve([makeLine({ orderRecordId, taxRate: null })]);
+      });
+      productsService.getEffectiveTaxRate.mockResolvedValue(notChecked);
+
+      const result = await service.classify(baseFilters, 'EUR');
+
+      const total =
+        result['tax-a'].length + result['tax-b'].length + result['tax-c'].length;
+      expect(total).toBe(candidates.length);
+      expect(result['tax-b']).toHaveLength(1);
+      expect(result['tax-a']).toHaveLength(1);
+      expect(result['tax-c']).toHaveLength(1);
+    });
+  });
+
+  describe('getCategoryPage', () => {
+    it('slices the classified result in-memory using the requested pagination', async () => {
+      const candidates = Array.from({ length: 5 }, (_, i) =>
+        candidate({ internalOrderId: `order-${i}`, taxRateEra: null })
+      );
+      recordRepository.findNetExcludedOrderCandidates.mockResolvedValue(candidates);
+
+      const result = await service.getCategoryPage('tax-b', baseFilters, 'EUR', {
+        limit: 2,
+        offset: 2,
+      });
+
+      expect(result.total).toBe(5);
+      expect(result.items).toHaveLength(2);
+      expect(result.items[0].internalOrderId).toBe('order-2');
+    });
+  });
+
+  describe('getCategoryCounts', () => {
+    it('returns a count per category, including zero for an empty category', async () => {
+      recordRepository.findNetExcludedOrderCandidates.mockResolvedValue([
+        candidate({ internalOrderId: 'order-1', taxRateEra: null }),
+      ]);
+
+      const counts = await service.getCategoryCounts(baseFilters, 'EUR');
+
+      expect(counts).toEqual({ 'tax-a': 0, 'tax-b': 1, 'tax-c': 0 });
+    });
+  });
+});

--- a/libs/core/src/orders/application/services/tax-coverage-detection.service.ts
+++ b/libs/core/src/orders/application/services/tax-coverage-detection.service.ts
@@ -1,0 +1,210 @@
+/**
+ * Tax Coverage Detection Service
+ *
+ * Splits the `netExcludedCount` population (already computed by
+ * `OrderRecordRepositoryPort.getDailyOrderAggregates`) into the three
+ * operator-actionable sub-categories the Data Coverage panel's mockup
+ * distinguishes (#2465):
+ *
+ * - `'tax-a'` (unconfirmed-but-resolvable): `taxRateEra = 'pre-rollout'`
+ *   AND every one of the order's unresolved lines resolves a rate from the
+ *   CURRENT catalogue — either because `TaxRateBackfillService` already
+ *   wrote it (`order_line_items.taxRate` is now set), or because a
+ *   read-only re-check via `IProductsService.getEffectiveTaxRate` resolves
+ *   it right now. Would become net-eligible if a future
+ *   `includeGuessedVatRatesInNetSales` setting (Phase 5) were turned on —
+ *   this service never writes anything, it only reports the fact.
+ * - `'tax-b'` (no tax rate at all): either the order is excluded for a
+ *   reason OTHER than the pre-rollout era (a genuinely unresolved line on a
+ *   post-rollout order, or no line items — {@link
+ *   findNetExcludedOrderCandidates}'s population can include both), or it
+ *   IS pre-rollout but the catalogue has confirmed at least one unresolved
+ *   line's product/variant carries NO rate (`taxRateState === 'no-rate'`).
+ *   No remediation action exists for this category.
+ * - `'tax-c'` (pre-rollout, not yet resolvable): `taxRateEra =
+ *   'pre-rollout'`, none of the order's unresolved lines were confirmed
+ *   rate-less, but at least one has never been asked about a rate at all
+ *   (`taxRateState === 'not-checked'`). A later catalogue sync, or the
+ *   backfill sweep once it reaches this connection's frontier, may still
+ *   resolve it.
+ *
+ * Read-only by design: this service calls `IProductsService.
+ * getEffectiveTaxRate` to CHECK resolvability, but never calls
+ * `TaxRateBackfillService.backfillPage` or writes to `order_line_items` —
+ * classification must not have the side effect of resolving what it is
+ * merely reporting on.
+ *
+ * Not pushed into SQL: whether a line "resolves a rate" depends on a live
+ * catalogue read (`IProductsService.getEffectiveTaxRate`), which has no SQL
+ * equivalent — so the base candidate population is fetched UNPAGED (see
+ * `OrderRecordRepositoryPort.findNetExcludedOrderCandidates`'s doc comment)
+ * and classified here in the application layer; page slicing for
+ * {@link getCategoryPage} happens in-memory over the already-classified
+ * result.
+ *
+ * @module libs/core/src/orders/application/services
+ * @implements {ITaxCoverageDetectionService}
+ */
+import { Inject, Injectable } from '@nestjs/common';
+import {
+  IProductsService,
+  PRODUCTS_SERVICE_TOKEN,
+  taxRateState,
+  type StoredTaxRate,
+} from '@openlinker/core/products';
+import { Logger } from '@openlinker/shared/logging';
+import type { ITaxCoverageDetectionService } from './tax-coverage-detection.service.interface';
+import { OrderRecordRepositoryPort } from '../../domain/ports/order-record-repository.port';
+import { OrderLineItemRepositoryPort } from '../../domain/ports/order-line-item-repository.port';
+import { ORDER_RECORD_REPOSITORY_TOKEN, ORDER_LINE_ITEM_REPOSITORY_TOKEN } from '../../orders.tokens';
+import { resolveNetSalesTaxRate } from '../../domain/types/net-sales-tax-rate.types';
+import type { SalesAnalyticsFilters } from '../../domain/types/order-sales-analytics.types';
+import {
+  TaxCoverageCategoryValues,
+  type CoverageDetectionPagination,
+  type NetExcludedOrderCandidate,
+  type PaginatedTaxCoverageOrders,
+  type TaxCoverageCategory,
+  type TaxCoverageClassification,
+  type TaxCoverageOrderRow,
+} from '../../domain/types/coverage-detection.types';
+
+const PRE_ROLLOUT_ERA = 'pre-rollout';
+
+@Injectable()
+export class TaxCoverageDetectionService implements ITaxCoverageDetectionService {
+  private readonly logger = new Logger(TaxCoverageDetectionService.name);
+
+  constructor(
+    @Inject(ORDER_RECORD_REPOSITORY_TOKEN)
+    private readonly orderRecordRepository: OrderRecordRepositoryPort,
+    @Inject(ORDER_LINE_ITEM_REPOSITORY_TOKEN)
+    private readonly orderLineItemRepository: OrderLineItemRepositoryPort,
+    @Inject(PRODUCTS_SERVICE_TOKEN)
+    private readonly productsService: IProductsService
+  ) {}
+
+  async classify(
+    filters: SalesAnalyticsFilters,
+    currentReportingCurrency: string
+  ): Promise<TaxCoverageClassification> {
+    const candidates = await this.orderRecordRepository.findNetExcludedOrderCandidates(
+      filters,
+      currentReportingCurrency
+    );
+
+    const result: TaxCoverageClassification = {
+      'tax-a': [],
+      'tax-b': [],
+      'tax-c': [],
+    };
+
+    for (const candidate of candidates) {
+      const category = await this.classifyOne(candidate);
+      result[category].push(this.toRow(candidate));
+    }
+
+    return result;
+  }
+
+  async getCategoryPage(
+    category: TaxCoverageCategory,
+    filters: SalesAnalyticsFilters,
+    currentReportingCurrency: string,
+    pagination: CoverageDetectionPagination
+  ): Promise<PaginatedTaxCoverageOrders> {
+    const classification = await this.classify(filters, currentReportingCurrency);
+    const rows = classification[category];
+    return {
+      items: rows.slice(pagination.offset, pagination.offset + pagination.limit),
+      total: rows.length,
+    };
+  }
+
+  async getCategoryCounts(
+    filters: SalesAnalyticsFilters,
+    currentReportingCurrency: string
+  ): Promise<Record<TaxCoverageCategory, number>> {
+    const classification = await this.classify(filters, currentReportingCurrency);
+    const counts: Partial<Record<TaxCoverageCategory, number>> = {};
+    for (const category of TaxCoverageCategoryValues) {
+      counts[category] = classification[category].length;
+    }
+    return counts as Record<TaxCoverageCategory, number>;
+  }
+
+  private toRow(candidate: NetExcludedOrderCandidate): TaxCoverageOrderRow {
+    return {
+      internalOrderId: candidate.internalOrderId,
+      sourceConnectionId: candidate.sourceConnectionId,
+      placedAt: candidate.placedAt,
+    };
+  }
+
+  /**
+   * Classify one candidate. A non-pre-rollout candidate is always `'tax-b'`
+   * — the A/C split only applies to the pre-rollout blanket-exclusion case
+   * (see the class doc comment).
+   */
+  private async classifyOne(candidate: NetExcludedOrderCandidate): Promise<TaxCoverageCategory> {
+    if (candidate.taxRateEra !== PRE_ROLLOUT_ERA) {
+      return 'tax-b';
+    }
+
+    const lines = await this.orderLineItemRepository.findByOrderId(candidate.internalOrderId);
+    const unresolvedLines = lines.filter(
+      (line) => resolveNetSalesTaxRate(line.taxRate).kind === 'unknown'
+    );
+
+    // Every line already resolves (e.g. the backfill sweep already wrote a
+    // rate to each one) — the order is fully resolvable, just blocked by
+    // the blanket pre-rollout exclusion.
+    if (unresolvedLines.length === 0) {
+      return 'tax-a';
+    }
+
+    let anyConfirmedNoRate = false;
+    let anyNotChecked = false;
+
+    for (const line of unresolvedLines) {
+      let rate: StoredTaxRate;
+      try {
+        rate = await this.productsService.getEffectiveTaxRate(
+          line.productId,
+          line.variantId ?? undefined
+        );
+      } catch (error) {
+        // A catalogue read failure tells us nothing about the rate's
+        // existence — treat like 'not-checked' rather than assuming the
+        // worst (a permanent 'no-rate' claim this order does not support).
+        this.logger.warn(
+          `Tax coverage classification: catalogue read failed for order ${candidate.internalOrderId} ` +
+            `line [productId=${line.productId}, variantId=${line.variantId ?? 'none'}]: ${(error as Error).message}`
+        );
+        anyNotChecked = true;
+        continue;
+      }
+
+      const state = taxRateState(rate);
+      if (state === 'known') {
+        continue;
+      }
+      if (state === 'no-rate') {
+        anyConfirmedNoRate = true;
+      } else {
+        anyNotChecked = true;
+      }
+    }
+
+    if (!anyConfirmedNoRate && !anyNotChecked) {
+      return 'tax-a';
+    }
+    // A confirmed no-rate line makes the order permanently unresolvable —
+    // takes precedence over a merely not-yet-checked sibling line, since
+    // "no remediation exists" is the stronger, more actionable fact.
+    if (anyConfirmedNoRate) {
+      return 'tax-b';
+    }
+    return 'tax-c';
+  }
+}

--- a/libs/core/src/orders/application/services/tax-coverage-detection.service.ts
+++ b/libs/core/src/orders/application/services/tax-coverage-detection.service.ts
@@ -133,6 +133,23 @@ export class TaxCoverageDetectionService implements ITaxCoverageDetectionService
     return counts as Record<TaxCoverageCategory, number>;
   }
 
+  async getAllCategoryPages(
+    filters: SalesAnalyticsFilters,
+    currentReportingCurrency: string,
+    pagination: CoverageDetectionPagination
+  ): Promise<Record<TaxCoverageCategory, PaginatedTaxCoverageOrders>> {
+    const classification = await this.classify(filters, currentReportingCurrency);
+    const pages: Partial<Record<TaxCoverageCategory, PaginatedTaxCoverageOrders>> = {};
+    for (const category of TaxCoverageCategoryValues) {
+      const rows = classification[category];
+      pages[category] = {
+        items: rows.slice(pagination.offset, pagination.offset + pagination.limit),
+        total: rows.length,
+      };
+    }
+    return pages as Record<TaxCoverageCategory, PaginatedTaxCoverageOrders>;
+  }
+
   private toRow(candidate: NetExcludedOrderCandidate): TaxCoverageOrderRow {
     return {
       internalOrderId: candidate.internalOrderId,

--- a/libs/core/src/orders/domain/ports/order-record-repository.port.ts
+++ b/libs/core/src/orders/domain/ports/order-record-repository.port.ts
@@ -29,6 +29,7 @@ import type {
   CoverageDetectionPagination,
   PaginatedCurrencyMismatchOrders,
   NetExcludedOrderCandidate,
+  PaginatedProductMatchingErrorOrders,
 } from '../types/coverage-detection.types';
 
 export interface OrderRecordRepositoryPort {
@@ -244,6 +245,22 @@ export interface OrderRecordRepositoryPort {
     filters: SalesAnalyticsFilters,
     currentReportingCurrency: string
   ): Promise<NetExcludedOrderCandidate[]>;
+
+  /**
+   * Data Coverage `'product-matching'` category drill-down (#2466) — orders
+   * stuck `recordStatus IN ('awaiting_mapping', 'source_deleted')`, the SAME
+   * predicate `countByHealth`'s `awaiting_mapping` + `source_deleted`
+   * buckets already partition (so `total` here always matches their sum for
+   * the same filters). Deliberately keyed on {@link OrderHealthSummaryFilters}
+   * (`createdAt`-scoped), NOT {@link SalesAnalyticsFilters} (`placedAt`-scoped)
+   * — #1985 populates `placedAt`/`totalAmount` only for `recordStatus =
+   * 'ready'` records, so a product-matching row's `placedAt` is always
+   * `null` and would be silently excluded by a `placedAt` range filter.
+   */
+  findProductMatchingErrorOrders(
+    filters: OrderHealthSummaryFilters,
+    pagination: CoverageDetectionPagination
+  ): Promise<PaginatedProductMatchingErrorOrders>;
 
   /**
    * Headline median order value for the sales & channel analytics read

--- a/libs/core/src/orders/domain/ports/order-record-repository.port.ts
+++ b/libs/core/src/orders/domain/ports/order-record-repository.port.ts
@@ -28,6 +28,7 @@ import type { DailyOrderAggregateRow, SalesAnalyticsFilters } from '../types/ord
 import type {
   CoverageDetectionPagination,
   PaginatedCurrencyMismatchOrders,
+  NetExcludedOrderCandidate,
 } from '../types/coverage-detection.types';
 
 export interface OrderRecordRepositoryPort {
@@ -217,6 +218,32 @@ export interface OrderRecordRepositoryPort {
     currentReportingCurrency: string,
     pagination: CoverageDetectionPagination
   ): Promise<PaginatedCurrencyMismatchOrders>;
+
+  /**
+   * Data Coverage tax A/B/C detector's base population (#2465) — every
+   * order EXCLUDED from `getDailyOrderAggregates`' `net_excluded_count`
+   * figure, i.e. the IDENTICAL predicate mirrored from
+   * `netExcludedAndNotCancelled` there: `recordStatus = 'ready'`, resolvable
+   * `placedAt`/`totalAmount`, `[filters.from, filters.to)`, optional
+   * connection narrowing, non-cancelled, current-era stamped
+   * (`reportingCurrency = currentReportingCurrency`), and `NOT
+   * netSalesOrderNetEligibleSql(...)`. Kept as the SAME predicate on purpose
+   * so `candidates.length` is exactly `netExcludedCount` summed over the
+   * same filters — the #2465 regression guard.
+   *
+   * Unpaged by design: unlike {@link findCurrencyMismatchOrders}, this read
+   * feeds `TaxCoverageDetectionService`'s classification pass, which needs
+   * the FULL candidate set (to compute correct per-category totals) before
+   * any page can be sliced — pushing pagination down to SQL here would
+   * paginate the wrong population (page-of-candidates, not
+   * page-of-one-category). Bounded in practice by the same
+   * `[filters.from, filters.to)` window every sales-analytics read already
+   * requires (10-100 orders/day persona scale, per #1985's ADR-039 note).
+   */
+  findNetExcludedOrderCandidates(
+    filters: SalesAnalyticsFilters,
+    currentReportingCurrency: string
+  ): Promise<NetExcludedOrderCandidate[]>;
 
   /**
    * Headline median order value for the sales & channel analytics read

--- a/libs/core/src/orders/domain/ports/order-record-repository.port.ts
+++ b/libs/core/src/orders/domain/ports/order-record-repository.port.ts
@@ -25,6 +25,10 @@ import type { SalesDocumentBlock } from '@openlinker/core/sales-documents';
 import type { OrderFxIntent, OrderFxStamp } from '../types/order-fx.types';
 import type { StampedReportingCurrencyCount } from '../types/order-fx-read.types';
 import type { DailyOrderAggregateRow, SalesAnalyticsFilters } from '../types/order-sales-analytics.types';
+import type {
+  CoverageDetectionPagination,
+  PaginatedCurrencyMismatchOrders,
+} from '../types/coverage-detection.types';
 
 export interface OrderRecordRepositoryPort {
   /**
@@ -191,6 +195,28 @@ export interface OrderRecordRepositoryPort {
     filters: SalesAnalyticsFilters,
     currentReportingCurrency: string
   ): Promise<DailyOrderAggregateRow[]>;
+
+  /**
+   * Data Coverage 'currency' category drill-down (#2464) — the paginated
+   * list of orders backing {@link getDailyOrderAggregates}' combined
+   * `unconvertedCount`/`unconvertedValue` figure. Same scope as
+   * {@link getDailyOrderAggregates} (`recordStatus = 'ready'`, resolvable
+   * `placedAt`/`totalAmount`, `[filters.from, filters.to)`, optional
+   * connection narrowing, non-cancelled) and the IDENTICAL currency-mismatch
+   * predicate: `reportingCurrency IS NULL OR reportingCurrency !=
+   * currentReportingCurrency`. That predicate already covers both
+   * populations the mockup's `detail-currency` state needs to show under one
+   * combined count - a never-stamped row (`stampedCurrency: null`) and a
+   * stamped-but-stale row (a prior reporting-currency era, ADR-040 - Decision
+   * 7's restatement case) - so `total` here is exactly
+   * `unconvertedCount` summed over the same filters, which the #2464 tests
+   * assert as a regression guard.
+   */
+  findCurrencyMismatchOrders(
+    filters: SalesAnalyticsFilters,
+    currentReportingCurrency: string,
+    pagination: CoverageDetectionPagination
+  ): Promise<PaginatedCurrencyMismatchOrders>;
 
   /**
    * Headline median order value for the sales & channel analytics read

--- a/libs/core/src/orders/domain/types/coverage-detection.types.ts
+++ b/libs/core/src/orders/domain/types/coverage-detection.types.ts
@@ -3,10 +3,11 @@
  *
  * Shared vocabulary for the `/analytics` Data Coverage panel's detectors
  * (epic #2452, mini-epic #2463) — the currency-mismatch detector (#2464,
- * this task) is the first consumer, and the tax A/B/C detector (#2465) plus
- * the product-matching detector + aggregate `GET /analytics/coverage`
- * endpoint (#2466) extend this same file. Kept additive on purpose: nothing
- * here is currency-specific except the types explicitly named for it.
+ * this task) is the first consumer, and the tax A/B/C detector (#2465, this
+ * extension) plus the product-matching detector + aggregate
+ * `GET /analytics/coverage` endpoint (#2466) extend this same file. Kept
+ * additive on purpose: nothing here is currency-specific except the types
+ * explicitly named for it.
  *
  * `CoverageCategory` / `CoverageResolutionStatus` follow the Phase 1 Task 1.2
  * decision doc (`docs/plans/analytics-coverage-remediation-decision.md`,
@@ -22,12 +23,12 @@
  */
 
 /**
- * Data Coverage category values. Only `'currency'` is populated by this
- * task (#2464) — the tax A/B/C categories (#2465) and the product-matching
- * category (#2466) are added here by those sibling tasks rather than
- * guessed at in advance.
+ * Data Coverage category values. `'currency'` was populated by #2464;
+ * `'tax-a'`/`'tax-b'`/`'tax-c'` are added here by this task (#2465) — the
+ * product-matching category (#2466) is added by that sibling task rather
+ * than guessed at in advance.
  */
-export const CoverageCategoryValues = ['currency'] as const;
+export const CoverageCategoryValues = ['currency', 'tax-a', 'tax-b', 'tax-c'] as const;
 
 /**
  * Data Coverage category type — one row per category in the
@@ -94,4 +95,92 @@ export interface CurrencyMismatchOrderRow {
 export interface PaginatedCurrencyMismatchOrders {
   items: CurrencyMismatchOrderRow[];
   total: number;
+}
+
+/**
+ * Tax A/B/C sub-category values (#2465) — the three operator-actionable
+ * partitions of the `netExcludedCount` population, each with a distinct
+ * remediation path (see `TaxCoverageDetectionService`'s doc comment for the
+ * classification rule):
+ *
+ * - `'tax-a'` — unconfirmed-but-resolvable: `taxRateEra = 'pre-rollout'` and
+ *   every one of the order's unresolved lines DOES resolve a rate from the
+ *   current catalogue (already backfilled, or resolvable right now). Would
+ *   become net-eligible if Phase 5's `includeGuessedVatRatesInNetSales`
+ *   setting were ON. Mockup `detail-tax`.
+ * - `'tax-b'` — no tax rate at all: either (i) the order is excluded for a
+ *   reason OTHER than the pre-rollout era (a post-rollout order with a
+ *   genuinely unresolved line, or no line items), or (ii) it IS pre-rollout
+ *   but the catalogue has been asked about at least one unresolved line's
+ *   product/variant and confirmed it carries none. No remediation action
+ *   exists for this category. Mockup `detail-novat`.
+ * - `'tax-c'` — pre-rollout, not yet resolvable: `taxRateEra = 'pre-rollout'`,
+ *   at least one unresolved line's product/variant has never been asked
+ *   about a tax rate at all (`taxRateState === 'not-checked'`), and none of
+ *   the order's unresolved lines were confirmed rate-less. A future catalogue
+ *   sync (or the backfill sweep, once it reaches this connection's frontier)
+ *   may still resolve it. Mockup `detail-postrollout`.
+ */
+export const TaxCoverageCategoryValues = ['tax-a', 'tax-b', 'tax-c'] as const;
+
+/**
+ * Tax coverage sub-category type — a narrowing of {@link CoverageCategory}
+ * scoped to the three tax-only values.
+ */
+export type TaxCoverageCategory = (typeof TaxCoverageCategoryValues)[number];
+
+/**
+ * One order in a tax coverage sub-category's drill-down list. Deliberately
+ * as minimal as {@link CurrencyMismatchOrderRow} — no thumbnail/order-number
+ * field, since `OrderRecord` denormalizes no such column.
+ */
+export interface TaxCoverageOrderRow {
+  internalOrderId: string;
+  sourceConnectionId: string;
+  /** `order_records.placedAt` — `null` for a historical row with no resolvable placement date. */
+  placedAt: Date | null;
+}
+
+/**
+ * Paginated result for {@link TaxCoverageOrderRow}, mirroring
+ * {@link PaginatedCurrencyMismatchOrders}'s `{ items, total }` shape.
+ */
+export interface PaginatedTaxCoverageOrders {
+  items: TaxCoverageOrderRow[];
+  total: number;
+}
+
+/**
+ * A `netExcludedCount` candidate order awaiting A/B/C classification — the
+ * minimal shape `OrderRecordRepositoryPort.findNetExcludedOrderCandidates`
+ * returns per row, before `TaxCoverageDetectionService` resolves each one's
+ * category (a per-line, live-catalogue check that cannot be pushed into
+ * SQL, so it happens in the application layer instead).
+ */
+export interface NetExcludedOrderCandidate {
+  internalOrderId: string;
+  sourceConnectionId: string;
+  placedAt: Date | null;
+  /**
+   * Raw `order_records.taxRateEra` value. Kept as `string | null` here
+   * (mirroring the ORM entity's own column type) rather than the narrower
+   * `TaxRateEra` from `@openlinker/core/sales-documents` — that type lives in
+   * a sibling context and `orders` already imports it only where the value
+   * is a live column). Classification treats anything other than the
+   * literal `'pre-rollout'` string as "not pre-rollout".
+   */
+  taxRateEra: string | null;
+}
+
+/**
+ * Every {@link NetExcludedOrderCandidate} classified into its A/B/C bucket
+ * (#2465). The three arrays are a complete partition of the input — every
+ * candidate lands in exactly one — which is the regression guard the #2465
+ * tests assert (`categoryA.length + categoryB.length + categoryC.length ===
+ * candidates.length`, and by construction, `=== netExcludedCount`).
+ */
+export interface TaxCoverageClassification {
+  'tax-a': TaxCoverageOrderRow[];
+  'tax-b': TaxCoverageOrderRow[];
+  'tax-c': TaxCoverageOrderRow[];
 }

--- a/libs/core/src/orders/domain/types/coverage-detection.types.ts
+++ b/libs/core/src/orders/domain/types/coverage-detection.types.ts
@@ -1,0 +1,97 @@
+/**
+ * Coverage Detection Types
+ *
+ * Shared vocabulary for the `/analytics` Data Coverage panel's detectors
+ * (epic #2452, mini-epic #2463) — the currency-mismatch detector (#2464,
+ * this task) is the first consumer, and the tax A/B/C detector (#2465) plus
+ * the product-matching detector + aggregate `GET /analytics/coverage`
+ * endpoint (#2466) extend this same file. Kept additive on purpose: nothing
+ * here is currency-specific except the types explicitly named for it.
+ *
+ * `CoverageCategory` / `CoverageResolutionStatus` follow the Phase 1 Task 1.2
+ * decision doc (`docs/plans/analytics-coverage-remediation-decision.md`,
+ * still unmerged as of this task — PR #2487): lifecycle (open/in-progress/
+ * resolved/failed) is tracked independently of display tone (success/
+ * warning/critical), mirroring the existing `deriveOrderHealth` /
+ * `ConnectionIngestionStatus` precedent of one closed lifecycle union plus a
+ * pure derivation function — `deriveCoverageDisplay` is that function's home
+ * once a consumer needs it; this task does not need it, so it is not added
+ * here speculatively.
+ *
+ * @module libs/core/src/orders/domain/types
+ */
+
+/**
+ * Data Coverage category values. Only `'currency'` is populated by this
+ * task (#2464) — the tax A/B/C categories (#2465) and the product-matching
+ * category (#2466) are added here by those sibling tasks rather than
+ * guessed at in advance.
+ */
+export const CoverageCategoryValues = ['currency'] as const;
+
+/**
+ * Data Coverage category type — one row per category in the
+ * `GET /analytics/coverage` response (#2466).
+ */
+export type CoverageCategory = (typeof CoverageCategoryValues)[number];
+
+/**
+ * Lifecycle status for a Data Coverage category row. Per the decision doc,
+ * this is lifecycle-only — `'open'`/`'in-progress'` describe whether a
+ * remediation run exists and has finished, `'resolved'`/`'failed'` describe
+ * how it ended. Every detector reports `'open'` today (Phase 5 is the only
+ * writer of the other three values, and only for the `'currency'` category).
+ */
+export const CoverageResolutionStatusValues = ['open', 'in-progress', 'resolved', 'failed'] as const;
+
+/**
+ * Lifecycle status type, shared by every Data Coverage category.
+ */
+export type CoverageResolutionStatus = (typeof CoverageResolutionStatusValues)[number];
+
+/**
+ * Page/limit pagination shape for a Data Coverage detail-row read, mirroring
+ * {@link OrderRecordPagination} — a distinct type (rather than reusing that
+ * one directly) so a coverage-specific constraint (e.g. a smaller max page
+ * size for a UI drill-down list) can be added later without widening the
+ * order-list pagination contract.
+ */
+export interface CoverageDetectionPagination {
+  limit: number;
+  offset: number;
+}
+
+/**
+ * One affected order in the `'currency'` category's paginated drill-down
+ * list (mockup state `detail-currency`). Deliberately does NOT carry a
+ * thumbnail/order-number field — `OrderRecord` denormalizes no such column,
+ * and inventing one here would assert data that does not exist; `apps/api`
+ * is free to add a hydration step from `orderSnapshot` later if the FE
+ * genuinely needs it, but that's a interfaces-layer concern, not this read.
+ *
+ * Covers BOTH currency-mismatch populations under one shape (#2464): a row
+ * with `stampedCurrency: null` was never stamped, a row with a non-null
+ * `stampedCurrency` that differs from the current reporting-currency setting
+ * was stamped against a prior era (ADR-040 §Decision 7's restatement case).
+ * The mockup does not distinguish the two to the operator — see
+ * `findCurrencyMismatchOrders`'s doc comment for the combined predicate.
+ */
+export interface CurrencyMismatchOrderRow {
+  internalOrderId: string;
+  sourceConnectionId: string;
+  /** `order_records.currency` — the order's own native currency, `null` for a historical row predating that column. */
+  nativeCurrency: string | null;
+  /** `order_records.reportingCurrency` — `null` when the order has never been stamped at all. */
+  stampedCurrency: string | null;
+  /** `order_records.fxStampedAt` — `null` while a stamp attempt is still deferred (or never attempted). */
+  stampedAt: Date | null;
+}
+
+/**
+ * Paginated result for {@link CurrencyMismatchOrderRow}, mirroring
+ * `PaginatedOrderRecords`'s `{ items, total }` shape.
+ */
+export interface PaginatedCurrencyMismatchOrders {
+  items: CurrencyMismatchOrderRow[];
+  total: number;
+}

--- a/libs/core/src/orders/domain/types/coverage-detection.types.ts
+++ b/libs/core/src/orders/domain/types/coverage-detection.types.ts
@@ -9,6 +9,13 @@
  * additive on purpose: nothing here is currency-specific except the types
  * explicitly named for it.
  *
+ * The product-matching detector (#2466) is the one genuinely new category —
+ * no existing aggregate tracked it before this. It reuses the
+ * `OrderRecordStatus` / `mappingFailureReason` vocabulary `OrderRecord`
+ * already carries for the #1689 stale-variant treatment (`awaiting_mapping`
+ * is self-healing, `source_deleted` is permanent) rather than inventing a
+ * parallel signal.
+ *
  * `CoverageCategory` / `CoverageResolutionStatus` follow the Phase 1 Task 1.2
  * decision doc (`docs/plans/analytics-coverage-remediation-decision.md`,
  * still unmerged as of this task — PR #2487): lifecycle (open/in-progress/
@@ -23,12 +30,17 @@
  */
 
 /**
- * Data Coverage category values. `'currency'` was populated by #2464;
- * `'tax-a'`/`'tax-b'`/`'tax-c'` are added here by this task (#2465) — the
- * product-matching category (#2466) is added by that sibling task rather
- * than guessed at in advance.
+ * Data Coverage category values. `'currency'` was populated by #2464,
+ * `'tax-a'`/`'tax-b'`/`'tax-c'` by #2465, and `'product-matching'` (an order
+ * stuck `recordStatus IN ('awaiting_mapping', 'source_deleted')`) by #2466.
  */
-export const CoverageCategoryValues = ['currency', 'tax-a', 'tax-b', 'tax-c'] as const;
+export const CoverageCategoryValues = [
+  'currency',
+  'tax-a',
+  'tax-b',
+  'tax-c',
+  'product-matching',
+] as const;
 
 /**
  * Data Coverage category type — one row per category in the
@@ -183,4 +195,42 @@ export interface TaxCoverageClassification {
   'tax-a': TaxCoverageOrderRow[];
   'tax-b': TaxCoverageOrderRow[];
   'tax-c': TaxCoverageOrderRow[];
+}
+
+/**
+ * One order in the `'product-matching'` category's drill-down list (mockup
+ * state `detail-mapping`, #2466) — an order stuck `recordStatus =
+ * 'awaiting_mapping' | 'source_deleted'` because at least one item
+ * reference failed resolution against the internal catalogue.
+ * `mappingFailureReason` is the SAME column both statuses populate
+ * (`OrderRecordService.updateItemResolutionFailure`, the #1689
+ * stale-variant treatment) — reused here rather than re-deriving a parallel
+ * signal, per this task's own scoping note.
+ *
+ * Deliberately as minimal as {@link CurrencyMismatchOrderRow} /
+ * {@link TaxCoverageOrderRow} — no thumbnail/order-number field, since
+ * `OrderRecord` denormalizes no such column. `placedAt` is omitted (unlike
+ * its siblings): #1985 populates `placedAt`/`totalAmount` only for
+ * `recordStatus = 'ready'` records, so a product-matching row's `placedAt`
+ * is always `null` — `createdAt` (always populated) is the only resolvable
+ * ordering/scoping timestamp for this category.
+ */
+export interface ProductMatchingErrorOrderRow {
+  internalOrderId: string;
+  sourceConnectionId: string;
+  /** Always `'awaiting_mapping'` or `'source_deleted'` — the two `OrderRecordStatus` values this detector's predicate matches. */
+  recordStatus: 'awaiting_mapping' | 'source_deleted';
+  /** `order_records.mappingFailureReason` — set alongside both matched statuses (#1689). */
+  mappingFailureReason: string | null;
+  /** `order_records.createdAt` — always populated, unlike `placedAt` for this category (see class doc comment). */
+  createdAt: Date;
+}
+
+/**
+ * Paginated result for {@link ProductMatchingErrorOrderRow}, mirroring
+ * {@link PaginatedCurrencyMismatchOrders}'s `{ items, total }` shape.
+ */
+export interface PaginatedProductMatchingErrorOrders {
+  items: ProductMatchingErrorOrderRow[];
+  total: number;
 }

--- a/libs/core/src/orders/index.ts
+++ b/libs/core/src/orders/index.ts
@@ -151,6 +151,7 @@ export {
 export {
   CoverageCategoryValues,
   CoverageResolutionStatusValues,
+  TaxCoverageCategoryValues,
 } from './domain/types/coverage-detection.types';
 export type {
   CoverageCategory,
@@ -158,6 +159,11 @@ export type {
   CoverageDetectionPagination,
   CurrencyMismatchOrderRow,
   PaginatedCurrencyMismatchOrders,
+  TaxCoverageCategory,
+  TaxCoverageOrderRow,
+  PaginatedTaxCoverageOrders,
+  NetExcludedOrderCandidate,
+  TaxCoverageClassification,
 } from './domain/types/coverage-detection.types';
 
 // Top products analytics (#1988) — response shapes for
@@ -229,6 +235,7 @@ export type {
   TaxRateBackfillPageInput,
   TaxRateBackfillPageResult,
 } from './application/services/tax-rate-backfill.service.interface';
+export type { ITaxCoverageDetectionService } from './application/services/tax-coverage-detection.service.interface';
 export type { IDisplayCurrencyConversionService } from './application/interfaces/display-currency-conversion.service.interface';
 export * from './orders.tokens';
 

--- a/libs/core/src/orders/index.ts
+++ b/libs/core/src/orders/index.ts
@@ -145,6 +145,21 @@ export {
   DailyTrendPoint,
 } from './domain/types/order-sales-analytics.types';
 
+// Data Coverage detection (epic #2452, mini-epic #2463) — shared vocabulary
+// consumed by the currency-mismatch detector (#2464) and its sibling
+// detectors (#2465/#2466).
+export {
+  CoverageCategoryValues,
+  CoverageResolutionStatusValues,
+} from './domain/types/coverage-detection.types';
+export type {
+  CoverageCategory,
+  CoverageResolutionStatus,
+  CoverageDetectionPagination,
+  CurrencyMismatchOrderRow,
+  PaginatedCurrencyMismatchOrders,
+} from './domain/types/coverage-detection.types';
+
 // Top products analytics (#1988) — response shapes for
 // IOrderRecordService.getTopProducts.
 export { TopProductSortByValues } from './domain/types/top-products.types';

--- a/libs/core/src/orders/index.ts
+++ b/libs/core/src/orders/index.ts
@@ -164,6 +164,8 @@ export type {
   PaginatedTaxCoverageOrders,
   NetExcludedOrderCandidate,
   TaxCoverageClassification,
+  ProductMatchingErrorOrderRow,
+  PaginatedProductMatchingErrorOrders,
 } from './domain/types/coverage-detection.types';
 
 // Top products analytics (#1988) — response shapes for

--- a/libs/core/src/orders/infrastructure/persistence/repositories/__tests__/order-record.repository.spec.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/__tests__/order-record.repository.spec.ts
@@ -456,6 +456,152 @@ describe('OrderRecordRepository', () => {
     });
   });
 
+  describe('findCurrencyMismatchOrders (#2464)', () => {
+    const baseFilters = {
+      from: new Date('2026-08-01T00:00:00.000Z'),
+      to: new Date('2026-08-08T00:00:00.000Z'),
+    };
+
+    const createMismatchEntity = (overrides: Partial<OrderRecordOrmEntity>): OrderRecordOrmEntity => {
+      const entity = createOrmEntity();
+      Object.assign(entity, overrides);
+      return entity;
+    };
+
+    it('applies the combined never-stamped-or-stale predicate, non-cancelled, with pagination', async () => {
+      const andWhere = jest.fn().mockReturnThis();
+      const orderBy = jest.fn().mockReturnThis();
+      const take = jest.fn().mockReturnThis();
+      const skip = jest.fn().mockReturnThis();
+      (ormRepository.createQueryBuilder as jest.Mock).mockReturnValue({
+        andWhere,
+        orderBy,
+        take,
+        skip,
+        getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+      });
+
+      await repository.findCurrencyMismatchOrders(baseFilters, 'EUR', { limit: 20, offset: 40 });
+
+      expect(andWhere).toHaveBeenCalledWith('rec."cancelledAt" IS NULL');
+      expect(andWhere).toHaveBeenCalledWith(
+        '(rec."reportingCurrency" IS NULL OR rec."reportingCurrency" != :currentReportingCurrency)',
+        { currentReportingCurrency: 'EUR' }
+      );
+      expect(orderBy).toHaveBeenCalledWith('rec."placedAt"', 'DESC');
+      expect(take).toHaveBeenCalledWith(20);
+      expect(skip).toHaveBeenCalledWith(40);
+    });
+
+    it('scopes to the sourceConnectionId filter when provided (via the shared analytics scope)', async () => {
+      const andWhere = jest.fn().mockReturnThis();
+      (ormRepository.createQueryBuilder as jest.Mock).mockReturnValue({
+        andWhere,
+        orderBy: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+      });
+
+      await repository.findCurrencyMismatchOrders(
+        { ...baseFilters, sourceConnectionId: 'conn-a' },
+        'EUR',
+        { limit: 20, offset: 0 }
+      );
+
+      expect(andWhere).toHaveBeenCalledWith('rec.sourceConnectionId = :salesConnectionId', {
+        salesConnectionId: 'conn-a',
+      });
+    });
+
+    it('maps a never-stamped row (reportingCurrency null) to the row shape', async () => {
+      const entity = createMismatchEntity({
+        internalOrderId: 'order-never-stamped',
+        sourceConnectionId: 'conn-a',
+        currency: 'PLN',
+        reportingCurrency: null,
+        fxStampedAt: null,
+      });
+      (ormRepository.createQueryBuilder as jest.Mock).mockReturnValue({
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        getManyAndCount: jest.fn().mockResolvedValue([[entity], 1]),
+      });
+
+      const result = await repository.findCurrencyMismatchOrders(baseFilters, 'EUR', {
+        limit: 20,
+        offset: 0,
+      });
+
+      expect(result.total).toBe(1);
+      expect(result.items).toEqual([
+        {
+          internalOrderId: 'order-never-stamped',
+          sourceConnectionId: 'conn-a',
+          nativeCurrency: 'PLN',
+          stampedCurrency: null,
+          stampedAt: null,
+        },
+      ]);
+    });
+
+    it('maps a stale-stamp row (reportingCurrency set to a prior era) to the row shape', async () => {
+      const stampedAt = new Date('2026-06-01T10:00:00.000Z');
+      const entity = createMismatchEntity({
+        internalOrderId: 'order-stale-stamp',
+        sourceConnectionId: 'conn-a',
+        currency: 'PLN',
+        reportingCurrency: 'EUR',
+        fxStampedAt: stampedAt,
+      });
+      (ormRepository.createQueryBuilder as jest.Mock).mockReturnValue({
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        getManyAndCount: jest.fn().mockResolvedValue([[entity], 1]),
+      });
+
+      // The demo-DB shape from the issue: a same-currency stale stamp
+      // (reportingCurrency='EUR', currency='PLN') — the current setting has
+      // since moved on to a different value, e.g. 'PLN'.
+      const result = await repository.findCurrencyMismatchOrders(baseFilters, 'PLN', {
+        limit: 20,
+        offset: 0,
+      });
+
+      expect(result.total).toBe(1);
+      expect(result.items).toEqual([
+        {
+          internalOrderId: 'order-stale-stamp',
+          sourceConnectionId: 'conn-a',
+          nativeCurrency: 'PLN',
+          stampedCurrency: 'EUR',
+          stampedAt,
+        },
+      ]);
+    });
+
+    it('returns an empty page when nothing matches (backs the all-clear mockup state)', async () => {
+      (ormRepository.createQueryBuilder as jest.Mock).mockReturnValue({
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+      });
+
+      const result = await repository.findCurrencyMismatchOrders(baseFilters, 'EUR', {
+        limit: 20,
+        offset: 0,
+      });
+
+      expect(result).toEqual({ items: [], total: 0 });
+    });
+  });
+
   describe('getMedianOrderValue (#1987)', () => {
     const baseFilters = {
       from: new Date('2026-08-01T00:00:00.000Z'),

--- a/libs/core/src/orders/infrastructure/persistence/repositories/__tests__/order-record.repository.spec.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/__tests__/order-record.repository.spec.ts
@@ -719,6 +719,131 @@ describe('OrderRecordRepository', () => {
     });
   });
 
+  describe('findProductMatchingErrorOrders (#2466)', () => {
+    const createMappingEntity = (
+      overrides: Partial<OrderRecordOrmEntity>
+    ): OrderRecordOrmEntity => {
+      const entity = createOrmEntity();
+      Object.assign(entity, overrides);
+      return entity;
+    };
+
+    it('applies the source_deleted OR awaiting_mapping predicate, newest-first, with pagination', async () => {
+      const andWhere = jest.fn().mockReturnThis();
+      const orderBy = jest.fn().mockReturnThis();
+      const take = jest.fn().mockReturnThis();
+      const skip = jest.fn().mockReturnThis();
+      (ormRepository.createQueryBuilder as jest.Mock).mockReturnValue({
+        andWhere,
+        orderBy,
+        take,
+        skip,
+        getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+      });
+
+      await repository.findProductMatchingErrorOrders({}, { limit: 20, offset: 40 });
+
+      expect(andWhere).toHaveBeenCalledWith(
+        `(rec."recordStatus" = 'source_deleted' OR rec."recordStatus" = 'awaiting_mapping')`
+      );
+      expect(orderBy).toHaveBeenCalledWith('rec."createdAt"', 'DESC');
+      expect(take).toHaveBeenCalledWith(20);
+      expect(skip).toHaveBeenCalledWith(40);
+    });
+
+    it('scopes to sourceConnectionId/customerId/createdFrom/createdTo when provided', async () => {
+      const andWhere = jest.fn().mockReturnThis();
+      (ormRepository.createQueryBuilder as jest.Mock).mockReturnValue({
+        andWhere,
+        orderBy: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+      });
+      const createdFrom = new Date('2026-08-01T00:00:00.000Z');
+      const createdTo = new Date('2026-08-08T00:00:00.000Z');
+
+      await repository.findProductMatchingErrorOrders(
+        { sourceConnectionId: 'conn-a', customerId: 'cust-a', createdFrom, createdTo },
+        { limit: 20, offset: 0 }
+      );
+
+      expect(andWhere).toHaveBeenCalledWith('rec.sourceConnectionId = :sourceConnectionId', {
+        sourceConnectionId: 'conn-a',
+      });
+      expect(andWhere).toHaveBeenCalledWith('rec.customerId = :customerId', {
+        customerId: 'cust-a',
+      });
+      expect(andWhere).toHaveBeenCalledWith('rec.createdAt >= :createdFrom', { createdFrom });
+      expect(andWhere).toHaveBeenCalledWith('rec.createdAt <= :createdTo', { createdTo });
+    });
+
+    it('maps an awaiting_mapping row to the row shape', async () => {
+      const entity = createMappingEntity({
+        internalOrderId: 'order-awaiting-mapping',
+        sourceConnectionId: 'conn-a',
+        recordStatus: 'awaiting_mapping',
+        mappingFailureReason: 'no variant mapping for SKU-123',
+        createdAt: new Date('2026-08-02T10:00:00.000Z'),
+      });
+      (ormRepository.createQueryBuilder as jest.Mock).mockReturnValue({
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        getManyAndCount: jest.fn().mockResolvedValue([[entity], 1]),
+      });
+
+      const result = await repository.findProductMatchingErrorOrders({}, { limit: 20, offset: 0 });
+
+      expect(result.total).toBe(1);
+      expect(result.items).toEqual([
+        {
+          internalOrderId: 'order-awaiting-mapping',
+          sourceConnectionId: 'conn-a',
+          recordStatus: 'awaiting_mapping',
+          mappingFailureReason: 'no variant mapping for SKU-123',
+          createdAt: entity.createdAt,
+        },
+      ]);
+    });
+
+    it('maps a source_deleted row to the row shape', async () => {
+      const entity = createMappingEntity({
+        internalOrderId: 'order-source-deleted',
+        sourceConnectionId: 'conn-a',
+        recordStatus: 'source_deleted',
+        mappingFailureReason: 'variant deleted at master',
+        createdAt: new Date('2026-08-03T10:00:00.000Z'),
+      });
+      (ormRepository.createQueryBuilder as jest.Mock).mockReturnValue({
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        getManyAndCount: jest.fn().mockResolvedValue([[entity], 1]),
+      });
+
+      const result = await repository.findProductMatchingErrorOrders({}, { limit: 20, offset: 0 });
+
+      expect(result.items[0].recordStatus).toBe('source_deleted');
+    });
+
+    it('returns an empty page when nothing matches (backs the all-clear mockup state)', async () => {
+      (ormRepository.createQueryBuilder as jest.Mock).mockReturnValue({
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        take: jest.fn().mockReturnThis(),
+        skip: jest.fn().mockReturnThis(),
+        getManyAndCount: jest.fn().mockResolvedValue([[], 0]),
+      });
+
+      const result = await repository.findProductMatchingErrorOrders({}, { limit: 20, offset: 0 });
+
+      expect(result).toEqual({ items: [], total: 0 });
+    });
+  });
+
   describe('getMedianOrderValue (#1987)', () => {
     const baseFilters = {
       from: new Date('2026-08-01T00:00:00.000Z'),

--- a/libs/core/src/orders/infrastructure/persistence/repositories/__tests__/order-record.repository.spec.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/__tests__/order-record.repository.spec.ts
@@ -602,6 +602,123 @@ describe('OrderRecordRepository', () => {
     });
   });
 
+  describe('findNetExcludedOrderCandidates (#2465)', () => {
+    const baseFilters = {
+      from: new Date('2026-08-01T00:00:00.000Z'),
+      to: new Date('2026-08-08T00:00:00.000Z'),
+    };
+
+    const createCandidateEntity = (
+      overrides: Partial<OrderRecordOrmEntity>
+    ): OrderRecordOrmEntity => {
+      const entity = createOrmEntity();
+      Object.assign(entity, overrides);
+      return entity;
+    };
+
+    it('applies the non-cancelled, current-era-stamped, NOT-net-eligible predicate', async () => {
+      const andWhere = jest.fn().mockReturnThis();
+      const orderBy = jest.fn().mockReturnThis();
+      (ormRepository.createQueryBuilder as jest.Mock).mockReturnValue({
+        andWhere,
+        orderBy,
+        getMany: jest.fn().mockResolvedValue([]),
+      });
+
+      await repository.findNetExcludedOrderCandidates(baseFilters, 'EUR');
+
+      expect(andWhere).toHaveBeenCalledWith(
+        expect.stringContaining('rec."cancelledAt" IS NULL AND rec."reportingCurrency" = :currentReportingCurrency AND NOT'),
+        { currentReportingCurrency: 'EUR' }
+      );
+      expect(orderBy).toHaveBeenCalledWith('rec."placedAt"', 'DESC');
+    });
+
+    it('is unpaged — no take/skip call on the query builder', async () => {
+      const qb: Record<string, jest.Mock> = {
+        andWhere: jest.fn(),
+        orderBy: jest.fn(),
+        getMany: jest.fn().mockResolvedValue([]),
+      };
+      qb.andWhere.mockReturnValue(qb);
+      qb.orderBy.mockReturnValue(qb);
+      (ormRepository.createQueryBuilder as jest.Mock).mockReturnValue(qb);
+
+      await repository.findNetExcludedOrderCandidates(baseFilters, 'EUR');
+
+      expect(qb.take).toBeUndefined();
+      expect(qb.skip).toBeUndefined();
+    });
+
+    it('maps a pre-rollout candidate to the row shape, including taxRateEra', async () => {
+      const entity = createCandidateEntity({
+        internalOrderId: 'order-pre-rollout',
+        sourceConnectionId: 'conn-a',
+        placedAt: new Date('2026-08-02T00:00:00.000Z'),
+        taxRateEra: 'pre-rollout',
+      });
+      (ormRepository.createQueryBuilder as jest.Mock).mockReturnValue({
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([entity]),
+      });
+
+      const result = await repository.findNetExcludedOrderCandidates(baseFilters, 'EUR');
+
+      expect(result).toEqual([
+        {
+          internalOrderId: 'order-pre-rollout',
+          sourceConnectionId: 'conn-a',
+          placedAt: entity.placedAt,
+          taxRateEra: 'pre-rollout',
+        },
+      ]);
+    });
+
+    it('maps a non-pre-rollout candidate with taxRateEra: null', async () => {
+      const entity = createCandidateEntity({
+        internalOrderId: 'order-post-rollout',
+        sourceConnectionId: 'conn-a',
+        placedAt: new Date('2026-08-03T00:00:00.000Z'),
+        taxRateEra: null,
+      });
+      (ormRepository.createQueryBuilder as jest.Mock).mockReturnValue({
+        andWhere: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([entity]),
+      });
+
+      const result = await repository.findNetExcludedOrderCandidates(baseFilters, 'EUR');
+
+      expect(result).toEqual([
+        {
+          internalOrderId: 'order-post-rollout',
+          sourceConnectionId: 'conn-a',
+          placedAt: entity.placedAt,
+          taxRateEra: null,
+        },
+      ]);
+    });
+
+    it('scopes to the sourceConnectionId filter when provided (via the shared analytics scope)', async () => {
+      const andWhere = jest.fn().mockReturnThis();
+      (ormRepository.createQueryBuilder as jest.Mock).mockReturnValue({
+        andWhere,
+        orderBy: jest.fn().mockReturnThis(),
+        getMany: jest.fn().mockResolvedValue([]),
+      });
+
+      await repository.findNetExcludedOrderCandidates(
+        { ...baseFilters, sourceConnectionId: 'conn-a' },
+        'EUR'
+      );
+
+      expect(andWhere).toHaveBeenCalledWith('rec.sourceConnectionId = :salesConnectionId', {
+        salesConnectionId: 'conn-a',
+      });
+    });
+  });
+
   describe('getMedianOrderValue (#1987)', () => {
     const baseFilters = {
       from: new Date('2026-08-01T00:00:00.000Z'),

--- a/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
@@ -58,6 +58,7 @@ import type {
   CoverageDetectionPagination,
   PaginatedCurrencyMismatchOrders,
   NetExcludedOrderCandidate,
+  PaginatedProductMatchingErrorOrders,
 } from '../../../domain/types/coverage-detection.types';
 
 @Injectable()
@@ -623,6 +624,56 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
       placedAt: entity.placedAt,
       taxRateEra: entity.taxRateEra,
     }));
+  }
+
+  /**
+   * Data Coverage `'product-matching'` category drill-down (#2466) — see
+   * the port's JSDoc. Same `source_deleted` / `awaiting_mapping` predicate
+   * {@link countByHealth} sums, filtered via {@link OrderHealthSummaryFilters}
+   * (`createdAt`-scoped, matching every other health-bucket read in this
+   * class) rather than the `placedAt`-scoped `SalesAnalyticsFilters`, since
+   * a matched row never carries a resolved `placedAt` (#1985).
+   */
+  async findProductMatchingErrorOrders(
+    filters: OrderHealthSummaryFilters,
+    pagination: CoverageDetectionPagination
+  ): Promise<PaginatedProductMatchingErrorOrders> {
+    const isProductMatchingError = `(${OrderRecordRepository.IS_SOURCE_DELETED} OR ${OrderRecordRepository.IS_MAPPING})`;
+
+    const qb = this.repository
+      .createQueryBuilder('rec')
+      .andWhere(isProductMatchingError)
+      .orderBy('rec."createdAt"', 'DESC')
+      .take(pagination.limit)
+      .skip(pagination.offset);
+
+    if (filters.sourceConnectionId) {
+      qb.andWhere('rec.sourceConnectionId = :sourceConnectionId', {
+        sourceConnectionId: filters.sourceConnectionId,
+      });
+    }
+    if (filters.customerId) {
+      qb.andWhere('rec.customerId = :customerId', { customerId: filters.customerId });
+    }
+    if (filters.createdFrom) {
+      qb.andWhere('rec.createdAt >= :createdFrom', { createdFrom: filters.createdFrom });
+    }
+    if (filters.createdTo) {
+      qb.andWhere('rec.createdAt <= :createdTo', { createdTo: filters.createdTo });
+    }
+
+    const [entities, total] = await qb.getManyAndCount();
+
+    return {
+      items: entities.map((entity) => ({
+        internalOrderId: entity.internalOrderId,
+        sourceConnectionId: entity.sourceConnectionId,
+        recordStatus: entity.recordStatus as 'awaiting_mapping' | 'source_deleted',
+        mappingFailureReason: entity.mappingFailureReason,
+        createdAt: entity.createdAt,
+      })),
+      total,
+    };
   }
 
   /**

--- a/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
@@ -57,6 +57,7 @@ import type {
 import type {
   CoverageDetectionPagination,
   PaginatedCurrencyMismatchOrders,
+  NetExcludedOrderCandidate,
 } from '../../../domain/types/coverage-detection.types';
 
 @Injectable()
@@ -590,6 +591,38 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
       })),
       total,
     };
+  }
+
+  /**
+   * Data Coverage tax A/B/C detector's base population (#2465) — see the
+   * port's JSDoc for the predicate rationale. Mirrors
+   * `getDailyOrderAggregates`'s `netExcludedAndNotCancelled` fragment
+   * EXACTLY (non-cancelled, current-era stamped, `NOT` net-eligible) so
+   * `candidates.length` is always the same figure as `netExcludedCount`
+   * for the identical filters/currency.
+   */
+  async findNetExcludedOrderCandidates(
+    filters: SalesAnalyticsFilters,
+    currentReportingCurrency: string
+  ): Promise<NetExcludedOrderCandidate[]> {
+    const { netEligible } = this.buildNetSalesOrderFragments();
+    const netExcludedAndNotCancelled = `rec."cancelledAt" IS NULL AND rec."reportingCurrency" = :currentReportingCurrency AND NOT ${netEligible}`;
+
+    const qb = this.repository
+      .createQueryBuilder('rec')
+      .andWhere(netExcludedAndNotCancelled, { currentReportingCurrency })
+      .orderBy('rec."placedAt"', 'DESC');
+
+    this.applySalesAnalyticsScope(qb, filters);
+
+    const entities = await qb.getMany();
+
+    return entities.map((entity) => ({
+      internalOrderId: entity.internalOrderId,
+      sourceConnectionId: entity.sourceConnectionId,
+      placedAt: entity.placedAt,
+      taxRateEra: entity.taxRateEra,
+    }));
   }
 
   /**

--- a/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
@@ -54,6 +54,10 @@ import type {
   DailyOrderAggregateRow,
   SalesAnalyticsFilters,
 } from '../../../domain/types/order-sales-analytics.types';
+import type {
+  CoverageDetectionPagination,
+  PaginatedCurrencyMismatchOrders,
+} from '../../../domain/types/coverage-detection.types';
 
 @Injectable()
 export class OrderRecordRepository implements OrderRecordRepositoryPort {
@@ -536,6 +540,56 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
       netExcludedCount: Number(row.net_excluded_count),
       netExcludedValue: Number(row.net_excluded_value),
     }));
+  }
+
+  /**
+   * Data Coverage 'currency' category drill-down (#2464). Paged list of
+   * orders whose reporting-currency stamp does not (yet) match the current
+   * setting, covering BOTH populations under one combined predicate - a
+   * never-stamped row (`reportingCurrency IS NULL`) and a stamped-but-stale
+   * row from a prior reporting-currency era (ADR-040) - so the returned
+   * `total` is exactly the same figure {@link getDailyOrderAggregates}
+   * reports as `unconvertedCount`, summed over the same filters (asserted
+   * as a regression guard by the #2464 tests).
+   *
+   * Deliberately the SAME scope predicate as `unconvertedAndNotCancelled`
+   * in {@link getDailyOrderAggregates} (`recordStatus = 'ready'`, resolvable
+   * `placedAt`/`totalAmount`, in-range, optional connection, non-cancelled)
+   * so the two reads can never silently diverge on what counts as
+   * "unconverted". Ordered newest-first so an operator drilling in sees the
+   * most recent mismatches first, mirroring `findUnstampedFxOrderIds`'s
+   * "most likely to matter" ordering convention.
+   */
+  async findCurrencyMismatchOrders(
+    filters: SalesAnalyticsFilters,
+    currentReportingCurrency: string,
+    pagination: CoverageDetectionPagination
+  ): Promise<PaginatedCurrencyMismatchOrders> {
+    const qb = this.repository
+      .createQueryBuilder('rec')
+      .andWhere('rec."cancelledAt" IS NULL')
+      .andWhere(
+        '(rec."reportingCurrency" IS NULL OR rec."reportingCurrency" != :currentReportingCurrency)',
+        { currentReportingCurrency }
+      )
+      .orderBy('rec."placedAt"', 'DESC')
+      .take(pagination.limit)
+      .skip(pagination.offset);
+
+    this.applySalesAnalyticsScope(qb, filters);
+
+    const [entities, total] = await qb.getManyAndCount();
+
+    return {
+      items: entities.map((entity) => ({
+        internalOrderId: entity.internalOrderId,
+        sourceConnectionId: entity.sourceConnectionId,
+        nativeCurrency: entity.currency,
+        stampedCurrency: entity.reportingCurrency,
+        stampedAt: entity.fxStampedAt,
+      })),
+      total,
+    };
   }
 
   /**

--- a/libs/core/src/orders/orders.module.ts
+++ b/libs/core/src/orders/orders.module.ts
@@ -24,6 +24,7 @@ import { RefundRecordRepository } from './infrastructure/persistence/repositorie
 import { RefundRecordOrmEntity } from './infrastructure/persistence/entities/refund-record.orm-entity';
 import { OrderLineItemOrmEntity } from './infrastructure/persistence/entities/order-line-item.orm-entity';
 import { TaxRateBackfillService } from './application/services/tax-rate-backfill.service';
+import { TaxCoverageDetectionService } from './application/services/tax-coverage-detection.service';
 import { DisplayCurrencyConversionService } from './application/services/display-currency-conversion.service';
 import {
   ORDER_SYNC_SERVICE_TOKEN,
@@ -39,6 +40,7 @@ import {
   ORDER_FX_READ_SERVICE_TOKEN,
   ORDER_LINE_ITEM_REPOSITORY_TOKEN,
   TAX_RATE_BACKFILL_SERVICE_TOKEN,
+  TAX_COVERAGE_DETECTION_SERVICE_TOKEN,
   DISPLAY_CURRENCY_CONVERSION_SERVICE_TOKEN,
 } from './orders.tokens';
 import { IntegrationsModule } from '@openlinker/core/integrations';
@@ -89,6 +91,7 @@ export { ORDER_SYNC_SERVICE_TOKEN } from './orders.tokens';
     RefundRecordRepository,
     OrderLineItemRepository,
     TaxRateBackfillService,
+    TaxCoverageDetectionService,
     DisplayCurrencyConversionService,
     // Then provide token bindings using useExisting
     {
@@ -144,6 +147,10 @@ export { ORDER_SYNC_SERVICE_TOKEN } from './orders.tokens';
       useExisting: TaxRateBackfillService,
     },
     {
+      provide: TAX_COVERAGE_DETECTION_SERVICE_TOKEN,
+      useExisting: TaxCoverageDetectionService,
+    },
+    {
       provide: DISPLAY_CURRENCY_CONVERSION_SERVICE_TOKEN,
       useExisting: DisplayCurrencyConversionService,
     },
@@ -165,6 +172,9 @@ export { ORDER_SYNC_SERVICE_TOKEN } from './orders.tokens';
     // Exported so the worker's `orders.taxRate.backfill` handler can inject
     // the backfill seam (#2440).
     TAX_RATE_BACKFILL_SERVICE_TOKEN,
+    // Exported so the `/analytics/coverage` endpoint (#2466) can inject the
+    // tax A/B/C detector seam (#2465).
+    TAX_COVERAGE_DETECTION_SERVICE_TOKEN,
     // Exported so the `/analytics` display-currency read surface (a later
     // phase of #2452) can inject this seam (#2458, ADR-064, pending in PR #2485).
     DISPLAY_CURRENCY_CONVERSION_SERVICE_TOKEN,

--- a/libs/core/src/orders/orders.tokens.ts
+++ b/libs/core/src/orders/orders.tokens.ts
@@ -26,6 +26,8 @@ export const ORDER_REFUND_SERVICE_TOKEN = Symbol('IOrderRefundService');
 export const ORDER_LINE_ITEM_REPOSITORY_TOKEN = Symbol('OrderLineItemRepositoryPort');
 // Tax-rate backfill sweep for pre-#2245 lines (#2440).
 export const TAX_RATE_BACKFILL_SERVICE_TOKEN = Symbol('ITaxRateBackfillService');
+// Data Coverage tax A/B/C detector (#2465).
+export const TAX_COVERAGE_DETECTION_SERVICE_TOKEN = Symbol('ITaxCoverageDetectionService');
 // Analytics display-currency conversion read model (#2458, ADR-064, pending in PR #2485).
 export const DISPLAY_CURRENCY_CONVERSION_SERVICE_TOKEN = Symbol(
   'IDisplayCurrencyConversionService'

--- a/libs/core/src/shipping/application/services/fulfillment-status-sync.service.spec.ts
+++ b/libs/core/src/shipping/application/services/fulfillment-status-sync.service.spec.ts
@@ -107,6 +107,8 @@ describe('FulfillmentStatusSyncService', () => {
       getEarliestOrderDateByConnection: jest.fn(),
       getSalesAndChannelAnalytics: jest.fn(),
       getTopProducts: jest.fn(),
+      getCurrencyMismatchOrders: jest.fn(),
+      getProductMatchingErrorOrders: jest.fn(),
     };
 
     routing = {

--- a/libs/core/src/shipping/application/services/shipment-dispatch-notification.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-dispatch-notification.service.spec.ts
@@ -105,6 +105,8 @@ describe('ShipmentDispatchNotificationService', () => {
       getEarliestOrderDateByConnection: jest.fn(),
       getSalesAndChannelAnalytics: jest.fn(),
       getTopProducts: jest.fn(),
+      getCurrencyMismatchOrders: jest.fn(),
+      getProductMatchingErrorOrders: jest.fn(),
     };
 
     integrations = {

--- a/libs/core/src/shipping/application/services/shipment-dispatch.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-dispatch.service.spec.ts
@@ -172,6 +172,8 @@ describe('ShipmentDispatchService', () => {
       getEarliestOrderDateByConnection: jest.fn(),
       getSalesAndChannelAnalytics: jest.fn(),
       getTopProducts: jest.fn(),
+      getCurrencyMismatchOrders: jest.fn(),
+      getProductMatchingErrorOrders: jest.fn(),
     };
     const fulfillmentProjection = { recompute: jest.fn() };
     // Uncontended by default (#1917): every pre-existing test asserts the

--- a/scripts/check-cross-context-imports.mjs
+++ b/scripts/check-cross-context-imports.mjs
@@ -466,6 +466,10 @@ const ALLOW_LIST = new Map([
     new Set(['OrderRecordRepositoryPort']),
   ],
   [
+    'apps/api/test/integration/orders/tax-coverage-net-excluded.int-spec.ts',
+    new Set(['OrderRecordRepositoryPort']),
+  ],
+  [
     'apps/api/test/integration/find-recently-listed-variant-ids.int-spec.ts',
     new Set(['OfferMappingRepositoryPort', 'ShopProductMappingRepositoryPort']),
   ],


### PR DESCRIPTION
## Summary

Phase 4 of epic #2452 — Backend: data-coverage detection (elevate existing exclusion counts).

Elevates the already-computed `unconvertedCount`/`unconvertedValue` (currency) and
`netExcludedCount`/`netExcludedValue` (tax) fields from `order-sales-aggregation.ts`
into a first-class `GET /analytics/coverage` endpoint with per-category sample order
ids, splits the tax category into A/B/C sub-cases, and adds the one genuinely new
detector (product-matching errors).

## Tasks (sequential — no per-task branches, all commit directly onto this phase branch)

- [x] #2464 — CORE: currency-mismatch drill-down
- [x] #2465 — CORE: tax-rate drill-down + A/B/C split
- [x] #2466 — CORE + Interface: product-matching-error detector + `GET /analytics/coverage` endpoint

Closes #2464
Closes #2465
Closes #2466

Part of #2463, #2452

---

Opened as **draft**; will move to ready-for-review once all three tasks land, then go
through the standard `/pr-review` fix loop.