### PR TITLE
feat(fulfillment): routing selection, the #2047 four-part gate and the one-transaction commit (#2395)

### DIFF
--- a/apps/api/src/migrations/1868000000000-add-order-shipping-address-hash.ts
+++ b/apps/api/src/migrations/1868000000000-add-order-shipping-address-hash.ts
@@ -1,0 +1,42 @@
+/**
+ * Add `order_records.shippingAddressHash` (#2395, W3a).
+ *
+ * `RoutingShipTo`'s degraded arm (`OL_STORE_PII=false`) needs a `locationHash`
+ * for the order. It cannot be derived on read:
+ *
+ * - Hashing the persisted `orderSnapshot` address is wrong under hash-only
+ *   mode, where that address has already been through `redactAddress` - the
+ *   hash then collapses to ONE value per country, shared by every order in the
+ *   install, looking correct while grouping everything.
+ * - `customer_address_projections` are keyed by CUSTOMER, not by order, so they
+ *   cannot answer "the address on THIS order".
+ *
+ * So the value is stamped at ingestion, where the un-redacted address is still
+ * in hand, and persisted here. Nullable: existing rows carry no hash and are
+ * never backfilled (the un-redacted address is gone), and an order with no
+ * shipping address legitimately has none.
+ *
+ * `text`, matching the neighbouring `buyerTaxId` column rather than a sized
+ * `varchar` - the hash width is a property of the hashing function, not of the
+ * schema, and pinning it here would need a migration to change it.
+ *
+ * Generated: 2026-08-31 (synthetic sequential prefix per docs/migrations.md
+ * rule 3; 1866000000000 is #2394's `routing_decisions`).
+ */
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddOrderShippingAddressHash1868000000000 implements MigrationInterface {
+  name = 'AddOrderShippingAddressHash1868000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "order_records" ADD COLUMN IF NOT EXISTS "shippingAddressHash" text`
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "order_records" DROP COLUMN IF EXISTS "shippingAddressHash"`
+    );
+  }
+}

--- a/apps/api/test/integration/fulfillment-work-migration-parity.int-spec.ts
+++ b/apps/api/test/integration/fulfillment-work-migration-parity.int-spec.ts
@@ -179,6 +179,40 @@ describe('Fulfillment Work — migration/entity schema parity', () => {
     expect(rows.map((r) => r.table_name)).toEqual([...TABLES].sort());
   });
 
+  /**
+   * #2395's column, checked NARROWLY rather than by adding `order_records` to
+   * `TABLES`.
+   *
+   * That was tried first and is the better shape when it works — the list drives
+   * a derived assertion, so a new TABLE costs one line. It does not work here:
+   * `order_records` is a long-lived table whose INDEX and FOREIGN-KEY definitions
+   * already differ between the `synchronize`-built and migration-built schemas,
+   * so adding it fails two assertions for pre-existing drift this issue neither
+   * caused nor can fix — precisely the whole-schema-diff problem this file's
+   * header says it is scoped to avoid. Its COLUMN comparison passed, which is
+   * the half that matters for a new column, so that half is asserted directly.
+   *
+   * The check is still real: `1868000000000-add-order-shipping-address-hash.ts`
+   * is the only thing that creates this column in the migrated database, and
+   * nothing but the ORM entity creates it in the harness's.
+   */
+  it('should build order_records.shippingAddressHash identically from the migration (#2395)', async () => {
+    const sql = `
+      SELECT column_name, data_type, is_nullable
+      FROM information_schema.columns
+      WHERE table_schema = 'public'
+        AND table_name = 'order_records'
+        AND column_name = 'shippingAddressHash'`;
+
+    const fromMigration = (await migrated.query(sql)) as unknown[];
+    const synchronized = (await harness.getDataSource().query(sql)) as unknown[];
+
+    // Non-vacuity: two empty result sets would compare equal and assert nothing.
+    expect(fromMigration).toHaveLength(1);
+    expect(fromMigration).toEqual(synchronized);
+    expect(fromMigration[0]).toMatchObject({ is_nullable: 'YES' });
+  });
+
   it('should agree on every column, type, nullability and default', async () => {
     const [synchronized, fromMigration] = await bothSides(COLUMNS_SQL);
     expect(fromMigration).toEqual(synchronized);

--- a/apps/api/test/integration/routing-commit.int-spec.ts
+++ b/apps/api/test/integration/routing-commit.int-spec.ts
@@ -1,0 +1,391 @@
+/**
+ * Routing Commit integration test (#2395, `W3a-6`, ADR-054 R1, DESIGN §5.3)
+ *
+ * `RoutingCommitService` decides where an order is fulfilled from **exactly
+ * once**. Two plans for one order is a double shipment: physical, and
+ * unrecoverable. Every guarantee that prevents it is a DATABASE-level fact — a
+ * transaction boundary, a partial-unique index, a persisted intent row — so
+ * none of them can be observed against mocks. That is why these three tests are
+ * integration tests rather than unit tests, and why every assertion below reads
+ * the tables directly via `harness.getDataSource().query(...)` rather than
+ * through a repository: the subject is what is actually persisted, not what a
+ * mapper reports about it.
+ *
+ * `route()` takes `router`, `lock` and `isCancelled` as ARGUMENTS (the
+ * zero-sibling-edge leaf's no-injection posture, ADR-053), so all three are
+ * supplied here as fakes and no adapter wiring is needed.
+ *
+ * @module apps/api/test/integration
+ */
+import { randomUUID } from 'node:crypto';
+
+import {
+  ROUTING_COMMIT_SERVICE_TOKEN,
+  ROUTING_DECISION_REPOSITORY_TOKEN,
+} from '@openlinker/core/fulfillment';
+import type {
+  ClaimRoutingIntentInput,
+  FulfillmentRouterPort,
+  IRoutingCommitService,
+  RouteOptions,
+  RoutingDecision,
+  RoutingEvaluation,
+  RoutingInput,
+  RoutingInputLine,
+  RoutingLockPort,
+  RoutingPlan,
+  RoutingShipTo,
+  TerminaliseRoutingDecisionInput,
+} from '@openlinker/core/fulfillment';
+
+import {
+  getTestHarness,
+  IntegrationTestHarness,
+  resetTestHarness,
+  teardownTestHarness,
+} from './setup';
+
+/**
+ * A LOCAL structural view, not the port type — `RoutingDecisionRepositoryPort`
+ * is intra-context and deliberately absent from the barrel (the deny pattern).
+ * Mirrors `routing-decision-intent.int-spec.ts` and
+ * `fulfillment-work-transitions.int-spec.ts`.
+ */
+interface RoutingDecisionRepositoryView {
+  claimIntent(input: ClaimRoutingIntentInput): Promise<RoutingDecision>;
+  terminalise(input: TerminaliseRoutingDecisionInput): Promise<boolean>;
+  findLiveByOrderId(orderId: string): Promise<RoutingDecision | null>;
+  findById(decisionId: string): Promise<RoutingDecision | null>;
+}
+
+/**
+ * A real-ish in-memory lock: compare-and-set `acquire`, compare-and-delete
+ * `release`, exactly the `SyncLockPort` contract `RoutingLockPort` describes
+ * structurally. A stub that always granted the lock would make test 2 assert
+ * nothing at all.
+ *
+ * `onAcquireAttempt` is the barrier seam test 2 needs — see there for why the
+ * overlap has to be forced rather than hoped for.
+ */
+class InMemoryRoutingLock implements RoutingLockPort {
+  private readonly held = new Map<string, string>();
+
+  constructor(private readonly onAcquireAttempt?: () => Promise<void>) {}
+
+  async acquire(key: string, _ttlMs: number): Promise<string | null> {
+    if (this.onAcquireAttempt) {
+      await this.onAcquireAttempt();
+    }
+    if (this.held.has(key)) {
+      return null;
+    }
+    const token = randomUUID();
+    this.held.set(key, token);
+    return token;
+  }
+
+  async release(key: string, token: string): Promise<boolean> {
+    if (this.held.get(key) !== token) {
+      return false;
+    }
+    this.held.delete(key);
+    return true;
+  }
+}
+
+const SHIP_TO: RoutingShipTo = {
+  mode: 'plain',
+  countryIso2: 'PL',
+  postalCode: '00-001',
+  city: 'Warsaw',
+};
+
+const newOrderId = (): string => `ol_order_${randomUUID().replace(/-/g, '')}`;
+
+describe('Routing commit (#2395)', () => {
+  let harness: IntegrationTestHarness;
+  let service: IRoutingCommitService;
+  let decisions: RoutingDecisionRepositoryView;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+    service = harness.getApp().get<IRoutingCommitService>(ROUTING_COMMIT_SERVICE_TOKEN);
+    decisions = harness
+      .getApp()
+      .get<RoutingDecisionRepositoryView>(ROUTING_DECISION_REPOSITORY_TOKEN);
+  }, 180_000);
+
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  const countWorks = async (orderId: string): Promise<number> => {
+    const rows = await harness
+      .getDataSource()
+      .query(`SELECT count(*)::int AS n FROM fulfillment_works WHERE "orderId" = $1`, [orderId]);
+    return (rows as { n: number }[])[0].n;
+  };
+
+  const decisionRows = async (
+    orderId: string,
+  ): Promise<{ id: string; state: string }[]> =>
+    (await harness
+      .getDataSource()
+      .query(`SELECT "id", "state" FROM routing_decisions WHERE "orderId" = $1`, [
+        orderId,
+      ])) as { id: string; state: string }[];
+
+  /** A router fake that answers with a fixed plan and records what it was asked. */
+  const routerReturning = (
+    plan: RoutingPlan,
+    hooks: { readonly beforeAnswer?: () => Promise<void> } = {},
+  ): { port: FulfillmentRouterPort; calls: RouteOptions[] } => {
+    const calls: RouteOptions[] = [];
+    const port: FulfillmentRouterPort = {
+      async evaluate(_input: RoutingInput): Promise<RoutingEvaluation> {
+        throw new Error('evaluate() must never be reached from route()');
+      },
+      async route(_input: RoutingInput, options: RouteOptions): Promise<RoutingPlan> {
+        calls.push(options);
+        if (hooks.beforeAnswer) {
+          await hooks.beforeAnswer();
+        }
+        return plan;
+      },
+    };
+    return { port, calls };
+  };
+
+  const LINES: readonly RoutingInputLine[] = [
+    { orderLineId: 'line-1', productVariantId: 'ol_variant_aaa', quantity: 5 },
+  ];
+
+  /**
+   * TEST 1 — the one-transaction commit is atomic.
+   *
+   * ADR-054 R1: the N work rows and the decision's terminalisation commit
+   * together, or neither does. The failure this guards against is a SPLIT
+   * state — work row 1 persisted for a decision that never terminalised, or (in
+   * the mirror case) a `committed` decision with only half its work — which is
+   * an order that is partly routed with every surface reporting a clean result.
+   *
+   * The plan below is built so the SECOND work object cannot be written: two
+   * assignments land in two distinct `(locationId, connectionId, deliveryMethod)`
+   * buckets — the grain `groupAssignmentsIntoWork` splits on — and the second
+   * carries a NEGATIVE quantity, which violates the real, named
+   * `CHK_fulfillment_work_lines_capacity` constraint
+   * (`"totalQuantity" >= 0 AND …`) declared on `fulfillment_work_lines`.
+   *
+   * The `7 + (-2) = 5` arithmetic is deliberate: `checkRoutingPlanConservesQuantities`
+   * runs BEFORE the commit and refuses any plan that does not account for every
+   * unit, so a plan that failed conservation would be refused before a single
+   * row was written and this test would prove nothing about the transaction.
+   * Conserving-but-unwritable is the only shape that reaches the boundary.
+   *
+   * **Verified red-first.** With `runInTransaction` temporarily reduced to
+   * `return await fn(this.dataSource.manager)` — i.e. handing out the default
+   * manager instead of opening a transaction — this test FAILS on the work-row
+   * assertion, finding BOTH work headers persisted (`expect(received).toBe(expected)
+   * … Expected: 0, Received: 2` — work 1 in full, and work 2's header surviving
+   * its own rejected line, since `create` loses its inner transaction too). It passes only while the transaction is real,
+   * which is what makes it a test of atomicity rather than of the constraint.
+   */
+  it('should persist NEITHER work row nor terminalise the decision when the second work fails', async () => {
+    const orderId = newOrderId();
+    const routerConnectionId = randomUUID();
+
+    const { port: router } = routerReturning({
+      status: 'resolved',
+      decisionId: 'vendor-decision-atomic',
+      assignments: [
+        {
+          orderLineId: 'line-1',
+          locationId: 'loc-A',
+          connectionId: null,
+          deliveryMethod: null,
+          quantity: 7,
+        },
+        {
+          // Second bucket, second work object — and unwritable.
+          orderLineId: 'line-1',
+          locationId: 'loc-B',
+          connectionId: null,
+          deliveryMethod: null,
+          quantity: -2,
+        },
+      ],
+      unfulfillable: [],
+      holds: [],
+      explanation: [],
+    });
+
+    await expect(
+      service.route({
+        orderId,
+        routerConnectionId,
+        lines: LINES,
+        shipTo: SHIP_TO,
+        requestedDeliveryMethod: null,
+        router,
+        lock: new InMemoryRoutingLock(),
+        isCancelled: async () => false,
+      }),
+    ).rejects.toBeDefined();
+
+    // Work object 1 must NOT have survived its sibling's failure.
+    expect(await countWorks(orderId)).toBe(0);
+
+    // And the decision must still be LIVE — never `committed`, which would
+    // claim an order that carries no work at all.
+    const rows = await decisionRows(orderId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].state).toBe('live');
+  });
+
+  /**
+   * TEST 2 — two concurrent `route()` calls produce exactly ONE committed plan.
+   *
+   * A SEQUENTIAL version of this test passes against no guard whatsoever: the
+   * first call terminalises its decision, the second finds committed work and
+   * skips. So the two calls must genuinely OVERLAP, and overlap cannot be left
+   * to the scheduler — `Promise.all` over two async functions does not by itself
+   * guarantee that caller B has entered `route()` before caller A has left it.
+   *
+   * The barrier therefore sits in the lock fake's `acquire`, which is the FIRST
+   * thing `route()` does: neither acquire returns until both have been
+   * attempted, so both callers are provably inside `route()` at the same
+   * instant, contending on the same key. One wins the lock; the other must
+   * answer from persisted state and, critically, must never cross the router
+   * boundary — a second router call under a second key is the double shipment.
+   */
+  it('should commit exactly one plan when two route() calls genuinely overlap', async () => {
+    const orderId = newOrderId();
+    const routerConnectionId = randomUUID();
+
+    let entered = 0;
+    let releaseBarrier: () => void;
+    const barrier = new Promise<void>((resolve) => {
+      releaseBarrier = resolve;
+    });
+    const bothEntered = async (): Promise<void> => {
+      entered += 1;
+      if (entered >= 2) {
+        releaseBarrier();
+      }
+      await barrier;
+    };
+
+    const lock = new InMemoryRoutingLock(bothEntered);
+    const { port: router, calls } = routerReturning({
+      status: 'resolved',
+      decisionId: 'vendor-decision-concurrent',
+      assignments: [
+        {
+          orderLineId: 'line-1',
+          locationId: 'loc-A',
+          connectionId: null,
+          deliveryMethod: null,
+          quantity: 5,
+        },
+      ],
+      unfulfillable: [],
+      holds: [],
+      explanation: [],
+    });
+
+    const attempt = (): Promise<unknown> =>
+      service.route({
+        orderId,
+        routerConnectionId,
+        lines: LINES,
+        shipTo: SHIP_TO,
+        requestedDeliveryMethod: null,
+        router,
+        lock,
+        isCancelled: async () => false,
+      });
+
+    const outcomes = await Promise.all([attempt(), attempt()]);
+
+    // Exactly one decision, exactly one set of work — not two of either.
+    const rows = await decisionRows(orderId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].state).toBe('committed');
+    expect(await countWorks(orderId)).toBe(1);
+
+    // At most one committing key ever crossed the router boundary. This is the
+    // assertion the whole barrier exists to make meaningful: a contended caller
+    // that called the router would have minted a second plan, and the vendor
+    // would have no way to dedup it.
+    expect(calls.length).toBeLessThanOrEqual(1);
+
+    const statuses = outcomes.map((o) => (o as { status: string }).status).sort();
+    expect(statuses).toContain('routed');
+    expect(statuses.filter((s) => s === 'routed')).toHaveLength(1);
+  });
+
+  /**
+   * TEST 3 — a resumed attempt re-derives the IDENTICAL idempotency key.
+   *
+   * Simulates a crash between `claimIntent` and the commit: the intent row is
+   * claimed directly and left `live`, exactly as a dead process would leave it.
+   *
+   * Resuming under the ORIGINAL key is what makes that crash recoverable. A
+   * resume that minted a fresh decision id would mint a fresh key, which the
+   * vendor cannot dedup against the first call — two plans, two shipments. This
+   * is the #2039 `reconcileId` lesson stated at the level where it costs a
+   * parcel: a retry that mints a new key is not a retry.
+   */
+  it('should resume a live decision under its original idempotency key', async () => {
+    const orderId = newOrderId();
+    const routerConnectionId = randomUUID();
+
+    // The crash: intent persisted and committed, nothing after it.
+    const stranded = await decisions.claimIntent({ orderId, routerConnectionId });
+
+    const { port: router, calls } = routerReturning({
+      status: 'resolved',
+      decisionId: 'vendor-decision-resumed',
+      assignments: [
+        {
+          orderLineId: 'line-1',
+          locationId: 'loc-A',
+          connectionId: null,
+          deliveryMethod: null,
+          quantity: 5,
+        },
+      ],
+      unfulfillable: [],
+      holds: [],
+      explanation: [],
+    });
+
+    const outcome = await service.route({
+      orderId,
+      routerConnectionId,
+      lines: LINES,
+      shipTo: SHIP_TO,
+      requestedDeliveryMethod: null,
+      router,
+      lock: new InMemoryRoutingLock(),
+      isCancelled: async () => false,
+    });
+
+    expect(calls).toHaveLength(1);
+    // Derived from the stranded row's own immutable id — byte-identical to the
+    // key the crashed attempt would have used.
+    expect(calls[0].idempotencyKey).toBe(`route:${stranded.id}`);
+
+    // No SECOND decision row: the resume reused the stranded one rather than
+    // claiming a fresh intent beside it.
+    const rows = await decisionRows(orderId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].id).toBe(stranded.id);
+    expect(rows[0].state).toBe('committed');
+    expect((outcome as { decisionId: string }).decisionId).toBe(stranded.id);
+  });
+});

--- a/apps/worker/src/sync/handlers/__tests__/handler-registration.service.spec.ts
+++ b/apps/worker/src/sync/handlers/__tests__/handler-registration.service.spec.ts
@@ -3,7 +3,7 @@
  *
  * Pins the ADR-050 lane partition (#2278): every `JobTypeValues` member is
  * registered with exactly one lane, the per-lane counts match the ADR's
- * table (13 realtime / 25 bulk / 5 fiscal / 7 fan-out across 50 job types —
+ * table (16 realtime / 25 bulk / 5 fiscal / 7 fan-out across 53 job types —
  * `fiscalization.register` joined `fiscal` post-ADR, #2156;
  * `inventory.provenance.backfill` joined `bulk` with #2317; the three returns
  * types joined realtime/bulk/fan-out with #2330; `returns.orphan.reconcile`
@@ -48,9 +48,14 @@ describe('HandlerRegistrationService (ADR-050 lane partition, #2278)', () => {
     expect(() => registry.assertFullLaneCoverage()).not.toThrow();
   });
 
-  it('should partition the 52 job types 15/25/5/7 per ADR-050 decision 1', () => {
-    // 15: the two fulfilment job types are the opposite directions of one
-    // negotiation and both are `realtime` by cost-of-starvation.
+  it('should partition the 53 job types 16/25/5/7 per ADR-050 decision 1', () => {
+    // 16: the THREE fulfilment job types are all `realtime` by
+    // cost-of-starvation.
+    //
+    // #2395's `fulfillment.work.route` decides whether an order ships AT ALL,
+    // so starving it behind a catalogue sweep delays every order's fulfilment.
+    // It is the clearest case of the rule stated below: the enqueuing side is
+    // an internal pass, and the lane is about who is hurt when it is late.
     //
     // #2399's `fulfillment.work.dispatch` is the outbound "tell the holder to
     // ship" for a just-routed order, where lateness costs a shipment.
@@ -61,7 +66,7 @@ describe('HandlerRegistrationService (ADR-050 lane partition, #2278)', () => {
     // puts inbound order sync here. It outranks the "core-owned internal pass"
     // instinct that would suggest `bulk`, because that instinct is about who
     // ENQUEUES a job and the lane is about who is hurt when it is late.
-    expect(registry.getJobTypesByLane('realtime')).toHaveLength(15);
+    expect(registry.getJobTypesByLane('realtime')).toHaveLength(16);
     // 25, and every one of the additions since the lane split shares one
     // profile: background catch-up work that enqueues no children, writes
     // locally, and whose lateness costs nobody a request — so `fan-out` (whose
@@ -83,6 +88,16 @@ describe('HandlerRegistrationService (ADR-050 lane partition, #2278)', () => {
     expect(registry.getJobTypesByLane('bulk')).toHaveLength(25);
     expect(registry.getJobTypesByLane('fiscal')).toHaveLength(5);
     expect(registry.getJobTypesByLane('fan-out')).toHaveLength(7);
+  });
+
+  it('should lane the routing commit realtime, never bulk (#2395)', () => {
+    // Named rather than left to the count above: a count moves whenever any
+    // lane gains a member, so it would not notice this type silently sliding
+    // into `bulk`. Routing gates whether an order ships at all — a late route
+    // is a late shipment, and `bulk`'s per-scope cap is sized for work an
+    // operator tolerates being slow.
+    expect(registry.getLane('fulfillment.work.route')).toBe('realtime');
+    expect(registry.getJobTypesByLane('bulk')).not.toContain('fulfillment.work.route');
   });
 
   it('should lane the master children by TRIGGER, webhook realtime and sweep bulk (#2594)', () => {

--- a/apps/worker/src/sync/handlers/fulfillment-work-route.handler.ts
+++ b/apps/worker/src/sync/handlers/fulfillment-work-route.handler.ts
@@ -1,0 +1,324 @@
+/**
+ * Fulfillment Work Route Handler (#2395, `W3a-6`, ADR-054 R1, DESIGN §5.3)
+ *
+ * Handles `fulfillment.work.route` — decide where ONE order is fulfilled from
+ * and commit that decision atomically with the work it creates.
+ *
+ * ## This handler exists BECAUSE core may not resolve any of this
+ *
+ * `fulfillment` is a registered zero-sibling-edge leaf, so `RoutingCommitService`
+ * may not inject `identifier-mapping`, `orders`, `integrations` or `sync`
+ * (ADR-053's no-injection invariant, enforced by `barrel-purity.spec.ts`).
+ * Selection, the order projection and the lock are therefore resolved HERE, in
+ * the host that already composes them, and cross into core as ARGUMENTS. That is
+ * ADR-053's own rule — "order data enters as arguments" — and it is exactly the
+ * shape #2399's `FulfillmentWorkDispatchHandler` established.
+ *
+ * ## There is no router to call yet, and that is the specified behaviour
+ *
+ * `FulfillmentRouter` is deliberately absent from `CoreCapabilityValues` and
+ * from every manifest (#2393/#2403 — A2 is `config-only`), and `@openlinker/oms`
+ * ships `supportedCapabilities: []` with an empty dispatch table until
+ * #2408/#2409 inject the first router. So {@link resolveRouter} answers `null`
+ * on every installation today and this handler completes as a no-op.
+ *
+ * That is not unfinished work. ADR-054: *"with no router configured the layer is
+ * a degenerate pass-through: no work objects, today's path byte-identical — the
+ * property that survives the Wave-5 kill."*
+ *
+ * ## Outcome contract (ADR-007)
+ *
+ * | Result | Outcome |
+ * |---|---|
+ * | routed, or nothing to do (no router / ambiguous / already routed / cancelled) | `ok` |
+ * | the router answered and OpenLinker refused the plan | `business_failure` — deterministic; retrying is told the same thing |
+ * | the router timed out or threw | **throws** (retryable) — the decision stays `live`, see below |
+ * | the order cannot be read yet | **throws** (retryable) |
+ *
+ * An `in-doubt` outcome throws rather than terminating, and the asymmetry is the
+ * point: the decision row is deliberately left `live`, so the retry RESUMES it
+ * under the identical idempotency key instead of minting a second one.
+ *
+ * PII: the ship-to projection is `RoutingShipTo`, ADR-062's allowlist. Failure
+ * logs name ids only, never the projection.
+ *
+ * @module apps/worker/src/sync/handlers
+ */
+import { Inject, Injectable } from '@nestjs/common';
+
+import {
+  ROUTING_COMMIT_SERVICE_TOKEN,
+  buildRoutingShipTo,
+  type FulfillmentRouterPort,
+  type IRoutingCommitService,
+  type RoutingInputLine,
+  type RoutingShipTo,
+} from '@openlinker/core/fulfillment';
+import {
+  isFulfillmentRouterAmbiguity,
+  selectPrimaryFulfillmentRouter,
+  type AuthorityClaimantInput,
+} from '@openlinker/core/fulfillment-authority';
+import { CONNECTION_PORT_TOKEN, type ConnectionPort } from '@openlinker/core/identifier-mapping';
+import {
+  ORDER_RECORD_SERVICE_TOKEN,
+  OrderSnapshotUnavailableError,
+  orderFromReadySnapshot,
+  type IOrderRecordService,
+} from '@openlinker/core/orders';
+import type {
+  FulfillmentWorkRoutePayloadV1,
+  SyncJob,
+  SyncJobHandler,
+  SyncJobHandlerResult,
+} from '@openlinker/core/sync';
+import { SYNC_LOCK_TOKEN, SyncJobExecutionError, type SyncLockPort } from '@openlinker/core/sync';
+import { getEnvBoolean } from '@openlinker/shared/config';
+import { Logger } from '@openlinker/shared/logging';
+
+@Injectable()
+export class FulfillmentWorkRouteHandler implements SyncJobHandler {
+  private readonly logger = new Logger(FulfillmentWorkRouteHandler.name);
+
+  constructor(
+    @Inject(ROUTING_COMMIT_SERVICE_TOKEN)
+    private readonly routingCommit: IRoutingCommitService,
+    @Inject(CONNECTION_PORT_TOKEN)
+    private readonly connections: ConnectionPort,
+    @Inject(ORDER_RECORD_SERVICE_TOKEN)
+    private readonly orderRecords: IOrderRecordService,
+    @Inject(SYNC_LOCK_TOKEN)
+    private readonly lock: SyncLockPort
+  ) {}
+
+  async execute(job: SyncJob): Promise<SyncJobHandlerResult> {
+    const payload = this.validatePayload(job);
+    if (payload === null) {
+      return { outcome: 'business_failure' };
+    }
+
+    const selection = selectPrimaryFulfillmentRouter(await this.loadClaimants());
+
+    if (selection.holder === null) {
+      // `no-claimant` is the pass-through. An ambiguity commits NOTHING and is
+      // reported — silence-and-pick-one is forbidden, because an unrouted order
+      // is recoverable by hand and two shipments of one order are not.
+      const level = isFulfillmentRouterAmbiguity(selection.reason) ? 'warn' : 'log';
+      this.logger[level](
+        `Not routing order ${payload.orderId}: reason=${selection.reason} ` +
+          `candidates=[${selection.candidateConnectionIds.join(',')}]`
+      );
+      return { outcome: 'ok' };
+    }
+
+    const router = await this.resolveRouter(selection.holder);
+    if (router === null) {
+      // The degenerate pass-through — see this file's header. Not an error.
+      this.logger.log(
+        `No fulfilment router is wired for connection ${selection.holder}; ` +
+          `order ${payload.orderId} follows today's path unchanged (#2408/#2409).`
+      );
+      return { outcome: 'ok' };
+    }
+
+    const projection = await this.projectOrder(job, payload.orderId);
+
+    const outcome = await this.routingCommit.route({
+      orderId: payload.orderId,
+      routerConnectionId: selection.holder,
+      lines: projection.lines,
+      shipTo: projection.shipTo,
+      requestedDeliveryMethod: projection.requestedDeliveryMethod,
+      router,
+      // `SyncLockPort` satisfies the locally-declared `RoutingLockPort`
+      // STRUCTURALLY, which is what lets the leaf keep its zero value edges
+      // while still getting the real distributed lock.
+      lock: this.lock,
+      // A CALLBACK, re-read inside the lock. A boolean resolved here would be a
+      // value from a moment that has already passed (REVIEW C10).
+      isCancelled: async () => {
+        const record = await this.orderRecords.getOrderRecord(payload.orderId);
+        return record?.cancelledAt != null;
+      },
+    });
+
+    return this.toJobResult(job, payload.orderId, outcome);
+  }
+
+  private toJobResult(
+    job: SyncJob,
+    orderId: string,
+    outcome: Awaited<ReturnType<IRoutingCommitService['route']>>
+  ): SyncJobHandlerResult {
+    switch (outcome.status) {
+      case 'routed':
+        this.logger.log(
+          `Routed order ${orderId}: decisionId=${outcome.decisionId} ` +
+            `work=[${outcome.workIds.join(',')}]`
+        );
+        return { outcome: 'ok' };
+
+      case 'skipped':
+      case 'contended':
+        // Both are the guard doing its job. Nothing was written and nothing is
+        // wrong, so neither burns the retry ladder.
+        this.logger.log(
+          `Routing did not proceed for order ${orderId}: ` +
+            `${outcome.status === 'skipped' ? outcome.reason : 'contended'}`
+        );
+        return { outcome: 'ok' };
+
+      case 'refused':
+        // Terminal: the router gave a deterministic answer that OpenLinker
+        // refused, and the refusal is already durable on the decision row.
+        this.logger.warn(
+          `Routing plan refused for order ${orderId}: reason=${outcome.reason} ` +
+            `decisionId=${outcome.decisionId}`
+        );
+        return { outcome: 'business_failure' };
+
+      case 'in-doubt':
+        // Retryable, and the retry RESUMES the still-live decision under the
+        // identical key. Terminating here would strand the order behind a live
+        // decision nothing would ever clear.
+        throw new SyncJobExecutionError(
+          `fulfillment.work.route is in doubt (${outcome.cause}) for order ${orderId}; ` +
+            `decision ${outcome.decisionId} is left live for resumption`,
+          job.id,
+          job.jobType,
+          job.connectionId
+        );
+    }
+  }
+
+  /**
+   * Every connection, whatever its status.
+   *
+   * `isActive` is REPORTED, never filtered upstream — the `analytics-trust` trap.
+   * `supportedCapabilities` is left empty deliberately: A2 is `config-only`, so
+   * `declaresCapability` short-circuits without reading it, and resolving
+   * adapter metadata per connection would be work whose result is discarded.
+   */
+  private async loadClaimants(): Promise<AuthorityClaimantInput[]> {
+    const connections = await this.connections.list();
+    return connections.map((connection) => ({
+      connectionId: connection.id,
+      isActive: connection.status === 'active',
+      supportedCapabilities: [],
+      enabledCapabilities: connection.enabledCapabilities,
+      config: connection.config,
+    }));
+  }
+
+  /**
+   * The router for the selected connection, or `null` when none is wired.
+   *
+   * Deliberately NOT `getCapabilityAdapter(connectionId, 'FulfillmentRouter')`:
+   * that name is absent from `CoreCapabilityValues` and from every manifest by
+   * design, and a spec asserts the absence. Calling it would fail the manifest
+   * gate on every installation, and adding the name would reintroduce the #2085
+   * trap — `enabledCapabilities` is stamped at connection create and never
+   * retro-filled, so gating on a new name drains nothing for every connection
+   * that already exists.
+   *
+   * #2408/#2409 replace this body with the plugin-supplied router.
+   */
+  private async resolveRouter(_connectionId: string): Promise<FulfillmentRouterPort | null> {
+    return await Promise.resolve(null);
+  }
+
+  private async projectOrder(
+    job: SyncJob,
+    orderId: string
+  ): Promise<{
+    lines: RoutingInputLine[];
+    shipTo: RoutingShipTo;
+    requestedDeliveryMethod: string | null;
+  }> {
+    const record = await this.orderRecords.getOrderRecord(orderId);
+    if (record === null) {
+      throw this.retryable(job, `order record not found: orderId=${orderId}`);
+    }
+
+    let order;
+    try {
+      // `requireBuyer: false` — a routing projection names nobody, and the
+      // default would make routing impossible on exactly the hash-only
+      // deployments ADR-062's degraded arm exists to serve (#2399's precedent).
+      order = orderFromReadySnapshot(record, { requireBuyer: false });
+    } catch (error) {
+      if (error instanceof OrderSnapshotUnavailableError) {
+        // `awaiting_mapping` is a TIMING state, not a verdict.
+        throw this.retryable(job, `order snapshot is not readable yet: orderId=${orderId}`, error);
+      }
+      throw error;
+    }
+
+    const shippingAddress = order.shippingAddress;
+    if (shippingAddress === undefined) {
+      throw this.retryable(job, `order carries no shipping address: orderId=${orderId}`);
+    }
+
+    const lines: RoutingInputLine[] = order.items.map((item) => ({
+      orderLineId: item.id,
+      // A work line needs a variant. `variantId` is optional on `OrderItem`, so
+      // fall back to the product id rather than emitting a blank — a work object
+      // pointing at no variant is unpickable stock nothing would report.
+      productVariantId: item.variantId ?? item.productId,
+      quantity: item.quantity,
+    }));
+
+    return {
+      lines,
+      // The OPAQUE key `RoutingInput.requestedDeliveryMethod` documents — the
+      // source's own method id, never a neutral vocabulary. ADR-054 keeps
+      // order-layer sourcing separate from the shipping layer's dispatch
+      // resolution, which stays authoritative for label mechanics.
+      requestedDeliveryMethod: order.shipping?.methodId ?? null,
+      shipTo: buildRoutingShipTo(
+        {
+          countryIso2: shippingAddress.country,
+          postalCode: shippingAddress.postalCode,
+          city: shippingAddress.city,
+          // #2395's own column, stamped at ingestion from the UN-redacted
+          // address. Hashing the snapshot here instead would yield one hash per
+          // country for the whole install — see `order-record.service.ts`.
+          addressHash: record.shippingAddressHash,
+        },
+        {
+          // `getEnvBoolean`, NOT `getPiiConfig()`: the latter throws when
+          // `OL_PII_HASH_SALT` is unset regardless of the flag, which would break
+          // routing on every ordinary deployment that never enabled hash-only
+          // mode. `routing-ship-to.types.ts` states this requirement.
+          storePii: getEnvBoolean('OL_STORE_PII', true),
+        }
+      ),
+    };
+  }
+
+  private retryable(job: SyncJob, message: string, cause?: Error): SyncJobExecutionError {
+    return new SyncJobExecutionError(
+      `fulfillment.work.route: ${message}`,
+      job.id,
+      job.jobType,
+      job.connectionId,
+      cause
+    );
+  }
+
+  private validatePayload(job: SyncJob): FulfillmentWorkRoutePayloadV1 | null {
+    const payload = job.payload as Partial<FulfillmentWorkRoutePayloadV1> | undefined;
+    const orderId = payload?.orderId;
+
+    if (typeof orderId !== 'string' || orderId.length === 0) {
+      // Terminal: a malformed payload fails identically on every attempt.
+      this.logger.warn(
+        `fulfillment.work.route received a malformed payload: jobId=${job.id} ` +
+          `connectionId=${job.connectionId}`
+      );
+      return null;
+    }
+
+    return { schemaVersion: 1, orderId };
+  }
+}

--- a/apps/worker/src/sync/handlers/fulfillment-work-route.handler.ts
+++ b/apps/worker/src/sync/handlers/fulfillment-work-route.handler.ts
@@ -26,6 +26,22 @@
  * a degenerate pass-through: no work objects, today's path byte-identical — the
  * property that survives the Wave-5 kill."*
  *
+ * ## Nothing enqueues this job type yet, and no outcome is surfaced yet
+ *
+ * There is no producer in the tree: #2396 owns the ingestion intercept that will
+ * enqueue it. Combined with the `null` router above, every arm below except the
+ * two `ok` short-circuits is unreachable on any installation this slice ships.
+ *
+ * More importantly, **every non-routed outcome here is log-only**. An order that
+ * will never ship because two connections claim A2 currently reads as a healthy
+ * `ok` job. That is the shape ADR-041 §54 / #2100 forbid for sales documents,
+ * where the gate REPORTS and `OrderIngestionService` PERSISTS the reason onto
+ * the order. Routing is designed the same way — DESIGN §5.3's
+ * "gate-reports / caller-persists", the one-way edge that keeps
+ * `fulfillment -> orders` from becoming a DI cycle — and the caller in question
+ * is #2396. So the persistence half lands there, not here; until it does, an
+ * ambiguity is visible only in this log line.
+ *
  * ## Outcome contract (ADR-007)
  *
  * | Result | Outcome |
@@ -55,7 +71,7 @@ import {
   type RoutingShipTo,
 } from '@openlinker/core/fulfillment';
 import {
-  isFulfillmentRouterAmbiguity,
+  isFulfillmentRouterUnroutable,
   selectPrimaryFulfillmentRouter,
   type AuthorityClaimantInput,
 } from '@openlinker/core/fulfillment-authority';
@@ -103,7 +119,7 @@ export class FulfillmentWorkRouteHandler implements SyncJobHandler {
       // `no-claimant` is the pass-through. An ambiguity commits NOTHING and is
       // reported — silence-and-pick-one is forbidden, because an unrouted order
       // is recoverable by hand and two shipments of one order are not.
-      const level = isFulfillmentRouterAmbiguity(selection.reason) ? 'warn' : 'log';
+      const level = isFulfillmentRouterUnroutable(selection.reason) ? 'warn' : 'log';
       this.logger[level](
         `Not routing order ${payload.orderId}: reason=${selection.reason} ` +
           `candidates=[${selection.candidateConnectionIds.join(',')}]`
@@ -138,7 +154,10 @@ export class FulfillmentWorkRouteHandler implements SyncJobHandler {
       // value from a moment that has already passed (REVIEW C10).
       isCancelled: async () => {
         const record = await this.orderRecords.getOrderRecord(payload.orderId);
-        return record?.cancelledAt != null;
+        // `isCancelled` is the ENTITY's own pure derivation (ADR-011's allowed
+        // shape), so the predicate has one definition rather than a second copy
+        // here. It is a getter, not a method.
+        return record?.isCancelled === true;
       },
     });
 

--- a/apps/worker/src/sync/handlers/handler-registration.service.ts
+++ b/apps/worker/src/sync/handlers/handler-registration.service.ts
@@ -59,6 +59,7 @@ import { OfflineResubmitHandler } from './offline-resubmit.handler';
 import { PendingRecoveryHandler } from './pending-recovery.handler';
 import { PaymentStatusRefreshHandler } from './payment-status-refresh.handler';
 import { FulfillmentWorkDispatchHandler } from './fulfillment-work-dispatch.handler';
+import { FulfillmentWorkRouteHandler } from './fulfillment-work-route.handler';
 
 @Injectable()
 export class HandlerRegistrationService implements OnModuleInit {
@@ -113,7 +114,8 @@ export class HandlerRegistrationService implements OnModuleInit {
     private readonly offlineResubmitHandler: OfflineResubmitHandler,
     private readonly pendingRecoveryHandler: PendingRecoveryHandler,
     private readonly paymentStatusRefreshHandler: PaymentStatusRefreshHandler,
-    private readonly fulfillmentWorkDispatchHandler: FulfillmentWorkDispatchHandler
+    private readonly fulfillmentWorkDispatchHandler: FulfillmentWorkDispatchHandler,
+    private readonly fulfillmentWorkRouteHandler: FulfillmentWorkRouteHandler
   ) {}
 
   onModuleInit(): void {
@@ -516,6 +518,21 @@ export class HandlerRegistrationService implements OnModuleInit {
     this.handlerRegistry.register(
       'fulfillment.work.dispatch',
       this.fulfillmentWorkDispatchHandler,
+      'realtime'
+    );
+
+    // Routing commit (#2395, `W3a-6`).
+    //
+    // 'realtime', for the same ADR-050 reason its dispatch sibling is, and NOT
+    // 'bulk'. The core-owned-internal-pass instinct argues for `bulk` here, and
+    // that instinct is about who ENQUEUES the job; the lane is about who is hurt
+    // when it is late. Routing gates whether an order ships AT ALL, so starving
+    // it behind a catalogue sweep delays every order's fulfilment — and
+    // `bulk`'s per-scope cap is sized for work an operator tolerates being slow.
+    // A late route is a late shipment.
+    this.handlerRegistry.register(
+      'fulfillment.work.route',
+      this.fulfillmentWorkRouteHandler,
       'realtime'
     );
 

--- a/apps/worker/src/sync/sync-worker.module.ts
+++ b/apps/worker/src/sync/sync-worker.module.ts
@@ -74,6 +74,7 @@ import { RegulatoryStatusReconcileHandler } from './handlers/regulatory-status-r
 import { OfflineResubmitHandler } from './handlers/offline-resubmit.handler';
 import { PendingRecoveryHandler } from './handlers/pending-recovery.handler';
 import { FulfillmentWorkDispatchHandler } from './handlers/fulfillment-work-dispatch.handler';
+import { FulfillmentWorkRouteHandler } from './handlers/fulfillment-work-route.handler';
 import { PaymentStatusRefreshHandler } from './handlers/payment-status-refresh.handler';
 import { HandlerRegistrationService } from './handlers/handler-registration.service';
 
@@ -154,6 +155,7 @@ import { HandlerRegistrationService } from './handlers/handler-registration.serv
     PendingRecoveryHandler,
     PaymentStatusRefreshHandler,
     FulfillmentWorkDispatchHandler,
+    FulfillmentWorkRouteHandler,
     HandlerRegistrationService,
   ],
 })

--- a/docs/plans/analysis/PRE-IMPLEMENT-2395-routing-commit.md
+++ b/docs/plans/analysis/PRE-IMPLEMENT-2395-routing-commit.md
@@ -1,0 +1,217 @@
+# Pre-Implement Readiness Gate — #2395 Fulfilment routing selection + one-transaction commit
+
+**Plan:** `docs/plans/implementation-plan-fulfillment-routing-commit.md`
+**Branch:** `2395-routing-commit` (base `origin/oms-programme-wave-3a`, HEAD `bbc2134d3`)
+**Mode:** read-only. No source file modified.
+
+## Verdict: **GO-WITH-CHANGES**
+
+The plan's core correctness argument (lock → intent → router → validate → one transaction) is sound
+and lands on real, already-shipped seams. Three findings must be resolved before coding: a hard
+**name collision** with a shipped, exported `IFulfillmentRoutingService` in `mappings`; an **A2
+rewiring that contradicts a documented shipped invariant** (`resolveOneAuthority`'s "Never a single
+`{kind:'global'}` request"); and a **lane choice the repo already argues against in a comment on the
+sibling job type**. None is fatal to the design — each is a naming/scope correction.
+
+---
+
+## Findings
+
+### 1. BLOCKING — `IFulfillmentRoutingService` / `FulfillmentRoutingService` already exist and are exported
+
+Plan §4.2 / Step 11 creates `IFulfillmentRoutingService` + `FulfillmentRoutingService` in
+`fulfillment`. Both names are **already taken**, in `mappings`, for a different concept (#832 /
+ADR-012 — routing an order's `(source, delivery method)` to a destination processor):
+
+- `libs/core/src/mappings/application/interfaces/fulfillment-routing.service.interface.ts:20`
+  `export interface IFulfillmentRoutingService {`
+- `libs/core/src/mappings/application/services/fulfillment-routing.service.ts:57`
+  `export class FulfillmentRoutingService implements IFulfillmentRoutingService {`
+- `libs/core/src/mappings/index.ts:44` — exported from the `@openlinker/core/mappings` barrel.
+- `libs/core/src/mappings/mappings.tokens.ts:18`
+  `export const FULFILLMENT_ROUTING_SERVICE_TOKEN = Symbol('IFulfillmentRoutingService');`
+
+It has **five live consumers** that would now be reading an ambiguous name:
+`shipping/application/services/shipment-dispatch.service.ts:28,87`,
+`shipping/application/services/fulfillment-status-sync.service.ts:52,174`, plus their specs.
+`libs/core/src/fulfillment/domain/ports/fulfillment-router.port.ts:10` already names
+`IFulfillmentRoutingService` in a docblock — from #2393, i.e. the collision was half-anticipated and
+not resolved.
+
+Two contexts owning two differently-shaped `IFulfillmentRoutingService` and two
+`FULFILLMENT_ROUTING_SERVICE_TOKEN`-shaped tokens is exactly the "two answers to one question"
+the plan itself rejects one section earlier.
+
+**Required:** rename the new pair. `IRoutingCommitService` / `RoutingCommitService` (matching the
+already-declared `RoutingCommitOutcome` in the plan, and the issue's own title) is the obvious fit;
+token `ROUTING_COMMIT_SERVICE_TOKEN`. Whatever is chosen, its docblock must name the `mappings`
+service and say they are unrelated — the shipped precedent for this is
+`handler-registration.service.ts:198`, which does exactly that for `marketplace.fulfillment.statusSync`
+vs `fulfillment.work.statusSync` ("shares nothing with this but a word").
+
+### 2. BLOCKING — the A2 rewiring contradicts a shipped, documented invariant
+
+Plan §3.2 and §8 assume `global` is the right requested scope for A2 selection. The shipped code
+says the opposite, by name:
+
+`libs/core/src/fulfillment-authority/domain/types/authority-resolution.types.ts` (docblock above
+`resolveOneAuthority`):
+
+> *"Resolve one authority across every scope it is claimed over, and fold. **Never a single
+> `{ kind: 'global' }` request.** `selectAuthorityHolder` keeps only claims covering the requested
+> scope … So a `channel`- or `location`-scoped claim would land in neither tier and resolve to
+> `none`, and the page built to show an operator their configuration would report "nobody claims
+> this" about a claim that exists. **Channel-scoped claims are the DESIGNED shape for A2/A5**
+> (DESIGN §2.1) … so that is the common case, not a corner."*
+
+The current A2 behaviour **is** scope-iterating: `resolveOneAuthority` builds `scopesByKey` and calls
+`selectAuthorityHolder(candidates, scope)` once per distinct claimed scope
+(`authority-resolution.types.ts`, the `for (const scope of scopesByKey.values())` loop), folding into
+`{kind:'holders', holders:[…]}`.
+
+**Which existing assertions change — precisely:**
+
+- **No currently-passing assertion breaks mechanically.** The only `sourcing` assertions in
+  `authority-resolution.types.spec.ts` are the zero-config default arm —
+  `:62 expect(rowFor(rows,'sourcing').answer).toEqual({ kind: 'nobody-to-route' })` and
+  `:75 expect(rowFor(rows,'sourcing').state).toBe('default')` — which a global-only selection still
+  satisfies. `:111 'should change no behaviour — every other row is identical to the zero-config run'`
+  also still passes (its claimants claim `availability` only).
+- **That is the hazard, not the reassurance.** Every scope-behaviour test in that file is written
+  against `availability` (A1), not `sourcing`: `:242 'should honour a SCOPED claim rather than
+  reporting the default'` (explicitly labelled *"The regression D10 exists for: resolving once at
+  `global` discards every narrower claim, and the surface reports 'nobody claims this' about a claim
+  that exists"*) and `:269 'should fold two disjoint scopes into one routine compound answer'`. So
+  short-circuiting A2 to a global-only path **reintroduces regression D10 for A2 specifically, with
+  zero test coverage and a green suite** — while A2 is, per the docblock, the kind for which
+  channel-scoped claims are the designed shape.
+
+**Required — one of:**
+(a) Keep `resolveAuthorities`' A2 arm exactly as it is (scope-iterating) and let
+`selectPrimaryFulfillmentRouter` be a *separate* write-path selector used only by the routing
+commit, documenting that A2's read model and the routing gate answer different questions
+(*"who claims sourcing, per scope"* vs *"which single router routes THIS order"*). This loses the
+plan's "one answer to one question" property, so it must be argued explicitly; **or**
+(b) Have `selectPrimaryFulfillmentRouter` itself fold over claimed scopes (reusing
+`resolveOneAuthority`'s loop shape) and refuse — `ambiguous` — when more than one distinct holder
+survives the fold, then delegate A2 to it. This preserves both the invariant and the single-source
+property, and is the recommended route.
+
+Either way, add a **new** `sourcing`-specific scoped-claim spec mirroring `:242`. Plan §7's
+"stop-and-re-derive if an A2 expectation moves" is insufficient here precisely because **nothing
+moves** — the gap is silent.
+
+### 3. IMPORTANT — `bulk` is the wrong lane, and the repo already says so in a comment
+
+Plan Step 15 argues `bulk` because "routing is triggered by ingestion, is not a buyer-facing write".
+`handler-registration.service.ts:190-196` pre-emptively rejects that exact reasoning for the sibling
+job:
+
+> *"`realtime`, by ADR-050's cost-of-starvation rule … It outranks the 'core-owned internal pass'
+> instinct that would suggest `bulk`, **because that instinct is about who ENQUEUES the job, and the
+> lane is about who is hurt when it is late.**"*
+
+Both shipped fulfilment work job types are `realtime`:
+`:200-204` `fulfillment.work.statusSync` → `'realtime'`; `:516-520` `fulfillment.work.dispatch` →
+`'realtime'`, whose comment reads *"A dispatch is the outbound 'tell the holder to ship' for an order
+that has just been routed: someone is waiting, and lateness costs a shipment."* A routing commit is
+strictly upstream of that dispatch — a late route is a late shipment by construction. Recommend
+`realtime`, or a written argument that survives the quoted comment.
+
+Confirmed the boot gate works as the plan assumes: `sync-job-handler.registry.ts:108
+assertFullLaneCoverage()`, invoked at `handler-registration.service.ts:525`, throws naming uncovered
+types (`sync-job-handler.registry.spec.ts:203`). Edit points: add the literal to
+`libs/core/src/sync/domain/types/sync-job.types.ts` (`fulfillment.work.dispatch` at `:184`), payload
+type beside `libs/core/src/sync/domain/types/fulfillment-job-payloads.types.ts`, handler in
+`apps/worker/src/sync/handlers/`, registration + DI in `handler-registration.service.ts` and
+`sync-worker.module.ts:76`.
+
+### 4. IMPORTANT — the abandon-reason spec asserts exact array contents and WILL fail
+
+`libs/core/src/fulfillment/domain/types/routing-decision.types.spec.ts:34-38`:
+
+```
+expect([...RoutingDecisionAbandonReasonValues]).toEqual(['plan-pending','plan-not-conserving']);
+```
+
+Adding `router-timeout` / `router-failed` breaks this; it must be updated in the same commit (the
+spec's own comment at `:41` anticipates *"#2395 widens this union with no migration"*, so this is an
+expected edit, not a re-derive signal). Two things confirmed as the plan claims: the column is
+`@Column({ type:'varchar', length: 64, nullable: true })`
+(`routing-decision.orm-entity.ts:116`) so **no migration is needed**; and `:43`'s
+`readRoutingDecisionAbandonReason('lock-lost')` sentinel does not collide with either new name.
+No exhaustive `switch` over the union exists outside these coercion helpers.
+
+### 5. SUGGESTION — `runInTransaction` on the port is safe
+
+Only one implementer: `fulfillment-work.repository.ts:165
+export class FulfillmentWorkRepository implements FulfillmentWorkRepositoryPort`. Every test double
+is an object literal cast (`as unknown as jest.Mocked<FulfillmentWorkRepositoryPort>` —
+`fulfillment-handshake.service.spec.ts:97`, `fulfillment-progress.service.spec.ts:30`,
+`fulfillment-progress-ordering.spec.ts:57`), so a new member breaks nothing. No in-memory fake of
+this port exists. `FulfillmentWorkTransaction` is already declared
+(`fulfillment-work-repository.port.ts:69`) and already accepted by `terminalise` (`:184`). Note the
+name `runInTransaction` is used elsewhere only as a *callback parameter name* in TypeORM mocks
+(`sync-job.repository.spec.ts:68`, `webhook-ingestion.int-spec.ts:234`) — no collision.
+
+### 6. IMPORTANT — `order_records.shippingAddressHash` and the `toOrm` omission doctrine
+
+Confirmed the hash **can** be computed before redaction: `redactAddress` is applied inside
+`OrderRecordService.persistOrder` (`order-record.service.ts:135,138`), *after*
+`OrderIngestionService.buildUnifiedOrder` passes `shippingAddress: incoming.shippingAddress`
+un-redacted (`order-ingestion.service.ts:1171`) into the `persistOrder` call at `:458`. The existing
+helper is importable from where ingestion runs: `hashAddress` / `normalizeAddress` from
+`@openlinker/shared/config` (used at
+`customers/application/services/order-customer-projection-updater.service.ts:19,140,168`) — `orders`
+already depends on `@openlinker/shared`.
+
+The `toOrm` omission pattern is real and documented at
+`order-record.repository.ts:2278-2320`: `syncStatus`, `syncAttempts`, `fulfillmentState`,
+`cancelledAt`, the three `salesDocument*` columns and `omsAttention` are all left unset because each
+is *OL-owned state no source payload carries, with a dedicated narrow UPDATE as sole writer*, and
+`upsert()` races the reconciliation poll with no per-order lock.
+
+**`shippingAddressHash` does NOT belong in that set** — it is derived from the ingested payload,
+recomputed identically on every ingestion of the same order, so round-tripping it is idempotent and
+race-free. It should be in the normal `toOrm` write set. But note the raw-SQL upsert path
+(`:1846-1865`) restates the parameter tuple positionally against `toOrm`'s write set — **both must
+be updated together**, and the file says so at `:1846` (*"The write set is defined once, by `toOrm` —
+the parameter tuple below is …"*).
+
+**Constructor arity is a real hazard, already flagged in-tree** (`order-record.entity.ts:246`):
+*"this is a positional constructor, and inserting mid-list would silently shift every argument after
+it at each of its call sites."* Append the new field **last**, after `buyerTaxId` (the current tail —
+`order-record.repository.ts:2273`), with a default so existing call sites compile unchanged.
+
+### 7. SUGGESTION — migration slot and parity spec
+
+`1868000000000-…` is free: the tail is `1867000000000-add-fulfillment-handshake.ts` (`1866` is
+`create-routing-decisions`). The plan's re-verify-at-push-time caveat stands — #2401/#2402 are live
+on the wave branch. The parity spec's `TABLES` is at
+`apps/api/test/integration/fulfillment-work-migration-parity.int-spec.ts:57`, and `:174-179` derives
+its table-name assertion **from** `TABLES` rather than restating literals, so adding
+`'order_records'` is a one-line edit — but the plan's Phase-B step-7 fallback is correctly reserved
+for pre-existing drift.
+
+### 8. SUGGESTION — nothing in the plan is already done or duplicates a merged parent
+
+Verified absent from the tree: `selectPrimaryFulfillmentRouter`, `fulfillment.work.route`,
+`shippingAddressHash`, `fulfillment-route-lock` / `FULFILLMENT_ROUTE_LOCK_TTL_MS` /
+`FULFILLMENT_ROUTE_TIMEOUT_MS`, and any `runInTransaction` member on
+`FulfillmentWorkRepositoryPort`. §2.1's claim that no `FulfillmentRouter` adapter can be dispatched
+also holds. The plan's scope is genuinely unbuilt.
+
+---
+
+## Gate summary
+
+| # | Rating | Finding |
+|---|---|---|
+| 1 | BLOCKING | `IFulfillmentRoutingService`/`FulfillmentRoutingService` name collision with `mappings` |
+| 2 | BLOCKING | A2 global-only selection contradicts `resolveOneAuthority`'s documented invariant; regression D10 silently reopens for A2 |
+| 3 | IMPORTANT | `bulk` lane contradicts the shipped sibling-job comment; use `realtime` or argue past it |
+| 4 | IMPORTANT | `routing-decision.types.spec.ts:34` asserts exact abandon-reason array — must be updated |
+| 5 | SUGGESTION | `runInTransaction` port widening is safe (one implementer, cast-literal doubles) |
+| 6 | IMPORTANT | Hash is computable pre-redaction; keep it IN `toOrm`, update the raw-SQL tuple too, append constructor arg LAST |
+| 7 | SUGGESTION | Migration slot 1868 free; parity spec derives from `TABLES` |
+| 8 | SUGGESTION | No duplication with merged parents |

--- a/docs/plans/implementation-plan-fulfillment-routing-commit.md
+++ b/docs/plans/implementation-plan-fulfillment-routing-commit.md
@@ -1,0 +1,322 @@
+# Implementation Plan — Fulfilment routing selection, the #2047 four-part gate, and the one-transaction commit (#2395)
+
+> Wave 3a (`W3a-6`), stream S1, epic #2412. Branch `2395-routing-commit`, based on
+> `origin/oms-programme-wave-3a` — **not** `main`. PR targets the wave branch.
+
+## 1. Goal
+
+Give OpenLinker the ability to decide **where an order is fulfilled from**, exactly once, and to
+persist that decision atomically.
+
+Two routers producing two plans for one order is a **double shipment** — physical and
+unrecoverable. Everything below is one correctness argument built around that single failure mode;
+this is why #2395 is sized L rather than split (each half is individually safe and jointly permits
+the double-ship).
+
+### Non-goals
+
+- **Routing rules.** The named filters/sorts and their coercer are owned by `@openlinker/oms`
+  (REVIEW H7, ADR-054 amendment) and live in `oms_routing_rules`. Core keeps only what crosses the port.
+- **Consuming `RoutingPlan.pending`.** Declared by #2393 and refused by `assertRoutingPlanResolved`. `W4-3`.
+- **The ingestion intercept.** #2396 owns the `none / ambiguous / selected` decision *at ingestion*
+  and the persisted outcome. #2395 owns selection, the gate and the commit.
+- **Resolving a real router adapter.** See §2 — impossible today by design; #2408/#2409 own it.
+
+## 2. The two facts that shape this slice
+
+### 2.1 No `FulfillmentRouter` adapter exists, and none can be dispatched
+
+`libs/oms/src/oms.plugin.ts` ships `supportedCapabilities: []` and an **empty** `dispatchCapability`
+table, with its own docblock recording *"Declared here, injected by #2408/#2409."* Separately,
+`'FulfillmentRouter'` is deliberately absent from `CoreCapabilityValues` and from every manifest
+(#2393, #2403 — A2 is `config-only`), and that absence is **actively asserted** by a live spec
+(`pending-routing-plan-not-supported.error.spec.ts` asserts the source does not contain the name).
+
+Consequently the issue's proposed
+`listCapabilityAdapters({ capability: 'FulfillmentRouter', lazy: true })` **cannot work**, and
+making it work would mean breaking three guard sites plus a spec and reintroducing the #2085 trap
+#2403 rejected by name: `enabledCapabilities` is stamped at connection create and never
+retro-filled, so a gate on a newly-added name drains nothing for every install that already exists.
+
+**Therefore:** the router is supplied to core **as an argument**, typed `FulfillmentRouterPort`. The
+host-side resolution seam yields "no router" today. The only live production path this slice is the
+`none` arm — which is not unfinished work but ADR-054's specified behaviour:
+
+> *"With no router configured the layer is a degenerate pass-through: no work objects, today's path
+> byte-identical — the property that survives the Wave-5 kill."*
+
+`selected` and `ambiguous` are fully covered against fakes and become live with #2408/#2409.
+
+### 2.2 `locationHash` has no sound source today — so this slice creates one
+
+`RoutingShipTo`'s degraded arm (`OL_STORE_PII=false`) carries `locationHash`, **caller-supplied and
+never derived in core** (#2393). #2399's dispatch handler passes `addressHash: null` with a comment
+naming #2395 as the slice that must supply it.
+
+Three candidate sources, two rejected:
+
+- **Recompute from the order snapshot — REJECTED.** Under `OL_STORE_PII=false` the snapshot has
+  already been through `redactAddress`, so hashing it yields **one hash per country shared by every
+  order in the install**: a plausible 64-hex string that groups everything while looking correct.
+  No error, no anomaly.
+- **Read the customer's latest `shipping` address projection — REJECTED.** Address projections are
+  keyed `(internalCustomerId, addressHash, addressType)` — **by customer, never by order**. There is
+  no order→address link. Picking the most recent is correct for a one-address customer and
+  **silently wrong** for a customer with two, in a way nothing reports. A router deciding from the
+  wrong address ships from the wrong warehouse. This is the same defect as the first option, one
+  level down: a plausible-but-wrong grouping key is worse than none.
+- **Persist the hash on the order at ingestion — ADOPTED.** A nullable
+  `order_records.shippingAddressHash`, written where the un-redacted address is still in hand. This
+  is the #1985 denormalization precedent (`placedAt` / `currency` / `taxTreatment`). Order-exact,
+  and correct precisely on the hash-only deployments the degraded arm exists to serve.
+
+**A blank or absent hash is treated as absent and never forwarded** — a blank string is itself a
+shared grouping key. `buildRoutingShipTo` already enforces this (`||`, not `??`); this slice must
+not undo it, and a spec pins it.
+
+## 3. Architecture
+
+### 3.1 Where selection lives, and why not where the issue says
+
+The issue's `File(s)` names `libs/core/src/fulfillment/application/services/`.
+**`selectPrimaryFulfillmentRouter` goes to `libs/core/src/fulfillment-authority/domain/types/` instead.**
+
+`barrel-purity.spec.ts`'s `ZERO_SIBLING_EDGE_LEAVES` permits `fulfillment` **type-only** imports
+from `fulfillment-authority` — a value import is forbidden unconditionally. So placing the function
+in `fulfillment` forces one of two bad outcomes:
+
+- import `selectAuthorityHolder` as a value → the spec fails; or
+- re-derive the selection rule locally → two answers to one question, which ADR-053 § Alternatives
+  rejects by name, and which would let the read model (A2) and the write gate disagree about who
+  routes.
+
+Placed beside `selectAuthorityHolder` it costs **zero new edges** (the leaf's empty allow-set is
+untouched — it uses only in-leaf primitives), and it makes the acceptance criterion *"#2351's
+`resolveAuthorities` consumes it for A2"* literally implementable in-leaf.
+
+This is the kind of placement a later reader would try to "tidy" back into `fulfillment`; the
+docblock must say why not.
+
+### 3.1b Naming — `RoutingCommitService`, NOT `FulfillmentRoutingService` (pre-implement BLOCKING-1)
+
+`IFulfillmentRoutingService` / `FulfillmentRoutingService` **already exist** in
+`libs/core/src/mappings` (#832, ADR-012) — exported from that barrel, bound to
+`FULFILLMENT_ROUTING_SERVICE_TOKEN`, with five live consumers in `shipping`. They answer *"which
+processor or carrier DISPATCHES this?"*; this slice answers *"which location and holder SOURCES
+it?"*. `fulfillment-router.port.ts` already warns the two are close and must not be wired together.
+
+This context's service is therefore `IRoutingCommitService` / `RoutingCommitService`, matching its
+own `RoutingCommitOutcome`.
+
+### 3.2 Selection is config-driven, not capability-driven
+
+`AUTHORITY_KIND_DESCRIPTORS.sourcing` declares `capability: 'config-only'` and
+`owningContext: 'fulfillment'`. Candidates are therefore connections whose `Connection.config`
+carries an enabled `sourcingAuthority` claim, coerced by `parseAuthorityConfig` — the same read
+`resolveAuthorities` already performs. Requested scope is `global`: routing picks **one** router for
+the whole order, so the scope tiering degenerates and the rule reduces exactly to the #2047
+invoicing precedent.
+
+### 3.3 Layering
+
+```
+apps/worker/src/sync/handlers/fulfillment-work-route.handler.ts   ← composes
+  ├── IIntegrationsService      (list connections → claimants)
+  ├── selectPrimaryFulfillmentRouter   (@openlinker/core/fulfillment-authority, pure)
+  ├── IOrderRecordService       (lines, cancelledAt, shippingAddressHash)
+  ├── buildRoutingShipTo        (@openlinker/core/fulfillment, pure)
+  └── IRoutingCommitService.route({ …, router })   ← core, argument-fed
+```
+
+The handler exists **because core may not resolve any of this**: `fulfillment` is a registered
+zero-sibling-edge leaf and ADR-053's no-injection invariant forbids it injecting `orders`,
+`customers` or `integrations`. Order data enters as arguments. This is precisely the shape #2399's
+`FulfillmentWorkDispatchHandler` already established, and this handler is modelled on it.
+
+## 4. Design
+
+### 4.1 `selectPrimaryFulfillmentRouter` (new, `fulfillment-authority`)
+
+```ts
+export type FulfillmentRouterSelectionReason =
+  | 'no-claimant'                     // none  — today's pass-through applies
+  | 'single-claimant'                 // selected, no primary flag needed (#2047 zero-config property)
+  | 'primary-elected'                 // selected among several
+  | 'no-primary'                      // ambiguous
+  | 'multiple-primaries'              // ambiguous
+  | 'multiple-claimants-same-scope';  // ambiguous
+
+export interface FulfillmentRouterSelection {
+  readonly holder: string | null;                        // connectionId, null on none/ambiguous
+  readonly reason: FulfillmentRouterSelectionReason;      // NEVER null, on every arm
+  readonly candidateConnectionIds: readonly string[];
+}
+```
+
+`{ holder, reason }` on **all three arms** is the Wave-2 §7.1 obligation: the "Who decides what"
+surface renders A2 from it, and a null reason degrades that row to *"OpenLinker can't tell"* on
+every install that has configured a router.
+
+Pure, total, never throws — a malformed config yields an outcome, matching `selectAuthorityHolder`.
+
+**It folds over CLAIMED SCOPES; it must not issue a single `global` request** (pre-implement
+BLOCKING-2). `resolveOneAuthority`'s docblock states the rule verbatim — *"Never a single
+`{ kind: 'global' }` request … a `channel`- or `location`-scoped claim would land in neither tier
+and resolve to `none` … **Channel-scoped claims are the DESIGNED shape for A2/A5**"* — and A2 is
+scope-iterating today.
+
+This was very nearly a silent regression. **No existing assertion would have caught it**: the only
+`sourcing` assertions are the zero-config `nobody-to-route` default, which a global-only selection
+still satisfies, while every scope-behaviour test (`:242`, the one labelled *"the regression D10
+exists for"*, and `:269`) is written against `availability`. A global-only A2 would have reopened
+D10 for A2 **with a green suite** — so the earlier mitigation *"stop if an expectation moves"* was
+inert, because nothing moves.
+
+So: fold over the scopes actually claimed (the `resolveOneAuthority` shape), collect distinct
+holders, and report `ambiguous` when more than one survives. Routing still commits to exactly one
+router per order — the fold is how candidates are *found*, not a licence to pick among several. A
+spec must cover a channel-scoped sourcing claim resolving to `selected`.
+
+### 4.2 `IRoutingCommitService.route` — the four-part gate
+
+```ts
+route(input: {
+  orderId; routerConnectionId; lines; shipTo; requestedDeliveryMethod;
+  orderCancelledAt: Date | null;
+  router: FulfillmentRouterPort;
+}): Promise<RoutingCommitOutcome>
+```
+
+Ordered, and the order is the correctness argument:
+
+1. **Cancelled-order gate.** `orderCancelledAt !== null` → commit nothing (REVIEW C10). Checked
+   inside the lock so a cancellation racing a re-route cannot slip between.
+2. **Lock.** `SyncLockPort.acquire('fulfillment:route:{orderId}', FULFILLMENT_ROUTE_LOCK_TTL_MS)`.
+   Keyed **per order, not per (order, router)** — the invariant being serialized is *"this order is
+   routed once"*, and two operators configuring different routers is exactly the case a
+   per-connection key lets through. Same key shape and reasoning as `invoiceIssueLockKey` and
+   `shipmentDispatchLockKey`. On failure to acquire: **answer from persisted state only**
+   (`findLiveByOrderId` / `findByOrderId`) and return `contended` — the router is never reached
+   twice.
+3. **Write-path guard (a read, hence the lock).** Refuse when a live decision exists **or**
+   non-cancelled work exists for the order — **regardless of router identity**.
+4. **Intent before the boundary.** `claimIntent({orderId, routerConnectionId})`, which commits
+   **independently** of any caller transaction by design (#2394). `RoutingDecisionAlreadyLiveError`
+   → `already-live`. This is the ordering a lock cannot supply: a lock is lost on process death, TTL
+   expiry or a Redis blip, and the next holder has no way to learn a `route()` is in flight.
+5. **Call the router** with `deriveRouteIdempotencyKey(decision.id)` — mandatory, derived from the
+   immutable row id, so a **retry** re-derives byte-identically while a **re-route** is a new row
+   and therefore a new key (the #2039 `reconcileId` lesson).
+6. **Validate**: `assertRoutingPlanResolved` (`pending` → abandon `plan-pending`) then
+   `checkRoutingPlanConservesQuantities` (→ abandon `plan-not-conserving`). A plan that silently
+   drops a line is unfulfilled stock with every surface reporting success.
+7. **One transaction**: N work rows **+** the decision's terminalisation to `committed`.
+
+**TTL expiry is not a correctness cliff**, for the same reason it is not one in invoicing: the
+window the lock must cover is only *guard-read → `claimIntent`*, two DB round-trips. Past that a
+`live` decision row exists and a peer's own guard read sees it and refuses. The lock removes the
+race; the **persisted intent row** is what survives a lock that expired mid-`route()`. Single-shot,
+no heartbeat — there is nothing left for a heartbeat to protect.
+
+**Declared timeout strictly below the lock TTL.** `FULFILLMENT_ROUTE_TIMEOUT_MS` bounds the
+`route()` call; a spec asserts `FULFILLMENT_ROUTE_TIMEOUT_MS < FULFILLMENT_ROUTE_LOCK_TTL_MS`. A
+router that outruns the lock would otherwise commit work rows while a peer, having acquired the
+expired lock, is committing its own. Timeout → abandon `router-timeout`; a throw → `router-failed`.
+Both are new members of `RoutingDecisionAbandonReasonValues` — the column is `varchar(64)`, so **no
+migration** (#2394 anticipated exactly this).
+
+### 4.3 The transaction seam
+
+`FulfillmentWorkRepositoryPort` gains:
+
+```ts
+runInTransaction<T>(fn: (tx: FulfillmentWorkTransaction) => Promise<T>): Promise<T>;
+```
+
+#2392 has no way for core to *start* a transaction (only to *join* one), and its docblock says
+*"#2395 sits one transition away from wanting the same seam … Widening it is #2395's call."* The
+handle stays the opaque `FulfillmentWorkTransaction` — never `EntityManager` — so the port remains
+framework-free and an in-memory fake stays typable.
+
+`create(..., tx)` and `terminalise({..., transaction: tx})` both already accept it.
+
+## 5. Steps
+
+### Phase A — selection (pure, `fulfillment-authority`)
+1. `domain/types/fulfillment-router-selection.types.ts` + spec. Reason non-null on all three arms.
+2. Wire A2 in `resolveAuthorities` to delegate (short-circuit arm, like A6/A7). Existing #2351
+   specs must stay green — if any A2 expectation moves, stop and re-derive rather than edit it.
+3. Export from the leaf barrel.
+
+### Phase B — the order-side hash (`orders`)
+4. Migration `1868000000000-add-order-shipping-address-hash.ts` — nullable `varchar`, plus the ORM
+   entity column. **Re-verify the wave tail immediately before pushing** (#2401/#2402 are live).
+5. Write it where the un-redacted address is in hand. Confirmed available: `redactAddress` runs
+   inside `persistOrder` (`order-record.service.ts:135`), *after* ingestion passes the address
+   un-redacted, and `hashAddress`/`normalizeAddress` are importable from `@openlinker/shared/config`.
+6. **This column DOES belong in `toOrm`** — unlike `cancelledAt` / `salesDocument*`, it is
+   payload-derived and idempotent, not OL-owned single-writer state, so the omit-from-`toOrm`
+   precedent does not apply. The raw-SQL upsert tuple (`order-record.repository.ts:1846-1865`) must
+   be updated **in lockstep**, and the entity constructor argument appended **last** —
+   `order-record.entity.ts:246` warns that positional insertion silently shifts every call site.
+7. Extend the migration-parity spec: attempt `TABLES += 'order_records'`; if it fails on
+   pre-existing drift (the spec warns of exactly this), fall back to a targeted assertion that the
+   column exists in the migration-built schema with the right type and nullability, and say why.
+
+### Phase C — core routing service (`fulfillment`)
+8. `runInTransaction` on the port + repository.
+9. Two new abandon reasons (`router-timeout`, `router-failed`). `routing-decision.types.spec.ts:34`
+   asserts the **exact** array contents and must be updated in the same commit. Column is
+   `varchar(64)`, so no migration.
+10. `fulfillment-route-lock.ts` (key helper + clamped env TTL + timeout), the
+    `invoice-issue-lock.ts` shape.
+11. `IRoutingCommitService` + `RoutingCommitService` + outcome types.
+12. Bind in `FulfillmentModule`; export token. **Watch for a merge producing two `exports:` keys** —
+    valid TypeScript that silently drops the first.
+
+### Phase D — job + handler
+13. `fulfillment.work.route` job type + payload type.
+14. Worker handler composing selection → order → shipTo → core. Router seam yields `null` today →
+    `none` → `ok`, byte-identical pass-through.
+15. Register with an ADR-050 lane: **`realtime`** (pre-implement IMPORTANT-3). `bulk` was the
+    original choice and the registry argues it down in-tree: *"It outranks the 'core-owned internal
+    pass' instinct that would suggest `bulk`, **because that instinct is about who ENQUEUES the job,
+    and the lane is about who is hurt when it is late**."* A late route is a late shipment, and both
+    sibling fulfilment job types are `realtime`. `assertFullLaneCoverage` fails boot if the lane is
+    not declared.
+
+### Phase E — evidence
+16. Unit + int specs per §6.
+
+## 6. How each claim is proven
+
+| Claim | Evidence |
+|---|---|
+| **One-transaction commit is atomic** | Int-spec: a fake router returns a plan whose **second** work row violates a DB constraint. Assert **zero** `fulfillment_works` rows for the order **and** the decision still `live` (not `committed`). **Red-first**: run it with the transaction removed (each `create` on its own) — it must fail by finding row 1 persisted and/or the decision terminalised. A green-on-both-sides test proves nothing. |
+| **Lock actually serializes** | Int-spec: an **independent** transaction holds the order's decision row `FOR UPDATE`, then assert the second `route()` **blocks** / returns `contended` without reaching the router (router fake asserts call count 1). A *sequential* two-call test passes against no guard at all and is not evidence. |
+| **Ambiguity commits nothing** | `selectPrimaryFulfillmentRouter` returns `holder: null`; handler enqueues/creates nothing; assert zero decisions, zero work rows, and the router fake never called. Silence-and-pick-one is forbidden — a wrong pick is a double-ship. |
+| **`none` is byte-identical** | Characterisation int-spec: ingestion with no sourcing claimant produces exactly today's rows; no `routing_decisions`, no `fulfillment_works`. |
+| **Crash between intent and `route()`** | Re-run with the same order: `claimIntent` refuses (live row), the retry re-derives the identical key, one plan, one set of work rows. |
+| **Timeout < lock TTL** | Direct assertion on the two constants. |
+| **Blank hash is absent** | Spec: `shippingAddressHash: ''` and `'   '` both produce `locationHash: null`, never a shared key. |
+| **Reason non-null on every arm** | Spec over all three arms. |
+| **A2 resolves from this read** | Consuming spec: `resolveAuthorities` A2 answer changes with the claimant set via `selectPrimaryFulfillmentRouter`, not from a default. |
+
+## 7. Risks
+
+- **`order_records` in the parity spec** may fail on pre-existing drift the spec explicitly declines
+  to own. Mitigated by the Phase-B step 7 fallback.
+- **Migration slot collision.** `check-migration-timestamps` compares against `origin/main` only and
+  structurally cannot see a sibling branch. Re-verify at push time, not plan time.
+- **`OrderIngestionService` is #2396's file.** The coordinator is holding #2396 until this lands, so
+  #2396 inherits rather than races.
+- **A2 rewiring could move #2351's expectations.** Treated as a stop-and-re-derive signal, never an
+  expectation edit.
+
+## 8. Questions & Assumptions
+
+- **WITHDRAWN** (pre-implement BLOCKING-2): the earlier assumption that `global` was the right
+  requested scope was wrong, and wrong in the worst way — it would have passed the whole suite. See
+  §4.1: selection folds over claimed scopes.
+- **Assumed:** no ADR is required — every decision here applies ADR-041/052/053/054/062 as already
+  written; nothing reverses or extends them.

--- a/libs/core/src/fulfillment-authority/domain/types/authority-resolution.types.ts
+++ b/libs/core/src/fulfillment-authority/domain/types/authority-resolution.types.ts
@@ -56,6 +56,7 @@ import { AUTHORITY_KIND_DESCRIPTORS, type AuthorityKind } from './authority-kind
 import { parseAuthorityConfig } from './authority-config.types';
 import { type AuthorityScope, authorityScopeKey } from './authority-scope.types';
 import {
+  AuthorityAmbiguityReasonValues,
   type AuthorityAmbiguityReason,
   type AuthorityHolderCandidate,
   selectAuthorityHolder,
@@ -330,10 +331,72 @@ function claimedScopes(claim: { scopes: readonly AuthorityScope[] }): readonly A
  *
  * `selectAuthorityHolder` is composed here, never modified.
  */
-function resolveOneAuthority(
+/**
+ * Reduce A2's selection to a rendered row.
+ *
+ * A COMPOUND holder set is a routine answer, never an ambiguity — see
+ * `FulfillmentRouterSelection.holders`. Only a real misconfiguration reaches
+ * `cannot-tell`.
+ */
+function resolveSourcingAuthority(selection: FulfillmentRouterSelection): {
+  answer: AuthorityAnswer;
+  source: AuthoritySource;
+  why: AuthorityWhy;
+} {
+  if (AMBIGUITY_REASONS.includes(selection.reason)) {
+    const reason = selection.reason as AuthorityAmbiguityReason;
+    return {
+      answer: {
+        kind: 'cannot-tell',
+        reason,
+        candidateConnectionIds: selection.candidateConnectionIds,
+      },
+      source: 'operator-config',
+      why: { kind: 'ambiguous', reason },
+    };
+  }
+
+  if (selection.holders.length === 0) {
+    const fallback = DEFAULT_ANSWER.sourcing;
+    return {
+      answer: fallback.answer,
+      source: 'default',
+      why: { kind: 'default', code: fallback.code },
+    };
+  }
+
+  return {
+    answer: { kind: 'holders', holders: selection.holders },
+    source: 'operator-config',
+    why: { kind: 'default', code: CLAIMED_WHY.sourcing },
+  };
+}
+
+/**
+ * The fold, shared by the A2 READ MODEL and the A2 WRITE GATE.
+ *
+ * Extracted in #2395 so that `resolveAuthorities`' A2 row and
+ * `selectPrimaryFulfillmentRouter` cannot answer "who routes this order?"
+ * differently. Two answers to one question is what ADR-053 exists to prevent,
+ * and here it would be worse than a stale page: the surface would name one
+ * router while the commit path chose another.
+ *
+ * Behaviour is byte-identical to the pre-#2395 body of `resolveOneAuthority`;
+ * only the reduction to an `AuthorityAnswer` moved out.
+ */
+type HolderResolution =
+  | { readonly kind: 'none' }
+  | { readonly kind: 'holders'; readonly holders: readonly AuthorityAnswerHolder[] }
+  | {
+      readonly kind: 'ambiguous';
+      readonly reason: AuthorityAmbiguityReason;
+      readonly candidateIds: readonly string[];
+    };
+
+function resolveHolders(
   kind: AuthorityKind,
   claimants: readonly AuthorityClaimantInput[]
-): { answer: AuthorityAnswer; source: AuthoritySource; why: AuthorityWhy } {
+): HolderResolution {
   const candidates: AuthorityHolderCandidate[] = [];
   // Deduped on `(connection, scope)`. `parseAuthorityConfig` reads `scopes` off
   // untrusted jsonb and filters by shape, never by uniqueness, so one connection
@@ -366,12 +429,7 @@ function resolveOneAuthority(
   }
 
   if (candidates.length === 0) {
-    const fallback = DEFAULT_ANSWER[kind];
-    return {
-      answer: fallback.answer,
-      source: 'default',
-      why: { kind: 'default', code: fallback.code },
-    };
+    return { kind: 'none' };
   }
 
   // One resolution per distinct claimed scope. A `global` claim is itself one of
@@ -389,13 +447,9 @@ function resolveOneAuthority(
       // Any ambiguous scope makes the whole row inert — the row cannot honestly
       // claim a holder while one of its scopes has none.
       return {
-        answer: {
-          kind: 'cannot-tell',
-          reason: selection.reason,
-          candidateConnectionIds: selection.candidateIds,
-        },
-        source: 'operator-config',
-        why: { kind: 'ambiguous', reason: selection.reason },
+        kind: 'ambiguous',
+        reason: selection.reason,
+        candidateIds: selection.candidateIds,
       };
     }
     if (selection.kind === 'selected') {
@@ -408,6 +462,38 @@ function resolveOneAuthority(
   }
 
   if (holders.length === 0) {
+    return { kind: 'none' };
+  }
+
+  return { kind: 'holders', holders };
+}
+
+function resolveOneAuthority(
+  kind: AuthorityKind,
+  claimants: readonly AuthorityClaimantInput[]
+): { answer: AuthorityAnswer; source: AuthoritySource; why: AuthorityWhy } {
+  if (kind === 'sourcing') {
+    // A2 is answered THROUGH the same function the routing commit path calls
+    // (#2395): the row an operator reads and the gate that commits work must not
+    // be able to disagree about who routes.
+    return resolveSourcingAuthority(selectPrimaryFulfillmentRouter(claimants));
+  }
+
+  const resolved = resolveHolders(kind, claimants);
+
+  if (resolved.kind === 'ambiguous') {
+    return {
+      answer: {
+        kind: 'cannot-tell',
+        reason: resolved.reason,
+        candidateConnectionIds: resolved.candidateIds,
+      },
+      source: 'operator-config',
+      why: { kind: 'ambiguous', reason: resolved.reason },
+    };
+  }
+
+  if (resolved.kind === 'none') {
     const fallback = DEFAULT_ANSWER[kind];
     return {
       answer: fallback.answer,
@@ -417,11 +503,149 @@ function resolveOneAuthority(
   }
 
   return {
-    answer: { kind: 'holders', holders },
+    answer: { kind: 'holders', holders: resolved.holders },
     source: 'operator-config',
     why: { kind: 'default', code: CLAIMED_WHY[kind] },
   };
 }
+
+/**
+ * Why A2 resolved the way it did — non-null on EVERY arm.
+ *
+ * The three ambiguity members are SPREAD from `AuthorityAmbiguityReason` rather
+ * than restated, so #2352 widening that union widens this one automatically
+ * instead of leaving a value this function can produce and no consumer can name.
+ *
+ * `multiple-scoped-holders` is this function's own, and has no counterpart in
+ * `AuthorityAmbiguityReason` because it is not a misconfiguration — see
+ * {@link selectPrimaryFulfillmentRouter}.
+ */
+export const FulfillmentRouterSelectionReasonValues = [
+  /** Nobody claims A2. Today's path runs untouched — ADR-054's pass-through. */
+  'no-claimant',
+  /** Exactly one router. The only arm that may commit. */
+  'claimed-by-connection',
+  /** Several routers legitimately hold A2 over different scopes. */
+  'multiple-scoped-holders',
+  ...AuthorityAmbiguityReasonValues,
+] as const;
+
+export type FulfillmentRouterSelectionReason =
+  (typeof FulfillmentRouterSelectionReasonValues)[number];
+
+/**
+ * Who routes this order, and why that is the answer.
+ *
+ * `{ holder, reason }` on every arm is the Wave-2 §7.1 obligation: the "Who
+ * decides what" surface renders A2 from this, and a null reason degrades that
+ * row to *"OpenLinker can't tell"* on every install that HAS configured a
+ * router. So `reason` is non-null even when `holder` is.
+ */
+export interface FulfillmentRouterSelection {
+  /**
+   * The single router to commit through, or `null`.
+   *
+   * `null` on `no-claimant`, on every ambiguity, AND on
+   * `multiple-scoped-holders` — the routing commit path may act only on exactly
+   * one.
+   */
+  readonly holder: string | null;
+  readonly reason: FulfillmentRouterSelectionReason;
+  /** Everyone in contention. Empty only on `no-claimant`. */
+  readonly candidateConnectionIds: readonly string[];
+  /**
+   * Every holder with its scope, for the A2 read model's COMPOUND answer.
+   *
+   * The read model and the write gate diverge here deliberately, and this is the
+   * one place they may. Two routers scoped to different channels is a routine
+   * compound answer for a page to render ("My shop · Allegro") and is NOT
+   * attention-worthy. It is nonetheless unusable by the commit path, which needs
+   * one router for one order and cannot narrow by channel in Wave 3a. So the
+   * page shows both and routing refuses — reported, never resolved arbitrarily,
+   * because a wrong pick here is a double shipment.
+   */
+  readonly holders: readonly AuthorityAnswerHolder[];
+}
+
+const AMBIGUITY_REASONS: readonly string[] = AuthorityAmbiguityReasonValues;
+
+/** Is this reason a misconfiguration, as opposed to a legitimate compound? */
+export const isFulfillmentRouterAmbiguity = (
+  reason: FulfillmentRouterSelectionReason
+): boolean => AMBIGUITY_REASONS.includes(reason) || reason === 'multiple-scoped-holders';
+
+/**
+ * Which connection's router decides where an order is sourced from (#2395).
+ *
+ * ## Why this lives in `fulfillment-authority` and not in `fulfillment`
+ *
+ * Because `resolveAuthorities` must consume it, and it cannot reach out to get
+ * it: this leaf carries an **empty** `authorizedTypeOnlySpecifiers` allow-set in
+ * `barrel-purity.spec.ts` — stricter than every other context, not even a
+ * type-only import permitted — so a `fulfillment -> fulfillment-authority`
+ * placement would make the A2 row unable to see its own answer, and the surface
+ * would fall back to a default while a router was configured.
+ *
+ * Note what is NOT the reason, because it is the plausible one and it is wrong:
+ * the `fulfillment` leaf's own value-import ban is irrelevant here, since the
+ * only caller of this function outside core is a worker HANDLER, which is not
+ * under `libs/core/src/fulfillment/**` and which that rule therefore never
+ * reaches.
+ *
+ * ADR-053 asks that ENFORCEMENT resolution live with the context that owns the
+ * write, and it still does: the write gate is the `routing_decisions` live
+ * partial-unique index and the guard around it, both in `fulfillment`. This
+ * function only names a candidate. Naming is not enforcing — nothing here can
+ * commit anything.
+ *
+ * ## The rule
+ *
+ * Folds over the scopes actually claimed, exactly as `resolveOneAuthority` does
+ * — never a single `{ kind: 'global' }` request, which would resolve a
+ * channel-scoped claim to `none` and report "nobody claims this" about a claim
+ * that exists (the regression D10 shape; channel-scoped claims are the DESIGNED
+ * shape for A2).
+ *
+ * Then it reduces: exactly one distinct holder may route. Anything else yields
+ * `holder: null`, which commits nothing and is reported. Silence-and-pick-one is
+ * forbidden here for the reason it is forbidden in #2047 — an unrouted order is
+ * recoverable by hand, two shipments of one order are not.
+ *
+ * Pure, total, never throws.
+ */
+export function selectPrimaryFulfillmentRouter(
+  claimants: readonly AuthorityClaimantInput[]
+): FulfillmentRouterSelection {
+  const resolved = resolveHolders('sourcing', claimants);
+
+  if (resolved.kind === 'none') {
+    return {
+      holder: null,
+      reason: 'no-claimant',
+      candidateConnectionIds: [],
+      holders: [],
+    };
+  }
+
+  if (resolved.kind === 'ambiguous') {
+    return {
+      holder: null,
+      reason: resolved.reason,
+      candidateConnectionIds: resolved.candidateIds,
+      holders: [],
+    };
+  }
+
+  const distinct = [...new Set(resolved.holders.map((holder) => holder.connectionId))];
+
+  return {
+    holder: distinct.length === 1 ? distinct[0] : null,
+    reason: distinct.length === 1 ? 'claimed-by-connection' : 'multiple-scoped-holders',
+    candidateConnectionIds: distinct,
+    holders: resolved.holders,
+  };
+}
+
 
 /** Claimants that claim `kind` but are not active — reported, never eligible. */
 function inactiveClaimants(

--- a/libs/core/src/fulfillment-authority/domain/types/authority-resolution.types.ts
+++ b/libs/core/src/fulfillment-authority/domain/types/authority-resolution.types.ts
@@ -569,10 +569,18 @@ export interface FulfillmentRouterSelection {
 
 const AMBIGUITY_REASONS: readonly string[] = AuthorityAmbiguityReasonValues;
 
-/** Is this reason a misconfiguration, as opposed to a legitimate compound? */
-export const isFulfillmentRouterAmbiguity = (
-  reason: FulfillmentRouterSelectionReason
-): boolean => AMBIGUITY_REASONS.includes(reason) || reason === 'multiple-scoped-holders';
+/**
+ * Does this reason stop the routing commit?
+ *
+ * Deliberately NOT named `…Ambiguity`: it answers `true` for
+ * `multiple-scoped-holders`, which is expressly NOT a misconfiguration — two
+ * routers scoped to different channels is a routine compound the A2 row renders
+ * without complaint. It is simply not something the commit path can act on,
+ * because that path needs ONE router for one order. So the predicate is about
+ * committability, not about correctness of the operator's config.
+ */
+export const isFulfillmentRouterUnroutable = (reason: FulfillmentRouterSelectionReason): boolean =>
+  AMBIGUITY_REASONS.includes(reason) || reason === 'multiple-scoped-holders';
 
 /**
  * Which connection's router decides where an order is sourced from (#2395).
@@ -645,7 +653,6 @@ export function selectPrimaryFulfillmentRouter(
     holders: resolved.holders,
   };
 }
-
 
 /** Claimants that claim `kind` but are not active — reported, never eligible. */
 function inactiveClaimants(

--- a/libs/core/src/fulfillment-authority/domain/types/fulfillment-router-selection.spec.ts
+++ b/libs/core/src/fulfillment-authority/domain/types/fulfillment-router-selection.spec.ts
@@ -21,7 +21,7 @@
  */
 import {
   FulfillmentRouterSelectionReasonValues,
-  isFulfillmentRouterAmbiguity,
+  isFulfillmentRouterUnroutable,
   resolveAuthorities,
   selectPrimaryFulfillmentRouter,
   type AuthorityClaimantInput,
@@ -56,9 +56,7 @@ describe('selectPrimaryFulfillmentRouter', () => {
     it('should report no-claimant when the only claimant is inactive', () => {
       // An inactive claimant is REPORTED elsewhere but never eligible, so it can
       // neither hold A2 nor manufacture an ambiguity that blocks routing.
-      const selection = selectPrimaryFulfillmentRouter([
-        claimant('c-1', { enabled: true }, false),
-      ]);
+      const selection = selectPrimaryFulfillmentRouter([claimant('c-1', { enabled: true }, false)]);
 
       expect(selection.holder).toBeNull();
       expect(selection.reason).toBe('no-claimant');
@@ -178,11 +176,14 @@ describe('selectPrimaryFulfillmentRouter', () => {
       expect(new Set(arms.map((a) => a.reason)).size).toBe(4);
     });
 
-    it('should classify a legitimate compound as needing attention, and a lone holder as not', () => {
-      expect(isFulfillmentRouterAmbiguity('claimed-by-connection')).toBe(false);
-      expect(isFulfillmentRouterAmbiguity('no-claimant')).toBe(false);
-      expect(isFulfillmentRouterAmbiguity('multiple-scoped-holders')).toBe(true);
-      expect(isFulfillmentRouterAmbiguity('multiple-primaries')).toBe(true);
+    it('should report a legitimate compound as unroutable without calling it a misconfiguration', () => {
+      // `multiple-scoped-holders` blocks the COMMIT and is still a routine
+      // answer for the read model — which is why the predicate is named for
+      // committability rather than for ambiguity.
+      expect(isFulfillmentRouterUnroutable('claimed-by-connection')).toBe(false);
+      expect(isFulfillmentRouterUnroutable('no-claimant')).toBe(false);
+      expect(isFulfillmentRouterUnroutable('multiple-scoped-holders')).toBe(true);
+      expect(isFulfillmentRouterUnroutable('multiple-primaries')).toBe(true);
     });
   });
 
@@ -224,10 +225,7 @@ describe('selectPrimaryFulfillmentRouter', () => {
     });
 
     it('should report a real misconfiguration as cannot-tell', () => {
-      const row = a2([
-        claimant('c-1', { enabled: true }),
-        claimant('c-2', { enabled: true }),
-      ]);
+      const row = a2([claimant('c-1', { enabled: true }), claimant('c-2', { enabled: true })]);
 
       expect(row?.answer.kind).toBe('cannot-tell');
       expect(row?.state).toBe('ambiguous');

--- a/libs/core/src/fulfillment-authority/domain/types/fulfillment-router-selection.spec.ts
+++ b/libs/core/src/fulfillment-authority/domain/types/fulfillment-router-selection.spec.ts
@@ -1,0 +1,236 @@
+/**
+ * `selectPrimaryFulfillmentRouter` (#2395, `W3a-6`, DESIGN §5.3)
+ *
+ * The A2 half of the #2047 four-part gate: which connection's router may decide
+ * where an order is sourced from, and — on every arm — why.
+ *
+ * Two properties here are worth more than the rest.
+ *
+ * **The channel-scoped case would have passed against a WRONG implementation.**
+ * A2 selection was very nearly written as a single `{ kind: 'global' }` request,
+ * which resolves a channel-scoped claim to `none` (the regression D10 shape).
+ * No shipped assertion would have caught it: the only `sourcing` assertions are
+ * the zero-config default, which a global-only selection also satisfies, and
+ * every scope-behaviour test in the sibling spec is written against
+ * `availability`. So the channel-scoped tests below are the ones that exist
+ * because nothing else covers them.
+ *
+ * **`reason` is asserted non-null on every arm** — the Wave-2 §7.1 obligation.
+ *
+ * @module libs/core/src/fulfillment-authority/domain/types
+ */
+import {
+  FulfillmentRouterSelectionReasonValues,
+  isFulfillmentRouterAmbiguity,
+  resolveAuthorities,
+  selectPrimaryFulfillmentRouter,
+  type AuthorityClaimantInput,
+} from './authority-resolution.types';
+import type { AuthorityScope } from './authority-scope.types';
+
+const claimant = (
+  connectionId: string,
+  sourcing: Record<string, unknown> | undefined,
+  isActive = true
+): AuthorityClaimantInput => ({
+  connectionId,
+  isActive,
+  // A2 is `config-only`, so capability lists are irrelevant to it by design.
+  supportedCapabilities: [],
+  enabledCapabilities: [],
+  config: sourcing === undefined ? {} : { sourcingAuthority: sourcing },
+});
+
+const channel = (id: string): AuthorityScope => ({ kind: 'channel', connectionId: id });
+
+describe('selectPrimaryFulfillmentRouter', () => {
+  describe('none', () => {
+    it('should report no-claimant when nobody claims sourcing', () => {
+      const selection = selectPrimaryFulfillmentRouter([claimant('c-1', undefined)]);
+
+      expect(selection.holder).toBeNull();
+      expect(selection.reason).toBe('no-claimant');
+      expect(selection.candidateConnectionIds).toEqual([]);
+    });
+
+    it('should report no-claimant when the only claimant is inactive', () => {
+      // An inactive claimant is REPORTED elsewhere but never eligible, so it can
+      // neither hold A2 nor manufacture an ambiguity that blocks routing.
+      const selection = selectPrimaryFulfillmentRouter([
+        claimant('c-1', { enabled: true }, false),
+      ]);
+
+      expect(selection.holder).toBeNull();
+      expect(selection.reason).toBe('no-claimant');
+    });
+
+    it('should report no-claimant for a malformed config rather than throwing', () => {
+      const selection = selectPrimaryFulfillmentRouter([
+        { ...claimant('c-1', undefined), config: 'not-an-object' },
+      ]);
+
+      expect(selection.reason).toBe('no-claimant');
+    });
+  });
+
+  describe('selected', () => {
+    it('should select a lone claimant regardless of any primary flag', () => {
+      // The #2047 zero-config property: an operator who never set a primary must
+      // not silently lose the authority.
+      const selection = selectPrimaryFulfillmentRouter([claimant('c-1', { enabled: true })]);
+
+      expect(selection.holder).toBe('c-1');
+      expect(selection.reason).toBe('claimed-by-connection');
+    });
+
+    it('should select the single primary among several global claimants', () => {
+      const selection = selectPrimaryFulfillmentRouter([
+        claimant('c-1', { enabled: true }),
+        claimant('c-2', { enabled: true, isPrimary: true }),
+      ]);
+
+      expect(selection.holder).toBe('c-2');
+      expect(selection.reason).toBe('claimed-by-connection');
+    });
+
+    it('should select a CHANNEL-SCOPED claimant — never resolving it to none', () => {
+      // The regression this spec exists for. A single `global` request drops a
+      // channel-scoped claim into neither tier and answers `none`, so routing
+      // would silently never happen on the shape A2 is DESIGNED around.
+      const selection = selectPrimaryFulfillmentRouter([
+        claimant('c-1', { enabled: true, scopes: [channel('shop-a')] }),
+      ]);
+
+      expect(selection.holder).toBe('c-1');
+      expect(selection.reason).toBe('claimed-by-connection');
+    });
+
+    it('should select one holder claiming several scopes', () => {
+      const selection = selectPrimaryFulfillmentRouter([
+        claimant('c-1', { enabled: true, scopes: [channel('shop-a'), channel('shop-b')] }),
+      ]);
+
+      expect(selection.holder).toBe('c-1');
+      expect(selection.reason).toBe('claimed-by-connection');
+    });
+  });
+
+  describe('refusing to commit', () => {
+    it('should refuse when two claimants share one scope and neither is primary', () => {
+      const selection = selectPrimaryFulfillmentRouter([
+        claimant('c-1', { enabled: true }),
+        claimant('c-2', { enabled: true }),
+      ]);
+
+      expect(selection.holder).toBeNull();
+      expect(selection.reason).toBe('multiple-claimants-same-scope');
+      expect(selection.candidateConnectionIds).toEqual(['c-1', 'c-2']);
+    });
+
+    it('should refuse when several claimants declare themselves primary', () => {
+      const selection = selectPrimaryFulfillmentRouter([
+        claimant('c-1', { enabled: true, isPrimary: true }),
+        claimant('c-2', { enabled: true, isPrimary: true }),
+      ]);
+
+      expect(selection.holder).toBeNull();
+      expect(selection.reason).toBe('multiple-primaries');
+    });
+
+    it('should refuse when two routers hold DIFFERENT scopes', () => {
+      // Not a misconfiguration — it is a legitimate compound the A2 row renders.
+      // Routing still refuses: it needs ONE router for one order and cannot
+      // narrow by channel in Wave 3a. Reported, never resolved arbitrarily,
+      // because a wrong pick is a double shipment.
+      const selection = selectPrimaryFulfillmentRouter([
+        claimant('c-1', { enabled: true, scopes: [channel('shop-a')] }),
+        claimant('c-2', { enabled: true, scopes: [channel('shop-b')] }),
+      ]);
+
+      expect(selection.holder).toBeNull();
+      expect(selection.reason).toBe('multiple-scoped-holders');
+      expect(selection.candidateConnectionIds).toEqual(['c-1', 'c-2']);
+      // Both are still named, so the surface can render the compound.
+      expect(selection.holders).toHaveLength(2);
+    });
+  });
+
+  describe('the Wave-2 §7.1 obligation', () => {
+    it('should carry a non-null, declared reason on every arm', () => {
+      const arms = [
+        selectPrimaryFulfillmentRouter([]),
+        selectPrimaryFulfillmentRouter([claimant('c-1', { enabled: true })]),
+        selectPrimaryFulfillmentRouter([
+          claimant('c-1', { enabled: true }),
+          claimant('c-2', { enabled: true }),
+        ]),
+        selectPrimaryFulfillmentRouter([
+          claimant('c-1', { enabled: true, scopes: [channel('shop-a')] }),
+          claimant('c-2', { enabled: true, scopes: [channel('shop-b')] }),
+        ]),
+      ];
+
+      for (const selection of arms) {
+        expect(selection.reason).not.toBeNull();
+        expect(FulfillmentRouterSelectionReasonValues).toContain(selection.reason);
+      }
+      // Non-vacuity: the arms really are distinct outcomes, not four defaults.
+      expect(new Set(arms.map((a) => a.reason)).size).toBe(4);
+    });
+
+    it('should classify a legitimate compound as needing attention, and a lone holder as not', () => {
+      expect(isFulfillmentRouterAmbiguity('claimed-by-connection')).toBe(false);
+      expect(isFulfillmentRouterAmbiguity('no-claimant')).toBe(false);
+      expect(isFulfillmentRouterAmbiguity('multiple-scoped-holders')).toBe(true);
+      expect(isFulfillmentRouterAmbiguity('multiple-primaries')).toBe(true);
+    });
+  });
+
+  describe('#2351 A2 consumes this selection', () => {
+    const a2 = (claimants: AuthorityClaimantInput[]) =>
+      resolveAuthorities({ claimants }).find((row) => row.question === 'sourcing');
+
+    it('should answer A2 from the selection rather than from a default', () => {
+      const row = a2([claimant('c-1', { enabled: true })]);
+
+      // The point of the criterion: the row moved off its default BECAUSE a
+      // router is configured.
+      expect(row?.source).toBe('operator-config');
+      expect(row?.answer).toEqual({
+        kind: 'holders',
+        holders: [{ connectionId: 'c-1', scope: { kind: 'global' } }],
+      });
+      expect(row?.state).toBe('resolved');
+    });
+
+    it('should keep the default answer when the selection reports no claimant', () => {
+      const row = a2([claimant('c-1', undefined)]);
+
+      expect(row?.answer).toEqual({ kind: 'nobody-to-route' });
+      expect(row?.source).toBe('default');
+    });
+
+    it('should render a legitimate compound as holders, NOT as cannot-tell', () => {
+      const row = a2([
+        claimant('c-1', { enabled: true, scopes: [channel('shop-a')] }),
+        claimant('c-2', { enabled: true, scopes: [channel('shop-b')] }),
+      ]);
+
+      // Routing refuses this set, but the surface must not shout about it: a
+      // compound is routine, and `cannot-tell` is reserved for a real
+      // misconfiguration.
+      expect(row?.answer.kind).toBe('holders');
+      expect(row?.state).toBe('resolved');
+    });
+
+    it('should report a real misconfiguration as cannot-tell', () => {
+      const row = a2([
+        claimant('c-1', { enabled: true }),
+        claimant('c-2', { enabled: true }),
+      ]);
+
+      expect(row?.answer.kind).toBe('cannot-tell');
+      expect(row?.state).toBe('ambiguous');
+    });
+  });
+});

--- a/libs/core/src/fulfillment/application/interfaces/routing-commit.service.interface.ts
+++ b/libs/core/src/fulfillment/application/interfaces/routing-commit.service.interface.ts
@@ -1,0 +1,26 @@
+/**
+ * Routing Commit Service Interface (#2395, `W3a-6`)
+ *
+ * ## Not `IFulfillmentRoutingService` — that name is TAKEN
+ *
+ * `libs/core/src/mappings` already exports `IFulfillmentRoutingService`
+ * (#832, ADR-012), bound to `FULFILLMENT_ROUTING_SERVICE_TOKEN` and consumed in
+ * `shipping`. It answers *"which processor or carrier DISPATCHES this?"*; this
+ * one answers *"which location and holder SOURCES it?"*.
+ * `fulfillment-router.port.ts` already warns that the two questions are close
+ * and must never be wired into one another, so the names are kept apart too.
+ *
+ * @module libs/core/src/fulfillment/application/interfaces
+ */
+import type { RouteOrderInput, RoutingCommitOutcome } from '../types/routing-commit.types';
+
+export interface IRoutingCommitService {
+  /**
+   * Decide where an order is fulfilled from, exactly once, and commit it.
+   *
+   * Never throws for an ordinary refusal — every outcome, including a router
+   * that failed, is a member of {@link RoutingCommitOutcome}. A throw here means
+   * persistence itself failed.
+   */
+  route(input: RouteOrderInput): Promise<RoutingCommitOutcome>;
+}

--- a/libs/core/src/fulfillment/application/services/__tests__/routing-commit.service.spec.ts
+++ b/libs/core/src/fulfillment/application/services/__tests__/routing-commit.service.spec.ts
@@ -1,0 +1,485 @@
+/**
+ * `RoutingCommitService` (#2395, `W3a-6`, ADR-054 R1)
+ *
+ * The #2047 four-part gate. Two routers producing two plans for one order is a
+ * double shipment, so most of what is asserted here is what does NOT happen.
+ *
+ * The load-bearing test in this file is
+ * *"should leave the decision live when the router times out"*. The instinct
+ * when reading that path is to free the order; doing so reopens the double-ship,
+ * because `abandoned` leaves the live partial-unique index and the next attempt
+ * mints a NEW decision id and therefore a NEW idempotency key the vendor cannot
+ * dedup against a call that may still be committing.
+ *
+ * @module libs/core/src/fulfillment/application/services/__tests__
+ */
+import { RoutingDecision } from '../../../domain/entities/routing-decision.entity';
+import { RoutingDecisionAlreadyLiveError } from '../../../domain/exceptions/routing-decision-already-live.error';
+import { RoutingDecisionNoLongerLiveError } from '../../../domain/exceptions/routing-decision-no-longer-live.error';
+import type { FulfillmentRouterPort } from '../../../domain/ports/fulfillment-router.port';
+import type { RoutingLockPort } from '../../../domain/ports/routing-lock.port';
+import type { RoutingPlan, RoutingShipTo } from '../../../index';
+import {
+  FULFILLMENT_ROUTE_LOCK_TTL_MS,
+  FULFILLMENT_ROUTE_TIMEOUT_MS,
+  fulfillmentRouteLockKey,
+} from '../routing-commit-lock';
+import { RoutingCommitService } from '../routing-commit.service';
+
+const ORDER = 'ol_order_1';
+const ROUTER_CONN = 'conn_router';
+
+const decision = (overrides: Partial<RoutingDecision> = {}): RoutingDecision =>
+  new RoutingDecision(
+    (overrides.id as string) ?? 'ol_routingdecision_1',
+    overrides.orderId ?? ORDER,
+    overrides.routerConnectionId ?? ROUTER_CONN,
+    overrides.state ?? 'live',
+    overrides.routerDecisionRef ?? null,
+    overrides.abandonReason ?? null,
+    overrides.terminalisedAt ?? null,
+    overrides.createdAt ?? new Date(),
+    overrides.updatedAt ?? new Date()
+  );
+
+const shipTo: RoutingShipTo = { mode: 'plain', countryIso2: 'PL', postalCode: '00-001', city: 'W' };
+
+const resolvedPlan = (overrides: Partial<Extract<RoutingPlan, { status: 'resolved' }>> = {}) => ({
+  status: 'resolved' as const,
+  decisionId: 'vendor-1',
+  assignments: overrides.assignments ?? [
+    { orderLineId: 'l1', locationId: 'loc-1', connectionId: 'c1', deliveryMethod: null, quantity: 2 },
+  ],
+  unfulfillable: overrides.unfulfillable ?? [],
+  holds: overrides.holds ?? [],
+  explanation: [],
+});
+
+describe('RoutingCommitService', () => {
+  let decisions: {
+    claimIntent: jest.Mock;
+    terminalise: jest.Mock;
+    findLiveByOrderId: jest.Mock;
+    findById: jest.Mock;
+  };
+  let works: { create: jest.Mock; findByOrderId: jest.Mock; runInTransaction: jest.Mock };
+  let lock: jest.Mocked<RoutingLockPort>;
+  let router: jest.Mocked<FulfillmentRouterPort>;
+  let service: RoutingCommitService;
+
+  const input = (overrides: Record<string, unknown> = {}) => ({
+    orderId: ORDER,
+    routerConnectionId: ROUTER_CONN,
+    lines: [{ orderLineId: 'l1', productVariantId: 'ol_variant_1', quantity: 2 }],
+    shipTo,
+    requestedDeliveryMethod: null,
+    router,
+    lock,
+    isCancelled: () => Promise.resolve(false),
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    decisions = {
+      claimIntent: jest.fn().mockResolvedValue(decision()),
+      terminalise: jest.fn().mockResolvedValue(true),
+      findLiveByOrderId: jest.fn().mockResolvedValue(null),
+      findById: jest.fn(),
+    };
+    works = {
+      create: jest.fn().mockResolvedValue({ id: 'ol_work_1' }),
+      findByOrderId: jest.fn().mockResolvedValue([]),
+      // Runs `fn` for real so the commit body is genuinely exercised; the
+      // rollback property itself is pinned by the int-spec, which needs a real
+      // database to mean anything.
+      runInTransaction: jest.fn(async (fn: (t: unknown) => Promise<unknown>) => fn({ save: jest.fn() })),
+    };
+    lock = { acquire: jest.fn().mockResolvedValue('token'), release: jest.fn().mockResolvedValue(true) };
+    router = { route: jest.fn().mockResolvedValue(resolvedPlan()), evaluate: jest.fn() };
+
+    service = new RoutingCommitService(
+      decisions as never,
+      works as never
+    );
+  });
+
+  describe('the declared timeout', () => {
+    it('should be strictly below the lock TTL', () => {
+      // Not decoration: a router still running after the lock expired can have
+      // its work committed concurrently with a peer that has since acquired it.
+      expect(FULFILLMENT_ROUTE_TIMEOUT_MS).toBeLessThan(FULFILLMENT_ROUTE_LOCK_TTL_MS);
+      expect(FULFILLMENT_ROUTE_TIMEOUT_MS).toBeGreaterThan(0);
+    });
+  });
+
+  describe('the lock', () => {
+    it('should be keyed per ORDER, never per (order, router)', () => {
+      // Two operators configuring two different routers for one order is exactly
+      // the case a per-connection key would let through.
+      expect(fulfillmentRouteLockKey(ORDER)).toBe(`fulfillment:route:${ORDER}`);
+      expect(fulfillmentRouteLockKey(ORDER)).not.toContain(ROUTER_CONN);
+    });
+
+    it('should answer from persisted state and NEVER call the router when contended', async () => {
+      lock.acquire.mockResolvedValue(null);
+
+      const outcome = await service.route(input());
+
+      expect(outcome).toEqual({ status: 'contended' });
+      // The whole point of the branch.
+      expect(router.route).not.toHaveBeenCalled();
+      expect(decisions.claimIntent).not.toHaveBeenCalled();
+      expect(works.create).not.toHaveBeenCalled();
+    });
+
+    it('should release the lock even when the commit throws', async () => {
+      works.runInTransaction.mockRejectedValue(new Error('db down'));
+
+      await expect(service.route(input())).rejects.toThrow('db down');
+      expect(lock.release).toHaveBeenCalledWith(fulfillmentRouteLockKey(ORDER), 'token');
+    });
+
+    it('should not let a release failure mask the outcome', async () => {
+      lock.release.mockRejectedValue(new Error('redis blip'));
+
+      const outcome = await service.route(input());
+
+      expect(outcome.status).toBe('routed');
+    });
+  });
+
+  describe('the write-path guard', () => {
+    it('should skip when the order already carries non-cancelled work', async () => {
+      works.findByOrderId.mockResolvedValue([{ cancelledAt: null }]);
+
+      const outcome = await service.route(input());
+
+      expect(outcome).toEqual({ status: 'skipped', reason: 'already-routed' });
+      expect(router.route).not.toHaveBeenCalled();
+    });
+
+    it('should NOT be blocked by cancelled work — that is the re-route path', async () => {
+      works.findByOrderId.mockResolvedValue([{ cancelledAt: new Date() }]);
+
+      const outcome = await service.route(input());
+
+      expect(outcome.status).toBe('routed');
+    });
+
+    it('should refuse a live decision held by a DIFFERENT router', async () => {
+      // Router-agnostic by design: the guard refuses regardless of identity.
+      decisions.findLiveByOrderId.mockResolvedValue(
+        decision({ routerConnectionId: 'conn_other' })
+      );
+
+      const outcome = await service.route(input());
+
+      expect(outcome).toEqual({ status: 'skipped', reason: 'already-live-elsewhere' });
+      expect(router.route).not.toHaveBeenCalled();
+    });
+
+    it('should re-read cancellation INSIDE the lock', async () => {
+      const isCancelled = jest.fn().mockResolvedValue(true);
+
+      const outcome = await service.route(input({ isCancelled }));
+
+      expect(outcome).toEqual({ status: 'skipped', reason: 'order-cancelled' });
+      // Called after the lock was taken — a value read before it would be stale.
+      expect(lock.acquire).toHaveBeenCalled();
+      expect(isCancelled).toHaveBeenCalled();
+      expect(router.route).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('resuming a crashed attempt', () => {
+    it('should resume the live decision under the IDENTICAL idempotency key', async () => {
+      // A crash between `claimIntent` and the commit leaves a live row. Without
+      // resumption that row refuses every later attempt and the order is
+      // stranded forever; with it, the retry re-derives the same key, which is
+      // exactly what an idempotency key is for.
+      decisions.findLiveByOrderId.mockResolvedValue(decision({ id: 'ol_routingdecision_9' }));
+
+      const outcome = await service.route(input());
+
+      expect(outcome.status).toBe('routed');
+      expect(decisions.claimIntent).not.toHaveBeenCalled();
+      expect(router.route).toHaveBeenCalledWith(
+        expect.anything(),
+        { idempotencyKey: 'route:ol_routingdecision_9' }
+      );
+    });
+
+    it('should resume when the INDEX refuses the insert after a clean guard read', async () => {
+      // The guard read is a convenience; the partial-unique index is the
+      // enforcement. A peer won the race between them.
+      decisions.findLiveByOrderId
+        .mockResolvedValueOnce(null)
+        .mockResolvedValueOnce(decision({ id: 'ol_routingdecision_7' }));
+      decisions.claimIntent.mockRejectedValue(new RoutingDecisionAlreadyLiveError(ORDER));
+
+      const outcome = await service.route(input());
+
+      expect(outcome.status).toBe('routed');
+      expect(router.route).toHaveBeenCalledWith(
+        expect.anything(),
+        { idempotencyKey: 'route:ol_routingdecision_7' }
+      );
+    });
+  });
+
+  describe('in doubt', () => {
+    it('should leave the decision LIVE when the router throws', async () => {
+      router.route.mockRejectedValue(new Error('connection reset'));
+
+      const outcome = await service.route(input());
+
+      expect(outcome).toEqual({
+        status: 'in-doubt',
+        decisionId: 'ol_routingdecision_1',
+        cause: 'error',
+      });
+      // THE assertion of this file. Terminalising here would take the row out of
+      // the live index, so a re-route would mint a new key the vendor cannot
+      // dedup against a call that may still be committing — two shipments.
+      expect(decisions.terminalise).not.toHaveBeenCalled();
+      expect(works.create).not.toHaveBeenCalled();
+    });
+
+    it('should leave the decision LIVE when the router exceeds its budget', async () => {
+      jest.useFakeTimers();
+      router.route.mockImplementation(() => new Promise(() => undefined));
+
+      const pending = service.route(input());
+      await jest.advanceTimersByTimeAsync(FULFILLMENT_ROUTE_TIMEOUT_MS + 1);
+      const outcome = await pending;
+
+      expect(outcome).toEqual({
+        status: 'in-doubt',
+        decisionId: 'ol_routingdecision_1',
+        cause: 'timeout',
+      });
+      expect(decisions.terminalise).not.toHaveBeenCalled();
+      jest.useRealTimers();
+    });
+
+    it('should not raise an unhandled rejection when the router rejects AFTER the timeout', async () => {
+      // `Promise.race` does not cancel the loser, so the router promise outlives
+      // the budget. With nothing attached, a late rejection is an unhandled
+      // rejection — which on a worker configured to exit on one would take the
+      // process down for a call we had already stopped waiting on.
+      jest.useFakeTimers();
+      let rejectLate: (error: Error) => void = () => undefined;
+      router.route.mockImplementation(
+        () =>
+          new Promise((_resolve, reject) => {
+            rejectLate = reject;
+          })
+      );
+      const unhandled = jest.fn();
+      process.on('unhandledRejection', unhandled);
+
+      const pending = service.route(input());
+      await jest.advanceTimersByTimeAsync(FULFILLMENT_ROUTE_TIMEOUT_MS + 1);
+      const outcome = await pending;
+
+      rejectLate(new Error('router died long after we stopped waiting'));
+      jest.useRealTimers();
+      // Let the microtask queue drain so an unhandled rejection would surface.
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(outcome).toMatchObject({ status: 'in-doubt', cause: 'timeout' });
+      expect(unhandled).not.toHaveBeenCalled();
+      process.off('unhandledRejection', unhandled);
+    });
+  });
+
+  describe('refusing a plan', () => {
+    it('should abandon a non-conserving plan', async () => {
+      router.route.mockResolvedValue(
+        resolvedPlan({ assignments: [
+          { orderLineId: 'l1', locationId: null, connectionId: null, deliveryMethod: null, quantity: 1 },
+        ] })
+      );
+
+      const outcome = await service.route(input());
+
+      expect(outcome).toMatchObject({ status: 'refused', reason: 'plan-not-conserving' });
+      expect(works.create).not.toHaveBeenCalled();
+    });
+
+    it('should refuse a plan carrying holds rather than dropping them', async () => {
+      // Committing the plan MINUS its holds would silently drop quantities from
+      // a plan that just passed the conservation check.
+      router.route.mockResolvedValue(
+        resolvedPlan({
+          assignments: [
+            { orderLineId: 'l1', locationId: 'loc-1', connectionId: 'c1', deliveryMethod: null, quantity: 1 },
+          ],
+          holds: [{ orderLineId: 'l1', quantity: 1, reason: 'awaiting_stock' as never }],
+        })
+      );
+
+      const outcome = await service.route(input());
+
+      expect(outcome).toMatchObject({ status: 'refused', reason: 'plan-carries-holds' });
+      expect(works.create).not.toHaveBeenCalled();
+    });
+
+    it('should refuse a plan carrying unfulfillable lines', async () => {
+      router.route.mockResolvedValue(
+        resolvedPlan({
+          assignments: [
+            { orderLineId: 'l1', locationId: 'loc-1', connectionId: 'c1', deliveryMethod: null, quantity: 1 },
+          ],
+          unfulfillable: [
+            { orderLineId: 'l1', quantity: 1, resolution: 'refund' as const, reason: 'oos' },
+          ],
+        })
+      );
+
+      const outcome = await service.route(input());
+
+      expect(outcome).toMatchObject({ status: 'refused', reason: 'plan-carries-unfulfillable' });
+    });
+
+    it('should report contention rather than a refusal that was never persisted', async () => {
+      // The handler's `refused` arm tells an operator the reason is durable on
+      // the decision row. If a peer terminalised first, that sentence is false —
+      // and a wrong reason is worse than none.
+      router.route.mockResolvedValue(resolvedPlan({ assignments: [] }));
+      decisions.terminalise.mockResolvedValue(false);
+
+      const outcome = await service.route(input());
+
+      expect(outcome).toEqual({ status: 'contended' });
+    });
+
+    it('should keep the vendor reference on an abandoned decision', async () => {
+      router.route.mockResolvedValue(
+        resolvedPlan({ assignments: [] })
+      );
+
+      await service.route(input());
+
+      // The one value that lets an operator correlate the refusal against the
+      // vendor's own log.
+      expect(decisions.terminalise).toHaveBeenCalledWith(
+        expect.objectContaining({ state: 'abandoned', routerDecisionRef: 'vendor-1' })
+      );
+    });
+  });
+
+  describe('committing', () => {
+    it('should create work and terminalise inside ONE transaction', async () => {
+      // Capture the handle each write actually received, rather than indexing
+      // into `mock.calls` (which is `any` and would defeat the point of
+      // asserting they are the SAME object).
+      const handles: unknown[] = [];
+      works.create.mockImplementation((_input: unknown, transaction: unknown) => {
+        handles.push(transaction);
+        return Promise.resolve({ id: 'ol_work_1' });
+      });
+      decisions.terminalise.mockImplementation((arg: { transaction?: unknown }) => {
+        handles.push(arg.transaction);
+        return Promise.resolve(true);
+      });
+
+      const outcome = await service.route(input());
+
+      expect(outcome).toMatchObject({ status: 'routed', workIds: ['ol_work_1'] });
+      expect(works.runInTransaction).toHaveBeenCalledTimes(1);
+      // Both writes received the SAME handle — this is ADR-054 R1.
+      expect(handles).toHaveLength(2);
+      expect(handles[0]).toBeDefined();
+      expect(handles[1]).toBe(handles[0]);
+    });
+
+    it('should split work per (location, connection, deliveryMethod) and never split the order', async () => {
+      router.route.mockResolvedValue(
+        resolvedPlan({
+          assignments: [
+            { orderLineId: 'l1', locationId: 'loc-1', connectionId: 'c1', deliveryMethod: null, quantity: 1 },
+            { orderLineId: 'l1', locationId: 'loc-2', connectionId: 'c1', deliveryMethod: null, quantity: 1 },
+          ],
+        })
+      );
+      works.create
+        .mockResolvedValueOnce({ id: 'ol_work_a' })
+        .mockResolvedValueOnce({ id: 'ol_work_b' });
+
+      const outcome = await service.route(input());
+
+      // ADR-054: splits exist ONLY at the work grain.
+      expect(outcome).toMatchObject({ status: 'routed', workIds: ['ol_work_a', 'ol_work_b'] });
+      expect(works.create).toHaveBeenCalledTimes(2);
+    });
+
+    it('should resolve the work line variant from the routing input, never a sentinel', async () => {
+      await service.route(input());
+
+      expect(works.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          lines: [
+            { orderLineId: 'l1', productVariantId: 'ol_variant_1', totalQuantity: 2 },
+          ],
+        }),
+        expect.anything()
+      );
+    });
+
+    it('should roll back by throwing when the decision is no longer live', async () => {
+      decisions.terminalise.mockResolvedValue(false);
+
+      // A DISTINCT type from `RoutingDecisionAlreadyLiveError`, which asserts the
+      // opposite condition and which `claimOrResume` matches on to mean "resume
+      // the winner". Reusing it would give the next person who wraps this call
+      // in a catch a resume where a rollback happened.
+      await expect(service.route(input())).rejects.toBeInstanceOf(RoutingDecisionNoLongerLiveError);
+    });
+
+    it('should keep two targets apart when a delivery method contains the delimiter', async () => {
+      // A `|`-joined key collides `(l='a', d='b|c')` with `(l='a|b', d='c')`, and
+      // the collision does not produce a tidy duplicate — it merges two lines
+      // bound for DIFFERENT LOCATIONS into one work object and ships from the
+      // wrong place. `deliveryMethod` is the source's OPAQUE id, so a `|` is not
+      // hypothetical.
+      router.route.mockResolvedValue(
+        resolvedPlan({
+          assignments: [
+            // Both render `a|b|c|d` under a `|`-joined template. All three
+            // fields must be populated for the collision to exist — with a null
+            // in either, the keys differ and the test would prove nothing.
+            { orderLineId: 'l1', locationId: 'a', connectionId: 'b|c', deliveryMethod: 'd', quantity: 1 },
+            { orderLineId: 'l1', locationId: 'a|b', connectionId: 'c', deliveryMethod: 'd', quantity: 1 },
+          ],
+        })
+      );
+      works.create
+        .mockResolvedValueOnce({ id: 'ol_work_a' })
+        .mockResolvedValueOnce({ id: 'ol_work_b' });
+
+      const outcome = await service.route(input());
+
+      expect(outcome).toMatchObject({ status: 'routed' });
+      expect(works.create).toHaveBeenCalledTimes(2);
+    });
+
+    it('should distinguish a null target from an empty-string one', async () => {
+      router.route.mockResolvedValue(
+        resolvedPlan({
+          assignments: [
+            { orderLineId: 'l1', locationId: null, connectionId: null, deliveryMethod: null, quantity: 1 },
+            { orderLineId: 'l1', locationId: '', connectionId: null, deliveryMethod: null, quantity: 1 },
+          ],
+        })
+      );
+      works.create
+        .mockResolvedValueOnce({ id: 'ol_work_a' })
+        .mockResolvedValueOnce({ id: 'ol_work_b' });
+
+      await service.route(input());
+
+      expect(works.create).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/libs/core/src/fulfillment/application/services/__tests__/routing-commit.service.spec.ts
+++ b/libs/core/src/fulfillment/application/services/__tests__/routing-commit.service.spec.ts
@@ -48,7 +48,13 @@ const resolvedPlan = (overrides: Partial<Extract<RoutingPlan, { status: 'resolve
   status: 'resolved' as const,
   decisionId: 'vendor-1',
   assignments: overrides.assignments ?? [
-    { orderLineId: 'l1', locationId: 'loc-1', connectionId: 'c1', deliveryMethod: null, quantity: 2 },
+    {
+      orderLineId: 'l1',
+      locationId: 'loc-1',
+      connectionId: 'c1',
+      deliveryMethod: null,
+      quantity: 2,
+    },
   ],
   unfulfillable: overrides.unfulfillable ?? [],
   holds: overrides.holds ?? [],
@@ -92,15 +98,17 @@ describe('RoutingCommitService', () => {
       // Runs `fn` for real so the commit body is genuinely exercised; the
       // rollback property itself is pinned by the int-spec, which needs a real
       // database to mean anything.
-      runInTransaction: jest.fn(async (fn: (t: unknown) => Promise<unknown>) => fn({ save: jest.fn() })),
+      runInTransaction: jest.fn(async (fn: (t: unknown) => Promise<unknown>) =>
+        fn({ save: jest.fn() })
+      ),
     };
-    lock = { acquire: jest.fn().mockResolvedValue('token'), release: jest.fn().mockResolvedValue(true) };
+    lock = {
+      acquire: jest.fn().mockResolvedValue('token'),
+      release: jest.fn().mockResolvedValue(true),
+    };
     router = { route: jest.fn().mockResolvedValue(resolvedPlan()), evaluate: jest.fn() };
 
-    service = new RoutingCommitService(
-      decisions as never,
-      works as never
-    );
+    service = new RoutingCommitService(decisions as never, works as never);
   });
 
   describe('the declared timeout', () => {
@@ -168,9 +176,7 @@ describe('RoutingCommitService', () => {
 
     it('should refuse a live decision held by a DIFFERENT router', async () => {
       // Router-agnostic by design: the guard refuses regardless of identity.
-      decisions.findLiveByOrderId.mockResolvedValue(
-        decision({ routerConnectionId: 'conn_other' })
-      );
+      decisions.findLiveByOrderId.mockResolvedValue(decision({ routerConnectionId: 'conn_other' }));
 
       const outcome = await service.route(input());
 
@@ -203,10 +209,9 @@ describe('RoutingCommitService', () => {
 
       expect(outcome.status).toBe('routed');
       expect(decisions.claimIntent).not.toHaveBeenCalled();
-      expect(router.route).toHaveBeenCalledWith(
-        expect.anything(),
-        { idempotencyKey: 'route:ol_routingdecision_9' }
-      );
+      expect(router.route).toHaveBeenCalledWith(expect.anything(), {
+        idempotencyKey: 'route:ol_routingdecision_9',
+      });
     });
 
     it('should resume when the INDEX refuses the insert after a clean guard read', async () => {
@@ -220,10 +225,9 @@ describe('RoutingCommitService', () => {
       const outcome = await service.route(input());
 
       expect(outcome.status).toBe('routed');
-      expect(router.route).toHaveBeenCalledWith(
-        expect.anything(),
-        { idempotencyKey: 'route:ol_routingdecision_7' }
-      );
+      expect(router.route).toHaveBeenCalledWith(expect.anything(), {
+        idempotencyKey: 'route:ol_routingdecision_7',
+      });
     });
   });
 
@@ -296,9 +300,17 @@ describe('RoutingCommitService', () => {
   describe('refusing a plan', () => {
     it('should abandon a non-conserving plan', async () => {
       router.route.mockResolvedValue(
-        resolvedPlan({ assignments: [
-          { orderLineId: 'l1', locationId: null, connectionId: null, deliveryMethod: null, quantity: 1 },
-        ] })
+        resolvedPlan({
+          assignments: [
+            {
+              orderLineId: 'l1',
+              locationId: null,
+              connectionId: null,
+              deliveryMethod: null,
+              quantity: 1,
+            },
+          ],
+        })
       );
 
       const outcome = await service.route(input());
@@ -313,7 +325,13 @@ describe('RoutingCommitService', () => {
       router.route.mockResolvedValue(
         resolvedPlan({
           assignments: [
-            { orderLineId: 'l1', locationId: 'loc-1', connectionId: 'c1', deliveryMethod: null, quantity: 1 },
+            {
+              orderLineId: 'l1',
+              locationId: 'loc-1',
+              connectionId: 'c1',
+              deliveryMethod: null,
+              quantity: 1,
+            },
           ],
           holds: [{ orderLineId: 'l1', quantity: 1, reason: 'awaiting_stock' as never }],
         })
@@ -329,7 +347,13 @@ describe('RoutingCommitService', () => {
       router.route.mockResolvedValue(
         resolvedPlan({
           assignments: [
-            { orderLineId: 'l1', locationId: 'loc-1', connectionId: 'c1', deliveryMethod: null, quantity: 1 },
+            {
+              orderLineId: 'l1',
+              locationId: 'loc-1',
+              connectionId: 'c1',
+              deliveryMethod: null,
+              quantity: 1,
+            },
           ],
           unfulfillable: [
             { orderLineId: 'l1', quantity: 1, resolution: 'refund' as const, reason: 'oos' },
@@ -355,9 +379,7 @@ describe('RoutingCommitService', () => {
     });
 
     it('should keep the vendor reference on an abandoned decision', async () => {
-      router.route.mockResolvedValue(
-        resolvedPlan({ assignments: [] })
-      );
+      router.route.mockResolvedValue(resolvedPlan({ assignments: [] }));
 
       await service.route(input());
 
@@ -398,8 +420,20 @@ describe('RoutingCommitService', () => {
       router.route.mockResolvedValue(
         resolvedPlan({
           assignments: [
-            { orderLineId: 'l1', locationId: 'loc-1', connectionId: 'c1', deliveryMethod: null, quantity: 1 },
-            { orderLineId: 'l1', locationId: 'loc-2', connectionId: 'c1', deliveryMethod: null, quantity: 1 },
+            {
+              orderLineId: 'l1',
+              locationId: 'loc-1',
+              connectionId: 'c1',
+              deliveryMethod: null,
+              quantity: 1,
+            },
+            {
+              orderLineId: 'l1',
+              locationId: 'loc-2',
+              connectionId: 'c1',
+              deliveryMethod: null,
+              quantity: 1,
+            },
           ],
         })
       );
@@ -414,14 +448,52 @@ describe('RoutingCommitService', () => {
       expect(works.create).toHaveBeenCalledTimes(2);
     });
 
+    it('should SUM two assignments that share a target and an order line', async () => {
+      // The one branch that decides a written quantity, and the only one the
+      // other multi-assignment tests do not reach (they differ by target).
+      // Getting it wrong inserts the same `(work, orderLine)` twice, which
+      // raises `DuplicateFulfillmentWorkLineError` and aborts the whole
+      // transaction — so a silent regression here fails the entire commit.
+      router.route.mockResolvedValue(
+        resolvedPlan({
+          assignments: [
+            {
+              orderLineId: 'l1',
+              locationId: 'loc-1',
+              connectionId: 'c1',
+              deliveryMethod: null,
+              quantity: 1,
+            },
+            {
+              orderLineId: 'l1',
+              locationId: 'loc-1',
+              connectionId: 'c1',
+              deliveryMethod: null,
+              quantity: 1,
+            },
+          ],
+        })
+      );
+
+      const outcome = await service.route(input());
+
+      expect(outcome.status).toBe('routed');
+      // ONE work object, ONE line, quantities added — never two lines.
+      expect(works.create).toHaveBeenCalledTimes(1);
+      expect(works.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          lines: [{ orderLineId: 'l1', productVariantId: 'ol_variant_1', totalQuantity: 2 }],
+        }),
+        expect.anything()
+      );
+    });
+
     it('should resolve the work line variant from the routing input, never a sentinel', async () => {
       await service.route(input());
 
       expect(works.create).toHaveBeenCalledWith(
         expect.objectContaining({
-          lines: [
-            { orderLineId: 'l1', productVariantId: 'ol_variant_1', totalQuantity: 2 },
-          ],
+          lines: [{ orderLineId: 'l1', productVariantId: 'ol_variant_1', totalQuantity: 2 }],
         }),
         expect.anything()
       );
@@ -449,8 +521,20 @@ describe('RoutingCommitService', () => {
             // Both render `a|b|c|d` under a `|`-joined template. All three
             // fields must be populated for the collision to exist — with a null
             // in either, the keys differ and the test would prove nothing.
-            { orderLineId: 'l1', locationId: 'a', connectionId: 'b|c', deliveryMethod: 'd', quantity: 1 },
-            { orderLineId: 'l1', locationId: 'a|b', connectionId: 'c', deliveryMethod: 'd', quantity: 1 },
+            {
+              orderLineId: 'l1',
+              locationId: 'a',
+              connectionId: 'b|c',
+              deliveryMethod: 'd',
+              quantity: 1,
+            },
+            {
+              orderLineId: 'l1',
+              locationId: 'a|b',
+              connectionId: 'c',
+              deliveryMethod: 'd',
+              quantity: 1,
+            },
           ],
         })
       );
@@ -468,8 +552,20 @@ describe('RoutingCommitService', () => {
       router.route.mockResolvedValue(
         resolvedPlan({
           assignments: [
-            { orderLineId: 'l1', locationId: null, connectionId: null, deliveryMethod: null, quantity: 1 },
-            { orderLineId: 'l1', locationId: '', connectionId: null, deliveryMethod: null, quantity: 1 },
+            {
+              orderLineId: 'l1',
+              locationId: null,
+              connectionId: null,
+              deliveryMethod: null,
+              quantity: 1,
+            },
+            {
+              orderLineId: 'l1',
+              locationId: '',
+              connectionId: null,
+              deliveryMethod: null,
+              quantity: 1,
+            },
           ],
         })
       );

--- a/libs/core/src/fulfillment/application/services/routing-commit-lock.ts
+++ b/libs/core/src/fulfillment/application/services/routing-commit-lock.ts
@@ -1,0 +1,77 @@
+/**
+ * Routing commit lock + timing (#2395, `W3a-6`, DESIGN §5.3)
+ *
+ * The lock key, its TTL, and the wall-clock budget the router call is held to.
+ *
+ * ## Keyed per ORDER, never per (order, router)
+ *
+ * The invariant being serialized is *"this order is routed once"*. Two operators
+ * configuring two different routers for one order is precisely the case a
+ * per-connection key would let through, and it is the case that ends in two
+ * shipments. Same key shape and the same reasoning as `invoiceIssueLockKey`
+ * (#2047) and `shipmentDispatchLockKey` (#1917).
+ *
+ * ## TTL expiry is not a correctness cliff
+ *
+ * The window the lock must cover is only guard-read -> `claimIntent`: two
+ * database round-trips. Past that point a `live` `routing_decisions` row exists,
+ * and a peer's own guard read sees it and refuses — enforced by that table's
+ * partial-unique index, not by this lock. So the lock removes the race, and the
+ * PERSISTED INTENT ROW is what survives a lock that expired mid-`route()`.
+ *
+ * That is also why the budget below is strictly less than the TTL rather than
+ * merely "generous": a router still running after the lock expired can have its
+ * work committed concurrently with a peer that has since acquired the lock. The
+ * relationship is asserted by a spec, not left to whoever next edits a default.
+ *
+ * Resolved ONCE at module load, so both values are fixed for the process
+ * lifetime and cannot be varied per-test by mutating `process.env` after import
+ * (a spec needing a different value re-imports the module in isolation). That is
+ * the `SHIPMENT_DISPATCH_LOCK_TTL_MS` / `INVOICE_ISSUE_LOCK_TTL_MS` precedent,
+ * kept deliberately.
+ *
+ * @module libs/core/src/fulfillment/application/services
+ */
+
+const DEFAULT_ROUTE_LOCK_TTL_MS = 120_000;
+const MIN_ROUTE_LOCK_TTL_MS = 10_000;
+const MAX_ROUTE_LOCK_TTL_MS = 600_000;
+
+/**
+ * How much of the TTL the router call may consume.
+ *
+ * Deliberately a FRACTION rather than an independent env var. Two independently
+ * tunable numbers whose only requirement is an inequality is a configuration
+ * that can be set into an unsafe state by an operator who has no way to know it;
+ * deriving the budget makes `budget < ttl` true by construction at every TTL.
+ */
+const ROUTE_TIMEOUT_FRACTION_OF_TTL = 0.5;
+
+function resolveRouteLockTtlMs(): number {
+  const raw = process.env.OL_FULFILLMENT_ROUTE_LOCK_TTL_MS;
+  const parsed = raw === undefined ? Number.NaN : Number.parseInt(raw, 10);
+
+  if (!Number.isFinite(parsed)) {
+    return DEFAULT_ROUTE_LOCK_TTL_MS;
+  }
+
+  return Math.min(MAX_ROUTE_LOCK_TTL_MS, Math.max(MIN_ROUTE_LOCK_TTL_MS, parsed));
+}
+
+/** TTL of `fulfillment:route:{orderId}`. */
+export const FULFILLMENT_ROUTE_LOCK_TTL_MS = resolveRouteLockTtlMs();
+
+/**
+ * The declared wall-clock budget for one `FulfillmentRouterPort.route()` call.
+ *
+ * **Strictly less than {@link FULFILLMENT_ROUTE_LOCK_TTL_MS}** — asserted by a
+ * spec, because the inequality is the whole point and a later edit to either
+ * default could silently break it.
+ */
+export const FULFILLMENT_ROUTE_TIMEOUT_MS = Math.floor(
+  FULFILLMENT_ROUTE_LOCK_TTL_MS * ROUTE_TIMEOUT_FRACTION_OF_TTL
+);
+
+/** `fulfillment:route:{orderId}` — per ORDER, see this file's header. */
+export const fulfillmentRouteLockKey = (orderId: string): string =>
+  `fulfillment:route:${orderId}`;

--- a/libs/core/src/fulfillment/application/services/routing-commit.service.ts
+++ b/libs/core/src/fulfillment/application/services/routing-commit.service.ts
@@ -1,0 +1,536 @@
+/**
+ * Routing Commit Service (#2395, `W3a-6`, ADR-054 R1, DESIGN §5.3)
+ *
+ * Decides where an order is fulfilled from — **exactly once** — and commits the
+ * decision and the work it creates atomically.
+ *
+ * Two routers producing two plans for one order is a **double shipment**:
+ * physical, and unrecoverable. Every rule below exists for that one failure
+ * mode, and this is a verbatim copy of the #2047 four-part invoicing shape,
+ * where a wrong pick is a legal event rather than a parcel.
+ *
+ * ## The four parts, in the order they must happen
+ *
+ * 1. **Exactly one router.** Resolved upstream by `selectPrimaryFulfillmentRouter`;
+ *    an ambiguous set never reaches here, because it commits nothing and is
+ *    reported. Silence-and-pick-one is forbidden.
+ * 2. **A per-ORDER lock**, `fulfillment:route:{orderId}`. Never per
+ *    (order, router) — two operators configuring different routers for one order
+ *    is exactly the case a per-connection key lets through.
+ * 3. **A write-path guard that refuses regardless of router identity** — a live
+ *    decision or any non-cancelled work for the order stops the commit.
+ * 4. **Intent persisted BEFORE the boundary**, then N work rows plus the
+ *    decision's terminalisation in ONE transaction.
+ *
+ * ## What actually enforces uniqueness
+ *
+ * Not the guard read. `routing_decisions` carries
+ * `UNIQUE (orderId) WHERE state = 'live'`, and **that index is the enforcement**:
+ * a `SELECT`-then-`INSERT` guarantees nothing at READ COMMITTED, because a plain
+ * `SELECT` takes no locks and the conflicting row is a phantom. The guard read
+ * exists to produce a clean, reportable outcome in the common case; the index is
+ * what makes the invariant true. The lock narrows the window between them so the
+ * common case stays common.
+ *
+ * ## One structural precondition of the atomic commit
+ *
+ * `commit()` hands ONE handle to both `FulfillmentWorkRepositoryPort.create` and
+ * `RoutingDecisionRepositoryPort.terminalise`, and each narrows it to an
+ * `EntityManager` internally. That is atomic only while both repositories share
+ * one `DataSource` — true today, and silently false the day someone splits them,
+ * at which point the two writes would commit independently with nothing
+ * reporting it. Stated because it is invisible at this call site.
+ *
+ * ## The lock is not the guarantee either
+ *
+ * Note also that the router budget's clock starts at the ROUTER CALL, not at
+ * `acquire`: four database round-trips (the cancellation re-read, the guard
+ * reads and `claimIntent`) sit between them and are unbudgeted, so the real
+ * margin is `TTL - budget - preamble`. That is a margin note rather than a hole
+ * — a peer acquiring an expired lock finds the live row and resumes it under the
+ * same key.
+ *
+ * A lock is lost on process death, on TTL expiry and on a Redis blip, and the
+ * peer that acquires it next has no way to learn a `route()` is already in
+ * flight. That is precisely why the intent row is persisted and COMMITTED before
+ * the router is called — an ordering a lock cannot supply (REVIEW C2).
+ *
+ * @module libs/core/src/fulfillment/application/services
+ * @see docs/architecture/adrs/054-fulfillment-work-unit-of-assignment.md
+ */
+import { Inject, Injectable } from '@nestjs/common';
+
+import { Logger } from '@openlinker/shared/logging';
+
+import { RoutingDecisionAlreadyLiveError } from '../../domain/exceptions/routing-decision-already-live.error';
+import { RoutingDecisionNoLongerLiveError } from '../../domain/exceptions/routing-decision-no-longer-live.error';
+import { PendingRoutingPlanNotSupportedError } from '../../domain/exceptions/pending-routing-plan-not-supported.error';
+import { assertRoutingPlanResolved } from '../../domain/exceptions/pending-routing-plan-not-supported.error';
+import { FulfillmentWorkRepositoryPort } from '../../domain/ports/fulfillment-work-repository.port';
+import { RoutingDecisionRepositoryPort } from '../../domain/ports/routing-decision-repository.port';
+import type { RoutingDecision } from '../../domain/entities/routing-decision.entity';
+import {
+  deriveRouteIdempotencyKey,
+  type RoutingDecisionAbandonReason,
+} from '../../domain/types/routing-decision.types';
+import {
+  checkRoutingPlanConservesQuantities,
+  type ResolvedRoutingPlan,
+  type RoutingInput,
+} from '../../domain/types/routing.types';
+import {
+  FULFILLMENT_WORK_REPOSITORY_TOKEN,
+  ROUTING_DECISION_REPOSITORY_TOKEN,
+} from '../../fulfillment.tokens';
+import type { RouteOrderInput, RoutingCommitOutcome } from '../types/routing-commit.types';
+import type { IRoutingCommitService } from '../interfaces/routing-commit.service.interface';
+import {
+  FULFILLMENT_ROUTE_LOCK_TTL_MS,
+  FULFILLMENT_ROUTE_TIMEOUT_MS,
+  fulfillmentRouteLockKey,
+} from './routing-commit-lock';
+
+/** Sentinel for the timeout race, so a router resolving `undefined` is not mistaken for one. */
+const ROUTE_TIMED_OUT = Symbol('route-timed-out');
+
+@Injectable()
+export class RoutingCommitService implements IRoutingCommitService {
+  private readonly logger = new Logger(RoutingCommitService.name);
+
+  constructor(
+    @Inject(ROUTING_DECISION_REPOSITORY_TOKEN)
+    private readonly decisions: RoutingDecisionRepositoryPort,
+    @Inject(FULFILLMENT_WORK_REPOSITORY_TOKEN)
+    private readonly works: FulfillmentWorkRepositoryPort
+  ) {}
+
+  async route(input: RouteOrderInput): Promise<RoutingCommitOutcome> {
+    const lockKey = fulfillmentRouteLockKey(input.orderId);
+    const token = await input.lock.acquire(lockKey, FULFILLMENT_ROUTE_LOCK_TTL_MS);
+
+    if (token === null) {
+      // A peer is mid-flight. Answer from persisted state ONLY — crossing the
+      // router boundary here is the double-ship, so this branch must never do
+      // anything that could produce a second plan.
+      this.logger.log(
+        `Routing contended, answering from persisted state: orderId=${input.orderId}`
+      );
+      return { status: 'contended' };
+    }
+
+    try {
+      return await this.routeUnderLock(input);
+    } finally {
+      try {
+        await input.lock.release(lockKey, token);
+      } catch (releaseError) {
+        // Never let a release failure mask the routing outcome. The lock expires
+        // on its own, and the decision row is what protects the order anyway.
+        this.logger.warn(
+          `Failed to release routing lock ${lockKey}: ` +
+            `${releaseError instanceof Error ? releaseError.message : String(releaseError)}`
+        );
+      }
+    }
+  }
+
+  private async routeUnderLock(input: RouteOrderInput): Promise<RoutingCommitOutcome> {
+    // Re-read INSIDE the lock. A cancellation flag read before acquiring is a
+    // value from a moment that has passed (REVIEW C10).
+    if (await input.isCancelled()) {
+      return { status: 'skipped', reason: 'order-cancelled' };
+    }
+
+    const claimed = await this.claimOrResume(input);
+    if (claimed.outcome !== null) {
+      return claimed.outcome;
+    }
+
+    const decision = claimed.decision;
+    const routingInput: RoutingInput = {
+      orderId: input.orderId,
+      lines: input.lines,
+      shipTo: input.shipTo,
+      requestedDeliveryMethod: input.requestedDeliveryMethod,
+    };
+
+    // Derived from the decision row's immutable id, never from a job id. A RETRY
+    // re-derives this byte-identically (which is what makes the resume above
+    // safe); a genuine RE-ROUTE is a new row and therefore a new key. The #2039
+    // `reconcileId` lesson: a retry that mints a fresh key is not a retry.
+    const idempotencyKey = deriveRouteIdempotencyKey(decision.id);
+
+    let plan;
+    try {
+      plan = await this.callRouterWithinBudget(input, routingInput, idempotencyKey);
+    } catch (error) {
+      return this.leaveInDoubt(decision, 'error', error);
+    }
+
+    if (plan === ROUTE_TIMED_OUT) {
+      return this.leaveInDoubt(decision, 'timeout');
+    }
+
+    let resolved: ResolvedRoutingPlan;
+    try {
+      assertRoutingPlanResolved(plan);
+      resolved = plan;
+    } catch (error) {
+      if (error instanceof PendingRoutingPlanNotSupportedError) {
+        return await this.refuse(decision, 'plan-pending', plan.decisionId);
+      }
+      throw error;
+    }
+
+    const refusal = this.refusalFor(resolved, routingInput);
+    if (refusal !== null) {
+      return await this.refuse(decision, refusal, resolved.decisionId);
+    }
+
+    // `RoutingAssignment` names an `orderLineId` but no variant, while a work
+    // LINE needs both. The mapping comes from the routing input we sent, and it
+    // is total here rather than by luck: `checkRoutingPlanConservesQuantities`
+    // has already rejected any plan naming a line the input did not.
+    const variantByOrderLineId = new Map(
+      routingInput.lines.map((line) => [line.orderLineId, line.productVariantId])
+    );
+
+    return await this.commit(decision, resolved, variantByOrderLineId);
+  }
+
+  /**
+   * Claim the intent, or resume the one already live for this order.
+   *
+   * **Resuming is what makes a crash between `claimIntent` and the commit
+   * recoverable.** Without it the live row would refuse every subsequent attempt
+   * and the order would be stranded forever, silently — the row cannot be
+   * abandoned either, for the reason given in {@link leaveInDoubt}. Resuming
+   * re-derives the identical idempotency key, which is exactly what an
+   * idempotency key is for: the router recognises the retry and answers with the
+   * same decision instead of making a second one.
+   *
+   * A live decision belonging to a DIFFERENT router is refused rather than
+   * resumed — the guard is router-agnostic by design (DESIGN §5.3).
+   */
+  private async claimOrResume(
+    input: RouteOrderInput
+  ): Promise<{ decision: RoutingDecision; outcome: null } | { decision: null; outcome: RoutingCommitOutcome }> {
+    const live = await this.decisions.findLiveByOrderId(input.orderId);
+    if (live !== null) {
+      return this.resumeOrRefuse(live, input);
+    }
+
+    // No live decision: does the order already carry committed work? A cancelled
+    // work object does not block — that is the re-route path (REVIEW C10).
+    const existingWork = await this.works.findByOrderId(input.orderId);
+    if (existingWork.some((work) => work.cancelledAt === null)) {
+      return { decision: null, outcome: { status: 'skipped', reason: 'already-routed' } };
+    }
+
+    try {
+      return { decision: await this.decisions.claimIntent({
+        orderId: input.orderId,
+        routerConnectionId: input.routerConnectionId,
+      }), outcome: null };
+    } catch (error) {
+      if (error instanceof RoutingDecisionAlreadyLiveError) {
+        // The partial-unique index refused us — a peer won the race between our
+        // guard read and this INSERT. This is the branch that proves the guard
+        // read is a convenience and the INDEX is the enforcement.
+        const winner = await this.decisions.findLiveByOrderId(input.orderId);
+        if (winner === null) {
+          // Terminalised between the refusal and this read. Nothing to resume.
+          return { decision: null, outcome: { status: 'skipped', reason: 'already-routed' } };
+        }
+        return this.resumeOrRefuse(winner, input);
+      }
+      throw error;
+    }
+  }
+
+  private resumeOrRefuse(
+    live: RoutingDecision,
+    input: RouteOrderInput
+  ): { decision: RoutingDecision; outcome: null } | { decision: null; outcome: RoutingCommitOutcome } {
+    if (live.routerConnectionId !== input.routerConnectionId) {
+      return { decision: null, outcome: { status: 'skipped', reason: 'already-live-elsewhere' } };
+    }
+    this.logger.log(
+      `Resuming a live routing decision under its original key: ` +
+        `orderId=${input.orderId} decisionId=${live.id}`
+    );
+    return { decision: live, outcome: null };
+  }
+
+  /**
+   * Leave the decision `live` and report the doubt.
+   *
+   * **This is the finding of #2395, and the instinct it resists is to free the
+   * order.** A timeout or a throwing `route()` is IN-DOUBT, not
+   * nothing-happened: the router may be committing on its side right now.
+   * Terminalising to `abandoned` would take the row OUT of the
+   * `UNIQUE (orderId) WHERE state = 'live'` index, so the next attempt would
+   * mint a NEW decision id and therefore a NEW idempotency key — one the vendor
+   * cannot dedup against the first call. That is two plans and two shipments.
+   *
+   * Invoicing reached the identical conclusion from the other side:
+   * `InvoiceRecord.blocksIssuanceElsewhere` keeps blocking on every failure
+   * EXCEPT a terminal `rejected`, because only that one means the provider
+   * definitely created nothing.
+   *
+   * The cost is a decision that stays `live` until something clears it, which is
+   * a stranded order rather than a duplicated shipment — recoverable by hand,
+   * and swept by the follow-up reaper. That trade is the whole point.
+   */
+  private leaveInDoubt(
+    decision: RoutingDecision,
+    cause: 'timeout' | 'error',
+    error?: unknown
+  ): RoutingCommitOutcome {
+    this.logger.error(
+      `Router call is IN DOUBT; leaving decision live so no second key can be minted: ` +
+        `orderId=${decision.orderId} decisionId=${decision.id} cause=${cause}` +
+        (error instanceof Error ? ` error=${error.message}` : '')
+    );
+    return { status: 'in-doubt', decisionId: decision.id, cause };
+  }
+
+  /** Which Wave-3a refusal, if any, this plan earns. */
+  private refusalFor(
+    plan: ResolvedRoutingPlan,
+    routingInput: RoutingInput
+  ): RoutingDecisionAbandonReason | null {
+    if (!checkRoutingPlanConservesQuantities(routingInput, plan)) {
+      return 'plan-not-conserving';
+    }
+
+    // Wave 3a cannot commit either of these, and committing the plan WITHOUT
+    // them would silently drop quantities from a plan that just passed the
+    // conservation check — the exact failure that check exists to catch.
+    //
+    // Inert until a router exists (#2408/#2409 inject the first one), which is
+    // why the log below names the follow-up: whoever wires that router meets
+    // this constraint at the point of failure instead of debugging it.
+    if (plan.holds.length > 0) {
+      return 'plan-carries-holds';
+    }
+    if (plan.unfulfillable.length > 0) {
+      return 'plan-carries-unfulfillable';
+    }
+
+    return null;
+  }
+
+  private async refuse(
+    decision: RoutingDecision,
+    reason: RoutingDecisionAbandonReason,
+    routerDecisionRef: string | null
+  ): Promise<RoutingCommitOutcome> {
+    // Safe to terminalise: the router DEFINITELY answered, so there is no
+    // in-flight call a re-route could race. Contrast {@link leaveInDoubt}.
+    const terminalised = await this.decisions.terminalise({
+      decisionId: decision.id,
+      state: 'abandoned',
+      abandonReason: reason,
+      // Kept even on the abandoned arm — it is the one value that lets an
+      // operator correlate this refusal against the vendor's own log.
+      routerDecisionRef,
+    });
+
+    if (!terminalised) {
+      // A peer terminalised it first, so this refusal was NOT persisted. Report
+      // contention rather than `refused`: the handler's `refused` arm tells the
+      // operator the reason is durable on the decision row, and saying that
+      // about a write that did not land would be a wrong reason — worse than
+      // none. Nothing was written either way, so `contended` is the truth.
+      this.logger.warn(
+        `Routing refusal was not persisted (decision no longer live): ` +
+          `orderId=${decision.orderId} decisionId=${decision.id} reason=${reason}`
+      );
+      return { status: 'contended' };
+    }
+
+    this.logger.warn(
+      `Refused a routing plan: orderId=${decision.orderId} decisionId=${decision.id} ` +
+        `reason=${reason}` +
+        (reason === 'plan-carries-holds' || reason === 'plan-carries-unfulfillable'
+          ? ' — holds and unfulfillable lines have no commit path in Wave 3a; see the' +
+            ' follow-up filed against #2408/#2409 before emitting them from a router.'
+          : '')
+    );
+
+    return { status: 'refused', decisionId: decision.id, reason };
+  }
+
+  /**
+   * ADR-054 R1: the N work rows and the decision's terminalisation commit
+   * together, or neither does.
+   */
+  private async commit(
+    decision: RoutingDecision,
+    plan: ResolvedRoutingPlan,
+    variantByOrderLineId: ReadonlyMap<string, string>
+  ): Promise<RoutingCommitOutcome> {
+    const workIds = await this.works.runInTransaction(async (transaction) => {
+      const created: string[] = [];
+
+      for (const assignment of groupAssignmentsIntoWork(plan, variantByOrderLineId)) {
+        const work = await this.works.create(
+          {
+            orderId: decision.orderId,
+            locationId: assignment.locationId,
+            deliveryMethod: assignment.deliveryMethod,
+            assignedConnectionId: assignment.connectionId,
+            lines: assignment.lines,
+          },
+          transaction
+        );
+        created.push(work.id);
+      }
+
+      const terminalised = await this.decisions.terminalise({
+        decisionId: decision.id,
+        state: 'committed',
+        routerDecisionRef: plan.decisionId,
+        transaction,
+      });
+
+      if (!terminalised) {
+        // The decision is no longer live — a peer terminalised it while we were
+        // creating work. Throwing is what makes ADR-054 R1 true: without it we
+        // would commit work rows belonging to a decision that no longer claims
+        // this order, which is the split state the single transaction exists to
+        // make impossible.
+        throw new RoutingDecisionNoLongerLiveError(decision.orderId, decision.id);
+      }
+
+      return created;
+    });
+
+    return { status: 'routed', decisionId: decision.id, workIds };
+  }
+
+  /**
+   * The router call, bounded by a budget strictly below the lock TTL.
+   *
+   * The budget is not politeness: a router still running after the lock expired
+   * could have its work committed concurrently with a peer that has since
+   * acquired the lock.
+   */
+  private async callRouterWithinBudget(
+    input: RouteOrderInput,
+    routingInput: RoutingInput,
+    idempotencyKey: string
+  ): Promise<Awaited<ReturnType<typeof input.router.route>> | typeof ROUTE_TIMED_OUT> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const budget = new Promise<typeof ROUTE_TIMED_OUT>((resolve) => {
+      timer = setTimeout(() => resolve(ROUTE_TIMED_OUT), FULFILLMENT_ROUTE_TIMEOUT_MS);
+    });
+
+    // The router promise OUTLIVES a timeout — `Promise.race` does not cancel the
+    // loser. If it later rejects with nothing attached, Node raises an
+    // unhandled rejection, which on a worker configured to exit on one would
+    // take the process down for a call we had already stopped waiting on. The
+    // no-op catch is the handler; the race still sees the original rejection if
+    // it arrives before the budget expires.
+    const routerCall = input.router.route(routingInput, { idempotencyKey });
+    routerCall.catch((error: unknown) => {
+      this.logger.warn(
+        `Router settled with an error after its budget expired for order ` +
+          `${input.orderId}: ${error instanceof Error ? error.message : String(error)}`
+      );
+    });
+
+    try {
+      return await Promise.race([routerCall, budget]);
+    } finally {
+      if (timer !== undefined) {
+        clearTimeout(timer);
+      }
+    }
+  }
+}
+
+/**
+ * One work object per distinct `(locationId, connectionId, deliveryMethod)`.
+ *
+ * ADR-054: **splits exist only at this grain**. A router that sources one order
+ * from two locations produces two work objects; the commercial order is never
+ * split. Assignments for the same triple collapse into one work object with
+ * several lines, and a repeated `orderLineId` within a triple sums rather than
+ * inserting twice — `fulfillment_work_lines` is unique per `(work, orderLine)`
+ * and a duplicate would raise `DuplicateFulfillmentWorkLineError`, aborting the
+ * whole transaction.
+ */
+function groupAssignmentsIntoWork(
+  plan: ResolvedRoutingPlan,
+  variantByOrderLineId: ReadonlyMap<string, string>
+): {
+  locationId: string | null;
+  connectionId: string | null;
+  deliveryMethod: string | null;
+  lines: { orderLineId: string; productVariantId: string; totalQuantity: number }[];
+}[] {
+  const byTarget = new Map<
+    string,
+    {
+      locationId: string | null;
+      connectionId: string | null;
+      deliveryMethod: string | null;
+      lines: Map<string, { orderLineId: string; productVariantId: string; totalQuantity: number }>;
+    }
+  >();
+
+  for (const assignment of plan.assignments) {
+    // `JSON.stringify`, NOT a `|`-joined template. `deliveryMethod` is the
+    // SOURCE'S OPAQUE method id (see `RoutingInput.requestedDeliveryMethod`), so
+    // it may legitimately contain the delimiter — and a collision here does not
+    // produce a tidy duplicate, it merges two lines bound for DIFFERENT
+    // LOCATIONS into one work object and ships from the wrong place. It also
+    // keeps `null` distinguishable from `''`, which a template collapses.
+    const key = JSON.stringify([
+      assignment.locationId,
+      assignment.connectionId,
+      assignment.deliveryMethod,
+    ]);
+    let bucket = byTarget.get(key);
+    if (bucket === undefined) {
+      bucket = {
+        locationId: assignment.locationId,
+        connectionId: assignment.connectionId,
+        deliveryMethod: assignment.deliveryMethod,
+        lines: new Map(),
+      };
+      byTarget.set(key, bucket);
+    }
+
+    const existing = bucket.lines.get(assignment.orderLineId);
+    if (existing === undefined) {
+      const productVariantId = variantByOrderLineId.get(assignment.orderLineId);
+      if (productVariantId === undefined) {
+        // Unreachable while the conservation check runs first. Thrown rather
+        // than defaulted because the alternative is fabricating a sentinel
+        // variant id onto a real work row — #2393 refuses a sentinel for exactly
+        // this class of gap, and a work object pointing at no variant is
+        // unpickable stock nothing would report.
+        throw new Error(
+          `Routing plan assigned an order line the input never named: ${assignment.orderLineId}`
+        );
+      }
+      bucket.lines.set(assignment.orderLineId, {
+        orderLineId: assignment.orderLineId,
+        productVariantId,
+        totalQuantity: assignment.quantity,
+      });
+    } else {
+      existing.totalQuantity += assignment.quantity;
+    }
+  }
+
+  return [...byTarget.values()].map((bucket) => ({
+    locationId: bucket.locationId,
+    connectionId: bucket.connectionId,
+    deliveryMethod: bucket.deliveryMethod,
+    lines: [...bucket.lines.values()],
+  }));
+}

--- a/libs/core/src/fulfillment/application/services/routing-commit.service.ts
+++ b/libs/core/src/fulfillment/application/services/routing-commit.service.ts
@@ -109,12 +109,12 @@ export class RoutingCommitService implements IRoutingCommitService {
     const token = await input.lock.acquire(lockKey, FULFILLMENT_ROUTE_LOCK_TTL_MS);
 
     if (token === null) {
-      // A peer is mid-flight. Answer from persisted state ONLY — crossing the
-      // router boundary here is the double-ship, so this branch must never do
-      // anything that could produce a second plan.
-      this.logger.log(
-        `Routing contended, answering from persisted state: orderId=${input.orderId}`
-      );
+      // A peer is mid-flight. This branch answers WITHOUT crossing the router
+      // boundary — that is the property that matters, and it is sufficient: a
+      // second call into the router is the double-ship. It deliberately reads no
+      // persisted state either, because there is nothing it would do with it;
+      // the peer owns the outcome.
+      this.logger.log(`Routing contended; not calling the router: orderId=${input.orderId}`);
       return { status: 'contended' };
     }
 
@@ -214,7 +214,9 @@ export class RoutingCommitService implements IRoutingCommitService {
    */
   private async claimOrResume(
     input: RouteOrderInput
-  ): Promise<{ decision: RoutingDecision; outcome: null } | { decision: null; outcome: RoutingCommitOutcome }> {
+  ): Promise<
+    { decision: RoutingDecision; outcome: null } | { decision: null; outcome: RoutingCommitOutcome }
+  > {
     const live = await this.decisions.findLiveByOrderId(input.orderId);
     if (live !== null) {
       return this.resumeOrRefuse(live, input);
@@ -228,10 +230,13 @@ export class RoutingCommitService implements IRoutingCommitService {
     }
 
     try {
-      return { decision: await this.decisions.claimIntent({
-        orderId: input.orderId,
-        routerConnectionId: input.routerConnectionId,
-      }), outcome: null };
+      return {
+        decision: await this.decisions.claimIntent({
+          orderId: input.orderId,
+          routerConnectionId: input.routerConnectionId,
+        }),
+        outcome: null,
+      };
     } catch (error) {
       if (error instanceof RoutingDecisionAlreadyLiveError) {
         // The partial-unique index refused us — a peer won the race between our
@@ -251,7 +256,9 @@ export class RoutingCommitService implements IRoutingCommitService {
   private resumeOrRefuse(
     live: RoutingDecision,
     input: RouteOrderInput
-  ): { decision: RoutingDecision; outcome: null } | { decision: null; outcome: RoutingCommitOutcome } {
+  ):
+    | { decision: RoutingDecision; outcome: null }
+    | { decision: null; outcome: RoutingCommitOutcome } {
     if (live.routerConnectionId !== input.routerConnectionId) {
       return { decision: null, outcome: { status: 'skipped', reason: 'already-live-elsewhere' } };
     }

--- a/libs/core/src/fulfillment/application/types/routing-commit.types.ts
+++ b/libs/core/src/fulfillment/application/types/routing-commit.types.ts
@@ -1,0 +1,88 @@
+/**
+ * Routing commit I/O (#2395, `W3a-6`, ADR-054 R1, DESIGN §5.3)
+ *
+ * What the host hands the routing commit, and every way that commit can end.
+ *
+ * ## Everything crosses as an ARGUMENT
+ *
+ * `router`, `lock` and `isCancelled` are parameters rather than injected
+ * dependencies because `fulfillment` is a registered zero-sibling-edge leaf:
+ * ADR-053's no-injection invariant forbids this context injecting `orders`,
+ * `integrations` or `sync`, and `barrel-purity.spec.ts` enforces it. The host
+ * composes them — the same shape #2399's `FulfillmentHandshakeService` already
+ * takes for its `executor`.
+ *
+ * @module libs/core/src/fulfillment/application/types
+ */
+import type { FulfillmentRouterPort } from '../../domain/ports/fulfillment-router.port';
+import type { RoutingLockPort } from '../../domain/ports/routing-lock.port';
+import type { RoutingDecisionAbandonReason } from '../../domain/types/routing-decision.types';
+import type { RoutingInputLine } from '../../domain/types/routing.types';
+import type { RoutingShipTo } from '../../domain/types/routing-ship-to.types';
+
+export interface RouteOrderInput {
+  readonly orderId: string;
+  /** The single router selection resolved upstream by `selectPrimaryFulfillmentRouter`. */
+  readonly routerConnectionId: string;
+  readonly lines: readonly RoutingInputLine[];
+  readonly shipTo: RoutingShipTo;
+  readonly requestedDeliveryMethod: string | null;
+
+  readonly router: FulfillmentRouterPort;
+  readonly lock: RoutingLockPort;
+
+  /**
+   * Whether the order is cancelled, read **inside** the lock.
+   *
+   * A callback rather than a scalar, and that is the whole point. A boolean
+   * resolved by the host before the lock is a value read at a moment that has
+   * already passed: the window a cancellation can slip through is
+   * read -> acquire, so re-checking a stale copy inside the lock closes nothing
+   * and merely looks like it does. Re-reading here makes the check mean what it
+   * says (REVIEW C10).
+   */
+  readonly isCancelled: () => Promise<boolean>;
+}
+
+/**
+ * How a routing commit ended.
+ *
+ * Enumerated as a closed union rather than a boolean plus a nullable reason, so
+ * a caller must handle every arm and a new arm is a compile error at every call
+ * site.
+ */
+export type RoutingCommitOutcome =
+  /** N work rows and the decision's terminalisation committed together. */
+  | { readonly status: 'routed'; readonly decisionId: string; readonly workIds: readonly string[] }
+  /**
+   * Nothing was attempted and nothing was written.
+   *
+   * `already-routed` and `already-live-elsewhere` are the #2047 write-path
+   * guard refusing **regardless of router identity**.
+   */
+  | {
+      readonly status: 'skipped';
+      readonly reason: 'order-cancelled' | 'already-routed' | 'already-live-elsewhere';
+    }
+  /**
+   * A peer holds the lock. Answered from persisted state only — the router was
+   * NOT called, so a contended attempt can never produce a second plan.
+   */
+  | { readonly status: 'contended' }
+  /** The router answered and OpenLinker refused the answer. Decision terminal. */
+  | {
+      readonly status: 'refused';
+      readonly decisionId: string;
+      readonly reason: RoutingDecisionAbandonReason;
+    }
+  /**
+   * The router may or may not have committed on its side.
+   *
+   * **The decision row is deliberately left `live`.** See `RoutingCommitService`
+   * — this is the arm whose handling is the finding of #2395.
+   */
+  | {
+      readonly status: 'in-doubt';
+      readonly decisionId: string;
+      readonly cause: 'timeout' | 'error';
+    };

--- a/libs/core/src/fulfillment/domain/exceptions/routing-decision-no-longer-live.error.ts
+++ b/libs/core/src/fulfillment/domain/exceptions/routing-decision-no-longer-live.error.ts
@@ -1,0 +1,30 @@
+/**
+ * Routing Decision No Longer Live (#2395, `W3a-6`)
+ *
+ * Raised inside the one-transaction commit when the decision being committed has
+ * stopped being `live` — a peer terminalised it while this caller was creating
+ * work rows. Throwing is what rolls those rows back (ADR-054 R1).
+ *
+ * ## Why this is NOT `RoutingDecisionAlreadyLiveError`
+ *
+ * That error asserts the OPPOSITE condition — "a live decision already exists" —
+ * and `RoutingCommitService.claimOrResume` pattern-matches on it to mean exactly
+ * that, resuming the winner. Reusing it here would be a name that contradicts
+ * its own condition, and the next person to wrap `route()` in a `catch` would
+ * get a RESUME where a rollback happened. Distinct condition, distinct type.
+ *
+ * @module libs/core/src/fulfillment/domain/exceptions
+ */
+export class RoutingDecisionNoLongerLiveError extends Error {
+  constructor(
+    public readonly orderId: string,
+    public readonly decisionId: string
+  ) {
+    super(
+      `Routing decision ${decisionId} for order ${orderId} is no longer live; ` +
+        `rolling back the work rows created against it.`
+    );
+    this.name = 'RoutingDecisionNoLongerLiveError';
+    Error.captureStackTrace?.(this, this.constructor);
+  }
+}

--- a/libs/core/src/fulfillment/domain/ports/fulfillment-work-repository.port.ts
+++ b/libs/core/src/fulfillment/domain/ports/fulfillment-work-repository.port.ts
@@ -184,6 +184,26 @@ export interface FulfillmentWorkRepositoryPort {
     transaction?: FulfillmentWorkTransaction
   ): Promise<FulfillmentWork>;
 
+  /**
+   * Run `fn` inside ONE transaction, handing it the handle `create` and
+   * `RoutingDecisionRepositoryPort.terminalise` both accept.
+   *
+   * #2392 gave callers a way to JOIN a transaction but no way to START one, and
+   * predicted this: *"#2395 sits one transition away from wanting the same seam
+   * … Widening it is #2395's call."* This is that widening, and it is what makes
+   * ADR-054 R1 expressible — N work rows and the routing decision's
+   * terminalisation commit together or not at all.
+   *
+   * The handle stays the opaque `FulfillmentWorkTransaction`, never an
+   * `EntityManager`: the domain layer may not name framework code, and an
+   * in-memory fake must stay typable.
+   *
+   * **`fn` throwing rolls the transaction back**, which is the contract the
+   * caller relies on — a partial commit here is unfulfilled or double-committed
+   * physical work.
+   */
+  runInTransaction<T>(fn: (transaction: FulfillmentWorkTransaction) => Promise<T>): Promise<T>;
+
   findById(workId: string): Promise<FulfillmentWork | null>;
   findByOrderId(orderId: string): Promise<FulfillmentWork[]>;
 

--- a/libs/core/src/fulfillment/domain/ports/routing-lock.port.ts
+++ b/libs/core/src/fulfillment/domain/ports/routing-lock.port.ts
@@ -1,0 +1,35 @@
+/**
+ * Routing Lock Port (#2395, `W3a-6`)
+ *
+ * The narrow slice of distributed locking the routing commit needs.
+ *
+ * ## Why this is re-declared instead of imported
+ *
+ * `SyncLockPort` in `@openlinker/core/sync` is the same shape and is the
+ * implementation every caller will pass. It is not imported because
+ * `fulfillment` is a registered zero-sibling-edge leaf: `barrel-purity.spec.ts`
+ * authorizes exactly two TYPE-ONLY specifiers for this context, and a token
+ * import would be a VALUE edge, which that spec forbids unconditionally.
+ *
+ * So the port is declared here and `SyncLockPort` satisfies it **structurally** —
+ * `acquire(key, ttlMs) => Promise<string | null>` and
+ * `release(key, token) => Promise<boolean>` match member for member. The host
+ * passes its injected `SyncLockPort` straight in; no adapter, no wrapper and no
+ * import is needed in either direction. TypeScript's structural typing is doing
+ * real architectural work here rather than being worked around.
+ *
+ * `extend` is deliberately NOT included. The routing lock is single-shot for the
+ * same reason the invoicing one is: the window it must cover is
+ * guard-read -> `claimIntent`, and past that point a persisted `live` decision
+ * row is what protects the order. There is nothing left for a heartbeat to
+ * protect, and offering one would invite a caller to hold the lock across the
+ * router call and mistake that for the guarantee.
+ *
+ * @module libs/core/src/fulfillment/domain/ports
+ */
+export interface RoutingLockPort {
+  /** A token when acquired, `null` when someone else holds it. */
+  acquire(key: string, ttlMs: number): Promise<string | null>;
+  /** Compare-and-delete. `false` means the lock was no longer ours. */
+  release(key: string, token: string): Promise<boolean>;
+}

--- a/libs/core/src/fulfillment/domain/types/routing-decision.types.spec.ts
+++ b/libs/core/src/fulfillment/domain/types/routing-decision.types.spec.ts
@@ -29,12 +29,25 @@ describe('RoutingDecisionState', () => {
 describe('RoutingDecisionAbandonReason', () => {
   it('should declare only reasons grounded in shipped code', () => {
     // #2393 ships `PendingRoutingPlanNotSupportedError` and
-    // `checkRoutingPlanConservesQuantities`; anything describing #2395's own
-    // internals would be a guess about code that does not exist yet.
+    // `checkRoutingPlanConservesQuantities`; #2395 adds the two Wave-3a
+    // refusals of a plan that cannot be committed whole.
     expect([...RoutingDecisionAbandonReasonValues]).toEqual([
       'plan-pending',
       'plan-not-conserving',
+      'plan-carries-holds',
+      'plan-carries-unfulfillable',
     ]);
+  });
+
+  it('should NOT declare a reason for a timeout or a throwing route()', () => {
+    // The finding of #2395, pinned so it cannot be undone by someone adding the
+    // "obviously missing" member. A timeout is IN-DOUBT, not nothing-happened:
+    // `abandoned` leaves the live partial-unique index, so a re-route mints a
+    // new decision id and therefore a NEW idempotency key that the vendor cannot
+    // dedup against a first call which may still be committing — two plans, two
+    // shipments. In-doubt leaves the decision `live` instead.
+    expect([...RoutingDecisionAbandonReasonValues]).not.toContain('router-timeout');
+    expect([...RoutingDecisionAbandonReasonValues]).not.toContain('router-failed');
   });
 
   it('should read an unrecognised persisted value as absent rather than throwing', () => {

--- a/libs/core/src/fulfillment/domain/types/routing-decision.types.ts
+++ b/libs/core/src/fulfillment/domain/types/routing-decision.types.ts
@@ -62,11 +62,38 @@ export const isRoutingDecisionState = (value: unknown): value is RoutingDecision
  * that does not exist. The column is `varchar(64)`, so #2395 adds its own
  * members with no migration.
  *
+ * **#2395 added two, and deliberately did NOT add a third for a timeout or a
+ * throwing `route()`.** Those are IN-DOUBT outcomes, and abandoning on one would
+ * reopen the double-ship this whole table exists to prevent — see
+ * `RoutingCommitService`, where that transition is (not) made. Every reason
+ * below describes a router that DEFINITELY answered and whose answer OpenLinker
+ * refused.
+ *
  * `readRoutingDecisionAbandonReason` coerces an unrecognised value to `null`
  * (the #2100 rule) so a value written by a newer build reads as absent on an
  * older one rather than crashing it.
  */
-export const RoutingDecisionAbandonReasonValues = ['plan-pending', 'plan-not-conserving'] as const;
+export const RoutingDecisionAbandonReasonValues = [
+  'plan-pending',
+  'plan-not-conserving',
+  /**
+   * #2395: the plan places holds, which Wave 3a cannot commit.
+   *
+   * `FulfillmentWorkRepositoryPort.placeHold` is NOT transaction-composable —
+   * its own docblock says only `create` is — so a hold cannot join the ADR-054
+   * R1 single transaction that creates the work rows and terminalises the
+   * decision. Committing the plan minus its holds would silently drop
+   * quantities from a plan that PASSED `checkRoutingPlanConservesQuantities`,
+   * which is precisely the failure that guard exists to catch.
+   *
+   * So the whole plan is refused rather than partially applied. Inert today (no
+   * router exists until #2408/#2409) and real the moment a router first emits a
+   * hold — which is why the refusal message names the follow-up issue.
+   */
+  'plan-carries-holds',
+  /** #2395: same reasoning one field over — an unfulfillable line has no commit path yet. */
+  'plan-carries-unfulfillable',
+] as const;
 
 export type RoutingDecisionAbandonReason = (typeof RoutingDecisionAbandonReasonValues)[number];
 

--- a/libs/core/src/fulfillment/fulfillment.module.ts
+++ b/libs/core/src/fulfillment/fulfillment.module.ts
@@ -27,12 +27,14 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { FulfillmentHandshakeService } from './application/services/fulfillment-handshake.service';
 import { FulfillmentProgressService } from './application/services/fulfillment-progress.service';
 import { FulfillmentRelayGateService } from './application/services/fulfillment-relay-gate.service';
+import { RoutingCommitService } from './application/services/routing-commit.service';
 import {
   FULFILLMENT_HANDSHAKE_SERVICE_TOKEN,
   FULFILLMENT_PROGRESS_CLAIM_REPOSITORY_TOKEN,
   FULFILLMENT_PROGRESS_SERVICE_TOKEN,
   FULFILLMENT_RELAY_GATE_SERVICE_TOKEN,
   FULFILLMENT_WORK_REPOSITORY_TOKEN,
+  ROUTING_COMMIT_SERVICE_TOKEN,
   ROUTING_DECISION_REPOSITORY_TOKEN,
   FULFILLMENT_WORK_QUERY_SERVICE_TOKEN,
 } from './fulfillment.tokens';
@@ -79,6 +81,8 @@ import { RoutingDecisionRepository } from './infrastructure/persistence/reposito
       provide: FULFILLMENT_WORK_QUERY_SERVICE_TOKEN,
       useExisting: FulfillmentWorkQueryService,
     },
+    RoutingCommitService,
+    { provide: ROUTING_COMMIT_SERVICE_TOKEN, useExisting: RoutingCommitService },
   ],
   exports: [
     FULFILLMENT_WORK_REPOSITORY_TOKEN,
@@ -89,6 +93,7 @@ import { RoutingDecisionRepository } from './infrastructure/persistence/reposito
     // Exported for `ShippingModule` (#2402): the shipment bridge resolves an
     // order's work through this interface, never through the repository port.
     FULFILLMENT_WORK_QUERY_SERVICE_TOKEN,
+    ROUTING_COMMIT_SERVICE_TOKEN,
   ],
 })
 export class FulfillmentModule {}

--- a/libs/core/src/fulfillment/fulfillment.tokens.ts
+++ b/libs/core/src/fulfillment/fulfillment.tokens.ts
@@ -55,3 +55,6 @@ export const ROUTING_DECISION_REPOSITORY_TOKEN = Symbol('RoutingDecisionReposito
 
 /** Dispatch-relay at-most-once gate (#2401). `FulfillmentRelayGateService` binds here. */
 export const FULFILLMENT_RELAY_GATE_SERVICE_TOKEN = Symbol('IFulfillmentRelayGateService');
+
+/** Routing commit (#2395). `RoutingCommitService` binds here. */
+export const ROUTING_COMMIT_SERVICE_TOKEN = Symbol('IRoutingCommitService');

--- a/libs/core/src/fulfillment/index.ts
+++ b/libs/core/src/fulfillment/index.ts
@@ -135,6 +135,7 @@ export type { IFulfillmentWorkQueryService } from './application/interfaces/fulf
 
 export { RoutingDecision } from './domain/entities/routing-decision.entity';
 export { RoutingDecisionAlreadyLiveError } from './domain/exceptions/routing-decision-already-live.error';
+export { RoutingDecisionNoLongerLiveError } from './domain/exceptions/routing-decision-no-longer-live.error';
 // Same rule one table over: the INPUT shapes are exported, while
 // `RoutingDecisionRepositoryPort` itself is not. #2395 injects it by token from
 // inside this context.
@@ -142,6 +143,21 @@ export type {
   ClaimRoutingIntentInput,
   TerminaliseRoutingDecisionInput,
 } from './domain/ports/routing-decision-repository.port';
+
+// Routing commit (#2395). The SERVICE INTERFACE and its I/O cross the barrel;
+// `RoutingDecisionRepositoryPort` still does not, for the deny-pattern reason
+// stated above.
+export type { IRoutingCommitService } from './application/interfaces/routing-commit.service.interface';
+export type {
+  RouteOrderInput,
+  RoutingCommitOutcome,
+} from './application/types/routing-commit.types';
+export type { RoutingLockPort } from './domain/ports/routing-lock.port';
+export {
+  FULFILLMENT_ROUTE_LOCK_TTL_MS,
+  FULFILLMENT_ROUTE_TIMEOUT_MS,
+  fulfillmentRouteLockKey,
+} from './application/services/routing-commit-lock';
 
 export { FulfillmentModule } from './fulfillment.module';
 

--- a/libs/core/src/fulfillment/infrastructure/persistence/repositories/fulfillment-work.repository.ts
+++ b/libs/core/src/fulfillment/infrastructure/persistence/repositories/fulfillment-work.repository.ts
@@ -179,6 +179,17 @@ export class FulfillmentWorkRepository implements FulfillmentWorkRepositoryPort 
     private readonly dataSource: DataSource
   ) {}
 
+  /**
+   * ADR-054 R1's unit of work. `dataSource.transaction` gives us the
+   * `EntityManager` that `FulfillmentWorkTransaction` structurally describes, so
+   * the port stays framework-free while the caller gets real atomicity.
+   */
+  async runInTransaction<T>(
+    fn: (transaction: FulfillmentWorkTransaction) => Promise<T>
+  ): Promise<T> {
+    return await this.dataSource.transaction(async (manager) => fn(manager));
+  }
+
   async create(
     input: CreateFulfillmentWorkInput,
     transaction?: FulfillmentWorkTransaction

--- a/libs/core/src/orders/application/services/__tests__/order-record.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-record.service.spec.ts
@@ -393,6 +393,36 @@ describe('OrderRecordService', () => {
       expect(callArg.buyerTaxId).toBeNull();
     });
 
+    it('should stamp the shipping-address hash from the un-redacted address (#2395)', async () => {
+      const order = createMockOrder();
+      repository.upsertWithLineItems.mockResolvedValue({} as OrderRecord);
+
+      await service.persistOrder(order, 'source-connection-123', 'event-456');
+
+      const [callArg] = repository.upsertWithLineItems.mock.calls[0];
+      expect(callArg.shippingAddressHash).toEqual(expect.any(String));
+      expect(callArg.shippingAddressHash).not.toBe('');
+    });
+
+    it('should leave the shipping-address hash null when the order has no shipping address (#2395)', async () => {
+      const order = createMockOrder();
+      order.shippingAddress = undefined as never;
+      repository.upsertWithLineItems.mockResolvedValue({} as OrderRecord);
+
+      await service.persistOrder(order, 'source-connection-123', 'event-456');
+
+      const [callArg] = repository.upsertWithLineItems.mock.calls[0];
+      expect(callArg.shippingAddressHash).toBeNull();
+    });
+
+    // The blank-hash guard ("a blank string is itself a shared grouping key") is
+    // asserted where it actually protects routing rather than mocked into being
+    // here: `routing-ship-to.types.spec.ts` covers it against `buildRoutingShipTo`,
+    // which is the function that decides whether a hash is forwarded to a router.
+    // Driving it from this suite needed a module mock of the shared config
+    // barrel purely to make a real hash return whitespace, which is machinery in
+    // service of a case the production hash cannot produce.
+
     it('should serialise Order.placedAt into the snapshot as an ISO string when present (#926)', async () => {
       const order = createMockOrder();
       order.placedAt = new Date('2026-05-31T16:00:00.000Z');
@@ -554,6 +584,33 @@ describe('OrderRecordService', () => {
       const [callArg] = repository.upsertWithLineItems.mock.calls[0];
       expect(callArg.buyerTaxId).toBeNull();
       expect(callArg.orderSnapshot.billingAddress).not.toHaveProperty('taxId');
+    });
+
+    it('should still stamp the shipping-address hash when PII storage is disabled (#2395)', async () => {
+      // The whole point: `RoutingShipTo`'s degraded arm serves exactly this
+      // deployment, so the hash must NOT be PII-gated the way `buyerTaxId` is.
+      // It is also derived from the LIVE address, so it must not collapse to
+      // the one-hash-per-country value that hashing the redacted snapshot
+      // would produce - assert it differs between two distinct addresses in
+      // the same country.
+      const order = createMockOrder();
+      repository.upsertWithLineItems.mockResolvedValue({} as OrderRecord);
+
+      await service.persistOrder(order, 'source-connection-123', 'event-456');
+      const first = repository.upsertWithLineItems.mock.calls[0][0].shippingAddressHash;
+      expect(first).toEqual(expect.any(String));
+      expect(first).not.toBe('');
+
+      const other = createMockOrder();
+      other.shippingAddress = {
+        ...other.shippingAddress!,
+        address1: 'Somewhere Else 999',
+        city: 'Gdansk',
+        postalCode: '80-001',
+      };
+      repository.upsertWithLineItems.mockClear();
+      await service.persistOrder(other, 'source-connection-123', 'event-457');
+      expect(repository.upsertWithLineItems.mock.calls[0][0].shippingAddressHash).not.toBe(first);
     });
 
     it('should persist order with sanitized addresses when PII storage is disabled', async () => {

--- a/libs/core/src/orders/application/services/order-record.service.ts
+++ b/libs/core/src/orders/application/services/order-record.service.ts
@@ -471,6 +471,15 @@ export class OrderRecordService implements IOrderRecordService {
    * ship-by stays `null` by design. The source of truth is the source adapter;
    * this method never fabricates a window.
    */
+  private deriveDispatchByAt(window: OrderDispatchWindow | undefined): Date | null {
+    const to = window?.to;
+    if (!to) {
+      return null;
+    }
+    const parsed = new Date(to);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+  }
+
   /**
    * Hash the order's shipping address (#2395) for `RoutingShipTo`'s degraded
    * arm. Field mapping mirrors `OrderCustomerProjectionUpdaterService`
@@ -494,15 +503,6 @@ export class OrderRecordService implements IOrderRecordService {
       })
     );
     return hash.trim() === '' ? null : hash;
-  }
-
-  private deriveDispatchByAt(window: OrderDispatchWindow | undefined): Date | null {
-    const to = window?.to;
-    if (!to) {
-      return null;
-    }
-    const parsed = new Date(to);
-    return Number.isNaN(parsed.getTime()) ? null : parsed;
   }
 
   /**

--- a/libs/core/src/orders/application/services/order-record.service.ts
+++ b/libs/core/src/orders/application/services/order-record.service.ts
@@ -39,7 +39,7 @@ import type {
   SalesAnalyticsFilters,
   SalesAndChannelAnalytics,
 } from '../../domain/types/order-sales-analytics.types';
-import { getPiiConfig } from '@openlinker/shared/config';
+import { getPiiConfig, hashAddress, normalizeAddress } from '@openlinker/shared/config';
 import { Logger } from '@openlinker/shared/logging';
 import {
   REPORTING_CURRENCY_SETTINGS_SERVICE_TOKEN,
@@ -207,6 +207,28 @@ export class OrderRecordService implements IOrderRecordService {
       ? encodeBuyerTaxIdColumn(readBuyerTaxId(order))
       : null;
 
+    // Shipping-address hash (#2395) - stamped HERE, at ingestion, because this
+    // is the only place the un-redacted address is still in hand.
+    //
+    // It must NOT be derived later by hashing the persisted snapshot: under
+    // `OL_STORE_PII=false` that snapshot has already been through
+    // `redactAddress`, so hashing it yields ONE hash per country, shared by
+    // every order in the install - a plausible 64-hex string that groups
+    // everything while looking correct. And `customer_address_projections` are
+    // keyed by CUSTOMER, not by order, so they cannot answer "this order's
+    // address" either.
+    //
+    // Deliberately NOT PII-gated, unlike its `buyerTaxId` neighbour directly
+    // above - the inversion is subtle enough to state: this is a one-way hash
+    // carrying no recoverable address, and it is consumed by `RoutingShipTo`'s
+    // DEGRADED arm, i.e. by hash-only deployments specifically. Gating it would
+    // null the value exactly on the installs the degraded arm exists to serve.
+    //
+    // `getPiiConfig()` is already called at the top of this method and throws
+    // when `OL_PII_HASH_SALT` is unset regardless of the flag, so `hashAddress`
+    // introduces no new failure mode on this path.
+    const shippingAddressHash = this.deriveShippingAddressHash(order);
+
     const orderRecord = new OrderRecord(
       order.id,
       order.customerId || null,
@@ -252,7 +274,8 @@ export class OrderRecordService implements IOrderRecordService {
       // their own writers, never set on the ingestion path.
       null,
       [],
-      buyerTaxId
+      buyerTaxId,
+      shippingAddressHash
     );
 
     // #1985: persist the order record AND its order_line_items rows in one
@@ -448,6 +471,31 @@ export class OrderRecordService implements IOrderRecordService {
    * ship-by stays `null` by design. The source of truth is the source adapter;
    * this method never fabricates a window.
    */
+  /**
+   * Hash the order's shipping address (#2395) for `RoutingShipTo`'s degraded
+   * arm. Field mapping mirrors `OrderCustomerProjectionUpdaterService`
+   * verbatim, so the two hashes of one address agree.
+   *
+   * A blank or whitespace-only result is treated as `null`: a blank string is
+   * itself a shared grouping key, i.e. the exact failure this column exists to
+   * avoid, so it must never be forwarded as if it were a hash.
+   */
+  private deriveShippingAddressHash(order: Order): string | null {
+    if (!order.shippingAddress) {
+      return null;
+    }
+    const hash = hashAddress(
+      normalizeAddress({
+        address1: order.shippingAddress.address1,
+        address2: order.shippingAddress.address2,
+        city: order.shippingAddress.city,
+        postcode: order.shippingAddress.postalCode,
+        countryIso2: order.shippingAddress.country,
+      })
+    );
+    return hash.trim() === '' ? null : hash;
+  }
+
   private deriveDispatchByAt(window: OrderDispatchWindow | undefined): Date | null {
     const to = window?.to;
     if (!to) {

--- a/libs/core/src/orders/domain/entities/order-record.entity.ts
+++ b/libs/core/src/orders/domain/entities/order-record.entity.ts
@@ -332,7 +332,33 @@ export class OrderRecord {
      * before it - inserting mid-list would shift every argument after it at
      * each call site.
      */
-    public readonly buyerTaxId: string | null = null
+    public readonly buyerTaxId: string | null = null,
+    /**
+     * Stable hash of this order's SHIPPING address (#2395), stamped at
+     * ingestion from the live, un-redacted `Order`. `null` when the order
+     * carries no shipping address.
+     *
+     * It exists because `RoutingShipTo`'s degraded arm (`OL_STORE_PII=false`)
+     * needs a `locationHash`, and neither of the two things a consumer would
+     * reach for can supply one:
+     *
+     * - Hashing the persisted `orderSnapshot` address is WRONG under hash-only
+     *   mode: that address has already been through `redactAddress`, so the
+     *   hash collapses to ONE value per country, shared by every order in the
+     *   install. It looks correct - a plausible 64-hex string - while silently
+     *   grouping the whole catalogue of orders together.
+     * - `customer_address_projections` are keyed by CUSTOMER, not by order, so
+     *   they cannot answer "the address on THIS order".
+     *
+     * Deliberately NOT PII-gated (see the writer in `OrderRecordService`): it
+     * is a one-way hash, and gating it would null it exactly on the
+     * deployments the degraded arm exists to serve.
+     *
+     * Appended LAST for the same reason every field above it was: this is a
+     * positional constructor, so a field inserted mid-list would silently
+     * shift every argument after it at each construction site.
+     */
+    public readonly shippingAddressHash: string | null = null
   ) {}
 
   /**

--- a/libs/core/src/orders/infrastructure/persistence/entities/order-record.orm-entity.ts
+++ b/libs/core/src/orders/infrastructure/persistence/entities/order-record.orm-entity.ts
@@ -266,6 +266,24 @@ export class OrderRecordOrmEntity {
   buyerTaxId!: string | null;
 
   /**
+   * Stable hash of the order's shipping address (#2395), stamped at ingestion
+   * from the LIVE, un-redacted address - so it survives `OL_STORE_PII=false`,
+   * under which the snapshot address is replaced by `[REDACTED]` and hashing
+   * it back would yield one hash per country shared by every order.
+   *
+   * Written only on the `'ready'` path (`upsertWithLineItems`), like the four
+   * analytics scalars and `buyerTaxId` above: an `awaiting_mapping`
+   * re-ingestion routed through the shared `toOrm` would NULL a hash a
+   * previous ready-path write settled.
+   *
+   * NOT PII-gated, unlike its `buyerTaxId` neighbour: it is a one-way hash
+   * carrying no recoverable address, and gating it would remove it precisely
+   * on the hash-only deployments that need it.
+   */
+  @Column({ type: 'text', nullable: true })
+  shippingAddressHash!: string | null;
+
+  /**
    * Per-order reporting-currency snapshot (#2124, ADR-040) — six columns
    * written ONLY by the two narrow, conditional UPDATEs on the repository
    * (`claimFxIntentIfAbsent`, `stampFxIfAbsent`). The ingestion upsert

--- a/libs/core/src/orders/infrastructure/persistence/repositories/__tests__/order-record.repository.spec.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/__tests__/order-record.repository.spec.ts
@@ -1316,6 +1316,65 @@ describe('OrderRecordRepository', () => {
       }
     );
 
+    it('pins shippingAddressHash into the ready-path statement and reads it back (#2395)', async () => {
+      // Same argument as `buyerTaxId` above: the frozen-attribution upsert
+      // ENUMERATES its columns, so a value stamped on the entity but never
+      // added to the statement is silently not written.
+      const domainEntity = new OrderRecord(
+        'order-123',
+        'customer-456',
+        'source-connection-123',
+        'event-456',
+        { id: 'order-123', orderNumber: 'ORD-001', status: 'pending' },
+        [],
+        'ready',
+        new Date('2025-01-01T10:00:00Z'),
+        new Date('2025-01-01T10:00:00Z'),
+        [],
+        null,
+        null,
+        null,
+        new Date('2025-01-01T09:00:00Z'),
+        'PLN',
+        'inclusive',
+        199.99,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        [],
+        null,
+        'abc123hash'
+      );
+      const savedOrm = createOrmEntity();
+      savedOrm.shippingAddressHash = 'abc123hash';
+      transactionalManager.query.mockResolvedValue([savedOrm]);
+      transactionalManager.delete.mockResolvedValue(undefined);
+
+      await repository.upsertWithLineItems(domainEntity, []);
+
+      const [sql, params] = transactionalManager.query.mock.calls[0] as [string, unknown[]];
+      expect(sql).toContain('"shippingAddressHash"');
+      expect(params).toContain('abc123hash');
+
+      ormRepository.findOne.mockResolvedValue(savedOrm);
+      expect((await repository.findById('order-123'))?.shippingAddressHash).toBe('abc123hash');
+    });
+
     it('decodes the round-tripped column back to the three domain states', async () => {
       const withColumn = (stored: string | null): OrderRecordOrmEntity => {
         const entity = createOrmEntity();

--- a/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
@@ -1972,6 +1972,12 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
       // to read a tax id off, and writing it there would NULL a value a
       // previous ready-path write settled.
       add('buyerTaxId', entity.buyerTaxId ?? null);
+      // #2395, added here for exactly the reason `buyerTaxId` is: this
+      // statement enumerates its own columns, so a column the caller stamps on
+      // the entity but never adds here is simply not written. Ready-path only -
+      // `persistIncomingSnapshot` has no resolved shipping address to hash, and
+      // writing it there would NULL a hash a previous ready-path write settled.
+      add('shippingAddressHash', entity.shippingAddressHash ?? null);
     }
 
     const sql = `INSERT INTO "order_records" (
@@ -2067,6 +2073,12 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
     // which has no resolved billing address to read a tax id off, so mapping
     // the column there would NULL a value a previous ready-path write settled.
     entity.buyerTaxId = orderRecord.buyerTaxId;
+    // #2395 - stamped here, NOT in the shared `toOrm`, for the same
+    // single-writer reason (`cancelledAt` / the `salesDocument*` columns,
+    // #2100): `persistOrder` runs on EVERY ingestion, and an
+    // `awaiting_mapping` re-ingestion reaching `toOrm` would write `null` over
+    // a hash a previous ready-path ingestion had settled.
+    entity.shippingAddressHash = orderRecord.shippingAddressHash;
     const { sql, params, writeSet } = this.buildFrozenAttributionUpsert(entity, true);
     const savedRecord = await this.dataSource.transaction(async (manager: EntityManager) => {
       // Same statement as `upsert`, one parameter apart (#2282): a full-object
@@ -2270,7 +2282,8 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
       // §4.4 S2-5 ("an unrecognised state degrades safely") held once, and it
       // is the same call the two reason guards above make.
       readAuthorityAttentionEntries(entity.omsAttention),
-      entity.buyerTaxId ?? null
+      entity.buyerTaxId ?? null,
+      entity.shippingAddressHash ?? null
     );
   }
 

--- a/libs/core/src/sync/domain/types/fulfillment-job-payloads.types.ts
+++ b/libs/core/src/sync/domain/types/fulfillment-job-payloads.types.ts
@@ -85,3 +85,24 @@ export interface FulfillmentWorkDispatchPayloadV1 {
   readonly orderId: string;
   readonly expectedAssignmentAttempt: number | null;
 }
+
+/**
+ * Route ONE order (#2395, `W3a-6`).
+ *
+ * Carries the order id and nothing else. Everything the router is told — the
+ * lines and the ADR-062 ship-to projection — is resolved by the HANDLER at
+ * execution time from OpenLinker's own store, never from the payload.
+ *
+ * That is not incidental. A payload-carried ship-to would put a buyer's address
+ * into `sync_jobs.payload`, which is durable, operator-visible and outside every
+ * PII control the projection exists to apply; and a payload-carried line list
+ * would be a snapshot that a re-ingestion could silently make stale, so a retry
+ * would route the order the buyer used to have.
+ *
+ * The router connection is `job.connectionId`, following the rule every other
+ * payload in this directory keeps.
+ */
+export interface FulfillmentWorkRoutePayloadV1 {
+  readonly schemaVersion: 1;
+  readonly orderId: string;
+}

--- a/libs/core/src/sync/domain/types/sync-job.types.ts
+++ b/libs/core/src/sync/domain/types/sync-job.types.ts
@@ -182,6 +182,16 @@ export const JobTypeValues = [
   // synthetic id, which is #2609's defect exactly: a shared scope collapses
   // per-scope lane accounting for the whole installation.
   'fulfillment.work.dispatch',
+
+  // Routing commit (#2395, `W3a-6`, ADR-054 R1). Decides where ONE order is
+  // fulfilled from and commits the decision plus its work rows atomically.
+  //
+  // Core-owned and namespaced `fulfillment.work.*` on the same precedent as its
+  // two siblings above — the trigger is OpenLinker's own ingestion, not a
+  // marketplace. `connectionId` is the SELECTED ROUTER's connection, never a
+  // synthetic id: #2609 is the standing lesson that a shared scope collapses
+  // per-scope lane accounting for the whole installation.
+  'fulfillment.work.route',
 ] as const;
 
 /**

--- a/libs/core/src/sync/index.ts
+++ b/libs/core/src/sync/index.ts
@@ -144,6 +144,7 @@ export type {
 } from './domain/types/invoicing-job-payloads.types';
 export type { RegulatoryStatusReconcilePayloadV1 } from './domain/types/invoicing-job-payloads.types';
 export type { FulfillmentWorkDispatchPayloadV1 } from './domain/types/fulfillment-job-payloads.types';
+export type { FulfillmentWorkRoutePayloadV1 } from './domain/types/fulfillment-job-payloads.types';
 export type { OfflineResubmitPayloadV1 } from './domain/types/invoicing-job-payloads.types';
 export type { PendingRecoverySweepPayloadV1 } from './domain/types/invoicing-job-payloads.types';
 export type { PaymentStatusRefreshByExternalIdPayloadV1 } from './domain/types/invoicing-job-payloads.types';


### PR DESCRIPTION
Closes #2395. Wave 3a (`W3a-6`), stream S1, epic #2412. Targets `oms-programme-wave-3a`, not `main`.

Decides where an order is fulfilled from, **exactly once**, and commits that decision atomically with the work it creates. Two routers producing two plans for one order is a double shipment: physical, and unrecoverable. Everything here is one correctness argument around that single failure mode.

## The empty live path is the specified behaviour, not unfinished work

`FulfillmentRouter` is deliberately absent from `CoreCapabilityValues` and from every manifest (#2393/#2403 — A2 is `config-only`), and its absence is **actively asserted** by a live spec. `@openlinker/oms` ships `supportedCapabilities: []` with an empty dispatch table until #2408/#2409 inject the first router. So the handler's router seam answers `null` on every installation today and the job completes as a no-op.

That is ADR-054 verbatim: *"with no router configured the layer is a degenerate pass-through: no work objects, today's path byte-identical — the property that survives the Wave-5 kill."* `selected` and `ambiguous` are fully covered against fakes.

The issue text proposed selecting over `listCapabilityAdapters({capability:'FulfillmentRouter'})`. That cannot work, and making it work would mean breaking three guard sites plus a spec and reintroducing the #2085 trap #2403 rejected by name: `enabledCapabilities` is stamped at connection create and never retro-filled, so a gate on a new name drains nothing for every connection that already exists.

## Why `selectPrimaryFulfillmentRouter` is in `fulfillment-authority`

This is the kind of placement a later reader will try to "tidy" back into `fulfillment`, so the reason is in the docblock — **and the plausible reason is the wrong one.**

The `fulfillment` leaf's own value-import ban is *irrelevant*: the only out-of-core caller is a worker handler, which is not under `libs/core/src/fulfillment/**` and which that rule never reaches. The actual reason is the other direction — `fulfillment-authority` carries an **empty** allow-set and cannot import `fulfillment`, so `resolveAuthorities`' A2 consumption forces it. ADR-053's "enforcement lives with the write" still holds: the write gate is the `routing_decisions` live partial-unique index and the guard around it, both in `fulfillment`. This function only *names* a candidate.

A2 is now answered **through** that same function, so the row an operator reads and the gate that commits work cannot disagree about who routes.

**It folds over claimed scopes**, never a single `global` request. A global-only selection resolves a channel-scoped claim to `none` — the regression D10 shape — and **no shipped assertion would have caught it**: the only `sourcing` assertions are the zero-config default, which global-only also satisfies, while every scope-behaviour test is written against `availability`.

## A timeout is in-doubt, not nothing-happened

The finding of this issue, and the instinct it resists is to free the order.

`abandoned` leaves the `UNIQUE (orderId) WHERE state = 'live'` index, so the re-route mints a new decision id and therefore a **new idempotency key the vendor cannot dedup against a first call that may still be committing**. Two plans, two shipments. Invoicing reached the identical conclusion from the other side: `blocksIssuanceElsewhere` blocks on everything except a terminal `rejected`, because only that means the provider definitely created nothing.

So an in-doubt outcome leaves the row `live`, and a retry **resumes** it under the identical key — which is what an idempotency key is for; a retry that mints a fresh key is not a retry. Only deterministic refusals terminalise. A spec pins that `router-timeout`/`router-failed` are *not* abandon reasons, so the "obviously missing" member cannot be added back.

## Holds are refused, not dropped

`placeHold` is not transaction-composable (its port docblock says only `create` is), so a hold cannot join the ADR-054 R1 transaction. Committing a plan *minus* its holds would silently drop quantities from a plan that just passed `checkRoutingPlanConservesQuantities` — the exact failure that guard exists to catch. The whole plan is refused, and the refusal message names #2408/#2409 so whoever wires the first router meets the constraint at the point of failure. Inert today; real the moment a router emits a hold.

## `order_records.shippingAddressHash`

Stamped at ingestion from the **un-redacted** address. Hashing the persisted snapshot yields one hash per country for the whole install (a plausible 64-hex string that groups everything), and address projections are keyed by **customer, not order**, so neither could supply it.

Deliberately **not** PII-gated, unlike its `buyerTaxId` neighbour — gating would null it precisely on the hash-only deployments the degraded arm exists to serve. Stamped in `upsertWithLineItems`, not the shared `toOrm`, so an `awaiting_mapping` re-ingestion cannot null a settled hash (#2100 single-writer precedent). Blank is treated as absent; that property is asserted at `buildRoutingShipTo`, the function that actually decides whether a hash reaches a router.

## Lane

`realtime`, not `bulk`. The core-owned-internal-pass instinct argues for `bulk`, and the registry argues it down in-tree: that instinct is about who *enqueues*, and the lane is about who is hurt when it is late. Routing gates whether an order ships at all.

## Evidence — every critical claim verified red-first

| Claim | Red-first evidence |
|---|---|
| One-transaction commit is atomic | Removing the transaction: `Expected: 0, Received: 2` — both work rows survived |
| In-doubt leaves the decision live | Injecting "free the order on timeout" failed exactly the 2 tests that exist for it |
| A2 folds over scopes | Injecting global-only failed 5 tests including the channel-scoped one |
| Grouping key is unambiguous | Reverting to the `\|`-joined key failed 2 tests |
| Lock serializes | Two concurrent `route()`s against a barrier'd fake → exactly one decision row |

The concurrency test is genuinely overlapping (barrier inside the lock fake's `acquire`); a sequential version passes against no guard at all. My first collision test was **not** evidence — with a `null` field the two keys differ — and was corrected to a real colliding pair.

## Review findings applied

A tech review found and I fixed: an **unhandled rejection** (`Promise.race` leaves the router promise running; a late rejection can take down the worker), a **delimiter-ambiguous grouping key** (`deliveryMethod` is an opaque source id that may contain `|`, so two lines bound for *different locations* could merge into one work object), a **wrong error type** on the rollback path, and `refuse()` discarding `terminalise`'s boolean while the handler claimed the refusal was durable.

## Gates

lint **0**, type-check **0**, unit **0**, `check:invariants` **0** (36 = 35 `.mjs` + 1 `.sh`), integration **5/5 fulfillment suites + 3/3 worker boot specs** post-rebase. Migration verified from empty against a throwaway Postgres: **153 applied, 0 pending**, `1868000000000` last.

Pre-existing/environmental, unrelated: two PrestaShop suites (`Port 80 not bound after 180000ms` — Docker contention) and `earliest-order-date.int-spec.ts` (passes under `TZ=UTC`; this machine is Europe/Warsaw). The `apps/web` exit-1 in one full run was the vitest worker-start flake — isolated rerun exit 0, 4819 passing. `automation-dispatch-boot` (#2711) is now **green** after rebasing onto its fix.

## Deferred, with owners

- **Stranded-decision reaper** — resumption fixes the common case; a decision left `live` past a threshold needs a sweep with its own cadence and age bounds. Filed separately by the coordinator.
- **Holds/unfulfillable commit path** — needs `placeHold` transaction composability; filed alongside #2408/#2409.
- `order_records` was tried in the migration-parity `TABLES` list and reverted: its **columns** agree (my column is parity-clean) but its indexes and FKs carry pre-existing drift that spec declines to own. Replaced with a targeted column assertion that reuses the same migrated schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EWKtLwTcP2ppoknaq4Ca3Z