### PR TITLE
docs: how OpenLinker decides which document a sale gets

### DIFF
--- a/docs/sales-documents-how-routing-decides.md
+++ b/docs/sales-documents-how-routing-decides.md
@@ -1,0 +1,79 @@
+# How OpenLinker decides which document a sale gets
+
+Every sale needs a document: either an **invoice** or a **fiscal receipt**. OpenLinker does not decide which one your business owes. You set that up per market, and OpenLinker follows what you set.
+
+This page explains how it follows it, so you can work out why any given order got the document it got, or why it got none.
+
+> Setting a market up for the first time: see [Setting up a market](./sales-documents-setting-up-a-market.md).
+> What a state on an order means: see [Sales document states](./sales-documents-state-reference.md).
+
+## The short version
+
+For each order, OpenLinker looks at the country the order is billed to, and then works through four steps in order. The first one that produces an answer wins.
+
+1. **Your rules for that country.** Exactly one must match.
+2. **That country's default**, if no rule matched. Exactly one default may apply.
+3. **Rest of world**, but only if that country has no rules and no default at all.
+4. **Nothing.** The order is held, and the reason is shown on the order.
+
+An order that is held is not lost. Nothing is issued, nothing is sent anywhere, and it will be issued as soon as the setup can answer.
+
+## Step 1: your rules
+
+A rule says: *when these things are true, issue this document through this provider.*
+
+All of a rule's conditions must be true for it to match. If several conditions are listed, they all apply, not any of them.
+
+Two things about rules surprise people, so they are worth stating plainly.
+
+**Exactly one rule must match.** Rules have no order and no priority. If two rules both match an order, OpenLinker does not pick the first, the newest, or the most specific one. It holds the order and tells you two rules matched. This is deliberate: for a tax document, picking one at random would be worse than waiting for you.
+
+So if you see *Two rules matched*, narrow the conditions until only one can apply to that kind of order.
+
+**A rule that asks about something OpenLinker does not know can never match.** If a condition reads a fact that is not recorded on your orders, the answer is neither yes nor no, so the rule simply never fires. The market page marks such a rule, and says how many are affected.
+
+This is not a hypothetical. The starter rules for Poland all ask whether the buyer gave a tax ID, and OpenLinker does not record that on any order yet. Adopt them as they are and none of the three will ever match.
+
+## Step 2: the country's default
+
+If no rule matched, the default for that country applies. A default says: *anything not covered by a rule gets this document from this provider.*
+
+**Only one default may apply.** You can set an invoice default and a receipt default separately, and if you set **both**, the default step cannot choose between them, so it does nothing. Every order that matches no rule is then held.
+
+This is the single most common way a market ends up issuing nothing while looking configured. If a market shows *Two defaults set*, remove one, or add a rule that decides between them.
+
+## Step 3: Rest of world
+
+**Rest of world** is a fallback market for countries you have not set up.
+
+It is reached only by a country that has **no rules and no default of its own**. A country you have configured never falls through to it: if that country's rules and default produce no answer, the order is held there.
+
+That distinction matters when you are debugging. Setting up Rest of world does not rescue a configured market that is not working.
+
+## Step 4: nothing
+
+If nothing above produced an answer, the order is held and the reason is recorded on it. You will see the reason on the order row and on the order itself, and the market page shows the same reason for the market as a whole.
+
+## Working out what happened to one order
+
+Open the order. The sales document panel states which document routing chose and which provider will issue it, or, if nothing was chosen, why not. **Why this document?** on that panel names the rule or default that decided it.
+
+If nothing was chosen, the reason is one of these:
+
+| Reason | What it means | What to do |
+|---|---|---|
+| No rule matched | The market has routing, but nothing matched this order and no single default applies | Add a rule that covers it, or leave exactly one default set |
+| Two rules matched | More than one rule fits this order | Narrow the conditions so only one can match |
+| Two defaults set | Both an invoice and a receipt default are set, and no rule matched | Set just one, or add a rule that decides |
+| No routing anywhere | Neither the country nor Rest of world has anything set | Set up that market, or give Rest of world a default |
+| Provider cannot issue this | The chosen provider does not issue that kind of document | Choose a provider that does |
+| Order is net-priced | A rule compares the order total, and this order is priced net | Use a condition that does not depend on the total |
+| Currency does not match | A rule's limit is in a different currency from the order | Set the limit in the order's currency, or use a different condition |
+
+Amounts are never converted when routing decides. A rule with a limit in one currency does not apply to an order in another.
+
+## Things OpenLinker will never do
+
+- **Guess.** If the setup does not produce exactly one answer, the order waits. A wrong document is a real tax document with the wrong details on it.
+- **Issue two documents for one sale.** One order gets one originating document. A correction is a follow-up to an existing one, not a second document.
+- **Change your rules.** Nothing is added, adopted or applied without you choosing it.


### PR DESCRIPTION
Part of #2499 → mini-epic #2509 (phase 3). PR targets the **mini-epic branch** `phase/docs-p3-operator`.

The four-step ladder existed only as ADR reasoning and code. An operator had no way to work out why an order got the document it got, and no way at all to work out why it got none.

## What it covers

The four steps in plain language, then the two traps that actually catch people:

- **A tie between rules holds the order.** Rules have no priority, so two matches do not resolve to the first or the most specific one. Written down because the current UI says the opposite.
- **Setting both defaults disables the default step.** This is the most common way a market ends up issuing nothing while looking configured.

Plus the dead-rule case, which is not hypothetical: the shipped Poland starter rules all ask whether the buyer gave a tax ID, and that is not recorded on any order, so none of the three can ever match.

Ends with a lookup table from each held reason to its fix, and a short "things OpenLinker will never do" — no guessing, no second document, no rule changed without you.

## Checked against

`libs/core/src/sales-documents/domain/domain-services/evaluate-sales-document-rules.ts`, not against prose — including the tier-3 condition, which only a market with **no rules and no default** reaches. A configured market holds the order instead, and the doc says so.

Closes #2510