### PR TITLE
feat(sales-documents): M4 - the routing configuration surface (#2528)

### DIFF
--- a/apps/api/src/integrations/http/connection.controller.spec.ts
+++ b/apps/api/src/integrations/http/connection.controller.spec.ts
@@ -422,6 +422,72 @@ describe('ConnectionController', () => {
         status: 'disabled',
       });
     });
+
+    // #2532: document kind, "goes first" and trigger are written through this
+    // same generic PATCH via the open `config` JSONB passthrough
+    // (`config.salesDocument.documentKind`, `config.invoicing.isPrimary`,
+    // `config.invoicing.triggerModel` — ADR-041 decision 4, #2047, #2159). A
+    // connection with no document kind is not a routing candidate at all, so
+    // these three fields are load-bearing: this suite pins that the
+    // controller forwards each of them to the service untouched, with no
+    // schema stripping any of the three keys.
+    it('should forward config.salesDocument.documentKind unchanged (#2532)', async () => {
+      service.update.mockResolvedValue(mockConnection);
+
+      const dto = { config: { salesDocument: { documentKind: 'invoice' } } };
+      await controller.update('connection-123', dto, mockAdminUser);
+
+      expect(service.update).toHaveBeenCalledWith('connection-123', {
+        config: { salesDocument: { documentKind: 'invoice' } },
+      });
+    });
+
+    it('should forward config.invoicing.isPrimary unchanged (#2532)', async () => {
+      service.update.mockResolvedValue(mockConnection);
+
+      const dto = { config: { invoicing: { isPrimary: true } } };
+      await controller.update('connection-123', dto, mockAdminUser);
+
+      expect(service.update).toHaveBeenCalledWith('connection-123', {
+        config: { invoicing: { isPrimary: true } },
+      });
+    });
+
+    it('should forward config.invoicing.triggerModel unchanged (#2532)', async () => {
+      service.update.mockResolvedValue(mockConnection);
+
+      const dto = { config: { invoicing: { triggerModel: 'on-paid' } } };
+      await controller.update('connection-123', dto, mockAdminUser);
+
+      expect(service.update).toHaveBeenCalledWith('connection-123', {
+        config: { invoicing: { triggerModel: 'on-paid' } },
+      });
+    });
+
+    it('should forward all three routing fields together in one write (#2532)', async () => {
+      service.update.mockResolvedValue(mockConnection);
+
+      const dto = {
+        config: {
+          salesDocument: { documentKind: 'fiscal-receipt' },
+          invoicing: { isPrimary: false, triggerModel: 'manual' },
+        },
+      };
+      await controller.update('connection-123', dto, mockAdminUser);
+
+      expect(service.update).toHaveBeenCalledWith('connection-123', { config: dto.config });
+    });
+
+    it('should clear the document kind by writing an empty string, matching the FE "Nothing" option (#2532)', async () => {
+      service.update.mockResolvedValue(mockConnection);
+
+      const dto = { config: { salesDocument: { documentKind: '' } } };
+      await controller.update('connection-123', dto, mockAdminUser);
+
+      expect(service.update).toHaveBeenCalledWith('connection-123', {
+        config: { salesDocument: { documentKind: '' } },
+      });
+    });
   });
 
   describe('disable', () => {

--- a/apps/api/src/sales-documents/data/sales-document-template-catalogue.spec.ts
+++ b/apps/api/src/sales-documents/data/sales-document-template-catalogue.spec.ts
@@ -1,0 +1,69 @@
+/**
+ * Sales-Document Starter-Template Catalogue Specs (#2529)
+ *
+ * Pins the two properties the settings surface depends on: the catalogue is
+ * country-keyed data with a citable source, and the ABSENCE of a template is
+ * a reportable answer rather than an empty template a surface could render as
+ * guidance.
+ *
+ * @module apps/api/src/sales-documents/data
+ */
+import {
+  getSalesDocumentStarterTemplate,
+  hasSalesDocumentStarterTemplate,
+  listSalesDocumentTemplateCountries,
+  SALES_DOCUMENT_TEMPLATE_PROVENANCE_BY_COUNTRY,
+} from './sales-document-template-catalogue';
+
+describe('sales-document starter-template catalogue', () => {
+  describe('listSalesDocumentTemplateCountries', () => {
+    it('should list Poland as the only researched market when read', () => {
+      expect(listSalesDocumentTemplateCountries().map((entry) => entry.country)).toEqual(['PL']);
+    });
+
+    it('should carry a citable source for every listed market when read', () => {
+      for (const entry of listSalesDocumentTemplateCountries()) {
+        expect(entry.sourceLabel.length).toBeGreaterThan(0);
+        expect(entry.sourceUrl).toMatch(/^https:\/\//);
+      }
+    });
+  });
+
+  describe('getSalesDocumentStarterTemplate', () => {
+    it('should report absence as null when the country has no researched guidance', () => {
+      expect(getSalesDocumentStarterTemplate('DE')).toBeNull();
+      expect(hasSalesDocumentStarterTemplate('DE')).toBe(false);
+    });
+
+    it('should never report absence as an empty template when the country has none', () => {
+      const template = getSalesDocumentStarterTemplate('CZ');
+      // An empty-but-present template would let a surface render "suggested
+      // setup" with nothing in it, which claims guidance that does not exist.
+      expect(template).toBeNull();
+    });
+
+    it('should resolve a lower-case country code when the caller passes one', () => {
+      expect(getSalesDocumentStarterTemplate('pl')?.country).toBe('PL');
+      expect(hasSalesDocumentStarterTemplate('pl')).toBe(true);
+    });
+
+    it('should carry the rule shapes and their required capability when Poland is read', () => {
+      const template = getSalesDocumentStarterTemplate('PL');
+      expect(template).not.toBeNull();
+      expect(template?.rules.map((rule) => rule.slot)).toEqual([
+        'no-tax-id',
+        'tax-id-below-threshold',
+        'tax-id-above-threshold',
+      ]);
+      for (const rule of template?.rules ?? []) {
+        expect(['Invoicing', 'Fiscalization']).toContain(rule.requiredCapability);
+      }
+    });
+
+    it('should carry a provenance tag for every listed market when adopted rows are written', () => {
+      for (const entry of listSalesDocumentTemplateCountries()) {
+        expect(SALES_DOCUMENT_TEMPLATE_PROVENANCE_BY_COUNTRY[entry.country]).toBeDefined();
+      }
+    });
+  });
+});

--- a/apps/api/src/sales-documents/data/sales-document-template-catalogue.ts
+++ b/apps/api/src/sales-documents/data/sales-document-template-catalogue.ts
@@ -1,23 +1,32 @@
 /**
- * Poland Starter Template — Sales-Document Rules (#2170)
+ * Sales-Document Starter-Template Catalogue (#2170, #2529)
  *
- * Poland-only curated seed content: sourced public guidance, an amount, and
- * the three rule SHAPES the mockup's "Review & adopt" screen previews. Ships
- * as DATA in `apps/api` — never as a literal string inside
- * `libs/core/src/sales-documents/**`, which is the acceptance criterion this
- * file exists to satisfy. No other country has a curated template yet; the
- * mechanism (`SalesDocumentTemplatesController`) is generic — a second
- * country's template is additive (another exported constant + one more
- * `TEMPLATES_BY_COUNTRY` entry), never a core code change.
+ * Country-keyed curated seed content: for each market we have researched
+ * public guidance for, a citable source and the rule SHAPES the "Review &
+ * adopt" screen previews. Poland is the only entry today.
+ *
+ * **Absence is a first-class answer, not silence** (ADR-066 decision 2). A
+ * country with no entry resolves `null` from
+ * {@link getSalesDocumentStarterTemplate} and is simply missing from
+ * {@link listSalesDocumentTemplateCountries}, so a surface can state "we have
+ * no guidance for this market" rather than presenting an empty template as
+ * though one existed. Nothing here recommends, applies or activates anything:
+ * reading the catalogue has no effect, and adoption is a separate explicit
+ * write (`POST /sales-documents/templates/:country/adopt`).
+ *
+ * Ships as DATA in `apps/api` - never as a literal string inside
+ * `libs/core/src/sales-documents/**`, which stays a zero-outbound-core-context
+ * -edge leaf and carries no market-specific content. A second country's
+ * template is additive: another exported constant plus one more
+ * `TEMPLATES_BY_COUNTRY` entry, never a core code change.
  *
  * Each template rule names a `requiredCapability` rather than a fixed
- * `connectionId` — the operator has not chosen a connection yet at preview
+ * `connectionId` - the operator has not chosen a connection yet at preview
  * time. "Review & adopt" resolves each slot against the operator's own
- * connections (client-side, from the same connections list the rest of this
- * feature already fetches) and POSTs the resolved `connectionId` per slot to
- * `/sales-documents/templates/PL/adopt`.
+ * connections and POSTs the resolved `connectionId` per slot.
  *
  * @module apps/api/src/sales-documents/data
+ * @see docs/architecture/adrs/066-sales-document-market-discovery.md
  */
 
 export interface SalesDocumentTemplateCondition {
@@ -119,3 +128,36 @@ export function getSalesDocumentStarterTemplate(country: string): SalesDocumentS
 export const SALES_DOCUMENT_TEMPLATE_PROVENANCE_BY_COUNTRY: Readonly<Record<string, string>> = {
   PL: 'PL starter template',
 };
+
+/** One catalogue entry, reduced to what a listing surface needs. */
+export interface SalesDocumentTemplateSummary {
+  readonly country: string;
+  readonly sourceLabel: string;
+  readonly sourceUrl: string;
+}
+
+/**
+ * Every country a curated starter template exists for, alphabetically.
+ *
+ * The list is the whole answer: a country missing from it has no guidance,
+ * which is a fact a surface may state. It never implies the market is
+ * unsupported or misconfigured.
+ */
+export function listSalesDocumentTemplateCountries(): SalesDocumentTemplateSummary[] {
+  return Object.values(TEMPLATES_BY_COUNTRY)
+    .map((template) => ({
+      country: template.country,
+      sourceLabel: template.sourceLabel,
+      sourceUrl: template.sourceUrl,
+    }))
+    .sort((a, b) => a.country.localeCompare(b.country));
+}
+
+/**
+ * Whether a curated starter template exists for `country`. Case-insensitive on
+ * the input, like {@link getSalesDocumentStarterTemplate}, so a country code
+ * read off an order matches the catalogue's canonical upper-case keys.
+ */
+export function hasSalesDocumentStarterTemplate(country: string): boolean {
+  return getSalesDocumentStarterTemplate(country) !== null;
+}

--- a/apps/api/src/sales-documents/http/dto/adopt-sales-document-template.dto.ts
+++ b/apps/api/src/sales-documents/http/dto/adopt-sales-document-template.dto.ts
@@ -2,7 +2,7 @@
  * Adopt Sales-Document Template DTO (#2170)
  *
  * The operator's per-slot connection selections for the "Review & adopt"
- * flow — see `apps/api/src/sales-documents/data/pl-starter-template.ts` for
+ * flow — see `apps/api/src/sales-documents/data/sales-document-template-catalogue.ts` for
  * the slot vocabulary. Adopting writes ORDINARY, fully-editable rows via the
  * same `createRule` path every other rule goes through, tagged with the
  * template's provenance string.

--- a/apps/api/src/sales-documents/http/dto/sales-document-market-response.dto.ts
+++ b/apps/api/src/sales-documents/http/dto/sales-document-market-response.dto.ts
@@ -1,0 +1,118 @@
+/**
+ * Sales-Document Merged Market Response DTOs (#2530, ADR-066)
+ *
+ * The settings page's single read: configured markets and detected markets in
+ * one shape, ordered so a market needing a decision comes first. Composing
+ * this in the browser from three separate reads (configured countries,
+ * detected markets, the template catalogue) would put the classification
+ * logic - and the risk of drift between two implementations of the same
+ * evaluator - in the client. This is a READ. It creates no rule, no country
+ * default, and no acknowledgment.
+ *
+ * Every row carries every field: a country that is only detected reports
+ * `ruleCount: 0` / null defaults rather than being a differently-shaped row,
+ * and a country that is only configured reports `orderCount: null` rather
+ * than `0` - `null` here means "not observed in the discovery window",
+ * distinct from a genuine zero, which the discovery read can never produce
+ * (`DetectedSalesDocumentMarket.orderCount` is always at least 1).
+ *
+ * `outcome` is the market's EFFECTIVE routing decision, resolved through the
+ * same shipped evaluator every real order resolves through
+ * (`ISalesDocumentRulesService.resolveRoutingBatch`) - never re-derived or
+ * hand-written here, per the routing-first invariant (ADR-041 amendment
+ * #2504). Because no single real order exists for this read, the evaluator is
+ * given a REPRESENTATIVE order for the country: `buyerHasTaxId: undefined`
+ * (the honest state - unless a caller collects and passes a real one, this is
+ * what OpenLinker knows about every order in the country) and no amount
+ * (`totalGross: 0`, `taxTreatment: undefined`), so an amount-conditioned rule
+ * correctly reports the same `net-priced-order` signal it would for a real
+ * order whose tax treatment isn't asserted. This is what surfaces the live
+ * Poland defect honestly: three rules that all test `buyerHasTaxId` cannot
+ * resolve against an order that carries no such fact, and this row says so
+ * instead of asserting the routing "works" for a case the evaluator has never
+ * actually been asked to decide.
+ *
+ * @module apps/api/src/sales-documents/http/dto
+ * @see docs/architecture/adrs/066-sales-document-market-discovery.md
+ */
+import { ApiProperty } from '@nestjs/swagger';
+import type { SalesDocumentDecision } from '@openlinker/core/sales-documents';
+
+export class SalesDocumentMarketOutcomeDto {
+  @ApiProperty({ enum: ['route', 'aggregate', 'unresolved'] })
+  kind!: 'route' | 'aggregate' | 'unresolved';
+
+  @ApiProperty({ required: false, nullable: true, description: 'Set when kind is "route".' })
+  documentKind?: string | null;
+
+  @ApiProperty({
+    required: false,
+    description: 'The connection this market resolves to. Set when kind is "route" or "aggregate".',
+  })
+  connectionId?: string;
+
+  @ApiProperty({ required: false, description: 'Set when kind is "unresolved".' })
+  reason?: string;
+
+  static fromDomain(decision: SalesDocumentDecision): SalesDocumentMarketOutcomeDto {
+    const dto = new SalesDocumentMarketOutcomeDto();
+    dto.kind = decision.kind;
+    if (decision.kind === 'route') {
+      dto.documentKind = decision.documentKind;
+      dto.connectionId = decision.connectionId;
+    } else if (decision.kind === 'aggregate') {
+      dto.connectionId = decision.connectionId;
+    } else {
+      dto.reason = decision.reason;
+    }
+    return dto;
+  }
+}
+
+export class SalesDocumentMarketRowDto {
+  @ApiProperty({ description: "ISO 3166-1 alpha-2, or '*' for Rest of world." })
+  country!: string;
+
+  @ApiProperty({
+    nullable: true,
+    description:
+      'Orders billed to this country in the discovery window, or null when the country was not ' +
+      'detected at all (a configured-only market). Never 0 - a detected market always has at least ' +
+      'one order.',
+  })
+  orderCount!: number | null;
+
+  @ApiProperty({ description: 'Whether a curated starter template exists for this country.' })
+  hasTemplate!: boolean;
+
+  @ApiProperty({ description: 'How many sales_document_rules rows target this country.' })
+  ruleCount!: number;
+
+  @ApiProperty({ nullable: true })
+  invoiceDefaultConnectionId!: string | null;
+
+  @ApiProperty({ nullable: true })
+  receiptDefaultConnectionId!: string | null;
+
+  @ApiProperty({ nullable: true })
+  acknowledgedNoDocumentAt!: string | null;
+
+  @ApiProperty({ type: SalesDocumentMarketOutcomeDto })
+  outcome!: SalesDocumentMarketOutcomeDto;
+}
+
+export class SalesDocumentMarketsResponseDto {
+  @ApiProperty({ description: 'The discovery window actually applied, in days.' })
+  windowDays!: number;
+
+  @ApiProperty({ description: 'ISO-8601 lower bound the detected order counts were taken from.' })
+  since!: string;
+
+  @ApiProperty({
+    type: [SalesDocumentMarketRowDto],
+    description:
+      'One row per country that is either configured or has orders in the discovery window. A ' +
+      'country in both never appears twice.',
+  })
+  markets!: SalesDocumentMarketRowDto[];
+}

--- a/apps/api/src/sales-documents/http/dto/sales-document-market-response.dto.ts
+++ b/apps/api/src/sales-documents/http/dto/sales-document-market-response.dto.ts
@@ -32,6 +32,20 @@
  * instead of asserting the routing "works" for a case the evaluator has never
  * actually been asked to decide.
  *
+ * `outcome.kind === 'acknowledged'` is a FOURTH state the evaluator itself
+ * cannot produce (#2531): an acknowledged market carries no rule and no
+ * default by construction (`acknowledgeNoDocument` / `createRule` /
+ * `upsertCountryDefault` mutually and automatically clear one another,
+ * `sales-document-rules.service.ts`), so `resolveRoutingBatch` would
+ * correctly-but-uselessly answer `unresolved`/`no-configuration-for-country`
+ * for it. Reporting that here would be a real regression, not a cosmetic
+ * one: it is exactly the state #2186's acknowledgment exists to distinguish
+ * from an outstanding problem, and this merged list is the one place that
+ * distinction has to survive into. The controller therefore overrides the
+ * evaluator's real answer with `acknowledged` whenever the row carries a
+ * `acknowledgedNoDocumentAt` - an acknowledged market is never reported as
+ * `unresolved`.
+ *
  * @module apps/api/src/sales-documents/http/dto
  * @see docs/architecture/adrs/066-sales-document-market-discovery.md
  */
@@ -39,8 +53,8 @@ import { ApiProperty } from '@nestjs/swagger';
 import type { SalesDocumentDecision } from '@openlinker/core/sales-documents';
 
 export class SalesDocumentMarketOutcomeDto {
-  @ApiProperty({ enum: ['route', 'aggregate', 'unresolved'] })
-  kind!: 'route' | 'aggregate' | 'unresolved';
+  @ApiProperty({ enum: ['route', 'aggregate', 'unresolved', 'acknowledged'] })
+  kind!: 'route' | 'aggregate' | 'unresolved' | 'acknowledged';
 
   @ApiProperty({ required: false, nullable: true, description: 'Set when kind is "route".' })
   documentKind?: string | null;
@@ -65,6 +79,13 @@ export class SalesDocumentMarketOutcomeDto {
     } else {
       dto.reason = decision.reason;
     }
+    return dto;
+  }
+
+  /** The market has been acknowledged as "no document, by design" (#2186 / #2531). */
+  static acknowledged(): SalesDocumentMarketOutcomeDto {
+    const dto = new SalesDocumentMarketOutcomeDto();
+    dto.kind = 'acknowledged';
     return dto;
   }
 }

--- a/apps/api/src/sales-documents/http/sales-document-markets.controller.spec.ts
+++ b/apps/api/src/sales-documents/http/sales-document-markets.controller.spec.ts
@@ -7,12 +7,15 @@ import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { ORDER_RECORD_SERVICE_TOKEN } from '@openlinker/core/orders';
 import type { IOrderRecordService } from '@openlinker/core/orders';
+import { SALES_DOCUMENT_RULES_SERVICE_TOKEN } from '@openlinker/core/sales-documents';
+import type { ISalesDocumentRulesService } from '@openlinker/core/sales-documents';
 
 import { SalesDocumentMarketsController } from './sales-document-markets.controller';
 
 describe('SalesDocumentMarketsController', () => {
   let controller: SalesDocumentMarketsController;
   let orderRecords: { discoverSalesDocumentMarkets: jest.Mock };
+  let rules: { listConfiguredCountries: jest.Mock; resolveRoutingBatch: jest.Mock };
 
   beforeEach(async () => {
     orderRecords = {
@@ -22,6 +25,10 @@ describe('SalesDocumentMarketsController', () => {
         markets: [],
       }),
     };
+    rules = {
+      listConfiguredCountries: jest.fn().mockResolvedValue([]),
+      resolveRoutingBatch: jest.fn().mockResolvedValue([]),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [SalesDocumentMarketsController],
@@ -29,6 +36,10 @@ describe('SalesDocumentMarketsController', () => {
         {
           provide: ORDER_RECORD_SERVICE_TOKEN,
           useValue: orderRecords as unknown as IOrderRecordService,
+        },
+        {
+          provide: SALES_DOCUMENT_RULES_SERVICE_TOKEN,
+          useValue: rules as unknown as ISalesDocumentRulesService,
         },
       ],
     }).compile();
@@ -90,5 +101,105 @@ describe('SalesDocumentMarketsController', () => {
     // Nothing else on the service is reachable from this controller: it holds
     // one dependency and calls one read. Discovery never creates routing.
     expect(Object.keys(orderRecords)).toEqual(['discoverSalesDocumentMarkets']);
+  });
+
+  describe('listMarkets', () => {
+    it('should merge a detected-only market and a configured-only market into two distinct rows', async () => {
+      orderRecords.discoverSalesDocumentMarkets.mockResolvedValue({
+        windowDays: 30,
+        since: '2026-07-31T10:00:00.000Z',
+        markets: [{ country: 'DE', orderCount: 12 }],
+      });
+      rules.listConfiguredCountries.mockResolvedValue([
+        {
+          country: 'PL',
+          ruleCount: 3,
+          invoiceDefaultConnectionId: 'c-ksef',
+          receiptDefaultConnectionId: 'c-epar',
+          acknowledgedNoDocumentAt: null,
+        },
+      ]);
+      rules.resolveRoutingBatch.mockResolvedValue([
+        { kind: 'unresolved', reason: 'no-matching-rule' },
+        { kind: 'unresolved', reason: 'no-configuration-for-country' },
+      ]);
+
+      const result = await controller.listMarkets();
+
+      expect(result.markets).toHaveLength(2);
+      const byCountry = new Map(result.markets.map((m) => [m.country, m]));
+      expect(byCountry.get('PL')).toMatchObject({ orderCount: null, ruleCount: 3 });
+      expect(byCountry.get('DE')).toMatchObject({ orderCount: 12, ruleCount: 0 });
+    });
+
+    it('should merge one row when a market is both configured and detected', async () => {
+      orderRecords.discoverSalesDocumentMarkets.mockResolvedValue({
+        windowDays: 30,
+        since: '2026-07-31T10:00:00.000Z',
+        markets: [{ country: 'PL', orderCount: 47 }],
+      });
+      rules.listConfiguredCountries.mockResolvedValue([
+        {
+          country: 'PL',
+          ruleCount: 3,
+          invoiceDefaultConnectionId: null,
+          receiptDefaultConnectionId: null,
+          acknowledgedNoDocumentAt: null,
+        },
+      ]);
+      rules.resolveRoutingBatch.mockResolvedValue([{ kind: 'unresolved', reason: 'no-matching-rule' }]);
+
+      const result = await controller.listMarkets();
+
+      expect(result.markets).toHaveLength(1);
+      expect(result.markets[0]).toMatchObject({ country: 'PL', orderCount: 47, ruleCount: 3 });
+    });
+
+    it('should resolve each row\'s outcome through the shared evaluator, never a hand-derived value', async () => {
+      orderRecords.discoverSalesDocumentMarkets.mockResolvedValue({
+        windowDays: 30,
+        since: '2026-07-31T10:00:00.000Z',
+        markets: [{ country: 'PL', orderCount: 47 }],
+      });
+      rules.listConfiguredCountries.mockResolvedValue([]);
+      rules.resolveRoutingBatch.mockResolvedValue([
+        { kind: 'route', documentKind: 'invoice', connectionId: 'c-ksef' },
+      ]);
+
+      const result = await controller.listMarkets();
+
+      expect(result.markets[0].outcome).toEqual({ kind: 'route', documentKind: 'invoice', connectionId: 'c-ksef' });
+      expect(rules.resolveRoutingBatch).toHaveBeenCalledWith([
+        expect.objectContaining({ country: 'PL', buyerHasTaxId: undefined }),
+      ]);
+    });
+
+    it('should report a template only for a market the catalogue has guidance for', async () => {
+      orderRecords.discoverSalesDocumentMarkets.mockResolvedValue({
+        windowDays: 30,
+        since: '2026-07-31T10:00:00.000Z',
+        markets: [
+          { country: 'PL', orderCount: 47 },
+          { country: 'DE', orderCount: 12 },
+        ],
+      });
+      rules.listConfiguredCountries.mockResolvedValue([]);
+      rules.resolveRoutingBatch.mockResolvedValue([
+        { kind: 'unresolved', reason: 'no-configuration-for-country' },
+        { kind: 'unresolved', reason: 'no-configuration-for-country' },
+      ]);
+
+      const result = await controller.listMarkets();
+
+      const byCountry = new Map(result.markets.map((m) => [m.country, m]));
+      expect(byCountry.get('PL')?.hasTemplate).toBe(true);
+      expect(byCountry.get('DE')?.hasTemplate).toBe(false);
+    });
+
+    it('should never write anything while listing markets', async () => {
+      await controller.listMarkets();
+
+      expect(Object.keys(rules)).toEqual(['listConfiguredCountries', 'resolveRoutingBatch']);
+    });
   });
 });

--- a/apps/api/src/sales-documents/http/sales-document-markets.controller.spec.ts
+++ b/apps/api/src/sales-documents/http/sales-document-markets.controller.spec.ts
@@ -201,5 +201,35 @@ describe('SalesDocumentMarketsController', () => {
 
       expect(Object.keys(rules)).toEqual(['listConfiguredCountries', 'resolveRoutingBatch']);
     });
+
+    it('should never report an acknowledged market as unresolved (#2531)', async () => {
+      orderRecords.discoverSalesDocumentMarkets.mockResolvedValue({
+        windowDays: 30,
+        since: '2026-07-31T10:00:00.000Z',
+        markets: [],
+      });
+      rules.listConfiguredCountries.mockResolvedValue([
+        {
+          country: 'GB',
+          ruleCount: 0,
+          invoiceDefaultConnectionId: null,
+          receiptDefaultConnectionId: null,
+          acknowledgedNoDocumentAt: '2026-08-01T00:00:00.000Z',
+        },
+      ]);
+      // Acknowledgment and configuration are mutually exclusive by
+      // construction, so the evaluator's real answer for GB would be
+      // exactly this — proving the override, not a scenario that cannot
+      // happen.
+      rules.resolveRoutingBatch.mockResolvedValue([
+        { kind: 'unresolved', reason: 'no-configuration-for-country' },
+      ]);
+
+      const result = await controller.listMarkets();
+
+      expect(result.markets).toHaveLength(1);
+      expect(result.markets[0].acknowledgedNoDocumentAt).toBe('2026-08-01T00:00:00.000Z');
+      expect(result.markets[0].outcome).toEqual({ kind: 'acknowledged' });
+    });
   });
 });

--- a/apps/api/src/sales-documents/http/sales-document-markets.controller.ts
+++ b/apps/api/src/sales-documents/http/sales-document-markets.controller.ts
@@ -27,8 +27,37 @@
 import { Controller, Get, HttpCode, HttpStatus, Inject } from '@nestjs/common';
 import { ApiBearerAuth, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
 import { IOrderRecordService, ORDER_RECORD_SERVICE_TOKEN } from '@openlinker/core/orders';
+import {
+  type ISalesDocumentRulesService,
+  SALES_DOCUMENT_RULES_SERVICE_TOKEN,
+  type SalesDocumentOrderFacts,
+} from '@openlinker/core/sales-documents';
 import { Roles } from '../../auth/decorators/roles.decorator';
+import { hasSalesDocumentStarterTemplate } from '../data/sales-document-template-catalogue';
 import { DetectedMarketsResponseDto } from './dto/detected-market-response.dto';
+import {
+  SalesDocumentMarketOutcomeDto,
+  SalesDocumentMarketRowDto,
+  SalesDocumentMarketsResponseDto,
+} from './dto/sales-document-market-response.dto';
+
+/**
+ * Builds the REPRESENTATIVE order facts a market's row is evaluated against
+ * (see the response DTO's own doc comment for why this is honest rather than
+ * a guess): no buyer tax id asserted, no amount asserted. `★ Rest of world`
+ * is not itself evaluated as a country here - its rules/defaults are read as
+ * the FALLBACK scope for every other country, exactly as a real order's
+ * evaluation would use them.
+ */
+function toRepresentativeOrderFacts(country: string): SalesDocumentOrderFacts {
+  return {
+    country,
+    totalGross: 0,
+    currency: '',
+    buyerHasTaxId: undefined,
+    taxTreatment: undefined,
+  };
+}
 
 @Roles('admin')
 @ApiBearerAuth()
@@ -38,6 +67,8 @@ export class SalesDocumentMarketsController {
   constructor(
     @Inject(ORDER_RECORD_SERVICE_TOKEN)
     private readonly orderRecords: IOrderRecordService,
+    @Inject(SALES_DOCUMENT_RULES_SERVICE_TOKEN)
+    private readonly rules: ISalesDocumentRulesService,
   ) {}
 
   @Get('markets/detected')
@@ -64,5 +95,57 @@ export class SalesDocumentMarketsController {
         orderCount: market.orderCount,
       })),
     };
+  }
+
+  @Get('markets')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Configured and detected markets, merged, with each market\'s effective routing outcome',
+    description:
+      'One row per country that is either configured (carries a rule, a country default, or a ' +
+      '"no document by choice" acknowledgment) or has orders in the discovery window - a country in ' +
+      'both never appears twice. Each row carries its effective outcome, resolved through the SAME ' +
+      'evaluator every real order resolves through, against a representative order for that country ' +
+      '(no buyer tax id asserted, no amount asserted) - never a hand-written guess. Read-only: this ' +
+      'never creates a rule, a default, or an acknowledgment.',
+  })
+  @ApiResponse({ status: 200, type: SalesDocumentMarketsResponseDto })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions' })
+  async listMarkets(): Promise<SalesDocumentMarketsResponseDto> {
+    const [discovery, configured] = await Promise.all([
+      this.orderRecords.discoverSalesDocumentMarkets(),
+      this.rules.listConfiguredCountries(),
+    ]);
+
+    const orderCountByCountry = new Map(discovery.markets.map((m) => [m.country, m.orderCount] as const));
+    const configuredByCountry = new Map(configured.map((c) => [c.country, c] as const));
+
+    // `★ Rest of world` appears as its own row only when it is itself
+    // CONFIGURED (carries a rule, a default, or an acknowledgment) —
+    // `listConfiguredCountries` already includes it in that case. It is
+    // never synthesized here: a real order's country is never literally
+    // `'*'`, so it can never be "detected", and adding a phantom row for an
+    // unconfigured Rest of world would assert a market exists that nobody
+    // has set up and no order has ever needed.
+    const countries = new Set<string>([...orderCountByCountry.keys(), ...configuredByCountry.keys()]);
+    const countryList = [...countries];
+    const orderFacts = countryList.map(toRepresentativeOrderFacts);
+    const outcomes = await this.rules.resolveRoutingBatch(orderFacts);
+
+    const markets: SalesDocumentMarketRowDto[] = countryList.map((country, index) => {
+      const summary = configuredByCountry.get(country);
+      const row = new SalesDocumentMarketRowDto();
+      row.country = country;
+      row.orderCount = orderCountByCountry.get(country) ?? null;
+      row.hasTemplate = hasSalesDocumentStarterTemplate(country);
+      row.ruleCount = summary?.ruleCount ?? 0;
+      row.invoiceDefaultConnectionId = summary?.invoiceDefaultConnectionId ?? null;
+      row.receiptDefaultConnectionId = summary?.receiptDefaultConnectionId ?? null;
+      row.acknowledgedNoDocumentAt = summary?.acknowledgedNoDocumentAt ?? null;
+      row.outcome = SalesDocumentMarketOutcomeDto.fromDomain(outcomes[index]);
+      return row;
+    });
+
+    return { windowDays: discovery.windowDays, since: discovery.since, markets };
   }
 }

--- a/apps/api/src/sales-documents/http/sales-document-markets.controller.ts
+++ b/apps/api/src/sales-documents/http/sales-document-markets.controller.ts
@@ -142,7 +142,16 @@ export class SalesDocumentMarketsController {
       row.invoiceDefaultConnectionId = summary?.invoiceDefaultConnectionId ?? null;
       row.receiptDefaultConnectionId = summary?.receiptDefaultConnectionId ?? null;
       row.acknowledgedNoDocumentAt = summary?.acknowledgedNoDocumentAt ?? null;
-      row.outcome = SalesDocumentMarketOutcomeDto.fromDomain(outcomes[index]);
+      // An acknowledged market is never reported as unresolved (#2531) -
+      // acknowledgment and configuration are mutually exclusive by
+      // construction, so the evaluator's real answer here would always be
+      // 'unresolved'/'no-configuration-for-country', which is exactly the
+      // outstanding-problem reading #2186's acknowledgment exists to rule
+      // out.
+      row.outcome =
+        row.acknowledgedNoDocumentAt !== null
+          ? SalesDocumentMarketOutcomeDto.acknowledged()
+          : SalesDocumentMarketOutcomeDto.fromDomain(outcomes[index]);
       return row;
     });
 

--- a/apps/api/src/sales-documents/http/sales-document-templates.controller.spec.ts
+++ b/apps/api/src/sales-documents/http/sales-document-templates.controller.spec.ts
@@ -1,0 +1,58 @@
+/**
+ * Sales-Document Templates Controller Specs (#2529)
+ *
+ * @module apps/api/src/sales-documents/http
+ */
+import { NotFoundException } from '@nestjs/common';
+import type { ISalesDocumentRulesService } from '@openlinker/core/sales-documents';
+import { SalesDocumentTemplatesController } from './sales-document-templates.controller';
+import type { SalesDocumentCapabilityGuardService } from '../sales-document-capability-guard.service';
+
+describe('SalesDocumentTemplatesController', () => {
+  let service: jest.Mocked<Pick<ISalesDocumentRulesService, 'createRule'>>;
+  let capabilityGuard: jest.Mocked<Pick<SalesDocumentCapabilityGuardService, 'assertConnectionSupportsKind'>>;
+  let controller: SalesDocumentTemplatesController;
+
+  beforeEach(() => {
+    service = { createRule: jest.fn() };
+    capabilityGuard = { assertConnectionSupportsKind: jest.fn().mockResolvedValue(undefined) };
+    controller = new SalesDocumentTemplatesController(
+      service as unknown as ISalesDocumentRulesService,
+      capabilityGuard as unknown as SalesDocumentCapabilityGuardService,
+    );
+  });
+
+  describe('listTemplates', () => {
+    it('should return only markets with researched guidance when listed', () => {
+      expect(controller.listTemplates()).toEqual({
+        countries: [{ country: 'PL', sourceLabel: 'ksef.podatki.gov.pl', sourceUrl: 'https://ksef.podatki.gov.pl/' }],
+      });
+    });
+
+    it('should create nothing when the catalogue is listed', () => {
+      controller.listTemplates();
+      expect(service.createRule).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getTemplate', () => {
+    it('should report 404 when the country has no curated template', () => {
+      expect(() => controller.getTemplate('DE')).toThrow(NotFoundException);
+    });
+
+    it('should flag the rules that condition on a buyer tax id when Poland is previewed', () => {
+      const template = controller.getTemplate('PL');
+      expect(template.country).toBe('PL');
+      expect(template.rules.every((rule) => rule.usesBuyerHasTaxId)).toBe(true);
+    });
+  });
+
+  describe('adoptTemplate', () => {
+    it('should reject adoption when the country has no curated template', async () => {
+      await expect(controller.adoptTemplate('DE', { selections: [] })).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
+      expect(service.createRule).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/api/src/sales-documents/http/sales-document-templates.controller.ts
+++ b/apps/api/src/sales-documents/http/sales-document-templates.controller.ts
@@ -21,8 +21,10 @@ import {
 } from '@openlinker/core/sales-documents';
 import {
   getSalesDocumentStarterTemplate,
+  listSalesDocumentTemplateCountries,
   SALES_DOCUMENT_TEMPLATE_PROVENANCE_BY_COUNTRY,
-} from '../data/pl-starter-template';
+  type SalesDocumentTemplateSummary,
+} from '../data/sales-document-template-catalogue';
 import { AdoptSalesDocumentTemplateDto } from './dto/adopt-sales-document-template.dto';
 import { SalesDocumentRuleResponseDto } from './dto/sales-document-rule-response.dto';
 import { SalesDocumentCapabilityGuardService } from '../sales-document-capability-guard.service';
@@ -37,6 +39,20 @@ export class SalesDocumentTemplatesController {
     private readonly service: ISalesDocumentRulesService,
     private readonly capabilityGuard: SalesDocumentCapabilityGuardService,
   ) {}
+
+  @Get()
+  @ApiOperation({
+    summary: 'List every market a curated starter template exists for',
+    description:
+      'The catalogue, as data. A country missing from this list has no researched guidance, which a ' +
+      'surface may state as such rather than offering a recommendation it cannot back. Poland is the ' +
+      'only entry today. Read-only: listing the catalogue creates no rule and no routing, and nothing ' +
+      'is applied until the operator adopts a template explicitly.',
+  })
+  @ApiResponse({ status: 200 })
+  listTemplates(): { countries: SalesDocumentTemplateSummary[] } {
+    return { countries: listSalesDocumentTemplateCountries() };
+  }
 
   @Get(':country')
   @ApiOperation({ summary: 'Preview the curated starter template for one country, if any exists' })


### PR DESCRIPTION
Mini-epic: closes #2528. Tasks #2529, #2530, #2531, #2532 — all merged into this branch (PRs #2721, #2722, #2723, #2724).

## What this adds

Country-keyed starter-template catalogue (`GET /sales-documents/templates`, Poland only today per ADR-066), a merged market list (`GET /sales-documents/markets`) that pairs detected order countries with configured routing state and a per-row routing outcome, and the "acknowledged, no document by choice" override so a deliberately-unconfigured country doesn't read as broken. #2532 adds controller-level test coverage for the three per-connection routing writes (documentKind, isPrimary, triggerModel).

## API shape for M6/M7

```
GET /sales-documents/templates -> { countries: [{ country, sourceLabel, sourceUrl }] }
GET /sales-documents/templates/:country          (unchanged: 200 preview | 404)
POST /sales-documents/templates/:country/adopt   (unchanged)
GET /sales-documents/markets/detected            (unchanged, M1 plain discovery)

GET /sales-documents/markets ->
{
  windowDays: number,
  since: string,
  markets: [{
    country: string,
    orderCount: number | null,
    hasTemplate: boolean,
    ruleCount: number,
    invoiceDefaultConnectionId: string | null,
    receiptDefaultConnectionId: string | null,
    acknowledgedNoDocumentAt: string | null,
    outcome: {
      kind: 'route' | 'aggregate' | 'unresolved' | 'acknowledged',
      documentKind?: string | null,
      connectionId?: string,
      reason?: string,
    },
  }]
}

PUT/DELETE /sales-documents/countries/:country/acknowledgment   (unchanged, #2186)
PATCH /connections/:id { config: { salesDocument: { documentKind }, invoicing: { isPrimary, triggerModel } } }
```

## Decisions worth review attention

- `outcome` on the merged list runs the real `resolveRoutingBatch` against a synthetic representative order (`buyerHasTaxId: undefined`, no amount asserted), never hand-derived — deliberate, to avoid guessing a fact that feeds a legal-document routing decision.
- `'*'` (Rest of world) only appears as its own row when it is itself configured.
- The `acknowledged` outcome kind is an API-layer presentation fact, not part of `SalesDocumentDecision` in core — kept out of the zero-outbound-edge sales-documents concern.
- #2532 found, filed but did not fix a pre-existing gap: connection `documentKind` writes have no save-time capability check (the rule engine has one). Not silent — `AutoIssueTriggerService` reports the mismatch at issuance time — but closing it at save time is out of this task's scope.

## Left out

No second country in the template catalogue (Poland only, per ADR-066 — no researched guidance yet for others). No FE consumption here — that's M6/M7. No caching/pagination on the markets read, matching the existing no-pagination stance for this admin-only settings page.

Gate: type-check clean across affected packages, `pnpm check:invariants` green, all commits GPG-verified.