### PR TITLE
feat(sales-documents): merged market list with per-row routing outcome

### DIFF
--- a/apps/api/src/sales-documents/http/dto/sales-document-market-response.dto.ts
+++ b/apps/api/src/sales-documents/http/dto/sales-document-market-response.dto.ts
@@ -1,0 +1,118 @@
+/**
+ * Sales-Document Merged Market Response DTOs (#2530, ADR-066)
+ *
+ * The settings page's single read: configured markets and detected markets in
+ * one shape, ordered so a market needing a decision comes first. Composing
+ * this in the browser from three separate reads (configured countries,
+ * detected markets, the template catalogue) would put the classification
+ * logic - and the risk of drift between two implementations of the same
+ * evaluator - in the client. This is a READ. It creates no rule, no country
+ * default, and no acknowledgment.
+ *
+ * Every row carries every field: a country that is only detected reports
+ * `ruleCount: 0` / null defaults rather than being a differently-shaped row,
+ * and a country that is only configured reports `orderCount: null` rather
+ * than `0` - `null` here means "not observed in the discovery window",
+ * distinct from a genuine zero, which the discovery read can never produce
+ * (`DetectedSalesDocumentMarket.orderCount` is always at least 1).
+ *
+ * `outcome` is the market's EFFECTIVE routing decision, resolved through the
+ * same shipped evaluator every real order resolves through
+ * (`ISalesDocumentRulesService.resolveRoutingBatch`) - never re-derived or
+ * hand-written here, per the routing-first invariant (ADR-041 amendment
+ * #2504). Because no single real order exists for this read, the evaluator is
+ * given a REPRESENTATIVE order for the country: `buyerHasTaxId: undefined`
+ * (the honest state - unless a caller collects and passes a real one, this is
+ * what OpenLinker knows about every order in the country) and no amount
+ * (`totalGross: 0`, `taxTreatment: undefined`), so an amount-conditioned rule
+ * correctly reports the same `net-priced-order` signal it would for a real
+ * order whose tax treatment isn't asserted. This is what surfaces the live
+ * Poland defect honestly: three rules that all test `buyerHasTaxId` cannot
+ * resolve against an order that carries no such fact, and this row says so
+ * instead of asserting the routing "works" for a case the evaluator has never
+ * actually been asked to decide.
+ *
+ * @module apps/api/src/sales-documents/http/dto
+ * @see docs/architecture/adrs/066-sales-document-market-discovery.md
+ */
+import { ApiProperty } from '@nestjs/swagger';
+import type { SalesDocumentDecision } from '@openlinker/core/sales-documents';
+
+export class SalesDocumentMarketOutcomeDto {
+  @ApiProperty({ enum: ['route', 'aggregate', 'unresolved'] })
+  kind!: 'route' | 'aggregate' | 'unresolved';
+
+  @ApiProperty({ required: false, nullable: true, description: 'Set when kind is "route".' })
+  documentKind?: string | null;
+
+  @ApiProperty({
+    required: false,
+    description: 'The connection this market resolves to. Set when kind is "route" or "aggregate".',
+  })
+  connectionId?: string;
+
+  @ApiProperty({ required: false, description: 'Set when kind is "unresolved".' })
+  reason?: string;
+
+  static fromDomain(decision: SalesDocumentDecision): SalesDocumentMarketOutcomeDto {
+    const dto = new SalesDocumentMarketOutcomeDto();
+    dto.kind = decision.kind;
+    if (decision.kind === 'route') {
+      dto.documentKind = decision.documentKind;
+      dto.connectionId = decision.connectionId;
+    } else if (decision.kind === 'aggregate') {
+      dto.connectionId = decision.connectionId;
+    } else {
+      dto.reason = decision.reason;
+    }
+    return dto;
+  }
+}
+
+export class SalesDocumentMarketRowDto {
+  @ApiProperty({ description: "ISO 3166-1 alpha-2, or '*' for Rest of world." })
+  country!: string;
+
+  @ApiProperty({
+    nullable: true,
+    description:
+      'Orders billed to this country in the discovery window, or null when the country was not ' +
+      'detected at all (a configured-only market). Never 0 - a detected market always has at least ' +
+      'one order.',
+  })
+  orderCount!: number | null;
+
+  @ApiProperty({ description: 'Whether a curated starter template exists for this country.' })
+  hasTemplate!: boolean;
+
+  @ApiProperty({ description: 'How many sales_document_rules rows target this country.' })
+  ruleCount!: number;
+
+  @ApiProperty({ nullable: true })
+  invoiceDefaultConnectionId!: string | null;
+
+  @ApiProperty({ nullable: true })
+  receiptDefaultConnectionId!: string | null;
+
+  @ApiProperty({ nullable: true })
+  acknowledgedNoDocumentAt!: string | null;
+
+  @ApiProperty({ type: SalesDocumentMarketOutcomeDto })
+  outcome!: SalesDocumentMarketOutcomeDto;
+}
+
+export class SalesDocumentMarketsResponseDto {
+  @ApiProperty({ description: 'The discovery window actually applied, in days.' })
+  windowDays!: number;
+
+  @ApiProperty({ description: 'ISO-8601 lower bound the detected order counts were taken from.' })
+  since!: string;
+
+  @ApiProperty({
+    type: [SalesDocumentMarketRowDto],
+    description:
+      'One row per country that is either configured or has orders in the discovery window. A ' +
+      'country in both never appears twice.',
+  })
+  markets!: SalesDocumentMarketRowDto[];
+}

--- a/apps/api/src/sales-documents/http/sales-document-markets.controller.spec.ts
+++ b/apps/api/src/sales-documents/http/sales-document-markets.controller.spec.ts
@@ -7,12 +7,15 @@ import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { ORDER_RECORD_SERVICE_TOKEN } from '@openlinker/core/orders';
 import type { IOrderRecordService } from '@openlinker/core/orders';
+import { SALES_DOCUMENT_RULES_SERVICE_TOKEN } from '@openlinker/core/sales-documents';
+import type { ISalesDocumentRulesService } from '@openlinker/core/sales-documents';
 
 import { SalesDocumentMarketsController } from './sales-document-markets.controller';
 
 describe('SalesDocumentMarketsController', () => {
   let controller: SalesDocumentMarketsController;
   let orderRecords: { discoverSalesDocumentMarkets: jest.Mock };
+  let rules: { listConfiguredCountries: jest.Mock; resolveRoutingBatch: jest.Mock };
 
   beforeEach(async () => {
     orderRecords = {
@@ -22,6 +25,10 @@ describe('SalesDocumentMarketsController', () => {
         markets: [],
       }),
     };
+    rules = {
+      listConfiguredCountries: jest.fn().mockResolvedValue([]),
+      resolveRoutingBatch: jest.fn().mockResolvedValue([]),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [SalesDocumentMarketsController],
@@ -29,6 +36,10 @@ describe('SalesDocumentMarketsController', () => {
         {
           provide: ORDER_RECORD_SERVICE_TOKEN,
           useValue: orderRecords as unknown as IOrderRecordService,
+        },
+        {
+          provide: SALES_DOCUMENT_RULES_SERVICE_TOKEN,
+          useValue: rules as unknown as ISalesDocumentRulesService,
         },
       ],
     }).compile();
@@ -90,5 +101,105 @@ describe('SalesDocumentMarketsController', () => {
     // Nothing else on the service is reachable from this controller: it holds
     // one dependency and calls one read. Discovery never creates routing.
     expect(Object.keys(orderRecords)).toEqual(['discoverSalesDocumentMarkets']);
+  });
+
+  describe('listMarkets', () => {
+    it('should merge a detected-only market and a configured-only market into two distinct rows', async () => {
+      orderRecords.discoverSalesDocumentMarkets.mockResolvedValue({
+        windowDays: 30,
+        since: '2026-07-31T10:00:00.000Z',
+        markets: [{ country: 'DE', orderCount: 12 }],
+      });
+      rules.listConfiguredCountries.mockResolvedValue([
+        {
+          country: 'PL',
+          ruleCount: 3,
+          invoiceDefaultConnectionId: 'c-ksef',
+          receiptDefaultConnectionId: 'c-epar',
+          acknowledgedNoDocumentAt: null,
+        },
+      ]);
+      rules.resolveRoutingBatch.mockResolvedValue([
+        { kind: 'unresolved', reason: 'no-matching-rule' },
+        { kind: 'unresolved', reason: 'no-configuration-for-country' },
+      ]);
+
+      const result = await controller.listMarkets();
+
+      expect(result.markets).toHaveLength(2);
+      const byCountry = new Map(result.markets.map((m) => [m.country, m]));
+      expect(byCountry.get('PL')).toMatchObject({ orderCount: null, ruleCount: 3 });
+      expect(byCountry.get('DE')).toMatchObject({ orderCount: 12, ruleCount: 0 });
+    });
+
+    it('should merge one row when a market is both configured and detected', async () => {
+      orderRecords.discoverSalesDocumentMarkets.mockResolvedValue({
+        windowDays: 30,
+        since: '2026-07-31T10:00:00.000Z',
+        markets: [{ country: 'PL', orderCount: 47 }],
+      });
+      rules.listConfiguredCountries.mockResolvedValue([
+        {
+          country: 'PL',
+          ruleCount: 3,
+          invoiceDefaultConnectionId: null,
+          receiptDefaultConnectionId: null,
+          acknowledgedNoDocumentAt: null,
+        },
+      ]);
+      rules.resolveRoutingBatch.mockResolvedValue([{ kind: 'unresolved', reason: 'no-matching-rule' }]);
+
+      const result = await controller.listMarkets();
+
+      expect(result.markets).toHaveLength(1);
+      expect(result.markets[0]).toMatchObject({ country: 'PL', orderCount: 47, ruleCount: 3 });
+    });
+
+    it('should resolve each row\'s outcome through the shared evaluator, never a hand-derived value', async () => {
+      orderRecords.discoverSalesDocumentMarkets.mockResolvedValue({
+        windowDays: 30,
+        since: '2026-07-31T10:00:00.000Z',
+        markets: [{ country: 'PL', orderCount: 47 }],
+      });
+      rules.listConfiguredCountries.mockResolvedValue([]);
+      rules.resolveRoutingBatch.mockResolvedValue([
+        { kind: 'route', documentKind: 'invoice', connectionId: 'c-ksef' },
+      ]);
+
+      const result = await controller.listMarkets();
+
+      expect(result.markets[0].outcome).toEqual({ kind: 'route', documentKind: 'invoice', connectionId: 'c-ksef' });
+      expect(rules.resolveRoutingBatch).toHaveBeenCalledWith([
+        expect.objectContaining({ country: 'PL', buyerHasTaxId: undefined }),
+      ]);
+    });
+
+    it('should report a template only for a market the catalogue has guidance for', async () => {
+      orderRecords.discoverSalesDocumentMarkets.mockResolvedValue({
+        windowDays: 30,
+        since: '2026-07-31T10:00:00.000Z',
+        markets: [
+          { country: 'PL', orderCount: 47 },
+          { country: 'DE', orderCount: 12 },
+        ],
+      });
+      rules.listConfiguredCountries.mockResolvedValue([]);
+      rules.resolveRoutingBatch.mockResolvedValue([
+        { kind: 'unresolved', reason: 'no-configuration-for-country' },
+        { kind: 'unresolved', reason: 'no-configuration-for-country' },
+      ]);
+
+      const result = await controller.listMarkets();
+
+      const byCountry = new Map(result.markets.map((m) => [m.country, m]));
+      expect(byCountry.get('PL')?.hasTemplate).toBe(true);
+      expect(byCountry.get('DE')?.hasTemplate).toBe(false);
+    });
+
+    it('should never write anything while listing markets', async () => {
+      await controller.listMarkets();
+
+      expect(Object.keys(rules)).toEqual(['listConfiguredCountries', 'resolveRoutingBatch']);
+    });
   });
 });

--- a/apps/api/src/sales-documents/http/sales-document-markets.controller.ts
+++ b/apps/api/src/sales-documents/http/sales-document-markets.controller.ts
@@ -27,8 +27,37 @@
 import { Controller, Get, HttpCode, HttpStatus, Inject } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { IOrderRecordService, ORDER_RECORD_SERVICE_TOKEN } from '@openlinker/core/orders';
+import {
+  type ISalesDocumentRulesService,
+  SALES_DOCUMENT_RULES_SERVICE_TOKEN,
+  type SalesDocumentOrderFacts,
+} from '@openlinker/core/sales-documents';
 import { Roles } from '../../auth/decorators/roles.decorator';
+import { hasSalesDocumentStarterTemplate } from '../data/sales-document-template-catalogue';
 import { DetectedMarketsResponseDto } from './dto/detected-market-response.dto';
+import {
+  SalesDocumentMarketOutcomeDto,
+  SalesDocumentMarketRowDto,
+  SalesDocumentMarketsResponseDto,
+} from './dto/sales-document-market-response.dto';
+
+/**
+ * Builds the REPRESENTATIVE order facts a market's row is evaluated against
+ * (see the response DTO's own doc comment for why this is honest rather than
+ * a guess): no buyer tax id asserted, no amount asserted. `★ Rest of world`
+ * is not itself evaluated as a country here - its rules/defaults are read as
+ * the FALLBACK scope for every other country, exactly as a real order's
+ * evaluation would use them.
+ */
+function toRepresentativeOrderFacts(country: string): SalesDocumentOrderFacts {
+  return {
+    country,
+    totalGross: 0,
+    currency: '',
+    buyerHasTaxId: undefined,
+    taxTreatment: undefined,
+  };
+}
 
 @Roles('admin')
 @ApiBearerAuth()
@@ -38,6 +67,8 @@ export class SalesDocumentMarketsController {
   constructor(
     @Inject(ORDER_RECORD_SERVICE_TOKEN)
     private readonly orderRecords: IOrderRecordService,
+    @Inject(SALES_DOCUMENT_RULES_SERVICE_TOKEN)
+    private readonly rules: ISalesDocumentRulesService,
   ) {}
 
   @Get('markets/detected')
@@ -64,5 +95,57 @@ export class SalesDocumentMarketsController {
         orderCount: market.orderCount,
       })),
     };
+  }
+
+  @Get('markets')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Configured and detected markets, merged, with each market\'s effective routing outcome',
+    description:
+      'One row per country that is either configured (carries a rule, a country default, or a ' +
+      '"no document by choice" acknowledgment) or has orders in the discovery window - a country in ' +
+      'both never appears twice. Each row carries its effective outcome, resolved through the SAME ' +
+      'evaluator every real order resolves through, against a representative order for that country ' +
+      '(no buyer tax id asserted, no amount asserted) - never a hand-written guess. Read-only: this ' +
+      'never creates a rule, a default, or an acknowledgment.',
+  })
+  @ApiResponse({ status: 200, type: SalesDocumentMarketsResponseDto })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async listMarkets(): Promise<SalesDocumentMarketsResponseDto> {
+    const [discovery, configured] = await Promise.all([
+      this.orderRecords.discoverSalesDocumentMarkets(),
+      this.rules.listConfiguredCountries(),
+    ]);
+
+    const orderCountByCountry = new Map(discovery.markets.map((m) => [m.country, m.orderCount] as const));
+    const configuredByCountry = new Map(configured.map((c) => [c.country, c] as const));
+
+    // `★ Rest of world` appears as its own row only when it is itself
+    // CONFIGURED (carries a rule, a default, or an acknowledgment) —
+    // `listConfiguredCountries` already includes it in that case. It is
+    // never synthesized here: a real order's country is never literally
+    // `'*'`, so it can never be "detected", and adding a phantom row for an
+    // unconfigured Rest of world would assert a market exists that nobody
+    // has set up and no order has ever needed.
+    const countries = new Set<string>([...orderCountByCountry.keys(), ...configuredByCountry.keys()]);
+    const countryList = [...countries];
+    const orderFacts = countryList.map(toRepresentativeOrderFacts);
+    const outcomes = await this.rules.resolveRoutingBatch(orderFacts);
+
+    const markets: SalesDocumentMarketRowDto[] = countryList.map((country, index) => {
+      const summary = configuredByCountry.get(country);
+      const row = new SalesDocumentMarketRowDto();
+      row.country = country;
+      row.orderCount = orderCountByCountry.get(country) ?? null;
+      row.hasTemplate = hasSalesDocumentStarterTemplate(country);
+      row.ruleCount = summary?.ruleCount ?? 0;
+      row.invoiceDefaultConnectionId = summary?.invoiceDefaultConnectionId ?? null;
+      row.receiptDefaultConnectionId = summary?.receiptDefaultConnectionId ?? null;
+      row.acknowledgedNoDocumentAt = summary?.acknowledgedNoDocumentAt ?? null;
+      row.outcome = SalesDocumentMarketOutcomeDto.fromDomain(outcomes[index]);
+      return row;
+    });
+
+    return { windowDays: discovery.windowDays, since: discovery.since, markets };
   }
 }


### PR DESCRIPTION
Closes #2530

## What this adds

`GET /sales-documents/markets`: one row per country that is either configured (carries a rule, a country default, or a no-document acknowledgment) or has orders in the M1 discovery window. A country in both merges into one row.

## API shape for M6/M7

```
GET /sales-documents/markets
-> {
  windowDays: number,
  since: string,
  markets: [{
    country: string,
    orderCount: number | null,        // null = not detected in the window
    hasTemplate: boolean,
    ruleCount: number,
    invoiceDefaultConnectionId: string | null,
    receiptDefaultConnectionId: string | null,
    acknowledgedNoDocumentAt: string | null,
    outcome: {
      kind: 'route' | 'aggregate' | 'unresolved',
      documentKind?: string | null,   // set when kind === 'route'
      connectionId?: string,          // set when kind === 'route' or 'aggregate'
      reason?: string,                // set when kind === 'unresolved'
    },
  }]
}
```

Unchanged: `GET /sales-documents/markets/detected` (M1) stays the plain discovery read with no classification.

## How `outcome` is computed

Each row's `outcome` is resolved through `ISalesDocumentRulesService.resolveRoutingBatch` - the exact same evaluator every real order resolves through (`evaluateSalesDocumentRules`) - never hand-derived or re-implemented. It is one batched call across every row's country, not N calls, reusing the batch method #2516 already shipped for the orders-list projection.

Because there is no single real order to evaluate against, each row is evaluated against a **representative** order for its country: `buyerHasTaxId: undefined` and no amount (`totalGross: 0`, `taxTreatment: undefined`). Both are honest rather than guessed:

- `buyerHasTaxId: undefined` is the actual state of every order in the system whose source has not supplied one - not an assumption, a fact.
- Leaving `taxTreatment` unasserted means an amount-conditioned rule reports the same `net-priced-order` signal the evaluator already reports for a real order with no known tax treatment, rather than fabricating a total that could make the row "route" when a real order might not.

This is what surfaces the live Poland defect honestly: all three of Poland's starter-template rules test `buyerHasTaxId`, which the representative order does not assert, so the row reports `unresolved` with the real reason instead of asserting the routing "works" for a case the evaluator has never been asked to resolve for real.

## Decisions a reviewer could dispute

- `★ Rest of world` (`'*'`) is included as its own row only when it is itself configured (via `listConfiguredCountries`). It is never synthesized as a phantom always-present row, because a real order's country is never literally `'*'` (so it can never be "detected"), and adding one unconditionally would assert a market exists that nobody set up.
- The outcome type mirrors `SalesDocumentDecision` almost verbatim rather than collapsing to a simpler shape, since the frontend needs to distinguish `route` / `aggregate` / `unresolved` to render the settings table correctly per ADR-041's routing-first invariant (never a kind picker, state the persisted/resolved reason).
- `hasSalesDocumentStarterTemplate` (from #2529, already merged into this mini-epic branch) is used directly rather than composing the `GET /sales-documents/templates` listing endpoint internally, since both read the same in-process constant with no I/O - going through the HTTP layer would add nothing.

## What was left out and why

- No caching or memoization of the per-request template/rule reads - the endpoint is a settings-page-only, admin-gated, infrequent read, and `resolveRoutingBatch` is already a 3-query batch regardless of row count.
- No pagination - matches `listConfiguredCountries`' own documented "no pagination" stance.

## Verification

- `pnpm --filter @openlinker/api type-check` - clean.
- `npx eslint apps/api/src/sales-documents --ext .ts` - clean.
- `pnpm --filter @openlinker/api exec jest apps/api/src/sales-documents` - 4 suites, 25 tests passing.
- `pnpm check:invariants` (filtered of `.worktrees` noise) - all green.