### PR TITLE
fix(web/orders): an unknown fulfillmentState degrades one cell, not the page (#2678)

### DIFF
--- a/apps/web/src/features/orders/api/orders.types.ts
+++ b/apps/web/src/features/orders/api/orders.types.ts
@@ -86,11 +86,37 @@ export const FulfillmentRollupStateValues = [
 ] as const;
 export type FulfillmentRollupStateValue = (typeof FulfillmentRollupStateValues)[number];
 
+/**
+ * Coerce an untrusted value — a field on a payload from a newer backend than
+ * this bundle, or a replayed cached response — to the union.
+ *
+ * Deliberately no fallback, matching `isOrderLifecyclePhase`: defaulting an
+ * unrecognised state to `not-shipped` would report "this order has not shipped"
+ * about an order whose real state this build cannot name. `fulfillmentBadge`
+ * (lib/order-health.ts) uses this to degrade one cell instead of throwing
+ * (#2678).
+ */
+export function isFulfillmentRollupState(value: unknown): value is FulfillmentRollupStateValue {
+  return (
+    typeof value === 'string' && (FulfillmentRollupStateValues as readonly string[]).includes(value)
+  );
+}
+
 // Ship-by SLA bucket (#1108). Hand-mirrored from `SlaStateValues` in
 // `@openlinker/core/orders`. BE-owned (single source of truth): the FE consumes
 // `slaState` and only renders the live countdown from `dispatchByAt`.
 export const SlaStateValues = ['none', 'on_track', 'at_risk', 'overdue'] as const;
 export type SlaStateValue = (typeof SlaStateValues)[number];
+
+/**
+ * Coerce an untrusted `slaState` to the union, same contract and same reason as
+ * `isFulfillmentRollupState` above. An unrecognised bucket must never collapse
+ * into `none` — `none` renders no badge at all, which would silently drop the
+ * one signal telling the operator this order's SLA is in a state OL cannot read.
+ */
+export function isSlaState(value: unknown): value is SlaStateValue {
+  return typeof value === 'string' && (SlaStateValues as readonly string[]).includes(value);
+}
 
 // Why OpenLinker issued no sales document (invoice or fiscal receipt) for an
 // order (#2100/#2156, ADR-041 decision 11). Hand-mirrored from
@@ -110,8 +136,7 @@ export const SalesDocumentGateBlockReasonValues = [
   'trigger-model-manual',
   'trigger-model-batched',
 ] as const;
-export type SalesDocumentGateBlockReasonValue =
-  (typeof SalesDocumentGateBlockReasonValues)[number];
+export type SalesDocumentGateBlockReasonValue = (typeof SalesDocumentGateBlockReasonValues)[number];
 
 export const SalesDocumentUnresolvedReasonValues = [
   'no-matching-rule',

--- a/apps/web/src/features/orders/lib/order-health.test.ts
+++ b/apps/web/src/features/orders/lib/order-health.test.ts
@@ -20,7 +20,12 @@ import {
   syncCellLabel,
   totalUnits,
 } from './order-health';
-import type { OrderRecord, OrderSyncStatus } from '../api/orders.types';
+import type {
+  OrderRecord,
+  OrderSyncStatus,
+  FulfillmentRollupStateValue,
+  SlaStateValue,
+} from '../api/orders.types';
 
 function syncEntry(overrides: Partial<OrderSyncStatus>): OrderSyncStatus {
   return {
@@ -57,7 +62,7 @@ describe('deriveOrderHealth', () => {
         recordStatus: 'source_deleted',
         syncStatus: [syncEntry({ status: 'failed' })],
         mappingFailureReason: 'variant ol_variant_b deleted at the master',
-      }),
+      })
     );
     expect(result.key).toBe('source_deleted');
     expect(result.tone).toBe('error');
@@ -71,7 +76,7 @@ describe('deriveOrderHealth', () => {
 
   it('should return awaiting_mapping when recordStatus is awaiting_mapping (highest precedence)', () => {
     const result = deriveOrderHealth(
-      order({ recordStatus: 'awaiting_mapping', syncStatus: [syncEntry({ status: 'failed' })] }),
+      order({ recordStatus: 'awaiting_mapping', syncStatus: [syncEntry({ status: 'failed' })] })
     );
     expect(result.key).toBe('awaiting_mapping');
     expect(result.tone).toBe('warning');
@@ -79,14 +84,14 @@ describe('deriveOrderHealth', () => {
 
   it('should surface mappingFailureReason on an awaiting_mapping order', () => {
     const result = deriveOrderHealth(
-      order({ recordStatus: 'awaiting_mapping', mappingFailureReason: 'no offer mapping yet' }),
+      order({ recordStatus: 'awaiting_mapping', mappingFailureReason: 'no offer mapping yet' })
     );
     expect(result.reason).toBe('no offer mapping yet');
   });
 
   it('should return needs_attention with the failed reason when a destination failed', () => {
     const result = deriveOrderHealth(
-      order({ syncStatus: [syncEntry({ status: 'failed', error: 'Carrier not mapped' })] }),
+      order({ syncStatus: [syncEntry({ status: 'failed', error: 'Carrier not mapped' })] })
     );
     expect(result.key).toBe('needs_attention');
     expect(result.tone).toBe('error');
@@ -100,7 +105,7 @@ describe('deriveOrderHealth', () => {
           syncEntry({ destinationConnectionId: 'a', status: 'synced' }),
           syncEntry({ destinationConnectionId: 'b', status: 'failed' }),
         ],
-      }),
+      })
     );
     expect(result.key).toBe('needs_attention');
   });
@@ -124,14 +129,14 @@ describe('deriveOrderHealth', () => {
           syncEntry({ destinationConnectionId: 'a', status: 'pending' }),
           syncEntry({ destinationConnectionId: 'b', status: 'syncing' }),
         ],
-      }),
+      })
     );
     expect(result.key).toBe('awaiting_dispatch');
   });
 
   it('should not set a reason for non-failed buckets', () => {
     expect(
-      deriveOrderHealth(order({ syncStatus: [syncEntry({ status: 'synced' })] })).reason,
+      deriveOrderHealth(order({ syncStatus: [syncEntry({ status: 'synced' })] })).reason
     ).toBeUndefined();
   });
 });
@@ -177,7 +182,9 @@ describe('deriveHealthLevel + healthLabel', () => {
   });
 
   it('prioritises attention when any destination failed', () => {
-    const level = deriveHealthLevel(rollupSyncStatus([status({ status: 'failed' }), status({ status: 'synced' })]));
+    const level = deriveHealthLevel(
+      rollupSyncStatus([status({ status: 'failed' }), status({ status: 'synced' })])
+    );
     expect(level).toBe('attention');
     expect(healthLabel(level)).toBe('Needs attention');
   });
@@ -188,7 +195,7 @@ describe('deriveHealthLevel + healthLabel', () => {
 
   it('does not read a skipped_cancelled destination as pending or attention', () => {
     expect(deriveHealthLevel(rollupSyncStatus([status({ status: 'skipped_cancelled' })]))).toBe(
-      'healthy',
+      'healthy'
     );
   });
 
@@ -204,15 +211,15 @@ describe('syncCellLabel', () => {
     expect(syncCellLabel(rollupSyncStatus([status({ status: 'failed' })]))).toBe('1 of 1 failed');
   });
   it('reports synced count otherwise', () => {
-    expect(syncCellLabel(rollupSyncStatus([status({ status: 'synced' }), status({ status: 'syncing' })]))).toBe(
-      '1 of 2 synced',
-    );
+    expect(
+      syncCellLabel(rollupSyncStatus([status({ status: 'synced' }), status({ status: 'syncing' })]))
+    ).toBe('1 of 2 synced');
   });
   it('surfaces the skipped count alongside the synced count', () => {
     expect(
       syncCellLabel(
-        rollupSyncStatus([status({ status: 'synced' }), status({ status: 'skipped_cancelled' })]),
-      ),
+        rollupSyncStatus([status({ status: 'synced' }), status({ status: 'skipped_cancelled' })])
+      )
     ).toBe('1 of 2 synced (1 skipped)');
   });
   it('handles no destinations', () => {
@@ -276,5 +283,45 @@ describe('fulfillmentBadge (#1108)', () => {
     expect(fulfillmentBadge('dispatched')).toEqual({ label: 'Dispatched', tone: 'info' });
     expect(fulfillmentBadge('delivered')).toEqual({ label: 'Delivered', tone: 'success' });
     expect(fulfillmentBadge('failed')).toEqual({ label: 'Dispatch failed', tone: 'error' });
+  });
+});
+
+describe('unrecognised state degradation (#2678)', () => {
+  // An unrecognised value is reachable without any bug in the union: a rolling
+  // deploy ships a new backend member before the browser bundle, a stale cached
+  // bundle outlives a deploy, or a cached API response is replayed. `GET /orders`
+  // is not schema-parsed, so the value arrives verbatim.
+  it('renders a neutral badge naming the value, rather than throwing', () => {
+    expect(fulfillmentBadge('teleported' as FulfillmentRollupStateValue)).toEqual({
+      label: 'Unknown (teleported)',
+      tone: 'neutral',
+    });
+  });
+
+  it('never reports an unrecognised fulfillment state as not-shipped', () => {
+    // The tempting one-character fix (`?? 'not-shipped'` widened to cover the
+    // miss) would say "Not shipped" about an order in an unknown state. Absent
+    // and unrecognised must stay distinguishable.
+    const unknown = fulfillmentBadge('teleported' as FulfillmentRollupStateValue);
+    expect(unknown).not.toEqual(fulfillmentBadge(undefined));
+    expect(unknown.label).not.toBe('Not shipped');
+  });
+
+  it('truncates a pathological value so one row cannot wreck the pill', () => {
+    const badge = fulfillmentBadge('x'.repeat(200) as FulfillmentRollupStateValue);
+    expect(badge.tone).toBe('neutral');
+    expect(badge.label).toBe(`Unknown (${'x'.repeat(15)}…)`);
+  });
+
+  it('surfaces an unrecognised SLA bucket instead of silently dropping it', () => {
+    // This one never crashed — every call site guards on `sla ?`, so an
+    // unrecognised bucket rendered nothing at all. A silent drop of the signal
+    // is its own defect: `none` legitimately means "no badge", so collapsing an
+    // unknown bucket into it makes the two indistinguishable.
+    expect(slaBadge('quantum' as SlaStateValue)).toEqual({
+      label: 'Unknown (quantum)',
+      tone: 'neutral',
+    });
+    expect(slaBadge('none')).toBeNull();
   });
 });

--- a/apps/web/src/features/orders/lib/order-health.test.ts
+++ b/apps/web/src/features/orders/lib/order-health.test.ts
@@ -20,12 +20,7 @@ import {
   syncCellLabel,
   totalUnits,
 } from './order-health';
-import type {
-  OrderRecord,
-  OrderSyncStatus,
-  FulfillmentRollupStateValue,
-  SlaStateValue,
-} from '../api/orders.types';
+import type { OrderRecord, OrderSyncStatus } from '../api/orders.types';
 
 function syncEntry(overrides: Partial<OrderSyncStatus>): OrderSyncStatus {
   return {
@@ -292,7 +287,7 @@ describe('unrecognised state degradation (#2678)', () => {
   // bundle outlives a deploy, or a cached API response is replayed. `GET /orders`
   // is not schema-parsed, so the value arrives verbatim.
   it('renders a neutral badge naming the value, rather than throwing', () => {
-    expect(fulfillmentBadge('teleported' as FulfillmentRollupStateValue)).toEqual({
+    expect(fulfillmentBadge('teleported')).toEqual({
       label: 'Unknown (teleported)',
       tone: 'neutral',
     });
@@ -302,15 +297,28 @@ describe('unrecognised state degradation (#2678)', () => {
     // The tempting one-character fix (`?? 'not-shipped'` widened to cover the
     // miss) would say "Not shipped" about an order in an unknown state. Absent
     // and unrecognised must stay distinguishable.
-    const unknown = fulfillmentBadge('teleported' as FulfillmentRollupStateValue);
+    const unknown = fulfillmentBadge('teleported');
     expect(unknown).not.toEqual(fulfillmentBadge(undefined));
     expect(unknown.label).not.toBe('Not shipped');
   });
 
   it('truncates a pathological value so one row cannot wreck the pill', () => {
-    const badge = fulfillmentBadge('x'.repeat(200) as FulfillmentRollupStateValue);
+    const badge = fulfillmentBadge('x'.repeat(200));
     expect(badge.tone).toBe('neutral');
     expect(badge.label).toBe(`Unknown (${'x'.repeat(15)}…)`);
+  });
+
+  it('says only what is true when the value is blank, rather than quoting nothing', () => {
+    // `Unknown ()` claims to name the offending value and names nothing. A
+    // JSON "" is a real degenerate wire value, so both resolvers must reach the
+    // same answer for it — `slaBadge` previously swallowed it via `!slaState`
+    // into the same result as `none`, i.e. "no badge, nothing is wrong".
+    expect(fulfillmentBadge('')).toEqual({ label: 'Unknown', tone: 'neutral' });
+    expect(fulfillmentBadge('   ')).toEqual({ label: 'Unknown', tone: 'neutral' });
+    expect(slaBadge('')).toEqual({ label: 'Unknown', tone: 'neutral' });
+    // Absent still means absent, on both.
+    expect(slaBadge(undefined)).toBeNull();
+    expect(fulfillmentBadge(undefined)).toEqual({ label: 'Not shipped', tone: 'neutral' });
   });
 
   it('surfaces an unrecognised SLA bucket instead of silently dropping it', () => {
@@ -318,7 +326,7 @@ describe('unrecognised state degradation (#2678)', () => {
     // unrecognised bucket rendered nothing at all. A silent drop of the signal
     // is its own defect: `none` legitimately means "no badge", so collapsing an
     // unknown bucket into it makes the two indistinguishable.
-    expect(slaBadge('quantum' as SlaStateValue)).toEqual({
+    expect(slaBadge('quantum')).toEqual({
       label: 'Unknown (quantum)',
       tone: 'neutral',
     });

--- a/apps/web/src/features/orders/lib/order-health.ts
+++ b/apps/web/src/features/orders/lib/order-health.ts
@@ -14,12 +14,14 @@
  *
  * @module apps/web/src/features/orders/lib
  */
-import type {
-  OrderRecord,
-  OrderHealthValue,
-  OrderSyncStatus,
-  SlaStateValue,
-  FulfillmentRollupStateValue,
+import {
+  isFulfillmentRollupState,
+  isSlaState,
+  type OrderRecord,
+  type OrderHealthValue,
+  type OrderSyncStatus,
+  type SlaStateValue,
+  type FulfillmentRollupStateValue,
 } from '../api/orders.types';
 import type { StatusBadgeTone } from '../../../shared/ui/status-badge';
 
@@ -190,7 +192,7 @@ export type FulfillmentState = (typeof FulfillmentStateValues)[number];
  */
 export function deriveFulfillment(
   shipmentStatuses: readonly string[] | null,
-  hasShippingCapability: boolean,
+  hasShippingCapability: boolean
 ): FulfillmentState {
   if (!hasShippingCapability) return 'unavailable';
   if (!shipmentStatuses || shipmentStatuses.length === 0) return 'not-shipped';
@@ -243,9 +245,17 @@ export const ORDER_SLA_META: Record<
  * FE never re-derives the bucket.
  */
 export function slaBadge(
-  slaState: SlaStateValue | undefined,
+  slaState: string | null | undefined
 ): { label: string; tone: StatusBadgeTone } | null {
-  if (!slaState || slaState === 'none') return null;
+  if (!slaState) return null;
+  // Membership is established BEFORE the `none` check, not after: `none` is a
+  // MEMBER of the union (meaning "no deadline, or already shipped"), so testing
+  // it first would conflate "the backend said none" with "the backend said
+  // something this build cannot read" — two different facts with two different
+  // right answers. It also re-widens the type past the narrowing, which is how
+  // the compiler found this.
+  if (!isSlaState(slaState)) return unknownStateBadge(slaState);
+  if (slaState === 'none') return null;
   return ORDER_SLA_META[slaState];
 }
 
@@ -260,10 +270,57 @@ export const ORDER_FULFILLMENT_META: Record<
   failed: { label: 'Dispatch failed', tone: 'error' },
 };
 
-/** Fulfillment badge for an order row. NULL/absent ≡ `not-shipped`. */
-export function fulfillmentBadge(state: FulfillmentRollupStateValue | undefined): {
+/**
+ * Fulfillment badge for an order row. NULL/absent ≡ `not-shipped` — that is a
+ * real backend contract, not a fallback.
+ *
+ * An UNRECOGNISED value is a different case and gets a different answer
+ * (#2678). The parameter is typed `string` rather than the union because that
+ * is what actually arrives: `GET /orders` is not schema-parsed anywhere in
+ * `features/orders/api/`, so the declared union is a claim about the wire, not
+ * a guarantee about it. A rolling deploy, a stale bundle or a replayed cached
+ * response can all put a value here that this build does not know.
+ *
+ * Before this it was `ORDER_FULFILLMENT_META[state ?? 'not-shipped']`, which
+ * returned `undefined`, and all three call sites read `.tone` off it
+ * immediately — inside a `DataTable` cell renderer, so the throw unmounted the
+ * whole `/orders` page rather than one cell.
+ *
+ * Two fixes were rejected. Coalescing to `not-shipped` would render "Not
+ * shipped" about an order whose state this build cannot name — a quiet lie
+ * about the operator's own data, and worse than the crash it replaces.
+ * Returning `null` would render nothing, which reads as a row that simply has
+ * no fulfilment fact. So the value is surfaced verbatim in a neutral badge, the
+ * way an unrecognised marketplace code is surfaced rather than dropped (#2231).
+ */
+export function fulfillmentBadge(state: string | null | undefined): {
   label: string;
   tone: StatusBadgeTone;
 } {
-  return ORDER_FULFILLMENT_META[state ?? 'not-shipped'];
+  if (state === null || state === undefined) return ORDER_FULFILLMENT_META['not-shipped'];
+  if (!isFulfillmentRollupState(state)) return unknownStateBadge(state);
+  return ORDER_FULFILLMENT_META[state];
+}
+
+/**
+ * How long an unrecognised raw value may be inside a status pill. A status pill
+ * is budgeted at ~17 characters (see `frontend-ui-style-guide.md` § Order-row
+ * signal placement), and `Unknown ()` already spends 10 of them. A real enum
+ * member is short, so this only bites a pathological value — where legibility
+ * of the row beats the budget anyway.
+ */
+const UNKNOWN_STATE_MAX_CHARS = 16;
+
+/**
+ * The one shared shape for "the backend said something this build does not
+ * know". Shared by `slaBadge` and `fulfillmentBadge` so the two cannot drift
+ * into describing the same condition differently.
+ *
+ * `neutral`, never a status tone: OL has no idea whether this state is good or
+ * bad, and picking a tone would assert one.
+ */
+function unknownStateBadge(raw: string): { label: string; tone: StatusBadgeTone } {
+  const shown =
+    raw.length > UNKNOWN_STATE_MAX_CHARS ? `${raw.slice(0, UNKNOWN_STATE_MAX_CHARS - 1)}…` : raw;
+  return { label: `Unknown (${shown})`, tone: 'neutral' };
 }

--- a/apps/web/src/features/orders/lib/order-health.ts
+++ b/apps/web/src/features/orders/lib/order-health.ts
@@ -247,7 +247,11 @@ export const ORDER_SLA_META: Record<
 export function slaBadge(
   slaState: string | null | undefined
 ): { label: string; tone: StatusBadgeTone } | null {
-  if (!slaState) return null;
+  // Only ABSENT short-circuits. An empty string is a value the backend sent and
+  // this build cannot read, so it must reach `unknownStateBadge` exactly as it
+  // does in `fulfillmentBadge` — `!slaState` would have swallowed it into the
+  // same answer as `none`, which means "no badge, nothing is wrong".
+  if (slaState === null || slaState === undefined) return null;
   // Membership is established BEFORE the `none` check, not after: `none` is a
   // MEMBER of the union (meaning "no deadline, or already shipped"), so testing
   // it first would conflate "the backend said none" with "the backend said
@@ -320,7 +324,14 @@ const UNKNOWN_STATE_MAX_CHARS = 16;
  * bad, and picking a tone would assert one.
  */
 function unknownStateBadge(raw: string): { label: string; tone: StatusBadgeTone } {
+  // A blank or whitespace-only value is still unreadable, but naming it is
+  // impossible — `Unknown ()` claims to quote the offending value and quotes
+  // nothing. Say only what is true: this build cannot read the state.
+  const trimmed = raw.trim();
+  if (trimmed === '') return { label: 'Unknown', tone: 'neutral' };
   const shown =
-    raw.length > UNKNOWN_STATE_MAX_CHARS ? `${raw.slice(0, UNKNOWN_STATE_MAX_CHARS - 1)}…` : raw;
+    trimmed.length > UNKNOWN_STATE_MAX_CHARS
+      ? `${trimmed.slice(0, UNKNOWN_STATE_MAX_CHARS - 1)}…`
+      : trimmed;
   return { label: `Unknown (${shown})`, tone: 'neutral' };
 }

--- a/apps/web/src/pages/orders/dispatch-risk-page.tsx
+++ b/apps/web/src/pages/orders/dispatch-risk-page.tsx
@@ -126,8 +126,11 @@ const COLUMNS: DataTableColumn<OrderRecord>[] = [
     header: 'Fulfillment',
     hideBelow: 768,
     cell: (order) => {
+      // No null guard: `fulfillmentBadge` is total by contract (#2678) — an
+      // absent state means `not-shipped` and an unrecognised one renders a
+      // neutral "Unknown (…)" badge. The guard that used to sit here was dead
+      // and read as coverage it never provided (the #2589 dead-fallback lesson).
       const badge = fulfillmentBadge(order.fulfillmentState);
-      if (!badge) return null;
       return (
         <StatusBadge tone={badge.tone} compact>
           {badge.label}
@@ -159,7 +162,7 @@ export function DispatchRiskPage(): ReactElement {
   const summaryQuery = useOrderSlaSummaryQuery(scope);
   const query = useOrdersQuery(
     { ...scope, slaState: bucket, sort: 'dispatchBy', dir: 'asc' },
-    { limit: PAGE_SIZE, offset },
+    { limit: PAGE_SIZE, offset }
   );
 
   const connectionsQuery = useConnectionsQuery();
@@ -271,7 +274,9 @@ export function DispatchRiskPage(): ReactElement {
       ) : rows.length === 0 ? (
         <EmptyState
           liveRegion="off"
-          title={noDeadlinesAnywhere ? 'No ship-by deadlines' : `Nothing ${meta.label.toLowerCase()}`}
+          title={
+            noDeadlinesAnywhere ? 'No ship-by deadlines' : `Nothing ${meta.label.toLowerCase()}`
+          }
           message={
             noDeadlinesAnywhere
               ? 'No open order carries a ship-by deadline, so there is nothing to rank. Deadlines come from the marketplace dispatch window.'

--- a/apps/web/src/pages/orders/orders-list-page.test.tsx
+++ b/apps/web/src/pages/orders/orders-list-page.test.tsx
@@ -11,7 +11,11 @@
 import { cleanup, fireEvent, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
-import { renderWithProviders, createMockApiClient, createAuthenticatedSessionAdapter } from '../../test/test-utils';
+import {
+  renderWithProviders,
+  createMockApiClient,
+  createAuthenticatedSessionAdapter,
+} from '../../test/test-utils';
 import { OrdersListPage } from './orders-list-page';
 import type {
   PaginatedOrders,
@@ -114,7 +118,7 @@ function mockMobileViewport(): { restore: () => void } {
         addListener: () => {},
         removeListener: () => {},
         dispatchEvent: () => false,
-      }) as MediaQueryList,
+      }) as MediaQueryList
   );
   return { restore: () => spy.mockRestore() };
 }
@@ -216,7 +220,7 @@ describe('OrdersListPage', () => {
     expect(await screen.findByText('No orders found')).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Manage connections' })).toHaveAttribute(
       'href',
-      '/connections',
+      '/connections'
     );
   });
 
@@ -230,9 +234,7 @@ describe('OrdersListPage', () => {
       route: '/orders?health=needs_attention',
     });
 
-    expect(
-      await screen.findByText('All clear — nothing needs your attention'),
-    ).toBeInTheDocument();
+    expect(await screen.findByText('All clear — nothing needs your attention')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'View all orders' })).toBeInTheDocument();
   });
 
@@ -264,7 +266,7 @@ describe('OrdersListPage', () => {
         // to /connections to debug an ingestion problem that does not exist.
         expect(screen.getByRole('button', { name: 'View all orders' })).toBeInTheDocument();
         expect(screen.queryByRole('link', { name: 'Manage connections' })).toBeNull();
-      },
+      }
     );
 
     it('should clear every filter in one write from the recovery button', async () => {
@@ -373,7 +375,7 @@ describe('OrdersListPage', () => {
 
     await vi.waitFor(() => {
       const values = Array.from(container.querySelectorAll('.metric-card__value')).map(
-        (el) => el.textContent,
+        (el) => el.textContent
       );
       expect(values).toContain('11'); // total
       expect(values).toContain('9'); // awaiting dispatch
@@ -395,7 +397,7 @@ describe('OrdersListPage', () => {
 
     await vi.waitFor(() => {
       const calledWithHealth = list.mock.calls.some(
-        ([filters]) => (filters as { health?: string } | undefined)?.health === 'needs_attention',
+        ([filters]) => (filters as { health?: string } | undefined)?.health === 'needs_attention'
       );
       expect(calledWithHealth).toBe(true);
     });
@@ -435,7 +437,7 @@ describe('OrdersListPage', () => {
       const calledWithAttention = list.mock.calls.some(
         ([filters, pagination]) =>
           (filters as { attention?: boolean } | undefined)?.attention === true &&
-          (pagination as { offset?: number } | undefined)?.offset === 0,
+          (pagination as { offset?: number } | undefined)?.offset === 0
       );
       expect(calledWithAttention).toBe(true);
     });
@@ -597,7 +599,7 @@ describe('OrdersListPage', () => {
       await screen.findByText('ALG-882414');
       const pill = container.querySelector(`.channel-pill[data-channel="${platformType}"]`);
       expect(pill?.textContent).toBe(expectedLabel);
-    },
+    }
   );
 
   it('should fall back to a SHORTENED internalOrderId when the snapshot has no orderNumber (#2091)', async () => {
@@ -633,7 +635,10 @@ describe('OrdersListPage', () => {
       connections: { list: vi.fn().mockResolvedValue([sampleConnection]) },
     });
 
-    renderWithProviders(<OrdersListPage />, { apiClient: mockApi, sessionAdapter: createAuthenticatedSessionAdapter() });
+    renderWithProviders(<OrdersListPage />, {
+      apiClient: mockApi,
+      sessionAdapter: createAuthenticatedSessionAdapter(),
+    });
 
     await screen.findByText('ALG-FAIL');
     await user.click(screen.getByRole('button', { name: 'Retry' }));
@@ -683,7 +688,7 @@ describe('OrdersListPage', () => {
     await screen.findByText('ALG-882414');
     expect(list).toHaveBeenCalledWith(
       expect.objectContaining({ sort: 'dispatchBy' }),
-      expect.anything(),
+      expect.anything()
     );
   });
 
@@ -719,7 +724,8 @@ describe('OrdersListPage', () => {
 
     await vi.waitFor(() => {
       const calledWithDue = list.mock.calls.some(
-        ([filters]) => typeof (filters as { dueBefore?: string } | undefined)?.dueBefore === 'string',
+        ([filters]) =>
+          typeof (filters as { dueBefore?: string } | undefined)?.dueBefore === 'string'
       );
       expect(calledWithDue).toBe(true);
     });
@@ -742,7 +748,7 @@ describe('OrdersListPage', () => {
       const called = list.mock.calls.some(
         ([filters]) =>
           (filters as { sourceConnectionId?: string } | undefined)?.sourceConnectionId ===
-          'conn_allegro_1',
+          'conn_allegro_1'
       );
       expect(called).toBe(true);
     });
@@ -849,7 +855,7 @@ describe('OrdersListPage', () => {
       const called = list.mock.calls.some(
         ([filters]) =>
           (filters as { createdFrom?: string } | undefined)?.createdFrom ===
-          '2026-05-01T00:00:00.000Z',
+          '2026-05-01T00:00:00.000Z'
       );
       expect(called).toBe(true);
     });
@@ -885,7 +891,7 @@ describe('OrdersListPage', () => {
     expect(
       screen.getByRole('button', {
         name: 'Copy internal order ID for order 186d7a20-5b82-11f1-979b-098d4666d4ec',
-      }),
+      })
     ).toBeInTheDocument();
   });
 
@@ -950,7 +956,10 @@ describe('OrdersListPage', () => {
         system: { getConfig: vi.fn().mockResolvedValue({ demoMode: true }) },
       });
 
-      renderWithProviders(<OrdersListPage />, { apiClient: mockApi, sessionAdapter: viewerSession });
+      renderWithProviders(<OrdersListPage />, {
+        apiClient: mockApi,
+        sessionAdapter: viewerSession,
+      });
 
       await screen.findByText('ALG-FAIL');
       const retryButton = await screen.findByRole('button', { name: 'Retry' });
@@ -966,7 +975,10 @@ describe('OrdersListPage', () => {
           system: { getConfig: vi.fn().mockResolvedValue({ demoMode: true }) },
         });
 
-        renderWithProviders(<OrdersListPage />, { apiClient: mockApi, sessionAdapter: viewerSession });
+        renderWithProviders(<OrdersListPage />, {
+          apiClient: mockApi,
+          sessionAdapter: viewerSession,
+        });
 
         await screen.findAllByText('ALG-FAIL');
         const retryButton = await screen.findByRole('button', { name: 'Retry' });
@@ -982,7 +994,10 @@ describe('OrdersListPage', () => {
         connections: { list: vi.fn().mockResolvedValue([sampleConnection]) },
       });
 
-      renderWithProviders(<OrdersListPage />, { apiClient: mockApi, sessionAdapter: viewerSession });
+      renderWithProviders(<OrdersListPage />, {
+        apiClient: mockApi,
+        sessionAdapter: viewerSession,
+      });
 
       await screen.findByText('ALG-FAIL');
       expect(screen.queryByRole('button', { name: 'Retry' })).not.toBeInTheDocument();
@@ -1121,7 +1136,7 @@ describe('OrdersListPage', () => {
                 salesDocumentBlockReason: 'unresolved-routing',
                 salesDocumentUnresolvedReason: 'ambiguous-connection-no-primary',
               }),
-            ]),
+            ])
           ),
         },
         connections: { list: vi.fn().mockResolvedValue([sampleConnection, invoicingConnection]) },
@@ -1167,7 +1182,7 @@ describe('OrdersListPage', () => {
                 salesDocumentUnresolvedReason: 'ambiguous-connection-no-primary',
                 orderSnapshot: { ...syncedOrder.orderSnapshot, invoice: rejectedInvoice },
               }),
-            ]),
+            ])
           ),
         },
         connections: { list: vi.fn().mockResolvedValue([sampleConnection, invoicingConnection]) },
@@ -1194,7 +1209,7 @@ describe('OrdersListPage', () => {
                 salesDocumentUnresolvedReason: 'ambiguous-connection-no-primary',
                 orderSnapshot: { ...syncedOrder.orderSnapshot, invoice: rejectedInvoice },
               }),
-            ]),
+            ])
           ),
         },
         connections: { list: vi.fn().mockResolvedValue([sampleConnection, invoicingConnection]) },
@@ -1234,7 +1249,7 @@ describe('OrdersListPage', () => {
                   },
                 },
               }),
-            ]),
+            ])
           ),
         },
         connections: { list: vi.fn().mockResolvedValue([sampleConnection, invoicingConnection]) },
@@ -1256,7 +1271,7 @@ describe('OrdersListPage', () => {
           list: vi
             .fn()
             .mockResolvedValue(
-              paginated([blockedOrder({ salesDocumentBlockReason: 'trigger-model-manual' })]),
+              paginated([blockedOrder({ salesDocumentBlockReason: 'trigger-model-manual' })])
             ),
         },
         connections: { list: vi.fn().mockResolvedValue([sampleConnection, invoicingConnection]) },
@@ -1289,7 +1304,7 @@ describe('OrdersListPage', () => {
                   },
                 },
               }),
-            ]),
+            ])
           ),
         },
         connections: { list: vi.fn().mockResolvedValue([sampleConnection, invoicingConnection]) },
@@ -1344,7 +1359,7 @@ describe('OrdersListPage', () => {
                 salesDocumentBlockReason: 'unresolved-routing',
                 salesDocumentUnresolvedReason: 'ambiguous-connection-no-primary',
               }),
-            ]),
+            ])
           ),
         },
         connections: { list: vi.fn().mockResolvedValue([sampleConnection, invoicingConnection]) },
@@ -1371,7 +1386,7 @@ describe('OrdersListPage', () => {
             list: vi
               .fn()
               .mockResolvedValue(
-                paginated([blockedOrder({ salesDocumentBlockReason: 'trigger-model-batched' })]),
+                paginated([blockedOrder({ salesDocumentBlockReason: 'trigger-model-batched' })])
               ),
           },
           connections: { list: vi.fn().mockResolvedValue([sampleConnection, invoicingConnection]) },
@@ -1447,9 +1462,7 @@ describe('OrdersListPage', () => {
 
       // Gating the chip on the count alone unmounted the ONLY control for this
       // param exactly when the remediation succeeded, stranding an applied filter.
-      expect(
-        await screen.findByRole('button', { name: /invoicing blocked/i }),
-      ).toBeInTheDocument();
+      expect(await screen.findByRole('button', { name: /invoicing blocked/i })).toBeInTheDocument();
       // And the empty state must not claim nothing has ever synced.
       // `findByText` (not `getByText`): the chip is sync-derived from the URL
       // param alone and can mount before the orders query resolves, so a
@@ -1687,11 +1700,11 @@ describe('OrdersListPage — shared Order identity cell (#2091)', () => {
     // The thumbnail is what this column never had (#1996 frame 04).
     expect(cell.querySelector('.product-thumbnail img')).toHaveAttribute(
       'src',
-      'https://cdn.example.test/filtr.jpg',
+      'https://cdn.example.test/filtr.jpg'
     );
     expect(within(cell).getByRole('link', { name: 'ALG-882414' })).toHaveAttribute(
       'href',
-      '/orders/ol_order_synced',
+      '/orders/ol_order_synced'
     );
     expect(within(cell).getByText('Filtr kubełkowy AquaPro')).toBeInTheDocument();
     expect(container.querySelector('.orders-cell-stack .order-cell')).not.toBeNull();
@@ -1732,7 +1745,7 @@ describe('OrdersListPage — shared Order identity cell (#2091)', () => {
     fireEvent.click(
       within(table).getByRole('button', {
         name: 'Copy internal order ID for order ALG-882414',
-      }),
+      })
     );
 
     expect(writeText).toHaveBeenCalledWith('ol_order_a3f24b09c4d1486789abcdef01234567');
@@ -1830,7 +1843,7 @@ describe('OrdersListPage — shared Order identity cell (#2091)', () => {
       // the pre-#2091 card had its own hand-rolled `EntityLabel`.
       expect(within(cell).getByRole('link', { name: 'ALG-882414' })).toHaveAttribute(
         'href',
-        '/orders/ol_order_synced',
+        '/orders/ol_order_synced'
       );
       fireEvent.click(within(cell).getByRole('button', { name: /^Copy internal order ID/ }));
       expect(writeText).toHaveBeenCalledWith('ol_order_synced');
@@ -1891,7 +1904,7 @@ describe('OrdersListPage — shared Order identity cell (#2091)', () => {
     // Two `erli` pills render on the desktop row — the order cell's fold and the
     // Channel column. Exclude the fold to assert the column's own lookup.
     const columnPill = Array.from(
-      container.querySelectorAll('.channel-pill[data-channel="erli"]'),
+      container.querySelectorAll('.channel-pill[data-channel="erli"]')
     ).find((pill) => pill.closest('.orders-order-channel') === null);
     expect(columnPill?.textContent).toBe('Erli');
     expect(columnPill?.parentElement?.textContent).toContain('→ WooCommerce');
@@ -1906,7 +1919,9 @@ describe('OrdersListPage — shared Order identity cell (#2091)', () => {
 
       await screen.findAllByText('ALG-882414');
       const subtitle = container.querySelector('.orders-card-sub') as HTMLElement;
-      expect(subtitle.querySelector('.channel-pill[data-channel="erli"]')?.textContent).toBe('Erli');
+      expect(subtitle.querySelector('.channel-pill[data-channel="erli"]')?.textContent).toBe(
+        'Erli'
+      );
       expect(within(subtitle).getByText('→ WooCommerce')).toBeInTheDocument();
     } finally {
       viewport.restore();
@@ -1937,7 +1952,7 @@ describe('OrdersListPage — shared Order identity cell (#2091)', () => {
 
     await screen.findByText('ALG-882414');
     await user.click(
-      screen.getByRole('button', { name: /Expand details for order ol_order_crosschannel/ }),
+      screen.getByRole('button', { name: /Expand details for order ol_order_crosschannel/ })
     );
 
     const detail = container.querySelector('.orders-detail') as HTMLElement;
@@ -2154,7 +2169,7 @@ describe('OrdersListPage — hold surfacing (#2342)', () => {
 
     await user.selectOptions(
       await screen.findByLabelText('Filter by hold reason'),
-      'address-invalid',
+      'address-invalid'
     );
 
     await vi.waitFor(() => {
@@ -2175,7 +2190,10 @@ describe('OrdersListPage — hold surfacing (#2342)', () => {
     const list = vi.fn().mockResolvedValue(paginated([]));
     const mockApi = createMockApiClient({ orders: { list } });
 
-    renderWithProviders(<OrdersListPage />, { apiClient: mockApi, route: '/orders?hold=fraud-review' });
+    renderWithProviders(<OrdersListPage />, {
+      apiClient: mockApi,
+      route: '/orders?hold=fraud-review',
+    });
 
     await vi.waitFor(() => {
       expect(list.mock.calls[0][0]).toMatchObject({ holdReason: 'fraud-review' });
@@ -2193,5 +2211,52 @@ describe('OrdersListPage — hold surfacing (#2342)', () => {
     await vi.waitFor(() => {
       expect(list.mock.calls[0][0].holdReason).toBeUndefined();
     });
+  });
+});
+
+describe('unrecognised fulfillmentState degrades one cell, not the page (#2678)', () => {
+  // The regression this guards is NOT that the badge resolver returned the
+  // wrong object — a lib-only test would pass against a fix that still crashed
+  // the page. It is that the throw happened inside a `DataTable` cell renderer,
+  // so React unmounted the whole route. This test therefore drives the value
+  // through the real query -> page -> table -> cell path and asserts the page
+  // still rendered.
+  const unknownStateOrder = {
+    ...syncedOrder,
+    internalOrderId: 'ol_order_unknown_state',
+    orderSnapshot: { ...syncedOrder.orderSnapshot, orderNumber: 'ALG-UNKNOWN' },
+    // Deliberately cast: this is exactly the value the closed union promises
+    // cannot arrive, and exactly what a rolling deploy puts on the wire.
+    fulfillmentState: 'teleported',
+  } as unknown as OrderRecord;
+
+  it('still renders the list, and every other row, when a row carries an unknown state', async () => {
+    const mockApi = createMockApiClient({
+      orders: { list: vi.fn().mockResolvedValue(paginated([unknownStateOrder, syncedOrder])) },
+    });
+
+    renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
+
+    // The page survived: the offending row renders...
+    expect(await screen.findByText('ALG-UNKNOWN')).toBeInTheDocument();
+    // ...and so does its neighbour, which the pre-fix crash also took down.
+    expect(screen.getByText('ALG-882414')).toBeInTheDocument();
+  });
+
+  it('names the unrecognised value rather than claiming the order is not shipped', async () => {
+    const mockApi = createMockApiClient({
+      orders: { list: vi.fn().mockResolvedValue(paginated([unknownStateOrder])) },
+    });
+
+    renderWithProviders(<OrdersListPage />, { apiClient: mockApi });
+
+    await screen.findByText('ALG-UNKNOWN');
+    expect(screen.getAllByText('Unknown (teleported)').length).toBeGreaterThan(0);
+    // No BADGE may claim "Not shipped" — the silent-fallback failure mode this
+    // fix exists to avoid. The filter dropdown legitimately offers it as an
+    // <option>, so the assertion is on what renders as a row signal, not on the
+    // string appearing anywhere on the page.
+    const notShipped = screen.queryAllByText('Not shipped');
+    expect(notShipped.every((el) => el.tagName === 'OPTION')).toBe(true);
   });
 });

--- a/docs/frontend-ui-style-guide.md
+++ b/docs/frontend-ui-style-guide.md
@@ -853,6 +853,28 @@ Recommended status vocabulary:
 
 Status should be consistent across orders, products, inventory, integrations, jobs, and automations.
 
+### An unrecognised backend value (#2678)
+
+A closed union on the frontend is a **claim about the wire, not a guarantee about
+it** — most list payloads are not schema-parsed, so a rolling deploy, a stale
+cached bundle, or a replayed cached response can all deliver a value this build
+does not know. Three rules:
+
+1. **Never render an unrecognised value as a known one.** Coalescing it into a
+   real member (`?? 'not-shipped'`) states something false about the operator's
+   own data. A quiet lie is worse than the loud failure it replaces.
+2. **Never drop it silently.** Rendering nothing reads as a row that has no such
+   fact, which is a different claim again.
+3. **Surface it, neutrally.** A `neutral` `StatusBadge` reading `Unknown ({raw})`
+   — never a status tone, which would assert whether the state is good or bad.
+   Truncate the raw value so one row cannot break the ~17-character pill budget,
+   and where the value is blank render bare `Unknown`: `Unknown ()` claims to
+   quote the offending value and quotes nothing.
+
+Absence is a separate question and keeps whatever contract the backend documents
+(on the orders list, an absent `fulfillmentState` genuinely means `not-shipped`).
+Distinguish the two — a guard that conflates them reintroduces rule 1.
+
 ### Order-row signal placement (#2081)
 
 The orders list carries several signals per row. They are organised into **three semantic groups**

--- a/docs/plans/implementation-plan-unknown-fulfillment-state.md
+++ b/docs/plans/implementation-plan-unknown-fulfillment-state.md
@@ -1,0 +1,108 @@
+# Implementation plan — an unknown `fulfillmentState` must degrade one cell, not the page (#2678)
+
+## 1. Root cause (verified in code, not assumed)
+
+`apps/web/src/features/orders/lib/order-health.ts`:
+
+```ts
+export function fulfillmentBadge(state: FulfillmentRollupStateValue | undefined) {
+  return ORDER_FULFILLMENT_META[state ?? 'not-shipped'];   // total on the TYPE, partial at RUNTIME
+}
+
+export function slaBadge(slaState: SlaStateValue | undefined) {
+  if (!slaState || slaState === 'none') return null;
+  return ORDER_SLA_META[slaState];                          // same shape
+}
+```
+
+Both are `Record` lookups whose key type is a closed union but whose runtime key is
+an unvalidated string off the wire. `GET /orders` is **not** zod-parsed anywhere in
+`features/orders/api/` (grep: no `z.` / no schema in `orders.api.ts`; zod in this
+feature is form-resolver-only). So the declared type is a claim, not a guarantee.
+
+An unrecognised value returns `undefined`, and every call site immediately reads
+`.tone` / `.label`:
+
+- `pages/orders/orders-list-page.tsx:954` (desktop Ship-by cell), `:1883` (mobile card),
+  `:2015` (mobile badge row)
+- `pages/orders/dispatch-risk-page.tsx:92` (sla), `:129` (fulfillment)
+
+The throw happens inside the table's `cell` render, so React unmounts the whole
+tree — the entire `/orders` page, not the offending cell.
+
+## 2. What "degrade" must mean here
+
+Two wrong fixes to avoid:
+
+- **`?? 'not-shipped'` on an unrecognised value** — that is a *lie*: the operator
+  reads "Not shipped" about an order in a state this build cannot name.
+- **Return `null` and render nothing** — a silent drop. The row then looks like a
+  row with no fulfilment fact at all.
+
+Correct: render a **neutral badge that names the unrecognised value verbatim**,
+matching the repo's established handling of an unknown channel code (an
+unrecognised offer-validation code is surfaced with its raw value, #2231) and the
+`phaseBadge` guard shape (#2310). `null`/absent keeps its documented meaning
+(`≡ not-shipped`) — that is a real contract, not a fallback.
+
+## 3. Changes
+
+### 3.1 `features/orders/api/orders.types.ts`
+Add two guards beside their unions, mirroring `isOrderLifecyclePhase`'s placement
+and its "deliberately no fallback" docblock:
+
+```ts
+export function isFulfillmentRollupState(v: unknown): v is FulfillmentRollupStateValue
+export function isSlaState(v: unknown): v is SlaStateValue
+```
+
+### 3.2 `features/orders/lib/order-health.ts`
+- Widen both params to `string | null | undefined` — the honest type for a value
+  off the wire. Call sites pass the union, which is assignable, so no call-site
+  churn and no `as`.
+- `fulfillmentBadge`: absent → `not-shipped` meta (unchanged); known → its meta;
+  **unrecognised → `{ label: 'Unknown (<raw>)', tone: 'neutral' }`**.
+- `slaBadge`: falsy or `'none'` → `null` (unchanged); known → its meta;
+  unrecognised → same neutral unknown badge.
+- One shared private `unknownStateBadge(raw)` so the two cannot drift, truncating
+  the raw value (32 chars) so a pathological string cannot wreck the row layout.
+- Return type of `fulfillmentBadge` stays non-nullable.
+
+### 3.3 `pages/orders/dispatch-risk-page.tsx`
+Delete the dead `if (!badge) return null;` at :129 — `fulfillmentBadge` has never
+returned `null` and still does not. This is exactly the `WHY_CODE_FALLBACK`
+dead-code lesson #2589 recorded: an unreachable guard reads as coverage and is not.
+
+## 4. Sibling lookups — searched, not assumed
+
+`grep -rn "META\[" apps/web/src` plus a read of every `Record<...>` in the orders
+feature:
+
+| Lookup | Verdict |
+|---|---|
+| `ORDER_FULFILLMENT_META[state ?? 'not-shipped']` | **FIXING** — unguarded, wire-driven |
+| `ORDER_SLA_META[slaState]` | **FIXING** — same shape |
+| `ORDER_HEALTH_META.<literal>` | safe — dot access on compile-time literals only |
+| `ORDER_LIFECYCLE_PHASE_META[phase]` | safe — behind `isOrderLifecyclePhase` (#2310) |
+| `ORDER_LIFECYCLE_PHASE_WAITING_ON[phase]` | safe — same guard |
+
+Any further `Record`-keyed lookup found during implementation gets the same
+treatment or an explicit out-of-scope note in the PR.
+
+## 5. Tests — red first
+
+1. `order-health.test.ts`: `fulfillmentBadge('teleported' as never)` returns a
+   neutral badge naming the value; `slaBadge('quantum' as never)` likewise;
+   absent/known behaviour unchanged. Red before the fix (`undefined` returned).
+2. `orders-list-page.test.tsx`: seed one row with an unrecognised
+   `fulfillmentState` through the **real** query/render path and assert the page
+   still renders (other rows visible, the neutral cell present). This is the
+   check that actually reproduces #2678 — a lib-only test would pass against a
+   version of the fix that still crashed the page.
+3. Both must be observed **red with the fix reverted**, not merely written.
+
+## 6. Out of scope (stated, not silently skipped)
+- Adding a zod parse layer to `GET /orders` — a much larger change; the guard at
+  the render seam is the proportionate fix and is what #2589 did.
+- A `check-*-mirror.mjs` invariant for `FulfillmentRollupStateValues` /
+  `SlaStateValues`. None exists today; adding one is a separate change.


### PR DESCRIPTION
Closes #2678

## Root cause

`fulfillmentBadge` was a single line:

```ts
return ORDER_FULFILLMENT_META[state ?? 'not-shipped'];
```

A lookup that is **total on the type but partial at runtime**. `GET /orders` is not schema-parsed anywhere in `features/orders/api/` (zod appears in that feature only as a form resolver), so `FulfillmentRollupStateValue` is a *claim about the wire*, not a guarantee about it.

An unrecognised value returns `undefined`, and all three call sites read `.tone` off it immediately — `orders-list-page.tsx` (desktop Ship-by cell, mobile card, mobile badge row) and `dispatch-risk-page.tsx`. Because that read happens inside a `DataTable` cell renderer, the throw unmounted the **whole `/orders` route**, not the offending cell.

Three routes reach an unrecognised value with no bug in the union, all version skew (the #2589 shape): a rolling deploy shipping a backend member before the browser bundle, a stale cached bundle after a deploy, or a replayed cached API response.

## Why this degrades rather than lies

Two cheaper fixes were rejected, and the reasoning is written at the seam so it is not re-litigated later:

- **`?? 'not-shipped'` widened to cover the miss** — this renders "Not shipped" about an order whose state this build cannot name. That is a quiet false claim about the operator's own data, and it is *worse* than the crash it replaces: a blank page is at least obviously broken.
- **Return `null` / render nothing** — a silent drop. The row then reads as one that simply has no fulfilment fact.

So the unrecognised value is **surfaced verbatim** in a neutral badge — `Unknown (teleported)` — the way an unrecognised marketplace validation code is surfaced rather than dropped (#2231). `neutral` is deliberate: OL has no idea whether the state is good or bad, and any status tone would assert one.

**Absent stays `not-shipped`.** That is a real backend contract, not a fallback, and absent and unrecognised remain distinguishable — a test pins exactly that.

## Sibling lookups — found by grep, not assumed

| Lookup | Verdict |
|---|---|
| `ORDER_FULFILLMENT_META[state ?? …]` | **fixed** — the crash |
| `ORDER_SLA_META[slaState]` | **fixed** — same shape, different symptom (below) |
| `PAYMENT_BADGE_META[status]` | safe — narrowed upstream by `readPaymentStatus`'s soft-parse |
| `ORDER_LIFECYCLE_PHASE_META[phase]` | safe — behind `isOrderLifecyclePhase` |
| `ORDER_HEALTH_META.<literal>` | safe — dot access on compile-time literals |

The clean underlying story: **snapshot** fields already go through `parseOrderSnapshot`'s soft-parse; the **top-level `OrderRecord` columns** did not. `lifecyclePhase` had a guard; `fulfillmentState` and `slaState` were the two that had none.

`slaBadge` shared the shape but **never crashed** — every call site guards on `sla ?`, so an unrecognised bucket rendered nothing, indistinguishable from the `none` member which legitimately means "no badge". A silent drop of the signal is its own defect, so it gets the same treatment. Note membership is established **before** the `none` check: `none` is a *member* of the union, not a miss, and testing it first conflates "the backend said none" with "the backend said something unreadable". The compiler found that ordering flaw during the gate.

Also removes a dead `if (!badge) return null` in `dispatch-risk-page` — `fulfillmentBadge` has never returned `null`, so that guard read as coverage it never provided (the #2589 `WHY_CODE_FALLBACK` dead-code lesson).

## Tests — observed red, not merely written

Every new test was run against a reverted fix before being kept:

- `orders-list-page.test.tsx` fails with the exact reported symptom, `TypeError: Cannot read properties of undefined (reading 'tone')`. It drives an unrecognised value through the **real** query → page → table → cell path and asserts both the offending row and its neighbour still render — so a lib-only fix that still crashed the page would not pass it.
- `order-health.test.ts` (5 cases) covers the neutral badge, the absent-vs-unrecognised distinction, truncation of a pathological value, the blank-value case, and the SLA silent-drop.

## `/pr-review` round — three findings, all applied (`c8dfce5cc`)

1. **The empty string diverged between the two resolvers, and produced a label that named nothing.** `slaBadge` short-circuited on `!slaState`, so a JSON `""` was swallowed into the same answer as the `none` *member* — "no badge, nothing is wrong" — while `fulfillmentBadge` rendered **`Unknown ()`**, which claims to quote the offending value and quotes nothing. Same condition, two answers, one useless. Both now short-circuit only on genuinely absent, and a blank/whitespace-only value renders a bare `Unknown`. New test, observed red first.
2. **The tests cast inputs `as FulfillmentRollupStateValue` / `as SlaStateValue`**, misrepresenting the contract under test — the parameter is deliberately `string`, because that is what the wire delivers. Casting to the union implied the opposite of the fix. Dropped.
3. **Documentation gap** — the change introduces a new operator-visible status label, and `frontend-ui-style-guide.md` governs that vocabulary. Recorded under § Status Language as three rules (never render an unrecognised value as a known one; never drop it silently; surface it neutrally), plus the note that absence is a separate question keeping whatever contract the backend documents — a guard conflating the two reintroduces rule 1.

## Gate

`lint` (0 errors), `type-check`, `check:invariants` and the full `pnpm test` all green via the pre-commit hook on **both** commits — `apps/web` 449 files / 4833 tests, `libs/core` 5684, every integration package passing.

## Note for #2410 / #2411

#2396 and #2406 are backend-only so far; no new FE cell consumes `fulfillmentBlockReason` or `supportedActions` yet. Those fields are the next place this class of bug appears — the guard pattern here (`is*` beside the union in `orders.types.ts`, neutral surfaced badge at the render seam, now written up in the style guide) is the one to copy. I deliberately did **not** pre-guard a field the FE does not yet read, since that would be the same dead-fallback mistake this PR removes.