### PR TITLE
feat(sales-documents): detected markets and suggested setup (#2542)

### DIFF
--- a/apps/web/src/features/sales-documents/components/sales-document-market-row.test.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-market-row.test.tsx
@@ -18,10 +18,15 @@ function makeRow(overrides: Partial<MarketRowData> = {}): MarketRowData {
   };
 }
 
-function renderRow(row: MarketRowData, onSelect = vi.fn(), disabled = false): void {
+function renderRow(
+  row: MarketRowData,
+  onSelect = vi.fn(),
+  disabled = false,
+  extra: { windowDays?: number; isSoleTemplatedMarket?: boolean } = {},
+): void {
   render(
     <ul>
-      <SalesDocumentMarketRow row={row} onSelect={onSelect} disabled={disabled} />
+      <SalesDocumentMarketRow row={row} onSelect={onSelect} disabled={disabled} {...extra} />
     </ul>,
   );
 }
@@ -64,5 +69,70 @@ describe('SalesDocumentMarketRow', () => {
   it('should render the Rest of world pseudo-country with its display label', () => {
     renderRow(makeRow({ country: '*' }));
     expect(screen.getByText('★ Rest of world')).toBeInTheDocument();
+  });
+
+  describe('detected markets (#2542)', () => {
+    it('should render a detected market\'s order count with its discovery window', () => {
+      renderRow(makeRow({ orderCount: 12 }), vi.fn(), false, { windowDays: 30 });
+      expect(screen.getByText(/12 orders in the last 30 days/)).toBeInTheDocument();
+    });
+
+    it('should render only the order count when the window is not known', () => {
+      renderRow(makeRow({ orderCount: 12 }));
+      expect(screen.getByText(/12 orders/)).toBeInTheDocument();
+      expect(screen.queryByText(/in the last/)).not.toBeInTheDocument();
+    });
+
+    it('should never render order counts for a configured-only market', () => {
+      renderRow(makeRow({ orderCount: null }), vi.fn(), false, { windowDays: 30 });
+      expect(screen.queryByText(/orders/)).not.toBeInTheDocument();
+    });
+
+    it('should name this market as the only one with guidance when it is the sole template', () => {
+      renderRow(
+        makeRow({
+          hasTemplate: true,
+          ruleCount: 0,
+          invoiceDefaultConnectionId: null,
+          outcome: { kind: 'unresolved', reason: 'no-configuration-for-country' },
+        }),
+        vi.fn(),
+        false,
+        { isSoleTemplatedMarket: true },
+      );
+      expect(screen.getByText(/the only market with guidance so far/)).toBeInTheDocument();
+    });
+
+    it('should not claim exclusivity when several markets carry a template', () => {
+      renderRow(
+        makeRow({
+          hasTemplate: true,
+          ruleCount: 0,
+          invoiceDefaultConnectionId: null,
+          outcome: { kind: 'unresolved', reason: 'no-configuration-for-country' },
+        }),
+        vi.fn(),
+        false,
+        { isSoleTemplatedMarket: false },
+      );
+      expect(screen.getByText(/Starter setup available/)).toBeInTheDocument();
+      expect(screen.queryByText(/the only market with guidance/)).not.toBeInTheDocument();
+    });
+
+    it('should never render the sole-template caption for a market without a template', () => {
+      renderRow(
+        makeRow({
+          hasTemplate: false,
+          ruleCount: 0,
+          invoiceDefaultConnectionId: null,
+          outcome: { kind: 'unresolved', reason: 'no-configuration-for-country' },
+        }),
+        vi.fn(),
+        false,
+        { isSoleTemplatedMarket: true },
+      );
+      expect(screen.queryByText(/Starter setup available/)).not.toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Set up' })).toBeInTheDocument();
+    });
   });
 });

--- a/apps/web/src/features/sales-documents/components/sales-document-market-row.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-market-row.tsx
@@ -1,5 +1,5 @@
 /**
- * SalesDocumentMarketRow (#2540)
+ * SalesDocumentMarketRow (#2540/#2542)
  *
  * One row per market on the settings page's market section — replacing the
  * five-element-per-market stack (eyebrow, two-line sentence, badge, rule
@@ -17,6 +17,17 @@
  *
  * Below 768px this becomes a card via `.sales-document-market-row` CSS
  * (`index.css`), never a second component — see #2540 acceptance criterion.
+ *
+ * **Detected markets (#2542)**: a market with `orderCount !== null` shows its
+ * count *and* the discovery window it was measured over (`windowDays`),
+ * because "12 orders" on its own answers "how many" but not "over what
+ * period" — an operator needs both to judge whether it's worth acting on.
+ * The suggested-setup caption is honest about scope: when this row's
+ * `hasTemplate` market is the ONLY one among the rendered rows carrying a
+ * template, the caption says so explicitly (`isSoleTemplatedMarket`,
+ * computed by the section over every row and passed down) rather than
+ * implying every market has guidance. A template-less market never gets a
+ * recommendation — its action stays a plain "Set up".
  *
  * @module apps/web/src/features/sales-documents/components
  */
@@ -52,12 +63,27 @@ export interface SalesDocumentMarketRowProps {
   onSelect: (country: string) => void;
   /** Disables the action while a mutation/query for this section is in flight (#2543). */
   disabled?: boolean;
+  /**
+   * The discovery window (in days) the merged read applied, rendered
+   * alongside a detected market's order count. Omitted only in contexts
+   * (e.g. a standalone render in a test) where the window isn't known.
+   */
+  windowDays?: number;
+  /**
+   * True when this row's `hasTemplate` market is the ONLY templated market
+   * among the section's rows — changes the suggested-setup caption from a
+   * generic "Starter setup available" to one naming the scope explicitly
+   * (#2542). Ignored when `row.hasTemplate` is false.
+   */
+  isSoleTemplatedMarket?: boolean;
 }
 
 export function SalesDocumentMarketRow({
   row,
   onSelect,
   disabled = false,
+  windowDays,
+  isSoleTemplatedMarket = false,
 }: SalesDocumentMarketRowProps): ReactElement {
   const copy = describeSalesDocumentMarketOutcome(row.outcome);
   const isDetectedOnly = row.orderCount !== null;
@@ -82,7 +108,11 @@ export function SalesDocumentMarketRow({
         <span className="sales-document-market-row__meta muted-text mono-text">
           {row.country === SALES_DOCUMENT_REST_OF_WORLD_COUNTRY ? 'Catch-all' : row.country} ·{' '}
           {row.ruleCount === 1 ? '1 rule' : `${row.ruleCount} rules`}
-          {isDetectedOnly ? ` · ${row.orderCount} orders` : ''}
+          {isDetectedOnly
+            ? ` · ${row.orderCount} orders${
+                windowDays !== undefined ? ` in the last ${windowDays} days` : ''
+              }`
+            : ''}
         </span>
       </div>
 
@@ -94,7 +124,11 @@ export function SalesDocumentMarketRow({
         {copy.needsDecision && copy.reasonShort ? (
           <span className="sales-document-market-row__reason muted-text">
             {copy.reasonShort}
-            {copy.needsDecision && row.hasTemplate ? ' · Starter setup available' : ''}
+            {row.hasTemplate
+              ? isSoleTemplatedMarket
+                ? ` · Starter setup available — the only market with guidance so far`
+                : ' · Starter setup available'
+              : ''}
           </span>
         ) : null}
       </div>

--- a/apps/web/src/features/sales-documents/components/sales-document-market-section.test.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-market-section.test.tsx
@@ -79,3 +79,89 @@ describe('SalesDocumentMarketSection — summary + empty state (#2541)', () => {
     expect(screen.getByText(/Nothing is lost/)).toBeInTheDocument();
   });
 });
+
+describe('SalesDocumentMarketSection — detected markets and suggested setup (#2542)', () => {
+  it('should render a detected market\'s order count alongside the discovery window', async () => {
+    const apiClient = createMockApiClient({
+      salesDocumentRules: {
+        listMarkets: vi.fn().mockResolvedValue({
+          windowDays: 30,
+          since: '2026-01-01T00:00:00.000Z',
+          markets: [
+            {
+              country: 'PL',
+              orderCount: 12,
+              hasTemplate: true,
+              ruleCount: 0,
+              invoiceDefaultConnectionId: null,
+              receiptDefaultConnectionId: null,
+              acknowledgedNoDocumentAt: null,
+              outcome: { kind: 'unresolved', reason: 'no-configuration-for-country' },
+            },
+          ],
+        }),
+      },
+    });
+    renderWithProviders(<SalesDocumentMarketSection onSelectCountry={vi.fn()} />, { apiClient });
+
+    await waitFor(() => expect(screen.getByText('PL')).toBeInTheDocument());
+    expect(screen.getByText(/12 orders in the last 30 days/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Use starter setup' })).toBeInTheDocument();
+    expect(screen.getByText(/the only market with guidance so far/)).toBeInTheDocument();
+  });
+
+  it('should give a detected market without a template a plain "Set up", never a recommendation', async () => {
+    const apiClient = createMockApiClient({
+      salesDocumentRules: {
+        listMarkets: vi.fn().mockResolvedValue({
+          windowDays: 30,
+          since: '2026-01-01T00:00:00.000Z',
+          markets: [
+            {
+              country: 'CZ',
+              orderCount: 3,
+              hasTemplate: false,
+              ruleCount: 0,
+              invoiceDefaultConnectionId: null,
+              receiptDefaultConnectionId: null,
+              acknowledgedNoDocumentAt: null,
+              outcome: { kind: 'unresolved', reason: 'no-configuration-for-country' },
+            },
+          ],
+        }),
+      },
+    });
+    renderWithProviders(<SalesDocumentMarketSection onSelectCountry={vi.fn()} />, { apiClient });
+
+    await waitFor(() => expect(screen.getByText('CZ')).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: 'Set up' })).toBeInTheDocument();
+    expect(screen.queryByText(/Starter setup available/)).not.toBeInTheDocument();
+  });
+
+  it('should not claim exclusivity when two markets in the same list both carry a template', async () => {
+    const templatedMarket = (country: string): Record<string, unknown> => ({
+      country,
+      orderCount: 5,
+      hasTemplate: true,
+      ruleCount: 0,
+      invoiceDefaultConnectionId: null,
+      receiptDefaultConnectionId: null,
+      acknowledgedNoDocumentAt: null,
+      outcome: { kind: 'unresolved' as const, reason: 'no-configuration-for-country' },
+    });
+    const apiClient = createMockApiClient({
+      salesDocumentRules: {
+        listMarkets: vi.fn().mockResolvedValue({
+          windowDays: 30,
+          since: '2026-01-01T00:00:00.000Z',
+          markets: [templatedMarket('PL'), templatedMarket('DE')],
+        }),
+      },
+    });
+    renderWithProviders(<SalesDocumentMarketSection onSelectCountry={vi.fn()} />, { apiClient });
+
+    await waitFor(() => expect(screen.getByText('PL')).toBeInTheDocument());
+    expect(screen.queryByText(/the only market with guidance/)).not.toBeInTheDocument();
+    expect(screen.getAllByText(/Starter setup available/)).toHaveLength(2);
+  });
+});

--- a/apps/web/src/features/sales-documents/components/sales-document-market-section.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-market-section.tsx
@@ -4,10 +4,12 @@
  * The settings page's headline half: one prose sentence answering "what does
  * each market issue" (#2541), then a scannable market list (#2540) — both
  * read the single merged `useSalesDocumentMarketsQuery` snapshot, so they
- * can never disagree about what "right now" means. The detected-market
- * suggested-setup wording (#2542) already renders inside each row; the
- * loading skeleton (#2543) builds on this same query in a later slice of
- * the same mini-epic.
+ * can never disagree about what "right now" means. Detected-market wording
+ * (#2542) — the order count, its discovery window, and the sole-templated-
+ * market caption — is computed here from the full row set and passed down
+ * to each row, since only the section can know whether a template is unique
+ * across the rendered markets. The loading skeleton (#2543) builds on this
+ * same query in a later slice of the same mini-epic.
  *
  * The summary and the empty state never both render (#2541 acceptance):
  * `summarizeSalesDocumentMarkets` returns `null` for an empty row set, and
@@ -74,6 +76,11 @@ export function SalesDocumentMarketSection({
   }
 
   const summary = summarizeSalesDocumentMarkets(rows);
+  const windowDays = marketsQuery.data?.windowDays;
+  // #2542 — a suggested-setup caption may only claim exclusivity ("the only
+  // market with guidance so far") when it's actually true of THIS section's
+  // rows, never hand-asserted from the current single-template catalogue.
+  const templatedMarketCount = rows.filter((row) => row.hasTemplate).length;
 
   return (
     <div className="page-section sales-document-market-section">
@@ -87,7 +94,13 @@ export function SalesDocumentMarketSection({
 
       <ul className="sales-document-market-row-list" aria-label="Sales-document markets">
         {rows.map((row) => (
-          <SalesDocumentMarketRow key={row.country} row={row} onSelect={onSelectCountry} />
+          <SalesDocumentMarketRow
+            key={row.country}
+            row={row}
+            onSelect={onSelectCountry}
+            windowDays={windowDays}
+            isSoleTemplatedMarket={row.hasTemplate && templatedMarketCount === 1}
+          />
         ))}
       </ul>
     </div>


### PR DESCRIPTION
## Summary

Closes the remaining #2542 scope on top of what #2540 already shipped (order-count rendering and the "Use starter setup" action label, which live in the same row component and could not be split out). This PR adds: the discovery window next to a detected market's order count, and an honest "the only market with guidance so far" caption computed over the actual rendered row set.

## What shipped

- `SalesDocumentMarketRow` gains two new optional props: `windowDays` (rendered as `"{orderCount} orders in the last {windowDays} days"` for a detected market; falls back to just the count when the window isn't known) and `isSoleTemplatedMarket` (swaps the caption from `"Starter setup available"` to `"Starter setup available — the only market with guidance so far"`).
- `SalesDocumentMarketSection` computes `isSoleTemplatedMarket` per row by counting `row.hasTemplate` across the **current rendered row set** and threads `windowDays` straight from the merged read's own `windowDays` field.
- A template-less detected market's action stays a plain `"Set up"` with no caption at all - never a recommendation.

## Decisions a reviewer could dispute

- **Exclusivity is computed, never hand-written.** The catalogue happens to have exactly one starter template (Poland) today, but the "only market with guidance" claim is derived by counting `hasTemplate` rows in the section, not asserted as a hardcoded fact. If a second template ships, both markets automatically stop claiming exclusivity (covered by the two-templated-market test in `sales-document-market-section.test.tsx`).
- **The window text says "in the last N days"**, matching the wording style already used elsewhere in this mini-epic (`summarize-sales-document-markets.ts`'s "over N markets" phrasing). No new backend field was needed - `windowDays` already exists on `SalesDocumentMarketsResponse` from #2540.
- **`windowDays` is optional on the row component** so a standalone unit test (or a future consumer that doesn't have the window) degrades gracefully to just the count, rather than requiring every caller to thread it.

## Deliberately left out / already covered elsewhere

- The underlying rendering of order counts and the starter-setup action label is #2540's, not duplicated here.
- No change to the summary sentence (#2541) - it already treats a detected-but-unconfigured market correctly via `describeSalesDocumentMarketOutcome`.

## Test plan

- [x] `pnpm --filter @openlinker/web type-check` — clean
- [x] `pnpm --filter @openlinker/web exec eslint src/features/sales-documents --max-warnings=0` — clean
- [x] `pnpm --filter @openlinker/web exec vitest run src/features/sales-documents` — 18 files / 123 tests passing
- [x] `pnpm check:invariants` (filtered of `.worktrees` noise) — all green

Closes #2542