### PR TITLE
fix(web): Wave-2 responsive audit — three measured defects closed (#2388)

### DIFF
--- a/apps/web/src/features/fulfillment-authority/who-decides-styles.test.ts
+++ b/apps/web/src/features/fulfillment-authority/who-decides-styles.test.ts
@@ -157,4 +157,61 @@ describe('who-decides stylesheet coverage', () => {
     expect(candidates.length).toBeGreaterThan(0);
     expect(inactive.filter((area) => candidates.includes(area))).toEqual([]);
   });
+
+  /**
+   * The row's mobile reflow must land on the SAME breakpoint as the shared list
+   * primitive (#2388).
+   *
+   * `.who-decides-row` shipped guarded by `max-width: 768px`, which MATCHES at
+   * exactly 768 px — while `DataTable`'s own card/table switch and all three
+   * `hide-below` queries use `max-width: 767.98px`, which does not. Measured on
+   * `/settings/who-decides` at innerWidth 768 before the fix: `matchMedia`
+   * reported `767.98px` false and `768px` true, so this row rendered its
+   * single-column mobile layout while every table on the page was still in its
+   * desktop branch — two components disagreeing about which band they are in,
+   * at one of the three audited widths.
+   *
+   * Asserted against `.data-table__cell--hide-below-768` rather than against a
+   * hardcoded string, so the row follows the primitive if the house breakpoint
+   * ever moves, instead of pinning a number that would then be wrong.
+   */
+  it('reflows on the same breakpoint the shared table primitive uses', () => {
+    const css = readFileSync(join(WEB_SRC, 'index.css'), 'utf8');
+
+    // Brace-matched, so only a media block's OWN body is searched — the
+    // `ConnectionFold.test.tsx` primitive. A naive `split('@media ')` sweeps up
+    // every rule that follows a block until the next one, and these selectors
+    // also appear outside any media query, so a looser guard finds the wrong
+    // block and passes by luck.
+    const queryFor = (selector: string): string | undefined => {
+      for (let at = css.indexOf('@media '); at !== -1; at = css.indexOf('@media ', at + 1)) {
+        const open = css.indexOf('{', at);
+        let depth = 0;
+        let close = open;
+        for (; close < css.length; close += 1) {
+          if (css[close] === '{') depth += 1;
+          else if (css[close] === '}') {
+            depth -= 1;
+            if (depth === 0) break;
+          }
+        }
+        if (css.slice(open + 1, close).includes(`${selector} {`)) {
+          return css.slice(at + '@media '.length, open).trim();
+        }
+      }
+      return undefined;
+    };
+
+    const rowQuery = queryFor('.who-decides-row');
+    const primitiveQuery = queryFor('.data-table__cell--hide-below-768');
+
+    expect(rowQuery).toBeDefined();
+    expect(primitiveQuery).toBeDefined();
+    expect(rowQuery).toBe(primitiveQuery);
+
+    // Guard of the guard: a selector that appears in NO media block must return
+    // undefined, or `queryFor` has decayed into a substring scan and the
+    // equality above would be comparing two accidental hits.
+    expect(queryFor('.who-decides-row__nonexistent-leaf')).toBeUndefined();
+  });
 });

--- a/apps/web/src/features/returns/components/return-order-cell.tsx
+++ b/apps/web/src/features/returns/components/return-order-cell.tsx
@@ -24,21 +24,37 @@ interface ReturnOrderCellProps {
   item: ReturnListItem;
 }
 
+/**
+ * The orphan flag, as ONE renderer shared by the desktop cell and the mobile
+ * card (#2091 / #2388).
+ *
+ * Extracted rather than duplicated because the card view renders solely from
+ * `cardView` — `DataTable` has no `columns` fallback — so before #2388 this
+ * badge existed only in the desktop cell and simply did not render below
+ * 767.98 px. Measured on the returns list: 2 error-tone badges at 1024 px, 0 at
+ * 375 px. A red badge that means "this return is blocked" is exactly the signal
+ * that must not be the one lost on a phone, so the two surfaces now share this
+ * function and cannot drift apart again.
+ */
+export function ReturnOrphanBadge(): ReactElement {
+  return (
+    // `StatusBadge` takes no `title`, so the explanation rides on a wrapper.
+    // It is the one piece of copy that must always be one hover away: the
+    // badge alone reads as a label, and the point is that it blocks work.
+    <span title={RETURNS_ORPHAN_COPY.explanation}>
+      <StatusBadge tone="error" compact>
+        {RETURNS_ORPHAN_COPY.badge}
+      </StatusBadge>
+    </span>
+  );
+}
+
 export function ReturnOrderCell({ item }: ReturnOrderCellProps): ReactElement {
   const isOrphan = item.bucket === 'orphan';
 
   return (
     <span className="returns-order-cell">
-      {isOrphan ? (
-        // `StatusBadge` takes no `title`, so the explanation rides on a wrapper.
-        // It is the one piece of copy that must always be one hover away: the
-        // badge alone reads as a label, and the point is that it blocks work.
-        <span title={RETURNS_ORPHAN_COPY.explanation}>
-          <StatusBadge tone="error" compact>
-            {RETURNS_ORPHAN_COPY.badge}
-          </StatusBadge>
-        </span>
-      ) : null}
+      {isOrphan ? <ReturnOrphanBadge /> : null}
 
       {item.internalOrderId !== null ? (
         <Link to={`/orders/${item.internalOrderId}`} className="mono-text">

--- a/apps/web/src/features/returns/index.ts
+++ b/apps/web/src/features/returns/index.ts
@@ -41,7 +41,7 @@ export {
   RETURN_RESTOCK_BLOCKED_EXPLAINER,
 } from './lib/restock-blocked.copy';
 export { ReturnIdentityCell, returnIdentitySummary } from './components/return-identity-cell';
-export { ReturnOrderCell, returnOrderSummary } from './components/return-order-cell';
+export { ReturnOrderCell, ReturnOrphanBadge, returnOrderSummary } from './components/return-order-cell';
 export { ReturnOpenedCell } from './components/return-opened-cell';
 export { ReturnSourceStatus } from './components/return-source-status';
 // #2377 replaced `ReturnStatusCell` (which could render only `Declined`, for

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2814,6 +2814,22 @@ a.delivery-rider-banner__button:focus-visible {
 
 .data-table__container {
   overflow-x: auto;
+  /* Containing block for absolutely-positioned descendants, so this container's
+     `overflow-x` actually CLIPS them (#2388).
+
+     An element with `overflow` only clips a descendant for which it is in the
+     containing-block chain, and a `position: static` box never is. `.sr-only`
+     is `position: absolute`, so every screen-reader label inside a row sat at
+     its static x — INSIDE the wide table — and escaped this clip entirely,
+     extending the document's own scroll area.
+
+     Measured on `/orders` at 768 px: `documentElement.scrollWidth` 947 vs
+     `clientWidth` 768, and the page really scrolled ~180 px sideways onto empty
+     space, against the style guide's "no horizontal scrolling at any
+     breakpoint". With this line the page reports 768/768 while the container
+     keeps scrolling its own columns (1151/718) — which is the one overflow the
+     guide does allow. */
+  position: relative;
   border: 1px solid var(--border-subtle);
   border-radius: var(--radius-lg);
   background: var(--bg-surface);
@@ -5092,6 +5108,39 @@ a.kpi-card:focus-visible {
   color: var(--text-primary);
   font-size: 0.8125rem;
   word-break: break-word;
+}
+
+/* `grid-template-columns: 1fr` above is `minmax(auto, 1fr)`, and that `auto`
+   minimum floors the track at the widest item's MIN-CONTENT. A value carrying
+   an inline-flex child that cannot wrap — `ConnectionEntityLabel` is the one
+   that surfaced it — therefore pushes the track past the list's own box, and
+   `.key-value-list`'s `overflow: hidden` then CLIPS it: no ellipsis, no
+   scrollbar, no way to read the rest.
+
+   Measured on `/returns` at 375 px before this rule (#2388): 3 of 8 lists had a
+   434 px track inside a 311 px box, cutting a 58-character connection name
+   mid-word AND hiding the id beside it. The page itself never scrolled — the
+   shell clips — so the loss was silent, which is worse than a scrollbar.
+
+   `min-width: 0` releases only the floor the `1fr` already intended, so the
+   child's own `text-overflow: ellipsis` (and its `title`) can finally do their
+   job. Nothing widens; the only change is that an over-wide value now shrinks
+   instead of being cut off. */
+.key-value-list__label,
+.key-value-list__value {
+  min-width: 0;
+}
+
+/* The host half of the same rule. `min-width: 0` lets the TRACK shrink, but an
+   inline-level child in a block value box still sizes to its own max-content
+   and overflows — `.entity-label` is `inline-flex`, so it did exactly that
+   (402 px inside a 309 px value). This is the containment pattern the #2094
+   connection fold already documents: a definite width on the host plus
+   `> * { max-width: 100% }`, without which a child's own ellipsis can never
+   fire. `.entity-label__name` already carries `text-overflow: ellipsis` and the
+   full string stays reachable through its `title`. */
+.key-value-list__value > * {
+  max-width: 100%;
 }
 
 .key-value-list__value--mono {
@@ -20094,7 +20143,7 @@ textarea.bulk-editor__input { resize: vertical; min-height: 66px; font-family: i
   color: var(--text-muted);
 }
 
-@media (max-width: 768px) {
+@media (max-width: 767.98px) {
   .who-decides-row {
     grid-template-areas:
       'question'

--- a/apps/web/src/pages/returns/returns-list-page.test.tsx
+++ b/apps/web/src/pages/returns/returns-list-page.test.tsx
@@ -2,6 +2,7 @@ import { cleanup, screen, waitFor, within, type RenderResult } from '@testing-li
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, it, expect, vi, type Mock } from 'vitest';
 import { renderWithProviders, createMockApiClient } from '../../test/test-utils';
+import { mockMobileViewport } from '../../test/viewport';
 import { ReturnsListPage } from './returns-list-page';
 import type { ReturnListItem, ReturnListResult } from '../../features/returns';
 import type { Connection } from '../../features/connections/api/connections.types';
@@ -289,6 +290,37 @@ describe('ReturnsListPage', () => {
       // Independent parts, never one ternary — the badge must not hide the
       // reference the re-attribution pass resolves the orphan by.
       expect(table.getByText('ORD-999')).toBeInTheDocument();
+    });
+
+    it('should badge an orphan return in the MOBILE CARD too, not only the desktop cell', async () => {
+      // #2388. `DataTable` renders the card view solely from `cardView` — there
+      // is no `columns` fallback — so before this the orphan badge existed only
+      // in the desktop cell and simply did not render below 767.98 px. The card
+      // still said "Unmatched", but as plain text inside `subtitle`, because
+      // `returnOrderSummary` returns a STRING. Measured on the running app:
+      // 2 error-tone badges at 1024 px, 0 at 375 px — the operator's most
+      // urgent signal was the one the phone dropped.
+      const viewport = mockMobileViewport();
+      try {
+        setup({
+          list: listResult({
+            items: [
+              makeReturn({ bucket: 'orphan', internalOrderId: null, externalOrderId: 'ORD-999' }),
+            ],
+            counts: { total: 1, orphan: 1, attributed: 0 },
+          }),
+        });
+
+        await screen.findByText('RET-1');
+        // No <table> at this width, so the desktop-scoped query above cannot be
+        // reused; scope to the card list instead, since the filter chip renders
+        // the word "Orphan" as well and an unscoped query would match it.
+        const cards = document.querySelector('.data-table__cards');
+        expect(cards).not.toBeNull();
+        expect(within(cards as HTMLElement).getByText('Orphan')).toBeInTheDocument();
+      } finally {
+        viewport.restore();
+      }
     });
 
     it('should render the source status verbatim and attributed', async () => {

--- a/apps/web/src/pages/returns/returns-list-page.tsx
+++ b/apps/web/src/pages/returns/returns-list-page.tsx
@@ -50,6 +50,7 @@ import {
   ReturnIdentityCell,
   ReturnOpenedCell,
   ReturnOrderCell,
+  ReturnOrphanBadge,
   ReturnSourceStatus,
   ReturnSegmentStrip,
   ReturnStageCell,
@@ -352,6 +353,21 @@ export function ReturnsListPage(): ReactElement {
               title: (item) => returnIdentitySummary(item),
               subtitle: (item) => returnOrderSummary(item),
               meta: (item) => <ReturnStageCell item={item} />,
+              // The orphan flag rides in `summary`, not `subtitle` (#2388).
+              //
+              // `subtitle` takes `returnOrderSummary`, a plain STRING — so the
+              // desktop cell's red badge degraded to the word "Unmatched" in
+              // running text below 767.98 px. Measured on this list: 2
+              // error-tone badges at 1024 px, 0 at 375 px, while the operator's
+              // most urgent signal is precisely the one that vanished.
+              //
+              // `summary` is the documented home for it: `data-table.tsx` calls
+              // that slot the "always-visible" facts block, while `detail` can
+              // be collapsed behind `collapsibleDetail` — which would re-hide
+              // the badge — and `meta` already carries the stage, a different
+              // fact. `ReturnOrphanBadge` is the SAME renderer `ReturnOrderCell`
+              // uses, so the two layouts cannot drift.
+              summary: (item) => (item.bucket === 'orphan' ? <ReturnOrphanBadge /> : null),
               // `KeyValueList`, not a hand-rolled `<dl>`: the peer lists
               // (`listings`, `orders`) render their card detail through the same
               // primitive, and a bare `<dl>` under a class no stylesheet defines

--- a/apps/web/src/shared/ui/responsive-containment-styles.test.ts
+++ b/apps/web/src/shared/ui/responsive-containment-styles.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Responsive containment — stylesheet contract (#2388)
+ *
+ * Two shared-primitive rules that a unit test, a type check and a rendered
+ * jsdom tree are all structurally blind to, because each is a property of the
+ * CASCADE rather than of any component's output. There is no CSS parser
+ * anywhere in this pipeline (#2674), so a test over the stylesheet text is the
+ * only gate either rule can ever have.
+ *
+ * Both were found by measuring the running app during the Wave-2 responsive
+ * audit, and both had already shipped: neither is hypothetical.
+ *
+ * 1. `.data-table__container` must establish a containing block. An element
+ *    with `overflow` only clips a descendant for which it is in the
+ *    containing-block chain, and a `position: static` box never is. `.sr-only`
+ *    is `position: absolute`, so every screen-reader label inside a row sat at
+ *    its static x — inside the wide table — and escaped the container's
+ *    `overflow-x` entirely. Measured on `/orders` at 768 px:
+ *    `documentElement.scrollWidth` 947 against `clientWidth` 768, and the page
+ *    really scrolled ~180 px sideways onto blank space.
+ *
+ * 2. `.key-value-list` must let an over-wide value shrink. Its
+ *    `grid-template-columns: 1fr` is `minmax(auto, 1fr)`, and that `auto`
+ *    minimum floors the track at the widest item's min-content — so a value
+ *    carrying a non-wrapping inline-flex child pushed the track past the list's
+ *    own box, which `overflow: hidden` then CUT, with no ellipsis and no
+ *    scrollbar. Measured on `/returns` at 375 px: 3 of 8 lists held a 434 px
+ *    track inside a 311 px box.
+ *
+ * Both are asserted as PER-SELECTOR facts, never as a file-wide property.
+ * `index.css` is one global stylesheet with no provenance marker, so a test
+ * cannot know which rules belong to which wave; a file-wide assertion would
+ * either fail on rules this audit deliberately left alone or be quietly
+ * narrowed to an unstated list — and a guard weakened after it first went red
+ * is the #2589 failure in a new costume.
+ *
+ * @module apps/web/src/shared/ui
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const CSS_PATH = join(__dirname, '..', '..', 'index.css');
+
+/**
+ * Rule bodies whose selector list contains `selector` as a WHOLE token.
+ *
+ * Anchored deliberately (#2589, and copied from
+ * `card-button-reset-styles.test.ts`): a substring test like
+ * `css.includes('.key-value-list')` also matches `.key-value-list__value`, so a
+ * selector with no rule of its own would pass on a longer sibling's strength.
+ */
+function ruleBodiesFor(css: string, selector: string): string[] {
+  // Comments are stripped first: they carry no braces, so an unstripped banner
+  // comment lands inside the captured selector text and `.trim()` leaves it
+  // glued to the first selector.
+  const bare = css.replace(/\/\*[\s\S]*?\*\//g, '');
+  const bodies: string[] = [];
+  for (const block of bare.matchAll(/([^{}]*)\{([^{}]*)\}/g)) {
+    const selectors = block[1].split(',').map((s) => s.trim());
+    if (selectors.includes(selector)) bodies.push(block[2]);
+  }
+  return bodies;
+}
+
+/** Every declared value for `property` across the rules matching `selector`. */
+function declaredValues(css: string, selector: string, property: string): string[] {
+  return ruleBodiesFor(css, selector)
+    .flatMap((body) => body.split(';'))
+    .map((decl) => decl.trim())
+    .filter((decl) => decl.startsWith(`${property}:`))
+    .map((decl) => decl.slice(property.length + 1).trim());
+}
+
+describe('responsive containment stylesheet contract (#2388)', () => {
+  const css = readFileSync(CSS_PATH, 'utf8');
+
+  describe('.data-table__container clips its absolutely-positioned descendants', () => {
+    it('still declares the horizontal overflow the clip depends on', () => {
+      // The premise. Without `overflow-x`, `position` below would be clipping
+      // nothing and the test would pass while asserting something vacuous.
+      expect(declaredValues(css, '.data-table__container', 'overflow-x')).toContain('auto');
+    });
+
+    it('establishes a containing block, so that overflow actually clips', () => {
+      const positions = declaredValues(css, '.data-table__container', 'position');
+      expect(positions.length).toBeGreaterThan(0);
+      // `static` is the one value that does NOT create a containing block, so
+      // it is the one value that reopens the ~180 px page scroll.
+      expect(positions).not.toContain('static');
+    });
+  });
+
+  describe('.key-value-list lets an over-wide value shrink instead of clipping it', () => {
+    it('still hides its own overflow, which is what made the cut silent', () => {
+      // The premise, again: this is why the symptom was a truncation with no
+      // scrollbar rather than a visible overflow.
+      expect(declaredValues(css, '.key-value-list', 'overflow')).toContain('hidden');
+    });
+
+    it('releases the min-content floor on the value and its label', () => {
+      expect(declaredValues(css, '.key-value-list__label', 'min-width')).toContain('0');
+      expect(declaredValues(css, '.key-value-list__value', 'min-width')).toContain('0');
+    });
+
+    it('bounds the value’s children, so a child’s own ellipsis can fire', () => {
+      // `min-width: 0` alone lets the TRACK shrink; an inline-level child in a
+      // block value box still sizes to its own max-content. This is the host
+      // half of the containment pattern the #2094 connection fold documents.
+      expect(declaredValues(css, '.key-value-list__value > *', 'max-width')).toContain('100%');
+    });
+  });
+
+  describe('guard of the guard', () => {
+    it('matches selectors as whole tokens, not as substrings', () => {
+      // A deliberately truncated selector must find nothing. If this ever
+      // returns rules, `ruleBodiesFor` has decayed into a substring match and
+      // every assertion above is passing on a longer sibling's strength.
+      expect(ruleBodiesFor(css, '.data-table__containe')).toEqual([]);
+      expect(ruleBodiesFor(css, '.key-value-list__valu')).toEqual([]);
+    });
+
+    it('does not treat a longer sibling as the selector it prefixes', () => {
+      // `.key-value-list` and `.key-value-list__value` are distinct rules; a
+      // substring matcher would conflate them and silently read the wrong body.
+      const listOverflow = declaredValues(css, '.key-value-list', 'overflow');
+      const valueOverflow = declaredValues(css, '.key-value-list__value', 'overflow');
+      expect(listOverflow).toContain('hidden');
+      expect(valueOverflow).not.toContain('hidden');
+    });
+  });
+});

--- a/docs/frontend-ui-style-guide.md
+++ b/docs/frontend-ui-style-guide.md
@@ -749,6 +749,20 @@ Breakpoints (defined in `index.css`):
 @media (min-width: 1024px) { /* desktop */ }
 ```
 
+**A `max-width` complement is fractional, and the `.02` is load-bearing (#2388).** Where a rule has to
+be written as the *lower* half of a band, its bound is `max-width: (N - 0.02)` — the spellings already
+in `index.css` are `479.98px` / `767.98px` / `1023.98px`, and `DataTable`'s own card/table switch
+reads `(max-width: 767.98px)`. A rounded `max-width: 768px` **matches at 768 px**, so it overlaps the
+tablet `min-width: 768px` band by exactly one pixel: at that width the rounded rule is in its mobile
+branch while every table on the page is in its desktop one. `.who-decides-row` shipped that way and
+was measured doing it, which is why `who-decides-styles.test.ts` now asserts the row's query equals
+`.data-table__cell--hide-below-768`'s rather than a hardcoded string — a component follows the
+primitive if the house breakpoint ever moves.
+
+When checking a boundary, read the branch off `matchMedia` rather than inferring it from a rect: a
+classic scrollbar makes `documentElement.clientWidth` ~15 px narrower than the width media queries
+evaluate against (768 vs 753 measured), which at a boundary inverts the answer.
+
 Parity matrix — what changes across sizes:
 
 | Surface | Mobile (≤ 767) | Tablet (768–1023) | Desktop (≥ 1024) |
@@ -777,7 +791,7 @@ desktop" hint, because there is nothing it refuses to do at that width.
 
 Rules:
 
-- **No horizontal scrolling** at any breakpoint except inside `RawPayloadPanel` and a table's own column-overflow area (`.data-table__container`, `overflow-x: auto` — both the virtualized scroller and the plain container). Dense tables (e.g. an 8-column invoices list) grow to their natural content width and scroll horizontally within that container rather than crushing columns; simple 2–4 column tables stay at `100%` width with no scrollbar since their natural width never exceeds the container. `RawPayloadPanel` also scrolls vertically when content exceeds its `max-height` cap (#390).
+- **No horizontal scrolling** at any breakpoint except inside `RawPayloadPanel` and a table's own column-overflow area (`.data-table__container`, `overflow-x: auto` — both the virtualized scroller and the plain container). That container also carries **`position: relative`**, and it is not decorative: `overflow` clips only a descendant the box is a containing block for, so while the container was `static` every `position: absolute` descendant — `.sr-only` labels, sitting at their static x inside the wide table — escaped it and extended the *document's* scroll area (#2388, measured on `/orders` at 768 px: `scrollWidth` 947 vs `clientWidth` 768, the page really scrolling ~180 px onto blank space, with **no visible element** overflowing to point at it). Dense tables (e.g. an 8-column invoices list) grow to their natural content width and scroll horizontally within that container rather than crushing columns; simple 2–4 column tables stay at `100%` width with no scrollbar since their natural width never exceeds the container. `RawPayloadPanel` also scrolls vertically when content exceeds its `max-height` cap (#390).
 - **Tap targets ≥ 44 px** on mobile for every interactive element (`.btn--sm` grows to 36 px min on touch; icon buttons to 40 px).
 - Text must remain readable at `13 px` body — no shrinking below that on mobile.
 - Status banners stack their action buttons below the body on mobile instead of pushing off-screen.

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -806,3 +806,57 @@ height was documented as four lines by two bodies independently when the composi
 **Applies to**: `apps/worker/src/sync/handlers/handler-registration.service.ts` (every `register(jobType, handler, lane)` call); any enqueue site supplying a `connectionId` that is not a real connection.
 
 **Source**: #2594 (the split + the first measured `bulk` caps), #2609 (the scope), [ADR-050](./architecture/adrs/050-workload-isolation-concurrency-lanes.md) § Amendment (#2594) and § Amendment (#2609).
+
+---
+
+## `overflow` only clips a descendant the box is a containing block for — a `position: static` scroller clips nothing absolute
+
+**Context**: the Wave-2 responsive audit (#2388), measuring `/orders` at 768 px.
+
+**Problem**: `.data-table__container` declared `overflow-x: auto` and was believed to bound its
+contents. It does not bound an **absolutely-positioned** descendant, because an element only clips a
+descendant for which it is in that descendant's containing-block chain, and a `position: static` box
+never is. `.sr-only` is `position: absolute`, so every screen-reader label sat at its static x —
+inside the 1176 px-wide table — escaped the container entirely, and extended the **document's** own
+scroll area: `documentElement.scrollWidth` 947 against `clientWidth` 768, with the page really
+scrolling ~180 px sideways onto blank space.
+
+It was invisible to the obvious diagnostic. Scanning for elements whose `right` exceeded the viewport
+and excluding the allowed scroll containers returned **zero** offenders, because the only offenders
+were 1 px and `clip`ped — visually absent, structurally load-bearing. `document.body.scrollWidth`
+also read a clean 768; only `documentElement` disagreed.
+
+**Rule**: a scroll container that must actually bound its contents needs `position: relative` as well
+as `overflow`. When `documentElement.scrollWidth > clientWidth` but nothing visible overflows, look
+for absolutely-positioned descendants — `.sr-only` first — and check whether their nearest scrolling
+ancestor is positioned. Confirm a page really scrolls by assigning `scrollLeft` and reading it back;
+`scrollWidth` alone does not prove a user can reach it, and `body.scrollWidth` can disagree with
+`documentElement`'s.
+
+**Applies to**: `apps/web/src/index.css` — any rule pairing `overflow` with content that may contain
+absolutely-positioned descendants.
+
+**Source**: PR #2676 (#2388).
+
+## A `max-width` breakpoint must be the fractional complement of its `min-width` partner, or the two bands overlap by one pixel
+
+**Context**: same audit; `/settings/who-decides` at exactly 768 px.
+
+**Problem**: `.who-decides-row` was guarded by `@media (max-width: 768px)`, which **matches at
+768 px**, while `DataTable`'s own card/table switch and all three `hide-below` queries use
+`767.98px`, which does not. At that one width `matchMedia('(max-width: 767.98px)')` was `false` while
+`matchMedia('(max-width: 768px)')` was `true`, so the authority row rendered its single-column mobile
+layout while every table on the page was still in its desktop branch — two components disagreeing
+about which band they were in, at one of the three audited widths.
+
+**Rule**: the house complement of a `min-width: N` band is `max-width: (N - 0.02)`, not
+`max-width: N`. `apps/web/src/index.css` uses `479.98` / `767.98` / `1023.98`, and
+`data-table.tsx` reads `(max-width: 767.98px)` — match those exactly rather than rounding. Test the
+boundary AT the breakpoint, not one pixel either side, and read the branch off `matchMedia` rather
+than inferring it from a rect: a classic scrollbar makes `clientWidth` ~15 px narrower than the width
+media queries evaluate against, which at a boundary inverts the reading.
+
+**Applies to**: `apps/web/src/index.css`; any component pairing its own media query with
+`DataTable`'s card/table switch.
+
+**Source**: PR #2676 (#2388), asserted by `who-decides-styles.test.ts`.

--- a/docs/plans/analysis/ANALYSIS-2388-wave2-responsive-audit.md
+++ b/docs/plans/analysis/ANALYSIS-2388-wave2-responsive-audit.md
@@ -1,0 +1,109 @@
+# Readiness Analysis: Wave-2 responsive audit (#2388)
+
+**Plan**: `docs/plans/implementation-plan-wave2-responsive-audit.md`
+**Date**: 2026-08-30
+**Baseline**: `origin/oms-programme-wave-2` (**not** `main` — every "already exists" check below is against the wave branch)
+**Gate**: read-only. No source and no plan file was edited.
+
+---
+
+## Verdict: **READY**
+
+No Critical findings. The plan creates no port, service, DI token, ORM entity, capability, controller or DTO, so the usual reuse-collision and contract-break classes are structurally absent — the only artifacts it touches are `apps/web` CSS, one `cardView` config, and test files. Three findings below are **reuse hits that strengthen the plan** (an existing test pattern the plan should copy rather than invent, and a canonical breakpoint spelling that settles the plan's own open question Q3), plus two Warnings about gates the work will pass through.
+
+---
+
+## Phase B — Reuse audit
+
+| Plan artifact | Classification | Evidence |
+|---|---|---|
+| Ports (`*Port`) | **None proposed** | Plan section 3 states no new port. Confirmed: no `libs/core` change in scope. |
+| Services (`*Service`) | **None proposed** | — |
+| DI tokens (`*.tokens.ts`) | **None proposed** | — |
+| ORM entities / schema | **None proposed** | No migration; `docs/migrations.md` not engaged. |
+| Capabilities (`CoreCapabilityValues`) | **None proposed** | — |
+| Controllers / DTOs | **None proposed** | — |
+| `DataTable` `cardView` seam | **ALREADY EXISTS -> reuse** | `apps/web/src/shared/ui/data-table.tsx` — `DataTableCardView<Row>` with `title` / `subtitle` / `meta` / `detail` / `summary` / `select` / `actions`. The plan correctly reuses it and adds no slot. |
+| `.card-button-reset` | **ALREADY EXISTS -> reuse** | `apps/web/src/index.css`, pinned by `apps/web/src/shared/ui/card-button-reset-styles.test.ts`. Plan section 3 already mandates reuse. |
+| CSS contract-test pattern | **ALREADY EXISTS -> reuse (see R1)** | Four in-tree precedents; one is a near-exact fit the plan did not cite. |
+| Breakpoint normalisation target | **ALREADY EXISTS -> reuse (see R2)** | The repo has a canonical spelling; the plan's Q3 can be closed. |
+
+### R1 — A closer precedent than the plan cites, for the Phase-3 breakpoint test
+
+The plan (section 4 "Testing patterns to follow", Phase 3) proposes copying `card-button-reset-styles.test.ts`'s anchoring discipline. That is right, but there is a **nearer** precedent the plan does not mention:
+
+`apps/web/src/features/connections/components/ConnectionFold.test.tsx:105` — *"is the exact CSS complement of the column it replaces"* — already extracts a **media query for a given selector** by brace-matching, and its own comments record why the naive approaches fail:
+
+> Brace-matched, so only the media block's OWN body is searched. A naive `split('@media ')` also sweeps up every rule that follows a block until the next one — and `.data-table__cell--hide-below-1024` appears outside any media query too (in a comma group), so a looser guard finds the wrong [block].
+
+The Phase-3 test needs exactly this primitive (`queryFor(selector)` -> the media condition guarding it). **Recommendation**: copy `ConnectionFold.test.tsx`'s brace-matched `queryFor` for the query-extraction half and `card-button-reset-styles.test.ts`'s whole-token selector matching + guard-of-the-guard for the anchoring half. Neither alone is sufficient: the first finds the right block, the second stops a prefixed class satisfying the assertion (the #2589 trap).
+
+This is a **reuse finding, not a defect** — the plan's approach is sound, it just under-cites.
+
+### R2 — The canonical breakpoint spelling is `X.98px`, which closes the plan's Q3
+
+The plan's finding F1 flags four spellings of the mobile bound and asks (Q3) how far normalisation should go, defaulting to the `767.98px` form "already used at L19055". The grep settles it more strongly than the plan states — `767.98px` is not merely *one of* the spellings in use, it is the spelling **the shared primitive and every column-hiding rule use**:
+
+| Consumer | Query | File:line |
+|---|---|---|
+| `DataTable` card/table switch | `(max-width: 767.98px)` | `data-table.tsx:248` |
+| `.data-table__cell--hide-below-480` | `(max-width: 479.98px)` | `index.css:3088` |
+| `.data-table__cell--hide-below-768` | `(max-width: 767.98px)` | `index.css:3094` |
+| `.data-table__cell--hide-below-1024` | `(max-width: 1023.98px)` | `index.css:3100` |
+
+So the `.98` form is the house convention for the *fractional-pixel complement of a `min-width` band*, applied consistently across the one primitive every list renders through. `.who-decides-row`'s `max-width: 768px` (index.css:20097) is the outlier, and the consequence is exactly what F1 predicts and is worth restating precisely:
+
+**At a viewport of exactly 768 px, `DataTable` is in its desktop-table branch (`767.98` does not match) while `.who-decides-row` is in its mobile single-column branch (`768` does match).** Two components on the same page disagree about which band they are in, at one of the three audited widths. That is a measurable defect, not a style preference.
+
+**Recommendation**: close Q3 in favour of the plan's own default — normalise `.who-decides-row` to `767.98px` and leave the rest of the file alone. Note that `index.css:10458` (`.error-list__row`) carries the same `max-width: 768px` spelling and is **pre-existing, not Wave 2**; the plan's scoping rule (Q3 default: Wave-2 rules only, and only where a measurement showed a defect) correctly excludes it. Say so in the PR so the next reader does not read the survivor as an oversight.
+
+### R3 — `640px` is a fifth band with no counterpart anywhere
+
+`@media (max-width: 640px)` (index.css:20434, `.automation-rules__state` / `.automation-suggestion__actions .button`) is not any documented band — the style guide defines only 768 and 1024. It is **not** one of the three audited widths, so it cannot be measured directly by this audit, and normalising it would be a behaviour change with no measurement behind it. **Recommendation**: report it as an observation in the PR, change nothing. Flagging it costs nothing and prevents it being mistaken for a bound this audit endorsed.
+
+---
+
+## Phase C — Backward-compatibility checklist
+
+| Surface | Assessment | Severity |
+|---|---|---|
+| Top-level barrels (`@openlinker/core/<ctx>`) | Untouched. `apps/web` cannot import `@openlinker/core` (#591) and the plan adds no such import. | — |
+| Port method signatures | Untouched. | — |
+| DTO shapes | Untouched — no API change. | — |
+| Symbol tokens | Untouched. | — |
+| ORM schema | Untouched. No migration required. | — |
+| **FE feature barrels** (`features/*/index.ts`) | The F2 fix may need the orphan badge rendering reachable from `returns-list-page.tsx`. `ReturnOrderCell` and `returnOrderSummary` are already used there, so the existing barrel surface is very likely sufficient. **If** a new symbol must be exported, that is a one-line barrel edit, not a break. | — |
+| `check-ui-vocabulary` | **W1** — see below. | Warning |
+| Existing CSS contract tests | **W2** — see below. | Warning |
+| `check-cross-context-imports` / `check-service-interfaces` | Not engaged — neither walker covers `apps/web`. | — |
+
+### W1 — Every folder the plan touches is a live `check-ui-vocabulary` scan root
+
+All four Wave-2 feature folders are declared **`pending: false`** in `scripts/check-ui-vocabulary.mjs` `SCAN_ROOTS`, i.e. actively scanned:
+
+| Folder | Declared owner |
+|---|---|
+| `apps/web/src/features/fulfillment-authority` | `W2-17 (#2354)` |
+| `apps/web/src/features/automation` | `W2-27 (#2364)` |
+| `apps/web/src/features/returns` | `W1c-8 (#2335)` |
+| `apps/web/src/features/orders` | `W2-A (#2342)` |
+
+Any operator-facing string the F2 fix introduces (e.g. a badge label or a `title` explanation on the returns card) is scanned. The house rule stands: **if the gate rejects a string, fix the copy, never the gate** — and specifically, do not add a file to the by-file exemption list to get a string through. **Mitigation**: prefer reusing the existing copy constants (`RETURNS_ORPHAN_COPY.badge` / `.explanation` in `features/returns/lib/returns-list.copy.ts`) over authoring new strings; reused copy is already gate-clean by construction.
+
+### W2 — Two existing CSS contract tests read the rules this plan may change
+
+- `who-decides-styles.test.ts` asserts (a) every rendered `who-decides-*` class has a rule in `index.css`, (b) `who-decides` rules reference only declared custom properties, (c) `who-decides-row__inactive` and `__candidates` do not share a `grid-area`. A breakpoint change to the `.who-decides-row` media block touches none of the three, but the test is the natural home for the new assertion (plan Phase 3 already proposes this).
+- `returns-styles.test.ts` asserts every rendered `returns-*` class has a rule. **If the F2 fix introduces a new `returns-*` class it must get a CSS rule in the same commit**, or this test fails. Reusing an existing class (or a non-`returns-`-prefixed shared class such as `StatusBadge`'s own) avoids the obligation entirely and is the lower-risk route.
+
+Neither is a break; both are gates the work passes through and should be anticipated rather than discovered.
+
+---
+
+## Open questions
+
+The plan's own Q1–Q3 are the real ones. This gate can close one and sharpen the others:
+
+- **Q3 — closed.** R2 above: normalise `.who-decides-row` to `767.98px`, scope the change to that rule, note the pre-existing `.error-list__row` sibling in the PR. No further sweep.
+- **Q1 — sharpened, still a judgement call for the human.** The plan's default (surface the orphan *badge* in the card; leave the `title`/`subtitle` plain-text summary shape alone) is consistent with `DataTable`'s documented constraint — the card renders **solely** from `cardView` with no `columns` fallback (`data-table.tsx`), so the badge really is lost at <= 767.98 px today, and that is a genuine operator-facing loss of a red attention signal rather than a cosmetic difference. Recommend proceeding with the default and stating both readings of AC-2 in the PR, exactly as the plan says.
+- **Q2 — leave as the plan states.** `dispatch-risk-page.tsx`'s two-slot `cardView` should be measured and reported; fix only on evidence of a lost *actionable control*. No reuse or contract consideration bears on it.
+- **New, minor**: the plan's Phase 0 allows a surface to be "audited empty". Recommend the PR state, per empty-state audit, the specific thing it cannot cover (long unbroken content — a mono id or a long connection name — is the usual real cause of overflow and is invisible in an empty state, as the plan's own section 8 Edge Cases notes).

--- a/docs/plans/implementation-plan-wave2-responsive-audit.md
+++ b/docs/plans/implementation-plan-wave2-responsive-audit.md
@@ -1,0 +1,305 @@
+# Implementation Plan: Wave-2 responsive audit across the new surfaces (#2388)
+
+**Date**: 2026-08-30
+**Status**: Ready for Review
+**Estimated Effort**: 1–1.5 days
+**Issue**: [#2388](https://github.com/openlinker-project/openlinker/issues/2388) (`W2-46b`, epic #2389)
+**Branch**: `2388-wave2-responsive-audit`, based on `origin/oms-programme-wave-2`
+
+---
+
+## 1. Task Summary
+
+**Objective**: Measure the rendered geometry of every surface OMS Wave 2 added, at 375 / 768 / 1024 px, and fix what the measurements show. Specifically: no horizontal page scroll at any of the three widths; mobile cards and desktop cells share one renderer on every new list; the automation composer dialog is fully operable at 375 px with no clipped control.
+
+**Context**: Responsiveness was filed separately from the feature issues precisely so it could not be quietly dropped from any of them, and it is the wave's last FE issue by construction — it can only *run* once the surfaces exist. Several of the acceptance criteria are already partly satisfied by the feature issues that shipped them (`#2354` gave the who-decides row its single-column reflow, `#2365` declared the composer's fully-interactive-at-375 departure, `#2335` gave the returns list a `cardView`). This issue is therefore an **audit**: verify by measurement, and fix the residue.
+
+**Classification**: Frontend (Interface layer). No CORE change, no adapter change, no migration.
+
+---
+
+## 2. Scope & Non-Goals
+
+### In Scope
+
+- A measured no-horizontal-scroll audit at **375 / 768 / 1024 px** of every Wave-2 surface:
+  - `/orders` list + `/orders/:id` detail — order holds (badges, `place-order-hold-dialog`, `release-order-hold-dialog`), the packed control, reservation shortfall (`stock-at-risk-badge` / `stock-at-risk-callout`)
+  - `/orders/dispatch-risk`
+  - `/settings/who-decides` — the authority surface, its seven-row table, preset cards, `ConfirmDialog`
+  - Attention badges/rows on `/orders`, `/connections`, `/products`
+  - `/automations`, `/automations/activity`, `/automations/:trigger` — including the run log (#2386) and the composer dialog (#2365)
+  - `/returns` list + `/returns/:id` detail — segment strip, custody panel, dispose/receive forms
+- Fixes for whatever the measurement shows, kept minimal and local.
+- A CSS contract test for any **new or changed** CSS carrying a real invariant, anchored (whole-token selector matching) with a guard-of-the-guard.
+- Verification that the returns list `cardView` reuses the desktop cell renderers, and closing the gap where it does not.
+
+### Out of Scope
+
+- Redesign. This is an audit and its repairs, not a visual pass.
+- New responsive behaviour for surfaces Wave 2 did not touch.
+- Touch-target auditing beyond what a no-scroll/clipping fix requires (`custody-touch-targets.test.ts` already pins the returns 44 px floor; #2380 pinned the custody rules).
+- Backend changes of any kind.
+- Re-litigating the two documented departures in `docs/frontend-ui-style-guide.md § Responsive` (the automation composer, the who-decides row carve-out). They are the spec; this issue verifies them.
+
+### Constraints
+
+- `apps/web` **cannot** import `@openlinker/core` (#591). Anything shared with core is a guarded mirror.
+- **Nothing in the pipeline parses `index.css`** (#2674), so a CSS contract test is the only gate CSS can have.
+- There is exactly **one** CSS file in `apps/web` (`src/index.css`, 21 029 lines). All Wave-2 styling landed there.
+- Copy must pass `scripts/check-ui-vocabulary.mjs`. If the gate rejects a string, fix the copy, never the gate.
+- `visible` and `canWrite` are different answers; admin-gated routes use `useIsAdmin() && <permission>`.
+
+---
+
+## 3. Architecture Mapping
+
+**Target Layer**: Interface (`apps/web/src`). Pages and feature components compose; `shared/ui/data-table.tsx` is the shared list primitive.
+
+**Existing components reused** (nothing new is introduced):
+
+| Component | Path | Role in this issue |
+|---|---|---|
+| `DataTable` | `apps/web/src/shared/ui/data-table.tsx` | The `cardView` seam (#2091). Card view renders **solely** from `cardView` — there is **no `columns` fallback** — so anything living only in a column disappears below the breakpoint. |
+| `.card-button-reset` | `apps/web/src/index.css` | The shared reset for a card inside a `<button>`. Applied to `.returns-segment` / `.orders-segment` / `.products-segment`; pinned by `card-button-reset-styles.test.ts`. **Use it** for any card-in-button touched here; do not hand-roll another partial reset. |
+| `who-decides-styles.test.ts` | `apps/web/src/features/fulfillment-authority/` | Existing CSS contract test — class coverage, custom-property declaration, grid-area disjointness. |
+| `returns-styles.test.ts` | `apps/web/src/features/returns/` | Existing class-coverage contract test. |
+| `custody-touch-targets.test.ts` | `apps/web/src/features/returns/lib/` | Existing 44 px floor assertion, declared **outside** any media query. |
+
+**No new components, hooks, services, ports, adapters, entities or routes.** If the audit shows a surface needs a `cardView` it does not have, that is a config object added to an existing `DataTable` call site, reusing the existing cell renderers.
+
+**Core vs Integration**: not applicable — this issue changes only `apps/web`.
+
+---
+
+## 4. Research
+
+### The three named acceptance criteria, and their current state
+
+| AC | Current state (read from the branch) | What this issue must do |
+|---|---|---|
+| Who-decides table collapses to stacked question/answer cards | **Shipped by #2354.** `/settings/who-decides` is a CSS-grid definition list (`.who-decides-row`, grid areas `question / answer / why / extras / inactive / badge`), with a single-column reflow at `@media (max-width: 768px)` (index.css L20097). It is deliberately **not** a `DataTable` — a `hideBelow` on the why-line would delete the feature on mobile (style guide § Density & Row Heights carve-out). | **Verify by measurement**, and fix the breakpoint (see finding F1). |
+| Attention rows render as mobile cards carrying the same badge | `OmsAttentionBadges` is rendered at both the desktop-cell and card/expand call sites on `/orders` (`orders-list-page.tsx:931` and `:2027`) and `/connections` (`:83` and `:235`). `/products` was touched by the wave. | **Verify the badge is present in the card branch at 375 px on all three**, and that the card and cell use the *same* component. |
+| Composer dialog fully operable at 375 px, no clipped control | **Declared** in `docs/frontend-ui-style-guide.md § Responsive` as a documented departure (#2365): fully interactive at 375 px, single column below 768 px, ≥ 44 px targets, no "open on desktop" hint. CSS exists at index.css L20517 (`min-width: 768px` two-column) and L20526 (`max-width: 767px` stack). | **Verify by measurement** — every control reachable and unclipped, dialog does not overflow the viewport. |
+| Returns list `cardView` reusing the same cell renderers (#2091) | **Shipped by #2335** (`returns-list-page.tsx:349`), citing #2091 in a comment. `meta` uses the real `<ReturnStageCell>`; `detail` uses the real `<ConnectionEntityLabel>` / `<ReturnOpenedCell>` / `<ReturnSourceStatus>`. But `title` and `subtitle` use plain-text summaries (`returnIdentitySummary` / `returnOrderSummary`) co-located with the cells, **not** the cell components. | **Assess** (see finding F2) — this is the one AC where the shipped state may not literally satisfy the wording. |
+
+### Findings already established from reading the branch
+
+**F1 — the breakpoint values are inconsistent, and one of them lands exactly on an audit width.**
+The house convention (style guide § Responsive) is mobile ≤ 767 px, tablet 768–1023 px, desktop ≥ 1024 px, expressed as mobile-first `min-width` queries. Wave-2 CSS uses four different spellings of the mobile bound:
+
+| index.css line | Query | Surface |
+|---|---|---|
+| 19055 | `@media (max-width: 767.98px)` | `.attention-list__item` |
+| **20097** | **`@media (max-width: 768px)`** | **`.who-decides-row`** |
+| 20342 | `@media (max-width: 767px)` | order-hold panel + dialog |
+| 20434 | `@media (max-width: 640px)` | automation rules state / suggestion actions |
+| 20526, 20614, 20658 | `@media (max-width: 767px)` | automation composer / dry-run / activity |
+
+`max-width: 768px` **fires at exactly 768 px**, which is the tablet band and one of the three audit widths. So at 768 px the who-decides row renders its mobile single-column layout while every other surface is in tablet — and the `min-width: 768px` tablet rules apply simultaneously to anything else on the page. This is a real, measurable inconsistency at an audited breakpoint, not a style nit. The `767.98px` spelling is the fractional-pixel-safe form; `767px` is the plain complement. Picking one is in scope; a wholesale sweep of the other 100+ media queries in the file is not.
+
+**F2 — the returns card `title`/`subtitle` are plain-text summaries, not the cell renderers.**
+`ReturnOrderCell` renders an **orphan `StatusBadge` with `tone="error"`** plus a hover explanation; `returnOrderSummary` degrades that to the plain string `"Unmatched · {externalOrderId}"`. So at 375 px the red badge that means *this return is blocked and needs attention* is not rendered — the very signal the wave's attention model exists to surface. Whether this satisfies AC-2 is a judgement call the audit must state explicitly rather than assume:
+- **Reading A (literal)**: the AC says *"mobile cards and desktop cells share one renderer"*. Title/subtitle do not. Gap.
+- **Reading B (as-designed)**: the card `title` slot renders inside `<strong>` (style-guide note on `.orders-cell-sub`), so a badge-bearing component is not a drop-in; the plain-text summaries live in the same file as the cell and share its fallback rule by construction, which is the spirit of #2091.
+
+**Recommendation**: treat the *orphan badge specifically* as the gap, and surface it in the card without restructuring the slots — the `meta` slot already renders a real component (`<ReturnStageCell>`) and is the natural home for a second status signal, or `detail` can carry it. Do not move `ReturnIdentityCell`/`ReturnOrderCell` wholesale into `title`/`subtitle`; that fights the primitive. State the reasoning in the PR.
+
+**F3 — three surfaces have no card safety net, and one has a thin one.**
+- `/settings/who-decides` has **no `DataTable` at all**; its responsiveness rests entirely on hand-written grid CSS, guarded only by the class-coverage/grid-area text test.
+- `automation-run-log.tsx` is a bare `<ul>`, not a `DataTable` — no `cardView`, no `hideBelow`. Its list-item CSS at index.css L20579–20607 is its only responsive behaviour.
+- `dispatch-risk-page.tsx:288` configures a `cardView` with **only `title` + `subtitle`** — no `meta`, no `detail`, no `actions`. Given `DataTable`'s documented no-columns-fallback rule, every other column vanishes below the card breakpoint. Worth measuring and reporting even if the fix is deferred.
+- Dialogs (`place`/`release-order-hold`, `automation-composer-dialog`, return custody/decline actions, the who-decides `ConfirmDialog`) have **no CSS contract test** covering small-viewport sizing.
+
+**F4 — the card-in-button fix is recent and must be built on, not redone.**
+The global `button, .button` rule (index.css:541) sets `height: 2rem; display: inline-flex; align-items: center; box-shadow: …; white-space: nowrap`. `.card-button-reset` releases all seven properties (`height: auto` specifically) and is applied to the three `*-segment` classes; `card-button-reset-styles.test.ts` asserts both the CSS half and the markup half (every `['…-segment', …]` className array must also contain `card-button-reset`). At 500 px the returns strip previously wrapped to four mutually-overlapping rows; that is fixed. **Re-verify at 375 px** rather than assuming.
+
+### Testing patterns to follow
+
+The repo has four existing CSS/geometry contract tests, all reading `src/index.css` from disk. The anchoring rule is the important one (#2589): `card-button-reset-styles.test.ts` strips comments, matches `([^{}]*)\{([^{}]*)\}`, splits the selector list on `,`, trims, and requires `selectors.includes(selector)` — **whole-token equality**, so `.card-button-reset--wide` cannot satisfy a test for `.card-button-reset`. It carries a guard-of-the-guard (`ruleBodiesFor(css, '.card-button-rese')` must return `[]`). `custody-touch-targets.test.ts` additionally strips media blocks by brace-counting, and tests its own stripper on nested blocks. Any new test here follows both patterns.
+
+---
+
+## 5. Questions & Assumptions
+
+### Open Questions
+
+- **Q1**: Is the F2 orphan-badge gap in scope for this issue, or a follow-up? The AC wording says renderers are shared; the shipped design deliberately does not share them for `title`/`subtitle`. **Proposed default**: fix the *badge* (a real operator-facing loss of a red attention signal at 375 px), leave the title/subtitle summary shape alone, and state both readings in the PR.
+- **Q2**: Should `dispatch-risk-page`'s two-slot `cardView` be enriched here? It is a Wave-2-touched file but the thin `cardView` is arguably pre-existing. **Proposed default**: measure it, report it, fix only if the measurement shows an actual loss of an actionable control (not merely a hidden informational column).
+- **Q3**: How wide should the breakpoint normalisation go? **Proposed default**: normalise only the Wave-2 rules this audit touches (F1), to the `767.98px` spelling already used at L19055, and only where a measurement showed a defect. A repo-wide media-query sweep is a separate change.
+
+### Assumptions
+
+- Desktop remains the design anchor; tablet and mobile are first-class (issue's own stated assumption + the house responsive-scope rule).
+- The two documented departures in the style guide are the spec, not defects.
+- The dev stack (API :3011, web :4174) can be seeded well enough that the returns list, the automation run log and the attention rows render **non-empty**. Where a surface can only be audited empty, the plan says so explicitly and states what that does not cover — an empty state cannot exercise long content, wrapping, or overflow.
+
+### Documentation Gaps
+
+- The style guide's parity matrix says `Tables → card view` at mobile but does not state which `cardView` slots are mandatory for a list to count as having one. `DataTable`'s own JSDoc (no columns fallback) is the real constraint and is the better citation.
+
+---
+
+## 6. Proposed Implementation Plan
+
+### Phase 0 — Instrument and seed (no product change)
+
+**Goal**: make the measurement real and repeatable.
+
+1. **Bring the stack up and confirm both halves.** API on :3011 (`.env.local`, gitignored), web on :4174 pointed at it. Verify a Wave-2 route answers (not 404/401-only).
+   - *Acceptance*: `/v1/health` 200; a wave-2 route reachable; the web app loads and authenticates.
+2. **Seed enough data that the audited surfaces are non-empty.** At minimum: some orders (for holds / attention / shortfall badges), some returns, some automation rules and runs. Where seeding is impractical, record the surface as **audited empty** and state what that does not cover.
+   - *Acceptance*: for each surface, either rows are present or the report names it as an empty-state audit.
+
+### Phase 1 — Measure
+
+**Goal**: numbers, per surface, per breakpoint. "Looks fine" is not a result.
+
+3. **For each surface × {375, 768, 1024}**, via Chrome DevTools MCP: resize, navigate, then evaluate and record
+   `document.documentElement.scrollWidth` vs `clientWidth` (and the same on `document.body`), plus `getBoundingClientRect()` for elements where overlap or clipping is plausible.
+   - Horizontal page scroll is a defect **except** inside `.data-table__container` and `RawPayloadPanel` (style guide § Responsive).
+   - *Acceptance*: a table of measured numbers covering every surface in § 2, at all three widths.
+4. **Open every dialog and measure it too** — `place-order-hold`, `release-order-hold`, `automation-composer-dialog`, return custody/decline/dispose, the who-decides `ConfirmDialog`. At 375 px specifically: every control reachable (scroll within the dialog is acceptable; clipped/unreachable is not), no control cut off horizontally, footer buttons not pushed off-screen.
+   - *Acceptance*: per dialog, at 375 px, a recorded rect for the dialog and for its footer actions, and an explicit statement that each control is reachable.
+5. **Re-verify the returns segment strip at 375 px** (F4) — measure each `.returns-segment` rect and assert no vertical overlap between consecutive rows.
+   - *Acceptance*: recorded rects; no overlap.
+6. **Verify the attention badge renders in the card branch** at 375 px on `/orders`, `/connections`, `/products`, and that it is the same `OmsAttentionBadges` component as the desktop cell.
+   - *Acceptance*: badge present at 375 px on all three; same component confirmed by reading the call sites.
+
+### Phase 2 — Fix
+
+**Goal**: minimal, local repairs for what Phase 1 measured. Each fix is justified by a recorded number.
+
+7. **F1 — normalise the who-decides breakpoint** if the 768 px measurement shows the mobile layout firing in the tablet band. Change `max-width: 768px` → the `767.98px` spelling already in the file.
+   - *File*: `apps/web/src/index.css` (the `.who-decides-row` block, ~L20097)
+   - *Acceptance*: at 768 px the row renders its multi-column grid; at 375 px it renders single-column; both measured.
+8. **F2 — surface the returns orphan signal in the mobile card** (per Q1's default), reusing the existing badge rendering rather than a new component.
+   - *Files*: `apps/web/src/pages/returns/returns-list-page.tsx` (the `cardView` config), possibly `apps/web/src/features/returns/components/return-order-cell.tsx`
+   - *Acceptance*: at 375 px an orphan return's card carries the same error-tone badge the desktop cell carries; the existing `returns-list-page.test.tsx` still passes; a new assertion covers the card branch.
+9. **Any horizontal-overflow fix Phase 1 surfaced**, scoped to the offending rule. Use `.card-button-reset` for any card-in-button; never a fresh partial reset.
+   - *Acceptance*: the measured `scrollWidth === clientWidth` at the width that failed.
+
+### Phase 3 — Pin
+
+**Goal**: nothing in the pipeline parses `index.css`, so any CSS invariant introduced or changed here gets a test.
+
+10. **Add or extend a CSS contract test** for each CSS invariant this issue introduces or changes. Follow `card-button-reset-styles.test.ts`: strip comments, match rule bodies, compare selectors as **whole tokens** (never `css.includes('.' + name)` — the #2589 trap, which has already produced a false pass on this branch), and include a **guard-of-the-guard** (a deliberately-truncated selector must return no rules).
+    - Candidate: a breakpoint-consistency assertion — every Wave-2 mobile-bound media query uses one spelling — with the guard-of-the-guard being a fabricated selector.
+    - *File*: extend `who-decides-styles.test.ts` for the breakpoint, or add a focused sibling.
+11. **See every new assertion fail first.** Temporarily break the CSS (or the markup), observe red, restore, observe green. State in the PR, per test, that it was seen red. An assertion nobody has seen fail is a claim, not a guard.
+    - *Acceptance*: an explicit red-then-green statement for every new assertion.
+
+### Phase 4 — Gate and ship
+
+12. `pnpm lint` (0 errors), `pnpm type-check`, `pnpm test`, `pnpm test:integration` — all four exit codes reported as numbers, read from the runner's own `Tests:` / `FAIL` lines. Never run the unit suite concurrently with integration. Node 22 throughout, including on the hook's PATH.
+    - Known pre-existing failures, named and not chased: **#2638** `earliest-order-date` (TZ offset), **#2639** `allegro-prestashop-carrier-mapping` (S-3 assertion failure, or whole-suite Docker container-creation errors — the latter is infrastructure: `docker container prune -f`, retry once).
+13. `git commit -s` (multi-line via tmp file + `-F`). Never `--no-verify`. PR into **`oms-programme-wave-2`**, never `main`.
+
+---
+
+## 7. Alternatives Considered
+
+### Alternative 1: Audit by reading CSS instead of measuring
+
+- **Description**: reason about the media queries and grid definitions to conclude the layouts are correct.
+- **Why rejected**: the issue is about rendered geometry, and the brief is explicit that measurement is required. Reading CSS would not have surfaced F1's off-by-one-pixel breakpoint as a *behaviour at an audited width*, and cannot detect overflow caused by content (a long connection name, an unwrapped mono id) rather than by a rule.
+
+### Alternative 2: Convert `/settings/who-decides` and the automation run log to `DataTable` so they inherit `cardView`
+
+- **Description**: replace the hand-written grid and the bare `<ul>` with the shared primitive.
+- **Why rejected**: the style guide documents the who-decides carve-out with a stated reason — the only column cheap enough to `hideBelow` is the why-line, which spec § 3.3 calls the whole point of the table, so `DataTable`'s hiding strategy would delete the feature on mobile. Seven fixed rows with no sort, no pagination and no row link are not a table's shape. Converting would be a redesign, explicitly out of scope, and would reverse a decision made with reasons on the record.
+
+### Alternative 3: Normalise every media query in `index.css` to one spelling
+
+- **Description**: sweep all 113 media queries to a single mobile bound.
+- **Why rejected**: out of proportion to the issue, touches surfaces this wave did not add, and risks regressions in areas with no measurement backing the change. Scoped to Wave-2 rules whose measurement showed a defect (Q3).
+
+---
+
+## 8. Validation & Risks
+
+### Architecture Compliance
+
+- ✅ Changes confined to `apps/web` (Interface layer). Dependency direction `app → pages → features → shared` untouched.
+- ✅ No `@openlinker/core` import added to `apps/web` (#591).
+- ✅ No new abstraction. Reuses `DataTable`, `.card-button-reset`, and the existing CSS-contract-test pattern.
+
+### Naming Conventions
+
+- ✅ Components `kebab-case.tsx` / `PascalCase` export; tests `*.test.ts(x)`; CSS contract tests follow the shipped `*-styles.test.ts` naming.
+
+### Risks
+
+- **A CSS contract test that passes on a prefixed class** — the #2589 trap, already responsible for one false pass on this branch. *Mitigation*: whole-token selector matching plus a guard-of-the-guard, per Phase 3; and every assertion seen red first.
+- **A fix at one breakpoint regressing another.** *Mitigation*: re-measure all three widths after each fix, not just the one that failed.
+- **Auditing an empty state and reporting it as coverage.** *Mitigation*: Phase 0 step 2 forces an explicit statement per surface; the report names any empty-state audit and what it does not cover.
+- **Scope creep into redesign.** *Mitigation*: § 2 non-goals; each fix must cite a recorded measurement.
+- **The shared dev stack.** Another session's servers occupy :3000/:4173; this work runs on :3011/:4174 against the shared Postgres. *Mitigation*: read-mostly; any seeding is additive.
+
+### Edge Cases
+
+- **Exactly 768 px** — the boundary between two bands and the case F1 is about. Measure at exactly 768, not 767 or 769.
+- **Long unbroken content** (a mono id, a long connection name) is the usual real cause of overflow, and is invisible in an empty state.
+- **A dialog taller than the viewport at 375 px** — internal scroll is acceptable; a clipped or unreachable control is not. The distinction must be stated per dialog.
+
+### Backward Compatibility
+
+- ✅ No API, schema or contract change. A breakpoint normalisation changes rendering in a 1 px band at one width, deliberately.
+
+---
+
+## 9. Testing Strategy & Acceptance Criteria
+
+### Unit / component tests
+
+- Extend the existing `returns-list-page.test.tsx` for the card-branch orphan badge (F2 fix).
+- Extend or add a CSS contract test for the breakpoint invariant (Phase 3), anchored, with a guard-of-the-guard, seen red first.
+- Existing tests that must keep passing: `card-button-reset-styles.test.ts`, `who-decides-styles.test.ts`, `returns-styles.test.ts`, `custody-touch-targets.test.ts`.
+
+### Integration tests
+
+- None expected — this issue changes no backend behaviour. `pnpm test:integration` is run as a regression gate, not extended.
+
+### Manual measurement (the primary evidence)
+
+Chrome DevTools MCP against the running app, per surface per breakpoint, recording `scrollWidth` vs `clientWidth` and bounding rects where overlap is plausible. Numbers go in the PR body.
+
+### Acceptance Criteria (from the issue)
+
+- [ ] All Wave-2 surfaces pass a no-horizontal-scroll audit at 375 / 768 / 1024 px — **with recorded numbers per surface per width**
+- [ ] Mobile cards and desktop cells share one renderer on every new list — **or the deviation is stated with its reason** (F2 / Q1)
+- [ ] The composer dialog is fully operable at 375 px with no clipped control — **verified by measurement, not by reading the documented departure**
+
+### Additional gates
+
+- [ ] `pnpm lint` 0 errors; `pnpm type-check`; `pnpm test`; `pnpm test:integration` — four exit codes reported as numbers
+- [ ] Every new assertion seen red before green, stated per test
+- [ ] Copy passes `check-ui-vocabulary`
+- [ ] Main checkout clean and on `main` (`git status --porcelain` empty)
+- [ ] PR opened into `oms-programme-wave-2`, not `main`
+
+---
+
+## 10. Alignment Checklist
+
+- [x] Follows hexagonal architecture — Interface layer only
+- [x] Respects CORE vs Integration boundaries — neither is touched
+- [x] Uses existing patterns (`DataTable` `cardView`, `.card-button-reset`, the `*-styles.test.ts` contract-test shape); no new abstraction
+- [x] Idempotency — not applicable (no jobs, no writes)
+- [x] Event-driven patterns — not applicable
+- [x] Rate limits & retries — not applicable
+- [x] Error handling — not applicable (no new failure paths)
+- [x] Testing strategy complete — CSS contract tests + component tests + recorded measurements
+- [x] Naming conventions followed
+- [x] File structure matches standards
+- [x] Plan is execution-ready
+- [x] Plan is saved as a markdown file
+
+---
+
+## Related Documentation
+
+- [Frontend UI Style Guide § Responsive](../frontend-ui-style-guide.md) — breakpoints, parity matrix, the two documented departures, the no-horizontal-scroll rule
+- [Frontend UI Style Guide § Density & Row Heights](../frontend-ui-style-guide.md) — the who-decides question-row carve-out
+- [Frontend Architecture](../frontend-architecture.md) — folder conventions, dependency rules, feature barrels
+- [Engineering Standards](../engineering-standards.md) — naming, testing standards
+- [Testing Guide](../testing-guide.md)

--- a/docs/plans/implementation-plan-wave2-responsive-audit.md
+++ b/docs/plans/implementation-plan-wave2-responsive-audit.md
@@ -157,8 +157,10 @@ The repo has four existing CSS/geometry contract tests, all reading `src/index.c
 3. **For each surface × {375, 768, 1024}**, via Chrome DevTools MCP: resize, navigate, then evaluate and record
    `document.documentElement.scrollWidth` vs `clientWidth` (and the same on `document.body`), plus `getBoundingClientRect()` for elements where overlap or clipping is plausible.
    - Horizontal page scroll is a defect **except** inside `.data-table__container` and `RawPayloadPanel` (style guide § Responsive).
-   - *Acceptance*: a table of measured numbers covering every surface in § 2, at all three widths.
+   - **Also record `window.innerWidth` and the two `matchMedia` verdicts** — `matchMedia('(max-width: 767.98px)').matches` and `matchMedia('(max-width: 768px)').matches` — at every width. A classic vertical scrollbar makes `documentElement.clientWidth` ~15 px narrower than the width media queries evaluate against, which at the 768 px boundary (the whole subject of F1) can invert the reading. Recording both verdicts **observes** which branch each rule took instead of inferring it from a rect.
+   - *Acceptance*: a table of measured numbers covering every surface in § 2, at all three widths, each row carrying both `matchMedia` verdicts.
 4. **Open every dialog and measure it too** — `place-order-hold`, `release-order-hold`, `automation-composer-dialog`, return custody/decline/dispose, the who-decides `ConfirmDialog`. At 375 px specifically: every control reachable (scroll within the dialog is acceptable; clipped/unreachable is not), no control cut off horizontally, footer buttons not pushed off-screen.
+   - **Vertical scroll inside a dialog is by design, not a finding.** `.dialog__content` is `width: min(520px, 92vw); max-height: min(90vh, 720px); overflow-y: auto` (index.css:5241-5244), so at 375 px it is 345 px wide and scrolls internally on purpose. What to look for is **horizontal** clipping, or a footer rendered outside the scroll container so it cannot be reached at all.
    - *Acceptance*: per dialog, at 375 px, a recorded rect for the dialog and for its footer actions, and an explicit statement that each control is reachable.
 5. **Re-verify the returns segment strip at 375 px** (F4) — measure each `.returns-segment` rect and assert no vertical overlap between consecutive rows.
    - *Acceptance*: recorded rects; no overlap.
@@ -169,10 +171,15 @@ The repo has four existing CSS/geometry contract tests, all reading `src/index.c
 
 **Goal**: minimal, local repairs for what Phase 1 measured. Each fix is justified by a recorded number.
 
+**If a surface measures clean, nothing is changed for it, and that is a complete result.** The deliverable of this issue is the recorded geometry; a surface with no defect owes no fix and no CSS test, and the PR says so per surface. Stated explicitly because an audit that finds little creates quiet pressure to manufacture a change to justify the issue — which would add unmeasured risk to surfaces that are working.
+
 7. **F1 — normalise the who-decides breakpoint** if the 768 px measurement shows the mobile layout firing in the tablet band. Change `max-width: 768px` → the `767.98px` spelling already in the file.
    - *File*: `apps/web/src/index.css` (the `.who-decides-row` block, ~L20097)
    - *Acceptance*: at 768 px the row renders its multi-column grid; at 375 px it renders single-column; both measured.
 8. **F2 — surface the returns orphan signal in the mobile card** (per Q1's default), reusing the existing badge rendering rather than a new component.
+   - **Use the `summary` slot**, not `meta` and not `detail`. `data-table.tsx` documents `summary` as the *"always-visible summary block … the handful of facts worth showing before expanding"* — an orphan flag is a fact. `meta` already carries `<ReturnStageCell>` (a different fact, and stacking two status signals in one slot is what #2100's independent-parts rule warns against), and `detail` can be collapsed behind `collapsibleDetail`, which would re-hide the badge the fix exists to reveal.
+   - **Reuse the existing copy constants** (`RETURNS_ORPHAN_COPY.badge` / `.explanation`, `features/returns/lib/returns-list.copy.ts`). `features/returns` is a live `check-ui-vocabulary` scan root; reused copy is gate-clean by construction, and a new string is not.
+   - **Prefer an existing class.** `returns-styles.test.ts` asserts every rendered `returns-*` class has a rule in `index.css`, so a NEW `returns-*` class obliges a CSS rule in the same commit. Reusing `StatusBadge`'s own markup avoids the obligation entirely.
    - *Files*: `apps/web/src/pages/returns/returns-list-page.tsx` (the `cardView` config), possibly `apps/web/src/features/returns/components/return-order-cell.tsx`
    - *Acceptance*: at 375 px an orphan return's card carries the same error-tone badge the desktop cell carries; the existing `returns-list-page.test.tsx` still passes; a new assertion covers the card branch.
 9. **Any horizontal-overflow fix Phase 1 surfaced**, scoped to the offending rule. Use `.card-button-reset` for any card-in-button; never a fresh partial reset.
@@ -182,9 +189,13 @@ The repo has four existing CSS/geometry contract tests, all reading `src/index.c
 
 **Goal**: nothing in the pipeline parses `index.css`, so any CSS invariant introduced or changed here gets a test.
 
-10. **Add or extend a CSS contract test** for each CSS invariant this issue introduces or changes. Follow `card-button-reset-styles.test.ts`: strip comments, match rule bodies, compare selectors as **whole tokens** (never `css.includes('.' + name)` — the #2589 trap, which has already produced a false pass on this branch), and include a **guard-of-the-guard** (a deliberately-truncated selector must return no rules).
-    - Candidate: a breakpoint-consistency assertion — every Wave-2 mobile-bound media query uses one spelling — with the guard-of-the-guard being a fabricated selector.
-    - *File*: extend `who-decides-styles.test.ts` for the breakpoint, or add a focused sibling.
+10. **Add or extend a CSS contract test** for each CSS invariant this issue introduces or changes. Combine the two in-tree precedents:
+    - **Finding the right rule** — `ConnectionFold.test.tsx:105` (`queryFor`): brace-match each `@media` block so only that block's OWN body is searched. Its comments record why the naive approaches fail (a `split('@media ')` sweeps up every rule following a block, and the selector also appears outside any media query in a comma group).
+    - **Anchoring the selector** — `card-button-reset-styles.test.ts`: strip comments, match rule bodies, compare selectors as **whole tokens** (never `css.includes('.' + name)` — the #2589 trap, which has already produced a false pass on this branch), plus a **guard-of-the-guard** (a deliberately-truncated selector must return no rules).
+
+    **The assertion is per-selector, never file-wide.** An earlier draft proposed *"every Wave-2 mobile-bound media query uses one spelling"*; that is **unimplementable** and must not be attempted. `index.css` is one global 21k-line stylesheet with no provenance marker, so a test cannot know which rules are Wave-2 — written literally it fails on `.error-list__row` (index.css:10458, `max-width: 768px`, **pre-existing**) and on the `640px` automation block that R3 deliberately leaves alone. The only outcomes are a permanently-red test or one quietly narrowed to an unstated hardcoded list, and a test weakened after it failed is the #2589 shape in a new costume.
+    - **Concrete form**: assert that the media query guarding `.who-decides-row` is exactly `(max-width: 767.98px)`. One selector, one expected string, honest about its scope, and it still catches the regression.
+    - *File*: extend `who-decides-styles.test.ts`, or add a focused sibling.
 11. **See every new assertion fail first.** Temporarily break the CSS (or the markup), observe red, restore, observe green. State in the PR, per test, that it was seen red. An assertion nobody has seen fail is a claim, not a guard.
     - *Acceptance*: an explicit red-then-green statement for every new assertion.
 


### PR DESCRIPTION
Closes #2388 (`W2-46b`, epic #2389).

Audited by **measuring the running app** against a seeded database at 375 / 768 / 1024 px, not by reading CSS. Every fix below cites the number that justified it; every surface that measured clean was left alone.

Base is `oms-programme-wave-2`, not `main`.

---

## Measured geometry

`pageHScroll` = `documentElement.scrollWidth > clientWidth`. "outside allowed" excludes `.data-table__container` and `RawPayloadPanel`, the two overflow exceptions the style guide permits.

### After the fixes — 8 routes × 3 widths, all clean

| Route | 375 | 768 | 1024 |
|---|---|---|---|
| `/orders` | 375/375, CARD, 12 cards, 0 outside | 768/768, TABLE, 12 rows | 1024/1024, TABLE, 12 rows |
| `/orders/dispatch-risk` | 375/375 | 768/768 | 1024/1024 |
| `/connections` | 375/375, CARD, 3 cards | 768/768, TABLE, 3 rows | 1024/1024, TABLE |
| `/products` | 375/375 | 768/768 | 1024/1024 |
| `/automations` | 375/375, CARD, 8 cards | 768/768, TABLE, 8 rows | 1024/1024, TABLE |
| `/automations/activity` (run log) | 375/375, CARD, 10 cards | 768/768, TABLE, 10 rows | 1024/1024, TABLE |
| `/returns` | 375/375, CARD, 8 cards | 768/768, TABLE, 8 rows | 1024/1024, TABLE |
| `/settings/who-decides` | 375/375, 7 rows, 1 col | 768/768, **3 cols** | 1024/1024, 3 cols |

`pageHScroll: false` and `actuallyScrolls: false` (verified by attempting `scrollLeft = 9999`) on every cell. Detail pages `/orders/:id` and `/returns/:id` also measured clean at 375.

Where `.data-table__container` scrolls its own columns (`/orders`, `/returns`, `/automations/activity`), that is the documented exception, and the page around it does not scroll.

---

## The three defects

### 1. `.who-decides-row` reflowed on the wrong side of the boundary

It shipped guarded by `max-width: 768px`, which **matches at exactly 768 px**, while `DataTable`'s own card/table switch (`data-table.tsx:248`) and all three `hide-below` queries use `767.98px`, which does not.

Measured at `innerWidth: 768` before the fix:

```
mq('(max-width: 767.98px)') = false   → DataTable stays in its desktop branch
mq('(max-width: 768px)')    = true    → .who-decides-row goes single-column
gridTemplateColumns: "671px"          (one column)
```

Two components, two different bands, one width. After: `gridTemplateColumns: "240.656px 336.93px 61.4141px"` — back in step with the primitive. 375 still stacks.

The identically-spelled block on `.error-list__row` (index.css:10458) is **pre-existing, not Wave 2**, and is deliberately left alone rather than swept up.

### 2. `.data-table__container` did not clip its absolutely-positioned descendants

An element with `overflow` only clips a descendant for which it is in the containing-block chain, and a `position: static` box never is. `.sr-only` is `position: absolute`, so every screen-reader label sat at its static x — *inside* the 1176 px table — and escaped the clip, extending the **document's** scroll area.

Measured on `/orders` at 768 px:

```
documentElement.scrollWidth 947  vs  clientWidth 768
actuallyScrollable: true, scrolled to 179.5px of blank space
offenders outside allowed containers: 0   ← nothing "looked" wrong
sr-only spans at left: 807, left: 947
```

`position: relative` → 768/768, `actuallyScrolls: false`, while the container keeps scrolling its own columns (1151/718).

### 3. `.key-value-list` cut an over-wide value instead of letting it shrink

`grid-template-columns: 1fr` is `minmax(auto, 1fr)`, and that `auto` floors the track at the widest item's **min-content**. A value carrying a non-wrapping `inline-flex` child (`ConnectionEntityLabel`) pushed the track past the list's own box, which `overflow: hidden` then cut — no ellipsis, no scrollbar, nothing to reveal it.

Measured on `/returns` at 375 px with a 58-character connection name:

```
3 of 8 lists: track 433.5px inside a 311px box
24 elements overflowing; name cut mid-word AND the id beside it hidden
page never scrolled (the shell clips) → the loss was SILENT
```

`min-width: 0` plus the host-side `> * { max-width: 100% }` — the containment pattern #2094 already documents — lets the child's own `text-overflow: ellipsis` and its `title` work. After: **0 clipped, 0 overflowing**, name ellipsised at 206 px, full string still in `title`.

---

## Acceptance criteria

**Who-decides collapses to stacked cards** — shipped by #2354; verified, and its breakpoint fixed (defect 1).

**Composer dialog fully operable at 375 px, no clipped control** — verified, no change needed. Fully expanded (condition row + 2 action rows):

```
dialog 345px wide (left 15, right 360), 15 controls
clipped controls: 0        controls under 44px: 0
composer rows: flex-direction: column  (all three)
footer reachable after scroll, both buttons 44px tall, column-reverse
page h-scroll: false       dialog h-scroll: false
```

Vertical scroll inside the dialog is by design (`.dialog__content` is `max-height: min(90vh, 720px); overflow-y: auto`), so the thing looked for was horizontal clipping and an unreachable footer — neither present.

**Attention rows carry the same badge / one renderer per list** — the order-hold and reservation-shortfall badges do render in the `/orders` card branch at 375 px (`On hold — Payment review`, `On hold — Stock shortfall`, `Short 2 × SOCK-WOOL-42`). The **returns orphan badge did not**:

```
1024 (TABLE): 12 badges, 2 error-tone "Orphan"
 375 (CARD):   8 badges, 0 error-tone     ← the red signal was lost
```

`DataTable` renders the card view solely from `cardView` — no `columns` fallback — and the card's `subtitle` takes `returnOrderSummary`, which returns a **string**, so "Unmatched" survived only as running text. The badge is now extracted as `ReturnOrphanBadge` and used by **both** `ReturnOrderCell` and the card, so they cannot drift. It rides in `summary` (the documented always-visible facts block), never `detail` (which `collapsibleDetail` can hide) and never `meta` (already carrying the stage). After: 2 "Orphan" badges at 375 px.

**Returns list `cardView` reusing the desktop renderers (#2091)** — already shipped by #2335 for `meta`/`detail`; this closes the badge, the one part that was genuinely lost.

---

## Tests

Nothing in the pipeline parses `index.css` (#2674), so each CSS invariant gets an anchored contract test, combining both in-tree precedents: whole-token selector matching + guard-of-the-guard from `card-button-reset-styles.test.ts`, and brace-matched media-block lookup from `ConnectionFold.test.tsx:105`.

**Every assertion is per-selector, never file-wide.** An earlier plan draft proposed "every Wave-2 mobile-bound media query uses one spelling"; that is unimplementable — `index.css` carries no provenance marker, so it could only be permanently red or quietly narrowed to an unstated list, which is #2589 in a new costume. The `/tech-review` of the plan caught this before any code was written.

**All five new assertions were seen RED before green**, by reverting each fix in turn:

| Assertion | Red output |
|---|---|
| breakpoint parity | `expected '(max-width: 768px)' to be '(max-width: 767.98px)'` |
| containing block | `× establishes a containing block, so that overflow actually clips` |
| `min-width: 0` | `× releases the min-content floor on the value and its label` |
| `max-width: 100%` | `× bounds the value's children, so a child's own ellipsis can fire` |
| mobile orphan badge | `Unable to find an element with the text: Orphan` |

---

## Gates

| Gate | Exit |
|---|---|
| `pnpm lint` | **0** |
| `pnpm type-check` | **0** |
| `pnpm test` | **0** (apps/web 448 files, 4819 passed, 1 skipped) |
| `pnpm test:integration` | **1** — `INT_EXIT=1` |

Integration: `Test Suites: 1 failed, 146 passed, 147 total` / `Tests: 1 failed, 1 skipped, 1214 passed, 1216 total`.

The sole failure is the known pre-existing **#2638** `earliest-order-date` — `Expected "2026-02-10T00:00:00.000Z"`, `Received "2026-02-10T01:00:00.000Z"`, a 1-hour TZ offset in backend SQL, untouchable by a frontend CSS change. **#2639** `allegro-prestashop-carrier-mapping` **passed** this run.

Node 22 throughout, including on the pre-commit hook's PATH — Node 25 fails `apps/web` wholesale on a happy-dom `localStorage` bug (65 tests), which was observed and worked around rather than mistaken for a real failure.

---

## Deliberately not done

- **`@media (max-width: 640px)`** on `.automation-rules__state` / `.automation-suggestion__actions` is a fifth band matching no documented breakpoint. It is not one of the three audited widths, so no measurement justifies changing it. Reported, not touched.
- **`.error-list__row`'s `max-width: 768px`** — pre-existing, not Wave 2. Left alone; the survivor is intentional, not an oversight.
- **`dispatch-risk-page`'s two-slot `cardView`** (`title` + `subtitle` only) — measured clean at all three widths and no *actionable control* is lost, so per the plan's own rule it is reported rather than changed.
- **An unknown `fulfillmentState` crashes `/orders` entirely.** `ORDER_FULFILLMENT_META` is an unguarded `Record` lookup, so an out-of-vocabulary value throws `Cannot read properties of undefined (reading 'tone')` and takes down the whole page instead of degrading. Found because my *seed data* used invalid values — the four real union members are exhaustive and the compiler enforces the map, so this is **not** reachable from valid data today and is **not** a Wave-2 defect. Worth a follow-up given the `readReturnReason`-style coercion the codebase already uses elsewhere; out of scope here.

## Coverage limits, stated

`/products` and `/orders/dispatch-risk` were audited **empty** — the seed created no products and no dispatch-risk-eligible rows. An empty state cannot exercise long unbroken content, wrapping, or column overflow, which is precisely the class of bug defect 3 turned out to be. Every other surface was measured with real rows, including deliberate stressors: a 58-character connection name, a 49-character unbroken external return id, and long mono ids.
