### PR TITLE
test(orders): the document popover survives a scrolled table and Escape (#2553)

### DIFF
--- a/apps/web/src/features/orders/components/sales-document-cell.test.tsx
+++ b/apps/web/src/features/orders/components/sales-document-cell.test.tsx
@@ -167,6 +167,45 @@ describe('SalesDocumentCell (#2552/#2553)', () => {
       );
     });
 
+    it('renders fully outside a scrolled, overflow-clipping ancestor (#2553)', async () => {
+      const user = userEvent.setup();
+      render(
+        <MemoryRouter>
+          <div className="data-table__container" style={{ overflowX: 'auto', width: '10px' }}>
+            <SalesDocumentCell
+              internalOrderId="ol_order_1"
+              view={baseView({ documentKind: 'invoice' })}
+              layout="stack"
+              hasIssuingCapability
+            />
+          </div>
+        </MemoryRouter>,
+      );
+
+      await user.click(screen.getByRole('button', { name: /invoice: not issued/i }));
+
+      const link = screen.getByRole('link', { name: /issue invoice/i });
+      // The M5 `Popover` primitive portals its content to the document root
+      // specifically so a cell-anchored panel is never clipped by the table's
+      // `overflow-x: auto` container (see `shared/ui/popover.tsx`) — assert
+      // that guarantee holds through THIS component, not just the primitive.
+      expect(document.querySelector('.data-table__container')?.contains(link)).toBe(false);
+    });
+
+    it('closes on Escape and returns focus to the trigger', async () => {
+      const user = userEvent.setup();
+      renderCell({ view: baseView({ documentKind: 'invoice' }) });
+
+      const trigger = screen.getByRole('button', { name: /invoice: not issued/i });
+      await user.click(trigger);
+      expect(screen.getByRole('link', { name: /issue invoice/i })).toBeInTheDocument();
+
+      await user.keyboard('{Escape}');
+
+      expect(screen.queryByRole('link', { name: /issue invoice/i })).not.toBeInTheDocument();
+      expect(trigger).toHaveFocus();
+    });
+
     it('warns when another connection holds a document for the same order', async () => {
       const user = userEvent.setup();
       renderCell({


### PR DESCRIPTION
Closes #2553.

## Summary

The popover itself (facts, reason, actions) shipped together with the row cell in #2552's `SalesDocumentCell`, because the row and its popover share one `Popover` trigger and one state resolver - see #2552's PR body for the full reasoning on why the two tasks were built in one pass. This PR is the genuine remainder of #2553's own acceptance criteria: two regression tests that pin the popover's behavior specifically as used by `SalesDocumentCell`, rather than relying on the shared `shared/ui/popover.tsx` primitive's own tests to cover it by proxy.

- `renders fully outside a scrolled, overflow-clipping ancestor`: mounts the cell inside a `10px`-wide `.data-table__container { overflow-x: auto }` (the real orders-list table's clipping ancestor class), opens the popover, and asserts the "Issue invoice" link is reachable and is NOT a DOM descendant of that container - the exact "last column of a scrolled table" shape the issue names.
- `closes on Escape and returns focus to the trigger`: opens the popover, presses Escape, asserts the popover content is gone and the trigger button has focus.

Both pass with zero component changes required: Radix's `Popover` already provides portal rendering, Escape-to-close, and focus-return, and the M5 `shared/ui/popover.tsx` wrapper already routes content through a portal for exactly this reason (see its own doc comment). The value here is pinning the guarantee at the `SalesDocumentCell` level, so a future change to the trigger markup (e.g. swapping `asChild` for a manual button, or moving the popover content structure) cannot silently regress it without a test failing.

## Acceptance criteria mapping

- "Every fact the old stacked cell showed is reachable in the popover" - shipped in #2552 (identity facts, reason, duplicate warning, actions).
- "It renders fully when opened from the last column of a scrolled table" - new test in this PR.
- "Escape and outside click close it; focus returns to the trigger" - Escape + focus-return covered by the new test in this PR; outside-click is Radix's default dismiss behavior (`Popover`'s `onOpenChange`), already exercised implicitly by the existing #2552 tests that open one popover and then query for a DIFFERENT one in the same render (each `render()` call is a fresh DOM, so this isn't a dedicated regression test - noting the gap rather than papering over it).
- "The reason shown is the persisted one" - shipped in #2552 (`resolveSalesDocumentReasonCopy`, keyed only on the persisted `blockReason`/`unresolvedReason`).

## Deliberately left out

- A dedicated outside-click-closes test. Radix's Popover default behavior already closes on outside pointer-down, and the existing #2552 popover tests exercise open/read but not an explicit outside-click-then-assert-closed step. Adding one would be pure primitive-coverage duplication (the `Popover` component's own tests, not `SalesDocumentCell`'s) - happy to add if requested in review.

## Gate

- `pnpm --filter @openlinker/web type-check`: clean.
- `eslint` on the changed file: 0 errors (1 pre-existing warning class, not new).
- `pnpm check:invariants` (filtered for `.worktrees`): all green.
- `sales-document-cell.test.tsx`: 11/11 passing (9 from #2552 + 2 new).