### PR TITLE
feat(ui): DocumentKindGlyph and DocumentHeadline primitives

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -19809,3 +19809,104 @@ textarea.bulk-editor__input { resize: vertical; min-height: 66px; font-family: i
   color: var(--status-warning-fg);
   font-weight: 600;
 }
+
+/* ── Sales-document glyph + headline (#2535) ───────────────────────────
+   The kind is an entity axis, so the glyph inherits `currentColor` and takes
+   no tone of its own. On the headline, colour marks exceptions only: `done`
+   and `idle` stay plain ink, and every tinted state carries a second
+   non-colour signal (a tick, a live dot, or the state word itself). */
+
+.document-glyph {
+  flex: none;
+  color: inherit;
+}
+
+.document-headline {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.document-headline__main {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: 1.0625rem;
+  font-weight: 600;
+  letter-spacing: var(--tracking-tight);
+  color: var(--text-primary);
+}
+
+.document-headline__main .document-glyph {
+  width: 20px;
+  height: 20px;
+}
+
+.document-headline__word {
+  min-width: 0;
+}
+
+.document-headline__sep {
+  color: var(--text-muted);
+  font-weight: 400;
+}
+
+.document-headline__main--idle {
+  color: var(--text-muted);
+}
+
+.document-headline__main--warning {
+  color: var(--status-warning-fg);
+}
+
+.document-headline__main--error {
+  color: var(--status-error-fg);
+}
+
+/* A finished or in-flight document is not an exception, so its glyph recedes
+   and the words stay in ordinary ink. */
+.document-headline__main--done .document-glyph,
+.document-headline__main--progress .document-glyph {
+  color: var(--text-muted);
+}
+
+.document-headline__tick {
+  flex: none;
+  color: var(--status-success);
+}
+
+.document-headline__live {
+  flex: none;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--status-info);
+  animation: document-headline-pulse 1.6s var(--ease-out) infinite;
+}
+
+@keyframes document-headline-pulse {
+  0% {
+    opacity: 0.95;
+  }
+  70% {
+    opacity: 0.45;
+  }
+  100% {
+    opacity: 0.95;
+  }
+}
+
+/* The dot's tint already says "in flight"; the animation is decorative. */
+@media (prefers-reduced-motion: reduce) {
+  .document-headline__live {
+    animation: none;
+  }
+}
+
+.document-headline__sub {
+  margin: 0;
+  font-family: var(--font-mono);
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  overflow-wrap: anywhere;
+}

--- a/apps/web/src/pages/dev-ui/sections/primitives-section.tsx
+++ b/apps/web/src/pages/dev-ui/sections/primitives-section.tsx
@@ -24,6 +24,8 @@ import {
   MetricCard,
   RawPayloadPanel,
   Select,
+  DocumentHeadline,
+  DocumentKindGlyph,
   StatusBadge,
   Textarea,
 } from '../../../shared/ui';
@@ -123,6 +125,35 @@ export function PrimitivesSection(): ReactElement {
           <StatusBadge tone="error" withDot>Failed</StatusBadge>
           <StatusBadge tone="review" withDot>Needs review</StatusBadge>
           <StatusBadge solid>Draft</StatusBadge>
+        </div>
+      </Group>
+
+      <Group
+        title="DocumentKindGlyph and DocumentHeadline"
+        description="The kind is a silhouette, not a word: a folded page for an invoice, a till slip for a receipt, a struck circle where routing named neither. The glyph inherits ink and carries no tone, because kind is an entity axis and not health. On the headline colour marks exceptions only, and never alone: a finished document gets a tick, an in-flight one a live dot."
+      >
+        <div className="ds-row">
+          <DocumentKindGlyph kind="invoice" />
+          <DocumentKindGlyph kind="fiscal-receipt" />
+          <DocumentKindGlyph kind={null} />
+        </div>
+        <div className="ds-stack">
+          <DocumentHeadline
+            kind="invoice"
+            state="Issued"
+            tone="done"
+            identity="FA/2026/08/0144 · KSeF Demo"
+          />
+          <DocumentHeadline
+            kind="fiscal-receipt"
+            state="Registering"
+            tone="progress"
+            identity="e-paragony Sandbox"
+          />
+          <DocumentHeadline kind="fiscal-receipt" state="Unconfirmed" tone="warning" />
+          <DocumentHeadline kind="invoice" state="KSeF rejected" tone="error" />
+          <DocumentHeadline kind="fiscal-receipt" state="Not registered" tone="idle" />
+          <DocumentHeadline kind={null} state="No routing" tone="error" />
         </div>
       </Group>
 

--- a/apps/web/src/shared/ui/document-headline.test.tsx
+++ b/apps/web/src/shared/ui/document-headline.test.tsx
@@ -1,0 +1,66 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { DocumentHeadline } from './document-headline';
+
+describe('DocumentHeadline', () => {
+  afterEach(cleanup);
+
+  it('should read as the kind and then the state', () => {
+    render(<DocumentHeadline kind="invoice" state="Issued" tone="done" />);
+    expect(screen.getByText(/Invoice/)).toBeInTheDocument();
+    expect(screen.getByText(/Issued/)).toBeInTheDocument();
+  });
+
+  it('should say no document when routing named none', () => {
+    render(<DocumentHeadline kind={null} state="No routing" tone="error" />);
+    expect(screen.getByText(/No document/)).toBeInTheDocument();
+  });
+
+  it('should not announce the kind twice', () => {
+    // The glyph sits beside the kind word, so it must be decorative here.
+    render(<DocumentHeadline kind="fiscal-receipt" state="Registered" tone="done" />);
+    expect(screen.queryByRole('img')).toBeNull();
+  });
+
+  it('should carry a tick on a finished document, so colour is not the only signal', () => {
+    const { container } = render(<DocumentHeadline kind="invoice" state="Issued" tone="done" />);
+    expect(container.querySelector('.document-headline__tick')).not.toBeNull();
+    expect(container.querySelector('.document-headline__live')).toBeNull();
+  });
+
+  it('should carry a live dot while a document is in flight', () => {
+    const { container } = render(
+      <DocumentHeadline kind="fiscal-receipt" state="Registering" tone="progress" />,
+    );
+    expect(container.querySelector('.document-headline__live')).not.toBeNull();
+    expect(container.querySelector('.document-headline__tick')).toBeNull();
+  });
+
+  it('should leave a finished document plain, tinting only what needs attention', () => {
+    const done = render(<DocumentHeadline kind="invoice" state="Issued" tone="done" />);
+    expect(done.container.querySelector('.document-headline__main--done')).not.toBeNull();
+    cleanup();
+
+    const rejected = render(
+      <DocumentHeadline kind="invoice" state="KSeF rejected" tone="error" />,
+    );
+    expect(rejected.container.querySelector('.document-headline__main--error')).not.toBeNull();
+  });
+
+  it('should default to the plain idle tone', () => {
+    const { container } = render(<DocumentHeadline kind="invoice" state="Not issued" />);
+    expect(container.querySelector('.document-headline__main--idle')).not.toBeNull();
+  });
+
+  it('should render the identity sub-line only when there is one', () => {
+    const withIdentity = render(
+      <DocumentHeadline kind="invoice" state="Issued" tone="done" identity="FA/2026/08/0144" />,
+    );
+    expect(screen.getByText('FA/2026/08/0144')).toBeInTheDocument();
+    expect(withIdentity.container.querySelector('.document-headline__sub')).not.toBeNull();
+    cleanup();
+
+    const without = render(<DocumentHeadline kind="invoice" state="Issued" tone="done" />);
+    expect(without.container.querySelector('.document-headline__sub')).toBeNull();
+  });
+});

--- a/apps/web/src/shared/ui/document-headline.tsx
+++ b/apps/web/src/shared/ui/document-headline.tsx
@@ -1,0 +1,99 @@
+/**
+ * DocumentHeadline (#2535)
+ *
+ * One line that says what a sale's document is and where it has got to:
+ * `<glyph> Invoice · Issued`, with an optional identity sub-line carrying the
+ * number and the provider.
+ *
+ * It exists so a list row and a detail panel describe the same document in the
+ * same words. Before this each surface composed its own wording, and the same
+ * order read two different ways depending on where you looked at it.
+ *
+ * What it will not do:
+ *
+ *  - **It never derives the state word.** The caller passes the word it read
+ *    from a persisted status. This component adds no vocabulary of its own, so
+ *    it cannot invent a state the backend does not report.
+ *  - **Colour marks exceptions only.** `done` and `idle` are plain ink; only
+ *    `warning` and `error` are tinted, and never alone - `done` also carries a
+ *    tick and `progress` a live dot, so the state survives without hue.
+ *
+ * @module shared/ui
+ */
+import type { ReactElement, ReactNode } from 'react';
+import { DocumentKindGlyph, DOCUMENT_KIND_LABEL, NO_DOCUMENT_LABEL } from './document-kind-glyph';
+import type { DocumentKind } from './document-kind-glyph';
+
+/**
+ * How a document's state reads, not what it is.
+ *
+ * `tone`, not `variant`, matching every other primitive in this catalogue.
+ * Deliberately its own small union rather than `StatusBadgeTone`: a headline has
+ * a finished state (`done`) and an in-flight one (`progress`) that a badge's
+ * `success` / `info` do not distinguish, and it has no `solid` or `review`.
+ */
+export type DocumentHeadlineTone = 'idle' | 'progress' | 'done' | 'warning' | 'error';
+
+export interface DocumentHeadlineProps {
+  /** `null` when routing named no document. */
+  kind: DocumentKind | null;
+  /** The state word, read from a persisted status. e.g. `Registered`. */
+  state: ReactNode;
+  tone?: DocumentHeadlineTone;
+  /** Number, provider, or both. Rendered in the mono sub-line, or omitted. */
+  identity?: ReactNode;
+  className?: string;
+}
+
+export function DocumentHeadline({
+  kind,
+  state,
+  tone = 'idle',
+  identity,
+  className = '',
+}: DocumentHeadlineProps): ReactElement {
+  const classes = ['document-headline', className].filter(Boolean).join(' ');
+
+  return (
+    <div className={classes}>
+      <span className={`document-headline__main document-headline__main--${tone}`}>
+        {/* Decorative: the kind is the very next word. */}
+        <DocumentKindGlyph kind={kind} decorative />
+        <span className="document-headline__word">
+          {kind === null ? NO_DOCUMENT_LABEL : DOCUMENT_KIND_LABEL[kind]}
+          <span className="document-headline__sep" aria-hidden="true">
+            {' · '}
+          </span>
+          {state}
+        </span>
+        {tone === 'done' ? <DoneTick /> : null}
+        {tone === 'progress' ? (
+          <span className="document-headline__live" aria-hidden="true" />
+        ) : null}
+      </span>
+      {identity ? <p className="document-headline__sub">{identity}</p> : null}
+    </div>
+  );
+}
+
+/** The second, non-colour carrier of `done`. */
+function DoneTick(): ReactElement {
+  return (
+    <svg
+      className="document-headline__tick"
+      viewBox="0 0 12 12"
+      width="14"
+      height="14"
+      aria-hidden="true"
+    >
+      <path
+        d="M2.5 6.4 4.7 8.6 9.5 3.8"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/apps/web/src/shared/ui/document-kind-glyph.test.tsx
+++ b/apps/web/src/shared/ui/document-kind-glyph.test.tsx
@@ -1,0 +1,54 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { DocumentKindGlyph } from './document-kind-glyph';
+
+describe('DocumentKindGlyph', () => {
+  afterEach(cleanup);
+
+  it('should name itself when it renders alone', () => {
+    // Rendered without adjacent text the glyph IS the statement of the kind, so
+    // a screen reader has nothing else to go on.
+    render(<DocumentKindGlyph kind="invoice" />);
+    expect(screen.getByRole('img', { name: 'Invoice' })).toBeInTheDocument();
+  });
+
+  it('should name a receipt as a receipt', () => {
+    render(<DocumentKindGlyph kind="fiscal-receipt" />);
+    expect(screen.getByRole('img', { name: 'Fiscal receipt' })).toBeInTheDocument();
+  });
+
+  it('should name the absence of a routing decision without calling it unknown', () => {
+    render(<DocumentKindGlyph kind={null} />);
+    expect(screen.getByRole('img', { name: 'No document' })).toBeInTheDocument();
+  });
+
+  it('should hide itself from assistive technology when the kind is already stated', () => {
+    const { container } = render(<DocumentKindGlyph kind="invoice" decorative />);
+    expect(screen.queryByRole('img')).toBeNull();
+    expect(container.querySelector('svg')).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('should give each kind a different silhouette', () => {
+    // The two are told apart across a list without reading a word, so their
+    // outlines have to differ - not only their inner detail.
+    const invoice = render(<DocumentKindGlyph kind="invoice" />).container.innerHTML;
+    cleanup();
+    const receipt = render(<DocumentKindGlyph kind="fiscal-receipt" />).container.innerHTML;
+    expect(invoice).not.toBe(receipt);
+  });
+
+  it('should carry no colour of its own, because kind is not health', () => {
+    const { container } = render(<DocumentKindGlyph kind="invoice" />);
+    const svg = container.querySelector('svg');
+    expect(svg?.getAttribute('class')).toBe('document-glyph');
+    // Every stroke inherits, so the glyph can never state a status.
+    for (const stroked of Array.from(container.querySelectorAll('[stroke]'))) {
+      expect(stroked.getAttribute('stroke')).toBe('currentColor');
+    }
+  });
+
+  it('should accept an overriding accessible name', () => {
+    render(<DocumentKindGlyph kind="invoice" label="Invoice FA/2026/08/0144" />);
+    expect(screen.getByRole('img', { name: 'Invoice FA/2026/08/0144' })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/shared/ui/document-kind-glyph.tsx
+++ b/apps/web/src/shared/ui/document-kind-glyph.tsx
@@ -1,0 +1,118 @@
+/**
+ * DocumentKindGlyph (#2535)
+ *
+ * The silhouette that says WHICH sales document a row or a panel is about: a
+ * folded page for an invoice, a till slip for a fiscal receipt, and a struck
+ * circle when routing named no document at all.
+ *
+ * Three properties are load-bearing.
+ *
+ *  1. **The kind is an entity axis, never health.** The glyph inherits
+ *     `currentColor` and carries no tone of its own, so a document's kind can
+ *     never be mistaken for its state. Colour is reserved for the states that
+ *     need attention; a finished document is plain ink.
+ *  2. **The silhouettes differ in outline, not only in detail.** A list is
+ *     scanned rather than read, so the two kinds have to be separable at a
+ *     glance across several rows: a rectangle with a folded corner against a
+ *     torn-off slip.
+ *  3. **It names itself.** Rendered on its own the glyph is the only statement
+ *     of the kind, so it is an `img` with an accessible name. Beside the kind
+ *     word - which is how {@link DocumentHeadline} uses it - that name would be
+ *     read twice, so the caller marks it `decorative`.
+ *
+ * @module shared/ui
+ */
+import type { ReactElement } from 'react';
+
+/**
+ * The two sales-document kinds, mirroring `SalesDocumentKind`
+ * (`@openlinker/core/sales-documents`). `null` is not a third kind: it is the
+ * absence of a routing decision, which the surfaces render alongside the two.
+ */
+export type DocumentKind = 'invoice' | 'fiscal-receipt';
+
+/** Accessible name per kind, and for the no-decision case. */
+export const DOCUMENT_KIND_LABEL: Record<DocumentKind, string> = {
+  invoice: 'Invoice',
+  'fiscal-receipt': 'Fiscal receipt',
+};
+
+/** What the struck circle means. Not "unknown": routing reached no decision. */
+export const NO_DOCUMENT_LABEL = 'No document';
+
+export interface DocumentKindGlyphProps {
+  /** `null` renders the no-document silhouette. */
+  kind: DocumentKind | null;
+  /**
+   * Hide the glyph from assistive technology. Pass this ONLY where the kind is
+   * already stated in adjacent text, or a screen reader announces it twice.
+   */
+  decorative?: boolean;
+  /** Overrides the accessible name. Ignored when `decorative`. */
+  label?: string;
+  className?: string;
+}
+
+export function DocumentKindGlyph({
+  kind,
+  decorative = false,
+  label,
+  className = '',
+}: DocumentKindGlyphProps): ReactElement {
+  const name = label ?? (kind === null ? NO_DOCUMENT_LABEL : DOCUMENT_KIND_LABEL[kind]);
+  const classes = ['document-glyph', className].filter(Boolean).join(' ');
+  const a11y = decorative
+    ? ({ 'aria-hidden': true } as const)
+    : ({ role: 'img', 'aria-label': name } as const);
+
+  return (
+    <svg className={classes} viewBox="0 0 16 16" width="16" height="16" {...a11y}>
+      {kind === 'invoice' ? INVOICE_PATHS : null}
+      {kind === 'fiscal-receipt' ? RECEIPT_PATHS : null}
+      {kind === null ? NO_DOCUMENT_PATHS : null}
+    </svg>
+  );
+}
+
+/** A page with a folded corner and two ruled lines. */
+const INVOICE_PATHS = (
+  <>
+    <path
+      d="M3.5 1.5h6l3 3v10h-9z"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.3"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M9.5 1.5v3h3"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.3"
+      strokeLinejoin="round"
+    />
+    <path d="M5.5 8h5M5.5 10.5h5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+  </>
+);
+
+/** A till slip: straight sides, a torn zig-zag foot. */
+const RECEIPT_PATHS = (
+  <>
+    <path
+      d="M3.5 1.5h9v13l-1.5-1-1.5 1-1.5-1-1.5 1-1.5-1-1.5 1z"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.3"
+      strokeLinejoin="round"
+    />
+    <path d="M6 5.5h4M6 8.5h4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+  </>
+);
+
+/** A struck circle. Deliberately not a document outline at all. */
+const NO_DOCUMENT_PATHS = (
+  <>
+    <circle cx="8" cy="8" r="6.2" fill="none" stroke="currentColor" strokeWidth="1.3" />
+    <path d="M4.4 11.6 11.6 4.4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+  </>
+);

--- a/apps/web/src/shared/ui/index.ts
+++ b/apps/web/src/shared/ui/index.ts
@@ -67,6 +67,12 @@ export { TimeDisplay } from './time-display';
 export { MetricCard } from './metric-card';
 export { KpiCard } from './kpi-card';
 
+// ── Sales documents (#2535) ────────────────────────────────────────
+export { DocumentKindGlyph, DOCUMENT_KIND_LABEL, NO_DOCUMENT_LABEL } from './document-kind-glyph';
+export type { DocumentKind, DocumentKindGlyphProps } from './document-kind-glyph';
+export { DocumentHeadline } from './document-headline';
+export type { DocumentHeadlineProps, DocumentHeadlineTone } from './document-headline';
+
 // ── Identity / labels ──────────────────────────────────────────────
 export { EntityLabel, shortenId } from './entity-label';
 export { ProductThumbnail } from './product-thumbnail';


### PR DESCRIPTION
## What this builds

Two primitives in `apps/web/src/shared/ui`, both exported from the catalogue (`shared/ui/index.ts`) and rendered in the dev-ui primitives gallery.

**`DocumentKindGlyph`** - the silhouette that says which sales document a row or panel is about.

- `invoice` is a page with a folded corner; `fiscal-receipt` is a straight-sided slip with a torn foot; `kind={null}` is a struck circle for the case where routing named no document. The outlines differ, not only the inner detail, because a list is scanned rather than read.
- It carries **no tone**. Every stroke is `currentColor` and the only class it sets is `document-glyph`, so a document's kind can never be mistaken for its state. A spec asserts that.
- Rendered alone it is `role="img"` with an accessible name (`Invoice` / `Fiscal receipt` / `No document`). `decorative` hides it from assistive technology, for the case where the kind is already the next word. A spec covers both.

**`DocumentHeadline`** - `<glyph> Invoice · Issued`, with an optional mono identity sub-line for the number and provider.

- The state word is **passed in**, never derived. The component adds no vocabulary, so it cannot state something the backend does not report.
- `tone` (not `variant`) is its own five-value union: `idle | progress | done | warning | error`. Deliberately not `StatusBadgeTone`, which has no way to separate a finished document from an in-flight one and carries `solid` / `review` that mean nothing here.
- **Colour marks exceptions only, and never alone.** `done` and `idle` are plain ink; `done` also carries a tick, `progress` a live dot, and only `warning` and `error` are tinted. The state word itself is always present.
- The live dot's pulse is behind `prefers-reduced-motion: reduce`, matching the `status-badge--pulse` precedent.

## Decisions a reviewer may want to dispute

- **`DocumentKind` lives in `shared/ui`.** It is the two-value vocabulary the glyph switches on, mirroring `SalesDocumentKind` by hand. `shared/` may not import `features/`, so a primitive that takes a kind has to name it. It is not marketplace vocabulary, so it does not fall under the domain-agnosticism rule the `shared/` lint guards. No mirror guard script was added for it: a two-value closed union with no wire contract of its own did not seem worth a fourth parser, and the frontend already mirrors `SALES_DOCUMENT_KIND_VALUES` in `features/sales-documents`. Say if you would rather it were guarded, or moved.
- **`null` is a value of the `kind` prop rather than a separate component.** The mockup renders the no-document case in the same slot as the two kinds, with the same layout, so branching at the call site would duplicate the surrounding markup at every consumer.
- **The primitives have no product consumer yet.** They are the shared half of this mini-epic and M8 (orders cell) and M9 (order panel) are their callers. They are rendered in the dev-ui gallery so the catalogue entry is exercised rather than merely declared.

## Left out

No lifecycle trail; that is #2536. No document cell, no popover; those are #2537 and M8.

## Gate

- `pnpm --filter @openlinker/web type-check` - clean
- `pnpm exec eslint` on the seven changed paths - clean
- `pnpm check:invariants` - clean
- `pnpm exec vitest run src/shared/ui/document-kind-glyph.test.tsx src/shared/ui/document-headline.test.tsx` - 15 tests passing

The full `pnpm test` was not run locally.

Closes #2535
