### PR TITLE
feat(orders): the document line inside the money cluster (#2552)

### DIFF
--- a/apps/web/src/features/orders/api/orders.types.ts
+++ b/apps/web/src/features/orders/api/orders.types.ts
@@ -103,6 +103,101 @@ export const SalesDocumentUnresolvedReasonValues = [
 export type SalesDocumentUnresolvedReasonValue =
   (typeof SalesDocumentUnresolvedReasonValues)[number];
 
+// ── Sales-document view (#2516/#2552, ADR-065) ──────────────────────────────
+// Hand-mirrored from `SalesDocumentView` (`@openlinker/core/sales-documents`)
+// and `SalesDocumentViewResponseDto`
+// (`apps/api/src/orders/http/dto/sales-document-view-response.dto.ts`), which
+// `GET /orders` batches onto every row (`OrderRecord.salesDocument` below) so
+// the money-cluster document line and its popover never issue a second
+// request. This is the SAME projection the order-detail panel and the
+// settings page's per-market evidence read (ADR-065) — one shape, three
+// renderers.
+//
+// Two rules travel from the DTO's own doc comment; a surface that forgets
+// them repeats a defect this epic has already shipped fixes for:
+//
+// 1. A fiscal receipt has no authority axis — `SalesDocumentReceiptView`
+//    carries no regulatory field at all, a discriminated union on `kind`
+//    rather than an optional field, so the missing axis is unrepresentable.
+// 2. `blockReason` / `unresolvedReason` / `blockDetail` are the PERSISTED
+//    reasons, verbatim — a surface renders the stored value through
+//    `resolveSalesDocumentReasonCopy` or renders nothing.
+
+/** Identity fields a surface renders for a document, whichever kind it is. */
+export interface SalesDocumentIdentity {
+  readonly recordId: string;
+  readonly connectionId: string;
+  /** `null` when the record exists but no provider has resolved onto it yet. */
+  readonly providerType: string | null;
+  /** `null` means no number has been assigned yet — never "this regime has none". */
+  readonly documentNumber: string | null;
+  readonly createdAt: string;
+  /** `null` while the document is still pending, in flight, or failed. */
+  readonly completedAt: string | null;
+  /** `null` means no in-flight claim is held. */
+  readonly inFlightUntil: string | null;
+}
+
+/** An invoice, on both its axes: issuance (`status`) and clearance (`regulatoryStatus`). */
+export interface SalesDocumentInvoiceView {
+  readonly kind: 'invoice';
+  readonly documentType: string;
+  readonly status: 'pending' | 'issued' | 'issuing' | 'failed';
+  readonly failureMode: 'rejected' | 'in-doubt' | null;
+  readonly failureCode: string | null;
+  readonly failureReason: string | null;
+  readonly regulatoryStatus:
+    | 'not-applicable'
+    | 'pending-submission'
+    | 'submitted'
+    | 'cleared'
+    | 'accepted'
+    | 'rejected';
+  readonly clearanceReference: string | null;
+  readonly identity: SalesDocumentIdentity;
+}
+
+/** A fiscal receipt, on its ONE axis — no clearance/authority field exists (ADR-042). */
+export interface SalesDocumentReceiptView {
+  readonly kind: 'fiscal-receipt';
+  readonly status: 'pending' | 'registering' | 'registered' | 'failed';
+  readonly failureMode: 'rejected' | 'in-doubt' | null;
+  readonly failureReason: string | null;
+  /** `0` on a `registered` row is a SUCCESS — a pure reporting regime returns no artefact. */
+  readonly artefactCount: number;
+  readonly identity: SalesDocumentIdentity;
+}
+
+export type SalesDocumentRecordView = SalesDocumentInvoiceView | SalesDocumentReceiptView;
+
+/** A record held for the same order on ANOTHER connection — reported, never hidden. */
+export interface SalesDocumentOtherRecord {
+  readonly recordId: string;
+  readonly connectionId: string;
+  readonly kind: string;
+  readonly blocksFurtherIssuance: boolean;
+}
+
+/** Everything a surface needs about one order's sales document (ADR-065). */
+export interface SalesDocumentView {
+  readonly orderId: string;
+  /**
+   * Open-world (unlike `document.kind`, which is closed on the two kinds this
+   * projection knows how to render). `null` means routing has NOT decided —
+   * never a fallback guess from the order's own country.
+   */
+  readonly documentKind: string | null;
+  /** `null` when none exists yet — an ordinary state alongside a non-null `documentKind`. */
+  readonly document: SalesDocumentRecordView | null;
+  /** The PERSISTED gate reason, verbatim. `null` means no block on the gate's last run. */
+  readonly blockReason: SalesDocumentGateBlockReasonValue | null;
+  /** Non-null only alongside `blockReason === 'unresolved-routing'` (ADR-041 §107). */
+  readonly unresolvedReason: SalesDocumentUnresolvedReasonValue | null;
+  /** Free-text elaboration the gate stored; never parsed, only displayed. */
+  readonly blockDetail: string | null;
+  readonly otherRecords: readonly SalesDocumentOtherRecord[];
+}
+
 // ── Mapping-aware delivery (epic #1776) ─────────────────────────────────────
 // Hand-mirrored from the BE order response DTOs (`OrderDeliveryResolutionDto`
 // #1791, `OrderDeliveryRiderDto` #1792) and the `@openlinker/core/mappings`
@@ -238,6 +333,13 @@ export interface OrderRecord {
   salesDocumentBlockedAt?: string | null;
   /** When the current hold ended (ISO 8601), cleared when a new one starts. */
   salesDocumentBlockReleasedAt?: string | null;
+  /**
+   * The batched per-order sales-document projection (#2516/#2552, ADR-065).
+   * Absent when the row predates this field or the batch read found nothing
+   * to attach — a surface must render the same "no document" state it already
+   * does for `documentKind: null`, never treat absence as an error.
+   */
+  salesDocument?: SalesDocumentView;
 }
 
 // Result ordering for the orders list (#927, extended #944). Mirrors

--- a/apps/web/src/features/orders/components/sales-document-cell.test.tsx
+++ b/apps/web/src/features/orders/components/sales-document-cell.test.tsx
@@ -1,0 +1,203 @@
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import { SalesDocumentCell } from './sales-document-cell';
+import type { SalesDocumentView } from '../api/orders.types';
+
+function baseView(over: Partial<SalesDocumentView> = {}): SalesDocumentView {
+  return {
+    orderId: 'ol_order_1',
+    documentKind: null,
+    document: null,
+    blockReason: null,
+    unresolvedReason: null,
+    blockDetail: null,
+    otherRecords: [],
+    ...over,
+  };
+}
+
+function renderCell(props: Partial<Parameters<typeof SalesDocumentCell>[0]> = {}) {
+  return render(
+    <MemoryRouter>
+      <SalesDocumentCell
+        internalOrderId="ol_order_1"
+        view={undefined}
+        layout="stack"
+        hasIssuingCapability
+        {...props}
+      />
+    </MemoryRouter>,
+  );
+}
+
+describe('SalesDocumentCell (#2552/#2553)', () => {
+  it('renders exactly one line for a row with no routed document', () => {
+    renderCell();
+    expect(screen.getByText('No routing')).toBeInTheDocument();
+  });
+
+  it('renders the tick for a finished (done) document, plain ink', () => {
+    const { container } = renderCell({
+      view: baseView({
+        documentKind: 'invoice',
+        document: {
+          kind: 'invoice',
+          documentType: 'vat',
+          status: 'issued',
+          failureMode: null,
+          failureCode: null,
+          failureReason: null,
+          regulatoryStatus: 'accepted',
+          clearanceReference: null,
+          identity: {
+            recordId: 'r1',
+            connectionId: 'c1',
+            providerType: null,
+            documentNumber: null,
+            createdAt: '2026-01-01T00:00:00.000Z',
+            completedAt: '2026-01-01T00:05:00.000Z',
+            inFlightUntil: null,
+          },
+        },
+      }),
+    });
+    expect(screen.getByText('Issued')).toBeInTheDocument();
+    expect(container.querySelector('.sales-doc__tick')).toBeInTheDocument();
+    expect(container.querySelector('.sales-doc--done')).toBeInTheDocument();
+    expect(container.querySelector('.sales-doc--error')).not.toBeInTheDocument();
+  });
+
+  it('shows a duplicate count badge when other records exist', () => {
+    renderCell({
+      view: baseView({
+        documentKind: 'invoice',
+        otherRecords: [{ recordId: 'r2', connectionId: 'c2', kind: 'invoice', blocksFurtherIssuance: true }],
+      }),
+    });
+    expect(screen.getByTitle('A second document exists for this order')).toBeInTheDocument();
+  });
+
+  it('renders an attention tone for an authority-rejected invoice', () => {
+    const { container } = renderCell({
+      view: baseView({
+        documentKind: 'invoice',
+        document: {
+          kind: 'invoice',
+          documentType: 'vat',
+          status: 'issued',
+          failureMode: null,
+          failureCode: null,
+          failureReason: null,
+          regulatoryStatus: 'rejected',
+          clearanceReference: null,
+          identity: {
+            recordId: 'r1',
+            connectionId: 'c1',
+            providerType: null,
+            documentNumber: null,
+            createdAt: '2026-01-01T00:00:00.000Z',
+            completedAt: null,
+            inFlightUntil: null,
+          },
+        },
+      }),
+    });
+    expect(screen.getByText('Authority rejected')).toBeInTheDocument();
+    expect(container.querySelector('.sales-doc--error')).toBeInTheDocument();
+  });
+
+  describe('popover (#2553)', () => {
+    it('opens the popover on click and shows the persisted reason', async () => {
+      const user = userEvent.setup();
+      renderCell({
+        view: baseView({
+          documentKind: 'invoice',
+          blockReason: 'unresolved-routing',
+          unresolvedReason: 'ambiguous-connection-no-primary',
+        }),
+      });
+
+      await user.click(screen.getByRole('button', { name: /invoice: two setups apply/i }));
+
+      expect(
+        screen.getByText(
+          /more than one setup could issue this document/i,
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it('offers the action when the state keeps it and a connection can issue', async () => {
+      const user = userEvent.setup();
+      renderCell({
+        view: baseView({ documentKind: 'invoice' }),
+        hasIssuingCapability: true,
+      });
+
+      await user.click(screen.getByRole('button', { name: /invoice: not issued/i }));
+
+      expect(screen.getByRole('link', { name: /issue invoice/i })).toHaveAttribute(
+        'href',
+        '/orders/ol_order_1#invoicing',
+      );
+    });
+
+    it('withholds the action when no connection can issue', async () => {
+      const user = userEvent.setup();
+      renderCell({
+        view: baseView({ documentKind: 'invoice' }),
+        hasIssuingCapability: false,
+      });
+
+      await user.click(screen.getByRole('button', { name: /invoice: not issued/i }));
+
+      expect(screen.queryByRole('link', { name: /issue invoice/i })).not.toBeInTheDocument();
+    });
+
+    it('offers "Set routing" instead of an issuing action when nothing is routed', async () => {
+      const user = userEvent.setup();
+      renderCell({ view: baseView() });
+
+      await user.click(screen.getByRole('button', { name: /no document: no routing/i }));
+
+      expect(screen.getByRole('link', { name: /set routing/i })).toHaveAttribute(
+        'href',
+        '/settings/sales-documents',
+      );
+    });
+
+    it('warns when another connection holds a document for the same order', async () => {
+      const user = userEvent.setup();
+      renderCell({
+        view: baseView({
+          documentKind: 'invoice',
+          document: {
+            kind: 'invoice',
+            documentType: 'vat',
+            status: 'issued',
+            failureMode: null,
+            failureCode: null,
+            failureReason: null,
+            regulatoryStatus: 'accepted',
+            clearanceReference: null,
+            identity: {
+              recordId: 'r1',
+              connectionId: 'c1',
+              providerType: null,
+              documentNumber: null,
+              createdAt: '2026-01-01T00:00:00.000Z',
+              completedAt: null,
+              inFlightUntil: null,
+            },
+          },
+          otherRecords: [{ recordId: 'r2', connectionId: 'conn_other', kind: 'invoice', blocksFurtherIssuance: true }],
+        }),
+      });
+
+      await user.click(screen.getByRole('button', { name: /invoice: issued/i }));
+
+      expect(screen.getByText(/also holds a document for this sale/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/features/orders/components/sales-document-cell.tsx
+++ b/apps/web/src/features/orders/components/sales-document-cell.tsx
@@ -1,0 +1,253 @@
+/**
+ * Sales-Document Cell (#2552/#2553, ADR-065)
+ *
+ * The line inside the money cluster where a hardcoded `+ Issue invoice`
+ * button used to sit (`OrderInvoicingCell`, retired by this component). One
+ * line at any state: a kind glyph, one word for the most actionable fact, a
+ * tick when finished, a quiet pulsing dot while in flight, and a count badge
+ * when a second record exists for the order. Clicking it opens a popover with
+ * the identity facts, the persisted reason, a duplicate warning, and the
+ * available action.
+ *
+ * Colour marks exceptions only (mini-epic #2551 acceptance criteria) — a
+ * finished document renders in the same ink as an in-flight one; only a
+ * `warning` / `error` tone tints the line. The word itself carries the
+ * actionable fact (`resolveSalesDocumentCellState`), so colour is never the
+ * only signal.
+ *
+ * The popover reuses the M5 `Popover` primitive (`shared/ui/popover.tsx`),
+ * which renders into a portal at the document root specifically so a
+ * cell-anchored panel is never clipped by the table's `overflow-x: auto`
+ * container (#2553 acceptance criteria) — no positioning code lives here.
+ * `dismissOnViewportChange` is on: the row this popover describes is no
+ * longer where the operator is looking once the table scrolls.
+ *
+ * Shared verbatim between the desktop cell and the mobile card, the same
+ * discipline `OrderInvoicingCell` established, so the two cannot drift.
+ *
+ * @module apps/web/src/features/orders/components
+ */
+import type { ReactNode } from 'react';
+import { Link } from 'react-router-dom';
+import { Popover, PopoverContent, PopoverTrigger } from '../../../shared/ui/popover';
+import { resolveSalesDocumentCellState } from '../lib/sales-document-cell-state';
+import type { SalesDocumentView } from '../api/orders.types';
+
+export interface SalesDocumentCellProps {
+  internalOrderId: string;
+  /** `undefined` (row predates this field or the batch found nothing) and a
+   *  null `documentKind` inside it render identically — see the resolver. */
+  view: SalesDocumentView | undefined;
+  /**
+   * `stack` lets the parent's `orders-cell-stack` lay the money-cluster lines
+   * out vertically (desktop); `row` wraps the line so a mobile `<dd>` still
+   * receives a single child. Layout only.
+   */
+  layout: 'stack' | 'row';
+  /**
+   * Whether ANY connection exposes the capability this order's kind needs.
+   * When none does, the action is withheld — offering it would dead-end the
+   * same way the retired `OrderInvoicingCell`'s CTA did (#1713).
+   */
+  hasIssuingCapability: boolean;
+}
+
+function InvoiceGlyph(): ReactNode {
+  return (
+    <svg className="sales-doc__glyph" viewBox="0 0 16 16" width="14" height="14" aria-hidden="true">
+      <path
+        d="M3.5 1.5h6l3 3v10h-9z"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.3"
+        strokeLinejoin="round"
+      />
+      <path d="M9.5 1.5v3h3" fill="none" stroke="currentColor" strokeWidth="1.3" strokeLinejoin="round" />
+      <path d="M5.5 8h5M5.5 10.5h5" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function ReceiptGlyph(): ReactNode {
+  return (
+    <svg className="sales-doc__glyph" viewBox="0 0 16 16" width="14" height="14" aria-hidden="true">
+      <path
+        d="M3.5 1.5h9v13l-1.5-1-1.5 1-1.5-1-1.5 1-1.5-1-1.5 1z"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.3"
+        strokeLinejoin="round"
+      />
+      <path d="M6 5.5h4M6 8.5h4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function NoDocumentGlyph(): ReactNode {
+  return (
+    <svg className="sales-doc__glyph" viewBox="0 0 16 16" width="14" height="14" aria-hidden="true">
+      <circle cx="8" cy="8" r="6.2" fill="none" stroke="currentColor" strokeWidth="1.3" />
+      <path d="M4.4 11.6 11.6 4.4" stroke="currentColor" strokeWidth="1.3" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function DocumentGlyph({ kind }: { kind: string | null }): ReactNode {
+  if (kind === 'invoice') return <InvoiceGlyph />;
+  if (kind === 'fiscal-receipt') return <ReceiptGlyph />;
+  return <NoDocumentGlyph />;
+}
+
+function TickIcon(): ReactNode {
+  return (
+    <svg className="sales-doc__tick" viewBox="0 0 12 12" width="12" height="12" aria-hidden="true">
+      <path
+        d="M2.5 6.4 4.7 8.6 9.5 3.8"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+/** Human-readable kind label — never a platform/provider name (that lives on `providerType`). */
+const KIND_LABEL: Record<string, string> = {
+  invoice: 'Invoice',
+  'fiscal-receipt': 'Fiscal receipt',
+};
+
+/** The action's own label, distinct per kind (mirrors the mockup's `c` map). */
+const ACTION_LABEL: Record<string, string> = {
+  invoice: 'Issue invoice',
+  'fiscal-receipt': 'Register receipt',
+};
+
+const REGULATORY_TONE: Record<string, 'success' | 'info' | 'error' | 'neutral'> = {
+  accepted: 'success',
+  cleared: 'success',
+  submitted: 'info',
+  'pending-submission': 'info',
+  rejected: 'error',
+  'not-applicable': 'neutral',
+};
+
+const REGULATORY_LABEL: Record<string, string> = {
+  accepted: 'Accepted',
+  cleared: 'Clearing',
+  submitted: 'Submitted',
+  'pending-submission': 'Awaiting submission',
+  rejected: 'Rejected',
+  'not-applicable': 'N/A',
+};
+
+function Fact({ label, children }: { label: string; children: ReactNode }): ReactNode {
+  return (
+    <div className="sales-doc-fact">
+      <span className="sales-doc-fact__label">{label}</span>
+      <span className="sales-doc-fact__value">{children}</span>
+    </div>
+  );
+}
+
+export function SalesDocumentCell({
+  internalOrderId,
+  view,
+  layout,
+  hasIssuingCapability,
+}: SalesDocumentCellProps): ReactNode {
+  const state = resolveSalesDocumentCellState(view);
+  const otherRecords = view?.otherRecords ?? [];
+  const dupeCount = otherRecords.length;
+  const kindLabel = state.kind ? (KIND_LABEL[state.kind] ?? state.kind) : 'No document';
+  // An action renders only when this order's kind still needs one AND some
+  // connection can issue it — offering a dead-end action is worse than none.
+  const showAction = state.keepsAction && state.kind !== null && hasIssuingCapability;
+  const actionLabel = state.kind ? (ACTION_LABEL[state.kind] ?? 'Open') : null;
+
+  const line = (
+    <span className={`sales-doc sales-doc--${state.tone}`}>
+      <span className="sr-only">{kindLabel}: </span>
+      <DocumentGlyph kind={state.kind} />
+      <span className="sales-doc__word">{state.word}</span>
+      {state.tone === 'done' ? <TickIcon /> : null}
+      {state.tone === 'progress' ? <span className="sales-doc__live" aria-hidden="true" /> : null}
+      {dupeCount > 0 ? (
+        <span className="sales-doc__dupe" title="A second document exists for this order">
+          <span className="sr-only">A second document exists for this order</span>
+          {dupeCount + 1}
+        </span>
+      ) : null}
+    </span>
+  );
+
+  const identity = view?.document?.identity ?? null;
+  const regulatoryStatus =
+    view?.document?.kind === 'invoice' ? view.document.regulatoryStatus : null;
+
+  const popoverBody = (
+    <>
+      {state.reasonDetail ? <p className="sales-doc-popover__why">{state.reasonDetail}</p> : null}
+      {identity?.documentNumber ? <Fact label="Number">{identity.documentNumber}</Fact> : null}
+      {identity?.connectionId ? <Fact label="Provider">{identity.providerType ?? identity.connectionId}</Fact> : null}
+      {regulatoryStatus ? (
+        <Fact label="Authority">
+          <span className={`sales-doc-tone sales-doc-tone--${REGULATORY_TONE[regulatoryStatus] ?? 'neutral'}`}>
+            {REGULATORY_LABEL[regulatoryStatus] ?? regulatoryStatus}
+          </span>
+        </Fact>
+      ) : null}
+      {dupeCount > 0 ? (
+        <p className="sales-doc-popover__warn">
+          {otherRecords.map((r) => r.connectionId).join(', ')} also holds a document for this
+          sale. One sale should have one document.
+        </p>
+      ) : null}
+    </>
+  );
+
+  return (
+    <Popover dismissOnViewportChange>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="sales-doc-trigger"
+          aria-label={`${kindLabel}: ${state.word}`}
+        >
+          {line}
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start" style={layout === 'row' ? { maxWidth: '20rem' } : { width: '20rem' }}>
+        <div className="sales-doc-popover__head">
+          <span className={`sales-doc sales-doc--${state.tone}`}>
+            <DocumentGlyph kind={state.kind} />
+            <span className="sales-doc__word">
+              {kindLabel} · {state.word}
+            </span>
+          </span>
+        </div>
+        <div className="sales-doc-popover__body">{popoverBody}</div>
+        <div className="sales-doc-popover__foot">
+          <Link className="orders-row-cta" to={`/orders/${internalOrderId}#invoicing`}>
+            Open order
+          </Link>
+          {showAction && actionLabel ? (
+            <Link className="orders-row-cta" to={`/orders/${internalOrderId}#invoicing`}>
+              <span className="orders-row-cta__plus" aria-hidden="true">
+                +
+              </span>{' '}
+              {actionLabel}
+            </Link>
+          ) : null}
+          {state.kind === null ? (
+            <Link className="orders-row-cta" to="/settings/sales-documents">
+              Set routing
+            </Link>
+          ) : null}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/src/features/orders/lib/sales-document-cell-state.test.ts
+++ b/apps/web/src/features/orders/lib/sales-document-cell-state.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest';
+import { resolveSalesDocumentCellState } from './sales-document-cell-state';
+import type { SalesDocumentIdentity, SalesDocumentView } from '../api/orders.types';
+
+function identity(): SalesDocumentIdentity {
+  return {
+    recordId: 'rec-1',
+    connectionId: 'conn-1',
+    providerType: 'ksef',
+    documentNumber: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    completedAt: null,
+    inFlightUntil: null,
+  };
+}
+
+function baseView(over: Partial<SalesDocumentView> = {}): SalesDocumentView {
+  return {
+    orderId: 'ol_order_1',
+    documentKind: null,
+    document: null,
+    blockReason: null,
+    unresolvedReason: null,
+    blockDetail: null,
+    otherRecords: [],
+    ...over,
+  };
+}
+
+describe('resolveSalesDocumentCellState (#2552)', () => {
+  it('reports "No routing" when the row carries no view at all', () => {
+    const state = resolveSalesDocumentCellState(undefined);
+    expect(state).toMatchObject({ kind: null, word: 'No routing', tone: 'error', attention: true });
+  });
+
+  it('reports "No routing" when documentKind is null', () => {
+    const state = resolveSalesDocumentCellState(baseView());
+    expect(state).toMatchObject({ kind: null, word: 'No routing', tone: 'error', attention: true });
+  });
+
+  it('renders "Issue on request" (idle, no attention) for trigger-model-manual with no document yet', () => {
+    const state = resolveSalesDocumentCellState(
+      baseView({ documentKind: 'invoice', blockReason: 'trigger-model-manual' }),
+    );
+    expect(state.attention).toBe(false);
+    expect(state.keepsAction).toBe(true);
+    expect(state.tone).toBe('idle');
+  });
+
+  it('renders the gate reason copy for a genuinely blocked order', () => {
+    const state = resolveSalesDocumentCellState(
+      baseView({ documentKind: 'invoice', blockReason: 'unresolved-routing', unresolvedReason: 'no-matching-rule' }),
+    );
+    expect(state.attention).toBe(true);
+    expect(state.word).toBe('No rule matched');
+  });
+
+  it('renders "Not issued" when routing decided but nothing blocks and nothing was attempted', () => {
+    const state = resolveSalesDocumentCellState(baseView({ documentKind: 'invoice' }));
+    expect(state).toMatchObject({ word: 'Not issued', tone: 'idle', attention: true, keepsAction: true });
+  });
+
+  it('prefers the authority answer over issuance when an invoice was rejected by the authority', () => {
+    const state = resolveSalesDocumentCellState(
+      baseView({
+        documentKind: 'invoice',
+        document: {
+          kind: 'invoice',
+          documentType: 'vat',
+          status: 'issued',
+          failureMode: null,
+          failureCode: null,
+          failureReason: null,
+          regulatoryStatus: 'rejected',
+          clearanceReference: null,
+          identity: identity(),
+        },
+      }),
+    );
+    expect(state).toMatchObject({ word: 'Authority rejected', tone: 'error', attention: true });
+  });
+
+  it('reports "Issued" for a fully cleared invoice, plain ink (done)', () => {
+    const state = resolveSalesDocumentCellState(
+      baseView({
+        documentKind: 'invoice',
+        document: {
+          kind: 'invoice',
+          documentType: 'vat',
+          status: 'issued',
+          failureMode: null,
+          failureCode: null,
+          failureReason: null,
+          regulatoryStatus: 'accepted',
+          clearanceReference: 'ref-1',
+          identity: identity(),
+        },
+      }),
+    );
+    expect(state).toMatchObject({ word: 'Issued', tone: 'done', attention: false });
+  });
+
+  it('reports "Registered" for a completed fiscal receipt', () => {
+    const state = resolveSalesDocumentCellState(
+      baseView({
+        documentKind: 'fiscal-receipt',
+        document: {
+          kind: 'fiscal-receipt',
+          status: 'registered',
+          failureMode: null,
+          failureReason: null,
+          artefactCount: 1,
+          identity: identity(),
+        },
+      }),
+    );
+    expect(state).toMatchObject({ word: 'Registered', tone: 'done', attention: false });
+  });
+
+  it('reports "Rejected" for a terminally rejected fiscal registration', () => {
+    const state = resolveSalesDocumentCellState(
+      baseView({
+        documentKind: 'fiscal-receipt',
+        document: {
+          kind: 'fiscal-receipt',
+          status: 'failed',
+          failureMode: 'rejected',
+          failureReason: 'refused',
+          artefactCount: 0,
+          identity: identity(),
+        },
+      }),
+    );
+    expect(state).toMatchObject({ word: 'Rejected', tone: 'error', attention: true });
+  });
+
+  it('reports "Unconfirmed" for an in-doubt fiscal registration failure', () => {
+    const state = resolveSalesDocumentCellState(
+      baseView({
+        documentKind: 'fiscal-receipt',
+        document: {
+          kind: 'fiscal-receipt',
+          status: 'failed',
+          failureMode: 'in-doubt',
+          failureReason: 'poll timeout',
+          artefactCount: 0,
+          identity: identity(),
+        },
+      }),
+    );
+    expect(state).toMatchObject({ word: 'Unconfirmed', tone: 'warning', attention: true });
+  });
+});

--- a/apps/web/src/features/orders/lib/sales-document-cell-state.ts
+++ b/apps/web/src/features/orders/lib/sales-document-cell-state.ts
@@ -1,0 +1,157 @@
+/**
+ * Sales-Document Cell State (#2552, ADR-065)
+ *
+ * Pure derivation of the money-cluster document line's word + tone from the
+ * batched `SalesDocumentView` (#2516/#2552). Kept out of the component so the
+ * rule is unit-testable without rendering, and shared between the desktop
+ * cell and the mobile card the same way `order-row.ts`'s badge resolvers are.
+ *
+ * The word names the MOST ACTIONABLE fact, never merely the raw status — an
+ * invoice the authority rejected reads "Authority rejected", not "Issued"
+ * beside a red dot, because colour is never the only carrier of a thing
+ * needing work (mini-epic #2551 acceptance criteria).
+ *
+ * No platform name leaks into the word ("Authority rejected", not "KSeF
+ * rejected") — the vocabulary here is the SAME neutral one `libs/core`
+ * enforces for the wire shape; a specific authority's name belongs on the
+ * popover's identity facts (`providerType`), never on the row.
+ *
+ * @module apps/web/src/features/orders/lib
+ */
+import { resolveSalesDocumentReasonCopy } from '../../sales-documents';
+import type { SalesDocumentReasonTone } from '../../sales-documents';
+import type { SalesDocumentView } from '../api/orders.types';
+
+export type SalesDocumentCellTone = 'idle' | 'progress' | 'done' | 'warning' | 'error';
+
+export interface SalesDocumentCellState {
+  /** The routed kind, or `null` when routing has not decided (mirrors `view.documentKind`). */
+  readonly kind: string | null;
+  /** The single word rendered on the row. */
+  readonly word: string;
+  readonly tone: SalesDocumentCellTone;
+  /** Whether this state needs the operator's attention (drives the tint). */
+  readonly attention: boolean;
+  /** Long-form explanation for the popover, or `null` when there is nothing to add. */
+  readonly reasonDetail: string | null;
+  /**
+   * Whether an "Issue…" action should still be offered alongside this state.
+   * True for `trigger-model-manual` (issuing by hand IS the workflow) and for
+   * the ordinary "routing decided, nothing issued yet" state; false once a
+   * document exists or a non-actionable block holds it.
+   */
+  readonly keepsAction: boolean;
+}
+
+function toneFromReasonTone(tone: SalesDocumentReasonTone): SalesDocumentCellTone {
+  switch (tone) {
+    case 'error':
+      return 'error';
+    case 'warning':
+      return 'warning';
+    case 'info':
+      return 'idle';
+    case 'neutral':
+    default:
+      return 'idle';
+  }
+}
+
+/**
+ * Resolve the row's word/tone from one order's sales-document view.
+ *
+ * `undefined` covers a row the batched read found nothing for (an older
+ * payload, or genuinely no projection) — rendered identically to a `null`
+ * `documentKind`, since a surface cannot tell the two apart and must not
+ * assert one over the other.
+ */
+export function resolveSalesDocumentCellState(
+  view: SalesDocumentView | undefined,
+): SalesDocumentCellState {
+  if (!view || view.documentKind === null) {
+    const copy = view
+      ? resolveSalesDocumentReasonCopy(view.blockReason, view.unresolvedReason)
+      : null;
+    return {
+      kind: null,
+      word: 'No routing',
+      tone: 'error',
+      attention: true,
+      reasonDetail: copy?.detail ?? null,
+      keepsAction: false,
+    };
+  }
+
+  const { document, blockReason, unresolvedReason } = view;
+
+  if (!document) {
+    const copy = resolveSalesDocumentReasonCopy(blockReason, unresolvedReason);
+    if (!copy) {
+      return {
+        kind: view.documentKind,
+        word: 'Not issued',
+        tone: 'idle',
+        attention: true,
+        reasonDetail: null,
+        keepsAction: true,
+      };
+    }
+    return {
+      kind: view.documentKind,
+      word: copy.short,
+      tone: toneFromReasonTone(copy.tone),
+      // `neutral` is the one tone that does not need attention — it is
+      // `trigger-model-manual`'s tone, and issue-on-request is reported
+      // separately from anything needing attention (#2554).
+      attention: copy.tone !== 'neutral',
+      reasonDetail: copy.detail,
+      keepsAction: copy.keepsAction,
+    };
+  }
+
+  if (document.kind === 'fiscal-receipt') {
+    if (document.status === 'pending') return withDoc(view.documentKind, 'Queued', 'progress', false);
+    if (document.status === 'registering')
+      return withDoc(view.documentKind, 'Registering', 'progress', false);
+    if (document.status === 'registered')
+      return withDoc(view.documentKind, 'Registered', 'done', false);
+    if (document.status === 'failed') {
+      return document.failureMode === 'rejected'
+        ? withDoc(view.documentKind, 'Rejected', 'error', true)
+        : withDoc(view.documentKind, 'Unconfirmed', 'warning', true);
+    }
+    // A status this build does not recognise — a newer backend answering an
+    // FE compiled against an older union. Reported as needing a look rather
+    // than silently rendering nothing.
+    return withDoc(view.documentKind, 'Unrecognised status', 'warning', true);
+  }
+
+  // document.kind === 'invoice'. Clearance takes precedence over issuance —
+  // "issued, then rejected by the authority" is the state a flattened status
+  // could not express (ADR-065), and it is more actionable than "Issued".
+  if (document.regulatoryStatus === 'rejected') {
+    return withDoc(view.documentKind, 'Authority rejected', 'error', true);
+  }
+  if (document.regulatoryStatus === 'submitted' || document.regulatoryStatus === 'pending-submission') {
+    return withDoc(view.documentKind, 'At authority', 'progress', false);
+  }
+  if (document.status === 'issued') return withDoc(view.documentKind, 'Issued', 'done', false);
+  if (document.status === 'issuing' || document.status === 'pending')
+    return withDoc(view.documentKind, 'Issuing', 'progress', false);
+  if (document.status === 'failed') {
+    return document.failureMode === 'rejected'
+      ? withDoc(view.documentKind, 'Failed', 'error', true)
+      : withDoc(view.documentKind, 'Needs review', 'warning', true);
+  }
+  // A status this build does not recognise.
+  return withDoc(view.documentKind, 'Unrecognised status', 'warning', true);
+}
+
+function withDoc(
+  kind: string,
+  word: string,
+  tone: SalesDocumentCellTone,
+  attention: boolean,
+): SalesDocumentCellState {
+  return { kind, word, tone, attention, reasonDetail: null, keepsAction: false };
+}

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -9374,6 +9374,108 @@ a.kpi-card:focus-visible {
 .orders-row-cta:focus-visible { outline: none; box-shadow: var(--shadow-focus); }
 .orders-row-cta__plus { color: var(--text-muted); font-weight: 700; }
 
+/* ── Sales-document cell (#2552/#2553) ──────────────────────────────────
+   The line inside the money cluster where the CTA above used to sit. Colour
+   marks exceptions only: `--done`/`--progress` stay in secondary ink, `--idle`
+   (issue-on-request, or nothing routed yet with no attention) is muted, and
+   only `--warning`/`--error` pick up a status tint. */
+.sales-doc {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  max-width: 100%;
+  font-size: 0.8125rem;
+  font-weight: 500;
+}
+.sales-doc__glyph { flex: none; }
+.sales-doc__word { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.sales-doc--done,
+.sales-doc--progress { color: var(--text-secondary); }
+.sales-doc--idle { color: var(--text-muted); }
+.sales-doc--warning { color: var(--status-warning-fg); }
+.sales-doc--error { color: var(--status-error-fg); }
+.sales-doc__tick { color: var(--status-success); flex: none; }
+.sales-doc__live {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--status-info);
+  flex: none;
+  animation: sales-doc-pulse 1.6s ease-in-out infinite;
+}
+@keyframes sales-doc-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.35; }
+}
+@media (prefers-reduced-motion: reduce) {
+  .sales-doc__live { animation: none; }
+}
+.sales-doc__dupe {
+  display: inline-grid;
+  place-items: center;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: var(--radius-pill);
+  background: var(--status-warning-soft);
+  border: 1px solid var(--status-warning-border);
+  color: var(--status-warning-fg);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  flex: none;
+}
+/* The clickable trigger (#2553) — same ink as the static line, an
+   underline-on-hover/focus is the only affordance change, matching the
+   ghost-first, accent-on-interaction rule the row CTA above already follows. */
+.sales-doc-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  max-width: 100%;
+  padding: 1px var(--space-1);
+  margin: -1px calc(var(--space-1) * -1);
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  cursor: pointer;
+  font: inherit;
+}
+.sales-doc-trigger:hover,
+.sales-doc-trigger:focus-visible { background: var(--bg-surface-hover); }
+.sales-doc-trigger:focus-visible { outline: none; box-shadow: var(--shadow-focus); }
+.sales-doc-popover__head { padding: var(--space-3) var(--space-4); border-bottom: 1px solid var(--border-subtle); }
+.sales-doc-popover__body { padding: var(--space-3) var(--space-4); display: flex; flex-direction: column; gap: var(--space-2); }
+.sales-doc-popover__foot {
+  padding: var(--space-3) var(--space-4);
+  border-top: 1px solid var(--border-subtle);
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+.sales-doc-popover__why { margin: 0; font-size: 0.8125rem; color: var(--text-secondary); }
+.sales-doc-popover__warn {
+  margin: 0;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-sm);
+  background: var(--status-warning-soft);
+  border: 1px solid var(--status-warning-border);
+  color: var(--status-warning-fg);
+  font-size: 0.8125rem;
+}
+.sales-doc-fact {
+  display: grid;
+  grid-template-columns: 5.5rem 1fr;
+  gap: var(--space-2);
+  font-size: 0.8125rem;
+}
+.sales-doc-fact__label { color: var(--text-muted); font-size: 0.75rem; }
+.sales-doc-fact__value { font-family: var(--font-mono); font-size: 0.75rem; overflow-wrap: anywhere; }
+.sales-doc-tone { font-weight: 500; font-size: 0.8125rem; }
+.sales-doc-tone--success { color: var(--status-success-fg); }
+.sales-doc-tone--info { color: var(--status-info-fg); }
+.sales-doc-tone--error { color: var(--status-error-fg); }
+.sales-doc-tone--neutral { color: var(--text-muted); }
+
 /* Inline Retry under the order name (#1713). Sits in the Order cell rather than
    a trailing column so a rare failed row can't widen the whole table. Carries an
    error tint because it only ever appears on a failed sync — a ghost button read

--- a/apps/web/src/pages/orders/orders-list-page.test.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.test.tsx
@@ -17,8 +17,23 @@ import type {
   PaginatedOrders,
   OrderRecord,
   OrderHealthSummary,
+  SalesDocumentView,
 } from '../../features/orders/api/orders.types';
 import type { Connection } from '../../features/connections';
+
+/** Base `SalesDocumentView` fixture (#2552) — override per scenario. */
+function baseSalesDocumentView(over: Partial<SalesDocumentView> = {}): SalesDocumentView {
+  return {
+    orderId: 'ol_order_synced',
+    documentKind: null,
+    document: null,
+    blockReason: null,
+    unresolvedReason: null,
+    blockDetail: null,
+    otherRecords: [],
+    ...over,
+  };
+}
 
 const captureDemoEvent = vi.fn();
 vi.mock('../../features/demo', () => ({
@@ -995,10 +1010,10 @@ describe('OrdersListPage', () => {
     expect(within(row).queryByText(/more$/)).not.toBeInTheDocument();
   });
 
-  it('should offer "Issue invoice" and "Generate label" actions for an order with neither yet (#1713)', async () => {
+  it('should offer "Issue invoice" (via the popover) and "Generate label" for an order with neither yet (#1713/#2552)', async () => {
     // Explicit not-shipped order (the Generate-label gate needs it explicit,
     // never undefined — #1713) with no invoice, plus an invoicing-capable
-    // connection so the "Issue invoice" CTA is offered rather than an em dash.
+    // connection so the popover offers the action rather than nothing.
     const notShippedOrder: OrderRecord = {
       ...syncedOrder,
       fulfillmentState: 'not-shipped',
@@ -1009,6 +1024,7 @@ describe('OrdersListPage', () => {
         processorConnectionId: 'conn-inpost',
         processorAvailable: true,
       },
+      salesDocument: baseSalesDocumentView({ documentKind: 'invoice' }),
     };
     const invoicingConnection: Connection = {
       ...sampleConnection,
@@ -1026,13 +1042,14 @@ describe('OrdersListPage', () => {
     await screen.findByText('ALG-882414');
     const row = container.querySelector('.data-table__row') as HTMLElement;
 
-    const invoiceCta = within(row).getByRole('link', { name: /issue invoice/i });
+    await userEvent.setup().click(within(row).getByRole('button', { name: /invoice: not issued/i }));
+    const invoiceCta = screen.getByRole('link', { name: /issue invoice/i });
     expect(invoiceCta).toHaveAttribute('href', '/orders/ol_order_synced#invoicing');
     const labelCta = within(row).getByRole('link', { name: /generate label/i });
     expect(labelCta).toHaveAttribute('href', '/orders/ol_order_synced#shipment');
   });
 
-  it('should show an em dash for "Issue invoice" when no connection can issue invoices (#1713)', async () => {
+  it('should withhold the issuing action when no connection can issue any sales document (#1713/#2552)', async () => {
     const notShippedOrder: OrderRecord = {
       ...syncedOrder,
       fulfillmentState: 'not-shipped',
@@ -1043,10 +1060,11 @@ describe('OrdersListPage', () => {
         processorConnectionId: 'conn-inpost',
         processorAvailable: true,
       },
+      salesDocument: baseSalesDocumentView({ documentKind: 'invoice' }),
     };
     const mockApi = createMockApiClient({
       orders: { list: vi.fn().mockResolvedValue(paginated([notShippedOrder])) },
-      // sampleConnection has no Invoicing capability.
+      // sampleConnection has no Invoicing/Fiscalization capability.
       connections: { list: vi.fn().mockResolvedValue([sampleConnection]) },
     });
 
@@ -1055,7 +1073,8 @@ describe('OrdersListPage', () => {
     await screen.findByText('ALG-882414');
     const row = container.querySelector('.data-table__row') as HTMLElement;
 
-    expect(within(row).queryByRole('link', { name: /issue invoice/i })).not.toBeInTheDocument();
+    await userEvent.setup().click(within(row).getByRole('button', { name: /invoice: not issued/i }));
+    expect(screen.queryByRole('link', { name: /issue invoice/i })).not.toBeInTheDocument();
     // Generate label is still offered — it isn't invoicing-gated.
     expect(within(row).getByRole('link', { name: /generate label/i })).toBeInTheDocument();
   });
@@ -1072,14 +1091,17 @@ describe('OrdersListPage', () => {
       return { ...syncedOrder, fulfillmentState: 'not-shipped', ...overrides };
     }
 
-    it('should replace the "Issue invoice" CTA with the block badge', async () => {
+    it('should replace the "Issue invoice" action with the block word', async () => {
       const mockApi = createMockApiClient({
         orders: {
           list: vi.fn().mockResolvedValue(
             paginated([
               blockedOrder({
-                salesDocumentBlockReason: 'unresolved-routing',
-                salesDocumentUnresolvedReason: 'ambiguous-connection-no-primary',
+                salesDocument: baseSalesDocumentView({
+                  documentKind: 'invoice',
+                  blockReason: 'unresolved-routing',
+                  unresolvedReason: 'ambiguous-connection-no-primary',
+                }),
               }),
             ]),
           ),
@@ -1094,38 +1116,50 @@ describe('OrdersListPage', () => {
 
       expect(within(row).getByText('Two setups apply')).toBeInTheDocument();
       // The CTA must be GONE: an order OpenLinker already refused is not an order
-      // waiting for a click, and the CTA alone made every cause look identical.
+      // waiting for a click, and offering it alongside made every cause look
+      // identical.
       expect(within(row).queryByRole('link', { name: /issue invoice/i })).not.toBeInTheDocument();
     });
 
     /**
-     * The row must render the invoice pill and the block badge as INDEPENDENT
-     * parts, not as a three-way choice (#2100 review round 4).
-     *
-     * `a ? pill : b ? badge : cta` made the badge unreachable behind any invoice
-     * record — including a terminal REJECTED failure, the one shape the backend
-     * gate, the panel, the timeline, the aggregate count and the
-     * `?invoicing=blocked` filter all deliberately keep blocked. Clicking the
-     * "Invoicing blocked" chip then landed the operator on rows whose only
-     * visible signal was `Failed`: true, but a different fact from "auto-issue
-     * was refused because no connection is primary".
+     * Once a document RECORD exists, the row's single word is resolved from the
+     * document's own axes, never from the persisted block reason (#2552,
+     * ADR-065) — a stale routing reason must not out-rank a terminal fact the
+     * provider already reported. This differs from the pre-#2552
+     * `OrderInvoicingCell`, which rendered the invoice pill and the block badge
+     * as two independent parts; the new cell renders exactly one word for the
+     * most actionable fact.
      */
-    const rejectedInvoice = {
-      invoiceId: 'inv-1',
-      status: 'failed' as const,
-      regulatoryStatus: 'not-applicable' as const,
-      blocksIssuanceElsewhere: false,
-    };
-
-    it('should show the block badge BESIDE a rejected invoice pill', async () => {
+    it('should resolve the word from the terminal invoice failure, not a stale block reason', async () => {
       const mockApi = createMockApiClient({
         orders: {
           list: vi.fn().mockResolvedValue(
             paginated([
               blockedOrder({
-                salesDocumentBlockReason: 'unresolved-routing',
-                salesDocumentUnresolvedReason: 'ambiguous-connection-no-primary',
-                orderSnapshot: { ...syncedOrder.orderSnapshot, invoice: rejectedInvoice },
+                salesDocument: baseSalesDocumentView({
+                  documentKind: 'invoice',
+                  blockReason: 'unresolved-routing',
+                  unresolvedReason: 'ambiguous-connection-no-primary',
+                  document: {
+                    kind: 'invoice',
+                    documentType: 'vat',
+                    status: 'failed',
+                    failureMode: 'rejected',
+                    failureCode: null,
+                    failureReason: 'refused',
+                    regulatoryStatus: 'not-applicable',
+                    clearanceReference: null,
+                    identity: {
+                      recordId: 'rec-1',
+                      connectionId: 'conn_invoicing_1',
+                      providerType: 'ksef',
+                      documentNumber: null,
+                      createdAt: '2026-01-15T10:00:00.000Z',
+                      completedAt: null,
+                      inFlightUntil: null,
+                    },
+                  },
+                }),
               }),
             ]),
           ),
@@ -1139,20 +1173,39 @@ describe('OrdersListPage', () => {
       const row = container.querySelector('.data-table__row') as HTMLElement;
 
       expect(within(row).getByText('Failed')).toBeInTheDocument();
-      expect(within(row).getByText('Two setups apply')).toBeInTheDocument();
+      expect(within(row).queryByText('Two setups apply')).not.toBeInTheDocument();
       // A record exists, so the next step is Retry in the panel, not a fresh issue.
       expect(within(row).queryByRole('link', { name: /issue invoice/i })).not.toBeInTheDocument();
     });
 
-    it('should show the block badge beside a rejected invoice on the mobile card too', async () => {
+    it('should render the same word on the mobile card path too', async () => {
       const mockApi = createMockApiClient({
         orders: {
           list: vi.fn().mockResolvedValue(
             paginated([
               blockedOrder({
-                salesDocumentBlockReason: 'unresolved-routing',
-                salesDocumentUnresolvedReason: 'ambiguous-connection-no-primary',
-                orderSnapshot: { ...syncedOrder.orderSnapshot, invoice: rejectedInvoice },
+                salesDocument: baseSalesDocumentView({
+                  documentKind: 'invoice',
+                  document: {
+                    kind: 'invoice',
+                    documentType: 'vat',
+                    status: 'failed',
+                    failureMode: 'rejected',
+                    failureCode: null,
+                    failureReason: 'refused',
+                    regulatoryStatus: 'not-applicable',
+                    clearanceReference: null,
+                    identity: {
+                      recordId: 'rec-1',
+                      connectionId: 'conn_invoicing_1',
+                      providerType: 'ksef',
+                      documentNumber: null,
+                      createdAt: '2026-01-15T10:00:00.000Z',
+                      completedAt: null,
+                      inFlightUntil: null,
+                    },
+                  },
+                }),
               }),
             ]),
           ),
@@ -1170,54 +1223,24 @@ describe('OrdersListPage', () => {
         const card = container.querySelector('.orders-card-summary') as HTMLElement;
 
         expect(within(card).getByText('Failed')).toBeInTheDocument();
-        expect(within(card).getByText('Two setups apply')).toBeInTheDocument();
       } finally {
         viewport.restore();
       }
     });
 
-    it('should still hide the badge behind an invoice that plausibly exists', async () => {
+    it('should keep the "Issue invoice" action reachable alongside issue-on-request', async () => {
       const mockApi = createMockApiClient({
         orders: {
           list: vi.fn().mockResolvedValue(
             paginated([
               blockedOrder({
-                salesDocumentBlockReason: 'unresolved-routing',
-                salesDocumentUnresolvedReason: 'ambiguous-connection-no-primary',
-                orderSnapshot: {
-                  ...syncedOrder.orderSnapshot,
-                  invoice: {
-                    invoiceId: 'inv-1',
-                    status: 'issued',
-                    regulatoryStatus: 'accepted',
-                    blocksIssuanceElsewhere: true,
-                  },
-                },
+                salesDocument: baseSalesDocumentView({
+                  documentKind: 'invoice',
+                  blockReason: 'trigger-model-manual',
+                }),
               }),
             ]),
           ),
-        },
-        connections: { list: vi.fn().mockResolvedValue([sampleConnection, invoicingConnection]) },
-      });
-
-      const { container } = renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
-
-      await screen.findByText('ALG-882414');
-      const row = container.querySelector('.data-table__row') as HTMLElement;
-
-      // "Two setups apply" beside an issued invoice is worse than no pill at all — and
-      // the backend gate refuses to persist a block here in the first place.
-      expect(within(row).queryByText('Two setups apply')).not.toBeInTheDocument();
-    });
-
-    it('should keep the "Issue invoice" CTA alongside a manual-only badge', async () => {
-      const mockApi = createMockApiClient({
-        orders: {
-          list: vi
-            .fn()
-            .mockResolvedValue(
-              paginated([blockedOrder({ salesDocumentBlockReason: 'trigger-model-manual' })]),
-            ),
         },
         connections: { list: vi.fn().mockResolvedValue([sampleConnection, invoicingConnection]) },
       });
@@ -1228,26 +1251,44 @@ describe('OrdersListPage', () => {
       const row = container.querySelector('.data-table__row') as HTMLElement;
 
       expect(within(row).getByText('Issued on request')).toBeInTheDocument();
-      // Issuing by hand IS the configured workflow here, so the affordance stays.
-      expect(within(row).getByRole('link', { name: /issue invoice/i })).toBeInTheDocument();
+      // Issuing by hand IS the configured workflow here, so the action stays
+      // reachable — one click away in the popover.
+      await userEvent.setup().click(within(row).getByRole('button', { name: /invoice: issued on request/i }));
+      expect(screen.getByRole('link', { name: /issue invoice/i })).toBeInTheDocument();
     });
 
-    it('should suppress the badge when the order already carries an invoice', async () => {
+    it('should render "Issued", never a stale block word, once the order carries an invoice', async () => {
       const mockApi = createMockApiClient({
         orders: {
           list: vi.fn().mockResolvedValue(
             paginated([
               blockedOrder({
-                salesDocumentBlockReason: 'unresolved-routing',
-                salesDocumentUnresolvedReason: 'ambiguous-connection-no-primary',
-                orderSnapshot: {
-                  ...syncedOrder.orderSnapshot,
-                  invoice: {
-                    invoiceId: 'inv-1',
+                salesDocument: baseSalesDocumentView({
+                  documentKind: 'invoice',
+                  // A stale reason from before the document existed — the row
+                  // must ignore it once a record is present (#2552).
+                  blockReason: 'unresolved-routing',
+                  unresolvedReason: 'ambiguous-connection-no-primary',
+                  document: {
+                    kind: 'invoice',
+                    documentType: 'vat',
                     status: 'issued',
+                    failureMode: null,
+                    failureCode: null,
+                    failureReason: null,
                     regulatoryStatus: 'not-applicable',
+                    clearanceReference: null,
+                    identity: {
+                      recordId: 'rec-1',
+                      connectionId: 'conn_invoicing_1',
+                      providerType: 'ksef',
+                      documentNumber: 'FV/1/2026',
+                      createdAt: '2026-01-15T10:00:00.000Z',
+                      completedAt: '2026-01-15T10:05:00.000Z',
+                      inFlightUntil: null,
+                    },
                   },
-                },
+                }),
               }),
             ]),
           ),
@@ -1260,9 +1301,6 @@ describe('OrdersListPage', () => {
       await screen.findByText('ALG-882414');
       const row = container.querySelector('.data-table__row') as HTMLElement;
 
-      // "Two setups apply" next to an issued invoice is worse than no badge at all, so
-      // the render refuses the contradiction rather than trusting the clear to
-      // have landed already.
       expect(within(row).queryByText('Two setups apply')).not.toBeInTheDocument();
       expect(within(row).getByText('Issued')).toBeInTheDocument();
     });
@@ -1295,14 +1333,17 @@ describe('OrdersListPage', () => {
       expect(filters).toMatchObject({ salesDocumentBlocked: true });
     });
 
-    it('should state the cause as the badge tooltip AND an accessible name', async () => {
+    it('should state the cause inside the popover, reachable by keyboard (#2553)', async () => {
       const mockApi = createMockApiClient({
         orders: {
           list: vi.fn().mockResolvedValue(
             paginated([
               blockedOrder({
-                salesDocumentBlockReason: 'unresolved-routing',
-                salesDocumentUnresolvedReason: 'ambiguous-connection-no-primary',
+                salesDocument: baseSalesDocumentView({
+                  documentKind: 'invoice',
+                  blockReason: 'unresolved-routing',
+                  unresolvedReason: 'ambiguous-connection-no-primary',
+                }),
               }),
             ]),
           ),
@@ -1314,25 +1355,33 @@ describe('OrdersListPage', () => {
 
       await screen.findByText('ALG-882414');
       const row = container.querySelector('.data-table__row') as HTMLElement;
-      const wrapper = within(row).getByText('Two setups apply').closest('span[title]');
 
-      // The hint is the ONLY statement of why on this surface, so it must reach the
-      // DOM — and `title` alone is unreachable by keyboard and unreliable in screen
-      // readers on a role-less span.
-      expect(wrapper).toHaveAttribute('title', expect.stringMatching(/nothing chooses between them/i));
-      expect(wrapper).toHaveAttribute('aria-label', expect.stringContaining('Two setups apply'));
+      // The row's word is the accessible name of the trigger button itself —
+      // reachable by keyboard, unlike a bare `title`.
+      const trigger = within(row).getByRole('button', { name: /invoice: two setups apply/i });
+      await userEvent.setup().click(trigger);
+
+      // The reason is the ONLY statement of why on this surface, and it now
+      // lives inside the popover body, not a `title` attribute nobody without
+      // a mouse could reach.
+      expect(screen.getByText(/nothing chooses between them/i)).toBeInTheDocument();
     });
 
-    it('should render the block badge on the mobile card path too', async () => {
+    it('should render the block word on the mobile card path too', async () => {
       const viewport = mockMobileViewport();
       try {
         const mockApi = createMockApiClient({
           orders: {
-            list: vi
-              .fn()
-              .mockResolvedValue(
-                paginated([blockedOrder({ salesDocumentBlockReason: 'trigger-model-batched' })]),
-              ),
+            list: vi.fn().mockResolvedValue(
+              paginated([
+                blockedOrder({
+                  salesDocument: baseSalesDocumentView({
+                    documentKind: 'invoice',
+                    blockReason: 'trigger-model-batched',
+                  }),
+                }),
+              ]),
+            ),
           },
           connections: { list: vi.fn().mockResolvedValue([sampleConnection, invoicingConnection]) },
         });
@@ -1541,21 +1590,34 @@ describe('OrdersListPage', () => {
     expect(within(row).queryByText('Unmapped')).not.toBeInTheDocument();
   });
 
-  it('should show status pills (not actions) once an invoice exists and the order is dispatched (#1713)', async () => {
+  it('should show status pills (not actions) once an invoice exists and the order is dispatched (#1713/#2552)', async () => {
     const richOrder: OrderRecord = {
       ...syncedOrder,
       internalOrderId: 'ol_order_rich',
       fulfillmentState: 'dispatched',
-      orderSnapshot: {
-        ...syncedOrder.orderSnapshot,
-        invoice: {
-          invoiceId: 'rec-1',
+      salesDocument: baseSalesDocumentView({
+        orderId: 'ol_order_rich',
+        documentKind: 'invoice',
+        document: {
+          kind: 'invoice',
+          documentType: 'vat',
           status: 'issued',
+          failureMode: null,
+          failureCode: null,
+          failureReason: null,
           regulatoryStatus: 'accepted',
           clearanceReference: 'KSEF-1',
-          confirmationDocumentAvailable: true,
+          identity: {
+            recordId: 'rec-1',
+            connectionId: 'conn_invoicing_1',
+            providerType: 'ksef',
+            documentNumber: null,
+            createdAt: '2026-01-15T10:00:00.000Z',
+            completedAt: '2026-01-15T10:05:00.000Z',
+            inFlightUntil: null,
+          },
         },
-      },
+      }),
     };
     const mockApi = createMockApiClient({
       orders: { list: vi.fn().mockResolvedValue(paginated([richOrder])) },
@@ -1569,7 +1631,9 @@ describe('OrdersListPage', () => {
 
     expect(within(row).queryByRole('link', { name: /issue invoice/i })).not.toBeInTheDocument();
     expect(within(row).queryByRole('link', { name: /generate label/i })).not.toBeInTheDocument();
-    expect(within(row).getByText('Cleared')).toBeInTheDocument();
+    // A fully accepted, already-issued invoice is "Issued" (done, plain ink) —
+    // the row's single word, not the retired "Cleared" invoice-pill vocabulary.
+    expect(within(row).getByText('Issued')).toBeInTheDocument();
     expect(within(row).getByText('Dispatched')).toBeInTheDocument();
   });
 });

--- a/apps/web/src/pages/orders/orders-list-page.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.tsx
@@ -54,9 +54,9 @@ import { useDemoMode } from '../../features/system';
 import { captureDemoEvent } from '../../features/demo';
 import { parseOrderSnapshot } from '../../features/orders/api/order-snapshot.schema';
 import { deriveOrderHealth, slaBadge, fulfillmentBadge } from '../../features/orders/lib/order-health';
-import { paymentBadge } from '../../features/orders/lib/order-row';
+import { paymentBadge, taxRateConflictBadge } from '../../features/orders/lib/order-row';
 import { OrderIdentityCell } from '../../features/orders';
-import { OrderInvoicingCell } from '../../features/orders/components/order-invoicing-cell';
+import { SalesDocumentCell } from '../../features/orders/components/sales-document-cell';
 import { deriveDeliveryOutcome, hasLiveOlCarrierRoute } from '../../features/orders/lib/delivery-outcome';
 import { DeliveryOutcomeChip } from '../../features/orders/components/delivery-chip';
 import { resolveDeliveryOwner } from '../../features/orders/lib/delivery-owner';
@@ -520,12 +520,18 @@ export function OrdersListPage(): ReactElement {
     [parsedFor],
   );
 
-  // Whether ANY connection exposes the Invoicing capability (#1713). When none
-  // does, the "Issue invoice" CTA degrades to an em dash — the platform can't
-  // issue invoices, so offering the action would dead-end. An existing invoice
-  // pill still renders regardless (the record exists independent of this gate).
-  const hasInvoicingCapability = useMemo(
-    () => (connectionsQuery.data ?? []).some((c) => c.enabledCapabilities.includes('Invoicing')),
+  // Whether ANY connection exposes a sales-document-issuing capability
+  // (#1713, extended #2552 to cover both kinds). When none does, the
+  // "Issue…" / "Register…" action degrades to nothing rather than dead-ending.
+  // An existing document still renders regardless (the record exists
+  // independent of this gate).
+  const hasIssuingCapability = useMemo(
+    () =>
+      (connectionsQuery.data ?? []).some(
+        (c) =>
+          c.enabledCapabilities.includes('Invoicing') ||
+          c.enabledCapabilities.includes('Fiscalization'),
+      ),
     [connectionsQuery.data],
   );
 
@@ -992,19 +998,30 @@ export function OrdersListPage(): ReactElement {
                   {pay.label}
                 </StatusBadge>
               ) : null}
-              {/* Invoice pill, block badge and "Issue invoice" CTA — independent
-                  parts, not a three-way choice; see `OrderInvoicingCell`. Shared
-                  verbatim with the mobile card so the two cannot drift again. */}
-              <OrderInvoicingCell
+              {/* The routed sales document (#2552, ADR-065) — kind-aware
+                  (invoice or fiscal receipt), reading the batched
+                  `SalesDocumentView` rather than the invoice-only projection
+                  `OrderInvoicingCell` rendered. Shared verbatim with the
+                  mobile card so the two cannot drift. */}
+              <SalesDocumentCell
                 internalOrderId={order.internalOrderId}
-                invoice={parsed.invoice}
-                blockReason={order.salesDocumentBlockReason}
-                unresolvedReason={order.salesDocumentUnresolvedReason}
-                hasInvoicingCapability={hasInvoicingCapability}
-                hasTaxRateConflict={hasTaxRateConflict(parsed)}
+                view={order.salesDocument}
                 layout="stack"
-                emptyFallback={<span className="text-muted">—</span>}
+                hasIssuingCapability={hasIssuingCapability}
               />
+              {/* #2254 — its own independent line, never folded into the
+                  document cell above: a conflict does not stop the invoice,
+                  so it can be true alongside any document state. */}
+              {hasTaxRateConflict(parsed) ? (
+                <span title={taxRateConflictBadge().hint}>
+                  <StatusBadge tone="conflict" withDot compact>
+                    {taxRateConflictBadge().label}
+                  </StatusBadge>
+                  <span className="sr-only">
+                    {taxRateConflictBadge().label}: {taxRateConflictBadge().hint}
+                  </span>
+                </span>
+              ) : null}
               <span className="text-muted orders-cell-sub mono tabular">
                 <TimeDisplay iso={order.createdAt} format="datetime" />
               </span>
@@ -1037,12 +1054,12 @@ export function OrdersListPage(): ReactElement {
       // active-state arrows track the current sort/dir. `sortLabel` is a
       // useCallback keyed on sort/dir, so this rebuilds exactly on a sort change.
       sortLabel,
-      // Per-page snapshot cache + invoicing-capability gate (#1713).
+      // Per-page snapshot cache + issuing-capability gate (#1713/#2552).
       parsedFor,
+      hasIssuingCapability,
       // The shared Order cell renderer (#2091) — a `useCallback` over
       // `parsedFor`, so this rebuilds exactly when the parse cache does.
       renderOrderIdentity,
-      hasInvoicingCapability,
     ],
   );
 
@@ -1650,21 +1667,24 @@ export function OrdersListPage(): ReactElement {
                         </dd>
                       </div>
                       <div>
-                        <dt>Invoice</dt>
+                        <dt>Document</dt>
                         <dd>
-                          {/* SAME component as the desktop cell — this used to be a
-                              hand-duplicated parallel render path, and the two
-                              diverged. */}
-                          <OrderInvoicingCell
+                          {/* SAME component as the desktop cell (#2552) — this
+                              used to be a hand-duplicated parallel render
+                              path, and the two diverged. */}
+                          <SalesDocumentCell
                             internalOrderId={order.internalOrderId}
-                            invoice={parsed.invoice}
-                            blockReason={order.salesDocumentBlockReason}
-                            unresolvedReason={order.salesDocumentUnresolvedReason}
-                            hasInvoicingCapability={hasInvoicingCapability}
-                            hasTaxRateConflict={hasTaxRateConflict(parsed)}
+                            view={order.salesDocument}
                             layout="row"
-                            emptyFallback="—"
+                            hasIssuingCapability={hasIssuingCapability}
                           />
+                          {hasTaxRateConflict(parsed) ? (
+                            <span title={taxRateConflictBadge().hint}>
+                              <StatusBadge tone="conflict" withDot compact>
+                                {taxRateConflictBadge().label}
+                              </StatusBadge>
+                            </span>
+                          ) : null}
                         </dd>
                       </div>
                       <div>


### PR DESCRIPTION
Closes #2552.

## Summary

Replaces the hardcoded `+ Issue invoice` button (rendered by `OrderInvoicingCell`) with `SalesDocumentCell`, one line driven by the batched per-order `SalesDocumentView` (#2516/#2584, ADR-065): a kind glyph, one word for the most actionable fact, a tick when finished, a quiet pulsing dot while in flight, and a count badge when a second record exists for the order. Clicking the line opens a popover (the M5 shared `Popover` primitive) with the identity facts, the persisted reason, a duplicate warning, and the available action.

The row's word is resolved by the pure `resolveSalesDocumentCellState` (`apps/web/src/features/orders/lib/sales-document-cell-state.ts`):

- Once a document record exists, the word comes from the document's own axes (never a stale persisted block reason) - clearance takes precedence over issuance for an invoice (`regulatoryStatus: 'rejected'` reads "Authority rejected" even when `status: 'issued'`).
- With no document yet, the word comes from `resolveSalesDocumentReasonCopy` (the existing M5 reason-copy map) keyed on the persisted `blockReason`/`unresolvedReason` - never re-derived from the order's country or connections.
- `trigger-model-manual` renders "Issued on request" as an idle (not-attention) state and keeps the action reachable in the popover.
- An unrecognised status value (a newer backend, an older FE build) reports "Unrecognised status" rather than rendering nothing.

## Deviation from the task body

The task issue scoped the popover to #2553. I built the row and its popover together in one component/commit because they share one `Popover` trigger and one state resolver - shipping the row alone would have meant a temporary non-interactive span with no independent test value, and reviewing the two together lets every acceptance criterion from both #2552 and #2553 be verified against the same running code. #2553's own PR is a small, genuine follow-up (see its description) rather than a re-implementation.

## What's included

- FE mirror of `SalesDocumentView` (and its sub-types) in `apps/web/src/features/orders/api/orders.types.ts`, alongside the existing `SalesDocumentGateBlockReasonValue`/`SalesDocumentUnresolvedReasonValue` mirrors - the same convention, guarded by the existing `check-sales-document-reason-mirror.mjs` for the reason unions. I did not add a separate structural-drift guard for the `SalesDocumentView` shape itself (unlike the reason unions, it is not a flat string array a script can diff cheaply) - this is a manual-mirror risk accepted for now, same posture as the untouched `OrderInvoicingCell`'s own props before this epic.
- `OrderRecord.salesDocument?: SalesDocumentView` wired onto the FE type (the backend DTO already served it, #2516/#2584 - no backend change in this PR).
- `SalesDocumentCell` + `sales-document-cell-state.ts`, both with colocated tests (19 unit tests, all passing).
- Wired into both the desktop money-cluster column and the mobile card in `orders-list-page.tsx`, replacing `OrderInvoicingCell` at both call sites (mobile-specific layout/skeleton polish is #2555's scope - this PR only swaps the component in).
- The pre-existing tax-rate-conflict badge stays an independent sibling line (unaffected - it composes with any document state, never folded in).
- Updated `orders-list-page.test.tsx`: the fixtures and assertions that exercised the old `OrderInvoicingCell` behavior (invoice pill + block badge as two independent parts, `title`-only reason tooltip) are rewritten for the new single-word + popover model. All 79 tests in that file pass.

## Deliberately left out

- #2554's attention-count wording ("Invoicing blocked" chip rename, the separate issue-on-request figure) - untouched in this PR.
- #2555's mobile-specific width/truncation and skeleton-height parity - the mobile card already renders `SalesDocumentCell`, but no mobile-specific CSS was added here.
- No backend change. The `salesDocument` field was already being served.

## Gate

- `pnpm --filter @openlinker/web type-check`: clean.
- `pnpm --filter @openlinker/core type-check` / `pnpm --filter @openlinker/api type-check`: clean (untouched by this PR, verified as a baseline).
- `eslint` on every changed file: 0 errors (pre-existing `explicit-function-return-type` warnings only, not introduced by this PR).
- `pnpm check:invariants` (filtered for `.worktrees`): all green, including `check-sales-document-reason-mirror`.
- Narrow tests run: `sales-document-cell-state.test.ts`, `sales-document-cell.test.tsx`, `orders-list-page.test.tsx` - 98 passing.