### PR TITLE
Defaults: honest two-defaults warning and single-default hint (#2547)

### DIFF
--- a/apps/web/src/features/sales-documents/components/sales-document-country-routing-dialog.test.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-country-routing-dialog.test.tsx
@@ -227,11 +227,14 @@ describe('SalesDocumentCountryRoutingDialog', () => {
     );
 
     expect(
-      await screen.findByText(/both an Invoice default and a Receipt default/i),
+      await screen.findByText(/Both an Invoice and a Receipt default are set/i),
     ).toBeInTheDocument();
+    // The consequence is stated, never reassurance that something resolves it.
+    expect(screen.getByText(/that step is disabled entirely/i)).toBeInTheDocument();
+    expect(screen.getByText(/an order that matches no rule is\s*held/i)).toBeInTheDocument();
   });
 
-  it('should not show the dual-default warning when only one default is set', async () => {
+  it('should not show the dual-default warning when only one default is set, and should show the single-default hint instead', async () => {
     const defaults: SalesDocumentCountryDefault[] = [
       { id: 'd1', country: 'PL', documentKind: 'invoice', connectionId: 'conn_1' },
     ];
@@ -253,7 +256,10 @@ describe('SalesDocumentCountryRoutingDialog', () => {
     );
 
     await screen.findByText(/Rules for PL/i);
-    expect(screen.queryByText(/both an Invoice default and a Receipt default/i)).toBeNull();
+    expect(screen.queryByText(/Both an Invoice and a Receipt default are set/i)).toBeNull();
+    expect(
+      await screen.findByText(/applies only when no rule above matches/i),
+    ).toBeInTheDocument();
   });
 
   it('should not show the dual-default warning when neither default is set', async () => {
@@ -275,7 +281,8 @@ describe('SalesDocumentCountryRoutingDialog', () => {
     );
 
     await screen.findByText(/Rules for PL/i);
-    expect(screen.queryByText(/both an Invoice default and a Receipt default/i)).toBeNull();
+    expect(screen.queryByText(/Both an Invoice and a Receipt default are set/i)).toBeNull();
+    expect(screen.queryByText(/applies only when no rule above matches/i)).toBeNull();
   });
 
   it('should render the "+ Add rule" composer with the elevated dialog tier when opened from within this dialog', async () => {

--- a/apps/web/src/features/sales-documents/components/sales-document-country-routing-dialog.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-country-routing-dialog.tsx
@@ -187,11 +187,17 @@ export function SalesDocumentCountryRoutingDialog({
           <SalesDocumentCountryDefaults country={country} />
           {hasDualDefault ? (
             <Alert tone="warning" title="Both an Invoice and a Receipt default are set">
-              {displayName} has both an Invoice default and a Receipt default configured. Which one
-              applies depends entirely on which rule (or manual action) decides the document kind
-              for a given order — confirm this is the intended configuration, since nothing here
-              decides between them automatically.
+              A default only applies when no rule above matched. With two defaults set for{' '}
+              {displayName}, that step is disabled entirely — an order that matches no rule is
+              held rather than taking either default. Remove one of the two to restore a working
+              fallback.
             </Alert>
+          ) : (hasInvoiceDefault || hasReceiptDefault) ? (
+            <p className="muted-text">
+              This default applies only when no rule above matches this order. Setting a default
+              for the other document kind too disables this fallback — one default, not two, keeps
+              it working.
+            </p>
           ) : null}
         </>
       ),


### PR DESCRIPTION
Closes #2547

## What changed

The dual-default warning already shipped in #2189, but its copy was wrong about the mechanism: "which one applies depends entirely on which rule (or manual action) decides the document kind" implies a rule mediates between the two defaults. Checked against `evaluateSalesDocumentRules` directly - the country's defaults (tier 2) are consulted only when NO rule matched at all (tier 1). Two defaults set there resolve `ambiguous-defaults` -> the `unresolved`/`'ambiguous-connection-no-primary'` reason, never a rule-mediated pick.

- Reworded the warning to state the real consequence: the default step is disabled entirely, and an unmatched order is held rather than taking either default.
- Added the missing single-default hint (mini-epic AC 3): "This default applies only when no rule above matches this order" - a statement of the fallback ladder's actual behavior, never implying validation the form doesn't perform.
- Updated the three existing tests whose assertions matched the old wording, and strengthened the both-set test to assert the stated consequence rather than only banner presence.

## Testing

- `pnpm --filter @openlinker/web type-check` — clean
- `npx eslint` on both touched files — clean
- `npx vitest run` on the dialog spec — 21/21 passing
- `pnpm check:invariants` — green