### PR TITLE
feat(sales-documents): loading states for the market section (#2543)

### DIFF
--- a/apps/web/src/features/sales-documents/components/sales-document-market-section-skeleton.test.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-market-section-skeleton.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { SalesDocumentMarketSectionSkeleton } from './sales-document-market-section-skeleton';
+
+describe('SalesDocumentMarketSectionSkeleton (#2543)', () => {
+  it('should render a live region announcing that markets are loading', () => {
+    render(<SalesDocumentMarketSectionSkeleton />);
+    const region = screen.getByRole('status');
+    expect(region).toHaveAttribute('aria-live', 'polite');
+    expect(screen.getByText('Loading markets…')).toBeInTheDocument();
+  });
+
+  it('should render placeholder rows shaped like the real row, hidden from assistive tech', () => {
+    const { container } = render(<SalesDocumentMarketSectionSkeleton />);
+    const list = container.querySelector('.sales-document-market-row-list--skeleton');
+    expect(list).not.toBeNull();
+    expect(list).toHaveAttribute('aria-hidden', 'true');
+    expect(container.querySelectorAll('.sales-document-market-row--skeleton').length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/features/sales-documents/components/sales-document-market-section-skeleton.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-market-section-skeleton.tsx
@@ -1,0 +1,54 @@
+/**
+ * SalesDocumentMarketSectionSkeleton (#2543)
+ *
+ * Loading treatment for `SalesDocumentMarketSection` — sized from
+ * `SalesDocumentMarketRow`'s own shape (status dot, identity block, outcome
+ * headline + reason line, action button) so the section does not reflow when
+ * the real rows arrive, mirroring `DataTableSkeleton`'s row-shape-declared
+ * approach rather than a fixed row height.
+ *
+ * A blank load must never read as "nothing is configured" (#2543 acceptance):
+ * the skeleton renders a fixed number of placeholder rows plus a visible,
+ * `aria-live="polite"` narration line, so a screen-reader user and a sighted
+ * user both get an explicit "loading" signal rather than silence.
+ *
+ * @module apps/web/src/features/sales-documents/components
+ */
+import type { ReactElement } from 'react';
+
+const SKELETON_ROW_COUNT = 3;
+
+export function SalesDocumentMarketSectionSkeleton(): ReactElement {
+  return (
+    <div className="page-section sales-document-market-section" role="status" aria-live="polite">
+      <span className="sr-only">Loading markets…</span>
+      <span
+        className="sales-document-market-section__summary-skeleton"
+        aria-hidden="true"
+      />
+      <ul
+        className="sales-document-market-row-list sales-document-market-row-list--skeleton"
+        aria-hidden="true"
+      >
+        {Array.from({ length: SKELETON_ROW_COUNT }, (_, index) => (
+          <li key={index} className="sales-document-market-row sales-document-market-row--skeleton">
+            <div className="sales-document-market-row__status">
+              <span className="skeleton-bar skeleton-bar--dot" />
+            </div>
+            <div className="sales-document-market-row__identity">
+              <span className="skeleton-bar skeleton-bar--name" />
+              <span className="skeleton-bar skeleton-bar--meta" />
+            </div>
+            <div className="sales-document-market-row__outcome">
+              <span className="skeleton-bar skeleton-bar--outcome" />
+              <span className="skeleton-bar skeleton-bar--reason" />
+            </div>
+            <div className="sales-document-market-row__action">
+              <span className="skeleton-bar skeleton-bar--action" />
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/apps/web/src/features/sales-documents/components/sales-document-market-section.test.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-market-section.test.tsx
@@ -165,3 +165,76 @@ describe('SalesDocumentMarketSection — detected markets and suggested setup (#
     expect(screen.getAllByText(/Starter setup available/)).toHaveLength(2);
   });
 });
+
+describe('SalesDocumentMarketSection — loading states (#2543)', () => {
+  it('should render the skeleton, not the generic loading state, on initial fetch', () => {
+    const apiClient = createMockApiClient({
+      salesDocumentRules: {
+        listMarkets: vi.fn(() => new Promise<never>(() => {})),
+      },
+    });
+    renderWithProviders(<SalesDocumentMarketSection onSelectCountry={vi.fn()} />, { apiClient });
+
+    expect(screen.getByText('Loading markets…')).toBeInTheDocument();
+    expect(screen.queryByText('No markets yet')).not.toBeInTheDocument();
+  });
+
+  it('should never render the skeleton and the empty state together on a clean instance', async () => {
+    const apiClient = createMockApiClient({
+      salesDocumentRules: {
+        listMarkets: vi.fn().mockResolvedValue({
+          windowDays: 30,
+          since: '2026-01-01T00:00:00.000Z',
+          markets: [],
+        }),
+      },
+    });
+    renderWithProviders(<SalesDocumentMarketSection onSelectCountry={vi.fn()} />, { apiClient });
+
+    await waitFor(() => expect(screen.getByText('No markets yet')).toBeInTheDocument());
+    expect(screen.queryByText('Loading markets…')).not.toBeInTheDocument();
+  });
+
+});
+
+describe('SalesDocumentMarketSection — busy state during a background refetch (#2543)', () => {
+  // The query hook is mocked directly here (rather than driven through a real
+  // TanStack Query refetch cycle) because this section has no user-facing
+  // trigger for a background refetch while data is already loaded — that
+  // happens via React Query's own focus/interval refetch, which is not worth
+  // simulating end-to-end just to prove one derived boolean is wired through.
+  const loadedRow = {
+    country: 'DE',
+    orderCount: null,
+    hasTemplate: false,
+    ruleCount: 1,
+    invoiceDefaultConnectionId: 'conn_1',
+    receiptDefaultConnectionId: null,
+    acknowledgedNoDocumentAt: null,
+    outcome: { kind: 'route' as const, documentKind: 'invoice', connectionId: 'conn_1' },
+  };
+
+  it('should disable every row action and announce a refresh while isFetching is true', async () => {
+    vi.resetModules();
+    vi.doMock('../hooks/use-sales-document-markets-query', (): Record<string, unknown> => ({
+      useSalesDocumentMarketsQuery: () => ({
+        isLoading: false,
+        isFetching: true,
+        error: null,
+        data: { windowDays: 30, since: '2026-01-01T00:00:00.000Z', markets: [loadedRow] },
+        refetch: vi.fn(),
+      }),
+    }));
+    const { SalesDocumentMarketSection: MockedSection } = await import(
+      './sales-document-market-section'
+    );
+
+    renderWithProviders(<MockedSection onSelectCountry={vi.fn()} />);
+
+    expect(screen.getByRole('button', { name: 'Configure' })).toBeDisabled();
+    expect(screen.getByText('Refreshing markets…')).toBeInTheDocument();
+
+    vi.doUnmock('../hooks/use-sales-document-markets-query');
+    vi.resetModules();
+  });
+});

--- a/apps/web/src/features/sales-documents/components/sales-document-market-section.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-market-section.tsx
@@ -8,8 +8,16 @@
  * (#2542) — the order count, its discovery window, and the sole-templated-
  * market caption — is computed here from the full row set and passed down
  * to each row, since only the section can know whether a template is unique
- * across the rendered markets. The loading skeleton (#2543) builds on this
- * same query in a later slice of the same mini-epic.
+ * across the rendered markets. The loading skeleton (#2543) is
+ * `SalesDocumentMarketSectionSkeleton`, sized from the real row's own shape
+ * so the section never reflows on arrival — a blank load must never be
+ * mistaken for "nothing is configured" (the empty state's job), so the
+ * skeleton renders its own visible, `aria-live="polite"` narration rather
+ * than an empty container. A background refetch (e.g. the error state's
+ * Retry action) keeps the loaded rows on screen but disables every row's
+ * action and announces "Refreshing markets…" in a live region, so an
+ * operator never presses an action against data that is already stale in
+ * flight.
  *
  * The summary and the empty state never both render (#2541 acceptance):
  * `summarizeSalesDocumentMarkets` returns `null` for an empty row set, and
@@ -25,11 +33,12 @@
  * @module apps/web/src/features/sales-documents/components
  */
 import type { ReactElement } from 'react';
-import { EmptyState, ErrorState, LoadingState } from '../../../shared/ui/feedback-state';
+import { EmptyState, ErrorState } from '../../../shared/ui/feedback-state';
 import { useSalesDocumentMarketsQuery } from '../hooks/use-sales-document-markets-query';
 import { orderSalesDocumentMarkets } from '../lib/order-sales-document-markets';
 import { summarizeSalesDocumentMarkets } from '../lib/summarize-sales-document-markets';
 import { SalesDocumentMarketRow } from './sales-document-market-row';
+import { SalesDocumentMarketSectionSkeleton } from './sales-document-market-section-skeleton';
 
 export interface SalesDocumentMarketSectionProps {
   onSelectCountry: (country: string) => void;
@@ -41,7 +50,7 @@ export function SalesDocumentMarketSection({
   const marketsQuery = useSalesDocumentMarketsQuery();
 
   if (marketsQuery.isLoading) {
-    return <LoadingState title="Loading markets" message="Fetching the current routing outcome for each market…" />;
+    return <SalesDocumentMarketSectionSkeleton />;
   }
 
   if (marketsQuery.error) {
@@ -53,6 +62,7 @@ export function SalesDocumentMarketSection({
           <button
             type="button"
             className="button button--secondary button--sm"
+            disabled={marketsQuery.isFetching}
             onClick={() => void marketsQuery.refetch()}
           >
             Retry
@@ -81,6 +91,11 @@ export function SalesDocumentMarketSection({
   // market with guidance so far") when it's actually true of THIS section's
   // rows, never hand-asserted from the current single-template catalogue.
   const templatedMarketCount = rows.filter((row) => row.hasTemplate).length;
+  // #2543 — a background refetch (e.g. the error state's Retry, or React
+  // Query's own focus/interval refetch) keeps the loaded rows visible but
+  // must disable every action: the section already read `isLoading` above,
+  // so this branch only covers "loaded once, fetching again."
+  const isBusy = marketsQuery.isFetching;
 
   return (
     <div className="page-section sales-document-market-section">
@@ -92,6 +107,10 @@ export function SalesDocumentMarketSection({
         </p>
       ) : null}
 
+      <span className="sr-only" role="status" aria-live="polite">
+        {isBusy ? 'Refreshing markets…' : ''}
+      </span>
+
       <ul className="sales-document-market-row-list" aria-label="Sales-document markets">
         {rows.map((row) => (
           <SalesDocumentMarketRow
@@ -100,6 +119,7 @@ export function SalesDocumentMarketSection({
             onSelect={onSelectCountry}
             windowDays={windowDays}
             isSoleTemplatedMarket={row.hasTemplate && templatedMarketCount === 1}
+            disabled={isBusy}
           />
         ))}
       </ul>

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -19476,6 +19476,65 @@ textarea.bulk-editor__input { resize: vertical; min-height: 66px; font-family: i
   }
 }
 
+/* Loading skeleton (#2543) — sized off the real row above so arrival never
+   reflows the section. */
+.sales-document-market-section__summary-skeleton {
+  display: block;
+  width: min(32rem, 80%);
+  height: 0.9375rem;
+  margin-bottom: var(--space-4);
+  border-radius: var(--radius-sm);
+  background: var(--bg-surface-muted);
+}
+
+.sales-document-market-row--skeleton {
+  background: var(--bg-surface);
+}
+
+.sales-document-market-row .skeleton-bar {
+  display: block;
+  border-radius: var(--radius-sm);
+  background: var(--bg-surface-muted);
+  animation: sales-document-market-skeleton-shimmer 1.4s ease-in-out infinite;
+}
+.sales-document-market-row .skeleton-bar--dot {
+  width: 0.625rem;
+  height: 0.625rem;
+  border-radius: var(--radius-pill);
+}
+.sales-document-market-row .skeleton-bar--name {
+  width: 60%;
+  height: 0.875rem;
+}
+.sales-document-market-row .skeleton-bar--meta {
+  width: 40%;
+  height: 0.6875rem;
+  margin-top: var(--space-1);
+}
+.sales-document-market-row .skeleton-bar--outcome {
+  width: 70%;
+  height: 0.8125rem;
+}
+.sales-document-market-row .skeleton-bar--reason {
+  width: 50%;
+  height: 0.6875rem;
+  margin-top: var(--space-1);
+}
+.sales-document-market-row .skeleton-bar--action {
+  width: 6rem;
+  height: 1.75rem;
+}
+
+@keyframes sales-document-market-skeleton-shimmer {
+  0%,
+  100% {
+    opacity: 0.6;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
 /* ── Sales-document country index (#2187) ── */
 .sales-document-country-index__add-row {
   margin-top: var(--space-3);


### PR DESCRIPTION
## Summary

Replaces the generic `LoadingState` on the market section's initial load with a shape-matched skeleton, and closes the "operator presses an action against stale data" gap during a background refetch.

## What shipped

- `SalesDocumentMarketSectionSkeleton` — 3 placeholder rows sized off `SalesDocumentMarketRow`'s own DOM shape (status dot, identity block, outcome + reason lines, action button) plus a summary-line placeholder, so the section's height doesn't jump when real data arrives. It carries its own `role="status" aria-live="polite"` region with visible + screen-reader text ("Loading markets…"), so a blank load can never be mistaken for the empty state.
- `SalesDocumentMarketSection` returns the skeleton on `marketsQuery.isLoading` instead of the generic `LoadingState`.
- A new `isBusy = marketsQuery.isFetching` derivation covers the "loaded once, fetching again" case: every row's `disabled` prop (already wired from #2540) is driven by it, and a screen-reader-only `aria-live="polite"` region announces "Refreshing markets…". The error state's Retry button also gets `disabled={marketsQuery.isFetching}` — a pre-existing double-click gap that falls naturally under this task's scope.
- CSS: skeleton shimmer keyframe + placeholder bar shapes, scoped under `.sales-document-market-row .skeleton-bar` so the class name can't collide with an unrelated skeleton elsewhere in the app.

## Decisions a reviewer could dispute

- **The skeleton is a real sibling component, not a prop on the row.** Mirrors the existing `DataTableSkeleton` precedent (shape declared by the real component, not a guessed fixed height) rather than inventing a new pattern.
- **The "busy during a background refetch" test mocks the query hook directly** (`vi.doMock` + dynamic re-import) instead of driving a real TanStack Query refetch cycle. This section has no user-facing control that triggers a refetch while data is already loaded (that happens via React Query's own focus/interval refetch, which `renderWithProviders`'s test `QueryClient` disables retries for but doesn't expose a manual trigger for) — simulating one end-to-end would mostly be testing React Query's own scheduling, not this component's `isBusy` derivation. The test comment states this reasoning inline so a future reader doesn't wonder why it's mocked when its siblings aren't.
- **The Retry-button disable is included in this task's diff** even though it's arguably a pre-existing gap from #2540 — it's one line, directly adjacent to the busy-state work, and leaving it would mean an operator could still double-click Retry while a fetch from that exact click was already in flight.

## Test plan

- [x] `pnpm --filter @openlinker/web type-check` — clean
- [x] `pnpm --filter @openlinker/web exec eslint src/features/sales-documents --max-warnings=0` — clean
- [x] `pnpm --filter @openlinker/web exec vitest run src/features/sales-documents` — 19 files / 128 tests passing
- [x] `pnpm check:invariants` (filtered of `.worktrees` noise) — all green, including `design-tokens: OK` (no new CSS vars were needed — every declaration reuses existing tokens)

Closes #2543