### PR TITLE
fix(sales-documents): say delivered to, not billed to, in market copy

### DIFF
--- a/apps/api/src/sales-documents/http/dto/sales-document-market-response.dto.ts
+++ b/apps/api/src/sales-documents/http/dto/sales-document-market-response.dto.ts
@@ -97,7 +97,7 @@ export class SalesDocumentMarketRowDto {
   @ApiProperty({
     nullable: true,
     description:
-      'Orders billed to this country in the discovery window, or null when the country was not ' +
+      'Orders delivered to this country in the discovery window, or null when the country was not ' +
       'detected at all (a configured-only market). Never 0 - a detected market always has at least ' +
       'one order.',
   })

--- a/apps/web/src/features/sales-documents/components/sales-document-country-routing-dialog.test.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-country-routing-dialog.test.tsx
@@ -746,7 +746,9 @@ describe('SalesDocumentCountryRoutingDialog — Reset country (#2189)', () => {
 
     expect(await screen.findByText(/Falls through to ★ Rest of world/i)).toBeInTheDocument();
     expect(
-      screen.getByText(/DE has no rules and no default, so an order billed here goes to/i),
+      screen.getByText(
+        /DE has no rules and no default, so an order delivered here goes to/i,
+      ),
     ).toBeInTheDocument();
     expect(screen.queryByText(/An unmatched order is held/i)).toBeNull();
   });

--- a/apps/web/src/features/sales-documents/components/sales-document-country-routing-dialog.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-country-routing-dialog.tsx
@@ -245,8 +245,9 @@ export function SalesDocumentCountryRoutingDialog({
       ) : (
         <div>
           <p className="muted-text">
-            {displayName} has no rules and no default, so an order billed here goes to{' '}
-            <span className="mono-text">★ Rest of world</span>&apos;s own rules and defaults.
+            {displayName} has no rules and no default, so an order delivered here goes to{' '}
+            <span className="mono-text">★ Rest of world</span>
+            &apos;s own rules and defaults.
           </p>
           <Button
             tone="secondary"


### PR DESCRIPTION
## Summary
- Sales-document routing and market discovery already evaluate on the **delivery** address's country (ADR-041 decision 5 — `order-to-sales-document-order-facts.mapper.ts` reads `order.shippingAddress.country`; `countOrdersByRoutingCountrySince`'s own in-code comment says the same).
- Two already-merged copy strings claimed **billing** country instead, contradicting the shipped logic. One is operator-facing dialog text, which actively misleads whenever an order's billing and delivery countries differ (gift order, drop-ship, corporate billing to a group HQ).
- Fixes wording only in the two spots not covered by the still-open docs PRs (#2570, #2720), which had the identical wording defect and are being fixed there.

## Changes
- `apps/api/src/sales-documents/http/dto/sales-document-market-response.dto.ts` — Swagger `orderCount` description: "billed to" → "delivered to"
- `apps/web/src/features/sales-documents/components/sales-document-country-routing-dialog.tsx` — operator-facing dialog copy: "billed to" → "delivered to"

## Test plan
- [x] `eslint` on both changed files — clean
- [x] `pnpm --filter @openlinker/api type-check` — clean
- [x] `pnpm --filter web type-check` — clean
- [x] Grepped `apps/api/src/sales-documents` and `apps/web/src/features/sales-documents` for any other "billed"/"billing" occurrence and any test asserting the old string — none found

Closes #2748