### PR TITLE
fix(orders): mobile card folding and skeleton parity for the sales-document line (#2555)

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -9384,11 +9384,22 @@ a.kpi-card:focus-visible {
   align-items: center;
   gap: var(--space-2);
   max-width: 100%;
+  min-width: 0;
   font-size: 0.8125rem;
   font-weight: 500;
 }
 .sales-doc__glyph { flex: none; }
-.sales-doc__word { white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+/* `min-width: 0` is load-bearing (#2555): a flex child defaults to
+   `min-width: auto`, which refuses to shrink below its own text's intrinsic
+   width — so on a narrow mobile card the word would push the trigger wider
+   than the card rather than truncate inside it. */
+.sales-doc__word {
+  flex: 1 1 auto;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 .sales-doc--done,
 .sales-doc--progress { color: var(--text-secondary); }
 .sales-doc--idle { color: var(--text-muted); }
@@ -9432,6 +9443,7 @@ a.kpi-card:focus-visible {
   align-items: center;
   gap: var(--space-2);
   max-width: 100%;
+  min-width: 0;
   padding: 1px var(--space-1);
   margin: -1px calc(var(--space-1) * -1);
   border: none;
@@ -9443,6 +9455,22 @@ a.kpi-card:focus-visible {
 .sales-doc-trigger:hover,
 .sales-doc-trigger:focus-visible { background: var(--bg-surface-hover); }
 .sales-doc-trigger:focus-visible { outline: none; box-shadow: var(--shadow-focus); }
+/* #2555 — a real tap target on touch: the button's own box is tight (icon +
+   word), so the minimum comes from padding rather than font-size. `min-height`
+   only; width is intentionally left to content — a full-width hit target here
+   would make the whole card row read as one giant tappable area. */
+@media (pointer: coarse) {
+  .sales-doc-trigger { min-height: 44px; }
+}
+/* The mobile card's document line must fold, never push the card sideways
+   (#2555 acceptance criteria: no horizontal page scroll at 360px). The card
+   grid cell already carries `min-width: 0` (`.orders-card-facts > div`), so
+   this only needs to stop the trigger claiming more than the cell offers. */
+@media (max-width: 767.98px) {
+  .orders-card-facts .sales-doc-trigger,
+  .orders-card-facts .sales-doc { max-width: 100%; }
+  .orders-card-facts .sales-doc__word { min-width: 0; }
+}
 .sales-doc-popover__head { padding: var(--space-3) var(--space-4); border-bottom: 1px solid var(--border-subtle); }
 .sales-doc-popover__body { padding: var(--space-3) var(--space-4); display: flex; flex-direction: column; gap: var(--space-2); }
 .sales-doc-popover__foot {

--- a/apps/web/src/pages/orders/orders-list-page.test.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.test.tsx
@@ -210,6 +210,41 @@ describe('OrdersListPage', () => {
     expect(screen.getByRole('status')).toBeInTheDocument();
   });
 
+  it('should reserve five stacked lines in the money-cluster skeleton column (#2555)', () => {
+    const mockApi = createMockApiClient({
+      orders: { list: vi.fn().mockReturnValue(new Promise(() => {})) },
+    });
+
+    const { container } = renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
+
+    // The money column is the LAST one (select, order, customer, channel,
+    // status, shipment, money) — total, payment badge, the sales-document
+    // line, an optional tax-rate-conflict badge, and created: five facts at
+    // the tallest, so the skeleton must reserve five bars or the real row
+    // (with a conflicting-rate order) grows past it on load.
+    const lastCell = container.querySelector('tbody tr td:last-child');
+    expect(lastCell?.querySelectorAll('.data-table-skeleton__bar').length).toBe(5);
+  });
+
+  it('should reserve the extra mobile-card line for the multi-fact money column (#2555)', () => {
+    const viewport = mockMobileViewport();
+    try {
+      const mockApi = createMockApiClient({
+        orders: { list: vi.fn().mockReturnValue(new Promise(() => {})) },
+      });
+
+      const { container } = renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
+
+      const card = container.querySelector('.data-table-skeleton__card');
+      // Title + subtitle + one more (tallestColumn > 1) + the row action bar
+      // (this page's rows carry an inline Retry) — never a bare two-line card
+      // for a row whose real money cluster stacks up to five facts.
+      expect(card?.querySelectorAll('.data-table-skeleton__bar').length).toBe(4);
+    } finally {
+      viewport.restore();
+    }
+  });
+
   it('should show error state when fetch fails', async () => {
     const mockApi = createMockApiClient({
       orders: { list: vi.fn().mockRejectedValue(new Error('Network error')) },

--- a/apps/web/src/pages/orders/orders-list-page.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.tsx
@@ -968,8 +968,11 @@ export function OrdersListPage(): ReactElement {
       },
       {
         id: 'money',
-        // #2538 - Total, payment badge, document and created date - the column that sets this row's height.
-        lines: 4,
+        // #2538/#2555 - Total, payment badge, the sales-document line, an
+        // optional tax-rate-conflict badge, and the created date - five
+        // stacked facts at the tallest (a conflicting-rate order), so the
+        // skeleton reserves that height rather than the pre-#2552 count of 4.
+        lines: 5,
         align: 'right',
         // Merged money column (#1713): total + payment pill + created, each an
         // independent per-label sort control in the header. Not `sortable` — the


### PR DESCRIPTION
Closes #2555.

## Summary

The mobile card already rendered `SalesDocumentCell` (wired in #2552's PR, since that PR swapped `OrderInvoicingCell` out at both the desktop and mobile call sites in one pass). This PR closes the remaining gaps: the CSS needed for the line to actually FOLD inside a narrow card rather than push it sideways, and skeleton-height parity now that #2552 turned one collective "document" slot into two independent stacked facts.

### CSS fixes

- `.sales-doc__word` gains `min-width: 0` and `flex: 1 1 auto`. A flex child defaults to `min-width: auto`, which refuses to shrink below its own text's intrinsic width - so on a narrow card the word text would keep the trigger (and the card) wider than the viewport instead of truncating with the ellipsis rule already on it.
- `.sales-doc` / `.sales-doc-trigger` gain `min-width: 0` so the whole flex chain can shrink to the grid cell's available width (`.orders-card-facts > div` already carries `min-width: 0` from the existing card grid).
- `.sales-doc-trigger` gains `min-height: 44px` under `@media (pointer: coarse)` - width is left to content so the whole card row doesn't read as one giant tappable region.

### Skeleton parity

The money column's `lines` goes from 4 to 5. #2552 split what was one collective "document" slot (invoice pill + block badge + CTA, rendered by the old `OrderInvoicingCell`) into two independent stack items: the sales-document line, and a separate tax-rate-conflict badge that can appear alongside it. The tallest real row (total, payment, document, conflict, created) is now five facts, not four - unreserved, the real row would grow past the skeleton on load, which is exactly the layout shift `DataTableSkeleton`'s `lines` mechanism exists to prevent.

## Deviation from the task body

The task's file list named `apps/web/src/features/orders/` for the mobile wiring, but that wiring already shipped in #2552 (both call sites were swapped together, since `OrderInvoicingCell` and `SalesDocumentCell` have incompatible props and leaving one call site on the old component while the other moved would have been a worse intermediate state than doing both at once - documented in #2552's PR body). This PR is therefore CSS + skeleton-config only, no component wiring.

## Deliberately left out

**No true "no horizontal scroll at 360px" or "44px tap target" test.** jsdom has no real layout engine - it doesn't compute box models, so neither claim is measurable from a Vitest unit test. What's verified here is structural: the correct `min-width`/`flex`/`min-height` rules exist and apply to the right selectors, matching the reasoning documented above and in the CSS comments. A Playwright/e2e check at a real 360px viewport would be the honest way to close that gap for real, and is out of scope for what this repo's unit-test suite can do - flagging it explicitly rather than writing a test that would pass regardless of whether the CSS actually works.

## What's included

- `apps/web/src/index.css`: the three CSS fixes above, plus the `lines: 5` skeleton-config comment update.
- `apps/web/src/pages/orders/orders-list-page.tsx`: `lines: 5` on the money column definition (was 4).
- `apps/web/src/pages/orders/orders-list-page.test.tsx`: two new tests - one asserting the desktop skeleton's last column renders 5 bars, one asserting the mobile skeleton card reserves its extra line (title + subtitle + one more + the row-action bar, since this page's rows carry an inline Retry).

## Gate

- `pnpm --filter @openlinker/web type-check`: clean.
- `eslint` on both changed source files: 0 errors (pre-existing warnings only).
- `pnpm check:invariants` (filtered for `.worktrees`): all green.
- `orders-list-page.test.tsx`: 83/83 passing.