### PR TITLE
fix(orders): clear the FX stamp on intent-pinned rows during restatement

### DIFF
--- a/apps/api/test/integration/analytics/currency-remediation.int-spec.ts
+++ b/apps/api/test/integration/analytics/currency-remediation.int-spec.ts
@@ -101,6 +101,52 @@ describe('Currency remediation against real Postgres (#2468)', () => {
     return record.internalOrderId;
   }
 
+  /**
+   * The DEFERRED shape (#2775): `claimFxIntentIfAbsent` pinned an intent under
+   * a prior reporting currency, then the provider blipped, so the attempt
+   * returned `kind: 'deferred'` and no figure was ever written. The row carries
+   * FX state without carrying a figure.
+   */
+  async function seedDeferredOrder(total: number): Promise<string> {
+    const record = await createTestOrderRecord(harness.getDataSource(), {
+      placedAt: new Date('2026-08-03T00:00:00.000Z'),
+      recordStatus: 'ready',
+      totalAmount: total,
+      currency: reportingCurrency,
+      orderSnapshot: { items: [], totals: { total, currency: reportingCurrency } },
+      reportingCurrency: null,
+      reportingTotalAmount: null,
+      exchangeRateId: null,
+      fxStampedAt: null,
+      fxIntendedCurrency: STALE_REPORTING_CURRENCY,
+      fxRule: 'prev-business-day',
+    });
+    return record.internalOrderId;
+  }
+
+  /**
+   * The TERMINAL-MARKED shape (#2775): the pipeline reached a terminal answer,
+   * so `fxStampedAt` is set, but no figure was produced.
+   * `countRemainingCurrencyMismatch` counts these explicitly as
+   * `terminal_marked`, so they are unambiguously in the repaired population.
+   */
+  async function seedTerminalMarkedOrder(total: number): Promise<string> {
+    const record = await createTestOrderRecord(harness.getDataSource(), {
+      placedAt: new Date('2026-08-03T00:00:00.000Z'),
+      recordStatus: 'ready',
+      totalAmount: total,
+      currency: reportingCurrency,
+      orderSnapshot: { items: [], totals: { total, currency: reportingCurrency } },
+      reportingCurrency: null,
+      reportingTotalAmount: null,
+      exchangeRateId: null,
+      fxStampedAt: new Date('2026-08-03T01:00:00.000Z'),
+      fxIntendedCurrency: STALE_REPORTING_CURRENCY,
+      fxRule: 'prev-business-day',
+    });
+    return record.internalOrderId;
+  }
+
   async function readOrder(internalOrderId: string): Promise<OrderRecordOrmEntity> {
     return harness
       .getDataSource()
@@ -273,6 +319,100 @@ describe('Currency remediation against real Postgres (#2468)', () => {
 
     expect(second.id).not.toBe(first.id);
     expect(second.status).toBe('in-progress');
+  });
+
+  it('clears a DEFERRED row, whose pinned intent would otherwise re-stamp the stale currency (#2775)', async () => {
+    const orderId = await seedDeferredOrder(100);
+    const run = await runs.openRun({
+      category: 'currency',
+      affectedCount: 1,
+      triggeredByUserId: 'user-1',
+    });
+
+    const page = await restatement.restatePage(scope, reportingCurrency, {
+      runId: run.id,
+      afterOrderId: null,
+      limit: 50,
+    });
+
+    expect(page).toMatchObject({ scanned: 1, cleared: 1, enqueued: 1 });
+    const row = await readOrder(orderId);
+    expect(row.reportingCurrency).toBeNull();
+    expect(row.reportingTotalAmount).toBeNull();
+    expect(row.exchangeRateId).toBeNull();
+    expect(row.fxStampedAt).toBeNull();
+    expect(row.fxIntendedCurrency).toBeNull();
+    expect(row.fxRule).toBeNull();
+
+    // The point of the clear: the re-stamp names the CURRENT currency. With the
+    // stale intent left behind, `resolveIntent` re-pins it and the run cannot
+    // converge.
+    await expect(fxStamp.stamp(orderId)).resolves.toMatchObject({
+      kind: 'stamped',
+      alreadyStamped: false,
+      reportingCurrency,
+    });
+  });
+
+  it('clears a TERMINAL-MARKED row, so it is not held out by its own marker (#2775)', async () => {
+    const orderId = await seedTerminalMarkedOrder(60);
+    const run = await runs.openRun({
+      category: 'currency',
+      affectedCount: 1,
+      triggeredByUserId: 'user-1',
+    });
+
+    const page = await restatement.restatePage(scope, reportingCurrency, {
+      runId: run.id,
+      afterOrderId: null,
+      limit: 50,
+    });
+
+    expect(page).toMatchObject({ scanned: 1, cleared: 1 });
+    const row = await readOrder(orderId);
+    expect(row.fxStampedAt).toBeNull();
+    expect(row.fxIntendedCurrency).toBeNull();
+    expect(row.fxRule).toBeNull();
+
+    await expect(fxStamp.stamp(orderId)).resolves.toMatchObject({
+      kind: 'stamped',
+      reportingCurrency,
+      reportingTotalAmount: 60,
+    });
+  });
+
+  it('reaches resolved over a mixed population of stale, deferred and terminal-marked rows (#2775)', async () => {
+    const orderIds = [
+      await seedStaleStampedOrder(100),
+      await seedDeferredOrder(250),
+      await seedTerminalMarkedOrder(75),
+    ];
+    const run = await runs.openRun({
+      category: 'currency',
+      affectedCount: orderIds.length,
+      triggeredByUserId: 'user-1',
+    });
+
+    const page = await restatement.restatePage(scope, reportingCurrency, {
+      runId: run.id,
+      afterOrderId: null,
+      limit: 50,
+    });
+    expect(page).toMatchObject({ scanned: 3, cleared: 3, enqueued: 3 });
+
+    for (const orderId of orderIds) {
+      await fxStamp.stamp(orderId);
+    }
+
+    // Before #2775 the deferred and terminal-marked rows re-stamped USD, so
+    // this total stuck at 2 and the run's completion poll closed `failed`.
+    await expect(restatement.countRemaining(scope, reportingCurrency)).resolves.toMatchObject({
+      total: 0,
+      terminalMarked: 0,
+      pending: 0,
+    });
+    await expect(runs.markResolved(run.id)).resolves.toBe(true);
+    await expect(runs.getRun(run.id)).resolves.toMatchObject({ status: 'resolved', detail: null });
   });
 
   it('leaves a never-stamped order uncleared but still enqueued, so the guard is idempotent', async () => {

--- a/libs/core/src/orders/application/services/__tests__/order-fx-stamp.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-fx-stamp.service.spec.ts
@@ -333,6 +333,31 @@ describe('OrderFxStampService', () => {
       expect(rates.getRateFor).not.toHaveBeenCalled();
     });
 
+    it('should resolve the CURRENT reporting currency once a restatement page cleared a deferred row (#2775)', async () => {
+      // The deferred shape carries a pinned intent and no figure. Before #2775
+      // the restatement clear skipped it, `resolveIntent` re-pinned the stale
+      // currency, and the run could never converge. After the clear all six FX
+      // columns are NULL, so the settings service is consulted again.
+      const clearedRecord = buildRecord({
+        totals: { total: 100, currency: 'EUR' },
+        fxIntendedCurrency: null,
+        fxRule: null,
+      });
+      repository.findById.mockResolvedValue(clearedRecord);
+      repository.claimFxIntentIfAbsent.mockResolvedValue(true);
+      settings.resolve.mockResolvedValue('EUR');
+
+      const outcome = await service.stamp('ol_order_1');
+
+      expect(settings.resolve).toHaveBeenCalled();
+      expect(repository.claimFxIntentIfAbsent).toHaveBeenCalledWith(
+        'ol_order_1',
+        expect.objectContaining({ reportingCurrency: 'EUR' })
+      );
+      expect(outcome.kind).toBe('stamped');
+      expect((outcome as { reportingCurrency: string }).reportingCurrency).toBe('EUR');
+    });
+
     it("should adopt the winner's intent when the intent claim is lost", async () => {
       const record = buildRecord({ totals: { total: 100, currency: 'EUR' } });
       const winnerRecord = buildRecord({

--- a/libs/core/src/orders/domain/ports/order-record-repository.port.ts
+++ b/libs/core/src/orders/domain/ports/order-record-repository.port.ts
@@ -583,10 +583,23 @@ export interface OrderRecordRepositoryPort {
    *   - `fxRule`                — written as a pair with the intent by
    *                               `claimFxIntentIfAbsent`
    *
-   * Guarded on `reportingCurrency IS NOT NULL` so it is idempotent under a
-   * re-delivered driver job and can never touch a row that was never stamped
-   * (a never-stamped order is in the mismatch population too, and needs only
-   * the enqueue).
+   * Guarded on `reportingCurrency IS NOT NULL OR fxIntendedCurrency IS NOT
+   * NULL OR fxStampedAt IS NOT NULL` (#2775) so it is idempotent under a
+   * re-delivered driver job and can never touch a row carrying NO FX STATE AT
+   * ALL — a virgin order is in the mismatch population too, and needs only the
+   * enqueue.
+   *
+   * The guard is deliberately NOT "was this row ever stamped". Two ordinary
+   * shapes carry a pinned intent while carrying no figure, and both are inside
+   * {@link findCurrencyMismatchOrderRefsAfter}'s population:
+   *   - DEFERRED       — an intent was pinned, then the rate provider blipped
+   *   - TERMINAL-MARKED — `fxStampedAt` set with `reportingCurrency` still
+   *                      `NULL`, which {@link countRemainingCurrencyMismatch}
+   *                      counts explicitly as `terminalMarked`
+   * A figure-only guard skipped exactly those rows, left the stale intent
+   * standing, and had the child job re-stamp the currency the operator just
+   * moved away from — so the run's completion poll could never reach zero and
+   * closed `failed` blaming rate resolution.
    */
   clearFxStampForRestatement(internalOrderId: string): Promise<boolean>;
 

--- a/libs/core/src/orders/infrastructure/persistence/repositories/__tests__/order-record.repository.spec.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/__tests__/order-record.repository.spec.ts
@@ -682,21 +682,33 @@ describe('OrderRecordRepository', () => {
       ).resolves.toEqual([{ internalOrderId: 'ol_order_a', sourceConnectionId: 'conn-a' }]);
     });
 
-    it('clears exactly the six FX columns, guarded on the row still carrying a stamp', async () => {
-      // Every one of the six matters — see the port's JSDoc. `fxIntendedCurrency`
+    /**
+     * Builds a mock `createQueryBuilder().update()` chain and returns it, so the
+     * guard can be asserted as SQL rather than as a TypeORM operator object.
+     */
+    const mockClearQueryBuilder = (
+      affected: number
+    ): { set: jest.Mock; where: jest.Mock; andWhere: jest.Mock } => {
+      const chain = {
+        update: jest.fn().mockReturnThis(),
+        set: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        execute: jest.fn().mockResolvedValue({ affected }),
+      };
+      (ormRepository.createQueryBuilder as jest.Mock).mockReturnValue(chain);
+      return chain;
+    };
+
+    it('clears exactly the six FX columns in one statement', async () => {
+      // Every one of the six matters - see the port's JSDoc. `fxIntendedCurrency`
       // is the subtle one: leaving it behind makes `resolveIntent` re-pin the
       // stale currency and re-stamp it, so the bug looks fixed and is not.
-      (ormRepository.update as jest.Mock).mockResolvedValue({ affected: 1 });
+      const chain = mockClearQueryBuilder(1);
 
       await expect(repository.clearFxStampForRestatement('ol_order_a')).resolves.toBe(true);
 
-      const [where, patch] = (ormRepository.update as jest.Mock).mock.calls[0] as [
-        Record<string, unknown>,
-        Record<string, unknown>,
-      ];
-      expect(where).toMatchObject({ internalOrderId: 'ol_order_a' });
-      expect(where.reportingCurrency).toBeDefined();
-      expect(patch).toEqual({
+      expect(chain.set).toHaveBeenCalledWith({
         reportingCurrency: null,
         reportingTotalAmount: null,
         exchangeRateId: null,
@@ -704,10 +716,30 @@ describe('OrderRecordRepository', () => {
         fxIntendedCurrency: null,
         fxRule: null,
       });
+      expect(chain.where).toHaveBeenCalledWith(expect.stringContaining('"internalOrderId"'), {
+        internalOrderId: 'ol_order_a',
+      });
     });
 
-    it('reports false when the row was never stamped, so the clear is idempotent', async () => {
-      (ormRepository.update as jest.Mock).mockResolvedValue({ affected: 0 });
+    it('guards on ANY FX-group state, not on a figure alone, so deferred and terminal-marked rows are repaired (#2775)', async () => {
+      // The enumeration deliberately includes rows carrying no figure. A
+      // figure-only guard skipped exactly those, left the stale
+      // `fxIntendedCurrency` standing, and had the child re-stamp the currency
+      // the operator moved away from - so the run could never converge.
+      const chain = mockClearQueryBuilder(1);
+
+      await repository.clearFxStampForRestatement('ol_order_a');
+
+      const guard = (chain.andWhere.mock.calls as unknown[][])
+        .map((call) => String(call[0]))
+        .join(' ');
+      expect(guard).toContain('"reportingCurrency" IS NOT NULL');
+      expect(guard).toContain('"fxIntendedCurrency" IS NOT NULL');
+      expect(guard).toContain('"fxStampedAt" IS NOT NULL');
+    });
+
+    it('reports false when the row carries no FX state at all, so the clear is idempotent (#2775)', async () => {
+      mockClearQueryBuilder(0);
 
       await expect(repository.clearFxStampForRestatement('ol_order_a')).resolves.toBe(false);
     });

--- a/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
@@ -11,7 +11,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import type { DataSource, EntityManager, SelectQueryBuilder } from 'typeorm';
-import { In, IsNull, LessThan, MoreThanOrEqual, Not, Repository } from 'typeorm';
+import { In, IsNull, LessThan, MoreThanOrEqual, Repository } from 'typeorm';
 import type { OrderSyncStatusJson, SyncAttemptJson } from '../entities/order-record.orm-entity';
 import { OrderRecordOrmEntity } from '../entities/order-record.orm-entity';
 import { OrderLineItemOrmEntity } from '../entities/order-line-item.orm-entity';
@@ -652,23 +652,42 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
    * The six columns are set in a single guarded statement — the same
    * "the group can never half-apply" shape {@link stampFxIfAbsent} uses — so
    * a partial clear that would violate `ck_order_records_fx_group` is not
-   * expressible. `reportingCurrency: IsNull()` in the WHERE is what makes it
-   * idempotent: a second delivery of the same driver job finds nothing to
-   * clear and reports `false` rather than re-clearing a row the stamp
-   * pipeline may already have re-answered.
+   * expressible.
+   *
+   * The guard is a DISJUNCTION over the three columns that can independently
+   * carry FX state (#2775), not `reportingCurrency IS NOT NULL` alone. A row
+   * can hold a pinned `fxIntendedCurrency` with no figure at all — the
+   * deferred path (`claimFxIntentIfAbsent` pinned an intent, then the provider
+   * blipped) and the terminal-marked path (`fxStampedAt` set, no figure, which
+   * {@link countRemainingCurrencyMismatch} counts explicitly). Both are inside
+   * {@link findCurrencyMismatchOrderRefsAfter}'s population, and for both a
+   * figure-only guard matched nothing, left the stale intent behind, and let
+   * `resolveIntent` re-pin the currency the operator just moved away from — so
+   * the run could never converge.
+   *
+   * A query builder rather than the object-literal `where`, because TypeORM
+   * cannot express an OR across columns in that API. Idempotency is preserved
+   * by the disjunction itself: a virgin row (all six columns `NULL`) still
+   * matches nothing and reports `false`, so a re-delivered driver job does not
+   * re-clear a row the stamp pipeline has already re-answered.
    */
   async clearFxStampForRestatement(internalOrderId: string): Promise<boolean> {
-    const result = await this.repository.update(
-      { internalOrderId, reportingCurrency: Not(IsNull()) },
-      {
+    const result = await this.repository
+      .createQueryBuilder()
+      .update(OrderRecordOrmEntity)
+      .set({
         reportingCurrency: null,
         reportingTotalAmount: null,
         exchangeRateId: null,
         fxStampedAt: null,
         fxIntendedCurrency: null,
         fxRule: null,
-      }
-    );
+      })
+      .where('"internalOrderId" = :internalOrderId', { internalOrderId })
+      .andWhere(
+        '("reportingCurrency" IS NOT NULL OR "fxIntendedCurrency" IS NOT NULL OR "fxStampedAt" IS NOT NULL)'
+      )
+      .execute();
     return (result.affected ?? 0) > 0;
   }
 


### PR DESCRIPTION
## What was wrong

Three pieces of the Phase 5 currency remediation (#2467) disagreed about what "needs restating" means:

1. **Enumeration** (`findCurrencyMismatchOrderRefsAfter`) selects `reportingCurrency IS NULL OR reportingCurrency != :current` - it deliberately **includes** rows that carry no figure.
2. **The clear** (`clearFxStampForRestatement`) was guarded `{ internalOrderId, reportingCurrency: Not(IsNull()) }` - for exactly those rows it matched nothing, returned `false`, and left `fxIntendedCurrency` holding the **old** currency.
3. **The child stamp** (`OrderFxStampService.resolveIntent`) reads the persisted intent first and, by design, never consults `IReportingCurrencySettingsService` when one is present (ADR-040).

Net effect: the child re-stamped the stale currency, `countRemainingCurrencyMismatch` never reached `0`, the completion poll burned all 12 of its 5-minute polls, and `analytics_remediation_runs` closed `failed` with a detail blaming rate resolution. Retrying failed identically.

Two ordinary row shapes fell into the gap:

- **Deferred** - `claimFxIntentIfAbsent` pinned an intent, then the rate provider blipped, so the attempt returned `kind: 'deferred'` with no figure.
- **Terminal-marked** - `fxStampedAt` set, `reportingCurrency` still `NULL`. `countRemainingCurrencyMismatch` already counts these explicitly as `terminal_marked`, so the code knew they were in scope.

## What changed

`clearFxStampForRestatement` now guards on **any** FX-group state rather than on a figure alone:

```sql
"reportingCurrency" IS NOT NULL
  OR "fxIntendedCurrency" IS NOT NULL
  OR "fxStampedAt" IS NOT NULL
```

TypeORM's object-literal `where` cannot express an OR across columns, so this became a `createQueryBuilder().update()` with an explicit `.where(...)` / `.andWhere(...)`. The six-column write stays a **single statement**, so `ck_order_records_fx_group` can never half-apply, and the return-`boolean` contract (`affected > 0`) is unchanged.

Idempotency is preserved by the disjunction itself, which is what the old `reportingCurrency` guard was buying: a virgin row (all six FX columns `NULL`) still matches nothing and returns `false`, so a re-delivered driver job does not re-clear a row the stamp pipeline has already re-answered.

The port JSDoc no longer justifies the guard with "can never touch a row that was never stamped" - that sentence is true of a virgin row and false of a deferred or terminal-marked one. It now names the real property ("never touch a row with no FX state at all") and documents both shapes.

**Deliberately not in scope**: making `resolveIntent` re-read the settings service. That would reopen the ADR-040 hazard the pinning exists to close - provider availability becoming a silent input to a financial figure. The intent must be *cleared* by the one writer licensed to move a stamp, not *overridden* at read time. No migration is needed (WHERE clause only).

## Acceptance criteria coverage

| AC | Covered by |
|---|---|
| 1. Deferred shape (`reportingCurrency = NULL`, `fxIntendedCurrency` set) is cleared, all six columns nulled | `currency-remediation.int-spec.ts` - "clears a DEFERRED row, whose pinned intent would otherwise re-stamp the stale currency (#2775)" (real Postgres, asserts all six columns) |
| 2. Terminal-marked shape (`fxStampedAt` set, `reportingCurrency = NULL`) | `currency-remediation.int-spec.ts` - "clears a TERMINAL-MARKED row, so it is not held out by its own marker (#2775)" |
| 3. Still returns `false` and writes nothing when all six FX columns are `NULL` | `order-record.repository.spec.ts` - "reports false when the row carries no FX state at all, so the clear is idempotent (#2775)", plus the pre-existing int-spec "leaves a never-stamped order uncleared but still enqueued" (asserts real column state) |
| 4. After a restatement page over a deferred row, `stamp` resolves the **current** reporting currency | `order-fx-stamp.service.spec.ts` - "should resolve the CURRENT reporting currency once a restatement page cleared a deferred row (#2775)"; also end-to-end in the two int-spec cases above |
| 5. A run over a population with a deferred and a terminal-marked row reaches `countRemainingCurrencyMismatch().total === 0` and closes `resolved` | `currency-remediation.int-spec.ts` - "reaches resolved over a mixed population of stale, deferred and terminal-marked rows (#2775)" |
| 6. Port JSDoc no longer claims the guard is about "never stamped" | `order-record-repository.port.ts` |
| 7. Tests added for non-trivial logic / no boundary violations | 3 int-spec cases, 1 new repository unit spec plus 2 rewritten, 1 new service spec; infrastructure + domain-port only |

The guard SQL itself is additionally pinned by a unit spec ("guards on ANY FX-group state, not on a figure alone") that asserts the three `IS NOT NULL` arms against the emitted WHERE fragments rather than against a TypeORM operator object.

## Verification

The three int-spec cases were written **first** and confirmed failing against the unfixed guard (`cleared: 0` where `1` was expected, and `cleared: 1` where `3` was expected on the mixed population), then pass after the fix.

Suites run locally:

- `pnpm --filter @openlinker/core test -- order-record.repository order-fx-stamp.service order-fx-restatement.service` - 125 passed
- `pnpm --filter @openlinker/api test:integration -- currency-remediation` - 11 passed (Testcontainers Postgres)
- `pnpm type-check` - clean
- `pnpm lint` - 0 errors

**Not** run locally: the full `pnpm test` unit suite and the rest of `test:integration` (resource-constrained machine); CI covers them. `pnpm check:invariants` reports two pre-existing `migration-timestamps` violations from earlier epic phases (`1842000000000-add-analytics-display-settings`, `1843000000000-add-analytics-remediation-runs`) - untouched by this PR, which adds no migration.

## Branching

Targets **`epic/2452-analytics-currency-coverage`**, per epic #2452's branching strategy. The epic's own PR to `main` is #2668.

Closes #2775
