### PR TITLE
feat(orders,sales-documents): market discovery, billing countries with order counts (#2518)

### DIFF
--- a/apps/api/src/orders/http/orders.controller.spec.ts
+++ b/apps/api/src/orders/http/orders.controller.spec.ts
@@ -69,6 +69,7 @@ describe('OrdersController', () => {
       findById: jest.fn(),
       findByIds: jest.fn(),
       findEarliestOrderDateByConnection: jest.fn(),
+      countOrdersByRoutingCountrySince: jest.fn(),
       upsert: jest.fn(),
       upsertWithLineItems: jest.fn(),
       updateSyncStatus: jest.fn(),

--- a/apps/api/src/orders/http/refunds.controller.spec.ts
+++ b/apps/api/src/orders/http/refunds.controller.spec.ts
@@ -49,6 +49,7 @@ describe('RefundsController', () => {
       getFailedSyncValueSummary: jest.fn(),
       getSalesAndChannelAnalytics: jest.fn(),
       getTopProducts: jest.fn(),
+      discoverSalesDocumentMarkets: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({

--- a/apps/api/src/sales-documents/http/dto/detected-market-response.dto.ts
+++ b/apps/api/src/sales-documents/http/dto/detected-market-response.dto.ts
@@ -1,0 +1,62 @@
+/**
+ * Detected Market Response DTOs (#2518, ADR-066)
+ *
+ * The wire shape of the market-discovery read: which countries orders arrived
+ * from over a window, and how many. It is what turns "you have no routing"
+ * into "47 orders here are waiting", which is the fact an operator can act on.
+ *
+ * Deliberately carries NO `configured` flag, no `hasTemplate` flag and no
+ * severity. Classification is the caller's job (ADR-066 decision 1): the
+ * settings page joins these rows against `GET /sales-documents/countries` and
+ * against the curated templates itself, because two sources of truth for "is
+ * this market set up" is the drift the routing-first redesign exists to
+ * remove. And a detected, unconfigured market is a NEUTRAL state, not a fault -
+ * a fresh install is not broken, so nothing here is named `missing` or
+ * `problem` for a surface to tint red.
+ *
+ * @module apps/api/src/sales-documents/http/dto
+ * @see docs/architecture/adrs/066-sales-document-market-discovery.md
+ */
+import { ApiProperty } from '@nestjs/swagger';
+
+export class DetectedMarketDto {
+  @ApiProperty({
+    description:
+      'ISO 3166-1 alpha-2 as the order carried it, verbatim - never normalised or mapped to a display ' +
+      'name here, because the value has to stay comparable with what a rule was authored against.',
+    example: 'PL',
+  })
+  country!: string;
+
+  @ApiProperty({
+    description: 'Orders from that country within the window. Always at least 1 - a zero row cannot exist.',
+    example: 47,
+  })
+  orderCount!: number;
+}
+
+export class DetectedMarketsResponseDto {
+  @ApiProperty({
+    description:
+      'The window actually applied, in days. Travels with the response so a surface can say "in the ' +
+      'last N days" without holding its own copy of the number and drifting from it. A documented ' +
+      'constant, not a per-operator setting (ADR-066).',
+    example: 30,
+  })
+  windowDays!: number;
+
+  @ApiProperty({
+    description: 'ISO-8601 lower bound the counts were taken from, inclusive.',
+    example: '2026-07-31T10:00:00.000Z',
+  })
+  since!: string;
+
+  @ApiProperty({
+    type: [DetectedMarketDto],
+    description:
+      'Detected markets, most orders first. A country with configured routing and one without are ' +
+      'BOTH returned. Empty on an instance that has ingested no orders in the window - a legitimate ' +
+      'brand-new-install state, not an error.',
+  })
+  markets!: DetectedMarketDto[];
+}

--- a/apps/api/src/sales-documents/http/sales-document-markets.controller.spec.ts
+++ b/apps/api/src/sales-documents/http/sales-document-markets.controller.spec.ts
@@ -1,0 +1,94 @@
+/**
+ * SalesDocumentMarketsController - unit tests (#2518, ADR-066)
+ *
+ * @module apps/api/src/sales-documents/http
+ */
+import type { TestingModule } from '@nestjs/testing';
+import { Test } from '@nestjs/testing';
+import { ORDER_RECORD_SERVICE_TOKEN } from '@openlinker/core/orders';
+import type { IOrderRecordService } from '@openlinker/core/orders';
+
+import { SalesDocumentMarketsController } from './sales-document-markets.controller';
+
+describe('SalesDocumentMarketsController', () => {
+  let controller: SalesDocumentMarketsController;
+  let orderRecords: { discoverSalesDocumentMarkets: jest.Mock };
+
+  beforeEach(async () => {
+    orderRecords = {
+      discoverSalesDocumentMarkets: jest.fn().mockResolvedValue({
+        windowDays: 30,
+        since: '2026-07-31T10:00:00.000Z',
+        markets: [],
+      }),
+    };
+
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [SalesDocumentMarketsController],
+      providers: [
+        {
+          provide: ORDER_RECORD_SERVICE_TOKEN,
+          useValue: orderRecords as unknown as IOrderRecordService,
+        },
+      ],
+    }).compile();
+
+    controller = module.get(SalesDocumentMarketsController);
+  });
+
+  it('should return country plus count over the window, most orders first', async () => {
+    orderRecords.discoverSalesDocumentMarkets.mockResolvedValue({
+      windowDays: 30,
+      since: '2026-07-31T10:00:00.000Z',
+      markets: [
+        { country: 'PL', orderCount: 47 },
+        { country: 'DE', orderCount: 12 },
+        { country: 'CZ', orderCount: 6 },
+      ],
+    });
+
+    const result = await controller.listDetectedMarkets();
+
+    expect(result.windowDays).toBe(30);
+    expect(result.since).toBe('2026-07-31T10:00:00.000Z');
+    expect(result.markets).toEqual([
+      { country: 'PL', orderCount: 47 },
+      { country: 'DE', orderCount: 12 },
+      { country: 'CZ', orderCount: 6 },
+    ]);
+  });
+
+  it('should classify nothing, so a configured and an unconfigured market are indistinguishable here', async () => {
+    orderRecords.discoverSalesDocumentMarkets.mockResolvedValue({
+      windowDays: 30,
+      since: '2026-07-31T10:00:00.000Z',
+      markets: [
+        { country: 'PL', orderCount: 47 },
+        { country: 'DE', orderCount: 12 },
+      ],
+    });
+
+    const result = await controller.listDetectedMarkets();
+
+    // Classification is the caller's job (ADR-066 decision 1). A `configured`
+    // or `hasTemplate` flag here would be a second source of truth for it.
+    for (const market of result.markets) {
+      expect(Object.keys(market).sort()).toEqual(['country', 'orderCount']);
+    }
+  });
+
+  it('should return an empty list for a brand-new instance rather than an error', async () => {
+    const result = await controller.listDetectedMarkets();
+
+    expect(result.markets).toEqual([]);
+  });
+
+  it('should issue exactly one read and no write', async () => {
+    await controller.listDetectedMarkets();
+
+    expect(orderRecords.discoverSalesDocumentMarkets).toHaveBeenCalledTimes(1);
+    // Nothing else on the service is reachable from this controller: it holds
+    // one dependency and calls one read. Discovery never creates routing.
+    expect(Object.keys(orderRecords)).toEqual(['discoverSalesDocumentMarkets']);
+  });
+});

--- a/apps/api/src/sales-documents/http/sales-document-markets.controller.ts
+++ b/apps/api/src/sales-documents/http/sales-document-markets.controller.ts
@@ -1,0 +1,68 @@
+/**
+ * Sales-Document Markets Controller (#2518, ADR-066)
+ *
+ * The market-discovery read: which countries the operator's orders arrive
+ * from, with their order counts over a window, so an unconfigured market is
+ * visible before somebody discovers it through missing documents.
+ *
+ * A READ, and only a read. It creates no rule, no country default and no
+ * routing - auto-applying a template on detection would be a legal act taken
+ * on the operator's behalf, which ADR-041 forbids and ADR-066 rejects
+ * outright. Nothing on this controller writes.
+ *
+ * It is a separate controller from `SalesDocumentRulesController` despite
+ * sharing the `sales-documents` prefix: that one is rule-engine CRUD against
+ * the sales-document store, this is one derived read against the ORDERS store,
+ * reached through `IOrderRecordService` (never a repository port across a
+ * context boundary, per architecture-overview.md).
+ *
+ * Admin-guarded like its neighbour rather than merely authenticated: the only
+ * consumer is `/settings/sales-documents`, which is admin-only in full, and a
+ * looser guard here would publish the operator's market distribution to every
+ * authenticated user for no gain.
+ *
+ * @module apps/api/src/sales-documents/http
+ * @see docs/architecture/adrs/066-sales-document-market-discovery.md
+ */
+import { Controller, Get, HttpCode, HttpStatus, Inject } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { IOrderRecordService, ORDER_RECORD_SERVICE_TOKEN } from '@openlinker/core/orders';
+import { Roles } from '../../auth/decorators/roles.decorator';
+import { DetectedMarketsResponseDto } from './dto/detected-market-response.dto';
+
+@Roles('admin')
+@ApiBearerAuth()
+@ApiTags('sales-documents')
+@Controller('sales-documents')
+export class SalesDocumentMarketsController {
+  constructor(
+    @Inject(ORDER_RECORD_SERVICE_TOKEN)
+    private readonly orderRecords: IOrderRecordService,
+  ) {}
+
+  @Get('markets/detected')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Markets detected from ingested orders',
+    description:
+      'Distinct countries the operator has orders from over a fixed window, each with its order count, ' +
+      'most orders first. The country is the one routing evaluates on, so configuring a market listed ' +
+      'here changes what those orders get. Countries WITH configured routing are returned too - ' +
+      'classification is the caller\'s job, which is what keeps this read and the configured-countries ' +
+      'read from becoming two sources of truth. Read-only: it never creates a rule, a default or any ' +
+      'routing, and a detected unconfigured market is a neutral state rather than a fault.',
+  })
+  @ApiResponse({ status: 200, description: 'Detected markets', type: DetectedMarketsResponseDto })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async listDetectedMarkets(): Promise<DetectedMarketsResponseDto> {
+    const discovery = await this.orderRecords.discoverSalesDocumentMarkets();
+    return {
+      windowDays: discovery.windowDays,
+      since: discovery.since,
+      markets: discovery.markets.map((market) => ({
+        country: market.country,
+        orderCount: market.orderCount,
+      })),
+    };
+  }
+}

--- a/apps/api/src/sales-documents/sales-documents-api.module.ts
+++ b/apps/api/src/sales-documents/sales-documents-api.module.ts
@@ -12,13 +12,21 @@
 import { Module } from '@nestjs/common';
 import { SalesDocumentsModule as CoreSalesDocumentsModule } from '@openlinker/core/sales-documents';
 import { IntegrationsModule as CoreIntegrationsModule } from '@openlinker/core/integrations';
+// #2518: market discovery is a read against the ORDERS store, reached through
+// `IOrderRecordService`. CoreOrdersModule exports that token.
+import { OrdersModule as CoreOrdersModule } from '@openlinker/core/orders';
 import { SalesDocumentRulesController } from './http/sales-document-rules.controller';
 import { SalesDocumentTemplatesController } from './http/sales-document-templates.controller';
+import { SalesDocumentMarketsController } from './http/sales-document-markets.controller';
 import { SalesDocumentCapabilityGuardService } from './sales-document-capability-guard.service';
 
 @Module({
-  imports: [CoreSalesDocumentsModule, CoreIntegrationsModule],
-  controllers: [SalesDocumentRulesController, SalesDocumentTemplatesController],
+  imports: [CoreSalesDocumentsModule, CoreIntegrationsModule, CoreOrdersModule],
+  controllers: [
+    SalesDocumentRulesController,
+    SalesDocumentTemplatesController,
+    SalesDocumentMarketsController,
+  ],
   providers: [SalesDocumentCapabilityGuardService],
 })
 export class SalesDocumentsApiModule {}

--- a/apps/api/src/shipping/http/shipment.controller.spec.ts
+++ b/apps/api/src/shipping/http/shipment.controller.spec.ts
@@ -134,6 +134,7 @@ describe('ShipmentController', () => {
       getEarliestOrderDateByConnection: jest.fn(),
       getSalesAndChannelAnalytics: jest.fn(),
       getTopProducts: jest.fn(),
+      discoverSalesDocumentMarkets: jest.fn(),
     };
     controller = new ShipmentController(
       query,

--- a/libs/core/src/orders/application/interfaces/order-record.service.interface.ts
+++ b/libs/core/src/orders/application/interfaces/order-record.service.interface.ts
@@ -19,7 +19,10 @@ import type {
   PaginatedOrderRecords,
 } from '../../domain/types/order-record.types';
 import type { FulfillmentRollupState } from '../../domain/types/order-fulfillment.types';
-import type { SalesDocumentBlock } from '@openlinker/core/sales-documents';
+import type {
+  SalesDocumentBlock,
+  SalesDocumentMarketDiscovery,
+} from '@openlinker/core/sales-documents';
 import type {
   SalesAnalyticsFilters,
   SalesAndChannelAnalytics,
@@ -132,6 +135,27 @@ export interface IOrderRecordService {
    * figure, so no administrative-bucket exclusion applies.
    */
   getEarliestOrderDateByConnection(connectionIds: string[]): Promise<Map<string, Date>>;
+
+  /**
+   * Which markets the operator has orders from, and how many (#2518, ADR-066).
+   *
+   * A clean instance has no sales-document routing, and nothing today says
+   * which markets need a decision - the failure is invisible until someone
+   * notices no documents exist. OpenLinker already knows where its orders are
+   * routed, so this derives the answer instead of asking for it.
+   *
+   * The cross-context surface the sales-document settings page uses -
+   * repository ports are forbidden across context boundaries per
+   * architecture-overview.md, so `apps/api` goes through this method rather
+   * than `OrderRecordRepositoryPort.countOrdersByRoutingCountrySince`.
+   *
+   * A READ, and only a read: it creates no rule, no country default and no
+   * routing. It also does not classify - a country with configured routing and
+   * one without are both returned, and joining these rows against
+   * `listConfiguredCountries` is the caller's job. `now` defaults to the system
+   * clock; pass it explicitly in tests.
+   */
+  discoverSalesDocumentMarkets(now?: Date): Promise<SalesDocumentMarketDiscovery>;
 
   /**
    * Push a per-order fulfillment rollup (#1108) onto the order record. The

--- a/libs/core/src/orders/application/services/__tests__/order-record.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-record.service.spec.ts
@@ -40,6 +40,7 @@ describe('OrderRecordService', () => {
       findById: jest.fn(),
       findByIds: jest.fn(),
       findEarliestOrderDateByConnection: jest.fn(),
+      countOrdersByRoutingCountrySince: jest.fn(),
       upsert: jest.fn(),
       upsertWithLineItems: jest.fn(),
       updateSyncStatus: jest.fn(),
@@ -1113,6 +1114,71 @@ describe('OrderRecordService', () => {
 
       expect(result).toBe(records);
       expect(repository.findByIds).toHaveBeenCalledWith(['order-123', 'order-456']);
+    });
+  });
+
+  describe('discoverSalesDocumentMarkets (#2518, ADR-066)', () => {
+    it('reports the window it applied and derives `since` from it', async () => {
+      repository.countOrdersByRoutingCountrySince.mockResolvedValue([]);
+
+      const result = await service.discoverSalesDocumentMarkets(
+        new Date('2026-08-30T10:00:00.000Z'),
+      );
+
+      expect(result.windowDays).toBe(30);
+      expect(result.since).toBe('2026-07-31T10:00:00.000Z');
+      expect(repository.countOrdersByRoutingCountrySince).toHaveBeenCalledWith(
+        new Date('2026-07-31T10:00:00.000Z'),
+      );
+    });
+
+    it('returns configured and unconfigured markets alike, most orders first', async () => {
+      repository.countOrdersByRoutingCountrySince.mockResolvedValue([
+        { country: 'PL', orderCount: 47 },
+        { country: 'DE', orderCount: 12 },
+        { country: 'CZ', orderCount: 6 },
+      ]);
+
+      const result = await service.discoverSalesDocumentMarkets(new Date());
+
+      // No `configured` / `hasTemplate` flag: classification is the caller's
+      // job, so this read cannot become a second source of truth for it.
+      expect(result.markets).toEqual([
+        { country: 'PL', orderCount: 47 },
+        { country: 'DE', orderCount: 12 },
+        { country: 'CZ', orderCount: 6 },
+      ]);
+    });
+
+    it('reports no markets on an instance with no orders in the window', async () => {
+      repository.countOrdersByRoutingCountrySince.mockResolvedValue([]);
+
+      const result = await service.discoverSalesDocumentMarkets(new Date());
+
+      // A brand-new install is a legitimate state, not an error.
+      expect(result.markets).toEqual([]);
+    });
+
+    it('issues ONE read, never one per country', async () => {
+      repository.countOrdersByRoutingCountrySince.mockResolvedValue([
+        { country: 'PL', orderCount: 47 },
+        { country: 'DE', orderCount: 12 },
+      ]);
+
+      await service.discoverSalesDocumentMarkets(new Date());
+
+      expect(repository.countOrdersByRoutingCountrySince).toHaveBeenCalledTimes(1);
+    });
+
+    it('writes nothing', async () => {
+      repository.countOrdersByRoutingCountrySince.mockResolvedValue([]);
+
+      await service.discoverSalesDocumentMarkets(new Date());
+
+      // Discovery must never create routing on its own (ADR-066 decision 1).
+      expect(repository.upsert).not.toHaveBeenCalled();
+      expect(repository.upsertWithLineItems).not.toHaveBeenCalled();
+      expect(repository.updateSalesDocumentBlock).not.toHaveBeenCalled();
     });
   });
 

--- a/libs/core/src/orders/application/services/order-record.service.ts
+++ b/libs/core/src/orders/application/services/order-record.service.ts
@@ -29,7 +29,11 @@ import type {
   PaginatedOrderRecords,
 } from '../../domain/types/order-record.types';
 import type { FulfillmentRollupState } from '../../domain/types/order-fulfillment.types';
-import type { SalesDocumentBlock } from '@openlinker/core/sales-documents';
+import { SALES_DOCUMENT_MARKET_DISCOVERY_WINDOW_DAYS } from '@openlinker/core/sales-documents';
+import type {
+  SalesDocumentBlock,
+  SalesDocumentMarketDiscovery,
+} from '@openlinker/core/sales-documents';
 import type {
   SalesAnalyticsFilters,
   SalesAndChannelAnalytics,
@@ -50,6 +54,9 @@ import { deriveOrderAnalyticsScalars, deriveOrderLineItems } from '../../domain/
 import { buildSalesAndChannelAnalytics } from '../../domain/order-sales-aggregation';
 import { buildTopProducts } from '../../domain/top-products-aggregation';
 import type { TopProductFilters, TopProductsResult } from '../../domain/types/top-products.types';
+
+/** One day in milliseconds, for the market-discovery window arithmetic (#2518). */
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
 
 @Injectable()
 export class OrderRecordService implements IOrderRecordService {
@@ -526,6 +533,27 @@ export class OrderRecordService implements IOrderRecordService {
 
   async getEarliestOrderDateByConnection(connectionIds: string[]): Promise<Map<string, Date>> {
     return this.repository.findEarliestOrderDateByConnection(connectionIds);
+  }
+
+  /**
+   * Which markets the operator has orders from, and how many (#2518, ADR-066).
+   *
+   * One grouped repository read plus the window arithmetic. It writes nothing
+   * and classifies nothing - see the interface for both rules. The resolved
+   * window travels back with the counts so no surface has to hold its own copy
+   * of the number and drift from it.
+   */
+  async discoverSalesDocumentMarkets(now: Date = new Date()): Promise<SalesDocumentMarketDiscovery> {
+    const since = new Date(
+      now.getTime() - SALES_DOCUMENT_MARKET_DISCOVERY_WINDOW_DAYS * MILLISECONDS_PER_DAY
+    );
+    const markets = await this.repository.countOrdersByRoutingCountrySince(since);
+
+    return {
+      windowDays: SALES_DOCUMENT_MARKET_DISCOVERY_WINDOW_DAYS,
+      since: since.toISOString(),
+      markets,
+    };
   }
 
   /**

--- a/libs/core/src/orders/domain/ports/order-record-repository.port.ts
+++ b/libs/core/src/orders/domain/ports/order-record-repository.port.ts
@@ -68,6 +68,27 @@ export interface OrderRecordRepositoryPort {
   findEarliestOrderDateByConnection(connectionIds: string[]): Promise<Map<string, Date>>;
 
   /**
+   * Orders per routing country since `since`, most orders first (#2518,
+   * ADR-066). ONE grouped query, never one per country.
+   *
+   * The country read is the order's DELIVERY address country in the snapshot -
+   * the SAME field `toSalesDocumentOrderFacts` builds the rule engine's facts
+   * from. ADR-066 requires that: discovery reading a different address would
+   * name markets the evaluator never sees, and an operator configuring one of
+   * them would change nothing.
+   *
+   * Rows with no country, or a blank one, are excluded rather than grouped
+   * under an empty key: the evaluator cannot route such an order either, so
+   * reporting it as a market would name something an operator cannot act on.
+   *
+   * Every record in the window counts, whatever its `recordStatus` and whether
+   * or not it was cancelled - this is a coverage fact about where orders
+   * arrive from, not a health or revenue figure, matching the reasoning on
+   * {@link findEarliestOrderDateByConnection}.
+   */
+  countOrdersByRoutingCountrySince(since: Date): Promise<{ country: string; orderCount: number }[]>;
+
+  /**
    * Upsert order record (create or update)
    * Uses internalOrderId as the primary key.
    *

--- a/libs/core/src/orders/infrastructure/persistence/repositories/__tests__/order-record.repository.spec.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/__tests__/order-record.repository.spec.ts
@@ -1491,4 +1491,107 @@ describe('OrderRecordRepository', () => {
       expect(new Set(pathKeyMatches)).toEqual(new Set(['taxRate', 'taxSource', 'taxRateReadAt']));
     });
   });
+
+  describe('countOrdersByRoutingCountrySince (#2518, ADR-066)', () => {
+    function stubQueryBuilder(rows: { country: string; order_count: string }[]): {
+      select: jest.Mock;
+      addSelect: jest.Mock;
+      where: jest.Mock;
+      andWhere: jest.Mock;
+      groupBy: jest.Mock;
+      orderBy: jest.Mock;
+      addOrderBy: jest.Mock;
+      getRawMany: jest.Mock;
+    } {
+      const parts = {
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        orderBy: jest.fn().mockReturnThis(),
+        addOrderBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue(rows),
+      };
+      (ormRepository.createQueryBuilder as jest.Mock).mockReturnValue(parts);
+      return parts;
+    }
+
+    it('should issue ONE grouped query, never one per country', async () => {
+      stubQueryBuilder([
+        { country: 'PL', order_count: '47' },
+        { country: 'DE', order_count: '12' },
+      ]);
+
+      const result = await repository.countOrdersByRoutingCountrySince(
+        new Date('2026-07-31T10:00:00.000Z')
+      );
+
+      expect(ormRepository.createQueryBuilder).toHaveBeenCalledTimes(1);
+      expect(result).toEqual([
+        { country: 'PL', orderCount: 47 },
+        { country: 'DE', orderCount: 12 },
+      ]);
+    });
+
+    it('should group on the DELIVERY address country the rule engine routes on', async () => {
+      const parts = stubQueryBuilder([]);
+
+      await repository.countOrdersByRoutingCountrySince(new Date());
+
+      // Must stay the same field `toSalesDocumentOrderFacts` reads, or
+      // discovery would name markets the evaluator never sees (ADR-066).
+      expect(parts.groupBy).toHaveBeenCalledWith(
+        expect.stringContaining(`'{shippingAddress,country}'`)
+      );
+      expect(parts.select).toHaveBeenCalledWith(
+        expect.stringContaining(`'{shippingAddress,country}'`),
+        'country'
+      );
+    });
+
+    it('should exclude a row with no country rather than grouping it under an empty key', async () => {
+      const parts = stubQueryBuilder([]);
+
+      await repository.countOrdersByRoutingCountrySince(new Date());
+
+      // NULLIF(btrim(...), '') collapses blank into NULL, and the NOT NULL arm
+      // then drops both: the evaluator cannot route such an order either.
+      expect(parts.select).toHaveBeenCalledWith(
+        expect.stringContaining("NULLIF(btrim("),
+        'country'
+      );
+      expect(parts.andWhere).toHaveBeenCalledWith(expect.stringContaining('IS NOT NULL'));
+    });
+
+    it('should bound the window on the same COALESCE the coverage read uses', async () => {
+      const parts = stubQueryBuilder([]);
+      const since = new Date('2026-07-31T10:00:00.000Z');
+
+      await repository.countOrdersByRoutingCountrySince(since);
+
+      expect(parts.where).toHaveBeenCalledWith(
+        expect.stringContaining('COALESCE(rec."placedAt", rec."createdAt")'),
+        { since }
+      );
+    });
+
+    it('should order by count descending with a deterministic country tiebreak', async () => {
+      const parts = stubQueryBuilder([]);
+
+      await repository.countOrdersByRoutingCountrySince(new Date());
+
+      expect(parts.orderBy).toHaveBeenCalledWith('COUNT(*)', 'DESC');
+      expect(parts.addOrderBy).toHaveBeenCalledWith(expect.any(String), 'ASC');
+    });
+
+    it('should coerce the driver-level string count to a number', async () => {
+      stubQueryBuilder([{ country: 'PL', order_count: '47' }]);
+
+      const [market] = await repository.countOrdersByRoutingCountrySince(new Date());
+
+      expect(market.orderCount).toBe(47);
+      expect(typeof market.orderCount).toBe('number');
+    });
+  });
 });

--- a/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
@@ -121,6 +121,32 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
     return new Map(rows.map((row) => [row.source_connection_id, row.earliest_at]));
   }
 
+  async countOrdersByRoutingCountrySince(
+    since: Date
+  ): Promise<{ country: string; orderCount: number }[]> {
+    // ONE grouped query for every market, never one per country. The country
+    // expression reads the DELIVERY address, matching what the rule engine
+    // routes on (#2518, ADR-066); `#>>` yields NULL rather than throwing when
+    // the snapshot has no shippingAddress object at all, and the NULLIF strips
+    // a blank one so it groups as "no country" and is then filtered out.
+    const rows = await this.repository
+      .createQueryBuilder('rec')
+      .select(OrderRecordRepository.ROUTING_COUNTRY_EXPR, 'country')
+      .addSelect('COUNT(*)', 'order_count')
+      .where(`COALESCE(rec."placedAt", rec."createdAt") >= :since`, { since })
+      .andWhere(`${OrderRecordRepository.ROUTING_COUNTRY_EXPR} IS NOT NULL`)
+      .groupBy(OrderRecordRepository.ROUTING_COUNTRY_EXPR)
+      .orderBy('COUNT(*)', 'DESC')
+      // Deterministic tiebreak so two markets with equal counts do not swap
+      // places between page loads.
+      .addOrderBy(OrderRecordRepository.ROUTING_COUNTRY_EXPR, 'ASC')
+      .getRawMany<{ country: string; order_count: string }>();
+
+    // pg returns COUNT(*) as a string at the driver level, mirroring the
+    // Number() the money columns already get in `toDomain`.
+    return rows.map((row) => ({ country: row.country, orderCount: Number(row.order_count) }));
+  }
+
   async findMany(
     filters: OrderRecordFilters,
     pagination: OrderRecordPagination
@@ -755,6 +781,14 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
   private static readonly TOTAL_EXPR =
     `CASE WHEN jsonb_typeof(rec."orderSnapshot"#>'{totals,total}') = 'number' ` +
     `THEN (rec."orderSnapshot"#>>'{totals,total}')::numeric END`;
+  /**
+   * The country routing evaluates on (#2518) - the DELIVERY address country,
+   * the same field `toSalesDocumentOrderFacts` reads. `NULLIF(btrim(...), '')`
+   * makes a blank indistinguishable from absent, so both are excluded rather
+   * than one of them becoming a market with an empty name.
+   */
+  private static readonly ROUTING_COUNTRY_EXPR = `NULLIF(btrim(rec."orderSnapshot"#>>'{shippingAddress,country}'), '')`;
+
   private static readonly CUSTOMER_EXPR = `lower(rec."orderSnapshot"#>>'{shippingAddress,lastName}')`;
   // Guarded so a malformed (non-array) `items` value sorts as NULL rather than
   // erroring the whole list query.

--- a/libs/core/src/sales-documents/domain/types/sales-document-market-discovery.types.ts
+++ b/libs/core/src/sales-documents/domain/types/sales-document-market-discovery.types.ts
@@ -1,0 +1,84 @@
+/**
+ * Sales-Document Market Discovery Types (#2518, ADR-066)
+ *
+ * A clean OpenLinker instance has no sales-document routing, and should not:
+ * which document a sale needs is a legal question about the seller's business.
+ * The consequence today is silence - orders arrive, no document is issued, and
+ * nothing says which markets need a decision.
+ *
+ * OpenLinker already knows where every order is routed, so the set of markets
+ * needing a decision is derivable. This is the shape of that derivation: one
+ * row per country orders arrived from over a window, with the count that makes
+ * an operator act. "Not configured" alone does not.
+ *
+ * Three properties are load-bearing:
+ *
+ * 1. **It is a READ.** Discovery never creates a rule, a country default or
+ *    any routing on its own. Issuing a fiscal document nobody chose is a legal
+ *    act taken on the operator's behalf, which ADR-041 forbids.
+ * 2. **Classification is the caller's job.** A country with configured routing
+ *    and one without are BOTH returned. This type carries no `configured` flag
+ *    and no `hasTemplate` flag - the settings page joins these rows against
+ *    `listConfiguredCountries` and against the curated templates itself. Two
+ *    sources of truth for "is this market set up" is exactly the drift the
+ *    routing-first redesign exists to remove.
+ * 3. **A detected, unconfigured market is NEUTRAL, not a fault.** Nothing here
+ *    is named `missing`, `unconfigured` or `problem`, because a fresh install
+ *    is not broken - nobody has made a decision yet, and rendering that as an
+ *    error tells a new operator their instance is misconfigured on day one.
+ *
+ * These types live in `sales-documents` beside `SalesDocumentCountrySummary`,
+ * its configured-side counterpart, rather than in `orders` where the read is
+ * executed: the vocabulary belongs to the concern that asks the question. The
+ * concern keeps its zero-outbound-core-context-edge property - this file
+ * imports nothing.
+ *
+ * @module libs/core/src/sales-documents/domain/types
+ * @see docs/architecture/adrs/066-sales-document-market-discovery.md
+ */
+
+/**
+ * How far back discovery looks, in days.
+ *
+ * A documented constant rather than a per-operator setting, per ADR-066: a
+ * short window under-reports a seasonal market and a long one lists markets
+ * the seller has left, and there is no evidence yet that one operator needs a
+ * different answer from another. 30 days matches the value the committed UX
+ * mockup renders beside each detected market.
+ *
+ * The resolved window travels on {@link SalesDocumentMarketDiscovery} rather
+ * than being read from here by a surface, so the copy can say "in the last 30
+ * days" without a frontend copy of this number that could drift from it.
+ */
+export const SALES_DOCUMENT_MARKET_DISCOVERY_WINDOW_DAYS = 30;
+
+/** One country orders arrived from over the window. */
+export interface DetectedSalesDocumentMarket {
+  /**
+   * ISO 3166-1 alpha-2 as the order carried it, verbatim.
+   *
+   * Never normalised, mapped to a display name, or matched case-insensitively
+   * here: the value has to be comparable with what a rule was authored
+   * against, and a surface that silently folded `pl` into `PL` would report a
+   * market whose rules the evaluator will never match.
+   */
+  readonly country: string;
+  /** Orders from that country within the window. Always at least 1 - a zero row cannot exist. */
+  readonly orderCount: number;
+}
+
+/**
+ * The discovery read's full answer, window included.
+ */
+export interface SalesDocumentMarketDiscovery {
+  /** The window actually applied, so a surface never hardcodes it. */
+  readonly windowDays: number;
+  /** ISO-8601 lower bound the counts were taken from, inclusive. */
+  readonly since: string;
+  /**
+   * Detected markets, most orders first. Empty on an instance that has
+   * ingested no orders in the window at all - which is a legitimate state (a
+   * brand-new install), not an error.
+   */
+  readonly markets: readonly DetectedSalesDocumentMarket[];
+}

--- a/libs/core/src/sales-documents/index.ts
+++ b/libs/core/src/sales-documents/index.ts
@@ -51,6 +51,7 @@ export * from './domain/types/sales-document-condition.types';
 export * from './domain/types/sales-document-order-facts.types';
 export * from './domain/types/sales-document-rule-write.types';
 export * from './domain/types/sales-document-country-summary.types';
+export * from './domain/types/sales-document-market-discovery.types';
 export * from './domain/types/sales-document-view.types';
 export * from './domain/ports/capabilities/self-routing-document-kind.capability';
 export * from './domain/domain-services/resolve-sales-document-routing';

--- a/libs/core/src/shipping/application/services/fulfillment-status-sync.service.spec.ts
+++ b/libs/core/src/shipping/application/services/fulfillment-status-sync.service.spec.ts
@@ -107,6 +107,7 @@ describe('FulfillmentStatusSyncService', () => {
       getEarliestOrderDateByConnection: jest.fn(),
       getSalesAndChannelAnalytics: jest.fn(),
       getTopProducts: jest.fn(),
+      discoverSalesDocumentMarkets: jest.fn(),
     };
 
     routing = {

--- a/libs/core/src/shipping/application/services/shipment-dispatch-notification.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-dispatch-notification.service.spec.ts
@@ -105,6 +105,7 @@ describe('ShipmentDispatchNotificationService', () => {
       getEarliestOrderDateByConnection: jest.fn(),
       getSalesAndChannelAnalytics: jest.fn(),
       getTopProducts: jest.fn(),
+      discoverSalesDocumentMarkets: jest.fn(),
     };
 
     integrations = {

--- a/libs/core/src/shipping/application/services/shipment-dispatch.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-dispatch.service.spec.ts
@@ -172,6 +172,7 @@ describe('ShipmentDispatchService', () => {
       getEarliestOrderDateByConnection: jest.fn(),
       getSalesAndChannelAnalytics: jest.fn(),
       getTopProducts: jest.fn(),
+      discoverSalesDocumentMarkets: jest.fn(),
     };
     const fulfillmentProjection = { recompute: jest.fn() };
     // Uncontended by default (#1917): every pre-existing test asserts the


### PR DESCRIPTION
Adds the market-discovery read the sales-document settings page needs: which countries the operator's orders arrive from, and how many, so an unconfigured market is visible before somebody discovers it through missing documents.

## What this adds

- **`OrderRecordRepositoryPort.countOrdersByRoutingCountrySince(since)`** - one grouped query returning `{country, orderCount}` rows, most orders first with a deterministic country tiebreak.
- **`IOrderRecordService.discoverSalesDocumentMarkets(now?)`** - the cross-context surface, returning the markets plus the window that was actually applied.
- **`GET /sales-documents/markets/detected`** on a new `SalesDocumentMarketsController`.
- **`SalesDocumentMarketDiscovery` / `DetectedSalesDocumentMarket` / `SALES_DOCUMENT_MARKET_DISCOVERY_WINDOW_DAYS`** in `libs/core/src/sales-documents/domain/types/`, beside `SalesDocumentCountrySummary`, its configured-side counterpart.

## The window: 30 days, and where it comes from

ADR-066 says the window is "a documented constant, not a per-operator setting, until there is evidence one is needed", and gives the reasoning (a short window under-reports a seasonal market, a long one lists markets the seller has left) but no number. The number is **30**, taken from the committed UX mockup, whose detected-market fixture carries `days: 30` on every row (`docs/plans/mockups/sales-document-routing.html`, `#page=settings`, states *brand new* and *orders arriving, nothing set up*; the file lives on `origin/epic/docs-sales-documents`, not on this branch).

The resolved `windowDays` and `since` travel **on the response**, so the copy can say "in the last 30 days" without a frontend copy of the number that could drift from the one the query used.

## The decision most likely to be disputed: which country

The issue title and ADR-066's prose both say **billing** country. This reads the **delivery** address country (`orderSnapshot.shippingAddress.country`).

That is deliberate, and it follows ADR-066's own decisive rule rather than its prose. The ADR rejects detecting by a different address with: *"routing evaluates on the billing/delivery country the rules are written against, so discovery must use the same field or it would name markets the evaluator never sees."* Today the evaluator's input is built by `toSalesDocumentOrderFacts`, which reads `order.shippingAddress.country` and has **no billing fallback** - ADR-041 decision 5's own stated choice of delivery over billing. So reading the billing address here would list markets whose configuration changes nothing for those orders, which is the failure mode the ADR names.

A repository spec pins the field, so if ADR-041 ever moves jurisdiction to the billing address, the two move together or the spec fails.

## Other decisions a reviewer could dispute

1. **The types live in `sales-documents`, the read lives in `orders`.** The vocabulary belongs to the concern asking the question and sits beside `SalesDocumentCountrySummary`; the query belongs where the data is. The new file imports nothing, so `sales-documents` keeps its zero-outbound-core-context-edge property (pinned by `barrel-purity.spec.ts`).
2. **The endpoint is `@Roles('admin')`, not merely authenticated.** The task brief says guard with the global `JwtAuthGuard` and keep writes admin. This is a read, so admin is stricter than required. Chosen because the only consumer is `/settings/sales-documents`, which is admin-only in full, and its sibling `SalesDocumentRulesController` is class-level admin - a looser guard would publish the operator's market distribution to every authenticated user for no gain. Easy to relax if that is wrong.
3. **Every order in the window counts**, whatever its `recordStatus` and whether or not it was cancelled. This is a coverage fact about where orders arrive from, not a health or revenue figure - the same reasoning documented on `findEarliestOrderDateByConnection` (#2083). A cancelled Polish order still means Poland is a market the operator sells into.
4. **Orders with no country are excluded**, not grouped under an empty key. `NULLIF(btrim(...), '')` collapses blank into `NULL` and the `IS NOT NULL` arm drops both. The evaluator cannot route such an order either, so reporting it as a market would name something an operator cannot act on. It also means the counts here do **not** sum to the order total, which is correct but worth knowing.
5. **The country is returned verbatim**, never uppercased or folded. The value has to stay comparable with what a rule was authored against; silently folding `pl` into `PL` would report a market whose rules the evaluator will never match.
6. **`windowDays` is a constant, not a query parameter.** ADR-066 is explicit that it is not a per-operator setting yet. Adding a `?days=` later is additive.
7. **The window is wall-clock, `now - 30 days`**, not a calendar boundary. So the counts drift slightly between two loads on the same day. A calendar-day boundary would need a timezone, and the operator's timezone is not a thing this read has.

## What it deliberately does not do

- **It never writes.** No rule, no country default, no acknowledgment, no routing. Auto-applying the Poland template on detection is rejected outright by ADR-066: issuing a fiscal document nobody chose is a legal act taken on the operator's behalf. A service spec asserts no write method on the repository is called.
- **It does not classify.** No `configured` flag, no `hasTemplate` flag, no severity, and nothing named `missing` or `problem`. The settings page joins these rows against `GET /sales-documents/countries` and against the curated templates itself, because two sources of truth for "is this market set up" is the drift this epic exists to remove. A controller spec asserts each row has exactly `country` and `orderCount`.
- **No presentation.** No country display name and no template pairing. A detected unconfigured market is a **neutral** state - a fresh install is not broken - and this payload gives a surface nothing to tint red with.
- **No pagination.** Same call as `listConfiguredCountries`: the row count is bounded by countries the operator actually sells into.
- **No integration test.** One grouped query plus window arithmetic, unit-covered on both sides; the harness is Docker-backed and out of reach on this machine. The SQL expression itself is asserted structurally rather than executed, which is this repository spec's existing pattern.

## Overlap with what landed on `main` during the pause

- **`apps/api/src/sales-documents/data/pl-starter-template.ts` (#2170)** does not collide. It is data behind `sales-documents/templates`, and the new route is `sales-documents/markets/detected` - no path clash, and the module already existed so wiring is additive. It is the natural consumer of this read: a detected market may or may not have a curated template, and ADR-066 decision 2 requires the UI to say which, so the pairing happens on the page rather than here.
- **The `order_records` buyer-tax-id migration (#2599)** does not affect this read. It was, however, a real behavioural collision for the sibling task and was fixed there - see #2587.

## Acceptance criteria

- [x] Returns country plus count over the window defined in ADR-066.
- [x] A country with configured routing and one without are both returned; classification is the caller's job.
- [x] A single query, not one per country - asserted in the repository spec.
- [x] Never writes: no routing, rule or default created as a side effect - asserted in the service spec.
- [x] Tests added.
- [x] No architecture boundary violations; `apps/api` reaches the orders store through `IOrderRecordService`, never a repository port.

## Verification

Run locally:

- `pnpm -r --filter "./libs/**" build`, then `pnpm --filter @openlinker/core type-check`, `pnpm --filter @openlinker/api type-check`, `pnpm --filter @openlinker/worker type-check` - clean.
- `pnpm exec eslint` over every changed file - no errors, no warnings.
- `pnpm check:invariants` - all checks pass.
- `pnpm --filter @openlinker/core exec jest src/orders src/sales-documents src/shipping` (66 suites, 917 tests) and `pnpm --filter @openlinker/api exec jest src/orders src/sales-documents src/shipping` (10 suites, 156 tests) - green.

The full `pnpm test` run was **not** executed locally (it exhausts this machine); CI covers it.

Closes #2518
