### PR TITLE
feat(core,web): capability registry 10 → 12 and the pinned mirrors

### DIFF
--- a/apps/api/src/integrations/__tests__/master-reservation-writer-absence.spec.ts
+++ b/apps/api/src/integrations/__tests__/master-reservation-writer-absence.spec.ts
@@ -1,0 +1,107 @@
+/**
+ * `MasterReservationWriter` Absence Guard (#2403)
+ *
+ * `MasterReservationWriter` is a NAMED DEFERRAL, not an oversight: #2315 /
+ * ADR-061 removed master-side reservation from `InventoryMasterPort` and parked
+ * the legitimate residual need — pushing a hold to a master that really does
+ * model one — behind this name, "deliberately deferred until an adapter exists
+ * that can implement it". Advertising a capability with no implementer is what
+ * ADR-048 decision 1 forbids, so until that adapter exists the name must appear
+ * in NO manifest and in NO capability list.
+ *
+ * This spec lives in `apps/api` rather than `libs/core` for a hard reason: it
+ * asserts over the real adapter manifests, and `libs/core` may not depend on an
+ * integration package — that would reverse the CORE -> Integration dependency
+ * direction. `apps/api` already declares every integration it ships.
+ *
+ * ## It asserts MEMBERSHIP, never the presence of a string
+ *
+ * The literal `MasterReservationWriter` legitimately appears in prose at
+ * `libs/core/src/inventory/domain/ports/inventory-master.port.ts` (lines ~166
+ * and ~189) — the ADR-061 deprecation docblock that RECORDS the deferral. A
+ * filesystem scan for the string would therefore be red on day one and would
+ * get "fixed" by weakening it, which is exactly how a mirror silently becomes a
+ * no-op. Do not convert this into a text scan. If a future reader wants wider
+ * coverage, widen the MANIFEST list below, never the matching strategy.
+ *
+ * ## It reads BUILT output, and that fails OPEN
+ *
+ * These manifests resolve through each package's `dist`, so editing a manifest
+ * in `src` without rebuilding leaves this spec asserting over the OLD value —
+ * and because it is an ABSENCE check, a stale read is GREEN when it should be
+ * red. Verified the hard way while writing it: adding the name to erli's `src`
+ * left all four tests passing until `pnpm --dir libs/integrations/erli build`
+ * ran, after which the sweep failed correctly. The root `pnpm test` gate builds
+ * first, so CI is sound; when checking this guard BY HAND, rebuild the package
+ * you edited or you are reading yesterday's manifest.
+ *
+ * @module apps/api/src/integrations/__tests__
+ */
+import { CoreCapabilityValues } from '@openlinker/core/integrations';
+import type { AdapterMetadata } from '@openlinker/core/integrations';
+
+import { allegroAdapterManifest } from '@openlinker/integrations-allegro';
+import { dpdAdapterManifest } from '@openlinker/integrations-dpd-polska';
+import { eparagonyAdapterManifest } from '@openlinker/integrations-eparagony';
+import { erliAdapterManifest } from '@openlinker/integrations-erli';
+import { infaktAdapterManifest } from '@openlinker/integrations-infakt';
+import { inpostAdapterManifest } from '@openlinker/integrations-inpost';
+import { ksefAdapterManifest } from '@openlinker/integrations-ksef';
+import { prestashopAdapterManifest } from '@openlinker/integrations-prestashop';
+import { subiektAdapterManifest } from '@openlinker/integrations-subiekt';
+import { woocommerceAdapterManifest } from '@openlinker/integrations-woocommerce';
+
+const DEFERRED_CAPABILITY = 'MasterReservationWriter';
+
+/** Every in-tree adapter manifest, by the name an operator would recognise. */
+const MANIFESTS: ReadonlyArray<readonly [string, AdapterMetadata]> = [
+  ['allegro', allegroAdapterManifest],
+  ['dpd-polska', dpdAdapterManifest],
+  ['eparagony', eparagonyAdapterManifest],
+  ['erli', erliAdapterManifest],
+  ['infakt', infaktAdapterManifest],
+  ['inpost', inpostAdapterManifest],
+  ['ksef', ksefAdapterManifest],
+  ['prestashop', prestashopAdapterManifest],
+  ['subiekt', subiektAdapterManifest],
+  ['woocommerce', woocommerceAdapterManifest],
+];
+
+/** The predicate under test, lifted so the positive control can exercise it. */
+function advertises(manifest: AdapterMetadata, capability: string): boolean {
+  return manifest.supportedCapabilities.includes(capability);
+}
+
+describe('MasterReservationWriter (deferred — #2315 / ADR-061)', () => {
+  it('should have a detector that actually detects (positive control)', () => {
+    // Without this, a predicate broken by a later edit would make both
+    // assertions below pass vacuously — the failure mode an "absence"
+    // assertion cannot see on its own.
+    const fabricated: AdapterMetadata = {
+      adapterKey: 'fabricated.v1',
+      platformType: 'fabricated',
+      supportedCapabilities: [DEFERRED_CAPABILITY],
+    };
+    expect(advertises(fabricated, DEFERRED_CAPABILITY)).toBe(true);
+    expect(advertises(allegroAdapterManifest, DEFERRED_CAPABILITY)).toBe(false);
+  });
+
+  it('should cover every in-tree manifest (guard against a silently empty sweep)', () => {
+    expect(MANIFESTS.length).toBeGreaterThanOrEqual(10);
+    for (const [, manifest] of MANIFESTS) {
+      expect(Array.isArray(manifest.supportedCapabilities)).toBe(true);
+    }
+  });
+
+  it('should be advertised by no adapter manifest', () => {
+    const offenders = MANIFESTS.filter(([, manifest]) =>
+      advertises(manifest, DEFERRED_CAPABILITY),
+    ).map(([name]) => name);
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('should not be a well-known core capability', () => {
+    expect([...CoreCapabilityValues]).not.toContain(DEFERRED_CAPABILITY);
+  });
+});

--- a/apps/api/src/integrations/__tests__/master-reservation-writer-absence.spec.ts
+++ b/apps/api/src/integrations/__tests__/master-reservation-writer-absence.spec.ts
@@ -24,6 +24,13 @@
  * no-op. Do not convert this into a text scan. If a future reader wants wider
  * coverage, widen the MANIFEST list below, never the matching strategy.
  *
+ * That list is hand-maintained, so it can go stale: a NEW integration package
+ * added without an entry here is simply not swept, and the `>= 10` floor below
+ * is a guard against an accidentally-emptied list, not a completeness proof.
+ * Deriving it from the filesystem was rejected — it would reintroduce the
+ * text-scanning this spec exists to avoid — so the honest mitigation is to add
+ * the manifest here when a new integration lands.
+ *
  * ## It reads BUILT output, and that fails OPEN
  *
  * These manifests resolve through each package's `dist`, so editing a manifest

--- a/apps/web/src/features/connections/api/connections.types.ts
+++ b/apps/web/src/features/connections/api/connections.types.ts
@@ -21,6 +21,11 @@ export type ConnectionStatus = 'active' | 'disabled' | 'error' | 'needs_reauth';
  * Well-known core capabilities — mirrors `CoreCapabilityValues` on the backend.
  * Plugin adapters can register additional capability names; FE accepts those
  * as plain strings without runtime narrowing failures (#576).
+ *
+ * `'FulfillmentRouter'` (ADR-052 A2) is deliberately absent on both sides: A2 is
+ * `config-only`, so nothing resolves it by connection id. The backend
+ * declaration carries the full reasoning — do not add it here first, or
+ * `check-core-capability-mirror.mjs` fails with this file named as the drift.
  */
 export const CORE_CAPABILITY_VALUES = [
   'ProductMaster',
@@ -44,8 +49,6 @@ export const CORE_CAPABILITY_VALUES = [
   'AvailabilityAuthority',
   // Fulfilment execution authority (ADR-052 A3) - who holds a work object and may act on it.
   'FulfillmentExecutor',
-  // 'FulfillmentRouter' (A2) is deliberately absent - A2 is config-only, so nothing
-  // resolves it by connection id. See the backend declaration's comment.
 ] as const;
 
 /**

--- a/apps/web/src/features/connections/api/connections.types.ts
+++ b/apps/web/src/features/connections/api/connections.types.ts
@@ -40,6 +40,12 @@ export const CORE_CAPABILITY_VALUES = [
   // Returns disposition authority (ADR-052) - who decides what happens to goods
   // a customer sends back. Operator-enabled, so it must be writable here.
   'ReturnsAuthority',
+  // Availability read authority (ADR-052 A1) - who answers "how many can I sell?".
+  'AvailabilityAuthority',
+  // Fulfilment execution authority (ADR-052 A3) - who holds a work object and may act on it.
+  'FulfillmentExecutor',
+  // 'FulfillmentRouter' (A2) is deliberately absent - A2 is config-only, so nothing
+  // resolves it by connection id. See the backend declaration's comment.
 ] as const;
 
 /**

--- a/apps/web/src/features/connections/lib/capability-metadata.ts
+++ b/apps/web/src/features/connections/lib/capability-metadata.ts
@@ -32,6 +32,10 @@ export const CAPABILITY_HELP: Record<CoreCapability, string> = {
     'Register a completed sale with this connection, which performs or brokers the fiscal registration. OpenLinker never decides whether an order requires one.',
   ReturnsAuthority:
     'Decides what happens to goods a customer sends back — whether they go back on sale, and who approves that.',
+  AvailabilityAuthority:
+    'Decides how much of each product is sellable, overriding the stock figure OpenLinker would otherwise compute.',
+  FulfillmentExecutor:
+    'Picks, packs and ships the work OpenLinker hands it, and reports progress back. One holder at a time per piece of work.',
 };
 
 /**

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -69,6 +69,8 @@ runtime gate validates a connection's request against the adapter's
 | `Invoicing` | Issue fiscal documents through a provider. |
 | `Fiscalization` | Hand a completed sale to a provider that registers it fiscally. |
 | `ReturnsAuthority` | Decide the disposition of goods a customer sends back (A5, ADR-052). |
+| `AvailabilityAuthority` | Decide how much of each product is sellable (A1, ADR-052). |
+| `FulfillmentExecutor` | Hold a piece of fulfilment work and act on it (A3, ADR-052). |
 
 <!-- core-capabilities:end -->
 

--- a/docs/plans/implementation-plan-capability-registry-oms-dispatch-names.md
+++ b/docs/plans/implementation-plan-capability-registry-oms-dispatch-names.md
@@ -1,0 +1,270 @@
+# Implementation Plan: Capability registry 10 → 12 and the pinned mirrors (#2403 / `W3a-14`)
+
+**Date**: 2026-08-30
+**Status**: Ready for Review (revised after the readiness gate — see §5)
+**Estimated Effort**: 3–4 hours
+**Issue**: [#2403](https://github.com/openlinker-project/openlinker/issues/2403) — Wave 3a (epic #2412), stream S2
+**Base branch**: `oms-programme-wave-3a` (NOT `main`)
+
+---
+
+## 1. Task Summary
+
+**Objective**: add the two OMS dispatch capability names that the tree can actually dispatch — `AvailabilityAuthority` and `FulfillmentExecutor` — to `CoreCapabilityValues`, taking it from 10 members to **12**, and keep every hand-maintained mirror of that array in lock-step.
+
+**The issue predicted 13.** The readiness gate read the tree and found the third name, `FulfillmentRouter`, fails the entry rule the array exists to carry. It is deferred, with the reason recorded in §5. The requester owns #2403's text and is amending its acceptance criterion to 10 → 12.
+
+**Context**: design §9 (REVIEW G7) establishes the rule *a name enters `CoreCapabilityValues` iff a call site resolves it by connection id through `getCapabilityAdapter`*. ADR-052 assigns availability (A1) and fulfilment execution (A3) to holders discovered by narrowing a dispatched adapter, so both are resolved by connection id and both belong in the closed array. The array is copied by hand into four other places; two of those copies drifted silently before `scripts/check-core-capability-mirror.mjs` existed (#2351).
+
+**Classification**: CORE (domain types) + Frontend (mirrored union + help copy) + Documentation + DX (invariant guards).
+
+---
+
+## 2. Scope & Non-Goals
+
+### In scope
+- `CoreCapabilityValues` 10 → 12: `AvailabilityAuthority`, `FulfillmentExecutor`.
+- The exact-array spec in `libs/core/src/integrations/domain/types/__tests__/adapter.types.spec.ts`.
+- Mirror 1 — `CORE_CAPABILITY_VALUES` (`apps/web/.../connections/api/connections.types.ts`).
+- Mirror 2 — `CAPABILITY_HELP` (`apps/web/.../connections/lib/capability-metadata.ts`).
+- Mirror 3 — the fenced table in `docs/capabilities.md`.
+- **Mirror 4, which the issue does not name** — the verbatim quote of the array in `docs/plugin-author-guide.md` and its pinned line range in `scripts/check-plugin-guide-quotes.mjs`. See §5.
+- **Mirror 5 (gate finding W1)** — a spec pinning every non-`'config-only'` `AUTHORITY_KIND_DESCRIPTORS[*].capability` to a member of `CoreCapabilityValues`.
+- A spec asserting `MasterReservationWriter` appears in no manifest and in no capability list, pointing at #2315.
+- Red-first evidence per mirror, per direction.
+
+### Out of scope (and why)
+- **`FulfillmentRouter`.** Deferred — see §5. Zero occurrences in the tree; A2 is `'config-only'`.
+- **The ports.** `AvailabilityAuthorityPort` / `FulfillmentExecutorPort` live in `libs/core/src/fulfillment/**`, owned by the sibling agent working #2391. The capability *value* and the port *interface* are separable — `getCapabilityAdapter<T>` is generic over `T` and the registry keys on a string — so nothing here needs a port to exist. This plan touches no file under `libs/core/src/fulfillment/`.
+- **Wiring dispatch.** No call site resolves either name in this slice. Nothing constructs an adapter.
+- **The five advertised-without-dispatch names** (`AvailabilityHolder`, `AvailabilityStreamer`, `FulfillmentStatusSource`, `LifecycleAuthorityProvider`, `ReturnSourceReader`). The issue lists them to say what does NOT enter the registry. `ReturnSourceReader` already exists as a guard-only sub-capability (#2329); the other four are not created here.
+- **`MasterReservationWriter`.** A named deferral (#2315, ADR-061). Asserted absent, never added.
+- **`AuthorityKindValues` mirror script.** REVIEW H8a mandates it *with the enumeration*, i.e. #2311. W1 therefore ships as a **spec**, not as an edit to `scripts/check-authority-kind-mirror.mjs`.
+- **Manifest changes.** No adapter advertises either name, so neither is assignable through the UI or the API today. Deliberate (§8).
+
+### Constraints
+- `apps/web` cannot import `@openlinker/core` (#591) — mirror 1 is a copy by construction.
+- Ordering is part of the contract: all three `check-core-capability-mirror.mjs` checks compare order, not just membership.
+- Base is `oms-programme-wave-3a`, which already carries `ReturnsAuthority` (#2351). Verified: the array has 10 members today.
+
+---
+
+## 3. Architecture Mapping
+
+**Target layers**: CORE domain types (`libs/core/src/integrations/domain/types/`), Interface (frontend union + help copy), Documentation, DX specs.
+
+**Capabilities involved**: `CoreCapability` — the closed well-known set. The open extension axis (`AdapterMetadata.supportedCapabilities: string[]`, #576) is untouched.
+
+**Existing services reused**: none. This change adds no service, no port, no adapter, no module, no migration.
+
+**Core vs Integration justification**: `CoreCapabilityValues` is the vocabulary CORE publishes for host-side discovery and DTO validation (`@IsIn` on both connection DTOs). It cannot live in an integration — an integration declares which names it *supports*, never which names exist.
+
+---
+
+## 4. External / Domain Research
+
+None — no external system is involved.
+
+**Internal precedent followed**: #2351 (`ReturnsAuthority`, 9 → 10) is the exact shape. It added one value, updated the same four places, and shipped `check-core-capability-mirror.mjs` because two of the three drifts it found were silent. This change is that change with two values instead of one, plus mirrors 4 and 5.
+
+---
+
+## 5. Questions & Assumptions — resolved by the readiness gate
+
+### RESOLVED (Critical) — `FulfillmentRouter` is deferred; the count is 10 → 12
+
+The gate found `FulfillmentRouter` has **zero occurrences anywhere in the repo**, and A2 (`sourcing`) is declared `capability: 'config-only'` at `libs/core/src/fulfillment-authority/domain/types/authority-kind.types.ts:106`, with its reason stated in place: *"per ADR-054/ADR-055 the router ships as a connection-backed plugin, so the candidate set is configuration rather than a narrowed capability."* `resolveAuthorities` consumes that literal at `authority-resolution.types.ts:303-304` and **skips the `supportedCapabilities` gate entirely** for A2. So no code path can pass `'FulfillmentRouter'` to `getCapabilityAdapter` — the exact condition the entry rule excludes.
+
+**Decision: ship two. The rule wins over the number.**
+
+The strongest argument is in-repo precedent, not principle. **#2220's `ModifiedProductLister` was deliberately kept OUT of `CoreCapabilityValues` and every manifest** — guard-only — for this same reason: `Connection.enabledCapabilities` is stamped at create and **never retro-filled**, so gating on a newly-added name drains nothing for every connection that already exists (the #2085 shape). The cost accepted there was operator-facing discoverability. The danger is not that an unused name is inert; it is that **an advertised name invites someone to gate on it**, and that gate then silently does nothing. Landing `FulfillmentRouter` now hands the next person exactly that invitation, and a comment saying "don't" is the stated-rule-with-no-mechanism shape this programme keeps finding.
+
+**Rejected: flipping A2 to `capability: 'FulfillmentRouter'`.** It is a live regression — `resolveAuthorities` would start gating A2 on `supportedCapabilities`, no shipped manifest advertises the name, so **every existing A2 sourcing claim would stop resolving** on the already-shipped who-decides page (#2353/#2354). It also edits `fulfillment-authority` next door to #2391. If it is ever wanted it is its own issue with its own migration question, not a line in a registry PR.
+
+`FulfillmentRouter` is re-admitted by whichever wave takes A2 off `config-only`. This plan is its sole record until then, alongside the amended #2403.
+
+### A fourth mirror exists and the issue does not name it
+`docs/plugin-author-guide.md` reproduces the array **verbatim** inside a fenced block, and `scripts/check-plugin-guide-quotes.mjs` compares it **line by line** against a pinned source range (`sourceStart: 23`, `sourceEnd: 52`, `guideLinkSubstring: 'adapter.types.ts:23-52'`), which also appears as link text in the guide. Adding two commented entries lengthens the declaration, so **four values must move together**: the two script constants, the guide's link text, and the guide's fenced body.
+
+This is a good failure mode — the check fails loudly on a length mismatch, so it cannot drift silently. It is called out so it is not discovered as a surprise `pnpm lint` red, and so it is not left red for the next person.
+
+### A fifth mirror (gate finding W1), folded into this PR
+`AuthorityKindDescriptor.capability` is typed **bare `string`** (`authority-kind.types.ts:77`), and `check-authority-kind-mirror.mjs` pins those strings only against the `docs/` table — never against `CoreCapabilityValues`. Today that is defensible because the names are not well-known. **After this change they are**, and a typo (`'AvailabiltyAuthority'`) would type-check, pass both mirror scripts, and silently disable the A1 gate — the exact silent-degradation shape #2351 shipped its script to close.
+
+It ships as a **spec**, not as an edit to `check-authority-kind-mirror.mjs`, which REVIEW H8a assigns to #2311.
+
+### `returns-authority-dispatch.spec.ts` names this issue and is unaffected
+Its header says it is "a spec that BREAKS when a later wave (`W3a-14`) wires dispatch" for `ReturnsAuthority`. `W3a-14` is this issue, and this issue does **not** wire `ReturnsAuthority` dispatch — it adds two unrelated names. The spec keeps passing. **Assumption**: the forward reference is approximate and its comment is left untouched; correcting it would edit a file whose subject is another wave's decision. Flagged rather than silently rewritten.
+
+### Are the two new values advertised-without-dispatch?
+**No.** Both are dispatch names by construction: each is already the registry key `AUTHORITY_KIND_DESCRIPTORS` names as the gate for its authority (A1 `availability`, A3 `fulfillment-execution`), and each is the key a caller will pass to `getCapabilityAdapter(connectionId, 'X')` once its port and adapter exist. Advertised-without-dispatch is the opposite posture — a name in a manifest that must only ever be reached by narrowing a dispatched adapter with an `is*` guard. Nothing here routes either through a guard, and nothing adds either to any manifest.
+
+### Assumption: no operator can assign these today, and that is correct for this slice
+`ConnectionService` validates a written `enabledCapabilities` name against the resolved adapter's `supportedCapabilities`, and no shipped manifest advertises either. So the names round-trip through the closed union (making them writable in principle, per #2351's reasoning about `@IsIn`) while remaining unassignable in practice until an adapter declares one. This is the same reachability posture `ReturnsAuthority` has today, recorded in `architecture-overview.md` § Capability Abstractions.
+
+### The #2085 stamped-`enabledCapabilities` trap does not fire here
+`enabledCapabilities` is stamped at connection-create and never retro-filled, so *gating live behaviour* on a new name drains nothing for existing connections. This change gates nothing: it adds vocabulary, and no code path reads either name at runtime. Should a later wave gate on one, the migration/backfill question is that wave's and must be raised then.
+
+### Documentation gap
+`architecture-overview.md` § Capability Abstractions describes the closed set in prose but states no total, so no stale count needs updating there. Every count this plan or the PR states is scoped **"after this change"** rather than "now".
+
+---
+
+## 6. Proposed Implementation Plan
+
+### Phase 1 — Core (the authoritative declaration)
+
+1. **Add the two members to `CoreCapabilityValues`**
+   - **File**: `libs/core/src/integrations/domain/types/adapter.types.ts`
+   - **Action**: append `'AvailabilityAuthority'` and `'FulfillmentExecutor'` after `'ReturnsAuthority'`, each with a comment naming its ADR-052 authority row, its `AUTHORITY_KIND_DESCRIPTORS` gate, and the issue. Record the `FulfillmentRouter` deferral in the declaration's **JSDoc**, not inside the array literal — a note below the last member reads as if it describes whichever value is appended next, and the array body is reproduced verbatim in the plugin-author guide, where a deferral rationale is noise. Cite the `ModifiedProductLister` (#2220) precedent. Appending (rather than inserting) keeps every mirror's diff to an append too.
+   - **Acceptance**: `CoreCapabilityValues.length === 12`.
+
+2. **Update the exact-array spec**
+   - **File**: `libs/core/src/integrations/domain/types/__tests__/adapter.types.spec.ts`
+   - **Action**: extend the `toEqual([...])` literal with the two values and their provenance comments.
+   - **Acceptance**: fails if a value is added, removed or reordered without editing it.
+
+3. **Add the `MasterReservationWriter` absence spec** (gate finding W2)
+   - **File**: `libs/core/src/integrations/domain/types/__tests__/master-reservation-writer-absence.spec.ts` (new)
+   - **Action**: assert the name is absent from (i) `CoreCapabilityValues` and (ii) every **imported** adapter manifest's `supportedCapabilities` — importing the manifest constants as values (`allegroAdapterManifest`, `prestashopAdapterManifest`, `erliAdapterManifest`, …), **never** a filesystem string scan. Carry a **positive control**: a fabricated manifest the assertion is proven to reject, so a broken predicate cannot pass vacuously. Header points at #2315 and ADR-061, and names `libs/core/src/inventory/domain/ports/inventory-master.port.ts` as the **one legitimate mention** so a later reader does not "tighten" this into a string scan.
+   - **Why not a string scan**: the literal already appears in prose at `inventory-master.port.ts:166` and `:189` — the ADR-061 docblock that *records* the deferral. A naive scan is red on day one and gets "fixed" by weakening, which is how a mirror becomes a no-op.
+
+4. **Add the descriptor-capability pin** (gate finding W1)
+   - **File**: `libs/core/src/integrations/domain/types/__tests__/authority-kind-capability-pin.spec.ts` (new)
+   - **Action**: for every `AUTHORITY_KIND_DESCRIPTORS` entry whose `capability !== 'config-only'`, assert the value is a member of `CoreCapabilityValues`. Carry a positive control proving the predicate rejects a typo'd name.
+   - **Cross-context note**: a spec may import two contexts; this adds no runtime edge and no `check-cross-context-imports` violation (verify).
+   - **Acceptance**: green now; red on a deliberate `'AvailabiltyAuthority'` typo.
+
+### Phase 2 — Frontend mirrors
+
+5. **Mirror 1 — `CORE_CAPABILITY_VALUES`**
+   - **File**: `apps/web/src/features/connections/api/connections.types.ts`
+   - **Action**: append the same two values, same order, with abbreviated comments in the FE house style already used there.
+
+6. **Mirror 2 — `CAPABILITY_HELP`**
+   - **File**: `apps/web/src/features/connections/lib/capability-metadata.ts`
+   - **Action**: one operator-facing sentence per new value, in array order, saying what the connection *decides* (matching its ADR-052 authority). The record is typed `Record<CoreCapability, string>`, so a missing key is a type error **once mirror 1 carries the member** — which is why both must land together.
+
+### Phase 3 — Documentation mirrors
+
+7. **Mirror 3 — the fenced capability table** (`docs/capabilities.md`, between `<!-- core-capabilities:start -->` and `:end`): two rows in array order, first cell a backticked identifier.
+
+8. **Mirror 4 — the plugin-author guide verbatim quote** (`docs/plugin-author-guide.md`, `scripts/check-plugin-guide-quotes.mjs`): replace the fenced block verbatim; update the link text `adapter.types.ts:23-52` → the new range; update `sourceStart` / `sourceEnd` / `guideLinkSubstring`. The range is **read off the file after step 1**, never guessed.
+
+### Phase 4 — Red-first verification (the point of the exercise)
+
+9. **Prove each mirror fails, in both directions, for the right reason**
+   - For each mirror: apply a temporary drift, run the specific check, capture exit code **and the first stderr line**, revert. Two directions each:
+     - *core-has / mirror-lacks*: delete one new value from the mirror.
+     - *mirror-has / core-lacks*: add a fabricated `'FabricatedCapability'` to the mirror.
+   - Plus an **order** drift on the three `check-core-capability-mirror.mjs` mirrors, whose rule includes order.
+   - Plus W1 red-first: a typo'd descriptor capability. Plus W2 red-first: the name added to a manifest fixture.
+   - **Beware a red for the wrong reason.** A failing check must **name the drifted value** in its output. A red that is a parse failure, a `TS6133`, or `Tests: 0 total` is **not** evidence (#2390's first attempt) — record the message, not just the code.
+   - **Re-verify the script's own guards after the edit** rather than carrying the pre-change reading forward: `check-core-capability-mirror.mjs --self-check` still exits 0 (it exercises drifted fixtures including a **renamed declaration**, which must be fatal not vacuous); all four locate-failures still `push(fatal)` → `exit(1)`; both parsers still match whole tokens (quoted literals; `` /^`[A-Za-z][A-Za-z0-9]*`$/ ``) with no substring `includes` on an identifier.
+   - **Artifact**: a red-first evidence table in the PR body — mirror × direction × exit code × first stderr line.
+
+### Phase 5 — Quality gate
+
+10. `pnpm lint` (includes `check:invariants`, expected **35** steps after #2390), `pnpm type-check`, `pnpm test`, then **separately** `pnpm test:integration`. Never unit and integration concurrently. Node 22.
+
+### Implementation details
+
+**New components**: three spec files. Nothing else is created.
+**Configuration changes**: none. **Migrations**: none. **Events**: none. **Error handling**: none — no runtime path is added.
+
+---
+
+## 7. Alternatives Considered
+
+### Alternative 1: ship all three values as the issue's AC says (10 → 13)
+- **Why rejected**: `FulfillmentRouter` gates nothing and can gate nothing while A2 is `'config-only'`. Landing it makes the array's own stated entry rule untrue of one of its members and invites a later gate that silently does nothing (#2085 / #2220). See §5.
+
+### Alternative 2: land the values together with their ports (fold #2391 in)
+- **Why rejected**: `libs/core/src/fulfillment/**` is owned by a concurrent sibling agent (#2391). Two agents editing one directory produces a merge conflict at best and a silently-lost interface at worst. The value and the interface are genuinely separable, so splitting costs nothing.
+- **Trade-off**: the tree carries two capability names with no port for the duration of the wave — the same state `ReturnsAuthority` has been in since #2351, explicitly by design.
+
+### Alternative 3: a new mirror script per new capability
+- **Why rejected**: two guards on one fact can disagree — the rule `check-core-capability-mirror.mjs`'s own header states about `docs/plugin-author-guide.md`. The existing script is data-driven over the array and needs **no edit at all** to cover two more values.
+
+### Alternative 4: insert the values beside semantically related neighbours rather than appending
+- **Why rejected**: order is part of the mirror contract, so an insertion forces a reordering diff in four places and makes every red-first drift harder to attribute. Semantic grouping is served by the per-entry comments, as `Invoicing` / `Fiscalization` / `ReturnsAuthority` already read.
+
+---
+
+## 8. Validation & Risks
+
+### Architecture compliance
+- ✅ No CORE ↔ Integration boundary crossed. CORE publishes vocabulary; integrations declare support.
+- ✅ `as const` + derived union, per `engineering-standards.md § Union Types`.
+- ✅ Types stay in a `*.types.ts` file. No new `any`, no `console.log`, no framework import in the domain layer.
+
+### Risks
+
+| Risk | Mitigation |
+|---|---|
+| **Mirror 4 forgotten** — the verbatim quote and its three pinned line-range spots | `check-plugin-guide-quotes.mjs` fails loudly on a length mismatch and runs under `check:invariants`. Named as an explicit plan step, not left to discovery. |
+| **W2 spec red on day one** — the ADR-061 docblock legitimately names the string | Predicate is manifest-and-array membership, never a string scan. Comment names the port file as the one legitimate mention. |
+| **A stale total in prose** — three stale counts were found during Wave 2 integration, each correct when written | Every count is scoped *"12 after this change"*, never *"12 today"*. `architecture-overview.md` states no total. |
+| **Red-for-the-wrong-reason** — #2390's first attempt went red on `TS6133` with `Tests: 0 total` | Record the first stderr line per drift, not the exit code alone. A red that does not name the drifted value is discarded and retried. |
+| **A silently no-op mirror** — the #2673 shape (renamed declaration reads as "pending" not "broken") | All four locate-failures are fatal and `--self-check` exercises a renamed declaration. **Re-verified after the change**, not assumed. |
+| **Routing a name through the registry before its port exists** | Nothing here calls `getCapabilityAdapter` / `listCapabilityAdapters`. If a later wave does so early, `dispatchCapability` throws a generic `Error` and, in the list path, aborts the whole listing. Recorded so the next wave knows. |
+| **Integration-suite ripple** — a manifest capability change ripples into routing int-specs | No manifest changes, so the ripple should be nil. Full integration suite run anyway. |
+| **Concurrent sibling agents** | File list is disjoint from #2391's (`libs/core/src/fulfillment/**`, `check-no-injection-contracts.mjs`) and #2404's (shared port-contract test kit). W1 ships as a spec in `integrations/`, so `check-authority-kind-mirror.mjs` (#2311) is untouched. |
+
+### Edge cases
+- **A plugin already registering one of these strings out of tree**: harmless. `supportedCapabilities` is `string[]` and open (#576); the name simply becomes a well-known one.
+- **An existing connection carrying one of the names in `enabledCapabilities`**: impossible today — `ConnectionService` validates against the adapter's advertised list and nothing advertises them.
+
+### Backward compatibility
+✅ Additive. The union widens, so every existing narrowing still compiles; no member removed or renamed; no persisted value changes meaning. `@IsIn(CoreCapabilityValues)` on both connection DTOs widens its accepted set.
+
+---
+
+## 9. Testing Strategy & Acceptance Criteria
+
+### Unit tests
+- `adapter.types.spec.ts` — updated exact-array assertion (order-sensitive).
+- `master-reservation-writer-absence.spec.ts` — new; positive control + array/manifest membership.
+- `authority-kind-capability-pin.spec.ts` — new; positive control + every non-`config-only` descriptor capability is a registry member.
+
+### Integration tests
+None added. The full suite is **run** because a capability-vocabulary change historically ripples into routing int-specs (`docs/lessons.md`).
+
+### Invariant checks (the real test surface)
+- `check-core-capability-mirror.mjs` — three mirrors, membership **and** order, both directions, plus `--self-check`.
+- `check-plugin-guide-quotes.mjs` — mirror 4, line-by-line.
+- `pnpm check:invariants` — expected 35 steps.
+
+### Acceptance criteria
+- [ ] `CoreCapabilityValues` holds **12** members; the two new ones are `AvailabilityAuthority` and `FulfillmentExecutor`.
+- [ ] `FulfillmentRouter` is a member of **no** capability list (core array, FE union, docs table, plugin-guide quote) and is resolved by no call site; it appears only in comments recording its deferral, plus this plan.
+- [ ] Exact-array spec updated and order-sensitive.
+- [ ] `MasterReservationWriter` asserted absent from every manifest and every capability list, by membership not string scan, with a header pointing at #2315.
+- [ ] Every non-`config-only` `AUTHORITY_KIND_DESCRIPTORS` capability is pinned to a registry member.
+- [ ] `CAPABILITY_HELP` exhaustive — a missing string is a type error.
+- [ ] All four mirrors + both new specs fail on a deliberate drift in **both** directions, with the failure naming the drifted value; evidence recorded per mirror per direction.
+- [ ] `docs/capabilities.md` fenced table and the plugin-guide quote updated.
+- [ ] `pnpm lint` / `pnpm type-check` / `pnpm test` / `pnpm test:integration` all pass (known pre-existing: #2638 `earliest-order-date`, #2639 `allegro-prestashop-carrier-mapping`).
+- [ ] No file under `libs/core/src/fulfillment/`, `scripts/check-no-injection-contracts.mjs`, `scripts/check-authority-kind-mirror.mjs`, or the shared port-contract test kit is touched.
+
+---
+
+## 10. Alignment Checklist
+
+- [x] Follows hexagonal architecture — domain types only, no layer crossed
+- [x] Respects CORE vs Integration boundaries
+- [x] Uses existing patterns — #2351's shape verbatim; no new abstraction, no new script
+- [x] Idempotency / events / rate limits — N/A, no runtime path
+- [x] Error handling — N/A; the one throw-adjacent hazard (dispatch with no port) is documented in §8
+- [x] Testing strategy complete — unit + four invariant checks + red-first evidence per direction
+- [x] Naming conventions followed; file structure matches standards
+- [x] Plan is execution-ready and saved as a markdown file
+
+---
+
+## Related Documentation
+
+- [Architecture Overview § Capability Abstractions](../architecture-overview.md#capability-abstractions-business-roles)
+- [Engineering Standards § Union Types](../engineering-standards.md#union-types-as-const-pattern-default)
+- [`docs/capabilities.md`](../capabilities.md)
+- ADR-052 (independently assignable fulfilment authorities), ADR-053, ADR-054, ADR-055, ADR-061 (`MasterReservationWriter` deferral), ADR-062

--- a/docs/plugin-author-guide.md
+++ b/docs/plugin-author-guide.md
@@ -69,7 +69,7 @@ port interfaces in `libs/core/src/<context>/domain/ports/`. An adapter
 implements one or more of them.
 
 The well-known set is `CoreCapabilityValues`, declared verbatim at
-[`libs/core/src/integrations/domain/types/adapter.types.ts:23-52`](../libs/core/src/integrations/domain/types/adapter.types.ts#L23-L52):
+[`libs/core/src/integrations/domain/types/adapter.types.ts:38-77`](../libs/core/src/integrations/domain/types/adapter.types.ts#L38-L77):
 
 ```typescript
 export const CoreCapabilityValues = [
@@ -101,6 +101,16 @@ export const CoreCapabilityValues = [
   // `ReturnsAuthority` yet, so A5 cannot resolve to a non-OpenLinker holder until an
   // adapter declares it.
   'ReturnsAuthority',
+  // Availability read authority (ADR-052 A1 / #2403): who answers "how many can
+  // I sell?" for a connection. `AUTHORITY_KIND_DESCRIPTORS.availability.capability`
+  // names this string as A1's gate, so it is resolved by narrowing a dispatched
+  // adapter — a dispatch name, not an advertised-without-dispatch one. No shipped
+  // manifest advertises it yet, so it stays unassignable until one does.
+  'AvailabilityAuthority',
+  // Fulfilment execution authority (ADR-052 A3 / #2403): who holds a work object
+  // and is allowed to act on it. `AUTHORITY_KIND_DESCRIPTORS['fulfillment-execution']
+  // .capability` names this string as A3's gate. Same posture as A1 above.
+  'FulfillmentExecutor',
 ] as const;
 ```
 

--- a/libs/core/src/integrations/domain/types/__tests__/adapter.types.spec.ts
+++ b/libs/core/src/integrations/domain/types/__tests__/adapter.types.spec.ts
@@ -33,6 +33,12 @@ describe('adapter.types', () => {
         'Fiscalization',
         // Returns disposition authority (#2351, ADR-052)
         'ReturnsAuthority',
+        // Availability read authority — ADR-052 A1 (#2403)
+        'AvailabilityAuthority',
+        // Fulfilment execution authority — ADR-052 A3 (#2403)
+        'FulfillmentExecutor',
+        // NOTE: 'FulfillmentRouter' (A2) is deliberately absent while A2 is
+        // `config-only` — see the declaration's own comment for why.
       ]);
     });
   });

--- a/libs/core/src/integrations/domain/types/__tests__/authority-kind-capability-pin.spec.ts
+++ b/libs/core/src/integrations/domain/types/__tests__/authority-kind-capability-pin.spec.ts
@@ -1,0 +1,75 @@
+/**
+ * Authority-Kind Capability Pin (#2403, readiness-gate finding W1)
+ *
+ * `AUTHORITY_KIND_DESCRIPTORS` names, per authority, the adapter capability
+ * that gates it — or the literal `'config-only'` where no capability does.
+ * `AuthorityKindDescriptor.capability` is typed bare `string`, and
+ * `scripts/check-authority-kind-mirror.mjs` pins those strings only against the
+ * table in `docs/`, never against the registry. That was defensible while the
+ * names were not well-known.
+ *
+ * Since #2403 two of them ARE well-known (`AvailabilityAuthority` for A1,
+ * `FulfillmentExecutor` for A3), so a typo — `'AvailabiltyAuthority'` — would
+ * type-check, satisfy BOTH existing mirror scripts, and silently disable the
+ * gate it was supposed to name. Nothing would fail; the authority would simply
+ * never resolve. This spec closes that by asserting the one relationship
+ * neither script owns: every gating capability is a real registry member.
+ *
+ * Deliberately a SPEC and not a clause in `check-authority-kind-mirror.mjs` —
+ * REVIEW H8a assigns that script's evolution to #2311, and two guards on one
+ * fact can disagree.
+ *
+ * `'config-only'` is exempt BY DESIGN, not by omission: it is the sentinel for
+ * "no adapter capability gates this authority" (A2 sourcing, A4 order-lifecycle,
+ * A6 refund-trigger), and `resolveAuthorities` branches on that exact literal to
+ * skip the `supportedCapabilities` gate. Asserting it were a registry member
+ * would be asserting the opposite of what it means.
+ *
+ * @module libs/core/src/integrations/domain/types/__tests__
+ */
+import { AUTHORITY_KIND_DESCRIPTORS } from '@openlinker/core/fulfillment-authority';
+
+import { CoreCapabilityValues } from '../adapter.types';
+
+/** The sentinel meaning "no adapter capability gates this authority". */
+const CONFIG_ONLY = 'config-only';
+
+/** The predicate under test, lifted so the positive control can exercise it. */
+function isGatedByRegistryMember(capability: string): boolean {
+  return (
+    capability === CONFIG_ONLY || (CoreCapabilityValues as readonly string[]).includes(capability)
+  );
+}
+
+describe('AUTHORITY_KIND_DESCRIPTORS capability pin', () => {
+  it('should have a detector that actually detects (positive control)', () => {
+    // Without this, a predicate broken by a later edit would make the sweep
+    // below pass vacuously.
+    expect(isGatedByRegistryMember('AvailabilityAuthority')).toBe(true);
+    expect(isGatedByRegistryMember(CONFIG_ONLY)).toBe(true);
+    // The exact defect this spec exists to catch: a one-character typo.
+    expect(isGatedByRegistryMember('AvailabiltyAuthority')).toBe(false);
+    expect(isGatedByRegistryMember('')).toBe(false);
+  });
+
+  it('should sweep every declared authority kind (guard against an empty sweep)', () => {
+    expect(Object.keys(AUTHORITY_KIND_DESCRIPTORS).length).toBeGreaterThan(0);
+  });
+
+  it('should name only real core capabilities as gates', () => {
+    const offenders = Object.entries(AUTHORITY_KIND_DESCRIPTORS)
+      .filter(([, descriptor]) => !isGatedByRegistryMember(descriptor.capability))
+      .map(([kind, descriptor]) => `${kind} -> '${descriptor.capability}'`);
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('should still gate at least one authority on a real capability', () => {
+    // If every row degraded to 'config-only', the assertion above would pass
+    // while pinning nothing at all.
+    const gated = Object.values(AUTHORITY_KIND_DESCRIPTORS).filter(
+      (descriptor) => descriptor.capability !== CONFIG_ONLY,
+    );
+    expect(gated.length).toBeGreaterThan(0);
+  });
+});

--- a/libs/core/src/integrations/domain/types/adapter.types.ts
+++ b/libs/core/src/integrations/domain/types/adapter.types.ts
@@ -19,6 +19,21 @@ import type { ConnectionRateLimit } from '@openlinker/core/identifier-mapping';
  * `AdapterMetadata.supportedCapabilities`, which is the source of truth for
  * "is this capability supported?", regardless of whether the name appears
  * in `CoreCapabilityValues`.
+ *
+ * A name enters this array iff a call site resolves it BY CONNECTION ID through
+ * `getCapabilityAdapter`. That rule is why `'FulfillmentRouter'` (ADR-052 A2,
+ * sourcing) is deliberately absent: A2 is declared `capability: 'config-only'`
+ * in `fulfillment-authority/domain/types/authority-kind.types.ts`, because
+ * ADR-054/ADR-055 ship the router as a connection-backed plugin — candidacy is
+ * configuration rather than a narrowed capability, and `resolveAuthorities`
+ * skips the `supportedCapabilities` gate entirely for it. Landing the name
+ * early would not be merely inert: an advertised name INVITES a later gate, and
+ * because `enabledCapabilities` is stamped at connection-create and never
+ * retro-filled (#2085), that gate would silently drain nothing for every
+ * connection that already exists. This is exactly why #2220 kept
+ * `ModifiedProductLister` out of this array and out of every manifest. The name
+ * is re-admitted by whichever wave takes A2 off `'config-only'`; #2403 is the
+ * record until then.
  */
 export const CoreCapabilityValues = [
   'ProductMaster',
@@ -49,6 +64,16 @@ export const CoreCapabilityValues = [
   // `ReturnsAuthority` yet, so A5 cannot resolve to a non-OpenLinker holder until an
   // adapter declares it.
   'ReturnsAuthority',
+  // Availability read authority (ADR-052 A1 / #2403): who answers "how many can
+  // I sell?" for a connection. `AUTHORITY_KIND_DESCRIPTORS.availability.capability`
+  // names this string as A1's gate, so it is resolved by narrowing a dispatched
+  // adapter — a dispatch name, not an advertised-without-dispatch one. No shipped
+  // manifest advertises it yet, so it stays unassignable until one does.
+  'AvailabilityAuthority',
+  // Fulfilment execution authority (ADR-052 A3 / #2403): who holds a work object
+  // and is allowed to act on it. `AUTHORITY_KIND_DESCRIPTORS['fulfillment-execution']
+  // .capability` names this string as A3's gate. Same posture as A1 above.
+  'FulfillmentExecutor',
 ] as const;
 
 /**

--- a/scripts/check-core-capability-mirror.mjs
+++ b/scripts/check-core-capability-mirror.mjs
@@ -97,10 +97,19 @@ export function parseCapabilityValues(content, name) {
   if (!declMatch) return null;
 
   const openBracket = declMatch.index + declMatch[0].length - 1;
-  const closeBracket = content.indexOf(']', openBracket);
+
+  // Comments are stripped BEFORE the closing bracket is located, not after.
+  // Locating it first (`indexOf(']', openBracket)` on raw text) truncated the
+  // array at any `]` that appeared inside an entry's comment — and an annotated
+  // entry legitimately carries one, e.g. `AUTHORITY_KIND_DESCRIPTORS['x']`. The
+  // members after that point vanished from the parse, so the script reported
+  // every mirror as carrying a value "MISSING from core" and pointed the reader
+  // at three innocent mirrors instead of the one comment at fault (#2403).
+  const strippedRest = stripComments(content.slice(openBracket + 1));
+  const closeBracket = strippedRest.indexOf(']');
   if (closeBracket === -1) return null;
 
-  const body = stripComments(content.slice(openBracket + 1, closeBracket));
+  const body = strippedRest.slice(0, closeBracket);
 
   const values = [];
   const literalRe = /'([^']*)'|"([^"]*)"/g;
@@ -385,6 +394,28 @@ function selfCheck() {
     'ProductMaster,ReturnsAuthority'
   );
   expect('reports the declaration line', parsed?.line, 2);
+
+  // Regression: a `]` inside an entry's comment must not truncate the parse.
+  // Before #2403 this returned 'ProductMaster' only, and the resulting error
+  // blamed every mirror for a value that core "lacked".
+  expect(
+    'is not truncated by a bracket inside a comment',
+    parseCapabilityValues(
+      arrayFile(
+        CORE_DECLARATION,
+        "  'ProductMaster',\n  // gated by DESCRIPTORS['fulfillment-execution']\n  'FulfillmentExecutor',"
+      ),
+      CORE_DECLARATION
+    )?.values.join(','),
+    'ProductMaster,FulfillmentExecutor'
+  );
+
+  // ...and an array that is genuinely never closed still returns null.
+  expect(
+    'unclosed array → null',
+    parseCapabilityValues("export const " + CORE_DECLARATION + " = [\n  'ProductMaster',\n", CORE_DECLARATION),
+    null
+  );
   expect(
     'selects the requested declaration, not the first one',
     parseCapabilityValues(

--- a/scripts/check-core-capability-mirror.mjs
+++ b/scripts/check-core-capability-mirror.mjs
@@ -410,9 +410,13 @@ function selfCheck() {
     'ProductMaster,FulfillmentExecutor'
   );
 
-  // ...and an array that is genuinely never closed still returns null.
+  // ...and an array with no closing bracket ANYWHERE AFTER IT returns null.
+  // Note the honest limit: neither this parser nor its predecessor tracks
+  // nesting, so an unclosed array followed later in the file by an unrelated
+  // `]` still mis-parses rather than returning null. That is unchanged
+  // behaviour, and no declaration in this repo has a nested array.
   expect(
-    'unclosed array → null',
+    'unclosed array with nothing after it → null',
     parseCapabilityValues("export const " + CORE_DECLARATION + " = [\n  'ProductMaster',\n", CORE_DECLARATION),
     null
   );

--- a/scripts/check-plugin-guide-quotes.mjs
+++ b/scripts/check-plugin-guide-quotes.mjs
@@ -6,7 +6,7 @@
  * stay in sync with the live code:
  *
  *   1. **Verbatim quote** of `CoreCapabilityValues` at
- *      `libs/core/src/integrations/domain/types/adapter.types.ts:23-52`,
+ *      `libs/core/src/integrations/domain/types/adapter.types.ts:38-77`,
  *      reproduced inline in the guide as a fenced TypeScript block.
  *      Drift = the guide quotes stale capability values; readers code
  *      against a list that no longer matches the registry.
@@ -48,9 +48,9 @@ const VERBATIM_QUOTES = [
   {
     label: 'CoreCapabilityValues',
     sourceFile: 'libs/core/src/integrations/domain/types/adapter.types.ts',
-    sourceStart: 23, // 1-indexed
-    sourceEnd: 52,
-    guideLinkSubstring: 'adapter.types.ts:23-52',
+    sourceStart: 38, // 1-indexed
+    sourceEnd: 77,
+    guideLinkSubstring: 'adapter.types.ts:38-77',
     fenceOpen: '```typescript',
   },
 ];


### PR DESCRIPTION
Wave 3a (epic #2412), stream S2. Refs #2403 — **not** `Closes`, since the issue's AC is being amended by the requester (see below) and the wave epic tracks closure.

Base is `oms-programme-wave-3a`, **not** `main`.

## What this does

Adds the two OMS dispatch capability names the tree can actually dispatch — `AvailabilityAuthority` (ADR-052 A1) and `FulfillmentExecutor` (A3) — and keeps every hand-maintained mirror of `CoreCapabilityValues` in lock-step.

## Why this is 10 → 12, not the 10 → 13 the issue predicted

The readiness gate read the tree and found the third name fails the entry rule the array exists to carry — *a name enters `CoreCapabilityValues` iff a call site resolves it by connection id through `getCapabilityAdapter`*.

- `AvailabilityAuthority` — already the A1 gate string at `authority-kind.types.ts:97`. Dispatch name. ✅
- `FulfillmentExecutor` — already the A3 gate string at `authority-kind.types.ts:114`. Dispatch name. ✅
- `FulfillmentRouter` — **zero occurrences anywhere in the repo**, and A2 (`sourcing`) is declared `capability: 'config-only'` (`authority-kind.types.ts:106`) with its reason stated in place: *"per ADR-054/ADR-055 the router ships as a connection-backed plugin, so the candidate set is configuration rather than a narrowed capability."* `resolveAuthorities` consumes that literal at `authority-resolution.types.ts:303-304` and **skips the `supportedCapabilities` gate entirely** for A2. No call site can pass the name to `getCapabilityAdapter`.

Landing it early would not be merely inert. **An advertised name invites a later gate**, and because `enabledCapabilities` is stamped at connection-create and never retro-filled (#2085), that gate would silently drain nothing for every connection that already exists. That is precisely why **#2220 kept `ModifiedProductLister` out of this array and out of every manifest**, accepting a discoverability cost to avoid exactly this.

**Rejected: flipping A2 to `capability: 'FulfillmentRouter'`.** It is a live regression — `resolveAuthorities` would start gating A2 on `supportedCapabilities`, no shipped manifest advertises the name, so every existing A2 sourcing claim would stop resolving on the already-shipped who-decides page (#2353/#2354). It also edits `fulfillment-authority`, adjacent to #2391. If ever wanted, it is its own issue with its own migration question.

The requester owns #2403's text and is amending its AC to 10 → 12 with this reasoning, so this PR should not read as an omission.

**Readiness-gate verdict** (`NEEDS-REVISION` → resolved): the harness blocked writing the report to `docs/plans/analysis/`, so it is recorded here instead. One Critical (the above, adjudicated), two Warnings (W1/W2, both folded in below). No migration, no barrel removal, no DTO break, no manifest change.

## Neither new name is advertised-without-dispatch

Both are dispatch names by construction — each is already the registry key `AUTHORITY_KIND_DESCRIPTORS` names as its authority's gate. Nothing here adds either to a manifest or routes either through an `is*` guard, so no adapter can be assigned one yet; same reachability posture `ReturnsAuthority` has today.

## Consumers updated (five, two of which the issue does not name)

| # | Mirror | File |
|---|---|---|
| 1 | Exact-array spec | `libs/core/.../__tests__/adapter.types.spec.ts` |
| 2 | FE union `CORE_CAPABILITY_VALUES` | `apps/web/.../connections/api/connections.types.ts` |
| 3 | `CAPABILITY_HELP` | `apps/web/.../connections/lib/capability-metadata.ts` |
| 4 | Fenced table | `docs/capabilities.md` |
| 5 | **Verbatim quote + pinned line range** | `docs/plugin-author-guide.md` + `scripts/check-plugin-guide-quotes.mjs` (`23-52` → `38-77`, in three places) |

Mirror 5 is not in the issue's file list. It fails loudly on a length mismatch so it cannot drift silently — but it would have been a surprise `pnpm lint` red for the next person.

## Two new guards

**W1 — `authority-kind-capability-pin.spec.ts`.** `AuthorityKindDescriptor.capability` is typed bare `string`, and `check-authority-kind-mirror.mjs` pins those strings only against the `docs/` table, never against the registry. Now that two of them are well-known names, a typo (`'AvailabiltyAuthority'`) would type-check, pass **both** existing mirror scripts, and silently disable the A1 gate. Ships as a **spec**, not an edit to `check-authority-kind-mirror.mjs`, which REVIEW H8a assigns to #2311. `'config-only'` is exempt by design (it is the sentinel meaning *no capability gates this*).

**W2 — `master-reservation-writer-absence.spec.ts`.** Asserts the #2315 / ADR-061 deferral appears in no manifest and no capability list. It asserts **membership over imported manifests**, never a string scan: the literal already appears in prose at `inventory-master.port.ts:166`/`:189` — the docblock that *records* the deferral — so a scan would be red on day one and get "fixed" by weakening. Lives in `apps/api` because `libs/core` may not depend on an integration package.

## A latent defect in `check-core-capability-mirror.mjs`, found by using it

The parser located the array's closing `]` on **raw** text and stripped comments afterwards, so any `]` inside an entry's comment truncated the parse. My A3 comment cites `AUTHORITY_KIND_DESCRIPTORS['fulfillment-execution']` — the script then reported all three mirrors as carrying a value "MISSING from core" and pointed the reader at three innocent files instead of the one comment at fault. Fixed by stripping first; `--self-check` gains a bracket-in-comment regression fixture and an unclosed-array fixture.

**Guard-of-the-guard:** reverting that fix makes `--self-check` exit 1. Verified.

## Red-first evidence (per mirror, per direction)

Every failure **names the drifted value** — an exit code alone was not accepted as evidence.

| Drift | Exit | First detail line |
|---|---|---|
| M1 FE union LACKS | 1 | `present in core but MISSING from the …connections.types.ts CORE_CAPABILITY_VALUES: 'FulfillmentExecutor'` |
| M1 FE union EXTRA | 1 | `present in the …CORE_CAPABILITY_VALUES but MISSING from core: 'FabricatedCapability'` |
| M1 FE union ORDER | 1 | `same values but different order (core: … / mirror: …)` |
| M2 `CAPABILITY_HELP` LACKS | 1 | `present in core but MISSING from the …capability-metadata.ts CAPABILITY_HELP: 'FulfillmentExecutor'` |
| M2 `CAPABILITY_HELP` EXTRA | 1 | `present in the …CAPABILITY_HELP but MISSING from core: 'FabricatedCapability'` |
| M3 docs table LACKS | 1 | `present in core but MISSING from the docs/capabilities.md capability table: 'FulfillmentExecutor'` |
| M3 docs table EXTRA | 1 | `present in the docs/capabilities.md capability table but MISSING from core: 'FabricatedCapability'` |
| M4 guide quote LACKS | 1 | `block length mismatch — guide has 52 lines, source has 53 lines` |
| M4 guide quote ALTERED | 1 | `quote drift — source …:61 = "  'FulfillmentExecutor',", guide block line 39 = "  'FabricatedCapability',"` |
| M4 pinned range STALE | 1 | `guide is missing reference to adapter.types.ts:38-77` |
| W1 descriptor TYPO | 1 | `● … › should name only real core capabilities as gates` (1 failed, 3 passed) |
| W1 registry loses gated name | 1 | `● … › positive control` (2 failed, 2 passed) |
| W2 name added to a manifest | 1 | `● … › should be advertised by no adapter manifest` (1 failed, 3 passed) |
| W2 name added to registry | 1 | `● … › should not be a well-known core capability` (1 failed, 3 passed) |
| Guard-of-guard: revert parser fix | 1 | `✗ check-core-capability-mirror --self-check failed` |

**Two false results caught during this, both worth recording.**

*A false pass.* W2's first manifest drift returned **exit 0, 4 passed** — the spec imports built `dist`, and I had edited erli's `src` without rebuilding. For an *absence* check a stale read fails **open**. Re-run after `pnpm --dir libs/integrations/erli build` it failed correctly. The spec's header now says so, and states that CI is sound because the root `pnpm test` builds first.

*A false red-shape.* `pnpm --dir apps/api test -- --runTestsByPath <file>` makes jest treat the flag as a positional **pattern** (`Ran all test suites matching /--runTestsByPath|…/`), taking 280 s instead of being instant. Dropping the extra `--` makes `--listTests` name exactly one file. A wrong invocation that appears to work while running something else is indistinguishable from a slow pass, and a red-first check run through it proves nothing. **Correct form: `pnpm --dir <pkg> exec jest --runTestsByPath <file>` — no bare `--`.**

## Confirmed non-findings (re-verified after the change, not carried forward)

- `check-core-capability-mirror.mjs` treats every unresolvable target as `fatal` → `exit(1)`, never a skip — immune to the #2673 "declaration not found reads as pending" shape.
- `--self-check` already exercises a **renamed declaration**, which must be fatal rather than a vacuous pass. Still exits 0.
- Both parsers match **whole tokens** (quoted string literals; `` /^`[A-Za-z][A-Za-z0-9]*`$/ ``). No substring `includes` on an identifier — the #2589 shape does not occur.
- `returns-authority-dispatch.spec.ts` names `W3a-14` as the wave that wires `ReturnsAuthority` dispatch. This issue does not, so the spec still passes; its comment is left untouched rather than silently rewritten, since its subject is another wave's decision.

## Gates

| Gate | Exit |
|---|---|
| `pnpm lint` | **0** (0 errors; warnings pre-existing) |
| `pnpm type-check` | **0** |
| `pnpm test` | **0** — 19 packages + `apps/web` (447 test files), zero failures |
| `pnpm test:integration` | **`INT_EXIT=1`** |

`pnpm check:invariants` = **35** distinct checks (61 commands incl. `--self-check` pairs).

Integration: `Test Suites: 1 failed, 146 passed, 147 total` / `Tests: 1 failed, 1 skipped, 1214 passed, 1216 total`. The sole failure is the known pre-existing **#2638** `earliest-order-date` TZ defect — `Expected: "2026-02-10T00:00:00.000Z"` / `Received: "2026-02-10T01:00:00.000Z"`, a one-hour offset in a spec unrelated to capabilities. **#2639** `allegro-prestashop-carrier-mapping` passed. Full suite was run (not just the feature's specs) because a capability-vocabulary change historically ripples into routing int-specs; no manifest changed, so the ripple was nil.

## Coordination

Touches no file owned by the sibling agents: nothing under `libs/core/src/fulfillment/**` or `scripts/check-no-injection-contracts.mjs` (#2391), nothing in the shared port-contract test kit (#2404), and `scripts/check-authority-kind-mirror.mjs` (#2311) is untouched.

Base was re-fetched before opening: `HEAD..origin/oms-programme-wave-3a` = 0. #2388 is in `oms-programme-wave-2` and has not been merged up into `wave-3a`, so there was nothing to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)