### PR TITLE
feat(ui): DocumentLifecycle trail for an invoice

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -19910,3 +19910,111 @@ textarea.bulk-editor__input { resize: vertical; min-height: 66px; font-family: i
   color: var(--text-muted);
   overflow-wrap: anywhere;
 }
+
+/* ── Document lifecycle trail (#2536) ──────────────────────────────────
+   One step per persisted stage of an invoice. State is carried by the
+   marker's SHAPE as well as its tint, and each step announces its state in
+   words, so the trail survives without colour. */
+
+.document-lifecycle {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: 1fr;
+  gap: var(--space-3);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.document-lifecycle__step {
+  position: relative;
+  display: grid;
+  grid-template-rows: auto auto auto;
+  gap: 2px;
+  padding-top: var(--space-3);
+}
+
+/* The connector runs from the previous marker to this one, so the first step
+   has none to its left and the last none to its right. */
+.document-lifecycle__step::before {
+  content: '';
+  position: absolute;
+  top: 5px;
+  left: 0;
+  right: 50%;
+  height: 2px;
+  background: var(--border-subtle);
+}
+
+.document-lifecycle__step:first-child::before {
+  left: 50%;
+}
+
+.document-lifecycle__step--done::before {
+  background: var(--status-success-border);
+}
+
+.document-lifecycle__marker {
+  position: absolute;
+  top: 0;
+  left: calc(50% - 6px);
+  display: inline-grid;
+  place-items: center;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  border: 2px solid var(--border-strong);
+  background: var(--bg-surface);
+  color: var(--text-inverse);
+}
+
+.document-lifecycle__step--done .document-lifecycle__marker {
+  border-color: var(--status-success);
+  background: var(--status-success);
+}
+
+.document-lifecycle__step--error .document-lifecycle__marker {
+  border-color: var(--status-error);
+  background: var(--status-error);
+}
+
+.document-lifecycle__step--active .document-lifecycle__marker {
+  border-color: var(--status-info);
+  animation: document-lifecycle-pulse 1.6s var(--ease-out) infinite;
+}
+
+@keyframes document-lifecycle-pulse {
+  0% {
+    opacity: 1;
+  }
+  70% {
+    opacity: 0.45;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+/* The marker's shape and the announced state word both survive without it. */
+@media (prefers-reduced-motion: reduce) {
+  .document-lifecycle__step--active .document-lifecycle__marker {
+    animation: none;
+  }
+}
+
+.document-lifecycle__label {
+  text-align: center;
+  font-size: 0.75rem;
+  font-weight: 500;
+}
+
+.document-lifecycle__step--todo .document-lifecycle__label {
+  color: var(--text-muted);
+}
+
+.document-lifecycle__time {
+  text-align: center;
+  font-family: var(--font-mono);
+  font-size: 0.6875rem;
+  color: var(--text-muted);
+}

--- a/apps/web/src/pages/dev-ui/sections/primitives-section.tsx
+++ b/apps/web/src/pages/dev-ui/sections/primitives-section.tsx
@@ -26,6 +26,7 @@ import {
   Select,
   DocumentHeadline,
   DocumentKindGlyph,
+  DocumentLifecycle,
   StatusBadge,
   Textarea,
 } from '../../../shared/ui';
@@ -155,6 +156,30 @@ export function PrimitivesSection(): ReactElement {
           <DocumentHeadline kind="fiscal-receipt" state="Not registered" tone="idle" />
           <DocumentHeadline kind={null} state="No routing" tone="error" />
         </div>
+      </Group>
+
+      <Group
+        title="DocumentLifecycle"
+        description="An invoice has two persisted axes, the document and the authority answer, so the trail walks them. One step per stage the system stores, with the time it stores for it and an explicit marker where it stores none. A fiscal receipt has no authority axis and gets no trail at all, which the component enforces rather than trusting each caller. State is carried by the marker's shape and an announced word, not by tint alone."
+      >
+        <DocumentLifecycle
+          kind="invoice"
+          label="Invoice lifecycle, issued and awaiting the authority"
+          steps={[
+            { id: 'issued', label: 'Issued', state: 'done', at: '2026-08-26T09:12:00.000Z' },
+            { id: 'sent', label: 'Sent to the authority', state: 'done', at: '2026-08-26T09:12:00.000Z' },
+            { id: 'answer', label: 'Authority answer', state: 'active', at: null },
+          ]}
+        />
+        <DocumentLifecycle
+          kind="invoice"
+          label="Invoice lifecycle, refused by the authority"
+          steps={[
+            { id: 'issued', label: 'Issued', state: 'done', at: '2026-08-25T16:04:00.000Z' },
+            { id: 'sent', label: 'Sent to the authority', state: 'done', at: '2026-08-25T16:04:00.000Z' },
+            { id: 'answer', label: 'Refused', state: 'error', at: '2026-08-25T16:07:00.000Z' },
+          ]}
+        />
       </Group>
 
       <Group

--- a/apps/web/src/shared/ui/document-lifecycle.test.tsx
+++ b/apps/web/src/shared/ui/document-lifecycle.test.tsx
@@ -1,0 +1,104 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { DocumentLifecycle, type DocumentLifecycleStep } from './document-lifecycle';
+
+const ISSUED: DocumentLifecycleStep = {
+  id: 'issued',
+  label: 'Issued',
+  state: 'done',
+  at: '2026-08-26T09:12:00.000Z',
+};
+const SENT: DocumentLifecycleStep = {
+  id: 'submitted',
+  label: 'Sent to the authority',
+  state: 'done',
+  at: '2026-08-26T09:12:00.000Z',
+};
+const ANSWER: DocumentLifecycleStep = {
+  id: 'answer',
+  label: 'Authority answer',
+  state: 'active',
+  at: null,
+};
+
+describe('DocumentLifecycle', () => {
+  afterEach(cleanup);
+
+  it('should render no trail for a fiscal receipt', () => {
+    // A receipt has no authority axis (ADR-042, ADR-065). Refusing here is what
+    // stops a caller padding one out of stages that do not exist.
+    const { container } = render(
+      <DocumentLifecycle kind="fiscal-receipt" steps={[ISSUED, SENT, ANSWER]} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('should render no trail when routing named no document', () => {
+    const { container } = render(<DocumentLifecycle kind={null} steps={[ISSUED]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('should render no trail when the caller has no persisted steps', () => {
+    const { container } = render(<DocumentLifecycle kind="invoice" steps={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('should render one step per persisted stage, and no others', () => {
+    render(<DocumentLifecycle kind="invoice" steps={[ISSUED, SENT, ANSWER]} />);
+    expect(screen.getAllByRole('listitem')).toHaveLength(3);
+    expect(screen.getByText('Issued')).toBeInTheDocument();
+    expect(screen.getByText('Sent to the authority')).toBeInTheDocument();
+    expect(screen.getByText('Authority answer')).toBeInTheDocument();
+  });
+
+  it('should announce each step state in words, not colour alone', () => {
+    render(
+      <DocumentLifecycle
+        kind="invoice"
+        steps={[ISSUED, { id: 'answer', label: 'Authority answer', state: 'error', at: null }]}
+      />,
+    );
+    expect(screen.getByText(', done')).toBeInTheDocument();
+    expect(screen.getByText(', failed')).toBeInTheDocument();
+  });
+
+  it('should give done, active and error markers different shapes', () => {
+    const { container } = render(
+      <DocumentLifecycle
+        kind="invoice"
+        steps={[
+          ISSUED,
+          ANSWER,
+          { id: 'x', label: 'Rejected', state: 'error', at: null },
+          { id: 'y', label: 'Later', state: 'todo', at: null },
+        ]}
+      />,
+    );
+    const markers = Array.from(container.querySelectorAll('.document-lifecycle__marker'));
+    // done carries a tick, error a cross, active and todo carry neither - so the
+    // four are separable with the tint removed.
+    expect(markers[0]?.querySelector('svg')).not.toBeNull();
+    expect(markers[1]?.querySelector('svg')).toBeNull();
+    expect(markers[2]?.querySelector('svg')).not.toBeNull();
+    expect(markers[0]?.innerHTML).not.toBe(markers[2]?.innerHTML);
+    expect(markers[3]?.querySelector('svg')).toBeNull();
+  });
+
+  it('should mark the in-flight step as the current one', () => {
+    render(<DocumentLifecycle kind="invoice" steps={[ISSUED, ANSWER]} />);
+    const items = screen.getAllByRole('listitem');
+    expect(items[0]).not.toHaveAttribute('aria-current');
+    expect(items[1]).toHaveAttribute('aria-current', 'step');
+  });
+
+  it('should state a missing timestamp as missing rather than borrowing one', () => {
+    render(<DocumentLifecycle kind="invoice" steps={[ISSUED, ANSWER]} />);
+    expect(screen.getByText('No time recorded for Authority answer')).toBeInTheDocument();
+    expect(screen.getAllByRole('time')).toHaveLength(1);
+  });
+
+  it('should name the trail for assistive technology', () => {
+    render(<DocumentLifecycle kind="invoice" steps={[ISSUED]} label="Invoice lifecycle" />);
+    expect(screen.getByRole('list', { name: 'Invoice lifecycle' })).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/shared/ui/document-lifecycle.tsx
+++ b/apps/web/src/shared/ui/document-lifecycle.tsx
@@ -1,0 +1,137 @@
+/**
+ * DocumentLifecycle (#2536)
+ *
+ * A compact horizontal trail of an invoice's persisted stages: the document
+ * itself, and separately the answer from the tax authority. One step per state
+ * the system stores, with the timestamp it stores for it, and nothing else.
+ *
+ * Three rules define it, and each closes a specific way this display goes wrong.
+ *
+ *  1. **A step exists only if the system stores it.** An earlier progress
+ *     display invented three device phases nothing observes, which turned a
+ *     waiting screen into a claim about hardware. The caller passes the steps it
+ *     read off persisted fields; this component adds none and infers none.
+ *  2. **A missing timestamp is stated as missing.** A step can legitimately be
+ *     reached with no time recorded for it, so the slot renders an explicit
+ *     absent marker rather than borrowing the neighbouring step's time or
+ *     quietly showing nothing.
+ *  3. **A fiscal receipt gets no trail at all.** It has no authority axis
+ *     (ADR-042, ADR-065), so there is no second stage to walk. The component
+ *     refuses to render one rather than trusting every caller to remember,
+ *     which is what makes "no surface can show a receipt an authority answer"
+ *     true rather than aspirational.
+ *
+ * State is never carried by colour alone: each step's marker has its own shape,
+ * and each step announces its state in words to assistive technology.
+ *
+ * @module shared/ui
+ */
+import type { ReactElement } from 'react';
+import { AbsentValue } from './absent-value';
+import { TimeDisplay } from './time-display';
+import type { DocumentKind } from './document-kind-glyph';
+
+/**
+ * Where one step stands.
+ *
+ * `todo` is a stage that has not been reached; `active` is the one in flight;
+ * `error` is a stage that resolved against the document. There is no `skipped`:
+ * a stage the document did not go through is not passed at all.
+ */
+export type DocumentLifecycleStepState = 'todo' | 'active' | 'done' | 'error';
+
+export interface DocumentLifecycleStep {
+  /** Stable key. Not the label, which is display copy and may change. */
+  id: string;
+  label: string;
+  state: DocumentLifecycleStepState;
+  /** ISO timestamp, or null when the system records none for this step. */
+  at?: string | null;
+}
+
+export interface DocumentLifecycleProps {
+  /** Anything other than `invoice` renders nothing. See rule 3 above. */
+  kind: DocumentKind | null;
+  steps: readonly DocumentLifecycleStep[];
+  /** Names the trail for assistive technology. */
+  label?: string;
+  className?: string;
+}
+
+/** Announced beside each step, so its state never rests on colour. */
+const STATE_WORD: Record<DocumentLifecycleStepState, string> = {
+  todo: 'not yet reached',
+  active: 'in progress',
+  done: 'done',
+  error: 'failed',
+};
+
+export function DocumentLifecycle({
+  kind,
+  steps,
+  label = 'Document lifecycle',
+  className = '',
+}: DocumentLifecycleProps): ReactElement | null {
+  if (kind !== 'invoice' || steps.length === 0) return null;
+
+  const classes = ['document-lifecycle', className].filter(Boolean).join(' ');
+
+  return (
+    <ol className={classes} aria-label={label}>
+      {steps.map((step) => (
+        <li
+          key={step.id}
+          className={`document-lifecycle__step document-lifecycle__step--${step.state}`}
+          aria-current={step.state === 'active' ? 'step' : undefined}
+        >
+          <StepMarker state={step.state} />
+          <span className="document-lifecycle__label">
+            {step.label}
+            <span className="sr-only">{`, ${STATE_WORD[step.state]}`}</span>
+          </span>
+          <span className="document-lifecycle__time">
+            {step.at ? (
+              <TimeDisplay iso={step.at} format="datetime" />
+            ) : (
+              <AbsentValue label={`No time recorded for ${step.label}`} />
+            )}
+          </span>
+        </li>
+      ))}
+    </ol>
+  );
+}
+
+/**
+ * The marker, whose SHAPE carries the state: a hollow ring not yet reached, a
+ * ringed dot in flight, a tick done, a cross failed.
+ */
+function StepMarker({ state }: { state: DocumentLifecycleStepState }): ReactElement {
+  return (
+    <span className="document-lifecycle__marker" aria-hidden="true">
+      {state === 'done' ? (
+        <svg viewBox="0 0 10 10" width="10" height="10">
+          <path
+            d="M2 5.2 4 7.2 8 2.8"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.8"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      ) : null}
+      {state === 'error' ? (
+        <svg viewBox="0 0 10 10" width="10" height="10">
+          <path
+            d="M3 3l4 4M7 3l-4 4"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="1.8"
+            strokeLinecap="round"
+          />
+        </svg>
+      ) : null}
+    </span>
+  );
+}

--- a/apps/web/src/shared/ui/index.ts
+++ b/apps/web/src/shared/ui/index.ts
@@ -72,6 +72,12 @@ export { DocumentKindGlyph, DOCUMENT_KIND_LABEL, NO_DOCUMENT_LABEL } from './doc
 export type { DocumentKind, DocumentKindGlyphProps } from './document-kind-glyph';
 export { DocumentHeadline } from './document-headline';
 export type { DocumentHeadlineProps, DocumentHeadlineTone } from './document-headline';
+export { DocumentLifecycle } from './document-lifecycle';
+export type {
+  DocumentLifecycleProps,
+  DocumentLifecycleStep,
+  DocumentLifecycleStepState,
+} from './document-lifecycle';
 
 // ── Identity / labels ──────────────────────────────────────────────
 export { EntityLabel, shortenId } from './entity-label';


### PR DESCRIPTION
## What this builds

`DocumentLifecycle` in `apps/web/src/shared/ui`, exported from the catalogue and rendered in the dev-ui primitives gallery in both its shapes.

It takes `kind` and a `steps` array of `{ id, label, state, at }`, where `state` is `todo | active | done | error`, and renders a compact horizontal trail.

Three rules define it:

1. **A step exists only if the system stores it.** The caller passes steps it read off persisted fields; this component adds none and infers none. The trap named in the issue was an earlier progress display that invented three device phases nothing observes, which turned a waiting screen into a claim about hardware.
2. **A missing timestamp is stated as missing.** `at: null` renders `AbsentValue` with a named reason, never a borrowed neighbouring time and never a silent blank. This matters immediately: the invoice record persists `issuedAt`, `createdAt` and `updatedAt` and **no** submitted-at or authority-answered-at, so a real trail today has a step with no time of its own.
3. **A fiscal receipt gets no trail.** It has no authority axis (ADR-042, ADR-065), so `kind` other than `invoice` returns `null`, as does an empty `steps`.

State never rests on colour: the marker's shape differs per state (a tick when done, a cross when failed, a bare ring otherwise), each step appends its state in words for assistive technology, the in-flight step carries `aria-current="step"`, and its pulse is behind `prefers-reduced-motion: reduce`.

## Decisions a reviewer may want to dispute

- **The receipt rule is enforced in the component, not left to callers.** Rule 3 could have been a caller convention with the component staying a dumb step renderer. Putting it in the component is what makes "no surface can show a receipt an authority answer" a property rather than a habit, and it is the reason the receipt case is testable at this layer at all, which the issue asks for. The cost is a primitive that knows one domain rule.
- **No step vocabulary ships here.** The component names no stages, so it cannot drift from the backend; deriving the actual steps of an invoice from `InvoiceRecord` is the order-panel's job in M9. That does mean this PR has no product caller yet, same as #2535.
- **`AbsentValue` over an em dash.** The absent slot reuses the shared absent-value primitive so the reason is announced, rather than the mockup's bare dash which says nothing to a screen reader.

## Left out

The derivation of an invoice's steps from its persisted record, and the panel that renders them. Both are M9. This PR ships only the trail and the rules it enforces.

## Gate

- `pnpm --filter @openlinker/web type-check` - clean
- `pnpm exec eslint` on the changed paths - clean
- `pnpm check:invariants` - clean
- `pnpm exec vitest run` on the three shared-ui document specs - 24 tests passing, 9 of them new

The full `pnpm test` was not run locally.

Closes #2536
