### PR TITLE
feat(web/fulfillment): desktop worklist with manual mark-picked / mark-shipped (#2410)

### DIFF
--- a/apps/web/src/app/nav-registry.ts
+++ b/apps/web/src/app/nav-registry.ts
@@ -39,6 +39,10 @@ export const BASE_NAV_GROUPS: readonly NavRegistryGroup[] = [
       { to: '/customers', label: 'Customers', countKey: 'customers' },
       { to: '/listings', label: 'Listings', countKey: 'listings' },
       { to: '/shipments', label: 'Shipments' },
+      // No `countKey`: the #2406 worklist read exposes no counts endpoint the
+      // nav could read, and a badge is worse absent than wrong (the `/returns`
+      // precedent one line down).
+      { to: '/fulfillment', label: 'Fulfilment' },
       // No `countKey`: the #2334 returns contract exposes no counts endpoint
       // the nav could read, and a badge is worse absent than wrong.
       { to: '/returns', label: 'Returns' },

--- a/apps/web/src/app/routes/fulfillment.route.tsx
+++ b/apps/web/src/app/routes/fulfillment.route.tsx
@@ -1,0 +1,31 @@
+/**
+ * Fulfilment route (#2410)
+ *
+ * `/fulfillment` — the standalone operator worklist. A single lazy leaf with
+ * its own crumb; the crumb-contract test asserts every lazy leaf carries one.
+ *
+ * The path keeps the American spelling every other identifier in this slice
+ * uses (the folder, the feature, the API), while the operator-facing TITLE is
+ * the British "Fulfilment" the epic's naming rule requires — the URL is not
+ * copy, and making the two agree would mean changing one of them for the wrong
+ * reason.
+ *
+ * @module app/routes
+ */
+import type { RouteObject } from 'react-router-dom';
+import type { RouteCrumbHandle } from '../nav-registry.types';
+
+const fulfillmentCrumb: RouteCrumbHandle = {
+  crumb: { group: 'Operations', title: 'Fulfilment' },
+};
+
+export const fulfillmentRoute: RouteObject = {
+  path: 'fulfillment',
+  handle: fulfillmentCrumb,
+  lazy: async () => {
+    const { FulfillmentWorklistPage } = await import(
+      '../../pages/fulfillment/fulfillment-worklist-page'
+    );
+    return { Component: FulfillmentWorklistPage };
+  },
+};

--- a/apps/web/src/app/routes/root.route.tsx
+++ b/apps/web/src/app/routes/root.route.tsx
@@ -41,6 +41,7 @@ import {
 } from './prompt-templates-legacy-redirects.route';
 import { automationsRoute } from './automations.route';
 import { returnsRoute } from './returns.route';
+import { fulfillmentRoute } from './fulfillment.route';
 import { operationalSettingsRoute } from './operational-settings.route';
 import { salesDocumentsRoute } from './sales-documents.route';
 import { whoDecidesRoute } from './who-decides.route';
@@ -65,6 +66,7 @@ export const coreChildren: RouteObject[] = [
   listingsRoute,
   shipmentsRoute,
   returnsRoute,
+  fulfillmentRoute,
   automationsRoute,
   invoicesRoute,
   connectionsRoute,

--- a/apps/web/src/app/routes/route-lazy.test.ts
+++ b/apps/web/src/app/routes/route-lazy.test.ts
@@ -74,7 +74,7 @@ const lazyRoutes = collectLazyRoutes([
  *   - login (first-paint optimization — see `login.route.tsx`)
  *   - prompt-templates-legacy-redirects (inline `<Navigate>` element)
  */
-const EXPECTED_LAZY_ROUTE_COUNT = 61;
+const EXPECTED_LAZY_ROUTE_COUNT = 62;
 
 describe('route lazy contract', () => {
   it(`the registered route tree contains exactly ${EXPECTED_LAZY_ROUTE_COUNT} lazy routes`, () => {

--- a/apps/web/src/features/fulfillment/api/fulfillment.api.test.ts
+++ b/apps/web/src/features/fulfillment/api/fulfillment.api.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Fulfilment api client (#2410).
+ *
+ * The load-bearing case is the FIRST one: #2410 re-expressed `listByOrder`
+ * through the new `list`, and that method is #2411's — an emitted URL that
+ * changed shape would break the order-detail panel silently, since the mock in
+ * every one of its tests answers whatever it is asked.
+ */
+import { describe, expect, it, vi } from 'vitest';
+
+import { buildFulfillmentWorksPath, createFulfillmentApi } from './fulfillment.api';
+
+function emptyPage(): unknown {
+  return { works: [], total: 0, limit: 25, offset: 0 };
+}
+
+describe('fulfillment api', () => {
+  it('emits the unchanged listByOrder URL after the re-expression', async () => {
+    const request = vi.fn().mockResolvedValue(emptyPage());
+    await createFulfillmentApi(request).listByOrder('ol_order_1');
+
+    expect(request).toHaveBeenCalledWith('/fulfillment/works?orderId=ol_order_1');
+  });
+
+  it('emits only the params that are set', () => {
+    expect(buildFulfillmentWorksPath({})).toBe('/fulfillment/works');
+    expect(buildFulfillmentWorksPath({ locationId: 'loc_a' })).toBe(
+      '/fulfillment/works?locationId=loc_a'
+    );
+    // `undefined` must never stringify into the query — the DTO would then try
+    // to validate the literal "undefined".
+    expect(buildFulfillmentWorksPath({ orderId: undefined, limit: 25 })).toBe(
+      '/fulfillment/works?limit=25'
+    );
+  });
+
+  it('emits an offset of zero rather than dropping it', () => {
+    // `0` is falsy, so a truthiness test here would silently page from wherever
+    // the server defaults to.
+    expect(buildFulfillmentWorksPath({ offset: 0 })).toBe('/fulfillment/works?offset=0');
+  });
+
+  it('encodes a value that needs escaping', () => {
+    expect(buildFulfillmentWorksPath({ orderId: 'a b&c' })).toBe(
+      '/fulfillment/works?orderId=a+b%26c'
+    );
+  });
+
+  it('gets one task by id', async () => {
+    const request = vi.fn().mockResolvedValue({
+      id: 'ol_work_1',
+      orderId: 'ol_order_1',
+      status: 'open',
+      requestStatus: 'unsubmitted',
+      assignmentAttempt: 0,
+      createdAt: '2026-08-20T10:00:00.000Z',
+      updatedAt: '2026-08-20T10:00:00.000Z',
+      lines: [],
+      activeHolds: [],
+      supportedActions: [],
+      version: 1,
+    });
+
+    await createFulfillmentApi(request).get('ol_work_1');
+
+    expect(request).toHaveBeenCalledWith('/fulfillment/works/ol_work_1');
+  });
+});

--- a/apps/web/src/features/fulfillment/api/fulfillment.api.ts
+++ b/apps/web/src/features/fulfillment/api/fulfillment.api.ts
@@ -1,9 +1,22 @@
 /**
- * Fulfilment-task API client (#2411)
+ * Fulfilment-task API client (#2411, list axis added by #2410)
  *
  * Thin typed access to the #2406 worklist read model. Every response is parsed
  * through the boundary schema so a shape change surfaces here rather than as an
  * `undefined` three components deep.
+ *
+ * ## `listByOrder` is `list` with one filter, not a second endpoint
+ *
+ * #2410's worklist needs the same `GET /fulfillment/works` with `locationId`
+ * and paging, so the query string is built once here and `listByOrder` is
+ * expressed through it. Two builders for one endpoint is how the order-scoped
+ * read and the worklist would come to encode a param differently — and the
+ * emitted URL is pinned by a test for exactly that reason.
+ *
+ * ## Only DEFINED params are emitted
+ *
+ * `URLSearchParams` stringifies `undefined` to the literal `"undefined"`, which
+ * the DTO would then try to validate. An absent filter must be an absent param.
  *
  * @module apps/web/src/features/fulfillment/api
  */
@@ -11,12 +24,23 @@ import { parseFulfillmentTask, parseFulfillmentTaskPage } from './fulfillment.sc
 import type {
   ApplyFulfillmentTaskActionRequest,
   FulfillmentTask,
+  FulfillmentTaskFilters,
   FulfillmentTaskPage,
 } from './fulfillment.types';
 
 export interface FulfillmentApi {
+  /**
+   * One filtered, paged page of fulfilment tasks.
+   *
+   * `status` / `requestStatus` are accepted by the endpoint and deliberately
+   * NOT exposed here: they are closed unions this app may not mirror (see the
+   * `fulfillment.types.ts` docblock), so there is nothing safe to send.
+   */
+  list: (filters?: FulfillmentTaskFilters) => Promise<FulfillmentTaskPage>;
   /** Every fulfilment task covering one order. */
   listByOrder: (orderId: string) => Promise<FulfillmentTaskPage>;
+  /** One fulfilment task by id. */
+  get: (workId: string) => Promise<FulfillmentTask>;
   /**
    * Apply one action. `expectedVersion` is required by the contract; a stale
    * token answers 409 `version_conflict` (retryable), an illegal action answers
@@ -33,13 +57,33 @@ interface ApiRequest {
   <T>(path: string, init?: RequestInit): Promise<T>;
 }
 
+/** `/fulfillment/works` plus only the params that are actually set. */
+export function buildFulfillmentWorksPath(filters: FulfillmentTaskFilters = {}): string {
+  const params = new URLSearchParams();
+  if (filters.orderId !== undefined) params.set('orderId', filters.orderId);
+  if (filters.locationId !== undefined) params.set('locationId', filters.locationId);
+  if (filters.limit !== undefined) params.set('limit', String(filters.limit));
+  if (filters.offset !== undefined) params.set('offset', String(filters.offset));
+  const query = params.toString();
+  return query.length > 0 ? `/fulfillment/works?${query}` : '/fulfillment/works';
+}
+
 export function createFulfillmentApi(request: ApiRequest): FulfillmentApi {
+  async function list(filters: FulfillmentTaskFilters = {}): Promise<FulfillmentTaskPage> {
+    const payload = await request<unknown>(buildFulfillmentWorksPath(filters));
+    return parseFulfillmentTaskPage(payload);
+  }
+
   return {
+    list,
     async listByOrder(orderId): Promise<FulfillmentTaskPage> {
+      return list({ orderId });
+    },
+    async get(workId): Promise<FulfillmentTask> {
       const payload = await request<unknown>(
-        `/fulfillment/works?orderId=${encodeURIComponent(orderId)}`
+        `/fulfillment/works/${encodeURIComponent(workId)}`
       );
-      return parseFulfillmentTaskPage(payload);
+      return parseFulfillmentTask(payload);
     },
     async applyAction(workId, action, body): Promise<FulfillmentTask> {
       const payload = await request<unknown>(

--- a/apps/web/src/features/fulfillment/api/fulfillment.query-keys.ts
+++ b/apps/web/src/features/fulfillment/api/fulfillment.query-keys.ts
@@ -17,5 +17,4 @@ export const fulfillmentQueryKeys = {
    * filter is a different query rather than a refetch of the same one.
    */
   list: (filters: FulfillmentTaskFilters) => ['fulfillment', 'works', 'list', filters] as const,
-  detail: (workId: string) => ['fulfillment', 'works', 'detail', workId] as const,
 };

--- a/apps/web/src/features/fulfillment/api/fulfillment.query-keys.ts
+++ b/apps/web/src/features/fulfillment/api/fulfillment.query-keys.ts
@@ -1,9 +1,21 @@
 /**
- * Fulfilment-task query keys (#2411)
+ * Fulfilment-task query keys (#2411, list axis added by #2410)
+ *
+ * Every key is prefixed `['fulfillment', …]`, which is what makes `all` a valid
+ * invalidation ancestor of all of them — the action mutation invalidates `all`
+ * precisely so an action taken on one surface refreshes the other (#2411).
  *
  * @module apps/web/src/features/fulfillment/api
  */
+import type { FulfillmentTaskFilters } from './fulfillment.types';
+
 export const fulfillmentQueryKeys = {
   all: ['fulfillment'] as const,
   worksByOrder: (orderId: string) => ['fulfillment', 'works', 'by-order', orderId] as const,
+  /**
+   * The worklist's rows. The filter object is part of the key, so changing a
+   * filter is a different query rather than a refetch of the same one.
+   */
+  list: (filters: FulfillmentTaskFilters) => ['fulfillment', 'works', 'list', filters] as const,
+  detail: (workId: string) => ['fulfillment', 'works', 'detail', workId] as const,
 };

--- a/apps/web/src/features/fulfillment/api/fulfillment.types.ts
+++ b/apps/web/src/features/fulfillment/api/fulfillment.types.ts
@@ -121,3 +121,22 @@ export interface ApplyFulfillmentTaskActionRequest {
   /** `release_hold` only — the note recorded on the RELEASE. */
   releaseNote?: string;
 }
+
+/**
+ * The filters `GET /fulfillment/works` accepts and this app is willing to send
+ * (#2410).
+ *
+ * `status` and `requestStatus` are accepted by the endpoint and ABSENT here on
+ * purpose. They are closed unions in `@openlinker/core/fulfillment` that this
+ * app may not mirror (see the module docblock), and the endpoint validates them
+ * — so a value forwarded raw from the URL bar would 400 the whole page over a
+ * typo, and a value this build invented would be silently dropped. Filtering is
+ * by the two free-string params until a server-supplied facet list exists.
+ */
+export interface FulfillmentTaskFilters {
+  orderId?: string;
+  locationId?: string;
+  /** Server-clamped; the response reports what was actually applied. */
+  limit?: number;
+  offset?: number;
+}

--- a/apps/web/src/features/fulfillment/components/fulfillment-lane-section.tsx
+++ b/apps/web/src/features/fulfillment/components/fulfillment-lane-section.tsx
@@ -1,0 +1,74 @@
+/**
+ * One worklist lane (#2410)
+ *
+ * A heading (where the goods are, how they leave) plus that lane's tasks
+ * rendered TWICE — as desktop rows and as cards — with a CSS media query
+ * deciding which is visible. That is the house pattern (`DataTable`'s own
+ * `cardView`), and it is what lets the two surfaces be asserted to show the
+ * same set of tasks: they are built from one array in one render.
+ *
+ * ## The `actions` slot is a FUNCTION of the task, not a node
+ *
+ * Both surfaces need their own element instance for the same task (one element
+ * cannot be in two places), and the dialog state lives on the page. So the page
+ * passes a renderer and this component calls it once per task per surface —
+ * which also means the two surfaces cannot be handed different action sets.
+ *
+ * @module apps/web/src/features/fulfillment/components
+ */
+import type { ReactElement } from 'react';
+
+import type { FulfillmentTask } from '../api/fulfillment.types';
+import type { FulfillmentLane } from '../lib/fulfillment-lanes';
+import { summariseLaneLines } from '../lib/fulfillment-lanes';
+import { FULFILLMENT_WORKLIST_COPY } from '../lib/fulfillment-worklist.copy';
+import { FulfillmentTaskCard } from './fulfillment-task-card';
+import { FulfillmentWorklistRow } from './fulfillment-worklist-row';
+
+export interface FulfillmentLaneSectionProps {
+  lane: FulfillmentLane;
+  /** Builds the action strip for one task. Called once per surface. */
+  renderActions: (task: FulfillmentTask) => ReactElement | null;
+}
+
+export function FulfillmentLaneSection({
+  lane,
+  renderActions,
+}: FulfillmentLaneSectionProps): ReactElement {
+  const lines = summariseLaneLines(lane);
+
+  return (
+    // Both axes in the accessible name: two lanes at one location differing
+    // only by delivery method would otherwise be indistinguishable to a screen
+    // reader listing the page's regions.
+    <section
+      className="fulfilment-worklist-lane"
+      aria-label={`${lane.locationLabel} — ${lane.deliveryMethodLabel}`}
+    >
+      <header className="fulfilment-worklist-lane__head">
+        <h3 className="fulfilment-worklist-lane__title">{lane.locationLabel}</h3>
+        <span className="fulfilment-worklist-lane__method text-muted">{lane.deliveryMethodLabel}</span>
+        <span className="fulfilment-worklist-lane__count tabular text-muted">
+          {FULFILLMENT_WORKLIST_COPY.row.lineCount(lines.fulfilled, lines.total)}
+        </span>
+      </header>
+      {/* Said per lane rather than per row: the rows are a paged slice, so a
+          lane is never the whole lane. */}
+      <p className="fulfilment-worklist-lane__scope text-muted">
+        {FULFILLMENT_WORKLIST_COPY.lane.pageScopeNote} {FULFILLMENT_WORKLIST_COPY.row.countersCaveat}
+      </p>
+
+      <ul className="fulfilment-worklist__desktop">
+        {lane.tasks.map((task) => (
+          <FulfillmentWorklistRow key={task.id} task={task} actions={renderActions(task)} />
+        ))}
+      </ul>
+
+      <ul className="fulfilment-worklist__cards fulfilment-task-list">
+        {lane.tasks.map((task) => (
+          <FulfillmentTaskCard key={task.id} task={task} actions={renderActions(task)} />
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/apps/web/src/features/fulfillment/components/fulfillment-worklist-row.test.tsx
+++ b/apps/web/src/features/fulfillment/components/fulfillment-worklist-row.test.tsx
@@ -1,0 +1,236 @@
+/**
+ * `FulfillmentWorklistRow` — AC1, "no client-side state machine" (#2410).
+ *
+ * `scripts/check-no-supported-actions-mirror.mjs` catches a `derive*` or a
+ * `FulfillmentWorkAction[Values]` declaration and says in its own docblock that
+ * it cannot catch an inline `if (status === 'open')`. #2411 already specs
+ * `FulfillmentTaskActions` itself, so the property is true of that component.
+ * What is NOT covered anywhere else is what the WORKLIST ROW selects to hand it
+ * — the only place in this body a legality decision could be reintroduced — so
+ * every assertion below is written against the row rather than the component.
+ *
+ * Each case asserts a NON-EMPTY baseline control list first. Comparing two
+ * empty arrays is exactly the shape of a check that cannot fail, and is what a
+ * `supportedActions: []` fixture — or a `visible: false` typo — would produce.
+ */
+import { cleanup, screen, within } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { FulfillmentWorklistRow } from './fulfillment-worklist-row';
+import { FulfillmentTaskActions } from './fulfillment-task-actions';
+import { renderWithProviders } from '../../../test/test-utils';
+import type { FulfillmentTask } from '../api/fulfillment.types';
+
+afterEach(cleanup);
+
+function task(overrides: Partial<FulfillmentTask> = {}): FulfillmentTask {
+  return {
+    id: 'ol_work_1',
+    orderId: 'ol_order_1',
+    locationId: 'loc_warsaw',
+    deliveryMethod: 'courier',
+    assignedConnectionId: null,
+    status: 'open',
+    requestStatus: 'unsubmitted',
+    assignmentAttempt: 0,
+    cancellationReason: null,
+    externalWorkId: null,
+    acceptedAt: null,
+    cancelledAt: null,
+    createdAt: '2026-08-20T10:00:00.000Z',
+    updatedAt: '2026-08-20T10:00:00.000Z',
+    lines: [
+      {
+        id: 'line_1',
+        orderLineId: 'ol_orderline_1',
+        productVariantId: 'ol_variant_1',
+        totalQuantity: 5,
+        fulfilledQuantity: 0,
+        cancelledQuantity: 0,
+      },
+    ],
+    activeHolds: [],
+    supportedActions: ['hold', 'close'],
+    version: 7,
+    ...overrides,
+  };
+}
+
+/** Renders the row exactly as the page composes it. */
+function renderRow(
+  subject: FulfillmentTask,
+  access: { visible?: boolean; readOnly?: boolean } = {}
+): HTMLElement {
+  const { container } = renderWithProviders(
+    <ul>
+      <FulfillmentWorklistRow
+        task={subject}
+        actions={
+          <FulfillmentTaskActions
+            task={subject}
+            visible={access.visible ?? true}
+            readOnly={access.readOnly ?? false}
+            busy={false}
+            onInvoke={vi.fn()}
+            onHold={vi.fn()}
+            onReleaseHold={vi.fn()}
+            onForceCancel={vi.fn()}
+          />
+        }
+      />
+    </ul>
+  );
+  return container.querySelector('li') as HTMLElement;
+}
+
+function controlLabels(row: HTMLElement): string[] {
+  return within(row)
+    .queryAllByRole('button')
+    .map((button) => button.textContent?.trim() ?? '');
+}
+
+describe('FulfillmentWorklistRow — actions come only from supportedActions', () => {
+  it('renders the same controls for two tasks that differ only in status', () => {
+    // The break this catches: `if (task.status !== 'open') return null;` around
+    // the row's action strip.
+    const open = renderRow(task({ status: 'open', requestStatus: 'unsubmitted' }));
+    const baseline = controlLabels(open);
+    expect(baseline.length).toBeGreaterThan(0);
+
+    cleanup();
+
+    const inProgress = renderRow(
+      task({ status: 'in_progress', requestStatus: 'accepted' })
+    );
+    expect(controlLabels(inProgress)).toEqual(baseline);
+  });
+
+  it('renders the same controls for two tasks that differ only in a line counter', () => {
+    // Counters are display-only (#2400 moves them without bumping `version`),
+    // so nothing may be gated on one.
+    const untouched = renderRow(task());
+    const baseline = controlLabels(untouched);
+    expect(baseline.length).toBeGreaterThan(0);
+
+    cleanup();
+
+    const partlyPicked = renderRow(
+      task({
+        lines: [
+          {
+            id: 'line_1',
+            orderLineId: 'ol_orderline_1',
+            productVariantId: 'ol_variant_1',
+            totalQuantity: 5,
+            fulfilledQuantity: 5,
+            cancelledQuantity: 0,
+          },
+        ],
+      })
+    );
+    expect(controlLabels(partlyPicked)).toEqual(baseline);
+  });
+
+  it('still offers hold on a task that already carries one', () => {
+    // The plausible row-level defect the two cases above miss: filtering `hold`
+    // out because the task is already held is a legality decision, and the
+    // server is the one that makes it — it simply does not offer `hold` when a
+    // second hold is not legal.
+    const unheld = renderRow(task());
+    const baseline = controlLabels(unheld);
+    expect(baseline.length).toBeGreaterThan(0);
+
+    cleanup();
+
+    const held = renderRow(
+      task({
+        activeHolds: [
+          {
+            id: 'hold_1',
+            reason: 'stock_shortfall',
+            note: null,
+            placedAt: '2026-08-20T11:00:00.000Z',
+          },
+        ],
+      })
+    );
+    expect(controlLabels(held)).toEqual(baseline);
+  });
+});
+
+describe('FulfillmentWorklistRow — write access is the page’s decision', () => {
+  it('renders no controls at all for an unauthorized session', () => {
+    const authorized = renderRow(task());
+    expect(controlLabels(authorized).length).toBeGreaterThan(0);
+
+    cleanup();
+
+    const unauthorized = renderRow(task(), { visible: false });
+    expect(controlLabels(unauthorized)).toEqual([]);
+  });
+
+  it('renders the same controls DISABLED, not hidden, in demo read-only', () => {
+    // #1615: a public demo advertises the capability rather than hiding it, so
+    // hiding on read-only is the regression this pins.
+    const writable = renderRow(task());
+    const baseline = controlLabels(writable);
+    expect(baseline.length).toBeGreaterThan(0);
+
+    cleanup();
+
+    const readOnly = renderRow(task(), { readOnly: true });
+    expect(controlLabels(readOnly)).toEqual(baseline);
+    for (const button of within(readOnly).getAllByRole('button')) {
+      expect(button).toBeDisabled();
+    }
+  });
+});
+
+describe('FulfillmentWorklistRow — what it shows', () => {
+  it('leads with the hold rather than the orchestration status when held', () => {
+    const row = renderRow(
+      task({
+        status: 'open',
+        activeHolds: [
+          {
+            id: 'hold_1',
+            reason: 'stock_shortfall',
+            note: null,
+            placedAt: '2026-08-20T11:00:00.000Z',
+          },
+        ],
+      })
+    );
+
+    // POSITIVE assertion — "does not say Open" would also pass on an empty row.
+    // Anchored: an unanchored /on hold/i also matches the "Put on hold" BUTTON,
+    // so it would pass on a row that rendered no hold badge at all.
+    expect(within(row).getByText(/^On hold —/)).toBeInTheDocument();
+    expect(row.dataset.held).toBe('true');
+  });
+
+  it('renders the display-only line counter', () => {
+    const row = renderRow(
+      task({
+        lines: [
+          {
+            id: 'line_1',
+            orderLineId: 'ol_orderline_1',
+            productVariantId: 'ol_variant_1',
+            totalQuantity: 5,
+            fulfilledQuantity: 3,
+            cancelledQuantity: 0,
+          },
+        ],
+      })
+    );
+
+    expect(within(row).getByText('3 of 5')).toBeInTheDocument();
+  });
+
+  it('says a task covers no lines rather than rendering an empty counter', () => {
+    const row = renderRow(task({ lines: [] }));
+    expect(within(row).getByText('No lines')).toBeInTheDocument();
+    expect(screen.queryByText('0 of 0')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/fulfillment/components/fulfillment-worklist-row.test.tsx
+++ b/apps/web/src/features/fulfillment/components/fulfillment-worklist-row.test.tsx
@@ -90,6 +90,32 @@ function controlLabels(row: HTMLElement): string[] {
 }
 
 describe('FulfillmentWorklistRow — actions come only from supportedActions', () => {
+  it('renders a DIFFERENT control set when the server offers a different one', () => {
+    // The three cases below hold `supportedActions` constant and assert the
+    // controls do not change — which a component that IGNORED the field and
+    // hardcoded its own list would also satisfy. This is the positive half:
+    // the rendered set TRACKS the server's, including an action this build has
+    // no copy table entry for, so nothing here can be a local vocabulary.
+    const both = renderRow(task({ supportedActions: ['hold', 'close'] }));
+    const baseline = controlLabels(both);
+    expect(baseline.length).toBeGreaterThan(1);
+
+    cleanup();
+
+    const one = renderRow(task({ supportedActions: ['close'] }));
+    const narrowed = controlLabels(one);
+    expect(narrowed.length).toBe(baseline.length - 1);
+    expect(baseline).toEqual(expect.arrayContaining(narrowed));
+
+    cleanup();
+
+    // An action the copy table does not know still reaches the operator: the
+    // row hands `supportedActions` through untouched, so the set cannot be
+    // narrowed to what this build happens to have words for.
+    const unknown = renderRow(task({ supportedActions: ['expedite_pick'] }));
+    expect(controlLabels(unknown)).toEqual(['Expedite pick']);
+  });
+
   it('renders the same controls for two tasks that differ only in status', () => {
     // The break this catches: `if (task.status !== 'open') return null;` around
     // the row's action strip.

--- a/apps/web/src/features/fulfillment/components/fulfillment-worklist-row.tsx
+++ b/apps/web/src/features/fulfillment/components/fulfillment-worklist-row.tsx
@@ -1,0 +1,94 @@
+/**
+ * One fulfilment task, desktop row (#2410)
+ *
+ * The wide-viewport counterpart of `FulfillmentTaskCard`. It composes the SAME
+ * `FulfillmentTaskActions` the card and the order-detail panel use, which is
+ * what makes "no client-side state machine" structurally true rather than
+ * separately argued: there is one component that turns `supportedActions` into
+ * controls, and this row hands it the task unchanged.
+ *
+ * ## This row decides NOTHING about legality
+ *
+ * It does not read `status`, it does not read `requestStatus`, it does not read
+ * a counter, and it does not filter `supportedActions` — not even to drop an
+ * action that "obviously" cannot apply. The server offers `hold` on a task that
+ * already carries a hold precisely when a second hold is legal; suppressing it
+ * here would be this surface overruling the only party that knows (DESIGN
+ * §5.2). `scripts/check-no-supported-actions-mirror.mjs` catches the two
+ * declaration shapes and says plainly that it cannot catch an inline
+ * `if (status === …)`, so the rule is honoured here rather than merely enforced.
+ *
+ * ## Heldness is `activeHolds`, and the counters are display-only
+ *
+ * Both rules are the card's (#2411) and are restated in the rendering, not
+ * re-derived: nothing writes `status = 'on_hold'`, and `recordLineProgress`
+ * moves a counter without bumping `version` (#2400).
+ *
+ * @module apps/web/src/features/fulfillment/components
+ */
+import type { ReactElement } from 'react';
+
+import { StatusBadge } from '../../../shared/ui/status-badge';
+import { holdReasonLabel } from '../../orders';
+import type { FulfillmentTask } from '../api/fulfillment.types';
+import {
+  fulfillmentRequestStatusLabel,
+  fulfillmentStatusLabel,
+} from '../lib/fulfillment-task.copy';
+import { FULFILLMENT_WORKLIST_COPY } from '../lib/fulfillment-worklist.copy';
+
+export interface FulfillmentWorklistRowProps {
+  task: FulfillmentTask;
+  /** The action controls, composed by the page (which owns the dialogs). */
+  actions?: ReactElement | null;
+}
+
+export function FulfillmentWorklistRow({
+  task,
+  actions,
+}: FulfillmentWorklistRowProps): ReactElement {
+  const held = task.activeHolds.length > 0;
+
+  const fulfilled = task.lines.reduce((sum, line) => sum + line.fulfilledQuantity, 0);
+  const total = task.lines.reduce((sum, line) => sum + line.totalQuantity, 0);
+
+  return (
+    <li className="fulfilment-worklist-row" data-held={held ? 'true' : 'false'}>
+      <div className="fulfilment-worklist-row__identity">
+        <span className="fulfilment-worklist-row__id mono-text" title={task.id}>
+          {task.id}
+        </span>
+        <span className="fulfilment-worklist-row__order mono-text text-muted" title={task.orderId}>
+          {task.orderId}
+        </span>
+      </div>
+
+      <div className="fulfilment-worklist-row__state">
+        {held ? (
+          task.activeHolds.map((hold) => (
+            <StatusBadge key={hold.id} tone="warning" withDot compact>
+              {`On hold — ${holdReasonLabel(hold.reason)}`}
+            </StatusBadge>
+          ))
+        ) : (
+          <StatusBadge tone="info" compact>
+            {fulfillmentStatusLabel(task.status)}
+          </StatusBadge>
+        )}
+        {/* Rendered even under a hold badge, so the underlying state is never
+            hidden by it — "held" and "scheduled" are both true at once. */}
+        <span className="fulfilment-worklist-row__substate text-muted">
+          {fulfillmentStatusLabel(task.status)} · {fulfillmentRequestStatusLabel(task.requestStatus)}
+        </span>
+      </div>
+
+      <div className="fulfilment-worklist-row__lines tabular">
+        {task.lines.length > 0
+          ? FULFILLMENT_WORKLIST_COPY.row.lineCount(fulfilled, total)
+          : FULFILLMENT_WORKLIST_COPY.row.noLines}
+      </div>
+
+      <div className="fulfilment-worklist-row__actions">{actions}</div>
+    </li>
+  );
+}

--- a/apps/web/src/features/fulfillment/fulfilment-worklist-styles.test.ts
+++ b/apps/web/src/features/fulfillment/fulfilment-worklist-styles.test.ts
@@ -1,0 +1,247 @@
+/**
+ * Fulfilment worklist — stylesheet coverage and the breakpoint switch (#2410).
+ *
+ * Structurally the `features/fulfillment-authority/who-decides-styles.test.ts`
+ * precedent, reused rather than re-derived: declared-selector MEMBERSHIP (never
+ * `css.includes('.' + name)`, which let a rule-less class pass on a longer
+ * sibling's selector), a BEM block-root exemption, and the guard-of-the-guard
+ * that proves the matcher is stronger than the one that shipped the defect.
+ *
+ * Scoped to the `fulfilment-worklist` prefix. `.fulfilment-task*` is #2411's
+ * and is guarded where it lives; the shared primitives own their own classes.
+ *
+ * @module apps/web/src/features/fulfillment
+ */
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const WEB_SRC = join(__dirname, '..', '..');
+const PREFIX = 'fulfilment-worklist';
+
+function collectSources(dir: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectSources(full));
+      continue;
+    }
+    if (entry.name.endsWith('.tsx') && !entry.name.includes('.test.')) files.push(full);
+  }
+  return files;
+}
+
+function worklistClassNames(source: string): string[] {
+  const names = new Set<string>();
+  for (const match of source.matchAll(/className="([^"]+)"/g)) {
+    for (const name of match[1].split(/\s+/)) {
+      if (name.startsWith(PREFIX)) names.add(name);
+    }
+  }
+  // A component that builds its class string from an array never puts the
+  // literal inside a `className="…"` attribute.
+  for (const match of source.matchAll(new RegExp(`'(${PREFIX}[^']*)'`, 'g'))) {
+    const name = match[1].trim();
+    if (name.length > 0) names.add(name);
+  }
+  return [...names];
+}
+
+function readCss(): string {
+  return readFileSync(join(WEB_SRC, 'index.css'), 'utf8');
+}
+
+/** A commented-out rule is the exact vector a naive regex matches. */
+function stripComments(css: string): string {
+  return css.replace(/\/\*[\s\S]*?\*\//g, '');
+}
+
+/**
+ * Every `@media` block, by BRACE COUNTING rather than a regex.
+ *
+ * A `/@media[^}]*}/` stops at the FIRST closing brace, which is the end of the
+ * media block's first RULE — so a rule after it reads as outside the block. The
+ * whole point of part 3 is knowing which side of a media block a declaration is
+ * on, so the extraction has to be exact.
+ */
+function mediaBlocks(css: string): { condition: string; body: string }[] {
+  const blocks: { condition: string; body: string }[] = [];
+  let index = css.indexOf('@media');
+  while (index !== -1) {
+    const open = css.indexOf('{', index);
+    if (open === -1) break;
+    const condition = css.slice(index + '@media'.length, open).trim();
+    let depth = 1;
+    let cursor = open + 1;
+    while (cursor < css.length && depth > 0) {
+      if (css[cursor] === '{') depth += 1;
+      else if (css[cursor] === '}') depth -= 1;
+      cursor += 1;
+    }
+    blocks.push({ condition, body: css.slice(open + 1, cursor - 1) });
+    index = css.indexOf('@media', cursor);
+  }
+  return blocks;
+}
+
+/** Does this chunk of CSS declare `display: none` for `className`? */
+function declaresDisplayNone(chunk: string, className: string): boolean {
+  const pattern = new RegExp(
+    `\\.${className.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\\\$&')}\\s*\\{[^}]*display\\s*:\\s*none`
+  );
+  return pattern.test(chunk);
+}
+
+describe('fulfilment worklist stylesheet coverage', () => {
+  it('defines a rule for every fulfilment-worklist* class the feature renders', () => {
+    const css = readCss();
+    const sources = [
+      ...collectSources(join(WEB_SRC, 'features', 'fulfillment')),
+      join(WEB_SRC, 'pages', 'fulfillment', 'fulfillment-worklist-page.tsx'),
+    ];
+
+    const used = new Set<string>();
+    for (const file of sources) {
+      for (const name of worklistClassNames(readFileSync(file, 'utf8'))) used.add(name);
+    }
+
+    // A guard over an empty set would pass forever; the classes are the point.
+    expect(used.size).toBeGreaterThan(0);
+
+    // ANCHORED, not `css.includes('.' + name)`: a substring test lets a class
+    // with no rule of its own pass on the strength of a longer sibling's
+    // selector, so the guard could not catch the rendered-invisible defect it
+    // exists for. Collect the declared selectors and test membership instead.
+    const declared = new Set<string>();
+    for (const match of css.matchAll(/\.(-?[_a-zA-Z][\w-]*)/g)) declared.add(match[1]);
+
+    // A BEM BLOCK ROOT is a namespace, not a claim of a rule. Requiring the
+    // `__`/`--` separator keeps this exact — a LEAF with no rule still fails,
+    // because a longer sibling no longer covers it.
+    const isBlockRoot = (name: string): boolean =>
+      css.includes(`.${name}__`) || css.includes(`.${name}--`);
+
+    const undefinedClasses = [...used].filter(
+      (name) => !declared.has(name) && !isBlockRoot(name)
+    );
+    expect(undefinedClasses).toEqual([]);
+
+    // The guard of the guard. Under the old substring test this fabricated leaf
+    // — a truncation of a real class — passed on the strength of its longer
+    // sibling, so the check could not fail for the defect it exists to catch.
+    const fabricatedLeaf = 'fulfilment-worklist-row__actio';
+    expect(declared.has(fabricatedLeaf)).toBe(false);
+    expect(isBlockRoot(fabricatedLeaf)).toBe(false);
+    expect(css.includes(`.${fabricatedLeaf}`)).toBe(true);
+  });
+
+  it('references only declared custom properties from fulfilment-worklist rules', () => {
+    // `var(--x)` with no declaration and no fallback is invalid at
+    // computed-value time, which makes the whole shorthand `unset` — a
+    // transparent row that throws nothing and shows up in no class-name check.
+    const css = readCss();
+
+    const declared = new Set<string>();
+    for (const match of css.matchAll(/--([a-zA-Z0-9-]+)\s*:/g)) declared.add(match[1]);
+
+    const referenced = new Set<string>();
+    for (const block of css.matchAll(
+      new RegExp(`([^{}]*${PREFIX}[^{}]*)\\{([^}]*)\\}`, 'g')
+    )) {
+      for (const use of block[2].matchAll(/var\(\s*--([a-zA-Z0-9-]+)\s*(\)|,)/g)) {
+        // A `var(--x, fallback)` reference is safe by construction.
+        if (use[2] === ',') continue;
+        referenced.add(use[1]);
+      }
+    }
+
+    expect(referenced.size).toBeGreaterThan(0);
+    expect([...referenced].filter((name) => !declared.has(name))).toEqual([]);
+  });
+
+  it('does not assign two worklist row parts to one grid area', () => {
+    // CSS Grid STACKS items assigned to one area rather than flowing them, so
+    // two independently non-empty parts sharing an area print through each
+    // other at every breakpoint.
+    const css = readCss();
+
+    const areaOf = (className: string): string[] => {
+      const areas: string[] = [];
+      for (const block of css.matchAll(/([^{}]*)\{([^}]*)\}/g)) {
+        if (!block[1].split(',').some((sel) => sel.trim().startsWith(`.${className}`))) continue;
+        for (const area of block[2].matchAll(/grid-area:\s*([a-zA-Z0-9_-]+)\s*;/g)) {
+          areas.push(area[1]);
+        }
+      }
+      return areas;
+    };
+
+    // The row is a plain column grid with no named areas today. Asserted as an
+    // equality rather than skipped, so the day one is introduced this case is
+    // already here to be filled in rather than remembered.
+    expect(areaOf('fulfilment-worklist-row__identity')).toEqual([]);
+    expect(areaOf('fulfilment-worklist-row__actions')).toEqual([]);
+  });
+});
+
+describe('fulfilment worklist breakpoint switch', () => {
+  it('hides the desktop surface ONLY inside a max-width media block', () => {
+    // Hoisted out of its `@media`, this rule hides the desktop table at every
+    // width — or, inverted, renders it on a phone. A regex for `display:none`
+    // near the class name passes on a match inside a comment, inside an
+    // unrelated `@media`, or on a rule a later block overrides.
+    const css = stripComments(readCss());
+    const blocks = mediaBlocks(css);
+
+    const inMaxWidth = blocks.filter(
+      (block) =>
+        block.condition.includes('max-width') &&
+        declaresDisplayNone(block.body, 'fulfilment-worklist__desktop')
+    );
+    expect(inMaxWidth.length).toBe(1);
+
+    // And NOWHERE else: not at top level, not in a min-width block.
+    const outsideMediaBlocks = blocks.reduce(
+      (rest, block) => rest.replace(block.body, ''),
+      css
+    );
+    expect(declaresDisplayNone(outsideMediaBlocks, 'fulfilment-worklist__desktop')).toBe(false);
+    expect(
+      blocks
+        .filter((block) => !block.condition.includes('max-width'))
+        .some((block) => declaresDisplayNone(block.body, 'fulfilment-worklist__desktop'))
+    ).toBe(false);
+  });
+
+  it('hides the card surface ONLY inside a min-width media block', () => {
+    const css = stripComments(readCss());
+    const blocks = mediaBlocks(css);
+
+    const inMinWidth = blocks.filter(
+      (block) =>
+        block.condition.includes('min-width') &&
+        declaresDisplayNone(block.body, 'fulfilment-worklist__cards')
+    );
+    expect(inMinWidth.length).toBe(1);
+
+    const outsideMediaBlocks = blocks.reduce(
+      (rest, block) => rest.replace(block.body, ''),
+      css
+    );
+    expect(declaresDisplayNone(outsideMediaBlocks, 'fulfilment-worklist__cards')).toBe(false);
+  });
+
+  it('extracts a media block by brace counting, not to its first closing brace', () => {
+    // The guard of the guard for part 3: a `/@media[^}]*}/` regex stops at the
+    // end of the block's FIRST rule, so a declaration in its second rule reads
+    // as top-level. This asserts the extractor sees both.
+    const sample = '@media (max-width: 767px) {\n  .a { color: red; }\n  .b { display: none; }\n}';
+    const [block] = mediaBlocks(sample);
+
+    expect(block.condition).toBe('(max-width: 767px)');
+    expect(declaresDisplayNone(block.body, 'b')).toBe(true);
+    // The naive regex would have missed it.
+    expect(/@media[^}]*}/.exec(sample)?.[0].includes('display: none')).toBe(false);
+  });
+});

--- a/apps/web/src/features/fulfillment/fulfilment-worklist-styles.test.ts
+++ b/apps/web/src/features/fulfillment/fulfilment-worklist-styles.test.ts
@@ -85,10 +85,23 @@ function mediaBlocks(css: string): { condition: string; body: string }[] {
   return blocks;
 }
 
+/**
+ * Escape a literal for use inside a `RegExp`.
+ *
+ * Spelled out rather than inlined into the template below: the inline form
+ * silently escaped NOTHING (its character class closed early on `[\\]`, leaving
+ * a pattern that matches no real class name), so a class name carrying a regex
+ * metacharacter would have made {@link declaresDisplayNone} answer `false` and
+ * the breakpoint guard pass while asserting nothing.
+ */
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 /** Does this chunk of CSS declare `display: none` for `className`? */
 function declaresDisplayNone(chunk: string, className: string): boolean {
   const pattern = new RegExp(
-    `\\.${className.replace(/[.*+?^${}()|[\\]\\\\]/g, '\\\\$&')}\\s*\\{[^}]*display\\s*:\\s*none`
+    `\\.${escapeRegExp(className)}\\s*\\{[^}]*display\\s*:\\s*none`
   );
   return pattern.test(chunk);
 }
@@ -230,6 +243,15 @@ describe('fulfilment worklist breakpoint switch', () => {
       css
     );
     expect(declaresDisplayNone(outsideMediaBlocks, 'fulfilment-worklist__cards')).toBe(false);
+  });
+
+  it('escapes a class name before matching it, rather than only appearing to', () => {
+    // The guard of the guard for the escape. The inline escape this replaced
+    // matched nothing, so `.` in a class name stayed a wildcard and the rule
+    // matched a DIFFERENT class — a breakpoint assertion that reads green
+    // against the wrong selector is worse than none.
+    expect(declaresDisplayNone('.axb { display: none; }', 'a.b')).toBe(false);
+    expect(declaresDisplayNone('.a.b { display: none; }', 'a.b')).toBe(true);
   });
 
   it('extracts a media block by brace counting, not to its first closing brace', () => {

--- a/apps/web/src/features/fulfillment/hooks/use-fulfillment-tasks-query.ts
+++ b/apps/web/src/features/fulfillment/hooks/use-fulfillment-tasks-query.ts
@@ -1,0 +1,41 @@
+/**
+ * Fulfilment worklist query (#2410)
+ *
+ * The filtered, paged read behind the standalone worklist. A sibling of
+ * `use-order-fulfillment-tasks-query.ts` rather than a replacement: that one is
+ * order-scoped and keyed `worksByOrder`, this one is filter-scoped and keyed
+ * `list(filters)`. Both keys live under `fulfillmentQueryKeys.all`, which is
+ * what the action mutation invalidates — so an action taken on either surface
+ * refreshes the other.
+ *
+ * ## The requested page size is a REQUEST, not a fact
+ *
+ * The server clamps `limit` (#2406), so the response reports what it actually
+ * applied. Nothing here reads the requested value back; the pager reads
+ * `page.limit` / `page.offset` off the response.
+ *
+ * @module apps/web/src/features/fulfillment/hooks
+ */
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { fulfillmentQueryKeys } from '../api/fulfillment.query-keys';
+import type { FulfillmentTaskFilters, FulfillmentTaskPage } from '../api/fulfillment.types';
+
+/**
+ * What the worklist asks for. The server's own default is 25 and it clamps
+ * anything larger, so this is deliberately the same number — asking for more
+ * than the server will give makes the request a lie about the page it gets.
+ */
+export const FULFILLMENT_WORKLIST_PAGE_SIZE = 25;
+
+export function useFulfillmentTasksQuery(
+  filters: FulfillmentTaskFilters
+): UseQueryResult<FulfillmentTaskPage> {
+  const apiClient = useApiClient();
+
+  return useQuery({
+    queryKey: fulfillmentQueryKeys.list(filters),
+    queryFn: () => apiClient.fulfillment.list(filters),
+  });
+}

--- a/apps/web/src/features/fulfillment/index.ts
+++ b/apps/web/src/features/fulfillment/index.ts
@@ -1,13 +1,64 @@
 /**
- * Fulfilment — public surface (#2411)
+ * Fulfilment — public surface (#2411, widened by #2410)
  *
- * The order-detail panel is the only export, because it is the only symbol any
- * module outside this folder imports. #2410's standalone worklist is the second
- * consumer of this slice's api/hooks/lib and adds its own line when it lands —
- * exporting them now would be a public surface with nothing behind it, which is
- * the `frontend-architecture.md § Feature Public Surface` start-narrow rule.
+ * #2411 exported only the order-detail panel and recorded that #2410's
+ * standalone worklist would be the second consumer of this slice's api / hooks
+ * / lib, adding its line when it landed. This is that line: the worklist page
+ * lives under `pages/`, so everything it composes has to leave the folder.
+ *
+ * Deliberately NOT exported, per the start-narrow rule: the api module and the
+ * query keys (the page reaches transport through the hooks, and the action
+ * mutation already invalidates the whole feature); and the row, the card, the
+ * lane grouping and the status/handshake labels, which are composed by
+ * `FulfillmentLaneSection` INSIDE this folder and have no consumer outside it
+ * (the page composes lanes, so `groupTasksIntoLanes` itself does leave).
+ * Adding any of them back is one line on the day something needs it.
  *
  * @module apps/web/src/features/fulfillment
  */
 export { OrderFulfillmentTasksPanel } from './components/order-fulfillment-tasks-panel';
 export type { OrderFulfillmentTasksPanelProps } from './components/order-fulfillment-tasks-panel';
+
+// #2410 — the standalone worklist's composition surface.
+export { FulfillmentLaneSection } from './components/fulfillment-lane-section';
+export type { FulfillmentLaneSectionProps } from './components/fulfillment-lane-section';
+export { FulfillmentTaskActions } from './components/fulfillment-task-actions';
+export type { FulfillmentTaskActionsProps } from './components/fulfillment-task-actions';
+export {
+  FulfillmentTaskActionDialog,
+  type FulfillmentTaskActionMode,
+} from './components/fulfillment-task-action-dialog';
+
+export {
+  useFulfillmentTasksQuery,
+  FULFILLMENT_WORKLIST_PAGE_SIZE,
+} from './hooks/use-fulfillment-tasks-query';
+export { useFulfillmentTaskActionMutation } from './hooks/use-fulfillment-task-action-mutation';
+
+export {
+  describeFulfillmentActionError,
+  readFulfillmentConflict,
+} from './lib/fulfillment-conflict';
+export { fulfillmentActionLabel, FULFILLMENT_ACTION_COPY } from './lib/fulfillment-task.copy';
+export { FULFILLMENT_WORKLIST_COPY } from './lib/fulfillment-worklist.copy';
+// The page groups the page's rows into lanes and maps them; `summariseLaneLines`
+// stays private because only `FulfillmentLaneSection` reads it.
+export { groupTasksIntoLanes } from './lib/fulfillment-lanes';
+export type { FulfillmentLane } from './lib/fulfillment-lanes';
+export {
+  clearFulfillmentFilters,
+  hasActiveFulfillmentFilters,
+  readFulfillmentFilters,
+  readFulfillmentOffset,
+  setFulfillmentFilterParam,
+  setFulfillmentOffsetParam,
+} from './lib/fulfillment-filters';
+
+export type {
+  ApplyFulfillmentTaskActionRequest,
+  FulfillmentTask,
+  FulfillmentTaskFilters,
+  FulfillmentTaskHold,
+  FulfillmentTaskLine,
+  FulfillmentTaskPage,
+} from './api/fulfillment.types';

--- a/apps/web/src/features/fulfillment/lib/fulfillment-filters.test.ts
+++ b/apps/web/src/features/fulfillment/lib/fulfillment-filters.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Fulfilment worklist filter helpers (#2410).
+ *
+ * The property that carries real operator consequence is the LAST one: `offset`
+ * is paging, not a filter, so a page emptied by paging past the end must not be
+ * reported as "no matches for your filters".
+ */
+import { describe, expect, it } from 'vitest';
+
+import {
+  clearFulfillmentFilters,
+  hasActiveFulfillmentFilters,
+  readFulfillmentFilters,
+  readFulfillmentOffset,
+  setFulfillmentFilterParam,
+  setFulfillmentOffsetParam,
+} from './fulfillment-filters';
+
+describe('fulfillment worklist filters', () => {
+  it('round-trips both filters through the search params', () => {
+    let params = new URLSearchParams();
+    params = setFulfillmentFilterParam(params, 'orderId', 'ol_order_1');
+    params = setFulfillmentFilterParam(params, 'locationId', 'loc_warsaw');
+
+    expect(readFulfillmentFilters(params)).toEqual({
+      orderId: 'ol_order_1',
+      locationId: 'loc_warsaw',
+    });
+  });
+
+  it('reads a present-but-empty param as an absent filter', () => {
+    // `?orderId=` would otherwise be forwarded, filtering to the orders whose
+    // id is the empty string — i.e. none — while the page reported itself
+    // unfiltered.
+    const params = new URLSearchParams('orderId=&locationId=');
+
+    expect(readFulfillmentFilters(params)).toEqual({
+      orderId: undefined,
+      locationId: undefined,
+    });
+    expect(hasActiveFulfillmentFilters(readFulfillmentFilters(params))).toBe(false);
+  });
+
+  it('clears the offset when a filter changes', () => {
+    const params = new URLSearchParams('offset=50');
+    const next = setFulfillmentFilterParam(params, 'orderId', 'ol_order_1');
+
+    expect(next.get('offset')).toBeNull();
+  });
+
+  it('drops the offset param entirely at the first page', () => {
+    const params = setFulfillmentOffsetParam(new URLSearchParams('offset=25'), 0);
+    expect(params.get('offset')).toBeNull();
+    expect(readFulfillmentOffset(params)).toBe(0);
+  });
+
+  it('reads a negative or non-numeric offset as the first page', () => {
+    expect(readFulfillmentOffset(new URLSearchParams('offset=-5'))).toBe(0);
+    expect(readFulfillmentOffset(new URLSearchParams('offset=nonsense'))).toBe(0);
+  });
+
+  it('clears every filter and the offset together', () => {
+    const params = new URLSearchParams('orderId=a&locationId=b&offset=25&keep=me');
+    const next = clearFulfillmentFilters(params);
+
+    expect(hasActiveFulfillmentFilters(readFulfillmentFilters(next))).toBe(false);
+    expect(next.get('offset')).toBeNull();
+    // Params this page does not own are left alone.
+    expect(next.get('keep')).toBe('me');
+  });
+
+  it('does NOT treat a page offset as an active filter', () => {
+    // The red-first break for this one is adding `offset` to the predicate:
+    // an operator who paged past the end would then be told their FILTERS
+    // matched nothing, and offered a "clear filters" remedy that changes
+    // nothing, instead of being sent back to the first page.
+    const pagedPastTheEnd = new URLSearchParams('offset=999');
+
+    expect(hasActiveFulfillmentFilters(readFulfillmentFilters(pagedPastTheEnd))).toBe(false);
+  });
+});

--- a/apps/web/src/features/fulfillment/lib/fulfillment-filters.ts
+++ b/apps/web/src/features/fulfillment/lib/fulfillment-filters.ts
@@ -1,0 +1,109 @@
+/**
+ * Fulfilment worklist filters (#2410)
+ *
+ * Pure read/write helpers over the `/fulfillment` search params, following the
+ * `features/returns/lib/returns-filters.ts` shape.
+ *
+ * Two rules this module owns.
+ *
+ * **`offset` is paging, not a filter.** {@link hasActiveFulfillmentFilters}
+ * deliberately excludes it: an empty page caused by paging past the end is a
+ * different operator situation from an empty page caused by a filter, and
+ * conflating the two makes the worklist claim there is nothing to do when there
+ * is.
+ *
+ * **Both filters are free strings and are forwarded verbatim.** Unlike the
+ * returns list there is no closed union to narrow against here — `orderId` and
+ * `locationId` are opaque ids the API takes as `@IsString()`, so there is no
+ * guard that could reject one without inventing a format the backend does not
+ * enforce. An id that matches nothing answers an empty page, which the page
+ * reports as "no matches" rather than as "nothing to do".
+ *
+ * @module apps/web/src/features/fulfillment/lib
+ */
+import type { FulfillmentTaskFilters } from '../api/fulfillment.types';
+
+/**
+ * Every param this page owns. `offset` is NOT here — it is paging, and listing
+ * it would put it in reach of {@link clearFulfillmentFilters}' semantics for
+ * the wrong reason. It is cleared explicitly instead, which is a different
+ * statement.
+ */
+export const FULFILLMENT_FILTER_PARAMS = ['orderId', 'locationId'] as const;
+
+export type FulfillmentFilterParam = (typeof FULFILLMENT_FILTER_PARAMS)[number];
+
+export const FULFILLMENT_OFFSET_PARAM = 'offset';
+
+/** Read the filters out of the URL. An empty string is an absent filter. */
+export function readFulfillmentFilters(params: URLSearchParams): FulfillmentTaskFilters {
+  const orderId = params.get('orderId');
+  const locationId = params.get('locationId');
+
+  return {
+    // `|| undefined`, not `?? undefined`: `?orderId=` is a present-but-empty
+    // param, and sending `orderId=` would filter to the orders whose id is the
+    // empty string — i.e. none — while the page reported itself unfiltered.
+    orderId: orderId || undefined,
+    locationId: locationId || undefined,
+  };
+}
+
+/**
+ * Read the page offset. A negative, non-numeric or absent value reads as 0 —
+ * the first page is always reachable, whatever is in the URL.
+ */
+export function readFulfillmentOffset(params: URLSearchParams): number {
+  const raw = Number(params.get(FULFILLMENT_OFFSET_PARAM) ?? '0');
+  if (!Number.isFinite(raw) || raw < 0) return 0;
+  return Math.floor(raw);
+}
+
+/**
+ * Whether any FILTER is narrowing the worklist.
+ *
+ * Reads the narrowed filters rather than the raw params, so `?orderId=` — which
+ * {@link readFulfillmentFilters} already dropped — does not make an unfiltered
+ * worklist claim to be filtered.
+ */
+export function hasActiveFulfillmentFilters(filters: FulfillmentTaskFilters): boolean {
+  return filters.orderId !== undefined || filters.locationId !== undefined;
+}
+
+/**
+ * Set (or clear, on an empty value) one filter param.
+ *
+ * Always clears `offset`: the row at offset 50 of the unfiltered worklist is
+ * not the row at offset 50 of the filtered one, so keeping the offset lands the
+ * operator on an arbitrary — usually empty — page.
+ */
+export function setFulfillmentFilterParam(
+  params: URLSearchParams,
+  key: FulfillmentFilterParam,
+  value: string
+): URLSearchParams {
+  const next = new URLSearchParams(params);
+  if (value) next.set(key, value);
+  else next.delete(key);
+  next.delete(FULFILLMENT_OFFSET_PARAM);
+  return next;
+}
+
+/** Drop every filter param (and the offset) in one call. */
+export function clearFulfillmentFilters(params: URLSearchParams): URLSearchParams {
+  const next = new URLSearchParams(params);
+  for (const key of FULFILLMENT_FILTER_PARAMS) next.delete(key);
+  next.delete(FULFILLMENT_OFFSET_PARAM);
+  return next;
+}
+
+/** Move to a page offset, dropping the param entirely at the first page. */
+export function setFulfillmentOffsetParam(
+  params: URLSearchParams,
+  offset: number
+): URLSearchParams {
+  const next = new URLSearchParams(params);
+  if (offset <= 0) next.delete(FULFILLMENT_OFFSET_PARAM);
+  else next.set(FULFILLMENT_OFFSET_PARAM, String(offset));
+  return next;
+}

--- a/apps/web/src/features/fulfillment/lib/fulfillment-lanes.test.ts
+++ b/apps/web/src/features/fulfillment/lib/fulfillment-lanes.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Lane grouping (#2410).
+ *
+ * Three properties matter: a `null` axis gets a stable label rather than a
+ * dropped row, two tasks sharing a (location, method) pair land in ONE lane,
+ * and a location whose id contains the separator cannot collide with a
+ * different lane.
+ */
+import { describe, expect, it } from 'vitest';
+
+import { groupTasksIntoLanes, summariseLaneLines } from './fulfillment-lanes';
+import { FULFILLMENT_WORKLIST_COPY } from './fulfillment-worklist.copy';
+import type { FulfillmentTask } from '../api/fulfillment.types';
+
+function task(overrides: Partial<FulfillmentTask> = {}): FulfillmentTask {
+  return {
+    id: 'ol_work_1',
+    orderId: 'ol_order_1',
+    locationId: 'loc_warsaw',
+    deliveryMethod: 'courier',
+    assignedConnectionId: null,
+    status: 'open',
+    requestStatus: 'unsubmitted',
+    assignmentAttempt: 0,
+    cancellationReason: null,
+    externalWorkId: null,
+    acceptedAt: null,
+    cancelledAt: null,
+    createdAt: '2026-08-20T10:00:00.000Z',
+    updatedAt: '2026-08-20T10:00:00.000Z',
+    lines: [],
+    activeHolds: [],
+    supportedActions: [],
+    version: 1,
+    ...overrides,
+  };
+}
+
+describe('groupTasksIntoLanes', () => {
+  it('puts two tasks sharing a location and delivery method in one lane', () => {
+    const lanes = groupTasksIntoLanes([
+      task({ id: 'a' }),
+      task({ id: 'b' }),
+    ]);
+
+    expect(lanes).toHaveLength(1);
+    expect(lanes[0].tasks.map((t) => t.id)).toEqual(['a', 'b']);
+  });
+
+  it('separates tasks that differ on either axis', () => {
+    const lanes = groupTasksIntoLanes([
+      task({ id: 'a', locationId: 'loc_a' }),
+      task({ id: 'b', locationId: 'loc_b' }),
+      task({ id: 'c', locationId: 'loc_a', deliveryMethod: 'pickup' }),
+    ]);
+
+    expect(lanes).toHaveLength(3);
+  });
+
+  it('preserves first-appearance lane order and within-lane row order', () => {
+    // The server ordered this page; re-sorting here would override a decision
+    // made where the data is.
+    const lanes = groupTasksIntoLanes([
+      task({ id: 'a', locationId: 'loc_z' }),
+      task({ id: 'b', locationId: 'loc_a' }),
+      task({ id: 'c', locationId: 'loc_z' }),
+    ]);
+
+    expect(lanes.map((lane) => lane.locationId)).toEqual(['loc_z', 'loc_a']);
+    expect(lanes[0].tasks.map((t) => t.id)).toEqual(['a', 'c']);
+  });
+
+  it('keeps a task with no location and gives it a stable label', () => {
+    const lanes = groupTasksIntoLanes([task({ locationId: null })]);
+
+    expect(lanes).toHaveLength(1);
+    expect(lanes[0].locationId).toBeNull();
+    expect(lanes[0].locationLabel).toBe(FULFILLMENT_WORKLIST_COPY.lane.noLocation);
+  });
+
+  it('keeps a task with no delivery method and gives it a stable label', () => {
+    const lanes = groupTasksIntoLanes([task({ deliveryMethod: null })]);
+
+    expect(lanes[0].deliveryMethod).toBeNull();
+    expect(lanes[0].deliveryMethodLabel).toBe(FULFILLMENT_WORKLIST_COPY.lane.noDeliveryMethod);
+  });
+
+  it('does not merge a location that is null with one that is the empty string', () => {
+    const lanes = groupTasksIntoLanes([
+      task({ id: 'a', locationId: null }),
+      task({ id: 'b', locationId: '' }),
+    ]);
+
+    // Both render the "no location" label, but they are different facts and the
+    // grouping must not silently claim otherwise… except that an empty string
+    // and null DO collapse under the key, which is acceptable because an empty
+    // location id is not a value the read model produces. Asserted so a future
+    // reader sees the behaviour rather than assuming the opposite.
+    expect(lanes).toHaveLength(1);
+  });
+
+  it('does not collide when a location id contains the lane separator', () => {
+    const lanes = groupTasksIntoLanes([
+      task({ id: 'a', locationId: 'x', deliveryMethod: 'y' }),
+      task({ id: 'b', locationId: 'x:y', deliveryMethod: null }),
+    ]);
+
+    expect(lanes).toHaveLength(2);
+  });
+
+  it('returns no lanes for no tasks', () => {
+    expect(groupTasksIntoLanes([])).toEqual([]);
+  });
+});
+
+describe('summariseLaneLines', () => {
+  it('sums the display-only counters across every task in the lane', () => {
+    const line = (fulfilled: number, total: number) => ({
+      id: `l${fulfilled}${total}`,
+      orderLineId: 'ol_orderline_1',
+      productVariantId: 'ol_variant_1',
+      totalQuantity: total,
+      fulfilledQuantity: fulfilled,
+      cancelledQuantity: 0,
+    });
+    const lanes = groupTasksIntoLanes([
+      task({ id: 'a', lines: [line(1, 3)] }),
+      task({ id: 'b', lines: [line(2, 5)] }),
+    ]);
+
+    expect(summariseLaneLines(lanes[0])).toEqual({ fulfilled: 3, total: 8 });
+  });
+
+  it('reports zeroes for a lane whose tasks carry no lines', () => {
+    const lanes = groupTasksIntoLanes([task()]);
+    expect(summariseLaneLines(lanes[0])).toEqual({ fulfilled: 0, total: 0 });
+  });
+});

--- a/apps/web/src/features/fulfillment/lib/fulfillment-lanes.ts
+++ b/apps/web/src/features/fulfillment/lib/fulfillment-lanes.ts
@@ -1,0 +1,102 @@
+/**
+ * Fulfilment worklist lanes (#2410)
+ *
+ * Groups the tasks on the CURRENT PAGE by the pair an operator actually works
+ * to: where the goods are and how they leave. Pure — it groups what it is
+ * handed and reads nothing else.
+ *
+ * ## A lane spans one page, never the whole worklist
+ *
+ * The rows are a server-paged slice, so a lane here is "the tasks for this
+ * location and method **on this page**". The page says so in the lane caption;
+ * this module simply must not be read as producing a complete lane, because a
+ * second page can add rows to a lane already rendered.
+ *
+ * ## `null` gets a stable label, not a dropped row
+ *
+ * `locationId` and `deliveryMethod` are both independently nullable in the read
+ * model (an unrouted task has neither). Skipping those rows would hide exactly
+ * the tasks that need an operator most, so each `null` axis gets its own lane
+ * with a fixed label — and the label is a copy string, so the vocabulary gate
+ * covers it.
+ *
+ * @module apps/web/src/features/fulfillment/lib
+ */
+import type { FulfillmentTask } from '../api/fulfillment.types';
+import { FULFILLMENT_WORKLIST_COPY } from './fulfillment-worklist.copy';
+
+export interface FulfillmentLane {
+  /** Stable within one render — `locationId` and `deliveryMethod` joined. */
+  id: string;
+  /** Raw location id, or `null` when the task carries none. */
+  locationId: string | null;
+  /** Raw delivery method, or `null`. */
+  deliveryMethod: string | null;
+  /** What to show as the lane's location. */
+  locationLabel: string;
+  /** What to show as the lane's delivery method. */
+  deliveryMethodLabel: string;
+  tasks: FulfillmentTask[];
+}
+
+/**
+ * NUL — a byte no id or delivery method can contain — rather than `:`, so a
+ * location literally named `a:b` cannot collide with location `a` plus method
+ * `b`. A key collision would merge two genuinely different lanes into one and
+ * render them under a single heading.
+ */
+const LANE_KEY_SEPARATOR = '\u0000';
+
+function laneKey(locationId: string | null, deliveryMethod: string | null): string {
+  return `${locationId ?? ''}${LANE_KEY_SEPARATOR}${deliveryMethod ?? ''}`;
+}
+
+/**
+ * Group tasks into lanes, preserving the server's ordering.
+ *
+ * Lane order is FIRST APPEARANCE of the lane in the incoming rows, and within a
+ * lane the rows keep their incoming order. The server already ordered this
+ * page; re-sorting here would silently override an ordering decision made where
+ * the data is, and would make the visible order depend on which page you are on.
+ */
+export function groupTasksIntoLanes(tasks: readonly FulfillmentTask[]): FulfillmentLane[] {
+  const lanes = new Map<string, FulfillmentLane>();
+
+  for (const task of tasks) {
+    const key = laneKey(task.locationId, task.deliveryMethod);
+    const existing = lanes.get(key);
+    if (existing) {
+      existing.tasks.push(task);
+      continue;
+    }
+    lanes.set(key, {
+      id: key,
+      locationId: task.locationId,
+      deliveryMethod: task.deliveryMethod,
+      locationLabel: task.locationId ?? FULFILLMENT_WORKLIST_COPY.lane.noLocation,
+      deliveryMethodLabel: task.deliveryMethod ?? FULFILLMENT_WORKLIST_COPY.lane.noDeliveryMethod,
+      tasks: [task],
+    });
+  }
+
+  return [...lanes.values()];
+}
+
+/**
+ * How many of a lane's lines are reported done, as `{ fulfilled, total }`.
+ *
+ * Both numbers come from the DISPLAY-ONLY counters (#2400 moves them without
+ * bumping `version`), so this is a progress hint and never an input to whether
+ * an action is offered.
+ */
+export function summariseLaneLines(lane: FulfillmentLane): { fulfilled: number; total: number } {
+  let fulfilled = 0;
+  let total = 0;
+  for (const task of lane.tasks) {
+    for (const line of task.lines) {
+      fulfilled += line.fulfilledQuantity;
+      total += line.totalQuantity;
+    }
+  }
+  return { fulfilled, total };
+}

--- a/apps/web/src/features/fulfillment/lib/fulfillment-worklist.copy.ts
+++ b/apps/web/src/features/fulfillment/lib/fulfillment-worklist.copy.ts
@@ -1,0 +1,114 @@
+/**
+ * Fulfilment worklist operator copy (#2410)
+ *
+ * Every user-visible string the standalone worklist renders.
+ *
+ * ## Why the PAGE holds no literals of its own
+ *
+ * `scripts/check-ui-vocabulary.mjs` reads string literals from a `*.copy.ts`
+ * and JSX text from a `.tsx`, and it scans only under
+ * `apps/web/src/features/*` — `SCAN_ROOT_PARENT` is that directory, so
+ * `pages/fulfillment` cannot be added as a scan root without changing a shared
+ * gate. Putting the worklist's copy HERE, under a folder the gate already
+ * scans, covers it with no script change and no shared-file edit.
+ *
+ * The filename is load-bearing for the same reason `fulfillment-task.copy.ts`
+ * says it is: named `fulfillment-worklist-copy.ts` — one character out — this
+ * file would be invisible to the gate while appearing to be covered by it.
+ *
+ * ## Naming (epic #2412, design rule P9)
+ *
+ * The operator noun is **fulfilment task**. The internal aggregate name, the
+ * word for who decides something, and the word for a stage of a process are all
+ * on the banned list, so questions are phrased "Who decides …?" and states are
+ * named for what they are.
+ *
+ * @module apps/web/src/features/fulfillment/lib
+ */
+
+export const FULFILLMENT_WORKLIST_COPY = {
+  page: {
+    eyebrow: 'Operations',
+    title: 'Fulfilment',
+    description:
+      'The fulfilment tasks waiting to be worked, grouped by where the goods are and how they leave.',
+  },
+
+  filter: {
+    orderLabel: 'Order',
+    orderPlaceholder: 'Filter by order id',
+    locationLabel: 'Location',
+    locationPlaceholder: 'Filter by location id',
+    clear: 'Clear filters',
+    groupLabel: 'Fulfilment task filters',
+  },
+
+  lane: {
+    /** Shown when a task carries no `locationId`. */
+    noLocation: 'No location yet',
+    /** Shown when a task carries no `deliveryMethod`. */
+    noDeliveryMethod: 'No delivery method yet',
+    /**
+     * Stated on every lane, because the rows are a paged slice: a lane shows
+     * the tasks for that pair ON THIS PAGE, and a later page can add more.
+     */
+    pageScopeNote: 'Grouped from the tasks on this page only.',
+  },
+
+  row: {
+    taskLabel: 'Fulfilment task',
+    stateLabel: 'State',
+    handshakeLabel: 'Handshake',
+    linesLabel: 'Lines',
+    actionsLabel: 'Actions',
+    /** `3 of 5` — the display-only counters. */
+    lineCount: (fulfilled: number, total: number): string => `${fulfilled} of ${total}`,
+    noLines: 'No lines',
+    /**
+     * The counters are moved by progress ingress without bumping the task's
+     * token (#2400), so they can legitimately be behind. Said once per lane
+     * rather than per row.
+     */
+    countersCaveat:
+      'Picked counts are reported by whoever is working the task and can be a little behind.',
+  },
+
+  loading: {
+    /** Never an empty-state sentence: an unresolved read says nothing yet. */
+    message: 'Loading fulfilment tasks…',
+  },
+
+  error: {
+    title: 'Could not load the fulfilment worklist',
+    message: 'The worklist could not be read just now. Nothing has been changed.',
+    retry: 'Retry',
+  },
+
+  empty: {
+    /** A filter is narrowing the list and matched nothing. */
+    filtered: {
+      title: 'No fulfilment tasks match these filters',
+      message: 'Nothing on this page matches what you filtered for. Clear the filters to see everything.',
+    },
+    /** Nothing is filtered and there is genuinely nothing to work. */
+    none: {
+      title: 'Nothing to work right now',
+      message:
+        'No fulfilment tasks are waiting. That is normal unless fulfilment routing is switched on.',
+    },
+    /** Paged past the end — rows exist, this page is simply beyond them. */
+    pastEnd: {
+      title: 'Nothing on this page',
+      message: 'There are fulfilment tasks, but none this far down the list.',
+      action: 'Back to the first page',
+    },
+  },
+
+  pagination: {
+    previous: 'Previous',
+    next: 'Next',
+    /** `Showing 1–25 of 92` */
+    range: (from: number, to: number, total: number): string =>
+      `Showing ${from}–${to} of ${total}`,
+  },
+} as const;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -21166,3 +21166,130 @@ textarea.bulk-editor__input { resize: vertical; min-height: 66px; font-family: i
   flex-direction: column;
   gap: var(--space-3);
 }
+
+/* ── Fulfilment worklist (#2410) ─────────────────────────────────────────── */
+
+.fulfilment-worklist-lane {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin-bottom: var(--space-5);
+}
+
+.fulfilment-worklist-lane__head {
+  align-items: baseline;
+  border-bottom: 1px solid var(--border-subtle);
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  padding-bottom: var(--space-1);
+}
+
+.fulfilment-worklist-lane__title {
+  font-size: 0.9375rem;
+  font-weight: 600;
+  margin: 0;
+}
+
+.fulfilment-worklist-lane__method {
+  font-size: 0.8125rem;
+}
+
+.fulfilment-worklist-lane__count {
+  font-size: 0.8125rem;
+  margin-left: auto;
+}
+
+.fulfilment-worklist-lane__scope {
+  font-size: 0.75rem;
+  margin: 0;
+}
+
+/* The two surfaces. Both are always rendered — the breakpoint below decides
+   which one is visible, so the desktop rows and the cards can never show a
+   different set of tasks. */
+.fulfilment-worklist__desktop,
+.fulfilment-worklist__cards {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.fulfilment-worklist-row {
+  align-items: center;
+  background: var(--bg-surface);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  display: grid;
+  gap: var(--space-3);
+  grid-template-columns: minmax(0, 2fr) minmax(0, 2fr) auto auto;
+  padding: var(--space-2) var(--space-3);
+}
+
+.fulfilment-worklist-row[data-held='true'] {
+  border-color: var(--status-warning-border);
+}
+
+.fulfilment-worklist-row__identity {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.fulfilment-worklist-row__id,
+.fulfilment-worklist-row__order {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.fulfilment-worklist-row__id {
+  font-size: 0.8125rem;
+}
+
+.fulfilment-worklist-row__order {
+  font-size: 0.75rem;
+}
+
+.fulfilment-worklist-row__state {
+  align-items: flex-start;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  min-width: 0;
+}
+
+.fulfilment-worklist-row__substate {
+  font-size: 0.75rem;
+}
+
+.fulfilment-worklist-row__lines {
+  font-size: 0.8125rem;
+  white-space: nowrap;
+}
+
+.fulfilment-worklist-row__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  justify-content: flex-end;
+}
+
+/* The breakpoint switch. Each `display: none` MUST stay inside its own media
+   block: hoisted out, the desktop grid renders on a phone (or the cards render
+   beside it on a desktop) and both surfaces show at once. */
+@media (min-width: 768px) {
+  .fulfilment-worklist__cards {
+    display: none;
+  }
+}
+
+@media (max-width: 767px) {
+  .fulfilment-worklist__desktop {
+    display: none;
+  }
+}

--- a/apps/web/src/pages/fulfillment/fulfillment-copy-audit.test.tsx
+++ b/apps/web/src/pages/fulfillment/fulfillment-copy-audit.test.tsx
@@ -1,0 +1,356 @@
+/**
+ * Fulfilment worklist — rendered-output copy audit (AC4, #2410).
+ *
+ * `scripts/check-ui-vocabulary.mjs` already scans `features/fulfillment`, so
+ * every `*.copy.ts` and `.tsx` this body adds under that folder is gated with
+ * no script change — which is why ALL worklist copy lives there and the page
+ * carries no string literals of its own.
+ *
+ * This test covers the script's own documented blind spots, and this body lands
+ * in two of the three: it renders a BACKEND-SOURCED message on the un-coded 409
+ * path, and it HUMANISES raw vocabulary values (`fulfillmentStatusLabel` falls
+ * back to a title-cased form of whatever the server sent). Neither reaches any
+ * source literal, so a source scan cannot see them. This is therefore a
+ * RENDERED-OUTPUT audit, not a second source scan.
+ *
+ * ## The banned terms are READ, not restated
+ *
+ * They come from the fenced `<!-- ui-vocabulary:start -->` table in the product
+ * spec — the same table the script treats as the single source under its Rule
+ * A. A hand-copied list here would be a second, ungated mirror of a nine-term
+ * vocabulary, drifting the day a tenth term or a mode change lands.
+ *
+ * The TABLE is read rather than the script's exported parser, because
+ * `check-ui-vocabulary.mjs` calls `main()` at module scope (and `process.exit`s
+ * on some paths), so importing it from a test would run the whole repo scan as
+ * a side effect. The parser below therefore mirrors the script's row rule — a
+ * backticked term cell plus a mode cell — while the VOCABULARY, which is the
+ * half that actually drifts, is read from the one source.
+ *
+ * If the fence parses to zero rows this test FAILS: the script's own Z1 rule,
+ * because a scan with an empty deny-list cannot fire.
+ */
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { cleanup, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { FulfillmentWorklistPage } from './fulfillment-worklist-page';
+import {
+  createAuthenticatedSessionAdapter,
+  createMockApiClient,
+  renderWithProviders,
+} from '../../test/test-utils';
+import type { FulfillmentTask } from '../../features/fulfillment';
+import type { SessionUser } from '../../shared/auth/session.types';
+import { ApiError } from '../../shared/api/api-error';
+
+afterEach(cleanup);
+
+const REPO_ROOT = join(__dirname, '..', '..', '..', '..', '..');
+const SPEC_FILE = join(
+  REPO_ROOT,
+  'docs',
+  'specs',
+  'product-spec-oms-wave2-operator-experience.md'
+);
+const FENCE_START = '<!-- ui-vocabulary:start -->';
+const FENCE_END = '<!-- ui-vocabulary:end -->';
+
+interface BannedTerm {
+  term: string;
+  mode: 'word' | 'exact';
+  alternates: string[];
+}
+
+function readBannedTerms(): BannedTerm[] {
+  const content = readFileSync(SPEC_FILE, 'utf8');
+  const start = content.indexOf(FENCE_START);
+  const end = content.indexOf(FENCE_END, start);
+  if (start === -1 || end === -1) return [];
+
+  const rows: BannedTerm[] = [];
+  for (const raw of content.slice(start + FENCE_START.length, end).split('\n')) {
+    const trimmed = raw.trim();
+    if (!trimmed.startsWith('|')) continue;
+    const cells = trimmed.split('|').slice(1, -1);
+    if (cells.length < 3) continue;
+
+    // A row counts only when its TERM cell is backticked — that skips the
+    // header and the `|---|` separator without counting either.
+    const termMatch = /^`([^`]+)`$/.exec(cells[1].trim());
+    if (!termMatch) continue;
+
+    const modeCell = cells[2].trim();
+    const mode: 'word' | 'exact' | null = /case-insensitive/i.test(modeCell)
+      ? 'word'
+      : /\bexact\b/i.test(modeCell)
+        ? 'exact'
+        : null;
+    // A mode the table does not name is FATAL rather than defaulted: guessing
+    // would make the mirror meaningless in exactly the direction it guards.
+    expect(mode, `unreadable match mode for \`${termMatch[1]}\``).not.toBeNull();
+
+    const alternates: string[] = [];
+    for (const alt of modeCell.matchAll(/["“”]([^"“”]+)["“”]/g)) alternates.push(alt[1]);
+
+    rows.push({ term: termMatch[1], mode: mode as 'word' | 'exact', alternates });
+  }
+  return rows;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** The matched term, or `null`. Mirrors the script's `matchBannedTerm`. */
+function matchBannedTerm(text: string, row: BannedTerm): string | null {
+  if (row.mode === 'word') {
+    if (new RegExp(`\\b${escapeRegExp(row.term)}\\b`, 'i').test(text)) return row.term;
+  } else if (text.includes(row.term)) {
+    return row.term;
+  }
+  for (const alt of row.alternates) {
+    // Alternates are case-SENSITIVE whole-word, so `ATP` does not fire on
+    // "adaptive".
+    if (new RegExp(`\\b${escapeRegExp(alt)}\\b`).test(text)) return alt;
+  }
+  return null;
+}
+
+const BANNED_TERMS = readBannedTerms();
+
+const OPERATOR: SessionUser = {
+  id: 'user_2',
+  username: 'operator',
+  email: 'operator@example.com',
+  role: 'operator',
+  permissions: ['orders:read', 'orders:write'],
+};
+
+function task(overrides: Partial<FulfillmentTask> = {}): FulfillmentTask {
+  return {
+    id: 'ol_work_1',
+    orderId: 'ol_order_1',
+    locationId: 'loc_warsaw',
+    deliveryMethod: 'courier',
+    assignedConnectionId: null,
+    status: 'open',
+    requestStatus: 'unsubmitted',
+    assignmentAttempt: 0,
+    cancellationReason: null,
+    externalWorkId: null,
+    acceptedAt: null,
+    cancelledAt: null,
+    createdAt: '2026-08-20T10:00:00.000Z',
+    updatedAt: '2026-08-20T10:00:00.000Z',
+    lines: [
+      {
+        id: 'line_1',
+        orderLineId: 'ol_orderline_1',
+        productVariantId: 'ol_variant_1',
+        totalQuantity: 5,
+        fulfilledQuantity: 3,
+        cancelledQuantity: 0,
+      },
+    ],
+    activeHolds: [],
+    supportedActions: ['hold', 'close'],
+    version: 3,
+    ...overrides,
+  };
+}
+
+function renderState(opts: {
+  list: ReturnType<typeof vi.fn>;
+  route?: string;
+  demoMode?: boolean;
+}): void {
+  const api = createMockApiClient({
+    system: {
+      getConfig: vi.fn().mockResolvedValue({ demoMode: opts.demoMode ?? false }),
+    },
+    fulfillment: {
+      list: opts.list,
+      applyAction: vi.fn().mockResolvedValue(task()),
+    } as never,
+  });
+
+  renderWithProviders(<FulfillmentWorklistPage />, {
+    apiClient: api,
+    route: opts.route ?? '/fulfillment',
+    sessionAdapter: createAuthenticatedSessionAdapter(OPERATOR),
+  });
+}
+
+/**
+ * Every user-visible string the render produced, as DISCRETE strings.
+ *
+ * Deliberately NOT `document.body.textContent`. That concatenates sibling
+ * nodes with no separator — a real render produced
+ * `…ol_work_1ol_order_1Posture check…` — so a whole-word rule finds no word
+ * boundary before a term that happens to abut the previous node, and the scan
+ * silently misses it. Six of the nine banned terms are whole-word rules, so
+ * that is most of the vocabulary failing to fire on most of the screen. The
+ * shared script scans discrete string literals for exactly this reason; this
+ * is the rendered-output analogue.
+ *
+ * User-facing ATTRIBUTES are collected too: a `title` is the tooltip an
+ * operator reads, and this feature puts an action's hint there.
+ */
+function visibleStrings(): string[] {
+  const strings: string[] = [];
+
+  const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+  for (let node = walker.nextNode(); node !== null; node = walker.nextNode()) {
+    const text = (node.textContent ?? '').trim();
+    if (text.length > 0) strings.push(text);
+  }
+
+  const ATTRIBUTES = ['title', 'aria-label', 'placeholder', 'alt'] as const;
+  for (const element of document.body.querySelectorAll('*')) {
+    for (const attribute of ATTRIBUTES) {
+      const value = element.getAttribute(attribute)?.trim() ?? '';
+      if (value.length > 0) strings.push(value);
+    }
+  }
+
+  return strings;
+}
+
+/**
+ * Assert the render produced text, contains a sentinel known to be in THIS
+ * state's copy, and carries none of the banned terms.
+ *
+ * The sentinel is the vacuity guard that matters most here: a banned-word scan
+ * over an empty render passes trivially, and the whole point of splitting the
+ * states into their own `it()`s is that one throwing render cannot silently
+ * skip the others.
+ */
+function expectCleanCopy(sentinel: string): void {
+  const strings = visibleStrings();
+  expect(strings.length).toBeGreaterThan(0);
+  expect(strings.join(' ')).toContain(sentinel);
+
+  const found: string[] = [];
+  for (const text of strings) {
+    for (const row of BANNED_TERMS) {
+      const matched = matchBannedTerm(text, row);
+      if (matched !== null) found.push(`${matched} (rule: ${row.term}) in "${text}"`);
+    }
+  }
+  expect(found, 'banned vocabulary reached the screen').toEqual([]);
+}
+
+describe('fulfilment worklist copy audit', () => {
+  it('reads a non-empty banned-term list from the fenced spec table', () => {
+    // The script's own Z1 rule: a scan with an empty deny-list cannot fire, so
+    // an unreadable fence is a FAILURE rather than a silent pass.
+    expect(BANNED_TERMS.length).toBeGreaterThan(0);
+    // The table is the vocabulary; if it ever parses to a single row that is a
+    // parser regression, not a shrinking vocabulary.
+    expect(BANNED_TERMS.length).toBeGreaterThanOrEqual(9);
+  });
+
+  it('is clean while loading', () => {
+    renderState({ list: vi.fn(() => new Promise(() => undefined)) });
+    expectCleanCopy('Loading fulfilment tasks');
+  });
+
+  it('is clean on a failed read', async () => {
+    renderState({ list: vi.fn().mockRejectedValue(new ApiError('boom', 500, {})) });
+    await screen.findByText('Could not load the fulfilment worklist');
+    expectCleanCopy('Could not load the fulfilment worklist');
+  });
+
+  it('is clean on an empty unfiltered worklist', async () => {
+    renderState({
+      list: vi.fn().mockResolvedValue({ works: [], total: 0, limit: 25, offset: 0 }),
+    });
+    await screen.findByText('Nothing to work right now');
+    expectCleanCopy('Nothing to work right now');
+  });
+
+  it('is clean on an empty filtered worklist', async () => {
+    renderState({
+      list: vi.fn().mockResolvedValue({ works: [], total: 0, limit: 25, offset: 0 }),
+      route: '/fulfillment?orderId=nope',
+    });
+    await screen.findByText('No fulfilment tasks match these filters');
+    expectCleanCopy('No fulfilment tasks match these filters');
+  });
+
+  it('is clean when paged past the end', async () => {
+    renderState({
+      list: vi.fn().mockResolvedValue({ works: [], total: 40, limit: 25, offset: 100 }),
+      route: '/fulfillment?offset=100',
+    });
+    await screen.findByText('Nothing on this page');
+    expectCleanCopy('Nothing on this page');
+  });
+
+  it('is clean with a populated worklist carrying a held task', async () => {
+    renderState({
+      list: vi.fn().mockResolvedValue({
+        works: [
+          task({
+            activeHolds: [
+              {
+                id: 'hold_1',
+                reason: 'awaiting_payment',
+                note: 'Buyer asked us to wait.',
+                placedAt: '2026-08-20T11:00:00.000Z',
+              },
+            ],
+          }),
+          task({ id: 'ol_work_2', locationId: null, deliveryMethod: null }),
+        ],
+        total: 2,
+        limit: 25,
+        offset: 0,
+      }),
+    });
+    await screen.findAllByText(/on hold/i);
+    expectCleanCopy('No location yet');
+  });
+
+  it('is clean when the server sends a status this build does not recognise', async () => {
+    // Reaches the screen ONLY through the humanising fallback — no source
+    // literal anywhere carries it, which is precisely the shared script's blind
+    // spot this test exists to cover.
+    renderState({
+      list: vi.fn().mockResolvedValue({
+        works: [task({ status: 'awaiting_wave', requestStatus: 'submitted' })],
+        total: 1,
+        limit: 25,
+        offset: 0,
+      }),
+    });
+    await screen.findAllByText(/awaiting wave/i);
+    expectCleanCopy('Awaiting wave');
+  });
+
+  it('is clean when the server offers an action this build has no copy for', async () => {
+    renderState({
+      list: vi.fn().mockResolvedValue({
+        works: [task({ supportedActions: ['expedite_pick'] })],
+        total: 1,
+        limit: 25,
+        offset: 0,
+      }),
+    });
+    await screen.findAllByRole('button', { name: 'Expedite pick' });
+    expectCleanCopy('Expedite pick');
+  });
+
+  it('is clean in the demo read-only render', async () => {
+    renderState({
+      list: vi.fn().mockResolvedValue({ works: [task()], total: 1, limit: 25, offset: 0 }),
+      demoMode: true,
+    });
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: 'Close' }).length).toBeGreaterThan(0);
+    });
+    expectCleanCopy('Close');
+  });
+});

--- a/apps/web/src/pages/fulfillment/fulfillment-worklist-page.test.tsx
+++ b/apps/web/src/pages/fulfillment/fulfillment-worklist-page.test.tsx
@@ -1,0 +1,374 @@
+/**
+ * `FulfillmentWorklistPage` — AC2 (the 409 path) and AC3 part 1 (the two
+ * surfaces agree) (#2410).
+ *
+ * ## What is deliberately NOT re-asserted here
+ *
+ * `readFulfillmentConflict` classifies both coded 409s and has its own spec
+ * (#2411). Re-testing that pure function over an in-memory object from a second
+ * file would pass with this entire body reverted, which is the vacuous shape
+ * this programme keeps shipping. What is NOT covered anywhere else is the
+ * WORKLIST's own behaviour on a 409, so that is what is written below.
+ *
+ * ## The assertion that actually fails when the handler is deleted
+ *
+ * `list` called EXACTLY twice. React Query settles either way, so an await-only
+ * test passes with the conflict branch removed — the call count is the only
+ * thing that observes the refresh happening.
+ */
+import { cleanup, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { FulfillmentWorklistPage } from './fulfillment-worklist-page';
+import {
+  createAuthenticatedSessionAdapter,
+  createMockApiClient,
+  renderWithProviders,
+} from '../../test/test-utils';
+import { FULFILLMENT_ACTION_COPY } from '../../features/fulfillment';
+import type { FulfillmentTask } from '../../features/fulfillment';
+import type { SessionUser } from '../../shared/auth/session.types';
+import { ApiError } from '../../shared/api/api-error';
+
+afterEach(cleanup);
+
+const OPERATOR: SessionUser = {
+  id: 'user_2',
+  username: 'operator',
+  email: 'operator@example.com',
+  role: 'operator',
+  permissions: ['orders:read', 'orders:write'],
+};
+
+function task(overrides: Partial<FulfillmentTask> = {}): FulfillmentTask {
+  return {
+    id: 'ol_work_1',
+    orderId: 'ol_order_1',
+    locationId: 'loc_warsaw',
+    deliveryMethod: 'courier',
+    assignedConnectionId: null,
+    status: 'open',
+    requestStatus: 'unsubmitted',
+    assignmentAttempt: 0,
+    cancellationReason: null,
+    externalWorkId: null,
+    acceptedAt: null,
+    cancelledAt: null,
+    createdAt: '2026-08-20T10:00:00.000Z',
+    updatedAt: '2026-08-20T10:00:00.000Z',
+    lines: [
+      {
+        id: 'line_1',
+        orderLineId: 'ol_orderline_1',
+        productVariantId: 'ol_variant_1',
+        totalQuantity: 5,
+        fulfilledQuantity: 3,
+        cancelledQuantity: 0,
+      },
+    ],
+    activeHolds: [],
+    supportedActions: ['close'],
+    version: 3,
+    ...overrides,
+  };
+}
+
+function page(tasks: FulfillmentTask[], overrides: Record<string, unknown> = {}): unknown {
+  return { works: tasks, total: tasks.length, limit: 25, offset: 0, ...overrides };
+}
+
+function renderPage(opts: {
+  list?: ReturnType<typeof vi.fn>;
+  applyAction?: ReturnType<typeof vi.fn>;
+  route?: string;
+}): { list: ReturnType<typeof vi.fn>; applyAction: ReturnType<typeof vi.fn> } {
+  const list = opts.list ?? vi.fn().mockResolvedValue(page([task()]));
+  const applyAction = opts.applyAction ?? vi.fn().mockResolvedValue(task());
+
+  const api = createMockApiClient({
+    system: { getConfig: vi.fn().mockResolvedValue({ demoMode: false }) },
+    fulfillment: { list, applyAction } as never,
+  });
+
+  renderWithProviders(<FulfillmentWorklistPage />, {
+    apiClient: api,
+    route: opts.route ?? '/fulfillment',
+    sessionAdapter: createAuthenticatedSessionAdapter(OPERATOR),
+  });
+
+  return { list, applyAction };
+}
+
+/**
+ * The desktop surface's container.
+ *
+ * Both surfaces are always in the DOM — the breakpoint is CSS, the house
+ * pattern — so every role query below is scoped to one of them. An unscoped
+ * `getByRole` finds each control twice.
+ */
+function desktop(): HTMLElement {
+  return document.querySelector('.fulfilment-worklist__desktop') as HTMLElement;
+}
+
+/** The desktop surface's rows. */
+function desktopTaskIds(): string[] {
+  return [...document.querySelectorAll('.fulfilment-worklist__desktop > li')].map(
+    (row) => row.querySelector('.fulfilment-worklist-row__id')?.textContent?.trim() ?? ''
+  );
+}
+
+/** The card surface's rows. */
+function cardTaskIds(): string[] {
+  return [...document.querySelectorAll('.fulfilment-worklist__cards > li')].map(
+    (card) => card.querySelector('.fulfilment-task__id')?.textContent?.trim() ?? ''
+  );
+}
+
+describe('FulfillmentWorklistPage — the 409 path (AC2)', () => {
+  it('refreshes and re-renders the server’s new action set on a version_conflict', async () => {
+    const user = userEvent.setup();
+    const list = vi
+      .fn()
+      .mockResolvedValueOnce(page([task({ version: 3, supportedActions: ['close'] })]))
+      .mockResolvedValue(page([task({ version: 4, supportedActions: ['hold'] })]));
+    const applyAction = vi.fn().mockRejectedValue(
+      new ApiError('stale', 409, {
+        code: 'version_conflict',
+        currentVersion: 4,
+        supportedActions: ['hold'],
+      })
+    );
+
+    renderPage({ list, applyAction });
+
+    await screen.findAllByRole('button', { name: FULFILLMENT_ACTION_COPY['close'].label });
+    await user.click(
+      within(desktop()).getByRole('button', { name: FULFILLMENT_ACTION_COPY['close'].label })
+    );
+
+    // (a) NO auto-retry, and the token that was RENDERED is the token sent.
+    await waitFor(() => {
+      expect(applyAction).toHaveBeenCalledTimes(1);
+    });
+    expect(applyAction).toHaveBeenCalledWith(
+      'ol_work_1',
+      'close',
+      expect.objectContaining({ expectedVersion: 3 })
+    );
+
+    // (b) The refresh happened. EXACTLY twice — not `>= 1`, and not merely
+    // "the promise settled": React Query settles either way, so this is the
+    // assertion that goes red when the mutation's conflict branch is deleted
+    // or its invalidation key is narrowed back to `worksByOrder`.
+    await waitFor(() => {
+      expect(list).toHaveBeenCalledTimes(2);
+    });
+
+    // (d) The refreshed action set is what renders. The label is read out of
+    // the copy table rather than hardcoded, so a copy edit cannot make this
+    // assertion silently stop asserting which action is offered.
+    await waitFor(() => {
+      expect(
+        screen.getAllByRole('button', { name: FULFILLMENT_ACTION_COPY['hold'].label }).length
+      ).toBeGreaterThan(0);
+    });
+    expect(
+      screen.queryAllByRole('button', { name: FULFILLMENT_ACTION_COPY['close'].label })
+    ).toEqual([]);
+
+    // (c) Non-destructive: the row is still there.
+    expect(desktopTaskIds()).toEqual(['ol_work_1']);
+  });
+
+  it('surfaces an action_not_legal without retrying and without destroying the row', async () => {
+    const user = userEvent.setup();
+    const list = vi.fn().mockResolvedValue(page([task()]));
+    const applyAction = vi.fn().mockRejectedValue(
+      new ApiError('not legal', 409, {
+        code: 'action_not_legal',
+        supportedActions: [],
+      })
+    );
+
+    renderPage({ list, applyAction });
+
+    await screen.findAllByRole('button', { name: FULFILLMENT_ACTION_COPY['close'].label });
+    await user.click(
+      within(desktop()).getByRole('button', { name: FULFILLMENT_ACTION_COPY['close'].label })
+    );
+
+    await waitFor(() => {
+      expect(applyAction).toHaveBeenCalledTimes(1);
+    });
+    await waitFor(() => {
+      expect(list).toHaveBeenCalledTimes(2);
+    });
+    expect(desktopTaskIds()).toEqual(['ol_work_1']);
+  });
+});
+
+describe('FulfillmentWorklistPage — both surfaces agree (AC3 part 1)', () => {
+  it('renders the same set of tasks in the desktop rows and in the cards', async () => {
+    // TWO tasks share a lane on purpose. With one task per lane, a per-lane
+    // divergence (a `slice`, a filter, a `find` instead of a `map`) drops
+    // nothing and the comparison passes while asserting nothing — which is
+    // exactly what this case is here to catch.
+    const tasks = [
+      task({ id: 'ol_work_1', locationId: 'loc_warsaw' }),
+      task({ id: 'ol_work_2', locationId: 'loc_warsaw' }),
+      task({ id: 'ol_work_3', locationId: 'loc_krakow' }),
+      task({ id: 'ol_work_4', locationId: null, deliveryMethod: null }),
+    ];
+    renderPage({ list: vi.fn().mockResolvedValue(page(tasks)) });
+
+    await screen.findAllByRole('button', { name: FULFILLMENT_ACTION_COPY['close'].label });
+
+    const desktop = desktopTaskIds();
+    // Vacuity guards: two empty sets are trivially equal, and a single-task
+    // lane cannot observe a per-lane divergence.
+    expect(desktop.length).toBe(4);
+    expect(
+      desktop.filter((id) => id === 'ol_work_1' || id === 'ol_work_2').length
+    ).toBe(2);
+    // The breakpoint is CSS, so both surfaces are in the DOM; that they are
+    // both present is incidental — showing DIFFERENT tasks is the real defect.
+    expect(new Set(cardTaskIds())).toEqual(new Set(desktop));
+    expect(cardTaskIds().length).toBe(desktop.length);
+  });
+});
+
+describe('FulfillmentWorklistPage — four distinct states', () => {
+  it('renders a loading line that is not an empty-state sentence', () => {
+    renderPage({ list: vi.fn(() => new Promise(() => undefined)) });
+
+    expect(screen.getByText('Loading fulfilment tasks…')).toBeInTheDocument();
+    expect(screen.queryByText('Nothing to work right now')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('No fulfilment tasks match these filters')
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders an error with a retry, never the empty state', async () => {
+    renderPage({ list: vi.fn().mockRejectedValue(new ApiError('boom', 500, {})) });
+
+    expect(
+      await screen.findByText('Could not load the fulfilment worklist')
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Nothing to work right now')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+  });
+
+  it('says "nothing to work" when nothing is filtered', async () => {
+    renderPage({ list: vi.fn().mockResolvedValue(page([])) });
+
+    expect(await screen.findByText('Nothing to work right now')).toBeInTheDocument();
+  });
+
+  it('says "no matches" when a filter is narrowing the list', async () => {
+    renderPage({
+      list: vi.fn().mockResolvedValue(page([])),
+      route: '/fulfillment?orderId=ol_order_missing',
+    });
+
+    expect(
+      await screen.findByText('No fulfilment tasks match these filters')
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Nothing to work right now')).not.toBeInTheDocument();
+  });
+
+  it('says "nothing on this page" when paged past the end', async () => {
+    // Paging past the end is neither of the two empty states: rows exist.
+    renderPage({
+      list: vi.fn().mockResolvedValue(page([], { total: 40, offset: 100 })),
+      route: '/fulfillment?offset=100',
+    });
+
+    expect(await screen.findByText('Nothing on this page')).toBeInTheDocument();
+    expect(screen.queryByText('Nothing to work right now')).not.toBeInTheDocument();
+  });
+});
+
+describe('FulfillmentWorklistPage — the pager reads the applied page', () => {
+  it('uses the limit the SERVER applied, not the one requested', async () => {
+    // The server clamps, so a pager reading its own request would render a
+    // range that does not describe the rows on screen.
+    renderPage({
+      list: vi.fn().mockResolvedValue(page([task()], { total: 60, limit: 25, offset: 0 })),
+    });
+
+    expect(await screen.findByText('Showing 1–25 of 60')).toBeInTheDocument();
+  });
+
+  it('asks for the page size the server will actually give', async () => {
+    const { list } = renderPage({});
+
+    await waitFor(() => {
+      expect(list).toHaveBeenCalledWith(expect.objectContaining({ limit: 25, offset: 0 }));
+    });
+  });
+});
+
+describe('FulfillmentWorklistPage — filters reach the request', () => {
+  it('sends both free-string filters read out of the URL', async () => {
+    const { list } = renderPage({
+      route: '/fulfillment?orderId=ol_order_7&locationId=loc_krakow',
+    });
+
+    await waitFor(() => {
+      expect(list).toHaveBeenCalledWith(
+        expect.objectContaining({ orderId: 'ol_order_7', locationId: 'loc_krakow' })
+      );
+    });
+  });
+
+  it('commits a filter on Enter, not only on blur', async () => {
+    // A filter box that reacts only to blur reads as broken to anyone who
+    // types and presses Enter.
+    const user = userEvent.setup();
+    const { list } = renderPage({});
+
+    await waitFor(() => {
+      expect(list).toHaveBeenCalledTimes(1);
+    });
+
+    await user.type(await screen.findByLabelText('Order'), 'ol_order_9{Enter}');
+
+    await waitFor(() => {
+      expect(list).toHaveBeenCalledWith(expect.objectContaining({ orderId: 'ol_order_9' }));
+    });
+  });
+
+  it('clears the visible filter text when the filters are cleared', async () => {
+    // The remedy the empty state offers must actually reset the control the
+    // operator typed into: a box still showing `ol_order_7` over an unfiltered
+    // list is the page contradicting itself.
+    const user = userEvent.setup();
+    renderPage({
+      list: vi.fn().mockResolvedValue(page([])),
+      route: '/fulfillment?orderId=ol_order_7',
+    });
+
+    const before = await screen.findByLabelText<HTMLInputElement>('Order');
+    expect(before.value).toBe('ol_order_7');
+
+    await user.click(screen.getAllByRole('button', { name: 'Clear filters' })[0]);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText<HTMLInputElement>('Order').value).toBe('');
+    });
+  });
+
+  it('offers a way out of a filter that matched nothing', async () => {
+    renderPage({
+      list: vi.fn().mockResolvedValue(page([])),
+      route: '/fulfillment?orderId=nope',
+    });
+
+    await screen.findByText('No fulfilment tasks match these filters');
+    // Two: the toolbar's and the empty state's own remedy.
+    expect(
+      screen.getAllByRole('button', { name: 'Clear filters' }).length
+    ).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/pages/fulfillment/fulfillment-worklist-page.tsx
+++ b/apps/web/src/pages/fulfillment/fulfillment-worklist-page.tsx
@@ -1,0 +1,382 @@
+/**
+ * Fulfilment worklist (#2410, `W3a-20`, DESIGN §5.2)
+ *
+ * The operator's standalone view of the fulfilment tasks waiting to be worked,
+ * grouped by where the goods are and how they leave, with the manual actions
+ * the SERVER says are legal on each right now.
+ *
+ * ## Four states, and none of them is allowed to impersonate another
+ *
+ * A loading read renders a loading line, a FAILED read renders an error with a
+ * retry, an empty page renders "no matches" when a filter is active and
+ * "nothing to work" when none is. Collapsing any pair would have this page tell
+ * an operator there is no work because a request timed out, or because they
+ * typed an order id that matched nothing.
+ *
+ * ## The version sent is the version RENDERED
+ *
+ * `expectedVersion` is read off the task object the button was rendered from,
+ * never re-read at click time. Substituting a fresher value would make
+ * `version_conflict` unreachable and hand the last writer the win — the
+ * double-ship the optimistic token exists to prevent.
+ *
+ * ## A `version_conflict` is never auto-retried
+ *
+ * The action mutation invalidates the whole feature (#2411), so the row
+ * refreshes itself and re-renders the server's new action set. Re-posting on
+ * the operator's behalf against state they have not seen is exactly what the
+ * token guards against.
+ *
+ * ## This file carries no user-visible string literals
+ *
+ * Every one lives in `features/fulfillment/lib/fulfillment-worklist.copy.ts`,
+ * because `scripts/check-ui-vocabulary.mjs` scans only under
+ * `apps/web/src/features` — copy written here would be ungated.
+ *
+ * @module apps/web/src/pages/fulfillment
+ */
+import { useMemo, useState, type KeyboardEvent, type ReactElement } from 'react';
+import { useSearchParams } from 'react-router-dom';
+
+import {
+  FULFILLMENT_WORKLIST_COPY,
+  FULFILLMENT_WORKLIST_PAGE_SIZE,
+  FulfillmentLaneSection,
+  FulfillmentTaskActionDialog,
+  FulfillmentTaskActions,
+  clearFulfillmentFilters,
+  describeFulfillmentActionError,
+  fulfillmentActionLabel,
+  groupTasksIntoLanes,
+  hasActiveFulfillmentFilters,
+  readFulfillmentConflict,
+  readFulfillmentFilters,
+  readFulfillmentOffset,
+  setFulfillmentFilterParam,
+  setFulfillmentOffsetParam,
+  useFulfillmentTaskActionMutation,
+  useFulfillmentTasksQuery,
+  type ApplyFulfillmentTaskActionRequest,
+  type FulfillmentTask,
+  type FulfillmentTaskActionMode,
+  type FulfillmentTaskHold,
+} from '../../features/fulfillment';
+import { useDemoMode } from '../../features/system';
+import { useWriteAccess } from '../../shared/auth/use-permission';
+import { Button } from '../../shared/ui/button';
+import { EmptyState, ErrorState } from '../../shared/ui/feedback-state';
+import { Input } from '../../shared/ui/input';
+import { PageLayout } from '../../shared/ui/page-layout';
+import { useToast } from '../../shared/ui/toast-provider';
+
+interface PendingForm {
+  mode: FulfillmentTaskActionMode;
+  task: FulfillmentTask;
+  hold?: FulfillmentTaskHold;
+  /** This form's own submit failure, scoped so a dismissed one cannot reappear. */
+  error?: unknown;
+}
+
+export function FulfillmentWorklistPage(): ReactElement {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const filters = useMemo(() => readFulfillmentFilters(searchParams), [searchParams]);
+  const offset = readFulfillmentOffset(searchParams);
+  const isFiltered = hasActiveFulfillmentFilters(filters);
+
+  const query = useFulfillmentTasksQuery({
+    ...filters,
+    limit: FULFILLMENT_WORKLIST_PAGE_SIZE,
+    offset,
+  });
+  const mutation = useFulfillmentTaskActionMutation();
+  const { showToast } = useToast();
+  const demoMode = useDemoMode();
+  // The same permission the order-detail panel resolves (#2411): the action
+  // route is `@Roles('admin','operator')`, exactly who holds `orders:write`.
+  // Resolved ONCE here rather than inside a component rendered per row.
+  const write = useWriteAccess('orders:write', demoMode);
+
+  const [pendingForm, setPendingForm] = useState<PendingForm | null>(null);
+  const [busyTaskId, setBusyTaskId] = useState<string | null>(null);
+
+  const setFilter = (key: 'orderId' | 'locationId', value: string): void => {
+    setSearchParams(setFulfillmentFilterParam(searchParams, key, value));
+  };
+  const clearFilters = (): void => {
+    setSearchParams(clearFulfillmentFilters(searchParams));
+  };
+  const goToOffset = (next: number): void => {
+    setSearchParams(setFulfillmentOffsetParam(searchParams, next));
+  };
+  /**
+   * Enter commits the filter, because a filter box that only reacts to blur
+   * reads as broken to anyone who types and presses Enter.
+   */
+  const commitOnEnter = (
+    event: KeyboardEvent<HTMLInputElement>,
+    key: 'orderId' | 'locationId'
+  ): void => {
+    if (event.key !== 'Enter') return;
+    event.preventDefault();
+    setFilter(key, event.currentTarget.value.trim());
+  };
+
+  const run = (
+    task: FulfillmentTask,
+    action: string,
+    body: Omit<ApplyFulfillmentTaskActionRequest, 'expectedVersion'>,
+    onDone?: () => void,
+    onFailure?: (error: unknown) => void
+  ): void => {
+    setBusyTaskId(task.id);
+    mutation.mutate(
+      {
+        workId: task.id,
+        action,
+        orderId: task.orderId,
+        // The token as RENDERED — see the module docblock.
+        expectedVersion: task.version,
+        ...body,
+      },
+      {
+        onSuccess: () => {
+          showToast({ tone: 'success', description: `${fulfillmentActionLabel(action)} applied.` });
+          onDone?.();
+        },
+        onError: (error) => {
+          const conflict = readFulfillmentConflict(error);
+          // A conflict closes the form and lets the operator re-read: keeping it
+          // open invites a resubmit carrying the same stale token.
+          const closesTheForm = conflict !== null || onFailure === undefined;
+          if (closesTheForm) {
+            showToast({
+              // A stale token is the guard working, not a fault.
+              tone: conflict?.retryable === true ? 'warning' : 'error',
+              description: describeFulfillmentActionError(
+                error,
+                `Could not ${fulfillmentActionLabel(action).toLowerCase()} this fulfilment task.`
+              ),
+            });
+          }
+          if (conflict) {
+            onDone?.();
+            return;
+          }
+          onFailure?.(error);
+        },
+        onSettled: () => {
+          setBusyTaskId(null);
+        },
+      }
+    );
+  };
+
+  const renderActions = (task: FulfillmentTask): ReactElement | null => (
+    <FulfillmentTaskActions
+      task={task}
+      visible={write.visible}
+      readOnly={write.demoReadOnly}
+      busy={busyTaskId === task.id}
+      onInvoke={(action) => {
+        run(task, action, {});
+      }}
+      onHold={() => {
+        setPendingForm({ mode: 'hold', task });
+      }}
+      onReleaseHold={(hold) => {
+        setPendingForm({ mode: 'release_hold', task, hold });
+      }}
+      onForceCancel={() => {
+        setPendingForm({ mode: 'force_cancel', task });
+      }}
+    />
+  );
+
+  const page = query.data;
+  const tasks = page?.works ?? [];
+  // Keyed on the query RESULT, which is stable per fetch — `tasks` is a fresh
+  // `?? []` array on every render, so memoising on it never hits.
+  const lanes = useMemo(() => groupTasksIntoLanes(page?.works ?? []), [page]);
+  // The server clamps, so the pager reads what it APPLIED, never what we asked.
+  const appliedLimit = page?.limit ?? FULFILLMENT_WORKLIST_PAGE_SIZE;
+  const appliedOffset = page?.offset ?? offset;
+  const total = page?.total ?? 0;
+
+  const body = ((): ReactElement => {
+    if (query.isPending) {
+      // Never an empty-state sentence: an unresolved read says nothing yet.
+      return <p className="text-muted">{FULFILLMENT_WORKLIST_COPY.loading.message}</p>;
+    }
+    if (query.isError) {
+      return (
+        <ErrorState
+          title={FULFILLMENT_WORKLIST_COPY.error.title}
+          message={FULFILLMENT_WORKLIST_COPY.error.message}
+          action={
+            <Button
+              onClick={() => {
+                void query.refetch();
+              }}
+            >
+              {FULFILLMENT_WORKLIST_COPY.error.retry}
+            </Button>
+          }
+        />
+      );
+    }
+    if (tasks.length === 0) {
+      // Paged past the end is a different situation from either empty state:
+      // rows exist, this page is simply beyond them.
+      if (appliedOffset > 0 && total > 0) {
+        return (
+          <EmptyState
+            liveRegion="off"
+            title={FULFILLMENT_WORKLIST_COPY.empty.pastEnd.title}
+            message={FULFILLMENT_WORKLIST_COPY.empty.pastEnd.message}
+            action={
+              <Button
+                onClick={() => {
+                  goToOffset(0);
+                }}
+              >
+                {FULFILLMENT_WORKLIST_COPY.empty.pastEnd.action}
+              </Button>
+            }
+          />
+        );
+      }
+      if (isFiltered) {
+        return (
+          <EmptyState
+            liveRegion="off"
+            title={FULFILLMENT_WORKLIST_COPY.empty.filtered.title}
+            message={FULFILLMENT_WORKLIST_COPY.empty.filtered.message}
+            action={
+              <Button onClick={clearFilters}>{FULFILLMENT_WORKLIST_COPY.filter.clear}</Button>
+            }
+          />
+        );
+      }
+      return (
+        <EmptyState
+          liveRegion="off"
+          title={FULFILLMENT_WORKLIST_COPY.empty.none.title}
+          message={FULFILLMENT_WORKLIST_COPY.empty.none.message}
+        />
+      );
+    }
+
+    return (
+      <>
+        {lanes.map((lane) => (
+          <FulfillmentLaneSection key={lane.id} lane={lane} renderActions={renderActions} />
+        ))}
+
+        <div className="pagination">
+          <span className="text-muted tabular">
+            {FULFILLMENT_WORKLIST_COPY.pagination.range(
+              appliedOffset + 1,
+              Math.min(appliedOffset + appliedLimit, total),
+              total
+            )}
+          </span>
+          <div className="pagination__actions">
+            <Button
+              disabled={appliedOffset <= 0}
+              onClick={() => {
+                goToOffset(Math.max(0, appliedOffset - appliedLimit));
+              }}
+            >
+              {FULFILLMENT_WORKLIST_COPY.pagination.previous}
+            </Button>
+            <Button
+              disabled={appliedOffset + appliedLimit >= total}
+              onClick={() => {
+                goToOffset(appliedOffset + appliedLimit);
+              }}
+            >
+              {FULFILLMENT_WORKLIST_COPY.pagination.next}
+            </Button>
+          </div>
+        </div>
+      </>
+    );
+  })();
+
+  return (
+    <PageLayout
+      eyebrow={FULFILLMENT_WORKLIST_COPY.page.eyebrow}
+      title={FULFILLMENT_WORKLIST_COPY.page.title}
+      description={FULFILLMENT_WORKLIST_COPY.page.description}
+    >
+      <div className="toolbar" role="group" aria-label={FULFILLMENT_WORKLIST_COPY.filter.groupLabel}>
+        {/* `key` is the URL's own value, so the box REMOUNTS whenever the filter
+            changes from outside it — which is what makes `Clear filters` clear
+            the text as well as the list. An uncontrolled input ignores a changed
+            `defaultValue`, so without this the page shows a filter box reading
+            `ol_order_7` over an unfiltered list and the remedy appears to do
+            nothing. Typing is still uncontrolled (no re-render per keystroke);
+            the key only moves when the committed value does. */}
+        <Input
+          key={`orderId:${filters.orderId ?? ''}`}
+          aria-label={FULFILLMENT_WORKLIST_COPY.filter.orderLabel}
+          placeholder={FULFILLMENT_WORKLIST_COPY.filter.orderPlaceholder}
+          defaultValue={filters.orderId ?? ''}
+          onBlur={(event) => {
+            setFilter('orderId', event.target.value.trim());
+          }}
+          onKeyDown={(event) => {
+            commitOnEnter(event, 'orderId');
+          }}
+        />
+        <Input
+          key={`locationId:${filters.locationId ?? ''}`}
+          aria-label={FULFILLMENT_WORKLIST_COPY.filter.locationLabel}
+          placeholder={FULFILLMENT_WORKLIST_COPY.filter.locationPlaceholder}
+          defaultValue={filters.locationId ?? ''}
+          onBlur={(event) => {
+            setFilter('locationId', event.target.value.trim());
+          }}
+          onKeyDown={(event) => {
+            commitOnEnter(event, 'locationId');
+          }}
+        />
+        {isFiltered ? (
+          <Button onClick={clearFilters}>{FULFILLMENT_WORKLIST_COPY.filter.clear}</Button>
+        ) : null}
+      </div>
+
+      {body}
+
+      {pendingForm ? (
+        <FulfillmentTaskActionDialog
+          // Remount per (task, mode, hold) so a draft never carries across.
+          key={`${pendingForm.task.id}:${pendingForm.mode}:${pendingForm.hold?.id ?? ''}`}
+          open
+          mode={pendingForm.mode}
+          holdId={pendingForm.hold?.id}
+          submitting={busyTaskId === pendingForm.task.id}
+          error={pendingForm.error ?? null}
+          onOpenChange={(open) => {
+            if (!open) setPendingForm(null);
+          }}
+          onSubmit={(actionBody) => {
+            setPendingForm((current) => (current ? { ...current, error: undefined } : current));
+            run(
+              pendingForm.task,
+              pendingForm.mode,
+              actionBody,
+              () => {
+                setPendingForm(null);
+              },
+              (error) => {
+                setPendingForm((current) => (current ? { ...current, error } : current));
+              }
+            );
+          }}
+        />
+      ) : null}
+    </PageLayout>
+  );
+}

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -710,6 +710,13 @@ export function createMockApiClient(
     // read `.works` as undefined and pass, while the real client never can.
     fulfillment: {
       listByOrder: vi.fn().mockResolvedValue({ works: [], total: 0, limit: 50, offset: 0 }),
+      // #2410. `list` and `get` are defaulted HERE rather than in the specs
+      // that need them: every worklist page test calls `list`, and an absent
+      // member fails as `apiClient.fulfillment.list is not a function` from
+      // inside a render — an inscrutable crash that reads as a defect in the
+      // page rather than as a missing mock.
+      list: vi.fn().mockResolvedValue({ works: [], total: 0, limit: 25, offset: 0 }),
+      get: vi.fn().mockResolvedValue(null),
       applyAction: vi.fn().mockResolvedValue(null),
       ...overrides.fulfillment,
     } as ApiClient['fulfillment'],

--- a/docs/frontend-ui-style-guide.md
+++ b/docs/frontend-ui-style-guide.md
@@ -649,6 +649,7 @@ Defaults (FE-002):
 | KPI card | auto, ~96 px | Label + value + hint. Sparkline floats top-right. |
 | Analytics KPI card (`.status-strip--analytics .kpi-card`, #1990) | auto, ~152 px | Documented carve-out — the six-card sales strip stacks a headline+metric+delta block on top of one-or-more qualifier rows pinned to the card floor by a hairline, provably taller than the ~96 px default. See the carve-out note below. |
 | Status banner | auto, ~64 px | Icon + title + message + actions. |
+| Fulfilment worklist row (`.fulfilment-worklist-row`, #2410) | auto, ~52 px | Documented carve-out — a two-line identity stack (task id + order id) beside status, a line counter and the server-supplied action strip. See the carve-out note below. |
 | Analytics trust-header row (`.trust-header__row`) | auto, ~52 px | `var(--space-3) var(--space-4)` padding. Per-connection freshness list, denser than a status banner because it repeats per row. Collapses to one column, auto height on mobile. |
 | Who-decides question row (`.who-decides-row`, #2354) | auto, ~76 px | Documented **non-`DataTable`** carve-out — question + answer + why-line + optional extras + badge. See the carve-out below. |
 
@@ -662,6 +663,25 @@ Two mechanical consequences worth knowing before copying the pattern:
 - Only the unbounded field gets a hard character cap. Capping *every* meta field ellipses a routine 20-char SKU on a wide desktop; `flex: 0 1 auto` + `min-width: 0` already truncates each field under real pressure.
 
 **Documented carve-out — the analytics KPI card (#1990).** The six-card sales KPI strip (Revenue, Orders, Order value, Units, Returns & refunds, Cancellations) carries a richer anatomy than the default KPI card: a headline+metric+delta stack plus one or more qualifier rows, each qualifier separated by a hairline (`.kpi-card__qualifier`, `border-top` + `padding-top: var(--space-3)`) and pinned to the card floor via `margin-top: auto`. That composition doesn't fit in ~96 px, so `.status-strip--analytics .kpi-card` sets `min-height: 9.5rem` (152 px) — every line is a fact (a definition, a value, a comparison basis), nothing decorative padded in to hit a number. The strip also runs a 3-column desktop grid (`.status-strip.status-strip--analytics` at ≥1024px) rather than the general dashboard `.status-strip`'s 4-column, because 6 cards divide evenly into 2 rows of 3 rather than an uneven 4-then-2 — see the parity matrix entry below (2×3 desktop, not the generic KPI strip's 1×4). This carve-out is for the analytics KPI card specifically; a new strip wanting either the taller card or the 3-column grid needs its own entry here.
+
+**Documented carve-out — the fulfilment worklist row (#2410).** `/fulfillment` groups its rows into
+lanes (location × delivery method) rather than rendering one flat table, so it is **not** a `DataTable`
+at all — a `DataTable` renders one ungrouped body, and the lane heading is the thing an operator scans
+to. The row is a four-column CSS grid: a two-line identity stack (task id over order id), the status
+group (hold badge or orchestration status, plus the state · handshake line), a line counter, and the
+action strip built from `supportedActions`. Two lines of identity is what makes it ~52 px rather than
+the 36 px table default — the same reason the identity carve-outs above take their height from content.
+
+Mechanics worth knowing before copying it:
+
+- **Both surfaces render, and the breakpoint is CSS.** `.fulfilment-worklist__desktop` and
+  `.fulfilment-worklist__cards` are both in the DOM; a `max-width` / `min-width` pair hides one. That is
+  the `DataTable` `cardView` mechanic reproduced by hand (the lane grouping is what rules `DataTable`
+  out), and it is what lets a test assert the two surfaces show the same set of tasks. Each `display:
+  none` MUST stay inside its own `@media` block — hoisted out, the desktop grid renders on a phone or
+  both surfaces render at once — and a test asserts exactly that by brace-counting the media blocks.
+- **No leading control, and no frozen pane**, so neither the `vertical-align` heuristic nor the
+  frozen-pane narrowing above applies here.
 
 **Documented carve-out — the shared identity row (#2086).** The five lists that answer *which order is this* and *which connection did it come from* render those facts through two shared cells — `OrderIdentityCell` (24 px `ProductThumbnail` + order number/id line + item-name/`+N` line) and `ConnectionCell` (adornment + name line + shortened-id/status line). Either one makes the row two-line, so a table adopting them takes its height from content, same as the listings row above and for the same reason: every line is a fact an operator scans for.
 

--- a/docs/plans/analysis/PRE-IMPLEMENT-2410-fulfilment-worklist-frontend.md
+++ b/docs/plans/analysis/PRE-IMPLEMENT-2410-fulfilment-worklist-frontend.md
@@ -1,0 +1,165 @@
+# Pre-implement readiness gate — #2410 fulfilment worklist (frontend)
+
+**Date**: 2026-09-01
+**Plan**: `docs/plans/implementation-plan-fulfilment-worklist-frontend.md`
+**Base**: `origin/oms-programme-wave-3a` @ `5f7586cae`
+**Sibling under review**: PR #2793 / `origin/2411-order-detail-task-panel` @ `be1071c36`
+**Verdict**: **CONDITIONAL GO** — plan is execution-ready; implementation is **gated on PR #2793 merging**. One coordination item (O1) is best resolved inside #2793.
+
+Read-only. Every claim below was verified by grep or `git show` against the two branches named
+above; nothing is asserted from the issue body or from the plan's own prose.
+
+---
+
+## 1. Reuse-collision sweep
+
+The whole risk profile of this body is that it is the second consumer of a slice another open PR
+creates. Each collision was resolved to one of three outcomes: *inherited* (#2410 makes no edit),
+*additive* (#2410 appends, #2793's consumer unaffected), or *conflict* (needs a decision).
+
+| # | Surface | On `wave-3a` | On `#2411` | Outcome |
+|---|---|---|---|---|
+| C1 | `apps/web/src/features/fulfillment/` | **absent** | 12 files | The slice does not exist on the base. #2410 cannot start until #2793 merges. **HARD GATE.** |
+| C2 | `.eslintrc.js` `no-restricted-imports` | 0 `fulfillment/api/**` matches | present in **both** pattern groups | **Inherited.** #2410 edits this file zero times. The standing S3 rule is satisfied; step 0 verifies by grep rather than assuming. |
+| C3 | `app/api/api-client.ts` `fulfillment` namespace | 0 matches | registered | **Inherited.** Zero edits. |
+| C4 | `scripts/check-ui-vocabulary.mjs` `SCAN_ROOTS` | 4 roots, no `fulfillment` | 5 roots, `features/fulfillment` owner `W3a-21 (#2411)` | **Inherited.** Zero edits — see § 3 D1. |
+| C5 | `SCAN_ROOT_PARENT` | `apps/web/src/features` (line 192) | unchanged | **Structural constraint confirmed.** A `pages/` scan root is impossible without editing this constant. The plan's D1 is correct and is not a rationalisation. |
+| C6 | `features/orders/index.ts` hold exports | **absent** | adds `HOLD_REASON_COPY`, `HoldReasonValues`, `holdReasonLabel`, `isHoldReason`, `type HoldReason` | **Inherited transitively.** #2410 does not import them directly; #2411's card and dialog do. A second reason #2410 cannot precede #2793. |
+| C7 | `apps/web/src/test/test-utils.tsx` `createMockApiClient` | no `fulfillment` mock | adds one with `listByOrder` + `applyAction` **only** | **Additive, and load-bearing.** Every page-level test in the plan's § 9 calls `apiClient.fulfillment.list(…)`, which is `undefined` on that default. #2410 adds `list` / `get` in Phase 1. Fifth shared file in the merge set. |
+| C14 | Write permission / demo read-only | `useWriteAccess(permission, demoMode)` + `useDemoMode()` exist in `shared/auth` | panel uses `useWriteAccess('orders:write', demoMode)`, passes `visible` / `readOnly` into `FulfillmentTaskActions` | **Decision required of #2410, now recorded as D6.** `FulfillmentTaskActions` takes the decision as props, so the worklist page must make it. `orders:write` is reused; the backend route is `@Roles('admin','operator')`. |
+| C8 | `apps/web/src/index.css` | no `.fulfilment-*` | appends a `.fulfilment-task*` block at EOF | **Additive**, both sides append at EOF. Textual merge, resolvable as "keep both". |
+| C9 | `features/fulfillment/index.ts` | n/a | 4 exports, docblock explicitly anticipates #2410 as the second consumer | **Additive.** |
+| C10 | `features/fulfillment/api/fulfillment.query-keys.ts` | n/a | `all`, `worksByOrder` | **Additive**; both new keys stay under the `all` prefix. |
+| C11 | `features/fulfillment/api/fulfillment.api.ts` | n/a | `listByOrder`, `applyAction` | **Additive + one re-expression** (`listByOrder` routed through the new `list`). Pinned by a regression test on the emitted URL. |
+| C12 | `hooks/use-fulfillment-task-action-mutation.ts` invalidation grain | n/a | `worksByOrder(orderId)` | **CONFLICT — see § 2 O1.** Not a defect in #2411; wrong grain for two consumers. |
+| C13 | Route / nav / page slug `fulfillment` | no route, no nav entry, no `pages/fulfillment` | #2411 adds **no route** (`git diff --stat -- app/routes/` is empty) | **Clear.** `EXPECTED_LAZY_ROUTE_COUNT` is 61 on the base and #2411 does not move it, so #2410's bump to 62 is uncontested. |
+
+Also verified present on the base, so no hidden dependency on #2793 for them:
+`ApiError.isConflict/isForbidden/isNotFound/details`; `shared/ui` `read-only-lock`, `status-badge`,
+`time-display`, `alert`, `button`, `dialog`, `select`, `textarea`, `form-field`, `data-table`;
+`DEMO_READ_ONLY_ACTION_MESSAGE`. The cited precedents exist:
+`features/returns/lib/returns-filters.ts` (whose docblock states the `offset`-is-not-a-filter rule
+the plan reuses, exported as `hasActiveReturnFilters` — #2410's will be
+`hasActiveFulfillmentFilters`, matching the convention) and
+`features/fulfillment-authority/who-decides-styles.test.ts` (the CSS-assertion precedent).
+
+**No file is stubbed, forked or reached across.** #2410's only edits to another live PR's files are
+appends to five shared files (§ 2 O2), each of which #2793 also only appends to.
+
+---
+
+## 2. Contract-surface findings
+
+### O1 — `use-fulfillment-task-action-mutation` invalidates an order-scoped key (COORDINATION, not blocking)
+
+`#2411`'s hook invalidates `fulfillmentQueryKeys.worksByOrder(variables.orderId)` on success and on
+a recognised conflict. The worklist's rows live under `fulfillmentQueryKeys.list(filters)`, which is
+a sibling, not a descendant — so an action taken from the worklist would refresh #2411's panel and
+**not the worklist that issued it**. The row would keep its pre-action `version`, which makes the
+operator's *next* click a `version_conflict` that the UI itself manufactured — a self-inflicted
+instance of exactly the failure the optimistic token exists to report.
+
+Invalidating `fulfillmentQueryKeys.all` fixes it in one line, still refreshes #2411's panel
+(`worksByOrder` is a descendant of `all`), and is **more correct for #2411 too**: a task can be moved
+from the worklist while an order-detail panel is open on the same order.
+
+- **Preferred**: #2793 makes the change before merging.
+- **Fallback**: #2410 makes it, as an edit to a then-merged file.
+
+Not blocking either PR: #2411 is correct in isolation, and #2410 has a working fallback.
+
+### O2 — five shared files are appended to by both bodies
+
+`apps/web/src/index.css`, `features/fulfillment/index.ts`,
+`features/fulfillment/api/fulfillment.query-keys.ts`,
+`features/fulfillment/api/fulfillment.api.ts`, `apps/web/src/test/test-utils.tsx`.
+
+All additive on both sides; resolution is "keep both", but per the repo's own lesson the merge is
+resolved **by intent and then re-grepped**, not accepted textually. The plan deliberately removes
+three further collision points (`.eslintrc.js`, `api-client.ts`, `check-ui-vocabulary.mjs`) by
+inheriting them instead of re-editing.
+
+### O3 — no shaping defect in #2411 beyond O1
+
+`FulfillmentTaskActions` takes `task` + callbacks and reads only `supportedActions` / `activeHolds`;
+`FulfillmentTaskCard` takes an `actions` slot; `FulfillmentTaskActionDialog` takes `mode` as a prop
+rather than inferring it; `readFulfillmentConflict` is a pure reader over `ApiError`. Every one is
+consumable by the worklist unchanged. The slice was built to be shared and the barrel docblock says
+so in as many words.
+
+### O4 — the plan does NOT duplicate #2406's contract
+
+`fulfillmentTaskPageSchema` already models `{works,total,limit,offset}`, i.e. exactly the list
+response, because #2411's panel calls the same list endpoint filtered by `orderId`. So #2410 adds no
+schema at all. This is the single largest scope reduction the reuse map buys, and it also means the
+**#939 `.nullish()` rule is inherited rather than re-satisfied** — verified: every nullable field in
+`fulfillment.schema.ts` is `.nullish()` with a `?? null` transform, and there is no `.optional()` in
+the file.
+
+---
+
+## 3. Vacuity review of the proposed checks
+
+The programme's recurring defect is a check that cannot fail. Each AC's proposed assertion was
+tested against two questions: *is the property already covered elsewhere?* and *does the assertion
+touch code this body changes?*
+
+| AC | Already covered? | Touches changed code? | Verdict |
+|---|---|---|---|
+| AC1 no client-side state machine | Partially — the static guard catches two declaration shapes and **says in its own docblock** it cannot catch an inline `if (status === …)`; #2411 specs its own component | Yes — the worklist **row** is new and is where such a condition would appear | **Sound.** Non-empty-control-list precondition is the right vacuity guard. |
+| AC2 the 409 path | `fulfillment-conflict.ts` + its spec are #2411's | Yes — the list query key, the page's mutation wiring and the O1 grain are this body's | **Sound, and the plan correctly declines to re-test the pure classifier**, which would pass with this entire body reverted. The "`list` called exactly twice" assertion is the one that fails when the handler is deleted; without it the test would survive that deletion. |
+| AC3 responsive | No | Yes | **Sound**, and the plan names the real prior defect (`css.includes('.' + name)`) and requires the rule-opener match plus a rename-only red run. |
+| AC4 copy audit | Partially — the shared gate already scans `features/fulfillment`; its blind spots are `pages/`, runtime-assembled strings, backend messages | Yes | **Sound.** The rendered-output audit is not a duplicate of the script: the humanised-raw-value red run proves the script stays green while the test goes red. The non-empty-render precondition and per-state `it()` split are required, not optional. |
+| AC5 tests for non-trivial logic | No | Yes | Sound. |
+| AC6 `shared` imports no `features`/`pages` | **Yes, fully — the ESLint rule exists and #2411 already registered the slug in both groups; this body adds no file under `shared/`** | **No** | **Correctly declines to add an assertion.** A test restating an existing lint rule over untouched code is the manufactured check the brief warns against. Verified by grep (C2) and by `pnpm lint`. |
+
+No proposed assertion was found to be vacuous or to duplicate existing coverage.
+
+---
+
+## 3b. Review pass
+
+A `/tech-review` of this plan (adversarial, run against both branches) returned **three BLOCKING
+findings**, all of which are corrections to the PLAN and none of which is a defect in #2793 or in
+#2406:
+
+1. `test/test-utils.tsx` was missing from the plan's reuse map, its O2 count and its steps, while
+   this gate's own C7 named it — the two documents disagreed. Fixed: § 3b row, Phase-1 step, O2
+   corrected from three files to five.
+2. Write permission and demo read-only were absent from the plan entirely, although
+   `FulfillmentTaskActions` takes `visible` / `readOnly` as required props. As written the page
+   would not compile, or would ship write controls to a read-only session. Fixed: D6, a step-11
+   change, an AC1(d) assertion and a risk row.
+3. AC3's breakpoint assertion named a claim with no mechanism and no red-first break — the shape of a
+   check that cannot fail. Fixed: comment-stripped, brace-counted media-block extraction with its own
+   named break (move the rule out of the `@media` → red).
+
+Four IMPORTANT findings were also applied: the CSS matcher now reuses `who-decides-styles.test.ts`
+structurally (declared-selector membership, BEM block-root exemption, fabricated-leaf guard-of-the-guard)
+instead of a re-derived rule-opener regex; the copy audit reads its banned terms from the fenced
+spec table instead of restating them (the draft had already drifted — it omitted `atpEffect`'s
+`'ATP'` alternate); the reuse map gained § 3d for the three #2411 files deliberately not used; and
+AC1 gained a hold-independence case, which is the row-level defect the status/counter cases miss.
+Both SUGGESTIONs were taken (AC2 reads its label from `FULFILLMENT_ACTION_COPY`; the styles test
+moved into the feature folder beside its precedent).
+
+The review independently re-verified and confirmed every factual claim in § 1 of this document.
+
+---
+
+## 4. Verdict
+
+**CONDITIONAL GO.**
+
+Blocking condition, and only one: **PR #2793 must merge first.** It is not a preference — the
+feature slice, the `fulfillment` api-client namespace, both ESLint pattern groups, the vocabulary
+scan root and the four `features/orders` hold exports are all absent from `oms-programme-wave-3a`
+and all present on #2411. Starting #2410 before then means creating the folder twice.
+
+Non-blocking, for the orchestrator: **O1** (preferably fixed inside #2793) and **O2** (a five-file
+additive merge, resolved by intent).
+
+Scope: reduced from the pre-reuse estimate by roughly 40% — no schema, no types, no api-client
+wiring, no ESLint edit, no vocabulary-script edit, no conflict reader, no copy table, no action
+component, no card, no dialog, no mutation hook. What remains is the list axis: filters, lanes,
+paging, one query hook, a desktop row, a page, a route and a nav entry.

--- a/docs/plans/implementation-plan-fulfilment-worklist-frontend.md
+++ b/docs/plans/implementation-plan-fulfilment-worklist-frontend.md
@@ -1,0 +1,534 @@
+# Implementation Plan: Fulfilment worklist (frontend)
+
+**Date**: 2026-09-01
+**Status**: Ready for Review — planning only, implementation gated on PR #2793
+**Issue**: #2410 (`W3a-20`), epic #2412, stream S3 — consumes #2406 (merged), **shares a feature slice with #2411 (PR #2793, in review)**
+**Branch**: `2410-fulfillment-worklist-fe`, cut from `origin/oms-programme-wave-3a`
+**Estimated Effort**: ~1 day of implementation once #2793 merges (down from ~1.5 — roughly 40% of the originally-planned surface already exists in #2411)
+
+---
+
+## 1. Task Summary
+
+**Objective**: ship the standalone operator worklist in `apps/web` over the #2406 read model — a
+filtered, paginated list of fulfilment tasks grouped by location and delivery method, showing
+per-line counters and work-grain hold chips, with the manual write actions the *server* says are
+legal, guarded by the optimistic token.
+
+**Context**: REVIEW D10 cuts Wave 3a at a desktop worklist — enough to light the 3PL story with no
+floor UI, deferring the scan-scale wizard to 3b. #2406 was shaped for this consumer:
+`supportedActions` and `version` ride with every row so no client-side state machine has anywhere
+to live.
+
+**The defining constraint of this body is that it is the SECOND consumer of a slice #2411 built.**
+#2411 (PR #2793) creates `apps/web/src/features/fulfillment/` with the api client, the boundary
+schema, the query keys, the conflict reader, the copy table, the action-controls component, the
+task card, the action dialog and the action mutation. #2410 does not re-create any of that. It adds
+the *list* axis — filters, paging, grouping, a route, a page — and consumes the rest unchanged.
+§ 3 is the file-by-file reuse map and is the substance of this plan.
+
+**Classification**: Frontend / Interface. No backend change, no core change, no migration.
+
+---
+
+## 2. Scope & Non-Goals
+
+### In scope
+- Route `/fulfillment` + nav entry, page under `apps/web/src/pages/fulfillment/`.
+- Filtered list read (`GET /fulfillment/works`) with URL-carried filters and **server-reported** paging.
+- Grouping by location + delivery method, with line counters and hold chips per task.
+- Actions rendered **only** from `supportedActions`, posted with `expectedVersion`.
+- Both 409 codes handled distinctly and non-destructively.
+- Desktop table-ish layout, tablet and mobile card layouts.
+- A rendered-output copy audit covering the page.
+
+### Out of scope / non-goals
+- **Any file `features/fulfillment/**` already carries from #2411 is not rewritten.** Where an
+  extension is needed it is stated in § 3 as an additive change that leaves #2411's consumer
+  byte-compatible.
+- **No status / requestStatus filter control.** See § 7 Alternative 1 — the two vocabularies are
+  closed unions in `libs/core` exposed by no endpoint, and `scripts/check-no-supported-actions-mirror.mjs`
+  plus the reasoning in #2411's `fulfillment.types.ts` docblock forbid retyping them in `apps/web`.
+  Filtering is by the two free-string server params (`orderId`, `locationId`).
+- `submit` / `request_cancellation` — not in `OPERATOR_INVOCABLE_ACTIONS`; they can never appear in
+  `supportedActions`, and the FE never names them.
+- Line-level progress recording — no HTTP surface; counters are display-only.
+- The order-detail panel — that is #2411.
+- Scan / barcode surfaces — Wave 3b.
+
+### Constraints
+- `apps/web` may not import `@openlinker/*`.
+- Zod over the projection uses `.nullish()`, never `.optional()` (#939) — **already satisfied by
+  #2411's `fulfillment.schema.ts`, which this body reuses rather than re-derives.**
+- `scripts/check-no-supported-actions-mirror.mjs` fails the build on a `derive*SupportedActions`
+  declaration or a `FulfillmentWorkAction[Values]` declaration under `apps/web/src`.
+- Banned user-visible vocabulary (nine terms, `check-ui-vocabulary.mjs`): notably **authority**,
+  **posture**, **FulfillmentWork** / "fulfillment work", **holder**, **phase**. Copy says
+  *"fulfilment tasks"*, and questions read *"Who decides X?"*.
+
+---
+
+## 3. Reuse map against #2411 (PR #2793) — file by file
+
+Read from `origin/2411-order-detail-task-panel` at plan time. Three columns of outcome: **reuse
+unchanged**, **extend additively**, **new**.
+
+### 3a. Consumed UNCHANGED — not touched by this body
+
+| File (on #2411) | What #2410 uses it for |
+|---|---|
+| `features/fulfillment/api/fulfillment.schema.ts` | The whole boundary parse. `fulfillmentTaskPageSchema` already models `{works,total,limit,offset}` — the exact list response #2410 needs — and `parseFulfillmentTaskPage` is already the page parser. Every nullable field is already `.nullish()`, so the #939 AC is inherited, not re-satisfied. |
+| `features/fulfillment/api/fulfillment.types.ts` | `FulfillmentTask`, `FulfillmentTaskLine`, `FulfillmentTaskHold`, `FulfillmentTaskPage`, `ApplyFulfillmentTaskActionRequest`. Also the *reasoning* the docblock records — three vocabularies stay `string`. |
+| `features/fulfillment/lib/fulfillment-conflict.ts` | `readFulfillmentConflict` (409 discrimination by `details.code`, never message prose) and `describeFulfillmentActionError`. The worklist's 409 path is this function plus a toast. |
+| `features/fulfillment/lib/fulfillment-task-copy.ts` | `fulfillmentActionLabel/Tone/Hint`, `FULFILLMENT_ACTIONS_NEEDING_A_FORM`, `fulfillmentStatusLabel`, `fulfillmentRequestStatusLabel`. This is also the file the vocabulary gate scans, so the worklist's action/status copy is already gated. |
+| `features/fulfillment/components/fulfillment-task-actions.tsx` | The action control strip, verbatim. Its props are `task, visible, readOnly, busy, onInvoke, onHold, onReleaseHold, onForceCancel`; it reads nothing off the task but `supportedActions` and `activeHolds`. `visible` / `readOnly` are a **permission decision the calling page makes** — see D6. This is the single most important reuse: **the AC "no client-side state machine" is satisfied by using #2411's component rather than writing a second one that could drift.** |
+| `features/fulfillment/components/fulfillment-task-card.tsx` | The mobile/tablet card. Already renders heldness-from-`activeHolds`, the status/handshake facts, location, delivery method, the counters and the display-only caveat, and accepts an `actions` slot. |
+| `features/fulfillment/components/fulfillment-task-action-dialog.tsx` + `.schema.ts` | The three form-bearing actions (`hold`, `release_hold`, `force_cancel`). Prop-driven `mode`, never inferred from state. |
+| `app/api/api-client.ts` | The `fulfillment` namespace is **already registered** by #2411. #2410 makes **zero** edits to this file. |
+| `.eslintrc.js` | The `**/fulfillment/{api,hooks,components,lib,types}/**` entries are **already present in both `no-restricted-imports` pattern groups** (#2411). #2410 makes **zero** edits to this file. The standing S3 rule is satisfied by inheritance; a verification step, not an edit (§ 6 step 0). |
+| `scripts/check-ui-vocabulary.mjs` | `features/fulfillment` is **already a scan root** (owner `W3a-21 (#2411)`). #2410 makes **zero** edits to this file — see § 5 D1 for why the page is covered without one. |
+
+### 3b. EXTENDED — additive, #2411's consumer unaffected
+
+| File | Extension | Why it cannot break #2411 |
+|---|---|---|
+| `features/fulfillment/api/fulfillment.api.ts` | Add `list(filters): Promise<FulfillmentTaskPage>` and `get(workId): Promise<FulfillmentTask>` to `FulfillmentApi`. `listByOrder` is **kept and re-expressed as `list({ orderId })`** — identical signature, identical URL, one query-string builder. | Purely additive interface members; `listByOrder`'s signature, return type and emitted URL are unchanged. A test pins that `listByOrder('x')` still requests `/fulfillment/works?orderId=x`. |
+| `features/fulfillment/api/fulfillment.query-keys.ts` | Add `list(filters)` and `detail(workId)`. `all` and `worksByOrder` untouched. | Additive. Both new keys are prefixed `['fulfillment', …]`, so `all` remains a valid invalidation ancestor of every key in the slice. |
+| `features/fulfillment/index.ts` | Add the worklist exports the page needs: `useFulfillmentTasksQuery`, `FulfillmentTaskActions`, `FulfillmentTaskCard`, `FulfillmentTaskActionDialog`, `useFulfillmentTaskActionMutation`, `readFulfillmentConflict`, the copy helpers, the filter helpers, and the `FulfillmentTaskFilters` type. | Additive exports only; #2411's four exports stay. The docblock's own words — *"#2410's standalone worklist is the second consumer of this slice's api/hooks/lib; those stay internal until it needs them"* — anticipate exactly this edit. |
+| `features/fulfillment/hooks/use-fulfillment-task-action-mutation.ts` | **One line**: invalidate `fulfillmentQueryKeys.all` instead of `fulfillmentQueryKeys.worksByOrder(orderId)`, on both the success and the conflict path. `orderId` stays on the input (it is not otherwise load-bearing, and removing it would be a breaking change for no gain). | Strictly widens what is refreshed. #2411's panel is a descendant of `all`, so it still refetches. **See § 5 O1 — this is the one item flagged to the orchestrator.** |
+| `apps/web/src/index.css` | Append a `.fulfilment-worklist*` block. `.fulfilment-task*` (#2411) is reused as-is for the card. | Appended after #2411's block; no existing selector is edited. Textual-merge risk only — see § 5 O2. |
+| `apps/web/src/test/test-utils.tsx` | Add `list` and `get` to the `fulfillment` entry of `createMockApiClient`. #2411's default answers `listByOrder` + `applyAction` only, so **every page-level test in § 9 would otherwise call `apiClient.fulfillment.list(…)` on `undefined`.** The default `list` returns a page object (`{ works: [], total: 0, limit: 25, offset: 0 }`), never a bare array, for the reason #2411's own comment gives. | Additive members on the same object literal; `listByOrder` and `applyAction` untouched. |
+
+### 3c. NEW to this body
+
+| File | Purpose |
+|---|---|
+| `features/fulfillment/lib/fulfillment-filters.ts` | Read/write `orderId`, `locationId`, `offset` search params. `offset` is paging, not a filter, so it is excluded from `hasActiveFilters` (the `returns-filters.ts` rule) — an empty page from paging past the end is a different operator situation from an empty page from a filter. |
+| `features/fulfillment/lib/fulfillment-lanes.ts` | Pure `groupTasksIntoLanes(tasks)` → ordered groups keyed by `locationId` + `deliveryMethod`, stable "No location" / "No delivery method" labels for `null`. |
+| `features/fulfillment/lib/fulfillment-worklist.copy.ts` | Every user-visible worklist string (headings, empty states, filter labels, toasts). A `*.copy.ts` under an already-scanned root, so the vocabulary gate covers it with no script change. |
+| `features/fulfillment/hooks/use-fulfillment-tasks-query.ts` | The filtered/paged list query, keyed `fulfillmentQueryKeys.list(filters)`. |
+| `features/fulfillment/components/fulfillment-worklist-row.tsx` | The desktop row. Composes the same `FulfillmentTaskActions` and the same hold/line renderings as the card, so the two surfaces cannot disagree about what a task is. |
+| `features/fulfillment/components/fulfillment-lane-section.tsx` | One lane heading + its rows/cards. |
+| `features/fulfillment/fulfilment-worklist-styles.test.ts` | The CSS gate. Placed **inside the feature folder**, beside the `who-decides-styles.test.ts` precedent it reuses structurally, reading both the feature dir and the page file from there. |
+| `pages/fulfillment/fulfillment-worklist-page.tsx` | Filters, lanes, paging, four distinct states, and the one `useWriteAccess('orders:write', useDemoMode())` call (D6). **Contains no string literals of its own** — all copy comes from the feature's `*.copy.ts`, which is what keeps it inside the vocabulary gate's reach (§ 5 D1). |
+| `app/routes/fulfillment.route.tsx` | Lazy route + `handle.crumb` `{ group: 'Operations', title: 'Fulfilment' }`. Bumps `EXPECTED_LAZY_ROUTE_COUNT` (61 → 62) in `app/routes/route-lazy.test.ts`. |
+| `app/nav-registry.ts` | Nav entry under Operations. |
+
+### 3d. On #2411 and deliberately NOT used
+
+| File | Why not |
+|---|---|
+| `features/fulfillment/hooks/use-order-fulfillment-tasks-query.ts` | Order-scoped (`listByOrder`), keyed `worksByOrder`. The worklist is filter-scoped and paged, so it gets its own hook (§ 3c). The hook is left untouched — but it is the **owner of the key O1 talks about**: after O1 the action mutation invalidates `all`, which is this hook's key's ancestor, so this panel still refetches. |
+| `features/fulfillment/components/order-fulfillment-tasks-panel.tsx` | The order-detail panel itself. The worklist is a different surface with filters, lanes and paging; nothing about the panel's shell is reusable, and its parts (card, actions, dialog) are consumed directly instead. |
+| `features/orders/index.ts` (the four hold exports #2411 adds) | Not imported by #2410 directly. Consumed **transitively** — #2411's card and dialog import `holdReasonLabel` / `HOLD_REASON_COPY` / `HoldReasonValues` through the orders barrel. A second reason #2410 cannot precede #2793 (they are absent from `wave-3a`). |
+
+---
+
+## 4. Research — the #2406 contract, read from source
+
+`GET /fulfillment/works` → `{ works, total, limit, offset }`. `limit`/`offset` in the response are
+**what the server applied after clamping** (`FULFILLMENT_WORKLIST_DEFAULT_LIMIT = 25`,
+`FULFILLMENT_WORKLIST_MAX_LIMIT`), so the pager reads them and never the values it requested.
+Query params: `status[]`, `requestStatus[]`, `locationId`, `orderId`, `limit`, `offset`; the DTO
+accepts both `?status=a&status=b` and `?status=a,b`.
+
+`POST /fulfillment/works/:workId/actions/:action` body:
+`{ expectedVersion (required), holdReason?, cancellationReason?, holdId?, note?, releaseNote? }`.
+Responds `201` with the refreshed task.
+
+Refusals, from `FulfillmentWorkController.toHttp`:
+
+| Status | `code` | Meaning for the client |
+|---|---|---|
+| 409 | `version_conflict` | Someone moved it first. Retryable **after the operator re-reads** — never automatically. |
+| 409 | `action_not_legal` | Token was current; the state refused. Not retryable. |
+| 409 | *(none)* | Hold limit exceeded / hold already released. The **server's own message** is used verbatim. |
+| 400 | — | Not invocable, or a missing per-action field. Server message used. |
+| 404 | — | No such task or hold. |
+
+`OPERATOR_INVOCABLE_ACTIONS = ['schedule','hold','release_hold','mark_in_progress','close','force_cancel']`.
+The issue title's "mark-picked / mark-shipped" map onto `mark_in_progress` and `close` in the
+shipped vocabulary. **The FE labels the ids the server sends and never assumes this set** —
+#2411's copy table is a lookup with a humanising fallback, not a declaration of legality.
+
+Two facts the contract states that the UI must obey, both already honoured by the #2411 components
+this body reuses:
+
+1. **Heldness is `activeHolds`, not `status`.** Nothing writes `status = 'on_hold'`.
+2. **Line counters are display-only.** `recordLineProgress` does not bump `version`, so a counter
+   can move under a valid token. No action may be gated on one.
+
+---
+
+## 5. Decisions, assumptions, and the items for the orchestrator
+
+### For the orchestrator
+
+- **O1 — `use-fulfillment-task-action-mutation.ts` invalidates an ORDER-scoped key, which is the
+  wrong grain for two consumers.** #2411 invalidates `fulfillmentQueryKeys.worksByOrder(orderId)`.
+  The worklist's rows are keyed `list(filters)`, so an action taken from the worklist would leave
+  the worklist itself showing the pre-action task — including a stale `version`, which turns the
+  operator's *next* click into a `version_conflict` the UI itself caused. Invalidating
+  `fulfillmentQueryKeys.all` fixes it, still refreshes #2411's panel (its key is a descendant), and
+  is a one-line change. **Preferred: #2793 makes this change before merging** — it is strictly
+  more correct for #2411 too, since a task can also be moved from the worklist while the panel is
+  open. **Fallback if #2793 merges first**: #2410 makes the one-line change, which is then an edit
+  to a merged file rather than a cross-PR reach. *This is NOT a blocking defect in #2793 —
+  #2411's panel is correct in isolation.*
+- **O2 — three shared files are appended to by both bodies and will need a textual merge**:
+  `apps/web/src/index.css` (both append a block at EOF), `features/fulfillment/index.ts` (both add
+  exports), and `features/fulfillment/api/fulfillment.query-keys.ts`. All three are additive on
+  both sides, so resolution is "keep both", but the merge must be resolved *by intent* and the
+  invariant re-grepped afterwards. #2410 makes **zero** edits to `.eslintrc.js`,
+  `apps/web/src/app/api/api-client.ts` and `scripts/check-ui-vocabulary.mjs`, so those three
+  collision points are removed entirely.
+- **O3 — no shaping defect found in #2411 beyond O1.** `FulfillmentTaskActions`,
+  `FulfillmentTaskCard`, `FulfillmentTaskActionDialog`, `readFulfillmentConflict` and the copy
+  table are all already prop-driven and order-agnostic; every one is consumable by the worklist
+  with no change.
+
+### Decisions
+
+- **D1 — the page carries no string literals; all worklist copy lives in
+  `features/fulfillment/lib/fulfillment-worklist.copy.ts`.** `check-ui-vocabulary.mjs` asserts
+  `SCAN_ROOT_PARENT === apps/web/src/features`, so `pages/fulfillment` **cannot** be added as a
+  scan root without restructuring a shared gate that #2793 is concurrently editing. Putting the
+  copy where the gate already looks is better than widening the gate: it needs no script change, no
+  cross-PR file, and it is where the copy belongs anyway. The AC's copy-audit test is then a
+  *rendered-output* audit (§ 9), which is strictly stronger than a source scan because it also
+  catches the gate's own documented blind spot #2 (runtime-assembled strings).
+- **D2 — a `supportedActions` entry with no copy is rendered with a humanised raw label**, per
+  #2411's already-shipped behaviour. Hiding it would silently conceal a legal operation the moment
+  the backend grows one. The worklist inherits this by reusing the component; it does not restate
+  the policy.
+- **D3 — a `version_conflict` is never auto-retried.** "Retryable" means the operator may retry
+  after seeing refreshed state. Silently re-posting `close` against state the operator has not seen
+  is exactly the double-ship the token exists to prevent.
+- **D4 — grouping groups the rows on the CURRENT PAGE.** Stated in the lane caption so a lane is
+  never read as complete.
+- **D5 — the pager reads `page.limit` / `page.offset` from the response**, never the requested
+  values, because the server clamps.
+- **D6 — write access is `useWriteAccess('orders:write', useDemoMode())`, the same permission
+  #2411's panel uses, and the page owns that decision.** `FulfillmentTaskActions` takes `visible`
+  and `readOnly` as props precisely so the permission is resolved once per surface rather than
+  inside a component that is rendered per row. `orders:write` is reused rather than a new
+  `fulfillment:write` minted, for two reasons: the backend route is `@Roles('admin','operator')` —
+  the same roles the order write routes carry, so a new permission would not narrow anything real —
+  and a permission that exists in `apps/web` and is granted to nobody would hide the whole worklist's
+  controls on every deployment. Introducing one is a session/RBAC change, not a frontend body's
+  decision. Consequences that must be honoured: `visible === false` (a genuinely unauthorized
+  non-demo session) renders **no** action controls, and `demoReadOnly === true` renders them
+  **disabled inside a `ReadOnlyLock`** rather than hidden — the #1615 split — so a public demo still
+  advertises the capability. Both are asserted (§ 9 AC1) and the read-only render is one of the
+  states the copy audit covers (§ 9 AC4).
+
+### Open questions (recorded, not blocking)
+
+- **Q1** — a status filter needs a server-supplied facet list; see § 7 Alternative 1. Recorded in
+  the PR body as a follow-up.
+- **Q2** — the hold cap (10 active) is enforced server-side and answers a bare 409. The FE surfaces
+  the server's sentence and does not pre-count.
+
+---
+
+## 6. Implementation Plan
+
+**Step 0 (gating)** — rebase onto `oms-programme-wave-3a` *after* #2793 merges, and verify by
+grep, not by assumption: `.eslintrc.js` carries `**/fulfillment/api/**` in both pattern groups;
+`api-client.ts` carries the `fulfillment` namespace; `check-ui-vocabulary.mjs` lists
+`features/fulfillment` as a scan root. If any is absent, the corresponding edit moves back into
+this body's scope and the plan's "zero edits" claims are revised in the PR body.
+
+**Phase 1 — data layer (extensions)**
+1. `api/fulfillment.api.ts` — add `list` / `get`; re-express `listByOrder` through `list`.
+2. `api/fulfillment.query-keys.ts` — add `list(filters)` / `detail(workId)`.
+3. `hooks/use-fulfillment-task-action-mutation.ts` — the O1 one-liner, if not already done by #2793.
+4. `apps/web/src/test/test-utils.tsx` — add `list` / `get` to the `fulfillment` mock. **Done in
+   Phase 1, not when a test first needs it**: every page-level test in § 9 depends on it, and a
+   default that answers `undefined` fails as an inscrutable render crash rather than as a missing mock.
+
+**Phase 2 — pure logic (all in `lib/`, all unit-tested)**
+5. `lib/fulfillment-filters.ts` — search-param read/write; `offset` excluded from `hasActiveFilters`.
+6. `lib/fulfillment-lanes.ts` — `groupTasksIntoLanes`.
+7. `lib/fulfillment-worklist.copy.ts` — every user-visible worklist string.
+
+**Phase 3 — hooks**
+8. `hooks/use-fulfillment-tasks-query.ts` — the filtered/paged list.
+
+**Phase 4 — components**
+9. `components/fulfillment-worklist-row.tsx` — desktop row, composing `FulfillmentTaskActions`.
+10. `components/fulfillment-lane-section.tsx` — lane heading + rows (desktop) / cards (below the
+   breakpoint), the card being #2411's `FulfillmentTaskCard`.
+
+**Phase 5 — page, route, nav**
+11. `pages/fulfillment/fulfillment-worklist-page.tsx` — filters, lanes, paging, and four **distinct**
+    states: loading (skeleton, never "no tasks"), error (retry), empty-because-filtered,
+    empty-because-nothing-to-do. Resolves write access once via `useWriteAccess('orders:write',
+    useDemoMode())` (D6), owns the dialog state, and passes `expectedVersion` from the task it
+    rendered.
+12. `app/routes/fulfillment.route.tsx` + `EXPECTED_LAZY_ROUTE_COUNT` 61 → 62.
+13. `app/nav-registry.ts` — Operations entry.
+14. `features/fulfillment/index.ts` — additive exports.
+15. `apps/web/src/index.css` — `.fulfilment-worklist*` block.
+16. `features/fulfillment/fulfilment-worklist-styles.test.ts` — the CSS gate, **inside the feature
+    folder** beside its `who-decides-styles.test.ts` precedent rather than under `pages/`, reading
+    both the feature dir and the page file from there (§ 9 AC3).
+
+---
+
+## 7. Alternatives Considered
+
+**Alternative 1 — ship a status / requestStatus filter. Rejected.** Both vocabularies are closed
+unions in `libs/core` exposed by no endpoint. Three substitutes were considered and each is worse:
+deriving options from the rows on the current page traps the operator the moment they filter (the
+other statuses are no longer in the data); a second unfiltered "facet" query is an extra request
+that is still incomplete past the first page; forwarding an unvalidated URL value 400s the whole
+page on a typo. The honest fix is a server-supplied facet list — a contract change to a just-merged
+shared surface. Deferred and recorded rather than approximated. Lane grouping gives the operator
+the structure a status filter would have.
+
+**Alternative 2 — build the worklist's own components rather than reusing #2411's. Rejected.** Two
+components rendering `supportedActions` is two places the "no client-side state machine" rule can be
+broken, and only one of them would be under the eye of the reviewer who wrote the rule. Reuse makes
+the AC structurally true rather than separately re-argued.
+
+**Alternative 3 — add `pages/fulfillment` as a vocabulary scan root. Rejected** — see D1. It
+requires changing `SCAN_ROOT_PARENT` on a shared gate #2793 is editing concurrently, to buy
+something D1 achieves with no shared-file edit at all.
+
+**Alternative 4 — auto-retry on `version_conflict`. Rejected** — see D3.
+
+**Alternative 5 — a second FE mirror of `HoldReasonValues` in `features/fulfillment`. Rejected.**
+`features/orders/lib/order-hold.types.ts` holds one and `scripts/check-hold-reason-mirror.mjs`
+guards it; #2411 already imports it through the orders barrel. A second copy would be unguarded.
+
+---
+
+## 8. Validation & Risks
+
+| Risk | Mitigation |
+|---|---|
+| A worklist component slips in an `if (status === …)` — the drift the static guard admits it cannot catch | The worklist renders actions **only** through #2411's `FulfillmentTaskActions`, and a test asserts two rows with identical `supportedActions` but different `status` render identical controls (§ 9 AC1). |
+| An action gated on a display-only counter | A test asserts two rows differing only in `fulfilledQuantity` render identical controls. |
+| An action taken from the worklist leaves the worklist stale, manufacturing the next 409 | O1 — invalidate `fulfillmentQueryKeys.all`. Asserted by a test, not by inspection. |
+| Pager disagrees with the server's clamp | Paging reads `page.limit` / `page.offset` from the response; a test feeds `limit: 100` requested / `25` returned and asserts the pager uses 25. |
+| "Nothing to do" rendered over an unresolved query | Loading and error are their own states; a test asserts the loading render contains neither empty-state sentence. |
+| A banned term ships in copy | All copy lives under the already-scanned feature root, plus the rendered-output audit (§ 9 AC4), whose term list is read from the fenced spec table rather than restated. |
+| Write controls ship to a read-only or unauthorized session | D6 — the page resolves `useWriteAccess('orders:write', useDemoMode())` once and passes `visible` / `readOnly` down; § 9 AC1(d) asserts both arms, including that demo read-only DISABLES rather than hides (#1615). |
+| A page-level test crashes on an incomplete api mock rather than on its subject | `test-utils.tsx`'s `fulfillment` mock gains `list` / `get` in Phase 1, before any test needs them. |
+| Textual merge with #2793 on three shared files | O2 — resolve by intent, then re-grep the invariants of step 0. |
+
+**Backward compatibility**: additive throughout. New route, new page, new modules in an existing
+feature slice, additive members on an existing api/query-key/barrel.
+
+---
+
+## 9. Testing strategy — and how each acceptance criterion is proven able to FAIL
+
+The programme's recurring defect is **a check that cannot fail**. For each AC below: what already
+covers it, the specific new assertion, whether that assertion touches code this body changes, and
+the concrete break that must turn it red. Where a property is already asserted on both sides and a
+new assertion would be vacuous, that is stated rather than a ceremonial test added.
+
+---
+
+**AC1 — "No client-side state machine: every action originates from `supportedActions`."**
+
+*Already covered elsewhere*: partially. `scripts/check-no-supported-actions-mirror.mjs` catches a
+`derive*SupportedActions` or `FulfillmentWorkAction[Values]` declaration under `apps/web/src`, and
+says in its own docblock that it cannot catch an inline `if (status === 'open')`. #2411 has a spec
+over `FulfillmentTaskActions` itself, and that component provably reads nothing but
+`supportedActions` and `activeHolds`. **So the property is already true of the component; what is
+NOT covered is what the worklist row SELECTS TO HAND DOWN**, which is the only place in this body a
+legality decision could be reintroduced. The assertions are written against the row for that reason,
+not against the component.
+
+*New assertions*, in `components/fulfillment-worklist-row.test.tsx`:
+- **(a) status-independence** — two tasks identical except for `status` (`'open'` vs `'in_progress'`)
+  and `requestStatus`, both `supportedActions: ['hold','close']`, render the same control labels.
+- **(b) counter-independence** — two tasks differing only in `lines[0].fulfilledQuantity`.
+- **(c) hold-independence** — one task with `supportedActions: ['hold','close']` and a **non-empty**
+  `activeHolds`; both controls still render. This is the plausible row-level defect the first two
+  miss (a row that suppresses `hold` because the task is already held is a legality decision, and
+  the server is the one that decides that — it simply does not offer `hold` when it is not legal).
+- **(d) permission** (D6) — `visible: false` renders zero controls; `readOnly: true` renders the
+  same control set, disabled, inside a `ReadOnlyLock`. Hiding on demo read-only is the #1615
+  regression this pins.
+
+*Does it touch code under change?* Yes — the row is new here and is the only place these decisions
+can live.
+
+*Red-first proof*: (a) add `if (task.status !== 'open') return null;` around the row's action strip
+→ the `'in_progress'` case renders zero controls, comparison fails. (c) add
+`supportedActions.filter(a => a !== 'hold' || task.activeHolds.length === 0)` → the held case loses
+a control. (d) change `readOnly` to hide rather than disable → the disabled-control assertion fails.
+Each run recorded in the PR body with its observed output.
+
+*Vacuity guard*: every case first asserts the baseline render produced a **non-empty** control list.
+Comparing two empty arrays is exactly the shape of a check that cannot fail, and is what a
+`supportedActions: []` fixture — or a `visible: false` typo'd into the shared fixture — would
+silently produce.
+
+---
+
+**AC2 — "The 409 path is covered by a test and produces a refreshed, non-destructive UI."**
+
+*Already covered elsewhere*: `lib/fulfillment-conflict.ts` and its spec are #2411's and classify
+both codes. **This body adds no assertion there** — re-testing a pure function over an in-memory
+object from a second file would pass with this entire body reverted, which is precisely the vacuous
+assertion the brief warns against. What is not covered is the worklist's own behaviour on a 409.
+
+*New assertion*, in `pages/fulfillment/fulfillment-worklist-page.test.tsx`, with a mocked api client:
+1. `list` resolves one task, `supportedActions: ['close']`, `version: 3`;
+2. the operator clicks the *Close* control; `applyAction` rejects with
+   `ApiError(409, { code: 'version_conflict', currentVersion: 4, supportedActions: ['hold'] })`;
+3. the next `list` resolves the same task with `version: 4`, `supportedActions: ['hold']`.
+
+Assert, in order: **(a)** `applyAction` was called **exactly once**, with `expectedVersion: 3` — no
+auto-retry, and the rendered token was sent rather than a fresher one; **(b)** `list` was called
+**exactly twice** — the refresh happened; **(c)** the row is still in the DOM — non-destructive;
+**(d)** after the refetch the visible control is the one labelled by
+`FULFILLMENT_ACTION_COPY['hold'].label` and the `['close']` label is gone. **(d) reads the label
+out of #2411's copy table rather than hardcoding "Put on hold"**, so a copy edit cannot make the
+assertion silently stop asserting anything about which action is offered. The `action_not_legal`
+case repeats (a)–(c) with the not-retryable copy.
+
+*Does it touch code under change?* Yes — the list query key, the page's mutation wiring and the O1
+invalidation grain are all this body's.
+
+*Red-first proof*: three independent breaks, each run and recorded.
+- Delete the mutation's `onError` conflict branch, or revert O1 to `worksByOrder`, → **(b)** fails,
+  because the list key is never invalidated. **This is the break a naive 409 test survives**, and is
+  the whole reason (b) counts calls.
+- Make the mutation read `version` out of the cache instead of the rendered task → (a) fails on the
+  `expectedVersion` argument.
+- Remove the row on error → (c) fails.
+
+*Vacuity guard*: (b) asserts the call count is exactly 2, never `>= 1` and never merely "the promise
+settled" — React Query settles either way, so an await-only test passes with the handler deleted.
+
+---
+
+**AC3 — "Desktop + tablet + mobile layouts verified."**
+
+*Already covered elsewhere*: no. `.fulfilment-task*` is #2411's; the lane and row layout is new.
+
+*New assertions*, three parts, because a JSDOM test cannot compute CSS and a text scan over CSS is
+where this programme has already shipped a check that could not fail.
+
+1. **Both surfaces agree** (`fulfillment-worklist-page.test.tsx`): the desktop container and the card
+   list both render — the breakpoint switch is CSS, the house pattern — and the set of task ids in
+   the card path equals the set in the desktop path. Two surfaces showing different tasks is the
+   real defect; that they are both present is incidental.
+2. **Class coverage** (`features/fulfillment/fulfilment-worklist-styles.test.ts`): **structurally
+   reuses `who-decides-styles.test.ts` rather than re-deriving a matcher.** That means: collect the
+   `.fulfilment-worklist*` class names the feature `.tsx` files and the page emit (both the
+   `className="…"` form and the `'…'` array form); build the set of **declared selectors** with
+   `css.matchAll(/\.(-?[_a-zA-Z][\w-]*)/g)` and test **membership**, never `css.includes('.'+name)`;
+   exempt a BEM **block root** via `css.includes('.'+name+'__') || css.includes('.'+name+'--')`, so a
+   namespace-only `.fulfilment-worklist` root does not fail spuriously and invite loosening the
+   matcher, while a **leaf** with no rule still fails; assert `used.size > 0`; and carry the
+   precedent's **guard of the guard** — a fabricated leaf name (a truncation of a real class) is
+   asserted to be absent from `declared`, absent from `isBlockRoot`, and **present** under the old
+   substring test, which is the standing proof that the matcher is stronger than the one that
+   shipped the defect. The precedent's second and third `it()`s (undeclared custom properties;
+   two parts sharing one grid area) are adopted verbatim in shape for the new classes.
+3. **The breakpoint itself** — same file. `display:none` on the desktop container must live **inside**
+   a `@media` block, or the desktop table renders on a phone. A regex for `display:none` near the
+   class name passes on a match inside a comment, inside an unrelated `@media`, or on a rule a later
+   block overrides — so the test **extracts media blocks by brace counting** (find `@media`, walk to
+   its matching close brace) and asserts: the `.fulfilment-worklist__desktop { display: none }`
+   declaration occurs **only** inside a media block whose condition contains `max-width`, and the
+   `.fulfilment-worklist__cards` `display:none` only inside one containing `min-width`. Comments are
+   stripped (`/\/\*[\s\S]*?\*\//g`) before any matching, since a commented-out rule is the exact
+   vector the brief names.
+
+*Does it touch code under change?* Yes — the markup, the classes and the CSS block are all new here.
+
+*Red-first proof*, four runs, all recorded: delete the `.fulfilment-worklist__cards` rule → part 2
+red. Rename that class in the CSS only → part 2 red **(a substring matcher would stay green; this is
+the run that proves the matcher, and the fabricated-leaf guard asserts the same thing statically)**.
+**Move the desktop `display:none` rule OUT of its `@media` block** → part 3 red. Make the card path
+render a different subset of tasks → part 1 red.
+
+*Manual verification*: 390 / 834 / 1440 in the browser, recorded in the PR body. The automated part
+proves the rules exist, are inside the right media blocks, and that the two surfaces agree — not
+that the result looks right, and the plan does not claim otherwise.
+
+---
+
+**AC4 — "Copy audit test: none of the three banned words appears in user-visible strings."**
+
+*Already covered elsewhere*: partially, and the boundary is the point.
+`check-ui-vocabulary.mjs` already scans `features/fulfillment` (#2411's scan root, verified), so
+every `*.copy.ts` and `.tsx` this body adds **under that folder** is gated with no script change —
+which is why D1 puts all worklist copy there. The script's own documented blind spots are `pages/`,
+runtime-assembled strings, and backend-sourced messages; this body renders a backend-sourced message
+on the un-coded 409 path and humanises raw vocabulary values, so it lands in two of the three.
+
+*New assertion*, `pages/fulfillment/fulfillment-copy-audit.test.tsx`: render the page across every
+state it can reach — loading, error, empty-filtered, empty-unfiltered, populated with a held task, a
+task with an unrecognised `status`, a task with an unrecognised action id, **and the demo read-only
+render (D6)** — and assert `document.body.textContent` matches none of the banned terms. A
+**rendered-output** audit, not a source scan.
+
+**The banned terms are READ, not restated.** The test parses the fenced `<!-- ui-vocabulary:start -->`
+table in `docs/specs/product-spec-oms-wave2-operator-experience.md` with the same fence constants the
+script uses — the script already treats that table as the single source under its Rule A, and a
+hand-copied list here would be a **second, ungated mirror of a nine-term vocabulary**, drifting the
+day a tenth term or a mode change lands. (The draft of this plan had already drifted: it enumerated
+the modes and omitted `atpEffect`'s `'ATP'` alternate.) Match modes come from the same rows, so
+whole-word vs case-sensitive-substring cannot diverge either. If the fence parses to zero rows the
+test **fails** — the script's own Z1 rule, because a scan with an empty deny-list cannot fire.
+
+*Does it touch code under change?* Yes — it renders this body's page and copy module.
+
+*Red-first proof*: two breaks. **(i)** plant `posture` in a `fulfillment-worklist.copy.ts` empty-state
+sentence → red. **(ii)** plant it in a **fixture's** `status` value, so it reaches the screen only
+through the humanising fallback and appears in no source literal → red **while the shared script
+stays green** — which is the evidence that this test is not a duplicate of the script but covers its
+blind spot.
+
+*Vacuity guard, and the one that matters most here*: each state's assertion first asserts the render
+produced **non-empty** text and contains a sentinel string known to be in that state's copy. A
+banned-word scan over an empty render passes trivially. Each state is its own `it()` so one throwing
+render cannot silently skip the other seven.
+
+---
+
+**AC5 — "Tests added or updated for non-trivial logic."**
+
+Covered by the above plus: `lib/fulfillment-lanes.test.ts` (ordering, `null` location and `null`
+delivery method get their stable labels, two tasks with the same pair land in one lane),
+`lib/fulfillment-filters.test.ts` (round-trip; `offset` excluded from `hasActiveFilters` — proved red
+by adding `offset` to the predicate and watching the "paged past the end is not filtered" case fail),
+`api/fulfillment.api.test.ts` (`list` emits only defined params; `listByOrder` still emits
+`/fulfillment/works?orderId=x` after the § 3b re-expression — the regression guard for the one
+existing method this body rewrites).
+
+**AC6 — "`shared` imports no `features`/`pages`."**
+
+*Already covered elsewhere*: **yes, fully and on both sides.** `.eslintrc.js` carries the
+`no-restricted-imports` pattern groups, and #2411 has already registered the `fulfillment/**`
+patterns in both. This body adds no file under `shared/` and edits no ESLint config. **No new
+assertion is added**: a test that re-states an existing lint rule over code this body does not touch
+would pass with the entire change reverted — the manufactured-check shape the brief warns against.
+Verification is step 0's grep plus `pnpm lint`, and the PR body records that this AC is satisfied by
+inheritance rather than by new coverage.
+
+---
+
+## 10. Alignment Checklist
+
+- [x] `app → pages → features → shared` respected; `shared/` untouched
+- [x] Feature barrel extended; both ESLint pattern groups already carry the slug (#2411) — verified, not re-added
+- [x] `.nullish()` over the projection (#939) — inherited from #2411's schema
+- [x] No `supportedActions` derivation; no action / status / requestStatus vocabulary retyped
+- [x] Every #2411 primitive consumed rather than duplicated; every extension additive and pinned by a regression test
+- [x] No backend change, no core change, no migration
+- [x] Loading / empty-filtered / empty-unfiltered / error states all distinct and deliberate
+- [x] Write access resolved once, at the page, through the existing `orders:write` permission (D6)
+- [x] The CSS gate reuses the shipped `who-decides-styles.test.ts` matcher, fabricated-leaf guard included — no re-derived substring check
+- [x] The copy audit reads its banned terms from the fenced spec table — no second ungated mirror
+- [x] Each acceptance criterion has a named assertion, a stated red-first break, and a vacuity guard — or a stated reason it needs no new assertion
+- [x] Execution-ready once #2793 merges


### PR DESCRIPTION
The standalone operator worklist over the #2406 read model: a filtered, paged list of fulfilment tasks grouped by location and delivery method, with per-line counters, work-grain hold chips, and the manual actions the **server** says are legal on each.

This is the **second consumer** of the `features/fulfillment` slice #2411 (PR #2793) created, so ~40% of the originally-planned surface is reuse. Consumed unchanged: the boundary schema (so #939&#39;s `.nullish()` rule is *inherited*, not re-satisfied), the transport types, the conflict reader, the copy table, `FulfillmentTaskActions`, `FulfillmentTaskCard` and the action dialog. Inherited with **zero edits**: the `fulfillment` api-client namespace, both `.eslintrc.js` pattern groups and the `check-ui-vocabulary.mjs` scan root — each verified by grep rather than assumed. New here: filters, lanes, the paged list hook, a desktop row, the page, a route and a nav entry.

## Four load-bearing properties

**No client-side state machine, structurally.** The row renders actions ONLY through #2411&#39;s `FulfillmentTaskActions` — it does not read `status`, `requestStatus` or a counter, and does not filter `supportedActions`, not even to drop `hold` on an already-held task: the server offers `hold` exactly when a second hold is legal, and suppressing it would overrule the only party that knows. `check-no-supported-actions-mirror.mjs` says in its own docblock that it cannot catch an inline `if (status === …)`, so the assertions are written against **the row** — the one place in this body such a decision could live.

**A 409 refreshes and re-renders the server&#39;s action set; it is never auto-retried.** The token sent is the one that was RENDERED. The test asserts `list` was called **exactly twice** — the assertion that fails when the mutation&#39;s conflict branch is deleted or its key is narrowed back to `worksByOrder`. An await-only test survives both, because React Query settles either way.

**Both surfaces are always in the DOM and the breakpoint is CSS** — the `DataTable` `cardView` mechanic reproduced by hand, because lane grouping rules `DataTable` out. That is what lets a test assert the desktop rows and the cards show the same tasks. Each `display: none` must stay inside its own `@media` block, asserted by **brace-counting** the media blocks rather than a regex that would match inside a comment or an unrelated block.

**The page carries no user-visible string literals.** `check-ui-vocabulary.mjs` scans only under `apps/web/src/features`, so all worklist copy lives in a `*.copy.ts` there — the filename is load-bearing, as #2411 recorded after a one-character miss left 26 strings unscanned.

## Acceptance criteria

| AC | Where it is proven |
|---|---|
| No client-side state machine | `fulfillment-worklist-row.test.tsx` — status-, counter- and hold-independence, the positive `supportedActions`-tracking case, plus the permission split |
| 409 covered, refreshed + non-destructive | `fulfillment-worklist-page.test.tsx` — both coded 409s |
| Desktop + tablet + mobile | `fulfilment-worklist-styles.test.ts` + the two-surfaces-agree page test for the rules; **plus a real browser pass at 390 / 834 / 1440** — see below |
| Copy audit, no banned words | `fulfillment-copy-audit.test.tsx` — rendered-output, across 8 states |
| Tests for non-trivial logic | `fulfillment-filters`, `fulfillment-lanes`, `fulfillment.api` specs |
| `shared` imports no `features`/`pages` | inheritance — no file added under `shared/`, no ESLint edit; `pnpm lint` + step-0 grep |

## Red-first evidence

Every check was broken, watched fail for the stated reason, and reverted. Two were **false greens that this discipline caught**, and both are worth flagging to a reviewer:

- **&#34;Both surfaces agree&#34; could not fail as first written.** The fixture put each of three tasks in its own lane, so a per-lane `slice(0,1)` dropped nothing. Fixed by making two tasks share a lane; the break then goes red (`Set{ol_work_1, ol_work_3, …} to deeply equal Set{ol_work_1, ol_work_2, …}`).
- **The copy audit could not fire on most of the screen.** It scanned `document.body.textContent`, which concatenates siblings with no separator (`…ol_order_1Posture check…`), so a whole-word rule finds no boundary before a term abutting the previous node — and 6 of the 9 banned terms are whole-word. It now scans **discrete text nodes plus user-facing attributes**, the rendered-output analogue of the script scanning discrete string literals.

The two breaks that matter most, verbatim:

- Delete the mutation&#39;s conflict branch → `expected &#34;vi.fn()&#34; to be called 2 times, but got 1 times`. Reverting O1 to `worksByOrder` gives the identical failure.
- Rename `.fulfilment-worklist__cards` in CSS only → class-coverage red, **while the harness printed `substring test would say declared: True`** — i.e. the old `css.includes(&#39;.&#39; + name)` matcher would have stayed green. That is the run that proves the matcher.

Also: moving the desktop `display:none` out of its `@media` → breakpoint test red; planting `posture` in a copy literal → both this audit *and* the shared script red; planting it in a fixture&#39;s `status` so it reaches the screen only via the humanising fallback → **this audit red while the shared script stays green**, which is the evidence it covers the blind spot rather than duplicating the gate.

## Review findings applied

From the earlier rounds:

- **The filter inputs were uncontrolled**, so `Clear filters` cleared the URL and the list but left the typed text on screen — the page contradicting itself, and clicking Clear again appeared to do nothing. They now remount on the URL&#39;s own value, and **Enter commits** alongside blur (the previously-dead `filter.apply` copy key is deleted rather than left promising a control that does not exist). Both pinned by tests proven to fail without the fix.
- `.fulfilment-worklist-row` is **registered in the style guide&#39;s Density &amp; Row Heights table** with its own carve-out note; that section forbids introducing an unlisted row height.
- The feature barrel is **narrowed to what actually leaves the folder** — the row, the card, `summariseLaneLines` and the status/handshake labels are composed inside it and stay private (start-narrow rule).
- The lane&#39;s accessible name carries **both axes**, so two lanes at one location differing only by delivery method are distinguishable.

From the final round (commit `dfff742`):

- **The styles gate&#39;s regex escape escaped nothing — a third instance of the check-that-cannot-fail class.** `declaresDisplayNone` built its pattern with an inline `.replace(/[.*+?^${}()|[\]\\]\\]/g, …)` whose character class closed early on `[\]`, leaving a regex that matches no real class name. Verified in node: it returned `a.b\c` unchanged where the *correct* sibling `escapeRegExp` in the copy audit returns `a\.b\\c`. Harmless for today&#39;s class names, but a guard whose escaping cannot fire is the same defect one level down. Extracted to a named `escapeRegExp` and pinned by its own guard-of-the-guard — under the old escape a `.` in a class name stayed a wildcard, so `declaresDisplayNone('.axb …', 'a.b')` matched a **different** class and the breakpoint assertion read green against the wrong selector.
- **The row spec claimed a property it did not assert.** Its three cases all hold `supportedActions` constant and assert the control list does not change — which a component that ignored the field and hardcoded its own list satisfies equally. The positive half is now written where the property is claimed: a narrower server list renders strictly fewer controls, and an action this build has no copy-table entry for still reaches the operator, so the set cannot be a local vocabulary. (It was already proven incidentally in the copy audit and the 409 test; it now lives in the file that claims it.)
- **`fulfillmentQueryKeys.detail` had no consumer**, so it is removed — the start-narrow rule the barrel&#39;s own docblock states.

Raised and **withdrawn with evidence**: the pager renders `offset + limit` capped by `total`, which was queried as claiming rows that are not on screen. It is the house pattern across eight sibling pages (`shipments`, `orders`, `products`, `listings`, `customers`, `sync-jobs`, `webhook-deliveries`, `failed-orders`), and this page improves on it by reading the **server-applied** limit rather than its own request. Changing it here alone would have been a lone deviation, not a fix.

## AC3 — the three-width browser pass

Run against the real app (api + web + seeded `fulfillment_works` rows across four lanes, one lane holding two rows, one task held), measured in-page rather than eyeballed. Screenshots taken at each width.

| | 390 (coarse pointer) | 834 | 1440 |
|---|---|---|---|
| `innerWidth` reported by the page | 390 | 834 | 1440 |
| Horizontal page scroll | 0 | 0 | 0 |
| Elements past the viewport | none | none | none |
| Surface shown | cards (desktop `display:none`) | desktop rows | desktop rows |
| Visible action controls | 18 | 18 | 36 |
| Min tap-target height | **44 px** | 28 px | 28 px |
| Opaque `ol_*` ids | wrap (`overflow-wrap: anywhere`), right edge 348 &lt; 390 | ellipsis + `title` | ellipsis + `title` |

The 44 px floor at 390 is measured under a **genuine coarse-pointer emulation** (`pointer: coarse` and `hover: none` both reported true by `matchMedia`), which is what makes the global `@media (hover: none) and (pointer: coarse)` rule apply. The 28 px at 834 / 1440 is the correct fine-pointer value on a desktop browser, not a violation — a real 834 px tablet reports a coarse pointer and takes the same 44 px floor.

Lane hierarchy stays legible at every width: heading (location · delivery method · lane counter), the page-scope caption, then rows or cards. The held task is distinguishable on both surfaces (amber border + `ON HOLD — AWAITING_PAYMENT` badge) and its action strip **differs from its siblings** — `Release hold` present, `Schedule` / `Mark in progress` absent — which is the server-driven action set visible in the running product rather than only in a test.

One thing worth stating rather than hiding: at 390 the counters caveat appears twice in quick succession — once in the lane&#39;s page-scope caption (this PR) and again inside each card (#2411&#39;s card copy). It is redundant, not wrong, and the lane caption cannot simply drop it because the desktop **row** carries no caveat of its own. Left as-is; the alternative is a copy restructure across two slices.

## Deliberately not shipped

**No status / requestStatus filter.** Both vocabularies are closed unions in `libs/core` exposed by no endpoint, and every substitute is worse than none: deriving options from the current page traps the operator the moment they filter, a second unfiltered facet query is still incomplete past page one, and forwarding an unvalidated URL value 400s the whole page on a typo. The honest fix is a server-supplied facet list — a contract change, recorded as a follow-up. Lane grouping gives the structure that filter would have.

`submit` / `request_cancellation` are not in `OPERATOR_INVOCABLE_ACTIONS`, can never appear in `supportedActions`, and the FE never names them. Line-level progress recording has no HTTP surface; counters are display-only (#2400 moves them without bumping `version`, stated per lane).

The lane heading renders the raw `locationId` (`loc_warsaw_central`) because no read on this route resolves a location&#39;s human name. Visible in the screenshots; a follow-up, not a regression.

## Gate

`pnpm lint` 0 errors · `pnpm type-check` clean · `pnpm check:invariants` green, including `check-ui-vocabulary` (9 terms, 135 files across 5 of 5 folders) and `check-no-supported-actions-mirror` (1534 files, no FE mirror found). The full pre-commit hook passed on `dfff742` with `apps/web test: Test Files 461 passed (461)`.

## Note for the reviewer

The plan (`docs/plans/implementation-plan-fulfilment-worklist-frontend.md`) and its pre-implement gate ride in the first commit; the second is the implementation; the third is the final review round. The three-width browser pass above closes the AC3 caveat this PR previously carried — the automated checks prove the rules exist and sit inside the right media blocks, and the browser pass proves the result behaves at each width.

Closes #2410