### PR TITLE
test(integrations): verify and cover the per-connection routing writes

### DIFF
--- a/apps/api/src/integrations/http/connection.controller.spec.ts
+++ b/apps/api/src/integrations/http/connection.controller.spec.ts
@@ -422,6 +422,72 @@ describe('ConnectionController', () => {
         status: 'disabled',
       });
     });
+
+    // #2532: document kind, "goes first" and trigger are written through this
+    // same generic PATCH via the open `config` JSONB passthrough
+    // (`config.salesDocument.documentKind`, `config.invoicing.isPrimary`,
+    // `config.invoicing.triggerModel` — ADR-041 decision 4, #2047, #2159). A
+    // connection with no document kind is not a routing candidate at all, so
+    // these three fields are load-bearing: this suite pins that the
+    // controller forwards each of them to the service untouched, with no
+    // schema stripping any of the three keys.
+    it('should forward config.salesDocument.documentKind unchanged (#2532)', async () => {
+      service.update.mockResolvedValue(mockConnection);
+
+      const dto = { config: { salesDocument: { documentKind: 'invoice' } } };
+      await controller.update('connection-123', dto, mockAdminUser);
+
+      expect(service.update).toHaveBeenCalledWith('connection-123', {
+        config: { salesDocument: { documentKind: 'invoice' } },
+      });
+    });
+
+    it('should forward config.invoicing.isPrimary unchanged (#2532)', async () => {
+      service.update.mockResolvedValue(mockConnection);
+
+      const dto = { config: { invoicing: { isPrimary: true } } };
+      await controller.update('connection-123', dto, mockAdminUser);
+
+      expect(service.update).toHaveBeenCalledWith('connection-123', {
+        config: { invoicing: { isPrimary: true } },
+      });
+    });
+
+    it('should forward config.invoicing.triggerModel unchanged (#2532)', async () => {
+      service.update.mockResolvedValue(mockConnection);
+
+      const dto = { config: { invoicing: { triggerModel: 'on-paid' } } };
+      await controller.update('connection-123', dto, mockAdminUser);
+
+      expect(service.update).toHaveBeenCalledWith('connection-123', {
+        config: { invoicing: { triggerModel: 'on-paid' } },
+      });
+    });
+
+    it('should forward all three routing fields together in one write (#2532)', async () => {
+      service.update.mockResolvedValue(mockConnection);
+
+      const dto = {
+        config: {
+          salesDocument: { documentKind: 'fiscal-receipt' },
+          invoicing: { isPrimary: false, triggerModel: 'manual' },
+        },
+      };
+      await controller.update('connection-123', dto, mockAdminUser);
+
+      expect(service.update).toHaveBeenCalledWith('connection-123', { config: dto.config });
+    });
+
+    it('should clear the document kind by writing an empty string, matching the FE "Nothing" option (#2532)', async () => {
+      service.update.mockResolvedValue(mockConnection);
+
+      const dto = { config: { salesDocument: { documentKind: '' } } };
+      await controller.update('connection-123', dto, mockAdminUser);
+
+      expect(service.update).toHaveBeenCalledWith('connection-123', {
+        config: { salesDocument: { documentKind: '' } },
+      });
+    });
   });
 
   describe('disable', () => {


### PR DESCRIPTION
Closes #2532

## What was verified

Document kind, "goes first" (isPrimary) and trigger (triggerModel) - the three per-connection routing fields - are written through the existing generic `PATCH /connections/:id`, via `config.salesDocument.documentKind` / `config.invoicing.isPrimary` / `config.invoicing.triggerModel`. This is the open `config` JSONB passthrough already shipped by ADR-041 decision 4 / #2047 / #2159; `UpdateConnectionDto.config: Record<string, unknown>` has no schema, and `ConnectionController.update` forwards it to `ConnectionService.update` verbatim.

**Nothing had to change functionally.** The write path was already correct: the controller does not strip or reshape any config key, and the frontend (`mergeSalesDocumentConfig`, `apps/web/src/features/sales-documents/lib/merge-sales-document-config.ts`, #2159) already merges only the two nested keys it owns while preserving every sibling config key (`rateLimit`, `pricingRule`, `stockSafetyBuffer`, etc.).

## The actual gap: test coverage

No spec asserted that any of the three fields - individually or together - actually survives the controller unmodified. Added five tests to `ConnectionController.update`:

- `config.salesDocument.documentKind` forwarded unchanged
- `config.invoicing.isPrimary` forwarded unchanged
- `config.invoicing.triggerModel` forwarded unchanged
- all three together in one write
- clearing the document kind via an empty string (`documentKind: ''`) is forwarded byte-for-byte at this layer - the FE's own choice to `delete` the key instead on empty-string is a separate, already-documented decision (`mergeSalesDocumentConfig`'s own doc comment) and is out of this controller's scope

## The one-primary-across-all-connections rule (AC item 3)

Already asserted, no new coverage needed:

- `libs/core/src/sales-documents/domain/domain-services/resolve-sales-document-routing.spec.ts`: "should resolve unresolved/ambiguous-connection-no-primary when several candidates and none is primary" and "...MORE than one primary" (decision 6)
- `libs/core/src/invoicing/application/services/auto-issue-trigger.service.spec.ts`

## Explicit record: what changed vs. what didn't

- **Changed**: nothing in production code. Only `apps/api/src/integrations/http/connection.controller.spec.ts`.
- **Not changed, and why**: no save-time capability check was added to this write path (unlike `SalesDocumentCapabilityGuardService` on the rule-engine's `createRule`/`upsertCountryDefault`/`adoptTemplate` endpoints). This is a **known, pre-existing asymmetry**, not something #2532 introduced: an operator can PATCH `config.salesDocument.documentKind = 'invoice'` onto a connection with no `Invoicing` capability enabled. It is not silent, though - `AutoIssueTriggerService` already reports this at issuance time as a persisted, operator-visible `unsupported-document-kind-on-connection` block reason (see `docs/architecture-overview.md` § Invoicing, "Cross-capability auto-issue gate"). Closing it at save time (mirroring the rule-engine's guard) would be a real improvement, but it is a genuinely separate, larger change - it needs the connections controller to depend on a sales-documents-owned guard service, a new dependency edge this task's scope did not ask for and the mini-epic's other tasks did not surface as blocking. Filed as a finding rather than silently left out.

## Verification

- `pnpm --filter @openlinker/api type-check` - clean.
- `npx eslint apps/api/src/integrations/http/connection.controller.spec.ts` - clean.
- `pnpm --filter @openlinker/api exec jest apps/api/src/integrations/http/connection.controller.spec.ts` - 34 tests passing (29 pre-existing + 5 new).
- `pnpm check:invariants` (filtered of `.worktrees` noise) - all green.

Note: running this spec locally required `pnpm --filter @openlinker/plugin-sdk build` first (a pre-existing worktree state issue - the module resolves through a workspace `dist/` that had not been built yet - unrelated to this change).