### PR TITLE
Reset country: gated by write-access visibility (#2549)

### DIFF
--- a/apps/web/src/features/sales-documents/components/sales-document-country-routing-dialog.test.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-country-routing-dialog.test.tsx
@@ -480,6 +480,35 @@ describe('SalesDocumentCountryRoutingDialog — acknowledgment banner (#2189)', 
 });
 
 describe('SalesDocumentCountryRoutingDialog — Reset country (#2189)', () => {
+  it('should not render the reset affordance at all for a session with no write permission (non-demo)', async () => {
+    const rules = [makeRule('r1', { country: 'DE' })];
+    const apiClient = createMockApiClient({
+      salesDocumentRules: {
+        listRules: vi.fn().mockResolvedValue(rules),
+        listCountryDefaults: vi.fn().mockResolvedValue([]),
+      },
+    });
+    // Default session adapter (no sessionAdapter passed) is anonymous/no
+    // permissions, and demo mode is off by default — `useWriteAccess`'s
+    // `visible` is false, so the reset danger-zone must not render at all
+    // rather than render disabled (docs/frontend-architecture.md's
+    // "otherwise hidden" rule for a write affordance).
+    renderWithProviders(
+      <SalesDocumentCountryRoutingDialog
+        open
+        country="DE"
+        cameFrom={null}
+        onOpenChange={vi.fn()}
+        onNavigate={vi.fn()}
+      />,
+      { apiClient },
+    );
+
+    await screen.findByText(/An unmatched order is held/i);
+    expect(screen.queryByRole('button', { name: 'Reset country' })).toBeNull();
+    expect(screen.queryByText(/Resetting deletes every rule and default/i)).toBeNull();
+  });
+
   it('should disable "Reset country" when the country has zero rules, zero defaults, and no acknowledgment', async () => {
     const apiClient = createMockApiClient({
       salesDocumentRules: {

--- a/apps/web/src/features/sales-documents/components/sales-document-country-routing-dialog.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-country-routing-dialog.tsx
@@ -347,22 +347,29 @@ export function SalesDocumentCountryRoutingDialog({
 
             {resetError ? <Alert tone="error">{resetError}</Alert> : null}
 
-            <div className="sales-document-country-routing-dialog__danger-zone">
-              <p className="muted-text">
-                Resetting deletes every rule and default configured for {displayName} here in
-                OpenLinker. It does not touch anything at the provider — no invoice or receipt
-                already issued is affected.
-              </p>
-              <ReadOnlyLock active={write.demoReadOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
-                <Button
-                  tone="danger"
-                  disabled={!write.canWrite || isSummaryLoading || hasNothingToReset || isResetting}
-                  onClick={() => setConfirmResetOpen(true)}
-                >
-                  Reset country
-                </Button>
-              </ReadOnlyLock>
-            </div>
+            {/* A genuinely unauthorized, non-demo session sees no reset
+                affordance at all rather than a disabled one — `visible` is
+                false only in that case (`useWriteAccess`'s own doc comment);
+                a demo viewer still sees it, disabled with a tooltip, via
+                `demoReadOnly` below. */}
+            {write.visible ? (
+              <div className="sales-document-country-routing-dialog__danger-zone">
+                <p className="muted-text">
+                  Resetting deletes every rule and default configured for {displayName} here in
+                  OpenLinker. It does not touch anything at the provider — no invoice or receipt
+                  already issued is affected.
+                </p>
+                <ReadOnlyLock active={write.demoReadOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
+                  <Button
+                    tone="danger"
+                    disabled={!write.canWrite || isSummaryLoading || hasNothingToReset || isResetting}
+                    onClick={() => setConfirmResetOpen(true)}
+                  >
+                    Reset country
+                  </Button>
+                </ReadOnlyLock>
+              </div>
+            ) : null}
           </div>
 
           <DialogFooter>


### PR DESCRIPTION
Closes #2549

## What changed

Reset country already had, before this task: danger tone, a `ConfirmDialog` gate naming exactly what it destroys, and its own bordered zone separate from the footer's primary "Done" action (all shipped in #2545). What was left was the read-only role.

`ReadOnlyLock` + `disabled` cover only the demo-viewer case. A genuinely unauthorized, non-demo session (no `connections:write` permission, not a demo deployment) still saw a disabled "Reset country" button. `docs/frontend-architecture.md`'s own write-affordance rule says that session should see nothing at all — `useWriteAccess` already returns a `visible` flag precisely for this split (`canWrite` -> enabled, `demoReadOnly` -> disabled+tooltip, neither -> hidden), and nothing in this dialog was reading it.

- Wrapped the whole danger-zone block (the "resetting deletes…" explanatory paragraph plus the button) in `{write.visible ? (...) : null}`, so an unauthorized non-demo session sees no reset affordance and no copy hinting one exists.
- New test asserting the default (anonymous, non-demo) session renders neither the button nor the paragraph, even for a country that has a rule to reset.

No new gating pattern — reuses `useWriteAccess` + `ReadOnlyLock`, matching the mini-epic constraint.

## Testing

- `pnpm --filter @openlinker/web type-check` — clean
- `npx eslint` on both touched files — clean
- `npx vitest run` on the dialog spec — 25/25 passing (1 new)
- `pnpm check:invariants` — green