### PR TITLE
feat(web): poll the registration read and state that the work continues (#2527)

### DIFF
--- a/apps/web/src/features/fiscalization/api/fiscalization.api.ts
+++ b/apps/web/src/features/fiscalization/api/fiscalization.api.ts
@@ -5,13 +5,19 @@
  *   - `GET /fiscal-registrations?orderId=…` — every record held by an order,
  *     newest-first, across every connection. Empty list is the normal
  *     never-registered state — never a 404.
- *   - `POST /fiscal-registrations` — register on an explicit operator request.
+ *   - `POST /fiscal-registrations` — ASK for a registration on an explicit
+ *     operator request. It accepts the work and returns; it does not perform it,
+ *     so the answer carries no outcome (#2525).
+ *   - `GET /orders/:orderId/fiscal-registration?connectionId=…` — where that
+ *     work has got to. The poll target, and a pure read (#2526).
  *   - `POST /fiscal-registrations/:id/reconcile` — settle an in-doubt outcome
  *     by asking the provider; never a resend.
  *
  * @module apps/web/src/features/fiscalization/api
  */
 import type {
+  AcceptedFiscalRegistration,
+  FiscalRegistrationProgressView,
   FiscalRegistrationRecord,
   ReconcileFiscalRegistrationResult,
   RegisterFiscalTransactionInput,
@@ -19,7 +25,8 @@ import type {
 
 export interface FiscalizationApi {
   listForOrder: (orderId: string) => Promise<FiscalRegistrationRecord[]>;
-  register: (input: RegisterFiscalTransactionInput) => Promise<FiscalRegistrationRecord>;
+  register: (input: RegisterFiscalTransactionInput) => Promise<AcceptedFiscalRegistration>;
+  getProgress: (orderId: string, connectionId: string) => Promise<FiscalRegistrationProgressView>;
   reconcile: (id: string) => Promise<ReconcileFiscalRegistrationResult>;
 }
 
@@ -35,12 +42,18 @@ export function createFiscalizationApi(request: ApiRequest): FiscalizationApi {
       const query = new URLSearchParams({ orderId }).toString();
       return request<FiscalRegistrationRecord[]>(`/fiscal-registrations?${query}`);
     },
-    register(input): Promise<FiscalRegistrationRecord> {
-      return request<FiscalRegistrationRecord>('/fiscal-registrations', {
+    register(input): Promise<AcceptedFiscalRegistration> {
+      return request<AcceptedFiscalRegistration>('/fiscal-registrations', {
         method: 'POST',
         headers: JSON_HEADERS,
         body: JSON.stringify(input),
       });
+    },
+    getProgress(orderId, connectionId): Promise<FiscalRegistrationProgressView> {
+      const query = new URLSearchParams({ connectionId }).toString();
+      return request<FiscalRegistrationProgressView>(
+        `/orders/${encodeURIComponent(orderId)}/fiscal-registration?${query}`,
+      );
     },
     reconcile(id): Promise<ReconcileFiscalRegistrationResult> {
       return request<ReconcileFiscalRegistrationResult>(

--- a/apps/web/src/features/fiscalization/api/fiscalization.query-keys.ts
+++ b/apps/web/src/features/fiscalization/api/fiscalization.query-keys.ts
@@ -7,4 +7,11 @@
 export const fiscalizationQueryKeys = {
   all: ['fiscalization'] as const,
   forOrder: (orderId: string) => ['fiscalization', 'order', orderId] as const,
+  /**
+   * Where a registration has got to, per (order, connection) - the same pair the
+   * exactly-once key is built from, so two connections cannot share a cache
+   * entry describing one of them.
+   */
+  progressForOrder: (orderId: string, connectionId: string) =>
+    ['fiscalization', 'order', orderId, 'progress', connectionId] as const,
 };

--- a/apps/web/src/features/fiscalization/api/fiscalization.types.ts
+++ b/apps/web/src/features/fiscalization/api/fiscalization.types.ts
@@ -69,6 +69,22 @@ export interface ReconcileFiscalRegistrationResult {
   record: FiscalRegistrationRecord;
 }
 
+/**
+ * Mirrors `AcceptedFiscalRegistrationResponseDto`.
+ *
+ * The answer to asking for a registration. It carries no status and no record,
+ * because when it is sent a job exists and no provider has been called. Nothing
+ * may read an outcome out of it.
+ */
+export interface AcceptedFiscalRegistration {
+  orderId: string;
+  connectionId: string;
+  idempotencyKey: string;
+  jobId: string;
+  /** The request restarted a job that had given up, rather than joining a live one. */
+  redrivenFromDead: boolean;
+}
+
 export interface RegisterFiscalTransactionInput {
   connectionId: string;
   orderId: string;

--- a/apps/web/src/features/fiscalization/hooks/use-fiscal-registration-progress-query.ts
+++ b/apps/web/src/features/fiscalization/hooks/use-fiscal-registration-progress-query.ts
@@ -1,0 +1,39 @@
+/**
+ * useFiscalRegistrationProgressQuery (#2527)
+ *
+ * Where this order's registration has got to on one connection, polled.
+ *
+ * It exists because registration no longer happens inside the request that asks
+ * for it (#2525). The work continues in the background, so the panel learns the
+ * outcome by reading persisted state rather than by holding a request open - and
+ * an order reopened halfway through shows the same in-flight state the operator
+ * left, instead of nothing.
+ *
+ * The read is pure on the backend: polling it takes no lock, writes nothing and
+ * cannot cause a registration.
+ *
+ * Disabled without a connection, because the answer is scoped to the same
+ * (order, connection) pair the exactly-once key is.
+ *
+ * @module apps/web/src/features/fiscalization/hooks
+ */
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { fiscalizationQueryKeys } from '../api/fiscalization.query-keys';
+import type { FiscalRegistrationProgressView } from '../api/fiscalization.types';
+import { fiscalProgressPollInterval } from '../lib/fiscal-poll-interval';
+
+export function useFiscalRegistrationProgressQuery(
+  orderId: string,
+  connectionId: string,
+): UseQueryResult<FiscalRegistrationProgressView> {
+  const apiClient = useApiClient();
+
+  return useQuery<FiscalRegistrationProgressView>({
+    queryKey: fiscalizationQueryKeys.progressForOrder(orderId, connectionId),
+    enabled: Boolean(orderId) && Boolean(connectionId),
+    queryFn: (): Promise<FiscalRegistrationProgressView> =>
+      apiClient.fiscalization.getProgress(orderId, connectionId),
+    refetchInterval: (query) => fiscalProgressPollInterval(query.state.data?.progress),
+  });
+}

--- a/apps/web/src/features/fiscalization/hooks/use-register-fiscal-receipt-mutation.ts
+++ b/apps/web/src/features/fiscalization/hooks/use-register-fiscal-receipt-mutation.ts
@@ -1,11 +1,14 @@
 /**
- * useRegisterFiscalReceiptMutation (#1909)
+ * useRegisterFiscalReceiptMutation (#1909, reworked by #2527)
  *
- * Mutation for `POST /fiscal-registrations` — the manual, explicit-operator-
- * request trigger (ADR-042: v1 registers on nothing else). On success, seeds
- * the per-order list cache by upserting the returned record rather than
- * discarding the list, and invalidates only while the row is still in flight
- * so the poll takes over from there.
+ * Mutation for `POST /fiscal-registrations` - the manual, explicit-operator-
+ * request trigger (ADR-042: v1 registers on nothing else).
+ *
+ * Since #2525 the endpoint ACCEPTS the work rather than performing it, so there
+ * is no record in the answer to seed a cache with. What the mutation can do is
+ * make both per-order reads re-fetch, and the progress read then polls itself to
+ * the outcome. That is the whole reason the panel survives being closed: nothing
+ * about the result depends on this mutation's promise still being alive.
  *
  * @module apps/web/src/features/fiscalization/hooks
  */
@@ -13,38 +16,30 @@ import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/r
 import { useApiClient } from '../../../app/api/api-client-provider';
 import { fiscalizationQueryKeys } from '../api/fiscalization.query-keys';
 import type {
-  FiscalRegistrationRecord,
+  AcceptedFiscalRegistration,
   RegisterFiscalTransactionInput,
 } from '../api/fiscalization.types';
 
-function upsertRecord(
-  existing: FiscalRegistrationRecord[] | undefined,
-  record: FiscalRegistrationRecord,
-): FiscalRegistrationRecord[] {
-  const rest = (existing ?? []).filter((r) => r.id !== record.id);
-  return [record, ...rest];
-}
-
 export function useRegisterFiscalReceiptMutation(): UseMutationResult<
-  FiscalRegistrationRecord,
+  AcceptedFiscalRegistration,
   Error,
   RegisterFiscalTransactionInput
 > {
   const apiClient = useApiClient();
   const queryClient = useQueryClient();
 
-  return useMutation<FiscalRegistrationRecord, Error, RegisterFiscalTransactionInput>({
+  return useMutation<AcceptedFiscalRegistration, Error, RegisterFiscalTransactionInput>({
     mutationFn: (input) => apiClient.fiscalization.register(input),
-    onSuccess: async (record, input) => {
-      queryClient.setQueryData<FiscalRegistrationRecord[]>(
-        fiscalizationQueryKeys.forOrder(input.orderId),
-        (existing) => upsertRecord(existing, record),
-      );
-      if (record.status === 'pending' || record.status === 'registering') {
-        await queryClient.invalidateQueries({
-          queryKey: fiscalizationQueryKeys.forOrder(input.orderId),
-        });
-      }
+    onSuccess: async (_accepted, input) => {
+      // Both reads, and the progress one first in intent: it is the one that can
+      // report the accepted-but-not-yet-running window, which the record list
+      // renders as an order nobody asked to register.
+      await queryClient.invalidateQueries({
+        queryKey: fiscalizationQueryKeys.progressForOrder(input.orderId, input.connectionId),
+      });
+      await queryClient.invalidateQueries({
+        queryKey: fiscalizationQueryKeys.forOrder(input.orderId),
+      });
     },
   });
 }

--- a/apps/web/src/features/fiscalization/index.ts
+++ b/apps/web/src/features/fiscalization/index.ts
@@ -13,6 +13,10 @@
 export { createFiscalizationApi } from './api/fiscalization.api';
 export type { FiscalizationApi } from './api/fiscalization.api';
 export type {
+  AcceptedFiscalRegistration,
+  FiscalRegistrationProgress,
+  FiscalRegistrationProgressView,
+  SalesDocumentInFlight,
   FiscalArtefact,
   FiscalArtefactMedium,
   FiscalArtefactDisposition,
@@ -27,6 +31,7 @@ export { FiscalReceiptStatusBadge } from './components/fiscal-receipt-status-bad
 export type { FiscalReceiptDisplayStatus } from './components/fiscal-receipt-status-badge';
 export { FiscalArtefactList } from './components/fiscal-artefact-list';
 export { useOrderFiscalRegistrationsQuery } from './hooks/use-order-fiscal-registrations-query';
+export { useFiscalRegistrationProgressQuery } from './hooks/use-fiscal-registration-progress-query';
 export { useRegisterFiscalReceiptMutation } from './hooks/use-register-fiscal-receipt-mutation';
 export { useReconcileFiscalRegistrationMutation } from './hooks/use-reconcile-fiscal-registration-mutation';
 export {

--- a/apps/web/src/features/fiscalization/lib/fiscal-poll-interval.test.ts
+++ b/apps/web/src/features/fiscalization/lib/fiscal-poll-interval.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { FISCAL_POLL_MS, fiscalPollInterval } from './fiscal-poll-interval';
+import {
+  FISCAL_POLL_MS,
+  fiscalPollInterval,
+  fiscalProgressPollInterval,
+} from './fiscal-poll-interval';
 import type { FiscalRegistrationStatus } from '../api/fiscalization.types';
 
 describe('fiscalPollInterval', () => {
@@ -22,5 +26,26 @@ describe('fiscalPollInterval', () => {
 
   it('should not poll when the order holds no record at all', () => {
     expect(fiscalPollInterval(undefined)).toBe(false);
+  });
+});
+
+describe('fiscalProgressPollInterval', () => {
+  it('should poll while work is outstanding', () => {
+    expect(fiscalProgressPollInterval('queued')).toBe(FISCAL_POLL_MS);
+    expect(fiscalProgressPollInterval('running')).toBe(FISCAL_POLL_MS);
+  });
+
+  it('should not poll a stalled registration, because nothing is running', () => {
+    // Refetching would describe something that is not happening. Only asking
+    // again moves it.
+    expect(fiscalProgressPollInterval('stalled')).toBe(false);
+  });
+
+  it('should not poll a settled outcome or an unasked sale', () => {
+    expect(fiscalProgressPollInterval('registered')).toBe(false);
+    expect(fiscalProgressPollInterval('rejected')).toBe(false);
+    expect(fiscalProgressPollInterval('in-doubt')).toBe(false);
+    expect(fiscalProgressPollInterval('not-requested')).toBe(false);
+    expect(fiscalProgressPollInterval(undefined)).toBe(false);
   });
 });

--- a/apps/web/src/features/fiscalization/lib/fiscal-poll-interval.ts
+++ b/apps/web/src/features/fiscalization/lib/fiscal-poll-interval.ts
@@ -14,7 +14,10 @@
  *
  * @module apps/web/src/features/fiscalization/lib
  */
-import type { FiscalRegistrationStatus } from '../api/fiscalization.types';
+import type {
+  FiscalRegistrationProgress,
+  FiscalRegistrationStatus,
+} from '../api/fiscalization.types';
 
 /** Poll cadence while a registration is genuinely in flight. */
 export const FISCAL_POLL_MS = 5000;
@@ -25,4 +28,24 @@ export const FISCAL_POLL_MS = 5000;
  */
 export function fiscalPollInterval(status: FiscalRegistrationStatus | undefined): number | false {
   return status === 'registering' ? FISCAL_POLL_MS : false;
+}
+
+/**
+ * Refetch interval for the per-order registration progress read (#2527).
+ *
+ * `queued` and `running` are the two states with work outstanding, and both must
+ * poll: `queued` covers the window between the request being accepted and the
+ * job running, which is precisely the window the operator is watching and the
+ * one the record cannot describe.
+ *
+ * `stalled` does NOT poll. Nothing is running, so refetching would describe
+ * something that is not happening; only asking again moves it. The three
+ * terminal states need no poll either.
+ *
+ * An absent progress value (not yet loaded) does not poll.
+ */
+export function fiscalProgressPollInterval(
+  progress: FiscalRegistrationProgress | undefined,
+): number | false {
+  return progress === 'queued' || progress === 'running' ? FISCAL_POLL_MS : false;
 }

--- a/apps/web/src/features/orders/components/sales-document-panel.test.tsx
+++ b/apps/web/src/features/orders/components/sales-document-panel.test.tsx
@@ -651,3 +651,87 @@ describe('SalesDocumentPanel - receipt path, missing rate (#2255/#2252)', () => 
     expect(screen.queryByText(/has no tax rate/i)).toBeNull();
   });
 });
+
+describe('SalesDocumentPanel — asynchronous registration (#2527)', () => {
+  it('shows the in-flight state when the order is reopened before any record exists', async () => {
+    // The window between the request being accepted and the job running. It has
+    // no record in it, so before #2526 this fell through to the empty state and
+    // offered to register the sale a second time.
+    renderWithProviders(<SalesDocumentPanel order={order} />, {
+      apiClient: createMockApiClient({
+        connections: { list: vi.fn().mockResolvedValue([fiscalConnection]) },
+        fiscalization: {
+          listForOrder: vi.fn().mockResolvedValue([]),
+          getProgress: vi
+            .fn()
+            .mockResolvedValue({ progress: 'queued', record: null, inFlight: null }),
+        },
+      }),
+      ...adminSession,
+    });
+
+    expect(
+      await screen.findByText(/Registering with the provider/),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Register receipt' })).toBeNull();
+  });
+
+  it('states that the work continues, and never asks anyone to keep the page open', async () => {
+    renderWithProviders(<SalesDocumentPanel order={order} />, {
+      apiClient: createMockApiClient({
+        connections: { list: vi.fn().mockResolvedValue([fiscalConnection]) },
+        fiscalization: {
+          listForOrder: vi.fn().mockResolvedValue([makeFiscalRecord({ status: 'registering' })]),
+          getProgress: vi.fn().mockResolvedValue({
+            progress: 'running',
+            record: makeFiscalRecord({ status: 'registering' }),
+            inFlight: null,
+          }),
+        },
+      }),
+      ...adminSession,
+    });
+
+    const notice = await screen.findByText(/This continues if you leave the page/);
+    expect(notice).toBeInTheDocument();
+    // The claim that was true before the work moved off the request, and is now
+    // false in the other direction.
+    expect(screen.queryByText(/keep this page open/i)).toBeNull();
+    expect(screen.queryByText(/close/i)).toBeNull();
+  });
+
+  it('says nothing is running, and offers to ask again, when the work stalled', async () => {
+    renderWithProviders(<SalesDocumentPanel order={order} />, {
+      apiClient: createMockApiClient({
+        connections: { list: vi.fn().mockResolvedValue([fiscalConnection]) },
+        fiscalization: {
+          listForOrder: vi.fn().mockResolvedValue([makeFiscalRecord({ status: 'pending' })]),
+          getProgress: vi.fn().mockResolvedValue({
+            progress: 'stalled',
+            record: makeFiscalRecord({ status: 'pending' }),
+            inFlight: null,
+          }),
+        },
+      }),
+      ...adminSession,
+    });
+
+    expect(await screen.findByText('Nothing is running for this receipt')).toBeInTheDocument();
+    expect(screen.getByText(/Nothing was registered with the provider/)).toBeInTheDocument();
+  });
+
+  it('polls the progress read for the (order, connection) pair the key is built from', async () => {
+    const getProgress = vi
+      .fn()
+      .mockResolvedValue({ progress: 'queued', record: null, inFlight: null });
+    renderWithProviders(<SalesDocumentPanel order={order} />, {
+      apiClient: createMockApiClient({
+        connections: { list: vi.fn().mockResolvedValue([fiscalConnection]) },
+        fiscalization: { listForOrder: vi.fn().mockResolvedValue([]), getProgress },
+      }),
+      ...adminSession,
+    });
+
+    await waitFor(() => expect(getProgress).toHaveBeenCalledWith(ORDER_ID, FISCAL_CONN_ID));
+  });
+});

--- a/apps/web/src/features/orders/components/sales-document-panel.tsx
+++ b/apps/web/src/features/orders/components/sales-document-panel.tsx
@@ -125,6 +125,7 @@ import {
 
 import {
   useOrderFiscalRegistrationsQuery,
+  useFiscalRegistrationProgressQuery,
   useRegisterFiscalReceiptMutation,
   useReconcileFiscalRegistrationMutation,
   selectFiscalizationCandidates,
@@ -267,6 +268,22 @@ export function SalesDocumentPanel({ order }: SalesDocumentPanelProps): ReactEle
   // a second connection is unusual but not this surface's concern to reconcile).
   const fiscalRecord = fiscalRecords[0] ?? null;
 
+  // ── Where the registration has got to (#2526) ──
+  // Scoped to the connection the record is on, or - before any record exists -
+  // the one an action here would register on, because that is the pair the
+  // exactly-once key is built from.
+  const fiscalProgressConnectionId =
+    fiscalRecord?.connectionId ?? pickedFiscalConnectionId ?? fiscalCandidates[0]?.id ?? '';
+  const fiscalProgressQuery = useFiscalRegistrationProgressQuery(
+    order.internalOrderId,
+    fiscalProgressConnectionId,
+  );
+  const fiscalProgress = fiscalProgressQuery.data?.progress;
+  // The two states with work outstanding. `queued` is the one no record can
+  // describe: the request has been accepted and the job has not run yet, so
+  // there is nothing but the job to read.
+  const fiscalWorkOutstanding = fiscalProgress === 'queued' || fiscalProgress === 'running';
+
   // Loading skeleton while connections settle — matches the pre-#2160 panels.
   if (connectionsQuery.isLoading) {
     return (
@@ -306,7 +323,10 @@ export function SalesDocumentPanel({ order }: SalesDocumentPanelProps): ReactEle
   const fiscalBlocks = fiscalRecord !== null && !canRetryFiscalReceipt(fiscalRecord);
 
   const showInvoiceSlot = invoice !== null;
-  const showFiscalSlot = !showInvoiceSlot && fiscalRecord !== null;
+  // Outstanding work opens the slot even with no record. Without that, an order
+  // reopened in the window right after the operator asked would fall through to
+  // the empty state and offer to register the sale again.
+  const showFiscalSlot = !showInvoiceSlot && (fiscalRecord !== null || fiscalWorkOutstanding);
   const showEmptyState = !showInvoiceSlot && !showFiscalSlot;
 
   // ── Invoicing connection resolution (verbatim from the pre-#2160 panel) ──
@@ -392,6 +412,7 @@ export function SalesDocumentPanel({ order }: SalesDocumentPanelProps): ReactEle
 
   const fiscalSettled = !fiscalQuery.isError && !fiscalQuery.isLoading;
   const fiscalDisplayStatus = deriveFiscalReceiptDisplayStatus(fiscalRecord);
+
 
   const handleRegister = (connectionId: string): void => {
     if (!connectionId) return;
@@ -850,13 +871,44 @@ export function SalesDocumentPanel({ order }: SalesDocumentPanelProps): ReactEle
             <div className="sales-document-panel__skeleton" aria-hidden="true" />
           ) : null}
 
-          {fiscalSettled && (fiscalDisplayStatus === 'pending' || fiscalDisplayStatus === 'registering') ? (
+          {fiscalWorkOutstanding ||
+          (fiscalProgress === undefined &&
+            fiscalSettled &&
+            (fiscalDisplayStatus === 'pending' || fiscalDisplayStatus === 'registering')) ? (
             <>
               <div className="sales-document-panel__skeleton" aria-hidden="true" />
               <p className="sales-document-panel__notice">
-                {t('fiscalReceipt.pending.body', 'Sent to the provider. This refreshes automatically when it responds.')}
+                {/* The work runs in the background since #2525, so this no
+                    longer asks anyone to wait with the page open. It says what
+                    is true and nothing more: it continues, and it will be here.
+                    There is deliberately no estimate - OpenLinker hands the sale
+                    over and waits for one answer, observing nothing in between. */}
+                {t(
+                  'fiscalReceipt.pending.body',
+                  'Registering with the provider. This continues if you leave the page, and the result will be here when you come back.',
+                )}
               </p>
             </>
+          ) : null}
+
+          {fiscalProgress === 'stalled' ? (
+            <Alert
+              tone="warning"
+              title={t('fiscalReceipt.stalled.title', 'Nothing is running for this receipt')}
+            >
+              {t(
+                'fiscalReceipt.stalled.body',
+                'The registration was requested and stopped before it finished. Nothing was registered with the provider. Asking again picks it up where it stopped.',
+              )}{' '}
+              <Button
+                tone="secondary"
+                className="button--sm"
+                disabled={registerMutation.isPending || !fiscalProgressConnectionId}
+                onClick={() => handleRegister(fiscalProgressConnectionId)}
+              >
+                {t('fiscalReceipt.action.retry', 'Register receipt')}
+              </Button>
+            </Alert>
           ) : null}
 
           {fiscalSettled && fiscalDisplayStatus === 'registered' && fiscalRecord ? (

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -299,7 +299,19 @@ export function createMockApiClient(
       // #1909 — empty list default: the normal never-registered state, never a
       // 404 (OpenLinker never asserts an order requires a receipt).
       listForOrder: vi.fn().mockResolvedValue([]),
-      register: vi.fn().mockResolvedValue(null),
+      register: vi.fn().mockResolvedValue({
+        orderId: 'ord_1',
+        connectionId: 'conn_fiscal',
+        idempotencyKey: 'fiscal:conn_fiscal:ord_1',
+        jobId: 'job_1',
+        redrivenFromDead: false,
+      }),
+      // #2526 — default: nobody has asked to register this sale.
+      getProgress: vi.fn().mockResolvedValue({
+        progress: 'not-requested',
+        record: null,
+        inFlight: null,
+      }),
       reconcile: vi.fn().mockResolvedValue(null),
       ...overrides.fiscalization,
     } as ApiClient['fiscalization'],


### PR DESCRIPTION
Closes #2527

## What changed

The panel no longer depends on the request that started a registration staying open.

- `useFiscalRegistrationProgressQuery(orderId, connectionId)` reads #2526's per-order registration state and polls while work is outstanding.
- The receipt slot opens on outstanding work, not only on an existing record, so an order reopened in the accepted-but-not-yet-running window shows the in-flight state instead of the empty state.
- The registering copy reads: "Registering with the provider. This continues if you leave the page, and the result will be here when you come back."
- `stalled` gets its own rendering: nothing is running, nothing was registered, and a control to ask again.
- The register mutation returns an acceptance rather than a record, so it invalidates both per-order reads instead of seeding a cache with a record it no longer receives.

## The copy, checked against what the backend reports

The claim that the work survives navigation is true only because #2525 moved the act into a job. Nothing else was added with it: no estimate, no remaining time, no progress fraction, no "safe to close" phrasing beyond the fact that the work continues, and nothing about delivery to the buyer. A test asserts the panel contains no "keep this page open" text, so the retired claim cannot come back in a later edit without failing.

## Decisions a reviewer could dispute

**Polling is scoped to one connection.** `fiscalRecord?.connectionId ?? pickedFiscalConnectionId ?? fiscalCandidates[0]?.id`. Before any record exists the panel polls the connection an action here would register on, which is the same pair the exactly-once key is built from. A record on a second connection is still out of this surface's scope, as it already was.

**`stalled` does not poll.** Nothing is running, so refetching would keep describing something that is not happening. Only asking again moves it, which is what the control does.

**The progress read degrades to the old behaviour rather than to a blank slot.** If it has not answered - loading, or failed - the registering block falls back to the record-derived status. A failing poll must not make an in-flight registration invisible.

**The hook is called before the panel's early returns.** It had to be, to keep hook order stable; the placement is above the loading and capability-gate returns for that reason and not by accident.

**`showFiscalSlot` widened.** It now opens on outstanding work as well as on a record. Without that the whole point of the read is unreachable: the window it describes is exactly the window with no record.

## Deliberately not done

- **The elapsed reading from `inFlight.since` is not rendered.** The value is available and typed, and `since` is a lower bound on elapsed time rather than a start, so rendering it needs wording the panel does not yet have. Left to the M9 panel work rather than guessed at here.
- **`redrivenFromDead` is not surfaced.** The acceptance carries it, and the honest place to say "a stopped attempt was restarted" is the stalled state's own copy, which already says asking again picks it up.
- **The list read is unchanged.** Both reads still run; the record list still supplies the detail rendering, and the progress read supplies the state.
