### PR TITLE
feat(prestashop): emit a product-deletion webhook

### DIFF
--- a/apps/prestashop-module/openlinker/README.md
+++ b/apps/prestashop-module/openlinker/README.md
@@ -150,6 +150,12 @@ With headers:
 ### `product.saved`
 Triggered when a product is created or updated.
 
+### `product.deleted`
+Triggered when a product is deleted. Shares the product-events toggle with
+`product.saved`. OpenLinker treats it as a trigger to re-read the product: the
+shop answering "no such product" is what pauses the listings, so a rolled-back
+delete costs one redundant re-sync and nothing more.
+
 ### `order.created`
 Triggered when a new order is validated/created.
 

--- a/apps/prestashop-module/openlinker/openlinker.php
+++ b/apps/prestashop-module/openlinker/openlinker.php
@@ -34,7 +34,7 @@
  * @see {@link HmacRequestVerifier} for inbound HMAC verification
  *
  * @author OpenLinker Team
- * @version 1.7.0
+ * @version 1.9.0
  */
 
 if (!defined('_PS_VERSION_')) {
@@ -96,7 +96,7 @@ class OpenLinker extends CarrierModule
     {
         $this->name = 'openlinker';
         $this->tab = 'administration';
-        $this->version = '1.8.0';
+        $this->version = '1.9.0';
         $this->author = 'OpenLinker Team';
         $this->need_instance = 0;
         $this->ps_versions_compliancy = [
@@ -124,6 +124,7 @@ class OpenLinker extends CarrierModule
         // in sync with the live row.
         $hooks = [
             'actionProductSave',
+            'actionProductDelete',
             'actionValidateOrderAfter',
             'actionOrderHistoryAddAfter',
             'actionUpdateQuantity',
@@ -182,6 +183,7 @@ class OpenLinker extends CarrierModule
         // Remove hooks
         $hooks = [
             'actionProductSave',
+            'actionProductDelete',
             'actionValidateOrderAfter',
             'actionOrderHistoryAddAfter',
             'actionUpdateQuantity',
@@ -1591,6 +1593,100 @@ class OpenLinker extends CarrierModule
             // Catch PHP 7+ fatal errors
             PrestaShopLogger::addLog(
                 'OpenLinker:Fatal error in product hook: ' . $e->getMessage() . ' | Trace: ' . $e->getTraceAsString(),
+                3,
+                null,
+                'Product',
+                $productId
+            );
+        }
+    }
+
+    /**
+     * Hook: Product deleted
+     *
+     * Captures product deletion. PrestaShop fires actionProductDelete from
+     * Product::delete() once the product is really gone - the hook is skipped
+     * while the product still has entries in another shop, so a multistore
+     * delete from one shop does not report a deletion the catalogue has not
+     * made yet.
+     *
+     * Without this hook a deletion reached OpenLinker only through the hourly
+     * deletion-audit pass, which walks the whole catalogue a page at a time, so
+     * on a large shop the deleted product kept selling on every marketplace for
+     * as long as the audit took to reach it (#2647). The audit pass is
+     * unchanged and stays the backstop for a lost delivery.
+     *
+     * The event carries the PrestaShop product id only. OpenLinker re-reads the
+     * product and treats the resulting not-found as the authoritative deletion
+     * signal, so the event is a trigger rather than a source of truth: if the
+     * delete was rolled back, the same re-read simply re-syncs a live product.
+     *
+     * Non-blocking: only enqueues to outbox, no HTTP calls.
+     *
+     * @param array $params Hook parameters
+     * @return void
+     */
+    public function hookActionProductDelete(array $params)
+    {
+        // Shares the product-events switch with actionProductSave - both report
+        // the same subject, and an operator turning product events off does not
+        // mean "keep sending me half of them".
+        if (!Configuration::get('ENABLE_PRODUCT_EVENTS')) {
+            return;
+        }
+
+        // Extract product ID
+        $productId = null;
+        if (isset($params['id_product'])) {
+            $productId = (int)$params['id_product'];
+        } elseif (isset($params['product']) && is_object($params['product'])) {
+            $productId = (int)$params['product']->id;
+        }
+
+        if (!$productId) {
+            return;
+        }
+
+        // Get connection ID (required for enqueueing)
+        $connectionId = Configuration::get('OPENLINKER_CONNECTION_ID');
+        if (empty($connectionId)) {
+            return; // Module not configured yet
+        }
+
+        // Enqueue event (non-blocking, fast write to outbox)
+        try {
+            // Ensure classes are loaded
+            $classesDir = dirname(__FILE__) . '/classes/';
+
+            if (!class_exists('EventIdGenerator')) {
+                require_once($classesDir . 'EventIdGenerator.php');
+            }
+            if (!class_exists('OutboxRepository')) {
+                require_once($classesDir . 'OutboxRepository.php');
+            }
+
+            $repository = new OutboxRepository();
+            $repository->enqueueEvent([
+                'connectionId' => $connectionId,
+                'eventType' => 'product.deleted',
+                'objectType' => 'product',
+                'externalId' => (string)$productId,
+                'occurredAt' => date('Y-m-d H:i:s'),
+                'payloadJson' => null, // The id is the whole event
+            ]);
+        } catch (Exception $e) {
+            // Log error but don't break the hook (non-fatal)
+            PrestaShopLogger::addLog(
+                'OpenLinker:Failed to enqueue product.deleted event: ' . $e->getMessage() . ' | Trace: ' . $e->getTraceAsString(),
+                3, // Error level
+                null,
+                'Product',
+                $productId
+            );
+        } catch (Throwable $e) {
+            // Catch PHP 7+ fatal errors
+            PrestaShopLogger::addLog(
+                'OpenLinker:Fatal error in product delete hook: ' . $e->getMessage() . ' | Trace: ' . $e->getTraceAsString(),
                 3,
                 null,
                 'Product',

--- a/apps/prestashop-module/openlinker/tests/Unit/ModuleHookRegistrationTest.php
+++ b/apps/prestashop-module/openlinker/tests/Unit/ModuleHookRegistrationTest.php
@@ -1,0 +1,79 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Hook registration invariants for openlinker.php.
+ *
+ * The module file cannot be loaded here - it extends PrestaShop's Module and
+ * pulls half the framework with it - so these read the source. That is enough
+ * for the two mistakes that are silent at runtime: a hook registered on install
+ * but never unregistered, and a hook registered with no handler method, which
+ * PrestaShop calls and quietly does nothing with.
+ */
+class ModuleHookRegistrationTest extends TestCase
+{
+    /** @var string */
+    private static $source;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$source = file_get_contents(dirname(__DIR__, 2) . '/openlinker.php');
+    }
+
+    /**
+     * @return string[][] one entry per `$hooks = [...]` literal in the file
+     */
+    private function hookLists(): array
+    {
+        preg_match_all('/\$hooks = \[(.*?)\];/s', self::$source, $matches);
+
+        $lists = [];
+        foreach ($matches[1] as $block) {
+            preg_match_all("/'([A-Za-z]+)'/", $block, $names);
+            $lists[] = $names[1];
+        }
+
+        return $lists;
+    }
+
+    public function testInstallAndUninstallRegisterTheSameHooks(): void
+    {
+        $lists = $this->hookLists();
+
+        self::assertCount(2, $lists, 'expected exactly the install and uninstall hook lists');
+        self::assertSame($lists[0], $lists[1], 'install and uninstall hook lists diverged');
+    }
+
+    public function testProductDeleteHookIsRegistered(): void
+    {
+        foreach ($this->hookLists() as $list) {
+            self::assertContains('actionProductDelete', $list);
+        }
+    }
+
+    public function testEveryRegisteredHookHasAHandler(): void
+    {
+        foreach ($this->hookLists()[0] as $hook) {
+            self::assertStringContainsString(
+                'public function hook' . ucfirst($hook) . '(',
+                self::$source,
+                'hook ' . $hook . ' is registered but has no handler method'
+            );
+        }
+    }
+
+    public function testProductDeleteHandlerEnqueuesADeletionEvent(): void
+    {
+        $start = strpos(self::$source, 'public function hookActionProductDelete(');
+        self::assertNotFalse($start);
+
+        $body = substr(self::$source, $start, 4000);
+
+        self::assertStringContainsString("'eventType' => 'product.deleted'", $body);
+        self::assertStringContainsString("'objectType' => 'product'", $body);
+        // The subject is the PrestaShop product id; OpenLinker resolves it to an
+        // internal id through the existing identifier mapping.
+        self::assertStringContainsString("'externalId' => (string)\$productId", $body);
+    }
+}

--- a/apps/prestashop-module/openlinker/upgrade/upgrade-1.9.0.php
+++ b/apps/prestashop-module/openlinker/upgrade/upgrade-1.9.0.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Module upgrade 1.9.0 - register the product-deletion hook (#2647).
+ *
+ * A product deleted in PrestaShop had no webhook at all, so it reached
+ * OpenLinker only through the hourly deletion-audit pass. That pass walks the
+ * catalogue a page at a time, so on a large shop the deleted product kept
+ * selling on every marketplace it was published to until the walk reached it.
+ *
+ * install() registers the hook for a fresh install; this upgrade adds it to a
+ * shop that is already running the module, which is otherwise the only way an
+ * existing shop would never get it.
+ */
+
+if (!defined('_PS_VERSION_')) {
+    exit;
+}
+
+/**
+ * @param OpenLinker $module
+ * @return bool
+ */
+function upgrade_module_1_9_0($module)
+{
+    // Re-registering an already-registered hook is harmless, but the check
+    // keeps the upgrade a no-op on a shop that somehow already has it.
+    if ($module->isRegisteredInHook('actionProductDelete')) {
+        return true;
+    }
+
+    return (bool) $module->registerHook('actionProductDelete');
+}

--- a/docs/webhooks/prestashop.md
+++ b/docs/webhooks/prestashop.md
@@ -91,6 +91,37 @@ Triggered when a product is created or updated.
 
 **Result**: Triggers `master.product.syncByExternalId` job to fetch full product data via PrestaShop WebService API.
 
+#### `product.deleted`
+Triggered when a product is deleted (PrestaShop's `actionProductDelete` hook).
+On a multistore install the hook fires only once the product is gone from every
+shop, so a delete in one shop does not report a deletion the catalogue has not
+made yet.
+
+**Payload**:
+```json
+{
+  "schemaVersion": 1,
+  "eventId": "prestashop-product-12345",
+  "eventType": "product.deleted",
+  "occurredAt": "2025-01-01T12:00:00.000Z",
+  "object": {
+    "type": "product",
+    "externalId": "12345"
+  }
+}
+```
+
+**Result**: Triggers the same `master.product.syncByExternalId` job. The webhook
+is a trigger, not the deletion itself - the shop answering "no such product" is
+the authoritative signal, which stales the product's variants, emits
+`master.product.stale` and pauses the offers on every marketplace.
+
+Without this event a deletion reached OpenLinker only through the hourly
+deletion-audit pass (`master.product.reconcile`), which walks the catalogue a
+page at a time, so on a large shop a deleted product kept selling for as long as
+the walk took to reach it. The audit pass is unchanged and stays the backstop
+for a lost or undelivered webhook.
+
 ### Inventory Events
 
 #### `stock.changed`

--- a/libs/core/src/sync/application/services/__tests__/inbound-routing-policy.service.spec.ts
+++ b/libs/core/src/sync/application/services/__tests__/inbound-routing-policy.service.spec.ts
@@ -102,6 +102,26 @@ describe('InboundRoutingPolicyService', () => {
     );
   });
 
+  it('should route a product deletion to the same re-read job, which owns the deletion decision', async () => {
+    // A deletion webhook is a trigger, not an assertion (#2647): it routes the
+    // ordinary re-read, and the master's not-found answer is what stales the
+    // variants and pauses the offers (#1599 / #1688 / #1689).
+    const outcome = await service.route(
+      event({ domain: 'product', eventType: 'product.deleted' }),
+      connection(['ProductMaster']),
+      ['ProductMaster'],
+      'evt-10'
+    );
+
+    expect(outcome.status).toBe('enqueued');
+    expect(jobEnqueue.enqueueJob).toHaveBeenCalledWith(
+      expect.objectContaining({
+        jobType: 'master.product.syncByExternalId',
+        payload: { schemaVersion: 1, externalId: '42', objectType: 'Product' },
+      })
+    );
+  });
+
   it('should route a shipment event to marketplace.shipment.syncByExternalId gated on ShippingProviderManager', async () => {
     const outcome = await service.route(
       event({ domain: 'shipment', eventType: 'tracking' }),

--- a/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-webhook-event-translator.adapter.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-webhook-event-translator.adapter.spec.ts
@@ -67,6 +67,20 @@ describe('PrestashopWebhookEventTranslatorAdapter', () => {
     expect(result?.externalId).toBe('99');
   });
 
+  it('should translate product.deleted to the product domain, keeping the event type', () => {
+    const result = translator.translate(
+      event({ objectType: 'product', eventType: 'product.deleted', externalId: '99' })
+    );
+
+    expect(result).toEqual({
+      domain: 'product',
+      externalId: '99',
+      eventType: 'product.deleted',
+      occurredAt: '2026-01-01T00:00:00.000Z',
+      payload: {},
+    });
+  });
+
   it('should be case-insensitive on objectType', () => {
     const result = translator.translate(event({ objectType: 'ORDER', eventType: 'order.created' }));
 

--- a/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-webhook-event-translator.adapter.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-webhook-event-translator.adapter.ts
@@ -6,8 +6,15 @@
  * The PS module emits these `objectType`/`eventType` pairs:
  *   - `order`   + `order.created` / `order.status_changed`
  *   - `stock`   + `stock.changed`      → canonical domain `inventory`
- *   - `product` + `product.saved`
+ *   - `product` + `product.saved` / `product.deleted`
  * (`test.ping` is short-circuited by the dispatcher before translation.)
+ *
+ * A deletion is the `product` domain like any other product event (#2647): the
+ * routed `master.product.syncByExternalId` re-reads the product and the
+ * resulting `MasterProductNotFoundError` is the authoritative deletion signal
+ * that stales the variants and pauses the offers (#1599 / #1688 / #1689). The
+ * webhook only says "look at this product now"; it never asserts the deletion
+ * itself, so a rolled-back delete costs one redundant re-sync and nothing more.
  *
  * This is the only place that holds PrestaShop's webhook vocabulary — the
  * core routing policy maps `domain → job` with zero platform knowledge.


### PR DESCRIPTION
Closes #2647.

The module registers `actionProductDelete` in both hook lists and enqueues a `product.deleted` outbox row through `OutboxRepository`, gated on `ENABLE_PRODUCT_EVENTS`. Version bumped 1.8.0 -> 1.9.0 with an `upgrade/upgrade-1.9.0.php` guarded by `isRegisteredInHook`.

No OpenLinker routing code was needed: the existing translator already maps `objectType: product` to the `product` domain, which routes to `master.product.syncByExternalId`, where `MasterProductNotFoundError` drives `markProductDeletedAtMaster`.

## Why this matters

#2644 measured the alternative. Without a delete hook, the only path from a deleted product to a paused offer is the `master.product.reconcile` audit, whose full cycle at 100 000 products is **41.7 days**. Until then the product's offers keep selling on every marketplace (#1689).

## Verified

- `pnpm lint` 0 errors, `pnpm type-check` clean
- translator spec 8/8, routing-policy spec 13/13

## Not verified

- No end-to-end deletion run against a live shop
- PHPUnit did not execute (no `vendor/` in the tree)
- The `parent::delete()` returning-false path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjNE35t6WXqevSXPuipS99