### PR TITLE
feat(sales-documents): country-keyed starter-template catalogue listing

### DIFF
--- a/apps/api/src/sales-documents/data/sales-document-template-catalogue.spec.ts
+++ b/apps/api/src/sales-documents/data/sales-document-template-catalogue.spec.ts
@@ -1,0 +1,69 @@
+/**
+ * Sales-Document Starter-Template Catalogue Specs (#2529)
+ *
+ * Pins the two properties the settings surface depends on: the catalogue is
+ * country-keyed data with a citable source, and the ABSENCE of a template is
+ * a reportable answer rather than an empty template a surface could render as
+ * guidance.
+ *
+ * @module apps/api/src/sales-documents/data
+ */
+import {
+  getSalesDocumentStarterTemplate,
+  hasSalesDocumentStarterTemplate,
+  listSalesDocumentTemplateCountries,
+  SALES_DOCUMENT_TEMPLATE_PROVENANCE_BY_COUNTRY,
+} from './sales-document-template-catalogue';
+
+describe('sales-document starter-template catalogue', () => {
+  describe('listSalesDocumentTemplateCountries', () => {
+    it('should list Poland as the only researched market when read', () => {
+      expect(listSalesDocumentTemplateCountries().map((entry) => entry.country)).toEqual(['PL']);
+    });
+
+    it('should carry a citable source for every listed market when read', () => {
+      for (const entry of listSalesDocumentTemplateCountries()) {
+        expect(entry.sourceLabel.length).toBeGreaterThan(0);
+        expect(entry.sourceUrl).toMatch(/^https:\/\//);
+      }
+    });
+  });
+
+  describe('getSalesDocumentStarterTemplate', () => {
+    it('should report absence as null when the country has no researched guidance', () => {
+      expect(getSalesDocumentStarterTemplate('DE')).toBeNull();
+      expect(hasSalesDocumentStarterTemplate('DE')).toBe(false);
+    });
+
+    it('should never report absence as an empty template when the country has none', () => {
+      const template = getSalesDocumentStarterTemplate('CZ');
+      // An empty-but-present template would let a surface render "suggested
+      // setup" with nothing in it, which claims guidance that does not exist.
+      expect(template).toBeNull();
+    });
+
+    it('should resolve a lower-case country code when the caller passes one', () => {
+      expect(getSalesDocumentStarterTemplate('pl')?.country).toBe('PL');
+      expect(hasSalesDocumentStarterTemplate('pl')).toBe(true);
+    });
+
+    it('should carry the rule shapes and their required capability when Poland is read', () => {
+      const template = getSalesDocumentStarterTemplate('PL');
+      expect(template).not.toBeNull();
+      expect(template?.rules.map((rule) => rule.slot)).toEqual([
+        'no-tax-id',
+        'tax-id-below-threshold',
+        'tax-id-above-threshold',
+      ]);
+      for (const rule of template?.rules ?? []) {
+        expect(['Invoicing', 'Fiscalization']).toContain(rule.requiredCapability);
+      }
+    });
+
+    it('should carry a provenance tag for every listed market when adopted rows are written', () => {
+      for (const entry of listSalesDocumentTemplateCountries()) {
+        expect(SALES_DOCUMENT_TEMPLATE_PROVENANCE_BY_COUNTRY[entry.country]).toBeDefined();
+      }
+    });
+  });
+});

--- a/apps/api/src/sales-documents/data/sales-document-template-catalogue.ts
+++ b/apps/api/src/sales-documents/data/sales-document-template-catalogue.ts
@@ -1,23 +1,32 @@
 /**
- * Poland Starter Template — Sales-Document Rules (#2170)
+ * Sales-Document Starter-Template Catalogue (#2170, #2529)
  *
- * Poland-only curated seed content: sourced public guidance, an amount, and
- * the three rule SHAPES the mockup's "Review & adopt" screen previews. Ships
- * as DATA in `apps/api` — never as a literal string inside
- * `libs/core/src/sales-documents/**`, which is the acceptance criterion this
- * file exists to satisfy. No other country has a curated template yet; the
- * mechanism (`SalesDocumentTemplatesController`) is generic — a second
- * country's template is additive (another exported constant + one more
- * `TEMPLATES_BY_COUNTRY` entry), never a core code change.
+ * Country-keyed curated seed content: for each market we have researched
+ * public guidance for, a citable source and the rule SHAPES the "Review &
+ * adopt" screen previews. Poland is the only entry today.
+ *
+ * **Absence is a first-class answer, not silence** (ADR-066 decision 2). A
+ * country with no entry resolves `null` from
+ * {@link getSalesDocumentStarterTemplate} and is simply missing from
+ * {@link listSalesDocumentTemplateCountries}, so a surface can state "we have
+ * no guidance for this market" rather than presenting an empty template as
+ * though one existed. Nothing here recommends, applies or activates anything:
+ * reading the catalogue has no effect, and adoption is a separate explicit
+ * write (`POST /sales-documents/templates/:country/adopt`).
+ *
+ * Ships as DATA in `apps/api` - never as a literal string inside
+ * `libs/core/src/sales-documents/**`, which stays a zero-outbound-core-context
+ * -edge leaf and carries no market-specific content. A second country's
+ * template is additive: another exported constant plus one more
+ * `TEMPLATES_BY_COUNTRY` entry, never a core code change.
  *
  * Each template rule names a `requiredCapability` rather than a fixed
- * `connectionId` — the operator has not chosen a connection yet at preview
+ * `connectionId` - the operator has not chosen a connection yet at preview
  * time. "Review & adopt" resolves each slot against the operator's own
- * connections (client-side, from the same connections list the rest of this
- * feature already fetches) and POSTs the resolved `connectionId` per slot to
- * `/sales-documents/templates/PL/adopt`.
+ * connections and POSTs the resolved `connectionId` per slot.
  *
  * @module apps/api/src/sales-documents/data
+ * @see docs/architecture/adrs/066-sales-document-market-discovery.md
  */
 
 export interface SalesDocumentTemplateCondition {
@@ -119,3 +128,36 @@ export function getSalesDocumentStarterTemplate(country: string): SalesDocumentS
 export const SALES_DOCUMENT_TEMPLATE_PROVENANCE_BY_COUNTRY: Readonly<Record<string, string>> = {
   PL: 'PL starter template',
 };
+
+/** One catalogue entry, reduced to what a listing surface needs. */
+export interface SalesDocumentTemplateSummary {
+  readonly country: string;
+  readonly sourceLabel: string;
+  readonly sourceUrl: string;
+}
+
+/**
+ * Every country a curated starter template exists for, alphabetically.
+ *
+ * The list is the whole answer: a country missing from it has no guidance,
+ * which is a fact a surface may state. It never implies the market is
+ * unsupported or misconfigured.
+ */
+export function listSalesDocumentTemplateCountries(): SalesDocumentTemplateSummary[] {
+  return Object.values(TEMPLATES_BY_COUNTRY)
+    .map((template) => ({
+      country: template.country,
+      sourceLabel: template.sourceLabel,
+      sourceUrl: template.sourceUrl,
+    }))
+    .sort((a, b) => a.country.localeCompare(b.country));
+}
+
+/**
+ * Whether a curated starter template exists for `country`. Case-insensitive on
+ * the input, like {@link getSalesDocumentStarterTemplate}, so a country code
+ * read off an order matches the catalogue's canonical upper-case keys.
+ */
+export function hasSalesDocumentStarterTemplate(country: string): boolean {
+  return getSalesDocumentStarterTemplate(country) !== null;
+}

--- a/apps/api/src/sales-documents/http/dto/adopt-sales-document-template.dto.ts
+++ b/apps/api/src/sales-documents/http/dto/adopt-sales-document-template.dto.ts
@@ -2,7 +2,7 @@
  * Adopt Sales-Document Template DTO (#2170)
  *
  * The operator's per-slot connection selections for the "Review & adopt"
- * flow — see `apps/api/src/sales-documents/data/pl-starter-template.ts` for
+ * flow — see `apps/api/src/sales-documents/data/sales-document-template-catalogue.ts` for
  * the slot vocabulary. Adopting writes ORDINARY, fully-editable rows via the
  * same `createRule` path every other rule goes through, tagged with the
  * template's provenance string.

--- a/apps/api/src/sales-documents/http/sales-document-templates.controller.spec.ts
+++ b/apps/api/src/sales-documents/http/sales-document-templates.controller.spec.ts
@@ -1,0 +1,58 @@
+/**
+ * Sales-Document Templates Controller Specs (#2529)
+ *
+ * @module apps/api/src/sales-documents/http
+ */
+import { NotFoundException } from '@nestjs/common';
+import type { ISalesDocumentRulesService } from '@openlinker/core/sales-documents';
+import { SalesDocumentTemplatesController } from './sales-document-templates.controller';
+import type { SalesDocumentCapabilityGuardService } from '../sales-document-capability-guard.service';
+
+describe('SalesDocumentTemplatesController', () => {
+  let service: jest.Mocked<Pick<ISalesDocumentRulesService, 'createRule'>>;
+  let capabilityGuard: jest.Mocked<Pick<SalesDocumentCapabilityGuardService, 'assertConnectionSupportsKind'>>;
+  let controller: SalesDocumentTemplatesController;
+
+  beforeEach(() => {
+    service = { createRule: jest.fn() };
+    capabilityGuard = { assertConnectionSupportsKind: jest.fn().mockResolvedValue(undefined) };
+    controller = new SalesDocumentTemplatesController(
+      service as unknown as ISalesDocumentRulesService,
+      capabilityGuard as unknown as SalesDocumentCapabilityGuardService,
+    );
+  });
+
+  describe('listTemplates', () => {
+    it('should return only markets with researched guidance when listed', () => {
+      expect(controller.listTemplates()).toEqual({
+        countries: [{ country: 'PL', sourceLabel: 'ksef.podatki.gov.pl', sourceUrl: 'https://ksef.podatki.gov.pl/' }],
+      });
+    });
+
+    it('should create nothing when the catalogue is listed', () => {
+      controller.listTemplates();
+      expect(service.createRule).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getTemplate', () => {
+    it('should report 404 when the country has no curated template', () => {
+      expect(() => controller.getTemplate('DE')).toThrow(NotFoundException);
+    });
+
+    it('should flag the rules that condition on a buyer tax id when Poland is previewed', () => {
+      const template = controller.getTemplate('PL');
+      expect(template.country).toBe('PL');
+      expect(template.rules.every((rule) => rule.usesBuyerHasTaxId)).toBe(true);
+    });
+  });
+
+  describe('adoptTemplate', () => {
+    it('should reject adoption when the country has no curated template', async () => {
+      await expect(controller.adoptTemplate('DE', { selections: [] })).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+      expect(service.createRule).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/sales-documents/http/sales-document-templates.controller.ts
+++ b/apps/api/src/sales-documents/http/sales-document-templates.controller.ts
@@ -21,8 +21,10 @@ import {
 } from '@openlinker/core/sales-documents';
 import {
   getSalesDocumentStarterTemplate,
+  listSalesDocumentTemplateCountries,
   SALES_DOCUMENT_TEMPLATE_PROVENANCE_BY_COUNTRY,
-} from '../data/pl-starter-template';
+  type SalesDocumentTemplateSummary,
+} from '../data/sales-document-template-catalogue';
 import { AdoptSalesDocumentTemplateDto } from './dto/adopt-sales-document-template.dto';
 import { SalesDocumentRuleResponseDto } from './dto/sales-document-rule-response.dto';
 import { SalesDocumentCapabilityGuardService } from '../sales-document-capability-guard.service';
@@ -37,6 +39,20 @@ export class SalesDocumentTemplatesController {
     private readonly service: ISalesDocumentRulesService,
     private readonly capabilityGuard: SalesDocumentCapabilityGuardService,
   ) {}
+
+  @Get()
+  @ApiOperation({
+    summary: 'List every market a curated starter template exists for',
+    description:
+      'The catalogue, as data. A country missing from this list has no researched guidance, which a ' +
+      'surface may state as such rather than offering a recommendation it cannot back. Poland is the ' +
+      'only entry today. Read-only: listing the catalogue creates no rule and no routing, and nothing ' +
+      'is applied until the operator adopts a template explicitly.',
+  })
+  @ApiResponse({ status: 200 })
+  listTemplates(): { countries: SalesDocumentTemplateSummary[] } {
+    return { countries: listSalesDocumentTemplateCountries() };
+  }
 
   @Get(':country')
   @ApiOperation({ summary: 'Preview the curated starter template for one country, if any exists' })


### PR DESCRIPTION
Closes #2529

## What this adds

- Renamed `apps/api/src/sales-documents/data/pl-starter-template.ts` to `sales-document-template-catalogue.ts` since it is the country-keyed catalogue mechanism, not Poland-specific content. No behavior change from the rename itself.
- `listSalesDocumentTemplateCountries()`: every country carrying a curated starter template, each with `{ country, sourceLabel, sourceUrl }`. Poland is the only entry.
- `hasSalesDocumentStarterTemplate(country)`: boolean convenience over the existing `getSalesDocumentStarterTemplate`.
- `GET /sales-documents/templates`: lists the catalogue. Read-only, admin-guarded like its siblings, creates nothing.

## API shape for M6/M7

```
GET /sales-documents/templates
-> { countries: [{ country: string, sourceLabel: string, sourceUrl: string }] }
```

Existing, unchanged:
```
GET  /sales-documents/templates/:country          -> 200 preview | 404 (no template)
POST /sales-documents/templates/:country/adopt     -> 201 created rules | 404 | 400
```

## Decisions a reviewer could dispute

- The listing endpoint is a bare `GET /sales-documents/templates` with no `:country` segment, distinct from the existing `GET /sales-documents/templates/:country` preview. Kept them as sibling routes on the same controller rather than overloading one route, since a listing and a single-country preview return structurally different shapes (a summary array vs. a full rule preview) and a 404-capable route should not also answer a "list everything" query.
- `hasSalesDocumentStarterTemplate` duplicates the null-check a caller could do inline against `getSalesDocumentStarterTemplate`. Added it anyway because the acceptance criteria call out "absence is a first-class answer" as a thing a caller should be able to ask directly, without needing to know the shape of what `getSalesDocumentStarterTemplate` returns when it does exist.
- The catalogue file's absence semantics (`getSalesDocumentStarterTemplate` returning `null` for an unknown country) were already correct before this task; nothing needed fixing there, only the listing surface was missing.

## What was left out and why

- No second country was added. The issue and ADR-066 are explicit that Poland is the only researched market today; adding a placeholder second entry would misstate what has been researched.
- No FE consumption in this PR - that is M6/M7's job, against the shape above.

## Verification

- `pnpm --filter @openlinker/api type-check` - clean.
- `npx eslint apps/api/src/sales-documents --ext .ts` - clean.
- `pnpm --filter @openlinker/api exec jest apps/api/src/sales-documents` - 4 suites, 20 tests passing (all pre-existing plus the two new spec files).
- `pnpm check:invariants` (filtered of `.worktrees` noise) - all green, including `check-sales-document-reason-mirror` and the other sales-documents-adjacent mirrors, unaffected by this change.