### PR TITLE
perf(prestashop): flush the response before draining the outbox

### DIFF
--- a/apps/prestashop-module/openlinker/classes/DeliveryRunner.php
+++ b/apps/prestashop-module/openlinker/classes/DeliveryRunner.php
@@ -38,7 +38,7 @@ class DeliveryRunner
     public static function run($source = 'unknown')
     {
         $classesDir = dirname(__FILE__) . '/';
-        foreach (['EventIdGenerator', 'OutboxEvent', 'OutboxRepository', 'WebhookSender'] as $class) {
+        foreach (['EventIdGenerator', 'OutboxEvent', 'OutboxRepository', 'WebhookSender', 'OutboxDrainer'] as $class) {
             if (!class_exists($class)) {
                 require_once($classesDir . $class . '.php');
             }
@@ -67,6 +67,7 @@ class DeliveryRunner
             $failed = 0;
             $attempted = 0;
             $budgetExhausted = false;
+            $maxAttempts = (int) Configuration::get('MAX_RETRY_ATTEMPTS') ?: 25;
 
             foreach ($events as $event) {
                 if (!OutboxRepository::hasBudgetForAnotherDelivery(
@@ -81,7 +82,7 @@ class DeliveryRunner
 
                 $attempted++;
 
-                if (self::deliverOne($repository, $sender, $event)) {
+                if (OutboxDrainer::deliverOne($repository, $sender, $event, $maxAttempts)) {
                     $delivered++;
                 } else {
                     $failed++;
@@ -142,41 +143,6 @@ class DeliveryRunner
             }
 
             throw $e;
-        }
-    }
-
-    /**
-     * Deliver one event, applying the retry ladder on failure.
-     *
-     * @param OutboxRepository $repository
-     * @param WebhookSender    $sender
-     * @param OutboxEvent      $event
-     * @return bool true when delivered.
-     */
-    private static function deliverOne($repository, $sender, $event)
-    {
-        try {
-            if ($sender->sendEvent($event)) {
-                $repository->markDelivered($event->id);
-
-                return true;
-            }
-
-            // sendEvent throws on failure, so this is defensive only.
-            $repository->scheduleRetry($event->id, $event->attempts, 'Webhook sender returned false');
-
-            return false;
-        } catch (Throwable $e) {
-            $errorMessage = WebhookSender::getErrorMessage($e);
-            $maxAttempts = (int) Configuration::get('MAX_RETRY_ATTEMPTS') ?: 25;
-
-            if ($event->attempts >= $maxAttempts) {
-                $repository->markFailed($event->id, $errorMessage);
-            } else {
-                $repository->scheduleRetry($event->id, $event->attempts, $errorMessage);
-            }
-
-            return false;
         }
     }
 

--- a/apps/prestashop-module/openlinker/classes/OutboxDrainer.php
+++ b/apps/prestashop-module/openlinker/classes/OutboxDrainer.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Outbox Drainer
+ *
+ * The claim-send-mark loop shared by the cron controller and the
+ * response-flush fast path (#2624). Extracted so the retry/backoff/error
+ * handling in that loop cannot drift between the two delivery paths - the
+ * fast path is a second caller of the exact same delivery semantics, not a
+ * parallel implementation of them.
+ *
+ * @module prestashop-module/classes
+ * @see {@link OutboxRepository} for event claiming and state management
+ * @see {@link WebhookSender} for HTTP delivery
+ */
+
+class OutboxDrainer
+{
+    /**
+     * Claims and delivers up to $batchSize outbox rows, optionally
+     * restricted to a set of `object_type` values.
+     *
+     * @param OutboxRepository $repository
+     * @param WebhookSender $sender
+     * @param int $batchSize
+     * @param string $runId Unique run identifier (used for the claim and,
+     *        on an outer failure, to requeue exactly this run's rows)
+     * @param string[]|null $objectTypes Restrict the claim to these object
+     *        types. Null claims any type (the cron path's behaviour).
+     * @param int $maxAttempts Attempts after which a failing event is marked
+     *        `failed` instead of retried. Taken as a plain parameter rather
+     *        than read from `Configuration` here, so this method has no
+     *        PrestaShop dependency beyond the two collaborators it is
+     *        handed — callers resolve the operator's configured value.
+     * @return array{claimed:int, delivered:int, failed:int}
+     */
+    public static function drainBatch($repository, $sender, $batchSize, $runId, $objectTypes = null, $maxAttempts = 25)
+    {
+        $events = $repository->claimBatchDueForDelivery($batchSize, $runId, $objectTypes);
+
+        if (empty($events)) {
+            return ['claimed' => 0, 'delivered' => 0, 'failed' => 0];
+        }
+
+        $delivered = 0;
+        $failed = 0;
+
+        foreach ($events as $event) {
+            try {
+                $success = $sender->sendEvent($event);
+
+                if ($success) {
+                    $repository->markDelivered($event->id);
+                    $delivered++;
+                } else {
+                    // Should not happen (sendEvent throws on failure), but
+                    // handle gracefully rather than leave the row stuck.
+                    $repository->scheduleRetry(
+                        $event->id,
+                        $event->attempts,
+                        'Webhook sender returned false'
+                    );
+                    $failed++;
+                }
+            } catch (Exception $e) {
+                $errorMessage = WebhookSender::getErrorMessage($e);
+
+                if ($event->attempts >= $maxAttempts) {
+                    $repository->markFailed($event->id, $errorMessage);
+                } else {
+                    $repository->scheduleRetry($event->id, $event->attempts, $errorMessage);
+                }
+                $failed++;
+            }
+        }
+
+        return ['claimed' => count($events), 'delivered' => $delivered, 'failed' => $failed];
+    }
+}

--- a/apps/prestashop-module/openlinker/classes/OutboxDrainer.php
+++ b/apps/prestashop-module/openlinker/classes/OutboxDrainer.php
@@ -2,22 +2,89 @@
 /**
  * Outbox Drainer
  *
- * The claim-send-mark loop shared by the cron controller and the
- * response-flush fast path (#2624). Extracted so the retry/backoff/error
- * handling in that loop cannot drift between the two delivery paths - the
- * fast path is a second caller of the exact same delivery semantics, not a
- * parallel implementation of them.
+ * The single deliver-one-event primitive shared by the cron controller
+ * (`DeliveryRunner`) and the response-flush fast path (#2624), plus a
+ * claim-and-drain-a-batch convenience built on top of it for callers (the
+ * fast path) that have no per-run wall-clock budget of their own to enforce
+ * between events. `DeliveryRunner::run` keeps its own claim/budget/retention
+ * loop — its budget check has to run *between* events, before this class
+ * ever sees the next one — but delegates the actual send-and-mark-outcome
+ * step for a single event to `self::deliverOne()` here, so the retry/backoff
+ * semantics (which exception types count, the attempts-vs-max comparison,
+ * which repository method fires) exist in exactly one place and cannot drift
+ * between the two delivery paths.
  *
  * @module prestashop-module/classes
  * @see {@link OutboxRepository} for event claiming and state management
  * @see {@link WebhookSender} for HTTP delivery
+ * @see {@link DeliveryRunner} for the budget-aware caller
  */
 
 class OutboxDrainer
 {
     /**
+     * Deliver a single already-claimed event, applying the retry ladder on
+     * failure.
+     *
+     * `catch (Throwable ...)`, not `Exception`: a `TypeError` or other
+     * `Error` raised inside `$sender->sendEvent()` must still resolve this
+     * one event to `retried` or `failed` rather than escaping uncaught -
+     * letting it escape would abort whichever caller's loop this runs
+     * inside (a caller may be draining several events per call), stranding
+     * every event after this one in `processing` until the next stale-row
+     * sweep for no better reason than a single bad row.
+     *
+     * @param OutboxRepository $repository
+     * @param WebhookSender $sender
+     * @param OutboxEvent $event
+     * @param int $maxAttempts Attempts after which a failing event is marked
+     *        `failed` instead of retried. Taken as a plain parameter rather
+     *        than read from `Configuration` here, so this method has no
+     *        PrestaShop dependency beyond the two collaborators it is
+     *        handed — callers resolve the operator's configured value.
+     * @return bool true when delivered.
+     */
+    public static function deliverOne($repository, $sender, $event, $maxAttempts = 25)
+    {
+        try {
+            $success = $sender->sendEvent($event);
+
+            if ($success) {
+                $repository->markDelivered($event->id);
+
+                return true;
+            }
+
+            // Should not happen (sendEvent throws on failure), but handle
+            // gracefully rather than leave the row stuck.
+            $repository->scheduleRetry(
+                $event->id,
+                $event->attempts,
+                'Webhook sender returned false'
+            );
+
+            return false;
+        } catch (Throwable $e) {
+            $errorMessage = WebhookSender::getErrorMessage($e);
+
+            if ($event->attempts >= $maxAttempts) {
+                $repository->markFailed($event->id, $errorMessage);
+            } else {
+                $repository->scheduleRetry($event->id, $event->attempts, $errorMessage);
+            }
+
+            return false;
+        }
+    }
+
+    /**
      * Claims and delivers up to $batchSize outbox rows, optionally
      * restricted to a set of `object_type` values.
+     *
+     * Unlike `DeliveryRunner::run`, this has no per-run wall-clock budget:
+     * every caller of this method (today, only the response-flush fast
+     * path) bounds its own cost instead via a small, fixed `$batchSize`
+     * and short per-request HTTP timeouts on `$sender`.
      *
      * @param OutboxRepository $repository
      * @param WebhookSender $sender
@@ -27,10 +94,7 @@ class OutboxDrainer
      * @param string[]|null $objectTypes Restrict the claim to these object
      *        types. Null claims any type (the cron path's behaviour).
      * @param int $maxAttempts Attempts after which a failing event is marked
-     *        `failed` instead of retried. Taken as a plain parameter rather
-     *        than read from `Configuration` here, so this method has no
-     *        PrestaShop dependency beyond the two collaborators it is
-     *        handed — callers resolve the operator's configured value.
+     *        `failed` instead of retried.
      * @return array{claimed:int, delivered:int, failed:int}
      */
     public static function drainBatch($repository, $sender, $batchSize, $runId, $objectTypes = null, $maxAttempts = 25)
@@ -45,30 +109,9 @@ class OutboxDrainer
         $failed = 0;
 
         foreach ($events as $event) {
-            try {
-                $success = $sender->sendEvent($event);
-
-                if ($success) {
-                    $repository->markDelivered($event->id);
-                    $delivered++;
-                } else {
-                    // Should not happen (sendEvent throws on failure), but
-                    // handle gracefully rather than leave the row stuck.
-                    $repository->scheduleRetry(
-                        $event->id,
-                        $event->attempts,
-                        'Webhook sender returned false'
-                    );
-                    $failed++;
-                }
-            } catch (Exception $e) {
-                $errorMessage = WebhookSender::getErrorMessage($e);
-
-                if ($event->attempts >= $maxAttempts) {
-                    $repository->markFailed($event->id, $errorMessage);
-                } else {
-                    $repository->scheduleRetry($event->id, $event->attempts, $errorMessage);
-                }
+            if (self::deliverOne($repository, $sender, $event, $maxAttempts)) {
+                $delivered++;
+            } else {
                 $failed++;
             }
         }

--- a/apps/prestashop-module/openlinker/classes/OutboxRepository.php
+++ b/apps/prestashop-module/openlinker/classes/OutboxRepository.php
@@ -537,14 +537,27 @@ class OutboxRepository
      *
      * @param int $limit Maximum number of events to claim
      * @param string $runId Unique run identifier for this cron execution
+     * @param string[]|null $objectTypes Restrict the claim to these
+     *        `object_type` values (e.g. `['stock', 'order']`). Null (default)
+     *        claims any type — the cron path's behaviour is unchanged. Used
+     *        by the response-flush fast path (#2624) so a catalogue import's
+     *        thousands of `product.saved` rows can never be claimed there.
      * @return array Array of OutboxEvent objects
      */
-    public function claimBatchDueForDelivery($limit, $runId)
+    public function claimBatchDueForDelivery($limit, $runId, $objectTypes = null)
     {
         // Ensure OutboxEvent class is loaded
         if (!class_exists('OutboxEvent')) {
             $classesDir = dirname(__FILE__) . '/';
             require_once($classesDir . 'OutboxEvent.php');
+        }
+
+        $objectTypeFilter = '';
+        if (!empty($objectTypes)) {
+            $quoted = array_map(function ($type) {
+                return '"' . pSQL($type) . '"';
+            }, $objectTypes);
+            $objectTypeFilter = 'AND `object_type` IN (' . implode(',', $quoted) . ')';
         }
 
         // Step 1: Atomically claim rows with this runId
@@ -565,6 +578,7 @@ class OutboxRepository
                     `updated_at` = NOW()
                 WHERE `status` = "pending"
                 AND (`next_attempt_at` IS NULL OR `next_attempt_at` <= NOW())
+                ' . $objectTypeFilter . '
                 ORDER BY `created_at` ASC
                 LIMIT ' . (int)$limit;
 

--- a/apps/prestashop-module/openlinker/classes/WebhookSender.php
+++ b/apps/prestashop-module/openlinker/classes/WebhookSender.php
@@ -16,12 +16,71 @@
 
 class WebhookSender
 {
-    // HTTP timeout constants
+    // HTTP timeout constants (the cron path's defaults)
     const HTTP_TIMEOUT_SECONDS = 10;
     const HTTP_CONNECT_TIMEOUT_SECONDS = 5;
 
+    // Response-flush fast path's shorter timeout (#2624): this send happens
+    // after the buyer's connection is already closed, inside a PHP-FPM
+    // worker the web server thinks is idle — a slow OpenLinker host must not
+    // be able to pin that worker for the cron path's full 10s.
+    const FAST_PATH_TIMEOUT_SECONDS = 3;
+    const FAST_PATH_CONNECT_TIMEOUT_SECONDS = 2;
+
     // Error message truncation
     const ERROR_MESSAGE_MAX_LENGTH = 200;
+
+    /** @var int */
+    private $timeoutSeconds;
+
+    /** @var int */
+    private $connectTimeoutSeconds;
+
+    /**
+     * @param int|null $timeoutSeconds Override the total curl timeout (defaults to HTTP_TIMEOUT_SECONDS)
+     * @param int|null $connectTimeoutSeconds Override the connect timeout (defaults to HTTP_CONNECT_TIMEOUT_SECONDS)
+     */
+    public function __construct($timeoutSeconds = null, $connectTimeoutSeconds = null)
+    {
+        $this->timeoutSeconds = $timeoutSeconds !== null ? $timeoutSeconds : self::HTTP_TIMEOUT_SECONDS;
+        $this->connectTimeoutSeconds = $connectTimeoutSeconds !== null ? $connectTimeoutSeconds : self::HTTP_CONNECT_TIMEOUT_SECONDS;
+    }
+
+    /**
+     * Whether this host can run the response-flush fast path (#2624).
+     *
+     * Both functions are required: `fastcgi_finish_request` actually flushes
+     * and closes the buyer's connection while PHP keeps running under
+     * PHP-FPM (a no-op / unavailable everywhere else — CLI, mod_php); without
+     * it there is nothing to flush and the "fast path" would just be normal
+     * synchronous work stacked onto the buyer's request. `ignore_user_abort`
+     * keeps the script running once the client is gone. No Polish host
+     * publishes its disabled-function list, so this probes rather than
+     * assumes — mirroring `OutboxRepository::hasDedupKeyColumn()`'s
+     * probe-and-degrade shape: never throws, just answers false.
+     *
+     * Both capability flags are optional, injectable params (mirroring
+     * `OutboxRepository::shouldRunRetention()`'s `$now`/`$lastRunAt`) so this
+     * can be unit-tested for both hosts without depending on which SAPI ran
+     * the test — `null` (the production call shape) probes the real
+     * functions.
+     *
+     * @param bool|null $fastcgiFinishRequestExists
+     * @param bool|null $ignoreUserAbortExists
+     * @return bool
+     */
+    public static function fastPathAvailable($fastcgiFinishRequestExists = null, $ignoreUserAbortExists = null)
+    {
+        if ($fastcgiFinishRequestExists === null) {
+            $fastcgiFinishRequestExists = function_exists('fastcgi_finish_request');
+        }
+        if ($ignoreUserAbortExists === null) {
+            $ignoreUserAbortExists = function_exists('ignore_user_abort');
+        }
+
+        return $fastcgiFinishRequestExists && $ignoreUserAbortExists;
+    }
+
     /**
      * Send webhook event to OpenLinker
      *
@@ -88,8 +147,8 @@ class WebhookSender
         curl_setopt($ch, CURLOPT_POSTFIELDS, $rawBody);
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($ch, CURLOPT_TIMEOUT, self::HTTP_TIMEOUT_SECONDS);
-        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, self::HTTP_CONNECT_TIMEOUT_SECONDS);
+        curl_setopt($ch, CURLOPT_TIMEOUT, $this->timeoutSeconds);
+        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $this->connectTimeoutSeconds);
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
         curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
 

--- a/apps/prestashop-module/openlinker/openlinker.php
+++ b/apps/prestashop-module/openlinker/openlinker.php
@@ -67,7 +67,15 @@ class OpenLinker extends CarrierModule
     // Response-flush fast path (#2624): deliberately small and fixed (not
     // the operator-configurable BATCH_SIZE) - this runs inside every urgent
     // request's PHP-FPM worker, so it must stay a handful of rows, not the
-    // cron path's full page.
+    // cron path's full page. Unlike DeliveryRunner::run, this batch has no
+    // wall-clock budget check between events - the bound here is coarse but
+    // fixed by construction: FAST_PATH_BATCH_LIMIT events, each capped at
+    // WebhookSender::FAST_PATH_TIMEOUT_SECONDS, so one shutdown-function run
+    // can hold its PHP-FPM worker for at most
+    // (5 * 3s =) 15 seconds even if every delivery times out. Keep this
+    // comment's arithmetic in sync with either constant if either changes -
+    // that worst case is what an operator's FPM `pm.max_children` sizing has
+    // to absorb under concurrent urgent requests.
     const FAST_PATH_BATCH_LIMIT = 5;
 
     // Dynamic shipping carrier — display name shown in PS admin carrier list.

--- a/apps/prestashop-module/openlinker/openlinker.php
+++ b/apps/prestashop-module/openlinker/openlinker.php
@@ -64,6 +64,11 @@ class OpenLinker extends CarrierModule
     // horizon and the pass bounds are OutboxRepository's - only this one is an
     // operator dial.
     const DEFAULT_OUTBOX_RETENTION_DAYS = 7;
+    // Response-flush fast path (#2624): deliberately small and fixed (not
+    // the operator-configurable BATCH_SIZE) - this runs inside every urgent
+    // request's PHP-FPM worker, so it must stay a handful of rows, not the
+    // cron path's full page.
+    const FAST_PATH_BATCH_LIMIT = 5;
 
     // Dynamic shipping carrier — display name shown in PS admin carrier list.
     const DYNAMIC_CARRIER_NAME = 'OpenLinker Dynamic';
@@ -91,6 +96,14 @@ class OpenLinker extends CarrierModule
      * request — share it; PHP resets it per request.
      */
     public static $suppressImportMail = false;
+
+    /**
+     * Request-scoped guard so a request that fires several urgent hooks
+     * (e.g. a multi-line order touching several products' stock) registers
+     * the response-flush fast-path shutdown drain once, not once per hook
+     * call (#2624).
+     */
+    public static $fastPathDrainScheduled = false;
 
     public function __construct()
     {
@@ -251,6 +264,14 @@ class OpenLinker extends CarrierModule
             $output .= $this->processManualDelivery();
         }
 
+        // #2624: whether this host can actually run the response-flush fast
+        // path — an operator believing they have seconds when they in fact
+        // have the cron interval is the same silence-instead-of-error
+        // failure the epic exists to remove, so the panel states it plainly.
+        if (!class_exists('WebhookSender')) {
+            require_once(dirname(__FILE__) . '/classes/WebhookSender.php');
+        }
+
         // Render configuration template
         $this->context->smarty->assign([
             'module_dir' => $this->_path,
@@ -296,6 +317,7 @@ class OpenLinker extends CarrierModule
             'outbox_stale_minutes_default' => OutboxRepository::defaultStaleThresholdMinutes(
                 OutboxRepository::readRunBudgetSeconds()
             ),
+            'fast_path_active' => WebhookSender::fastPathAvailable(),
             'statistics' => $this->getStatistics(),
             // Whether delivery is actually running at all (#2618). Without
             // this a dead cron is indistinguishable from an empty queue.
@@ -1906,6 +1928,10 @@ class OpenLinker extends CarrierModule
                 $orderId
             );
         }
+
+        // Urgent event type (#2624): try to flush the buyer's response now
+        // and deliver it invisibly, instead of waiting for the next cron tick.
+        self::scheduleFastPathDrain();
     }
 
     /**
@@ -2001,6 +2027,9 @@ class OpenLinker extends CarrierModule
                 $orderId
             );
         }
+
+        // Urgent event type (#2624): see hookActionValidateOrderAfter.
+        self::scheduleFastPathDrain();
     }
 
     /**
@@ -2087,5 +2116,84 @@ class OpenLinker extends CarrierModule
                 $productId
             );
         }
+
+        // Urgent event type (#2624): see hookActionValidateOrderAfter.
+        self::scheduleFastPathDrain();
+    }
+
+    /**
+     * Response-flush fast path (#2624): flush the buyer's response now, then
+     * deliver a small batch of urgent (stock/order) outbox events invisibly
+     * to them. Registers a `register_shutdown_function` callback that runs
+     * AFTER PrestaShop finishes rendering the page, mirroring the pattern
+     * PrestaShop's own `cronjobs` module uses.
+     *
+     * Never runs when `WebhookSender::fastPathAvailable()` is false (no
+     * `fastcgi_finish_request`/`ignore_user_abort` on this host, e.g. plain
+     * mod_php or CLI) — those installs keep delivering exclusively via the
+     * cron controller, unchanged.
+     *
+     * @return void
+     */
+    public static function scheduleFastPathDrain()
+    {
+        if (self::$fastPathDrainScheduled) {
+            return;
+        }
+        self::$fastPathDrainScheduled = true;
+
+        if (!WebhookSender::fastPathAvailable()) {
+            return;
+        }
+
+        $classesDir = dirname(__FILE__) . '/classes/';
+
+        register_shutdown_function(function () use ($classesDir) {
+            // Flush and close the buyer's connection now. Everything below
+            // this line runs invisibly to them, however long it takes.
+            ignore_user_abort(true);
+            fastcgi_finish_request();
+
+            try {
+                if (!class_exists('OutboxEvent')) {
+                    require_once($classesDir . 'OutboxEvent.php');
+                }
+                if (!class_exists('OutboxRepository')) {
+                    require_once($classesDir . 'OutboxRepository.php');
+                }
+                if (!class_exists('WebhookSender')) {
+                    require_once($classesDir . 'WebhookSender.php');
+                }
+                if (!class_exists('OutboxDrainer')) {
+                    require_once($classesDir . 'OutboxDrainer.php');
+                }
+
+                $repository = new OutboxRepository();
+                $sender = new WebhookSender(
+                    WebhookSender::FAST_PATH_TIMEOUT_SECONDS,
+                    WebhookSender::FAST_PATH_CONNECT_TIMEOUT_SECONDS
+                );
+
+                OutboxDrainer::drainBatch(
+                    $repository,
+                    $sender,
+                    OpenLinker::FAST_PATH_BATCH_LIMIT,
+                    uniqid('fastpath_', true),
+                    ['stock', 'order'],
+                    (int)Configuration::get('MAX_RETRY_ATTEMPTS') ?: 25
+                );
+            } catch (Throwable $e) {
+                // The buyer is long gone and the cron path still owns these
+                // rows either way - never let a fast-path failure surface
+                // anywhere but the log.
+                PrestaShopLogger::addLog(
+                    'OpenLinker: response-flush fast-path drain failed: ' . WebhookSender::getErrorMessage($e),
+                    2,
+                    null,
+                    'Module',
+                    null
+                );
+            }
+        });
     }
 }

--- a/apps/prestashop-module/openlinker/tests/Unit/CronDeliveryHardeningTest.php
+++ b/apps/prestashop-module/openlinker/tests/Unit/CronDeliveryHardeningTest.php
@@ -22,6 +22,36 @@ class CronDeliveryHardeningTest extends TestCase
         self::assertStringContainsString('catch (Throwable', $source);
     }
 
+    /**
+     * OutboxDrainer::deliverOne (#2635 review) is the single per-event
+     * delivery primitive both DeliveryRunner and the response-flush fast
+     * path now share. A regression back to `catch (Exception ...)` here
+     * would let a TypeError/Error from `sendEvent()` escape uncaught,
+     * aborting whichever caller's batch loop is in progress instead of
+     * resolving just that one event to retried/failed.
+     */
+    public function testTheOutboxDrainerCatchesErrorsAsWellAsExceptions(): void
+    {
+        $source = self::sourceOf('classes/OutboxDrainer.php');
+
+        self::assertStringNotContainsString('catch (Exception', $source);
+        self::assertStringContainsString('catch (Throwable', $source);
+    }
+
+    /**
+     * DeliveryRunner must delegate its per-event delivery to
+     * OutboxDrainer::deliverOne rather than re-implementing the claim-send-
+     * mark loop itself (#2635 review) - a second implementation is exactly
+     * how the two delivery paths' retry semantics drift apart.
+     */
+    public function testTheDeliveryPassDelegatesPerEventDeliveryToOutboxDrainer(): void
+    {
+        $source = self::sourceOf('classes/DeliveryRunner.php');
+
+        self::assertStringContainsString('OutboxDrainer::deliverOne', $source);
+        self::assertStringNotContainsString('private static function deliverOne', $source);
+    }
+
     public function testTheCronFileCatchesErrorsAsWellAsExceptions(): void
     {
         $source = self::sourceOf('cron/openlinker-cron.php');

--- a/apps/prestashop-module/openlinker/tests/Unit/OutboxDrainerTest.php
+++ b/apps/prestashop-module/openlinker/tests/Unit/OutboxDrainerTest.php
@@ -72,6 +72,22 @@ class OutboxDrainerTest extends TestCase
         $this->assertSame([6], $repository->failedIds);
     }
 
+    public function testSchedulesARetryWhenSendingRaisesAnErrorRatherThanAnException(): void
+    {
+        // A TypeError/Error does not extend Exception - if drainBatch ever
+        // regresses to `catch (Exception ...)`, this event's Error escapes
+        // the loop uncaught instead of being retried, and PHPUnit reports it
+        // as an uncaught-error test failure rather than an assertion failure.
+        $repository = new FakeOutboxDrainerRepository([$this->makeEvent(9, 1)]);
+        $sender = new FakeOutboxDrainerSender(['9' => new TypeError('bad argument')]);
+
+        $result = OutboxDrainer::drainBatch($repository, $sender, 5, 'run-1', null, 25);
+
+        $this->assertSame(['claimed' => 1, 'delivered' => 0, 'failed' => 1], $result);
+        $this->assertSame([9], $repository->retriedIds);
+        $this->assertSame([], $repository->failedIds);
+    }
+
     public function testSchedulesARetryWhenTheSenderReturnsFalseInsteadOfThrowing(): void
     {
         $repository = new FakeOutboxDrainerRepository([$this->makeEvent(7)]);
@@ -139,7 +155,7 @@ class FakeOutboxDrainerRepository
 
 class FakeOutboxDrainerSender
 {
-    /** @var array<string, Exception> keyed by event id */
+    /** @var array<string, Throwable> keyed by event id */
     private $throwFor;
 
     /** @var array<int|string> event ids for which sendEvent() returns false */

--- a/apps/prestashop-module/openlinker/tests/Unit/OutboxDrainerTest.php
+++ b/apps/prestashop-module/openlinker/tests/Unit/OutboxDrainerTest.php
@@ -1,0 +1,165 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for OutboxDrainer::drainBatch() (#2624).
+ *
+ * This is the claim-send-mark loop shared by the cron controller and the
+ * response-flush fast path — a defect here reaches both delivery paths, so
+ * it is covered independently of either caller. No PrestaShop/DB dependency:
+ * the repository and sender are plain test doubles, and `$maxAttempts` is a
+ * parameter rather than a `Configuration::get()` read inside the method
+ * under test (see OutboxDrainer's own docblock for why).
+ *
+ * @see OutboxDrainer
+ */
+class OutboxDrainerTest extends TestCase
+{
+    private function makeEvent($id, $attempts = 0)
+    {
+        $event = new stdClass();
+        $event->id = $id;
+        $event->attempts = $attempts;
+        return $event;
+    }
+
+    public function testReturnsZeroedResultWithoutCallingTheSenderWhenNothingIsClaimed(): void
+    {
+        $repository = new FakeOutboxDrainerRepository([]);
+        $sender = new FakeOutboxDrainerSender();
+
+        $result = OutboxDrainer::drainBatch($repository, $sender, 5, 'run-1');
+
+        $this->assertSame(['claimed' => 0, 'delivered' => 0, 'failed' => 0], $result);
+        $this->assertSame([], $sender->sentEventIds);
+    }
+
+    public function testMarksEverySuccessfullySentEventDelivered(): void
+    {
+        $repository = new FakeOutboxDrainerRepository([$this->makeEvent(1), $this->makeEvent(2)]);
+        $sender = new FakeOutboxDrainerSender(); // succeeds by default
+
+        $result = OutboxDrainer::drainBatch($repository, $sender, 5, 'run-1');
+
+        $this->assertSame(['claimed' => 2, 'delivered' => 2, 'failed' => 0], $result);
+        $this->assertSame([1, 2], $repository->deliveredIds);
+        $this->assertSame([], $repository->retriedIds);
+        $this->assertSame([], $repository->failedIds);
+    }
+
+    public function testSchedulesARetryWhenSendingThrowsAndAttemptsAreBelowTheMax(): void
+    {
+        $repository = new FakeOutboxDrainerRepository([$this->makeEvent(5, 2)]);
+        $sender = new FakeOutboxDrainerSender(['5' => new Exception('boom')]);
+
+        $result = OutboxDrainer::drainBatch($repository, $sender, 5, 'run-1', null, 25);
+
+        $this->assertSame(['claimed' => 1, 'delivered' => 0, 'failed' => 1], $result);
+        $this->assertSame([5], $repository->retriedIds);
+        $this->assertSame([], $repository->failedIds);
+    }
+
+    public function testMarksFailedInsteadOfRetryingOnceAttemptsReachTheMax(): void
+    {
+        $repository = new FakeOutboxDrainerRepository([$this->makeEvent(6, 25)]);
+        $sender = new FakeOutboxDrainerSender(['6' => new Exception('boom')]);
+
+        $result = OutboxDrainer::drainBatch($repository, $sender, 5, 'run-1', null, 25);
+
+        $this->assertSame(['claimed' => 1, 'delivered' => 0, 'failed' => 1], $result);
+        $this->assertSame([], $repository->retriedIds);
+        $this->assertSame([6], $repository->failedIds);
+    }
+
+    public function testSchedulesARetryWhenTheSenderReturnsFalseInsteadOfThrowing(): void
+    {
+        $repository = new FakeOutboxDrainerRepository([$this->makeEvent(7)]);
+        $sender = new FakeOutboxDrainerSender();
+        $sender->falseFor = [7];
+
+        $result = OutboxDrainer::drainBatch($repository, $sender, 5, 'run-1');
+
+        $this->assertSame(['claimed' => 1, 'delivered' => 0, 'failed' => 1], $result);
+        $this->assertSame([7], $repository->retriedIds);
+    }
+
+    public function testPassesTheBatchSizeRunIdAndObjectTypesThroughToTheClaim(): void
+    {
+        $repository = new FakeOutboxDrainerRepository([]);
+        $sender = new FakeOutboxDrainerSender();
+
+        OutboxDrainer::drainBatch($repository, $sender, 5, 'run-xyz', ['stock', 'order']);
+
+        $this->assertSame([5, 'run-xyz', ['stock', 'order']], $repository->lastClaimArgs);
+    }
+}
+
+class FakeOutboxDrainerRepository
+{
+    /** @var array */
+    private $events;
+
+    /** @var array|null */
+    public $lastClaimArgs;
+
+    public $deliveredIds = [];
+    public $retriedIds = [];
+    public $failedIds = [];
+
+    public function __construct(array $events)
+    {
+        $this->events = $events;
+    }
+
+    public function claimBatchDueForDelivery($limit, $runId, $objectTypes = null)
+    {
+        $this->lastClaimArgs = [$limit, $runId, $objectTypes];
+        return $this->events;
+    }
+
+    public function markDelivered($outboxId)
+    {
+        $this->deliveredIds[] = $outboxId;
+        return true;
+    }
+
+    public function scheduleRetry($outboxId, $attemptNumber, $errorMessage)
+    {
+        $this->retriedIds[] = $outboxId;
+        return true;
+    }
+
+    public function markFailed($outboxId, $errorMessage)
+    {
+        $this->failedIds[] = $outboxId;
+        return true;
+    }
+}
+
+class FakeOutboxDrainerSender
+{
+    /** @var array<string, Exception> keyed by event id */
+    private $throwFor;
+
+    /** @var array<int|string> event ids for which sendEvent() returns false */
+    public $falseFor = [];
+
+    public $sentEventIds = [];
+
+    public function __construct(array $throwFor = [])
+    {
+        $this->throwFor = $throwFor;
+    }
+
+    public function sendEvent($event)
+    {
+        $this->sentEventIds[] = $event->id;
+
+        if (isset($this->throwFor[(string)$event->id])) {
+            throw $this->throwFor[(string)$event->id];
+        }
+
+        return !in_array($event->id, $this->falseFor, true);
+    }
+}

--- a/apps/prestashop-module/openlinker/tests/Unit/WebhookSenderFastPathTest.php
+++ b/apps/prestashop-module/openlinker/tests/Unit/WebhookSenderFastPathTest.php
@@ -1,0 +1,48 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for WebhookSender::fastPathAvailable() (#2624).
+ *
+ * No Polish host publishes its disabled-function list, so the response-flush
+ * fast path must probe rather than assume — and both capability flags matter
+ * independently: fastcgi_finish_request is what actually lets the buyer's
+ * connection close while PHP keeps running, ignore_user_abort is what keeps
+ * PHP running once it does. Either missing means no fast path.
+ *
+ * @see WebhookSender
+ */
+class WebhookSenderFastPathTest extends TestCase
+{
+    public function testAvailableWhenBothFunctionsExist(): void
+    {
+        $this->assertTrue(WebhookSender::fastPathAvailable(true, true));
+    }
+
+    public function testUnavailableWithoutFastcgiFinishRequest(): void
+    {
+        // The common real-world case: plain mod_php or CLI, where
+        // ignore_user_abort exists (core PHP) but fastcgi_finish_request
+        // does not (FPM-only).
+        $this->assertFalse(WebhookSender::fastPathAvailable(false, true));
+    }
+
+    public function testUnavailableWithoutIgnoreUserAbort(): void
+    {
+        $this->assertFalse(WebhookSender::fastPathAvailable(true, false));
+    }
+
+    public function testUnavailableWhenNeitherFunctionExists(): void
+    {
+        $this->assertFalse(WebhookSender::fastPathAvailable(false, false));
+    }
+
+    public function testProbesTheRealRuntimeWhenNoOverrideIsGiven(): void
+    {
+        // No assertion on the value itself — that depends on the SAPI
+        // running this test. Only pins that the no-args call shape (the one
+        // every production caller uses) never throws and returns a bool.
+        $this->assertIsBool(WebhookSender::fastPathAvailable());
+    }
+}

--- a/apps/prestashop-module/openlinker/views/templates/admin/configure.tpl
+++ b/apps/prestashop-module/openlinker/views/templates/admin/configure.tpl
@@ -298,6 +298,18 @@
             </tr>
             {/if}
             <tr>
+                <td><strong>{l s='Fast Delivery' mod='openlinker'}</strong></td>
+                <td>
+                    {if $fast_path_active}
+                        <span class="text-success">{l s='Active' mod='openlinker'}</span>
+                        <span class="help-block">{l s='Stock and order changes are delivered within seconds on this host.' mod='openlinker'}</span>
+                    {else}
+                        <span class="text-warning">{l s='Not available on this host' mod='openlinker'}</span>
+                        <span class="help-block">{l s='This host does not support the fast delivery path. Stock and order changes are delivered on the next cron run instead - expect the interval configured for the cron trigger, not seconds.' mod='openlinker'}</span>
+                    {/if}
+                </td>
+            </tr>
+            <tr>
                 <td><strong>{l s='Pending Events' mod='openlinker'}</strong></td>
                 <td>{$statistics.pending|intval}</td>
             </tr>


### PR DESCRIPTION
## Summary
- New `OutboxDrainer::drainBatch` shared by cron.php and the new fast path (no duplicated retry logic)
- `OutboxRepository::claimBatchDueForDelivery` gains an optional object-type filter (urgent-only: stock/order, never product)
- Urgent hooks schedule a post-response shutdown drain via `fastcgi_finish_request`/`ignore_user_abort`, gated by `function_exists`
- Admin panel states whether the fast path is active on this host

Closes #2624

## Test plan
- [x] `php -l` on every changed/new file (via the openlinker-prestashop dev-stack container)
- [x] Full PHPUnit Unit suite run in an isolated container copy: 48/48 pass (43 pre-existing + 5 new)
- [ ] Buyer-facing response time measured on a real PHP-FPM host (needs the live dev stack, not done in this session)