### PR TITLE
feat(sales-documents): acknowledged markets never report unresolved in the merged list

### DIFF
--- a/apps/api/src/sales-documents/http/dto/sales-document-market-response.dto.ts
+++ b/apps/api/src/sales-documents/http/dto/sales-document-market-response.dto.ts
@@ -32,6 +32,20 @@
  * instead of asserting the routing "works" for a case the evaluator has never
  * actually been asked to decide.
  *
+ * `outcome.kind === 'acknowledged'` is a FOURTH state the evaluator itself
+ * cannot produce (#2531): an acknowledged market carries no rule and no
+ * default by construction (`acknowledgeNoDocument` / `createRule` /
+ * `upsertCountryDefault` mutually and automatically clear one another,
+ * `sales-document-rules.service.ts`), so `resolveRoutingBatch` would
+ * correctly-but-uselessly answer `unresolved`/`no-configuration-for-country`
+ * for it. Reporting that here would be a real regression, not a cosmetic
+ * one: it is exactly the state #2186's acknowledgment exists to distinguish
+ * from an outstanding problem, and this merged list is the one place that
+ * distinction has to survive into. The controller therefore overrides the
+ * evaluator's real answer with `acknowledged` whenever the row carries a
+ * `acknowledgedNoDocumentAt` - an acknowledged market is never reported as
+ * `unresolved`.
+ *
  * @module apps/api/src/sales-documents/http/dto
  * @see docs/architecture/adrs/066-sales-document-market-discovery.md
  */
@@ -39,8 +53,8 @@ import { ApiProperty } from '@nestjs/swagger';
 import type { SalesDocumentDecision } from '@openlinker/core/sales-documents';
 
 export class SalesDocumentMarketOutcomeDto {
-  @ApiProperty({ enum: ['route', 'aggregate', 'unresolved'] })
-  kind!: 'route' | 'aggregate' | 'unresolved';
+  @ApiProperty({ enum: ['route', 'aggregate', 'unresolved', 'acknowledged'] })
+  kind!: 'route' | 'aggregate' | 'unresolved' | 'acknowledged';
 
   @ApiProperty({ required: false, nullable: true, description: 'Set when kind is "route".' })
   documentKind?: string | null;
@@ -65,6 +79,13 @@ export class SalesDocumentMarketOutcomeDto {
     } else {
       dto.reason = decision.reason;
     }
+    return dto;
+  }
+
+  /** The market has been acknowledged as "no document, by design" (#2186 / #2531). */
+  static acknowledged(): SalesDocumentMarketOutcomeDto {
+    const dto = new SalesDocumentMarketOutcomeDto();
+    dto.kind = 'acknowledged';
     return dto;
   }
 }

--- a/apps/api/src/sales-documents/http/sales-document-markets.controller.spec.ts
+++ b/apps/api/src/sales-documents/http/sales-document-markets.controller.spec.ts
@@ -201,5 +201,35 @@ describe('SalesDocumentMarketsController', () => {
 
       expect(Object.keys(rules)).toEqual(['listConfiguredCountries', 'resolveRoutingBatch']);
     });
+
+    it('should never report an acknowledged market as unresolved (#2531)', async () => {
+      orderRecords.discoverSalesDocumentMarkets.mockResolvedValue({
+        windowDays: 30,
+        since: '2026-07-31T10:00:00.000Z',
+        markets: [],
+      });
+      rules.listConfiguredCountries.mockResolvedValue([
+        {
+          country: 'GB',
+          ruleCount: 0,
+          invoiceDefaultConnectionId: null,
+          receiptDefaultConnectionId: null,
+          acknowledgedNoDocumentAt: '2026-08-01T00:00:00.000Z',
+        },
+      ]);
+      // Acknowledgment and configuration are mutually exclusive by
+      // construction, so the evaluator's real answer for GB would be
+      // exactly this — proving the override, not a scenario that cannot
+      // happen.
+      rules.resolveRoutingBatch.mockResolvedValue([
+        { kind: 'unresolved', reason: 'no-configuration-for-country' },
+      ]);
+
+      const result = await controller.listMarkets();
+
+      expect(result.markets).toHaveLength(1);
+      expect(result.markets[0].acknowledgedNoDocumentAt).toBe('2026-08-01T00:00:00.000Z');
+      expect(result.markets[0].outcome).toEqual({ kind: 'acknowledged' });
+    });
   });
 });

--- a/apps/api/src/sales-documents/http/sales-document-markets.controller.ts
+++ b/apps/api/src/sales-documents/http/sales-document-markets.controller.ts
@@ -142,7 +142,16 @@ export class SalesDocumentMarketsController {
       row.invoiceDefaultConnectionId = summary?.invoiceDefaultConnectionId ?? null;
       row.receiptDefaultConnectionId = summary?.receiptDefaultConnectionId ?? null;
       row.acknowledgedNoDocumentAt = summary?.acknowledgedNoDocumentAt ?? null;
-      row.outcome = SalesDocumentMarketOutcomeDto.fromDomain(outcomes[index]);
+      // An acknowledged market is never reported as unresolved (#2531) -
+      // acknowledgment and configuration are mutually exclusive by
+      // construction, so the evaluator's real answer here would always be
+      // 'unresolved'/'no-configuration-for-country', which is exactly the
+      // outstanding-problem reading #2186's acknowledgment exists to rule
+      // out.
+      row.outcome =
+        row.acknowledgedNoDocumentAt !== null
+          ? SalesDocumentMarketOutcomeDto.acknowledged()
+          : SalesDocumentMarketOutcomeDto.fromDomain(outcomes[index]);
       return row;
     });
 


### PR DESCRIPTION
Closes #2531

## What was already there

The acknowledged "no document by choice" state was fully shipped by #2186, before this mini-epic existed:

- `ISalesDocumentRulesService.acknowledgeNoDocument(country)` / `.clearAcknowledgment(country)`
- `PUT` / `DELETE /sales-documents/countries/:country/acknowledgment`
- `acknowledgedNoDocumentAt` on `SalesDocumentCountrySummary`, surfaced by `listConfiguredCountries`
- Mutual exclusion: `createRule` / `upsertCountryDefault` auto-clear any acknowledgment for the country, and `acknowledgeNoDocument` refuses when the country already carries a rule or default (`SalesDocumentCountryAlreadyConfiguredException`)
- Set/read/clear round-trip already covered by `libs/core/src/sales-documents/application/services/sales-document-rules.service.spec.ts` (`describe('acknowledgment lifecycle (#2186)')`)
- `acknowledgedNoDocumentAt` was already present on every row of the #2530 merged market list (this mini-epic's own prior task)

## The actual gap

Because acknowledgment and configuration are mutually exclusive by construction, an acknowledged country carries zero rules and zero defaults - so the #2530 merged list's per-row `outcome`, computed through the real evaluator (`resolveRoutingBatch`) against a representative order, always answered `unresolved` / `no-configuration-for-country` for it. That is precisely the "outstanding problem" reading the acknowledgment exists to rule out, and it is a violation of the AC: "An acknowledged market is never reported as unresolved."

## The fix

Added a fourth outcome kind, `'acknowledged'`, on `SalesDocumentMarketOutcomeDto` (API-layer only - `SalesDocumentDecision` in core is untouched, since the evaluator's real answer for an unconfigured country genuinely is `unresolved` and that fact is not wrong, just not what this merged list should surface for an acknowledged row). `SalesDocumentMarketsController.listMarkets` substitutes it whenever a row's `acknowledgedNoDocumentAt` is non-null, instead of the evaluator's raw output.

## Decisions a reviewer could dispute

- The override lives at the API layer (`sales-document-markets.controller.ts`), not inside `sales-documents`'s `evaluateSalesDocumentRules`/`resolveRoutingBatch`. Keeping it there means the core evaluator's contract stays exactly "what would routing actually decide" with no acknowledgment-awareness baked in - the acknowledgment is a presentation-layer fact about *this specific merged read*, not a new evaluator tier. Given the mutual-exclusion invariant already lives in the write path, and the read path already has both pieces of data (`summary.acknowledgedNoDocumentAt` and the evaluator's own answer) in hand, overriding here is the smaller and more honest change.
- `'acknowledged'` carries no `reason` field. There is nothing more specific to say - the market was deliberately marked as issuing nothing, which is itself the complete answer.

## What was left out and why

- No change to core `sales-documents` - the AC's remaining three bullets (round-trip, clear-returns-to-underlying-state, set/read/clear spec coverage) were already satisfied by #2186 and needed no new code, only verification.

## Verification

- `pnpm --filter @openlinker/api type-check` - clean.
- `npx eslint apps/api/src/sales-documents --ext .ts` - clean.
- `pnpm --filter @openlinker/api exec jest apps/api/src/sales-documents` - 4 suites, 26 tests passing.
- `pnpm check:invariants` (filtered of `.worktrees` noise) - all green.