### PR TITLE
perf(allegro): shorten the order poll interval

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -144,8 +144,12 @@ CREDENTIALS_TEST_CREDENTIALS_REF=BXCJUVRP6K6ZBGXF9YSLL47Q48INUS3W
 # ==============================================================================
 
 # --- Schedulers: Allegro orders poll ------------------------------------------
-ALLEGRO_POLL_SCHEDULER_ENABLED=false
-ALLEGRO_POLL_INTERVAL_CRON=*/5 * * * *
+# Allegro has no order webhook, so this cadence is the only lever on
+# sale-to-ingested-order latency. Default every minute (#2620, shortened from
+# every 5 minutes) — a tick costs one GET /order/events request per
+# connection, negligible against Allegro's 9000 req/min-per-client-id budget.
+OL_ALLEGRO_POLL_SCHEDULER_ENABLED=false
+OL_ALLEGRO_POLL_INTERVAL_CRON=*/1 * * * *
 
 # --- Schedulers: master catalog sync (capability-based, ProductMaster) --------
 # Enumerates the source platform's product catalog and fans out per-product sync

--- a/libs/integrations/allegro/src/infrastructure/scheduler/__tests__/allegro-scheduler-tasks.spec.ts
+++ b/libs/integrations/allegro/src/infrastructure/scheduler/__tests__/allegro-scheduler-tasks.spec.ts
@@ -126,6 +126,10 @@ describe('buildAllegroSchedulerTasks', () => {
       expect(key).toBe('marketplace:conn-allegro-1:orders:poll:2026-05-11-12-34');
     });
 
+    it('should default to an every-minute cron (#2620)', () => {
+      expect(ordersPoll?.cronExpression).toBe('*/1 * * * *');
+    });
+
     it('should honour OL_ALLEGRO_POLL_INTERVAL_CRON override', () => {
       const tasks2 = buildAllegroSchedulerTasks(
         makeConfig({ OL_ALLEGRO_POLL_INTERVAL_CRON: '*/2 * * * *' })

--- a/libs/integrations/allegro/src/infrastructure/scheduler/allegro-scheduler-tasks.ts
+++ b/libs/integrations/allegro/src/infrastructure/scheduler/allegro-scheduler-tasks.ts
@@ -5,7 +5,15 @@
  * `SchedulerTaskRegistryService` (#584). Four tasks today:
  *
  *   - `allegro-orders-poll` — incremental `/order/events` ingest, default
- *     every 5 minutes. Cursor key `allegro.orders.lastEventId`.
+ *     every minute (#2620 — shortened from 5 minutes). A tick costs exactly
+ *     one `GET /order/events` request per connection regardless of how many
+ *     events it returns (hydration of each event happens later, in the
+ *     per-item `marketplace.order.sync` job), so going from every 5 minutes
+ *     to every minute costs at most 4 extra requests/minute/connection —
+ *     negligible against Allegro's 9000 requests/minute-per-client-id budget
+ *     (ADR-038). Allegro has no order webhook, so this cadence is the only
+ *     lever on sale-to-ingested-order latency. Cursor key
+ *     `allegro.orders.lastEventId`.
  *   - `allegro-offers-sync` — incremental offer-events ingest (or full
  *     listing, depending on `OL_ALLEGRO_OFFERS_SYNC_FEED_TYPE`), default
  *     every 30 minutes. Cursor key `allegro.offers.lastEventId`.
@@ -58,9 +66,11 @@ export function buildAllegroSchedulerTasks(configService: ConfigService): Schedu
   const tasks: SchedulerTaskConfig[] = [];
 
   if (isEnabled(configService, 'OL_ALLEGRO_POLL_SCHEDULER_ENABLED')) {
+    // Default shortened from every 5 minutes to every minute (#2620) — see
+    // the module doc-comment above for the request-budget justification.
     const cronExpression = configService.get<string>(
       'OL_ALLEGRO_POLL_INTERVAL_CRON',
-      '*/5 * * * *'
+      '*/1 * * * *'
     );
 
     tasks.push({


### PR DESCRIPTION
## Summary
- Default order-poll cron shortened from every 5 minutes to every minute
- Justified against Allegro's request budget (one GET per tick, negligible vs 9000/min)
- Fixed a pre-existing missing OL_ prefix on the related .env.example entries

Part of #2620

## Test plan
- [x] Unit test asserting the new default cron
- [x] `type-check` clean