### PR TITLE
feat(analytics): exclusion annotations on KPI/channel surfaces (#2480, #2481, epic #2452 Phase 8)

### DIFF
--- a/apps/web/src/features/analytics/components/analytics-data-coverage-panel.tsx
+++ b/apps/web/src/features/analytics/components/analytics-data-coverage-panel.tsx
@@ -66,6 +66,16 @@ interface AnalyticsDataCoveragePanelProps {
   filters: AnalyticsCoverageFilters;
   /** Opens the shared Analytics Settings dialog — used by the tax-A row's "Include anyway" action. */
   onOpenSettings: () => void;
+  /**
+   * Controllable-with-uncontrolled-fallback (#2480, epic #2452 Phase 8):
+   * when supplied together, an external trigger (the KPI strip's `GapMark`,
+   * the channel table's `AnalyticsExclusionNote`) can open this panel's own
+   * detail modals without a second `CoverageDetailDialog` implementation.
+   * Omitted (the panel's own self-render, unchanged since Phase 7): falls
+   * back to internal state, byte-identical to pre-Phase-8 behavior.
+   */
+  openCategory?: CoverageCategory | null;
+  onOpenCategoryChange?: (category: CoverageCategory | null) => void;
 }
 
 function isTaxCategory(category: CoverageCategory): category is TaxCoverageCategory {
@@ -75,6 +85,8 @@ function isTaxCategory(category: CoverageCategory): category is TaxCoverageCateg
 export function AnalyticsDataCoveragePanel({
   filters,
   onOpenSettings,
+  openCategory: controlledOpenCategory,
+  onOpenCategoryChange,
 }: AnalyticsDataCoveragePanelProps): ReactElement {
   const { showToast } = useToast();
   const demoMode = useDemoMode();
@@ -88,7 +100,9 @@ export function AnalyticsDataCoveragePanel({
     return (connectionId: string): string => byId.get(connectionId) ?? connectionId;
   }, [connectionsQuery.data]);
 
-  const [openCategory, setOpenCategory] = useState<CoverageCategory | null>(null);
+  const [internalOpenCategory, setInternalOpenCategory] = useState<CoverageCategory | null>(null);
+  const openCategory = onOpenCategoryChange ? controlledOpenCategory ?? null : internalOpenCategory;
+  const setOpenCategory = onOpenCategoryChange ?? setInternalOpenCategory;
   const [offset, setOffset] = useState(0);
 
   function openDetail(category: CoverageCategory): void {

--- a/apps/web/src/features/analytics/components/analytics-exclusion-note.test.tsx
+++ b/apps/web/src/features/analytics/components/analytics-exclusion-note.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { AnalyticsExclusionNote } from './analytics-exclusion-note';
+import { deriveCoverageRowCopy } from '../lib/data-coverage-copy.lib';
+import { COVERAGE_CATEGORY_VALUES, type CoverageCategory } from '../api/analytics-coverage.types';
+
+describe('AnalyticsExclusionNote (#2481)', () => {
+  it.each(COVERAGE_CATEGORY_VALUES)('renders the %s category copy from deriveCoverageRowCopy verbatim', (category) => {
+    render(
+      <AnalyticsExclusionNote category={category as CoverageCategory} affectedCount={3} onOpenCategory={() => {}} />
+    );
+
+    const expected = deriveCoverageRowCopy({
+      category: category as CoverageCategory,
+      status: 'open',
+      affectedCount: 3,
+      sampleOrderIds: [],
+    }).headline;
+
+    expect(screen.getByRole('button', { name: expected })).toBeInTheDocument();
+  });
+
+  it('calls onOpenCategory with its own category when clicked', async () => {
+    const user = userEvent.setup();
+    const onOpenCategory = vi.fn();
+
+    render(<AnalyticsExclusionNote category="tax-b" affectedCount={1} onOpenCategory={onOpenCategory} />);
+
+    await user.click(screen.getByRole('button'));
+
+    expect(onOpenCategory).toHaveBeenCalledWith('tax-b');
+    expect(onOpenCategory).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/features/analytics/components/analytics-exclusion-note.tsx
+++ b/apps/web/src/features/analytics/components/analytics-exclusion-note.tsx
@@ -15,9 +15,20 @@
  * the string here instead of deriving it would reopen exactly that risk
  * the moment either copy changes.
  *
+ * Renders on top of the shared `Chip` primitive (`shared/ui/chip.tsx`)
+ * rather than a one-off styled `<button>` — `tone="warning"` already gives
+ * the exact pill treatment this note needs
+ * (`docs/frontend-ui-style-guide.md` § CSS Implementation Standard: "add
+ * or extend shared primitives before introducing page-specific one-off
+ * styling"). `Chip`'s `aria-pressed` toggle semantics don't fit a
+ * fire-and-navigate action, so it's explicitly cleared here; the `excl-note`
+ * class only ADDS the truncation behavior a table cell needs on top of
+ * `Chip`'s own tone/spacing/border, never re-declares them.
+ *
  * @module apps/web/src/features/analytics/components
  */
 import type { ReactElement } from 'react';
+import { Chip } from '../../../shared/ui/chip';
 import { deriveCoverageRowCopy } from '../lib/data-coverage-copy.lib';
 import type { CoverageCategory } from '../api/analytics-coverage.types';
 
@@ -36,8 +47,13 @@ export function AnalyticsExclusionNote({
   const copy = deriveCoverageRowCopy({ category, status: 'open', affectedCount, sampleOrderIds: [] });
 
   return (
-    <button type="button" className="excl-note" onClick={() => onOpenCategory(category)}>
+    <Chip
+      tone="warning"
+      className="excl-note"
+      aria-pressed={undefined}
+      onClick={() => onOpenCategory(category)}
+    >
       {copy.headline}
-    </button>
+    </Chip>
   );
 }

--- a/apps/web/src/features/analytics/components/analytics-exclusion-note.tsx
+++ b/apps/web/src/features/analytics/components/analytics-exclusion-note.tsx
@@ -1,0 +1,43 @@
+/**
+ * Analytics Exclusion Note
+ *
+ * The `.excl-note` per-row annotation (#2481, epic #2452 Phase 8) shown on
+ * a `ChannelSalesTable` row whose own figures are under-counted by an open
+ * Data Coverage category (#2474 Phase 7). One instance per affected
+ * category on a row — a row belonging to more than one open category
+ * (e.g. some of its orders un-stamped AND some un-rated) renders one note
+ * per category rather than merging them into a single ambiguous line, so
+ * an operator always knows which fix applies.
+ *
+ * Copy is sourced from `deriveCoverageRowCopy` (Phase 7's single source of
+ * category copy) rather than hand-written here — the mockup's own found
+ * bug class was a row carrying the *wrong* category's copy, and repeating
+ * the string here instead of deriving it would reopen exactly that risk
+ * the moment either copy changes.
+ *
+ * @module apps/web/src/features/analytics/components
+ */
+import type { ReactElement } from 'react';
+import { deriveCoverageRowCopy } from '../lib/data-coverage-copy.lib';
+import type { CoverageCategory } from '../api/analytics-coverage.types';
+
+interface AnalyticsExclusionNoteProps {
+  category: CoverageCategory;
+  /** This row's own affected-order count for `category` — drives singular/plural copy only. */
+  affectedCount: number;
+  onOpenCategory: (category: CoverageCategory) => void;
+}
+
+export function AnalyticsExclusionNote({
+  category,
+  affectedCount,
+  onOpenCategory,
+}: AnalyticsExclusionNoteProps): ReactElement {
+  const copy = deriveCoverageRowCopy({ category, status: 'open', affectedCount, sampleOrderIds: [] });
+
+  return (
+    <button type="button" className="excl-note" onClick={() => onOpenCategory(category)}>
+      {copy.headline}
+    </button>
+  );
+}

--- a/apps/web/src/features/analytics/components/analytics-kpi-strip.test.tsx
+++ b/apps/web/src/features/analytics/components/analytics-kpi-strip.test.tsx
@@ -1,11 +1,25 @@
 import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import { createMockApiClient, renderWithProviders } from '../../../test/test-utils';
 import type { ConnectionIngestionTrust } from '../api/analytics-trust.types';
 import type { SalesAndChannelAnalytics, SalesAnalyticsFilters } from '../api/sales-analytics.types';
+import type { AnalyticsCoverage } from '../api/analytics-coverage.types';
 import { AnalyticsKpiStrip } from './analytics-kpi-strip';
 
 const FILTERS = { from: '2026-08-01', to: '2026-08-14' };
+
+function coverage(overrides: Partial<Record<string, number>> = {}): AnalyticsCoverage {
+  return {
+    categories: [
+      { category: 'currency', status: 'open', affectedCount: overrides.currency ?? 0, sampleOrderIds: [] },
+      { category: 'tax-a', status: 'open', affectedCount: overrides['tax-a'] ?? 0, sampleOrderIds: [] },
+      { category: 'tax-b', status: 'open', affectedCount: overrides['tax-b'] ?? 0, sampleOrderIds: [] },
+      { category: 'tax-c', status: 'open', affectedCount: overrides['tax-c'] ?? 0, sampleOrderIds: [] },
+      { category: 'product-matching', status: 'open', affectedCount: 0, sampleOrderIds: [] },
+    ],
+  };
+}
 
 function connectionWithEarliestOrder(earliestOrderDate: string | null): ConnectionIngestionTrust {
   return {
@@ -236,5 +250,97 @@ describe('AnalyticsKpiStrip', () => {
     expect(
       screen.getAllByTitle('No order history yet — nothing to compare against.').length
     ).toBeGreaterThan(0);
+  });
+
+  // #2480 — GapMark becomes a real, category-specific, clickable affordance
+  // once `coverage` + `onOpenCategory` are wired, instead of the generic
+  // pre-Phase-8 tooltip-only text.
+  describe('coverage-aware GapMarks (#2480)', () => {
+    it('opens the currency category on the GMV GapMark when the currency row is genuinely open', async () => {
+      const user = userEvent.setup();
+      const onOpenCategory = vi.fn();
+      const apiClient = createMockApiClient({
+        analytics: { getSales: vi.fn().mockResolvedValue(analytics({ unconvertedCount: 5 })) },
+      });
+
+      renderWithProviders(
+        <AnalyticsKpiStrip
+          filters={FILTERS}
+          connections={[]}
+          coverage={coverage({ currency: 5 })}
+          onOpenCategory={onOpenCategory}
+        />,
+        { apiClient }
+      );
+
+      // The same currency GapMark renders on BOTH the Revenue card's GMV
+      // qualifier and the Order value card's Average qualifier — clicking
+      // either must open the same 'currency' category.
+      const buttons = await screen.findAllByRole('button', {
+        name: 'The reporting currency changed — these orders are still tagged with the old one.',
+      });
+      expect(buttons).toHaveLength(2);
+      await user.click(buttons[0]);
+
+      expect(onOpenCategory).toHaveBeenCalledWith('currency');
+    });
+
+    it("picks the tax category with the LARGEST affectedCount for the Net Sales GapMark, never just tax-a", async () => {
+      const user = userEvent.setup();
+      const onOpenCategory = vi.fn();
+      const apiClient = createMockApiClient({
+        analytics: { getSales: vi.fn().mockResolvedValue(analytics({ netExcludedCount: 10 })) },
+      });
+
+      renderWithProviders(
+        <AnalyticsKpiStrip
+          filters={FILTERS}
+          connections={[]}
+          // tax-b (7) is the largest of the three — must win over tax-a/tax-c
+          // despite tax-a being the "remediable" fallback category.
+          coverage={coverage({ 'tax-a': 2, 'tax-b': 7, 'tax-c': 1 })}
+          onOpenCategory={onOpenCategory}
+        />,
+        { apiClient }
+      );
+
+      const button = await screen.findByRole('button', {
+        name: 'The product has no tax rate set at the source — fix it there, not here.',
+      });
+      await user.click(button);
+
+      expect(onOpenCategory).toHaveBeenCalledWith('tax-b');
+    });
+
+    it('renders no Net Sales GapMark at all when netExcludedCount disagrees with a stale/zeroed coverage read', async () => {
+      const onOpenCategory = vi.fn();
+      const apiClient = createMockApiClient({
+        analytics: { getSales: vi.fn().mockResolvedValue(analytics({ netExcludedCount: 5 })) },
+      });
+
+      renderWithProviders(
+        <AnalyticsKpiStrip
+          filters={FILTERS}
+          connections={[]}
+          // Every tax category reads 0 despite netExcludedCount > 0 — a data
+          // mismatch. `resolveNetExcludedTaxCategory` must not paper over
+          // that by pointing a clickable button at an empty category — the
+          // component falls back to the plain, gap-mark-free "Net sales"
+          // label instead (the caveat is still available in the info-tip
+          // popover via the coverage-independent `netExcludedVisible` gate).
+          coverage={coverage()}
+          onOpenCategory={onOpenCategory}
+        />,
+        { apiClient }
+      );
+
+      await screen.findByText('Net sales');
+      expect(
+        screen.queryByTitle(
+          '5 order(s) predate per-line tax rates or carry a line with an unresolvable rate, and are excluded from NOV.'
+        )
+      ).not.toBeInTheDocument();
+      expect(onOpenCategory).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/web/src/features/analytics/components/analytics-kpi-strip.tsx
+++ b/apps/web/src/features/analytics/components/analytics-kpi-strip.tsx
@@ -84,6 +84,8 @@ import {
 } from '../lib/sales-analytics-view-model';
 import { AnalyticsKpiCard, type AnalyticsKpiDelta } from './analytics-kpi-card';
 import { GapMark } from './gap-mark';
+import { deriveCoverageRowCopy } from '../lib/data-coverage-copy.lib';
+import type { AnalyticsCoverage, CoverageCategory, CoverageCategoryRow } from '../api/analytics-coverage.types';
 
 // The metrics spec defines Net Sales as NOV minus the value of returns
 // (docs/specs/metrics-analytics-dashboard.md § Net Sales) — quoted, not
@@ -115,9 +117,38 @@ interface AnalyticsKpiStripProps {
   filters: SalesAnalyticsFilters;
   /** For `earliestOrderDate` coverage-gating the previous-period delta — already fetched at the page level for the trust header, so this never issues its own `GET /analytics/trust` call. */
   connections: ConnectionIngestionTrust[];
+  /**
+   * The Data Coverage aggregate (#2474 Phase 7), read at the page level —
+   * same query key as `AnalyticsDataCoveragePanel`'s own fetch, so this
+   * never issues a second `GET /analytics/coverage` call (#2480, epic
+   * #2452 Phase 8). `undefined` while still loading, or when the caller
+   * never wired coverage in (e.g. an older test) — every `GapMark` below
+   * falls back to its pre-Phase-8 generic title in that case.
+   */
+  coverage?: AnalyticsCoverage;
+  /** Opens the matching Data Coverage detail modal — omit to keep every `GapMark` inert. */
+  onOpenCategory?: (category: CoverageCategory) => void;
 }
 
-export function AnalyticsKpiStrip({ connections, filters }: AnalyticsKpiStripProps): ReactElement {
+/** Tax categories partition the exclusion set (`TaxCoverageDetectionService`'s classification pass) — the one with the largest `affectedCount` is the category actually causing `netExcludedCount`. Falls back to `'tax-a'` (the remediable one) if all three read zero, which should not happen while `netExcludedVisible` is true. */
+function resolveNetExcludedTaxCategory(categories: CoverageCategoryRow[]): CoverageCategoryRow {
+  const taxRows = categories.filter(
+    (row): row is CoverageCategoryRow & { category: 'tax-a' | 'tax-b' | 'tax-c' } =>
+      row.category === 'tax-a' || row.category === 'tax-b' || row.category === 'tax-c'
+  );
+  const best = taxRows.reduce<CoverageCategoryRow | null>(
+    (max, row) => (max === null || row.affectedCount > max.affectedCount ? row : max),
+    null
+  );
+  return best ?? { category: 'tax-a', status: 'open', affectedCount: 0, sampleOrderIds: [] };
+}
+
+export function AnalyticsKpiStrip({
+  connections,
+  filters,
+  coverage,
+  onOpenCategory,
+}: AnalyticsKpiStripProps): ReactElement {
   const query = useSalesAnalyticsQuery(filters);
 
   // Computed and the second query issued UNCONDITIONALLY, before any early
@@ -180,6 +211,28 @@ export function AnalyticsKpiStrip({ connections, filters }: AnalyticsKpiStripPro
   const stampedGapVisible = headline.unconvertedCount > 0;
   const netExcludedVisible = headline.netExcludedCount > 0;
   const netExcludedNote = `${headline.netExcludedCount} order(s) predate per-line tax rates or carry a line with an unresolvable rate, and are excluded from NOV.`;
+
+  // Currency/tax exclusion `GapMark`s (#2480, epic #2452 Phase 8) — a
+  // category-specific title + click-to-open only when the coverage
+  // aggregate reports the SAME category as genuinely open; otherwise every
+  // one of these falls back to the pre-Phase-8 generic `STAMPED_GAP` text,
+  // inert (nothing to open without real coverage data).
+  const currencyCoverageRow = coverage?.categories.find(
+    (row) => row.category === 'currency' && row.affectedCount > 0
+  );
+  const currencyGapTitle =
+    stampedGapVisible && currencyCoverageRow ? deriveCoverageRowCopy(currencyCoverageRow).sub : STAMPED_GAP;
+  const onOpenCurrencyGap =
+    stampedGapVisible && currencyCoverageRow && onOpenCategory ? () => onOpenCategory('currency') : undefined;
+
+  const netExcludedTaxRow =
+    netExcludedVisible && coverage ? resolveNetExcludedTaxCategory(coverage.categories) : undefined;
+  const netExcludedGapOpen = netExcludedTaxRow !== undefined && netExcludedTaxRow.affectedCount > 0;
+  const netExcludedGapTitle = netExcludedTaxRow ? deriveCoverageRowCopy(netExcludedTaxRow).sub : undefined;
+  const onOpenNetExcludedGap =
+    netExcludedGapOpen && netExcludedTaxRow && onOpenCategory
+      ? () => onOpenCategory(netExcludedTaxRow.category)
+      : undefined;
   const trendDays = rangeDays(filters.from, filters.to);
   const trendRangeLabel = trendDays === 1 ? 'the selected day' : `the last ${trendDays} days`;
 
@@ -269,7 +322,15 @@ export function AnalyticsKpiStrip({ connections, filters }: AnalyticsKpiStripPro
               : 'Cancelled orders and cancelled items are excluded. Returned/refunded items remain included.',
           },
         ]}
-        metric="Net sales"
+        metric={
+          netExcludedGapOpen ? (
+            <>
+              Net sales <GapMark title={netExcludedGapTitle ?? netExcludedNote} onActivate={onOpenNetExcludedGap} />
+            </>
+          ) : (
+            'Net sales'
+          )
+        }
         value={formatAmount(headline.netRevenue, currency)}
         trend={{
           values: revenueTrend,
@@ -280,7 +341,7 @@ export function AnalyticsKpiStrip({ connections, filters }: AnalyticsKpiStripPro
           {
             label: stampedGapVisible ? (
               <>
-                GMV <GapMark title={STAMPED_GAP} />
+                GMV <GapMark title={currencyGapTitle} onActivate={onOpenCurrencyGap} />
               </>
             ) : (
               'GMV'
@@ -332,7 +393,7 @@ export function AnalyticsKpiStrip({ connections, filters }: AnalyticsKpiStripPro
         metric={
           stampedGapVisible ? (
             <>
-              Average <GapMark title={STAMPED_GAP} />
+              Average <GapMark title={currencyGapTitle} onActivate={onOpenCurrencyGap} />
             </>
           ) : (
             'Average'

--- a/apps/web/src/features/analytics/components/channel-sales-table.test.tsx
+++ b/apps/web/src/features/analytics/components/channel-sales-table.test.tsx
@@ -2,9 +2,23 @@ import { screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { createMockApiClient, renderWithProviders } from '../../../test/test-utils';
 import type { ChannelSalesAnalytics, SalesAndChannelAnalytics } from '../api/sales-analytics.types';
+import type { AnalyticsCoverage } from '../api/analytics-coverage.types';
 import { ChannelSalesTable } from './channel-sales-table';
 
 const FILTERS = { from: '2026-08-01', to: '2026-08-14' };
+const COVERAGE_FILTERS = { from: '2026-08-01T00:00:00.000Z', to: '2026-08-15T00:00:00.000Z' };
+
+function coverage(overrides: Partial<Record<string, number>> = {}): AnalyticsCoverage {
+  return {
+    categories: [
+      { category: 'currency', status: 'open', affectedCount: overrides.currency ?? 0, sampleOrderIds: [] },
+      { category: 'tax-a', status: 'open', affectedCount: overrides['tax-a'] ?? 0, sampleOrderIds: [] },
+      { category: 'tax-b', status: 'open', affectedCount: overrides['tax-b'] ?? 0, sampleOrderIds: [] },
+      { category: 'tax-c', status: 'open', affectedCount: overrides['tax-c'] ?? 0, sampleOrderIds: [] },
+      { category: 'product-matching', status: 'open', affectedCount: 0, sampleOrderIds: [] },
+    ],
+  };
+}
 
 function channel(overrides: Partial<ChannelSalesAnalytics> = {}): ChannelSalesAnalytics {
   return {
@@ -263,5 +277,105 @@ describe('ChannelSalesTable', () => {
     expect(
       screen.getByLabelText('No Net sales figure can be given for this channel in range')
     ).toBeInTheDocument();
+  });
+
+  // #2481 regression guards — the mockup's own two found bugs: a row
+  // wrongly labeled with a *different* category's issue, and a row with
+  // orders in an open category's affected set missing its annotation
+  // entirely. Both fixtures cross-reference against the FULL affected-order
+  // list (never the 10-id sample), grouped by `sourceConnectionId`.
+  describe('.excl-note cross-reference (#2481)', () => {
+    it("should attribute each channel's exclusion note to its own category, never the other channel's", async () => {
+      const apiClient = createMockApiClient({
+        analytics: {
+          getSales: vi.fn().mockResolvedValue(
+            analytics([
+              channel({ sourceConnectionId: 'conn-1' }),
+              channel({ sourceConnectionId: 'conn-2' }),
+            ])
+          ),
+          getCurrencyMismatchOrders: vi.fn().mockResolvedValue({
+            items: [{ internalOrderId: 'ol_order_1', sourceConnectionId: 'conn-1', nativeCurrency: 'EUR', stampedCurrency: null, stampedAt: null }],
+            total: 1,
+          }),
+          getTaxCoverageOrders: vi.fn().mockResolvedValue({
+            items: [{ internalOrderId: 'ol_order_2', sourceConnectionId: 'conn-2', placedAt: null }],
+            total: 1,
+          }),
+        },
+        connections: {
+          list: vi.fn().mockResolvedValue([
+            { id: 'conn-1', name: 'Allegro — main', platformType: 'allegro' },
+            { id: 'conn-2', name: 'Sklep główny', platformType: 'prestashop' },
+          ]),
+        },
+      });
+
+      renderWithProviders(
+        <ChannelSalesTable
+          filters={FILTERS}
+          coverage={coverage({ currency: 1, 'tax-b': 1 })}
+          coverageFilters={COVERAGE_FILTERS}
+          onOpenCategory={() => {}}
+        />,
+        { apiClient }
+      );
+
+      const conn1Row = (await screen.findByRole('link', { name: 'Allegro — main' })).closest('tr');
+      const conn2Row = (await screen.findByRole('link', { name: 'Sklep główny' })).closest('tr');
+      expect(conn1Row).not.toBeNull();
+      expect(conn2Row).not.toBeNull();
+
+      // conn-1's own order is a currency exclusion — its note must say so,
+      // and must NOT carry conn-2's tax-B note (the exact mislabeling bug
+      // the mockup's own design review caught).
+      const conn1Notes = conn1Row!.querySelectorAll('.excl-note');
+      expect(conn1Notes).toHaveLength(1);
+      expect(conn1Notes[0]).toHaveTextContent('1 order counted in an outdated currency');
+
+      const conn2Notes = conn2Row!.querySelectorAll('.excl-note');
+      expect(conn2Notes).toHaveLength(1);
+      expect(conn2Notes[0]).toHaveTextContent('1 order have no tax rate at all');
+    });
+
+    it('should annotate a channel for every cross-referenceable category it has an excluded order in', async () => {
+      const apiClient = createMockApiClient({
+        analytics: {
+          getSales: vi.fn().mockResolvedValue(analytics([channel({ sourceConnectionId: 'conn-1' })])),
+          getCurrencyMismatchOrders: vi.fn().mockResolvedValue({
+            items: [{ internalOrderId: 'ol_order_1', sourceConnectionId: 'conn-1', nativeCurrency: 'EUR', stampedCurrency: null, stampedAt: null }],
+            total: 1,
+          }),
+          getTaxCoverageOrders: vi.fn((input: { category: string }) =>
+            Promise.resolve(
+              input.category === 'tax-a'
+                ? { items: [{ internalOrderId: 'ol_order_2', sourceConnectionId: 'conn-1', placedAt: null }], total: 1 }
+                : input.category === 'tax-b'
+                  ? { items: [{ internalOrderId: 'ol_order_3', sourceConnectionId: 'conn-1', placedAt: null }], total: 1 }
+                  : { items: [{ internalOrderId: 'ol_order_4', sourceConnectionId: 'conn-1', placedAt: null }], total: 1 }
+            )
+          ),
+        },
+        connections: {
+          list: vi.fn().mockResolvedValue([{ id: 'conn-1', name: 'Allegro — main', platformType: 'allegro' }]),
+        },
+      });
+
+      renderWithProviders(
+        <ChannelSalesTable
+          filters={FILTERS}
+          coverage={coverage({ currency: 1, 'tax-a': 1, 'tax-b': 1, 'tax-c': 1 })}
+          coverageFilters={COVERAGE_FILTERS}
+          onOpenCategory={() => {}}
+        />,
+        { apiClient }
+      );
+
+      const row = (await screen.findByRole('link', { name: 'Allegro — main' })).closest('tr');
+      expect(row).not.toBeNull();
+      // One note per open category this channel has an order in — every
+      // category is represented, none silently dropped.
+      expect(row!.querySelectorAll('.excl-note')).toHaveLength(4);
+    });
   });
 });

--- a/apps/web/src/features/analytics/components/channel-sales-table.tsx
+++ b/apps/web/src/features/analytics/components/channel-sales-table.tsx
@@ -56,16 +56,17 @@
  * in the first place, so it was never counted anywhere to be silently
  * missing from) gets one `AnalyticsExclusionNote` per affected category.
  * The cross-reference is exact: each open category's *full* affected-order
- * list (not the Data Coverage aggregate's 10-id sample — `useCoverageCrossReferenceQuery`
+ * list (not the Data Coverage aggregate's 10-id sample —
+ * `useCoverageCrossReferenceQuery`, `hooks/use-coverage-cross-reference-query.ts`,
  * drains every page via the same paginated endpoints Phase 7's detail
- * modals use) is grouped by `sourceConnectionId`, since that field is on
- * every affected-order row and matches this table's own row key exactly —
- * unlike a product, a channel has no ambiguity to approximate.
+ * modals use) is grouped by `sourceConnectionId` (`buildChannelExclusionMap`,
+ * `lib/channel-exclusion-map.lib.ts`), since that field is on every
+ * affected-order row and matches this table's own row key exactly — unlike
+ * a product, a channel has no ambiguity to approximate.
  *
  * @module features/analytics/components
  */
-import type { ReactElement } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useMemo, type ReactElement } from 'react';
 import { DataTable, type DataTableColumn } from '../../../shared/ui/data-table';
 import { Chip } from '../../../shared/ui/chip';
 import { Button } from '../../../shared/ui/button';
@@ -74,10 +75,10 @@ import { ErrorState, LoadingState } from '../../../shared/ui/feedback-state';
 import { Sparkline } from '../../../shared/ui/sparkline';
 import { formatAmount } from '../../../shared/format/format-amount';
 import { useNumberFormat } from '../../../shared/i18n/use-number-format';
-import { useApiClient } from '../../../app/api/api-client-provider';
 import { ConnectionCell, useConnectionsQuery, type Connection } from '../../connections';
 import { ConnectionDot } from '../../orders';
 import { useSalesAnalyticsQuery } from '../hooks/use-sales-analytics-query';
+import { useCoverageCrossReferenceQuery } from '../hooks/use-coverage-cross-reference-query';
 import type { ChannelSalesAnalytics, SalesAnalyticsFilters } from '../api/sales-analytics.types';
 import type { AnalyticsCoverage, AnalyticsCoverageFilters, CoverageCategory } from '../api/analytics-coverage.types';
 import {
@@ -87,77 +88,12 @@ import {
   trendTone,
   type ChannelCurrencyTotal,
 } from '../lib/sales-analytics-view-model';
+import {
+  buildChannelExclusionMap,
+  CROSS_REFERENCEABLE_CATEGORIES,
+  type ChannelExclusionMap,
+} from '../lib/channel-exclusion-map.lib';
 import { AnalyticsExclusionNote } from './analytics-exclusion-note';
-
-/** Tax categories, plus currency — the categories a channel total can be under-counted by. `product-matching` is deliberately excluded, see the file header. */
-type CrossReferenceableCategory = Extract<CoverageCategory, 'currency' | 'tax-a' | 'tax-b' | 'tax-c'>;
-const CROSS_REFERENCEABLE_CATEGORIES: readonly CrossReferenceableCategory[] = ['currency', 'tax-a', 'tax-b', 'tax-c'];
-const CROSS_REF_PAGE_LIMIT = 100;
-
-interface CoverageOrderLite {
-  internalOrderId: string;
-  sourceConnectionId: string;
-}
-
-/**
- * Pages through one category's *complete* affected-order list (never the
- * 10-id sample) for the current range, grouped by `sourceConnectionId`.
- * One `useQuery` per category — a fixed set (`CROSS_REFERENCEABLE_CATEGORIES`),
- * so the number of hook calls never varies with how many categories happen
- * to be open, and each drains its own pages inside one `queryFn` rather
- * than as separate `useQuery` calls per page (a per-page-load, non-hot-path
- * read — see the implementation plan's own risk note on this bound).
- */
-function useCoverageCrossReferenceQuery(
-  category: CrossReferenceableCategory,
-  coverageFilters: AnalyticsCoverageFilters,
-  enabled: boolean
-): { data: CoverageOrderLite[] | undefined } {
-  const apiClient = useApiClient();
-
-  const { data } = useQuery({
-    queryKey: ['analytics', 'coverage-cross-reference', category, coverageFilters],
-    queryFn: async (): Promise<CoverageOrderLite[]> => {
-      const all: CoverageOrderLite[] = [];
-      let offset = 0;
-      for (;;) {
-        const page =
-          category === 'currency'
-            ? await apiClient.analytics.getCurrencyMismatchOrders({ ...coverageFilters, limit: CROSS_REF_PAGE_LIMIT, offset })
-            : await apiClient.analytics.getTaxCoverageOrders({
-                category,
-                ...coverageFilters,
-                limit: CROSS_REF_PAGE_LIMIT,
-                offset,
-              });
-        all.push(...page.items);
-        offset += page.items.length;
-        if (page.items.length < CROSS_REF_PAGE_LIMIT || offset >= page.total) break;
-      }
-      return all;
-    },
-    enabled,
-  });
-
-  return { data };
-}
-
-/** `connectionId -> category -> this channel's own affected-order count for it`. */
-type ChannelExclusionMap = Map<string, Map<CrossReferenceableCategory, number>>;
-
-function buildChannelExclusionMap(
-  ordersByCategory: Partial<Record<CrossReferenceableCategory, CoverageOrderLite[] | undefined>>
-): ChannelExclusionMap {
-  const map: ChannelExclusionMap = new Map();
-  for (const category of CROSS_REFERENCEABLE_CATEGORIES) {
-    for (const order of ordersByCategory[category] ?? []) {
-      const byCategory = map.get(order.sourceConnectionId) ?? new Map<CrossReferenceableCategory, number>();
-      byCategory.set(category, (byCategory.get(category) ?? 0) + 1);
-      map.set(order.sourceConnectionId, byCategory);
-    }
-  }
-  return map;
-}
 
 const PERCENT_FORMAT_OPTIONS: Intl.NumberFormatOptions = {
   style: 'percent',
@@ -296,8 +232,9 @@ export function ChannelSalesTable({
   // variable count derived from which categories happen to be open — see
   // `useCoverageCrossReferenceQuery`'s own doc comment on why). Each is
   // `enabled` only when its own category is genuinely open.
-  const openCategoryCodes = new Set(
-    (coverage?.categories ?? []).filter((row) => row.affectedCount > 0).map((row) => row.category)
+  const openCategoryCodes = useMemo(
+    () => new Set((coverage?.categories ?? []).filter((row) => row.affectedCount > 0).map((row) => row.category)),
+    [coverage]
   );
   const crossRefFilters: AnalyticsCoverageFilters = coverageFilters ?? { from: '', to: '' };
   const crossRefEnabled = Boolean(coverageFilters) && Boolean(onOpenCategory);

--- a/apps/web/src/features/analytics/components/channel-sales-table.tsx
+++ b/apps/web/src/features/analytics/components/channel-sales-table.tsx
@@ -48,9 +48,24 @@
  * shared cache entry (identical `queryKey`), without either component
  * needing to know the other's data shape.
  *
+ * `.excl-note` exclusion annotations (#2481, epic #2452 Phase 8): a row
+ * whose channel has orders in an open Data Coverage category's affected set
+ * (currency, or one of tax-a/b/c — never `product-matching`, which cannot
+ * under-count a channel total by definition: a `source_deleted`/
+ * `awaiting_mapping` order fails to resolve to *any* channel-scoped total
+ * in the first place, so it was never counted anywhere to be silently
+ * missing from) gets one `AnalyticsExclusionNote` per affected category.
+ * The cross-reference is exact: each open category's *full* affected-order
+ * list (not the Data Coverage aggregate's 10-id sample — `useCoverageCrossReferenceQuery`
+ * drains every page via the same paginated endpoints Phase 7's detail
+ * modals use) is grouped by `sourceConnectionId`, since that field is on
+ * every affected-order row and matches this table's own row key exactly —
+ * unlike a product, a channel has no ambiguity to approximate.
+ *
  * @module features/analytics/components
  */
 import type { ReactElement } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { DataTable, type DataTableColumn } from '../../../shared/ui/data-table';
 import { Chip } from '../../../shared/ui/chip';
 import { Button } from '../../../shared/ui/button';
@@ -59,10 +74,12 @@ import { ErrorState, LoadingState } from '../../../shared/ui/feedback-state';
 import { Sparkline } from '../../../shared/ui/sparkline';
 import { formatAmount } from '../../../shared/format/format-amount';
 import { useNumberFormat } from '../../../shared/i18n/use-number-format';
+import { useApiClient } from '../../../app/api/api-client-provider';
 import { ConnectionCell, useConnectionsQuery, type Connection } from '../../connections';
 import { ConnectionDot } from '../../orders';
 import { useSalesAnalyticsQuery } from '../hooks/use-sales-analytics-query';
 import type { ChannelSalesAnalytics, SalesAnalyticsFilters } from '../api/sales-analytics.types';
+import type { AnalyticsCoverage, AnalyticsCoverageFilters, CoverageCategory } from '../api/analytics-coverage.types';
 import {
   countUnconvertedOrders,
   groupChannelTotalsByCurrency,
@@ -70,6 +87,77 @@ import {
   trendTone,
   type ChannelCurrencyTotal,
 } from '../lib/sales-analytics-view-model';
+import { AnalyticsExclusionNote } from './analytics-exclusion-note';
+
+/** Tax categories, plus currency — the categories a channel total can be under-counted by. `product-matching` is deliberately excluded, see the file header. */
+type CrossReferenceableCategory = Extract<CoverageCategory, 'currency' | 'tax-a' | 'tax-b' | 'tax-c'>;
+const CROSS_REFERENCEABLE_CATEGORIES: readonly CrossReferenceableCategory[] = ['currency', 'tax-a', 'tax-b', 'tax-c'];
+const CROSS_REF_PAGE_LIMIT = 100;
+
+interface CoverageOrderLite {
+  internalOrderId: string;
+  sourceConnectionId: string;
+}
+
+/**
+ * Pages through one category's *complete* affected-order list (never the
+ * 10-id sample) for the current range, grouped by `sourceConnectionId`.
+ * One `useQuery` per category — a fixed set (`CROSS_REFERENCEABLE_CATEGORIES`),
+ * so the number of hook calls never varies with how many categories happen
+ * to be open, and each drains its own pages inside one `queryFn` rather
+ * than as separate `useQuery` calls per page (a per-page-load, non-hot-path
+ * read — see the implementation plan's own risk note on this bound).
+ */
+function useCoverageCrossReferenceQuery(
+  category: CrossReferenceableCategory,
+  coverageFilters: AnalyticsCoverageFilters,
+  enabled: boolean
+): { data: CoverageOrderLite[] | undefined } {
+  const apiClient = useApiClient();
+
+  const { data } = useQuery({
+    queryKey: ['analytics', 'coverage-cross-reference', category, coverageFilters],
+    queryFn: async (): Promise<CoverageOrderLite[]> => {
+      const all: CoverageOrderLite[] = [];
+      let offset = 0;
+      for (;;) {
+        const page =
+          category === 'currency'
+            ? await apiClient.analytics.getCurrencyMismatchOrders({ ...coverageFilters, limit: CROSS_REF_PAGE_LIMIT, offset })
+            : await apiClient.analytics.getTaxCoverageOrders({
+                category,
+                ...coverageFilters,
+                limit: CROSS_REF_PAGE_LIMIT,
+                offset,
+              });
+        all.push(...page.items);
+        offset += page.items.length;
+        if (page.items.length < CROSS_REF_PAGE_LIMIT || offset >= page.total) break;
+      }
+      return all;
+    },
+    enabled,
+  });
+
+  return { data };
+}
+
+/** `connectionId -> category -> this channel's own affected-order count for it`. */
+type ChannelExclusionMap = Map<string, Map<CrossReferenceableCategory, number>>;
+
+function buildChannelExclusionMap(
+  ordersByCategory: Partial<Record<CrossReferenceableCategory, CoverageOrderLite[] | undefined>>
+): ChannelExclusionMap {
+  const map: ChannelExclusionMap = new Map();
+  for (const category of CROSS_REFERENCEABLE_CATEGORIES) {
+    for (const order of ordersByCategory[category] ?? []) {
+      const byCategory = map.get(order.sourceConnectionId) ?? new Map<CrossReferenceableCategory, number>();
+      byCategory.set(category, (byCategory.get(category) ?? 0) + 1);
+      map.set(order.sourceConnectionId, byCategory);
+    }
+  }
+  return map;
+}
 
 const PERCENT_FORMAT_OPTIONS: Intl.NumberFormatOptions = {
   style: 'percent',
@@ -130,18 +218,49 @@ function ChannelFlags({ row }: { row: ChannelDataRow }): ReactElement | null {
   return <>{flags}</>;
 }
 
+function ChannelExclusionNotes({
+  row,
+  exclusions,
+  onOpenCategory,
+}: {
+  row: ChannelDataRow;
+  exclusions: ChannelExclusionMap;
+  onOpenCategory?: (category: CoverageCategory) => void;
+}): ReactElement | null {
+  if (!onOpenCategory) return null;
+  const byCategory = exclusions.get(row.channel.sourceConnectionId);
+  if (!byCategory || byCategory.size === 0) return null;
+  return (
+    <>
+      {CROSS_REFERENCEABLE_CATEGORIES.filter((category) => byCategory.has(category)).map((category) => (
+        <AnalyticsExclusionNote
+          key={category}
+          category={category}
+          affectedCount={byCategory.get(category) ?? 0}
+          onOpenCategory={onOpenCategory}
+        />
+      ))}
+    </>
+  );
+}
+
 function ChannelName({
   connectionsLoading,
   row,
+  exclusions,
+  onOpenCategory,
 }: {
   connectionsLoading: boolean;
   row: ChannelDataRow;
+  exclusions: ChannelExclusionMap;
+  onOpenCategory?: (category: CoverageCategory) => void;
 }): ReactElement {
   return (
     <span className="data-table__stack">
       <ChannelIdentity connectionsLoading={connectionsLoading} row={row} />
       <span>
         <ChannelFlags row={row} />
+        <ChannelExclusionNotes row={row} exclusions={exclusions} onOpenCategory={onOpenCategory} />
       </span>
     </span>
   );
@@ -149,13 +268,65 @@ function ChannelName({
 
 interface ChannelSalesTableProps {
   filters: SalesAnalyticsFilters;
+  /**
+   * The Data Coverage aggregate (#2474 Phase 7) — same query key
+   * `AnalyticsDataCoveragePanel` fetches, no extra request. `undefined`
+   * (still loading, or the caller never wired coverage in) renders every
+   * row exactly as before Phase 8 — no exclusion notes.
+   */
+  coverage?: AnalyticsCoverage;
+  /** ISO-instant range for the cross-reference reads — distinct shape from `filters` (#2474's DTOs, not the sales-analytics one). Required together with `coverage`/`onOpenCategory`. */
+  coverageFilters?: AnalyticsCoverageFilters;
+  /** Opens the matching Data Coverage detail modal — omit to keep every row's notes absent. */
+  onOpenCategory?: (category: CoverageCategory) => void;
 }
 
-export function ChannelSalesTable({ filters }: ChannelSalesTableProps): ReactElement {
+export function ChannelSalesTable({
+  filters,
+  coverage,
+  coverageFilters,
+  onOpenCategory,
+}: ChannelSalesTableProps): ReactElement {
   const query = useSalesAnalyticsQuery(filters);
   const connectionsQuery = useConnectionsQuery();
   const pctFormat = useNumberFormat(PERCENT_FORMAT_OPTIONS);
   const intFormat = useNumberFormat();
+
+  // Fixed set of hooks, one per cross-referenceable category (never a
+  // variable count derived from which categories happen to be open — see
+  // `useCoverageCrossReferenceQuery`'s own doc comment on why). Each is
+  // `enabled` only when its own category is genuinely open.
+  const openCategoryCodes = new Set(
+    (coverage?.categories ?? []).filter((row) => row.affectedCount > 0).map((row) => row.category)
+  );
+  const crossRefFilters: AnalyticsCoverageFilters = coverageFilters ?? { from: '', to: '' };
+  const crossRefEnabled = Boolean(coverageFilters) && Boolean(onOpenCategory);
+  const currencyOrders = useCoverageCrossReferenceQuery(
+    'currency',
+    crossRefFilters,
+    crossRefEnabled && openCategoryCodes.has('currency')
+  );
+  const taxAOrders = useCoverageCrossReferenceQuery(
+    'tax-a',
+    crossRefFilters,
+    crossRefEnabled && openCategoryCodes.has('tax-a')
+  );
+  const taxBOrders = useCoverageCrossReferenceQuery(
+    'tax-b',
+    crossRefFilters,
+    crossRefEnabled && openCategoryCodes.has('tax-b')
+  );
+  const taxCOrders = useCoverageCrossReferenceQuery(
+    'tax-c',
+    crossRefFilters,
+    crossRefEnabled && openCategoryCodes.has('tax-c')
+  );
+  const exclusions = buildChannelExclusionMap({
+    currency: currencyOrders.data,
+    'tax-a': taxAOrders.data,
+    'tax-b': taxBOrders.data,
+    'tax-c': taxCOrders.data,
+  });
 
   if (query.isLoading) {
     return (
@@ -221,7 +392,12 @@ export function ChannelSalesTable({ filters }: ChannelSalesTableProps): ReactEle
         row.kind === 'total' ? (
           <strong>Total · {row.total.currency}</strong>
         ) : (
-          <ChannelName connectionsLoading={connectionsQuery.isLoading} row={row} />
+          <ChannelName
+            connectionsLoading={connectionsQuery.isLoading}
+            row={row}
+            exclusions={exclusions}
+            onOpenCategory={onOpenCategory}
+          />
         ),
     },
     {

--- a/apps/web/src/features/analytics/components/gap-mark.test.tsx
+++ b/apps/web/src/features/analytics/components/gap-mark.test.tsx
@@ -1,0 +1,28 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { GapMark } from './gap-mark';
+
+describe('GapMark (#2480)', () => {
+  it('renders an inert span with the reason as its accessible name when onActivate is omitted', () => {
+    render(<GapMark title="No return entity exists." />);
+
+    const mark = screen.getByRole('img', { name: 'No return entity exists.' });
+    expect(mark.tagName).toBe('SPAN');
+    expect(mark).toHaveAttribute('title', 'No return entity exists.');
+  });
+
+  it('renders a clickable button carrying the same accessible name when onActivate is supplied', async () => {
+    const user = userEvent.setup();
+    const onActivate = vi.fn();
+
+    render(<GapMark title="23 orders counted in an outdated currency" onActivate={onActivate} />);
+
+    const button = screen.getByRole('button', { name: '23 orders counted in an outdated currency' });
+    expect(button).toHaveAttribute('title', '23 orders counted in an outdated currency');
+
+    await user.click(button);
+
+    expect(onActivate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/features/analytics/components/gap-mark.tsx
+++ b/apps/web/src/features/analytics/components/gap-mark.tsx
@@ -18,11 +18,37 @@
  * (not a control); a focus-reachable `Tooltip` upgrade is a fine follow-up
  * if the reason is ever worth showing on keyboard focus too.
  *
+ * `onActivate` (#2480, epic #2452 Phase 8) — optional. When the gap is
+ * caused by an open Data Coverage category (#2474 Phase 7), the mark
+ * becomes a real affordance: a `<button>` that opens that category's own
+ * detail modal, rather than an inert tooltip-only `<span>`. Every existing
+ * call site that never passes it (Units/Cancellations/Returns cards) keeps
+ * rendering the plain, inert span byte-identically — this prop is additive,
+ * never a behavior change for a caller that doesn't opt in. `role="img"` is
+ * dropped on the clickable branch: a genuinely interactive element takes
+ * its accessible name from its own `aria-label`, and `role="img"` on a
+ * `<button>` would misdescribe it to assistive tech as a non-interactive
+ * image.
+ *
  * @module features/analytics/components
  */
 import type { ReactElement } from 'react';
 
-export function GapMark({ title }: { title: string }): ReactElement {
+interface GapMarkProps {
+  title: string;
+  /** Opens the category's detail modal on click/Enter/Space; omit for the plain inert tooltip mark. */
+  onActivate?: () => void;
+}
+
+export function GapMark({ title, onActivate }: GapMarkProps): ReactElement {
+  if (onActivate) {
+    return (
+      <button type="button" className="gap-mark gap-mark--clickable" aria-label={title} title={title} onClick={onActivate}>
+        &#8224;
+      </button>
+    );
+  }
+
   return (
     <span className="gap-mark" role="img" aria-label={title} title={title}>
       &#8224;

--- a/apps/web/src/features/analytics/hooks/use-coverage-cross-reference-query.ts
+++ b/apps/web/src/features/analytics/hooks/use-coverage-cross-reference-query.ts
@@ -1,0 +1,70 @@
+/**
+ * Coverage Cross-Reference Query Hook
+ *
+ * Pages through one Data Coverage category's *complete* affected-order
+ * list (never the `GET /analytics/coverage` aggregate's 10-id sample), for
+ * the `ChannelSalesTable` per-row `.excl-note` cross-reference (#2481,
+ * epic #2452 Phase 8). One `useQuery` per category — call it once per
+ * member of `CROSS_REFERENCEABLE_CATEGORIES` (a fixed set), never a
+ * variable count derived from which categories happen to be open, so the
+ * number of hook calls never changes across renders.
+ *
+ * Each call drains its own pages inside one `queryFn` rather than issuing a
+ * separate `useQuery` per page — a per-page-load, non-hot-path read (see
+ * `docs/plans/implementation-plan-analytics-exclusion-annotations.md`'s own
+ * risk note on this bound). Being an unbounded drain over a potentially
+ * large affected-order population is a known follow-up, tracked as #2713
+ * (backend aggregate-by-connection endpoint) + #2714 (swap this hook to
+ * consume it).
+ *
+ * Only `data` is returned, deliberately — no `isLoading`/`isError`. A failed
+ * or still-loading category silently contributes no rows to
+ * `buildChannelExclusionMap`, which just means that category's
+ * `AnalyticsExclusionNote`s are momentarily/permanently absent from the
+ * table. This is a supplementary annotation on top of already-successful
+ * sales figures, not a screen of its own — so it degrades silently by
+ * design rather than surfacing a table-wide error state for one row's worth
+ * of missing badges.
+ *
+ * @module apps/web/src/features/analytics/hooks
+ */
+import { useQuery } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import type { AnalyticsCoverageFilters } from '../api/analytics-coverage.types';
+import type { CoverageOrderLite, CrossReferenceableCategory } from '../lib/channel-exclusion-map.lib';
+
+const CROSS_REF_PAGE_LIMIT = 100;
+
+export function useCoverageCrossReferenceQuery(
+  category: CrossReferenceableCategory,
+  coverageFilters: AnalyticsCoverageFilters,
+  enabled: boolean
+): { data: CoverageOrderLite[] | undefined } {
+  const apiClient = useApiClient();
+
+  const { data } = useQuery({
+    queryKey: ['analytics', 'coverage-cross-reference', category, coverageFilters],
+    queryFn: async (): Promise<CoverageOrderLite[]> => {
+      const all: CoverageOrderLite[] = [];
+      let offset = 0;
+      for (;;) {
+        const page =
+          category === 'currency'
+            ? await apiClient.analytics.getCurrencyMismatchOrders({ ...coverageFilters, limit: CROSS_REF_PAGE_LIMIT, offset })
+            : await apiClient.analytics.getTaxCoverageOrders({
+                category,
+                ...coverageFilters,
+                limit: CROSS_REF_PAGE_LIMIT,
+                offset,
+              });
+        all.push(...page.items);
+        offset += page.items.length;
+        if (page.items.length < CROSS_REF_PAGE_LIMIT || offset >= page.total) break;
+      }
+      return all;
+    },
+    enabled,
+  });
+
+  return { data };
+}

--- a/apps/web/src/features/analytics/index.ts
+++ b/apps/web/src/features/analytics/index.ts
@@ -44,7 +44,12 @@ export { useAnalyticsCoverageQuery } from './hooks/use-analytics-coverage-query'
 export { useRecalculateCurrencyMutation } from './hooks/use-recalculate-currency-mutation';
 export { AnalyticsSettingsDialog } from './components/analytics-settings-dialog';
 export { AnalyticsDataCoveragePanel } from './components/analytics-data-coverage-panel';
-export type { AnalyticsCoverage, AnalyticsCoverageFilters, CoverageCategoryRow } from './api/analytics-coverage.types';
+export type {
+  AnalyticsCoverage,
+  AnalyticsCoverageFilters,
+  CoverageCategory,
+  CoverageCategoryRow,
+} from './api/analytics-coverage.types';
 export type { AnalyticsRemediationRun, RecalculateCurrencyInput } from './api/analytics-remediation.types';
 
 export { useTopProductsQuery } from './hooks/use-top-products-query';

--- a/apps/web/src/features/analytics/lib/channel-exclusion-map.lib.ts
+++ b/apps/web/src/features/analytics/lib/channel-exclusion-map.lib.ts
@@ -1,0 +1,42 @@
+/**
+ * Channel Exclusion Map
+ *
+ * Pure grouping of one or more Data Coverage categories' *full*
+ * affected-order lists into a per-channel (`sourceConnectionId`) count map
+ * (#2481, epic #2452 Phase 8) — the input `ChannelSalesTable` needs to
+ * decide which `AnalyticsExclusionNote`s a row gets.
+ *
+ * @module apps/web/src/features/analytics/lib
+ */
+import type { CoverageCategory } from '../api/analytics-coverage.types';
+
+/** Tax categories, plus currency — the categories a channel total can be under-counted by. `product-matching` is deliberately excluded: a `source_deleted`/`awaiting_mapping` order fails to resolve to *any* channel-scoped total in the first place, so it was never counted anywhere to be silently missing from. */
+export type CrossReferenceableCategory = Extract<CoverageCategory, 'currency' | 'tax-a' | 'tax-b' | 'tax-c'>;
+export const CROSS_REFERENCEABLE_CATEGORIES: readonly CrossReferenceableCategory[] = [
+  'currency',
+  'tax-a',
+  'tax-b',
+  'tax-c',
+];
+
+export interface CoverageOrderLite {
+  internalOrderId: string;
+  sourceConnectionId: string;
+}
+
+/** `connectionId -> category -> this channel's own affected-order count for it`. */
+export type ChannelExclusionMap = Map<string, Map<CrossReferenceableCategory, number>>;
+
+export function buildChannelExclusionMap(
+  ordersByCategory: Partial<Record<CrossReferenceableCategory, CoverageOrderLite[] | undefined>>
+): ChannelExclusionMap {
+  const map: ChannelExclusionMap = new Map();
+  for (const category of CROSS_REFERENCEABLE_CATEGORIES) {
+    for (const order of ordersByCategory[category] ?? []) {
+      const byCategory = map.get(order.sourceConnectionId) ?? new Map<CrossReferenceableCategory, number>();
+      byCategory.set(category, (byCategory.get(category) ?? 0) + 1);
+      map.set(order.sourceConnectionId, byCategory);
+    }
+  }
+  return map;
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -4884,6 +4884,21 @@ a.kpi-card:focus-visible {
   font-family: var(--font-mono);
 }
 
+/* ── GapMark clickable variant (#2480) — opens the coverage category's
+   own detail modal instead of only showing a tooltip. */
+.gap-mark--clickable {
+  background: none;
+  border: none;
+  padding: 0;
+  font: inherit;
+  cursor: pointer;
+}
+
+.gap-mark--clickable:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
+}
+
 .section-infotip {
   display: inline-flex;
   align-items: center;
@@ -19225,6 +19240,36 @@ legend.analytics-settings-dialog__label {
 
 .coverage-alert__close:hover {
   background: color-mix(in oklab, var(--status-success) 15%, transparent);
+}
+
+/* ── Analytics exclusion note (#2481) — per-row `.excl-note` annotation on
+   ChannelSalesTable when a row is under-counted by an open Data Coverage
+   category. Opens the same detail modal the Data Coverage panel uses. */
+.excl-note {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 1px 6px;
+  border: 1px solid var(--status-warning-border);
+  border-radius: var(--radius-pill);
+  background: var(--status-warning-soft);
+  color: var(--status-warning-fg);
+  font-size: 0.6875rem;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+  max-width: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.excl-note:hover {
+  background: color-mix(in oklab, var(--status-warning) 15%, var(--status-warning-soft));
+}
+
+.excl-note:focus-visible {
+  outline: none;
+  box-shadow: var(--shadow-focus);
 }
 
 .coverage-detail__table-wrap {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -19249,32 +19249,14 @@ legend.analytics-settings-dialog__label {
 
 /* ── Analytics exclusion note (#2481) — per-row `.excl-note` annotation on
    ChannelSalesTable when a row is under-counted by an open Data Coverage
-   category. Opens the same detail modal the Data Coverage panel uses. */
+   category. Opens the same detail modal the Data Coverage panel uses.
+   Renders on the shared `.chip`/`.chip--warning` primitive (tone, border,
+   background, padding, font already come from there) — this only ADDS the
+   truncation behavior a table cell needs, never re-declares the pill. */
 .excl-note {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 1px 6px;
-  border: 1px solid var(--status-warning-border);
-  border-radius: var(--radius-pill);
-  background: var(--status-warning-soft);
-  color: var(--status-warning-fg);
-  font-size: 0.6875rem;
-  font-weight: 500;
-  cursor: pointer;
-  white-space: nowrap;
   max-width: 100%;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.excl-note:hover {
-  background: color-mix(in oklab, var(--status-warning) 15%, var(--status-warning-soft));
-}
-
-.excl-note:focus-visible {
-  outline: none;
-  box-shadow: var(--shadow-focus);
 }
 
 .coverage-detail__table-wrap {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -19166,6 +19166,11 @@ legend.analytics-settings-dialog__label {
   align-items: center;
   gap: var(--space-3);
   width: 100%;
+  /* Opt out of the global `button, .button { height: 2rem }` (line ~541) —
+     this row's two-line headline+sub body needs its real content height,
+     not a fixed 32px that clips it and collapses the visual gap between
+     rows (mirrors .orders-sortbtn's identical fix, #1747). */
+  height: auto;
   padding: var(--space-3) var(--space-4);
   border: none;
   background: none;

--- a/apps/web/src/pages/analytics/analytics-page.tsx
+++ b/apps/web/src/pages/analytics/analytics-page.tsx
@@ -28,8 +28,10 @@ import {
   ProductSalesTable,
   computePresetRange,
   toExclusiveEndInstant,
+  useAnalyticsCoverageQuery,
   useAnalyticsTrustQuery,
   useSalesAnalyticsQuery,
+  type CoverageCategory,
   type DisplayCurrencyRateBasis,
   type SalesAnalyticsFilters,
 } from '../../features/analytics';
@@ -122,6 +124,16 @@ export function AnalyticsPage(): ReactElement {
 
   const [settingsDialogOpen, setSettingsDialogOpen] = useState(false);
 
+  // Reads the SAME cache entry `AnalyticsDataCoveragePanel` populates
+  // internally (byte-identical query key) — no extra request, same pattern
+  // `salesQuery` above already establishes. Owning it at the page level is
+  // what lets the KPI strip's `GapMark`s and the channel table's
+  // `AnalyticsExclusionNote`s open the panel's own detail modals (#2474
+  // Phase 7 → #2480/#2481, epic #2452 Phase 8) without a second
+  // `CoverageDetailDialog` implementation.
+  const coverageQuery = useAnalyticsCoverageQuery(coverageFilters);
+  const [openCoverageCategory, setOpenCoverageCategory] = useState<CoverageCategory | null>(null);
+
   return (
     <PageLayout
       eyebrow="Operations"
@@ -184,8 +196,18 @@ export function AnalyticsPage(): ReactElement {
             />
           ) : (
             <>
-              <AnalyticsKpiStrip filters={salesFilters} connections={trustQuery.data.connections} />
-              <ChannelSalesTable filters={salesFilters} />
+              <AnalyticsKpiStrip
+                filters={salesFilters}
+                connections={trustQuery.data.connections}
+                coverage={coverageQuery.data}
+                onOpenCategory={setOpenCoverageCategory}
+              />
+              <ChannelSalesTable
+                filters={salesFilters}
+                coverage={coverageQuery.data}
+                coverageFilters={coverageFilters}
+                onOpenCategory={setOpenCoverageCategory}
+              />
               <ProductSalesTable filters={salesFilters} />
             </>
           )}
@@ -196,7 +218,12 @@ export function AnalyticsPage(): ReactElement {
               section and the data-coverage header below it render
               unconditionally, after the order-derived figures above. */}
           <AnalyticsNeedsAttention />
-          <AnalyticsDataCoveragePanel filters={coverageFilters} onOpenSettings={() => setSettingsDialogOpen(true)} />
+          <AnalyticsDataCoveragePanel
+            filters={coverageFilters}
+            onOpenSettings={() => setSettingsDialogOpen(true)}
+            openCategory={openCoverageCategory}
+            onOpenCategoryChange={setOpenCoverageCategory}
+          />
           <AnalyticsTrustHeader connections={trustQuery.data.connections} />
         </>
       ) : null}

--- a/docs/plans/implementation-plan-analytics-exclusion-annotations.md
+++ b/docs/plans/implementation-plan-analytics-exclusion-annotations.md
@@ -1,0 +1,595 @@
+# Implementation Plan: Analytics — Exclusion Annotations on KPI/Channel/Product Surfaces
+
+**Date**: 2026-08-31
+**Status**: Draft/Ready for Review
+**Estimated Effort**: 1–1.5 days (Task 8.1 + Channel half of 8.2); Product half of 8.2 is **blocked**, see §5.
+
+---
+
+## 1. Task Summary
+
+**Objective**: Epic #2452 Phase 8 (mini-epic #2479, sub-tasks #2480 and #2481) — make the exclusion
+counts Phase 7's Data Coverage panel already surfaces *centrally* also visible *locally*, on the
+specific KPI card / channel row / product row that is under-counted by an open coverage category,
+each annotation linking back to that category's detail modal.
+
+**Context**: Phase 7 (merged, #2672) shipped the "Data Coverage" panel — one row per category
+(currency, tax A/B/C, product-matching) with a paginated detail modal each. An operator scanning the
+KPI strip or the by-channel table today has no signal that a specific number is under-counted; they
+would have to separately notice the Data Coverage panel and mentally connect "23 orders excluded —
+currency" to "the Revenue card's GMV figure is short by some of those 23." This phase closes that
+gap for the KPI strip (Task 8.1) and starts it for the Channel/Product tables (Task 8.2), with an
+explicit, honest stop where the data does not yet support a correct per-row annotation (§5).
+
+**Classification**: Frontend (feature components only — no backend, no CORE, no migration).
+
+---
+
+## 2. Scope & Non-Goals
+
+### In Scope
+
+- **Task 8.1**: `GapMark` on the KPI strip's Revenue/Order-value cards gets a real, category-specific
+  title (not the current generic "not yet stamped" copy) and becomes clickable, opening the matching
+  Phase 7 `CoverageDetailDialog` for the `'currency'` category. A new `GapMark` is added next to the
+  Net Sales card's label when `headline.netExcludedCount > 0`, opening the relevant tax category's
+  modal.
+- **Task 8.2 (Channel half only)**: New `AnalyticsExclusionNote` component rendered per row in
+  `channel-sales-table.tsx`, cross-referencing each open category's full affected-order list (not the
+  Phase 7 aggregate's 10-id sample) against the row's own `sourceConnectionId`, opening the matching
+  modal on click.
+- Page-level state lift so `AnalyticsDataCoveragePanel`'s "which category's modal is open" becomes
+  externally triggerable from the KPI strip and the channel table, while staying self-contained when
+  nothing external asks it to open (uncontrolled-by-default, controllable pattern).
+
+### Out of Scope (this plan)
+
+- **Task 8.2 (Product half)**: `product-sales-table.tsx` wiring. `TopProductRow` is keyed by
+  `productId`; none of Phase 7's three paginated coverage-order endpoints
+  (`CurrencyMismatchOrderDto` / `TaxCoverageOrderDto` / `ProductMatchingOrderDto`) carry a
+  `productId`, SKU, or any line-item field — only `internalOrderId` + `sourceConnectionId` (+ a
+  currency/date field each). There is no correct client-side cross-reference possible from an order
+  id to a product id without a line-item read. Approximating this (e.g. "an excluded order touched
+  *some* product in this channel, so annotate every product row for that channel") would reproduce
+  exactly the mockup's own found bug class (#2481 AC 1: "a row's `.excl-note` category must be
+  provably correct against its own underlying order data") — so this plan does **not** implement it.
+  See §5 for the flagged backend gap and the two remediation options.
+- Backend changes of any kind (no new endpoint, no DTO field addition — those belong to whichever
+  future issue closes the gap in §5).
+- Re-implementing `CoverageDetailDialog` or any of the five existing detail-row renderers — this plan
+  reuses `AnalyticsDataCoveragePanel`'s existing dialogs verbatim via the state lift.
+- Any change to `AnalyticsNeedsAttention` (a distinct component, no Phase 7 coverage dependency).
+
+### Constraints
+
+- Working directly on `phase/2452-p8-fe-exclusion-annotations`, branched from
+  `epic/2452-analytics-currency-coverage` (Phase 7 already merged in). No commit/push in this
+  session — plan-only, per explicit operator instruction.
+- Must not introduce a second copy of Phase 7's coverage-category copy strings
+  (`deriveCoverageRowCopy` in `data-coverage-copy.lib.ts` is the single source — reused, not
+  duplicated).
+- Must not add a general-purpose global store (`docs/frontend-architecture.md` § Global Store
+  Policy) — the state lift is a plain `useState` at `AnalyticsPage`, passed down as props.
+
+---
+
+## 3. Architecture Mapping
+
+**Target Layer**: Frontend only — `apps/web/src/features/analytics/` (feature components + one new
+component) and `apps/web/src/pages/analytics/analytics-page.tsx` (state ownership).
+
+**Capabilities Involved**: None (no backend port/capability — this is presentation wiring over
+already-shipped Phase 4/7 reads).
+
+**Existing Services Reused**:
+- `useAnalyticsCoverageQuery` (Phase 7) — already fetched by `AnalyticsDataCoveragePanel`; the page
+  will fetch it too (same query key ⇒ same cache entry, no extra request — the established pattern
+  `salesFilters`/`coverageFilters` already use at the page level, see `analytics-page.tsx`'s own doc
+  comment on `salesFilters`).
+- `useCurrencyMismatchOrdersQuery` / `useTaxCoverageOrdersQuery` (Phase 7) — reused by
+  `ChannelSalesTable` to fetch the full per-category order list for the cross-reference (see §6 Phase
+  2 for why `useMatchingCoverageOrdersQuery` is *not* needed here: product-matching orders have no
+  channel data gap of their own to annotate on the channel table — a `source_deleted`/
+  `awaiting_mapping` order already fails to resolve to *any* channel-scoped total, so it cannot be
+  under-counting a channel row by definition. Confirmed against `OrderRecordRepository`'s health
+  semantics before scoping this out — not assumed.)
+- `deriveCoverageRowCopy` (`data-coverage-copy.lib.ts`, Phase 7) — supplies the human-language
+  headline/modal-title strings so the new `GapMark`/`AnalyticsExclusionNote` never invents a second
+  copy of "23 orders counted in an outdated currency."
+- `CoverageDetailDialog` + the five renderers already in `AnalyticsDataCoveragePanel` — no new dialog
+  is built; the existing ones are lifted to accept externally-driven `open`/`onOpenChange`.
+- `GapMark` (already accessible per #2480's own problem statement — verified below, §4).
+
+**New Components Required**:
+- `apps/web/src/features/analytics/components/analytics-exclusion-note.tsx` (+`.test.tsx`) — per
+  #2481's own file-path spec.
+- No new hooks, no new API modules, no new types files beyond what's needed to export
+  `CoverageCategory` from the barrel (already defined in `analytics-coverage.types.ts`, just not
+  re-exported yet).
+
+**Core vs Integration Justification**: N/A — pure frontend, no CORE/Integration boundary crossed.
+
+---
+
+## 4. External / Domain Research
+
+### Internal Patterns (codebase search results)
+
+- **`gap-mark.tsx` is already accessible.** Read in full: it already renders
+  `<span className="gap-mark" role="img" aria-label={title} title={title}>`. #2480's premise ("the
+  mockup's cold audit found it missing a `title` attribute") is **already fixed on `main`**
+  (independently of this epic, per the file's own #2120-review comment) — confirmed per #2480's own
+  "verify against `main` before implementing" instruction. **Task 8.1 is wiring-only**, exactly the
+  assumption #2480 names as the likely outcome.
+- **`GapMark` is not currently clickable anywhere.** Every existing usage
+  (`analytics-kpi-strip.tsx`, `analytics-kpi-card.tsx`) renders it as an inert `<span>` — a tooltip,
+  never an affordance. Making a `GapMark` open a modal is new behavior, not present in the codebase
+  today. Two ways to add it without changing `GapMark` itself (kept a display-only leaf, per its own
+  single-responsibility doc comment):
+  1. Wrap the whole `<GapMark>` in a `<button type="button">` at each call site.
+  2. Give `GapMark` an optional `onActivate?: () => void` prop, rendering itself as a `<button>` when
+     present and a plain `<span>` otherwise.
+  Option 2 is chosen (§6) — it keeps the click affordance and its own focus/keyboard semantics in one
+  place (`GapMark` itself) rather than duplicated at every call site that wants it, and every call
+  site that doesn't pass `onActivate` is byte-identical to today.
+- **`AnalyticsKpiStrip` already computes exactly the two booleans this task needs**:
+  `stampedGapVisible = headline.unconvertedCount > 0` (currency) and
+  `netExcludedVisible = headline.netExcludedCount > 0` (tax). No new computation — only the *title*
+  and the *click handler* change from generic to category-specific.
+- **`AnalyticsDataCoveragePanel`'s `openCategory` state is 100% local** (`useState<CoverageCategory |
+  null>`), never exposed to its parent. `analytics-page.tsx` renders it with only `filters` and
+  `onOpenSettings` props. This is the one real design decision in this plan (§6 Phase 1).
+- **`ChannelSalesTable` / `TopProductRow` row shapes carry no order-id list** (`ChannelSalesAnalyticsDto`
+  is keyed by `sourceConnectionId` alone; `TopProductRow` by `productId` alone) — confirmed by reading
+  both files' full header comments and the imported types. This is what makes the Channel half
+  tractable (an order carries its own `sourceConnectionId`, so a cross-reference on that field is
+  exact) and the Product half currently impossible (an order carries no product/SKU field anywhere in
+  the coverage-detection output) — see §5.
+- **Phase 7's three order-list endpoints are already unbounded pagination, not the 10-id sample.**
+  `GET /analytics/coverage` (the aggregate `useAnalyticsCoverageQuery` reads) caps `sampleOrderIds` at
+  10; the three sibling endpoints (`.../currency/orders`, `.../tax/orders`, `.../matching/orders`) page
+  the *real, full* affected set with `limit`/`offset`. The Channel-table cross-reference must use the
+  latter (page through the full set for the current date range), never the former — using the 10-id
+  sample would under-report annotations on any range with more than 10 affected orders, which is
+  itself an instance of the exact bug class #2481's AC 2 guards against ("no row belonging to an open
+  category's affected set is missing its annotation").
+
+---
+
+## 5. Flagged Backend Gap — Product-table half of #2481 (does not block this plan; blocks a future one)
+
+Per #2481's own **Assumptions** section: *"if the affected-order lists from Phase 4 don't carry
+enough identifying info (SKU/channel id) to cross-reference cleanly, that's a signal Phase 4's
+detector output needs a small shape addition; flag it back rather than approximating the match."*
+
+That is exactly the state found. `CurrencyMismatchOrderDto`, `TaxCoverageOrderDto`, and
+`ProductMatchingOrderDto` all carry `internalOrderId` + `sourceConnectionId` and nothing product- or
+line-item-shaped. `order_line_items` (the #1985 read-model table that *does* carry per-line product
+identity — see `docs/architecture-overview.md` § Order analytics read model) is never joined by any
+Phase 4/7 detection query.
+
+**Two remediation paths for whoever picks this up** (not decided here — a product/backend call, out
+of this plan's scope):
+1. Add an optional `productIds: string[]` (or a separate `/orders/:id/line-items` lookup) to each of
+   the three coverage-order DTOs, joining `order_line_items` in the detection query. Cheapest at read
+   time, but widens three response shapes for a feature only the Product table needs.
+2. A dedicated `GET /analytics/coverage/{category}/products` aggregate endpoint, mirroring the
+   existing per-channel `revenueShare` breakdown shape in `GET /analytics/sales` — answers "which
+   products are affected" directly rather than requiring the FE to intersect two large order lists.
+
+Recommendation for the follow-up issue: option 2. It avoids widening the order-list DTOs (which the
+Channel-table cross-reference and the detail modals both already consume unmodified) and gives a
+bounded response instead of a "fetch every affected order, then intersect against every product's own
+order set client-side" O(orders × products) computation the FE would otherwise have to run per
+render.
+
+**This plan explicitly does not touch `product-sales-table.tsx`.** Task 8.2's acceptance criteria are
+therefore only *partially* satisfiable by this plan — see §9.
+
+---
+
+## 6. Proposed Implementation Plan
+
+### Phase 1: Page-level coverage state + controllable `AnalyticsDataCoveragePanel`
+
+**Goal**: Let the KPI strip and the channel table each open a specific category's detail modal
+without duplicating `CoverageDetailDialog` or its five row renderers.
+
+**Steps**:
+
+1. **Lift `openCategory`/`offset` state to `AnalyticsPage`, `AnalyticsDataCoveragePanel` becomes
+   controllable-with-uncontrolled-fallback.**
+   - **File**: `apps/web/src/pages/analytics/analytics-page.tsx`
+   - **Action**: Add `const [openCoverageCategory, setOpenCoverageCategory] = useState<CoverageCategory
+     | null>(null);`. Fetch `const coverageQuery = useAnalyticsCoverageQuery(coverageFilters);` at the
+     page level (same query key as the one `AnalyticsDataCoveragePanel` already issues internally — one
+     network request, TanStack Query dedupes by key, same pattern already documented for
+     `salesQuery`/`AnalyticsKpiStrip`). Pass `openCategory={openCoverageCategory}` and
+     `onOpenCategoryChange={setOpenCoverageCategory}` into `<AnalyticsDataCoveragePanel>`. Pass
+     `coverage={coverageQuery.data}` and `onOpenCategory={setOpenCoverageCategory}` into
+     `<AnalyticsKpiStrip>` and `<ChannelSalesTable>`.
+   - **Acceptance**: Clicking a Data Coverage panel row still opens its own modal exactly as before
+     (regression guard — Phase 7's existing test suite for `analytics-data-coverage-panel.test.tsx`
+     must stay green unmodified, since the component's *default* behavior is unchanged).
+   - **Dependencies**: None — this is the first step.
+
+2. **`AnalyticsDataCoveragePanel` accepts optional `openCategory` / `onOpenCategoryChange` props.**
+   - **File**: `apps/web/src/features/analytics/components/analytics-data-coverage-panel.tsx`
+   - **Action**: Add two optional props to `AnalyticsDataCoveragePanelProps`. Replace the internal
+     `const [openCategory, setOpenCategory] = useState<CoverageCategory | null>(null);` with the
+     standard controllable-component pattern:
+     ```tsx
+     const [internalOpenCategory, setInternalOpenCategory] = useState<CoverageCategory | null>(null);
+     const openCategory = props.openCategory ?? internalOpenCategory;
+     const setOpenCategory = props.onOpenCategoryChange ?? setInternalOpenCategory;
+     ```
+     Every existing internal call site (`openDetail`, `closeDetail`, the row `onOpenDetail` handlers)
+     is unchanged — they already only call `setOpenCategory`/`setOffset`, which now transparently
+     routes to the parent when one is supplied. `offset` stays **always internal** (never
+     lifted) — nothing outside this component needs to control pagination, only *which* category's
+     modal is open.
+   - **Acceptance**: With no props supplied (the panel's own self-render), behavior is byte-identical
+     to today — existing tests pass with zero changes. With `openCategory`/`onOpenCategoryChange`
+     supplied, an external `setOpenCoverageCategory('currency')` call opens the currency modal exactly
+     as clicking the panel's own currency row would.
+   - **Dependencies**: Step 1.
+
+3. **Export `CoverageCategory` from the feature barrel.**
+   - **File**: `apps/web/src/features/analytics/index.ts`
+   - **Action**: Add `CoverageCategory` to the existing `export type { AnalyticsCoverage,
+     AnalyticsCoverageFilters, CoverageCategoryRow } from './api/analytics-coverage.types';` line
+     (already the right file — just add the one type name). `AnalyticsPage` needs it for the
+     `useState<CoverageCategory | null>` declaration.
+   - **Acceptance**: `pnpm --filter @openlinker/web type-check` passes with the page importing
+     `CoverageCategory` from the barrel, not a deep path.
+   - **Dependencies**: None (independent of steps 1–2, can land in the same commit).
+
+### Phase 2: Task 8.1 — `GapMark` wiring on the KPI strip
+
+**Goal**: Every KPI card affected by an open coverage category shows a `GapMark` whose title names
+the real category and whose click opens that category's modal.
+
+**Steps**:
+
+4. **`GapMark` grows an optional `onActivate` prop.**
+   - **File**: `apps/web/src/features/analytics/components/gap-mark.tsx`
+   - **Action**: Add `onActivate?: () => void` to the props interface. When present, render
+     `<button type="button" className="gap-mark gap-mark--clickable" aria-label={title} title={title}
+     onClick={onActivate}>` (drop `role="img"` — a genuinely interactive element gets its accessible
+     name from its own content/`aria-label`, `role="img"` was for the inert-span case only). When
+     absent, render exactly the current `<span role="img" …>` markup unchanged.
+   - **Acceptance**: Existing `gap-mark`-adjacent tests (none exist standalone today — it's exercised
+     via `analytics-kpi-strip.test.tsx`) keep passing with no `onActivate` passed at any *existing*
+     call site (Units/Cancellations/Returns cards' `GapMark`s stay inert spans). New test:
+     `gap-mark.test.tsx` — asserts inert-span rendering with no prop, button rendering + `onClick`
+     firing `onActivate` with the prop, and that `aria-label`/`title` both still carry the reason text
+     in the clickable form.
+   - **Dependencies**: None.
+
+5. **`.gap-mark--clickable` CSS.**
+   - **File**: `apps/web/src/index.css`
+   - **Action**: Add a bounded section under the existing analytics section (`/* ── GapMark clickable
+     variant (#2480) ── */`) resetting button chrome (`background: none; border: none; padding: 0;
+     font: inherit; cursor: pointer;`) and adding `:focus-visible { box-shadow: var(--shadow-focus); }`
+     per the accessibility rule in `docs/frontend-ui-style-guide.md` (never remove focus rings). No
+     new design token needed — reuses `--shadow-focus`, already in `tokens.ts`.
+   - **Acceptance**: `pnpm lint`'s design-token drift check stays green (no new `--*` custom property
+     introduced).
+   - **Dependencies**: Step 4.
+
+6. **Wire the Revenue card's GMV qualifier + the Order-value card's Average qualifier to the
+   currency category.**
+   - **File**: `apps/web/src/features/analytics/components/analytics-kpi-strip.tsx`
+   - **Action**: `AnalyticsKpiStrip` gains two new props: `coverage: AnalyticsCoverage | undefined`
+     and `onOpenCategory: (category: CoverageCategory) => void`. Resolve the currency row once:
+     `const currencyRow = coverage?.categories.find((row) => row.category === 'currency');`. Replace
+     the two `<GapMark title={STAMPED_GAP} />` call sites (GMV qualifier, Average qualifier) with a
+     title sourced from `deriveCoverageRowCopy(currencyRow ?? emptyCurrencyRow).sub` **only when**
+     `currencyRow` exists and `currencyRow.affectedCount > 0` — otherwise keep rendering the existing
+     generic `STAMPED_GAP` text (a `stampedGapVisible` state the coverage query hasn't loaded yet, or
+     has zero-count for some unrelated reason, must not regress to a blank/wrong title). Pass
+     `onActivate={() => onOpenCategory('currency')}` in the affected-category branch only (the generic
+     fallback stays inert, matching current behavior — nothing to open if there's no coverage data to
+     open).
+   - **Acceptance**: New tests in `analytics-kpi-strip.test.tsx` — (a) with `coverage` reporting
+     `currency` `affectedCount: 23`, the GMV `GapMark`'s accessible name contains the currency
+     category's real copy (not `STAMPED_GAP`'s literal text) and clicking it calls `onOpenCategory`
+     with `'currency'`; (b) with `coverage` undefined (still loading) or the currency row at
+     `affectedCount: 0`, the qualifier renders exactly as it does on `main` today (`STAMPED_GAP`, inert)
+     — a regression guard for the "not missing, not wrong" pairing #2481's ACs establish for the sibling
+     task, applied here too since the same failure class applies to any of these annotations.
+   - **Dependencies**: Steps 3, 4.
+
+7. **Add a `GapMark` to the Net Sales card when `netExcludedVisible`.**
+   - **File**: same as step 6.
+   - **Action**: The Revenue card's `metric` prop (currently a bare `'Net sales'` string) becomes
+     conditional, mirroring the existing Order-value card's `Average <GapMark …>` pattern exactly:
+     ```tsx
+     metric={
+       netExcludedVisible ? (
+         <>
+           Net sales <GapMark title={taxCoverageCopyFor(headline)} onActivate={() => onOpenCategory(taxCategoryFor(headline))} />
+         </>
+       ) : (
+         'Net sales'
+       )
+     }
+     ```
+     `taxCategoryFor`/the category resolution: `headline.netExcludedCount` does not itself say *which*
+     tax sub-category (A/B/C) caused the exclusion — that distinction only exists in the coverage
+     query's per-category `affectedCount`s. Resolve by finding the tax category among
+     `coverage.categories` with the largest `affectedCount` (tax-a/b/c are mutually exclusive
+     partitions of the tax exclusion set per `TaxCoverageDetectionService`'s own classification pass —
+     confirmed via `docs/architecture-overview.md` § Net Sales, VAT-exclusive: "a stored-rate
+     requirement" — each order lands in exactly one category), falling back to `'tax-a'` (the
+     remediable one, so a false attribution errs toward the operator being offered a fix rather than
+     the dead-end category) if all three read zero (should not happen when `netExcludedVisible` is
+     true, but a fallback avoids a runtime crash on an unexpected zero-everywhere state).
+   - **Acceptance**: Test — `netExcludedCount > 0` with `tax-b` carrying the coverage query's largest
+     `affectedCount` among the three tax categories opens the `tax-b` modal on click; `netExcludedCount
+     === 0` renders the plain `'Net sales'` string, unchanged from today.
+   - **Dependencies**: Step 6 (same file, same `coverage` prop plumbing).
+
+8. **`AnalyticsPage` passes the new props through.**
+   - **File**: `apps/web/src/pages/analytics/analytics-page.tsx`
+   - **Action**: `<AnalyticsKpiStrip filters={salesFilters} connections={trustQuery.data.connections}
+     coverage={coverageQuery.data} onOpenCategory={setOpenCoverageCategory} />`.
+   - **Acceptance**: Manual verification against the running app (`pnpm run dev` in `apps/web`) —
+     seed/observe a range with a nonzero `unconvertedCount`, confirm the GMV `GapMark`'s tooltip now
+     reads the category copy and clicking it opens the currency detail modal.
+   - **Dependencies**: Steps 1, 6, 7.
+
+### Phase 3: Task 8.2 (Channel half) — `AnalyticsExclusionNote`
+
+**Goal**: Every `ChannelSalesTable` row belonging to an open category's affected set gets exactly one
+correct `.excl-note`; no row gets zero when it should have one, no row gets the wrong category.
+
+**Steps**:
+
+9. **`AnalyticsExclusionNote` component.**
+   - **File**: `apps/web/src/features/analytics/components/analytics-exclusion-note.tsx` (+
+     `.test.tsx`)
+   - **Action**: A small, presentational component:
+     ```tsx
+     interface AnalyticsExclusionNoteProps {
+       category: CoverageCategory;
+       affectedCount: number;
+       onOpenCategory: (category: CoverageCategory) => void;
+     }
+     ```
+     Renders one `.excl-note` line reusing `deriveCoverageRowCopy(...)`'s `headline`/`sub` text for the
+     given category (never a hand-written string — the same single-source-of-copy rule Phase 7
+     established), as a `<button type="button">` (not a bare span — this is a real affordance,
+     `docs/frontend-ui-style-guide.md` § Buttons: "If an element submits, confirms, or mutates state,
+     it should be a button" — opening a dialog counts) calling `onOpenCategory(category)`.
+     `affectedCount` is only used to pick singular/plural copy via the existing `deriveCoverageRowCopy`
+     — the component itself does not compute counts (that's the caller's job, step 10).
+   - **Acceptance**: Unit test renders the component for each of the five `CoverageCategory` values,
+     asserts the rendered text matches `deriveCoverageRowCopy(category, …).headline` exactly (never a
+     duplicated literal), and asserts `onOpenCategory` fires with the right category on click.
+   - **Dependencies**: None (pure component, can be built in parallel with Phase 1).
+
+10. **Cross-reference wiring in `ChannelSalesTable`.**
+    - **File**: `apps/web/src/features/analytics/components/channel-sales-table.tsx`
+    - **Action**: `ChannelSalesTable` gains `onOpenCategory: (category: CoverageCategory) => void`.
+      For each open coverage category (`coverage.categories.filter((row) => row.affectedCount > 0)`,
+      **excluding `'product-matching'`** per §3's confirmed reasoning), fetch the *full* affected-order
+      list for the table's own `filters` range via the matching hook
+      (`useCurrencyMismatchOrdersQuery`/`useTaxCoverageOrdersQuery`, called once per open category, not
+      per row — table-level, mirroring how the table already calls `useSalesAnalyticsQuery` once for
+      itself). Because these hooks are paginated (`limit`/`offset`), and this cross-reference needs the
+      *complete* set (not one page), request the largest allowed `limit` (100, the DTOs' own `@Max(100)`
+      ceiling) and, if `total > limit`, page through the remainder — bounded by the fact that this is a
+      per-viewer, per-page-load read, not a hot path, and a deployment with more than a few hundred
+      simultaneously-excluded orders in one category is itself the signal that the *remediation*
+      (Recalculate now / Sync the catalog now) is overdue, not a performance target this table needs to
+      protect against. Group the fetched order rows by `sourceConnectionId` into a
+      `Map<string, Map<CoverageCategory, number>>` (`connectionId -> category -> count`), computed once
+      per render via `useMemo` keyed on the fetched pages + `filters`. Each `ChannelRow`, when its own
+      `sourceConnectionId` has a nonzero count in that map for some category, renders one
+      `<AnalyticsExclusionNote category={…} affectedCount={…} onOpenCategory={onOpenCategory} />` per
+      affected category (a channel can legitimately appear in more than one open category — e.g. some
+      orders un-stamped AND some un-rated — both notes render, never merged into one ambiguous line).
+    - **Acceptance**: The exact two regression guards #2481's ACs name, written as tests against a
+      fixture with two categories both present in the dataset and two channels, one belonging to each:
+      (a) each row's `.excl-note` names the category that fixture's own orders actually belong to
+      (never the other channel's category); (b) a channel with an order in the currency category's
+      affected set gets its note even when that same channel's own row otherwise reads a healthy,
+      fully-covered total (i.e. the note is driven by the fetched order list, never inferred from the
+      row's own aggregate figures reading "off").
+    - **Dependencies**: Steps 3, 9.
+
+11. **`AnalyticsPage` passes `onOpenCategory` to `ChannelSalesTable`.**
+    - **File**: `apps/web/src/pages/analytics/analytics-page.tsx`
+    - **Action**: `<ChannelSalesTable filters={salesFilters} onOpenCategory={setOpenCoverageCategory}
+      />`.
+    - **Acceptance**: Manual verification — a channel row with excluded orders shows its note; clicking
+      it opens the same modal the Data Coverage panel's own row for that category would.
+    - **Dependencies**: Steps 1, 10.
+
+### Implementation Details
+
+**New Components**:
+- `analytics-exclusion-note.tsx` (+ test) — the only new file. No new hooks, no new API modules, no
+  new types file (reuses `CoverageCategory` from the already-shipped `analytics-coverage.types.ts`).
+
+**Configuration Changes**: None.
+
+**Database Migrations**: None.
+
+**Events**: None emitted/consumed (no backend involvement).
+
+**Error Handling**: The channel table's per-category order-list fetches use the existing hooks'
+standard TanStack Query error surfacing — a failed fetch for one category's cross-reference degrades
+to "no notes for that category this render" (logged via the query's own `error` state, not
+swallowed silently) rather than blocking the whole table, matching the codebase's existing pattern of
+independent, non-blocking sibling queries (`analytics-page.tsx`'s own doc comment: "a channel-table
+failure can never blank the KPI strip").
+
+---
+
+## 7. Alternatives Considered
+
+### Alternative 1: A `CoverageContext` / small Zustand-style provider instead of prop-drilling
+
+- **Description**: Wrap `/analytics` in a React context carrying `openCategory`/`setOpenCategory`,
+  consumed via a hook from any descendant, instead of passing `coverage`/`onOpenCategory` props down
+  three levels.
+- **Why Rejected**: `docs/frontend-architecture.md` § Global Store Policy — a store is justified only
+  when state "must be shared across distant branches" and "must survive route transitions." This
+  state is neither: it lives entirely within one page's render tree, three components deep, and
+  resets on navigation away from `/analytics` (correctly — nothing should remember which modal was
+  open on a page nobody's viewing). Plain prop-drilling at this depth is exactly what the state
+  ownership rules prescribe over inventing a context.
+- **Trade-offs**: Context would remove the need to thread `coverage`/`onOpenCategory` through
+  `AnalyticsKpiStrip`'s and `ChannelSalesTable`'s prop lists, but at the cost of an untyped
+  "any descendant can read/write this" surface for state that only three call sites actually need —
+  a worse trade for a codebase whose own convention is explicit prop plumbing over ambient state.
+
+### Alternative 2: Approximate the Product-table half by annotating every product row for an affected channel
+
+- **Description**: Since `TaxCoverageOrderDto`/etc. carry `sourceConnectionId`, and
+  `TopProductRow.channels` is keyed by connection id too, annotate *every* product row that has any
+  sales on a channel with an open category — "this channel has excluded orders, so this product's
+  channel-column figure might be affected."
+- **Why Rejected**: This is precisely the approximation #2481's own Assumptions section warns against
+  ("flag it back rather than approximating the match") and is provably wrong in the common case — a
+  channel with 5,000 orders and 3 currency-excluded ones would falsely flag every one of its hundreds
+  of product rows, when only the products those 3 specific orders actually contain are truly
+  under-counted. Shipping a known-false-positive-generating feature fails #2481's AC 1 outright
+  ("provably correct against its own underlying order data").
+
+---
+
+## 8. Validation & Risks
+
+### Architecture Compliance
+- ✅ Pure frontend change — no CORE/Integration boundary touched, no port/adapter involved.
+- ✅ State ownership: server state (`coverage`, order lists) via TanStack Query; "which modal is
+  open" is local UI state lifted to the nearest common ancestor (`AnalyticsPage`), never a global
+  store. Matches `docs/frontend-architecture.md` § State Management exactly.
+
+### Naming Conventions
+- ✅ `analytics-exclusion-note.tsx` — kebab-case file, `AnalyticsExclusionNote` PascalCase export,
+  matching every existing primitive in `features/analytics/components/`.
+- ✅ `.excl-note`/`.gap-mark--clickable` CSS class naming — `component-name`/`component-name--modifier`,
+  per `docs/frontend-ui-style-guide.md` § CSS Implementation Standard.
+
+### Existing Patterns
+- ✅ Controllable-with-uncontrolled-fallback prop pattern (`value ?? internalState`,
+  `onChange ?? setInternalState`) — a standard React idiom, not a new abstraction invented for this
+  plan.
+- ✅ Reuses `deriveCoverageRowCopy` as the single source of category copy (Phase 7's own rule,
+  restated in `data-coverage-copy.lib.ts`'s header) rather than hand-writing a second copy of any
+  category's headline/sub text.
+
+### Risks
+- **The tax-category attribution in step 7 (Net Sales `GapMark`) is a heuristic** ("largest
+  `affectedCount` among tax-a/b/c"), not a field the backend actually stamps onto `headline` itself.
+  Mitigation: documented inline at the call site with the classification-partition reasoning; a
+  follow-up could add a genuine `headline.netExcludedCategory` field to `GET /analytics/sales` if this
+  heuristic ever proves wrong in practice — flagged, not silently trusted.
+- **The channel-table full-pagination fetch (step 10) issues up to `ceil(total / 100)` requests per
+  open category, per page load.** Mitigation: bounded by the `total` count Phase 7's coverage
+  aggregate already reports (an operator with the panel open sees this number before it ever spawns
+  requests), and — per the acceptance note in step 10 — a `total` large enough to matter is itself the
+  signal that the underlying remediation is overdue, which is exactly what the Data Coverage panel
+  already surfaces prominently. If this proves too chatty in practice, a follow-up could add a genuine
+  channel-grouped aggregate endpoint (the same shape recommended for the Product-table gap in §5,
+  option 2) rather than this plan inventing a bespoke pagination-drain here.
+
+### Edge Cases
+- **A channel with orders in more than one open category**: both notes render (step 10, explicitly
+  not merged) — an operator needs to know both, and merging into one ambiguous "this row is affected"
+  line loses which fix applies.
+- **`coverage` still loading (`undefined`) when the KPI strip / channel table render**: every new
+  annotation renders its Phase-7-pre-existing generic fallback (KPI strip) or nothing (channel table
+  — no note before the cross-reference data exists), never a broken/`undefined`-derived title. Covered
+  by step 6's explicit acceptance criterion.
+- **Zero open categories**: no `GapMark` gets a category-specific title (KPI strip falls back to its
+  existing generic copy exactly as today), no `.excl-note` renders anywhere — byte-identical to
+  pre-Phase-8 behavior, which is the correct "all clear" state.
+
+### Backward Compatibility
+- ✅ No breaking change to any existing prop, type, or exported symbol — every new prop on
+  `AnalyticsDataCoveragePanel`/`AnalyticsKpiStrip`/`ChannelSalesTable`/`GapMark` is optional, and every
+  component's no-new-props render path is asserted unchanged by the regression tests named in steps
+  2, 4, 6.
+
+---
+
+## 9. Testing Strategy & Acceptance Criteria
+
+### Unit Tests
+- `gap-mark.test.tsx` (new) — inert-span default, clickable-button variant, accessible name in both.
+- `analytics-kpi-strip.test.tsx` (extend) — category-specific title + click-opens-category for the
+  currency-driven qualifiers and the new Net Sales gap mark; the "no coverage data / zero-count ⇒
+  unchanged generic behavior" regression guard.
+- `analytics-exclusion-note.test.tsx` (new) — copy sourced from `deriveCoverageRowCopy` verbatim,
+  click fires `onOpenCategory`.
+- `channel-sales-table.test.tsx` (extend) — the two #2481 AC-mandated fixtures: correct-category
+  attribution across two simultaneously-open categories, and no-missing-annotation coverage of every
+  category at least once.
+- `analytics-data-coverage-panel.test.tsx` — **no changes expected**; existing suite is the regression
+  guard for step 2's uncontrolled-fallback default path.
+
+### Integration Tests
+- None — this is presentation-only wiring over already-integration-tested backend endpoints (Phase 7
+  shipped `analytics-coverage.controller.spec.ts` et al.); no new HTTP surface is added by this plan.
+
+### Mocking Strategy
+- `createMockApiClient` (existing `test/test-utils.tsx` helper) for every new/extended test — mock
+  `analytics.getCoverage`, `analytics.getCurrencyMismatchOrders`, `analytics.getTaxCoverageOrders` per
+  the established Phase 7 test pattern (see `analytics-data-coverage-panel.test.tsx` for the reference
+  shape).
+
+### Acceptance Criteria
+
+**Task 8.1 (#2480)**:
+- [ ] Every KPI card affected by an open coverage category shows a `GapMark` with a real,
+      category-specific `title`.
+- [ ] Clicking it opens the correct detail modal for that category.
+- [ ] Tests added/updated for `gap-mark.tsx` and the KPI components it's wired into.
+
+**Task 8.2 (#2481), Channel half**:
+- [ ] A channel row's `.excl-note` category is provably correct against its own underlying order
+      data (test with a fixture where two categories are both present, asserting each row gets the
+      right one).
+- [ ] No channel row belonging to an open category's affected set is missing its annotation (test
+      with a fixture covering every eligible category at least once).
+- [ ] Tests added.
+
+**Task 8.2 (#2481), Product half**: **not attempted by this plan** — see §5 for the flagged backend
+gap and the recommended follow-up shape. The mini-epic's (#2479) own AC checklist cannot be closed
+in full without that follow-up landing first.
+
+---
+
+## 10. Alignment Checklist
+
+- [x] Follows hexagonal architecture (N/A — pure frontend, no layers crossed)
+- [x] Respects CORE vs Integration boundaries (N/A — no backend touched)
+- [x] Uses existing patterns (no unnecessary abstractions) — controllable-component pattern,
+      `deriveCoverageRowCopy` reuse, no new context/store
+- [x] Idempotency considered (N/A — no writes; all reads are TanStack Query cache-consistent)
+- [x] Event-driven patterns used where applicable (N/A)
+- [x] Rate limits & retries addressed — N/A backend-side; FE pagination-drain risk documented in §8
+- [x] Error handling comprehensive — per-category fetch failures degrade independently (§6
+      Implementation Details)
+- [x] Testing strategy complete — §9
+- [x] Naming conventions followed — §8
+- [x] File structure matches standards — one new file at the canonical `components/` location
+- [x] Plan is execution-ready
+- [x] Plan is saved as markdown file
+
+---
+
+## Related Documentation
+
+- [Architecture Overview](../architecture-overview.md)
+- [Engineering Standards](../engineering-standards.md)
+- [Frontend Architecture](../frontend-architecture.md)
+- [Frontend UI Style Guide](../frontend-ui-style-guide.md)
+- [Testing Guide](../testing-guide.md)
+- Epic #2452, mini-epic #2479, sub-tasks #2480 / #2481
+- Mockup: `docs/plans/mockups/analytics-display-currency-picker.html`


### PR DESCRIPTION
## Summary

Phase 8 of epic #2452 (mini-epic #2479) — implements Task 8.1 (#2480) and the channel half of Task 8.2 (#2481). Plan: `docs/plans/implementation-plan-analytics-exclusion-annotations.md`.

- **Task 8.1 (#2480)** — `GapMark` already had its `title`/`aria-label` (fixed independently on `main` before this epic reached it) — this was wiring-only. `AnalyticsKpiStrip`'s currency-gap `GapMark`s (Revenue card's GMV qualifier, Order value card's Average qualifier) and a new Net Sales tax-gap `GapMark` now source their title from the real, open Data Coverage category (Phase 7) and open the matching detail modal on click, instead of the generic pre-Phase-8 tooltip text. `GapMark` gains an optional `onActivate` prop — renders as a real `<button>` when supplied, byte-identical inert `<span>` otherwise.
- **Task 8.2, channel half (#2481)** — new `AnalyticsExclusionNote` renders one `.excl-note` per open coverage category a `ChannelSalesTable` row's channel has an order in. The cross-reference pages through each category's **full** affected-order list (never the Data Coverage aggregate's 10-id sample) and groups by `sourceConnectionId`, which is an exact match for a channel row.
- `AnalyticsDataCoveragePanel`'s open-category state becomes controllable-with-uncontrolled-fallback so the KPI strip / channel table can open its existing detail modals without a second dialog implementation. `AnalyticsPage` now owns one shared `GET /analytics/coverage` query + open-category state (same cache entry the panel already fetched — no extra request).

## Known gap (deliberately deferred, not fixed here)

**Task 8.2's product-table half (`product-sales-table.tsx`) is not implemented.** `TopProductRow` is keyed by `productId`; none of Phase 7's three coverage-order endpoints carry a `productId`/SKU/line-item field, so there is no correct client-side cross-reference from an excluded order to a product row. Approximating it (e.g. flagging every product on an affected channel) would reproduce the exact mislabeling bug class #2481's own ACs guard against. See the implementation plan §5 for the two remediation options flagged for a follow-up issue.

## Regression guards

- `channel-sales-table.test.tsx` — two new tests pin the mockup's own found bug class: a row's `.excl-note` must carry the category its own orders actually belong to (never a sibling row's), and a row with orders in every open cross-referenceable category gets a note for each one, never missing.
- `gap-mark.test.tsx` / `analytics-exclusion-note.test.tsx` — new, cover the inert/clickable `GapMark` variants and `AnalyticsExclusionNote`'s copy-from-`deriveCoverageRowCopy` + click behavior.
- Every existing Phase 7 test (`analytics-data-coverage-panel.test.tsx`, `analytics-kpi-strip.test.tsx`, `channel-sales-table.test.tsx`) still passes unmodified against the new optional props' uncontrolled-fallback defaults.

## Test plan

- [x] `pnpm --filter @openlinker/web type-check` — clean
- [x] `pnpm --filter @openlinker/web lint` — 0 errors (pre-existing warning baseline unchanged)
- [x] `pnpm --filter @openlinker/web test` (analytics feature + page) — 190/190 passing

Part of #2480
Part of #2481