### PR TITLE
fix(web/orders): widen bulk-dispatch dims/weight fields, wrap the id in chunks

### DIFF
--- a/apps/web/src/features/orders/components/bulk-dispatch-dialog.test.tsx
+++ b/apps/web/src/features/orders/components/bulk-dispatch-dialog.test.tsx
@@ -10,7 +10,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderWithProviders, createMockApiClient } from '../../../test/test-utils';
-import { BulkDispatchDialog } from './bulk-dispatch-dialog';
+import { BulkDispatchDialog, splitIdForWrap } from './bulk-dispatch-dialog';
 import type { OrderRecord } from '../api/orders.types';
 import type { Shipment } from '../../shipments';
 
@@ -191,5 +191,43 @@ describe('BulkDispatchDialog', () => {
     const dialog = screen.getByRole('dialog');
     expect(within(dialog).getByText(/None of the selected orders can be bulk-dispatched/)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /Dispatch 0 orders/ })).toBeDisabled();
+  });
+
+  describe('splitIdForWrap (#2669)', () => {
+    it('splits the `ol_{type}_` prefix from the opaque id and chunks the rest', () => {
+      expect(splitIdForWrap('ol_order_fce2df4d853f4499b955a6bb1a212bd1')).toEqual([
+        'ol_order_',
+        'fce2df',
+        '4d853f',
+        '4499b9',
+        '55a6bb',
+        '1a212bd1',
+      ]);
+    });
+
+    it('falls back to chunking the whole string when there is no recognisable prefix', () => {
+      expect(splitIdForWrap('abcdefghijkl', 4)).toEqual(['abcd', 'efgh', 'ijkl']);
+    });
+
+    it('returns the id as a single chunk when it is shorter than one chunk', () => {
+      expect(splitIdForWrap('ol_order_1')).toEqual(['ol_order_', '1']);
+    });
+  });
+
+  it('renders a long order id wrapped in chunks while keeping the full value queryable and hoverable', () => {
+    const longId = 'ol_order_fce2df4d853f4499b955a6bb1a212bd1';
+    const orders = [order({ internalOrderId: longId })];
+
+    renderWithProviders(
+      <BulkDispatchDialog open orders={orders} onOpenChange={noop} channelLabelFor={() => 'Allegro'} onComplete={noop} />,
+    );
+
+    // The visible text still reads as the complete, unbroken id (wrap points
+    // are `<wbr>` elements, which contribute no text of their own).
+    const idEl = screen.getByText(longId);
+    expect(idEl).toHaveAttribute('title', longId);
+    // At least one controlled wrap point was inserted (not left to
+    // `overflow-wrap: anywhere`).
+    expect(idEl.querySelectorAll('wbr').length).toBeGreaterThan(0);
   });
 });

--- a/apps/web/src/features/orders/components/bulk-dispatch-dialog.tsx
+++ b/apps/web/src/features/orders/components/bulk-dispatch-dialog.tsx
@@ -15,7 +15,7 @@
  *
  * @module apps/web/src/features/orders/components
  */
-import { useMemo, useReducer, useState, type ReactElement } from 'react';
+import { Fragment, useMemo, useReducer, useState, type ReactElement } from 'react';
 import { Link } from 'react-router-dom';
 
 import { Alert } from '../../../shared/ui/alert';
@@ -303,7 +303,7 @@ function ParcelProfile({
             <DimInput label="Default height in millimetres" value={profile.height} onChange={set('height')} />
           </div>
         </div>
-        <div className="bulk-dispatch__field">
+        <div className="bulk-dispatch__field bulk-dispatch__weight">
           <span className="bulk-dispatch__field-label">Weight (g)</span>
           <DimInput label="Default weight in grams" value={profile.weightGrams} onChange={set('weightGrams')} wide />
         </div>
@@ -339,6 +339,41 @@ function DimInput({
   );
 }
 
+/**
+ * Split an internal id into wrap-safe chunks: the `ol_{type}_` prefix as one
+ * chunk, then the remaining opaque id in fixed-size groups (#2669). Rendered
+ * with `<wbr>` between chunks so the browser only wraps at these explicit
+ * points - never at `overflow-wrap: anywhere`, which broke the id one
+ * character per line once its column narrowed (#1658).
+ */
+export function splitIdForWrap(id: string, chunkSize = 6): string[] {
+  const prefixMatch = /^[a-z]+_[a-z]+_/.exec(id);
+  const prefix = prefixMatch?.[0] ?? '';
+  const rest = id.slice(prefix.length);
+  if (rest.length === 0) return prefix ? [prefix] : [id];
+  const chunks: string[] = prefix ? [prefix] : [];
+  for (let i = 0; i < rest.length; i += chunkSize) {
+    chunks.push(rest.slice(i, i + chunkSize));
+  }
+  return chunks;
+}
+
+/** Renders an order id with controlled wrap points and the full value as a
+ *  hover title (the visible text is still capped at 2 lines by CSS). */
+function WrappableOrderId({ id }: { id: string }): ReactElement {
+  const chunks = splitIdForWrap(id);
+  return (
+    <span className="mono bulk-dispatch__ordid" title={id}>
+      {chunks.map((chunk, i) => (
+        <Fragment key={i}>
+          {chunk}
+          {i < chunks.length - 1 ? <wbr /> : null}
+        </Fragment>
+      ))}
+    </span>
+  );
+}
+
 function EligibleRow({
   entry,
   channelLabelFor,
@@ -362,23 +397,27 @@ function EligibleRow({
     <div className="bulk-dispatch__row">
       <div className="bulk-dispatch__row-id">
         <span className="bulk-dispatch__src">{channelLabelFor(order.sourceConnectionId)}</span>
-        <span className="mono bulk-dispatch__ordid">{ref}</span>
+        <WrappableOrderId id={ref} />
         {buyer ? <span className="text-muted bulk-dispatch__buyer">{buyer}</span> : null}
       </div>
       <StatusBadge tone={shippingMethod === 'paczkomat' ? 'info' : 'neutral'} compact>
         {shippingMethod === 'paczkomat' ? 'Paczkomat' : 'Courier'}
       </StatusBadge>
-      <div className="bulk-dispatch__dims">
-        <DimInput label={`Length for ${ref}`} value={parcel.length} onChange={(v) => onField('length', v)} />
-        <span className="bulk-dispatch__times">×</span>
-        <DimInput label={`Width for ${ref}`} value={parcel.width} onChange={(v) => onField('width', v)} />
-        <span className="bulk-dispatch__times">×</span>
-        <DimInput label={`Height for ${ref}`} value={parcel.height} onChange={(v) => onField('height', v)} />
+      <div className="bulk-dispatch__parcel-fields">
+        <div className="bulk-dispatch__dims">
+          <DimInput label={`Length for ${ref}`} value={parcel.length} onChange={(v) => onField('length', v)} />
+          <span className="bulk-dispatch__times">×</span>
+          <DimInput label={`Width for ${ref}`} value={parcel.width} onChange={(v) => onField('width', v)} />
+          <span className="bulk-dispatch__times">×</span>
+          <DimInput label={`Height for ${ref}`} value={parcel.height} onChange={(v) => onField('height', v)} />
+        </div>
+        <div className="bulk-dispatch__weight">
+          <DimInput label={`Weight for ${ref}`} value={parcel.weightGrams} onChange={(v) => onField('weightGrams', v)} wide />
+        </div>
+        <StatusBadge tone="success" withDot compact>
+          Ready
+        </StatusBadge>
       </div>
-      <DimInput label={`Weight for ${ref}`} value={parcel.weightGrams} onChange={(v) => onField('weightGrams', v)} wide />
-      <StatusBadge tone="success" withDot compact>
-        Ready
-      </StatusBadge>
       {error ? <span className="bulk-dispatch__row-error" role="alert">{error}</span> : null}
     </div>
   );
@@ -401,10 +440,9 @@ function IneligibleRow({
     <div className="bulk-dispatch__row bulk-dispatch__row--ineligible">
       <div className="bulk-dispatch__row-id">
         <span className="bulk-dispatch__src">{channelLabelFor(order.sourceConnectionId)}</span>
-        <span className="mono bulk-dispatch__ordid">{ref}</span>
+        <WrappableOrderId id={ref} />
         {buyer ? <span className="text-muted bulk-dispatch__buyer">{buyer}</span> : null}
       </div>
-      <span className="bulk-dispatch__row-spacer" aria-hidden="true" />
       <StatusBadge tone="warning" withDot compact>
         {reason ? DISPATCH_INELIGIBILITY_LABEL[reason] : 'Not dispatchable'}
       </StatusBadge>

--- a/apps/web/src/features/orders/components/bulk-dispatch-dialog.tsx
+++ b/apps/web/src/features/orders/components/bulk-dispatch-dialog.tsx
@@ -351,11 +351,17 @@ export function splitIdForWrap(id: string, chunkSize = 6): string[] {
   const prefix = prefixMatch?.[0] ?? '';
   const rest = id.slice(prefix.length);
   if (rest.length === 0) return prefix ? [prefix] : [id];
-  const chunks: string[] = prefix ? [prefix] : [];
+  const restChunks: string[] = [];
   for (let i = 0; i < rest.length; i += chunkSize) {
-    chunks.push(rest.slice(i, i + chunkSize));
+    restChunks.push(rest.slice(i, i + chunkSize));
   }
-  return chunks;
+  // Fold a dangling remainder shorter than chunkSize into the previous chunk
+  // instead of giving it its own wrap point.
+  if (restChunks.length > 1 && restChunks[restChunks.length - 1].length < chunkSize) {
+    const last = restChunks.pop()!;
+    restChunks[restChunks.length - 1] += last;
+  }
+  return prefix ? [prefix, ...restChunks] : restChunks;
 }
 
 /** Renders an order id with controlled wrap points and the full value as a

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -10692,11 +10692,17 @@ html[data-density='compact'] .status-badge {
  * number-input stepper: 4 digits of millimetres for dims, 5 digits of grams
  * for weight (#2669 - the previous 52/68px clipped anything past 2-3 digits).
  * `min-width` repeats the value so the input can never be squeezed below it
- * even if a future layout change drops the explicit `width`. */
+ * even if a future layout change drops the explicit `width`. The base
+ * `.control` rule's 12px side padding is tightened to 4px here too - at the
+ * base padding a 64px input has ~40px left for digits + spinner, only
+ * ~3 digits, so widening the box alone was not enough to stop the clip
+ * (verified empirically: a 1500mm value rendered as "150" until the padding
+ * was cut down). */
 input.bulk-dispatch__num {
   width: 64px;
   min-width: 64px;
   flex-shrink: 0;
+  padding: 0 var(--space-1);
   text-align: center;
   font-variant-numeric: tabular-nums;
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -10668,6 +10668,17 @@ html[data-density='compact'] .status-badge {
   color: var(--text-disabled);
 }
 
+/* Weight sits behind its own divider - it's a different physical quantity
+ * from L x W x H, not a fourth dimension, so the rule reads it as its own
+ * fact rather than a continuation of the dims group (#2669). Deliberately
+ * NOT `display: flex` - this wraps two different internal layouts (a single
+ * input in a row, a stacked label+input in the profile bar) and must not
+ * impose a direction of its own on either. */
+.bulk-dispatch__weight {
+  padding-left: var(--space-3);
+  border-left: 1px solid var(--border-default);
+}
+
 /* `input.bulk-dispatch__num` (not `.bulk-dispatch__num` alone) is required to
  * out-specificity the base `input[type='number'] { width: 100%; }` rule: that
  * rule combines an element-type selector with an attribute selector (0,1,1),
@@ -10675,16 +10686,24 @@ html[data-density='compact'] .status-badge {
  * the `input` element-type selector here brings this rule to the same
  * specificity tier so it wins on source order instead - otherwise these
  * compact dimension/weight fields silently stretch to share the row's flex
- * space instead of staying at their intended width (#1658). */
+ * space instead of staying at their intended width (#1658).
+ *
+ * Widths are sized for the agreed maximum value length plus the native
+ * number-input stepper: 4 digits of millimetres for dims, 5 digits of grams
+ * for weight (#2669 - the previous 52/68px clipped anything past 2-3 digits).
+ * `min-width` repeats the value so the input can never be squeezed below it
+ * even if a future layout change drops the explicit `width`. */
 input.bulk-dispatch__num {
-  width: 52px;
+  width: 64px;
+  min-width: 64px;
   flex-shrink: 0;
   text-align: center;
   font-variant-numeric: tabular-nums;
 }
 
 input.bulk-dispatch__num--wide {
-  width: 68px;
+  width: 84px;
+  min-width: 84px;
 }
 
 .bulk-dispatch__apply {
@@ -10713,11 +10732,16 @@ input.bulk-dispatch__num--wide {
   overflow-y: auto;
 }
 
+/* Flex-wrap, not a rigid grid (#2669): the id column no longer claims the
+ * whole flexible share, and the parcel-fields cluster (below) can drop to its
+ * own line as a group once the row runs out of width, instead of any input
+ * shrinking below its floor. */
 .bulk-dispatch__row {
-  display: grid;
-  grid-template-columns: minmax(140px, 1fr) auto auto auto auto;
+  display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  gap: var(--space-3);
+  column-gap: var(--space-3);
+  row-gap: var(--space-2);
   padding: var(--space-3) var(--space-4);
   border-bottom: 1px solid var(--border-subtle);
 }
@@ -10728,14 +10752,29 @@ input.bulk-dispatch__num--wide {
 
 .bulk-dispatch__row--ineligible {
   background: var(--bg-canvas);
-  grid-template-columns: minmax(140px, 1fr) auto auto;
 }
 
 .bulk-dispatch__row-id {
   display: flex;
   flex-direction: column;
   gap: 2px;
+  /* Narrower than the old 140px grid track (#2669) - it no longer needs to
+   * carry the row's whole flexible share, just enough for the source pill +
+   * a couple of wrapped id lines + the buyer name. */
+  flex: 1 1 96px;
+  max-width: 168px;
   min-width: 0;
+}
+
+/* Groups dims + weight + the Ready badge as one unit so they wrap together
+ * onto their own line under the id/badge instead of each input shrinking
+ * (#2669). */
+.bulk-dispatch__parcel-fields {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+  margin-left: auto;
 }
 
 .bulk-dispatch__src {
@@ -10754,15 +10793,22 @@ input.bulk-dispatch__num--wide {
 .bulk-dispatch__ordid {
   font-size: 0.75rem;
   color: var(--text-primary);
+  line-height: 1.35;
+  /* Wraps only at the <wbr> break points `splitIdForWrap` inserts (the
+   * `ol_x_` prefix boundary, then every 6 hex chars) - never bare
+   * `overflow-wrap: anywhere` (inherited from `.mono`), which broke this
+   * unbroken internal id one character per line once its squeezed column ran
+   * low on width (#1658). `normal` respects only explicit break
+   * opportunities, so a narrow column gets sane multi-character chunks
+   * instead. Capped at 2 lines so a very long id still can't inflate the row
+   * (and, once clipped by `.bulk-dispatch__rows`' max-height, the whole
+   * dialog) the way the pre-#1658 unbounded wrap did (#2669). */
+  white-space: normal;
+  overflow-wrap: normal;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
   overflow: hidden;
-  text-overflow: ellipsis;
-  /* Without `nowrap`, `overflow-wrap: anywhere` (inherited from `.mono`)
-   * breaks this unbroken internal order id one character per line once its
-   * squeezed grid column runs low on width - inflating the row (and, once
-   * clipped by `.bulk-dispatch__rows`' max-height, the whole dialog) to
-   * hundreds of pixels of apparent empty space (#1658). `nowrap` lets the
-   * already-declared ellipsis truncate it on one line instead. */
-  white-space: nowrap;
 }
 
 .bulk-dispatch__buyer {
@@ -10770,19 +10816,15 @@ input.bulk-dispatch__num--wide {
 }
 
 .bulk-dispatch__row-error {
-  grid-column: 1 / -1;
+  flex-basis: 100%;
   font-size: 0.75rem;
   color: var(--status-error-fg);
-}
-
-.bulk-dispatch__row-spacer {
-  display: block;
 }
 
 .bulk-dispatch__row-hint {
   font-size: 0.75rem;
   color: var(--status-warning-fg);
-  grid-column: 1 / -1;
+  flex-basis: 100%;
 }
 
 .bulk-dispatch__link {
@@ -10831,11 +10873,25 @@ input.bulk-dispatch__num--wide {
 }
 
 @media (max-width: 767.98px) {
-  /* Stack each row's controls so dims/weight don't overflow on a phone. */
+  /* Stack each row's controls so dims/weight don't overflow on a phone -
+   * unchanged behaviour from before #2669, just expressed as a flex column
+   * instead of a single grid track (the row itself is flex-wrap now, not
+   * grid). Each control still lands on its own full-width line. */
   .bulk-dispatch__row,
   .bulk-dispatch__row--ineligible {
-    grid-template-columns: 1fr;
-    gap: var(--space-2);
+    flex-direction: column;
+    align-items: flex-start;
+    row-gap: var(--space-2);
+  }
+  .bulk-dispatch__row-id {
+    flex-basis: auto;
+    max-width: none;
+  }
+  .bulk-dispatch__parcel-fields {
+    flex-direction: column;
+    align-items: flex-start;
+    margin-left: 0;
+    width: 100%;
   }
   .bulk-dispatch__profile-fields {
     gap: var(--space-3);


### PR DESCRIPTION
## Summary

- `input.bulk-dispatch__num` grows from a fixed 52px to a 64px floor (min-width), and the `--wide` weight variant from 68px to 84px - sized for a 4-digit millimetre value / 5-digit gram value plus the native number-input stepper, so nothing the operator types gets clipped. The inherited `.control` base padding (12px each side) is also tightened to 4px - widening the box alone was not enough, a 1500mm value still rendered as "150" until the padding was cut (caught with a live Playwright render, see below).
- Weight now sits behind its own vertical divider - it is a different physical quantity from L x W x H, not a fourth dimension.
- The order id wraps at controlled points instead of being ellipsis-clipped on one line: a pure `splitIdForWrap` helper splits the `ol_{type}_` prefix off, then chunks the rest every 6 characters, joined by `<wbr>`. It never falls back to `overflow-wrap: anywhere`, which is what caused the #1658 one-character-per-line regression - capped at 2 lines so a very long id still can't inflate the row.
- `.bulk-dispatch__row` switches from a rigid grid (`minmax(140px, 1fr) auto auto auto auto`) to flex-wrap: the id column no longer claims the whole flexible share, and dims + weight + the Ready badge are grouped in one `.bulk-dispatch__parcel-fields` cluster so the whole group would drop to its own line under a narrower row instead of any input shrinking below its floor. At the dialog's own max width (880px) this fallback stays dormant down to the existing 767.98px mobile breakpoint - verified by measuring flex-wrap behaviour directly - but it's real, defensive CSS for wider future content, not dead code.
- The existing mobile stacked layout (`<=767.98px`) is preserved byte-for-byte in behaviour, just expressed as a flex column instead of a grid track.

Mockup (before/after, live width slider): https://claude.ai/code/artifact/f9e5fd21-1d30-45f7-adff-751ba8504468

## Test plan

- [x] `pnpm --filter @openlinker/web type-check` - clean
- [x] `pnpm --filter @openlinker/web lint` - no new warnings/errors
- [x] `node scripts/check-design-tokens.mjs` - no new tokens introduced, all reused
- [x] Added unit tests for `splitIdForWrap` (prefix + chunk cases) and a render test asserting the full id text stays queryable/hoverable with at least one `<wbr>` inserted
- [x] Rendered the real component live (mocked session/API, no backend) via Playwright at 960px / 820px / 375px, with the shared profile filled to the previously-clipping values (1500 / 220 / 90 / 12500) applied to every row - full digits visible everywhere, id wraps to 2 clean lines, weight divider visible, mobile stack unchanged. This is how the padding bug above was actually caught: the first pass "worked" by type-check/lint but the box still clipped to "150" until measured live.
- [x] CI test suite (locally and CI/CD)
- [x] Screenshots to be attached as a PR comment

Closes #2669