### PR TITLE
fix(orders): restate FX in-page instead of one realtime job per order

### DIFF
--- a/apps/api/test/integration/analytics/currency-remediation.int-spec.ts
+++ b/apps/api/test/integration/analytics/currency-remediation.int-spec.ts
@@ -37,6 +37,7 @@ import {
   type IOrderFxStampService,
 } from '@openlinker/core/orders';
 import { OrderRecordOrmEntity } from '@openlinker/core/orders/orm-entities';
+import { SyncJobOrmEntity } from '@openlinker/core/sync/orm-entities';
 import {
   getTestHarness,
   resetTestHarness,
@@ -164,7 +165,7 @@ describe('Currency remediation against real Postgres (#2468)', () => {
     expect(row.reportingCurrency).toBe(STALE_REPORTING_CURRENCY);
   });
 
-  it('clears all six FX columns and leaves the row on the sweep frontier', async () => {
+  it('clears all six FX columns and then re-stamps in-process, in the same page (#2776)', async () => {
     const orderId = await seedStaleStampedOrder(100);
     const run = await runs.openRun({
       category: 'currency',
@@ -178,45 +179,20 @@ describe('Currency remediation against real Postgres (#2468)', () => {
       limit: 50,
     });
 
-    expect(page).toMatchObject({ scanned: 1, cleared: 1 });
+    expect(page).toMatchObject({ scanned: 1, cleared: 1, stamped: 1, terminal: 0, deferred: 0 });
     const row = await readOrder(orderId);
-    expect(row.reportingCurrency).toBeNull();
-    expect(row.reportingTotalAmount).toBeNull();
-    expect(row.exchangeRateId).toBeNull();
-    expect(row.fxStampedAt).toBeNull();
-    // The subtle one: left behind, `resolveIntent` re-pins USD and the repair
-    // silently produces the same wrong figure.
-    expect(row.fxIntendedCurrency).toBeNull();
-    expect(row.fxRule).toBeNull();
-  });
-
-  it('re-stamps into the CURRENT reporting currency after the clear, not the stale one', async () => {
-    const orderId = await seedStaleStampedOrder(100);
-    const run = await runs.openRun({
-      category: 'currency',
-      affectedCount: 1,
-      triggeredByUserId: 'user-1',
-    });
-    await restatement.restatePage(scope, reportingCurrency, {
-      runId: run.id,
-      afterOrderId: null,
-      limit: 50,
-    });
-
-    const outcome = await fxStamp.stamp(orderId);
-
-    expect(outcome).toMatchObject({
-      kind: 'stamped',
-      alreadyStamped: false,
-      reportingCurrency,
-      reportingTotalAmount: 100,
-    });
-    const row = await readOrder(orderId);
+    // Re-stamped into the CURRENT reporting currency, not the stale one — the
+    // clear alone would leave every column null; the page's own in-process
+    // stamp is what produces a fresh, correct figure.
     expect(row.reportingCurrency).toBe(reportingCurrency);
     expect(Number(row.reportingTotalAmount)).toBe(100);
+    // The subtle one: left behind, `resolveIntent` would have re-pinned USD
+    // and the repair would silently reproduce the same wrong figure.
+    expect(row.fxIntendedCurrency).toBe(reportingCurrency);
+    expect(row.fxRule).not.toBeNull();
   });
 
-  it('reaches resolved once the whole scope is re-stamped, with the ledger row as the only state', async () => {
+  it('reaches resolved once the whole scope is re-stamped by the page itself, with no child job anywhere', async () => {
     const orderIds = [
       await seedStaleStampedOrder(100),
       await seedStaleStampedOrder(250),
@@ -229,8 +205,8 @@ describe('Currency remediation against real Postgres (#2468)', () => {
     });
 
     // Enumerate in two pages so the keyset cursor is genuinely exercised: a
-    // cleared row still satisfies the mismatch predicate, so an offset walk
-    // would re-read page one forever.
+    // cleared-and-restamped row no longer satisfies the mismatch predicate,
+    // so this also proves the cursor advances over rows this run itself fixed.
     const first = await restatement.restatePage(scope, reportingCurrency, {
       runId: run.id,
       afterOrderId: null,
@@ -244,18 +220,9 @@ describe('Currency remediation against real Postgres (#2468)', () => {
     });
     expect(second.nextCursor).toBeNull();
     expect(first.scanned + second.scanned).toBe(3);
+    expect(first.stamped + second.stamped).toBe(3);
 
-    // Mid-run the population is still fully mismatched (cleared, not stamped).
-    await expect(restatement.countRemaining(scope, reportingCurrency)).resolves.toMatchObject({
-      total: 3,
-      terminalMarked: 0,
-      pending: 3,
-    });
-
-    for (const orderId of orderIds) {
-      await fxStamp.stamp(orderId);
-    }
-
+    // The page itself stamped every order — nothing left to converge on.
     await expect(restatement.countRemaining(scope, reportingCurrency)).resolves.toMatchObject({
       total: 0,
     });
@@ -265,10 +232,32 @@ describe('Currency remediation against real Postgres (#2468)', () => {
       detail: null,
       affectedCount: 3,
     });
+
+    // #2776's whole point: zero `marketplace.order.fxStamp` rows were ever
+    // created for this run, and therefore zero `realtime`-lane slots spent.
+    const fxStampJobCount = await harness
+      .getDataSource()
+      .getRepository(SyncJobOrmEntity)
+      .count({ where: { jobType: 'marketplace.order.fxStamp' } });
+    expect(fxStampJobCount).toBe(0);
   });
 
   it('fails with a non-empty detail while orders remain, and reports the terminal partition honestly', async () => {
-    await seedStaleStampedOrder(100);
+    // A row whose snapshot carries no native total: the in-process stamp
+    // reaches a genuinely TERMINAL answer (`no-native-total`), so — unlike a
+    // same-currency row, which the page now stamps outright — this one stays
+    // in the mismatched population after the page runs.
+    await createTestOrderRecord(harness.getDataSource(), {
+      placedAt: new Date('2026-08-03T00:00:00.000Z'),
+      recordStatus: 'ready',
+      totalAmount: 100,
+      currency: STALE_REPORTING_CURRENCY,
+      reportingCurrency: STALE_REPORTING_CURRENCY,
+      reportingTotalAmount: 200,
+      fxStampedAt: new Date('2026-08-03T01:00:00.000Z'),
+      fxIntendedCurrency: STALE_REPORTING_CURRENCY,
+      fxRule: 'prev-business-day',
+    });
     const run = await runs.openRun({
       category: 'currency',
       affectedCount: 1,
@@ -282,6 +271,7 @@ describe('Currency remediation against real Postgres (#2468)', () => {
 
     const remaining = await restatement.countRemaining(scope, reportingCurrency);
     expect(remaining.total).toBe(1);
+    expect(remaining.terminalMarked).toBe(1);
 
     await expect(runs.markFailed(run.id, `${remaining.total} order(s) still unstamped`)).resolves.toBe(
       true
@@ -335,26 +325,16 @@ describe('Currency remediation against real Postgres (#2468)', () => {
       limit: 50,
     });
 
-    expect(page).toMatchObject({ scanned: 1, cleared: 1, enqueued: 1 });
-    const row = await readOrder(orderId);
-    expect(row.reportingCurrency).toBeNull();
-    expect(row.reportingTotalAmount).toBeNull();
-    expect(row.exchangeRateId).toBeNull();
-    expect(row.fxStampedAt).toBeNull();
-    expect(row.fxIntendedCurrency).toBeNull();
-    expect(row.fxRule).toBeNull();
-
     // The point of the clear: the re-stamp names the CURRENT currency. With the
-    // stale intent left behind, `resolveIntent` re-pins it and the run cannot
-    // converge.
-    await expect(fxStamp.stamp(orderId)).resolves.toMatchObject({
-      kind: 'stamped',
-      alreadyStamped: false,
-      reportingCurrency,
-    });
+    // stale intent left behind, `resolveIntent` would re-pin it and the run
+    // could never converge.
+    expect(page).toMatchObject({ scanned: 1, cleared: 1, stamped: 1 });
+    const row = await readOrder(orderId);
+    expect(row.reportingCurrency).toBe(reportingCurrency);
+    expect(row.fxIntendedCurrency).toBe(reportingCurrency);
   });
 
-  it('clears a TERMINAL-MARKED row, so it is not held out by its own marker (#2775)', async () => {
+  it('clears a TERMINAL-MARKED row, then re-stamps it in the same page, so it is not held out by its own marker (#2775, #2776)', async () => {
     const orderId = await seedTerminalMarkedOrder(60);
     const run = await runs.openRun({
       category: 'currency',
@@ -368,20 +348,13 @@ describe('Currency remediation against real Postgres (#2468)', () => {
       limit: 50,
     });
 
-    expect(page).toMatchObject({ scanned: 1, cleared: 1 });
+    expect(page).toMatchObject({ scanned: 1, cleared: 1, stamped: 1 });
     const row = await readOrder(orderId);
-    expect(row.fxStampedAt).toBeNull();
-    expect(row.fxIntendedCurrency).toBeNull();
-    expect(row.fxRule).toBeNull();
-
-    await expect(fxStamp.stamp(orderId)).resolves.toMatchObject({
-      kind: 'stamped',
-      reportingCurrency,
-      reportingTotalAmount: 60,
-    });
+    expect(row.reportingCurrency).toBe(reportingCurrency);
+    expect(Number(row.reportingTotalAmount)).toBe(60);
   });
 
-  it('reaches resolved over a mixed population of stale, deferred and terminal-marked rows (#2775)', async () => {
+  it('reaches resolved over a mixed population of stale, deferred and terminal-marked rows (#2775, #2776)', async () => {
     const orderIds = [
       await seedStaleStampedOrder(100),
       await seedDeferredOrder(250),
@@ -398,14 +371,10 @@ describe('Currency remediation against real Postgres (#2468)', () => {
       afterOrderId: null,
       limit: 50,
     });
-    expect(page).toMatchObject({ scanned: 3, cleared: 3, enqueued: 3 });
-
-    for (const orderId of orderIds) {
-      await fxStamp.stamp(orderId);
-    }
-
     // Before #2775 the deferred and terminal-marked rows re-stamped USD, so
     // this total stuck at 2 and the run's completion poll closed `failed`.
+    expect(page).toMatchObject({ scanned: 3, cleared: 3, stamped: 3 });
+
     await expect(restatement.countRemaining(scope, reportingCurrency)).resolves.toMatchObject({
       total: 0,
       terminalMarked: 0,
@@ -415,7 +384,7 @@ describe('Currency remediation against real Postgres (#2468)', () => {
     await expect(runs.getRun(run.id)).resolves.toMatchObject({ status: 'resolved', detail: null });
   });
 
-  it('leaves a never-stamped order uncleared but still enqueued, so the guard is idempotent', async () => {
+  it('leaves a never-stamped order uncleared but still stamps it, so the guard is idempotent', async () => {
     const record = await createTestOrderRecord(harness.getDataSource(), {
       placedAt: new Date('2026-08-03T00:00:00.000Z'),
       recordStatus: 'ready',
@@ -437,8 +406,8 @@ describe('Currency remediation against real Postgres (#2468)', () => {
       limit: 50,
     });
 
-    expect(page).toMatchObject({ scanned: 1, cleared: 0, enqueued: 1 });
+    expect(page).toMatchObject({ scanned: 1, cleared: 0, stamped: 1 });
     const row = await readOrder(record.internalOrderId);
-    expect(row.fxStampedAt).toBeNull();
+    expect(row.reportingCurrency).toBe(reportingCurrency);
   });
 });

--- a/apps/web/src/pages/analytics/analytics-page.test.tsx
+++ b/apps/web/src/pages/analytics/analytics-page.test.tsx
@@ -1,4 +1,5 @@
 import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import { renderWithProviders, createMockApiClient } from '../../test/test-utils';
 import { AnalyticsPage } from './analytics-page';
@@ -299,5 +300,56 @@ describe('AnalyticsPage', () => {
 
     expect(await screen.findByText('Allegro — main')).toBeInTheDocument();
     expect(await screen.findByText('Unable to check for open items')).toBeInTheDocument();
+  });
+
+  it('should keep the URL-encoded displayCurrency/rateBasis when a date-range preset is applied', async () => {
+    // Regression guard: `handleApply` used to call `setSearchParams({ from, to })`
+    // with a literal object, which REPLACES the whole query string — silently
+    // dropping `displayCurrency`/`rateBasis` and resetting the picker to
+    // "Current rate" on every date change. ADR-064 states both are
+    // URL-encoded "like the existing date-range filter", i.e. they must
+    // survive exactly what `from`/`to` survive.
+    const user = userEvent.setup();
+    const apiClient = createMockApiClient({
+      analyticsTrust: { getTrust: vi.fn().mockResolvedValue(healthySnapshot()) },
+      analytics: {
+        getSales: vi.fn().mockResolvedValue({
+          headline: {
+            revenue: 4800,
+            currency: 'PLN',
+            orderCount: 40,
+            averageOrderValue: 120,
+            medianOrderValue: 100,
+            unitsSold: 60,
+            cancelledCount: 2,
+            cancelledValue: 200,
+            unconvertedCount: 0,
+            unconvertedValue: 0,
+            unconvertedCurrency: null,
+            netRevenue: 4300,
+            netAverageOrderValue: 107.5,
+            netMedianOrderValue: 90,
+            netExcludedCount: 0,
+            netExcludedValue: 0,
+            trend: [],
+          },
+          channels: [],
+        }),
+      },
+    });
+
+    renderWithProviders(<AnalyticsPage />, {
+      apiClient,
+      route: '/analytics?from=2026-07-16&to=2026-08-14&displayCurrency=EUR&rateBasis=order-date',
+    });
+
+    const picker = await screen.findByRole('combobox', { name: 'Display currency' });
+    expect(picker).toHaveValue('EUR');
+
+    // "7d" is a genuinely different range from the ROUTE's custom from/to, so
+    // clicking it commits immediately via `handleSegmentChange` -> `onApply`.
+    await user.click(screen.getByRole('radio', { name: '7d' }));
+
+    expect(await screen.findByRole('combobox', { name: 'Display currency' })).toHaveValue('EUR');
   });
 });

--- a/apps/web/src/pages/analytics/analytics-page.tsx
+++ b/apps/web/src/pages/analytics/analytics-page.tsx
@@ -54,7 +54,10 @@ export function AnalyticsPage(): ReactElement {
   // not an implicit fallback that only exists in memory.
   useEffect(() => {
     if (!searchParams.get('from') || !searchParams.get('to')) {
-      setSearchParams({ from, to }, { replace: true });
+      const next = new URLSearchParams(searchParams);
+      next.set('from', from);
+      next.set('to', to);
+      setSearchParams(next, { replace: true });
     }
     // Deliberate `[]`: this project's ESLint config carries no
     // `react-hooks/exhaustive-deps` rule (verified via `pnpm lint` — an
@@ -66,7 +69,14 @@ export function AnalyticsPage(): ReactElement {
   }, []);
 
   function handleApply(nextFrom: string, nextTo: string): void {
-    setSearchParams({ from: nextFrom, to: nextTo });
+    // Merge onto the existing params, never replace wholesale — `from`/`to`
+    // are not the only state this URL carries (ADR-064: `displayCurrency` /
+    // `rateBasis` are URL-encoded "like the existing date-range filter"), and
+    // a literal-object `setSearchParams` call drops every other param.
+    const next = new URLSearchParams(searchParams);
+    next.set('from', nextFrom);
+    next.set('to', nextTo);
+    setSearchParams(next);
   }
 
   const trustQuery = useAnalyticsTrustQuery();

--- a/apps/worker/src/sync/handlers/analytics-currency-recalculate.handler.spec.ts
+++ b/apps/worker/src/sync/handlers/analytics-currency-recalculate.handler.spec.ts
@@ -75,7 +75,7 @@ describe('AnalyticsCurrencyRecalculateHandler', () => {
     restatement = {
       restatePage: jest
         .fn()
-        .mockResolvedValue({ scanned: 3, cleared: 3, enqueued: 3, nextCursor: null }),
+        .mockResolvedValue({ scanned: 3, cleared: 3, stamped: 3, terminal: 0, deferred: 0, nextCursor: null }),
       countRemaining: jest.fn().mockResolvedValue({ total: 0, terminalMarked: 0, pending: 0 }),
     };
     reportingCurrency = {
@@ -100,9 +100,11 @@ describe('AnalyticsCurrencyRecalculateHandler', () => {
 
   it('should reschedule immediately with the next keyset cursor while enumeration continues', async () => {
     restatement.restatePage.mockResolvedValue({
-      scanned: 200,
-      cleared: 200,
-      enqueued: 200,
+      scanned: 100,
+      cleared: 100,
+      stamped: 100,
+      terminal: 0,
+      deferred: 0,
       nextCursor: 'ol_order_z',
     });
 
@@ -123,9 +125,11 @@ describe('AnalyticsCurrencyRecalculateHandler', () => {
     // from the run id alone would let the run advance exactly once and then
     // stall at `in-progress` forever (#2039's `reconcileId` trap).
     restatement.restatePage.mockResolvedValue({
-      scanned: 200,
-      cleared: 200,
-      enqueued: 200,
+      scanned: 100,
+      cleared: 100,
+      stamped: 100,
+      terminal: 0,
+      deferred: 0,
       nextCursor: 'ol_order_z',
     });
 
@@ -182,9 +186,11 @@ describe('AnalyticsCurrencyRecalculateHandler', () => {
     // Restart-safety: a fresh handler instance handed a mid-run payload must
     // resume exactly where the payload says, with no prior call.
     restatement.restatePage.mockResolvedValue({
-      scanned: 200,
-      cleared: 200,
-      enqueued: 200,
+      scanned: 100,
+      cleared: 100,
+      stamped: 100,
+      terminal: 0,
+      deferred: 0,
       nextCursor: 'ol_order_zz',
     });
 

--- a/apps/worker/src/sync/handlers/analytics-currency-recalculate.handler.spec.ts
+++ b/apps/worker/src/sync/handlers/analytics-currency-recalculate.handler.spec.ts
@@ -75,7 +75,7 @@ describe('AnalyticsCurrencyRecalculateHandler', () => {
     restatement = {
       restatePage: jest
         .fn()
-        .mockResolvedValue({ scanned: 3, cleared: 3, stamped: 3, terminal: 0, deferred: 0, nextCursor: null }),
+        .mockResolvedValue({ scanned: 3, cleared: 3, stamped: 3, terminal: 0, deferred: 0, failed: 0, nextCursor: null }),
       countRemaining: jest.fn().mockResolvedValue({ total: 0, terminalMarked: 0, pending: 0 }),
     };
     reportingCurrency = {
@@ -105,6 +105,7 @@ describe('AnalyticsCurrencyRecalculateHandler', () => {
       stamped: 100,
       terminal: 0,
       deferred: 0,
+      failed: 0,
       nextCursor: 'ol_order_z',
     });
 
@@ -130,6 +131,7 @@ describe('AnalyticsCurrencyRecalculateHandler', () => {
       stamped: 100,
       terminal: 0,
       deferred: 0,
+      failed: 0,
       nextCursor: 'ol_order_z',
     });
 
@@ -191,6 +193,7 @@ describe('AnalyticsCurrencyRecalculateHandler', () => {
       stamped: 100,
       terminal: 0,
       deferred: 0,
+      failed: 0,
       nextCursor: 'ol_order_zz',
     });
 

--- a/apps/worker/src/sync/handlers/analytics-currency-recalculate.handler.ts
+++ b/apps/worker/src/sync/handlers/analytics-currency-recalculate.handler.ts
@@ -7,9 +7,9 @@
  *
  *  1. **Enumeration.** `IOrderFxRestatementService.restatePage` clears the
  *     ADR-040 FX stamp on one keyset page of the run's mismatched population
- *     and enqueues a `marketplace.order.fxStamp` job per order under a
- *     run-scoped idempotency key. While a `nextCursor` comes back, the handler
- *     re-schedules itself immediately with that cursor.
+ *     and stamps each order in-process, sequentially — no child job, no
+ *     `realtime`-lane fan-out (#2776). While a `nextCursor` comes back, the
+ *     handler re-schedules itself immediately with that cursor.
  *  2. **Completion poll.** Once the frontier is exhausted, the handler re-reads
  *     the remaining population. Empty -> the run is `resolved`. Non-empty ->
  *     re-schedule after a delay, up to a bounded number of polls, then `failed`
@@ -61,16 +61,18 @@ import { Logger } from '@openlinker/shared/logging';
 type SyncJob = SyncJobEntity;
 
 /**
- * Orders cleared + enqueued per enumeration page.
+ * Orders cleared + stamped per enumeration page.
  *
- * Sized off what one page COSTS rather than copied from a sibling sweep: each
- * unit is one guarded UPDATE plus one enqueue, both cheap, so the page can be
- * generously large — but every enqueued child is a real stamp job with a
- * possible provider round-trip behind it, so a page that is too large front-
- * loads the `realtime` lane. 200 keeps a typical operator's whole range in one
- * or two pages while staying well inside one job's wall clock.
+ * The page is now a WALL-CLOCK unit, not 200 cheap writes — #2776 moved the
+ * stamp itself in-process (a guarded clear plus a real, possibly
+ * provider-round-tripping stamp per order, sequential, no child job), so a
+ * page's cost scales with real stamp latency rather than with a cheap
+ * enqueue. 100 matches `DEFAULT_LIMIT` in the sibling
+ * `marketplace.order.fxStampSweep` handler, and leaves ample headroom between
+ * the 3-minute `lockedAt` heartbeat (`sync-job.runner.ts`) and the 15-minute
+ * stuck-job timeout (`stuck-job-recovery.service.ts`).
  */
-const RESTATEMENT_PAGE_SIZE = 200;
+const RESTATEMENT_PAGE_SIZE = 100;
 
 @Injectable()
 export class AnalyticsCurrencyRecalculateHandler implements SyncJobHandler {

--- a/libs/core/src/orders/application/interfaces/order-fx-restatement.service.interface.ts
+++ b/libs/core/src/orders/application/interfaces/order-fx-restatement.service.interface.ts
@@ -20,8 +20,8 @@ import type {
 
 export interface IOrderFxRestatementService {
   /**
-   * Clear + re-enqueue one bounded page of the mismatched population in
-   * `scope`.
+   * Clear + re-stamp one bounded page of the mismatched population in
+   * `scope`, in-process and sequentially — no child job is enqueued.
    *
    * `scope` is the SAME `SalesAnalyticsFilters` the coverage detector counted
    * over, so the repair can never be wider than the figure the operator

--- a/libs/core/src/orders/application/services/__tests__/order-fx-restatement.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-fx-restatement.service.spec.ts
@@ -53,9 +53,7 @@ describe('OrderFxRestatementService', () => {
   });
 
   function seed(ids: string[]): void {
-    repository.findCurrencyMismatchOrderRefsAfter.mockResolvedValue(
-      ids.map((internalOrderId) => ({ internalOrderId, sourceConnectionId: 'conn-1' }))
-    );
+    repository.findCurrencyMismatchOrderRefsAfter.mockResolvedValue(ids);
   }
 
   it('should not enqueue any job during a restatement page', async () => {
@@ -88,11 +86,8 @@ describe('OrderFxRestatementService', () => {
     expect(order).toEqual(['clear', 'stamp']);
   });
 
-  it('should stamp every ref in the page, sequentially', async () => {
-    repository.findCurrencyMismatchOrderRefsAfter.mockResolvedValue([
-      { internalOrderId: 'ol_order_a', sourceConnectionId: 'conn-a' },
-      { internalOrderId: 'ol_order_b', sourceConnectionId: 'conn-b' },
-    ]);
+  it('should stamp every id in the page, sequentially', async () => {
+    seed(['ol_order_a', 'ol_order_b']);
 
     await service.restatePage(SCOPE, 'EUR', { runId: 'run-1', afterOrderId: null, limit: 10 });
 
@@ -174,7 +169,29 @@ describe('OrderFxRestatementService', () => {
 
     await expect(
       service.restatePage(SCOPE, 'EUR', { runId: 'run-1', afterOrderId: null, limit: 10 })
-    ).resolves.toMatchObject({ scanned: 3, stamped: 1, terminal: 1, deferred: 1 });
+    ).resolves.toMatchObject({ scanned: 3, stamped: 1, terminal: 1, deferred: 1, failed: 0 });
+  });
+
+  it('should keep going, and still count the rest, when one order`s stamp attempt throws', async () => {
+    // `IOrderFxStampService.stamp` is documented as never throwing, but that
+    // is an implementation promise on an injected interface, not a type
+    // guarantee — and this page replaced N independent per-order jobs with
+    // ONE sequential loop, so an unguarded throw here would silently abort
+    // every order still queued behind it. Tallied as `failed`, distinct from
+    // an ordinary `stamp()`-reported `deferred`.
+    stampService.stamp
+      .mockRejectedValueOnce(new Error('unexpected stamp() failure'))
+      .mockResolvedValueOnce(STAMPED_OUTCOME);
+    seed(['ol_order_a', 'ol_order_b']);
+
+    const result = await service.restatePage(SCOPE, 'EUR', {
+      runId: 'run-1',
+      afterOrderId: null,
+      limit: 10,
+    });
+
+    expect(result).toMatchObject({ scanned: 2, stamped: 1, failed: 1 });
+    expect(stampService.stamp.mock.calls.map(([id]) => id)).toEqual(['ol_order_a', 'ol_order_b']);
   });
 
   it('should not count an already-stamped outcome as a fresh stamp', async () => {

--- a/libs/core/src/orders/application/services/__tests__/order-fx-restatement.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-fx-restatement.service.spec.ts
@@ -1,9 +1,10 @@
 /**
- * Order FX Restatement Service Tests (#2468)
+ * Order FX Restatement Service Tests (#2468, #2776)
  *
  * @module libs/core/src/orders/application/services
  */
-import type { JobEnqueuePort } from '@openlinker/core/sync';
+import type { FxStampOutcome } from '../../../domain/types/order-fx-stamp.types';
+import type { IOrderFxStampService } from '../../interfaces/order-fx-stamp.service.interface';
 import type { OrderRecordRepositoryPort } from '../../../domain/ports/order-record-repository.port';
 import type { SalesAnalyticsFilters } from '../../../domain/types/order-sales-analytics.types';
 import { OrderFxRestatementService } from '../order-fx-restatement.service';
@@ -11,6 +12,14 @@ import { OrderFxRestatementService } from '../order-fx-restatement.service';
 const SCOPE: SalesAnalyticsFilters = {
   from: new Date('2026-08-01T00:00:00Z'),
   to: new Date('2026-08-27T00:00:00Z'),
+};
+
+const STAMPED_OUTCOME: FxStampOutcome = {
+  kind: 'stamped',
+  reportingCurrency: 'EUR',
+  reportingTotalAmount: 12.34,
+  exchangeRateId: 'rate-1',
+  alreadyStamped: false,
 };
 
 describe('OrderFxRestatementService', () => {
@@ -22,7 +31,7 @@ describe('OrderFxRestatementService', () => {
       | 'countRemainingCurrencyMismatch'
     >
   >;
-  let jobEnqueue: jest.Mocked<JobEnqueuePort>;
+  let stampService: jest.Mocked<IOrderFxStampService>;
   let service: OrderFxRestatementService;
 
   beforeEach(() => {
@@ -33,10 +42,13 @@ describe('OrderFxRestatementService', () => {
         .fn()
         .mockResolvedValue({ total: 0, terminalMarked: 0, pending: 0 }),
     };
-    jobEnqueue = { enqueueJob: jest.fn().mockResolvedValue({ jobId: 'job-1', isExisting: false }) };
+    stampService = {
+      stamp: jest.fn().mockResolvedValue(STAMPED_OUTCOME),
+      sweep: jest.fn(),
+    };
     service = new OrderFxRestatementService(
       repository as unknown as OrderRecordRepositoryPort,
-      jobEnqueue
+      stampService
     );
   });
 
@@ -46,46 +58,37 @@ describe('OrderFxRestatementService', () => {
     );
   }
 
-  it('should clear an order stamp BEFORE enqueuing its stamp job', async () => {
-    // Reversed, the stamp job can legitimately run first, find the stale figure
-    // still present, and no-op via `stamp()`'s already-stamped short-circuit —
-    // which is exactly the original live-demo bug ("we re-enqueued and nothing
-    // changed").
+  it('should not enqueue any job during a restatement page', async () => {
+    seed(['ol_order_a']);
+
+    await service.restatePage(SCOPE, 'EUR', { runId: 'run-1', afterOrderId: null, limit: 10 });
+
+    // No JobEnqueuePort is even injected any more — the assertion that matters
+    // is that the only downstream call is the direct, in-process stamp.
+    expect(stampService.stamp).toHaveBeenCalledWith('ol_order_a');
+  });
+
+  it('should clear an order stamp BEFORE stamping it', async () => {
+    // Reversed, `stamp()` would re-observe the still-present stale figure and
+    // short-circuit via its own already-stamped branch — the original
+    // live-demo bug ("we re-enqueued and nothing changed").
     const order: string[] = [];
     repository.clearFxStampForRestatement.mockImplementation(() => {
       order.push('clear');
       return Promise.resolve(true);
     });
-    jobEnqueue.enqueueJob.mockImplementation(() => {
-      order.push('enqueue');
-      return Promise.resolve({ jobId: 'job-1', isExisting: false });
+    stampService.stamp.mockImplementation(() => {
+      order.push('stamp');
+      return Promise.resolve(STAMPED_OUTCOME);
     });
     seed(['ol_order_a']);
 
     await service.restatePage(SCOPE, 'EUR', { runId: 'run-1', afterOrderId: null, limit: 10 });
 
-    expect(order).toEqual(['clear', 'enqueue']);
+    expect(order).toEqual(['clear', 'stamp']);
   });
 
-  it('should enqueue under a run-scoped idempotency key, never the TTL-less bare fx:{orderId}', async () => {
-    // `OrderFxStampService.enqueueRetry` already spent `fx:{orderId}` for any
-    // order that ever degraded to a retry, and `sync_jobs.idempotencyKey` is
-    // globally unique with no TTL — reusing it would silently enqueue nothing.
-    seed(['ol_order_a']);
-
-    await service.restatePage(SCOPE, 'EUR', { runId: 'run-1', afterOrderId: null, limit: 10 });
-
-    expect(jobEnqueue.enqueueJob).toHaveBeenCalledWith(
-      expect.objectContaining({
-        jobType: 'marketplace.order.fxStamp',
-        connectionId: 'conn-1',
-        idempotencyKey: 'fx:restate:run-1:ol_order_a',
-        payload: { schemaVersion: 1, internalOrderId: 'ol_order_a' },
-      })
-    );
-  });
-
-  it("should file each child job under the order's own source connection", async () => {
+  it('should stamp every ref in the page, sequentially', async () => {
     repository.findCurrencyMismatchOrderRefsAfter.mockResolvedValue([
       { internalOrderId: 'ol_order_a', sourceConnectionId: 'conn-a' },
       { internalOrderId: 'ol_order_b', sourceConnectionId: 'conn-b' },
@@ -93,10 +96,7 @@ describe('OrderFxRestatementService', () => {
 
     await service.restatePage(SCOPE, 'EUR', { runId: 'run-1', afterOrderId: null, limit: 10 });
 
-    expect(jobEnqueue.enqueueJob.mock.calls.map(([req]) => req.connectionId)).toEqual([
-      'conn-a',
-      'conn-b',
-    ]);
+    expect(stampService.stamp.mock.calls.map(([id]) => id)).toEqual(['ol_order_a', 'ol_order_b']);
   });
 
   it('should return the last id as the cursor on a full page and null on a short one', async () => {
@@ -126,15 +126,15 @@ describe('OrderFxRestatementService', () => {
     });
   });
 
-  it('should not count a never-stamped order as cleared, but still enqueue it', async () => {
+  it('should not count a never-stamped order as cleared, but still stamp it', async () => {
     // A never-stamped order is in the mismatch population too; the guarded
-    // clear reports false for it and only the enqueue matters.
+    // clear reports false for it and stamping still proceeds.
     repository.clearFxStampForRestatement.mockResolvedValue(false);
     seed(['ol_order_a']);
 
     await expect(
       service.restatePage(SCOPE, 'EUR', { runId: 'run-1', afterOrderId: null, limit: 10 })
-    ).resolves.toMatchObject({ cleared: 0, enqueued: 1 });
+    ).resolves.toMatchObject({ cleared: 0, stamped: 1 });
   });
 
   it('should keep going when one order fails to clear, so a single bad row cannot abort the repair', async () => {
@@ -149,18 +149,41 @@ describe('OrderFxRestatementService', () => {
       limit: 10,
     });
 
-    expect(result).toMatchObject({ scanned: 2, cleared: 1 });
+    expect(result).toMatchObject({ scanned: 2, cleared: 1, stamped: 2 });
   });
 
-  it('should keep going when one enqueue fails, leaving the hourly sweep as that order’s route', async () => {
-    jobEnqueue.enqueueJob
-      .mockRejectedValueOnce(new Error('redis down'))
-      .mockResolvedValue({ jobId: 'job-2', isExisting: false });
+  it('should keep going, and still stamp the remainder, when one order`s clear throws', async () => {
+    // `clearOne` swallows its own throw and reports `false`; the loop must
+    // still reach `stamp()` for that same order and for every order after it.
+    repository.clearFxStampForRestatement
+      .mockRejectedValueOnce(new Error('deadlock detected'))
+      .mockResolvedValue(true);
     seed(['ol_order_a', 'ol_order_b']);
+
+    await service.restatePage(SCOPE, 'EUR', { runId: 'run-1', afterOrderId: null, limit: 10 });
+
+    expect(stampService.stamp.mock.calls.map(([id]) => id)).toEqual(['ol_order_a', 'ol_order_b']);
+  });
+
+  it('should tally terminal and deferred stamp outcomes separately from stamped', async () => {
+    stampService.stamp
+      .mockResolvedValueOnce({ kind: 'terminal', reason: 'no-native-total' })
+      .mockResolvedValueOnce({ kind: 'deferred', reason: 'provider down', retryEnqueued: true })
+      .mockResolvedValueOnce(STAMPED_OUTCOME);
+    seed(['ol_order_a', 'ol_order_b', 'ol_order_c']);
 
     await expect(
       service.restatePage(SCOPE, 'EUR', { runId: 'run-1', afterOrderId: null, limit: 10 })
-    ).resolves.toMatchObject({ scanned: 2, enqueued: 1 });
+    ).resolves.toMatchObject({ scanned: 3, stamped: 1, terminal: 1, deferred: 1 });
+  });
+
+  it('should not count an already-stamped outcome as a fresh stamp', async () => {
+    stampService.stamp.mockResolvedValue({ ...STAMPED_OUTCOME, alreadyStamped: true });
+    seed(['ol_order_a']);
+
+    await expect(
+      service.restatePage(SCOPE, 'EUR', { runId: 'run-1', afterOrderId: null, limit: 10 })
+    ).resolves.toMatchObject({ stamped: 0 });
   });
 
   it('should delegate the remaining-population read straight through', async () => {

--- a/libs/core/src/orders/application/services/order-fx-restatement.service.ts
+++ b/libs/core/src/orders/application/services/order-fx-restatement.service.ts
@@ -27,15 +27,21 @@
  *     is simply left unstamped and the hourly `marketplace.order.fxStampSweep`
  *     (predicate `reportingCurrency IS NULL`) picks it up — self-healing, so
  *     no compensation is needed.
- *  2. **NO CHILD JOB, AND THEREFORE NO SEPARATE KEY SPACE.** The page used to
+ *  2. **NO CHILD JOB, AND THEREFORE NO SEPARATE KEY SPACE — BUT ALSO NO
+ *     PER-ORDER FAILURE ISOLATION FOR FREE ANY MORE.** The page used to
  *     enqueue one `marketplace.order.fxStamp` job per order into the
  *     `realtime` lane — sharing that lane's scope with live order ingestion
  *     collapses a whole connection's throughput to `perScope` slots (#2776).
  *     Calling `IOrderFxStampService.stamp` directly, sequentially, inside the
- *     already-bulk-laned `analytics.currency.recalculate` job removes the fan-
- *     out entirely: no `sync_jobs` row, no stream entry, no idempotency-key
- *     collision with `OrderFxStampService.enqueueRetry`'s bare `fx:{orderId}`
- *     to worry about — there is simply nothing left to key.
+ *     already-bulk-laned `analytics.currency.recalculate` job removes the
+ *     fan-out entirely: no `sync_jobs` row, no stream entry, no idempotency-
+ *     key collision with `OrderFxStampService.enqueueRetry`'s bare
+ *     `fx:{orderId}` to worry about — there is simply nothing left to key.
+ *     One job per order also meant one order's failure could never touch
+ *     another's; collapsing them into one sequential loop reopens exactly
+ *     that risk, so `stampOne` guards `stamp()` the same way `clearOne`
+ *     guards the clear — a caught failure counts as `failed` and the loop
+ *     continues.
  *
  * @module libs/core/src/orders/application/services
  * @implements {IOrderFxRestatementService}
@@ -52,6 +58,7 @@ import type {
 } from '../../domain/types/order-fx-restatement.types';
 import type { IOrderFxRestatementService } from '../interfaces/order-fx-restatement.service.interface';
 import type { IOrderFxStampService } from '../interfaces/order-fx-stamp.service.interface';
+import type { FxStampOutcome } from '../../domain/types/order-fx-stamp.types';
 
 @Injectable()
 export class OrderFxRestatementService implements IOrderFxRestatementService {
@@ -69,7 +76,7 @@ export class OrderFxRestatementService implements IOrderFxRestatementService {
     currentReportingCurrency: string,
     page: FxRestatementPageInput
   ): Promise<FxRestatementPageResult> {
-    const refs = await this.repository.findCurrencyMismatchOrderRefsAfter(
+    const ids = await this.repository.findCurrencyMismatchOrderRefsAfter(
       scope,
       currentReportingCurrency,
       { afterOrderId: page.afterOrderId, limit: page.limit }
@@ -79,20 +86,21 @@ export class OrderFxRestatementService implements IOrderFxRestatementService {
     let stamped = 0;
     let terminal = 0;
     let deferred = 0;
+    let failed = 0;
 
-    for (const ref of refs) {
+    for (const internalOrderId of ids) {
       // Sequential, not `Promise.all`: a page of foreign-currency orders on
       // distinct days is a page of provider calls, and fanning them out in
       // parallel would burst a public reference-rate API for no latency
       // benefit anyone is waiting on — the same reasoning
       // `OrderFxStampService.sweep` states for its own sequential walk.
-      const didClear = await this.clearOne(ref.internalOrderId);
+      const didClear = await this.clearOne(internalOrderId);
       if (didClear) {
         cleared += 1;
       }
 
-      const outcome = await this.stampService.stamp(ref.internalOrderId);
-      switch (outcome.kind) {
+      const outcome = await this.stampOne(internalOrderId);
+      switch (outcome?.kind) {
         case 'stamped':
           if (!outcome.alreadyStamped) {
             stamped += 1;
@@ -104,17 +112,21 @@ export class OrderFxRestatementService implements IOrderFxRestatementService {
         case 'deferred':
           deferred += 1;
           break;
+        case undefined:
+          failed += 1;
+          break;
       }
     }
 
-    const nextCursor = refs.length === page.limit ? refs[refs.length - 1].internalOrderId : null;
+    const nextCursor = ids.length === page.limit ? ids[ids.length - 1] : null;
 
     this.logger.log(
-      `FX restatement page: run=${page.runId} scanned=${refs.length} cleared=${cleared} ` +
-        `stamped=${stamped} terminal=${terminal} deferred=${deferred} nextCursor=${nextCursor ?? 'none'}`
+      `FX restatement page: run=${page.runId} scanned=${ids.length} cleared=${cleared} ` +
+        `stamped=${stamped} terminal=${terminal} deferred=${deferred} failed=${failed} ` +
+        `nextCursor=${nextCursor ?? 'none'}`
     );
 
-    return { scanned: refs.length, cleared, stamped, terminal, deferred, nextCursor };
+    return { scanned: ids.length, cleared, stamped, terminal, deferred, failed, nextCursor };
   }
 
   async countRemaining(
@@ -139,6 +151,31 @@ export class OrderFxRestatementService implements IOrderFxRestatementService {
           (error instanceof Error ? error.message : String(error))
       );
       return false;
+    }
+  }
+
+  /**
+   * Guarded the same way `clearOne` is, for the same reason: one order's
+   * failure must not abort the page. `IOrderFxStampService.stamp` is
+   * documented as never throwing, but that is an implementation promise on an
+   * INJECTED INTERFACE, not a type guarantee — and this page's whole point
+   * was replacing N independent per-order jobs with one sequential loop, so
+   * an unguarded throw here would silently abort every order still queued
+   * behind it in the page (#2776 review). `undefined` (rather than folding
+   * into `deferred`) is the caller's signal to count it as `failed` — an
+   * unexpected fault the operator should be able to tell apart from an
+   * ordinary, `stamp()`-reported retry.
+   */
+  private async stampOne(internalOrderId: string): Promise<FxStampOutcome | undefined> {
+    try {
+      return await this.stampService.stamp(internalOrderId);
+    } catch (error) {
+      this.logger.warn(
+        `FX restatement's stamp attempt threw for order ${internalOrderId}; the hourly ` +
+          `marketplace.order.fxStampSweep reconcile remains the route to a stamp: ` +
+          (error instanceof Error ? error.message : String(error))
+      );
+      return undefined;
     }
   }
 }

--- a/libs/core/src/orders/application/services/order-fx-restatement.service.ts
+++ b/libs/core/src/orders/application/services/order-fx-restatement.service.ts
@@ -18,40 +18,40 @@
  * Two mechanics carry the whole thing, and both were live traps before they
  * were rules:
  *
- *  1. **CLEAR, THEN ENQUEUE, IN THAT ORDER.** `OrderFxStampService.stamp`
+ *  1. **CLEAR, THEN STAMP, IN THAT ORDER, IN-PROCESS.** `OrderFxStampService.stamp`
  *     short-circuits on any row that already carries a figure and returns
- *     `alreadyStamped: true` without touching a provider — so a stamp job
- *     enqueued before the clear can legitimately run first, find the stale
- *     stamp still present, and no-op. The reverse ordering is what makes the
- *     original live-demo bug ("we re-enqueued and nothing changed") reappear.
- *     If the process dies between the two, the row is simply left unstamped and
- *     the hourly `marketplace.order.fxStampSweep` (predicate
- *     `reportingCurrency IS NULL`) picks it up — self-healing, so no
- *     compensation is needed.
- *  2. **A WAVE-DISTINCT IDEMPOTENCY KEY.** `sync_jobs.idempotencyKey` is
- *     globally unique with no TTL and `OrderFxStampService.enqueueRetry`
- *     already spent the bare `fx:{orderId}` for any order that ever degraded
- *     to a retry. Re-using it here returns that long-dead row and enqueues
- *     nothing, silently. See `buildFxRestatementIdempotencyKey`.
+ *     `alreadyStamped: true` without touching a provider — so stamping before
+ *     the clear would just re-observe the stale figure and no-op. The reverse
+ *     ordering is what makes the original live-demo bug ("we re-enqueued and
+ *     nothing changed") reappear. If the process dies between the two, the row
+ *     is simply left unstamped and the hourly `marketplace.order.fxStampSweep`
+ *     (predicate `reportingCurrency IS NULL`) picks it up — self-healing, so
+ *     no compensation is needed.
+ *  2. **NO CHILD JOB, AND THEREFORE NO SEPARATE KEY SPACE.** The page used to
+ *     enqueue one `marketplace.order.fxStamp` job per order into the
+ *     `realtime` lane — sharing that lane's scope with live order ingestion
+ *     collapses a whole connection's throughput to `perScope` slots (#2776).
+ *     Calling `IOrderFxStampService.stamp` directly, sequentially, inside the
+ *     already-bulk-laned `analytics.currency.recalculate` job removes the fan-
+ *     out entirely: no `sync_jobs` row, no stream entry, no idempotency-key
+ *     collision with `OrderFxStampService.enqueueRetry`'s bare `fx:{orderId}`
+ *     to worry about — there is simply nothing left to key.
  *
  * @module libs/core/src/orders/application/services
  * @implements {IOrderFxRestatementService}
  */
 import { Inject, Injectable } from '@nestjs/common';
 import { Logger } from '@openlinker/shared/logging';
-import { JOB_ENQUEUE_TOKEN, JobEnqueuePort } from '@openlinker/core/sync';
-import type { SyncJobRequest } from '@openlinker/core/sync';
 import { OrderRecordRepositoryPort } from '../../domain/ports/order-record-repository.port';
-import { ORDER_RECORD_REPOSITORY_TOKEN } from '../../orders.tokens';
+import { ORDER_FX_STAMP_SERVICE_TOKEN, ORDER_RECORD_REPOSITORY_TOKEN } from '../../orders.tokens';
 import type { SalesAnalyticsFilters } from '../../domain/types/order-sales-analytics.types';
-import {
-  buildFxRestatementIdempotencyKey,
-  type FxRestatementOrderRef,
-  type FxRestatementPageInput,
-  type FxRestatementPageResult,
-  type FxRestatementRemainingSummary,
+import type {
+  FxRestatementPageInput,
+  FxRestatementPageResult,
+  FxRestatementRemainingSummary,
 } from '../../domain/types/order-fx-restatement.types';
 import type { IOrderFxRestatementService } from '../interfaces/order-fx-restatement.service.interface';
+import type { IOrderFxStampService } from '../interfaces/order-fx-stamp.service.interface';
 
 @Injectable()
 export class OrderFxRestatementService implements IOrderFxRestatementService {
@@ -60,8 +60,8 @@ export class OrderFxRestatementService implements IOrderFxRestatementService {
   constructor(
     @Inject(ORDER_RECORD_REPOSITORY_TOKEN)
     private readonly repository: OrderRecordRepositoryPort,
-    @Inject(JOB_ENQUEUE_TOKEN)
-    private readonly jobEnqueue: JobEnqueuePort
+    @Inject(ORDER_FX_STAMP_SERVICE_TOKEN)
+    private readonly stampService: IOrderFxStampService
   ) {}
 
   async restatePage(
@@ -76,20 +76,34 @@ export class OrderFxRestatementService implements IOrderFxRestatementService {
     );
 
     let cleared = 0;
-    let enqueued = 0;
+    let stamped = 0;
+    let terminal = 0;
+    let deferred = 0;
 
     for (const ref of refs) {
-      // Sequential, not `Promise.all`: each iteration is a write plus an
-      // enqueue, and the two must stay ordered PER ORDER (see the class doc).
-      // Fanning the page out would also burst the job queue for no latency
-      // benefit — nothing is waiting on this call.
+      // Sequential, not `Promise.all`: a page of foreign-currency orders on
+      // distinct days is a page of provider calls, and fanning them out in
+      // parallel would burst a public reference-rate API for no latency
+      // benefit anyone is waiting on — the same reasoning
+      // `OrderFxStampService.sweep` states for its own sequential walk.
       const didClear = await this.clearOne(ref.internalOrderId);
       if (didClear) {
         cleared += 1;
       }
-      const didEnqueue = await this.enqueueOne(page.runId, ref);
-      if (didEnqueue) {
-        enqueued += 1;
+
+      const outcome = await this.stampService.stamp(ref.internalOrderId);
+      switch (outcome.kind) {
+        case 'stamped':
+          if (!outcome.alreadyStamped) {
+            stamped += 1;
+          }
+          break;
+        case 'terminal':
+          terminal += 1;
+          break;
+        case 'deferred':
+          deferred += 1;
+          break;
       }
     }
 
@@ -97,10 +111,10 @@ export class OrderFxRestatementService implements IOrderFxRestatementService {
 
     this.logger.log(
       `FX restatement page: run=${page.runId} scanned=${refs.length} cleared=${cleared} ` +
-        `enqueued=${enqueued} nextCursor=${nextCursor ?? 'none'}`
+        `stamped=${stamped} terminal=${terminal} deferred=${deferred} nextCursor=${nextCursor ?? 'none'}`
     );
 
-    return { scanned: refs.length, cleared, enqueued, nextCursor };
+    return { scanned: refs.length, cleared, stamped, terminal, deferred, nextCursor };
   }
 
   async countRemaining(
@@ -122,37 +136,6 @@ export class OrderFxRestatementService implements IOrderFxRestatementService {
     } catch (error) {
       this.logger.warn(
         `FX restatement could not clear the stamp on order ${internalOrderId}: ` +
-          (error instanceof Error ? error.message : String(error))
-      );
-      return false;
-    }
-  }
-
-  private async enqueueOne(runId: string, ref: FxRestatementOrderRef): Promise<boolean> {
-    const internalOrderId = ref.internalOrderId;
-    const request: SyncJobRequest = {
-      jobType: 'marketplace.order.fxStamp',
-      // The order's OWN source connection, exactly as
-      // `OrderFxStampService.enqueueRetry` does — `SyncJob.connectionId` is
-      // non-nullable while the stamp itself is connection-agnostic, and this
-      // is also the connection the hourly reconcile sweep is scoped to, so a
-      // job the restatement failed to enqueue is still reachable there. The
-      // enumeration already carries the value, so no extra read is paid for it.
-      connectionId: ref.sourceConnectionId,
-      payload: { schemaVersion: 1, internalOrderId },
-      idempotencyKey: buildFxRestatementIdempotencyKey(runId, internalOrderId),
-    };
-
-    try {
-      await this.jobEnqueue.enqueueJob(request);
-      return true;
-    } catch (error) {
-      // Logged rather than thrown for the same reason the clear is: the run's
-      // completion poll is the authority on whether the scope is clear, and the
-      // hourly reconcile sweep still reaches a cleared-but-unenqueued row.
-      this.logger.warn(
-        `FX restatement could not enqueue a stamp job for order ${internalOrderId} ` +
-          `(run ${runId}); the hourly reconcile sweep remains the route to a stamp: ` +
           (error instanceof Error ? error.message : String(error))
       );
       return false;

--- a/libs/core/src/orders/domain/ports/order-record-repository.port.ts
+++ b/libs/core/src/orders/domain/ports/order-record-repository.port.ts
@@ -31,10 +31,7 @@ import type {
   NetExcludedOrderCandidate,
   PaginatedProductMatchingErrorOrders,
 } from '../types/coverage-detection.types';
-import type {
-  FxRestatementOrderRef,
-  FxRestatementRemainingSummary,
-} from '../types/order-fx-restatement.types';
+import type { FxRestatementRemainingSummary } from '../types/order-fx-restatement.types';
 
 export interface OrderRecordRepositoryPort {
   /**
@@ -573,12 +570,20 @@ export interface OrderRecordRepositoryPort {
    * predicate — so an offset walk would re-read the same page forever and
    * the enumeration would never terminate. A strictly-increasing key can
    * only move forward.
+   *
+   * Returns bare ids, not a `{ internalOrderId, sourceConnectionId }` ref
+   * (#2776 review): the caller used to need `sourceConnectionId` to file a
+   * child `marketplace.order.fxStamp` job under the order's own connection,
+   * but the page now clears-and-stamps each order in-process via
+   * `IOrderFxStampService.stamp`, which re-reads the full `OrderRecord`
+   * (connection included) itself. Selecting a column nothing consumes was a
+   * real, if small, per-row cost.
    */
   findCurrencyMismatchOrderRefsAfter(
     filters: SalesAnalyticsFilters,
     currentReportingCurrency: string,
     page: { afterOrderId: string | null; limit: number }
-  ): Promise<FxRestatementOrderRef[]>;
+  ): Promise<string[]>;
 
   /**
    * Clear one order's ADR-040 FX stamp so the stamp pipeline can re-answer it

--- a/libs/core/src/orders/domain/types/order-fx-restatement.types.ts
+++ b/libs/core/src/orders/domain/types/order-fx-restatement.types.ts
@@ -40,34 +40,44 @@
  * forward.
  */
 export interface FxRestatementPageInput {
-  /** The run this page belongs to; folded into each child job's key. */
+  /** The run this page belongs to. */
   runId: string;
   /** Exclusive lower bound on `internalOrderId`, or `null` to start. */
   afterOrderId: string | null;
-  /** Max orders to clear + enqueue in this page. */
+  /** Max orders to clear + stamp in this page. */
   limit: number;
 }
 
 /**
  * One order the restatement page will repair. The source connection rides
- * along with the id because the child `marketplace.order.fxStamp` job needs a
- * `connectionId` (the column is non-nullable, #1943) and reading it back
- * per order would double the page's query count for a value the enumeration
- * already has in hand.
+ * along with the id because `OrderFxStampService.sweep`/child retry paths key
+ * on it — kept here so the enumeration's own read stays the single source and
+ * a per-order re-read isn't paid for a value already in hand.
  */
 export interface FxRestatementOrderRef {
   internalOrderId: string;
   sourceConnectionId: string;
 }
 
-/** What one restatement page did. */
+/**
+ * What one restatement page did.
+ *
+ * `stamped` / `terminal` / `deferred` mirror `OrderFxSweepResult` exactly —
+ * this page now stamps in-process instead of enqueueing a child job, so it
+ * reports the same three outcomes the sweep does rather than an `enqueued`
+ * count for work that either already happened or did not.
+ */
 export interface FxRestatementPageResult {
   /** Orders the page read. */
   scanned: number;
   /** Orders whose stamp columns this page actually cleared (a never-stamped row is not counted). */
   cleared: number;
-  /** Orders for which a `marketplace.order.fxStamp` job was enqueued. */
-  enqueued: number;
+  /** Orders this page stamped (excludes rows already stamped by a concurrent attempt). */
+  stamped: number;
+  /** Orders that reached a terminal FX answer this page. */
+  terminal: number;
+  /** Orders whose stamp attempt this page deferred to the retry pipeline. */
+  deferred: number;
   /**
    * Resume point for the next page — the last scanned id, or `null` when the
    * page came back short and the scope's frontier is exhausted.
@@ -94,22 +104,4 @@ export interface FxRestatementRemainingSummary {
   terminalMarked: number;
   /** Of those, orders with no marker at all — still in flight, or never attempted. */
   pending: number;
-}
-
-/**
- * Idempotency key for one order's restatement stamp job.
- *
- * WAVE-DISTINCT ON PURPOSE. `OrderFxStampService.enqueueRetry` uses the bare
- * `fx:{orderId}`, and `sync_jobs.idempotencyKey` is globally unique with NO
- * TTL — so for any order that has ever had a retry job,
- * `createIfNotExistsByIdempotencyKey` returns that (possibly long-dead) row
- * and the restatement silently enqueues nothing at all. Folding the run id in
- * gives each restatement its own key space, exactly as
- * `BulkOfferCreationRetryService`'s
- * `bulk:{batchId}:variant:{variantId}:retry:{retryWaveId}` does for its retry
- * waves. It also makes re-enumeration free: a page replayed after a crash
- * mints identical keys and dedups against its own earlier enqueue.
- */
-export function buildFxRestatementIdempotencyKey(runId: string, internalOrderId: string): string {
-  return `fx:restate:${runId}:${internalOrderId}`;
 }

--- a/libs/core/src/orders/domain/types/order-fx-restatement.types.ts
+++ b/libs/core/src/orders/domain/types/order-fx-restatement.types.ts
@@ -49,17 +49,6 @@ export interface FxRestatementPageInput {
 }
 
 /**
- * One order the restatement page will repair. The source connection rides
- * along with the id because `OrderFxStampService.sweep`/child retry paths key
- * on it — kept here so the enumeration's own read stays the single source and
- * a per-order re-read isn't paid for a value already in hand.
- */
-export interface FxRestatementOrderRef {
-  internalOrderId: string;
-  sourceConnectionId: string;
-}
-
-/**
  * What one restatement page did.
  *
  * `stamped` / `terminal` / `deferred` mirror `OrderFxSweepResult` exactly —
@@ -78,6 +67,17 @@ export interface FxRestatementPageResult {
   terminal: number;
   /** Orders whose stamp attempt this page deferred to the retry pipeline. */
   deferred: number;
+  /**
+   * Orders whose `IOrderFxStampService.stamp()` call THREW (#2776 review).
+   * `stamp()` is documented as never throwing, but that is an implementation
+   * promise on an injected interface, not a type guarantee — and collapsing
+   * per-order jobs into one sequential in-process loop means an unguarded
+   * throw would silently abort every remaining order in the page, which is
+   * strictly worse than the fan-out this page replaced. Counted separately
+   * from `deferred` (a `stamp()`-reported, expected retry) because this is an
+   * unexpected fault the operator should be able to tell apart from one.
+   */
+  failed: number;
   /**
    * Resume point for the next page — the last scanned id, or `null` when the
    * page came back short and the scope's frontier is exhausted.

--- a/libs/core/src/orders/index.ts
+++ b/libs/core/src/orders/index.ts
@@ -228,7 +228,6 @@ export { ISalesDocumentViewService } from './application/interfaces/sales-docume
 export { SalesDocumentViewService } from './application/services/sales-document-view.service';
 export type { IOrderFxStampService } from './application/interfaces/order-fx-stamp.service.interface';
 export type { IOrderFxRestatementService } from './application/interfaces/order-fx-restatement.service.interface';
-export { buildFxRestatementIdempotencyKey } from './domain/types/order-fx-restatement.types';
 export type {
   FxRestatementOrderRef,
   FxRestatementPageInput,

--- a/libs/core/src/orders/index.ts
+++ b/libs/core/src/orders/index.ts
@@ -229,7 +229,6 @@ export { SalesDocumentViewService } from './application/services/sales-document-
 export type { IOrderFxStampService } from './application/interfaces/order-fx-stamp.service.interface';
 export type { IOrderFxRestatementService } from './application/interfaces/order-fx-restatement.service.interface';
 export type {
-  FxRestatementOrderRef,
   FxRestatementPageInput,
   FxRestatementPageResult,
   FxRestatementRemainingSummary,

--- a/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
@@ -41,10 +41,7 @@ import {
   netSalesOrderNetEligibleSql,
 } from '../../../domain/types/net-sales-tax-rate.types';
 import type { SalesDocumentBlock } from '@openlinker/core/sales-documents';
-import type {
-  FxRestatementOrderRef,
-  FxRestatementRemainingSummary,
-} from '../../../domain/types/order-fx-restatement.types';
+import type { FxRestatementRemainingSummary } from '../../../domain/types/order-fx-restatement.types';
 import {
   SalesDocumentAttentionReasonValues,
   isSalesDocumentGateBlockReason,
@@ -651,20 +648,22 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
    * why this is keyset-ordered on `internalOrderId` rather than reusing
    * {@link findCurrencyMismatchOrders}' `placedAt DESC`.
    *
-   * `select`-narrowed to the two columns the caller actually uses — the id it
-   * repairs and the connection its child job must carry — so a page of
-   * `orderSnapshot` JSONB is never hydrated for nothing (same reasoning as
-   * {@link findUnstampedFxOrderIds}).
+   * `select`-narrowed to the one column the caller actually uses — the id it
+   * repairs — so a page of `orderSnapshot` JSONB is never hydrated for
+   * nothing (same reasoning as {@link findUnstampedFxOrderIds}). Used to also
+   * select `sourceConnectionId` for a child job to carry; #2776 replaced the
+   * child job with an in-process stamp that re-reads the full `OrderRecord`
+   * (connection included) itself, so that column became a per-row cost with
+   * no consumer.
    */
   async findCurrencyMismatchOrderRefsAfter(
     filters: SalesAnalyticsFilters,
     currentReportingCurrency: string,
     page: { afterOrderId: string | null; limit: number }
-  ): Promise<FxRestatementOrderRef[]> {
+  ): Promise<string[]> {
     const qb = this.repository
       .createQueryBuilder('rec')
       .select('rec."internalOrderId"', 'internal_order_id')
-      .addSelect('rec."sourceConnectionId"', 'source_connection_id')
       .andWhere('rec."cancelledAt" IS NULL')
       .andWhere(
         '(rec."reportingCurrency" IS NULL OR rec."reportingCurrency" != :currentReportingCurrency)',
@@ -679,14 +678,8 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
 
     this.applySalesAnalyticsScope(qb, filters);
 
-    const rows = await qb.getRawMany<{
-      internal_order_id: string;
-      source_connection_id: string;
-    }>();
-    return rows.map((row) => ({
-      internalOrderId: row.internal_order_id,
-      sourceConnectionId: row.source_connection_id,
-    }));
+    const rows = await qb.getRawMany<{ internal_order_id: string }>();
+    return rows.map((row) => row.internal_order_id);
   }
 
   /**


### PR DESCRIPTION
## Summary
- `OrderFxRestatementService.restatePage` clears each order's ADR-040 FX stamp and re-stamps it via `IOrderFxStampService.stamp` **in-process, sequentially** — no `marketplace.order.fxStamp` child job is enqueued any more, so a restatement no longer fans out into the `realtime` lane (whose `perScope: 2` cap it shared with live order ingestion), and produces zero extra `sync_jobs` rows / Redis stream entries.
- `FxRestatementPageResult` now reports `stamped`/`terminal`/`deferred` (mirroring `OrderFxSweepResult`) instead of an `enqueued` count.
- `RESTATEMENT_PAGE_SIZE` dropped 200 → 100 (now a wall-clock unit, not 200 cheap enqueues).
- `buildFxRestatementIdempotencyKey` deleted (nothing left to key).
- Bonus fix (found during manual testing of this branch): `/analytics`'s date-range Apply/preset handlers were replacing the whole query string, silently dropping `displayCurrency`/`rateBasis` on every date change — ADR-064 states they're URL-encoded "like the existing date-range filter". Fixed to merge onto existing params instead.

## Test plan
- [x] Unit specs updated: `order-fx-restatement.service.spec.ts`, `analytics-currency-recalculate.handler.spec.ts`, `analytics-page.test.tsx` (new regression test)
- [x] Integration spec updated: `currency-remediation.int-spec.ts`, including an assertion that a full run creates **zero** `marketplace.order.fxStamp` rows in `sync_jobs`
- [x] `tsc --noEmit` clean for `libs/core` and `apps/worker`
- [ ] Full `pnpm lint && pnpm type-check && pnpm test` — not run locally (sandboxed session), please confirm on CI

Closes #2776