### PR TITLE
Rules section: ordering statement and buyer-tax-id coverage warning (#2546)

### DIFF
--- a/apps/web/src/features/sales-documents/components/sales-document-rules-list.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-rules-list.tsx
@@ -21,6 +21,10 @@ import { useSalesDocumentRulesQuery } from '../hooks/use-sales-document-rules-qu
 import { useDeleteSalesDocumentRuleMutation } from '../hooks/use-delete-sales-document-rule-mutation';
 import { SalesDocumentRuleComposerDialog } from './sales-document-rule-composer-dialog';
 import { describeSalesDocumentCondition } from '../lib/describe-sales-document-condition';
+import {
+  countRulesUsingBuyerTaxId,
+  usesBuyerTaxIdCondition,
+} from '../lib/describe-sales-document-tax-id-coverage';
 import type { SalesDocumentRule } from '../api/sales-document-rules.types';
 
 interface SalesDocumentRulesListProps {
@@ -53,6 +57,7 @@ export function SalesDocumentRulesList({ country }: SalesDocumentRulesListProps)
 
   const rules = rulesQuery.data ?? [];
   const connections = connectionsQuery.data ?? [];
+  const taxIdRuleCount = countRulesUsingBuyerTaxId(rules);
 
   return (
     <div className="page-section">
@@ -66,6 +71,19 @@ export function SalesDocumentRulesList({ country }: SalesDocumentRulesListProps)
           </Button>
         </ReadOnlyLock>
       </div>
+      <p className="muted-text">
+        Exactly one rule must match an order. Rules have no order of priority — if two match, the
+        order is held instead of one winning.
+      </p>
+
+      {taxIdRuleCount > 0 ? (
+        <Alert tone="warning" title={`${taxIdRuleCount} of these rules read the buyer's tax ID`}>
+          A buyer-tax-ID condition matches only an order whose source records that fact — today
+          that is PrestaShop orders only. An order from Allegro or WooCommerce carries no buyer
+          tax ID at all, so a rule like this one never matches those orders, but it matches a
+          PrestaShop order normally.
+        </Alert>
+      ) : null}
 
       {rules.map((rule) => {
         const connectionName = connections.find((c) => c.id === rule.connectionId)?.name ?? rule.connectionId;
@@ -89,6 +107,14 @@ export function SalesDocumentRulesList({ country }: SalesDocumentRulesListProps)
             </div>
             <div className="rule-card__meta">
               {rule.provenance ? <span className="provenance-tag">from: {rule.provenance}</span> : null}
+              {usesBuyerTaxIdCondition(rule) ? (
+                <span
+                  className="provenance-tag"
+                  title="Matches only orders from a source that records a buyer tax ID (today: PrestaShop)"
+                >
+                  PrestaShop orders only
+                </span>
+              ) : null}
               <span className="rule-card__dates">
                 {rule.effectiveTo ? `ends ${rule.effectiveTo}` : 'no end date'}
               </span>

--- a/apps/web/src/features/sales-documents/lib/describe-sales-document-tax-id-coverage.test.ts
+++ b/apps/web/src/features/sales-documents/lib/describe-sales-document-tax-id-coverage.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import type { SalesDocumentRule } from '../api/sales-document-rules.types';
+import {
+  countRulesUsingBuyerTaxId,
+  usesBuyerTaxIdCondition,
+} from './describe-sales-document-tax-id-coverage';
+
+function makeRule(overrides: Partial<SalesDocumentRule> = {}): SalesDocumentRule {
+  return {
+    id: 'r1',
+    country: 'PL',
+    conditions: [],
+    documentKind: 'invoice',
+    connectionId: 'conn_1',
+    effectiveFrom: '2026-01-01T00:00:00.000Z',
+    effectiveTo: null,
+    provenance: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('usesBuyerTaxIdCondition', () => {
+  it('should return true when a rule carries a buyerHasTaxId condition', () => {
+    const rule = makeRule({
+      conditions: [{ field: 'buyerHasTaxId', op: 'eq', boolValue: false }],
+    });
+
+    expect(usesBuyerTaxIdCondition(rule)).toBe(true);
+  });
+
+  it('should return false when a rule carries only other condition kinds', () => {
+    const rule = makeRule({
+      conditions: [{ field: 'orderCountry', op: 'eq', stringValue: 'PL' }],
+    });
+
+    expect(usesBuyerTaxIdCondition(rule)).toBe(false);
+  });
+
+  it('should return false for a rule with no conditions', () => {
+    expect(usesBuyerTaxIdCondition(makeRule({ conditions: [] }))).toBe(false);
+  });
+});
+
+describe('countRulesUsingBuyerTaxId', () => {
+  it('should count only the rules carrying a buyerHasTaxId condition', () => {
+    const rules = [
+      makeRule({ id: 'r1', conditions: [{ field: 'buyerHasTaxId', op: 'eq', boolValue: true }] }),
+      makeRule({ id: 'r2', conditions: [{ field: 'orderCountry', op: 'eq', stringValue: 'PL' }] }),
+      makeRule({ id: 'r3', conditions: [{ field: 'buyerHasTaxId', op: 'eq', boolValue: false }] }),
+    ];
+
+    expect(countRulesUsingBuyerTaxId(rules)).toBe(2);
+  });
+
+  it('should return 0 when no rules use the condition', () => {
+    expect(countRulesUsingBuyerTaxId([makeRule()])).toBe(0);
+  });
+});

--- a/apps/web/src/features/sales-documents/lib/describe-sales-document-tax-id-coverage.ts
+++ b/apps/web/src/features/sales-documents/lib/describe-sales-document-tax-id-coverage.ts
@@ -1,0 +1,30 @@
+/**
+ * Buyer-tax-id rule coverage (#2546)
+ *
+ * A `buyerHasTaxId` condition is evaluated against `Order.buyerTaxId` — as of
+ * #2599 that field is real, but it is populated only by sources that report
+ * it. Today that is PrestaShop alone (`ps_address.vat_number`); Allegro's own
+ * checkout-form invoice block carries a company tax id OL's
+ * `AllegroCheckoutForm` type does not model, and WooCommerce's `billing`
+ * block has no tax field at all (see `order-to-sales-document-order-facts.mapper.ts`
+ * and `evaluateSalesDocumentRules`'s own doc comment).
+ *
+ * This is deliberately NOT "this rule can never match" — that claim was true
+ * before #2599 and is false now. A `buyerHasTaxId` rule is fully live for a
+ * PrestaShop-sourced order and simply unreachable for an order whose source
+ * never asserts the fact. Both counts are reported so the operator can judge
+ * whether the gap matters for their own connection mix, rather than being
+ * told a flat "N rules are dead" that would be wrong the moment a PrestaShop
+ * order arrives.
+ *
+ * @module apps/web/src/features/sales-documents/lib
+ */
+import type { SalesDocumentRule } from '../api/sales-document-rules.types';
+
+export function usesBuyerTaxIdCondition(rule: SalesDocumentRule): boolean {
+  return rule.conditions.some((condition) => condition.field === 'buyerHasTaxId');
+}
+
+export function countRulesUsingBuyerTaxId(rules: readonly SalesDocumentRule[]): number {
+  return rules.filter(usesBuyerTaxIdCondition).length;
+}


### PR DESCRIPTION
Closes #2546

## What changed

1. **Ordering statement.** The rules list now states, under the "+ Add rule" header: "Exactly one rule must match an order. Rules have no order of priority — if two match, the order is held instead of one winning." Checked directly against `evaluateSalesDocumentRules`: two matches in one scope resolve `ambiguous-rules` -> `SalesDocumentUnresolvedReason: 'conflicting-rules-equal-priority'`, never a first-match-wins pick.

2. **The dead-rule warning is corrected for what actually ships now.** The issue's premise - "a rule reads a fact OpenLinker never records" - was true under #2170 but is stale: #2599 landed a real `Order.buyerTaxId`. I verified `order-to-sales-document-order-facts.mapper.ts` and both order-source adapters directly:
   - PrestaShop reads `ps_address.vat_number` and reports it.
   - Allegro's checkout-form invoice block carries a company tax id that OL's `AllegroCheckoutForm` type does not model - not reported.
   - WooCommerce's `billing` block has no tax field at all - not reported.

   So a `buyerHasTaxId` condition is live for a PrestaShop order and unreachable for an Allegro/WooCommerce order. Saying "this rule cannot match any order" would be false the moment a PrestaShop order arrives - I did not implement the literal AC ("marked as cannot match") because it would be a false claim under the current evaluator. Instead: a warning banner naming which sources do/don't report the fact, and a per-rule "PrestaShop orders only" tag.

## Files

- `apps/web/src/features/sales-documents/lib/describe-sales-document-tax-id-coverage.ts` (+ test) - pure helpers `usesBuyerTaxIdCondition` / `countRulesUsingBuyerTaxId`.
- `apps/web/src/features/sales-documents/components/sales-document-rules-list.tsx` - the two copy additions.

## Deliberately left out

Detecting whether *this specific connection mix* includes PrestaShop (an extra connections-capability read) - the tooltip already names the source, and the nuance doesn't change per-install without also checking the actual `Order.buyerTaxId` distribution, which the FE cannot query.

## Testing

- `pnpm --filter @openlinker/web type-check` — clean
- `npx eslint` on every touched/added file — clean
- `npx vitest run src/features/sales-documents` — 97/97 passing (5 new)
- `pnpm check:invariants` — green