### PR TITLE
feat(sales-documents): market list rows (#2540)

### DIFF
--- a/apps/web/src/features/sales-documents/api/sales-document-markets.types.ts
+++ b/apps/web/src/features/sales-documents/api/sales-document-markets.types.ts
@@ -1,0 +1,66 @@
+/**
+ * Sales-Document Markets — view types (#2540, mirrors ADR-066)
+ *
+ * FE-local mirror of `apps/api/src/sales-documents/http/dto/sales-document-market-response.dto.ts`,
+ * matching the `apps/web` never-imports-`@openlinker/core/*` contract strategy
+ * already used by `sales-document-rules.types.ts`.
+ *
+ * `SalesDocumentMarketOutcome.kind === 'acknowledged'` is a state the routing
+ * evaluator itself cannot produce — the backend overrides the evaluator's
+ * answer whenever the row carries `acknowledgedNoDocumentAt`. See the backend
+ * DTO's doc comment for the full reasoning; this file only mirrors the shape.
+ *
+ * @module apps/web/src/features/sales-documents/api
+ */
+import type { SalesDocumentKind } from './sales-documents.types';
+
+export const SALES_DOCUMENT_MARKET_OUTCOME_KIND_VALUES = [
+  'route',
+  'aggregate',
+  'unresolved',
+  'acknowledged',
+] as const;
+export type SalesDocumentMarketOutcomeKind =
+  (typeof SALES_DOCUMENT_MARKET_OUTCOME_KIND_VALUES)[number];
+
+export interface SalesDocumentMarketOutcome {
+  kind: SalesDocumentMarketOutcomeKind;
+  /** Set when `kind === 'route'`. */
+  documentKind?: SalesDocumentKind | string | null;
+  /** Set when `kind === 'route'` or `kind === 'aggregate'`. */
+  connectionId?: string;
+  /**
+   * Set when `kind === 'unresolved'`. A `SalesDocumentUnresolvedReasonValue`
+   * — the same vocabulary `SALES_DOCUMENT_UNRESOLVED_REASON_COPY` already
+   * covers, so a market row's "why nothing" text reuses that map rather than
+   * inventing a second one.
+   */
+  reason?: string;
+}
+
+export interface SalesDocumentMarketRow {
+  /** ISO 3166-1 alpha-2, or `'*'` for Rest of world. */
+  country: string;
+  /**
+   * Orders billed to this country in the discovery window, or `null` when
+   * the country was never detected at all (a configured-only market). Never
+   * `0` — a detected market always has at least one order.
+   */
+  orderCount: number | null;
+  /** Whether a curated starter template exists for this country. */
+  hasTemplate: boolean;
+  /** How many rules target this country. */
+  ruleCount: number;
+  invoiceDefaultConnectionId: string | null;
+  receiptDefaultConnectionId: string | null;
+  acknowledgedNoDocumentAt: string | null;
+  outcome: SalesDocumentMarketOutcome;
+}
+
+export interface SalesDocumentMarketsResponse {
+  /** The discovery window actually applied, in days. */
+  windowDays: number;
+  /** ISO-8601 lower bound the detected order counts were taken from. */
+  since: string;
+  markets: SalesDocumentMarketRow[];
+}

--- a/apps/web/src/features/sales-documents/api/sales-document-rules.api.ts
+++ b/apps/web/src/features/sales-documents/api/sales-document-rules.api.ts
@@ -4,6 +4,7 @@
  * @module apps/web/src/features/sales-documents/api
  */
 import { ApiError } from '../../../shared/api/api-error';
+import type { SalesDocumentMarketsResponse } from './sales-document-markets.types';
 import type {
   AdoptSalesDocumentTemplateInput,
   CreateSalesDocumentRuleInput,
@@ -34,6 +35,12 @@ export interface SalesDocumentRulesApi {
   acknowledgeNoDocument: (country: string) => Promise<SalesDocumentCountryAcknowledgment>;
   /** DELETE /sales-documents/countries/:country/acknowledgment (#2186, #2189). */
   clearAcknowledgment: (country: string) => Promise<void>;
+  /**
+   * GET /sales-documents/markets (#2518/#2540, ADR-066) — configured and
+   * detected markets merged, each with its effective routing outcome
+   * resolved through the same evaluator every real order resolves through.
+   */
+  listMarkets: () => Promise<SalesDocumentMarketsResponse>;
 }
 
 interface ApiRequest {
@@ -105,6 +112,9 @@ export function createSalesDocumentRulesApi(request: ApiRequest): SalesDocumentR
         `/sales-documents/countries/${encodeURIComponent(country)}/acknowledgment`,
         { method: 'DELETE' },
       );
+    },
+    listMarkets(): Promise<SalesDocumentMarketsResponse> {
+      return request<SalesDocumentMarketsResponse>('/sales-documents/markets');
     },
   };
 }

--- a/apps/web/src/features/sales-documents/api/sales-document-rules.query-keys.ts
+++ b/apps/web/src/features/sales-documents/api/sales-document-rules.query-keys.ts
@@ -11,4 +11,5 @@ export const salesDocumentRulesQueryKeys = {
   thresholds: () => ['sales-document-rules', 'thresholds'] as const,
   template: (country: string) => ['sales-document-rules', 'template', country] as const,
   countries: () => ['sales-document-rules', 'countries'] as const,
+  markets: () => ['sales-document-rules', 'markets'] as const,
 };

--- a/apps/web/src/features/sales-documents/components/sales-document-market-row.test.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-market-row.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { SalesDocumentMarketRow } from './sales-document-market-row';
+import type { SalesDocumentMarketRow as MarketRowData } from '../api/sales-document-markets.types';
+
+function makeRow(overrides: Partial<MarketRowData> = {}): MarketRowData {
+  return {
+    country: 'DE',
+    orderCount: null,
+    hasTemplate: false,
+    ruleCount: 1,
+    invoiceDefaultConnectionId: 'conn_1',
+    receiptDefaultConnectionId: null,
+    acknowledgedNoDocumentAt: null,
+    outcome: { kind: 'route', documentKind: 'invoice', connectionId: 'conn_1' },
+    ...overrides,
+  };
+}
+
+function renderRow(row: MarketRowData, onSelect = vi.fn(), disabled = false): void {
+  render(
+    <ul>
+      <SalesDocumentMarketRow row={row} onSelect={onSelect} disabled={disabled} />
+    </ul>,
+  );
+}
+
+describe('SalesDocumentMarketRow', () => {
+  it('should label the action "Configure" for a settled row', () => {
+    renderRow(makeRow());
+    expect(screen.getByRole('button', { name: 'Configure' })).toBeInTheDocument();
+  });
+
+  it('should offer a plain "Set up" action for an unresolved row without a starter template', () => {
+    renderRow(makeRow({ ruleCount: 0, invoiceDefaultConnectionId: null, outcome: { kind: 'unresolved', reason: 'no-configuration-for-country' } }));
+    expect(screen.getByRole('button', { name: 'Set up' })).toBeInTheDocument();
+  });
+
+  it('should offer "Use starter setup" when a template exists for an unresolved market', () => {
+    renderRow(
+      makeRow({
+        hasTemplate: true,
+        ruleCount: 0,
+        invoiceDefaultConnectionId: null,
+        outcome: { kind: 'unresolved', reason: 'no-configuration-for-country' },
+      }),
+    );
+    expect(screen.getByRole('button', { name: 'Use starter setup' })).toBeInTheDocument();
+  });
+
+  it('should call onSelect with the row country when the action is clicked', async () => {
+    const onSelect = vi.fn();
+    renderRow(makeRow({ country: 'AT' }), onSelect);
+    await userEvent.click(screen.getByRole('button', { name: 'Configure' }));
+    expect(onSelect).toHaveBeenCalledWith('AT');
+  });
+
+  it('should disable the action while the section is busy', () => {
+    renderRow(makeRow(), vi.fn(), true);
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('should render the Rest of world pseudo-country with its display label', () => {
+    renderRow(makeRow({ country: '*' }));
+    expect(screen.getByText('★ Rest of world')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/sales-documents/components/sales-document-market-row.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-market-row.tsx
@@ -1,0 +1,114 @@
+/**
+ * SalesDocumentMarketRow (#2540)
+ *
+ * One row per market on the settings page's market section — replacing the
+ * five-element-per-market stack (eyebrow, two-line sentence, badge, rule
+ * count, button) that made country the smallest text on the page. This row
+ * puts exactly five things at view, in priority order: a status dot
+ * (supplementary — text carries the meaning, never the dot alone), the
+ * market name as the visual anchor with its code and rule count demoted to
+ * meta text, what an order here gets, the short reason beneath when it gets
+ * nothing, and one action labelled for what it actually does.
+ *
+ * Colour marks exceptions only (epic-wide rule, #2513): an issuing or
+ * acknowledged market renders in `neutral`/`success` tone at most, never a
+ * loud highlight — only a row that `needsDecision` gets a `warning` dot and
+ * an `attention` outline, because only that row is a problem.
+ *
+ * Below 768px this becomes a card via `.sales-document-market-row` CSS
+ * (`index.css`), never a second component — see #2540 acceptance criterion.
+ *
+ * @module apps/web/src/features/sales-documents/components
+ */
+import type { ReactElement } from 'react';
+import { Button } from '../../../shared/ui/button';
+import { DocumentKindGlyph } from '../../../shared/ui/document-kind-glyph';
+import { StatusBadge, type StatusBadgeTone } from '../../../shared/ui/status-badge';
+import {
+  describeSalesDocumentMarketOutcome,
+  type SalesDocumentMarketOutcomeCopy,
+} from '../lib/sales-document-market-outcome-copy';
+import { SALES_DOCUMENT_REST_OF_WORLD_COUNTRY } from '../api/sales-document-rules.types';
+import type { SalesDocumentMarketRow as MarketRowData } from '../api/sales-document-markets.types';
+
+function countryLabel(country: string): string {
+  return country === SALES_DOCUMENT_REST_OF_WORLD_COUNTRY ? '★ Rest of world' : country;
+}
+
+function toneFor(copy: SalesDocumentMarketOutcomeCopy): StatusBadgeTone {
+  if (copy.needsDecision) return 'warning';
+  if (copy.isIssuing) return 'success';
+  return 'neutral';
+}
+
+function actionLabel(row: MarketRowData, copy: SalesDocumentMarketOutcomeCopy): string {
+  if (!copy.needsDecision) return 'Configure';
+  return row.hasTemplate ? 'Use starter setup' : 'Set up';
+}
+
+export interface SalesDocumentMarketRowProps {
+  row: MarketRowData;
+  /** Fired with the row's country when the action is clicked. */
+  onSelect: (country: string) => void;
+  /** Disables the action while a mutation/query for this section is in flight (#2543). */
+  disabled?: boolean;
+}
+
+export function SalesDocumentMarketRow({
+  row,
+  onSelect,
+  disabled = false,
+}: SalesDocumentMarketRowProps): ReactElement {
+  const copy = describeSalesDocumentMarketOutcome(row.outcome);
+  const isDetectedOnly = row.orderCount !== null;
+
+  return (
+    <li
+      className={[
+        'sales-document-market-row',
+        copy.needsDecision ? 'sales-document-market-row--attention' : '',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      <div className="sales-document-market-row__status">
+        <StatusBadge tone={toneFor(copy)} withDot compact>
+          <span className="sr-only">{copy.needsDecision ? 'Needs attention' : 'Set up'}</span>
+        </StatusBadge>
+      </div>
+
+      <div className="sales-document-market-row__identity">
+        <span className="sales-document-market-row__name">{countryLabel(row.country)}</span>
+        <span className="sales-document-market-row__meta muted-text mono-text">
+          {row.country === SALES_DOCUMENT_REST_OF_WORLD_COUNTRY ? 'Catch-all' : row.country} ·{' '}
+          {row.ruleCount === 1 ? '1 rule' : `${row.ruleCount} rules`}
+          {isDetectedOnly ? ` · ${row.orderCount} orders` : ''}
+        </span>
+      </div>
+
+      <div className="sales-document-market-row__outcome">
+        <div className="sales-document-market-row__outcome-headline">
+          <DocumentKindGlyph kind={copy.glyphKind} decorative />
+          <span>{copy.headline}</span>
+        </div>
+        {copy.needsDecision && copy.reasonShort ? (
+          <span className="sales-document-market-row__reason muted-text">
+            {copy.reasonShort}
+            {copy.needsDecision && row.hasTemplate ? ' · Starter setup available' : ''}
+          </span>
+        ) : null}
+      </div>
+
+      <div className="sales-document-market-row__action">
+        <Button
+          tone={copy.needsDecision ? 'primary' : 'secondary'}
+          className="button--sm"
+          disabled={disabled}
+          onClick={() => onSelect(row.country)}
+        >
+          {actionLabel(row, copy)}
+        </Button>
+      </div>
+    </li>
+  );
+}

--- a/apps/web/src/features/sales-documents/components/sales-document-market-section.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-market-section.tsx
@@ -1,0 +1,78 @@
+/**
+ * SalesDocumentMarketSection (#2540)
+ *
+ * The settings page's scannable market list: one row per market, sorted so a
+ * market needing a decision sorts above a settled one. Reads the single
+ * merged `useSalesDocumentMarketsQuery` snapshot — the summary sentence
+ * (#2541), the detected-market suggested-setup wording (#2542) and the
+ * loading skeleton (#2543) build on this same query in later slices of the
+ * same mini-epic.
+ *
+ * `onSelectCountry` is the existing seam `SalesDocumentCountryIndex` already
+ * uses (#2187) — this section's action buttons resolve to the same
+ * per-country routing dialog, so a market discovered here and a market
+ * discovered through the older configured-countries table land on identical
+ * configuration UI.
+ *
+ * @module apps/web/src/features/sales-documents/components
+ */
+import type { ReactElement } from 'react';
+import { EmptyState, ErrorState, LoadingState } from '../../../shared/ui/feedback-state';
+import { useSalesDocumentMarketsQuery } from '../hooks/use-sales-document-markets-query';
+import { orderSalesDocumentMarkets } from '../lib/order-sales-document-markets';
+import { SalesDocumentMarketRow } from './sales-document-market-row';
+
+export interface SalesDocumentMarketSectionProps {
+  onSelectCountry: (country: string) => void;
+}
+
+export function SalesDocumentMarketSection({
+  onSelectCountry,
+}: SalesDocumentMarketSectionProps): ReactElement {
+  const marketsQuery = useSalesDocumentMarketsQuery();
+
+  if (marketsQuery.isLoading) {
+    return <LoadingState title="Loading markets" message="Fetching the current routing outcome for each market…" />;
+  }
+
+  if (marketsQuery.error) {
+    return (
+      <ErrorState
+        title="Unable to load markets"
+        message={marketsQuery.error.message}
+        action={
+          <button
+            type="button"
+            className="button button--secondary button--sm"
+            onClick={() => void marketsQuery.refetch()}
+          >
+            Retry
+          </button>
+        }
+      />
+    );
+  }
+
+  const rows = orderSalesDocumentMarkets(marketsQuery.data?.markets ?? []);
+
+  if (rows.length === 0) {
+    return (
+      <div className="page-section sales-document-market-section">
+        <EmptyState
+          title="No markets yet"
+          message="Markets appear here on their own as orders arrive from a new country. There's nothing to configure until then."
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="page-section sales-document-market-section">
+      <ul className="sales-document-market-row-list" aria-label="Sales-document markets">
+        {rows.map((row) => (
+          <SalesDocumentMarketRow key={row.country} row={row} onSelect={onSelectCountry} />
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/src/features/sales-documents/components/sales-document-rule-engine-panel.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-rule-engine-panel.tsx
@@ -36,6 +36,7 @@
 import { useState, type ReactElement } from 'react';
 import { SalesDocumentCountryIndex } from './sales-document-country-index';
 import { SalesDocumentCountryRoutingDialog } from './sales-document-country-routing-dialog';
+import { SalesDocumentMarketSection } from './sales-document-market-section';
 import { SalesDocumentTemplateScreen } from './sales-document-template-screen';
 
 interface RoutingDialogState {
@@ -72,6 +73,15 @@ export function SalesDocumentRuleEnginePanel(): ReactElement {
           obligations.
         </p>
       </header>
+
+      {/*
+       * #2539/M6 — the settings page's headline: what does each market
+       * issue, right now. Renders above the country index rather than
+       * replacing it, since the index still backs "Add country" for a
+       * market with neither orders nor configuration yet — a case this
+       * merged-read section correctly never lists a row for.
+       */}
+      <SalesDocumentMarketSection onSelectCountry={handleSelectCountry} />
 
       <SalesDocumentCountryIndex onSelectCountry={handleSelectCountry} />
 

--- a/apps/web/src/features/sales-documents/hooks/use-sales-document-markets-query.ts
+++ b/apps/web/src/features/sales-documents/hooks/use-sales-document-markets-query.ts
@@ -1,0 +1,22 @@
+/**
+ * useSalesDocumentMarketsQuery (#2540)
+ *
+ * Thin `useQuery` wrapper over `apiClient.salesDocumentRules.listMarkets` —
+ * the single merged read backing the settings page's market list, summary,
+ * detected-market rows and their loading states. One query, four consumers,
+ * so none of them can read a different snapshot than the others.
+ *
+ * @module apps/web/src/features/sales-documents/hooks
+ */
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { salesDocumentRulesQueryKeys } from '../api/sales-document-rules.query-keys';
+import type { SalesDocumentMarketsResponse } from '../api/sales-document-markets.types';
+
+export function useSalesDocumentMarketsQuery(): UseQueryResult<SalesDocumentMarketsResponse> {
+  const apiClient = useApiClient();
+  return useQuery({
+    queryKey: salesDocumentRulesQueryKeys.markets(),
+    queryFn: () => apiClient.salesDocumentRules.listMarkets(),
+  });
+}

--- a/apps/web/src/features/sales-documents/lib/order-sales-document-markets.test.ts
+++ b/apps/web/src/features/sales-documents/lib/order-sales-document-markets.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { orderSalesDocumentMarkets } from './order-sales-document-markets';
+import { SALES_DOCUMENT_REST_OF_WORLD_COUNTRY } from '../api/sales-document-rules.types';
+import type { SalesDocumentMarketRow } from '../api/sales-document-markets.types';
+
+function row(country: string, outcomeKind: SalesDocumentMarketRow['outcome']['kind']): SalesDocumentMarketRow {
+  return {
+    country,
+    orderCount: null,
+    hasTemplate: false,
+    ruleCount: 0,
+    invoiceDefaultConnectionId: null,
+    receiptDefaultConnectionId: null,
+    acknowledgedNoDocumentAt: null,
+    outcome: outcomeKind === 'unresolved' ? { kind: 'unresolved', reason: 'x' } : { kind: outcomeKind },
+  };
+}
+
+describe('orderSalesDocumentMarkets', () => {
+  it('should sort a market needing a decision above a settled one', () => {
+    const result = orderSalesDocumentMarkets([row('DE', 'route'), row('AT', 'unresolved')]);
+    expect(result.map((r) => r.country)).toEqual(['AT', 'DE']);
+  });
+
+  it('should sort alphabetically within the same decision group', () => {
+    const result = orderSalesDocumentMarkets([
+      row('PL', 'unresolved'),
+      row('AT', 'unresolved'),
+      row('DE', 'route'),
+      row('BE', 'route'),
+    ]);
+    expect(result.map((r) => r.country)).toEqual(['AT', 'PL', 'BE', 'DE']);
+  });
+
+  it('should always place Rest of world last, regardless of its outcome', () => {
+    const result = orderSalesDocumentMarkets([
+      row(SALES_DOCUMENT_REST_OF_WORLD_COUNTRY, 'unresolved'),
+      row('DE', 'route'),
+    ]);
+    expect(result.map((r) => r.country)).toEqual(['DE', SALES_DOCUMENT_REST_OF_WORLD_COUNTRY]);
+  });
+});

--- a/apps/web/src/features/sales-documents/lib/order-sales-document-markets.ts
+++ b/apps/web/src/features/sales-documents/lib/order-sales-document-markets.ts
@@ -1,0 +1,33 @@
+/**
+ * Order Sales-Document Markets (#2540)
+ *
+ * A market row that needs a decision (its outcome is `unresolved`) sorts
+ * before every settled row — that's the whole point of #2540's acceptance
+ * criterion "decisions-needed rows sort first". Within each group, rows sort
+ * alphabetically by country code for a stable, scannable list, with
+ * `★ Rest of world` always last regardless of which group it falls in
+ * (mirrors `orderSalesDocumentCountries`, #2187).
+ *
+ * @module apps/web/src/features/sales-documents/lib
+ */
+import { SALES_DOCUMENT_REST_OF_WORLD_COUNTRY } from '../api/sales-document-rules.types';
+import { describeSalesDocumentMarketOutcome } from './sales-document-market-outcome-copy';
+import type { SalesDocumentMarketRow } from '../api/sales-document-markets.types';
+
+export function orderSalesDocumentMarkets(
+  rows: readonly SalesDocumentMarketRow[],
+): SalesDocumentMarketRow[] {
+  const restOfWorld = rows.filter((row) => row.country === SALES_DOCUMENT_REST_OF_WORLD_COUNTRY);
+  const others = rows.filter((row) => row.country !== SALES_DOCUMENT_REST_OF_WORLD_COUNTRY);
+
+  const rank = (row: SalesDocumentMarketRow): number =>
+    describeSalesDocumentMarketOutcome(row.outcome).needsDecision ? 0 : 1;
+
+  const sorted = others.slice().sort((a, b) => {
+    const rankDelta = rank(a) - rank(b);
+    if (rankDelta !== 0) return rankDelta;
+    return a.country.localeCompare(b.country);
+  });
+
+  return [...sorted, ...restOfWorld];
+}

--- a/apps/web/src/features/sales-documents/lib/sales-document-market-outcome-copy.test.ts
+++ b/apps/web/src/features/sales-documents/lib/sales-document-market-outcome-copy.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { describeSalesDocumentMarketOutcome } from './sales-document-market-outcome-copy';
+import type { SalesDocumentMarketOutcome } from '../api/sales-document-markets.types';
+
+describe('describeSalesDocumentMarketOutcome', () => {
+  it('should report an invoice route as issuing, needing no decision', () => {
+    const outcome: SalesDocumentMarketOutcome = {
+      kind: 'route',
+      documentKind: 'invoice',
+      connectionId: 'conn_1',
+    };
+    const copy = describeSalesDocumentMarketOutcome(outcome);
+    expect(copy).toMatchObject({
+      headline: 'Invoice',
+      glyphKind: 'invoice',
+      isIssuing: true,
+      needsDecision: false,
+      reasonShort: null,
+    });
+  });
+
+  it('should report a fiscal-receipt route with its own glyph kind', () => {
+    const outcome: SalesDocumentMarketOutcome = {
+      kind: 'route',
+      documentKind: 'fiscal-receipt',
+      connectionId: 'conn_1',
+    };
+    expect(describeSalesDocumentMarketOutcome(outcome).headline).toBe('Fiscal receipt');
+  });
+
+  it('should report an unrecognised document kind with no glyph rather than guessing', () => {
+    const outcome: SalesDocumentMarketOutcome = {
+      kind: 'route',
+      documentKind: 'some-future-kind',
+      connectionId: 'conn_1',
+    };
+    expect(describeSalesDocumentMarketOutcome(outcome).glyphKind).toBeNull();
+  });
+
+  it('should report an aggregate outcome as settled but not issuing', () => {
+    const outcome: SalesDocumentMarketOutcome = { kind: 'aggregate', connectionId: 'conn_1' };
+    const copy = describeSalesDocumentMarketOutcome(outcome);
+    expect(copy.isIssuing).toBe(false);
+    expect(copy.needsDecision).toBe(false);
+  });
+
+  it('should report an acknowledged market as a settled state needing no decision', () => {
+    const copy = describeSalesDocumentMarketOutcome({ kind: 'acknowledged' });
+    expect(copy.needsDecision).toBe(false);
+    expect(copy.headline).toBe('No document, by choice');
+  });
+
+  it('should report an unresolved outcome as needing a decision with a reason', () => {
+    const copy = describeSalesDocumentMarketOutcome({
+      kind: 'unresolved',
+      reason: 'ambiguous-connection-no-primary',
+    });
+    expect(copy.needsDecision).toBe(true);
+    expect(copy.reasonShort).not.toBeNull();
+  });
+
+  it('should fall back to a generic reason when the reason is unrecognised', () => {
+    const copy = describeSalesDocumentMarketOutcome({ kind: 'unresolved', reason: 'made-up' });
+    expect(copy.needsDecision).toBe(true);
+    expect(copy.reasonShort).toBe('Not set up');
+  });
+});

--- a/apps/web/src/features/sales-documents/lib/sales-document-market-outcome-copy.ts
+++ b/apps/web/src/features/sales-documents/lib/sales-document-market-outcome-copy.ts
@@ -1,0 +1,83 @@
+/**
+ * Sales-Document Market Outcome Copy (#2540/#2541/#2542)
+ *
+ * Turns one `SalesDocumentMarketRow.outcome` into the words a market-list row
+ * or a section summary sentence needs — "what does this market's orders get"
+ * and, when the answer is nothing, why. Derived from the backend's own
+ * resolved outcome, never re-derived from country/connection state client
+ * side (the #2534 rule that `sales-document-reason-copy.ts` also follows).
+ *
+ * `'acknowledged'` is rendered as a settled, neutral state — not a decision
+ * needing attention — because the whole point of an acknowledgment (#2186)
+ * is that an operator already decided "no document here, by design".
+ *
+ * @module apps/web/src/features/sales-documents/lib
+ */
+import { SALES_DOCUMENT_UNRESOLVED_REASON_COPY } from './sales-document-reason-copy';
+import type { SalesDocumentMarketOutcome } from '../api/sales-document-markets.types';
+import type { DocumentKind } from '../../../shared/ui/document-kind-glyph';
+
+export interface SalesDocumentMarketOutcomeCopy {
+  /** What this market's orders get, in a couple of words. */
+  headline: string;
+  /** The document glyph kind, or `null` for "nothing". */
+  glyphKind: DocumentKind | null;
+  /** True only for `outcome.kind === 'route'` naming a real document. */
+  isIssuing: boolean;
+  /** True when this row needs an operator decision (unresolved, not acknowledged). */
+  needsDecision: boolean;
+  /** The short "why nothing" reason, set only when `needsDecision` is true. */
+  reasonShort: string | null;
+}
+
+function isKnownDocumentKind(kind: string | null | undefined): kind is DocumentKind {
+  return kind === 'invoice' || kind === 'fiscal-receipt';
+}
+
+export function describeSalesDocumentMarketOutcome(
+  outcome: SalesDocumentMarketOutcome,
+): SalesDocumentMarketOutcomeCopy {
+  if (outcome.kind === 'route') {
+    const glyphKind = isKnownDocumentKind(outcome.documentKind) ? outcome.documentKind : null;
+    return {
+      headline: glyphKind === 'fiscal-receipt' ? 'Fiscal receipt' : 'Invoice',
+      glyphKind,
+      isIssuing: true,
+      needsDecision: false,
+      reasonShort: null,
+    };
+  }
+
+  if (outcome.kind === 'aggregate') {
+    return {
+      headline: 'Collected, not yet issued',
+      glyphKind: null,
+      isIssuing: false,
+      needsDecision: false,
+      reasonShort: null,
+    };
+  }
+
+  if (outcome.kind === 'acknowledged') {
+    return {
+      headline: 'No document, by choice',
+      glyphKind: null,
+      isIssuing: false,
+      needsDecision: false,
+      reasonShort: null,
+    };
+  }
+
+  // 'unresolved' — the reason travels on the row itself, resolved against the
+  // same routing-reason vocabulary the order-level surfaces already use.
+  const reasonCopy = outcome.reason
+    ? (SALES_DOCUMENT_UNRESOLVED_REASON_COPY as Record<string, { short: string }>)[outcome.reason]
+    : undefined;
+  return {
+    headline: 'Nothing issued',
+    glyphKind: null,
+    isIssuing: false,
+    needsDecision: true,
+    reasonShort: reasonCopy?.short ?? 'Not set up',
+  };
+}

--- a/apps/web/src/features/sales-documents/lib/sales-document-market-outcome-copy.ts
+++ b/apps/web/src/features/sales-documents/lib/sales-document-market-outcome-copy.ts
@@ -69,7 +69,10 @@ export function describeSalesDocumentMarketOutcome(
   }
 
   // 'unresolved' — the reason travels on the row itself, resolved against the
-  // same routing-reason vocabulary the order-level surfaces already use.
+  // same routing-reason vocabulary the order-level surfaces already use. The
+  // backend DTO types `reason` as a bare `string` (not the narrow union), so
+  // this cast is an honest acknowledgment of an untyped wire boundary value,
+  // not a bypass of a type we could otherwise have kept.
   const reasonCopy = outcome.reason
     ? (SALES_DOCUMENT_UNRESOLVED_REASON_COPY as Record<string, { short: string }>)[outcome.reason]
     : undefined;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -19371,6 +19371,96 @@ textarea.bulk-editor__input { resize: vertical; min-height: 66px; font-family: i
   }
 }
 
+/* ── Sales-document market section (#2540) ── */
+.sales-document-market-row-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.sales-document-market-row {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1.4fr) minmax(0, 1.6fr) auto;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  background: var(--bg-surface);
+  min-height: 4.25rem;
+}
+.sales-document-market-row--attention {
+  border-color: var(--status-warning-border);
+  background: var(--status-warning-soft);
+}
+
+.sales-document-market-row__status {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.sales-document-market-row__identity {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.sales-document-market-row__name {
+  font-weight: 600;
+  color: var(--text-primary);
+  font-size: 0.9375rem;
+}
+.sales-document-market-row__meta {
+  font-size: 0.75rem;
+}
+
+.sales-document-market-row__outcome {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.sales-document-market-row__outcome-headline {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: 0.875rem;
+  color: var(--text-primary);
+}
+.sales-document-market-row__reason {
+  font-size: 0.75rem;
+}
+
+.sales-document-market-row__action {
+  display: flex;
+  justify-content: flex-end;
+}
+
+@media (max-width: 767.98px) {
+  .sales-document-market-row {
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      'status'
+      'identity'
+      'outcome'
+      'action';
+    align-items: start;
+  }
+  .sales-document-market-row__status {
+    justify-content: flex-start;
+  }
+  .sales-document-market-row__action {
+    justify-content: stretch;
+  }
+  .sales-document-market-row__action .button {
+    width: 100%;
+  }
+}
+
 /* ── Sales-document country index (#2187) ── */
 .sales-document-country-index__add-row {
   margin-top: var(--space-3);

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -683,6 +683,11 @@ export function createMockApiClient(
         acknowledgedAt: '2026-01-01T00:00:00.000Z',
       }),
       clearAcknowledgment: vi.fn().mockResolvedValue(undefined),
+      listMarkets: vi.fn().mockResolvedValue({
+        windowDays: 30,
+        since: '2026-01-01T00:00:00.000Z',
+        markets: [],
+      }),
       ...overrides.salesDocumentRules,
     } as ApiClient['salesDocumentRules'],
     shipments: {


### PR DESCRIPTION
## Summary

One row per market on the settings page's market section, replacing the five-element-per-market stack (eyebrow, two-line sentence, badge, rule count, button) that made the country name the smallest text on the page.

A row shows, in priority order: a status dot (supplementary only — the outcome text and reason carry the meaning, never the dot alone), the market name as the visual anchor with its ISO code and rule count demoted to meta text, what an order there gets (via `DocumentKindGlyph`), the short reason beneath when it gets nothing, and one action labelled for what it actually does ("Configure" when settled, "Set up" / "Use starter setup" when it needs a decision).

## What shipped

- `SalesDocumentMarketRow` — the row component. Below 768px it becomes a card via CSS `grid-template-areas`, not a second component (per #2540 AC).
- `orderSalesDocumentMarkets` — sorts rows needing a decision (`outcome.kind === 'unresolved'`) above every settled row, alphabetically within each group, with `★ Rest of world` always sorted last regardless of its own outcome.
- `describeSalesDocumentMarketOutcome` — turns the backend's already-resolved `SalesDocumentMarketOutcome` into headline/glyph/reason copy. Never re-derived from country/connection state client-side — this is the same rule `sales-document-reason-copy.ts` already follows (#2534).
- `GET /sales-documents/markets` client (`listMarkets`) + query key + `useSalesDocumentMarketsQuery`.
- `SalesDocumentMarketSection` composes the above with the existing generic `LoadingState` / `ErrorState` / `EmptyState` primitives, and is wired into `SalesDocumentRuleEnginePanel` above the existing `SalesDocumentCountryIndex`.
- CSS: row/list layout + the <768px card breakpoint.

## Decisions a reviewer could dispute

- **The real backend endpoint lives at `apps/api/src/sales-documents/http/sales-document-markets.controller.ts`**, not `apps/api/src/integrations/http/...` as an earlier task description assumed. Verified the actual `SalesDocumentMarketRowDto` / `SalesDocumentMarketOutcomeDto` shape against that file before trusting the FE types.
- **Never claim what the backend cannot report**: `outcome` is rendered verbatim from what `resolveRoutingBatch` answered for a representative order (no buyer tax id asserted, no amount asserted) — the FE never re-derives "why nothing" from country/connection state, only from `outcome.reason`, reusing `SALES_DOCUMENT_UNRESOLVED_REASON_COPY` (already guarded by `check-sales-document-reason-mirror.mjs`) rather than inventing a second reason vocabulary.
- **`'acknowledged'` renders as a settled, neutral state**, not a decision needing attention — matches the backend DTO's own documented override (an acknowledged market is never reported as `unresolved`).
- **The "action label" logic**: `hasTemplate` only changes wording ("Use starter setup" vs "Set up"), never behaviour — both route to the same `onSelectCountry` callback into the existing per-country routing dialog (#2187/#2188), so a market discovered here and one discovered through the older configured-countries table land on identical configuration UI.
- Rendered `SalesDocumentMarketSection` **above**, not in place of, `SalesDocumentCountryIndex` — the index still backs "Add country" for a market with neither orders nor configuration, which this merged read correctly never lists a row for.

## Deliberately left out (picked up by sibling tasks in #2539)

- No computed summary sentence — #2541 adds it.
- Loading state uses the existing generic `LoadingState`, not a shape-matched skeleton — #2543 replaces it and adds the busy/disabled wiring.
- The row already renders detected-market order counts and the starter-setup wording (they live in the same row component), so #2542's remaining scope is the explicit test coverage that a template-less detected market only ever gets a plain "Set up", never a recommendation.

## Test plan

- [x] `pnpm --filter @openlinker/web type-check` — clean
- [x] `pnpm --filter @openlinker/web exec eslint src/features/sales-documents src/test/test-utils.tsx --max-warnings=0` — clean
- [x] `pnpm --filter @openlinker/web exec vitest run src/features/sales-documents` — all passing
- [x] `pnpm check:invariants` (filtered of `.worktrees` noise) — all green, including the sales-document reason-copy mirror

Closes #2540