### PR TITLE
fix(automation): assert dispatch BEHAVIOUR, not a class identity (#2711)

### DIFF
--- a/apps/worker/test/integration/automation-dispatch-boot.int-spec.ts
+++ b/apps/worker/test/integration/automation-dispatch-boot.int-spec.ts
@@ -54,15 +54,19 @@ import { ORDER_LIFECYCLE_RELAY_SERVICE_TOKEN } from '@openlinker/core/orders';
 const NOW = new Date('2026-08-31T10:00:00.000Z');
 
 /**
- * A rule carrying one A1 step. A1 is parameterless and resolves to
- * `UnavailableActionExecutorService` in this build, so the step is
- * deterministic and performs no I/O — no mailer, no relay, no outbound call —
- * while still proving the dispatcher's step loop ran.
+ * A rule carrying one IRREVERSIBLE step (A1). Named for that role rather than
+ * for its payload: test 2 depends on the irreversibility, not on documents.
+ *
+ * A1 is parameterless and, in this build, resolves to
+ * `UnavailableActionExecutorService` (`automation-action-executor.registry.ts`),
+ * so the step is deterministic and performs no I/O — no mailer, no relay, no
+ * outbound call — while still proving the dispatcher's step loop ran. Test 1
+ * PINS that inertness; see the comment there.
  *
  * `triggerConfig` is a real `EmptyTriggerConfig` (`{}`), which is what
  * `order.packed` carries; no cast is needed.
  */
-function issueDocumentRule(id: string): AutomationRule {
+function irreversibleRule(id: string): AutomationRule {
   return new AutomationRule(
     id,
     `Rule ${id}`,
@@ -126,7 +130,7 @@ describe('Automation action dispatch — DI boot (HARD GATE, #2361)', () => {
     // One rule cannot collide with itself, so it must survive #2362's gate and
     // reach the dispatcher. An inert binding records nothing at all.
     const record = spyOnRecorder();
-    const rule = issueDocumentRule('rule-survivor');
+    const rule = irreversibleRule('rule-survivor');
 
     await harness.get<IAutomationDispatchService>(AUTOMATION_DISPATCH_SERVICE_TOKEN).dispatch({
       trigger: 'order.packed',
@@ -142,6 +146,16 @@ describe('Automation action dispatch — DI boot (HARD GATE, #2361)', () => {
     // actions. A `blocked` verdict records an empty `steps` array by contract.
     expect(run.steps).toHaveLength(1);
     expect(run.steps[0].action).toBe('issue-sales-document');
+    // PIN, not decoration. This test executes a REAL executor chain for an
+    // IRREVERSIBLE action; it is safe only because A1 currently resolves to
+    // `UnavailableActionExecutorService`, which always reports `failed`. When
+    // A1 lands (#2361 — the gate service's docblock says it "arms the moment
+    // A1/A2 land") this assertion breaks and a human decides, instead of the
+    // boot suite silently issuing a fiscal document with every other assertion
+    // still green. Same rule as the `resolve_category` pin in
+    // engineering-standards § MCP tools: a latent write in the chain gets
+    // pinned so wiring it fails the build.
+    expect(run.steps[0].status).toBe('failed');
     // Kept although the two assertions above already exclude it (a `blocked`
     // verdict records `steps: []`): on a hard gate, a failure message that
     // names `blocked` explicitly beats one assertion fewer. A runtime check is
@@ -155,12 +169,17 @@ describe('Automation action dispatch — DI boot (HARD GATE, #2361)', () => {
     // Two rules claiming the same irreversible action: the gate refuses BOTH
     // (ADR-041 §6 — it never picks). A binding that resolved straight to
     // `AutomationDispatchService` would run both and issue two documents.
+    //
+    // DELIBERATELY NOT SYMMETRIC with test 1: this test needs no inertness pin
+    // and must not be given one. The gate blocks both rules by construction, so
+    // no executor is ever reached and there is no latent write to pin. Adding a
+    // step assertion here would assert something that cannot happen.
     const record = spyOnRecorder();
 
     await harness.get<IAutomationDispatchService>(AUTOMATION_DISPATCH_SERVICE_TOKEN).dispatch({
       trigger: 'order.packed',
       facts: { subjectKind: 'order', subjectId: 'ol_order_2711_collision' },
-      matchedRules: [issueDocumentRule('rule-a'), issueDocumentRule('rule-b')],
+      matchedRules: [irreversibleRule('rule-a'), irreversibleRule('rule-b')],
       now: NOW,
     });
 

--- a/apps/worker/test/integration/automation-dispatch-boot.int-spec.ts
+++ b/apps/worker/test/integration/automation-dispatch-boot.int-spec.ts
@@ -11,6 +11,23 @@
  * the worker: an unreplaced binding would leave every automation firing logged
  * and inert, which reads exactly like a rule that did not match.
  *
+ * **Why this asserts BEHAVIOUR and not a class identity (#2711).** Until #2711
+ * the gate read `expect(dispatcher).toBeInstanceOf(AutomationDispatchService)`.
+ * #2362 then bound the token to `AutomationIrreversibleGateService`, which
+ * **decorates** the real dispatcher — it partitions the matched rules and hands
+ * every survivor to `AutomationDispatchService` unchanged. The binding was
+ * correct and the assertion still went red: an identity check **cannot survive a
+ * legitimate decoration**. Nor could it survive in the other direction — a class
+ * merely *named* `AutomationDispatchService` would satisfy it while doing
+ * nothing. So the property is asserted where it actually lives, in what the
+ * token DOES:
+ *
+ * - an inert placeholder records no run at all           → test 1 fails;
+ * - a binding that bypasses #2362's gate runs both rules → test 2 fails.
+ *
+ * Do not "simplify" either test back to `toBeInstanceOf`. That is the check
+ * that cannot fail, and it is what #2711 removed.
+ *
  * **What this spec deliberately does NOT assert**: that every executor's
  * delegate token resolves. `MAILER_TOKEN` is bound only in `apps/api`, so such
  * an assertion would FAIL on correct behaviour. The worker's missing mailer is
@@ -25,9 +42,44 @@ import {
   AUTOMATION_RUN_RECORDER_TOKEN,
   AutomationActionExecutorRegistry,
   AutomationActionValues,
-  AutomationDispatchService,
+  AutomationRule,
+} from '@openlinker/core/automation';
+import type {
+  AutomationRunRecord,
+  IAutomationDispatchService,
+  IAutomationRunRecorderService,
 } from '@openlinker/core/automation';
 import { ORDER_LIFECYCLE_RELAY_SERVICE_TOKEN } from '@openlinker/core/orders';
+
+const NOW = new Date('2026-08-31T10:00:00.000Z');
+
+/**
+ * A rule carrying one A1 step. A1 is parameterless and resolves to
+ * `UnavailableActionExecutorService` in this build, so the step is
+ * deterministic and performs no I/O — no mailer, no relay, no outbound call —
+ * while still proving the dispatcher's step loop ran.
+ *
+ * `triggerConfig` is a real `EmptyTriggerConfig` (`{}`), which is what
+ * `order.packed` carries; no cast is needed.
+ */
+function issueDocumentRule(id: string): AutomationRule {
+  return new AutomationRule(
+    id,
+    `Rule ${id}`,
+    'order.packed',
+    {},
+    [],
+    [{ action: 'issue-sales-document' }],
+    `hash-${id}`,
+    true,
+    NOW,
+    null,
+    null,
+    null,
+    NOW,
+    NOW
+  );
+}
 
 describe('Automation action dispatch — DI boot (HARD GATE, #2361)', () => {
   let harness: WorkerIntegrationTestHarness;
@@ -44,11 +96,80 @@ describe('Automation action dispatch — DI boot (HARD GATE, #2361)', () => {
     await teardownTestHarness();
   });
 
-  it('resolves the REAL dispatcher, not #2360s inert placeholder', () => {
-    // The whole point of the #2360 seam was that #2361 is one provider binding.
-    // If the swap is missed, every firing logs and does nothing.
-    const dispatcher = harness.get(AUTOMATION_DISPATCH_SERVICE_TOKEN);
-    expect(dispatcher).toBeInstanceOf(AutomationDispatchService);
+  // LOAD-BEARING, not hygiene. The "resolves the run-recorder seam" test below
+  // resolves the SAME container singleton these two spy on, and runs after
+  // them — it is honest only because the restore happened. Do not tidy this
+  // into a `beforeAll`, or that test starts observing a stub.
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  /**
+   * Observe the dispatch through the container's own recorder singleton, with
+   * the write stubbed: the seam every outcome already reports through, so a
+   * dispatch that ran is visible without persisting an `automation_runs` row
+   * for a rule that was never inserted.
+   *
+   * **Why ONE spy can see BOTH branches**, which is what the two tests below
+   * depend on: `AUTOMATION_RUN_RECORDER_TOKEN` is the single seam the
+   * dispatcher reports a run through AND the gate reports a `blocked` verdict
+   * through (#2362 property 3). So "did this dispatch reach the real
+   * dispatcher, or was it blocked short of it" is answerable from one
+   * observation point, with no second write path that could disagree.
+   */
+  function spyOnRecorder(): jest.SpyInstance<Promise<void>, [AutomationRunRecord]> {
+    const recorder = harness.get<IAutomationRunRecorderService>(AUTOMATION_RUN_RECORDER_TOKEN);
+    return jest.spyOn(recorder, 'record').mockResolvedValue(undefined);
+  }
+
+  it('dispatches a surviving rule through the REAL dispatcher, not an inert placeholder', async () => {
+    // One rule cannot collide with itself, so it must survive #2362's gate and
+    // reach the dispatcher. An inert binding records nothing at all.
+    const record = spyOnRecorder();
+    const rule = issueDocumentRule('rule-survivor');
+
+    await harness.get<IAutomationDispatchService>(AUTOMATION_DISPATCH_SERVICE_TOKEN).dispatch({
+      trigger: 'order.packed',
+      facts: { subjectKind: 'order', subjectId: 'ol_order_2711' },
+      matchedRules: [rule],
+      now: NOW,
+    });
+
+    expect(record).toHaveBeenCalledTimes(1);
+    const run = record.mock.calls[0][0];
+    expect(run.rule.id).toBe('rule-survivor');
+    // Steps exist only if the dispatcher's own step loop ran over the rule's
+    // actions. A `blocked` verdict records an empty `steps` array by contract.
+    expect(run.steps).toHaveLength(1);
+    expect(run.steps[0].action).toBe('issue-sales-document');
+    // Kept although the two assertions above already exclude it (a `blocked`
+    // verdict records `steps: []`): on a hard gate, a failure message that
+    // names `blocked` explicitly beats one assertion fewer. A runtime check is
+    // also not dropped merely because something else currently implies it —
+    // the implication can be widened away silently, and then this was the only
+    // thing standing.
+    expect(run.outcome).not.toBe('blocked');
+  });
+
+  it('blocks colliding irreversible rules — #2362s gate is composed in, not bypassed', async () => {
+    // Two rules claiming the same irreversible action: the gate refuses BOTH
+    // (ADR-041 §6 — it never picks). A binding that resolved straight to
+    // `AutomationDispatchService` would run both and issue two documents.
+    const record = spyOnRecorder();
+
+    await harness.get<IAutomationDispatchService>(AUTOMATION_DISPATCH_SERVICE_TOKEN).dispatch({
+      trigger: 'order.packed',
+      facts: { subjectKind: 'order', subjectId: 'ol_order_2711_collision' },
+      matchedRules: [issueDocumentRule('rule-a'), issueDocumentRule('rule-b')],
+      now: NOW,
+    });
+
+    expect(record).toHaveBeenCalledTimes(2);
+    for (const [run] of record.mock.calls) {
+      expect(run.outcome).toBe('blocked');
+      // Nothing ran, so nothing may be reported as having run.
+      expect(run.steps).toHaveLength(0);
+    }
   });
 
   it('resolves the run-recorder seam #2385 will replace', () => {
@@ -58,7 +179,9 @@ describe('Automation action dispatch — DI boot (HARD GATE, #2361)', () => {
   it('registers an executor for EVERY declared action', () => {
     // A rule may be saved for any of the six (#2359 legality permits it), so an
     // uncovered action would fire silently rather than reporting why it cannot.
-    const registry = harness.get(AutomationActionExecutorRegistry);
+    const registry = harness.get<AutomationActionExecutorRegistry>(
+      AutomationActionExecutorRegistry
+    );
     for (const action of AutomationActionValues) {
       expect(registry.resolve(action)).toBeDefined();
     }

--- a/docs/plans/implementation-plan-2711-automation-dispatch-boot-gate.md
+++ b/docs/plans/implementation-plan-2711-automation-dispatch-boot-gate.md
@@ -1,0 +1,127 @@
+# Implementation Plan — #2711: `automation-dispatch-boot` HARD GATE is red on `oms-programme-wave-3a`
+
+## 1. The failure and its cause
+
+`apps/worker/test/integration/automation-dispatch-boot.int-spec.ts:51` asserts:
+
+```ts
+expect(dispatcher).toBeInstanceOf(AutomationDispatchService);
+```
+
+`AUTOMATION_DISPATCH_SERVICE_TOKEN` resolves to `AutomationIrreversibleGateService`
+(`automation.module.ts`, from #2362). Only that identity assertion fails; the other three
+tests in the file pass.
+
+## 2. The judgement: identity vs behaviour
+
+**#2362's binding is correct and must not be reverted.** Verified by reading the service:
+`AutomationIrreversibleGateService` **decorates** `AutomationDispatchService` —
+
+- it takes `AutomationDispatchService` as a concrete constructor dependency;
+- it partitions matched rules via the pure `gateIrreversibleAutomationActions`;
+- it hands **every survivor** to `this.dispatcher.dispatch(...)` unchanged
+  (`automation-irreversible-gate.service.ts:96`), skipping the call only when the survivor
+  set is empty (which would be a no-op iteration anyway);
+- blocked rules are recorded through the same `AUTOMATION_RUN_RECORDER_TOKEN` seam.
+
+It does not swallow survivors. `automation.module.ts` already documents this intent in a
+comment beside the binding. So the gate's **intent** ("the real dispatcher, not an inert
+placeholder") still holds; its **assertion** is a stale proxy — it tests class identity
+where the property defended is behavioural.
+
+**Resolution: replace the identity assertion with a behavioural one.** Rejected
+alternatives, each of which would leave a gate defending nothing (the "check that cannot
+fail" class, #2673/#2589/#2393):
+
+- `toBeInstanceOf(Object)` / deleting the assertion — passes for a placeholder.
+- `toBeInstanceOf(AutomationIrreversibleGateService)` — a class merely having the right
+  name satisfies it; an inert gate would pass.
+
+## 3. The change
+
+One file: `apps/worker/test/integration/automation-dispatch-boot.int-spec.ts`.
+
+Replace the single identity test with two behavioural tests, both driving the **real
+container-resolved** `AUTOMATION_DISPATCH_SERVICE_TOKEN` and observing through a `jest.spyOn`
+on the container's `AUTOMATION_RUN_RECORDER_TOKEN` singleton (`mockResolvedValue(undefined)` —
+so no `automation_runs` row is written and no FK on a non-existent rule is needed).
+
+1. **`dispatches a surviving rule through the REAL dispatcher, not an inert placeholder`**
+   One matched rule carrying `issue-sales-document`. With one rule there is no collision, so
+   it must survive the gate and reach the dispatcher. Assert `record` was called once, with
+   `outcome !== 'blocked'` and a **non-empty `steps`** array — steps only exist if the
+   dispatcher's `runRule` loop actually ran.
+   *An inert placeholder records nothing → red.*
+
+2. **`blocks colliding irreversible rules — the gate is composed in, not bypassed`**
+   Two matched rules both carrying `issue-sales-document`. Assert `record` called twice, each
+   with `outcome === 'blocked'` and `steps` empty.
+   *A bare `AutomationDispatchService` binding (gate bypassed) would run both → red.*
+
+Test 1 asserts the **positive** fact — exactly one step, whose `action` is
+`issue-sales-document` — rather than only `outcome !== 'blocked'`, so it reads as a claim about
+what ran instead of as the absence of one.
+
+`issue-sales-document` is chosen deliberately: it resolves to `UnavailableActionExecutorService`
+in this build, so the step is deterministic and side-effect-free — no mailer, no relay, no
+outbound call — while still proving the dispatcher body executed.
+
+Supporting edits in the same file:
+- drop the now-unused `AutomationDispatchService` import (avoids `TS6133`, which would present
+  as a false pass with `Tests: 0 total`);
+- add a local `issueDocumentRule(id)` fixture. It needs **no casts at all**: `EmptyTriggerConfig`
+  (`Record<string, never>`) is a member of the `AutomationTriggerConfig` union, so the plain `{}`
+  that `order.packed` carries type-checks directly — the unit spec's `{} as never` is not
+  reproduced here, and A1 is parameterless (`{ action: 'issue-sales-document' }`);
+- `afterEach` restores the spy;
+- **explicit type parameters on every `harness.get`** — `get<T = any>(token): T` defaults to
+  `any`, which yields an untyped spy whose `mock.calls[0][0]` is `any`: the shape that lets a
+  *wrong* assertion type-check, which on a hard gate is the failure being fixed. Both
+  `IAutomationDispatchService` and `IAutomationRunRecorderService` are exported from the
+  `@openlinker/core/automation` barrel, so no deep import is needed;
+- update the file docblock so it still states the property defended, and update the test titles
+  to name *behaviour* rather than a class.
+
+**No production code changes. No migration.**
+
+## 4. Docs
+
+`docs/architecture-overview.md` § Automation, line 508, already states that the token "resolves
+to `AutomationIrreversibleGateService`, which partitions the matched set ... and hands the
+survivors to `AutomationDispatchService`". That is exactly the composition the new tests assert,
+so **no doc amendment is required**. No production behaviour changes, so no ADR.
+
+The docblock of the spec itself carries the finding a future reader needs: an identity check
+could not survive a legitimate decoration, which is what happened here, and it is what stops
+someone "fixing" this back to `toBeInstanceOf` the next time a decorator lands.
+
+## 5. Red-first proof, in BOTH directions (required, not optional)
+
+The pair is only worth having if each half is falsifiable, so both are proven by temporarily
+rebinding `AUTOMATION_DISPATCH_SERVICE_TOKEN` in `automation.module.ts`:
+
+1. **Inert placeholder** (`useValue: { dispatch: () => Promise.resolve() }`) → **test 1 must
+   fail** on "recorder never called".
+2. **Gate bypassed** (`useExisting: AutomationDispatchService`) → **test 2 must fail** because
+   both colliding rules actually ran.
+
+Each red must be a real `Tests: N failed` assertion failure — **not** a `TS6133` compile red
+with `Tests: 0 total`, which is a false pass.
+
+**The rebinding reaches the test from SOURCE, not from `dist`.**
+`apps/worker/test/jest-integration.cjs:29-30` maps `^@openlinker/core/(.*)$` to
+`libs/core/src/$1`, so no `pnpm -r build` is needed for the experiment and inspecting
+`libs/core/dist` would prove nothing. (A `libs` build *is* needed once per fresh worktree for
+`@openlinker/test-kit`'s `dist`, which the Jest `globalSetup` loads as real build output.)
+
+**Revert and verify, then re-run green.** `git diff --stat` must show `automation.module.ts`
+untouched before commit, and the **final green run happens after the revert** — a green
+recorded before a revert is not evidence about the shipped tree. Leaving the experimental
+rebinding in a shipped commit would re-red the exact hard gate this issue exists to fix.
+
+## 6. Gates
+
+`pnpm lint` (0 errors), `pnpm type-check`, `pnpm test`, and the **worker** integration suite
+explicitly (root `test:integration` is `@openlinker/api` only, #2670), running this spec via
+`--runTestsByPath`. Known pre-existing and not chased: #2638, #2639, and the
+`inventory-location-propagation-e2e` salt gap (#2670).


### PR DESCRIPTION
Closes #2711

`automation-dispatch-boot` is a **HARD GATE** and it was red on `oms-programme-wave-3a`, so every Wave-3a PR inherited a red suite — which is how a real failure starts reading as background noise.

## Why change a hard gate's assertion

The first question any reviewer should ask. The answer is that this is a **strengthening, not a loosening**.

The assertion was `expect(dispatcher).toBeInstanceOf(AutomationDispatchService)`. #2362 then bound `AUTOMATION_DISPATCH_SERVICE_TOKEN` to `AutomationIrreversibleGateService`, which **decorates** the real dispatcher: it partitions the matched rules via the pure `gateIrreversibleAutomationActions` and hands **every survivor** to `AutomationDispatchService` unchanged (`automation-irreversible-gate.service.ts:96`), skipping the call only when the survivor set is empty — a no-op iteration anyway.

So #2362's binding is **correct** and the assertion was the stale artefact. An identity check **cannot survive a legitimate decoration** — and it could not survive in the other direction either, since a class merely *named* `AutomationDispatchService` would satisfy it while doing nothing.

The property is therefore asserted where it actually lives — in what the token **does**:

1. **a surviving rule reaches the real dispatcher** (exactly one step ran, and it is the rule's own action);
2. **two rules claiming the same irreversible action are BOTH blocked** (ADR-041 §6 — the gate refuses, it never picks).

**Falsifiable in both directions, which the identity assertion never was.** That is the whole point.

## Red-first evidence (both directions, proven not claimed)

Each was produced by temporarily rebinding the token in `automation.module.ts` and observing a **real assertion failure** — not a `TS6133` compile red with `Tests: 0 total`, which is a false pass.

| Temporary binding | Result | Failure reason |
|---|---|---|
| Inert placeholder (`useValue: { dispatch: () => Promise.resolve() }`) | `Tests: 2 failed, 3 passed` | **test 1**: `toHaveBeenCalledTimes` — `Expected: 1, Received: 0` (recorder never called) |
| Gate bypassed (`useExisting: AutomationDispatchService`) | `Tests: 1 failed, 4 passed` | **test 2**: `Expected: "blocked", Received: "failed"` — both colliding rules actually ran |

The second row is the discriminator the old identity check could never make.

**The experiment was reverted and the final green run happened after the revert** — a green recorded before a revert is not evidence about the shipped tree. `git diff --stat` against the base shows `automation.module.ts` untouched (0 hits). Leaving the rebinding in would have re-red'd the exact gate this PR exists to fix.

## ⚠️ If you are wiring A1 (`issue-sales-document`), read this

Test 1 executes a **real executor chain** for an **irreversible** action. It is safe today only because `automation-action-executor.registry.ts` maps `issue-sales-document` to `UnavailableActionExecutorService` — and `AutomationIrreversibleGateService`'s own docblock says the gate "arms the moment A1/A2 land".

At that moment the test would stop exercising a stub and start **issuing a fiscal document inside a Testcontainers boot suite**, with every other assertion still green. So that assumption is **pinned**: `expect(run.steps[0].status).toBe('failed')`. Wiring A1 breaks this gate and a human decides, instead of the suite silently performing an irreversible act. Same rule as the `resolve_category` pin in engineering-standards § MCP tools — a latent write in the chain is pinned so wiring it fails the build.

Test 2 deliberately has **no** such pin and must not be given one: the gate blocks both rules by construction, so no executor is ever reached and there is nothing to pin. The comment says so, because that asymmetry otherwise reads as an oversight.

## The compile gate for this file is the worker integration run (#2670)

`apps/worker/test` is **outside `pnpm type-check`'s coverage**, so a green lint + type-check says nothing about this file — the only thing that compiles it is ts-jest at integration-run time. This PR is a live demonstration of #2670: the fix for a hard gate sits in a directory no type gate covers. The worker integration run below is the compile evidence, not an optional extra.

## Gates

| Gate | Exit | Result |
|---|---|---|
| `pnpm lint` | 0 | 0 errors |
| `pnpm type-check` | 0 | clean (does **not** cover this file) |
| `pnpm test` | 0 | all suites pass |
| worker int-spec (`--runTestsByPath`) | 0 | `Tests: 5 passed, 5 total` (re-run after the pin, on the merged tree) |

## Notes

- **No production code changed.** #2362's gate composition is untouched and was not weakened to make a test pass.
- `docs/architecture-overview.md` § Automation already describes the composition accurately ("hands the survivors to `AutomationDispatchService`"), so **no doc amendment was needed**.
- The fixture needs **no casts**: `EmptyTriggerConfig` is a member of the `AutomationTriggerConfig` union and A1 is parameterless. The unit spec's `{} as never` was deliberately not copied forward — a cast that evades the no-`any` posture is not the same as satisfying it.
- Explicit type parameters on every `harness.get` — `get<T = any>` otherwise yields an untyped spy whose `mock.calls[0][0]` is `any`, the shape that lets a *wrong* assertion type-check.
- `jest.restoreAllMocks()` is documented as **load-bearing**, not hygiene: a later test resolves the same singleton the behavioural tests spy on.
- The redundant `not.toBe('blocked')` is kept with its reason stated — on a hard gate a failure message that names `blocked` beats one assertion fewer, and a runtime check should not be dropped merely because something else currently implies it.
- The spec docblock records why this is behavioural, so the next decorator does not prompt someone to "fix" it back to `toBeInstanceOf`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EWKtLwTcP2ppoknaq4Ca3Z