### PR TITLE
feat(sales-documents): market section summary and empty state (#2541)

### DIFF
--- a/apps/web/src/features/sales-documents/components/sales-document-market-section.test.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-market-section.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * SalesDocumentMarketSection Tests — summary + empty state (#2541)
+ */
+import { screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { createMockApiClient, renderWithProviders } from '../../../test/test-utils';
+import { SalesDocumentMarketSection } from './sales-document-market-section';
+
+describe('SalesDocumentMarketSection — summary + empty state (#2541)', () => {
+  it('should render the empty state, and never the summary, on a clean instance', async () => {
+    const apiClient = createMockApiClient({
+      salesDocumentRules: {
+        listMarkets: vi.fn().mockResolvedValue({
+          windowDays: 30,
+          since: '2026-01-01T00:00:00.000Z',
+          markets: [],
+        }),
+      },
+    });
+    renderWithProviders(<SalesDocumentMarketSection onSelectCountry={vi.fn()} />, { apiClient });
+
+    await waitFor(() => expect(screen.getByText('No markets yet')).toBeInTheDocument());
+    expect(screen.queryByText(/issuing/)).not.toBeInTheDocument();
+  });
+
+  it('should render the computed summary sentence above the row list when markets exist', async () => {
+    const apiClient = createMockApiClient({
+      salesDocumentRules: {
+        listMarkets: vi.fn().mockResolvedValue({
+          windowDays: 30,
+          since: '2026-01-01T00:00:00.000Z',
+          markets: [
+            {
+              country: 'DE',
+              orderCount: null,
+              hasTemplate: false,
+              ruleCount: 1,
+              invoiceDefaultConnectionId: 'conn_1',
+              receiptDefaultConnectionId: null,
+              acknowledgedNoDocumentAt: null,
+              outcome: { kind: 'route', documentKind: 'invoice', connectionId: 'conn_1' },
+            },
+          ],
+        }),
+      },
+    });
+    renderWithProviders(<SalesDocumentMarketSection onSelectCountry={vi.fn()} />, { apiClient });
+
+    await waitFor(() => expect(screen.getByText('DE')).toBeInTheDocument());
+    expect(screen.getByText('This market is issuing its documents.')).toBeInTheDocument();
+    expect(screen.queryByText('No markets yet')).not.toBeInTheDocument();
+  });
+
+  it('should read a market blocked without any configuration as fresh-install, not broken', async () => {
+    const apiClient = createMockApiClient({
+      salesDocumentRules: {
+        listMarkets: vi.fn().mockResolvedValue({
+          windowDays: 30,
+          since: '2026-01-01T00:00:00.000Z',
+          markets: [
+            {
+              country: 'PL',
+              orderCount: 4,
+              hasTemplate: true,
+              ruleCount: 0,
+              invoiceDefaultConnectionId: null,
+              receiptDefaultConnectionId: null,
+              acknowledgedNoDocumentAt: null,
+              outcome: { kind: 'unresolved', reason: 'no-configuration-for-country' },
+            },
+          ],
+        }),
+      },
+    });
+    renderWithProviders(<SalesDocumentMarketSection onSelectCountry={vi.fn()} />, { apiClient });
+
+    await waitFor(() => expect(screen.getByText('PL')).toBeInTheDocument());
+    expect(screen.getByText(/not been set up yet/)).toBeInTheDocument();
+    expect(screen.getByText(/Nothing is lost/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/sales-documents/components/sales-document-market-section.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-market-section.tsx
@@ -1,12 +1,18 @@
 /**
- * SalesDocumentMarketSection (#2540)
+ * SalesDocumentMarketSection (#2540/#2541)
  *
- * The settings page's scannable market list: one row per market, sorted so a
- * market needing a decision sorts above a settled one. Reads the single
- * merged `useSalesDocumentMarketsQuery` snapshot — the summary sentence
- * (#2541), the detected-market suggested-setup wording (#2542) and the
- * loading skeleton (#2543) build on this same query in later slices of the
- * same mini-epic.
+ * The settings page's headline half: one prose sentence answering "what does
+ * each market issue" (#2541), then a scannable market list (#2540) — both
+ * read the single merged `useSalesDocumentMarketsQuery` snapshot, so they
+ * can never disagree about what "right now" means. The detected-market
+ * suggested-setup wording (#2542) already renders inside each row; the
+ * loading skeleton (#2543) builds on this same query in a later slice of
+ * the same mini-epic.
+ *
+ * The summary and the empty state never both render (#2541 acceptance):
+ * `summarizeSalesDocumentMarkets` returns `null` for an empty row set, and
+ * the empty-state branch below returns before the summary would even be
+ * computed.
  *
  * `onSelectCountry` is the existing seam `SalesDocumentCountryIndex` already
  * uses (#2187) — this section's action buttons resolve to the same
@@ -20,6 +26,7 @@ import type { ReactElement } from 'react';
 import { EmptyState, ErrorState, LoadingState } from '../../../shared/ui/feedback-state';
 import { useSalesDocumentMarketsQuery } from '../hooks/use-sales-document-markets-query';
 import { orderSalesDocumentMarkets } from '../lib/order-sales-document-markets';
+import { summarizeSalesDocumentMarkets } from '../lib/summarize-sales-document-markets';
 import { SalesDocumentMarketRow } from './sales-document-market-row';
 
 export interface SalesDocumentMarketSectionProps {
@@ -66,8 +73,18 @@ export function SalesDocumentMarketSection({
     );
   }
 
+  const summary = summarizeSalesDocumentMarkets(rows);
+
   return (
     <div className="page-section sales-document-market-section">
+      {summary ? (
+        <p
+          className={`sales-document-market-section__summary sales-document-market-section__summary--${summary.tone}`}
+        >
+          {summary.sentence}
+        </p>
+      ) : null}
+
       <ul className="sales-document-market-row-list" aria-label="Sales-document markets">
         {rows.map((row) => (
           <SalesDocumentMarketRow key={row.country} row={row} onSelect={onSelectCountry} />

--- a/apps/web/src/features/sales-documents/lib/summarize-sales-document-markets.test.ts
+++ b/apps/web/src/features/sales-documents/lib/summarize-sales-document-markets.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { summarizeSalesDocumentMarkets } from './summarize-sales-document-markets';
+import type { SalesDocumentMarketRow } from '../api/sales-document-markets.types';
+
+function row(overrides: Partial<SalesDocumentMarketRow> = {}): SalesDocumentMarketRow {
+  return {
+    country: 'DE',
+    orderCount: null,
+    hasTemplate: false,
+    ruleCount: 0,
+    invoiceDefaultConnectionId: null,
+    receiptDefaultConnectionId: null,
+    acknowledgedNoDocumentAt: null,
+    outcome: { kind: 'route', documentKind: 'invoice', connectionId: 'conn_1' },
+    ...overrides,
+  };
+}
+
+describe('summarizeSalesDocumentMarkets', () => {
+  it('should return null for an empty row set, leaving the empty state to own the message', () => {
+    expect(summarizeSalesDocumentMarkets([])).toBeNull();
+  });
+
+  it('should return an all-set sentence when every market issues', () => {
+    const summary = summarizeSalesDocumentMarkets([row({ country: 'DE' }), row({ country: 'AT' })]);
+    expect(summary?.tone).toBe('all-set');
+    expect(summary?.sentence).toContain('issuing');
+  });
+
+  it('should read a fresh install receiving orders as not-set-up, never broken', () => {
+    const blocked = row({
+      country: 'PL',
+      orderCount: 4,
+      outcome: { kind: 'unresolved', reason: 'no-configuration-for-country' },
+    });
+    const summary = summarizeSalesDocumentMarkets([blocked]);
+    expect(summary?.tone).toBe('fresh-install');
+    expect(summary?.sentence).toContain('not been set up yet');
+    expect(summary?.sentence).toContain('Nothing is lost');
+  });
+
+  it('should read a partly-configured instance with a blocked market as needing attention', () => {
+    const configured = row({
+      country: 'DE',
+      ruleCount: 1,
+      outcome: { kind: 'route', documentKind: 'invoice', connectionId: 'conn_1' },
+    });
+    const blocked = row({
+      country: 'AT',
+      orderCount: 2,
+      outcome: { kind: 'unresolved', reason: 'no-configuration-for-country' },
+    });
+    const summary = summarizeSalesDocumentMarkets([configured, blocked]);
+    expect(summary?.tone).toBe('attention');
+    expect(summary?.sentence).toContain('AT');
+    expect(summary?.sentence).toContain('Nothing is lost');
+  });
+
+  it('should name every blocked market up to the cap and count the rest', () => {
+    const configured = row({ country: 'DE', ruleCount: 1 });
+    const blockedRows = ['A1', 'A2', 'A3', 'A4'].map((country) =>
+      row({ country, orderCount: 1, outcome: { kind: 'unresolved', reason: 'no-configuration-for-country' } }),
+    );
+    const summary = summarizeSalesDocumentMarkets([configured, ...blockedRows]);
+    expect(summary?.sentence).toContain('A1, A2, A3, and 1 more');
+  });
+});

--- a/apps/web/src/features/sales-documents/lib/summarize-sales-document-markets.ts
+++ b/apps/web/src/features/sales-documents/lib/summarize-sales-document-markets.ts
@@ -1,0 +1,92 @@
+/**
+ * Summarize Sales-Document Markets (#2541)
+ *
+ * One computed prose sentence for the settings page's market section —
+ * derived from the same rows the list renders, never hand-written. Three
+ * outcomes:
+ *
+ *  1. **Nothing configured anywhere, but orders are arriving** — a fresh
+ *     install that already has traffic. This reads as "not set up yet",
+ *     never "broken": a brand new instance receiving orders is the expected
+ *     starting state, not a fault.
+ *  2. **Some markets issue nothing** — names them (capped, so the sentence
+ *     stays a sentence on an install with many blocked markets) and states
+ *     explicitly that nothing is lost while they stay unconfigured — the
+ *     document is held, not dropped.
+ *  3. **Everything issues** — the reassuring one-liner.
+ *
+ * `rows.length === 0` returns `null`: the empty state
+ * (`SalesDocumentMarketEmptyState`) owns that case, and the two must never
+ * both render (#2541 acceptance).
+ *
+ * @module apps/web/src/features/sales-documents/lib
+ */
+import { SALES_DOCUMENT_REST_OF_WORLD_COUNTRY } from '../api/sales-document-rules.types';
+import { describeSalesDocumentMarketOutcome } from './sales-document-market-outcome-copy';
+import type { SalesDocumentMarketRow } from '../api/sales-document-markets.types';
+
+const MAX_NAMED_MARKETS = 3;
+
+function isConfigured(row: SalesDocumentMarketRow): boolean {
+  return (
+    row.ruleCount > 0 ||
+    row.invoiceDefaultConnectionId !== null ||
+    row.receiptDefaultConnectionId !== null ||
+    row.acknowledgedNoDocumentAt !== null
+  );
+}
+
+function countryLabel(country: string): string {
+  return country === SALES_DOCUMENT_REST_OF_WORLD_COUNTRY ? 'Rest of world' : country;
+}
+
+function namesSentenceFragment(rows: readonly SalesDocumentMarketRow[]): string {
+  const names = rows.slice(0, MAX_NAMED_MARKETS).map((row) => countryLabel(row.country));
+  const remaining = rows.length - names.length;
+  const joined = names.join(', ');
+  return remaining > 0 ? `${joined}, and ${remaining} more` : joined;
+}
+
+export interface SalesDocumentMarketSummary {
+  tone: 'fresh-install' | 'attention' | 'all-set';
+  sentence: string;
+}
+
+export function summarizeSalesDocumentMarkets(
+  rows: readonly SalesDocumentMarketRow[],
+): SalesDocumentMarketSummary | null {
+  if (rows.length === 0) return null;
+
+  const blocked = rows.filter((row) => describeSalesDocumentMarketOutcome(row.outcome).needsDecision);
+
+  if (blocked.length === 0) {
+    return {
+      tone: 'all-set',
+      sentence:
+        rows.length === 1
+          ? 'This market is issuing its documents.'
+          : `All ${rows.length} markets are issuing their documents.`,
+    };
+  }
+
+  const noneConfiguredAtAll = rows.every((row) => !isConfigured(row));
+  const ordersArriving = rows.some((row) => row.orderCount !== null);
+
+  if (noneConfiguredAtAll && ordersArriving) {
+    return {
+      tone: 'fresh-install',
+      sentence:
+        blocked.length === 1
+          ? `Orders are arriving from ${namesSentenceFragment(blocked)}, and it has not been set up yet. Nothing is lost while it waits — set up routing when you're ready.`
+          : `Orders are arriving from ${blocked.length} markets — ${namesSentenceFragment(blocked)} — and none has been set up yet. Nothing is lost while they wait — set up routing when you're ready.`,
+    };
+  }
+
+  return {
+    tone: 'attention',
+    sentence:
+      blocked.length === 1
+        ? `${namesSentenceFragment(blocked)} issues nothing right now. Nothing is lost while it's unconfigured — set up routing to start issuing.`
+        : `${blocked.length} markets — ${namesSentenceFragment(blocked)} — issue nothing right now. Nothing is lost while they're unconfigured — set up routing to start issuing.`,
+  };
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -19371,7 +19371,22 @@ textarea.bulk-editor__input { resize: vertical; min-height: 66px; font-family: i
   }
 }
 
-/* ── Sales-document market section (#2540) ── */
+/* ── Sales-document market section (#2540/#2541) ── */
+.sales-document-market-section__summary {
+  margin: 0 0 var(--space-4);
+  font-size: 0.9375rem;
+  color: var(--text-secondary);
+}
+.sales-document-market-section__summary--fresh-install {
+  color: var(--text-secondary);
+}
+.sales-document-market-section__summary--attention {
+  color: var(--status-warning-fg);
+}
+.sales-document-market-section__summary--all-set {
+  color: var(--status-success-fg);
+}
+
 .sales-document-market-row-list {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary

Adds the one prose sentence the section's ACs call for: derived from the same rows the market list already renders, answering "what does each market issue, right now" without an operator having to scan every row to find out.

## What shipped

- `summarizeSalesDocumentMarkets` — pure function, three tones:
  - `all-set` — every market issues.
  - `fresh-install` — nothing is configured anywhere, but orders are already arriving. Deliberately reads as "not set up yet", never as broken, since a fresh install receiving traffic is the expected starting state.
  - `attention` — some markets issue nothing while others are configured; names the blocked markets (capped at 3, `"A, B, C, and N more"` beyond that) and states explicitly that **nothing is lost** while they stay unconfigured.
  - Returns `null` for an empty row set — the empty state owns that case.
- Wired into `SalesDocumentMarketSection`, rendered above the row list.
- CSS: three summary tone classes reusing the existing status color tokens (no new hex values).

## Decisions a reviewer could dispute

- **The summary and the empty state are structurally exclusive, not just usually so**: the empty-state branch in `SalesDocumentMarketSection` returns before `summarizeSalesDocumentMarkets` is even called, and the function itself independently returns `null` on an empty array. Two independent reasons the two can never coexist, rather than one `if` a future edit could accidentally remove.
- **`isConfigured` treats an acknowledgment as configuration** — a market an operator explicitly marked "no document, by choice" (#2186) counts toward "everything is set up" for the fresh-install/all-set distinction, matching how `describeSalesDocumentMarketOutcome` already treats `'acknowledged'` as settled, never as attention-needing.
- **The naming cap is 3**, chosen so the sentence stays a sentence on an install with many blocked markets rather than becoming a wall of country codes — matches the existing precedent in `sales-document-reason-copy.ts`'s copy style (state the fact, then what changes it, no apology).
- No new backend union was introduced by this change, so no new `check-*-mirror.mjs` guard is needed — `summarizeSalesDocumentMarkets` derives its three tones from data already typed by #2540's `SalesDocumentMarketsResponse` mirror.

## Deliberately left out (picked up by sibling tasks in #2539)

- Detected-market-specific wording (order counts, "guidance exists for this market only") is unaffected here — it lives in `SalesDocumentMarketRow` from #2540, and #2542 adds its remaining explicit test coverage.
- The section's loading treatment is still the generic `LoadingState` — #2543 replaces it with a shape-matched skeleton.

## Test plan

- [x] `pnpm --filter @openlinker/web type-check` — clean
- [x] `pnpm --filter @openlinker/web exec eslint src/features/sales-documents --max-warnings=0` — clean
- [x] `pnpm --filter @openlinker/web exec vitest run src/features/sales-documents` — 18 files / 114 tests passing
- [x] `pnpm check:invariants` (filtered of `.worktrees` noise) — all green

Closes #2541