### PR TITLE
fix(web): correct sales-document settings copy against the shipped routing evaluator

### DIFF
--- a/apps/web/src/features/sales-documents/components/sales-document-country-defaults.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-country-defaults.tsx
@@ -14,6 +14,7 @@ import { useConnectionsQuery } from '../../connections';
 import { selectInvoicingCandidates } from '../../invoicing';
 import { selectFiscalizationCandidates } from '../../fiscalization';
 import { Select } from '../../../shared/ui/select';
+import { Alert } from '../../../shared/ui/alert';
 import { LoadingState, ErrorState } from '../../../shared/ui/feedback-state';
 import { ReadOnlyLock } from '../../../shared/ui/read-only-lock';
 import { useWriteAccess } from '../../../shared/auth/use-permission';
@@ -74,24 +75,36 @@ export function SalesDocumentCountryDefaults({
               ? selectInvoicingCandidates(connections)
               : selectFiscalizationCandidates(connections);
           const current = defaults.find((d) => d.documentKind === documentKind) ?? null;
+          const isSavingThisKind =
+            upsert.isPending && upsert.variables?.documentKind === documentKind;
+          const isRemovingThisKind =
+            remove.isPending && current !== null && remove.variables === current.id;
+          const isPendingThisKind = isSavingThisKind || isRemovingThisKind;
+          const saveFailedForThisKind =
+            upsert.isError && upsert.variables?.documentKind === documentKind ? upsert.error : null;
+          const removeFailedForThisKind =
+            remove.isError && current !== null && remove.variables === current.id
+              ? remove.error
+              : null;
 
           return (
             <div key={documentKind} className="page-section">
               <label className="eyebrow" htmlFor={`sd-default-${documentKind}`} style={{ marginBottom: 2 }}>
                 {label}
+                {isPendingThisKind ? ' — Saving…' : null}
               </label>
               <ReadOnlyLock active={write.demoReadOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
                 <Select
                   id={`sd-default-${documentKind}`}
                   value={current?.connectionId ?? ''}
-                  disabled={!write.canWrite || candidates.length === 0}
+                  disabled={!write.canWrite || candidates.length === 0 || isPendingThisKind}
                   onChange={(event) => {
                     const connectionId = event.target.value;
                     if (connectionId === '') {
-                      if (current) void remove.mutateAsync(current.id);
+                      if (current) void remove.mutateAsync(current.id).catch(() => {});
                       return;
                     }
-                    void upsert.mutateAsync({ country, documentKind, connectionId });
+                    void upsert.mutateAsync({ country, documentKind, connectionId }).catch(() => {});
                   }}
                 >
                   <option value="">Not set</option>
@@ -106,6 +119,10 @@ export function SalesDocumentCountryDefaults({
                 Filtered to connections with <span className="chip mono-text">{capability}</span>.
                 {candidates.length === 0 ? ' No eligible connection yet.' : null}
               </p>
+              {saveFailedForThisKind ? <Alert tone="error">{saveFailedForThisKind.message}</Alert> : null}
+              {removeFailedForThisKind ? (
+                <Alert tone="error">{removeFailedForThisKind.message}</Alert>
+              ) : null}
             </div>
           );
         })}

--- a/apps/web/src/features/sales-documents/components/sales-document-country-defaults.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-country-defaults.tsx
@@ -101,10 +101,10 @@ export function SalesDocumentCountryDefaults({
                   onChange={(event) => {
                     const connectionId = event.target.value;
                     if (connectionId === '') {
-                      if (current) void remove.mutateAsync(current.id).catch(() => {});
+                      if (current) remove.mutate(current.id);
                       return;
                     }
-                    void upsert.mutateAsync({ country, documentKind, connectionId }).catch(() => {});
+                    upsert.mutate({ country, documentKind, connectionId });
                   }}
                 >
                   <option value="">Not set</option>

--- a/apps/web/src/features/sales-documents/components/sales-document-country-routing-dialog.test.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-country-routing-dialog.test.tsx
@@ -801,4 +801,34 @@ describe('SalesDocumentCountryRoutingDialog — Reset country (#2189)', () => {
 
     expect(await screen.findByText(/An unmatched order is held/i)).toBeInTheDocument();
   });
+
+  it('should not claim a country has no rules and no default while the counts are still loading', async () => {
+    // `rules`/`defaults` read `?? []` while the queries are in flight, so an
+    // ungated tier would assert "DE has no rules and no default" about a
+    // configured country and then flip once the real counts land.
+    const apiClient = createMockApiClient({
+      salesDocumentRules: {
+        listRules: vi.fn().mockReturnValue(new Promise(() => {})),
+        listCountryDefaults: vi.fn().mockReturnValue(new Promise(() => {})),
+      },
+    });
+    renderWithProviders(
+      <SalesDocumentCountryRoutingDialog
+        open
+        country="DE"
+        cameFrom={null}
+        onOpenChange={vi.fn()}
+        onNavigate={vi.fn()}
+      />,
+      { apiClient },
+    );
+
+    expect(
+      await screen.findByText(/What happens to an unmatched order/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/DE has no rules and no default/i)).toBeNull();
+    expect(screen.queryByText(/Falls through to ★ Rest of world/i)).toBeNull();
+    expect(screen.queryByText(/An unmatched order is held/i)).toBeNull();
+    expect(screen.queryByRole('button', { name: /Open ★ Rest of world/i })).toBeNull();
+  });
 });

--- a/apps/web/src/features/sales-documents/components/sales-document-country-routing-dialog.test.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-country-routing-dialog.test.tsx
@@ -227,11 +227,14 @@ describe('SalesDocumentCountryRoutingDialog', () => {
     );
 
     expect(
-      await screen.findByText(/both an Invoice default and a Receipt default/i),
+      await screen.findByText(/Both an Invoice and a Receipt default are set/i),
     ).toBeInTheDocument();
+    // The consequence is stated, never reassurance that something resolves it.
+    expect(screen.getByText(/that step is disabled entirely/i)).toBeInTheDocument();
+    expect(screen.getByText(/an order that matches no rule is\s*held/i)).toBeInTheDocument();
   });
 
-  it('should not show the dual-default warning when only one default is set', async () => {
+  it('should not show the dual-default warning when only one default is set, and should show the single-default hint instead', async () => {
     const defaults: SalesDocumentCountryDefault[] = [
       { id: 'd1', country: 'PL', documentKind: 'invoice', connectionId: 'conn_1' },
     ];
@@ -253,7 +256,10 @@ describe('SalesDocumentCountryRoutingDialog', () => {
     );
 
     await screen.findByText(/Rules for PL/i);
-    expect(screen.queryByText(/both an Invoice default and a Receipt default/i)).toBeNull();
+    expect(screen.queryByText(/Both an Invoice and a Receipt default are set/i)).toBeNull();
+    expect(
+      await screen.findByText(/applies only when no rule above matches/i),
+    ).toBeInTheDocument();
   });
 
   it('should not show the dual-default warning when neither default is set', async () => {
@@ -275,7 +281,8 @@ describe('SalesDocumentCountryRoutingDialog', () => {
     );
 
     await screen.findByText(/Rules for PL/i);
-    expect(screen.queryByText(/both an Invoice default and a Receipt default/i)).toBeNull();
+    expect(screen.queryByText(/Both an Invoice and a Receipt default are set/i)).toBeNull();
+    expect(screen.queryByText(/applies only when no rule above matches/i)).toBeNull();
   });
 
   it('should render the "+ Add rule" composer with the elevated dialog tier when opened from within this dialog', async () => {

--- a/apps/web/src/features/sales-documents/components/sales-document-country-routing-dialog.test.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-country-routing-dialog.test.tsx
@@ -633,4 +633,60 @@ describe('SalesDocumentCountryRoutingDialog — Reset country (#2189)', () => {
       expect(screen.getByRole('button', { name: 'Reset country' })).toBeDisabled();
     });
   });
+
+  it('should offer an explicit "Done" close action so the operator does not rely on Escape or a backdrop click', async () => {
+    const onOpenChange = vi.fn();
+    const apiClient = createMockApiClient({
+      salesDocumentRules: {
+        listRules: vi.fn().mockResolvedValue([]),
+        listCountryDefaults: vi.fn().mockResolvedValue([]),
+      },
+    });
+    renderWithProviders(
+      <SalesDocumentCountryRoutingDialog
+        open
+        country="DE"
+        cameFrom={null}
+        onOpenChange={onOpenChange}
+        onNavigate={vi.fn()}
+      />,
+      { apiClient },
+    );
+
+    await screen.findByText(/Rules for DE/i);
+    const doneButton = screen.getByRole('button', { name: 'Done' });
+    await userEvent.click(doneButton);
+
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('should surface a per-rule delete failure without hiding the rest of the dialog', async () => {
+    const rules = [makeRule('r1')];
+    const deleteRule = vi.fn().mockRejectedValue(new Error('Rule is referenced elsewhere'));
+    const apiClient = createMockApiClient({
+      salesDocumentRules: {
+        listRules: vi.fn().mockResolvedValue(rules),
+        listCountryDefaults: vi.fn().mockResolvedValue([]),
+        deleteRule,
+      },
+    });
+    renderWithProviders(
+      <SalesDocumentCountryRoutingDialog
+        open
+        country="DE"
+        cameFrom={null}
+        onOpenChange={vi.fn()}
+        onNavigate={vi.fn()}
+      />,
+      { apiClient, sessionAdapter: createAuthenticatedSessionAdapter() },
+    );
+
+    const deleteButton = await screen.findByRole('button', { name: 'Delete' });
+    await userEvent.click(deleteButton);
+
+    await screen.findByText('Rule is referenced elsewhere');
+    // The failure is scoped to the rule row — the rest of the dialog (e.g.
+    // its title) is still there, not replaced by a full-dialog error state.
+    expect(screen.getByText(/Sales-document routing · DE/i)).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/features/sales-documents/components/sales-document-country-routing-dialog.test.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-country-routing-dialog.test.tsx
@@ -696,4 +696,80 @@ describe('SalesDocumentCountryRoutingDialog — Reset country (#2189)', () => {
     // its title) is still there, not replaced by a full-dialog error state.
     expect(screen.getByText(/Sales-document routing · DE/i)).toBeInTheDocument();
   });
+
+  it('should state that an unmatched order falls through when the country has no rule and no default', async () => {
+    const apiClient = createMockApiClient({
+      salesDocumentRules: {
+        listRules: vi.fn().mockResolvedValue([]),
+        listCountryDefaults: vi.fn().mockResolvedValue([]),
+      },
+    });
+    renderWithProviders(
+      <SalesDocumentCountryRoutingDialog
+        open
+        country="DE"
+        cameFrom={null}
+        onOpenChange={vi.fn()}
+        onNavigate={vi.fn()}
+      />,
+      { apiClient },
+    );
+
+    expect(await screen.findByText(/Falls through to ★ Rest of world/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/DE has no rules and no default, so an order billed here goes to/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/An unmatched order is held/i)).toBeNull();
+  });
+
+  it('should state that an unmatched order is held, and never falls through, once the country carries a rule', async () => {
+    const rules = [makeRule('r1', { country: 'DE' })];
+    const apiClient = createMockApiClient({
+      salesDocumentRules: {
+        listRules: vi.fn().mockResolvedValue(rules),
+        listCountryDefaults: vi.fn().mockResolvedValue([]),
+      },
+    });
+    renderWithProviders(
+      <SalesDocumentCountryRoutingDialog
+        open
+        country="DE"
+        cameFrom={null}
+        onOpenChange={vi.fn()}
+        onNavigate={vi.fn()}
+      />,
+      { apiClient },
+    );
+
+    expect(await screen.findByText(/An unmatched order is held/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/DE has its own routing, so an order that matches nothing here is/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/Falls through to ★ Rest of world/i)).toBeNull();
+    expect(screen.queryByRole('button', { name: /Open ★ Rest of world/i })).toBeNull();
+  });
+
+  it('should state that an unmatched order is held once the country carries a default, even with no rules', async () => {
+    const defaults: SalesDocumentCountryDefault[] = [
+      { id: 'd1', country: 'DE', documentKind: 'invoice', connectionId: 'conn_1' },
+    ];
+    const apiClient = createMockApiClient({
+      salesDocumentRules: {
+        listRules: vi.fn().mockResolvedValue([]),
+        listCountryDefaults: vi.fn().mockResolvedValue(defaults),
+      },
+    });
+    renderWithProviders(
+      <SalesDocumentCountryRoutingDialog
+        open
+        country="DE"
+        cameFrom={null}
+        onOpenChange={vi.fn()}
+        onNavigate={vi.fn()}
+      />,
+      { apiClient },
+    );
+
+    expect(await screen.findByText(/An unmatched order is held/i)).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/features/sales-documents/components/sales-document-country-routing-dialog.test.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-country-routing-dialog.test.tsx
@@ -480,6 +480,35 @@ describe('SalesDocumentCountryRoutingDialog — acknowledgment banner (#2189)', 
 });
 
 describe('SalesDocumentCountryRoutingDialog — Reset country (#2189)', () => {
+  it('should not render the reset affordance at all for a session with no write permission (non-demo)', async () => {
+    const rules = [makeRule('r1', { country: 'DE' })];
+    const apiClient = createMockApiClient({
+      salesDocumentRules: {
+        listRules: vi.fn().mockResolvedValue(rules),
+        listCountryDefaults: vi.fn().mockResolvedValue([]),
+      },
+    });
+    // Default session adapter (no sessionAdapter passed) is anonymous/no
+    // permissions, and demo mode is off by default — `useWriteAccess`'s
+    // `visible` is false, so the reset danger-zone must not render at all
+    // rather than render disabled (docs/frontend-architecture.md's
+    // "otherwise hidden" rule for a write affordance).
+    renderWithProviders(
+      <SalesDocumentCountryRoutingDialog
+        open
+        country="DE"
+        cameFrom={null}
+        onOpenChange={vi.fn()}
+        onNavigate={vi.fn()}
+      />,
+      { apiClient },
+    );
+
+    await screen.findByText(/An unmatched order is held/i);
+    expect(screen.queryByRole('button', { name: 'Reset country' })).toBeNull();
+    expect(screen.queryByText(/Resetting deletes every rule and default/i)).toBeNull();
+  });
+
   it('should disable "Reset country" when the country has zero rules, zero defaults, and no acknowledgment', async () => {
     const apiClient = createMockApiClient({
       salesDocumentRules: {

--- a/apps/web/src/features/sales-documents/components/sales-document-country-routing-dialog.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-country-routing-dialog.tsx
@@ -58,7 +58,7 @@
  */
 import { useState, type ReactElement, type ReactNode } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
-import { Dialog, DialogContent, DialogFooter, DialogTitle } from '../../../shared/ui/dialog';
+import { Dialog, DialogClose, DialogContent, DialogFooter, DialogTitle } from '../../../shared/ui/dialog';
 import { Alert } from '../../../shared/ui/alert';
 import { Button } from '../../../shared/ui/button';
 import { ConfirmDialog } from '../../../shared/ui/confirm-dialog';
@@ -248,6 +248,9 @@ export function SalesDocumentCountryRoutingDialog({
           ) : null}
 
           <DialogTitle>Sales-document routing · {displayName}</DialogTitle>
+          <p className="muted-text sales-document-country-routing-dialog__save-note">
+            Every control here saves as you change it — there is nothing to submit.
+          </p>
 
           <div className="sales-document-country-routing-dialog__body">
             {isEmptyCountry ? (
@@ -316,18 +319,29 @@ export function SalesDocumentCountryRoutingDialog({
             ))}
 
             {resetError ? <Alert tone="error">{resetError}</Alert> : null}
+
+            <div className="sales-document-country-routing-dialog__danger-zone">
+              <p className="muted-text">
+                Resetting deletes every rule and default configured for {displayName} here in
+                OpenLinker. It does not touch anything at the provider — no invoice or receipt
+                already issued is affected.
+              </p>
+              <ReadOnlyLock active={write.demoReadOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
+                <Button
+                  tone="danger"
+                  disabled={!write.canWrite || isSummaryLoading || hasNothingToReset || isResetting}
+                  onClick={() => setConfirmResetOpen(true)}
+                >
+                  Reset country
+                </Button>
+              </ReadOnlyLock>
+            </div>
           </div>
 
           <DialogFooter>
-            <ReadOnlyLock active={write.demoReadOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
-              <Button
-                tone="danger"
-                disabled={!write.canWrite || isSummaryLoading || hasNothingToReset || isResetting}
-                onClick={() => setConfirmResetOpen(true)}
-              >
-                Reset country
-              </Button>
-            </ReadOnlyLock>
+            <DialogClose asChild>
+              <Button tone="primary">Done</Button>
+            </DialogClose>
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/apps/web/src/features/sales-documents/components/sales-document-country-routing-dialog.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-country-routing-dialog.tsx
@@ -347,22 +347,29 @@ export function SalesDocumentCountryRoutingDialog({
 
             {resetError ? <Alert tone="error">{resetError}</Alert> : null}
 
-            <div className="sales-document-country-routing-dialog__danger-zone">
-              <p className="muted-text">
-                Resetting deletes every rule and default configured for {displayName} here in
-                OpenLinker. It does not touch anything at the provider — no invoice or receipt
-                already issued is affected.
-              </p>
-              <ReadOnlyLock active={write.demoReadOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
-                <Button
-                  tone="danger"
-                  disabled={!write.canWrite || isSummaryLoading || hasNothingToReset || isResetting}
-                  onClick={() => setConfirmResetOpen(true)}
-                >
-                  Reset country
-                </Button>
-              </ReadOnlyLock>
-            </div>
+            {/* A genuinely unauthorized, non-demo session sees no reset
+                affordance at all rather than a disabled one — `visible` is
+                false only in that case (`useWriteAccess`'s own doc comment);
+                a demo viewer still sees it, disabled with a tooltip, via
+                `demoReadOnly` below. */}
+            {write.visible ? (
+              <div className="sales-document-country-routing-dialog__danger-zone">
+                <p className="muted-text">
+                  Resetting deletes every rule and default configured for {displayName} here in
+                  OpenLinker. It does not touch anything at the provider — no invoice or receipt
+                  already issued is affected.
+                </p>
+                <ReadOnlyLock active={write.demoReadOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
+                  <Button
+                    tone="danger"
+                    disabled={!write.canWrite || isSummaryLoading || hasNothingToReset || isResetting}
+                    onClick={() => setConfirmResetOpen(true)}
+                  >
+                    Reset country
+                  </Button>
+                </ReadOnlyLock>
+              </div>
+            ) : null}
           </div>
 
           <DialogFooter>

--- a/apps/web/src/features/sales-documents/components/sales-document-country-routing-dialog.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-country-routing-dialog.tsx
@@ -204,16 +204,35 @@ export function SalesDocumentCountryRoutingDialog({
     },
   ];
 
+  // A country with ANY rule or ANY default is "configured", and a configured
+  // country never falls through — `evaluateSalesDocumentRules` only reaches
+  // ★ Rest of world when `countryConfigured` is false (rules.length === 0 &&
+  // defaults.length === 0). A configured country whose rule/default simply
+  // didn't match resolves `unresolved`/`no-matching-rule` (or
+  // `ambiguous-connection-no-primary`) — the order is HELD, never passed to
+  // ★ Rest of world. The tier title and body below must say which one is
+  // true for THIS country, not a general claim that fall-through always
+  // applies once nothing above matches.
+  const isCountryConfigured = rules.length > 0 || defaults.length > 0;
+
   if (!isRestOfWorld) {
     tiers.push({
       key: 'rest-of-world',
-      title: 'Falls through to ★ Rest of world',
-      content: (
+      title: isCountryConfigured
+        ? 'An unmatched order is held'
+        : 'Falls through to ★ Rest of world',
+      content: isCountryConfigured ? (
+        <p className="muted-text">
+          {displayName} has its own routing, so an order that matches nothing here is{' '}
+          <strong>held</strong>. It does <strong>not</strong> go to{' '}
+          <span className="mono-text">★ Rest of world</span> — only a market with no rules and no
+          default at all falls through there.
+        </p>
+      ) : (
         <div>
           <p className="muted-text">
-            An order billed to {displayName} that matches no rule above and has no country default
-            here falls through to <span className="mono-text">★ Rest of world</span>
-            &apos;s own rules and defaults.
+            {displayName} has no rules and no default, so an order billed here goes to{' '}
+            <span className="mono-text">★ Rest of world</span>&apos;s own rules and defaults.
           </p>
           <Button
             tone="secondary"
@@ -234,7 +253,9 @@ export function SalesDocumentCountryRoutingDialog({
       <p className="muted-text">
         {isRestOfWorld
           ? 'If nothing above matches, the order has no configured fallback left and is reported unresolved.'
-          : `If ★ Rest of world also has no matching rule or default, the order is reported unresolved.`}
+          : isCountryConfigured
+            ? 'The order is held, as stated above — it is never passed to ★ Rest of world once this country has any rule or default of its own.'
+            : 'If ★ Rest of world also has no matching rule or default, the order is reported unresolved.'}
       </p>
     ),
   });

--- a/apps/web/src/features/sales-documents/components/sales-document-country-routing-dialog.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-country-routing-dialog.tsx
@@ -213,15 +213,29 @@ export function SalesDocumentCountryRoutingDialog({
   // ★ Rest of world. The tier title and body below must say which one is
   // true for THIS country, not a general claim that fall-through always
   // applies once nothing above matches.
-  const isCountryConfigured = rules.length > 0 || defaults.length > 0;
+  //
+  // `null` while the counts are still loading: `rules`/`defaults` read `?? []`,
+  // so a plain boolean would say "no rules and no default" about a configured
+  // country for as long as the queries are in flight, then flip — a false
+  // statement about the operator's own configuration, which is exactly the
+  // defect class this file exists to close. The tier renders neutral copy
+  // until the real counts arrive.
+  const isCountryConfigured: boolean | null = isSummaryLoading
+    ? null
+    : rules.length > 0 || defaults.length > 0;
 
   if (!isRestOfWorld) {
     tiers.push({
       key: 'rest-of-world',
-      title: isCountryConfigured
-        ? 'An unmatched order is held'
-        : 'Falls through to ★ Rest of world',
-      content: isCountryConfigured ? (
+      title:
+        isCountryConfigured === null
+          ? 'What happens to an unmatched order'
+          : isCountryConfigured
+            ? 'An unmatched order is held'
+            : 'Falls through to ★ Rest of world',
+      content: isCountryConfigured === null ? (
+        <p className="muted-text">Reading this market&apos;s rules and defaults…</p>
+      ) : isCountryConfigured ? (
         <p className="muted-text">
           {displayName} has its own routing, so an order that matches nothing here is{' '}
           <strong>held</strong>. It does <strong>not</strong> go to{' '}
@@ -253,9 +267,11 @@ export function SalesDocumentCountryRoutingDialog({
       <p className="muted-text">
         {isRestOfWorld
           ? 'If nothing above matches, the order has no configured fallback left and is reported unresolved.'
-          : isCountryConfigured
-            ? 'The order is held, as stated above — it is never passed to ★ Rest of world once this country has any rule or default of its own.'
-            : 'If ★ Rest of world also has no matching rule or default, the order is reported unresolved.'}
+          : isCountryConfigured === null
+            ? 'What happens here depends on whether this market has any routing of its own — reading that now.'
+            : isCountryConfigured
+              ? 'The order is held, as stated above — it is never passed to ★ Rest of world once this country has any rule or default of its own.'
+              : 'If ★ Rest of world also has no matching rule or default, the order is reported unresolved.'}
       </p>
     ),
   });

--- a/apps/web/src/features/sales-documents/components/sales-document-country-routing-dialog.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-country-routing-dialog.tsx
@@ -187,11 +187,17 @@ export function SalesDocumentCountryRoutingDialog({
           <SalesDocumentCountryDefaults country={country} />
           {hasDualDefault ? (
             <Alert tone="warning" title="Both an Invoice and a Receipt default are set">
-              {displayName} has both an Invoice default and a Receipt default configured. Which one
-              applies depends entirely on which rule (or manual action) decides the document kind
-              for a given order — confirm this is the intended configuration, since nothing here
-              decides between them automatically.
+              A default only applies when no rule above matched. With two defaults set for{' '}
+              {displayName}, that step is disabled entirely — an order that matches no rule is
+              held rather than taking either default. Remove one of the two to restore a working
+              fallback.
             </Alert>
+          ) : (hasInvoiceDefault || hasReceiptDefault) ? (
+            <p className="muted-text">
+              This default applies only when no rule above matches this order. Setting a default
+              for the other document kind too disables this fallback — one default, not two, keeps
+              it working.
+            </p>
           ) : null}
         </>
       ),

--- a/apps/web/src/features/sales-documents/components/sales-document-rules-list.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-rules-list.tsx
@@ -10,6 +10,7 @@
  */
 import { useState, type ReactElement } from 'react';
 import { useConnectionsQuery } from '../../connections';
+import { Alert } from '../../../shared/ui/alert';
 import { Button } from '../../../shared/ui/button';
 import { LoadingState, ErrorState } from '../../../shared/ui/feedback-state';
 import { ReadOnlyLock } from '../../../shared/ui/read-only-lock';
@@ -68,6 +69,9 @@ export function SalesDocumentRulesList({ country }: SalesDocumentRulesListProps)
 
       {rules.map((rule) => {
         const connectionName = connections.find((c) => c.id === rule.connectionId)?.name ?? rule.connectionId;
+        const isDeletingThisRule = deleteRule.isPending && deleteRule.variables === rule.id;
+        const deleteFailedForThisRule =
+          deleteRule.isError && deleteRule.variables === rule.id ? deleteRule.error : null;
         return (
           <div key={rule.id} className="rule-card">
             <div className="rule-card__flow">
@@ -93,12 +97,15 @@ export function SalesDocumentRulesList({ country }: SalesDocumentRulesListProps)
                   tone="secondary"
                   className="button--sm"
                   disabled={!write.canWrite || deleteRule.isPending}
-                  onClick={() => void deleteRule.mutateAsync(rule.id)}
+                  onClick={() => void deleteRule.mutateAsync(rule.id).catch(() => {})}
                 >
-                  Delete
+                  {isDeletingThisRule ? 'Deleting…' : 'Delete'}
                 </Button>
               </ReadOnlyLock>
             </div>
+            {deleteFailedForThisRule ? (
+              <Alert tone="error">{deleteFailedForThisRule.message}</Alert>
+            ) : null}
           </div>
         );
       })}

--- a/apps/web/src/features/sales-documents/components/sales-document-rules-list.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-rules-list.tsx
@@ -21,6 +21,10 @@ import { useSalesDocumentRulesQuery } from '../hooks/use-sales-document-rules-qu
 import { useDeleteSalesDocumentRuleMutation } from '../hooks/use-delete-sales-document-rule-mutation';
 import { SalesDocumentRuleComposerDialog } from './sales-document-rule-composer-dialog';
 import { describeSalesDocumentCondition } from '../lib/describe-sales-document-condition';
+import {
+  countRulesUsingBuyerTaxId,
+  usesBuyerTaxIdCondition,
+} from '../lib/describe-sales-document-tax-id-coverage';
 import type { SalesDocumentRule } from '../api/sales-document-rules.types';
 
 interface SalesDocumentRulesListProps {
@@ -53,6 +57,7 @@ export function SalesDocumentRulesList({ country }: SalesDocumentRulesListProps)
 
   const rules = rulesQuery.data ?? [];
   const connections = connectionsQuery.data ?? [];
+  const taxIdRuleCount = countRulesUsingBuyerTaxId(rules);
 
   return (
     <div className="page-section">
@@ -66,6 +71,19 @@ export function SalesDocumentRulesList({ country }: SalesDocumentRulesListProps)
           </Button>
         </ReadOnlyLock>
       </div>
+      <p className="muted-text">
+        Exactly one rule must match an order. Rules have no order of priority — if two match, the
+        order is held instead of one winning.
+      </p>
+
+      {taxIdRuleCount > 0 ? (
+        <Alert tone="warning" title={`${taxIdRuleCount} of these rules read the buyer's tax ID`}>
+          A buyer-tax-ID condition matches only an order whose source records that fact — today
+          that is PrestaShop orders only. An order from Allegro or WooCommerce carries no buyer
+          tax ID at all, so a rule like this one never matches those orders, but it matches a
+          PrestaShop order normally.
+        </Alert>
+      ) : null}
 
       {rules.map((rule) => {
         const connectionName = connections.find((c) => c.id === rule.connectionId)?.name ?? rule.connectionId;
@@ -89,6 +107,14 @@ export function SalesDocumentRulesList({ country }: SalesDocumentRulesListProps)
             </div>
             <div className="rule-card__meta">
               {rule.provenance ? <span className="provenance-tag">from: {rule.provenance}</span> : null}
+              {usesBuyerTaxIdCondition(rule) ? (
+                <span
+                  className="provenance-tag"
+                  title="Matches only orders from a source that records a buyer tax ID (today: PrestaShop)"
+                >
+                  PrestaShop orders only
+                </span>
+              ) : null}
               <span className="rule-card__dates">
                 {rule.effectiveTo ? `ends ${rule.effectiveTo}` : 'no end date'}
               </span>

--- a/apps/web/src/features/sales-documents/components/sales-document-rules-list.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-rules-list.tsx
@@ -122,8 +122,8 @@ export function SalesDocumentRulesList({ country }: SalesDocumentRulesListProps)
                 <Button
                   tone="secondary"
                   className="button--sm"
-                  disabled={!write.canWrite || deleteRule.isPending}
-                  onClick={() => void deleteRule.mutateAsync(rule.id).catch(() => {})}
+                  disabled={!write.canWrite || isDeletingThisRule}
+                  onClick={() => deleteRule.mutate(rule.id)}
                 >
                   {isDeletingThisRule ? 'Deleting…' : 'Delete'}
                 </Button>

--- a/apps/web/src/features/sales-documents/components/sales-document-rules-list.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-rules-list.tsx
@@ -23,6 +23,7 @@ import { SalesDocumentRuleComposerDialog } from './sales-document-rule-composer-
 import { describeSalesDocumentCondition } from '../lib/describe-sales-document-condition';
 import {
   countRulesUsingBuyerTaxId,
+  describeBuyerTaxIdRuleCount,
   usesBuyerTaxIdCondition,
 } from '../lib/describe-sales-document-tax-id-coverage';
 import type { SalesDocumentRule } from '../api/sales-document-rules.types';
@@ -77,7 +78,7 @@ export function SalesDocumentRulesList({ country }: SalesDocumentRulesListProps)
       </p>
 
       {taxIdRuleCount > 0 ? (
-        <Alert tone="warning" title={`${taxIdRuleCount} of these rules read the buyer's tax ID`}>
+        <Alert tone="warning" title={describeBuyerTaxIdRuleCount(taxIdRuleCount)}>
           A buyer-tax-ID condition matches only an order whose source records that fact — today
           that is PrestaShop orders only. An order from Allegro or WooCommerce carries no buyer
           tax ID at all, so a rule like this one never matches those orders, but it matches a

--- a/apps/web/src/features/sales-documents/components/sales-documents-panel.test.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-documents-panel.test.tsx
@@ -6,7 +6,7 @@
  * picking a new primary clears the previous one (never leaving two primaries
  * set at once from this UI).
  */
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import {
@@ -180,5 +180,59 @@ describe('SalesDocumentsPanel', () => {
     });
 
     expect(await screen.findByText(/No sales-document connections yet/i)).toBeInTheDocument();
+  });
+
+  it('should state that a connection needing re-authentication cannot issue (#2550)', async () => {
+    const needsReauth: Connection = {
+      ...EPARAGONY,
+      status: 'needs_reauth',
+    };
+    const apiClient = createMockApiClient({
+      connections: { list: vi.fn().mockResolvedValue([INFAKT, needsReauth]) },
+    });
+
+    renderWithProviders(<SalesDocumentsPanel />, {
+      apiClient,
+      sessionAdapter: createAuthenticatedSessionAdapter(),
+    });
+
+    await screen.findByText('eparagony.pl');
+    expect(screen.getByText('Cannot issue until reconnected')).toBeInTheDocument();
+    // The healthy row does not carry the same note.
+    const infaktRow = screen.getByText('inFakt').closest('tr');
+    expect(infaktRow ? within(infaktRow).queryByText(/Cannot issue/i) : null).toBeNull();
+  });
+
+  it('should mark a connection with nothing set as not a routing candidate (#2550)', async () => {
+    const unconfigured: Connection = {
+      ...EPARAGONY,
+      config: {},
+    };
+    const apiClient = createMockApiClient({
+      connections: { list: vi.fn().mockResolvedValue([INFAKT, unconfigured]) },
+    });
+
+    renderWithProviders(<SalesDocumentsPanel />, {
+      apiClient,
+      sessionAdapter: createAuthenticatedSessionAdapter(),
+    });
+
+    await screen.findByText('eparagony.pl');
+    expect(screen.getByText('Not a routing candidate')).toBeInTheDocument();
+  });
+
+  it('should state where the primary rule applies, above the table', async () => {
+    const apiClient = createMockApiClient({
+      connections: { list: vi.fn().mockResolvedValue([INFAKT, EPARAGONY]) },
+    });
+
+    renderWithProviders(<SalesDocumentsPanel />, {
+      apiClient,
+      sessionAdapter: createAuthenticatedSessionAdapter(),
+    });
+
+    expect(
+      await screen.findByText(/Only one connection may go first across ALL of them/i),
+    ).toBeInTheDocument();
   });
 });

--- a/apps/web/src/features/sales-documents/components/sales-documents-panel.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-documents-panel.tsx
@@ -153,6 +153,12 @@ export function SalesDocumentsPanel(): ReactElement {
         </Alert>
       ) : null}
 
+      <p className="muted-text">
+        What each connection may issue, whether it goes first, and when. Only one connection may
+        go first across ALL of them, whatever it issues — the Primary column is a single choice,
+        not one per row. A connection with nothing set here is not a routing candidate at all.
+      </p>
+
       <div className="data-table__container">
         <table className="data-table" aria-label="Sales-document routing per connection">
           <caption className="sr-only">
@@ -183,6 +189,12 @@ export function SalesDocumentsPanel(): ReactElement {
                     <StatusBadge tone={toStatusTone(row.status)} compact>
                       {row.status}
                     </StatusBadge>
+                    {row.status === 'needs_reauth' ? (
+                      <>
+                        <br />
+                        <span className="text-muted">Cannot issue until reconnected</span>
+                      </>
+                    ) : null}
                   </td>
                   <td>
                     <StatusBadge tone="neutral" compact>
@@ -204,6 +216,12 @@ export function SalesDocumentsPanel(): ReactElement {
                         ))}
                       </Select>
                     </ReadOnlyLock>
+                    {row.documentKind === null ? (
+                      <>
+                        <br />
+                        <span className="text-muted">Not a routing candidate</span>
+                      </>
+                    ) : null}
                   </td>
                   <td>
                     <ReadOnlyLock active={write.demoReadOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
@@ -243,9 +261,8 @@ export function SalesDocumentsPanel(): ReactElement {
         </table>
       </div>
       <p className="muted-text">
-        One radio group across ALL rows, regardless of capability — decision 3a (ADR-041) is
-        singular: invoice XOR receipt, never both. Trigger is greyed out for a non-primary row
-        since the timing choice does not matter until a connection is actually the one issuing.
+        Trigger is greyed out for a non-primary row since the timing choice does not matter until
+        a connection is actually the one issuing.
       </p>
     </div>
   );

--- a/apps/web/src/features/sales-documents/components/sales-documents-panel.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-documents-panel.tsx
@@ -192,7 +192,7 @@ export function SalesDocumentsPanel(): ReactElement {
                     {row.status === 'needs_reauth' ? (
                       <>
                         <br />
-                        <span className="text-muted">Cannot issue until reconnected</span>
+                        <span className="muted-text">Cannot issue until reconnected</span>
                       </>
                     ) : null}
                   </td>
@@ -219,7 +219,7 @@ export function SalesDocumentsPanel(): ReactElement {
                     {row.documentKind === null ? (
                       <>
                         <br />
-                        <span className="text-muted">Not a routing candidate</span>
+                        <span className="muted-text">Not a routing candidate</span>
                       </>
                     ) : null}
                   </td>

--- a/apps/web/src/features/sales-documents/components/sales-documents-panel.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-documents-panel.tsx
@@ -183,17 +183,14 @@ export function SalesDocumentsPanel(): ReactElement {
                   <td>
                     <span>{row.name}</span>
                     <br />
-                    <span className="text-muted mono-text">{row.platformType}</span>
+                    <span className="muted-text mono-text">{row.platformType}</span>
                   </td>
                   <td>
                     <StatusBadge tone={toStatusTone(row.status)} compact>
                       {row.status}
                     </StatusBadge>
                     {row.status === 'needs_reauth' ? (
-                      <>
-                        <br />
-                        <span className="muted-text">Cannot issue until reconnected</span>
-                      </>
+                      <div className="muted-text">Cannot issue until reconnected</div>
                     ) : null}
                   </td>
                   <td>
@@ -217,10 +214,7 @@ export function SalesDocumentsPanel(): ReactElement {
                       </Select>
                     </ReadOnlyLock>
                     {row.documentKind === null ? (
-                      <>
-                        <br />
-                        <span className="muted-text">Not a routing candidate</span>
-                      </>
+                      <div className="muted-text">Not a routing candidate</div>
                     ) : null}
                   </td>
                   <td>
@@ -234,7 +228,7 @@ export function SalesDocumentsPanel(): ReactElement {
                           onChange={() => handleSelectPrimary(row)}
                           aria-label={`Mark ${row.name} as the primary sales-document connection`}
                         />
-                        <span className="text-muted">{row.isPrimary ? 'Primary' : '—'}</span>
+                        <span className="muted-text">{row.isPrimary ? 'Primary' : '—'}</span>
                       </label>
                     </ReadOnlyLock>
                   </td>

--- a/apps/web/src/features/sales-documents/lib/describe-sales-document-tax-id-coverage.test.ts
+++ b/apps/web/src/features/sales-documents/lib/describe-sales-document-tax-id-coverage.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import type { SalesDocumentRule } from '../api/sales-document-rules.types';
+import {
+  countRulesUsingBuyerTaxId,
+  usesBuyerTaxIdCondition,
+} from './describe-sales-document-tax-id-coverage';
+
+function makeRule(overrides: Partial<SalesDocumentRule> = {}): SalesDocumentRule {
+  return {
+    id: 'r1',
+    country: 'PL',
+    conditions: [],
+    documentKind: 'invoice',
+    connectionId: 'conn_1',
+    effectiveFrom: '2026-01-01T00:00:00.000Z',
+    effectiveTo: null,
+    provenance: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('usesBuyerTaxIdCondition', () => {
+  it('should return true when a rule carries a buyerHasTaxId condition', () => {
+    const rule = makeRule({
+      conditions: [{ field: 'buyerHasTaxId', op: 'eq', boolValue: false }],
+    });
+
+    expect(usesBuyerTaxIdCondition(rule)).toBe(true);
+  });
+
+  it('should return false when a rule carries only other condition kinds', () => {
+    const rule = makeRule({
+      conditions: [{ field: 'orderCountry', op: 'eq', stringValue: 'PL' }],
+    });
+
+    expect(usesBuyerTaxIdCondition(rule)).toBe(false);
+  });
+
+  it('should return false for a rule with no conditions', () => {
+    expect(usesBuyerTaxIdCondition(makeRule({ conditions: [] }))).toBe(false);
+  });
+});
+
+describe('countRulesUsingBuyerTaxId', () => {
+  it('should count only the rules carrying a buyerHasTaxId condition', () => {
+    const rules = [
+      makeRule({ id: 'r1', conditions: [{ field: 'buyerHasTaxId', op: 'eq', boolValue: true }] }),
+      makeRule({ id: 'r2', conditions: [{ field: 'orderCountry', op: 'eq', stringValue: 'PL' }] }),
+      makeRule({ id: 'r3', conditions: [{ field: 'buyerHasTaxId', op: 'eq', boolValue: false }] }),
+    ];
+
+    expect(countRulesUsingBuyerTaxId(rules)).toBe(2);
+  });
+
+  it('should return 0 when no rules use the condition', () => {
+    expect(countRulesUsingBuyerTaxId([makeRule()])).toBe(0);
+  });
+});

--- a/apps/web/src/features/sales-documents/lib/describe-sales-document-tax-id-coverage.ts
+++ b/apps/web/src/features/sales-documents/lib/describe-sales-document-tax-id-coverage.ts
@@ -28,3 +28,7 @@ export function usesBuyerTaxIdCondition(rule: SalesDocumentRule): boolean {
 export function countRulesUsingBuyerTaxId(rules: readonly SalesDocumentRule[]): number {
   return rules.filter(usesBuyerTaxIdCondition).length;
 }
+
+export function describeBuyerTaxIdRuleCount(count: number): string {
+  return count === 1 ? "1 rule reads the buyer's tax ID" : `${count} rules read the buyer's tax ID`;
+}

--- a/apps/web/src/features/sales-documents/lib/describe-sales-document-tax-id-coverage.ts
+++ b/apps/web/src/features/sales-documents/lib/describe-sales-document-tax-id-coverage.ts
@@ -1,0 +1,30 @@
+/**
+ * Buyer-tax-id rule coverage (#2546)
+ *
+ * A `buyerHasTaxId` condition is evaluated against `Order.buyerTaxId` — as of
+ * #2599 that field is real, but it is populated only by sources that report
+ * it. Today that is PrestaShop alone (`ps_address.vat_number`); Allegro's own
+ * checkout-form invoice block carries a company tax id OL's
+ * `AllegroCheckoutForm` type does not model, and WooCommerce's `billing`
+ * block has no tax field at all (see `order-to-sales-document-order-facts.mapper.ts`
+ * and `evaluateSalesDocumentRules`'s own doc comment).
+ *
+ * This is deliberately NOT "this rule can never match" — that claim was true
+ * before #2599 and is false now. A `buyerHasTaxId` rule is fully live for a
+ * PrestaShop-sourced order and simply unreachable for an order whose source
+ * never asserts the fact. Both counts are reported so the operator can judge
+ * whether the gap matters for their own connection mix, rather than being
+ * told a flat "N rules are dead" that would be wrong the moment a PrestaShop
+ * order arrives.
+ *
+ * @module apps/web/src/features/sales-documents/lib
+ */
+import type { SalesDocumentRule } from '../api/sales-document-rules.types';
+
+export function usesBuyerTaxIdCondition(rule: SalesDocumentRule): boolean {
+  return rule.conditions.some((condition) => condition.field === 'buyerHasTaxId');
+}
+
+export function countRulesUsingBuyerTaxId(rules: readonly SalesDocumentRule[]): number {
+  return rules.filter(usesBuyerTaxIdCondition).length;
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -3673,6 +3673,20 @@ a.delivery-rider-banner__button:focus-visible {
   gap: var(--space-5);
 }
 
+.sales-document-country-routing-dialog__save-note {
+  margin: calc(-1 * var(--space-2)) 0 0;
+}
+
+/* Reset lives in its own zone below the tiers, never beside the footer's
+   primary "Done" action (#2549) — a destructive control next to the ordinary
+   close action reads as a choice between two equally weighted buttons. */
+.sales-document-country-routing-dialog__danger-zone {
+  display: grid;
+  gap: var(--space-2);
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--border-subtle);
+}
+
 .trigger-sync-dialog__description {
   margin: 0;
 }

--- a/apps/web/src/pages/settings/sales-documents-page.tsx
+++ b/apps/web/src/pages/settings/sales-documents-page.tsx
@@ -34,16 +34,19 @@ export function SalesDocumentsPage(): ReactElement {
       description="Choose what each connected provider issues, and which one issues first. OpenLinker never decides which document an order legally needs."
       backTo={{ to: '/settings', label: 'Settings' }}
     >
-      <SalesDocumentsPanel />
       {/*
-       * #2170 — the country-agnostic rule engine, rendered alongside the
-       * #2156 operator-configured table above rather than replacing it:
-       * `AutoIssueTriggerService` still resolves via that table today, so
-       * removing it would leave operators unable to configure what
-       * actually auto-issues. See `SalesDocumentRuleEnginePanel`'s own doc
-       * comment.
+       * #2170 — the country-agnostic rule engine is the page's primary
+       * authoring surface (M7 / #2550): it runs FIRST and consults
+       * `evaluateSalesDocumentRules` before the #2156 operator-configured
+       * table below ever applies. The table is demoted below it, not
+       * stripped — it is the only place document kind, "goes first" and
+       * the trigger are set at all, and a connection with nothing set
+       * there is not a routing candidate for the rule engine either. See
+       * `SalesDocumentRuleEnginePanel`'s own doc comment for the full
+       * precedence.
        */}
       <SalesDocumentRuleEnginePanel />
+      <SalesDocumentsPanel />
     </PageLayout>
   );
 }


### PR DESCRIPTION
## Summary

M7 of the sales-document routing-first UX epic (#2513): the authoring half of the settings page (#2544). Independent of PR #2746 (M6) - both branch from `epic/sales-documents-ux` and target `main` directly.

- Routing dialog: explicit "Done" close action, a "saves as you go" note, and per-control pending/error state on rule delete and default upsert, which previously failed silently (#2545)
- Rules section: states the real evaluator rule - exactly one match wins, no priority, a tie holds the order - and flags rules that read the buyer's tax ID, since that condition is live for a PrestaShop-sourced order and unreachable for Allegro/WooCommerce (#2599 made the field real for PrestaShop only) (#2546)
- Defaults: corrected the two-defaults warning to state the real mechanism (the default tier is skipped entirely when both are set, not "decided by some other rule") (#2547)
- Fall-through: the copy is now conditional on whether the country itself is configured - a configured country's unmatched order is held, never passed to Rest of world; only a country with no rules and no default at all falls through (#2548)
- Reset: gated by write-access visibility, so an unauthorized session sees no reset control at all rather than a disabled one (#2549)
- Providers table: corrected two false claims ("one radio group across all rows" when the primary selector is per-connection state, and a blanket capability statement), added `needs_reauth` and unset-row copy, and demoted the table below the rule-engine panel, which is now the page's primary authoring surface (#2550)

## Test plan
- [ ] `pnpm lint && pnpm type-check`
- [ ] `pnpm --filter @openlinker/web test`

🤖 Generated with Claude Code
