### PR TITLE
perf(allegro): implement updateOfferQuantitiesBatch

### DIFF
--- a/apps/api/src/integrations/http/allegro.controller.spec.ts
+++ b/apps/api/src/integrations/http/allegro.controller.spec.ts
@@ -69,6 +69,7 @@ describe('AllegroController', () => {
       find: jest.fn(),
       create: jest.fn(),
       updateStatus: jest.fn(),
+      updateOfferStatus: jest.fn(),
     } as unknown as jest.Mocked<AllegroQuantityCommandRepositoryPort>;
 
     const mockIntegrationsService = {
@@ -422,7 +423,7 @@ describe('AllegroController', () => {
   });
 
   describe('getCommand', () => {
-    it('should return command by ID for connection', async () => {
+    it('should return command rows by ID for connection', async () => {
       const connectionId = 'connection-123';
       const commandId = 'cmd-123';
       const command = AllegroQuantityCommand.create(
@@ -433,20 +434,36 @@ describe('AllegroController', () => {
         'accepted'
       );
 
-      commandRepository.findByCommandId.mockResolvedValue(command);
+      commandRepository.findByCommandId.mockResolvedValue([command]);
 
       const result = await controller.getCommand(connectionId, commandId);
 
-      expect(result.commandId).toBe(commandId);
-      expect(result.connectionId).toBe(connectionId);
+      expect(result).toHaveLength(1);
+      expect(result[0].commandId).toBe(commandId);
+      expect(result[0].connectionId).toBe(connectionId);
       expect(commandRepository.findByCommandId).toHaveBeenCalledWith(commandId);
+    });
+
+    it('should return one row per offer for a batched command (#2622)', async () => {
+      const connectionId = 'connection-123';
+      const commandId = 'cmd-batch';
+      const commands = [
+        AllegroQuantityCommand.create(commandId, connectionId, 'offer-1', 10, 'succeeded'),
+        AllegroQuantityCommand.create(commandId, connectionId, 'offer-2', 10, 'failed', 'boom'),
+      ];
+
+      commandRepository.findByCommandId.mockResolvedValue(commands);
+
+      const result = await controller.getCommand(connectionId, commandId);
+
+      expect(result.map((r) => r.offerId).sort()).toEqual(['offer-1', 'offer-2']);
     });
 
     it('should throw NotFoundException when command not found', async () => {
       const connectionId = 'connection-123';
       const commandId = 'non-existent-cmd';
 
-      commandRepository.findByCommandId.mockResolvedValue(null);
+      commandRepository.findByCommandId.mockResolvedValue([]);
 
       await expect(controller.getCommand(connectionId, commandId)).rejects.toThrow(
         NotFoundException
@@ -467,7 +484,7 @@ describe('AllegroController', () => {
         'accepted'
       );
 
-      commandRepository.findByCommandId.mockResolvedValue(command);
+      commandRepository.findByCommandId.mockResolvedValue([command]);
 
       await expect(controller.getCommand(connectionId, commandId)).rejects.toThrow(
         NotFoundException

--- a/apps/api/src/integrations/http/allegro.controller.ts
+++ b/apps/api/src/integrations/http/allegro.controller.ts
@@ -350,32 +350,35 @@ export class AllegroController {
 
   @ApiBearerAuth()
   @Get('connections/:id/commands/:commandId')
-  @ApiOperation({ summary: 'Get quantity command by commandId for a connection' })
+  @ApiOperation({
+    summary:
+      'Get quantity command rows by commandId for a connection — one row per offer named ' +
+      'in the command (a batched command, #2622, covers several offers under one commandId)',
+  })
   @ApiParam({ name: 'id', description: 'Connection ID (UUID)' })
   @ApiParam({ name: 'commandId', description: 'Allegro command ID' })
   @ApiResponse({
     status: 200,
-    description: 'Command details',
-    type: AllegroQuantityCommandResponseDto,
+    description: 'Command rows for this commandId, scoped to the connection',
+    type: [AllegroQuantityCommandResponseDto],
   })
   @ApiResponse({ status: 404, description: 'Command not found' })
   async getCommand(
     @Param('id') connectionId: string,
     @Param('commandId') commandId: string
-  ): Promise<AllegroQuantityCommandResponseDto> {
+  ): Promise<AllegroQuantityCommandResponseDto[]> {
     this.logger.log(`Getting command: ${commandId} for connection: ${connectionId}`);
 
-    const command = await this.commandRepository.findByCommandId(commandId);
-    if (!command) {
+    const commands = await this.commandRepository.findByCommandId(commandId);
+
+    // Validate that every row belongs to the specified connection (all rows
+    // for one commandId always share a connection, so this is all-or-nothing).
+    const scoped = commands.filter((command) => command.connectionId === connectionId);
+    if (scoped.length === 0) {
       throw new NotFoundException(`Command not found: ${commandId}`);
     }
 
-    // Validate that command belongs to the specified connection
-    if (command.connectionId !== connectionId) {
-      throw new NotFoundException(`Command not found: ${commandId}`);
-    }
-
-    return AllegroQuantityCommandResponseDto.fromDomain(command);
+    return scoped.map((command) => AllegroQuantityCommandResponseDto.fromDomain(command));
   }
 
   /**

--- a/libs/integrations/allegro/src/domain/ports/allegro-quantity-command-repository.port.ts
+++ b/libs/integrations/allegro/src/domain/ports/allegro-quantity-command-repository.port.ts
@@ -30,12 +30,16 @@ export interface AllegroQuantityCommandFilters {
  */
 export interface AllegroQuantityCommandRepositoryPort {
   /**
-   * Find command by commandId
+   * Find every command record sharing a commandId.
+   *
+   * A single-item update always yields exactly one row. A batch command
+   * (#2622) covers several offers under one Allegro commandId, so this can
+   * return more than one row — one per offer named in that command.
    *
    * @param commandId - Allegro command ID
-   * @returns Command record or null if not found
+   * @returns Command records for this commandId (empty array if none)
    */
-  findByCommandId(commandId: string): Promise<AllegroQuantityCommand | null>;
+  findByCommandId(commandId: string): Promise<AllegroQuantityCommand[]>;
 
   /**
    * Find commands by filters
@@ -65,6 +69,25 @@ export interface AllegroQuantityCommandRepositoryPort {
    */
   updateStatus(
     commandId: string,
+    status: AllegroQuantityCommandStatus,
+    error?: string | null
+  ): Promise<AllegroQuantityCommand>;
+
+  /**
+   * Update status and error for one offer's row within a (possibly batched)
+   * command. Unlike `updateStatus`, this disambiguates by (commandId,
+   * offerId) — required once a single commandId can back several rows.
+   *
+   * @param commandId - Allegro command ID
+   * @param offerId - The offer whose row should be updated
+   * @param status - New status
+   * @param error - Error message (optional)
+   * @returns Updated command
+   * @throws Error if no row exists for (commandId, offerId)
+   */
+  updateOfferStatus(
+    commandId: string,
+    offerId: string,
     status: AllegroQuantityCommandStatus,
     error?: string | null
   ): Promise<AllegroQuantityCommand>;

--- a/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
+++ b/libs/integrations/allegro/src/domain/types/allegro-api.types.ts
@@ -226,6 +226,15 @@ export interface AllegroOfferQuantityChangeCommand {
 }
 
 /**
+ * Allegro's `{code, message}` error shape, shared by the quantity-change
+ * command's synchronous rejection and by each polled task's own errors.
+ */
+export interface AllegroTaskError {
+  code: string;
+  message: string;
+}
+
+/**
  * Allegro offer quantity change command response
  *
  * Response from PUT /sale/offer-quantity-change-commands/{commandId} endpoint.
@@ -233,10 +242,7 @@ export interface AllegroOfferQuantityChangeCommand {
 export interface AllegroOfferQuantityChangeCommandResponse {
   id: string;
   status: 'QUEUED' | 'ACCEPTED' | 'REJECTED';
-  errors?: Array<{
-    code: string;
-    message: string;
-  }>;
+  errors?: AllegroTaskError[];
 }
 
 /**
@@ -255,10 +261,7 @@ export interface AllegroQuantityChangeCommandStatusResponse {
     offerId: string;
     status: AllegroCommandTaskStatus;
     message?: string;
-    errors?: Array<{
-      code: string;
-      message: string;
-    }>;
+    errors?: AllegroTaskError[];
   }>;
 }
 

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
@@ -677,6 +677,54 @@ describe('AllegroOfferManagerAdapter', () => {
       ]);
     });
 
+    it('falls back to "rejected" (not an empty string) when a REJECTED command carries an empty errors array (#2622 review)', async () => {
+      const batchAdapter = fastAdapter();
+
+      httpClient.put.mockResolvedValueOnce({
+        data: {
+          id: 'cmd-rejected-empty-errors',
+          status: 'REJECTED',
+          errors: [],
+        } as AllegroOfferQuantityChangeCommandResponse,
+        status: 200,
+        headers: {},
+      });
+
+      const result = await batchAdapter.updateOfferQuantitiesBatch({
+        items: [{ offerId: 'offer-1', quantity: 10, idempotencyKey: 'key-1' }],
+      });
+
+      expect(result.failed).toEqual([{ offerId: 'offer-1', errorCode: 'rejected', message: 'rejected' }]);
+    });
+
+    it('falls back to the task message (not an empty string) when a FAIL task carries an empty errors array (#2622 review)', async () => {
+      const batchAdapter = fastAdapter();
+
+      httpClient.put.mockResolvedValueOnce({
+        data: { id: 'cmd-fail-empty-errors', status: 'ACCEPTED' } as AllegroOfferQuantityChangeCommandResponse,
+        status: 200,
+        headers: {},
+      });
+      httpClient.get.mockResolvedValueOnce({
+        data: {
+          id: 'cmd-fail-empty-errors',
+          taskCount: 1,
+          completedTaskCount: 1,
+          tasks: [{ offerId: 'offer-1', status: 'FAIL', message: 'Offer is inactive', errors: [] }],
+        },
+        status: 200,
+        headers: {},
+      });
+
+      const result = await batchAdapter.updateOfferQuantitiesBatch({
+        items: [{ offerId: 'offer-1', quantity: 10, idempotencyKey: 'key-1' }],
+      });
+
+      expect(result.failed).toEqual([
+        { offerId: 'offer-1', errorCode: 'unknown', message: 'Offer is inactive' },
+      ]);
+    });
+
     it('should report poll-timeout for an offer the terminal response omits, without affecting siblings', async () => {
       const batchAdapter = fastAdapter();
 

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
@@ -410,6 +410,7 @@ describe('AllegroOfferManagerAdapter', () => {
         find: jest.fn(),
         create: jest.fn(),
         updateStatus: jest.fn(),
+        updateOfferStatus: jest.fn(),
       };
 
       const adapterWithRepo = new AllegroOfferManagerAdapter(
@@ -442,14 +443,14 @@ describe('AllegroOfferManagerAdapter', () => {
   describe('updateOfferQuantitiesBatch', () => {
     // Fast, deterministic polling so these tests don't pay the production
     // 2s/30s backoff in real wall-clock time.
-    const fastAdapter = () =>
+    const fastAdapter = (commandRepository?: AllegroQuantityCommandRepositoryPort) =>
       new AllegroOfferManagerAdapter(
         connectionId,
         httpClient,
         uploadHttpClient,
         identifierMapping,
         connection,
-        undefined,
+        commandRepository,
         { initialDelayMs: 1, maxDelayMs: 1, maxAttempts: 2, backoffMultiplier: 1 }
       );
 
@@ -638,6 +639,179 @@ describe('AllegroOfferManagerAdapter', () => {
         { offerId: 'offer-1', errorCode: 'transport-error', message: 'network timeout' },
         { offerId: 'offer-2', errorCode: 'transport-error', message: 'network timeout' },
       ]);
+    });
+
+    it('should report poll-timeout for an offer the terminal response omits, without affecting siblings', async () => {
+      const batchAdapter = fastAdapter();
+
+      httpClient.put.mockResolvedValueOnce({
+        data: { id: 'cmd-timeout', status: 'ACCEPTED' } as AllegroOfferQuantityChangeCommandResponse,
+        status: 200,
+        headers: {},
+      });
+      // The response is terminal (every listed task is SUCCESS/FAIL), but it
+      // only names offer-1 — offer-2 never appears in any task, so it can
+      // never be found in tasksByOfferId once polling stops.
+      httpClient.get.mockResolvedValueOnce({
+        data: {
+          id: 'cmd-timeout',
+          taskCount: 2,
+          completedTaskCount: 1,
+          tasks: [{ offerId: 'offer-1', status: 'SUCCESS' }],
+        },
+        status: 200,
+        headers: {},
+      });
+
+      const result = await batchAdapter.updateOfferQuantitiesBatch({
+        items: [
+          { offerId: 'offer-1', quantity: 10, idempotencyKey: 'key-1' },
+          { offerId: 'offer-2', quantity: 10, idempotencyKey: 'key-2' },
+        ],
+      });
+
+      expect(result.succeeded).toEqual(['offer-1']);
+      expect(result.failed).toEqual([
+        {
+          offerId: 'offer-2',
+          errorCode: 'poll-timeout',
+          message: expect.stringContaining('did not report a terminal status'),
+        },
+      ]);
+    });
+
+    it('should report poll-timeout for every item when the command never reaches a terminal status', async () => {
+      const batchAdapter = fastAdapter();
+
+      httpClient.put.mockResolvedValueOnce({
+        data: { id: 'cmd-all-timeout', status: 'ACCEPTED' } as AllegroOfferQuantityChangeCommandResponse,
+        status: 200,
+        headers: {},
+      });
+      // Never terminal (one attempt reports QUEUED-ish "no tasks yet"),
+      // so pollQuantityCommandStatus exhausts its attempts and returns null.
+      httpClient.get.mockResolvedValue({
+        data: { id: 'cmd-all-timeout', taskCount: 1, completedTaskCount: 0, tasks: [] },
+        status: 200,
+        headers: {},
+      });
+
+      const result = await batchAdapter.updateOfferQuantitiesBatch({
+        items: [{ offerId: 'offer-1', quantity: 10, idempotencyKey: 'key-1' }],
+      });
+
+      expect(result.succeeded).toEqual([]);
+      expect(result.failed).toEqual([
+        {
+          offerId: 'offer-1',
+          errorCode: 'poll-timeout',
+          message: expect.stringContaining('did not report a terminal status'),
+        },
+      ]);
+    });
+
+    it('should persist one command row per offer and update each row per-offer on success/failure (#2622 review)', async () => {
+      const commandRepository: jest.Mocked<AllegroQuantityCommandRepositoryPort> = {
+        findByCommandId: jest.fn(),
+        find: jest.fn(),
+        create: jest.fn(),
+        updateStatus: jest.fn(),
+        updateOfferStatus: jest.fn(),
+      };
+      commandRepository.create.mockResolvedValue({} as never);
+      commandRepository.updateOfferStatus.mockResolvedValue({} as never);
+
+      const batchAdapter = fastAdapter(commandRepository);
+
+      httpClient.put.mockResolvedValueOnce({
+        data: { id: 'cmd-persist', status: 'ACCEPTED' } as AllegroOfferQuantityChangeCommandResponse,
+        status: 200,
+        headers: {},
+      });
+      httpClient.get.mockResolvedValueOnce({
+        data: {
+          id: 'cmd-persist',
+          taskCount: 2,
+          completedTaskCount: 2,
+          tasks: [
+            { offerId: 'offer-1', status: 'SUCCESS' },
+            {
+              offerId: 'offer-2',
+              status: 'FAIL',
+              errors: [{ code: 'OFFER_INACTIVE', message: 'Offer is inactive' }],
+            },
+          ],
+        },
+        status: 200,
+        headers: {},
+      });
+
+      await batchAdapter.updateOfferQuantitiesBatch({
+        items: [
+          { offerId: 'offer-1', quantity: 10, idempotencyKey: 'key-1' },
+          { offerId: 'offer-2', quantity: 10, idempotencyKey: 'key-2' },
+        ],
+      });
+
+      // One created row per offer, all under the shared batch commandId.
+      expect(commandRepository.create).toHaveBeenCalledTimes(2);
+      const createdOfferIds = commandRepository.create.mock.calls.map(
+        ([command]) => (command as { offerId: string }).offerId
+      );
+      expect(createdOfferIds.sort()).toEqual(['offer-1', 'offer-2']);
+      const createdCommandIds = new Set(
+        commandRepository.create.mock.calls.map(
+          ([command]) => (command as { commandId: string }).commandId
+        )
+      );
+      expect(createdCommandIds.size).toBe(1);
+
+      // Per-offer status disambiguated by (commandId, offerId).
+      expect(commandRepository.updateOfferStatus).toHaveBeenCalledWith(
+        expect.any(String),
+        'offer-1',
+        'succeeded'
+      );
+      expect(commandRepository.updateOfferStatus).toHaveBeenCalledWith(
+        expect.any(String),
+        'offer-2',
+        'failed',
+        'OFFER_INACTIVE: Offer is inactive'
+      );
+    });
+
+    it('should never throw when the command repository itself fails to persist', async () => {
+      const commandRepository: jest.Mocked<AllegroQuantityCommandRepositoryPort> = {
+        findByCommandId: jest.fn(),
+        find: jest.fn(),
+        create: jest.fn().mockRejectedValue(new Error('db unavailable')),
+        updateStatus: jest.fn(),
+        updateOfferStatus: jest.fn().mockRejectedValue(new Error('db unavailable')),
+      };
+
+      const batchAdapter = fastAdapter(commandRepository);
+
+      httpClient.put.mockResolvedValueOnce({
+        data: { id: 'cmd-db-down', status: 'ACCEPTED' } as AllegroOfferQuantityChangeCommandResponse,
+        status: 200,
+        headers: {},
+      });
+      httpClient.get.mockResolvedValueOnce({
+        data: {
+          id: 'cmd-db-down',
+          taskCount: 1,
+          completedTaskCount: 1,
+          tasks: [{ offerId: 'offer-1', status: 'SUCCESS' }],
+        },
+        status: 200,
+        headers: {},
+      });
+
+      const result = await batchAdapter.updateOfferQuantitiesBatch({
+        items: [{ offerId: 'offer-1', quantity: 10, idempotencyKey: 'key-1' }],
+      });
+
+      expect(result.succeeded).toEqual(['offer-1']);
     });
   });
 

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
@@ -641,6 +641,42 @@ describe('AllegroOfferManagerAdapter', () => {
       ]);
     });
 
+    it('should report the platform rejection reason for a synchronously REJECTED command, without polling', async () => {
+      const batchAdapter = fastAdapter();
+
+      httpClient.put.mockResolvedValueOnce({
+        data: {
+          id: 'cmd-rejected',
+          status: 'REJECTED',
+          errors: [{ code: 'INVALID_MODIFICATION', message: 'Value must be non-negative' }],
+        } as AllegroOfferQuantityChangeCommandResponse,
+        status: 200,
+        headers: {},
+      });
+
+      const result = await batchAdapter.updateOfferQuantitiesBatch({
+        items: [
+          { offerId: 'offer-1', quantity: 10, idempotencyKey: 'key-1' },
+          { offerId: 'offer-2', quantity: 10, idempotencyKey: 'key-2' },
+        ],
+      });
+
+      expect(httpClient.get).not.toHaveBeenCalled();
+      expect(result.succeeded).toEqual([]);
+      expect(result.failed.sort((a, b) => a.offerId.localeCompare(b.offerId))).toEqual([
+        {
+          offerId: 'offer-1',
+          errorCode: 'rejected',
+          message: 'INVALID_MODIFICATION: Value must be non-negative',
+        },
+        {
+          offerId: 'offer-2',
+          errorCode: 'rejected',
+          message: 'INVALID_MODIFICATION: Value must be non-negative',
+        },
+      ]);
+    });
+
     it('should report poll-timeout for an offer the terminal response omits, without affecting siblings', async () => {
       const batchAdapter = fastAdapter();
 
@@ -766,11 +802,14 @@ describe('AllegroOfferManagerAdapter', () => {
       );
       expect(createdCommandIds.size).toBe(1);
 
-      // Per-offer status disambiguated by (commandId, offerId).
+      // Per-offer status disambiguated by (commandId, offerId). The succeeded
+      // call forwards `error` positionally even when absent (undefined), so
+      // the assertion must match that shape rather than a truncated 3-arg call.
       expect(commandRepository.updateOfferStatus).toHaveBeenCalledWith(
         expect.any(String),
         'offer-1',
-        'succeeded'
+        'succeeded',
+        undefined
       );
       expect(commandRepository.updateOfferStatus).toHaveBeenCalledWith(
         expect.any(String),

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
@@ -27,6 +27,7 @@ import {
   isCategoryPathReader,
   isEanCategoryMatcher,
   isEanCategoryMatcherStreaming,
+  isOfferQuantityBatchUpdater,
   isOfferSmartClassificationReader,
   isOfferStatusReader,
   isSafetyAttachmentUploader,
@@ -435,6 +436,208 @@ describe('AllegroOfferManagerAdapter', () => {
       });
 
       expect(commandRepository.updateStatus).toHaveBeenCalledWith('cmd-1', 'succeeded');
+    });
+  });
+
+  describe('updateOfferQuantitiesBatch', () => {
+    // Fast, deterministic polling so these tests don't pay the production
+    // 2s/30s backoff in real wall-clock time.
+    const fastAdapter = () =>
+      new AllegroOfferManagerAdapter(
+        connectionId,
+        httpClient,
+        uploadHttpClient,
+        identifierMapping,
+        connection,
+        undefined,
+        { initialDelayMs: 1, maxDelayMs: 1, maxAttempts: 2, backoffMultiplier: 1 }
+      );
+
+    it('should be recognised by the OfferQuantityBatchUpdater guard', () => {
+      expect(isOfferQuantityBatchUpdater(adapter)).toBe(true);
+    });
+
+    it('should issue a single command for items sharing the same quantity', async () => {
+      const batchAdapter = fastAdapter();
+
+      httpClient.put.mockResolvedValueOnce({
+        data: { id: 'cmd-batch-1', status: 'ACCEPTED' } as AllegroOfferQuantityChangeCommandResponse,
+        status: 200,
+        headers: {},
+      });
+      httpClient.get.mockResolvedValueOnce({
+        data: {
+          id: 'cmd-batch-1',
+          taskCount: 2,
+          completedTaskCount: 2,
+          tasks: [
+            { offerId: 'offer-1', status: 'SUCCESS' },
+            { offerId: 'offer-2', status: 'SUCCESS' },
+          ],
+        },
+        status: 200,
+        headers: {},
+      });
+
+      const result = await batchAdapter.updateOfferQuantitiesBatch({
+        items: [
+          { offerId: 'offer-1', quantity: 10, idempotencyKey: 'key-1' },
+          { offerId: 'offer-2', quantity: 10, idempotencyKey: 'key-2' },
+        ],
+      });
+
+      expect(httpClient.put).toHaveBeenCalledTimes(1);
+      expect(httpClient.put).toHaveBeenCalledWith(
+        expect.stringMatching(/^\/sale\/offer-quantity-change-commands\/[a-f0-9-]+$/),
+        expect.objectContaining({
+          modification: { changeType: 'FIXED', value: 10 },
+          offerCriteria: [
+            {
+              offers: [{ id: 'offer-1' }, { id: 'offer-2' }],
+              type: 'CONTAINS_OFFERS',
+            },
+          ],
+        })
+      );
+      expect(result.succeeded.sort()).toEqual(['offer-1', 'offer-2']);
+      expect(result.failed).toEqual([]);
+    });
+
+    it('should issue one command per distinct quantity group', async () => {
+      const batchAdapter = fastAdapter();
+
+      httpClient.put.mockResolvedValue({
+        data: { id: 'cmd-x', status: 'ACCEPTED' } as AllegroOfferQuantityChangeCommandResponse,
+        status: 200,
+        headers: {},
+      });
+      httpClient.get.mockResolvedValue({
+        data: {
+          id: 'cmd-x',
+          taskCount: 1,
+          completedTaskCount: 1,
+          tasks: [
+            { offerId: 'offer-1', status: 'SUCCESS' },
+            { offerId: 'offer-2', status: 'SUCCESS' },
+          ],
+        },
+        status: 200,
+        headers: {},
+      });
+
+      await batchAdapter.updateOfferQuantitiesBatch({
+        items: [
+          { offerId: 'offer-1', quantity: 10, idempotencyKey: 'key-1' },
+          { offerId: 'offer-2', quantity: 5, idempotencyKey: 'key-2' },
+        ],
+      });
+
+      expect(httpClient.put).toHaveBeenCalledTimes(2);
+    });
+
+    it('should report a per-offer failure without failing the whole batch', async () => {
+      const batchAdapter = fastAdapter();
+
+      httpClient.put.mockResolvedValueOnce({
+        data: { id: 'cmd-mixed', status: 'ACCEPTED' } as AllegroOfferQuantityChangeCommandResponse,
+        status: 200,
+        headers: {},
+      });
+      httpClient.get.mockResolvedValueOnce({
+        data: {
+          id: 'cmd-mixed',
+          taskCount: 2,
+          completedTaskCount: 2,
+          tasks: [
+            { offerId: 'offer-1', status: 'SUCCESS' },
+            {
+              offerId: 'offer-2',
+              status: 'FAIL',
+              errors: [{ code: 'OFFER_INACTIVE', message: 'Offer is inactive' }],
+            },
+          ],
+        },
+        status: 200,
+        headers: {},
+      });
+
+      const result = await batchAdapter.updateOfferQuantitiesBatch({
+        items: [
+          { offerId: 'offer-1', quantity: 10, idempotencyKey: 'key-1' },
+          { offerId: 'offer-2', quantity: 10, idempotencyKey: 'key-2' },
+        ],
+      });
+
+      expect(result.succeeded).toEqual(['offer-1']);
+      expect(result.failed).toEqual([
+        {
+          offerId: 'offer-2',
+          errorCode: 'OFFER_INACTIVE',
+          message: 'OFFER_INACTIVE: Offer is inactive',
+        },
+      ]);
+    });
+
+    it('should fail an item without an idempotency key without calling Allegro', async () => {
+      const batchAdapter = fastAdapter();
+
+      httpClient.put.mockResolvedValueOnce({
+        data: { id: 'cmd-solo', status: 'ACCEPTED' } as AllegroOfferQuantityChangeCommandResponse,
+        status: 200,
+        headers: {},
+      });
+      httpClient.get.mockResolvedValueOnce({
+        data: {
+          id: 'cmd-solo',
+          taskCount: 1,
+          completedTaskCount: 1,
+          tasks: [{ offerId: 'offer-1', status: 'SUCCESS' }],
+        },
+        status: 200,
+        headers: {},
+      });
+
+      const result = await batchAdapter.updateOfferQuantitiesBatch({
+        items: [
+          { offerId: 'offer-1', quantity: 10, idempotencyKey: 'key-1' },
+          { offerId: 'offer-2', quantity: 10 },
+        ],
+      });
+
+      expect(httpClient.put).toHaveBeenCalledTimes(1);
+      expect(httpClient.put).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          offerCriteria: [{ offers: [{ id: 'offer-1' }], type: 'CONTAINS_OFFERS' }],
+        })
+      );
+      expect(result.succeeded).toEqual(['offer-1']);
+      expect(result.failed).toEqual([
+        {
+          offerId: 'offer-2',
+          errorCode: 'missing-idempotency-key',
+          message: 'idempotencyKey is required for Allegro offer quantity updates',
+        },
+      ]);
+    });
+
+    it('should report every item in a group as failed when the command submit rejects, without throwing', async () => {
+      const batchAdapter = fastAdapter();
+
+      httpClient.put.mockRejectedValueOnce(new Error('network timeout'));
+
+      const result = await batchAdapter.updateOfferQuantitiesBatch({
+        items: [
+          { offerId: 'offer-1', quantity: 10, idempotencyKey: 'key-1' },
+          { offerId: 'offer-2', quantity: 10, idempotencyKey: 'key-2' },
+        ],
+      });
+
+      expect(result.succeeded).toEqual([]);
+      expect(result.failed.sort((a, b) => a.offerId.localeCompare(b.offerId))).toEqual([
+        { offerId: 'offer-1', errorCode: 'transport-error', message: 'network timeout' },
+        { offerId: 'offer-2', errorCode: 'transport-error', message: 'network timeout' },
+      ]);
     });
   });
 

--- a/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/__tests__/allegro-offer-manager.adapter.spec.ts
@@ -694,14 +694,19 @@ describe('AllegroOfferManagerAdapter', () => {
         items: [{ offerId: 'offer-1', quantity: 10, idempotencyKey: 'key-1' }],
       });
 
-      expect(result.failed).toEqual([{ offerId: 'offer-1', errorCode: 'rejected', message: 'rejected' }]);
+      expect(result.failed).toEqual([
+        { offerId: 'offer-1', errorCode: 'rejected', message: 'rejected' },
+      ]);
     });
 
     it('falls back to the task message (not an empty string) when a FAIL task carries an empty errors array (#2622 review)', async () => {
       const batchAdapter = fastAdapter();
 
       httpClient.put.mockResolvedValueOnce({
-        data: { id: 'cmd-fail-empty-errors', status: 'ACCEPTED' } as AllegroOfferQuantityChangeCommandResponse,
+        data: {
+          id: 'cmd-fail-empty-errors',
+          status: 'ACCEPTED',
+        } as AllegroOfferQuantityChangeCommandResponse,
         status: 200,
         headers: {},
       });

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
@@ -99,6 +99,7 @@ import { toNeutralCategoryParameter } from '../mappers/allegro-category-paramete
 import type {
   AllegroOfferQuantityChangeCommandResponse,
   AllegroQuantityChangeCommandStatusResponse,
+  AllegroTaskError,
   AllegroCategoryParametersResponse,
   AllegroCategoriesResponse,
   AllegroCategoryResponse,
@@ -805,9 +806,7 @@ export class AllegroOfferManagerAdapter
    * `errors` is present but empty, so callers can safely `?? fallback`
    * without a defined-but-empty string masking it (#2622 review).
    */
-  private formatAllegroTaskErrors(
-    errors: Array<{ code: string; message: string }> | undefined
-  ): string | undefined {
+  private formatAllegroTaskErrors(errors: AllegroTaskError[] | undefined): string | undefined {
     if (!errors || errors.length === 0) {
       return undefined;
     }

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
@@ -683,17 +683,16 @@ export class AllegroOfferManagerAdapter
       );
 
       this.logger.debug(
-        `Allegro batch offer quantity command submitted: commandId=${response.data.id}, offers=${items.length} (connection: ${this.connectionId})`
+        `Allegro batch offer quantity command submitted: commandId=${commandId}, offers=${items.length} (connection: ${this.connectionId})`
       );
 
-      await this.persistBatchCommandRows(response.data.id, response.data.status, items);
+      await this.persistBatchCommandRows(commandId, response.data.status, items);
 
       if (response.data.status === 'REJECTED') {
         // Allegro answered synchronously — there is nothing to poll for and
         // no task will ever appear, so reporting this via the poll-timeout
         // branch below would discard the platform's own rejection reason.
-        const message =
-          response.data.errors?.map((e) => `${e.code}: ${e.message}`).join('; ') ?? 'rejected';
+        const message = this.formatAllegroTaskErrors(response.data.errors) ?? 'rejected';
         for (const item of items) {
           failed.push({ offerId: item.offerId, errorCode: 'rejected', message });
           await this.persistBatchOfferStatus(commandId, item.offerId, 'failed', message);
@@ -701,7 +700,7 @@ export class AllegroOfferManagerAdapter
         return;
       }
 
-      const result = await this.pollQuantityCommandStatus(response.data.id);
+      const result = await this.pollQuantityCommandStatus(commandId);
       const tasksByOfferId = new Map((result?.tasks ?? []).map((task) => [task.offerId, task]));
 
       for (const item of items) {
@@ -713,8 +712,7 @@ export class AllegroOfferManagerAdapter
         }
         if (task) {
           const errorCode = task.errors?.[0]?.code ?? 'unknown';
-          const message =
-            task.errors?.map((e) => `${e.code}: ${e.message}`).join('; ') ?? task.message;
+          const message = this.formatAllegroTaskErrors(task.errors) ?? task.message;
           failed.push({ offerId: item.offerId, errorCode, message });
           await this.persistBatchOfferStatus(commandId, item.offerId, 'failed', message ?? null);
           continue;
@@ -799,6 +797,21 @@ export class AllegroOfferManagerAdapter
         `Failed to persist batch offer quantity command status (commandId: ${commandId}, offerId: ${offerId}): ${(persistError as Error).message}`
       );
     }
+  }
+
+  /**
+   * Joins Allegro's `{code, message}` error list into one string, or
+   * returns `undefined` when there is nothing to report — including when
+   * `errors` is present but empty, so callers can safely `?? fallback`
+   * without a defined-but-empty string masking it (#2622 review).
+   */
+  private formatAllegroTaskErrors(
+    errors: Array<{ code: string; message: string }> | undefined
+  ): string | undefined {
+    if (!errors || errors.length === 0) {
+      return undefined;
+    }
+    return errors.map((e) => `${e.code}: ${e.message}`).join('; ');
   }
 
   /**
@@ -2596,8 +2609,7 @@ export class AllegroOfferManagerAdapter
     if (failedTasks.length > 0) {
       const errorMessages = failedTasks
         .map((t) => {
-          const errDetails =
-            t.errors?.map((e) => `${e.code}: ${e.message}`).join('; ') ?? t.message ?? 'unknown';
+          const errDetails = this.formatAllegroTaskErrors(t.errors) ?? t.message ?? 'unknown';
           return `offer ${t.offerId}: ${errDetails}`;
         })
         .join(', ');

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
@@ -46,6 +46,10 @@ import type {
   OfferFeedOutput,
   UpdateOfferQuantityCommand,
   UpdateOfferFieldsCommand,
+  OfferQuantityBatchUpdater,
+  UpdateOfferQuantitiesBatchCommand,
+  UpdateOfferQuantitiesBatchResult,
+  UpdateOfferQuantitiesBatchFailure,
   CreateOfferCommand,
   OfferCondition,
   OfferParameter,
@@ -288,6 +292,7 @@ export interface QuantityPollConfig {
 export class AllegroOfferManagerAdapter
   implements
     OfferManagerPort,
+    OfferQuantityBatchUpdater,
     OfferLister,
     OfferEventReader,
     OfferFieldUpdater,
@@ -589,6 +594,132 @@ export class AllegroOfferManagerAdapter
         error
       );
       throw error;
+    }
+  }
+
+  /**
+   * Batched counterpart of `updateOfferQuantity` (#2622). Allegro's
+   * quantity-change-commands endpoint applies ONE `modification` value to
+   * every offer named in `offerCriteria` — there is no per-offer distinct
+   * quantity in a single command — so items are grouped by their target
+   * quantity and one command is issued per group, rather than one per item.
+   * A batch that happens to share the same quantity across all offers costs
+   * exactly one request; a batch with N distinct quantities costs N requests
+   * (still far below Allegro's ~60/min single-offer throttle for anything
+   * larger than a handful of distinct values).
+   *
+   * Never throws: a whole-group failure (submit or poll) is reported as a
+   * per-item failure for every offer in that group, so one bad group cannot
+   * sink offers in a sibling group, and the caller never falls back to the
+   * N-request single-item path unnecessarily.
+   */
+  async updateOfferQuantitiesBatch(
+    cmd: UpdateOfferQuantitiesBatchCommand
+  ): Promise<UpdateOfferQuantitiesBatchResult> {
+    const succeeded: string[] = [];
+    const failed: UpdateOfferQuantitiesBatchFailure[] = [];
+
+    const groups = new Map<number, UpdateOfferQuantityCommand[]>();
+    for (const item of cmd.items) {
+      if (!item.idempotencyKey) {
+        failed.push({
+          offerId: item.offerId,
+          errorCode: 'missing-idempotency-key',
+          message: 'idempotencyKey is required for Allegro offer quantity updates',
+        });
+        continue;
+      }
+      const group = groups.get(item.quantity);
+      if (group) {
+        group.push(item);
+      } else {
+        groups.set(item.quantity, [item]);
+      }
+    }
+
+    await Promise.all(
+      Array.from(groups.values()).map((items) => this.submitQuantityGroup(items, succeeded, failed))
+    );
+
+    return { succeeded, failed };
+  }
+
+  /**
+   * Submits one quantity-change command covering every item in `items` (all
+   * sharing the same target quantity) and maps Allegro's per-offer task
+   * outcomes onto `succeeded`/`failed`. The commandId is derived from the
+   * sorted set of item idempotency keys, so a retried batch with the same
+   * membership dedupes against the same Allegro command.
+   */
+  private async submitQuantityGroup(
+    items: UpdateOfferQuantityCommand[],
+    succeeded: string[],
+    failed: UpdateOfferQuantitiesBatchFailure[]
+  ): Promise<void> {
+    const quantity = items[0].quantity;
+    const groupKey = items
+      .map((item) => item.idempotencyKey)
+      .sort()
+      .join(',');
+    const commandId = this.generateCommandIdFromIdempotencyKey(groupKey);
+
+    try {
+      const commandBody: Record<string, unknown> = {
+        modification: {
+          changeType: 'FIXED',
+          value: quantity,
+        },
+        offerCriteria: [
+          {
+            offers: items.map((item) => ({ id: item.offerId })),
+            type: 'CONTAINS_OFFERS',
+          },
+        ],
+      };
+
+      const response = await this.httpClient.put<AllegroOfferQuantityChangeCommandResponse>(
+        `/sale/offer-quantity-change-commands/${commandId}`,
+        commandBody
+      );
+
+      this.logger.debug(
+        `Allegro batch offer quantity command submitted: commandId=${response.data.id}, offers=${items.length} (connection: ${this.connectionId})`
+      );
+
+      const result = await this.pollQuantityCommandStatus(response.data.id);
+      const tasksByOfferId = new Map((result?.tasks ?? []).map((task) => [task.offerId, task]));
+
+      for (const item of items) {
+        const task = tasksByOfferId.get(item.offerId);
+        if (task?.status === 'SUCCESS') {
+          succeeded.push(item.offerId);
+          continue;
+        }
+        if (task) {
+          const errorCode = task.errors?.[0]?.code ?? 'unknown';
+          const message =
+            task.errors?.map((e) => `${e.code}: ${e.message}`).join('; ') ?? task.message;
+          failed.push({ offerId: item.offerId, errorCode, message });
+          continue;
+        }
+        failed.push({
+          offerId: item.offerId,
+          errorCode: 'poll-timeout',
+          message: `Allegro quantity command ${commandId} did not report a terminal status for this offer`,
+        });
+      }
+    } catch (error) {
+      this.logger.error(
+        `Failed to submit Allegro batch offer quantity command (offers=${items.length}, connection: ${this.connectionId}): ${(error as Error).message}`,
+        error
+      );
+      for (const item of items) {
+        failed.push({
+          offerId: item.offerId,
+          errorCode: 'transport-error',
+          message: (error as Error).message,
+        });
+      }
     }
   }
 

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
@@ -686,6 +686,8 @@ export class AllegroOfferManagerAdapter
         `Allegro batch offer quantity command submitted: commandId=${response.data.id}, offers=${items.length} (connection: ${this.connectionId})`
       );
 
+      await this.persistBatchCommandRows(response.data.id, response.data.status, items);
+
       const result = await this.pollQuantityCommandStatus(response.data.id);
       const tasksByOfferId = new Map((result?.tasks ?? []).map((task) => [task.offerId, task]));
 
@@ -693,6 +695,7 @@ export class AllegroOfferManagerAdapter
         const task = tasksByOfferId.get(item.offerId);
         if (task?.status === 'SUCCESS') {
           succeeded.push(item.offerId);
+          await this.persistBatchOfferStatus(commandId, item.offerId, 'succeeded');
           continue;
         }
         if (task) {
@@ -700,6 +703,7 @@ export class AllegroOfferManagerAdapter
           const message =
             task.errors?.map((e) => `${e.code}: ${e.message}`).join('; ') ?? task.message;
           failed.push({ offerId: item.offerId, errorCode, message });
+          await this.persistBatchOfferStatus(commandId, item.offerId, 'failed', message ?? null);
           continue;
         }
         failed.push({
@@ -720,6 +724,67 @@ export class AllegroOfferManagerAdapter
           message: (error as Error).message,
         });
       }
+    }
+  }
+
+  /**
+   * Best-effort per-offer command-record creation for a batch group (#2622
+   * review). `updateOfferQuantity`'s single-item path persists one row per
+   * command via `commandRepository.create`; a batch command covers several
+   * offers under one Allegro commandId, so this persists one row PER OFFER
+   * against that same commandId — the widened (commandId, offerId) unique
+   * index (see the migration) is what makes that possible. Never throws:
+   * losing observability must never sink a batch that Allegro itself accepted.
+   */
+  private async persistBatchCommandRows(
+    commandId: string,
+    allegroStatus: 'QUEUED' | 'ACCEPTED' | 'REJECTED',
+    items: UpdateOfferQuantityCommand[]
+  ): Promise<void> {
+    if (!this.commandRepository) {
+      return;
+    }
+    const status = this.mapAllegroCommandStatus(allegroStatus);
+    await Promise.all(
+      items.map(async (item) => {
+        try {
+          const command = AllegroQuantityCommand.create(
+            commandId,
+            this.connectionId,
+            item.offerId,
+            item.quantity,
+            status
+          );
+          await this.commandRepository?.create(command);
+        } catch (persistError) {
+          this.logger.warn(
+            `Failed to persist batch offer quantity command row (commandId: ${commandId}, offerId: ${item.offerId}): ${(persistError as Error).message}`
+          );
+        }
+      })
+    );
+  }
+
+  /**
+   * Best-effort per-offer status update for a batch group (#2622 review).
+   * Mirrors `pollAndUpdateCommandStatus`'s persistence, but disambiguated by
+   * (commandId, offerId) since one batch commandId can back several rows.
+   */
+  private async persistBatchOfferStatus(
+    commandId: string,
+    offerId: string,
+    status: 'succeeded' | 'failed',
+    error?: string | null
+  ): Promise<void> {
+    if (!this.commandRepository) {
+      return;
+    }
+    try {
+      await this.commandRepository.updateOfferStatus(commandId, offerId, status, error);
+    } catch (persistError) {
+      this.logger.warn(
+        `Failed to persist batch offer quantity command status (commandId: ${commandId}, offerId: ${offerId}): ${(persistError as Error).message}`
+      );
     }
   }
 

--- a/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
+++ b/libs/integrations/allegro/src/infrastructure/adapters/allegro-offer-manager.adapter.ts
@@ -688,6 +688,19 @@ export class AllegroOfferManagerAdapter
 
       await this.persistBatchCommandRows(response.data.id, response.data.status, items);
 
+      if (response.data.status === 'REJECTED') {
+        // Allegro answered synchronously — there is nothing to poll for and
+        // no task will ever appear, so reporting this via the poll-timeout
+        // branch below would discard the platform's own rejection reason.
+        const message =
+          response.data.errors?.map((e) => `${e.code}: ${e.message}`).join('; ') ?? 'rejected';
+        for (const item of items) {
+          failed.push({ offerId: item.offerId, errorCode: 'rejected', message });
+          await this.persistBatchOfferStatus(commandId, item.offerId, 'failed', message);
+        }
+        return;
+      }
+
       const result = await this.pollQuantityCommandStatus(response.data.id);
       const tasksByOfferId = new Map((result?.tasks ?? []).map((task) => [task.offerId, task]));
 

--- a/libs/integrations/allegro/src/infrastructure/persistence/entities/allegro-quantity-command.orm-entity.ts
+++ b/libs/integrations/allegro/src/infrastructure/persistence/entities/allegro-quantity-command.orm-entity.ts
@@ -17,7 +17,9 @@ import {
 import { AllegroQuantityCommandStatus } from '../../../domain/entities/allegro-quantity-command.entity';
 
 @Entity('allegro_quantity_commands')
-@Index(['commandId'], { unique: true })
+// A batch command (#2622) covers several offers under one Allegro commandId,
+// so uniqueness is per (commandId, offerId) — not commandId alone.
+@Index(['commandId', 'offerId'], { unique: true })
 @Index(['connectionId', 'createdAt'])
 @Index(['status', 'createdAt'])
 export class AllegroQuantityCommandOrmEntity {

--- a/libs/integrations/allegro/src/infrastructure/persistence/repositories/__tests__/allegro-quantity-command.repository.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/persistence/repositories/__tests__/allegro-quantity-command.repository.spec.ts
@@ -62,6 +62,7 @@ describe('AllegroQuantityCommandRepository', () => {
 
     ormRepository = {
       findOne: jest.fn(),
+      find: jest.fn(),
       save: jest.fn(),
       createQueryBuilder: jest.fn().mockReturnValue(mockQueryBuilder),
     } as unknown as jest.Mocked<Repository<AllegroQuantityCommandOrmEntity>>;
@@ -84,28 +85,40 @@ describe('AllegroQuantityCommandRepository', () => {
   });
 
   describe('findByCommandId', () => {
-    it('should return command when found', async () => {
+    it('should return the command when found', async () => {
       const entity = createOrmEntity({ commandId: 'cmd-123' });
-      ormRepository.findOne.mockResolvedValue(entity);
+      ormRepository.find.mockResolvedValue([entity]);
 
       const result = await repository.findByCommandId('cmd-123');
 
-      expect(result).toBeDefined();
-      expect(result?.commandId).toBe('cmd-123');
-      expect(result?.connectionId).toBe(entity.connectionId);
-      expect(result?.offerId).toBe(entity.offerId);
-      expect(ormRepository.findOne).toHaveBeenCalledWith({
+      expect(result).toHaveLength(1);
+      expect(result[0].commandId).toBe('cmd-123');
+      expect(result[0].connectionId).toBe(entity.connectionId);
+      expect(result[0].offerId).toBe(entity.offerId);
+      expect(ormRepository.find).toHaveBeenCalledWith({
         where: { commandId: 'cmd-123' },
       });
     });
 
-    it('should return null when not found', async () => {
-      ormRepository.findOne.mockResolvedValue(null);
+    it('should return every row sharing a commandId (batched command, #2622)', async () => {
+      const entities = [
+        createOrmEntity({ commandId: 'cmd-batch', offerId: 'offer-1' }),
+        createOrmEntity({ commandId: 'cmd-batch', offerId: 'offer-2' }),
+      ];
+      ormRepository.find.mockResolvedValue(entities);
+
+      const result = await repository.findByCommandId('cmd-batch');
+
+      expect(result.map((c) => c.offerId).sort()).toEqual(['offer-1', 'offer-2']);
+    });
+
+    it('should return an empty array when not found', async () => {
+      ormRepository.find.mockResolvedValue([]);
 
       const result = await repository.findByCommandId('non-existent-cmd');
 
-      expect(result).toBeNull();
-      expect(ormRepository.findOne).toHaveBeenCalledWith({
+      expect(result).toEqual([]);
+      expect(ormRepository.find).toHaveBeenCalledWith({
         where: { commandId: 'non-existent-cmd' },
       });
     });
@@ -328,6 +341,56 @@ describe('AllegroQuantityCommandRepository', () => {
         AllegroQuantityCommandNotFoundException
       );
       await expect(repository.updateStatus(commandId, 'accepted')).rejects.toThrow(commandId);
+    });
+  });
+
+  describe('updateOfferStatus', () => {
+    it('should update only the row matching (commandId, offerId)', async () => {
+      const commandId = 'cmd-batch';
+      const entity = createOrmEntity({ commandId, offerId: 'offer-1', status: 'accepted' });
+      const updatedEntity = createOrmEntity({ commandId, offerId: 'offer-1', status: 'succeeded' });
+      ormRepository.findOne.mockResolvedValue(entity);
+      ormRepository.save.mockResolvedValue(updatedEntity);
+
+      const result = await repository.updateOfferStatus(commandId, 'offer-1', 'succeeded');
+
+      expect(result.status).toBe('succeeded');
+      expect(ormRepository.findOne).toHaveBeenCalledWith({
+        where: { commandId, offerId: 'offer-1' },
+      });
+      expect(entity.status).toBe('succeeded');
+    });
+
+    it('should update status and error message', async () => {
+      const commandId = 'cmd-batch';
+      const entity = createOrmEntity({ commandId, offerId: 'offer-2', status: 'accepted' });
+      const updatedEntity = createOrmEntity({
+        commandId,
+        offerId: 'offer-2',
+        status: 'failed',
+        error: 'OFFER_INACTIVE: Offer is inactive',
+      });
+      ormRepository.findOne.mockResolvedValue(entity);
+      ormRepository.save.mockResolvedValue(updatedEntity);
+
+      const result = await repository.updateOfferStatus(
+        commandId,
+        'offer-2',
+        'failed',
+        'OFFER_INACTIVE: Offer is inactive'
+      );
+
+      expect(result.status).toBe('failed');
+      expect(result.error).toBe('OFFER_INACTIVE: Offer is inactive');
+    });
+
+    it('should throw AllegroQuantityCommandNotFoundException when no row matches (commandId, offerId)', async () => {
+      const commandId = 'cmd-batch';
+      ormRepository.findOne.mockResolvedValue(null);
+
+      await expect(
+        repository.updateOfferStatus(commandId, 'offer-missing', 'succeeded')
+      ).rejects.toThrow(AllegroQuantityCommandNotFoundException);
     });
   });
 });

--- a/libs/integrations/allegro/src/infrastructure/persistence/repositories/allegro-quantity-command.repository.ts
+++ b/libs/integrations/allegro/src/infrastructure/persistence/repositories/allegro-quantity-command.repository.ts
@@ -33,14 +33,14 @@ export class AllegroQuantityCommandRepository implements AllegroQuantityCommandR
     private readonly ormRepository: Repository<AllegroQuantityCommandOrmEntity>
   ) {}
 
-  async findByCommandId(commandId: string): Promise<AllegroQuantityCommand | null> {
-    this.logger.debug(`Finding command by commandId: ${commandId}`);
+  async findByCommandId(commandId: string): Promise<AllegroQuantityCommand[]> {
+    this.logger.debug(`Finding commands by commandId: ${commandId}`);
 
-    const entity = await this.ormRepository.findOne({
+    const entities = await this.ormRepository.find({
       where: { commandId },
     });
 
-    return entity ? this.toDomain(entity) : null;
+    return entities.map((entity) => this.toDomain(entity));
   }
 
   async find(filters: AllegroQuantityCommandFilters): Promise<AllegroQuantityCommand[]> {
@@ -122,6 +122,35 @@ export class AllegroQuantityCommandRepository implements AllegroQuantityCommandR
     const saved = await this.ormRepository.save(entity);
     this.logger.debug(
       `Command status updated: commandId=${saved.commandId}, status=${saved.status}`
+    );
+    return this.toDomain(saved);
+  }
+
+  async updateOfferStatus(
+    commandId: string,
+    offerId: string,
+    status: AllegroQuantityCommandStatus,
+    error?: string | null
+  ): Promise<AllegroQuantityCommand> {
+    this.logger.debug(
+      `Updating command offer status: commandId=${commandId}, offerId=${offerId}, status=${status}`
+    );
+
+    const entity = await this.ormRepository.findOne({
+      where: { commandId, offerId },
+    });
+
+    if (!entity) {
+      throw new AllegroQuantityCommandNotFoundException(commandId);
+    }
+
+    entity.status = status;
+    entity.error = error || null;
+    entity.updatedAt = new Date();
+
+    const saved = await this.ormRepository.save(entity);
+    this.logger.debug(
+      `Command offer status updated: commandId=${saved.commandId}, offerId=${saved.offerId}, status=${saved.status}`
     );
     return this.toDomain(saved);
   }

--- a/libs/integrations/allegro/src/migrations/1841000000007-widen-allegro-quantity-command-unique-index.ts
+++ b/libs/integrations/allegro/src/migrations/1841000000007-widen-allegro-quantity-command-unique-index.ts
@@ -1,0 +1,37 @@
+/**
+ * Migration: Widen Allegro Quantity Command Unique Index
+ *
+ * A batch quantity-change command (#2622) covers several offers under one
+ * Allegro commandId — `PUT /sale/offer-quantity-change-commands/{id}` applies
+ * one command to every offer named in `offerCriteria`. The original unique
+ * index on `commandId` alone assumed one offer per command and would reject
+ * every row past the first for a batch command. This widens uniqueness to
+ * (commandId, offerId), so one row per offer can be persisted per command.
+ *
+ * @module libs/integrations/allegro/src/migrations
+ */
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class WidenAllegroQuantityCommandUniqueIndex1841000000007 implements MigrationInterface {
+  name = 'WidenAllegroQuantityCommandUniqueIndex1841000000007';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_allegro_quantity_commands_commandId"`);
+
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX "IDX_allegro_quantity_commands_commandId_offerId"
+      ON "allegro_quantity_commands" ("commandId", "offerId")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "IDX_allegro_quantity_commands_commandId_offerId"`
+    );
+
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX "IDX_allegro_quantity_commands_commandId"
+      ON "allegro_quantity_commands" ("commandId")
+    `);
+  }
+}


### PR DESCRIPTION
## Summary
- Implements the `OfferQuantityBatchUpdater` capability on `AllegroOfferManagerAdapter`
- Groups items by target quantity, one Allegro command per group
- Per-item success/failure reporting, never fails the whole batch on one bad group

Closes #2622

## Test plan
- [x] Unit tests added (grouping, per-item failure, transport-error resilience)
- [x] `type-check` clean