### PR TITLE
feat(orders): attention count excludes issue-on-request, reported separately (#2554)

### DIFF
--- a/apps/api/src/orders/http/dto/order-health-summary-response.dto.ts
+++ b/apps/api/src/orders/http/dto/order-health-summary-response.dto.ts
@@ -61,4 +61,12 @@ export class OrderHealthSummaryResponseDto {
       'dotted badge to a row that already has two SLA badges.',
   })
   salesDocumentBlockedOldestAt!: string | null;
+
+  @ApiProperty({
+    description:
+      'Orders whose sales document is issued ONLY on request — the trigger-model-manual gate ' +
+      'reason (#2554). Its OWN count, never part of salesDocumentBlocked: manual is the default ' +
+      'trigger model, so counting it as blocked would put a large red number on a healthy install.',
+  })
+  salesDocumentIssuedOnRequest!: number;
 }

--- a/apps/api/src/orders/http/orders.controller.spec.ts
+++ b/apps/api/src/orders/http/orders.controller.spec.ts
@@ -539,7 +539,7 @@ describe('OrdersController', () => {
         needsAttention: 1,
         synced: 1,
         awaitingDispatch: 9,
-        salesDocumentBlocked: 0, taxRateConflict: 0, salesDocumentBlockedOldestAt: null,
+        salesDocumentBlocked: 0, taxRateConflict: 0, salesDocumentBlockedOldestAt: null, salesDocumentIssuedOnRequest: 0,
       });
 
       const result = await controller.statusSummary({});
@@ -557,7 +557,7 @@ describe('OrdersController', () => {
         needsAttention: 0,
         synced: 0,
         awaitingDispatch: 0,
-        salesDocumentBlocked: 0, taxRateConflict: 0, salesDocumentBlockedOldestAt: null,
+        salesDocumentBlocked: 0, taxRateConflict: 0, salesDocumentBlockedOldestAt: null, salesDocumentIssuedOnRequest: 0,
       });
 
       await controller.statusSummary({

--- a/apps/web/src/features/orders/api/orders.types.ts
+++ b/apps/web/src/features/orders/api/orders.types.ts
@@ -408,6 +408,15 @@ export interface OrderHealthSummary {
    * carries two SLA badges.
    */
   salesDocumentBlockedOldestAt?: string | null;
+  /**
+   * Orders whose sales document is issued ONLY on request (#2554, the
+   * `trigger-model-manual` gate reason) — reported separately, and neutrally,
+   * from `salesDocumentBlocked`. Manual is the default trigger model, so on a
+   * manual install every uninvoiced order carries it; counting it as blocked
+   * would put a large red number on a healthy install (ADR-041 §54). Optional
+   * for graceful degradation against an older API.
+   */
+  salesDocumentIssuedOnRequest?: number;
 }
 
 export interface OrderFilters {

--- a/apps/web/src/pages/orders/orders-list-page.test.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.test.tsx
@@ -1320,7 +1320,7 @@ describe('OrdersListPage', () => {
 
       renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
 
-      const chip = await screen.findByRole('button', { name: /invoicing blocked/i });
+      const chip = await screen.findByRole('button', { name: /sales documents blocked/i });
       expect(chip).toHaveTextContent('2');
 
       const before = list.mock.calls.length;
@@ -1331,6 +1331,57 @@ describe('OrdersListPage', () => {
       });
       const [filters] = list.mock.calls[list.mock.calls.length - 1];
       expect(filters).toMatchObject({ salesDocumentBlocked: true });
+    });
+
+    it('should report issue-on-request as its own neutral figure, never inside the blocked count (#2554)', async () => {
+      const mockApi = createMockApiClient({
+        orders: {
+          list: vi.fn().mockResolvedValue(paginated([syncedOrder])),
+          statusSummary: vi.fn().mockResolvedValue({
+            total: 5,
+            sourceDeleted: 0,
+            awaitingMapping: 0,
+            needsAttention: 0,
+            synced: 5,
+            awaitingDispatch: 0,
+            salesDocumentBlocked: 2,
+            salesDocumentIssuedOnRequest: 3,
+          }),
+        },
+      });
+
+      renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
+
+      const chip = await screen.findByRole('button', { name: /sales documents blocked/i });
+      // The blocked chip's own count is unaffected by the separate figure.
+      expect(chip).toHaveTextContent('2');
+      expect(await screen.findByText('3 issued on request')).toBeInTheDocument();
+      // Neutral, not a filter: no button/link role for this figure.
+      expect(screen.queryByRole('button', { name: /issued on request/i })).not.toBeInTheDocument();
+    });
+
+    it('should render neither figure when the summary reports zero of each (#2554)', async () => {
+      const mockApi = createMockApiClient({
+        orders: {
+          list: vi.fn().mockResolvedValue(paginated([syncedOrder])),
+          statusSummary: vi.fn().mockResolvedValue({
+            total: 1,
+            sourceDeleted: 0,
+            awaitingMapping: 0,
+            needsAttention: 0,
+            synced: 1,
+            awaitingDispatch: 0,
+            salesDocumentBlocked: 0,
+            salesDocumentIssuedOnRequest: 0,
+          }),
+        },
+      });
+
+      renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
+
+      await screen.findByText('ALG-882414');
+      expect(screen.queryByRole('button', { name: /sales documents blocked/i })).not.toBeInTheDocument();
+      expect(screen.queryByText(/issued on request/i)).not.toBeInTheDocument();
     });
 
     it('should state the cause inside the popover, reachable by keyboard (#2553)', async () => {
@@ -1417,7 +1468,7 @@ describe('OrdersListPage', () => {
         route: '/orders?invoicing=blocked&offset=20',
       });
 
-      const chip = await screen.findByRole('button', { name: /invoicing blocked/i });
+      const chip = await screen.findByRole('button', { name: /sales documents blocked/i });
       expect(chip).toHaveAttribute('aria-pressed', 'true');
       expect(list.mock.calls[0][0]).toMatchObject({ salesDocumentBlocked: true });
 
@@ -1457,7 +1508,7 @@ describe('OrdersListPage', () => {
       // Gating the chip on the count alone unmounted the ONLY control for this
       // param exactly when the remediation succeeded, stranding an applied filter.
       expect(
-        await screen.findByRole('button', { name: /invoicing blocked/i }),
+        await screen.findByRole('button', { name: /sales documents blocked/i }),
       ).toBeInTheDocument();
       // And the empty state must not claim nothing has ever synced.
       // `findByText` (not `getByText`): the chip is sync-derived from the URL
@@ -1465,7 +1516,7 @@ describe('OrdersListPage', () => {
       // synchronous assertion here raced the async empty-state render under
       // load (flaked when this file ran alongside its siblings, though not in
       // isolation) — this text depends on `query.data`, so it must be awaited.
-      expect(await screen.findByText(/Nothing is blocked from invoicing/i)).toBeInTheDocument();
+      expect(await screen.findByText(/Nothing is blocked/i)).toBeInTheDocument();
       expect(screen.queryByText(/No order records have been synced yet/i)).toBeNull();
     });
 
@@ -1525,7 +1576,7 @@ describe('OrdersListPage', () => {
 
       await screen.findByText('ALG-882414');
       // An install that never hits this state gets no extra control.
-      expect(screen.queryByRole('button', { name: /invoicing blocked/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /sales documents blocked/i })).not.toBeInTheDocument();
     });
   });
 

--- a/apps/web/src/pages/orders/orders-list-page.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.tsx
@@ -1351,14 +1351,35 @@ export function OrdersListPage(): ReactElement {
           <Chip tone="error" active={invoicingBlocked} onClick={toggleInvoicingBlocked}>
             {/* The count is omitted until the summary resolves rather than
                 defaulted to 0 — asserting a number the client does not have yet
-                would be worse than showing none. */}
-            Invoicing blocked
+                would be worse than showing none.
+
+                #2554 — cross-kind wording: the underlying reasons cover both
+                invoices and fiscal receipts, so "Invoicing blocked" asserted a
+                narrower fact than the count behind it. "Sales documents
+                blocked" names what `salesDocumentBlocked` actually counts
+                (`SalesDocumentAttentionReasonValues`, which already excludes
+                `trigger-model-manual` — see the neutral figure below). */}
+            Sales documents blocked
             {summary?.salesDocumentBlocked === undefined
               ? ''
               : ` ${summary.salesDocumentBlocked}${blockedAgeSuffix(
                   summary.salesDocumentBlockedOldestAt,
                 )}`}
           </Chip>
+        ) : null}
+        {/* #2554 — issue-on-request is NOT counted above (the backend already
+            excludes `trigger-model-manual` from `salesDocumentBlocked`, per
+            ADR-041 §54: manual is the default trigger model, so counting it
+            would put a large red number on a healthy install). Reported here
+            as its own neutral figure, not a chip: it names orders waiting for
+            the operator by CONFIGURATION, not orders anything is wrong with,
+            and there is no separate filter for it to link to — the manual
+            reason is visible per-row wherever the document line itself
+            renders "Issued on request". */}
+        {summary?.salesDocumentIssuedOnRequest ? (
+          <span className="text-muted mono tabular" style={{ fontSize: '0.75rem' }}>
+            {summary.salesDocumentIssuedOnRequest} issued on request
+          </span>
         ) : null}
         {/* #2254 — its own count, and it mounts on `filterActive || count` for
             the same nine-line reason the chip above does: gating on the count
@@ -1451,8 +1472,8 @@ export function OrdersListPage(): ReactElement {
           */
           <EmptyState
             liveRegion="off"
-            title="Nothing is blocked from invoicing"
-            message="No order is waiting on an invoicing decision right now."
+            title="Nothing is blocked"
+            message="No order's sales document is waiting on a routing decision right now."
             action={
               <Button onClick={() => { clearAllFilters(setSearchParams); }}>
                 View all orders

--- a/libs/core/src/orders/domain/types/order-record.types.ts
+++ b/libs/core/src/orders/domain/types/order-record.types.ts
@@ -115,6 +115,17 @@ export interface OrderHealthSummary {
    * adding a third dotted badge to a row that already has two SLA badges.
    */
   salesDocumentBlockedOldestAt: Date | null;
+  /**
+   * Orders whose sales document is issued ONLY on request — the
+   * `'trigger-model-manual'` gate reason (#2554). Its OWN count, deliberately
+   * NOT part of `salesDocumentBlocked`: manual is `parseTriggerModel`'s
+   * default, so on a manual install every uninvoiced order carries it, and
+   * folding it into the blocked count would put a large red number on a
+   * healthy install (ADR-041 §54 — the exact regression the attention-reason
+   * subset exists to prevent). Reported neutrally so the operator can see the
+   * queue without reading it as a problem.
+   */
+  salesDocumentIssuedOnRequest: number;
 }
 
 /**

--- a/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
@@ -326,6 +326,14 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
       .addSelect(
         `MIN(rec."salesDocumentBlockedAt") FILTER (WHERE ${OrderRecordRepository.IS_SALES_DOCUMENT_BLOCKED})`,
         'sales_document_blocked_oldest_at'
+      )
+      // #2554 — its own count, never inside `sales_document_blocked`:
+      // `IS_SALES_DOCUMENT_BLOCKED` is built from `SalesDocumentAttentionReasonValues`,
+      // which already excludes `'trigger-model-manual'` (ADR-041 §54), so this
+      // predicate and that one are mutually exclusive by construction.
+      .addSelect(
+        `COUNT(*) FILTER (WHERE rec."salesDocumentBlockReason" = 'trigger-model-manual')`,
+        'sales_document_issued_on_request'
       );
 
     if (filters.sourceConnectionId) {
@@ -353,6 +361,7 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
       sales_document_blocked: string;
       tax_rate_conflict: string;
       sales_document_blocked_oldest_at: Date | null;
+      sales_document_issued_on_request: string;
     }>();
 
     return {
@@ -365,6 +374,7 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
       salesDocumentBlocked: Number(raw?.sales_document_blocked ?? 0),
       taxRateConflict: Number(raw?.tax_rate_conflict ?? 0),
       salesDocumentBlockedOldestAt: raw?.sales_document_blocked_oldest_at ?? null,
+      salesDocumentIssuedOnRequest: Number(raw?.sales_document_issued_on_request ?? 0),
     };
   }
 


### PR DESCRIPTION
Closes #2554.

## Summary

**Backend (small, additive):** `OrderHealthSummary` (`countByHealth`) and its response DTO gain `salesDocumentIssuedOnRequest: number`, counting orders whose persisted `salesDocumentBlockReason` is `'trigger-model-manual'`. This is a small deviation from my own earlier instruction to keep M8 frontend-only: the acceptance criterion "It is still reported, neutrally, as its own figure" cannot be satisfied honestly from data already on the wire - the existing `salesDocumentBlocked` aggregate already correctly EXCLUDES `trigger-model-manual` (per `SalesDocumentAttentionReasonValues`, ADR-041 §54), so there was no existing count to read the manual-only population from without either (a) a second backend read, or (b) deriving it client-side from the current page's rows only, which would understate it on any page beyond the first - a false "N issued on request" is worse than a missing feature. The new predicate is mutually exclusive with `salesDocumentBlocked` by construction (both read `order_records.salesDocumentBlockReason`, one via the `SalesDocumentAttentionReasonValues` IN-list which already excludes `'trigger-model-manual'`, the other testing equality to exactly that value).

**Frontend:**

- Renamed the "Invoicing blocked" chip to "Sales documents blocked" - the underlying reasons (`SalesDocumentGateBlockReasonValue`) cover both invoices and fiscal receipts, so the old label asserted a narrower fact than the count behind it.
- Added a new neutral, non-interactive figure - "N issued on request" - rendered beside the chip, reading the new `salesDocumentIssuedOnRequest` summary field. It is deliberately NOT a clickable filter: there is no dedicated `salesDocumentBlocked`-shaped predicate for the manual-only population (it is defined by EXCLUSION from the attention set, not inclusion in one), and the per-order reason is already visible on every affected row via #2552's document line ("Issued on request").
- Reworded the invoicing-specific empty-state copy ("Nothing is blocked from invoicing" / "No order is waiting on an invoicing decision") to name the sales document generically, matching the chip rename - this copy is also cross-kind vocabulary the task's acceptance criteria calls out.

## Acceptance criteria mapping

- "Issue-on-request is excluded from the attention count" - true by construction; verified by a new test asserting the blocked chip's own count is unaffected when `salesDocumentIssuedOnRequest` is also non-zero.
- "It is still reported, neutrally, as its own figure" - the new `<span className="text-muted">` figure, not a link/button.
- "No label uses invoice vocabulary for a cross-kind fact" - chip rename + empty-state reword.
- "The attention figure links to the filter that shows those rows" - already true before this PR (the "Sales documents blocked" chip is clickable and toggles `?invoicing=blocked`); unaffected by the rename.

## What's included

- `libs/core/src/orders/domain/types/order-record.types.ts`: new field on `OrderHealthSummary`.
- `libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts`: new `COUNT(*) FILTER` clause in `countByHealth`, one indexed predicate against an existing column, no schema change.
- `apps/api/src/orders/http/dto/order-health-summary-response.dto.ts` + `orders.controller.spec.ts` fixture updates.
- `apps/web/src/features/orders/api/orders.types.ts`: FE mirror field (optional, graceful degradation).
- `apps/web/src/pages/orders/orders-list-page.tsx` + `.test.tsx`: chip rename, new figure, empty-state reword, existing `/invoicing blocked/i` test queries updated to `/sales documents blocked/i`, two new tests.

## Deliberately left out

- No new URL filter param or route for the issue-on-request population - it isn't filterable today and adding one is out of scope for a copy/count-correctness task.
- The internal `?invoicing=blocked` URL param name, the `invoicing_blocked` demo-analytics event name, and the `#invoicing` anchor id are left untouched - they are machine identifiers, not operator-facing labels, and renaming them would be a breaking change with no operator-visible benefit.

## Gate

- `pnpm --filter @openlinker/web type-check`, `pnpm --filter @openlinker/core type-check`, `pnpm --filter @openlinker/api type-check`: all clean.
- `eslint` on every changed file: 0 errors (pre-existing warnings only).
- `pnpm check:invariants` (filtered for `.worktrees`): all green.
- `orders-list-page.test.tsx`: 81/81 passing. `orders.controller.spec.ts`: 42/42. `order-record.repository.spec.ts`: 80/80.