### PR TITLE
feat(orders,analytics): aggregate-by-connection reads for Data Coverage categories

### DIFF
--- a/apps/api/src/analytics/http/analytics-coverage.controller.spec.ts
+++ b/apps/api/src/analytics/http/analytics-coverage.controller.spec.ts
@@ -19,16 +19,23 @@ import type { AnalyticsCoverageQueryDto } from './dto/analytics-coverage-query.d
 
 describe('AnalyticsCoverageController (#2466)', () => {
   const createOrderRecordService = (): jest.Mocked<
-    Pick<IOrderRecordService, 'getCurrencyMismatchOrders' | 'getProductMatchingErrorOrders'>
+    Pick<
+      IOrderRecordService,
+      | 'getCurrencyMismatchOrders'
+      | 'getCurrencyMismatchOrdersByConnection'
+      | 'getProductMatchingErrorOrders'
+    >
   > => ({
     getCurrencyMismatchOrders: jest.fn(),
+    getCurrencyMismatchOrdersByConnection: jest.fn(),
     getProductMatchingErrorOrders: jest.fn(),
   });
 
   const createTaxCoverageDetectionService = (): jest.Mocked<
-    Pick<ITaxCoverageDetectionService, 'getAllCategoryPages'>
+    Pick<ITaxCoverageDetectionService, 'getAllCategoryPages' | 'getAllCategoryCountsByConnection'>
   > => ({
     getAllCategoryPages: jest.fn(),
+    getAllCategoryCountsByConnection: jest.fn(),
   });
 
   const createReportingCurrencySettings = (): jest.Mocked<
@@ -293,5 +300,128 @@ describe('AnalyticsCoverageController (#2466)', () => {
     await expect(
       controller.getCoverage({ from: '2020-01-01T00:00:00.000Z', to: '2026-08-08T00:00:00.000Z' })
     ).rejects.toThrow(BadRequestException);
+  });
+
+  describe('getCoverageByConnection (#2713)', () => {
+    it('composes the currency + tax A/B/C aggregates into one { category, rows } list, excluding product-matching', async () => {
+      const { controller, orderRecordService, taxCoverageDetectionService, reportingCurrencySettings } =
+        buildController();
+      reportingCurrencySettings.resolve.mockResolvedValue('EUR');
+      orderRecordService.getCurrencyMismatchOrdersByConnection.mockResolvedValue([
+        { sourceConnectionId: 'conn-a', affectedCount: 3 },
+        { sourceConnectionId: 'conn-b', affectedCount: 1 },
+      ]);
+      taxCoverageDetectionService.getAllCategoryCountsByConnection.mockResolvedValue({
+        'tax-a': [{ sourceConnectionId: 'conn-a', affectedCount: 2 }],
+        'tax-b': [],
+        'tax-c': [{ sourceConnectionId: 'conn-b', affectedCount: 5 }],
+      });
+
+      const result = await controller.getCoverageByConnection(query);
+
+      expect(result.categories.map((row) => row.category).sort()).toEqual(
+        ['currency', 'tax-a', 'tax-b', 'tax-c'].sort()
+      );
+      const byCategory = new Map(result.categories.map((row) => [row.category, row.rows]));
+      expect(byCategory.get('currency')).toEqual([
+        { sourceConnectionId: 'conn-a', affectedCount: 3 },
+        { sourceConnectionId: 'conn-b', affectedCount: 1 },
+      ]);
+      expect(byCategory.get('tax-a')).toEqual([{ sourceConnectionId: 'conn-a', affectedCount: 2 }]);
+      expect(byCategory.get('tax-b')).toEqual([]);
+      expect(byCategory.get('tax-c')).toEqual([{ sourceConnectionId: 'conn-b', affectedCount: 5 }]);
+    });
+
+    it('resolves the current reporting currency ONCE and threads it into both reads', async () => {
+      const { controller, orderRecordService, taxCoverageDetectionService, reportingCurrencySettings } =
+        buildController();
+      reportingCurrencySettings.resolve.mockResolvedValue('PLN');
+      orderRecordService.getCurrencyMismatchOrdersByConnection.mockResolvedValue([]);
+      taxCoverageDetectionService.getAllCategoryCountsByConnection.mockResolvedValue({
+        'tax-a': [],
+        'tax-b': [],
+        'tax-c': [],
+      });
+
+      await controller.getCoverageByConnection(query);
+
+      expect(reportingCurrencySettings.resolve).toHaveBeenCalledTimes(1);
+      expect(orderRecordService.getCurrencyMismatchOrdersByConnection).toHaveBeenCalledWith(
+        expect.anything(),
+        'PLN'
+      );
+      expect(taxCoverageDetectionService.getAllCategoryCountsByConnection).toHaveBeenCalledWith(
+        expect.anything(),
+        'PLN',
+        expect.anything()
+      );
+    });
+
+    it("threads the operator's backfilled-tax-rate opt-in through (#2469)", async () => {
+      const displaySettings = createDisplaySettings(true);
+      const { controller, orderRecordService, taxCoverageDetectionService, reportingCurrencySettings } =
+        buildController(undefined, undefined, undefined, displaySettings);
+      reportingCurrencySettings.resolve.mockResolvedValue('EUR');
+      orderRecordService.getCurrencyMismatchOrdersByConnection.mockResolvedValue([]);
+      taxCoverageDetectionService.getAllCategoryCountsByConnection.mockResolvedValue({
+        'tax-a': [],
+        'tax-b': [],
+        'tax-c': [],
+      });
+
+      await controller.getCoverageByConnection(query);
+
+      expect(taxCoverageDetectionService.getAllCategoryCountsByConnection).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        true
+      );
+    });
+
+    it('narrows both underlying reads when sourceConnectionId is provided', async () => {
+      const { controller, orderRecordService, taxCoverageDetectionService, reportingCurrencySettings } =
+        buildController();
+      reportingCurrencySettings.resolve.mockResolvedValue('EUR');
+      orderRecordService.getCurrencyMismatchOrdersByConnection.mockResolvedValue([]);
+      taxCoverageDetectionService.getAllCategoryCountsByConnection.mockResolvedValue({
+        'tax-a': [],
+        'tax-b': [],
+        'tax-c': [],
+      });
+
+      await controller.getCoverageByConnection({ ...query, sourceConnectionId: 'conn-a' });
+
+      expect(orderRecordService.getCurrencyMismatchOrdersByConnection).toHaveBeenCalledWith(
+        expect.objectContaining({ sourceConnectionId: 'conn-a' }),
+        'EUR'
+      );
+      expect(taxCoverageDetectionService.getAllCategoryCountsByConnection).toHaveBeenCalledWith(
+        expect.objectContaining({ sourceConnectionId: 'conn-a' }),
+        'EUR',
+        expect.anything()
+      );
+    });
+
+    it('throws BadRequestException when to is not after from', async () => {
+      const { controller } = buildController();
+
+      await expect(
+        controller.getCoverageByConnection({
+          from: '2026-08-08T00:00:00.000Z',
+          to: '2026-08-01T00:00:00.000Z',
+        })
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('throws BadRequestException when the range exceeds the max window', async () => {
+      const { controller } = buildController();
+
+      await expect(
+        controller.getCoverageByConnection({
+          from: '2020-01-01T00:00:00.000Z',
+          to: '2026-08-08T00:00:00.000Z',
+        })
+      ).rejects.toThrow(BadRequestException);
+    });
   });
 });

--- a/apps/api/src/analytics/http/analytics-coverage.controller.ts
+++ b/apps/api/src/analytics/http/analytics-coverage.controller.ts
@@ -22,6 +22,18 @@
  * `CoverageCategoryRowDto`'s own header for why this is load-bearing rather
  * than cosmetic.
  *
+ * `GET /analytics/coverage/by-connection` (#2713) is the aggregate-by-
+ * connection sibling: `channel-sales-table.tsx`'s
+ * `useCoverageCrossReferenceQuery` used to derive per-connection counts
+ * client-side by paging through the full affected-order list; this endpoint
+ * does the `GROUP BY sourceConnectionId` server-side instead. It reuses the
+ * SAME query DTO and range validation as `getCoverage` (extracted into
+ * {@link parseAndValidateRange}) and composes only the currency + tax A/B/C
+ * aggregates — `product-matching` has no FE consumer to cross-reference
+ * (confirmed: `channel-sales-table.tsx`'s own header states the
+ * cross-reference is never done for that category), so it is deliberately
+ * NOT included here.
+ *
  * @module apps/api/src/analytics/http
  */
 import { BadRequestException, Controller, Get, Inject, Query } from '@nestjs/common';
@@ -49,6 +61,10 @@ import {
   AnalyticsCoverageResponseDto,
   CoverageCategoryRowDto,
 } from './dto/analytics-coverage-response.dto';
+import {
+  AnalyticsCoverageByConnectionResponseDto,
+  CoverageCategoryConnectionRowsDto,
+} from './dto/analytics-coverage-by-connection-response.dto';
 
 /**
  * Sample size for `sampleOrderIds` — deliberately small. This endpoint's job
@@ -87,17 +103,7 @@ export class AnalyticsCoverageController {
   async getCoverage(
     @Query() query: AnalyticsCoverageQueryDto
   ): Promise<AnalyticsCoverageResponseDto> {
-    const from = new Date(query.from);
-    const to = new Date(query.to);
-    if (to.getTime() <= from.getTime()) {
-      throw new BadRequestException('to must be after from');
-    }
-    const rangeDays = (to.getTime() - from.getTime()) / (24 * 60 * 60 * 1000);
-    if (rangeDays > MAX_COVERAGE_RANGE_DAYS) {
-      throw new BadRequestException(
-        `Range too wide: ${Math.ceil(rangeDays)} days exceeds the ${MAX_COVERAGE_RANGE_DAYS}-day limit`
-      );
-    }
+    const { from, to } = this.parseAndValidateRange(query);
 
     const salesFilters = { from, to, sourceConnectionId: query.sourceConnectionId };
     const healthFilters = {
@@ -154,5 +160,64 @@ export class AnalyticsCoverageController {
     const response = new AnalyticsCoverageResponseDto();
     response.categories = categories;
     return response;
+  }
+
+  @Get('coverage/by-connection')
+  @ApiOperation({
+    summary:
+      'Data Coverage panel, per-connection breakdown — affected-order counts grouped by sourceConnectionId (currency, tax A/B/C)',
+  })
+  @ApiResponse({ status: 200, type: AnalyticsCoverageByConnectionResponseDto })
+  async getCoverageByConnection(
+    @Query() query: AnalyticsCoverageQueryDto
+  ): Promise<AnalyticsCoverageByConnectionResponseDto> {
+    const { from, to } = this.parseAndValidateRange(query);
+
+    const salesFilters = { from, to, sourceConnectionId: query.sourceConnectionId };
+
+    const currentReportingCurrency = await this.reportingCurrencySettings.resolve();
+    const { includeBackfilledTaxRatesInNetSales } = await this.displaySettings.getSettings();
+
+    const [currencyRows, taxRowsByCategory] = await Promise.all([
+      this.orderRecordService.getCurrencyMismatchOrdersByConnection(
+        salesFilters,
+        currentReportingCurrency
+      ),
+      this.taxCoverageDetectionService.getAllCategoryCountsByConnection(
+        salesFilters,
+        currentReportingCurrency,
+        includeBackfilledTaxRatesInNetSales
+      ),
+    ]);
+
+    const response = new AnalyticsCoverageByConnectionResponseDto();
+    response.categories = [
+      CoverageCategoryConnectionRowsDto.of('currency', currencyRows),
+      ...TaxCoverageCategoryValues.map((category) =>
+        CoverageCategoryConnectionRowsDto.of(category, taxRowsByCategory[category])
+      ),
+    ];
+    return response;
+  }
+
+  /**
+   * Shared `from`/`to` parsing + `MAX_COVERAGE_RANGE_DAYS` validation for
+   * every `/analytics/coverage*` route — extracted so `getCoverageByConnection`
+   * (#2713) doesn't duplicate `getCoverage`'s validation block verbatim.
+   * Behavior-preserving: same error messages, same 400 status.
+   */
+  private parseAndValidateRange(query: AnalyticsCoverageQueryDto): { from: Date; to: Date } {
+    const from = new Date(query.from);
+    const to = new Date(query.to);
+    if (to.getTime() <= from.getTime()) {
+      throw new BadRequestException('to must be after from');
+    }
+    const rangeDays = (to.getTime() - from.getTime()) / (24 * 60 * 60 * 1000);
+    if (rangeDays > MAX_COVERAGE_RANGE_DAYS) {
+      throw new BadRequestException(
+        `Range too wide: ${Math.ceil(rangeDays)} days exceeds the ${MAX_COVERAGE_RANGE_DAYS}-day limit`
+      );
+    }
+    return { from, to };
   }
 }

--- a/apps/api/src/analytics/http/analytics-tax-remediation.controller.spec.ts
+++ b/apps/api/src/analytics/http/analytics-tax-remediation.controller.spec.ts
@@ -25,6 +25,7 @@ describe('AnalyticsTaxRemediationController (#2469)', () => {
       getCategoryPage: jest.fn(),
       getCategoryCounts: jest.fn(),
       getAllCategoryPages: jest.fn(),
+      getAllCategoryCountsByConnection: jest.fn(),
     };
     reportingCurrencySettings = {
       resolve: jest.fn().mockResolvedValue('EUR'),

--- a/apps/api/src/analytics/http/dto/analytics-coverage-by-connection-response.dto.ts
+++ b/apps/api/src/analytics/http/dto/analytics-coverage-by-connection-response.dto.ts
@@ -15,7 +15,21 @@
  * @module apps/api/src/analytics/http/dto
  */
 import { ApiProperty } from '@nestjs/swagger';
-import { CoverageCategoryValues, type CoverageCategory } from '@openlinker/core/orders';
+import { TaxCoverageCategoryValues } from '@openlinker/core/orders';
+
+/**
+ * The categories this endpoint's controller actually emits (`'currency'` plus
+ * the tax A/B/C sub-categories) — deliberately narrower than the full
+ * `CoverageCategoryValues` union, which also carries `'product-matching'`.
+ * `AnalyticsCoverageController.getCoverageByConnection` never dispatches that
+ * category, so declaring it here would overstate the Swagger contract.
+ */
+export const CoverageCategoryConnectionRowValues = [
+  'currency',
+  ...TaxCoverageCategoryValues,
+] as const;
+export type CoverageCategoryConnectionRowCategory =
+  (typeof CoverageCategoryConnectionRowValues)[number];
 
 export class CoverageConnectionRowDto {
   @ApiProperty({ description: 'The connection this count belongs to.' })
@@ -28,14 +42,14 @@ export class CoverageConnectionRowDto {
 }
 
 export class CoverageCategoryConnectionRowsDto {
-  @ApiProperty({ enum: CoverageCategoryValues })
-  category!: CoverageCategory;
+  @ApiProperty({ enum: CoverageCategoryConnectionRowValues })
+  category!: CoverageCategoryConnectionRowCategory;
 
   @ApiProperty({ type: [CoverageConnectionRowDto] })
   rows!: CoverageConnectionRowDto[];
 
   static of(
-    category: CoverageCategory,
+    category: CoverageCategoryConnectionRowCategory,
     rows: CoverageConnectionRowDto[]
   ): CoverageCategoryConnectionRowsDto {
     const dto = new CoverageCategoryConnectionRowsDto();

--- a/apps/api/src/analytics/http/dto/analytics-coverage-by-connection-response.dto.ts
+++ b/apps/api/src/analytics/http/dto/analytics-coverage-by-connection-response.dto.ts
@@ -1,0 +1,51 @@
+/**
+ * Analytics Coverage By-Connection Response DTO
+ *
+ * Response body for `GET /analytics/coverage/by-connection` (#2713) — the
+ * server-side `GROUP BY sourceConnectionId` counterpart of
+ * `AnalyticsCoverageResponseDto`. `channel-sales-table.tsx`'s
+ * `useCoverageCrossReferenceQuery` previously derived this same shape
+ * client-side by paging through the full affected-order list; this endpoint
+ * lets the FE ask for per-connection counts directly instead.
+ *
+ * Deliberately carries no `status`/`activeRunId` per row — those are
+ * per-CATEGORY lifecycle facts (`AnalyticsCoverageResponseDto`'s concern),
+ * not per-connection ones.
+ *
+ * @module apps/api/src/analytics/http/dto
+ */
+import { ApiProperty } from '@nestjs/swagger';
+import { CoverageCategoryValues, type CoverageCategory } from '@openlinker/core/orders';
+
+export class CoverageConnectionRowDto {
+  @ApiProperty({ description: 'The connection this count belongs to.' })
+  sourceConnectionId!: string;
+
+  @ApiProperty({
+    description: 'Total orders in this category, on this connection, for the requested range.',
+  })
+  affectedCount!: number;
+}
+
+export class CoverageCategoryConnectionRowsDto {
+  @ApiProperty({ enum: CoverageCategoryValues })
+  category!: CoverageCategory;
+
+  @ApiProperty({ type: [CoverageConnectionRowDto] })
+  rows!: CoverageConnectionRowDto[];
+
+  static of(
+    category: CoverageCategory,
+    rows: CoverageConnectionRowDto[]
+  ): CoverageCategoryConnectionRowsDto {
+    const dto = new CoverageCategoryConnectionRowsDto();
+    dto.category = category;
+    dto.rows = rows;
+    return dto;
+  }
+}
+
+export class AnalyticsCoverageByConnectionResponseDto {
+  @ApiProperty({ type: [CoverageCategoryConnectionRowsDto] })
+  categories!: CoverageCategoryConnectionRowsDto[];
+}

--- a/apps/api/src/orders/http/orders.controller.spec.ts
+++ b/apps/api/src/orders/http/orders.controller.spec.ts
@@ -92,6 +92,7 @@ describe('OrdersController', () => {
       patchSnapshotTaxRates: jest.fn(),
       getNetMedianOrderValue: jest.fn(),
       findCurrencyMismatchOrders: jest.fn(),
+      findCurrencyMismatchOrdersByConnection: jest.fn(),
       findNetExcludedOrderCandidates: jest.fn(),
       findProductMatchingErrorOrders: jest.fn(),
       findCurrencyMismatchOrderRefsAfter: jest.fn(),

--- a/apps/api/src/orders/http/refunds.controller.spec.ts
+++ b/apps/api/src/orders/http/refunds.controller.spec.ts
@@ -50,6 +50,7 @@ describe('RefundsController', () => {
       getSalesAndChannelAnalytics: jest.fn(),
       getTopProducts: jest.fn(),
       getCurrencyMismatchOrders: jest.fn(),
+      getCurrencyMismatchOrdersByConnection: jest.fn(),
       getProductMatchingErrorOrders: jest.fn(),
       discoverSalesDocumentMarkets: jest.fn(),
     };

--- a/apps/api/src/shipping/http/shipment.controller.spec.ts
+++ b/apps/api/src/shipping/http/shipment.controller.spec.ts
@@ -135,6 +135,7 @@ describe('ShipmentController', () => {
       getSalesAndChannelAnalytics: jest.fn(),
       getTopProducts: jest.fn(),
       getCurrencyMismatchOrders: jest.fn(),
+      getCurrencyMismatchOrdersByConnection: jest.fn(),
       getProductMatchingErrorOrders: jest.fn(),
       discoverSalesDocumentMarkets: jest.fn(),
     };

--- a/apps/api/test/integration/sales-analytics-aggregates.int-spec.ts
+++ b/apps/api/test/integration/sales-analytics-aggregates.int-spec.ts
@@ -411,6 +411,123 @@ describe('Sales analytics daily aggregates (integration, #1987)', () => {
     });
   });
 
+  describe('findCurrencyMismatchOrdersByConnection (#2713)', () => {
+    const OTHER_CONNECTION = '22222222-2222-4222-8222-222222222222';
+
+    it('groups mismatch counts across ≥2 connections, matching findCurrencyMismatchOrders.total per connection', async () => {
+      const day = new Date('2026-08-02T10:00:00.000Z');
+      // Two mismatches on the default CONNECTION.
+      await seedStampedOrder({
+        placedAt: day,
+        currency: 'PLN',
+        totalAmount: 10,
+        reportingCurrency: null,
+        reportingTotalAmount: null,
+        fxStampedAt: null,
+      });
+      await seedStampedOrder({
+        placedAt: day,
+        currency: 'USD',
+        totalAmount: 20,
+        reportingCurrency: 'EUR',
+        reportingTotalAmount: 18,
+        fxStampedAt: new Date('2026-05-01T00:00:00.000Z'),
+      });
+      // One mismatch on a SECOND, distinct connection.
+      await seedStampedOrder({
+        placedAt: day,
+        sourceConnectionId: OTHER_CONNECTION,
+        currency: 'PLN',
+        totalAmount: 30,
+        reportingCurrency: null,
+        reportingTotalAmount: null,
+        fxStampedAt: null,
+      });
+      // Current-era stamped on the second connection — must not be counted.
+      await seedStampedOrder({
+        placedAt: day,
+        sourceConnectionId: OTHER_CONNECTION,
+        currency: 'EUR',
+        totalAmount: 40,
+        reportingCurrency: 'EUR',
+        reportingTotalAmount: 40,
+        fxStampedAt: new Date('2026-08-02T00:00:00Z'),
+      });
+
+      const filters = {
+        from: new Date('2026-08-01T00:00:00.000Z'),
+        to: new Date('2026-08-08T00:00:00.000Z'),
+      };
+
+      const rows = await repository.findCurrencyMismatchOrdersByConnection(filters, 'EUR');
+
+      const byConnection = new Map(rows.map((row) => [row.sourceConnectionId, row.affectedCount]));
+      expect(byConnection.get(CONNECTION)).toBe(2);
+      expect(byConnection.get(OTHER_CONNECTION)).toBe(1);
+      expect(rows).toHaveLength(2);
+
+      // Cross-check against the paginated read's per-connection total, so a
+      // regression that lets the two predicates drift is caught here rather
+      // than only by the source-level "identical predicate" comment.
+      const [connectionPage, otherConnectionPage] = await Promise.all([
+        repository.findCurrencyMismatchOrders(
+          { ...filters, sourceConnectionId: CONNECTION },
+          'EUR',
+          { limit: 20, offset: 0 }
+        ),
+        repository.findCurrencyMismatchOrders(
+          { ...filters, sourceConnectionId: OTHER_CONNECTION },
+          'EUR',
+          { limit: 20, offset: 0 }
+        ),
+      ]);
+      expect(byConnection.get(CONNECTION)).toBe(connectionPage.total);
+      expect(byConnection.get(OTHER_CONNECTION)).toBe(otherConnectionPage.total);
+    });
+
+    it('excludes cancelled orders from the count, matching the paginated read', async () => {
+      await seedStampedOrder({
+        placedAt: new Date('2026-08-03T10:00:00.000Z'),
+        currency: 'PLN',
+        totalAmount: 10,
+        reportingCurrency: null,
+        reportingTotalAmount: null,
+        fxStampedAt: null,
+        cancelledAt: new Date('2026-08-03T12:00:00.000Z'),
+      });
+
+      const filters = {
+        from: new Date('2026-08-01T00:00:00.000Z'),
+        to: new Date('2026-08-08T00:00:00.000Z'),
+      };
+
+      const rows = await repository.findCurrencyMismatchOrdersByConnection(filters, 'EUR');
+
+      expect(rows).toEqual([]);
+    });
+
+    it('returns an empty array — a connection with zero mismatches is simply absent — when every order is current-era stamped', async () => {
+      await seedStampedOrder({
+        placedAt: new Date('2026-08-04T10:00:00.000Z'),
+        currency: 'EUR',
+        totalAmount: 50,
+        reportingCurrency: 'EUR',
+        reportingTotalAmount: 50,
+        fxStampedAt: new Date('2026-08-04T00:00:00.000Z'),
+      });
+
+      const rows = await repository.findCurrencyMismatchOrdersByConnection(
+        {
+          from: new Date('2026-08-01T00:00:00.000Z'),
+          to: new Date('2026-08-08T00:00:00.000Z'),
+        },
+        'EUR'
+      );
+
+      expect(rows).toEqual([]);
+    });
+  });
+
   describe('findProductMatchingErrorOrders (#2466)', () => {
     it(
       'reports the SAME total as countByHealth.sourceDeleted + awaitingMapping, mapping both ' +

--- a/apps/web/src/features/analytics/api/analytics-coverage.api.ts
+++ b/apps/web/src/features/analytics/api/analytics-coverage.api.ts
@@ -1,14 +1,22 @@
 /**
  * Analytics Coverage API client
  *
- * Thin request module for `GET /analytics/coverage` (#2466).
+ * Thin request module for `GET /analytics/coverage` (#2466) and
+ * `GET /analytics/coverage/by-connection` (#2713) — the latter is the
+ * server-side `GROUP BY sourceConnectionId` counterpart the former's
+ * per-category drill-downs used to derive client-side.
  *
  * @module features/analytics/api
  */
-import type { AnalyticsCoverage, AnalyticsCoverageFilters } from './analytics-coverage.types';
+import type {
+  AnalyticsCoverage,
+  AnalyticsCoverageByConnection,
+  AnalyticsCoverageFilters,
+} from './analytics-coverage.types';
 
 export interface AnalyticsCoverageApi {
   getCoverage: (filters: AnalyticsCoverageFilters) => Promise<AnalyticsCoverage>;
+  getCoverageByConnection: (filters: AnalyticsCoverageFilters) => Promise<AnalyticsCoverageByConnection>;
 }
 
 interface ApiRequest {
@@ -28,5 +36,7 @@ function buildQuery(filters: AnalyticsCoverageFilters): string {
 export function createAnalyticsCoverageApi(request: ApiRequest): AnalyticsCoverageApi {
   return {
     getCoverage: (filters) => request(`/analytics/coverage?${buildQuery(filters)}`),
+    getCoverageByConnection: (filters) =>
+      request(`/analytics/coverage/by-connection?${buildQuery(filters)}`),
   };
 }

--- a/apps/web/src/features/analytics/api/analytics-coverage.query-keys.ts
+++ b/apps/web/src/features/analytics/api/analytics-coverage.query-keys.ts
@@ -3,4 +3,6 @@ import type { AnalyticsCoverageFilters } from './analytics-coverage.types';
 export const analyticsCoverageQueryKeys = {
   all: ['analytics', 'coverage'] as const,
   coverage: (filters: AnalyticsCoverageFilters) => ['analytics', 'coverage', filters] as const,
+  byConnection: (filters: AnalyticsCoverageFilters) =>
+    ['analytics', 'coverage', 'by-connection', filters] as const,
 };

--- a/apps/web/src/features/analytics/api/analytics-coverage.types.ts
+++ b/apps/web/src/features/analytics/api/analytics-coverage.types.ts
@@ -47,3 +47,25 @@ export interface AnalyticsCoverageFilters {
   to: string;
   sourceConnectionId?: string;
 }
+
+/**
+ * Mirrors `AnalyticsCoverageByConnectionResponseDto` / `CoverageCategoryConnectionRowsDto`
+ * (`GET /analytics/coverage/by-connection`, #2713) — one entry per category
+ * (`'currency' | 'tax-a' | 'tax-b' | 'tax-c'`, never `'product-matching'`),
+ * each carrying the affected-order count per `sourceConnectionId`. Replaces
+ * `useCoverageCrossReferenceQuery`'s client-side page-draining grouping for
+ * `ChannelSalesTable` (#2714).
+ */
+export interface CoverageConnectionRow {
+  sourceConnectionId: string;
+  affectedCount: number;
+}
+
+export interface CoverageCategoryConnectionRows {
+  category: CoverageCategory;
+  rows: CoverageConnectionRow[];
+}
+
+export interface AnalyticsCoverageByConnection {
+  categories: CoverageCategoryConnectionRows[];
+}

--- a/apps/web/src/features/analytics/components/channel-sales-table.test.tsx
+++ b/apps/web/src/features/analytics/components/channel-sales-table.test.tsx
@@ -286,9 +286,10 @@ describe('ChannelSalesTable', () => {
   // #2481 regression guards — the mockup's own two found bugs: a row
   // wrongly labeled with a *different* category's issue, and a row with
   // orders in an open category's affected set missing its annotation
-  // entirely. Both fixtures cross-reference against the FULL affected-order
-  // list (never the 10-id sample), grouped by `sourceConnectionId`.
-  describe('.excl-note cross-reference (#2481)', () => {
+  // entirely. Both fixtures cross-reference against the aggregate-by-
+  // connection endpoint (#2713/#2714), grouped by `sourceConnectionId`
+  // server-side.
+  describe('.excl-note cross-reference (#2481, ported to the aggregate endpoint by #2714)', () => {
     it("should attribute each channel's exclusion note to its own category, never the other channel's", async () => {
       const apiClient = createMockApiClient({
         analytics: {
@@ -298,13 +299,13 @@ describe('ChannelSalesTable', () => {
               channel({ sourceConnectionId: 'conn-2' }),
             ])
           ),
-          getCurrencyMismatchOrders: vi.fn().mockResolvedValue({
-            items: [{ internalOrderId: 'ol_order_1', sourceConnectionId: 'conn-1', nativeCurrency: 'EUR', stampedCurrency: null, stampedAt: null }],
-            total: 1,
-          }),
-          getTaxCoverageOrders: vi.fn().mockResolvedValue({
-            items: [{ internalOrderId: 'ol_order_2', sourceConnectionId: 'conn-2', placedAt: null }],
-            total: 1,
+          getCoverageByConnection: vi.fn().mockResolvedValue({
+            categories: [
+              { category: 'currency', rows: [{ sourceConnectionId: 'conn-1', affectedCount: 1 }] },
+              { category: 'tax-a', rows: [] },
+              { category: 'tax-b', rows: [{ sourceConnectionId: 'conn-2', affectedCount: 1 }] },
+              { category: 'tax-c', rows: [] },
+            ],
           }),
         },
         connections: {
@@ -346,19 +347,14 @@ describe('ChannelSalesTable', () => {
       const apiClient = createMockApiClient({
         analytics: {
           getSales: vi.fn().mockResolvedValue(analytics([channel({ sourceConnectionId: 'conn-1' })])),
-          getCurrencyMismatchOrders: vi.fn().mockResolvedValue({
-            items: [{ internalOrderId: 'ol_order_1', sourceConnectionId: 'conn-1', nativeCurrency: 'EUR', stampedCurrency: null, stampedAt: null }],
-            total: 1,
+          getCoverageByConnection: vi.fn().mockResolvedValue({
+            categories: [
+              { category: 'currency', rows: [{ sourceConnectionId: 'conn-1', affectedCount: 1 }] },
+              { category: 'tax-a', rows: [{ sourceConnectionId: 'conn-1', affectedCount: 1 }] },
+              { category: 'tax-b', rows: [{ sourceConnectionId: 'conn-1', affectedCount: 1 }] },
+              { category: 'tax-c', rows: [{ sourceConnectionId: 'conn-1', affectedCount: 1 }] },
+            ],
           }),
-          getTaxCoverageOrders: vi.fn((input: { category: string }) =>
-            Promise.resolve(
-              input.category === 'tax-a'
-                ? { items: [{ internalOrderId: 'ol_order_2', sourceConnectionId: 'conn-1', placedAt: null, lineRates: [] }], total: 1 }
-                : input.category === 'tax-b'
-                  ? { items: [{ internalOrderId: 'ol_order_3', sourceConnectionId: 'conn-1', placedAt: null, lineRates: [] }], total: 1 }
-                  : { items: [{ internalOrderId: 'ol_order_4', sourceConnectionId: 'conn-1', placedAt: null, lineRates: [] }], total: 1 }
-            )
-          ),
         },
         connections: {
           list: vi.fn().mockResolvedValue([{ id: 'conn-1', name: 'Allegro — main', platformType: 'allegro' }]),

--- a/apps/web/src/features/analytics/components/channel-sales-table.tsx
+++ b/apps/web/src/features/analytics/components/channel-sales-table.tsx
@@ -55,14 +55,17 @@
  * `awaiting_mapping` order fails to resolve to *any* channel-scoped total
  * in the first place, so it was never counted anywhere to be silently
  * missing from) gets one `AnalyticsExclusionNote` per affected category.
- * The cross-reference is exact: each open category's *full* affected-order
- * list (not the Data Coverage aggregate's 10-id sample —
- * `useCoverageCrossReferenceQuery`, `hooks/use-coverage-cross-reference-query.ts`,
- * drains every page via the same paginated endpoints Phase 7's detail
- * modals use) is grouped by `sourceConnectionId` (`buildChannelExclusionMap`,
- * `lib/channel-exclusion-map.lib.ts`), since that field is on every
- * affected-order row and matches this table's own row key exactly — unlike
- * a product, a channel has no ambiguity to approximate.
+ * The cross-reference is exact: `GET /analytics/coverage/by-connection`
+ * (#2713) already returns each open category's affected-order count
+ * `GROUP BY sourceConnectionId` server-side — one request
+ * (`useCoverageByConnectionQuery`, `hooks/use-coverage-by-connection-query.ts`)
+ * instead of draining every page of four separate order lists client-side
+ * (the pre-#2714 approach, still used by `ProductSalesTable` for its
+ * per-product cross-reference, which has no connection-level aggregate to
+ * consume) — reshaped into the same `sourceConnectionId`-keyed map
+ * (`buildChannelExclusionMap`, `lib/channel-exclusion-map.lib.ts`), since
+ * that field matches this table's own row key exactly — unlike a product, a
+ * channel has no ambiguity to approximate.
  *
  * @module features/analytics/components
  */
@@ -78,7 +81,7 @@ import { useNumberFormat } from '../../../shared/i18n/use-number-format';
 import { ConnectionCell, useConnectionsQuery, type Connection } from '../../connections';
 import { ConnectionDot } from '../../orders';
 import { useSalesAnalyticsQuery } from '../hooks/use-sales-analytics-query';
-import { useCoverageCrossReferenceQuery } from '../hooks/use-coverage-cross-reference-query';
+import { useCoverageByConnectionQuery } from '../hooks/use-coverage-by-connection-query';
 import {
   createReportingCurrencyConverter,
   isCurrencyRecalculating,
@@ -234,42 +237,30 @@ export function ChannelSalesTable({
   const pctFormat = useNumberFormat(PERCENT_FORMAT_OPTIONS);
   const intFormat = useNumberFormat();
 
-  // Fixed set of hooks, one per cross-referenceable category (never a
-  // variable count derived from which categories happen to be open — see
-  // `useCoverageCrossReferenceQuery`'s own doc comment on why). Each is
-  // `enabled` only when its own category is genuinely open.
+  // One request for every cross-referenceable category together (#2713/
+  // #2714) — `enabled` only when the `coverage` prop (the unfiltered
+  // GET /analytics/coverage aggregate) says at least one of them has a
+  // nonzero affectedCount, matching the pre-#2714 gate's own source of
+  // truth exactly (`openCategoryCodes`, unchanged) — just "any" instead of
+  // "each", since there is now only one request to gate. This is the same
+  // approximation the old per-category gates already made: `coverage` and
+  // `crossRefFilters`/`coverageFilters` are independent props (see this
+  // component's own prop doc comments), so the guarantee is "no request
+  // when the panel overall reads all-clear," not a filter-range match.
   const openCategoryCodes = useMemo(
     () => new Set((coverage?.categories ?? []).filter((row) => row.affectedCount > 0).map((row) => row.category)),
     [coverage]
   );
   const crossRefFilters: AnalyticsCoverageFilters = coverageFilters ?? { from: '', to: '' };
   const crossRefEnabled = Boolean(coverageFilters) && Boolean(onOpenCategory);
-  const currencyOrders = useCoverageCrossReferenceQuery(
-    'currency',
-    crossRefFilters,
-    crossRefEnabled && openCategoryCodes.has('currency')
+  const anyOpenCrossReferenceable = CROSS_REFERENCEABLE_CATEGORIES.some((category) =>
+    openCategoryCodes.has(category)
   );
-  const taxAOrders = useCoverageCrossReferenceQuery(
-    'tax-a',
+  const byConnection = useCoverageByConnectionQuery(
     crossRefFilters,
-    crossRefEnabled && openCategoryCodes.has('tax-a')
+    crossRefEnabled && anyOpenCrossReferenceable
   );
-  const taxBOrders = useCoverageCrossReferenceQuery(
-    'tax-b',
-    crossRefFilters,
-    crossRefEnabled && openCategoryCodes.has('tax-b')
-  );
-  const taxCOrders = useCoverageCrossReferenceQuery(
-    'tax-c',
-    crossRefFilters,
-    crossRefEnabled && openCategoryCodes.has('tax-c')
-  );
-  const exclusions = buildChannelExclusionMap({
-    currency: currencyOrders.data,
-    'tax-a': taxAOrders.data,
-    'tax-b': taxBOrders.data,
-    'tax-c': taxCOrders.data,
-  });
+  const exclusions = buildChannelExclusionMap(byConnection.data);
 
   if (query.isLoading) {
     return (

--- a/apps/web/src/features/analytics/hooks/use-coverage-by-connection-query.ts
+++ b/apps/web/src/features/analytics/hooks/use-coverage-by-connection-query.ts
@@ -1,0 +1,38 @@
+/**
+ * Coverage By-Connection Query Hook
+ *
+ * Fetches `GET /analytics/coverage/by-connection` (#2713) — currency + tax
+ * A/B/C affected-order counts already `GROUP BY sourceConnectionId`d
+ * server-side — in ONE request, for `ChannelSalesTable`'s `.excl-note`
+ * cross-reference (#2714). Replaces `useCoverageCrossReferenceQuery`'s four
+ * page-draining calls (one per `CROSS_REFERENCEABLE_CATEGORIES` member) for
+ * that one consumer; `ProductSalesTable` still needs the full per-order
+ * `productId`/`lineRates` shape (no product-level aggregate exists), so it
+ * keeps using the old hook — see that hook's own doc comment.
+ *
+ * Same silent-degradation contract as its predecessor: only `data` is
+ * returned, no `isLoading`/`isError` — a still-loading or failed read simply
+ * contributes no exclusion notes for this render rather than surfacing a
+ * table-wide error state for a supplementary annotation.
+ *
+ * @module apps/web/src/features/analytics/hooks
+ */
+import { useQuery } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { analyticsCoverageQueryKeys } from '../api/analytics-coverage.query-keys';
+import type { AnalyticsCoverageByConnection, AnalyticsCoverageFilters } from '../api/analytics-coverage.types';
+
+export function useCoverageByConnectionQuery(
+  filters: AnalyticsCoverageFilters,
+  enabled: boolean
+): { data: AnalyticsCoverageByConnection | undefined } {
+  const apiClient = useApiClient();
+
+  const { data } = useQuery({
+    queryKey: analyticsCoverageQueryKeys.byConnection(filters),
+    queryFn: () => apiClient.analytics.getCoverageByConnection(filters),
+    enabled,
+  });
+
+  return { data };
+}

--- a/apps/web/src/features/analytics/hooks/use-coverage-cross-reference-query.ts
+++ b/apps/web/src/features/analytics/hooks/use-coverage-cross-reference-query.ts
@@ -2,24 +2,30 @@
  * Coverage Cross-Reference Query Hook
  *
  * Pages through one Data Coverage category's *complete* affected-order
- * list (never the `GET /analytics/coverage` aggregate's 10-id sample), for
- * the `ChannelSalesTable` per-row `.excl-note` cross-reference (#2481,
- * epic #2452 Phase 8). One `useQuery` per category — call it once per
- * member of `CROSS_REFERENCEABLE_CATEGORIES` (a fixed set), never a
- * variable count derived from which categories happen to be open, so the
- * number of hook calls never changes across renders.
+ * list (never the `GET /analytics/coverage` aggregate's 10-id sample). One
+ * `useQuery` per category — call it once per member of
+ * `CROSS_REFERENCEABLE_CATEGORIES` (a fixed set), never a variable count
+ * derived from which categories happen to be open, so the number of hook
+ * calls never changes across renders.
  *
  * Each call drains its own pages inside one `queryFn` rather than issuing a
  * separate `useQuery` per page — a per-page-load, non-hot-path read (see
  * `docs/plans/implementation-plan-analytics-exclusion-annotations.md`'s own
- * risk note on this bound). Being an unbounded drain over a potentially
- * large affected-order population is a known follow-up, tracked as #2713
- * (backend aggregate-by-connection endpoint) + #2714 (swap this hook to
- * consume it).
+ * risk note on this bound).
+ *
+ * **`ChannelSalesTable` no longer uses this hook (#2714)** — its per-row
+ * `.excl-note` cross-reference (#2481, epic #2452 Phase 8) now consumes
+ * `GET /analytics/coverage/by-connection` (#2713) via
+ * `useCoverageByConnectionQuery`, which returns every category's
+ * `sourceConnectionId`-grouped counts in ONE request instead of draining
+ * four full order lists. `ProductSalesTable` still calls this hook: its
+ * per-product cross-reference (`buildProductExclusionMap`) needs each
+ * order's `productId`/`lineRates`, which the connection-level aggregate
+ * doesn't carry — there is no equivalent aggregate to swap it to.
  *
  * Only `data` is returned, deliberately — no `isLoading`/`isError`. A failed
  * or still-loading category silently contributes no rows to
- * `buildChannelExclusionMap`, which just means that category's
+ * `buildProductExclusionMap`, which just means that category's
  * `AnalyticsExclusionNote`s are momentarily/permanently absent from the
  * table. This is a supplementary annotation on top of already-successful
  * sales figures, not a screen of its own — so it degrades silently by

--- a/apps/web/src/features/analytics/lib/channel-exclusion-map.lib.test.ts
+++ b/apps/web/src/features/analytics/lib/channel-exclusion-map.lib.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { buildChannelExclusionMap } from './channel-exclusion-map.lib';
+import type { AnalyticsCoverageByConnection } from '../api/analytics-coverage.types';
+
+describe('buildChannelExclusionMap (#2714)', () => {
+  it('returns an empty map for undefined input (never-loaded state)', () => {
+    const map = buildChannelExclusionMap(undefined);
+
+    expect(map.size).toBe(0);
+  });
+
+  it('returns an empty map when every category has an empty rows array (all-clear)', () => {
+    const byConnection: AnalyticsCoverageByConnection = {
+      categories: [
+        { category: 'currency', rows: [] },
+        { category: 'tax-a', rows: [] },
+        { category: 'tax-b', rows: [] },
+        { category: 'tax-c', rows: [] },
+      ],
+    };
+
+    const map = buildChannelExclusionMap(byConnection);
+
+    expect(map.size).toBe(0);
+  });
+
+  it('groups multiple connections under the same category, keeping each connection distinct', () => {
+    const byConnection: AnalyticsCoverageByConnection = {
+      categories: [
+        {
+          category: 'currency',
+          rows: [
+            { sourceConnectionId: 'conn-a', affectedCount: 3 },
+            { sourceConnectionId: 'conn-b', affectedCount: 1 },
+          ],
+        },
+        { category: 'tax-a', rows: [] },
+        { category: 'tax-b', rows: [] },
+        { category: 'tax-c', rows: [] },
+      ],
+    };
+
+    const map = buildChannelExclusionMap(byConnection);
+
+    expect(map.get('conn-a')?.get('currency')).toBe(3);
+    expect(map.get('conn-b')?.get('currency')).toBe(1);
+    expect(map.size).toBe(2);
+  });
+
+  it('attributes each category to the connection it actually belongs to, never mixing them', () => {
+    const byConnection: AnalyticsCoverageByConnection = {
+      categories: [
+        { category: 'currency', rows: [{ sourceConnectionId: 'conn-a', affectedCount: 1 }] },
+        { category: 'tax-a', rows: [] },
+        { category: 'tax-b', rows: [{ sourceConnectionId: 'conn-b', affectedCount: 1 }] },
+        { category: 'tax-c', rows: [] },
+      ],
+    };
+
+    const map = buildChannelExclusionMap(byConnection);
+
+    expect(map.get('conn-a')?.size).toBe(1);
+    expect(map.get('conn-a')?.has('currency')).toBe(true);
+    expect(map.get('conn-a')?.has('tax-b')).toBe(false);
+
+    expect(map.get('conn-b')?.size).toBe(1);
+    expect(map.get('conn-b')?.has('tax-b')).toBe(true);
+    expect(map.get('conn-b')?.has('currency')).toBe(false);
+  });
+
+  it('carries the count through verbatim, since grouping already happened server-side', () => {
+    const byConnection: AnalyticsCoverageByConnection = {
+      categories: [
+        { category: 'currency', rows: [{ sourceConnectionId: 'conn-a', affectedCount: 42 }] },
+        { category: 'tax-a', rows: [] },
+        { category: 'tax-b', rows: [] },
+        { category: 'tax-c', rows: [] },
+      ],
+    };
+
+    const map = buildChannelExclusionMap(byConnection);
+
+    expect(map.get('conn-a')?.get('currency')).toBe(42);
+  });
+});

--- a/apps/web/src/features/analytics/lib/channel-exclusion-map.lib.ts
+++ b/apps/web/src/features/analytics/lib/channel-exclusion-map.lib.ts
@@ -1,14 +1,18 @@
 /**
  * Channel Exclusion Map
  *
- * Pure grouping of one or more Data Coverage categories' *full*
- * affected-order lists into a per-channel (`sourceConnectionId`) count map
- * (#2481, epic #2452 Phase 8) — the input `ChannelSalesTable` needs to
- * decide which `AnalyticsExclusionNote`s a row gets.
+ * Reshapes the `GET /analytics/coverage/by-connection` aggregate (#2713)
+ * into a per-channel (`sourceConnectionId`) count map (#2481, epic #2452
+ * Phase 8, reshaped by #2714) — the input `ChannelSalesTable` needs to
+ * decide which `AnalyticsExclusionNote`s a row gets. Grouping happens
+ * server-side now (`GROUP BY sourceConnectionId`), so this is a pure
+ * re-index rather than a count — `buildChannelExclusionMap` has exactly one
+ * caller (`ChannelSalesTable`), which is why the reshape happened in place
+ * rather than adding a second function.
  *
  * @module apps/web/src/features/analytics/lib
  */
-import type { CoverageCategory } from '../api/analytics-coverage.types';
+import type { AnalyticsCoverageByConnection, CoverageCategory } from '../api/analytics-coverage.types';
 
 /** Tax categories, plus currency — the categories a channel total can be under-counted by. `product-matching` is deliberately excluded: a `source_deleted`/`awaiting_mapping` order fails to resolve to *any* channel-scoped total in the first place, so it was never counted anywhere to be silently missing from. */
 export type CrossReferenceableCategory = Extract<CoverageCategory, 'currency' | 'tax-a' | 'tax-b' | 'tax-c'>;
@@ -19,15 +23,20 @@ export const CROSS_REFERENCEABLE_CATEGORIES: readonly CrossReferenceableCategory
   'tax-c',
 ];
 
+/**
+ * `product-sales-table.tsx`'s per-order shape, still used by
+ * `buildProductExclusionMap` (`product-exclusion-map.lib.ts`, via
+ * `useCoverageCrossReferenceQuery`) — the connection-level aggregate
+ * `buildChannelExclusionMap` now consumes has no product identity to give,
+ * so this type no longer has a role in THIS file's own function.
+ */
 export interface CoverageOrderLite {
   internalOrderId: string;
   sourceConnectionId: string;
   /**
    * One representative line's product id (#2799) — present (possibly
    * `null`) on a `'currency'` row, absent on a tax row (see `lineRates`
-   * instead). Optional here so this shared shape can widen without forcing
-   * every consumer (e.g. `buildChannelExclusionMap`, which only ever needs
-   * `sourceConnectionId`) to care about it.
+   * instead).
    */
   productId?: string | null;
   /**
@@ -42,14 +51,21 @@ export interface CoverageOrderLite {
 export type ChannelExclusionMap = Map<string, Map<CrossReferenceableCategory, number>>;
 
 export function buildChannelExclusionMap(
-  ordersByCategory: Partial<Record<CrossReferenceableCategory, CoverageOrderLite[] | undefined>>
+  byConnection: AnalyticsCoverageByConnection | undefined
 ): ChannelExclusionMap {
+  const rowsByCategory = new Map(
+    (byConnection?.categories ?? []).map((entry) => [entry.category, entry.rows])
+  );
   const map: ChannelExclusionMap = new Map();
   for (const category of CROSS_REFERENCEABLE_CATEGORIES) {
-    for (const order of ordersByCategory[category] ?? []) {
-      const byCategory = map.get(order.sourceConnectionId) ?? new Map<CrossReferenceableCategory, number>();
-      byCategory.set(category, (byCategory.get(category) ?? 0) + 1);
-      map.set(order.sourceConnectionId, byCategory);
+    // `.set()`, not an accumulate — the backend's own `GROUP BY
+    // sourceConnectionId` (#2713) already guarantees at most one row per
+    // `(category, sourceConnectionId)` pair, so there is nothing to sum
+    // here, unlike the pre-#2714 client-side counting this replaced.
+    for (const row of rowsByCategory.get(category) ?? []) {
+      const byCategory = map.get(row.sourceConnectionId) ?? new Map<CrossReferenceableCategory, number>();
+      byCategory.set(category, row.affectedCount);
+      map.set(row.sourceConnectionId, byCategory);
     }
   }
   return map;

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -193,6 +193,14 @@ export function createMockApiClient(
       }),
       getCurrencyMismatchOrders: vi.fn().mockResolvedValue({ items: [], total: 0 }),
       getTaxCoverageOrders: vi.fn().mockResolvedValue({ items: [], total: 0 }),
+      getCoverageByConnection: vi.fn().mockResolvedValue({
+        categories: [
+          { category: 'currency', rows: [] },
+          { category: 'tax-a', rows: [] },
+          { category: 'tax-b', rows: [] },
+          { category: 'tax-c', rows: [] },
+        ],
+      }),
       rerunTaxBackfill: vi.fn().mockResolvedValue({ scanned: 0, updated: 0 }),
       getProductMatchingOrders: vi.fn().mockResolvedValue({ items: [], total: 0 }),
       ...overrides.analytics,

--- a/docs/plans/implementation-plan-coverage-by-connection-fe.md
+++ b/docs/plans/implementation-plan-coverage-by-connection-fe.md
@@ -1,0 +1,201 @@
+# Implementation Plan — Swap channel-table exclusion cross-reference to the aggregate endpoint
+
+- **Issue**: [#2714](https://github.com/openlinker-project/openlinker/issues/2714)
+- **Type**: Frontend
+- **Layer**: Feature (`analytics`)
+- **Depends on**: [#2713](https://github.com/openlinker-project/openlinker/issues/2713) — `GET /analytics/coverage/by-connection`, shipped in PR [#2810](https://github.com/openlinker-project/openlinker/pull/2810) (not yet merged to `main`). This branch is built on top of `2713-coverage-by-connection-reads`.
+
+## 1. Goal & scope
+
+### Goal
+
+`ChannelSalesTable`'s `.excl-note` cross-reference currently drains **every page** of the currency-mismatch and tax A/B/C affected-order lists client-side (`useCoverageCrossReferenceQuery`, 4 separate `useQuery` calls, one per category) purely to build a `sourceConnectionId -> category -> count` map. Replace that with a single call to the new `GET /analytics/coverage/by-connection` endpoint, which already returns exactly that shape, grouped server-side.
+
+### Non-goals
+
+- `product-sales-table.tsx`'s use of `useCoverageCrossReferenceQuery` is **untouched**. It needs the FULL per-order `productId`/`lineRates` (there is no product-level aggregate — #2713 only groups by connection), so it keeps draining pages via the existing hook. Confirmed via `product-exclusion-map.lib.ts`'s doc comment and `buildProductExclusionMap`'s use of `lineRates`/`productId`.
+- No change to `GET /analytics/coverage` (the 10-id-sample aggregate) or its hook (`useAnalyticsCoverageQuery`) — that's a different read (open/in-progress status + a small sample), consumed by `AnalyticsDataCoveragePanel`.
+- No change to `product-matching` handling — it was already excluded from `CROSS_REFERENCEABLE_CATEGORIES` and the backend `by-connection` endpoint doesn't return it either (#2713).
+
+## 2. Research summary
+
+- **`useCoverageCrossReferenceQuery`** (`apps/web/src/features/analytics/hooks/use-coverage-cross-reference-query.ts`) is called 4× in `ChannelSalesTable` (currency, tax-a, tax-b, tax-c) and 4× in `ProductSalesTable` — **8 total call sites**, but only the 4 in `ChannelSalesTable` are in scope.
+- **`buildChannelExclusionMap`** (`apps/web/src/features/analytics/lib/channel-exclusion-map.lib.ts`) is called from exactly one place: `ChannelSalesTable`. Its sibling `buildProductExclusionMap` (`product-exclusion-map.lib.ts`) re-exports `CROSS_REFERENCEABLE_CATEGORIES`/`CrossReferenceableCategory` from the same file but does **not** call `buildChannelExclusionMap` itself — so reshaping that one function's signature has no other blast radius.
+- **The consumer of the result** (`ChannelExclusionNotes` in `channel-sales-table.tsx`) only ever reads `ChannelExclusionMap` (`Map<string, Map<CrossReferenceableCategory, number>>`) — untouched by this change, since both the old and new producer functions return that same shape.
+- **Backend contract** (`AnalyticsCoverageByConnectionResponseDto`, PR #2810): `GET /analytics/coverage/by-connection?from=&to=&sourceConnectionId=` → `{ categories: [{ category, rows: [{ sourceConnectionId, affectedCount }] } ] }`, one entry per `'currency' | 'tax-a' | 'tax-b' | 'tax-c'` (never `'product-matching'`), each carrying a possibly-empty `rows` array.
+- **Existing sibling pattern to mirror**: `analytics-coverage.api.ts` already has `getCoverage` for `GET /analytics/coverage`, reusing one `buildQuery` helper — `getCoverageByConnection` is a second method on the same `AnalyticsCoverageApi` interface/factory, same query-string shape.
+- **Test fixtures to update**: `channel-sales-table.test.tsx`'s `.excl-note` describe block (2 tests) mocks `getCurrencyMismatchOrders`/`getTaxCoverageOrders`; these need to mock `getCoverageByConnection` instead, with the SAME expected rendered output (issue's own acceptance criterion — "should not need to change shape, only their mocked apiClient calls"). `test-utils.tsx`'s default `createMockApiClient` needs a default `getCoverageByConnection` mock so every OTHER test rendering `ChannelSalesTable` (which doesn't explicitly mock it) doesn't crash on an undefined function call.
+
+## 3. Design
+
+### 3.1 Types — `apps/web/src/features/analytics/api/analytics-coverage.types.ts`
+
+Add, alongside the existing `AnalyticsCoverage`/`CoverageCategoryRow`:
+
+```typescript
+export interface CoverageConnectionRow {
+  sourceConnectionId: string;
+  affectedCount: number;
+}
+
+export interface CoverageCategoryConnectionRows {
+  category: CoverageCategory;
+  rows: CoverageConnectionRow[];
+}
+
+export interface AnalyticsCoverageByConnection {
+  categories: CoverageCategoryConnectionRows[];
+}
+```
+
+(`category` stays the broad `CoverageCategory` — same choice `CoverageCategoryRow` already makes — rather than importing the narrower `CrossReferenceableCategory` from `channel-exclusion-map.lib.ts`, which would create a `types.ts -> lib.ts` import in the wrong direction; the narrowing happens where it's consumed, per §3.4.)
+
+### 3.2 API client — `apps/web/src/features/analytics/api/analytics-coverage.api.ts`
+
+Add `getCoverageByConnection` to `AnalyticsCoverageApi` and its factory, reusing the existing `buildQuery` helper verbatim (same filters shape):
+
+```typescript
+export interface AnalyticsCoverageApi {
+  getCoverage: (filters: AnalyticsCoverageFilters) => Promise<AnalyticsCoverage>;
+  getCoverageByConnection: (filters: AnalyticsCoverageFilters) => Promise<AnalyticsCoverageByConnection>;
+}
+...
+getCoverageByConnection: (filters) => request(`/analytics/coverage/by-connection?${buildQuery(filters)}`),
+```
+
+### 3.3 Query keys — `apps/web/src/features/analytics/api/analytics-coverage.query-keys.ts`
+
+Add a sibling key factory:
+
+```typescript
+byConnection: (filters: AnalyticsCoverageFilters) => ['analytics', 'coverage', 'by-connection', filters] as const,
+```
+
+### 3.4 New hook — `apps/web/src/features/analytics/hooks/use-coverage-by-connection-query.ts`
+
+One `useQuery`, no per-category fan-out (replaces `useCoverageCrossReferenceQuery`'s 4 calls with 1):
+
+```typescript
+export function useCoverageByConnectionQuery(
+  filters: AnalyticsCoverageFilters,
+  enabled: boolean
+): { data: AnalyticsCoverageByConnection | undefined } {
+  const apiClient = useApiClient();
+  const { data } = useQuery({
+    queryKey: analyticsCoverageQueryKeys.byConnection(filters),
+    queryFn: () => apiClient.analytics.getCoverageByConnection(filters),
+    enabled,
+  });
+  return { data };
+}
+```
+
+Same silent-degradation contract as its predecessor (only `data`, no `isLoading`/`isError` — a still-loading/failed read just contributes no exclusion notes for one render, never a table-wide error state).
+
+### 3.5 `buildChannelExclusionMap` — reshaped, not duplicated
+
+`channel-exclusion-map.lib.ts`'s `buildChannelExclusionMap` currently counts a `Partial<Record<CrossReferenceableCategory, CoverageOrderLite[]>>` client-side. Since it has exactly one caller (being changed in this same task) and the grouping now happens server-side, **reshape it in place** rather than adding a second function:
+
+```typescript
+export function buildChannelExclusionMap(
+  byConnection: AnalyticsCoverageByConnection | undefined
+): ChannelExclusionMap {
+  const rowsByCategory = new Map(
+    (byConnection?.categories ?? []).map((entry) => [entry.category, entry.rows])
+  );
+  const map: ChannelExclusionMap = new Map();
+  for (const category of CROSS_REFERENCEABLE_CATEGORIES) {
+    for (const row of rowsByCategory.get(category) ?? []) {
+      const byCategory = map.get(row.sourceConnectionId) ?? new Map<CrossReferenceableCategory, number>();
+      byCategory.set(category, row.affectedCount);
+      map.set(row.sourceConnectionId, byCategory);
+    }
+  }
+  return map;
+}
+```
+
+`CoverageOrderLite` and `CrossReferenceableCategory`/`CROSS_REFERENCEABLE_CATEGORIES` stay exported unchanged — `product-exclusion-map.lib.ts` still needs all three for its own, untouched function.
+
+### 3.6 `ChannelSalesTable` — swap the call site
+
+`apps/web/src/features/analytics/components/channel-sales-table.tsx`:
+
+- Replace the `useCoverageCrossReferenceQuery` import with `useCoverageByConnectionQuery`.
+- Replace the 4 hook calls + the `buildChannelExclusionMap({ currency: ..., 'tax-a': ..., ... })` object-literal call with:
+
+```typescript
+const anyOpenCrossReferenceable = CROSS_REFERENCEABLE_CATEGORIES.some((c) => openCategoryCodes.has(c));
+const byConnection = useCoverageByConnectionQuery(
+  crossRefFilters,
+  crossRefEnabled && anyOpenCrossReferenceable
+);
+const exclusions = buildChannelExclusionMap(byConnection.data);
+```
+
+`openCategoryCodes` stays (still needed to gate the single request when every cross-referenceable category is already `affectedCount: 0` — preserving the existing "no network call when Data Coverage is all-clear" property, now expressed as "any", not "each").
+
+- Update the component's header doc comment (the `.excl-note` paragraph, ~line 53) to describe the single aggregate call instead of "drains every page via `useCoverageCrossReferenceQuery`".
+
+### 3.7 `useCoverageCrossReferenceQuery` doc comment
+
+Update its header to state it is now consumed ONLY by `ProductSalesTable` (product-level cross-reference has no aggregate equivalent — #2713 groups by connection, not by product) and that `ChannelSalesTable` was swapped off it by #2714. No code change to the hook itself.
+
+### 3.8 Tests
+
+- `channel-sales-table.test.tsx`'s `.excl-note` describe block: replace `getCurrencyMismatchOrders`/`getTaxCoverageOrders` mocks with a single `getCoverageByConnection` mock per test, returning the equivalent `{ categories: [...] }` shape. Assertions on rendered `.excl-note` text/count stay byte-identical (issue's own acceptance criterion).
+- `test-utils.tsx`: add a default `getCoverageByConnection: vi.fn().mockResolvedValue({ categories: [] })` to `createMockApiClient`'s `analytics` namespace, mirroring the existing `getCurrencyMismatchOrders`/`getTaxCoverageOrders` defaults, so every other test that renders `ChannelSalesTable` without explicitly mocking it doesn't hit an undefined function.
+- New unit test for `buildChannelExclusionMap`'s reshaped signature (none existed before — add one, since this is now the shape doing the real work), covering: multi-connection grouping, an empty `rows` array for an open-but-zero category, and `undefined` input (never-loaded state).
+- No new test needed for `useCoverageByConnectionQuery`/`getCoverageByConnection` beyond what the component test already exercises through `createMockApiClient` — matches the existing `useCoverageCrossReferenceQuery`'s own test coverage (none dedicated; exercised via the component).
+
+## 4. Files touched
+
+| File | Change |
+|---|---|
+| `apps/web/src/features/analytics/api/analytics-coverage.types.ts` | + `CoverageConnectionRow`, `CoverageCategoryConnectionRows`, `AnalyticsCoverageByConnection` |
+| `apps/web/src/features/analytics/api/analytics-coverage.api.ts` | + `getCoverageByConnection` |
+| `apps/web/src/features/analytics/api/analytics-coverage.query-keys.ts` | + `byConnection` key factory |
+| `apps/web/src/features/analytics/hooks/use-coverage-by-connection-query.ts` | new file |
+| `apps/web/src/features/analytics/hooks/use-coverage-cross-reference-query.ts` | doc comment only |
+| `apps/web/src/features/analytics/lib/channel-exclusion-map.lib.ts` | `buildChannelExclusionMap` reshaped |
+| `apps/web/src/features/analytics/lib/channel-exclusion-map.test.ts` | new file (unit test) |
+| `apps/web/src/features/analytics/components/channel-sales-table.tsx` | swap call site, doc comment |
+| `apps/web/src/features/analytics/components/channel-sales-table.test.tsx` | `.excl-note` mocks updated |
+| `apps/web/src/test/test-utils.tsx` | + default `getCoverageByConnection` mock |
+
+No backend, no migration, no cross-package boundary change — `apps/web` never imports `@openlinker/core` (#591), consistent with the existing pattern.
+
+## 5. Step-by-step plan
+
+1. Add the three new types (§3.1).
+2. Add `getCoverageByConnection` to the API client + query keys (§3.2, §3.3).
+3. Add `useCoverageByConnectionQuery` (§3.4).
+4. Reshape `buildChannelExclusionMap` (§3.5); add its unit test.
+5. Swap `ChannelSalesTable`'s call site + doc comment (§3.6).
+6. Update `useCoverageCrossReferenceQuery`'s doc comment (§3.7).
+7. Update `channel-sales-table.test.tsx`'s `.excl-note` mocks (§3.8).
+8. Add the default `getCoverageByConnection` mock to `test-utils.tsx` (§3.8).
+9. `pnpm --filter @openlinker/web type-check` + lint on touched files.
+10. `pnpm --filter @openlinker/web test` (or the affected test files) — full FE suite is fast/no Docker, unlike backend `pnpm test:integration`.
+
+## 6. Risks & edge cases
+
+- **All-clear state**: when every cross-referenceable category has `affectedCount: 0` in the already-fetched `coverage` prop, the new hook is disabled entirely (`anyOpenCrossReferenceable` false) — zero network calls, matching current behavior's intent (previously: zero of the 4 per-category calls fired either, for the same reason).
+- **Partial category presence**: the backend `by-connection` response always includes all 4 categories (even with an empty `rows` array) per PR #2810's design — `rowsByCategory.get(category) ?? []` handles a hypothetically missing entry defensively anyway.
+- **`onOpenCategory`/`coverageFilters` optional**: unchanged gating (`crossRefEnabled`), so a caller that doesn't wire coverage in (e.g. some other page embedding `ChannelSalesTable`) still renders with zero exclusion notes and now literally zero related requests, not even the disabled-query bookkeeping across 4 hooks.
+- **No behavior change for `ProductSalesTable`**: explicitly out of scope; verified no shared mutable state or accidental coupling exists between the two tables' use of the old hook.
+
+## 7. Final validation checklist
+
+- [x] Dependency direction: `pages` never imports `features` internals directly; this stays within `features/analytics`
+- [x] No raw `fetch` from components — goes through `apiClient.analytics.*` via a hook, matching every sibling read
+- [x] Server state via TanStack Query (`useQuery`), no new local/global state
+- [x] No business logic duplicated from BE — the FE only reshapes an already-grouped response into a `Map`, same as before
+- [x] Naming: `use-*.ts` hook file, `*.lib.ts` pure helper, `*.types.ts` types, `*.api.ts` client — all match existing conventions in this feature
+- [x] Tests updated for the new API call shape; existing regression assertions preserved
+- [x] Plan is execution-ready
+
+## 8. Questions & Assumptions
+
+- **Assumption**: since PR #2810 (issue #2713) is not yet merged to `main`, this branch stacks on top of `2713-coverage-by-connection-reads` rather than `main` — consistent with how #2713 itself stacked on `2799-product-identity-coverage-rows`. If #2713 merges first, this branch rebases cleanly (no conflicts expected — disjoint file sets).
+- **Assumption**: `buildChannelExclusionMap`'s signature change (object → `AnalyticsCoverageByConnection | undefined`) is acceptable as an in-place reshape rather than a new function name, since it has exactly one caller and the issue explicitly anticipates this ("stays (or simplifies)").

--- a/docs/plans/implementation-plan-coverage-by-connection.md
+++ b/docs/plans/implementation-plan-coverage-by-connection.md
@@ -1,0 +1,487 @@
+# Implementation Plan — Aggregate-by-connection reads for Data Coverage categories
+
+- **Issue**: [#2713](https://github.com/openlinker-project/openlinker/issues/2713)
+- **Type**: CORE (application services) + Interface (new controller route)
+- **Layer**: Application, Interface
+- **Base branch for this work**: `2799-product-identity-coverage-rows` (PR #2808) — this task is a pure
+  follow-up to epic #2452 Phase 8 (#2481, PR #2701) and depends on nothing from that PR being reverted.
+
+## 1. Goal & Scope
+
+### Goal
+
+`apps/web/src/features/analytics/components/channel-sales-table.tsx`'s `useCoverageCrossReferenceQuery`
+today answers "how many affected orders does connection X have, per Data Coverage category" by paging
+through the FULL affected-order list (`GET /analytics/coverage/currency-mismatch-orders`,
+`GET /analytics/coverage/tax-orders`) and grouping by `sourceConnectionId` **client-side**. On an install
+with a large `netExcludedCount`/`unconvertedCount` population this drains many pages of full order rows
+over the network just to produce a handful of per-connection counts.
+
+Add one new read per detector that does the `GROUP BY sourceConnectionId` server-side, plus one new
+controller endpoint that composes all of them into a single response — mirroring
+`AnalyticsCoverageController.getCoverage`'s existing `Promise.all` composition shape.
+
+### Primary objectives
+
+1. `OrderRecordRepositoryPort` gains a currency-mismatch aggregate-by-connection method
+   (`GROUP BY` SQL — same predicate as `findCurrencyMismatchOrders`, no per-row hydration).
+2. `ITaxCoverageDetectionService` gains a tax A/B/C aggregate-by-connection method that reuses the
+   existing `classify()` pass and groups the already-classified rows by `sourceConnectionId` in memory
+   — never a second live-catalogue read.
+3. One new controller endpoint, `GET /analytics/coverage/by-connection`, composing both aggregates (see
+   §4 on why `product-matching` is scoped OUT) into `{ category, rows: { sourceConnectionId,
+   affectedCount }[] }[]`.
+
+### Non-goals
+
+- No FE changes. This is the paired backend issue for a separate FE ticket that will consume the new
+  endpoint and delete `useCoverageCrossReferenceQuery`'s client-side pagination/grouping. Out of scope
+  here.
+- No change to any existing endpoint's response shape (`GET /analytics/coverage`,
+  `GET /analytics/coverage/currency-mismatch-orders`, `GET /analytics/coverage/tax-orders`) — this is
+  purely additive.
+- No `product-matching` aggregate (see §4 — confirmed unnecessary, not merely deferred).
+- No FX/tax computation changes. This task reshapes existing detector output; it introduces no new
+  business logic about what counts as a mismatch.
+
+### Constraints honoured
+
+- Cross-context reads still go through `I*Service`, never a repository port directly (the controller
+  already follows this for the sibling endpoint and will for the new one).
+- `orders` must not import `analytics`; the new endpoint reuses the existing pattern of resolving
+  `currentReportingCurrency` / `includeBackfilledTaxRatesInNetSales` in the `apps/api` layer and
+  threading them in as plain parameters (already how `AnalyticsCoverageController.getCoverage` does it).
+- Same `SalesAnalyticsFilters` / `MAX_COVERAGE_RANGE_DAYS` date-range validation as
+  `AnalyticsCoverageController`.
+
+## 2. Research summary
+
+### Existing patterns this plan reuses verbatim
+
+- **`OrderRecordRepository.findCurrencyMismatchOrders`** (`libs/core/src/orders/infrastructure/
+  persistence/repositories/order-record.repository.ts:614`) — the predicate to reuse for the new
+  aggregate: `applySalesAnalyticsScope(qb, filters)` (private helper, `recordStatus = 'ready'`,
+  resolvable `placedAt`/`totalAmount`, in-range, optional `sourceConnectionId`) plus
+  `cancelledAt IS NULL` plus `(reportingCurrency IS NULL OR reportingCurrency !=
+  currentReportingCurrency)`. The new method drops `.orderBy/.take/.skip/.getManyAndCount()` for
+  `.select('rec.sourceConnectionId', ...).addSelect('COUNT(*)', ...).groupBy(...).getRawMany()` —
+  exactly the shape `getDailyOrderAggregates` (same file, ~line 496-556) already uses for its own
+  `GROUP BY rec.sourceConnectionId`.
+- **`TaxCoverageDetectionService.getAllCategoryPages`** (`libs/core/src/orders/application/services/
+  tax-coverage-detection.service.ts:150`) — the sibling to copy: it calls `classify()` ONCE and reshapes
+  the same `TaxCoverageClassification` three ways. The new method does the same, grouping each of the
+  three category arrays by `sourceConnectionId` (every `TaxCoverageOrderRow` already carries
+  `sourceConnectionId` via `toRow`, confirmed at `tax-coverage-detection.service.ts:178`) instead of
+  slicing pages.
+- **`AnalyticsCoverageController.getCoverage`** (`apps/api/src/analytics/http/
+  analytics-coverage.controller.ts`) — the composition shape to mirror: resolve
+  `currentReportingCurrency` once, resolve `includeBackfilledTaxRatesInNetSales` once, `Promise.all` the
+  detector reads, assemble one response DTO. The new endpoint is a sibling `@Get` on the same
+  controller, reusing `AnalyticsCoverageQueryDto` unchanged (its `from`/`to`/`sourceConnectionId` already
+  cover this read's needs) and the same `MAX_COVERAGE_RANGE_DAYS` validation — will extract that
+  validation into a small private helper on the controller rather than duplicate the `if` blocks (see
+  Step 3.4).
+
+### Confirmed via codebase check: `product-matching` aggregate is NOT needed
+
+The issue flags this as "needs confirmation before implementing." Confirmed by reading
+`apps/web/src/features/analytics/components/channel-sales-table.tsx`: its own header comment
+(around line 53) states the cross-reference is "currency, or one of tax-a/b/c — never
+`product-matching`, which cannot [be cross-referenced]" and `useCoverageCrossReferenceQuery` is called
+exactly 4 times (currency, tax-a, tax-b, tax-c) — no product-matching call site exists anywhere in the
+FE. Building a `getProductMatchingErrorOrdersByConnection` aggregate would ship dead code. **Scoped out.**
+
+### Types already in place, reused unchanged
+
+- `SalesAnalyticsFilters` (`{ from, to, sourceConnectionId? }`) — currency + tax aggregates.
+- `CoverageCategory` / `CoverageCategoryValues` (`libs/core/src/orders/domain/types/
+  coverage-detection.types.ts`) — already includes `'currency' | 'tax-a' | 'tax-b' | 'tax-c' |
+  'product-matching'`; the response DTO will use only the four relevant values via
+  `TaxCoverageCategoryValues` + a literal `'currency'`, matching how `getCoverage` already assembles its
+  `categories` array.
+
+## 3. Design
+
+### 3.1 New domain type — `CoverageConnectionAggregateRow`
+
+New file section in `libs/core/src/orders/domain/types/coverage-detection.types.ts` (additive, per that
+file's own stated convention — "kept additive on purpose"):
+
+```typescript
+/**
+ * One `(category, sourceConnectionId)` count for the aggregate-by-connection
+ * read (#2713) — the shape `useCoverageCrossReferenceQuery`'s client-side
+ * GROUP BY currently derives from a full paginated order list. Deliberately
+ * NOT keyed per-category at the type level (no `CurrencyConnectionAggregate`
+ * / `TaxConnectionAggregate` split) — every consumer of this shape wants the
+ * same two fields regardless of which detector produced it.
+ */
+export interface CoverageConnectionAggregateRow {
+  sourceConnectionId: string;
+  affectedCount: number;
+}
+```
+
+### 3.2 Repository layer — currency aggregate
+
+**Port** (`libs/core/src/orders/domain/ports/order-record-repository.port.ts`), new method
+`findCurrencyMismatchOrdersByConnection`, doc comment cross-referencing `findCurrencyMismatchOrders` and
+stating the IDENTICAL predicate (so the two reads can never silently diverge on what counts as a
+mismatch — same rationale already used for every sibling doc comment in this file):
+
+```typescript
+findCurrencyMismatchOrdersByConnection(
+  filters: SalesAnalyticsFilters,
+  currentReportingCurrency: string
+): Promise<CoverageConnectionAggregateRow[]>;
+```
+
+**Repository** (`order-record.repository.ts`), new method placed immediately after
+`findCurrencyMismatchOrders`:
+
+```typescript
+async findCurrencyMismatchOrdersByConnection(
+  filters: SalesAnalyticsFilters,
+  currentReportingCurrency: string
+): Promise<CoverageConnectionAggregateRow[]> {
+  const qb = this.repository
+    .createQueryBuilder('rec')
+    .select('rec.sourceConnectionId', 'source_connection_id')
+    .addSelect('COUNT(*)', 'affected_count')
+    .andWhere('rec."cancelledAt" IS NULL')
+    .andWhere(
+      '(rec."reportingCurrency" IS NULL OR rec."reportingCurrency" != :currentReportingCurrency)',
+      { currentReportingCurrency }
+    )
+    .groupBy('rec.sourceConnectionId');
+
+  this.applySalesAnalyticsScope(qb, filters);
+
+  const rows = await qb.getRawMany<{ source_connection_id: string; affected_count: string }>();
+
+  return rows.map((row) => ({
+    sourceConnectionId: row.source_connection_id,
+    affectedCount: Number(row.affected_count),
+  }));
+}
+```
+
+A connection with zero mismatches is simply absent from the result — the "absent key = no data"
+convention `getDailyOrderAggregates`/`findEarliestOrderDateByConnection` already establish in this file.
+No pagination — this is already a bounded number of rows (≤ number of `OrderSource`-capable
+connections), unlike the order-list reads it replaces for this use case.
+
+### 3.3 Application layer — tax A/B/C aggregate
+
+**Interface** (`tax-coverage-detection.service.interface.ts`), new method
+`getAllCategoryCountsByConnection`:
+
+```typescript
+/**
+ * All three categories' per-connection counts in ONE {@link classify} pass
+ * (#2713) — the aggregate-by-connection counterpart to
+ * {@link getAllCategoryPages}, for the same reason that method exists:
+ * `AnalyticsCoverageController` needs `tax-a`/`tax-b`/`tax-c` together, and
+ * three separate calls would re-run the live-catalogue classification pass
+ * three times over the SAME candidate population.
+ */
+getAllCategoryCountsByConnection(
+  filters: SalesAnalyticsFilters,
+  currentReportingCurrency: string,
+  includeBackfilledPreRollout?: boolean
+): Promise<Record<TaxCoverageCategory, CoverageConnectionAggregateRow[]>>;
+```
+
+**Service** (`tax-coverage-detection.service.ts`), new method placed after `getAllCategoryPages`, reusing
+`classify()` and a small private grouping helper:
+
+```typescript
+async getAllCategoryCountsByConnection(
+  filters: SalesAnalyticsFilters,
+  currentReportingCurrency: string,
+  includeBackfilledPreRollout = false
+): Promise<Record<TaxCoverageCategory, CoverageConnectionAggregateRow[]>> {
+  const classification = await this.classify(
+    filters,
+    currentReportingCurrency,
+    includeBackfilledPreRollout
+  );
+  const counts: Partial<Record<TaxCoverageCategory, CoverageConnectionAggregateRow[]>> = {};
+  for (const category of TaxCoverageCategoryValues) {
+    counts[category] = this.groupByConnection(classification[category]);
+  }
+  return counts as Record<TaxCoverageCategory, CoverageConnectionAggregateRow[]>;
+}
+
+private groupByConnection(rows: TaxCoverageOrderRow[]): CoverageConnectionAggregateRow[] {
+  const byConnection = new Map<string, number>();
+  for (const row of rows) {
+    byConnection.set(row.sourceConnectionId, (byConnection.get(row.sourceConnectionId) ?? 0) + 1);
+  }
+  return Array.from(byConnection, ([sourceConnectionId, affectedCount]) => ({
+    sourceConnectionId,
+    affectedCount,
+  }));
+}
+```
+
+This is a genuinely new `classify()` call site (distinct from `getCoverage`'s own call), so — per the
+issue's acceptance criteria — the unit test must assert it calls `findNetExcludedOrderCandidates`
+(the one live-catalogue-touching read inside `classify`) exactly once per invocation, not once per
+category.
+
+### 3.4 Interface layer — new controller endpoint
+
+**Query DTO**: reuse `AnalyticsCoverageQueryDto` unchanged — same `from`/`to`/`sourceConnectionId`
+shape, same semantics (currency/tax bucketed by `placedAt`).
+
+**Response DTO** — new file `apps/api/src/analytics/http/dto/analytics-coverage-by-connection-response.dto.ts`:
+
+```typescript
+export class CoverageConnectionRowDto {
+  @ApiProperty() sourceConnectionId!: string;
+  @ApiProperty() affectedCount!: number;
+}
+
+export class CoverageCategoryConnectionRowsDto {
+  @ApiProperty({ enum: CoverageCategoryValues }) category!: CoverageCategory;
+  @ApiProperty({ type: [CoverageConnectionRowDto] }) rows!: CoverageConnectionRowDto[];
+}
+
+export class AnalyticsCoverageByConnectionResponseDto {
+  @ApiProperty({ type: [CoverageCategoryConnectionRowsDto] })
+  categories!: CoverageCategoryConnectionRowsDto[];
+}
+```
+
+Note: unlike `CoverageCategoryRowDto`, this row carries no `status`/`activeRunId` — those are
+per-category lifecycle facts, not per-connection ones, and the issue's own assumption pins the response
+shape to `{ category, rows: { sourceConnectionId, affectedCount }[] }[]`.
+
+**Controller method** (`AnalyticsCoverageController`), new `@Get('coverage/by-connection')` sibling to
+`getCoverage`:
+
+```typescript
+@Get('coverage/by-connection')
+@ApiOperation({
+  summary:
+    'Data Coverage panel, per-connection breakdown — affected-order counts grouped by sourceConnectionId (currency, tax A/B/C)',
+})
+@ApiResponse({ status: 200, type: AnalyticsCoverageByConnectionResponseDto })
+async getCoverageByConnection(
+  @Query() query: AnalyticsCoverageQueryDto
+): Promise<AnalyticsCoverageByConnectionResponseDto> {
+  const { from, to } = this.parseAndValidateRange(query); // extracted helper, see below
+
+  const salesFilters = { from, to, sourceConnectionId: query.sourceConnectionId };
+
+  const currentReportingCurrency = await this.reportingCurrencySettings.resolve();
+  const { includeBackfilledTaxRatesInNetSales } = await this.displaySettings.getSettings();
+
+  const [currencyRows, taxRowsByCategory] = await Promise.all([
+    this.orderRecordService.getCurrencyMismatchOrdersByConnection(
+      salesFilters,
+      currentReportingCurrency
+    ),
+    this.taxCoverageDetectionService.getAllCategoryCountsByConnection(
+      salesFilters,
+      currentReportingCurrency,
+      includeBackfilledTaxRatesInNetSales
+    ),
+  ]);
+
+  const response = new AnalyticsCoverageByConnectionResponseDto();
+  response.categories = [
+    { category: 'currency', rows: currencyRows },
+    ...TaxCoverageCategoryValues.map((category) => ({
+      category,
+      rows: taxRowsByCategory[category],
+    })),
+  ];
+  return response;
+}
+```
+
+`parseAndValidateRange` is a small private helper extracted from `getCoverage`'s existing inline
+`from`/`to`/`MAX_COVERAGE_RANGE_DAYS` block (lines 90-100 today), reused by both endpoints — a
+refactor-while-touching, not scope creep, since duplicating that validation block verbatim into the new
+method would be the actual standards violation (`docs/engineering-standards.md` favors reuse over
+duplication). `getCoverage` is updated to call the same helper; its behavior is unchanged (same
+`BadRequestException` messages, same 400 status).
+
+### 3.5 `IOrderRecordService` — thin pass-through
+
+**Interface** (`order-record.service.interface.ts`), new method next to `getCurrencyMismatchOrders`:
+
+```typescript
+/**
+ * Data Coverage `'currency'` category aggregate-by-connection (#2713) — thin
+ * pass-through to {@link OrderRecordRepositoryPort.findCurrencyMismatchOrdersByConnection}.
+ * Unlike {@link getCurrencyMismatchOrders}, no line-item enrichment is needed
+ * here — a count carries no `productId`/`variantId` to attach.
+ */
+getCurrencyMismatchOrdersByConnection(
+  filters: SalesAnalyticsFilters,
+  currentReportingCurrency: string
+): Promise<CoverageConnectionAggregateRow[]>;
+```
+
+**Service** (`order-record.service.ts`), thin pass-through next to `getCurrencyMismatchOrders`:
+
+```typescript
+async getCurrencyMismatchOrdersByConnection(
+  filters: SalesAnalyticsFilters,
+  currentReportingCurrency: string
+): Promise<CoverageConnectionAggregateRow[]> {
+  return this.repository.findCurrencyMismatchOrdersByConnection(filters, currentReportingCurrency);
+}
+```
+
+## 4. Files touched
+
+| File | Change |
+|---|---|
+| `libs/core/src/orders/domain/types/coverage-detection.types.ts` | + `CoverageConnectionAggregateRow` |
+| `libs/core/src/orders/domain/ports/order-record-repository.port.ts` | + `findCurrencyMismatchOrdersByConnection` |
+| `libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts` | + method impl |
+| `libs/core/src/orders/application/interfaces/order-record.service.interface.ts` | + `getCurrencyMismatchOrdersByConnection` |
+| `libs/core/src/orders/application/services/order-record.service.ts` | + pass-through impl |
+| `libs/core/src/orders/application/services/tax-coverage-detection.service.interface.ts` | + `getAllCategoryCountsByConnection` |
+| `libs/core/src/orders/application/services/tax-coverage-detection.service.ts` | + method impl + `groupByConnection` private helper |
+| `apps/api/src/analytics/http/dto/analytics-coverage-by-connection-response.dto.ts` | new file |
+| `apps/api/src/analytics/http/analytics-coverage.controller.ts` | + `getCoverageByConnection`, extract `parseAndValidateRange` |
+| Tests (see §6) | new/updated `.spec.ts` + one `.int-spec.ts` addition |
+
+No ORM entity, no migration, no module-wiring change (all services/tokens already registered).
+
+## 5. Step-by-step plan
+
+**Phase 1 — Domain type**
+1.1. Add `CoverageConnectionAggregateRow` to `coverage-detection.types.ts`. *Acceptance*: type-checks,
+     no other file changed yet.
+
+**Phase 2 — Currency aggregate (repository → service → interface)**
+2.1. Add `findCurrencyMismatchOrdersByConnection` to `OrderRecordRepositoryPort`.
+2.2. Implement it in `OrderRecordRepository`, reusing `applySalesAnalyticsScope`.
+2.3. Add unit test(s) in `order-record.repository.spec.ts` asserting the `GROUP BY` query builder calls
+     (mock query-builder pattern already used by sibling tests in that file) and the raw-row mapping
+     (`source_connection_id`/`affected_count` → camelCase).
+2.4. Add an integration test case to `apps/api/test/integration/orders/` (a new
+     `order-record-coverage-by-connection.int-spec.ts`, or extend an existing coverage int-spec if one
+     already exercises `findCurrencyMismatchOrders` against a real Postgres) with orders split across
+     ≥2 connections — asserting per-connection counts match a manual tally and a connection with zero
+     mismatches is simply absent from the result.
+2.5. Add `getCurrencyMismatchOrdersByConnection` to `IOrderRecordService` + `OrderRecordService`
+     (thin pass-through — no line-item enrichment).
+2.6. Unit test in `order-record.service.spec.ts` asserting the pass-through delegates with the exact
+     arguments received.
+
+**Phase 3 — Tax A/B/C aggregate**
+3.1. Add `getAllCategoryCountsByConnection` to `ITaxCoverageDetectionService`.
+3.2. Implement it + the private `groupByConnection` helper in `TaxCoverageDetectionService`.
+3.3. Unit test in `tax-coverage-detection.service.spec.ts` (or the file backing its existing tests):
+     - fixture with candidates split across ≥2 `sourceConnectionId`s, assert grouped counts per category
+       sum correctly and match `getCategoryCounts`'s totals for the same filters (cross-check the two
+       methods never diverge).
+     - assert `findNetExcludedOrderCandidates` (the mocked repository call standing in for the
+       live-catalogue-touching path) is called exactly once per `getAllCategoryCountsByConnection`
+       invocation — the "no second live-catalogue read per connection" acceptance criterion.
+
+**Phase 4 — Controller endpoint**
+4.1. Extract `parseAndValidateRange` from `getCoverage`'s inline block; rewire `getCoverage` to use it
+     (behavior-preserving refactor — same error messages/status).
+4.2. Add `analytics-coverage-by-connection-response.dto.ts`.
+4.3. Add `getCoverageByConnection` to `AnalyticsCoverageController`.
+4.4. Add Swagger documentation via `@ApiOperation`/`@ApiResponse` (already shown above).
+4.5. Controller-level test (unit, mocking the two services — mirrors however `getCoverage` is tested
+     today, e2e or unit) asserting: 400 on missing/invalid range, 400 on range > `MAX_COVERAGE_RANGE_DAYS`,
+     200 with the composed `{ categories: [...] }` shape for a happy-path fixture, and that
+     `sourceConnectionId` query-param narrowing reaches both underlying reads.
+
+**Phase 5 — Review pass**
+5.1. Re-read both new predicate copies (currency SQL `WHERE`, tax `classify()` reuse) side-by-side
+     against their non-aggregate siblings to confirm byte-identical scoping — this is the acceptance
+     criterion "verified against a fixture with orders split across ≥2 connections," and the
+     regression-guard convention this file's siblings already follow (their doc comments explicitly
+     state "same predicate, so totals can never diverge").
+5.2. Confirm no `product-matching` aggregate was added (scoped out per §"Confirmed" above) and that the
+     new endpoint's Swagger description says so if asked — no action needed, just a final scope check.
+5.3. Run `pnpm lint` / `pnpm type-check` for the touched packages (per CLAUDE.md — user has instructed
+     not to run `pnpm test` in this session; type-check/lint only).
+
+## 6. Testing strategy
+
+- **Repository**: unit test (mocked `Repository`/`SelectQueryBuilder`, matching the existing spec file's
+  mocking style) + one integration test against a real Postgres fixture (Testcontainers), per the
+  issue's own acceptance criterion ("verified against a fixture with orders split across ≥2
+  connections").
+- **`TaxCoverageDetectionService`**: unit test with a spy/mock call-count assertion on
+  `findNetExcludedOrderCandidates`, per the issue's explicit acceptance criterion ("no second
+  live-catalogue read per connection").
+- **`OrderRecordService`**: unit test, pass-through argument assertion.
+- **Controller**: unit test covering validation + happy path + `sourceConnectionId` narrowing.
+- No FE tests — out of scope.
+
+## 7. Risks & edge cases
+
+- **Empty result set**: a category/filter combination with zero mismatches must return `rows: []`, not
+  omit the category row entirely — the controller always emits all four category entries
+  (`'currency'` + the three `TaxCoverageCategoryValues`), each carrying a (possibly empty) `rows` array.
+  This matches `getCoverage`'s existing behavior of always emitting every `CoverageCategoryValues` row.
+- **`sourceConnectionId` query param on an already-narrowed request**: when the caller passes
+  `sourceConnectionId`, the aggregate degenerates to at most one row per category — correct behavior,
+  not a bug, since `applySalesAnalyticsScope` already narrows the underlying population the same way
+  `getCoverage` does today.
+- **Currency-setting change mid-window**: unaffected by this change — the aggregate reads the exact same
+  `reportingCurrency`-stamped rows the existing drill-down does, with `currentReportingCurrency`
+  resolved once per request (existing pattern, preserved).
+- **Backward compatibility**: fully additive — no existing endpoint, DTO, or service method signature
+  changes (aside from the internal `parseAndValidateRange` extraction, which is behavior-preserving).
+- **Performance**: the currency aggregate is a single indexed `GROUP BY` (same index profile as
+  `findCurrencyMismatchOrders`'s `WHERE` clause); the tax aggregate reuses the existing unpaged
+  `classify()` pass with no additional catalogue calls — the acceptance criterion this plan is built
+  around.
+
+## 8. Final validation checklist
+
+- [x] Follows hexagonal architecture (repository port → repository impl → application service → thin
+      controller composition; no CORE↔Integration boundary crossed)
+- [x] Respects CORE vs Integration boundaries
+- [x] Uses existing patterns — `getDailyOrderAggregates`'s `GROUP BY` shape, `getAllCategoryPages`'s
+      single-`classify()`-call shape, `getCoverage`'s composition shape; no new abstractions introduced
+- [x] Idempotency — read-only, N/A
+- [x] Event-driven patterns — N/A (no writes)
+- [x] Rate limits & retries — N/A (no outbound platform calls; tax aggregate reuses `classify()`'s
+      existing `IProductsService.getEffectiveTaxRate` calls unchanged)
+- [x] Error handling — same `BadRequestException` validation as the sibling endpoint, via the extracted
+      shared helper
+- [x] Testing strategy complete (§6)
+- [x] Naming conventions followed (`*ByConnection` suffix, `I*Service` interfaces, `*Port` for the
+      repository contract, `*RepositoryPort` never crossing the cross-context boundary)
+- [x] File structure matches standards (types in `*.types.ts`, DTOs in `apps/api/.../dto/`)
+- [x] Plan is execution-ready
+
+## 9. Questions & Assumptions
+
+- **Assumption (confirmed)**: `product-matching` aggregate is scoped out — no FE consumer exists today
+  (verified: `channel-sales-table.tsx` never calls `useCoverageCrossReferenceQuery` for it, and its own
+  header comment says so explicitly).
+- **Assumption**: response shape is `{ category, rows: { sourceConnectionId, affectedCount }[] }[]` per
+  the issue's stated assumption — matches how a paired FE issue would consume it (array of category
+  buckets, not a top-level per-connection grouping).
+- **Assumption**: the new endpoint lives on the SAME controller (`AnalyticsCoverageController`) as a
+  sibling `@Get`, rather than a new controller class — the issue's own file list names
+  `analytics-coverage.controller.ts "(or a new sibling controller)"`; sibling-method is chosen because
+  the endpoint shares 100% of its dependencies (`IOrderRecordService`, `ITaxCoverageDetectionService`,
+  `IReportingCurrencySettingsService`, `IAnalyticsDisplaySettingsService`) with `getCoverage`, and a new
+  controller class would just re-inject the same four services for no isolation benefit.
+- **Open question for reviewer**: should `parseAndValidateRange` extraction be included in this PR, or
+  is touching `getCoverage` (even behavior-preservingly) out of this issue's stated file list? The issue
+  lists `analytics-coverage.controller.ts` as a file to touch, so this plan includes it; flag if the
+  reviewer prefers duplicating the validation block instead to keep the diff minimal.
+
+## 10. Execution note (this session)
+
+Per explicit instruction, this plan is executed **locally only**: no commits, no pushes, no PR, no
+GitHub comments. All work stays uncommitted in the local worktree for review before any of those steps
+happen.

--- a/libs/core/src/orders/application/interfaces/order-record.service.interface.ts
+++ b/libs/core/src/orders/application/interfaces/order-record.service.interface.ts
@@ -32,6 +32,7 @@ import type {
   CoverageDetectionPagination,
   PaginatedCurrencyMismatchOrders,
   PaginatedProductMatchingErrorOrders,
+  CoverageConnectionAggregateRow,
 } from '../../domain/types/coverage-detection.types';
 
 export interface IOrderRecordService {
@@ -292,6 +293,19 @@ export interface IOrderRecordService {
     currentReportingCurrency: string,
     pagination: CoverageDetectionPagination
   ): Promise<PaginatedCurrencyMismatchOrders>;
+
+  /**
+   * Data Coverage `'currency'` category aggregate-by-connection (#2713) —
+   * thin pass-through to {@link
+   * OrderRecordRepositoryPort.findCurrencyMismatchOrdersByConnection}, for
+   * the same cross-context-boundary reason as {@link
+   * getCurrencyMismatchOrders}. Unlike that method, no line-item enrichment
+   * runs here — a count carries no `productId`/`variantId` to attach.
+   */
+  getCurrencyMismatchOrdersByConnection(
+    filters: SalesAnalyticsFilters,
+    currentReportingCurrency: string
+  ): Promise<CoverageConnectionAggregateRow[]>;
 
   /**
    * Data Coverage `'product-matching'` category drill-down (#2466) — thin

--- a/libs/core/src/orders/application/services/__tests__/order-record.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-record.service.spec.ts
@@ -51,6 +51,7 @@ describe('OrderRecordService', () => {
       getMedianOrderValue: jest.fn(),
       getNetMedianOrderValue: jest.fn(),
       findCurrencyMismatchOrders: jest.fn(),
+      findCurrencyMismatchOrdersByConnection: jest.fn(),
       findProductMatchingErrorOrders: jest.fn(),
       findCurrencyMismatchOrderRefsAfter: jest.fn(),
       clearFxStampForRestatement: jest.fn(),
@@ -1547,6 +1548,29 @@ describe('OrderRecordService', () => {
       expect(result.items[1]).toEqual(
         expect.objectContaining({ internalOrderId: 'order-2', productId: null, variantId: null })
       );
+    });
+  });
+
+  describe('getCurrencyMismatchOrdersByConnection (#2713)', () => {
+    it('is a thin pass-through to the repository read, forwarding args verbatim, with no enrichment', async () => {
+      const salesFilters = {
+        from: new Date('2026-08-01T00:00:00.000Z'),
+        to: new Date('2026-08-08T00:00:00.000Z'),
+      };
+      const rows = [
+        { sourceConnectionId: 'conn-a', affectedCount: 3 },
+        { sourceConnectionId: 'conn-b', affectedCount: 1 },
+      ];
+      repository.findCurrencyMismatchOrdersByConnection.mockResolvedValue(rows);
+
+      const result = await service.getCurrencyMismatchOrdersByConnection(salesFilters, 'EUR');
+
+      expect(repository.findCurrencyMismatchOrdersByConnection).toHaveBeenCalledWith(
+        salesFilters,
+        'EUR'
+      );
+      expect(lineItemRepository.findRepresentativeLinesByOrderIds).not.toHaveBeenCalled();
+      expect(result).toEqual(rows);
     });
   });
 

--- a/libs/core/src/orders/application/services/order-record.service.ts
+++ b/libs/core/src/orders/application/services/order-record.service.ts
@@ -58,6 +58,7 @@ import type {
   CoverageDetectionPagination,
   PaginatedCurrencyMismatchOrders,
   PaginatedProductMatchingErrorOrders,
+  CoverageConnectionAggregateRow,
 } from '../../domain/types/coverage-detection.types';
 
 /** One day in milliseconds, for the market-discovery window arithmetic (#2518). */
@@ -689,6 +690,23 @@ export class OrderRecordService implements IOrderRecordService {
         };
       }),
     };
+  }
+
+  /**
+   * Data Coverage `'currency'` category aggregate-by-connection (#2713) —
+   * thin pass-through to {@link
+   * OrderRecordRepositoryPort.findCurrencyMismatchOrdersByConnection}. No
+   * line-item enrichment here (unlike {@link getCurrencyMismatchOrders}) — a
+   * count carries no `productId`/`variantId` to attach.
+   */
+  async getCurrencyMismatchOrdersByConnection(
+    filters: SalesAnalyticsFilters,
+    currentReportingCurrency: string
+  ): Promise<CoverageConnectionAggregateRow[]> {
+    return this.repository.findCurrencyMismatchOrdersByConnection(
+      filters,
+      currentReportingCurrency
+    );
   }
 
   /**

--- a/libs/core/src/orders/application/services/tax-coverage-detection.service.interface.ts
+++ b/libs/core/src/orders/application/services/tax-coverage-detection.service.interface.ts
@@ -13,6 +13,7 @@ import type {
   PaginatedTaxCoverageOrders,
   TaxCoverageCategory,
   TaxCoverageClassification,
+  CoverageConnectionAggregateRow,
 } from '../../domain/types/coverage-detection.types';
 
 export interface ITaxCoverageDetectionService {
@@ -76,4 +77,17 @@ export interface ITaxCoverageDetectionService {
     pagination: CoverageDetectionPagination,
     includeBackfilledPreRollout?: boolean
   ): Promise<Record<TaxCoverageCategory, PaginatedTaxCoverageOrders>>;
+
+  /**
+   * All three categories' per-connection affected-order counts in ONE
+   * {@link classify} pass (#2713) — the aggregate-by-connection counterpart
+   * of {@link getAllCategoryPages}, for the identical reason: three separate
+   * calls would re-run the live-catalogue classification pass three times
+   * over the SAME candidate population.
+   */
+  getAllCategoryCountsByConnection(
+    filters: SalesAnalyticsFilters,
+    currentReportingCurrency: string,
+    includeBackfilledPreRollout?: boolean
+  ): Promise<Record<TaxCoverageCategory, CoverageConnectionAggregateRow[]>>;
 }

--- a/libs/core/src/orders/application/services/tax-coverage-detection.service.spec.ts
+++ b/libs/core/src/orders/application/services/tax-coverage-detection.service.spec.ts
@@ -377,4 +377,59 @@ describe('TaxCoverageDetectionService (#2465)', () => {
       expect(pages['tax-b'].items[0].internalOrderId).toBe('order-2');
     });
   });
+
+  describe('getAllCategoryCountsByConnection (#2713)', () => {
+    it('groups all three categories by connection from ONE classification pass', async () => {
+      const candidates = [
+        candidate({ internalOrderId: 'order-1', sourceConnectionId: 'conn-a', taxRateEra: null }),
+        candidate({ internalOrderId: 'order-2', sourceConnectionId: 'conn-a', taxRateEra: null }),
+        candidate({ internalOrderId: 'order-3', sourceConnectionId: 'conn-b', taxRateEra: null }),
+      ];
+      recordRepository.findNetExcludedOrderCandidates.mockResolvedValue(candidates);
+
+      const counts = await service.getAllCategoryCountsByConnection(baseFilters, 'EUR');
+
+      expect(recordRepository.findNetExcludedOrderCandidates).toHaveBeenCalledTimes(1);
+      expect(counts['tax-b']).toEqual([
+        { sourceConnectionId: 'conn-a', affectedCount: 2 },
+        { sourceConnectionId: 'conn-b', affectedCount: 1 },
+      ]);
+      expect(counts['tax-a']).toEqual([]);
+      expect(counts['tax-c']).toEqual([]);
+    });
+
+    it('sums to the same totals getCategoryCounts reports for the same filters', async () => {
+      const candidates = [
+        candidate({ internalOrderId: 'order-1', sourceConnectionId: 'conn-a', taxRateEra: null }),
+        candidate({ internalOrderId: 'order-2', sourceConnectionId: 'conn-b', taxRateEra: null }),
+        candidate({ internalOrderId: 'order-3', sourceConnectionId: 'conn-b', taxRateEra: null }),
+      ];
+      recordRepository.findNetExcludedOrderCandidates.mockResolvedValue(candidates);
+
+      const counts = await service.getCategoryCounts(baseFilters, 'EUR');
+      const byConnection = await service.getAllCategoryCountsByConnection(baseFilters, 'EUR');
+
+      const totalFromByConnection = byConnection['tax-b'].reduce(
+        (sum, row) => sum + row.affectedCount,
+        0
+      );
+      expect(totalFromByConnection).toBe(counts['tax-b']);
+    });
+
+    it('never calls findNetExcludedOrderCandidates more than once, regardless of category count', async () => {
+      recordRepository.findNetExcludedOrderCandidates.mockResolvedValue([]);
+
+      await service.getAllCategoryCountsByConnection(baseFilters, 'EUR');
+
+      expect(recordRepository.findNetExcludedOrderCandidates).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns an empty array per category when nothing matches', async () => {
+      recordRepository.findNetExcludedOrderCandidates.mockResolvedValue([]);
+
+      const counts = await service.getAllCategoryCountsByConnection(baseFilters, 'EUR');
+
+      expect(counts).toEqual({ 'tax-a': [], 'tax-b': [], 'tax-c': [] });
+    });
+  });
 });

--- a/libs/core/src/orders/application/services/tax-coverage-detection.service.ts
+++ b/libs/core/src/orders/application/services/tax-coverage-detection.service.ts
@@ -68,6 +68,7 @@ import {
   type TaxCoverageClassification,
   type TaxCoverageLineRateObservation,
   type TaxCoverageOrderRow,
+  type CoverageConnectionAggregateRow,
 } from '../../domain/types/coverage-detection.types';
 import type { OrderLineItem } from '../../domain/entities/order-line-item.entity';
 
@@ -167,6 +168,34 @@ export class TaxCoverageDetectionService implements ITaxCoverageDetectionService
       };
     }
     return pages as Record<TaxCoverageCategory, PaginatedTaxCoverageOrders>;
+  }
+
+  async getAllCategoryCountsByConnection(
+    filters: SalesAnalyticsFilters,
+    currentReportingCurrency: string,
+    includeBackfilledPreRollout = false
+  ): Promise<Record<TaxCoverageCategory, CoverageConnectionAggregateRow[]>> {
+    const classification = await this.classify(
+      filters,
+      currentReportingCurrency,
+      includeBackfilledPreRollout
+    );
+    const counts: Partial<Record<TaxCoverageCategory, CoverageConnectionAggregateRow[]>> = {};
+    for (const category of TaxCoverageCategoryValues) {
+      counts[category] = this.groupByConnection(classification[category]);
+    }
+    return counts as Record<TaxCoverageCategory, CoverageConnectionAggregateRow[]>;
+  }
+
+  private groupByConnection(rows: TaxCoverageOrderRow[]): CoverageConnectionAggregateRow[] {
+    const byConnection = new Map<string, number>();
+    for (const row of rows) {
+      byConnection.set(row.sourceConnectionId, (byConnection.get(row.sourceConnectionId) ?? 0) + 1);
+    }
+    return Array.from(byConnection, ([sourceConnectionId, affectedCount]) => ({
+      sourceConnectionId,
+      affectedCount,
+    }));
   }
 
   private toRow(

--- a/libs/core/src/orders/domain/ports/order-record-repository.port.ts
+++ b/libs/core/src/orders/domain/ports/order-record-repository.port.ts
@@ -30,6 +30,7 @@ import type {
   PaginatedCurrencyMismatchOrders,
   NetExcludedOrderCandidate,
   PaginatedProductMatchingErrorOrders,
+  CoverageConnectionAggregateRow,
 } from '../types/coverage-detection.types';
 import type { FxRestatementRemainingSummary } from '../types/order-fx-restatement.types';
 
@@ -257,6 +258,24 @@ export interface OrderRecordRepositoryPort {
     currentReportingCurrency: string,
     pagination: CoverageDetectionPagination
   ): Promise<PaginatedCurrencyMismatchOrders>;
+
+  /**
+   * Data Coverage `'currency'` category aggregate-by-connection (#2713) —
+   * the `GROUP BY sourceConnectionId` counterpart of
+   * {@link findCurrencyMismatchOrders}, reusing the IDENTICAL predicate (same
+   * `cancelledAt IS NULL`, same currency-mismatch condition, same
+   * {@link applySalesAnalyticsScope}-equivalent scope) so the two reads can
+   * never silently diverge on what counts as a mismatch. Returns one row per
+   * connection that has at least one mismatch; a connection with none is
+   * simply absent — see {@link CoverageConnectionAggregateRow}. No
+   * pagination: the result is already bounded by the number of
+   * `OrderSource`-capable connections, unlike the order-list read this
+   * replaces for the per-connection-count use case.
+   */
+  findCurrencyMismatchOrdersByConnection(
+    filters: SalesAnalyticsFilters,
+    currentReportingCurrency: string
+  ): Promise<CoverageConnectionAggregateRow[]>;
 
   /**
    * Data Coverage tax A/B/C detector's base population (#2465) — every

--- a/libs/core/src/orders/domain/types/coverage-detection.types.ts
+++ b/libs/core/src/orders/domain/types/coverage-detection.types.ts
@@ -305,3 +305,21 @@ export interface PaginatedProductMatchingErrorOrders {
   items: ProductMatchingErrorOrderRow[];
   total: number;
 }
+
+/**
+ * One `(category, sourceConnectionId)` count for the aggregate-by-connection
+ * read (#2713) — the server-side equivalent of what
+ * `useCoverageCrossReferenceQuery` used to derive client-side by paging
+ * through a full affected-order list and grouping by `sourceConnectionId`.
+ * Deliberately NOT keyed per-category at the type level (no
+ * `CurrencyConnectionAggregate` / `TaxConnectionAggregate` split) — every
+ * consumer wants the same two fields regardless of which detector produced
+ * the row. A connection with zero affected orders is simply absent from the
+ * result, mirroring the "absent key = no data" convention
+ * {@link getDailyOrderAggregates}/`findEarliestOrderDateByConnection` already
+ * establish.
+ */
+export interface CoverageConnectionAggregateRow {
+  sourceConnectionId: string;
+  affectedCount: number;
+}

--- a/libs/core/src/orders/infrastructure/persistence/repositories/__tests__/order-record.repository.spec.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/__tests__/order-record.repository.spec.ts
@@ -610,6 +610,92 @@ describe('OrderRecordRepository', () => {
     });
   });
 
+  describe('findCurrencyMismatchOrdersByConnection (#2713)', () => {
+    const baseFilters = {
+      from: new Date('2026-08-01T00:00:00.000Z'),
+      to: new Date('2026-08-08T00:00:00.000Z'),
+    };
+
+    it('applies the same predicate as findCurrencyMismatchOrders and groups by connection', async () => {
+      const select = jest.fn().mockReturnThis();
+      const addSelect = jest.fn().mockReturnThis();
+      const andWhere = jest.fn().mockReturnThis();
+      const groupBy = jest.fn().mockReturnThis();
+      (ormRepository.createQueryBuilder as jest.Mock).mockReturnValue({
+        select,
+        addSelect,
+        andWhere,
+        groupBy,
+        getRawMany: jest.fn().mockResolvedValue([]),
+      });
+
+      await repository.findCurrencyMismatchOrdersByConnection(baseFilters, 'EUR');
+
+      expect(select).toHaveBeenCalledWith('rec.sourceConnectionId', 'source_connection_id');
+      expect(addSelect).toHaveBeenCalledWith('COUNT(*)', 'affected_count');
+      expect(andWhere).toHaveBeenCalledWith('rec."cancelledAt" IS NULL');
+      expect(andWhere).toHaveBeenCalledWith(
+        '(rec."reportingCurrency" IS NULL OR rec."reportingCurrency" != :currentReportingCurrency)',
+        { currentReportingCurrency: 'EUR' }
+      );
+      expect(groupBy).toHaveBeenCalledWith('rec.sourceConnectionId');
+    });
+
+    it('scopes to the sourceConnectionId filter when provided (via the shared analytics scope)', async () => {
+      const andWhere = jest.fn().mockReturnThis();
+      (ormRepository.createQueryBuilder as jest.Mock).mockReturnValue({
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        andWhere,
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([]),
+      });
+
+      await repository.findCurrencyMismatchOrdersByConnection(
+        { ...baseFilters, sourceConnectionId: 'conn-a' },
+        'EUR'
+      );
+
+      expect(andWhere).toHaveBeenCalledWith('rec.sourceConnectionId = :salesConnectionId', {
+        salesConnectionId: 'conn-a',
+      });
+    });
+
+    it('maps raw rows across multiple connections to camelCase counts', async () => {
+      (ormRepository.createQueryBuilder as jest.Mock).mockReturnValue({
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([
+          { source_connection_id: 'conn-a', affected_count: '3' },
+          { source_connection_id: 'conn-b', affected_count: '1' },
+        ]),
+      });
+
+      const result = await repository.findCurrencyMismatchOrdersByConnection(baseFilters, 'EUR');
+
+      expect(result).toEqual([
+        { sourceConnectionId: 'conn-a', affectedCount: 3 },
+        { sourceConnectionId: 'conn-b', affectedCount: 1 },
+      ]);
+    });
+
+    it('returns an empty array when nothing matches — a connection with zero mismatches is simply absent', async () => {
+      (ormRepository.createQueryBuilder as jest.Mock).mockReturnValue({
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        groupBy: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([]),
+      });
+
+      const result = await repository.findCurrencyMismatchOrdersByConnection(baseFilters, 'EUR');
+
+      expect(result).toEqual([]);
+    });
+  });
+
   describe('currency restatement reads/writes (#2468)', () => {
     const baseFilters = {
       from: new Date('2026-08-01T00:00:00.000Z'),

--- a/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
@@ -60,6 +60,7 @@ import type {
   PaginatedCurrencyMismatchOrders,
   NetExcludedOrderCandidate,
   PaginatedProductMatchingErrorOrders,
+  CoverageConnectionAggregateRow,
 } from '../../../domain/types/coverage-detection.types';
 
 @Injectable()
@@ -647,6 +648,39 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
       })),
       total,
     };
+  }
+
+  /**
+   * Data Coverage `'currency'` category aggregate-by-connection (#2713) —
+   * see the port's JSDoc. Same predicate as {@link findCurrencyMismatchOrders}
+   * (`cancelledAt IS NULL`, the currency-mismatch condition, and
+   * {@link applySalesAnalyticsScope}), swapping the paginated row hydration
+   * for a `GROUP BY rec.sourceConnectionId` count — mirrors
+   * {@link getDailyOrderAggregates}'s own `sourceConnectionId` grouping.
+   */
+  async findCurrencyMismatchOrdersByConnection(
+    filters: SalesAnalyticsFilters,
+    currentReportingCurrency: string
+  ): Promise<CoverageConnectionAggregateRow[]> {
+    const qb = this.repository
+      .createQueryBuilder('rec')
+      .select('rec.sourceConnectionId', 'source_connection_id')
+      .addSelect('COUNT(*)', 'affected_count')
+      .andWhere('rec."cancelledAt" IS NULL')
+      .andWhere(
+        '(rec."reportingCurrency" IS NULL OR rec."reportingCurrency" != :currentReportingCurrency)',
+        { currentReportingCurrency }
+      )
+      .groupBy('rec.sourceConnectionId');
+
+    this.applySalesAnalyticsScope(qb, filters);
+
+    const rows = await qb.getRawMany<{ source_connection_id: string; affected_count: string }>();
+
+    return rows.map((row) => ({
+      sourceConnectionId: row.source_connection_id,
+      affectedCount: Number(row.affected_count),
+    }));
   }
 
   /**

--- a/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
@@ -65,6 +65,19 @@ import type {
 
 @Injectable()
 export class OrderRecordRepository implements OrderRecordRepositoryPort {
+  /**
+   * The "currency mismatch" predicate (#2464/#2713/#2468 review) — a row
+   * that either never got an FX stamp (`reportingCurrency IS NULL`) or was
+   * stamped under a PREVIOUS reporting-currency era (ADR-040). Every reader
+   * of this population — {@link findCurrencyMismatchOrders},
+   * {@link findCurrencyMismatchOrdersByConnection},
+   * {@link findCurrencyMismatchOrderRefsAfter}, and
+   * {@link countRemainingCurrencyMismatch} — shares this ONE fragment so the
+   * definition of "unconverted" can never silently diverge between them.
+   */
+  private static readonly CURRENCY_MISMATCH_FRAGMENT =
+    '(rec."reportingCurrency" IS NULL OR rec."reportingCurrency" != :currentReportingCurrency)';
+
   constructor(
     @InjectRepository(OrderRecordOrmEntity)
     private readonly repository: Repository<OrderRecordOrmEntity>
@@ -468,7 +481,7 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
     // figures into `revenue` after an operator changes the reporting setting.
     // A prior-era stamp therefore reads as unconverted, same as never-stamped.
     const isStamped = 'rec."reportingCurrency" = :currentReportingCurrency';
-    const isUnconverted = `(rec."reportingCurrency" IS NULL OR rec."reportingCurrency" != :currentReportingCurrency)`;
+    const isUnconverted = OrderRecordRepository.CURRENCY_MISMATCH_FRAGMENT;
     const stampedAndNotCancelled = `${notCancelled} AND ${isStamped}`;
     const unconvertedAndNotCancelled = `${notCancelled} AND ${isUnconverted}`;
     const stampedAndCancelled = `${isCancelled} AND ${isStamped}`;
@@ -621,7 +634,7 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
       .createQueryBuilder('rec')
       .andWhere('rec."cancelledAt" IS NULL')
       .andWhere(
-        '(rec."reportingCurrency" IS NULL OR rec."reportingCurrency" != :currentReportingCurrency)',
+        OrderRecordRepository.CURRENCY_MISMATCH_FRAGMENT,
         { currentReportingCurrency }
       )
       .orderBy('rec."placedAt"', 'DESC')
@@ -668,7 +681,7 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
       .addSelect('COUNT(*)', 'affected_count')
       .andWhere('rec."cancelledAt" IS NULL')
       .andWhere(
-        '(rec."reportingCurrency" IS NULL OR rec."reportingCurrency" != :currentReportingCurrency)',
+        OrderRecordRepository.CURRENCY_MISMATCH_FRAGMENT,
         { currentReportingCurrency }
       )
       .groupBy('rec.sourceConnectionId');
@@ -706,7 +719,7 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
       .select('rec."internalOrderId"', 'internal_order_id')
       .andWhere('rec."cancelledAt" IS NULL')
       .andWhere(
-        '(rec."reportingCurrency" IS NULL OR rec."reportingCurrency" != :currentReportingCurrency)',
+        OrderRecordRepository.CURRENCY_MISMATCH_FRAGMENT,
         { currentReportingCurrency }
       )
       .orderBy('rec."internalOrderId"', 'ASC')
@@ -792,7 +805,7 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
       )
       .andWhere('rec."cancelledAt" IS NULL')
       .andWhere(
-        '(rec."reportingCurrency" IS NULL OR rec."reportingCurrency" != :currentReportingCurrency)',
+        OrderRecordRepository.CURRENCY_MISMATCH_FRAGMENT,
         { currentReportingCurrency }
       );
 

--- a/libs/core/src/shipping/application/services/fulfillment-status-sync.service.spec.ts
+++ b/libs/core/src/shipping/application/services/fulfillment-status-sync.service.spec.ts
@@ -108,6 +108,7 @@ describe('FulfillmentStatusSyncService', () => {
       getSalesAndChannelAnalytics: jest.fn(),
       getTopProducts: jest.fn(),
       getCurrencyMismatchOrders: jest.fn(),
+      getCurrencyMismatchOrdersByConnection: jest.fn(),
       getProductMatchingErrorOrders: jest.fn(),
       discoverSalesDocumentMarkets: jest.fn(),
     };

--- a/libs/core/src/shipping/application/services/shipment-dispatch-notification.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-dispatch-notification.service.spec.ts
@@ -106,6 +106,7 @@ describe('ShipmentDispatchNotificationService', () => {
       getSalesAndChannelAnalytics: jest.fn(),
       getTopProducts: jest.fn(),
       getCurrencyMismatchOrders: jest.fn(),
+      getCurrencyMismatchOrdersByConnection: jest.fn(),
       getProductMatchingErrorOrders: jest.fn(),
       discoverSalesDocumentMarkets: jest.fn(),
     };

--- a/libs/core/src/shipping/application/services/shipment-dispatch.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-dispatch.service.spec.ts
@@ -173,6 +173,7 @@ describe('ShipmentDispatchService', () => {
       getSalesAndChannelAnalytics: jest.fn(),
       getTopProducts: jest.fn(),
       getCurrencyMismatchOrders: jest.fn(),
+      getCurrencyMismatchOrdersByConnection: jest.fn(),
       getProductMatchingErrorOrders: jest.fn(),
       discoverSalesDocumentMarkets: jest.fn(),
     };


### PR DESCRIPTION
## Summary
- Adds `OrderRecordRepositoryPort.findCurrencyMismatchOrdersByConnection` — a `GROUP BY sourceConnectionId` counterpart to `findCurrencyMismatchOrders`, same predicate.
- Adds `ITaxCoverageDetectionService.getAllCategoryCountsByConnection` — groups the existing `classify()` pass by connection, no extra live-catalogue reads.
- Adds `GET /analytics/coverage/by-connection`, composing both into `{ category, rows: { sourceConnectionId, affectedCount }[] }[]`, so `channel-sales-table.tsx` can stop deriving per-connection counts client-side by paging through full order lists.
- `product-matching` deliberately excluded — no FE consumer today (confirmed against `channel-sales-table.tsx`).

## Test plan
- [x] Unit tests: repository (`GROUP BY` query-builder assertions + row mapping), service pass-through, tax-aggregate service (incl. single-`classify()`-call assertion), controller (composition + validation + `sourceConnectionId` narrowing)
- [x] Integration test (Testcontainers Postgres): counts grouped across ≥2 connections, cross-checked against `findCurrencyMismatchOrders` per-connection totals; cancelled-order exclusion; empty-result case
- [x] `pnpm lint`, `pnpm type-check`, `pnpm check:invariants` all green

Closes #2713