### PR TITLE
feat(inventory,orders): queue propagation on stock event and after order creation

### DIFF
--- a/libs/core/src/orders/application/services/__tests__/order-sync.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-sync.service.spec.ts
@@ -685,5 +685,72 @@ describe('OrderSyncService', () => {
 
       expect(results[0]).toMatchObject({ status: 'success' });
     });
+
+    it('should not fail order sync when resolving InventoryMaster connections itself throws', async () => {
+      registerDestinationsAndInventoryMaster('dest-a', 'master-conn');
+      integrationsService.listCapabilityAdapters.mockImplementation((filters) => {
+        if (filters.capability === 'InventoryMaster') {
+          return Promise.reject(new Error('registry unavailable'));
+        }
+        return Promise.resolve([
+          {
+            connectionId: 'dest-a',
+            connection: {} as never,
+            adapter: makeAdapter(),
+            metadata: {} as never,
+          },
+        ]);
+      });
+
+      const results = await service.syncOrder({ order: createOrder(), sourceConnectionId: 'source-1' });
+
+      expect(results[0]).toMatchObject({ status: 'success' });
+      expect(jobQueue.enqueue).not.toHaveBeenCalled();
+    });
+
+    it('should enqueue nothing when every destination create fails', async () => {
+      integrationsService.listCapabilityAdapters.mockImplementation((filters) => {
+        if (filters.capability === 'InventoryMaster') {
+          return Promise.resolve([
+            {
+              connectionId: 'master-conn',
+              connection: {} as never,
+              adapter: {} as never,
+              metadata: {} as never,
+            },
+          ]);
+        }
+        const failingAdapter: jest.Mocked<OrderProcessorManagerPort> = {
+          createOrder: jest.fn().mockRejectedValue(new Error('destination unreachable')),
+        };
+        return Promise.resolve([
+          {
+            connectionId: 'dest-a',
+            connection: {} as never,
+            adapter: failingAdapter,
+            metadata: {} as never,
+          },
+        ]);
+      });
+      identifierMapping.getExternalIds.mockImplementation((entityType) =>
+        Promise.resolve(
+          entityType === 'Product'
+            ? [
+                {
+                  externalId: 'PS-PRODUCT-789',
+                  connectionId: 'master-conn',
+                  platformType: 'prestashop',
+                  entityType: 'Product',
+                },
+              ]
+            : []
+        )
+      );
+
+      const results = await service.syncOrder({ order: createOrder(), sourceConnectionId: 'source-1' });
+
+      expect(results[0]).toMatchObject({ status: 'failed' });
+      expect(jobQueue.enqueue).not.toHaveBeenCalled();
+    });
   });
 });

--- a/libs/core/src/orders/application/services/__tests__/order-sync.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-sync.service.spec.ts
@@ -15,7 +15,7 @@ import type { OrderRef } from '../../../domain/types/order-processor.types';
 import type { IMappingConfigService } from '@openlinker/core/mappings';
 import { NoOrderDestinationsAvailableException } from '../../../domain/exceptions/no-order-destinations-available.exception';
 import { OrderCreateContendedException } from '../../../domain/exceptions/order-create-contended.exception';
-import type { SyncLockPort } from '@openlinker/core/sync';
+import type { SyncLockPort, SyncJobQueuePort } from '@openlinker/core/sync';
 import type { IIdentifierMappingService } from '@openlinker/core/identifier-mapping';
 import {
   DuplicateIdentifierMappingError,
@@ -28,6 +28,7 @@ describe('OrderSyncService', () => {
   let mappingConfigService: jest.Mocked<IMappingConfigService>;
   let syncLock: jest.Mocked<SyncLockPort>;
   let identifierMapping: jest.Mocked<IIdentifierMappingService>;
+  let jobQueue: jest.Mocked<SyncJobQueuePort>;
 
   const makeAdapter = (orderRef: OrderRef = { orderId: 'dest_order' }) =>
     ({
@@ -119,11 +120,17 @@ describe('OrderSyncService', () => {
       batchGetOrCreateInternalIds: jest.fn(),
     } as unknown as jest.Mocked<IIdentifierMappingService>;
 
+    jobQueue = {
+      enqueue: jest.fn().mockResolvedValue('job-id'),
+      enqueueBulk: jest.fn().mockResolvedValue([]),
+    } as jest.Mocked<SyncJobQueuePort>;
+
     service = new OrderSyncService(
       integrationsService,
       mappingConfigService,
       syncLock,
-      identifierMapping
+      identifierMapping,
+      jobQueue
     );
   });
 
@@ -575,6 +582,108 @@ describe('OrderSyncService', () => {
         status: 'success',
         orderRef: { orderId: 'PS-555' },
       });
+    });
+  });
+
+  describe('post-sale master inventory refresh (#2623)', () => {
+    // resolveDestinations and the InventoryMaster lookup share one mocked
+    // method (`listCapabilityAdapters`) — this discriminates by `capability`
+    // so both callers get the right answer in the same test.
+    const registerDestinationsAndInventoryMaster = (
+      destinationConnectionId: string,
+      inventoryMasterConnectionId: string | null
+    ): void => {
+      integrationsService.listCapabilityAdapters.mockImplementation((filters) => {
+        if (filters.capability === 'InventoryMaster') {
+          return Promise.resolve(
+            inventoryMasterConnectionId
+              ? [
+                  {
+                    connectionId: inventoryMasterConnectionId,
+                    connection: {} as never,
+                    adapter: {} as never,
+                    metadata: {} as never,
+                  },
+                ]
+              : []
+          );
+        }
+        return Promise.resolve([
+          {
+            connectionId: destinationConnectionId,
+            connection: {} as never,
+            adapter: makeAdapter(),
+            metadata: {} as never,
+          },
+        ]);
+      });
+    };
+
+    it('should enqueue a master inventory refresh for a product mapped at an InventoryMaster connection', async () => {
+      registerDestinationsAndInventoryMaster('dest-a', 'master-conn');
+      identifierMapping.getExternalIds.mockImplementation((entityType) =>
+        Promise.resolve(
+          entityType === 'Product'
+            ? [
+                {
+                  externalId: 'PS-PRODUCT-789',
+                  connectionId: 'master-conn',
+                  platformType: 'prestashop',
+                  entityType: 'Product',
+                },
+              ]
+            : []
+        )
+      );
+
+      await service.syncOrder({ order: createOrder(), sourceConnectionId: 'source-1' });
+
+      expect(jobQueue.enqueue).toHaveBeenCalledWith({
+        type: 'master.inventory.syncByExternalId',
+        connectionId: 'master-conn',
+        payload: { schemaVersion: 1, externalId: 'PS-PRODUCT-789', objectType: 'Inventory' },
+        options: { dedupeKey: 'order:ol_order_123:inventory:sync:master-conn:PS-PRODUCT-789' },
+      });
+    });
+
+    it('should enqueue nothing when no InventoryMaster-capable connection exists', async () => {
+      registerDestinationsAndInventoryMaster('dest-a', null);
+
+      await service.syncOrder({ order: createOrder(), sourceConnectionId: 'source-1' });
+
+      expect(jobQueue.enqueue).not.toHaveBeenCalled();
+    });
+
+    it('should enqueue nothing for a product with no external-id mapping at any InventoryMaster connection', async () => {
+      registerDestinationsAndInventoryMaster('dest-a', 'master-conn');
+      identifierMapping.getExternalIds.mockResolvedValue([]);
+
+      await service.syncOrder({ order: createOrder(), sourceConnectionId: 'source-1' });
+
+      expect(jobQueue.enqueue).not.toHaveBeenCalled();
+    });
+
+    it('should not fail order sync when the inventory refresh enqueue itself fails', async () => {
+      registerDestinationsAndInventoryMaster('dest-a', 'master-conn');
+      identifierMapping.getExternalIds.mockImplementation((entityType) =>
+        Promise.resolve(
+          entityType === 'Product'
+            ? [
+                {
+                  externalId: 'PS-PRODUCT-789',
+                  connectionId: 'master-conn',
+                  platformType: 'prestashop',
+                  entityType: 'Product',
+                },
+              ]
+            : []
+        )
+      );
+      jobQueue.enqueue.mockRejectedValue(new Error('queue unavailable'));
+
+      const results = await service.syncOrder({ order: createOrder(), sourceConnectionId: 'source-1' });
+
+      expect(results[0]).toMatchObject({ status: 'success' });
     });
   });
 });

--- a/libs/core/src/orders/application/services/order-sync.service.ts
+++ b/libs/core/src/orders/application/services/order-sync.service.ts
@@ -148,12 +148,21 @@ export class OrderSyncService implements IOrderSyncService {
     // backstop — this just avoids waiting for it. Never allowed to fail the
     // sync itself: the destination create above is the correctness-critical
     // half, this is a latency optimization on top of it.
-    try {
-      await this.enqueuePostSaleInventoryRefresh(order);
-    } catch (error) {
-      this.logger.warn(
-        `Failed to enqueue post-sale master inventory refresh for order ${order.id}: ${error instanceof Error ? error.message : String(error)}`
-      );
+    //
+    // Only fires when at least one destination actually created the order:
+    // if every destination failed, nothing downstream decremented the
+    // master's stock, so a refresh here would just spend outbound API quota
+    // against the master for no observable change — worst timed during a
+    // destination outage, when many orders fail at once.
+    const anyDestinationSucceeded = settled.some((outcome) => outcome.status === 'fulfilled');
+    if (anyDestinationSucceeded) {
+      try {
+        await this.enqueuePostSaleInventoryRefresh(order);
+      } catch (error) {
+        this.logger.warn(
+          `Failed to enqueue post-sale master inventory refresh for order ${order.id}: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
     }
 
     return settled.map((outcome, index): OrderSyncResult => {
@@ -401,7 +410,7 @@ export class OrderSyncService implements IOrderSyncService {
               payload: {
                 schemaVersion: 1,
                 externalId: mapping.externalId,
-                objectType: 'Inventory',
+                objectType: CORE_ENTITY_TYPE.Inventory,
               },
               options: {
                 // Order-scoped, not write-event-scoped like `setInventory`'s

--- a/libs/core/src/orders/application/services/order-sync.service.ts
+++ b/libs/core/src/orders/application/services/order-sync.service.ts
@@ -368,6 +368,9 @@ export class OrderSyncService implements IOrderSyncService {
    * the destination that just created the order, or the SKU has no master
    * connection configured) simply enqueues nothing for that product — this is
    * a latency optimization on top of the sweep, not a new correctness path.
+   *
+   * Only called from `syncOrder` when `anyDestinationSucceeded` — see that
+   * gate's comment for why a fully-failed dispatch enqueues nothing here.
    */
   private async enqueuePostSaleInventoryRefresh(order: Order): Promise<void> {
     const inventoryMasters = await this.integrationsService.listCapabilityAdapters<unknown>({
@@ -382,7 +385,9 @@ export class OrderSyncService implements IOrderSyncService {
     const masterConnectionIds = new Set(inventoryMasters.map((m) => m.connectionId));
     const uniqueProductIds = Array.from(new Set(order.items.map((item) => item.productId)));
 
-    await Promise.all(
+    // allSettled, not all: one product's getExternalIds rejecting must never
+    // suppress the enqueues that other products' lookups already resolved.
+    await Promise.allSettled(
       uniqueProductIds.map((productId) =>
         this.enqueueInventoryRefreshForProduct(order.id, productId, masterConnectionIds)
       )

--- a/libs/core/src/orders/application/services/order-sync.service.ts
+++ b/libs/core/src/orders/application/services/order-sync.service.ts
@@ -19,11 +19,11 @@ import type {
 } from '../interfaces/order-sync.service.interface';
 import type { OrderProcessorManagerPort } from '../../domain/ports/order-processor-manager.port';
 import type { OrderCreate, OrderRef } from '../../domain/types/order-processor.types';
-import { OrderStatusValues } from '../../domain/types/order.types';
+import { OrderStatusValues, type Order } from '../../domain/types/order.types';
 import { IIntegrationsService } from '@openlinker/core/integrations';
 import { INTEGRATIONS_SERVICE_TOKEN } from '@openlinker/core/integrations';
 import { IMappingConfigService, MAPPING_CONFIG_SERVICE_TOKEN } from '@openlinker/core/mappings';
-import { SyncLockPort, SYNC_LOCK_TOKEN } from '@openlinker/core/sync';
+import { SyncLockPort, SYNC_LOCK_TOKEN, SyncJobQueuePort, SYNC_JOB_QUEUE_TOKEN } from '@openlinker/core/sync';
 import {
   IIdentifierMappingService,
   IDENTIFIER_MAPPING_SERVICE_TOKEN,
@@ -48,7 +48,9 @@ export class OrderSyncService implements IOrderSyncService {
     @Inject(SYNC_LOCK_TOKEN)
     private readonly syncLock: SyncLockPort,
     @Inject(IDENTIFIER_MAPPING_SERVICE_TOKEN)
-    private readonly identifierMapping: IIdentifierMappingService
+    private readonly identifierMapping: IIdentifierMappingService,
+    @Inject(SYNC_JOB_QUEUE_TOKEN)
+    private readonly jobQueue: SyncJobQueuePort
   ) {}
 
   async syncOrder(request: OrderSyncRequest): Promise<OrderSyncResult[]> {
@@ -139,6 +141,19 @@ export class OrderSyncService implements IOrderSyncService {
     if (contended) {
       this.logger.warn(`Order ${order.id} create contended on a destination; retrying sync job`);
       throw contended.reason;
+    }
+
+    // Best-effort post-sale close of the "it sold, so re-read the master and
+    // propagate" loop (#2623). The sweep (`master.inventory.syncAll`) is the
+    // backstop — this just avoids waiting for it. Never allowed to fail the
+    // sync itself: the destination create above is the correctness-critical
+    // half, this is a latency optimization on top of it.
+    try {
+      await this.enqueuePostSaleInventoryRefresh(order);
+    } catch (error) {
+      this.logger.warn(
+        `Failed to enqueue post-sale master inventory refresh for order ${order.id}: ${error instanceof Error ? error.message : String(error)}`
+      );
     }
 
     return settled.map((outcome, index): OrderSyncResult => {
@@ -329,5 +344,80 @@ export class OrderSyncService implements IOrderSyncService {
     }
     this.logger.warn(`Unknown order status: ${status}, defaulting to 'pending'`);
     return 'pending';
+  }
+
+  /**
+   * Closes the third trigger `master.inventory.syncByExternalId` was missing
+   * (#2623): a webhook and the sweep re-read a master product's stock, but
+   * nothing did after a sale sold it down. For every distinct product on this
+   * order, enqueues one re-read per `InventoryMaster`-capable connection that
+   * has an external-id mapping for it — mirroring the sweep child's own job
+   * type/payload shape (`libs/core/src/sync/domain/types/master-job-payloads.types.ts`)
+   * so the existing handler needs no change.
+   *
+   * A product with no `InventoryMaster` mapping anywhere (e.g. the master IS
+   * the destination that just created the order, or the SKU has no master
+   * connection configured) simply enqueues nothing for that product — this is
+   * a latency optimization on top of the sweep, not a new correctness path.
+   */
+  private async enqueuePostSaleInventoryRefresh(order: Order): Promise<void> {
+    const inventoryMasters = await this.integrationsService.listCapabilityAdapters<unknown>({
+      capability: 'InventoryMaster',
+      lazy: true,
+    });
+
+    if (inventoryMasters.length === 0) {
+      return;
+    }
+
+    const masterConnectionIds = new Set(inventoryMasters.map((m) => m.connectionId));
+    const uniqueProductIds = Array.from(new Set(order.items.map((item) => item.productId)));
+
+    await Promise.all(
+      uniqueProductIds.map((productId) =>
+        this.enqueueInventoryRefreshForProduct(order.id, productId, masterConnectionIds)
+      )
+    );
+  }
+
+  private async enqueueInventoryRefreshForProduct(
+    orderId: string,
+    productId: string,
+    masterConnectionIds: Set<string>
+  ): Promise<void> {
+    const mappings = await this.identifierMapping.getExternalIds(
+      CORE_ENTITY_TYPE.Product,
+      productId
+    );
+
+    await Promise.all(
+      mappings
+        .filter((mapping) => masterConnectionIds.has(mapping.connectionId))
+        .map(async (mapping) => {
+          try {
+            await this.jobQueue.enqueue({
+              type: 'master.inventory.syncByExternalId',
+              connectionId: mapping.connectionId,
+              payload: {
+                schemaVersion: 1,
+                externalId: mapping.externalId,
+                objectType: 'Inventory',
+              },
+              options: {
+                // Order-scoped, not write-event-scoped like `setInventory`'s
+                // dedupe key: a retried order-sync job re-dispatches
+                // every destination (see the contended-retry comment above),
+                // and must not re-enqueue N redundant refreshes for the same
+                // SKU on the same order.
+                dedupeKey: `order:${orderId}:inventory:sync:${mapping.connectionId}:${mapping.externalId}`,
+              },
+            });
+          } catch (error) {
+            this.logger.warn(
+              `Failed to enqueue post-sale master inventory refresh (order ${orderId}, connection ${mapping.connectionId}, externalId ${mapping.externalId}): ${error instanceof Error ? error.message : String(error)}`
+            );
+          }
+        })
+    );
   }
 }


### PR DESCRIPTION
## Summary
- Confirmed `InventoryService.setInventory` already closes the "stock event" trigger (no change needed)
- Added the missing "post-order-creation" trigger: `OrderSyncService` enqueues `master.inventory.syncByExternalId` for every InventoryMaster-mapped SKU on a synced order
- Best-effort, order-scoped dedupe key, never fails the order sync itself

Closes #2623

## Test plan
- [x] Unit tests: enqueue-on-mapped-product, no-op without InventoryMaster, no-op without mapping, resilience to enqueue failure
- [x] Full existing `order-sync.service.spec.ts` suite re-run (27/27 pass)
- [x] `type-check` clean, invariants clean