### PR TITLE
Providers table: honesty pass, demoted below the rule engine (#2550)

### DIFF
--- a/apps/web/src/features/sales-documents/components/sales-documents-panel.test.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-documents-panel.test.tsx
@@ -6,7 +6,7 @@
  * picking a new primary clears the previous one (never leaving two primaries
  * set at once from this UI).
  */
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import {
@@ -180,5 +180,59 @@ describe('SalesDocumentsPanel', () => {
     });
 
     expect(await screen.findByText(/No sales-document connections yet/i)).toBeInTheDocument();
+  });
+
+  it('should state that a connection needing re-authentication cannot issue (#2550)', async () => {
+    const needsReauth: Connection = {
+      ...EPARAGONY,
+      status: 'needs_reauth',
+    };
+    const apiClient = createMockApiClient({
+      connections: { list: vi.fn().mockResolvedValue([INFAKT, needsReauth]) },
+    });
+
+    renderWithProviders(<SalesDocumentsPanel />, {
+      apiClient,
+      sessionAdapter: createAuthenticatedSessionAdapter(),
+    });
+
+    await screen.findByText('eparagony.pl');
+    expect(screen.getByText('Cannot issue until reconnected')).toBeInTheDocument();
+    // The healthy row does not carry the same note.
+    const infaktRow = screen.getByText('inFakt').closest('tr');
+    expect(infaktRow ? within(infaktRow).queryByText(/Cannot issue/i) : null).toBeNull();
+  });
+
+  it('should mark a connection with nothing set as not a routing candidate (#2550)', async () => {
+    const unconfigured: Connection = {
+      ...EPARAGONY,
+      config: {},
+    };
+    const apiClient = createMockApiClient({
+      connections: { list: vi.fn().mockResolvedValue([INFAKT, unconfigured]) },
+    });
+
+    renderWithProviders(<SalesDocumentsPanel />, {
+      apiClient,
+      sessionAdapter: createAuthenticatedSessionAdapter(),
+    });
+
+    await screen.findByText('eparagony.pl');
+    expect(screen.getByText('Not a routing candidate')).toBeInTheDocument();
+  });
+
+  it('should state where the primary rule applies, above the table', async () => {
+    const apiClient = createMockApiClient({
+      connections: { list: vi.fn().mockResolvedValue([INFAKT, EPARAGONY]) },
+    });
+
+    renderWithProviders(<SalesDocumentsPanel />, {
+      apiClient,
+      sessionAdapter: createAuthenticatedSessionAdapter(),
+    });
+
+    expect(
+      await screen.findByText(/Only one connection may go first across ALL of them/i),
+    ).toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/sales-documents/components/sales-documents-panel.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-documents-panel.tsx
@@ -153,6 +153,12 @@ export function SalesDocumentsPanel(): ReactElement {
         </Alert>
       ) : null}
 
+      <p className="muted-text">
+        What each connection may issue, whether it goes first, and when. Only one connection may
+        go first across ALL of them, whatever it issues — the Primary column is a single choice,
+        not one per row. A connection with nothing set here is not a routing candidate at all.
+      </p>
+
       <div className="data-table__container">
         <table className="data-table" aria-label="Sales-document routing per connection">
           <caption className="sr-only">
@@ -183,6 +189,12 @@ export function SalesDocumentsPanel(): ReactElement {
                     <StatusBadge tone={toStatusTone(row.status)} compact>
                       {row.status}
                     </StatusBadge>
+                    {row.status === 'needs_reauth' ? (
+                      <>
+                        <br />
+                        <span className="text-muted">Cannot issue until reconnected</span>
+                      </>
+                    ) : null}
                   </td>
                   <td>
                     <StatusBadge tone="neutral" compact>
@@ -204,6 +216,12 @@ export function SalesDocumentsPanel(): ReactElement {
                         ))}
                       </Select>
                     </ReadOnlyLock>
+                    {row.documentKind === null ? (
+                      <>
+                        <br />
+                        <span className="text-muted">Not a routing candidate</span>
+                      </>
+                    ) : null}
                   </td>
                   <td>
                     <ReadOnlyLock active={write.demoReadOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
@@ -243,9 +261,8 @@ export function SalesDocumentsPanel(): ReactElement {
         </table>
       </div>
       <p className="muted-text">
-        One radio group across ALL rows, regardless of capability — decision 3a (ADR-041) is
-        singular: invoice XOR receipt, never both. Trigger is greyed out for a non-primary row
-        since the timing choice does not matter until a connection is actually the one issuing.
+        Trigger is greyed out for a non-primary row since the timing choice does not matter until
+        a connection is actually the one issuing.
       </p>
     </div>
   );

--- a/apps/web/src/pages/settings/sales-documents-page.tsx
+++ b/apps/web/src/pages/settings/sales-documents-page.tsx
@@ -34,16 +34,19 @@ export function SalesDocumentsPage(): ReactElement {
       description="Choose what each connected provider issues, and which one issues first. OpenLinker never decides which document an order legally needs."
       backTo={{ to: '/settings', label: 'Settings' }}
     >
-      <SalesDocumentsPanel />
       {/*
-       * #2170 — the country-agnostic rule engine, rendered alongside the
-       * #2156 operator-configured table above rather than replacing it:
-       * `AutoIssueTriggerService` still resolves via that table today, so
-       * removing it would leave operators unable to configure what
-       * actually auto-issues. See `SalesDocumentRuleEnginePanel`'s own doc
-       * comment.
+       * #2170 — the country-agnostic rule engine is the page's primary
+       * authoring surface (M7 / #2550): it runs FIRST and consults
+       * `evaluateSalesDocumentRules` before the #2156 operator-configured
+       * table below ever applies. The table is demoted below it, not
+       * stripped — it is the only place document kind, "goes first" and
+       * the trigger are set at all, and a connection with nothing set
+       * there is not a routing candidate for the rule engine either. See
+       * `SalesDocumentRuleEnginePanel`'s own doc comment for the full
+       * precedence.
        */}
       <SalesDocumentRuleEnginePanel />
+      <SalesDocumentsPanel />
     </PageLayout>
   );
 }


### PR DESCRIPTION
Closes #2550

## What changed

Document kind, "goes first" and trigger stay fully editable — this task never demoted them, only moved the table's page position and fixed three copy gaps.

1. **Demotion, not stripping.** `SalesDocumentsPanel` (this table) now renders below `SalesDocumentRuleEnginePanel` on the settings page. Note: M6's dedicated redesigned "market section" component has not merged into this branch yet (this mini-epic branches from `epic/sales-documents-ux`, not from M6), so `SalesDocumentRuleEnginePanel` — the existing per-country rule-engine surface — is what this table is demoted below here. When M6 merges, whoever wires the final page composition should re-check this ordering against the real market section.
2. **`needs_reauth` says it cannot issue.** Previously only a warning-toned badge; now "Cannot issue until reconnected" renders under it.
3. **A connection with nothing set says so.** `documentKind === null` now shows "Not a routing candidate" under the Issues select, instead of reading identically to a configured row.
4. **The one-primary rule moved to where the control is** — a sentence directly above the table, not a footnote below it. The footnote keeps only the trigger-greyed-out rationale (which the primary-rule sentence doesn't cover).

## Testing

- `pnpm --filter @openlinker/web type-check` — clean
- `npx eslint` on all three touched files — clean
- `npx vitest run` on the panel spec — 9/9 passing (3 new, 6 pre-existing unchanged — none asserted the removed footnote wording)
- `pnpm check:invariants` — green

No test exists for `sales-documents-page.tsx` itself (page composition only, no logic), so the reorder is verified by reading the JSX rather than a snapshot.