### PR TITLE
Routing dialog: explicit close and per-control save/error state (#2545)

### DIFF
--- a/apps/web/src/features/sales-documents/components/sales-document-country-defaults.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-country-defaults.tsx
@@ -14,6 +14,7 @@ import { useConnectionsQuery } from '../../connections';
 import { selectInvoicingCandidates } from '../../invoicing';
 import { selectFiscalizationCandidates } from '../../fiscalization';
 import { Select } from '../../../shared/ui/select';
+import { Alert } from '../../../shared/ui/alert';
 import { LoadingState, ErrorState } from '../../../shared/ui/feedback-state';
 import { ReadOnlyLock } from '../../../shared/ui/read-only-lock';
 import { useWriteAccess } from '../../../shared/auth/use-permission';
@@ -74,24 +75,36 @@ export function SalesDocumentCountryDefaults({
               ? selectInvoicingCandidates(connections)
               : selectFiscalizationCandidates(connections);
           const current = defaults.find((d) => d.documentKind === documentKind) ?? null;
+          const isSavingThisKind =
+            upsert.isPending && upsert.variables?.documentKind === documentKind;
+          const isRemovingThisKind =
+            remove.isPending && current !== null && remove.variables === current.id;
+          const isPendingThisKind = isSavingThisKind || isRemovingThisKind;
+          const saveFailedForThisKind =
+            upsert.isError && upsert.variables?.documentKind === documentKind ? upsert.error : null;
+          const removeFailedForThisKind =
+            remove.isError && current !== null && remove.variables === current.id
+              ? remove.error
+              : null;
 
           return (
             <div key={documentKind} className="page-section">
               <label className="eyebrow" htmlFor={`sd-default-${documentKind}`} style={{ marginBottom: 2 }}>
                 {label}
+                {isPendingThisKind ? ' — Saving…' : null}
               </label>
               <ReadOnlyLock active={write.demoReadOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
                 <Select
                   id={`sd-default-${documentKind}`}
                   value={current?.connectionId ?? ''}
-                  disabled={!write.canWrite || candidates.length === 0}
+                  disabled={!write.canWrite || candidates.length === 0 || isPendingThisKind}
                   onChange={(event) => {
                     const connectionId = event.target.value;
                     if (connectionId === '') {
-                      if (current) void remove.mutateAsync(current.id);
+                      if (current) void remove.mutateAsync(current.id).catch(() => {});
                       return;
                     }
-                    void upsert.mutateAsync({ country, documentKind, connectionId });
+                    void upsert.mutateAsync({ country, documentKind, connectionId }).catch(() => {});
                   }}
                 >
                   <option value="">Not set</option>
@@ -106,6 +119,10 @@ export function SalesDocumentCountryDefaults({
                 Filtered to connections with <span className="chip mono-text">{capability}</span>.
                 {candidates.length === 0 ? ' No eligible connection yet.' : null}
               </p>
+              {saveFailedForThisKind ? <Alert tone="error">{saveFailedForThisKind.message}</Alert> : null}
+              {removeFailedForThisKind ? (
+                <Alert tone="error">{removeFailedForThisKind.message}</Alert>
+              ) : null}
             </div>
           );
         })}

--- a/apps/web/src/features/sales-documents/components/sales-document-country-routing-dialog.test.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-country-routing-dialog.test.tsx
@@ -633,4 +633,60 @@ describe('SalesDocumentCountryRoutingDialog — Reset country (#2189)', () => {
       expect(screen.getByRole('button', { name: 'Reset country' })).toBeDisabled();
     });
   });
+
+  it('should offer an explicit "Done" close action so the operator does not rely on Escape or a backdrop click', async () => {
+    const onOpenChange = vi.fn();
+    const apiClient = createMockApiClient({
+      salesDocumentRules: {
+        listRules: vi.fn().mockResolvedValue([]),
+        listCountryDefaults: vi.fn().mockResolvedValue([]),
+      },
+    });
+    renderWithProviders(
+      <SalesDocumentCountryRoutingDialog
+        open
+        country="DE"
+        cameFrom={null}
+        onOpenChange={onOpenChange}
+        onNavigate={vi.fn()}
+      />,
+      { apiClient },
+    );
+
+    await screen.findByText(/Rules for DE/i);
+    const doneButton = screen.getByRole('button', { name: 'Done' });
+    await userEvent.click(doneButton);
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('should surface a per-rule delete failure without hiding the rest of the dialog', async () => {
+    const rules = [makeRule('r1')];
+    const deleteRule = vi.fn().mockRejectedValue(new Error('Rule is referenced elsewhere'));
+    const apiClient = createMockApiClient({
+      salesDocumentRules: {
+        listRules: vi.fn().mockResolvedValue(rules),
+        listCountryDefaults: vi.fn().mockResolvedValue([]),
+        deleteRule,
+      },
+    });
+    renderWithProviders(
+      <SalesDocumentCountryRoutingDialog
+        open
+        country="DE"
+        cameFrom={null}
+        onOpenChange={vi.fn()}
+        onNavigate={vi.fn()}
+      />,
+      { apiClient, sessionAdapter: createAuthenticatedSessionAdapter() },
+    );
+
+    const deleteButton = await screen.findByRole('button', { name: 'Delete' });
+    await userEvent.click(deleteButton);
+
+    await screen.findByText('Rule is referenced elsewhere');
+    // The failure is scoped to the rule row — the rest of the dialog (e.g.
+    // its title) is still there, not replaced by a full-dialog error state.
+    expect(screen.getByText(/Sales-document routing · DE/i)).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/features/sales-documents/components/sales-document-country-routing-dialog.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-country-routing-dialog.tsx
@@ -58,7 +58,7 @@
  */
 import { useState, type ReactElement, type ReactNode } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
-import { Dialog, DialogContent, DialogFooter, DialogTitle } from '../../../shared/ui/dialog';
+import { Dialog, DialogClose, DialogContent, DialogFooter, DialogTitle } from '../../../shared/ui/dialog';
 import { Alert } from '../../../shared/ui/alert';
 import { Button } from '../../../shared/ui/button';
 import { ConfirmDialog } from '../../../shared/ui/confirm-dialog';
@@ -248,6 +248,9 @@ export function SalesDocumentCountryRoutingDialog({
           ) : null}
 
           <DialogTitle>Sales-document routing · {displayName}</DialogTitle>
+          <p className="muted-text sales-document-country-routing-dialog__save-note">
+            Every control here saves as you change it — there is nothing to submit.
+          </p>
 
           <div className="sales-document-country-routing-dialog__body">
             {isEmptyCountry ? (
@@ -316,18 +319,29 @@ export function SalesDocumentCountryRoutingDialog({
             ))}
 
             {resetError ? <Alert tone="error">{resetError}</Alert> : null}
+
+            <div className="sales-document-country-routing-dialog__danger-zone">
+              <p className="muted-text">
+                Resetting deletes every rule and default configured for {displayName} here in
+                OpenLinker. It does not touch anything at the provider — no invoice or receipt
+                already issued is affected.
+              </p>
+              <ReadOnlyLock active={write.demoReadOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
+                <Button
+                  tone="danger"
+                  disabled={!write.canWrite || isSummaryLoading || hasNothingToReset || isResetting}
+                  onClick={() => setConfirmResetOpen(true)}
+                >
+                  Reset country
+                </Button>
+              </ReadOnlyLock>
+            </div>
           </div>
 
           <DialogFooter>
-            <ReadOnlyLock active={write.demoReadOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
-              <Button
-                tone="danger"
-                disabled={!write.canWrite || isSummaryLoading || hasNothingToReset || isResetting}
-                onClick={() => setConfirmResetOpen(true)}
-              >
-                Reset country
-              </Button>
-            </ReadOnlyLock>
+            <DialogClose asChild>
+              <Button tone="primary">Done</Button>
+            </DialogClose>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/apps/web/src/features/sales-documents/components/sales-document-rules-list.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-rules-list.tsx
@@ -10,6 +10,7 @@
  */
 import { useState, type ReactElement } from 'react';
 import { useConnectionsQuery } from '../../connections';
+import { Alert } from '../../../shared/ui/alert';
 import { Button } from '../../../shared/ui/button';
 import { LoadingState, ErrorState } from '../../../shared/ui/feedback-state';
 import { ReadOnlyLock } from '../../../shared/ui/read-only-lock';
@@ -68,6 +69,9 @@ export function SalesDocumentRulesList({ country }: SalesDocumentRulesListProps)
 
       {rules.map((rule) => {
         const connectionName = connections.find((c) => c.id === rule.connectionId)?.name ?? rule.connectionId;
+        const isDeletingThisRule = deleteRule.isPending && deleteRule.variables === rule.id;
+        const deleteFailedForThisRule =
+          deleteRule.isError && deleteRule.variables === rule.id ? deleteRule.error : null;
         return (
           <div key={rule.id} className="rule-card">
             <div className="rule-card__flow">
@@ -93,12 +97,15 @@ export function SalesDocumentRulesList({ country }: SalesDocumentRulesListProps)
                   tone="secondary"
                   className="button--sm"
                   disabled={!write.canWrite || deleteRule.isPending}
-                  onClick={() => void deleteRule.mutateAsync(rule.id)}
+                  onClick={() => void deleteRule.mutateAsync(rule.id).catch(() => {})}
                 >
-                  Delete
+                  {isDeletingThisRule ? 'Deleting…' : 'Delete'}
                 </Button>
               </ReadOnlyLock>
             </div>
+            {deleteFailedForThisRule ? (
+              <Alert tone="error">{deleteFailedForThisRule.message}</Alert>
+            ) : null}
           </div>
         );
       })}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -3593,6 +3593,20 @@ a.delivery-rider-banner__button:focus-visible {
   gap: var(--space-5);
 }
 
+.sales-document-country-routing-dialog__save-note {
+  margin: calc(-1 * var(--space-2)) 0 0;
+}
+
+/* Reset lives in its own zone below the tiers, never beside the footer's
+   primary "Done" action (#2549) — a destructive control next to the ordinary
+   close action reads as a choice between two equally weighted buttons. */
+.sales-document-country-routing-dialog__danger-zone {
+  display: grid;
+  gap: var(--space-2);
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--border-subtle);
+}
+
 .trigger-sync-dialog__description {
   margin: 0;
 }


### PR DESCRIPTION
Closes #2545

## What changed

The routing dialog already used the shipped Radix `Dialog` primitive (focus trap, initial focus, Escape-to-close, focus restore all come from Radix for free), and Reset country was already a danger-toned button behind `ConfirmDialog`. What #2545 actually needed on top of that:

1. **Explicit close.** Added a "Done" button in the footer via `DialogClose`, plus a one-line note under the title stating every control saves as it changes. There is no batched form state in this dialog (each field is its own mutation), so there is nothing a backdrop click or Escape could discard - the note says so honestly rather than inventing a discard-guard for edits that do not exist.
2. **Reset moved out of the footer**, into its own bordered zone below the tiers with a sentence naming exactly what it deletes, so it no longer sits beside the (now-added) primary "Done" action.
3. **Per-control pending/error state**, which did not exist before:
   - Rules list: the Delete button reads "Deleting…" while its own mutation runs, and a failure renders inline under that specific rule (matched via `mutation.variables === rule.id`), not as a dialog-wide error.
   - Country defaults: the same treatment for both the upsert (picking a connection) and the remove (back to "Not set") mutations, per document kind.
4. Suppressed the unhandled promise rejection this reveals: the three fire-and-forget `mutateAsync(...)` calls never had a `.catch`, and the error was only ever surfaced through the mutation's `isError`/`error` state - Vitest now flags the raw promise when a rejecting mock is used, which is how the gap was found.

## Deliberately left alone

The tier structure, tier numbering, the acknowledgment banner, and the reset confirmation flow itself - #2545 didn't ask for any of those to change, and they already satisfy the mini-epic's dialog-level acceptance criteria (focus trap/restore, Escape, danger-toned confirmed reset).

## Testing

- `pnpm --filter @openlinker/web type-check` - clean
- `npx eslint` on every touched file - clean
- `npx vitest run` on the dialog's own spec - 21/21 passing (19 pre-existing + 2 new: the "Done" close action, and a per-rule delete failure staying scoped to its row)
- `pnpm check:invariants` - green