### PR TITLE
Fall-through disclosure: conditional on the market's actual configuration (#2548)

### DIFF
--- a/apps/web/src/features/sales-documents/components/sales-document-country-routing-dialog.test.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-country-routing-dialog.test.tsx
@@ -696,4 +696,80 @@ describe('SalesDocumentCountryRoutingDialog — Reset country (#2189)', () => {
     // its title) is still there, not replaced by a full-dialog error state.
     expect(screen.getByText(/Sales-document routing · DE/i)).toBeInTheDocument();
   });
+
+  it('should state that an unmatched order falls through when the country has no rule and no default', async () => {
+    const apiClient = createMockApiClient({
+      salesDocumentRules: {
+        listRules: vi.fn().mockResolvedValue([]),
+        listCountryDefaults: vi.fn().mockResolvedValue([]),
+      },
+    });
+    renderWithProviders(
+      <SalesDocumentCountryRoutingDialog
+        open
+        country="DE"
+        cameFrom={null}
+        onOpenChange={vi.fn()}
+        onNavigate={vi.fn()}
+      />,
+      { apiClient },
+    );
+
+    expect(await screen.findByText(/Falls through to ★ Rest of world/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/DE has no rules and no default, so an order billed here goes to/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/An unmatched order is held/i)).toBeNull();
+  });
+
+  it('should state that an unmatched order is held, and never falls through, once the country carries a rule', async () => {
+    const rules = [makeRule('r1', { country: 'DE' })];
+    const apiClient = createMockApiClient({
+      salesDocumentRules: {
+        listRules: vi.fn().mockResolvedValue(rules),
+        listCountryDefaults: vi.fn().mockResolvedValue([]),
+      },
+    });
+    renderWithProviders(
+      <SalesDocumentCountryRoutingDialog
+        open
+        country="DE"
+        cameFrom={null}
+        onOpenChange={vi.fn()}
+        onNavigate={vi.fn()}
+      />,
+      { apiClient },
+    );
+
+    expect(await screen.findByText(/An unmatched order is held/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/DE has its own routing, so an order that matches nothing here is/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Falls through to ★ Rest of world/i)).toBeNull();
+    expect(screen.queryByRole('button', { name: /Open ★ Rest of world/i })).toBeNull();
+  });
+
+  it('should state that an unmatched order is held once the country carries a default, even with no rules', async () => {
+    const defaults: SalesDocumentCountryDefault[] = [
+      { id: 'd1', country: 'DE', documentKind: 'invoice', connectionId: 'conn_1' },
+    ];
+    const apiClient = createMockApiClient({
+      salesDocumentRules: {
+        listRules: vi.fn().mockResolvedValue([]),
+        listCountryDefaults: vi.fn().mockResolvedValue(defaults),
+      },
+    });
+    renderWithProviders(
+      <SalesDocumentCountryRoutingDialog
+        open
+        country="DE"
+        cameFrom={null}
+        onOpenChange={vi.fn()}
+        onNavigate={vi.fn()}
+      />,
+      { apiClient },
+    );
+
+    expect(await screen.findByText(/An unmatched order is held/i)).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/features/sales-documents/components/sales-document-country-routing-dialog.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-country-routing-dialog.tsx
@@ -204,16 +204,35 @@ export function SalesDocumentCountryRoutingDialog({
     },
   ];
 
+  // A country with ANY rule or ANY default is "configured", and a configured
+  // country never falls through — `evaluateSalesDocumentRules` only reaches
+  // ★ Rest of world when `countryConfigured` is false (rules.length === 0 &&
+  // defaults.length === 0). A configured country whose rule/default simply
+  // didn't match resolves `unresolved`/`no-matching-rule` (or
+  // `ambiguous-connection-no-primary`) — the order is HELD, never passed to
+  // ★ Rest of world. The tier title and body below must say which one is
+  // true for THIS country, not a general claim that fall-through always
+  // applies once nothing above matches.
+  const isCountryConfigured = rules.length > 0 || defaults.length > 0;
+
   if (!isRestOfWorld) {
     tiers.push({
       key: 'rest-of-world',
-      title: 'Falls through to ★ Rest of world',
-      content: (
+      title: isCountryConfigured
+        ? 'An unmatched order is held'
+        : 'Falls through to ★ Rest of world',
+      content: isCountryConfigured ? (
+        <p className="muted-text">
+          {displayName} has its own routing, so an order that matches nothing here is{' '}
+          <strong>held</strong>. It does <strong>not</strong> go to{' '}
+          <span className="mono-text">★ Rest of world</span> — only a market with no rules and no
+          default at all falls through there.
+        </p>
+      ) : (
         <div>
           <p className="muted-text">
-            An order billed to {displayName} that matches no rule above and has no country default
-            here falls through to <span className="mono-text">★ Rest of world</span>
-            &apos;s own rules and defaults.
+            {displayName} has no rules and no default, so an order billed here goes to{' '}
+            <span className="mono-text">★ Rest of world</span>&apos;s own rules and defaults.
           </p>
           <Button
             tone="secondary"
@@ -234,7 +253,9 @@ export function SalesDocumentCountryRoutingDialog({
       <p className="muted-text">
         {isRestOfWorld
           ? 'If nothing above matches, the order has no configured fallback left and is reported unresolved.'
-          : `If ★ Rest of world also has no matching rule or default, the order is reported unresolved.`}
+          : isCountryConfigured
+            ? 'The order is held, as stated above — it is never passed to ★ Rest of world once this country has any rule or default of its own.'
+            : 'If ★ Rest of world also has no matching rule or default, the order is reported unresolved.'}
       </p>
     ),
   });


### PR DESCRIPTION
Closes #2548

## What changed

The tier-3 disclosure previously stated, unconditionally, that an unmatched order falls through to ★ Rest of world. Checked directly against `evaluateSalesDocumentRules`: that is only true when the country carries **zero rules and zero defaults** (`countryConfigured === false`). A country with a rule or a default that simply didn't match resolves `unresolved` (`'no-matching-rule'` / `'ambiguous-connection-no-primary'`) directly - the order is held, and ★ Rest of world is never consulted.

- The tier title and body now branch on `rules.length > 0 || defaults.length > 0`:
  - Unconfigured -> unchanged "Falls through to ★ Rest of world" copy + the cross-link.
  - Configured -> "An unmatched order is held", stating explicitly it does NOT go to ★ Rest of world, and drops the cross-link (there is nothing on the other side of it relevant to this order).
- The Unresolved tier's text follows the same branch, so a configured country's copy never re-mentions ★ Rest of world's own match state.
- One naming used throughout: `★ Rest of world` (mono-text), matching the country index.

## Tests

Four new cases: falls-through when genuinely unconfigured, held once a rule exists, held once a default exists with zero rules, and the cross-link button disappears once the country is configured. All 24 tests in the dialog spec pass (20 pre-existing + 4 new — 2 assertions from a prior task's earlier PR round also updated for the `is held` copy overlap between this tier and the rules-list ordering statement).

- `pnpm --filter @openlinker/web type-check` — clean
- `npx eslint` on both touched files — clean
- `npx vitest run` on the dialog spec — 24/24 passing
- `pnpm check:invariants` — green