### PR TITLE
docs(lessons): read the code before a surface asserts a behaviour

### DIFF
--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -23,6 +23,53 @@ When a lesson hardens into a rule, **graduate it** to the canonical doc and leav
 
 ---
 
+## Before a surface asserts a behaviour, read the code that implements it
+
+**Context**: redesigning the three sales-document surfaces (#2513). The design was worked out from
+the architecture prose, the ADRs, and screenshots of the live pages. Four independent review passes
+were then run over the result, one per flow.
+
+**Problem**: the prose was accurate and the design was still wrong, because prose describes intent
+while a surface makes claims. Six of them could not be supported:
+
+- a three-step progress trail through a fiscal printer, which OpenLinker cannot observe at all - the
+  printer sits below the middleware boundary, which is why #1910 was closed;
+- "safe to leave this page", on a path where the adapter is called **inline**, so closing the tab
+  cuts the request off;
+- "buyer copy: emailed", which no shipped adapter reports;
+- an authority-clearance state on a **fiscal receipt**, whose status terminalises at `registered`
+  with no authority rung at all;
+- a time estimate ("usually under a minute") derived from an adapter constant that never reaches
+  the frontend;
+- "setting both defaults is normal", when the evaluator routes at that tier only where there is
+  exactly **one** default, so setting both holds every non-matching order.
+
+The same pass also invented a third status vocabulary while two already shipped, and re-derived a
+block reason the backend persists - printing `no rule for PL` over an entirely different cause.
+The most useful signal was that the surface's own annotation claimed a change ("the template now
+only appears where a market has no rules") that had never been built.
+
+**Rule**: a user-visible claim about a decision must be **derived from the function that makes the
+decision**, not restated beside it. Concretely, before writing a state, a label, or a reassurance:
+open the evaluator, the port, or the badge component that owns it; check what the type can actually
+express (an axis that does not exist cannot be rendered); and where the claim depends on a contract
+gap, mark it as a prerequisite instead of writing the copy as if the gap were closed. If a surface
+must state an outcome, compute it from the same code path the backend runs rather than writing the
+sentence by hand - the mockup does this for its routing verdicts, which is what caught that Poland
+issues nothing.
+
+**Applies to**: any operator-facing surface that reports a domain decision or a provider lifecycle -
+`apps/web/src/features/**`, design mockups under `docs/plans/mockups/`, and the ADRs that specify
+them.
+
+**Source**: #2508, from the four review passes on #2513; the decisions they produced are
+[ADR-065](./architecture/adrs/065-sales-document-read-surface.md),
+[ADR-066](./architecture/adrs/066-sales-document-market-discovery.md), and the amendments to
+[ADR-041](./architecture/adrs/041-sales-document-routing-policy.md) and
+[ADR-042](./architecture/adrs/042-fiscalization-capability.md).
+
+---
+
 ## An id is assigned before its transaction commits, so id order is not visibility order
 
 **Context**: designing the reader contract for ADR-049's durability spine — how a consumer advances


### PR DESCRIPTION
Part of #2499 → mini-epic #2505 (phase 2). PR targets the **mini-epic branch**.

## The lesson

The sales-document redesign was designed from the architecture prose, the ADRs and screenshots of the live pages. **The prose was accurate and the design was still wrong**, because prose describes intent while a surface makes claims. Four review passes found six that the system cannot support:

- a three-step progress trail through a fiscal printer OpenLinker cannot observe (the printer is below the middleware boundary — #1910 was closed on exactly that finding)
- "safe to leave this page", on a path where the adapter is called **inline**
- "buyer copy: emailed", which no shipped adapter reports
- an authority-clearance state on a **fiscal receipt**, which has no authority rung
- a time estimate from an adapter constant that never reaches the frontend
- "setting both defaults is normal", when setting both holds every non-matching order

The same pass invented a third status vocabulary while two already shipped, and re-derived a reason the backend persists. The sharpest signal was the design's own annotation claiming a change that had never been built.

## The rule

A user-visible claim about a decision must be **derived from the function that makes the decision**, not restated beside it — and where a claim depends on a contract gap, it is marked as a prerequisite rather than written as if the gap were closed.

Closes #2508