### PR TITLE
fix(ui): let a cell-anchored popover escape the table's scroll container

### DIFF
--- a/apps/web/src/shared/ui/index.ts
+++ b/apps/web/src/shared/ui/index.ts
@@ -56,6 +56,7 @@ export { Dialog } from './dialog';
 export { ConfirmDialog } from './confirm-dialog';
 export { DropdownMenu } from './dropdown-menu';
 export { Popover, PopoverTrigger, PopoverContent } from './popover';
+export type { PopoverProps } from './popover';
 export { Tooltip } from './tooltip';
 
 // ── Data surfaces ──────────────────────────────────────────────────

--- a/apps/web/src/shared/ui/popover.test.tsx
+++ b/apps/web/src/shared/ui/popover.test.tsx
@@ -1,12 +1,33 @@
-import { cleanup, render, screen } from '@testing-library/react';
+import { act, cleanup, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ReactElement } from 'react';
 import { Popover, PopoverContent, PopoverTrigger } from './popover';
+
+/** A trigger inside a horizontally scrolling table container, as a cell would be. */
+function ClippedTable({ dismiss = false }: { dismiss?: boolean }): ReactElement {
+  return (
+    <div className="data-table__container" style={{ overflowX: 'auto' }}>
+      <table>
+        <tbody>
+          <tr>
+            <td>
+              <Popover dismissOnViewportChange={dismiss}>
+                <PopoverTrigger>Document</PopoverTrigger>
+                <PopoverContent>Invoice FA/2026/08/0144</PopoverContent>
+              </Popover>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  );
+}
 
 describe('Popover (Radix wrapper)', () => {
   afterEach(cleanup);
 
-  it('toggles content on trigger click', async () => {
+  it('should toggle content on trigger click', async () => {
     const user = userEvent.setup();
     render(
       <Popover>
@@ -18,5 +39,133 @@ describe('Popover (Radix wrapper)', () => {
     expect(screen.queryByText('Filter body')).toBeNull();
     await user.click(screen.getByText('Filters'));
     expect(screen.getByText('Filter body')).toBeInTheDocument();
+  });
+
+  it('should render outside a clipping scroll container', async () => {
+    // `.data-table__container` sets `overflow-x: auto`, so content positioned
+    // inside a cell is cut off at the table's edge. The portal is what stops it.
+    const user = userEvent.setup();
+    const { container } = render(<ClippedTable />);
+
+    await user.click(screen.getByText('Document'));
+    const content = screen.getByText('Invoice FA/2026/08/0144');
+    const clipper = container.querySelector('.data-table__container');
+
+    expect(clipper).not.toBeNull();
+    expect(clipper?.contains(content)).toBe(false);
+    expect(document.body.contains(content)).toBe(true);
+  });
+
+  it('should close on a scroll of the clipping ancestor when asked to', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<ClippedTable dismiss />);
+
+    await user.click(screen.getByText('Document'));
+    expect(screen.getByText('Invoice FA/2026/08/0144')).toBeInTheDocument();
+
+    const clipper = container.querySelector('.data-table__container');
+    // A scroll event does not bubble, so only a capture-phase listener sees it.
+    act(() => {
+      clipper?.dispatchEvent(new Event('scroll', { bubbles: false }));
+    });
+
+    expect(screen.queryByText('Invoice FA/2026/08/0144')).toBeNull();
+  });
+
+  it('should close on resize when asked to', async () => {
+    const user = userEvent.setup();
+    render(<ClippedTable dismiss />);
+
+    await user.click(screen.getByText('Document'));
+    act(() => {
+      window.dispatchEvent(new Event('resize'));
+    });
+
+    expect(screen.queryByText('Invoice FA/2026/08/0144')).toBeNull();
+  });
+
+  it('should survive a scroll inside its own body', async () => {
+    // Closing here would make a scrollable panel impossible to read.
+    const user = userEvent.setup();
+    render(<ClippedTable dismiss />);
+
+    await user.click(screen.getByText('Document'));
+    const content = screen.getByText('Invoice FA/2026/08/0144');
+    act(() => {
+      content.dispatchEvent(new Event('scroll', { bubbles: false }));
+    });
+
+    expect(screen.getByText('Invoice FA/2026/08/0144')).toBeInTheDocument();
+  });
+
+  it('should stay open on a scroll when the caller did not opt in', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<ClippedTable />);
+
+    await user.click(screen.getByText('Document'));
+    act(() => {
+      container.querySelector('.data-table__container')?.dispatchEvent(new Event('scroll'));
+    });
+
+    expect(screen.getByText('Invoice FA/2026/08/0144')).toBeInTheDocument();
+  });
+
+  it('should close on Escape and return focus to the trigger', async () => {
+    const user = userEvent.setup();
+    render(<ClippedTable dismiss />);
+
+    const trigger = screen.getByText('Document');
+    await user.click(trigger);
+    await user.keyboard('{Escape}');
+
+    expect(screen.queryByText('Invoice FA/2026/08/0144')).toBeNull();
+    expect(trigger).toHaveFocus();
+  });
+
+  it('should report every open and close to a controlling caller', async () => {
+    const user = userEvent.setup();
+    const onOpenChange = vi.fn();
+    render(
+      <Popover onOpenChange={onOpenChange} dismissOnViewportChange>
+        <PopoverTrigger>Document</PopoverTrigger>
+        <PopoverContent>Body</PopoverContent>
+      </Popover>,
+    );
+
+    await user.click(screen.getByText('Document'));
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+
+    act(() => {
+      window.dispatchEvent(new Event('resize'));
+    });
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+  });
+
+  it('should honour a controlled open prop', () => {
+    const { rerender } = render(
+      <Popover open={false} onOpenChange={vi.fn()}>
+        <PopoverTrigger>Document</PopoverTrigger>
+        <PopoverContent>Body</PopoverContent>
+      </Popover>,
+    );
+    expect(screen.queryByText('Body')).toBeNull();
+
+    rerender(
+      <Popover open onOpenChange={vi.fn()}>
+        <PopoverTrigger>Document</PopoverTrigger>
+        <PopoverContent>Body</PopoverContent>
+      </Popover>,
+    );
+    expect(screen.getByText('Body')).toBeInTheDocument();
+  });
+
+  it('should open from defaultOpen without a controlling caller', () => {
+    render(
+      <Popover defaultOpen>
+        <PopoverTrigger>Document</PopoverTrigger>
+        <PopoverContent>Body</PopoverContent>
+      </Popover>,
+    );
+    expect(screen.getByText('Body')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/shared/ui/popover.tsx
+++ b/apps/web/src/shared/ui/popover.tsx
@@ -1,19 +1,125 @@
+/**
+ * Popover (Radix wrapper)
+ *
+ * The public surface is this wrapper; Radix is an implementation detail.
+ *
+ * **Where the content renders is the point** (#2537). `.data-table__container`
+ * sets `overflow-x: auto`, so anything positioned inside a cell is clipped at
+ * the table's edge - reproduced while building the sales-document mockup, where
+ * a panel opened from the last column was cut in half. `PopoverContent` renders
+ * into a portal at the document root, outside every clipping ancestor, and
+ * Radix's collision handling then keeps it inside the viewport. A cell-anchored
+ * popover therefore needs no positioning code of its own.
+ *
+ * A portal alone leaves one gap: the content is positioned once against the
+ * trigger's rect, so scrolling the clipping ancestor slides the trigger away
+ * from a panel that stays put. `dismissOnViewportChange` closes it instead of
+ * chasing it, which is the right answer for a panel anchored to a row: the row
+ * the operator opened it from is no longer where they are looking.
+ *
+ * @module shared/ui
+ */
 import * as RadixPopover from '@radix-ui/react-popover';
-import { forwardRef, type ComponentPropsWithoutRef } from 'react';
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useState,
+  type ComponentPropsWithoutRef,
+  type ReactElement,
+} from 'react';
 
-export const Popover = RadixPopover.Root;
 export const PopoverTrigger = RadixPopover.Trigger;
 export const PopoverClose = RadixPopover.Close;
 export const PopoverAnchor = RadixPopover.Anchor;
 
+/** Marks our own content node, so the dismiss handler can ignore scrolls inside it. */
+const CONTENT_SLOT = 'popover-content';
+
+export interface PopoverProps extends ComponentPropsWithoutRef<typeof RadixPopover.Root> {
+  /**
+   * Close the popover when anything scrolls or the window resizes.
+   *
+   * Opt-in rather than the default: a popover anchored to a page-level control
+   * (a filter, an infotip) should survive an incidental scroll, while one
+   * anchored to a table row should not outlive the row's position. Both are
+   * legitimate, so the caller says which it is.
+   */
+  dismissOnViewportChange?: boolean;
+}
+
+export function Popover({
+  dismissOnViewportChange = false,
+  open,
+  defaultOpen,
+  onOpenChange,
+  children,
+  ...props
+}: PopoverProps): ReactElement {
+  const [uncontrolledOpen, setUncontrolledOpen] = useState(defaultOpen ?? false);
+  const isControlled = open !== undefined;
+  const isOpen = isControlled ? open : uncontrolledOpen;
+
+  const setOpen = useCallback(
+    (next: boolean) => {
+      if (!isControlled) setUncontrolledOpen(next);
+      onOpenChange?.(next);
+    },
+    [isControlled, onOpenChange],
+  );
+
+  useEffect(() => {
+    if (!dismissOnViewportChange || !isOpen) return undefined;
+
+    const dismiss = (event: Event): void => {
+      // A scroll inside the popover's own body is not the ancestor moving out
+      // from under it, and closing on it would make a scrollable panel unusable.
+      const target = event.target;
+      if (
+        event.type === 'scroll' &&
+        target instanceof Element &&
+        target.closest(`[data-slot="${CONTENT_SLOT}"]`) !== null
+      ) {
+        return;
+      }
+      setOpen(false);
+    };
+
+    // Capture, because a scroll event does not bubble: the clipping ancestor is
+    // what moves, and only the capture path reaches the window from it.
+    window.addEventListener('scroll', dismiss, true);
+    window.addEventListener('resize', dismiss);
+    return () => {
+      window.removeEventListener('scroll', dismiss, true);
+      window.removeEventListener('resize', dismiss);
+    };
+  }, [dismissOnViewportChange, isOpen, setOpen]);
+
+  return (
+    <RadixPopover.Root {...props} open={isOpen} onOpenChange={setOpen}>
+      {children}
+    </RadixPopover.Root>
+  );
+}
+
 export const PopoverContent = forwardRef<
   HTMLDivElement,
   ComponentPropsWithoutRef<typeof RadixPopover.Content>
->(function PopoverContent({ className = '', sideOffset = 6, children, ...props }, ref) {
+>(function PopoverContent(
+  { className = '', sideOffset = 6, collisionPadding = 8, children, ...props },
+  ref,
+) {
   const classes = ['popover__content', className].filter(Boolean).join(' ');
   return (
     <RadixPopover.Portal>
-      <RadixPopover.Content ref={ref} className={classes} sideOffset={sideOffset} {...props}>
+      <RadixPopover.Content
+        ref={ref}
+        data-slot={CONTENT_SLOT}
+        className={classes}
+        sideOffset={sideOffset}
+        collisionPadding={collisionPadding}
+        {...props}
+      >
         {children}
       </RadixPopover.Content>
     </RadixPopover.Portal>


### PR DESCRIPTION
## What this builds

Changes to `apps/web/src/shared/ui/popover.tsx`, keeping the Radix wrapper as the public surface:

- **The clipping case is now asserted.** `PopoverContent` already rendered into `RadixPopover.Portal`, at the document root and outside every `overflow` ancestor, which is what stops `.data-table__container` cutting it off. Nothing said so and nothing tested it, so a spec now renders a trigger inside that container and asserts the content is not a descendant of it and is a descendant of `document.body`.
- **`dismissOnViewportChange`**, a new opt-in prop on `Popover`. A portalled panel is positioned once against the trigger's rect, so scrolling the clipping ancestor slides the trigger away from a panel that stays put. This closes it on a scroll or a resize instead.
- **A default `collisionPadding` of 8** on the content, so a popover opened from the last column is clamped inside the viewport rather than sitting half off it.
- `PopoverProps` is exported from the catalogue.

`Popover` is now a component rather than `RadixPopover.Root` re-exported, because the dismiss behaviour needs the open state. It accepts the same props and supports controlled, `defaultOpen` and fully uncontrolled callers; specs cover all three.

## Decisions a reviewer may want to dispute

- **Dismiss is opt-in, not the default.** The AC reads "it closes on scroll and on resize", and I have made that true for a caller that asks. Closing every popover in the app on any scroll would change the three shipped analytics popovers, where an incidental page scroll is not a reason to lose an infotip. A popover anchored to a table row is a different case, and the caller is what knows which it is. Say if you would rather it were unconditional.
- **The listener is capture-phase and window-scoped**, rather than attached to a resolved scrolling ancestor. A scroll event does not bubble, so a bubble-phase listener would never see the ancestor move; walking up to find the scroller would need the trigger's node and would still miss a second scroller further up. The cost is that a scroll anywhere closes it, which is the intended behaviour for this prop.
- **A scroll raised inside the popover's own body is ignored**, matched via a `data-slot="popover-content"` attribute this wrapper sets. Without that a scrollable panel closes itself as it is read. The attribute is ours, deliberately not one of Radix's internal `data-radix-*` hooks.
- **`data-table.tsx` is untouched.** The issue lists it, but the fix is entirely in where the content renders, and the table needs no coordinate handoff for that. Nothing was added to the table that would then need removing.

## Left out

No cell-anchored popover consumer. The document cell that uses this is M8; this PR is the primitive it needs, plus the regression cover for the defect that was reproduced on the mockup.

## Gate

- `pnpm --filter @openlinker/web type-check` - clean
- `pnpm exec eslint` on the three changed paths - clean
- `pnpm check:invariants` - clean
- `pnpm exec vitest run src/features/analytics src/shared/ui` - 64 files, 526 tests passing, which covers the three shipped popover consumers as well as the 10 specs here

The full `pnpm test` was not run locally.

Closes #2537
