### PR TITLE
feat(fiscalization): route manual registration through the register job (#2525)

### DIFF
--- a/apps/api/src/fiscalization/http/dto/accepted-fiscal-registration-response.dto.ts
+++ b/apps/api/src/fiscalization/http/dto/accepted-fiscal-registration-response.dto.ts
@@ -1,0 +1,50 @@
+/**
+ * Accepted Fiscal Registration Response DTO (#2525)
+ *
+ * The answer to `POST /fiscal-registrations`, which now ACCEPTS a registration
+ * rather than performing one.
+ *
+ * It deliberately carries no status, no record and no outcome. The endpoint
+ * previously returned the registration record, and a caller could read a
+ * completed act out of the response of the request that asked for it. That is no
+ * longer true at any point in this response's life: when it is sent, a job row
+ * exists and nothing has been sent to a provider. A caller learns the outcome by
+ * reading the order's registration state.
+ *
+ * There is likewise no field expressing when the answer will arrive. OpenLinker
+ * hands the sale to a provider and waits for one answer; it observes no steps in
+ * between and can promise no deadline.
+ *
+ * @module apps/api/src/fiscalization/http/dto
+ */
+import { ApiProperty } from '@nestjs/swagger';
+
+export class AcceptedFiscalRegistrationResponseDto {
+  @ApiProperty({ description: 'The order whose sale was accepted for registration' })
+  orderId!: string;
+
+  @ApiProperty({ description: 'The fiscalization connection it will be registered on' })
+  connectionId!: string;
+
+  @ApiProperty({
+    description:
+      'The exactly-once key this request is held under. Derived from (connection, order) and ' +
+      'never caller-supplied, so a repeat of this request joins the same work rather than ' +
+      'starting a second registration of the same sale.',
+  })
+  idempotencyKey!: string;
+
+  @ApiProperty({
+    description:
+      'The enqueued registration job. A repeated request returns the id of the job the first ' +
+      'one created rather than a second job.',
+  })
+  jobId!: string;
+
+  @ApiProperty({
+    description:
+      'True when this request restarted a job that had exhausted its retries, rather than ' +
+      'enqueueing or joining a live one. Says nothing about whether the sale is registered.',
+  })
+  redrivenFromDead!: boolean;
+}

--- a/apps/api/src/fiscalization/http/fiscalization.controller.spec.ts
+++ b/apps/api/src/fiscalization/http/fiscalization.controller.spec.ts
@@ -118,6 +118,14 @@ describe('FiscalizationController', () => {
   beforeEach(async () => {
     service = {
       register: jest.fn(),
+      requestRegistration: jest.fn().mockResolvedValue({
+        orderId: ORDER_ID,
+        connectionId: CONNECTION_ID,
+        idempotencyKey: `fiscal:${CONNECTION_ID}:${ORDER_ID}`,
+        jobId: 'job-1',
+        redrivenFromDead: false,
+      }),
+      assertRegistrable: jest.fn(),
       getByOrderId: jest.fn(),
       getById: jest.fn(),
       reconcileInDoubt: jest.fn(),
@@ -155,12 +163,12 @@ describe('FiscalizationController', () => {
       // This is what makes a double click harmless without the client having to
       // remember to send a key.
       orders.getOrderRecord.mockResolvedValue(orderRecord());
-      service.register.mockResolvedValue(registrationRecord());
 
       await controller.register({ connectionId: CONNECTION_ID, orderId: ORDER_ID });
 
-      expect(service.register).toHaveBeenCalledWith(
+      expect(service.requestRegistration).toHaveBeenCalledWith(
         expect.objectContaining({ idempotencyKey: `fiscal:${CONNECTION_ID}:${ORDER_ID}` }),
+        expect.anything(),
       );
     });
 
@@ -171,7 +179,6 @@ describe('FiscalizationController', () => {
       // field is off the request DTO (so `forbidNonWhitelisted` 400s it at the
       // pipe), and the controller must not read one even if it arrives.
       orders.getOrderRecord.mockResolvedValue(orderRecord());
-      service.register.mockResolvedValue(registrationRecord());
 
       await controller.register({
         connectionId: CONNECTION_ID,
@@ -179,8 +186,9 @@ describe('FiscalizationController', () => {
         idempotencyKey: 'retry-1',
       } as unknown as RegisterFiscalTransactionRequestDto);
 
-      expect(service.register).toHaveBeenCalledWith(
+      expect(service.requestRegistration).toHaveBeenCalledWith(
         expect.objectContaining({ idempotencyKey: `fiscal:${CONNECTION_ID}:${ORDER_ID}` }),
+        expect.anything(),
       );
     });
 
@@ -188,7 +196,7 @@ describe('FiscalizationController', () => {
       // The service refuses a second ORIGINATING registration; the operator needs
       // that as a conflict naming the blocking record, not a 500.
       orders.getOrderRecord.mockResolvedValue(orderRecord());
-      service.register.mockRejectedValue(
+      service.requestRegistration.mockRejectedValue(
         new OrderAlreadyRegisteredException(
           ORDER_ID,
           'conn-other',
@@ -205,11 +213,10 @@ describe('FiscalizationController', () => {
 
     it('should compose the sale lines server-side from the order snapshot', async () => {
       orders.getOrderRecord.mockResolvedValue(orderRecord());
-      service.register.mockResolvedValue(registrationRecord());
 
       await controller.register({ connectionId: CONNECTION_ID, orderId: ORDER_ID });
 
-      expect(service.register).toHaveBeenCalledWith(
+      expect(service.requestRegistration).toHaveBeenCalledWith(
         expect.objectContaining({
           orderId: ORDER_ID,
           currency: 'PLN',
@@ -218,6 +225,7 @@ describe('FiscalizationController', () => {
             { name: 'Widget', quantity: 1, unitPriceGross: 100, taxRate: '', sku: null },
           ],
         }),
+        expect.anything(),
       );
     });
 
@@ -227,7 +235,7 @@ describe('FiscalizationController', () => {
       await expect(
         controller.register({ connectionId: CONNECTION_ID, orderId: 'nope' }),
       ).rejects.toBeInstanceOf(NotFoundException);
-      expect(service.register).not.toHaveBeenCalled();
+      expect(service.requestRegistration).not.toHaveBeenCalled();
     });
 
     it('should 422 when the order snapshot cannot be rehydrated', async () => {
@@ -247,7 +255,7 @@ describe('FiscalizationController', () => {
       await expect(
         controller.register({ connectionId: CONNECTION_ID, orderId: ORDER_ID }),
       ).rejects.toBeInstanceOf(UnprocessableEntityException);
-      expect(service.register).not.toHaveBeenCalled();
+      expect(service.requestRegistration).not.toHaveBeenCalled();
     });
 
     it('should register an order whose addresses are PII-redacted', async () => {
@@ -278,67 +286,77 @@ describe('FiscalizationController', () => {
         NOW,
       );
       orders.getOrderRecord.mockResolvedValue(redacted);
-      service.register.mockResolvedValue(registrationRecord());
 
       await controller.register({ connectionId: CONNECTION_ID, orderId: ORDER_ID });
 
-      expect(service.register).toHaveBeenCalledWith(
+      expect(service.requestRegistration).toHaveBeenCalledWith(
         expect.objectContaining({ totalGross: 100 }),
+        expect.anything(),
       );
-      expect(service.register.mock.calls[0]?.[0].recipient).toBeUndefined();
+      expect(service.requestRegistration.mock.calls[0]?.[0].recipient).toBeUndefined();
     });
 
-    it('should return a FAILED registration as a body, not an exception', async () => {
-      // An in-doubt outcome must stay visible and carry its record id; throwing
-      // would hide both.
+    it('should answer that the work was accepted, never that the sale was registered', async () => {
+      // The response of the request that ASKS cannot report an outcome: when it
+      // is sent, a job row exists and no provider has been called.
       orders.getOrderRecord.mockResolvedValue(orderRecord());
-      service.register.mockResolvedValue(
-        registrationRecord({
-          status: 'failed',
-          failureMode: 'in-doubt',
-          failureReason: 'The provider did not confirm the registration.',
+
+      const response = await controller.register({
+        connectionId: CONNECTION_ID,
+        orderId: ORDER_ID,
+      });
+
+      expect(response).toEqual({
+        orderId: ORDER_ID,
+        connectionId: CONNECTION_ID,
+        idempotencyKey: `fiscal:${CONNECTION_ID}:${ORDER_ID}`,
+        jobId: 'job-1',
+        redrivenFromDead: false,
+      });
+      // No status, no failure mode, no record id: there is nothing to read an
+      // outcome out of, deliberately.
+      expect(Object.keys(response)).not.toContain('status');
+      expect(Object.keys(response)).not.toContain('failureMode');
+    });
+
+    it('should enqueue rather than register inline', async () => {
+      orders.getOrderRecord.mockResolvedValue(orderRecord());
+
+      await controller.register({ connectionId: CONNECTION_ID, orderId: ORDER_ID });
+
+      expect(service.requestRegistration).toHaveBeenCalledWith(
+        expect.objectContaining({
+          orderId: ORDER_ID,
+          connectionId: CONNECTION_ID,
+          idempotencyKey: `fiscal:${CONNECTION_ID}:${ORDER_ID}`,
         }),
+        expect.objectContaining({ sourceConnectionId: 'conn_src' }),
+      );
+      // The inline path is gone; nothing here may perform the registration.
+      expect(service.register).not.toHaveBeenCalled();
+    });
+
+    it('should derive the same key on every repeat of one request', async () => {
+      orders.getOrderRecord.mockResolvedValue(orderRecord());
+
+      await controller.register({ connectionId: CONNECTION_ID, orderId: ORDER_ID });
+      await controller.register({ connectionId: CONNECTION_ID, orderId: ORDER_ID });
+
+      const keys = service.requestRegistration.mock.calls.map(
+        ([command]) => command.idempotencyKey,
+      );
+      expect(keys[0]).toBe(keys[1]);
+    });
+
+    it('should map a blocking document to 409 at the point of asking', async () => {
+      orders.getOrderRecord.mockResolvedValue(orderRecord());
+      service.requestRegistration.mockRejectedValue(
+        new OrderAlreadyRegisteredException(ORDER_ID, 'other-conn', CONNECTION_ID, 'registered', 'rec-9'),
       );
 
-      const response = await controller.register({
-        connectionId: CONNECTION_ID,
-        orderId: ORDER_ID,
-      });
-
-      expect(response.status).toBe('failed');
-      expect(response.failureMode).toBe('in-doubt');
-      expect(response.id).toBe('11111111-1111-1111-1111-111111111111');
-    });
-
-    it('should never expose the internal diagnostic', async () => {
-      orders.getOrderRecord.mockResolvedValue(orderRecord());
-      service.register.mockResolvedValue(registrationRecord({ status: 'failed' }));
-
-      const response = await controller.register({
-        connectionId: CONNECTION_ID,
-        orderId: ORDER_ID,
-      });
-
-      expect(JSON.stringify(response)).not.toContain('internal diagnostic');
-    });
-
-    it('should project the neutral identity set, extras included', async () => {
-      orders.getOrderRecord.mockResolvedValue(orderRecord());
-      service.register.mockResolvedValue(registrationRecord());
-
-      const response = await controller.register({
-        connectionId: CONNECTION_ID,
-        orderId: ORDER_ID,
-      });
-
-      expect(response).toMatchObject({
-        providerReference: 'p-1',
-        documentReference: 'd-1',
-        signingIdentity: 's-1',
-        regimeExtras: { someRegimeKey: 'value' },
-        artefacts: [],
-      });
-      expect(response.registeredAt).toBe(NOW.toISOString());
+      await expect(
+        controller.register({ connectionId: CONNECTION_ID, orderId: ORDER_ID }),
+      ).rejects.toBeInstanceOf(ConflictException);
     });
   });
 
@@ -380,7 +398,7 @@ describe('FiscalizationController', () => {
       const response = await controller.listForOrder(ORDER_ID);
 
       expect(response[0]?.inFlight).toBe(true);
-      expect(service.register).not.toHaveBeenCalled();
+      expect(service.requestRegistration).not.toHaveBeenCalled();
       expect(service.reconcileInDoubt).not.toHaveBeenCalled();
     });
 

--- a/apps/api/src/fiscalization/http/fiscalization.controller.ts
+++ b/apps/api/src/fiscalization/http/fiscalization.controller.ts
@@ -48,6 +48,7 @@ import {
   IFiscalRegistrationService,
   InvalidFiscalLineError,
   MissingIdempotencyKeyException,
+  fiscalRegistrationIdempotencyKey,
   OrderAlreadyHasInvoiceException,
   OrderAlreadyRegisteredException,
   UnsupportedFiscalPriceTreatmentError,
@@ -55,6 +56,7 @@ import {
 } from '@openlinker/core/fiscalization';
 import type {
   FiscalRegistrationRecord,
+  FiscalRegistrationRequestAccepted,
   RegisterTransactionCommand,
 } from '@openlinker/core/fiscalization';
 import {
@@ -66,25 +68,27 @@ import {
 import type { Order, OrderRecord } from '@openlinker/core/orders';
 
 import { Roles } from '../../auth/decorators/roles.decorator';
+import { AcceptedFiscalRegistrationResponseDto } from './dto/accepted-fiscal-registration-response.dto';
 import { FiscalRegistrationResponseDto } from './dto/fiscal-registration-response.dto';
 import { ReconcileFiscalRegistrationResponseDto } from './dto/reconcile-fiscal-registration-response.dto';
 import { RegisterFiscalTransactionRequestDto } from './dto/register-fiscal-transaction-request.dto';
 
 /**
- * The exactly-once key for this surface. One connection registering one order is
- * one sale, so this makes a repeated request - a double click, a retried fetch, a
- * duplicated job - idempotent BY CONSTRUCTION rather than by the caller
- * remembering to send a key.
+ * The exactly-once key for this surface.
+ *
+ * One connection registering one order is one sale, so a repeated request - a
+ * double click, a retried fetch, a duplicated job - is idempotent BY
+ * CONSTRUCTION rather than by the caller remembering to send a key.
  *
  * It is the ONLY key this endpoint can produce: the request DTO deliberately
  * carries no `idempotencyKey`, because a caller-chosen key would bypass the read
  * gate and register the same sale a second time. See the DTO for the full
- * reasoning; the mandatory-key contract of ADR-042 decision 6 lives at the
- * service boundary, which this function satisfies.
+ * reasoning.
+ *
+ * The format itself lives in `@openlinker/core/fiscalization` (#2525) so this
+ * surface and the auto-issue gate cannot drift apart; two copies of a key format
+ * that must be byte-identical is how one sale ends up with two receipts.
  */
-function idempotencyKeyFor(connectionId: string, orderId: string): string {
-  return `fiscal:${connectionId}:${orderId}`;
-}
 
 @ApiTags('fiscalization')
 @ApiBearerAuth()
@@ -99,30 +103,35 @@ export class FiscalizationController {
 
   @Roles('admin')
   @Post('fiscal-registrations')
-  @HttpCode(HttpStatus.OK)
+  @HttpCode(HttpStatus.ACCEPTED)
   @ApiOperation({
-    summary: 'Register an order`s sale with a fiscalization provider',
+    summary: 'Ask for an order`s sale to be registered with a fiscalization provider',
     description:
-      'Composes the command server-side from the order and delegates to the core service, which ' +
-      'owns the exactly-once guarantee. The exactly-once key is derived from (connection, order) ' +
-      'and cannot be supplied by the caller, so a repeat resumes the existing record and can ' +
-      'never produce a second registration of the same sale; an order that already carries a ' +
-      'non-rejected registration is refused with 409 rather than registered again. ' +
-      'Returns 200 with the record even when the attempt FAILED - an indeterminate outcome must ' +
-      'be visibly indeterminate, and the caller needs the record id to reconcile against. Read ' +
-      '`status` / `failureMode`, never the status code, to decide whether the sale was registered.',
+      'ACCEPTS the registration; it does not perform it. The command is composed server-side ' +
+      'from the order and enqueued as a `fiscalization.register` job, which the worker runs. ' +
+      'A 202 therefore says the request was recorded and nothing more - never that the sale was ' +
+      'registered, and never that it will be. Read the order`s registration state to learn the ' +
+      'outcome. ' +
+      'The exactly-once key is derived from (connection, order) and cannot be supplied by the ' +
+      'caller, so a repeat joins the same job and can never produce a second registration of ' +
+      'the same sale; an order that already carries a non-rejected document is refused with 409 ' +
+      'at this point rather than by a job failing out of sight.',
   })
-  @ApiResponse({ status: 200, description: 'Registration record', type: FiscalRegistrationResponseDto })
+  @ApiResponse({
+    status: 202,
+    description: 'Registration accepted and enqueued',
+    type: AcceptedFiscalRegistrationResponseDto,
+  })
   @ApiResponse({ status: 404, description: 'Order not found' })
   @ApiResponse({
     status: 409,
-    description: 'The order already carries a fiscal registration that is not terminally rejected',
+    description: 'The order already carries a sales document that is not terminally rejected',
   })
   @ApiResponse({ status: 422, description: 'The order cannot be composed into a registrable sale' })
   @ApiResponse({ status: 403, description: 'Insufficient permissions' })
   async register(
     @Body() dto: RegisterFiscalTransactionRequestDto,
-  ): Promise<FiscalRegistrationResponseDto> {
+  ): Promise<AcceptedFiscalRegistrationResponseDto> {
     const record = await this.orders.getOrderRecord(dto.orderId);
     if (!record) {
       throw new NotFoundException(`Order not found: ${dto.orderId}`);
@@ -132,10 +141,14 @@ export class FiscalizationController {
 
     let command: RegisterTransactionCommand;
     try {
+      // Composed HERE, not in the worker, so a sale that cannot be expressed as
+      // a registrable command is refused while the operator is still looking at
+      // it. Deferring the composition would turn a 422 into an accepted request
+      // that fails later with nothing on screen to explain it.
       command = toRegisterTransactionCommand({
         order,
         connectionId: dto.connectionId,
-        idempotencyKey: idempotencyKeyFor(dto.connectionId, dto.orderId),
+        idempotencyKey: fiscalRegistrationIdempotencyKey(dto.connectionId, dto.orderId),
         // #2260 review: a manual registration of a pre-rollout order must reach
         // the same verdict the manual invoice path does, so the marker travels
         // with the command rather than being re-derived (or lost) downstream.
@@ -145,13 +158,15 @@ export class FiscalizationController {
       throw this.toHttpException(error);
     }
 
-    let registered: FiscalRegistrationRecord;
+    let accepted: FiscalRegistrationRequestAccepted;
     try {
-      registered = await this.fiscalRegistrations.register(command);
+      accepted = await this.fiscalRegistrations.requestRegistration(command, {
+        sourceConnectionId: record.sourceConnectionId,
+      });
     } catch (error) {
       throw this.toHttpException(error);
     }
-    return this.toDto(registered);
+    return accepted;
   }
 
   @Get('fiscal-registrations')

--- a/apps/api/test/integration/fiscalization/manual-registration-enqueue.int-spec.ts
+++ b/apps/api/test/integration/fiscalization/manual-registration-enqueue.int-spec.ts
@@ -1,0 +1,98 @@
+/**
+ * Manual Registration Enqueue Integration Test (#2525)
+ *
+ * The manual path no longer registers inline; it writes a
+ * `fiscalization.register` job and returns. That moves one half of the
+ * exactly-once guarantee onto a row this test is about: if a repeated request
+ * could write a SECOND job, the same sale would be registered twice, and no
+ * amount of care further down would prevent it.
+ *
+ * The guarantee holds against a real database or not at all, so it is exercised
+ * here rather than against a mocked repository:
+ *
+ *   - two schedules under the deterministic (connection, order) key produce ONE
+ *     row, and the second answers with the first one's id;
+ *   - the payload the worker will read survives the jsonb round trip carrying
+ *     the same key, so the record the job eventually writes is held under the
+ *     key the job row is held under.
+ *
+ * The record-side half of the guarantee - the unique index and the CAS claim -
+ * is covered by `fiscal-registration-record-repository.int-spec.ts`.
+ *
+ * @module apps/api/test/integration/fiscalization
+ */
+import { fiscalRegistrationIdempotencyKey } from '@openlinker/core/fiscalization';
+import { SYNC_JOBS_SERVICE_TOKEN, type ISyncJobsService } from '@openlinker/core/sync';
+import { SyncJobOrmEntity } from '@openlinker/core/sync/orm-entities';
+
+import { getTestHarness, resetTestHarness, teardownTestHarness } from '../setup';
+import type { IntegrationTestHarness } from '../setup';
+
+const CONNECTION_ID = '00000000-0000-0000-0000-0000000019a8';
+const ORDER_ID = 'ol_order_manual_register_1';
+
+describe('manual fiscal registration enqueue (integration)', () => {
+  let harness: IntegrationTestHarness;
+  let syncJobs: ISyncJobsService;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+    syncJobs = harness.getApp().get<ISyncJobsService>(SYNC_JOBS_SERVICE_TOKEN);
+  });
+
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  function scheduleRegistration(): Promise<{ id: string }> {
+    const idempotencyKey = fiscalRegistrationIdempotencyKey(CONNECTION_ID, ORDER_ID);
+    return syncJobs.schedule({
+      jobType: 'fiscalization.register',
+      connectionId: CONNECTION_ID,
+      idempotencyKey,
+      maxAttempts: 3,
+      runAfter: new Date(),
+      payload: {
+        schemaVersion: 1,
+        connectionId: CONNECTION_ID,
+        orderId: ORDER_ID,
+        idempotencyKey,
+        currency: 'PLN',
+        lines: [{ name: 'Widget', quantity: 1, unitPriceGross: 100, taxRate: '23', sku: null }],
+        totalGross: 100,
+        sourceConnectionId: CONNECTION_ID,
+      },
+    });
+  }
+
+  it('should produce ONE job when the same sale is submitted twice', async () => {
+    const first = await scheduleRegistration();
+    const second = await scheduleRegistration();
+
+    expect(second.id).toBe(first.id);
+
+    const rows = await harness
+      .getDataSource()
+      .getRepository(SyncJobOrmEntity)
+      .find({ where: { jobType: 'fiscalization.register' } });
+    expect(rows).toHaveLength(1);
+  });
+
+  it('should carry the same exactly-once key into the payload the worker reads', async () => {
+    await scheduleRegistration();
+
+    const row = await harness
+      .getDataSource()
+      .getRepository(SyncJobOrmEntity)
+      .findOneOrFail({ where: { jobType: 'fiscalization.register' } });
+
+    // The record the job writes is held under the payload's key. If the two
+    // could differ, the job row would dedupe one thing and the record another.
+    expect((row.payload as { idempotencyKey?: string }).idempotencyKey).toBe(row.idempotencyKey);
+    expect(row.idempotencyKey).toBe(`fiscal:${CONNECTION_ID}:${ORDER_ID}`);
+  });
+});

--- a/libs/core/src/fiscalization/application/mappers/register-transaction-command-to-payload.mapper.ts
+++ b/libs/core/src/fiscalization/application/mappers/register-transaction-command-to-payload.mapper.ts
@@ -1,0 +1,68 @@
+/**
+ * Register Transaction Command to Job Payload Mapper (#2525)
+ *
+ * Flattens a `RegisterTransactionCommand` into the serializable
+ * `fiscalization.register` job payload.
+ *
+ * It exists because there are now two callers that enqueue that job - the
+ * auto-issue gate and the manual HTTP path - and a payload composed twice is a
+ * payload that can be composed differently twice. The `occurredAt` `Date` to
+ * ISO-8601 conversion in particular is the kind of detail one call site loses
+ * silently, and the job would then register the sale at the wrong instant.
+ *
+ * Pure: no I/O, no injected dependency, and it reads only the command it is
+ * given plus the provenance the caller passes alongside it.
+ *
+ * @module libs/core/src/fiscalization/application/mappers
+ */
+import type { FiscalizationRegisterPayloadV1 } from '@openlinker/core/sync';
+
+import type { RegisterTransactionCommand } from '../../domain/types/fiscalization.types';
+
+/**
+ * Provenance the payload carries but the command does not: which connection the
+ * ORDER came from, and the trace token of the event that led here.
+ */
+export interface FiscalizationRegisterPayloadProvenance {
+  /** The order's source connection - never the fiscalization one. */
+  sourceConnectionId: string;
+  /** Only trace token at the seam; absent for an operator-initiated request. */
+  sourceEventId?: string;
+}
+
+export function toFiscalizationRegisterPayload(
+  command: RegisterTransactionCommand,
+  provenance: FiscalizationRegisterPayloadProvenance,
+): FiscalizationRegisterPayloadV1 {
+  const payload: FiscalizationRegisterPayloadV1 = {
+    schemaVersion: 1,
+    connectionId: command.connectionId,
+    orderId: command.orderId,
+    idempotencyKey: command.idempotencyKey,
+    currency: command.currency,
+    lines: command.lines,
+    totalGross: command.totalGross,
+    sourceConnectionId: provenance.sourceConnectionId,
+  };
+
+  // SERIALIZATION CONTRACT: `occurredAt` is a `Date` on the command; the jsonb
+  // payload carries it as ISO-8601 (see the payload type's own doc).
+  if (command.occurredAt !== undefined) {
+    payload.occurredAt = command.occurredAt.toISOString();
+  }
+  if (command.recipient !== undefined) {
+    payload.recipient = command.recipient;
+  }
+  if (provenance.sourceEventId !== undefined) {
+    payload.sourceEventId = provenance.sourceEventId;
+  }
+  // The era marker exempts pre-rollout history from the write-path tax-rate
+  // guard (#2260 review). It has to survive the hop or the guard in
+  // `FiscalRegistrationService` re-decides the question without it - accepting
+  // the order here and refusing it there.
+  if (command.taxRateEra !== undefined && command.taxRateEra !== null) {
+    payload.taxRateEra = command.taxRateEra;
+  }
+
+  return payload;
+}

--- a/libs/core/src/fiscalization/application/services/fiscal-registration.service.interface.ts
+++ b/libs/core/src/fiscalization/application/services/fiscal-registration.service.interface.ts
@@ -10,6 +10,7 @@
 import type { SalesDocumentInFlight } from '@openlinker/core/sales-documents';
 
 import type { FiscalRegistrationRecord } from '../../domain/entities/fiscal-registration-record.entity';
+import type { FiscalRegistrationRequestAccepted } from '../../domain/types/fiscal-registration-request.types';
 import type {
   FiscalReconcileOutcome,
   RegisterTransactionCommand,
@@ -78,6 +79,69 @@ export interface IFiscalRegistrationService {
    * nothing was attempted and there is no record to reason about.
    */
   register(cmd: RegisterTransactionCommand): Promise<FiscalRegistrationRecord>;
+
+  /**
+   * ASK for a registration, without performing one (#2525).
+   *
+   * Writes a `fiscalization.register` job and returns. The sale is registered
+   * later, by {@link register} running inside that job, so this method never
+   * reaches a provider and never produces a record. Its answer says the request
+   * was accepted and nothing more; a caller learns the outcome by reading the
+   * order's registration state afterwards.
+   *
+   * This is the path an operator-initiated registration takes. Performing the
+   * work inline inside the HTTP request instead tied a fiscal act to a browser
+   * tab: the provider poll can outlast the request, and a closed tab cut the
+   * request off while the record it had already written stayed behind, so the
+   * operator lost sight of a registration that was still happening.
+   *
+   * EXACTLY-ONCE IS UNCHANGED, and is not weakened by there now being a queue in
+   * front of it. Three layers hold, and this method adds nothing of its own:
+   *   1. the job's `idempotencyKey` is the same deterministic
+   *      `(connectionId, orderId)` key the record uses, so two requests for one
+   *      sale produce ONE job row and the second joins the first;
+   *   2. the job payload carries that key into `register`, which applies the
+   *      read gate, the unique index and the in-flight claim exactly as before;
+   *   3. the order-level guard is re-applied under the per-order lock when the
+   *      job runs, so nothing decided here can license a second document.
+   *
+   * A job left `dead` after exhausting its retries is re-driven rather than
+   * ignored, because otherwise a lost job would leave an order permanently
+   * un-registrable from the UI: the enqueue would keep returning the dead row.
+   * Re-driving re-runs the SAME key against the SAME record, which is a resume,
+   * not a resend.
+   *
+   * Throws the same refusals {@link assertRegistrable} does when the order
+   * already carries a blocking document, so an operator is told at the point of
+   * asking rather than by a job that quietly fails later.
+   */
+  requestRegistration(
+    cmd: RegisterTransactionCommand,
+    provenance: { sourceConnectionId: string; sourceEventId?: string },
+  ): Promise<FiscalRegistrationRequestAccepted>;
+
+  /**
+   * Refuse, as a READ, an order that already carries a blocking sales document.
+   *
+   * The same predicate the write path enforces under the per-order lock, exposed
+   * so a caller that is only ASKING for a registration can be refused at that
+   * point instead of being told the request was accepted and then having a job
+   * fail out of sight. It takes no lock, writes nothing and calls no provider.
+   *
+   * ADVISORY BY CONSTRUCTION. Passing here does not license anything: the
+   * authoritative guard is the one {@link register} runs inside the lock, and a
+   * peer can persist a blocking record between this read and that write. Nothing
+   * may treat a clean answer here as permission.
+   *
+   * Throws `OrderAlreadyRegisteredException` for a blocking fiscal record on any
+   * connection, and `OrderAlreadyHasInvoiceException` for a blocking invoice.
+   *
+   * It is the guard for a NEW originating registration, so a caller resuming an
+   * existing attempt under the same key must not run it - a `pending` row and a
+   * `registering` row both block, correctly, and a resume is not a second
+   * document. {@link requestRegistration} makes that distinction itself.
+   */
+  assertRegistrable(orderId: string, requestedConnectionId: string): Promise<void>;
 
   /** Every registration record held by an order, across connections, newest-first. */
   getByOrderId(orderId: string): Promise<FiscalRegistrationRecord[]>;

--- a/libs/core/src/fiscalization/application/services/fiscal-registration.service.spec.ts
+++ b/libs/core/src/fiscalization/application/services/fiscal-registration.service.spec.ts
@@ -10,7 +10,7 @@
  * @module libs/core/src/fiscalization/application/services
  */
 import type { IIntegrationsService } from '@openlinker/core/integrations';
-import type { SyncLockPort } from '@openlinker/core/sync';
+import type { ISyncJobsService, SyncLockPort } from '@openlinker/core/sync';
 import { Logger } from '@openlinker/shared/logging';
 import type { IInvoiceService } from '@openlinker/core/invoicing';
 
@@ -98,6 +98,7 @@ describe('FiscalRegistrationService', () => {
   let adapter: jest.Mocked<FiscalizationPort>;
   let registrationLock: jest.Mocked<SyncLockPort>;
   let invoiceService: jest.Mocked<Pick<IInvoiceService, 'findBlockingInvoiceForOrder'>>;
+  let syncJobs: jest.Mocked<Pick<ISyncJobsService, 'schedule' | 'requeueDeadByIdempotencyKey'>>;
   let service: FiscalRegistrationService;
 
   beforeEach(() => {
@@ -128,11 +129,18 @@ describe('FiscalRegistrationService', () => {
     invoiceService = {
       findBlockingInvoiceForOrder: jest.fn().mockResolvedValue(null),
     };
+    // #2525: the enqueue seam. `schedule` answers with a job row; a dead-job
+    // re-drive reports nothing to re-drive unless a case says otherwise.
+    syncJobs = {
+      schedule: jest.fn().mockResolvedValue({ id: 'job-1' }),
+      requeueDeadByIdempotencyKey: jest.fn().mockResolvedValue(false),
+    };
     service = new FiscalRegistrationService(
       repo,
       integrations as unknown as IIntegrationsService,
       registrationLock,
       invoiceService as unknown as IInvoiceService,
+      syncJobs as unknown as ISyncJobsService,
     );
   });
 
@@ -1423,6 +1431,119 @@ describe('FiscalRegistrationService', () => {
       await expect(service.getById('nope')).rejects.toThrow(
         FiscalRegistrationRecordNotFoundException,
       );
+    });
+  });
+
+  describe('requestRegistration (#2525)', () => {
+    it('should enqueue the register job and never reach the provider when a registration is requested', async () => {
+      repo.findByIdempotencyKey.mockResolvedValue(null);
+      repo.findAllByOrderId.mockResolvedValue([]);
+
+      const accepted = await service.requestRegistration(command(), {
+        sourceConnectionId: 'src-conn',
+      });
+
+      expect(syncJobs.schedule).toHaveBeenCalledWith(
+        expect.objectContaining({
+          jobType: 'fiscalization.register',
+          connectionId: CONNECTION_ID,
+          idempotencyKey: KEY,
+        }),
+      );
+      expect(accepted).toEqual({
+        orderId: ORDER_ID,
+        connectionId: CONNECTION_ID,
+        idempotencyKey: KEY,
+        jobId: 'job-1',
+        redrivenFromDead: false,
+      });
+      // The whole point: asking does not register. No adapter is resolved and
+      // no record is written by this path.
+      expect(integrations.getCapabilityAdapter).not.toHaveBeenCalled();
+      expect(repo.create).not.toHaveBeenCalled();
+    });
+
+    it('should carry the SAME key both requests derive when the same sale is requested twice', async () => {
+      repo.findByIdempotencyKey.mockResolvedValue(null);
+      repo.findAllByOrderId.mockResolvedValue([]);
+
+      const first = await service.requestRegistration(command(), { sourceConnectionId: 'src' });
+      const second = await service.requestRegistration(command(), { sourceConnectionId: 'src' });
+
+      // Two requests, one key. Deduplication is the job row's unique key doing
+      // its work, which is why both answers name the same job.
+      expect(first.idempotencyKey).toBe(second.idempotencyKey);
+      const keys = syncJobs.schedule.mock.calls.map(([input]) => input.idempotencyKey);
+      expect(keys).toEqual([KEY, KEY]);
+    });
+
+    it('should refuse when the order already carries a blocking registration', async () => {
+      repo.findByIdempotencyKey.mockResolvedValue(null);
+      repo.findAllByOrderId.mockResolvedValue([
+        record('registered', { id: 'other', connectionId: 'conn-other', idempotencyKey: 'other-key' }),
+      ]);
+
+      await expect(
+        service.requestRegistration(command(), { sourceConnectionId: 'src' }),
+      ).rejects.toBeInstanceOf(OrderAlreadyRegisteredException);
+      expect(syncJobs.schedule).not.toHaveBeenCalled();
+    });
+
+    it('should refuse when the order already carries a blocking invoice', async () => {
+      repo.findByIdempotencyKey.mockResolvedValue(null);
+      repo.findAllByOrderId.mockResolvedValue([]);
+      invoiceService.findBlockingInvoiceForOrder.mockResolvedValue({
+        id: 'inv-1',
+        connectionId: 'inv-conn',
+        status: 'issued',
+      } as never);
+
+      await expect(
+        service.requestRegistration(command(), { sourceConnectionId: 'src' }),
+      ).rejects.toBeInstanceOf(OrderAlreadyHasInvoiceException);
+      expect(syncJobs.schedule).not.toHaveBeenCalled();
+    });
+
+    it('should treat a same-key pending row as a resume rather than a second document', async () => {
+      // A `pending` row blocks a NEW originating registration, correctly. It
+      // must not block the request that re-drives its own stalled job.
+      repo.findByIdempotencyKey.mockResolvedValue(record('pending'));
+      repo.findAllByOrderId.mockResolvedValue([record('pending')]);
+
+      await expect(
+        service.requestRegistration(command(), { sourceConnectionId: 'src' }),
+      ).resolves.toMatchObject({ jobId: 'job-1' });
+    });
+
+    it('should refuse a same-key row that is in doubt, because the sale may already be registered', async () => {
+      const inDoubt = record('failed', { failureMode: 'in-doubt' });
+      repo.findByIdempotencyKey.mockResolvedValue(inDoubt);
+      repo.findAllByOrderId.mockResolvedValue([inDoubt]);
+
+      await expect(
+        service.requestRegistration(command(), { sourceConnectionId: 'src' }),
+      ).rejects.toBeInstanceOf(OrderAlreadyRegisteredException);
+      expect(syncJobs.schedule).not.toHaveBeenCalled();
+    });
+
+    it('should report a re-driven dead job so a repeated request is not silently inert', async () => {
+      repo.findByIdempotencyKey.mockResolvedValue(record('pending'));
+      repo.findAllByOrderId.mockResolvedValue([record('pending')]);
+      syncJobs.requeueDeadByIdempotencyKey.mockResolvedValue(true);
+
+      const accepted = await service.requestRegistration(command(), { sourceConnectionId: 'src' });
+
+      expect(accepted.redrivenFromDead).toBe(true);
+      expect(syncJobs.requeueDeadByIdempotencyKey).toHaveBeenCalledWith(KEY);
+    });
+
+    it('should refuse a request carrying no exactly-once key', async () => {
+      await expect(
+        service.requestRegistration(command({ idempotencyKey: '  ' }), {
+          sourceConnectionId: 'src',
+        }),
+      ).rejects.toBeInstanceOf(MissingIdempotencyKeyException);
+      expect(syncJobs.schedule).not.toHaveBeenCalled();
     });
   });
 });

--- a/libs/core/src/fiscalization/application/services/fiscal-registration.service.ts
+++ b/libs/core/src/fiscalization/application/services/fiscal-registration.service.ts
@@ -22,7 +22,12 @@ import {
   IIntegrationsService,
   INTEGRATIONS_SERVICE_TOKEN,
 } from '@openlinker/core/integrations';
-import { type SyncLockPort, SYNC_LOCK_TOKEN } from '@openlinker/core/sync';
+import {
+  type SyncLockPort,
+  SYNC_LOCK_TOKEN,
+  type ISyncJobsService,
+  SYNC_JOBS_SERVICE_TOKEN,
+} from '@openlinker/core/sync';
 import { IInvoiceService } from '@openlinker/core/invoicing';
 import {
   INVOICE_SERVICE_TOKEN,
@@ -50,6 +55,8 @@ import { OrderAlreadyHasInvoiceException } from '../../domain/exceptions/order-a
 import { FiscalRegistrationContendedException } from '../../domain/exceptions/fiscal-registration-contended.exception';
 import { FiscalReconcileCheckFailedException } from '../../domain/exceptions/fiscal-reconcile-check-failed.exception';
 import { FISCAL_REGISTRATION_RECORD_REPOSITORY_TOKEN } from '../../fiscalization.tokens';
+import type { FiscalRegistrationRequestAccepted } from '../../domain/types/fiscal-registration-request.types';
+import { toFiscalizationRegisterPayload } from '../mappers/register-transaction-command-to-payload.mapper';
 import type {
   FiscalRegistrationFailureMode,
   FiscalRegistrationOutcomePatch,
@@ -64,6 +71,16 @@ import { readFiscalLocateAnswer } from '../../domain/types/fiscalization.types';
  * against that list.
  */
 const FISCALIZATION_CAPABILITY = 'Fiscalization';
+
+/**
+ * Attempts a manually requested `fiscalization.register` job is given.
+ *
+ * Matches the auto-issue gate's budget, deliberately: the two paths enqueue the
+ * same job to perform the same act, and a manual request that gave up sooner (or
+ * later) than an automatic one would make the retry behaviour of a sale depend
+ * on who asked for it.
+ */
+export const MANUAL_REGISTRATION_RETRY_BUDGET = 3;
 
 /** Max persisted length of the INTERNAL-ONLY sanitized diagnostic. */
 const MAX_ERROR_MESSAGE_LENGTH = 500;
@@ -166,6 +183,8 @@ export class FiscalRegistrationService implements IFiscalRegistrationService {
     private readonly registrationLock: SyncLockPort,
     @Inject(INVOICE_SERVICE_TOKEN)
     private readonly invoiceService: IInvoiceService,
+    @Inject(SYNC_JOBS_SERVICE_TOKEN)
+    private readonly syncJobs: ISyncJobsService,
   ) {}
 
   /**
@@ -183,6 +202,75 @@ export class FiscalRegistrationService implements IFiscalRegistrationService {
    * ({@link registerContended}), never crossing the provider boundary while a
    * peer holds the lock.
    */
+  /**
+   * Enqueue a registration instead of performing one (#2525). See the interface
+   * for the contract; what follows is why each step is where it is.
+   */
+  async requestRegistration(
+    cmd: RegisterTransactionCommand,
+    provenance: { sourceConnectionId: string; sourceEventId?: string },
+  ): Promise<FiscalRegistrationRequestAccepted> {
+    const key = cmd.idempotencyKey?.trim() ?? '';
+    if (key.length === 0) {
+      // The same refusal `register` makes, made earlier: a request with no key
+      // would enqueue a job that can only fail, and the failure would surface
+      // in a log rather than to whoever asked.
+      throw new MissingIdempotencyKeyException(cmd.orderId);
+    }
+
+    // Read gate FIRST, exactly as `registerLocked` does it. A same-key row is a
+    // resume, not a second originating registration, so the order-level guard
+    // must not be applied to it - a `pending` row whose job died blocks
+    // `blocksFurtherRegistration`, and running the guard here would make the
+    // re-drive below unreachable for the one case it exists to fix.
+    const existing = await this.repo.findByIdempotencyKey(cmd.connectionId, key);
+    if (existing === null || !isResumableUnderSameKey(existing)) {
+      await this.assertRegistrable(cmd.orderId, cmd.connectionId);
+    }
+
+    const payload = toFiscalizationRegisterPayload({ ...cmd, idempotencyKey: key }, provenance);
+
+    const job = await this.syncJobs.schedule({
+      jobType: 'fiscalization.register',
+      connectionId: cmd.connectionId,
+      payload: payload as unknown as Record<string, unknown>,
+      idempotencyKey: key,
+      maxAttempts: MANUAL_REGISTRATION_RETRY_BUDGET,
+      runAfter: new Date(),
+    });
+
+    // A job that exhausted its retries is left `dead`, and `schedule` returns
+    // that dead row rather than a fresh one - the key is already taken. Without
+    // this the order would be un-registrable from any surface for good: the
+    // enqueue would keep reporting success and nothing would ever run.
+    // Re-driving re-runs the SAME key against the SAME record, which the write
+    // path treats as a resume, so it can never become a second registration.
+    const redrivenFromDead = await this.syncJobs.requeueDeadByIdempotencyKey(key);
+
+    this.logger.log(
+      `Fiscal registration requested: orderId=${cmd.orderId} connectionId=${cmd.connectionId} ` +
+        `jobId=${job.id} redrivenFromDead=${String(redrivenFromDead)}`,
+    );
+
+    return {
+      orderId: cmd.orderId,
+      connectionId: cmd.connectionId,
+      idempotencyKey: key,
+      jobId: job.id,
+      redrivenFromDead,
+    };
+  }
+
+  /**
+   * Public, read-only form of the order-level guard (#2525). The private
+   * {@link assertNotAlreadyRegistered} is its implementation, so the advisory
+   * refusal an asking caller gets and the authoritative one the write path
+   * makes cannot be two different rules.
+   */
+  async assertRegistrable(orderId: string, requestedConnectionId: string): Promise<void> {
+    await this.assertNotAlreadyRegistered(orderId, requestedConnectionId);
+  }
+
   async register(cmd: RegisterTransactionCommand): Promise<FiscalRegistrationRecord> {
     const key = cmd.idempotencyKey?.trim() ?? '';
     if (key.length === 0) {
@@ -797,4 +885,27 @@ export class FiscalRegistrationService implements IFiscalRegistrationService {
       MAX_FAILURE_REASON_LENGTH,
     );
   }
+}
+
+/**
+ * Is an existing same-key record one a repeat request RESUMES rather than
+ * duplicates?
+ *
+ * Mirrors the resume invariant `resumeExisting` enforces, from the outside: a
+ * `pending` row was never sent, a `registering` row is either in flight (the
+ * repeat is a no-op) or was abandoned by a dead process (the repeat re-claims it
+ * under the same key), and a terminally `rejected` failure means the provider
+ * definitely created nothing.
+ *
+ * `registered` and any other failure - `in-doubt` included - are excluded, so a
+ * repeat on those falls through to the order-level guard and is refused there.
+ * That is the point: a request must never be reported as accepted when the sale
+ * is already registered, or may be.
+ */
+function isResumableUnderSameKey(record: FiscalRegistrationRecord): boolean {
+  return (
+    record.status === 'pending' ||
+    record.status === 'registering' ||
+    record.isReattemptableFailure
+  );
 }

--- a/libs/core/src/fiscalization/domain/types/fiscal-registration-request.types.ts
+++ b/libs/core/src/fiscalization/domain/types/fiscal-registration-request.types.ts
@@ -1,0 +1,67 @@
+/**
+ * Fiscal Registration Request Types (#2525)
+ *
+ * The vocabulary of ASKING for a registration, as distinct from performing one.
+ *
+ * A manual registration used to be performed inline inside the HTTP request that
+ * asked for it, so "asked" and "registered" were the same event and needed no
+ * separate words. They are now separate acts: the request records an intention
+ * and returns, and the sale is registered later by the `fiscalization.register`
+ * job. Nothing here reports an outcome, and there is deliberately nothing in it
+ * a caller could read as one.
+ *
+ * @module libs/core/src/fiscalization/domain/types
+ */
+
+/**
+ * The exactly-once key one connection registering one order is held under.
+ *
+ * ONE definition, three callers - the HTTP surface, the auto-issue gate, and the
+ * service that enqueues on their behalf. It was previously written out at two
+ * call sites that had to agree by inspection; they now agree by construction,
+ * which is what keeps a manual request and an automatic one from becoming two
+ * registrations of one sale.
+ *
+ * It is derived from `(connectionId, orderId)` and is never caller-supplied: a
+ * caller-chosen key misses the `(connectionId, idempotencyKey)` read gate and
+ * registers the same sale again. See `RegisterFiscalTransactionRequestDto` for
+ * the full reasoning.
+ */
+export function fiscalRegistrationIdempotencyKey(
+  connectionId: string,
+  orderId: string,
+): string {
+  return `fiscal:${connectionId}:${orderId}`;
+}
+
+/**
+ * What a caller learns from asking for a registration.
+ *
+ * It says the request was ACCEPTED and names the row that will carry the answer.
+ * It carries no status, no outcome and no estimate of when the answer arrives,
+ * because at this point none of the three exists: the job has been written and
+ * nothing has been sent to any provider.
+ *
+ * `jobId` identifies the enqueued `fiscalization.register` job, which may be one
+ * a previous request already created - two requests for the same
+ * `(connection, order)` produce one job, and the second returns the first one's
+ * id rather than a second job or an error.
+ */
+export interface FiscalRegistrationRequestAccepted {
+  orderId: string;
+  connectionId: string;
+  /** The exactly-once key the job and the eventual record both carry. */
+  idempotencyKey: string;
+  /** The enqueued (or already-enqueued) `fiscalization.register` job. */
+  jobId: string;
+  /**
+   * True when this request re-drove a job that had exhausted its retries and was
+   * left `dead`, rather than enqueueing or joining a live one.
+   *
+   * Reported because it is the difference between "your request is waiting its
+   * turn" and "a previous attempt had given up and has been restarted", which an
+   * operator repeating an action is entitled to know. It says nothing about
+   * whether the sale is registered.
+   */
+  redrivenFromDead: boolean;
+}

--- a/libs/core/src/fiscalization/index.ts
+++ b/libs/core/src/fiscalization/index.ts
@@ -12,6 +12,8 @@
  * @module libs/core/src/fiscalization
  */
 export * from './domain/types/fiscalization.types';
+// The exactly-once key format and the accepted-request shape (#2525).
+export * from './domain/types/fiscal-registration-request.types';
 export * from './domain/entities/fiscal-registration-record.entity';
 export * from './domain/ports/fiscalization.port';
 // Re-exports both `FiscalRegistrationLocator` and `isFiscalRegistrationLocator`.
@@ -30,6 +32,10 @@ export * from './domain/exceptions/order-already-has-invoice.exception';
 export * from './domain/exceptions/fiscal-registration-contended.exception';
 export { InvalidFiscalLineError } from './application/mappers/errors/invalid-fiscal-line.error';
 export { UnsupportedFiscalPriceTreatmentError } from './application/mappers/errors/unsupported-fiscal-price-treatment.error';
+export {
+  toFiscalizationRegisterPayload,
+  type FiscalizationRegisterPayloadProvenance,
+} from './application/mappers/register-transaction-command-to-payload.mapper';
 export {
   toRegisterTransactionCommand,
   OrderToRegisterTransactionCommandInput,

--- a/libs/core/src/invoicing/application/services/auto-issue-trigger.service.ts
+++ b/libs/core/src/invoicing/application/services/auto-issue-trigger.service.ts
@@ -165,7 +165,11 @@ import {
 // the one function used in the lazy require below. Erases at compile time,
 // never emits a runtime require(), so it cannot reintroduce the CommonJS
 // cycle that require breaks.
-import type { toRegisterTransactionCommand as ToRegisterTransactionCommandType } from '@openlinker/core/fiscalization';
+import type {
+  toRegisterTransactionCommand as ToRegisterTransactionCommandType,
+  toFiscalizationRegisterPayload as ToFiscalizationRegisterPayloadType,
+  fiscalRegistrationIdempotencyKey as FiscalRegistrationIdempotencyKeyType,
+} from '@openlinker/core/fiscalization';
 // Same lazy-require reason as `toRegisterTransactionCommand` above and as
 // `InvoiceService.resolveFiscalRegistrationService` — see either doc comment.
 import type {
@@ -905,10 +909,12 @@ export class AutoIssueTriggerService implements IAutoIssueTriggerService {
         return await this.reportBlock({ reason: gate.reason }, order.id);
       }
 
-      // Same key FORMAT the fiscalization HTTP controller already uses for
-      // the identical semantic (one connection registering one order is one
-      // sale) — see `apps/api/src/fiscalization/http/fiscalization.controller.ts`.
-      const idempotencyKey = `fiscal:${connection.id}:${order.id}`;
+      // ONE definition of the key, shared with every other caller that asks for
+      // a registration (#2525). It used to be written out here and again at the
+      // HTTP surface, so the two agreed only by inspection - and they have to
+      // agree exactly, or a manual request and an automatic one register the
+      // same sale twice.
+      const idempotencyKey = this.fiscalRegistrationKey(connection.id, order.id);
       const payload = this.composeFiscalReceiptPayload(
         order,
         connection,
@@ -1192,9 +1198,11 @@ export class AutoIssueTriggerService implements IAutoIssueTriggerService {
     taxRateEra?: string | null,
   ): FiscalizationRegisterPayloadV1 {
     // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires -- lazy require needed to break a CommonJS barrel-load cycle with `@openlinker/core/fiscalization` (see the doc comment above)
-    const { toRegisterTransactionCommand } = require('@openlinker/core/fiscalization') as {
+    const fiscalization = require('@openlinker/core/fiscalization') as {
       toRegisterTransactionCommand: typeof ToRegisterTransactionCommandType;
+      toFiscalizationRegisterPayload: typeof ToFiscalizationRegisterPayloadType;
     };
+    const { toRegisterTransactionCommand, toFiscalizationRegisterPayload } = fiscalization;
     const command = toRegisterTransactionCommand({
       order,
       connectionId: connection.id,
@@ -1203,38 +1211,25 @@ export class AutoIssueTriggerService implements IAutoIssueTriggerService {
       taxRateEra,
     });
 
-    const payload: FiscalizationRegisterPayloadV1 = {
-      schemaVersion: 1,
-      connectionId: command.connectionId,
-      orderId: command.orderId,
-      idempotencyKey,
-      currency: command.currency,
-      lines: command.lines,
-      totalGross: command.totalGross,
+    return toFiscalizationRegisterPayload(command, {
       sourceConnectionId,
-    };
-
-    // SERIALIZATION CONTRACT: `occurredAt` is a `Date` on the command; the
-    // jsonb payload carries it as ISO-8601 (see the payload type's own doc).
-    if (command.occurredAt !== undefined) {
-      payload.occurredAt = command.occurredAt.toISOString();
-    }
-    if (command.recipient !== undefined) {
-      payload.recipient = command.recipient;
-    }
-    if (sourceEventId !== undefined) {
-      payload.sourceEventId = sourceEventId;
-    }
-    // #2260 review: the gate above is era-aware, so the marker HAS to survive
-    // the hop or the write gate in `FiscalRegistrationService` re-decides the
-    // question without it - passing the order here and refusing it there, with
-    // no persisted reason for the refusal.
-    if (command.taxRateEra !== undefined && command.taxRateEra !== null) {
-      payload.taxRateEra = command.taxRateEra;
-    }
-
-    return payload;
+      ...(sourceEventId !== undefined ? { sourceEventId } : {}),
+    });
   }
+
+  /**
+   * The exactly-once key, resolved through the fiscalization context's own
+   * definition rather than restated here (#2525). Lazily required for the same
+   * CommonJS barrel-cycle reason `composeFiscalReceiptPayload` documents.
+   */
+  private fiscalRegistrationKey(connectionId: string, orderId: string): string {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires -- lazy require needed to break a CommonJS barrel-load cycle with `@openlinker/core/fiscalization`
+    const { fiscalRegistrationIdempotencyKey } = require('@openlinker/core/fiscalization') as {
+      fiscalRegistrationIdempotencyKey: typeof FiscalRegistrationIdempotencyKeyType;
+    };
+    return fiscalRegistrationIdempotencyKey(connectionId, orderId);
+  }
+
 
   /**
    * Read the connection's optional operator-supplied shipping-line label


### PR DESCRIPTION
Closes #2525

## What changed

`POST /fiscal-registrations` performed the registration inline. eparagony polls its device to a terminal state inside that call, so the request could sit for a long time, and a closed tab cut it off while the record it had already written stayed behind. The operator lost sight of a registration that was still happening.

The manual path now enqueues the same `fiscalization.register` job the auto-issue gate enqueues:

- `IFiscalRegistrationService.requestRegistration(cmd, provenance)` writes the job and returns. It never resolves an adapter and never writes a record.
- `fiscalRegistrationIdempotencyKey(connectionId, orderId)` is now one definition in `@openlinker/core/fiscalization`, consumed by the HTTP surface and by `AutoIssueTriggerService`. It was previously written out at both call sites, agreeing only by inspection.
- `toFiscalizationRegisterPayload` is the single command-to-payload flattening, used by both callers. The gate's private copy is gone.
- The endpoint answers `202` with `AcceptedFiscalRegistrationResponseDto` (`orderId`, `connectionId`, `idempotencyKey`, `jobId`, `redrivenFromDead`). It carries no status, no record and no outcome.

## Exactly-once

Unchanged, and not weakened by there now being a queue in front of it.

- The job's `idempotencyKey` is the same deterministic `(connection, order)` key the record uses, so two requests produce one job row and the second joins the first. An integration test asserts that against real Postgres, and asserts the payload's key equals the job row's key so the record cannot end up held under a different key than the job.
- `register()` still applies the read gate, the unique index, the in-flight claim and the order-level guard under the per-order lock when the job runs. Nothing decided at enqueue licenses anything.

## Decisions a reviewer could dispute

**The order-level guard now also runs as a read, at the point of asking.** `assertRegistrable` is public and delegates to the same private `assertNotAlreadyRegistered` the write path uses, so there is one predicate, not two. Without it a double registration attempt would have been answered `202` and then failed inside a job, with nothing on the operator's screen. It is advisory by construction and documented as such: passing it licenses nothing, and a peer can persist a blocking record between the read and the write.

**A same-key record is exempt from that guard when it is resumable.** `pending`, `registering` and a terminally `rejected` failure are resumes, not second documents. `registered` and every other failure, `in-doubt` included, fall through to the guard and are refused. Without the exemption the re-drive below would be unreachable for the one case it exists to fix, because a `pending` row blocks.

**A `dead` job is re-driven by the request.** `schedule` returns the dead row rather than a fresh one, so without this an order whose job had exhausted its retries would be permanently un-registrable from any surface while the endpoint kept answering success. Re-driving re-runs the same key against the same record, which the write path treats as a resume. `redrivenFromDead` is reported because an operator repeating an action is entitled to know the difference between waiting and restarting.

**Command composition stays in the controller, not the worker.** A sale that cannot be expressed as a registrable command is still a `422` while the operator is looking at it. Deferring it would turn that into an accepted request that fails later with nothing to explain it.

**`maxAttempts` matches the auto-issue budget (3).** The two paths enqueue the same job to perform the same act; a manual request that gave up sooner or later would make a sale's retry behaviour depend on who asked for it.

## Deliberately not done

- **No poll target.** This PR changes what the write does; reading the state back is #2526. Until that lands, the panel still reads `GET /fiscal-registrations?orderId=`, which shows nothing during the window between enqueue and the job creating the record.
- **No frontend change.** The response shape changed, and the FE consumes it. That is #2527, which is gated on this and on #2526 by design so the copy change is deliberate.
- **The auto-issue gate keeps its own `schedule` call.** It runs inside a transition with its own block-reporting contract and its own provenance; routing it through `requestRegistration` would have pulled the advisory guard and the dead-job re-drive into a path that has neither. The two now share the key and the payload, which is where drift was actually possible.
- **No `sourceEventId` on the manual path.** An operator request is not a source event, and inventing a token would put a false trace on the job.
