### PR TITLE
fix(2590): delete the replay-guard error key on uninstall

### DIFF
--- a/apps/prestashop-module/openlinker/openlinker.php
+++ b/apps/prestashop-module/openlinker/openlinker.php
@@ -1517,6 +1517,7 @@ class OpenLinker extends CarrierModule
         Configuration::deleteByName('OPENLINKER_CRON_LAST_RUN_AT');
         Configuration::deleteByName('OPENLINKER_CRON_LAST_RUN_SOURCE');
         Configuration::deleteByName('OPENLINKER_REPLAY_GUARD_DEGRADED_AT');
+        Configuration::deleteByName('OPENLINKER_REPLAY_GUARD_DEGRADED_ERROR');
         Configuration::deleteByName(self::DYNAMIC_CARRIER_CONFIG_KEY);
         // Retired in 1.3.0; still deleted so an install that predates the
         // upgrade does not leave the row behind.


### PR DESCRIPTION
Third and last invariant on the config key finding 14 added — and my second partial fix for it.

`ModuleSettings::KEYS` is guarded by **three** assertions, not one:

1. the key must be listed in `KEYS` — fixed in #2664
2. it must not be written per-shop — already true
3. `clearConfiguration()` must delete it — **missed, fixed here**

I fixed (1), CI came back red on (3), because I read the one failing assertion rather than the file it lives in. The consequence is a row left in `ps_configuration` after an uninstall, which is precisely what `testEveryKeyIsDeletedOnUninstall`'s docblock says it exists to catch ("three keys were listed and never deleted... Nothing enforced the claim, so this does").

## What I did differently

Rather than sample again, I re-derived **every** source-text assertion in `ModuleSettingsTest`, `EndpointHardeningTest` and `CronDeliveryHardeningTest` against the real files — including the `@dataProvider` scoping, which is what made my previous pass both incomplete and, in one place, falsely alarming. All pass.

PHPUnit still cannot run here: no `vendor/`, no `php` binary. **This is a re-derivation of the checks, not a run of them**, and CI remains the authority. I am not calling this green until the job says so.

Base: `epic/2590-prestashop-no-module`. Follows #2663 and #2664.
