### PR TITLE
docs(sales-documents): ADR-070 market discovery and what OpenLinker may recommend

### DIFF
--- a/docs/architecture/adrs/070-sales-document-market-discovery.md
+++ b/docs/architecture/adrs/070-sales-document-market-discovery.md
@@ -8,9 +8,9 @@
 
 A clean OpenLinker instance has **no sales-document routing at all**, and it should not: which document a sale needs is a legal question about the seller's business, and [ADR-041](./041-sales-document-routing-policy.md) is explicit that OpenLinker executes configured routing rather than deciding tax obligations.
 
-The consequence today is silence. Orders arrive, no document is issued, and nothing on any screen says which markets the operator would need to configure. The failure is invisible until someone notices no documents exist - which on the live demo is exactly what happened for Poland, where three configured rules key on a buyer tax ID that OpenLinker never records, so every Polish order resolves to no document while the settings page presents the configuration as working.
+The consequence today is silence. Orders arrive, no document is issued, and nothing on any screen says which markets the operator would need to configure. The failure is invisible until someone notices no documents exist - which on the live demo is exactly what happened for Poland, where three configured rules key on a buyer tax ID that neither the Allegro nor the WooCommerce order source supplies - #2599 carries the field (`order_records.buyerTaxId`, populated from `ps_address.vat_number`), but only PrestaShop populates it - so every Polish order from those sources resolves to no document while the settings page presents the configuration as working.
 
-OpenLinker does already know where orders are delivered: every `order_records` row carries its delivery-address country - the same field [ADR-041](./041-sales-document-routing-policy.md) decision 5 routes on. So the set of markets that need a decision is derivable, and leaving it underived is a choice, not a limitation.
+OpenLinker does already know where orders are delivered: an `order_records` row carries its delivery-address country - the same field [ADR-041](./041-sales-document-routing-policy.md) decision 5 routes on. It is not a column, though: the value lives in the `orderSnapshot` jsonb as `shippingAddress.country`, it survives `OL_STORE_PII=false` (`sanitizeAddress` redacts every address field except the country code), and it is absent on a non-`ready` record and on any source that supplies no shipping address. So the set of markets that need a decision is derivable, and leaving it underived is a choice, not a limitation.
 
 Separately, we have researched starter rules for exactly **one** market (Poland, sourced from public guidance) and none for any other. A generic "suggested setup" affordance would therefore imply guidance we do not have.
 
@@ -49,4 +49,4 @@ One presentational rule follows and is load-bearing: **a detected, unconfigured 
 
 - Related issues: #2503, #2513, #2518, #2528, #2529, #2530
 - Related ADRs: [ADR-041](./041-sales-document-routing-policy.md), [ADR-065](./065-sales-document-read-surface.md)
-- UX mockup: [`docs/plans/mockups/sales-document-routing.html`](../../plans/mockups/sales-document-routing.html) - `#page=settings`, states *brand new* and *orders arriving, nothing set up*
+- UX mockup: [`docs/plans/mockups/sales-document-routing.html`](../../plans/mockups/sales-document-routing.html) - `#page=settings&state=fresh` (*Brand new*) and `#page=settings&state=detected` (*Orders arriving, nothing set up*)

--- a/docs/architecture/adrs/070-sales-document-market-discovery.md
+++ b/docs/architecture/adrs/070-sales-document-market-discovery.md
@@ -1,0 +1,52 @@
+# ADR-070: Market discovery, and what OpenLinker may recommend
+
+- **Status**: Proposed
+- **Date**: 2026-08-26
+- **Authors**: @norbert-kulus-blockydevs
+
+## Context
+
+A clean OpenLinker instance has **no sales-document routing at all**, and it should not: which document a sale needs is a legal question about the seller's business, and [ADR-041](./041-sales-document-routing-policy.md) is explicit that OpenLinker executes configured routing rather than deciding tax obligations.
+
+The consequence today is silence. Orders arrive, no document is issued, and nothing on any screen says which markets the operator would need to configure. The failure is invisible until someone notices no documents exist - which on the live demo is exactly what happened for Poland, where three configured rules key on a buyer tax ID that OpenLinker never records, so every Polish order resolves to no document while the settings page presents the configuration as working.
+
+OpenLinker does already know where orders are billed: every `order_records` row carries its country. So the set of markets that need a decision is derivable, and leaving it underived is a choice, not a limitation.
+
+Separately, we have researched starter rules for exactly **one** market (Poland, sourced from public guidance) and none for any other. A generic "suggested setup" affordance would therefore imply guidance we do not have.
+
+## Decision
+
+**Two decisions, and the second bounds the first.**
+
+1. **A country that orders are billed to is surfaced as a first-class market, whether or not it is configured.** The settings page lists detected markets alongside configured ones, each with its order count over a window. The count is what makes an operator act; "not configured" alone does not. This is a **read**: discovery never creates a rule, a default, or any routing on its own.
+
+2. **A suggested setup is offered only where researched guidance exists, and its scarcity is stated.** Templates are country-keyed data with a citable source. Poland is the only entry. A detected market without one gets a plain *set up* affordance, never a recommendation we cannot back, and the UI says which markets we have guidance for rather than implying every market has some.
+
+One presentational rule follows and is load-bearing: **a detected, unconfigured market is a neutral state, not a fault.** A fresh install is not broken. Rendering it as an error tells a new operator their instance is misconfigured on day one, when in truth nobody has made a decision yet.
+
+## Alternatives considered
+
+- **Ask the operator to enumerate their markets by hand.** Rejected: it asks for information the system already holds, and a forgotten market fails silently, which is the exact defect this closes.
+- **Auto-apply the Poland template when Polish orders are detected.** Rejected outright. Issuing a fiscal document nobody chose is a legal act taken on the operator's behalf, and ADR-041 forbids OpenLinker deciding what a sale requires.
+- **A generic "suggested setup" for every market, generated from the routing model.** Rejected: it would present a shape as advice. We have guidance for one market; saying so is the honest surface.
+- **Detect by shipping address rather than billing country.** Rejected: routing evaluates on the billing/delivery country the rules are written against, so discovery must use the same field or it would name markets the evaluator never sees.
+
+## Consequences
+
+**Pros:**
+- An unconfigured market is visible before an operator discovers it through missing documents.
+- The order count turns "you have no routing" into "47 orders here are waiting", which is actionable.
+- Template scarcity is explicit, so the absence of advice is itself informative.
+
+**Cons / trade-offs:**
+- One more read on the orders store, and a window to choose. A short window under-reports a seasonal market; a long one lists markets the seller has left. The window is a documented constant, not a per-operator setting, until there is evidence one is needed.
+- A market appearing in the list is not a recommendation to configure it, and the copy has to carry that distinction.
+
+**Migration path:**
+- Additive and read-only. An existing install gains the list; nothing about its routing changes.
+
+## References
+
+- Related issues: #2503, #2513, #2518, #2528, #2529, #2530
+- Related ADRs: [ADR-041](./041-sales-document-routing-policy.md), [ADR-065](./065-sales-document-read-surface.md)
+- UX mockup: [`docs/plans/mockups/sales-document-routing.html`](../../plans/mockups/sales-document-routing.html) - `#page=settings`, states *brand new* and *orders arriving, nothing set up*

--- a/docs/architecture/adrs/070-sales-document-market-discovery.md
+++ b/docs/architecture/adrs/070-sales-document-market-discovery.md
@@ -10,7 +10,7 @@ A clean OpenLinker instance has **no sales-document routing at all**, and it sho
 
 The consequence today is silence. Orders arrive, no document is issued, and nothing on any screen says which markets the operator would need to configure. The failure is invisible until someone notices no documents exist - which on the live demo is exactly what happened for Poland, where three configured rules key on a buyer tax ID that OpenLinker never records, so every Polish order resolves to no document while the settings page presents the configuration as working.
 
-OpenLinker does already know where orders are billed: every `order_records` row carries its country. So the set of markets that need a decision is derivable, and leaving it underived is a choice, not a limitation.
+OpenLinker does already know where orders are delivered: every `order_records` row carries its delivery-address country - the same field [ADR-041](./041-sales-document-routing-policy.md) decision 5 routes on. So the set of markets that need a decision is derivable, and leaving it underived is a choice, not a limitation.
 
 Separately, we have researched starter rules for exactly **one** market (Poland, sourced from public guidance) and none for any other. A generic "suggested setup" affordance would therefore imply guidance we do not have.
 
@@ -18,7 +18,7 @@ Separately, we have researched starter rules for exactly **one** market (Poland,
 
 **Two decisions, and the second bounds the first.**
 
-1. **A country that orders are billed to is surfaced as a first-class market, whether or not it is configured.** The settings page lists detected markets alongside configured ones, each with its order count over a window. The count is what makes an operator act; "not configured" alone does not. This is a **read**: discovery never creates a rule, a default, or any routing on its own.
+1. **A country that orders are delivered to is surfaced as a first-class market, whether or not it is configured.** The settings page lists detected markets alongside configured ones, each with its order count over a window. The count is what makes an operator act; "not configured" alone does not. This is a **read**: discovery never creates a rule, a default, or any routing on its own.
 
 2. **A suggested setup is offered only where researched guidance exists, and its scarcity is stated.** Templates are country-keyed data with a citable source. Poland is the only entry. A detected market without one gets a plain *set up* affordance, never a recommendation we cannot back, and the UI says which markets we have guidance for rather than implying every market has some.
 
@@ -29,7 +29,7 @@ One presentational rule follows and is load-bearing: **a detected, unconfigured 
 - **Ask the operator to enumerate their markets by hand.** Rejected: it asks for information the system already holds, and a forgotten market fails silently, which is the exact defect this closes.
 - **Auto-apply the Poland template when Polish orders are detected.** Rejected outright. Issuing a fiscal document nobody chose is a legal act taken on the operator's behalf, and ADR-041 forbids OpenLinker deciding what a sale requires.
 - **A generic "suggested setup" for every market, generated from the routing model.** Rejected: it would present a shape as advice. We have guidance for one market; saying so is the honest surface.
-- **Detect by shipping address rather than billing country.** Rejected: routing evaluates on the billing/delivery country the rules are written against, so discovery must use the same field or it would name markets the evaluator never sees.
+- **Detect by billing address rather than delivery country.** Rejected: routing evaluates on the delivery country the rules are written against ([ADR-041](./041-sales-document-routing-policy.md) decision 5), so discovery must use the same field or it would name markets the evaluator never sees - a billing-address order that ships elsewhere would surface a market routing never matches.
 
 ## Consequences
 

--- a/docs/architecture/adrs/README.md
+++ b/docs/architecture/adrs/README.md
@@ -161,6 +161,7 @@ One pointer per section, identical format every time.
 | [ADR-067](./067-freshness-token-write-ordering.md) | Ordering a concurrent write by a single-clock freshness token plus a short per-target lock | Accepted | 2026-08-27 |
 | [ADR-068](./068-page-to-the-end-or-fail-loudly.md) | Page to the end or fail loudly - a truncated read must never be indistinguishable from a complete one | Accepted | 2026-08-27 |
 | [ADR-069](./069-operator-settable-sweep-pacing.md) | Sweep pacing is the operator's decision, bounded by a two-tier ceiling, and reported must equal enforced | Accepted | 2026-08-28 |
+| [ADR-070](./070-sales-document-market-discovery.md) | Market discovery, and what OpenLinker may recommend | Proposed | 2026-08-26 |
 
 > *Dates for pre-trail ADRs (001, 004) are approximate to the month — the underlying decisions predate the project's current git history. Other dates are merge-date of the cited PR.*
 


### PR DESCRIPTION
Part of the documentation epic #2499, mini-epic #2500 (phase 1).

**Stacked on #2568** so the ADR index row applies cleanly - both PRs add a row after ADR-064 and would otherwise conflict. Retarget this to `main` once #2568 merges, or merge it into #2568 first; either way phase 1 lands on `main`.

## Two decisions

1. **A country that orders are delivered to is a first-class market, configured or not.** The delivery country is the axis [ADR-041](docs/architecture/adrs/041-sales-document-routing-policy.md) decision 5 routes on and the shipped evaluator reads (`order.shippingAddress.country`), so discovery uses the same field - it must, or it would name markets routing never sees. Leaving the set underived is a choice, and it is why the live demo issued nothing for Poland with nobody noticing. Discovery is a **read**: it never creates routing.
2. **A suggested setup is offered only where researched guidance exists, and the scarcity is stated.** Poland is the only entry. A detected market without one gets a plain "set up", never a recommendation we cannot back.

One presentational rule follows: **a detected, unconfigured market is neutral, not a fault.** A fresh install is not broken, and rendering it as an error tells a new operator their instance is misconfigured on day one.

## Rejected, worth naming

**Auto-applying the Poland template when Polish orders appear.** Issuing a fiscal document nobody chose is a legal act taken on the operator's behalf, and ADR-041 forbids OpenLinker deciding what a sale requires.

**Detecting by billing address.** Rejected for the reason above: routing evaluates the delivery country, so a billing-address order shipping elsewhere would surface a market the evaluator never matches.

Closes #2503