### PR TITLE
fix(shipments): distinguish label-download failure classes instead of one generic toast

### DIFF
--- a/apps/e2e/playwright.config.ts
+++ b/apps/e2e/playwright.config.ts
@@ -305,5 +305,16 @@ export default defineConfig({
       // making any assertion more truthful.
       use: { ...devices['Desktop Chrome'] },
     },
+    {
+      // Label-download failure-class mapping on the /shipments row accordion
+      // (#2671). Every OL route the page touches is stubbed in-test, following
+      // the `wizard-blockers` shape - no seeded stack, no shared auth artifact,
+      // just a served web app. `retries: 1` (nothing is mutated; the download
+      // call always fails by design).
+      name: 'label-download-errors',
+      testMatch: /label-download-errors\/.*\.spec\.ts/,
+      retries: 1,
+      use: { ...devices['Desktop Chrome'] },
+    },
   ],
 });

--- a/apps/e2e/tests/label-download-errors/label-download-errors.spec.ts
+++ b/apps/e2e/tests/label-download-errors/label-download-errors.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * Label-download error mapping - visual evidence (#2671)
+ *
+ * The operator-facing defect this fixes: every backend outcome from
+ * `GET /shipments/:id/label` collapsed into one toast, "Could not download
+ * the label. Try again." - wrong for 404/422, where retrying can never help.
+ * This walks the real `/shipments` row accordion through every failure class
+ * against a stubbed OL API (no seeded stack, no shared auth artifact - the
+ * session bootstrap is stubbed too, same shape as `wizard-blockers`), so the
+ * project needs only a served web app.
+ *
+ * Each case writes a named screenshot into its own test output directory and
+ * attaches it to the HTML report - a copy change is best evidenced by a
+ * picture of the copy, not by an assertion string alone.
+ *
+ * @module tests/label-download-errors
+ */
+import { test, type Page, type TestInfo } from '@playwright/test';
+import {
+  SHIPMENT_ID,
+  stubLabelDownloadFailure,
+  stubShipmentsPageApi,
+  type FailureCase,
+} from './stub';
+
+async function captureState(page: Page, testInfo: TestInfo, name: string): Promise<void> {
+  const file = testInfo.outputPath(`${name}.png`);
+  await page.screenshot({ path: file });
+  await testInfo.attach(name, { path: file, contentType: 'image/png' });
+}
+
+/**
+ * Open the /shipments page, expand the seeded row, click Download label.
+ * Below the mobile breakpoint `DataTable` renders cards instead of the
+ * desktop accordion (`renderCards = cardView && isMobile`,
+ * `shared/ui/data-table.tsx`), and the mobile card's own disclosure toggle
+ * reads "View full details" / "Hide details", not "Expand details for
+ * shipment ...". Both toggles land on the same `ShipmentRowDetail`.
+ */
+async function triggerDownload(page: Page, viewportWidth = 1280): Promise<void> {
+  await page.goto('/shipments');
+  const toggle =
+    viewportWidth < 768
+      ? page.getByRole('button', { name: 'View full details' })
+      : page.getByRole('button', { name: `Expand details for shipment ${SHIPMENT_ID}` });
+  await toggle.click();
+  await page.getByRole('button', { name: 'Download label' }).click();
+}
+
+const CASES: Array<{ kind: FailureCase; title: string }> = [
+  { kind: 'not-found', title: 'no shipment matches this id' },
+  { kind: 'not-yet-generated', title: 'no label to download yet' },
+  { kind: 'carrier-unsupported', title: 'this carrier doesn’t provide a downloadable label' },
+  { kind: 'provider-rejection', title: 'the carrier rejected the request' },
+  { kind: 'provider-auth', title: 'our stored carrier credentials were rejected' },
+  { kind: 'unclassified', title: 'something went wrong' },
+  { kind: 'network', title: 'couldn’t reach openlinker' },
+];
+
+test.describe('label-download failure toasts, desktop', () => {
+  for (const { kind, title } of CASES) {
+    test(`${kind} renders "${title}"`, async ({ page }, testInfo) => {
+      await stubShipmentsPageApi(page);
+      await stubLabelDownloadFailure(page, kind);
+      await triggerDownload(page);
+
+      // `.toast__title` scoped explicitly: Radix's aria-live announcer
+      // duplicates the toast text into a second, hidden `role="status"`
+      // region, which a bare `getByText` also matches (strict-mode violation).
+      await page.locator('.toast__title').getByText(new RegExp(title, 'i')).waitFor();
+      await captureState(page, testInfo, `desktop-${kind}`);
+    });
+  }
+});
+
+// Breakpoints (#2671 review): no CSS changed by this fix - same `Toast` /
+// `Button` components, same existing responsive rules - but the fix is
+// worth seeing at the widths that actually stack `.shipment-action-buttons`
+// and reflow `.toast-region`, not just assumed from the unchanged CSS.
+const BREAKPOINT_CASES: Array<{ kind: FailureCase; width: number; height: number; label: string }> = [
+  { kind: 'not-found', width: 375, height: 812, label: 'mobile' },
+  { kind: 'provider-auth', width: 375, height: 812, label: 'mobile' },
+  { kind: 'provider-rejection', width: 768, height: 1024, label: 'tablet' },
+];
+
+test.describe('label-download failure toasts, responsive', () => {
+  for (const { kind, width, height, label } of BREAKPOINT_CASES) {
+    test(`${kind} at ${label} (${width}x${height})`, async ({ page }, testInfo) => {
+      await page.setViewportSize({ width, height });
+      await stubShipmentsPageApi(page);
+      await stubLabelDownloadFailure(page, kind);
+      await triggerDownload(page, width);
+
+      await page.waitForTimeout(300); // let the toast slide-in animation settle
+      await captureState(page, testInfo, `${label}-${kind}`);
+    });
+  }
+});

--- a/apps/e2e/tests/label-download-errors/stub.ts
+++ b/apps/e2e/tests/label-download-errors/stub.ts
@@ -1,0 +1,159 @@
+/**
+ * Label-download error stub (#2671)
+ *
+ * Stubs the `/shipments` page's whole read surface so every label-download
+ * failure class can be driven from a served web app alone - no seeded stack,
+ * no shared auth artifact. Mirrors `tests/wizard-blockers/wizard-stub.ts`'s
+ * session-bootstrap shape (auth refresh + `/auth/me` + a `system/**` catch-all)
+ * since that stub already proved this pattern hermetic for a permission-gated
+ * page.
+ *
+ * @module tests/label-download-errors
+ */
+import type { Page, Route } from '@playwright/test';
+
+export const CONNECTION_ID = '00000000-0000-4000-8000-000000002671';
+export const SHIPMENT_ID = 'ol_shipment_2671';
+export const ORDER_ID = 'ol_order_2671';
+
+const SESSION_PERMISSIONS = ['shipments:read', 'shipments:write', 'connections:read', 'connections:write'];
+
+function json(route: Route, body: unknown, status = 200): Promise<void> {
+  return route.fulfill({ status, contentType: 'application/json', body: JSON.stringify(body) });
+}
+
+/** Stub every OL route the `/shipments` page reads on load. */
+export async function stubShipmentsPageApi(page: Page): Promise<void> {
+  const now = new Date().toISOString();
+
+  await page.route('**/v1/auth/refresh', (route) => json(route, { access_token: 'e2e-2671-token' }));
+  await page.route('**/v1/auth/me', (route) =>
+    json(route, {
+      id: 'usr_e2e_2671',
+      username: 'e2e-operator',
+      email: 'e2e-operator@openlinker.local',
+      role: 'admin',
+      permissions: SESSION_PERMISSIONS,
+      analyticsConsent: false,
+    }),
+  );
+  await page.route('**/v1/system/**', (route) => json(route, {}));
+
+  await page.route('**/v1/connections', (route) =>
+    json(route, [
+      {
+        id: CONNECTION_ID,
+        name: 'DPD Poland',
+        platformType: 'dpd-polska',
+        status: 'active',
+        config: {},
+        credentialsBacked: true,
+        adapterKey: 'dpd-polska.rest.v1',
+        enabledCapabilities: ['OrderProcessorManager'],
+        supportedCapabilities: ['OrderProcessorManager'],
+        defaultRateLimit: null,
+        createdAt: now,
+        updatedAt: now,
+      },
+    ]),
+  );
+
+  await page.route('**/v1/shipments?*', (route) =>
+    json(route, {
+      items: [
+        {
+          id: SHIPMENT_ID,
+          orderId: ORDER_ID,
+          customerId: null,
+          connectionId: CONNECTION_ID,
+          shippingMethod: 'kurier',
+          status: 'generated',
+          providerShipmentId: 'DPD-9911',
+          paczkomatId: null,
+          sourceDeliveryMethodId: null,
+          deliveryIntent: 'address',
+          trackingNumber: null,
+          providerCode: null,
+          carrier: 'dpd',
+          labelPdfRef: 'dpd:label:9911',
+          dispatchedAt: null,
+          deliveredAt: null,
+          cancelledAt: null,
+          failedAt: null,
+          errorMessage: null,
+          createdAt: now,
+          updatedAt: now,
+          orderSummary: null,
+        },
+      ],
+      total: 1,
+      limit: 20,
+      offset: 0,
+    }),
+  );
+}
+
+/** One `GET /shipments/:id/label` failure per case, keyed exactly to what
+ *  `apps/api/src/shipping/http/shipment.controller.ts`'s `toHttpException`
+ *  actually produces (see `label-download-error.ts`'s own header comment). */
+export type FailureCase =
+  | 'not-found'
+  | 'not-yet-generated'
+  | 'carrier-unsupported'
+  | 'provider-rejection'
+  | 'provider-auth'
+  | 'unclassified'
+  | 'network';
+
+export async function stubLabelDownloadFailure(page: Page, kind: FailureCase): Promise<void> {
+  await page.route(`**/v1/shipments/${SHIPMENT_ID}/label`, async (route) => {
+    switch (kind) {
+      case 'not-found':
+        return json(
+          route,
+          { statusCode: 404, message: `Shipment not found: ${SHIPMENT_ID}`, error: 'Not Found' },
+          404,
+        );
+      case 'not-yet-generated':
+        return json(
+          route,
+          {
+            statusCode: 422,
+            message: `No label has been generated for shipment ${SHIPMENT_ID} yet - generate the label first`,
+            error: 'Unprocessable Entity',
+          },
+          422,
+        );
+      case 'carrier-unsupported':
+        return json(
+          route,
+          {
+            statusCode: 422,
+            message: `Cannot fetch label for shipment ${SHIPMENT_ID}: connection ${CONNECTION_ID} does not support returning label documents`,
+            error: 'Unprocessable Entity',
+          },
+          422,
+        );
+      case 'provider-rejection':
+        return json(
+          route,
+          { message: 'Waybill reference expired for this shipment', providerCode: 'DPD.WAYBILL_EXPIRED' },
+          502,
+        );
+      case 'provider-auth':
+        return json(
+          route,
+          { statusCode: 502, message: 'Carrier credentials rejected', error: 'Bad Gateway' },
+          502,
+        );
+      case 'unclassified':
+        return json(
+          route,
+          { statusCode: 500, message: 'Unexpected token in JSON', error: 'Internal Server Error' },
+          500,
+        );
+      case 'network':
+        return route.abort('failed');
+    }
+  });
+}

--- a/apps/web/src/features/orders/components/generate-label-form.test.tsx
+++ b/apps/web/src/features/orders/components/generate-label-form.test.tsx
@@ -513,6 +513,39 @@ describe('GenerateLabelForm — happy path', () => {
     vi.restoreAllMocks();
   });
 
+  it('should surface a distinct failure when the post-generation auto-download fails, without implying generation itself failed (#2671)', async () => {
+    const downloadLabel = vi
+      .fn()
+      .mockRejectedValue(new ApiError('Bad Gateway', 502, { message: 'Bad Gateway', error: 'Bad Gateway' }));
+    const apiClient = createMockApiClient({
+      shipments: {
+        generateLabel: vi.fn().mockResolvedValue({
+          kind: 'dispatched',
+          shipment: { id: 'ol_shipment_99', labelPdfRef: 'shipx:label:99' },
+        }),
+        downloadLabel,
+      },
+    });
+
+    renderWithProviders(
+      <GenerateLabelForm order={makeOrder()} onSuccess={vi.fn()} onCancel={vi.fn()} />,
+      { apiClient },
+    );
+
+    fireEvent.change(screen.getByLabelText(/Length in millimetres/i), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText(/Width in millimetres/i), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText(/Height in millimetres/i), { target: { value: '100' } });
+    fireEvent.change(screen.getByLabelText(/^Weight \(g\)$/i), { target: { value: '500' } });
+
+    fireEvent.click(screen.getByRole('button', { name: /^Generate label$/ }));
+
+    // The success toast ("Label generated") still fires - the label WAS
+    // bought - and the download failure is a SECOND, separate toast.
+    expect(await screen.findByText('Label generated')).toBeInTheDocument();
+    expect(await screen.findByText("Couldn't fetch the label file")).toBeInTheDocument();
+    expect(screen.queryByText(/Could not download the label\. Try again\./i)).not.toBeInTheDocument();
+  });
+
   it('captures demo_label_generate_attempted with the routed carrier on submit (#1788)', async () => {
     const generateLabel = vi.fn().mockResolvedValue({ kind: 'dispatched', shipment: null });
     const apiClient = createMockApiClient({ shipments: { generateLabel } });

--- a/apps/web/src/features/orders/components/generate-label-form.tsx
+++ b/apps/web/src/features/orders/components/generate-label-form.tsx
@@ -54,6 +54,7 @@ import {
   extractShippingTraceId,
   useGenerateLabelMutation,
   useLabelDownload,
+  resolveLabelDownloadError,
   type GenerateLabelInput,
 } from '../../shipments';
 import {
@@ -415,7 +416,22 @@ export function GenerateLabelForm({
         // returned result so it fires exactly once per issuance — NOT a reactive
         // effect, which would re-fire on the post-success query invalidation.
         if (result.shipment?.labelPdfRef) {
-          void labelDownload.download(result.shipment.id);
+          const shipmentId = result.shipment.id;
+          void labelDownload.download(shipmentId).then((downloadResult) => {
+            if (!downloadResult.ok) {
+              // The label WAS bought (the toast above already said so) - only
+              // the fetch failed. The title must never suggest generation
+              // itself failed, or the operator will retry the whole form and
+              // risk a second dispatch. The mapper's description carries the
+              // actual "what next" (retry / not now / needs admin).
+              const mapped = resolveLabelDownloadError(downloadResult.error);
+              showToast({
+                tone: mapped.tone,
+                title: "Couldn't fetch the label file",
+                description: mapped.description,
+              });
+            }
+          });
         }
       } else {
         // omp_fulfilled (#953): the destination store fulfils this order — no OL

--- a/apps/web/src/features/orders/components/shipment-action-buttons.test.tsx
+++ b/apps/web/src/features/orders/components/shipment-action-buttons.test.tsx
@@ -9,9 +9,11 @@
  * hook mocking needed.
  */
 import { describe, it, expect, vi } from 'vitest';
-import { screen } from '@testing-library/react';
-import { renderWithProviders } from '../../../test/test-utils';
+import { fireEvent, screen } from '@testing-library/react';
+import { createMockApiClient, renderWithProviders } from '../../../test/test-utils';
+import { ApiError } from '../../../shared/api/api-error';
 import { ShipmentActionButtons } from './shipment-action-buttons';
+import type { Shipment } from '../../shipments';
 import type { PaymentStatus } from '../api/order-snapshot.schema';
 
 function renderGate(paymentStatus?: PaymentStatus): void {
@@ -74,5 +76,109 @@ describe('ShipmentActionButtons payment gate (#928)', () => {
     const button = screen.getByRole('button', { name: /shipments:write permission/i });
     expect(button).toBeDisabled();
     expect(button).toHaveAttribute('title', expect.stringMatching(/shipments:write permission/i));
+  });
+});
+
+function makeDownloadableShipment(): Shipment {
+  return {
+    id: 'ol_shipment_1',
+    orderId: 'ol_order_1',
+    customerId: null,
+    connectionId: 'conn-dpd',
+    shippingMethod: 'kurier',
+    status: 'generated',
+    providerShipmentId: null,
+    paczkomatId: null,
+    sourceDeliveryMethodId: null,
+    deliveryIntent: null,
+    trackingNumber: null,
+    carrier: null,
+    labelPdfRef: 'shipx:label:1',
+    dispatchedAt: null,
+    deliveredAt: null,
+    cancelledAt: null,
+    failedAt: null,
+    errorMessage: null,
+    providerCode: null,
+    createdAt: '2026-08-01T00:00:00.000Z',
+    updatedAt: '2026-08-01T00:00:00.000Z',
+    orderSummary: null,
+  };
+}
+
+// Each failure class must surface its own toast copy, never the collapsed
+// generic string (#2671). One shared apiClient rejection per class, keyed
+// to the exact wire shapes `toHttpException` produces.
+const DOWNLOAD_FAILURES: Array<[string, ApiError, RegExp]> = [
+  [
+    '404 - shipment gone',
+    new ApiError('Shipment not found: ol_shipment_1', 404, {
+      statusCode: 404,
+      message: 'Shipment not found: ol_shipment_1',
+      error: 'Not Found',
+    }),
+    /no shipment matches this id/i,
+  ],
+  [
+    '422 - not generated yet',
+    new ApiError(
+      'No label has been generated for shipment ol_shipment_1 yet - generate the label first',
+      422,
+      { statusCode: 422, message: 'No label has been generated for shipment ol_shipment_1 yet - generate the label first' },
+    ),
+    /no label to download yet/i,
+  ],
+  [
+    '422 - carrier has none',
+    new ApiError(
+      'Cannot fetch label for shipment ol_shipment_1: connection conn-1 does not support returning label documents',
+      422,
+      {
+        statusCode: 422,
+        message:
+          'Cannot fetch label for shipment ol_shipment_1: connection conn-1 does not support returning label documents',
+      },
+    ),
+    /doesn.t provide a downloadable label/i,
+  ],
+  [
+    '502 - provider rejected',
+    new ApiError('Waybill expired', 502, {
+      message: 'Waybill expired for this shipment',
+      providerCode: 'DPD.WAYBILL_EXPIRED',
+    }),
+    /the carrier rejected the request/i,
+  ],
+  [
+    '502 - our credentials rejected',
+    new ApiError('Carrier credentials rejected', 502, {
+      statusCode: 502,
+      message: 'Carrier credentials rejected',
+      error: 'Bad Gateway',
+    }),
+    /our stored carrier credentials were rejected/i,
+  ],
+  [
+    'unclassified 500',
+    new ApiError('boom', 500, { statusCode: 500, message: 'boom', error: 'Internal Server Error' }),
+    /something went wrong/i,
+  ],
+  ['network', ApiError.fromNetworkFailure(new Error('Failed to fetch')), /couldn.t reach openlinker/i],
+];
+
+describe('ShipmentActionButtons download-label failure mapping (#2671)', () => {
+  it.each(DOWNLOAD_FAILURES)('renders distinct copy for %s', async (_label, error, expectedTitle) => {
+    const apiClient = createMockApiClient({
+      shipments: { downloadLabel: vi.fn().mockRejectedValue(error) },
+    });
+    renderWithProviders(
+      <ShipmentActionButtons shipment={makeDownloadableShipment()} canWrite onGenerateLabelClick={vi.fn()} />,
+      { apiClient },
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /download shipping label/i }));
+
+    expect(await screen.findByText(expectedTitle)).toBeInTheDocument();
+    expect(screen.queryByText(/Could not download the label\. Try again\./i)).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/orders/components/shipment-action-buttons.tsx
+++ b/apps/web/src/features/orders/components/shipment-action-buttons.tsx
@@ -20,6 +20,7 @@ import {
   useCancelShipmentMutation,
   useNotifyDispatchedMutation,
   useLabelDownload,
+  resolveLabelDownloadError,
   getCarrierDisplayName,
   canRegenerateLabel,
   CAN_GENERATE,
@@ -180,9 +181,10 @@ export function ShipmentActionButtons({
 
   const handleDownloadLabel = (): void => {
     if (!shipment) return;
-    void labelDownload.download(shipment.id).then((ok) => {
-      if (!ok) {
-        showToast({ tone: 'error', description: 'Could not download the label. Try again.' });
+    void labelDownload.download(shipment.id).then((result) => {
+      if (!result.ok) {
+        const mapped = resolveLabelDownloadError(result.error);
+        showToast({ tone: mapped.tone, title: mapped.title, description: mapped.description });
       }
     });
   };

--- a/apps/web/src/features/shipments/components/shipment-row-detail.test.tsx
+++ b/apps/web/src/features/shipments/components/shipment-row-detail.test.tsx
@@ -8,6 +8,7 @@ import { cleanup, fireEvent, screen, waitFor, within } from '@testing-library/re
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { createMockApiClient, renderWithProviders } from '../../../test/test-utils';
+import { ApiError } from '../../../shared/api/api-error';
 import { REDACTED_ERROR_MESSAGE, type Shipment } from '../api/shipments.types';
 import { ShipmentRowDetail } from './shipment-row-detail';
 
@@ -586,5 +587,87 @@ describe('ShipmentRowDetail — empty-content fallback (#1826)', () => {
     );
     expect(screen.queryByText(/No actions available/)).not.toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Track parcel' })).toBeInTheDocument();
+  });
+});
+
+// Each failure class must surface its own toast copy, never the collapsed
+// generic string (#2671). Mirrors the equivalent table in
+// shipment-action-buttons.test.tsx - the two manual call sites must never
+// disagree about what a given backend response means.
+const DOWNLOAD_FAILURES: Array<[string, ApiError, RegExp]> = [
+  [
+    '404 - shipment gone',
+    new ApiError('Shipment not found: ol_shipment_1', 404, {
+      statusCode: 404,
+      message: 'Shipment not found: ol_shipment_1',
+      error: 'Not Found',
+    }),
+    /no shipment matches this id/i,
+  ],
+  [
+    '422 - not generated yet',
+    new ApiError(
+      'No label has been generated for shipment ol_shipment_1 yet - generate the label first',
+      422,
+      { statusCode: 422, message: 'No label has been generated for shipment ol_shipment_1 yet - generate the label first' },
+    ),
+    /no label to download yet/i,
+  ],
+  [
+    '422 - carrier has none',
+    new ApiError(
+      'Cannot fetch label for shipment ol_shipment_1: connection conn-dpd does not support returning label documents',
+      422,
+      {
+        statusCode: 422,
+        message:
+          'Cannot fetch label for shipment ol_shipment_1: connection conn-dpd does not support returning label documents',
+      },
+    ),
+    /doesn.t provide a downloadable label/i,
+  ],
+  [
+    '502 - provider rejected',
+    new ApiError('Waybill expired', 502, {
+      message: 'Waybill expired for this shipment',
+      providerCode: 'DPD.WAYBILL_EXPIRED',
+    }),
+    /the carrier rejected the request/i,
+  ],
+  [
+    '502 - our credentials rejected',
+    new ApiError('Carrier credentials rejected', 502, {
+      statusCode: 502,
+      message: 'Carrier credentials rejected',
+      error: 'Bad Gateway',
+    }),
+    /our stored carrier credentials were rejected/i,
+  ],
+  [
+    'unclassified 500',
+    new ApiError('boom', 500, { statusCode: 500, message: 'boom', error: 'Internal Server Error' }),
+    /something went wrong/i,
+  ],
+  ['network', ApiError.fromNetworkFailure(new Error('Failed to fetch')), /couldn.t reach openlinker/i],
+];
+
+describe('ShipmentRowDetail download-label failure mapping (#2671)', () => {
+  it.each(DOWNLOAD_FAILURES)('renders distinct copy for %s', async (_label, error, expectedTitle) => {
+    const apiClient = createMockApiClient({
+      shipments: { downloadLabel: vi.fn().mockRejectedValue(error) },
+    });
+    renderWithProviders(
+      <ShipmentRowDetail
+        shipment={makeShipment({ status: 'generated', errorMessage: null, failedAt: null, labelPdfRef: 'shipx:label:1' })}
+        canWrite
+        canReviewConnection
+      />,
+      { apiClient },
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /^Download label$/ }));
+
+    expect(await screen.findByText(expectedTitle)).toBeInTheDocument();
+    expect(screen.queryByText(/Could not download the label\. Try again\./i)).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/shipments/components/shipment-row-detail.tsx
+++ b/apps/web/src/features/shipments/components/shipment-row-detail.tsx
@@ -60,6 +60,7 @@ import {
   type Shipment,
 } from '../api/shipments.types';
 import { buildCarrierTrackingUrl, getCarrierDisplayName } from '../lib/carrier-tracking-url';
+import { resolveLabelDownloadError } from '../lib/label-download-error';
 import { deriveRetryabilityClass, RETRYABILITY_LABEL } from '../lib/shipment-retryability';
 import { useCancelShipmentMutation } from '../hooks/use-cancel-shipment-mutation';
 import { useLabelDownload } from '../hooks/use-label-download';
@@ -187,9 +188,10 @@ export function ShipmentRowDetail({
   );
 
   const handleDownloadLabel = (): void => {
-    void labelDownload.download(shipment.id).then((ok) => {
-      if (!ok) {
-        showToast({ tone: 'error', description: 'Could not download the label. Try again.' });
+    void labelDownload.download(shipment.id).then((result) => {
+      if (!result.ok) {
+        const mapped = resolveLabelDownloadError(result.error);
+        showToast({ tone: mapped.tone, title: mapped.title, description: mapped.description });
       }
     });
   };

--- a/apps/web/src/features/shipments/hooks/use-label-download.ts
+++ b/apps/web/src/features/shipments/hooks/use-label-download.ts
@@ -4,8 +4,14 @@
  * One-shot action (NOT a TanStack mutation) that fetches a shipment's label
  * document via `apiClient.shipments.downloadLabel(id)` and triggers a browser
  * download. Filename extension is derived from `blob.type` (see
- * `lib/label-download`). Exposes local `{ download, isDownloading, error }` —
- * there's nothing to cache, so this is deliberately not a query/mutation hook.
+ * `lib/label-download`). There's nothing to cache, so this is deliberately
+ * not a query/mutation hook.
+ *
+ * `download()` resolves with the raw failure, not a boolean (#2671). A
+ * caller that read a hook-state `error` field inside `.then()` would close
+ * over the PRE-CLICK render's value, which is stale by the time the promise
+ * settles - the resolved value is the only way a caller can react to the
+ * failure that just happened.
  *
  * @module apps/web/src/features/shipments/hooks
  */
@@ -13,30 +19,27 @@ import { useCallback, useState } from 'react';
 import { useApiClient } from '../../../app/api/api-client-provider';
 import { extensionForBlob, triggerBlobDownload } from '../lib/label-download';
 
+export type LabelDownloadResult = { ok: true } | { ok: false; error: unknown };
+
 interface UseLabelDownload {
-  /** Fetch + trigger the browser download. Resolves `true` on success, `false`
-   *  when the fetch failed (the error is also exposed via `error`). */
-  download: (shipmentId: string) => Promise<boolean>;
+  /** Fetch + trigger the browser download. */
+  download: (shipmentId: string) => Promise<LabelDownloadResult>;
   isDownloading: boolean;
-  error: Error | null;
 }
 
 export function useLabelDownload(): UseLabelDownload {
   const apiClient = useApiClient();
   const [isDownloading, setIsDownloading] = useState(false);
-  const [error, setError] = useState<Error | null>(null);
 
   const download = useCallback(
-    async (shipmentId: string): Promise<boolean> => {
+    async (shipmentId: string): Promise<LabelDownloadResult> => {
       setIsDownloading(true);
-      setError(null);
       try {
         const blob = await apiClient.shipments.downloadLabel(shipmentId);
         triggerBlobDownload(blob, `ol-shipment-${shipmentId}.${extensionForBlob(blob)}`);
-        return true;
+        return { ok: true };
       } catch (caught) {
-        setError(caught instanceof Error ? caught : new Error(String(caught)));
-        return false;
+        return { ok: false, error: caught };
       } finally {
         setIsDownloading(false);
       }
@@ -44,5 +47,5 @@ export function useLabelDownload(): UseLabelDownload {
     [apiClient],
   );
 
-  return { download, isDownloading, error };
+  return { download, isDownloading };
 }

--- a/apps/web/src/features/shipments/index.ts
+++ b/apps/web/src/features/shipments/index.ts
@@ -47,6 +47,12 @@ export { useGenerateLabelMutation } from './hooks/use-generate-label-mutation';
 export { useCancelShipmentMutation } from './hooks/use-cancel-shipment-mutation';
 export { useNotifyDispatchedMutation } from './hooks/use-notify-dispatched-mutation';
 export { useLabelDownload } from './hooks/use-label-download';
+export type { LabelDownloadResult } from './hooks/use-label-download';
+export {
+  resolveLabelDownloadError,
+  canRetryLabelDownload,
+} from './lib/label-download-error';
+export type { LabelDownloadError } from './lib/label-download-error';
 export { useBulkGenerateLabelsMutation } from './hooks/use-bulk-generate-labels-mutation';
 export { useProtocolDownload } from './hooks/use-protocol-download';
 export { ShipmentStatusBadge } from './components/shipment-status-badge';

--- a/apps/web/src/features/shipments/index.ts
+++ b/apps/web/src/features/shipments/index.ts
@@ -48,10 +48,7 @@ export { useCancelShipmentMutation } from './hooks/use-cancel-shipment-mutation'
 export { useNotifyDispatchedMutation } from './hooks/use-notify-dispatched-mutation';
 export { useLabelDownload } from './hooks/use-label-download';
 export type { LabelDownloadResult } from './hooks/use-label-download';
-export {
-  resolveLabelDownloadError,
-  canRetryLabelDownload,
-} from './lib/label-download-error';
+export { resolveLabelDownloadError } from './lib/label-download-error';
 export type { LabelDownloadError } from './lib/label-download-error';
 export { useBulkGenerateLabelsMutation } from './hooks/use-bulk-generate-labels-mutation';
 export { useProtocolDownload } from './hooks/use-protocol-download';

--- a/apps/web/src/features/shipments/lib/label-download-error.test.ts
+++ b/apps/web/src/features/shipments/lib/label-download-error.test.ts
@@ -7,7 +7,7 @@
  */
 import { describe, expect, it } from 'vitest';
 import { ApiError } from '../../../shared/api/api-error';
-import { canRetryLabelDownload, resolveLabelDownloadError } from './label-download-error';
+import { resolveLabelDownloadError } from './label-download-error';
 
 describe('resolveLabelDownloadError', () => {
   it('maps a network failure (status 0) to transient, with no server text echoed', () => {
@@ -126,14 +126,5 @@ describe('resolveLabelDownloadError', () => {
     const result = resolveLabelDownloadError(new Error('boom'));
     expect(result.retryable).toBe('unknown');
     expect(result.title).toBe('Something went wrong');
-  });
-});
-
-describe('canRetryLabelDownload', () => {
-  it('offers retry for transient and unknown only', () => {
-    expect(canRetryLabelDownload('transient')).toBe(true);
-    expect(canRetryLabelDownload('unknown')).toBe(true);
-    expect(canRetryLabelDownload('permanent')).toBe(false);
-    expect(canRetryLabelDownload('auth')).toBe(false);
   });
 });

--- a/apps/web/src/features/shipments/lib/label-download-error.test.ts
+++ b/apps/web/src/features/shipments/lib/label-download-error.test.ts
@@ -1,0 +1,139 @@
+/**
+ * Unit tests for resolveLabelDownloadError (#2671).
+ *
+ * Covers every branch the mapper's own header comment documents, keyed to
+ * the exact wire shapes `apps/api/src/shipping/http/shipment.controller.ts`
+ * produces for each source exception.
+ */
+import { describe, expect, it } from 'vitest';
+import { ApiError } from '../../../shared/api/api-error';
+import { canRetryLabelDownload, resolveLabelDownloadError } from './label-download-error';
+
+describe('resolveLabelDownloadError', () => {
+  it('maps a network failure (status 0) to transient, with no server text echoed', () => {
+    const error = ApiError.fromNetworkFailure(new Error('Failed to fetch'));
+    const result = resolveLabelDownloadError(error);
+    expect(result.retryable).toBe('transient');
+    expect(result.tone).toBe('warning');
+    expect(result.title).toBe('Couldn’t reach OpenLinker');
+  });
+
+  it('maps a client-side timeout (status 0) to transient', () => {
+    const error = ApiError.fromTimeout('/v1/shipments/ol_shipment_1/label');
+    const result = resolveLabelDownloadError(error);
+    expect(result.retryable).toBe('transient');
+  });
+
+  it('maps 404 ShipmentNotFoundException to permanent, without guessing a cause', () => {
+    const error = new ApiError('Shipment not found: ol_shipment_1', 404, {
+      statusCode: 404,
+      message: 'Shipment not found: ol_shipment_1',
+      error: 'Not Found',
+    });
+    const result = resolveLabelDownloadError(error);
+    expect(result.retryable).toBe('permanent');
+    expect(result.tone).toBe('warning');
+    expect(result.title).toBe('No shipment matches this id');
+    expect(result.description).not.toMatch(/cancelled|replaced/i);
+  });
+
+  it('maps 422 LabelNotAvailableException ("not yet") to permanent, distinct copy from the unsupported case', () => {
+    const error = new ApiError(
+      'No label has been generated for shipment ol_shipment_1 yet - generate the label first',
+      422,
+      {
+        statusCode: 422,
+        message: 'No label has been generated for shipment ol_shipment_1 yet - generate the label first',
+        error: 'Unprocessable Entity',
+      },
+    );
+    const result = resolveLabelDownloadError(error);
+    expect(result.retryable).toBe('permanent');
+    expect(result.title).toBe('No label to download yet');
+  });
+
+  it('maps 422 LabelDocumentNotSupportedException ("never") to permanent, distinct copy from the not-yet case', () => {
+    const error = new ApiError(
+      'Cannot fetch label for shipment ol_shipment_1: connection conn-1 does not support returning label documents',
+      422,
+      {
+        statusCode: 422,
+        message:
+          'Cannot fetch label for shipment ol_shipment_1: connection conn-1 does not support returning label documents',
+        error: 'Unprocessable Entity',
+      },
+    );
+    const result = resolveLabelDownloadError(error);
+    expect(result.retryable).toBe('permanent');
+    expect(result.title).toBe('This carrier doesn’t provide a downloadable label');
+  });
+
+  it('maps 502 ShippingProviderRejectionException to unknown, echoing the server message + providerCode verbatim', () => {
+    const error = new ApiError('Waybill expired', 502, {
+      message: 'Waybill expired for this shipment',
+      providerCode: 'DPD.WAYBILL_EXPIRED',
+      details: undefined,
+    });
+    const result = resolveLabelDownloadError(error);
+    expect(result.retryable).toBe('unknown');
+    expect(result.tone).toBe('error');
+    expect(result.title).toBe('The carrier rejected the request');
+    expect(result.description).toBe('Waybill expired for this shipment (ref: DPD.WAYBILL_EXPIRED)');
+  });
+
+  it('never re-redacts a 502 rejection already redacted server-side for a viewer', () => {
+    // #1826: a viewer session receives `message: REDACTED_ERROR_MESSAGE` from
+    // the API itself. The mapper must echo it unchanged, not substitute its
+    // own copy - re-redacting would be the FE inventing a second policy.
+    const error = new ApiError('Details hidden for this role.', 502, {
+      message: 'Details hidden for this role.',
+      providerCode: 'DPD.WAYBILL_EXPIRED',
+    });
+    const result = resolveLabelDownloadError(error);
+    expect(result.description).toBe('Details hidden for this role. (ref: DPD.WAYBILL_EXPIRED)');
+  });
+
+  it('handles a 502 rejection with a null providerCode without appending a bogus ref', () => {
+    const error = new ApiError('Rejected', 502, { message: 'Rejected', providerCode: null });
+    const result = resolveLabelDownloadError(error);
+    expect(result.description).toBe('Rejected');
+  });
+
+  it('maps 502 ShippingProviderAuthException (no providerCode key) to auth, needing an admin', () => {
+    const error = new ApiError('Carrier credentials rejected', 502, {
+      statusCode: 502,
+      message: 'Carrier credentials rejected',
+      error: 'Bad Gateway',
+    });
+    const result = resolveLabelDownloadError(error);
+    expect(result.retryable).toBe('auth');
+    expect(result.tone).toBe('error');
+    expect(result.title).toBe('Our stored carrier credentials were rejected');
+  });
+
+  it('maps an unclassified 500 to a fixed fallback, never echoing the raw backend message', () => {
+    const error = new ApiError('Unexpected token in JSON at position 0', 500, {
+      statusCode: 500,
+      message: 'Unexpected token in JSON at position 0',
+      error: 'Internal Server Error',
+    });
+    const result = resolveLabelDownloadError(error);
+    expect(result.retryable).toBe('unknown');
+    expect(result.description).not.toContain('Unexpected token');
+  });
+
+  it('falls back to the unknown-fixed copy for a non-ApiError throw', () => {
+    const result = resolveLabelDownloadError(new Error('boom'));
+    expect(result.retryable).toBe('unknown');
+    expect(result.title).toBe('Something went wrong');
+  });
+});
+
+describe('canRetryLabelDownload', () => {
+  it('offers retry for transient and unknown only', () => {
+    expect(canRetryLabelDownload('transient')).toBe(true);
+    expect(canRetryLabelDownload('unknown')).toBe(true);
+    expect(canRetryLabelDownload('permanent')).toBe(false);
+    expect(canRetryLabelDownload('auth')).toBe(false);
+  });
+});

--- a/apps/web/src/features/shipments/lib/label-download-error.ts
+++ b/apps/web/src/features/shipments/lib/label-download-error.ts
@@ -19,6 +19,13 @@
  * shipment field to key off (see that module's own header comment). The two
  * share only the vocabulary, not the derivation.
  *
+ * No call site renders a distinct "Try again" affordance today - the copy
+ * alone carries the retryable/not-retryable distinction (a `transient`
+ * network toast reads "try again"; a `permanent` 404/422 toast doesn't). A
+ * `retryable`-gated retry BUTTON would need a toast action slot the shared
+ * `ToastProvider` doesn't have yet; wiring one is future work, not something
+ * to half-build here as an unused export (PR #2700 review).
+ *
  * Discriminators below are pinned to
  * `apps/api/src/shipping/http/shipment.controller.ts`'s `toHttpException`
  * (read from source, not guessed):
@@ -165,12 +172,4 @@ export function resolveLabelDownloadError(error: unknown): LabelDownloadError {
   }
 
   return withTone(UNKNOWN_FALLBACK);
-}
-
-/** Whether the mapped failure's copy invites the operator to try again -
- *  the "Try again" affordance the issue's AC gates on. `transient`/`unknown`
- *  only: `permanent` never resolves by retrying, and `auth` needs an admin,
- *  not another click. */
-export function canRetryLabelDownload(retryable: RetryabilityClass): boolean {
-  return retryable === 'transient' || retryable === 'unknown';
 }

--- a/apps/web/src/features/shipments/lib/label-download-error.ts
+++ b/apps/web/src/features/shipments/lib/label-download-error.ts
@@ -1,0 +1,176 @@
+/**
+ * resolveLabelDownloadError (#2671)
+ *
+ * Pure mapper from a shipment label-download failure to an operator-facing
+ * struct, shared by both manual call sites (order-detail panel's
+ * `ShipmentActionButtons`, the `/shipments` row accordion's
+ * `ShipmentRowDetail`) and the post-generation auto-download path in
+ * `GenerateLabelForm`, so the three cannot drift into three different toast
+ * strings for the same backend outcome.
+ *
+ * `retryable` is typed as the existing `RetryabilityClass` (not a plain
+ * boolean) so a carrier-credential rejection renders a distinct "needs
+ * admin" state instead of collapsing into the same "no retry" bucket as a
+ * 404 or a 422 - a click from the operator can never fix either, but only
+ * one of them is actually the operator's problem to fix. This does NOT call
+ * `deriveRetryabilityClass` from `shipment-retryability.ts` - that helper
+ * classifies a label-GENERATION failure from a persisted `providerCode`
+ * string shape, and this is a download-time HTTP failure with no persisted
+ * shipment field to key off (see that module's own header comment). The two
+ * share only the vocabulary, not the derivation.
+ *
+ * Discriminators below are pinned to
+ * `apps/api/src/shipping/http/shipment.controller.ts`'s `toHttpException`
+ * (read from source, not guessed):
+ *
+ *   1. `ApiError.isNetworkError()` (status 0 - the fetch never got a
+ *      response, or `ApiError.fromTimeout`) -> transient. The request never
+ *      reached the API at all, distinct from #6 below.
+ *   2. status 404 (`ShipmentNotFoundException`) -> permanent. NestJS's
+ *      default `NotFoundException(message)` body carries no exception-name
+ *      field, so status alone is the only, and here unambiguous, signal.
+ *   3. status 422, `error.message` contains 'generate the label first'
+ *      (`LabelNotAvailableException`) -> permanent, "not yet".
+ *   4. status 422, otherwise (`LabelDocumentNotSupportedException`) ->
+ *      permanent, "never". Distinguished from #3 by MESSAGE TEXT only - the
+ *      controller wraps both in a bare `new UnprocessableEntityException(
+ *      error.message)` with no `error: exceptionName` field, so there is
+ *      nothing else to key on without a backend change (explicitly out of
+ *      scope for #2671). Keep the substring in lockstep with
+ *      `LabelNotAvailableException`'s own message template.
+ *   5. status 502, `details.providerCode` is an own property
+ *      (`ShippingProviderRejectionException` - the controller builds this
+ *      branch's body as `{ message, providerCode, details }`, always
+ *      including the key) -> unknown ("maybe" - a structured carrier
+ *      rejection, may or may not resolve on retry). `details.message` is
+ *      ALREADY role-redacted server-side (#1826) - echo it verbatim, never
+ *      re-redact on the FE. `providerCode` is a non-PII support reference
+ *      (#1428) and is always present regardless of role.
+ *   6. status 502, no `providerCode` key at all
+ *      (`ShippingProviderAuthException` - the controller passes a plain
+ *      string to `new BadGatewayException(error.message)`, which has no
+ *      `providerCode` field) -> auth. Our stored carrier credentials were
+ *      rejected; nothing the operator's retry can fix.
+ *   7. any other status (the unclassified 500, or an unmodeled shape) ->
+ *      unknown, FIXED copy only.
+ *
+ * Security invariant: only branch 5 surfaces the server's own message -
+ * and only because the backend has already redacted it for a
+ * non-`shipments:write` caller. Every other branch, including the
+ * unclassified-500 fallback, emits fixed copy. The controller's own comment
+ * on that branch notes it logs+returns the raw `error.message` unsanitised -
+ * an unmodeled shape must never be echoed to the operator.
+ *
+ * @module apps/web/src/features/shipments/lib
+ */
+import { ApiError } from '../../../shared/api/api-error';
+import type { AlertTone } from '../../../shared/ui/alert';
+import type { RetryabilityClass } from './shipment-retryability';
+
+export interface LabelDownloadError {
+  title: string;
+  description: string;
+  retryable: RetryabilityClass;
+  /** Derived from `retryable` alone (see `TONE_BY_RETRYABLE`) - one place
+   *  decides how urgent a class reads, so a call site never picks its own
+   *  tone per branch and drifts from the other two call sites. */
+  tone: AlertTone;
+}
+
+interface ProviderRejectionBody {
+  message?: string;
+  providerCode?: string | null;
+}
+
+function hasProviderCode(details: unknown): details is ProviderRejectionBody {
+  return typeof details === 'object' && details !== null && 'providerCode' in details;
+}
+
+/** `permanent` (404/422) is not urgent - it's an "unavailable" state, not a
+ *  failure the operator caused. `transient` (network) is a hiccup. `auth`
+ *  and `unknown` (structured rejection / unclassified) are real problems. */
+const TONE_BY_RETRYABLE: Record<RetryabilityClass, AlertTone> = {
+  permanent: 'warning',
+  transient: 'warning',
+  auth: 'error',
+  unknown: 'error',
+};
+
+type UntonedLabelDownloadError = Omit<LabelDownloadError, 'tone'>;
+
+function withTone(result: UntonedLabelDownloadError): LabelDownloadError {
+  return { ...result, tone: TONE_BY_RETRYABLE[result.retryable] };
+}
+
+const UNKNOWN_FALLBACK: UntonedLabelDownloadError = {
+  title: 'Something went wrong',
+  description: 'Try again in a moment. If it keeps happening, contact support with the order id.',
+  retryable: 'unknown',
+};
+
+export function resolveLabelDownloadError(error: unknown): LabelDownloadError {
+  if (!(error instanceof ApiError)) {
+    return withTone(UNKNOWN_FALLBACK);
+  }
+
+  if (error.isNetworkError()) {
+    return withTone({
+      title: 'Couldn’t reach OpenLinker',
+      description: 'Check your connection and try again.',
+      retryable: 'transient',
+    });
+  }
+
+  if (error.status === 404) {
+    return withTone({
+      title: 'No shipment matches this id',
+      description:
+        'It may have been removed, or the link is stale. Refresh the order to see its current shipment.',
+      retryable: 'permanent',
+    });
+  }
+
+  if (error.status === 422) {
+    if (error.message.includes('generate the label first')) {
+      return withTone({
+        title: 'No label to download yet',
+        description: 'A label hasn’t been generated for this shipment. Generate one first.',
+        retryable: 'permanent',
+      });
+    }
+    return withTone({
+      title: 'This carrier doesn’t provide a downloadable label',
+      description: 'The label lives with the carrier directly - retrying here will never produce a file.',
+      retryable: 'permanent',
+    });
+  }
+
+  if (error.status === 502) {
+    if (hasProviderCode(error.details)) {
+      const body = error.details;
+      const code = body.providerCode;
+      const message = body.message ?? error.message;
+      return withTone({
+        title: 'The carrier rejected the request',
+        description: code ? `${message} (ref: ${code})` : message,
+        retryable: 'unknown',
+      });
+    }
+    return withTone({
+      title: 'Our stored carrier credentials were rejected',
+      description:
+        'This is a connection problem, not something a retry fixes. Ask an admin to reconnect this carrier.',
+      retryable: 'auth',
+    });
+  }
+
+  return withTone(UNKNOWN_FALLBACK);
+}
+
+/** Whether the mapped failure's copy invites the operator to try again -
+ *  the "Try again" affordance the issue's AC gates on. `transient`/`unknown`
+ *  only: `permanent` never resolves by retrying, and `auth` needs an admin,
+ *  not another click. */
+export function canRetryLabelDownload(retryable: RetryabilityClass): boolean {
+  return retryable === 'transient' || retryable === 'unknown';
+}

--- a/libs/core/src/shipping/domain/exceptions/__tests__/label-not-available.exception.spec.ts
+++ b/libs/core/src/shipping/domain/exceptions/__tests__/label-not-available.exception.spec.ts
@@ -1,0 +1,26 @@
+/**
+ * LabelNotAvailableException — message substring pinned for the FE mapper (#2671, PR #2700 review).
+ *
+ * `apps/web/src/features/shipments/lib/label-download-error.ts` distinguishes
+ * this exception's 422 from `LabelDocumentNotSupportedException`'s 422 purely
+ * by testing `error.message.includes('generate the label first')` - the
+ * controller wraps both in a bare `UnprocessableEntityException` with no
+ * exception-name field on the wire. A reword here silently reroutes every
+ * "label not generated yet" download into the FE's "carrier doesn't support
+ * labels" copy. This spec is what turns that reword into a failing build.
+ */
+import { LabelNotAvailableException } from '../label-not-available.exception';
+
+describe('LabelNotAvailableException', () => {
+  it('should keep the substring the FE label-download mapper keys on', () => {
+    const error = new LabelNotAvailableException('shipment-1');
+
+    expect(error.message).toContain('generate the label first');
+  });
+
+  it('should have a stable `name` field', () => {
+    const error = new LabelNotAvailableException('shipment-1');
+
+    expect(error.name).toBe('LabelNotAvailableException');
+  });
+});


### PR DESCRIPTION
## Summary

- Downloading a shipment label collapsed every backend outcome (404 / 422 / 502 / network / 5xx) into one toast, "Could not download the label. Try again." - actively wrong for 404/422, where no retry ever helps.
- The auto-download that fires right after "Generate label" failed completely silently: no toast, no error, just a missing file.
- Adds one shared mapper, `resolveLabelDownloadError` (`apps/web/src/features/shipments/lib/label-download-error.ts`), turning the failure into `{ title, description, retryable, tone }`, typed against the existing 4-way `RetryabilityClass` (`transient | permanent | auth | unknown`) so a carrier-credential rejection renders a distinct "needs admin" state instead of collapsing into the same "no retry" bucket as a plain 404.
- Wires all three call sites through it: `ShipmentActionButtons` (order-detail panel), `ShipmentRowDetail` (`/shipments` row accordion), and `GenerateLabelForm`'s auto-download - so they can no longer drift into three different strings for the same backend outcome.
- `useLabelDownload.download()` now resolves with the failure instead of stashing it in hook state, closing the stale-closure trap the issue itself flagged: a `.then()` callback reading `labelDownload.error` would have closed over the pre-click render's value.

## Design mock

Before/after mock (real app components, dark theme, all 7 failure classes including the auth/"needs admin" state and the role-redaction toggle for the one branch that's actually gated server-side): https://claude.ai/code/artifact/bbd49ce3-3de8-460a-bbb4-5d6255bbc60f

## Discriminators (verified against source, not guessed)

`apps/api/src/shipping/http/shipment.controller.ts`'s `toHttpException` was read directly rather than assumed:

- 404 (`ShipmentNotFoundException`) and both 422s (`LabelNotAvailableException` / `LabelDocumentNotSupportedException`) carry no structured exception-name field on the wire, only `{ statusCode, message }` - the two 422s are told apart by a message substring, kept in lockstep with the exception's own message template (documented in the mapper's header comment).
- 502 `ShippingProviderRejectionException` builds its body as `{ message, providerCode, details }` (providerCode always present, message already role-redacted server-side per #1826) - the FE echoes it verbatim and never re-redacts.
- 502 `ShippingProviderAuthException` passes a plain string to `BadGatewayException`, so it has no `providerCode` key at all - that's the discriminator between the two 502 cases, without needing a backend change.
- Status 0 (`ApiError.isNetworkError()` / `ApiError.fromTimeout`) is a real, separate case from the unclassified 500 - the request never reached the API at all.

## Test plan

- [x] `pnpm --filter @openlinker/web type-check` - clean
- [x] `pnpm --filter @openlinker/web lint` - 0 errors (pre-existing warnings elsewhere, untouched)
- [x] Unit tests for the mapper covering every branch (`label-download-error.test.ts`)
- [x] Component tests at both manual call sites (`shipment-action-buttons.test.tsx`, `shipment-row-detail.test.tsx`) - `it.each` over all 7 failure classes, asserting distinct copy per class and that the old generic string never appears
- [x] Component test for the auto-download path (`generate-label-form.test.tsx`) - asserts the success toast still fires (the label WAS bought) and a second, distinct failure toast appears, never implying generation itself failed
- [x] Manual QA in a running dev stack across mobile/tablet/desktop breakpoints - no CSS or layout changed (same `Toast`/`Button` components, same responsive rules already covering `.toast-region` / `.shipment-action-buttons`), so no new breakpoint risk was introduced, but this is still pending a real-browser pass before merge

Closes #2671
