### PR TITLE
feat(web,analytics): swap channel-table exclusion cross-reference to the aggregate endpoint

### DIFF
--- a/apps/web/src/features/analytics/api/analytics-coverage.api.ts
+++ b/apps/web/src/features/analytics/api/analytics-coverage.api.ts
@@ -1,14 +1,22 @@
 /**
  * Analytics Coverage API client
  *
- * Thin request module for `GET /analytics/coverage` (#2466).
+ * Thin request module for `GET /analytics/coverage` (#2466) and
+ * `GET /analytics/coverage/by-connection` (#2713) — the latter is the
+ * server-side `GROUP BY sourceConnectionId` counterpart the former's
+ * per-category drill-downs used to derive client-side.
  *
  * @module features/analytics/api
  */
-import type { AnalyticsCoverage, AnalyticsCoverageFilters } from './analytics-coverage.types';
+import type {
+  AnalyticsCoverage,
+  AnalyticsCoverageByConnection,
+  AnalyticsCoverageFilters,
+} from './analytics-coverage.types';
 
 export interface AnalyticsCoverageApi {
   getCoverage: (filters: AnalyticsCoverageFilters) => Promise<AnalyticsCoverage>;
+  getCoverageByConnection: (filters: AnalyticsCoverageFilters) => Promise<AnalyticsCoverageByConnection>;
 }
 
 interface ApiRequest {
@@ -28,5 +36,7 @@ function buildQuery(filters: AnalyticsCoverageFilters): string {
 export function createAnalyticsCoverageApi(request: ApiRequest): AnalyticsCoverageApi {
   return {
     getCoverage: (filters) => request(`/analytics/coverage?${buildQuery(filters)}`),
+    getCoverageByConnection: (filters) =>
+      request(`/analytics/coverage/by-connection?${buildQuery(filters)}`),
   };
 }

--- a/apps/web/src/features/analytics/api/analytics-coverage.query-keys.ts
+++ b/apps/web/src/features/analytics/api/analytics-coverage.query-keys.ts
@@ -3,4 +3,6 @@ import type { AnalyticsCoverageFilters } from './analytics-coverage.types';
 export const analyticsCoverageQueryKeys = {
   all: ['analytics', 'coverage'] as const,
   coverage: (filters: AnalyticsCoverageFilters) => ['analytics', 'coverage', filters] as const,
+  byConnection: (filters: AnalyticsCoverageFilters) =>
+    ['analytics', 'coverage', 'by-connection', filters] as const,
 };

--- a/apps/web/src/features/analytics/api/analytics-coverage.types.ts
+++ b/apps/web/src/features/analytics/api/analytics-coverage.types.ts
@@ -47,3 +47,25 @@ export interface AnalyticsCoverageFilters {
   to: string;
   sourceConnectionId?: string;
 }
+
+/**
+ * Mirrors `AnalyticsCoverageByConnectionResponseDto` / `CoverageCategoryConnectionRowsDto`
+ * (`GET /analytics/coverage/by-connection`, #2713) — one entry per category
+ * (`'currency' | 'tax-a' | 'tax-b' | 'tax-c'`, never `'product-matching'`),
+ * each carrying the affected-order count per `sourceConnectionId`. Replaces
+ * `useCoverageCrossReferenceQuery`'s client-side page-draining grouping for
+ * `ChannelSalesTable` (#2714).
+ */
+export interface CoverageConnectionRow {
+  sourceConnectionId: string;
+  affectedCount: number;
+}
+
+export interface CoverageCategoryConnectionRows {
+  category: CoverageCategory;
+  rows: CoverageConnectionRow[];
+}
+
+export interface AnalyticsCoverageByConnection {
+  categories: CoverageCategoryConnectionRows[];
+}

--- a/apps/web/src/features/analytics/components/channel-sales-table.test.tsx
+++ b/apps/web/src/features/analytics/components/channel-sales-table.test.tsx
@@ -286,9 +286,10 @@ describe('ChannelSalesTable', () => {
   // #2481 regression guards — the mockup's own two found bugs: a row
   // wrongly labeled with a *different* category's issue, and a row with
   // orders in an open category's affected set missing its annotation
-  // entirely. Both fixtures cross-reference against the FULL affected-order
-  // list (never the 10-id sample), grouped by `sourceConnectionId`.
-  describe('.excl-note cross-reference (#2481)', () => {
+  // entirely. Both fixtures cross-reference against the aggregate-by-
+  // connection endpoint (#2713/#2714), grouped by `sourceConnectionId`
+  // server-side.
+  describe('.excl-note cross-reference (#2481, ported to the aggregate endpoint by #2714)', () => {
     it("should attribute each channel's exclusion note to its own category, never the other channel's", async () => {
       const apiClient = createMockApiClient({
         analytics: {
@@ -298,13 +299,13 @@ describe('ChannelSalesTable', () => {
               channel({ sourceConnectionId: 'conn-2' }),
             ])
           ),
-          getCurrencyMismatchOrders: vi.fn().mockResolvedValue({
-            items: [{ internalOrderId: 'ol_order_1', sourceConnectionId: 'conn-1', nativeCurrency: 'EUR', stampedCurrency: null, stampedAt: null }],
-            total: 1,
-          }),
-          getTaxCoverageOrders: vi.fn().mockResolvedValue({
-            items: [{ internalOrderId: 'ol_order_2', sourceConnectionId: 'conn-2', placedAt: null }],
-            total: 1,
+          getCoverageByConnection: vi.fn().mockResolvedValue({
+            categories: [
+              { category: 'currency', rows: [{ sourceConnectionId: 'conn-1', affectedCount: 1 }] },
+              { category: 'tax-a', rows: [] },
+              { category: 'tax-b', rows: [{ sourceConnectionId: 'conn-2', affectedCount: 1 }] },
+              { category: 'tax-c', rows: [] },
+            ],
           }),
         },
         connections: {
@@ -346,19 +347,14 @@ describe('ChannelSalesTable', () => {
       const apiClient = createMockApiClient({
         analytics: {
           getSales: vi.fn().mockResolvedValue(analytics([channel({ sourceConnectionId: 'conn-1' })])),
-          getCurrencyMismatchOrders: vi.fn().mockResolvedValue({
-            items: [{ internalOrderId: 'ol_order_1', sourceConnectionId: 'conn-1', nativeCurrency: 'EUR', stampedCurrency: null, stampedAt: null }],
-            total: 1,
+          getCoverageByConnection: vi.fn().mockResolvedValue({
+            categories: [
+              { category: 'currency', rows: [{ sourceConnectionId: 'conn-1', affectedCount: 1 }] },
+              { category: 'tax-a', rows: [{ sourceConnectionId: 'conn-1', affectedCount: 1 }] },
+              { category: 'tax-b', rows: [{ sourceConnectionId: 'conn-1', affectedCount: 1 }] },
+              { category: 'tax-c', rows: [{ sourceConnectionId: 'conn-1', affectedCount: 1 }] },
+            ],
           }),
-          getTaxCoverageOrders: vi.fn((input: { category: string }) =>
-            Promise.resolve(
-              input.category === 'tax-a'
-                ? { items: [{ internalOrderId: 'ol_order_2', sourceConnectionId: 'conn-1', placedAt: null, lineRates: [] }], total: 1 }
-                : input.category === 'tax-b'
-                  ? { items: [{ internalOrderId: 'ol_order_3', sourceConnectionId: 'conn-1', placedAt: null, lineRates: [] }], total: 1 }
-                  : { items: [{ internalOrderId: 'ol_order_4', sourceConnectionId: 'conn-1', placedAt: null, lineRates: [] }], total: 1 }
-            )
-          ),
         },
         connections: {
           list: vi.fn().mockResolvedValue([{ id: 'conn-1', name: 'Allegro — main', platformType: 'allegro' }]),

--- a/apps/web/src/features/analytics/components/channel-sales-table.tsx
+++ b/apps/web/src/features/analytics/components/channel-sales-table.tsx
@@ -55,14 +55,17 @@
  * `awaiting_mapping` order fails to resolve to *any* channel-scoped total
  * in the first place, so it was never counted anywhere to be silently
  * missing from) gets one `AnalyticsExclusionNote` per affected category.
- * The cross-reference is exact: each open category's *full* affected-order
- * list (not the Data Coverage aggregate's 10-id sample —
- * `useCoverageCrossReferenceQuery`, `hooks/use-coverage-cross-reference-query.ts`,
- * drains every page via the same paginated endpoints Phase 7's detail
- * modals use) is grouped by `sourceConnectionId` (`buildChannelExclusionMap`,
- * `lib/channel-exclusion-map.lib.ts`), since that field is on every
- * affected-order row and matches this table's own row key exactly — unlike
- * a product, a channel has no ambiguity to approximate.
+ * The cross-reference is exact: `GET /analytics/coverage/by-connection`
+ * (#2713) already returns each open category's affected-order count
+ * `GROUP BY sourceConnectionId` server-side — one request
+ * (`useCoverageByConnectionQuery`, `hooks/use-coverage-by-connection-query.ts`)
+ * instead of draining every page of four separate order lists client-side
+ * (the pre-#2714 approach, still used by `ProductSalesTable` for its
+ * per-product cross-reference, which has no connection-level aggregate to
+ * consume) — reshaped into the same `sourceConnectionId`-keyed map
+ * (`buildChannelExclusionMap`, `lib/channel-exclusion-map.lib.ts`), since
+ * that field matches this table's own row key exactly — unlike a product, a
+ * channel has no ambiguity to approximate.
  *
  * @module features/analytics/components
  */
@@ -78,7 +81,7 @@ import { useNumberFormat } from '../../../shared/i18n/use-number-format';
 import { ConnectionCell, useConnectionsQuery, type Connection } from '../../connections';
 import { ConnectionDot } from '../../orders';
 import { useSalesAnalyticsQuery } from '../hooks/use-sales-analytics-query';
-import { useCoverageCrossReferenceQuery } from '../hooks/use-coverage-cross-reference-query';
+import { useCoverageByConnectionQuery } from '../hooks/use-coverage-by-connection-query';
 import {
   createReportingCurrencyConverter,
   isCurrencyRecalculating,
@@ -234,42 +237,30 @@ export function ChannelSalesTable({
   const pctFormat = useNumberFormat(PERCENT_FORMAT_OPTIONS);
   const intFormat = useNumberFormat();
 
-  // Fixed set of hooks, one per cross-referenceable category (never a
-  // variable count derived from which categories happen to be open — see
-  // `useCoverageCrossReferenceQuery`'s own doc comment on why). Each is
-  // `enabled` only when its own category is genuinely open.
+  // One request for every cross-referenceable category together (#2713/
+  // #2714) — `enabled` only when the `coverage` prop (the unfiltered
+  // GET /analytics/coverage aggregate) says at least one of them has a
+  // nonzero affectedCount, matching the pre-#2714 gate's own source of
+  // truth exactly (`openCategoryCodes`, unchanged) — just "any" instead of
+  // "each", since there is now only one request to gate. This is the same
+  // approximation the old per-category gates already made: `coverage` and
+  // `crossRefFilters`/`coverageFilters` are independent props (see this
+  // component's own prop doc comments), so the guarantee is "no request
+  // when the panel overall reads all-clear," not a filter-range match.
   const openCategoryCodes = useMemo(
     () => new Set((coverage?.categories ?? []).filter((row) => row.affectedCount > 0).map((row) => row.category)),
     [coverage]
   );
   const crossRefFilters: AnalyticsCoverageFilters = coverageFilters ?? { from: '', to: '' };
   const crossRefEnabled = Boolean(coverageFilters) && Boolean(onOpenCategory);
-  const currencyOrders = useCoverageCrossReferenceQuery(
-    'currency',
-    crossRefFilters,
-    crossRefEnabled && openCategoryCodes.has('currency')
+  const anyOpenCrossReferenceable = CROSS_REFERENCEABLE_CATEGORIES.some((category) =>
+    openCategoryCodes.has(category)
   );
-  const taxAOrders = useCoverageCrossReferenceQuery(
-    'tax-a',
+  const byConnection = useCoverageByConnectionQuery(
     crossRefFilters,
-    crossRefEnabled && openCategoryCodes.has('tax-a')
+    crossRefEnabled && anyOpenCrossReferenceable
   );
-  const taxBOrders = useCoverageCrossReferenceQuery(
-    'tax-b',
-    crossRefFilters,
-    crossRefEnabled && openCategoryCodes.has('tax-b')
-  );
-  const taxCOrders = useCoverageCrossReferenceQuery(
-    'tax-c',
-    crossRefFilters,
-    crossRefEnabled && openCategoryCodes.has('tax-c')
-  );
-  const exclusions = buildChannelExclusionMap({
-    currency: currencyOrders.data,
-    'tax-a': taxAOrders.data,
-    'tax-b': taxBOrders.data,
-    'tax-c': taxCOrders.data,
-  });
+  const exclusions = buildChannelExclusionMap(byConnection.data);
 
   if (query.isLoading) {
     return (

--- a/apps/web/src/features/analytics/hooks/use-coverage-by-connection-query.ts
+++ b/apps/web/src/features/analytics/hooks/use-coverage-by-connection-query.ts
@@ -1,0 +1,38 @@
+/**
+ * Coverage By-Connection Query Hook
+ *
+ * Fetches `GET /analytics/coverage/by-connection` (#2713) — currency + tax
+ * A/B/C affected-order counts already `GROUP BY sourceConnectionId`d
+ * server-side — in ONE request, for `ChannelSalesTable`'s `.excl-note`
+ * cross-reference (#2714). Replaces `useCoverageCrossReferenceQuery`'s four
+ * page-draining calls (one per `CROSS_REFERENCEABLE_CATEGORIES` member) for
+ * that one consumer; `ProductSalesTable` still needs the full per-order
+ * `productId`/`lineRates` shape (no product-level aggregate exists), so it
+ * keeps using the old hook — see that hook's own doc comment.
+ *
+ * Same silent-degradation contract as its predecessor: only `data` is
+ * returned, no `isLoading`/`isError` — a still-loading or failed read simply
+ * contributes no exclusion notes for this render rather than surfacing a
+ * table-wide error state for a supplementary annotation.
+ *
+ * @module apps/web/src/features/analytics/hooks
+ */
+import { useQuery } from '@tanstack/react-query';
+import { useApiClient } from '../../../app/api/api-client-provider';
+import { analyticsCoverageQueryKeys } from '../api/analytics-coverage.query-keys';
+import type { AnalyticsCoverageByConnection, AnalyticsCoverageFilters } from '../api/analytics-coverage.types';
+
+export function useCoverageByConnectionQuery(
+  filters: AnalyticsCoverageFilters,
+  enabled: boolean
+): { data: AnalyticsCoverageByConnection | undefined } {
+  const apiClient = useApiClient();
+
+  const { data } = useQuery({
+    queryKey: analyticsCoverageQueryKeys.byConnection(filters),
+    queryFn: () => apiClient.analytics.getCoverageByConnection(filters),
+    enabled,
+  });
+
+  return { data };
+}

--- a/apps/web/src/features/analytics/hooks/use-coverage-cross-reference-query.ts
+++ b/apps/web/src/features/analytics/hooks/use-coverage-cross-reference-query.ts
@@ -2,24 +2,30 @@
  * Coverage Cross-Reference Query Hook
  *
  * Pages through one Data Coverage category's *complete* affected-order
- * list (never the `GET /analytics/coverage` aggregate's 10-id sample), for
- * the `ChannelSalesTable` per-row `.excl-note` cross-reference (#2481,
- * epic #2452 Phase 8). One `useQuery` per category — call it once per
- * member of `CROSS_REFERENCEABLE_CATEGORIES` (a fixed set), never a
- * variable count derived from which categories happen to be open, so the
- * number of hook calls never changes across renders.
+ * list (never the `GET /analytics/coverage` aggregate's 10-id sample). One
+ * `useQuery` per category — call it once per member of
+ * `CROSS_REFERENCEABLE_CATEGORIES` (a fixed set), never a variable count
+ * derived from which categories happen to be open, so the number of hook
+ * calls never changes across renders.
  *
  * Each call drains its own pages inside one `queryFn` rather than issuing a
  * separate `useQuery` per page — a per-page-load, non-hot-path read (see
  * `docs/plans/implementation-plan-analytics-exclusion-annotations.md`'s own
- * risk note on this bound). Being an unbounded drain over a potentially
- * large affected-order population is a known follow-up, tracked as #2713
- * (backend aggregate-by-connection endpoint) + #2714 (swap this hook to
- * consume it).
+ * risk note on this bound).
+ *
+ * **`ChannelSalesTable` no longer uses this hook (#2714)** — its per-row
+ * `.excl-note` cross-reference (#2481, epic #2452 Phase 8) now consumes
+ * `GET /analytics/coverage/by-connection` (#2713) via
+ * `useCoverageByConnectionQuery`, which returns every category's
+ * `sourceConnectionId`-grouped counts in ONE request instead of draining
+ * four full order lists. `ProductSalesTable` still calls this hook: its
+ * per-product cross-reference (`buildProductExclusionMap`) needs each
+ * order's `productId`/`lineRates`, which the connection-level aggregate
+ * doesn't carry — there is no equivalent aggregate to swap it to.
  *
  * Only `data` is returned, deliberately — no `isLoading`/`isError`. A failed
  * or still-loading category silently contributes no rows to
- * `buildChannelExclusionMap`, which just means that category's
+ * `buildProductExclusionMap`, which just means that category's
  * `AnalyticsExclusionNote`s are momentarily/permanently absent from the
  * table. This is a supplementary annotation on top of already-successful
  * sales figures, not a screen of its own — so it degrades silently by

--- a/apps/web/src/features/analytics/lib/channel-exclusion-map.lib.test.ts
+++ b/apps/web/src/features/analytics/lib/channel-exclusion-map.lib.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { buildChannelExclusionMap } from './channel-exclusion-map.lib';
+import type { AnalyticsCoverageByConnection } from '../api/analytics-coverage.types';
+
+describe('buildChannelExclusionMap (#2714)', () => {
+  it('returns an empty map for undefined input (never-loaded state)', () => {
+    const map = buildChannelExclusionMap(undefined);
+
+    expect(map.size).toBe(0);
+  });
+
+  it('returns an empty map when every category has an empty rows array (all-clear)', () => {
+    const byConnection: AnalyticsCoverageByConnection = {
+      categories: [
+        { category: 'currency', rows: [] },
+        { category: 'tax-a', rows: [] },
+        { category: 'tax-b', rows: [] },
+        { category: 'tax-c', rows: [] },
+      ],
+    };
+
+    const map = buildChannelExclusionMap(byConnection);
+
+    expect(map.size).toBe(0);
+  });
+
+  it('groups multiple connections under the same category, keeping each connection distinct', () => {
+    const byConnection: AnalyticsCoverageByConnection = {
+      categories: [
+        {
+          category: 'currency',
+          rows: [
+            { sourceConnectionId: 'conn-a', affectedCount: 3 },
+            { sourceConnectionId: 'conn-b', affectedCount: 1 },
+          ],
+        },
+        { category: 'tax-a', rows: [] },
+        { category: 'tax-b', rows: [] },
+        { category: 'tax-c', rows: [] },
+      ],
+    };
+
+    const map = buildChannelExclusionMap(byConnection);
+
+    expect(map.get('conn-a')?.get('currency')).toBe(3);
+    expect(map.get('conn-b')?.get('currency')).toBe(1);
+    expect(map.size).toBe(2);
+  });
+
+  it('attributes each category to the connection it actually belongs to, never mixing them', () => {
+    const byConnection: AnalyticsCoverageByConnection = {
+      categories: [
+        { category: 'currency', rows: [{ sourceConnectionId: 'conn-a', affectedCount: 1 }] },
+        { category: 'tax-a', rows: [] },
+        { category: 'tax-b', rows: [{ sourceConnectionId: 'conn-b', affectedCount: 1 }] },
+        { category: 'tax-c', rows: [] },
+      ],
+    };
+
+    const map = buildChannelExclusionMap(byConnection);
+
+    expect(map.get('conn-a')?.size).toBe(1);
+    expect(map.get('conn-a')?.has('currency')).toBe(true);
+    expect(map.get('conn-a')?.has('tax-b')).toBe(false);
+
+    expect(map.get('conn-b')?.size).toBe(1);
+    expect(map.get('conn-b')?.has('tax-b')).toBe(true);
+    expect(map.get('conn-b')?.has('currency')).toBe(false);
+  });
+
+  it('carries the count through verbatim, since grouping already happened server-side', () => {
+    const byConnection: AnalyticsCoverageByConnection = {
+      categories: [
+        { category: 'currency', rows: [{ sourceConnectionId: 'conn-a', affectedCount: 42 }] },
+        { category: 'tax-a', rows: [] },
+        { category: 'tax-b', rows: [] },
+        { category: 'tax-c', rows: [] },
+      ],
+    };
+
+    const map = buildChannelExclusionMap(byConnection);
+
+    expect(map.get('conn-a')?.get('currency')).toBe(42);
+  });
+});

--- a/apps/web/src/features/analytics/lib/channel-exclusion-map.lib.ts
+++ b/apps/web/src/features/analytics/lib/channel-exclusion-map.lib.ts
@@ -1,14 +1,18 @@
 /**
  * Channel Exclusion Map
  *
- * Pure grouping of one or more Data Coverage categories' *full*
- * affected-order lists into a per-channel (`sourceConnectionId`) count map
- * (#2481, epic #2452 Phase 8) — the input `ChannelSalesTable` needs to
- * decide which `AnalyticsExclusionNote`s a row gets.
+ * Reshapes the `GET /analytics/coverage/by-connection` aggregate (#2713)
+ * into a per-channel (`sourceConnectionId`) count map (#2481, epic #2452
+ * Phase 8, reshaped by #2714) — the input `ChannelSalesTable` needs to
+ * decide which `AnalyticsExclusionNote`s a row gets. Grouping happens
+ * server-side now (`GROUP BY sourceConnectionId`), so this is a pure
+ * re-index rather than a count — `buildChannelExclusionMap` has exactly one
+ * caller (`ChannelSalesTable`), which is why the reshape happened in place
+ * rather than adding a second function.
  *
  * @module apps/web/src/features/analytics/lib
  */
-import type { CoverageCategory } from '../api/analytics-coverage.types';
+import type { AnalyticsCoverageByConnection, CoverageCategory } from '../api/analytics-coverage.types';
 
 /** Tax categories, plus currency — the categories a channel total can be under-counted by. `product-matching` is deliberately excluded: a `source_deleted`/`awaiting_mapping` order fails to resolve to *any* channel-scoped total in the first place, so it was never counted anywhere to be silently missing from. */
 export type CrossReferenceableCategory = Extract<CoverageCategory, 'currency' | 'tax-a' | 'tax-b' | 'tax-c'>;
@@ -19,15 +23,20 @@ export const CROSS_REFERENCEABLE_CATEGORIES: readonly CrossReferenceableCategory
   'tax-c',
 ];
 
+/**
+ * `product-sales-table.tsx`'s per-order shape, still used by
+ * `buildProductExclusionMap` (`product-exclusion-map.lib.ts`, via
+ * `useCoverageCrossReferenceQuery`) — the connection-level aggregate
+ * `buildChannelExclusionMap` now consumes has no product identity to give,
+ * so this type no longer has a role in THIS file's own function.
+ */
 export interface CoverageOrderLite {
   internalOrderId: string;
   sourceConnectionId: string;
   /**
    * One representative line's product id (#2799) — present (possibly
    * `null`) on a `'currency'` row, absent on a tax row (see `lineRates`
-   * instead). Optional here so this shared shape can widen without forcing
-   * every consumer (e.g. `buildChannelExclusionMap`, which only ever needs
-   * `sourceConnectionId`) to care about it.
+   * instead).
    */
   productId?: string | null;
   /**
@@ -42,14 +51,21 @@ export interface CoverageOrderLite {
 export type ChannelExclusionMap = Map<string, Map<CrossReferenceableCategory, number>>;
 
 export function buildChannelExclusionMap(
-  ordersByCategory: Partial<Record<CrossReferenceableCategory, CoverageOrderLite[] | undefined>>
+  byConnection: AnalyticsCoverageByConnection | undefined
 ): ChannelExclusionMap {
+  const rowsByCategory = new Map(
+    (byConnection?.categories ?? []).map((entry) => [entry.category, entry.rows])
+  );
   const map: ChannelExclusionMap = new Map();
   for (const category of CROSS_REFERENCEABLE_CATEGORIES) {
-    for (const order of ordersByCategory[category] ?? []) {
-      const byCategory = map.get(order.sourceConnectionId) ?? new Map<CrossReferenceableCategory, number>();
-      byCategory.set(category, (byCategory.get(category) ?? 0) + 1);
-      map.set(order.sourceConnectionId, byCategory);
+    // `.set()`, not an accumulate — the backend's own `GROUP BY
+    // sourceConnectionId` (#2713) already guarantees at most one row per
+    // `(category, sourceConnectionId)` pair, so there is nothing to sum
+    // here, unlike the pre-#2714 client-side counting this replaced.
+    for (const row of rowsByCategory.get(category) ?? []) {
+      const byCategory = map.get(row.sourceConnectionId) ?? new Map<CrossReferenceableCategory, number>();
+      byCategory.set(category, row.affectedCount);
+      map.set(row.sourceConnectionId, byCategory);
     }
   }
   return map;

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -193,6 +193,14 @@ export function createMockApiClient(
       }),
       getCurrencyMismatchOrders: vi.fn().mockResolvedValue({ items: [], total: 0 }),
       getTaxCoverageOrders: vi.fn().mockResolvedValue({ items: [], total: 0 }),
+      getCoverageByConnection: vi.fn().mockResolvedValue({
+        categories: [
+          { category: 'currency', rows: [] },
+          { category: 'tax-a', rows: [] },
+          { category: 'tax-b', rows: [] },
+          { category: 'tax-c', rows: [] },
+        ],
+      }),
       rerunTaxBackfill: vi.fn().mockResolvedValue({ scanned: 0, updated: 0 }),
       getProductMatchingOrders: vi.fn().mockResolvedValue({ items: [], total: 0 }),
       ...overrides.analytics,

--- a/docs/plans/implementation-plan-coverage-by-connection-fe.md
+++ b/docs/plans/implementation-plan-coverage-by-connection-fe.md
@@ -1,0 +1,201 @@
+# Implementation Plan — Swap channel-table exclusion cross-reference to the aggregate endpoint
+
+- **Issue**: [#2714](https://github.com/openlinker-project/openlinker/issues/2714)
+- **Type**: Frontend
+- **Layer**: Feature (`analytics`)
+- **Depends on**: [#2713](https://github.com/openlinker-project/openlinker/issues/2713) — `GET /analytics/coverage/by-connection`, shipped in PR [#2810](https://github.com/openlinker-project/openlinker/pull/2810) (not yet merged to `main`). This branch is built on top of `2713-coverage-by-connection-reads`.
+
+## 1. Goal & scope
+
+### Goal
+
+`ChannelSalesTable`'s `.excl-note` cross-reference currently drains **every page** of the currency-mismatch and tax A/B/C affected-order lists client-side (`useCoverageCrossReferenceQuery`, 4 separate `useQuery` calls, one per category) purely to build a `sourceConnectionId -> category -> count` map. Replace that with a single call to the new `GET /analytics/coverage/by-connection` endpoint, which already returns exactly that shape, grouped server-side.
+
+### Non-goals
+
+- `product-sales-table.tsx`'s use of `useCoverageCrossReferenceQuery` is **untouched**. It needs the FULL per-order `productId`/`lineRates` (there is no product-level aggregate — #2713 only groups by connection), so it keeps draining pages via the existing hook. Confirmed via `product-exclusion-map.lib.ts`'s doc comment and `buildProductExclusionMap`'s use of `lineRates`/`productId`.
+- No change to `GET /analytics/coverage` (the 10-id-sample aggregate) or its hook (`useAnalyticsCoverageQuery`) — that's a different read (open/in-progress status + a small sample), consumed by `AnalyticsDataCoveragePanel`.
+- No change to `product-matching` handling — it was already excluded from `CROSS_REFERENCEABLE_CATEGORIES` and the backend `by-connection` endpoint doesn't return it either (#2713).
+
+## 2. Research summary
+
+- **`useCoverageCrossReferenceQuery`** (`apps/web/src/features/analytics/hooks/use-coverage-cross-reference-query.ts`) is called 4× in `ChannelSalesTable` (currency, tax-a, tax-b, tax-c) and 4× in `ProductSalesTable` — **8 total call sites**, but only the 4 in `ChannelSalesTable` are in scope.
+- **`buildChannelExclusionMap`** (`apps/web/src/features/analytics/lib/channel-exclusion-map.lib.ts`) is called from exactly one place: `ChannelSalesTable`. Its sibling `buildProductExclusionMap` (`product-exclusion-map.lib.ts`) re-exports `CROSS_REFERENCEABLE_CATEGORIES`/`CrossReferenceableCategory` from the same file but does **not** call `buildChannelExclusionMap` itself — so reshaping that one function's signature has no other blast radius.
+- **The consumer of the result** (`ChannelExclusionNotes` in `channel-sales-table.tsx`) only ever reads `ChannelExclusionMap` (`Map<string, Map<CrossReferenceableCategory, number>>`) — untouched by this change, since both the old and new producer functions return that same shape.
+- **Backend contract** (`AnalyticsCoverageByConnectionResponseDto`, PR #2810): `GET /analytics/coverage/by-connection?from=&to=&sourceConnectionId=` → `{ categories: [{ category, rows: [{ sourceConnectionId, affectedCount }] } ] }`, one entry per `'currency' | 'tax-a' | 'tax-b' | 'tax-c'` (never `'product-matching'`), each carrying a possibly-empty `rows` array.
+- **Existing sibling pattern to mirror**: `analytics-coverage.api.ts` already has `getCoverage` for `GET /analytics/coverage`, reusing one `buildQuery` helper — `getCoverageByConnection` is a second method on the same `AnalyticsCoverageApi` interface/factory, same query-string shape.
+- **Test fixtures to update**: `channel-sales-table.test.tsx`'s `.excl-note` describe block (2 tests) mocks `getCurrencyMismatchOrders`/`getTaxCoverageOrders`; these need to mock `getCoverageByConnection` instead, with the SAME expected rendered output (issue's own acceptance criterion — "should not need to change shape, only their mocked apiClient calls"). `test-utils.tsx`'s default `createMockApiClient` needs a default `getCoverageByConnection` mock so every OTHER test rendering `ChannelSalesTable` (which doesn't explicitly mock it) doesn't crash on an undefined function call.
+
+## 3. Design
+
+### 3.1 Types — `apps/web/src/features/analytics/api/analytics-coverage.types.ts`
+
+Add, alongside the existing `AnalyticsCoverage`/`CoverageCategoryRow`:
+
+```typescript
+export interface CoverageConnectionRow {
+  sourceConnectionId: string;
+  affectedCount: number;
+}
+
+export interface CoverageCategoryConnectionRows {
+  category: CoverageCategory;
+  rows: CoverageConnectionRow[];
+}
+
+export interface AnalyticsCoverageByConnection {
+  categories: CoverageCategoryConnectionRows[];
+}
+```
+
+(`category` stays the broad `CoverageCategory` — same choice `CoverageCategoryRow` already makes — rather than importing the narrower `CrossReferenceableCategory` from `channel-exclusion-map.lib.ts`, which would create a `types.ts -> lib.ts` import in the wrong direction; the narrowing happens where it's consumed, per §3.4.)
+
+### 3.2 API client — `apps/web/src/features/analytics/api/analytics-coverage.api.ts`
+
+Add `getCoverageByConnection` to `AnalyticsCoverageApi` and its factory, reusing the existing `buildQuery` helper verbatim (same filters shape):
+
+```typescript
+export interface AnalyticsCoverageApi {
+  getCoverage: (filters: AnalyticsCoverageFilters) => Promise<AnalyticsCoverage>;
+  getCoverageByConnection: (filters: AnalyticsCoverageFilters) => Promise<AnalyticsCoverageByConnection>;
+}
+...
+getCoverageByConnection: (filters) => request(`/analytics/coverage/by-connection?${buildQuery(filters)}`),
+```
+
+### 3.3 Query keys — `apps/web/src/features/analytics/api/analytics-coverage.query-keys.ts`
+
+Add a sibling key factory:
+
+```typescript
+byConnection: (filters: AnalyticsCoverageFilters) => ['analytics', 'coverage', 'by-connection', filters] as const,
+```
+
+### 3.4 New hook — `apps/web/src/features/analytics/hooks/use-coverage-by-connection-query.ts`
+
+One `useQuery`, no per-category fan-out (replaces `useCoverageCrossReferenceQuery`'s 4 calls with 1):
+
+```typescript
+export function useCoverageByConnectionQuery(
+  filters: AnalyticsCoverageFilters,
+  enabled: boolean
+): { data: AnalyticsCoverageByConnection | undefined } {
+  const apiClient = useApiClient();
+  const { data } = useQuery({
+    queryKey: analyticsCoverageQueryKeys.byConnection(filters),
+    queryFn: () => apiClient.analytics.getCoverageByConnection(filters),
+    enabled,
+  });
+  return { data };
+}
+```
+
+Same silent-degradation contract as its predecessor (only `data`, no `isLoading`/`isError` — a still-loading/failed read just contributes no exclusion notes for one render, never a table-wide error state).
+
+### 3.5 `buildChannelExclusionMap` — reshaped, not duplicated
+
+`channel-exclusion-map.lib.ts`'s `buildChannelExclusionMap` currently counts a `Partial<Record<CrossReferenceableCategory, CoverageOrderLite[]>>` client-side. Since it has exactly one caller (being changed in this same task) and the grouping now happens server-side, **reshape it in place** rather than adding a second function:
+
+```typescript
+export function buildChannelExclusionMap(
+  byConnection: AnalyticsCoverageByConnection | undefined
+): ChannelExclusionMap {
+  const rowsByCategory = new Map(
+    (byConnection?.categories ?? []).map((entry) => [entry.category, entry.rows])
+  );
+  const map: ChannelExclusionMap = new Map();
+  for (const category of CROSS_REFERENCEABLE_CATEGORIES) {
+    for (const row of rowsByCategory.get(category) ?? []) {
+      const byCategory = map.get(row.sourceConnectionId) ?? new Map<CrossReferenceableCategory, number>();
+      byCategory.set(category, row.affectedCount);
+      map.set(row.sourceConnectionId, byCategory);
+    }
+  }
+  return map;
+}
+```
+
+`CoverageOrderLite` and `CrossReferenceableCategory`/`CROSS_REFERENCEABLE_CATEGORIES` stay exported unchanged — `product-exclusion-map.lib.ts` still needs all three for its own, untouched function.
+
+### 3.6 `ChannelSalesTable` — swap the call site
+
+`apps/web/src/features/analytics/components/channel-sales-table.tsx`:
+
+- Replace the `useCoverageCrossReferenceQuery` import with `useCoverageByConnectionQuery`.
+- Replace the 4 hook calls + the `buildChannelExclusionMap({ currency: ..., 'tax-a': ..., ... })` object-literal call with:
+
+```typescript
+const anyOpenCrossReferenceable = CROSS_REFERENCEABLE_CATEGORIES.some((c) => openCategoryCodes.has(c));
+const byConnection = useCoverageByConnectionQuery(
+  crossRefFilters,
+  crossRefEnabled && anyOpenCrossReferenceable
+);
+const exclusions = buildChannelExclusionMap(byConnection.data);
+```
+
+`openCategoryCodes` stays (still needed to gate the single request when every cross-referenceable category is already `affectedCount: 0` — preserving the existing "no network call when Data Coverage is all-clear" property, now expressed as "any", not "each").
+
+- Update the component's header doc comment (the `.excl-note` paragraph, ~line 53) to describe the single aggregate call instead of "drains every page via `useCoverageCrossReferenceQuery`".
+
+### 3.7 `useCoverageCrossReferenceQuery` doc comment
+
+Update its header to state it is now consumed ONLY by `ProductSalesTable` (product-level cross-reference has no aggregate equivalent — #2713 groups by connection, not by product) and that `ChannelSalesTable` was swapped off it by #2714. No code change to the hook itself.
+
+### 3.8 Tests
+
+- `channel-sales-table.test.tsx`'s `.excl-note` describe block: replace `getCurrencyMismatchOrders`/`getTaxCoverageOrders` mocks with a single `getCoverageByConnection` mock per test, returning the equivalent `{ categories: [...] }` shape. Assertions on rendered `.excl-note` text/count stay byte-identical (issue's own acceptance criterion).
+- `test-utils.tsx`: add a default `getCoverageByConnection: vi.fn().mockResolvedValue({ categories: [] })` to `createMockApiClient`'s `analytics` namespace, mirroring the existing `getCurrencyMismatchOrders`/`getTaxCoverageOrders` defaults, so every other test that renders `ChannelSalesTable` without explicitly mocking it doesn't hit an undefined function.
+- New unit test for `buildChannelExclusionMap`'s reshaped signature (none existed before — add one, since this is now the shape doing the real work), covering: multi-connection grouping, an empty `rows` array for an open-but-zero category, and `undefined` input (never-loaded state).
+- No new test needed for `useCoverageByConnectionQuery`/`getCoverageByConnection` beyond what the component test already exercises through `createMockApiClient` — matches the existing `useCoverageCrossReferenceQuery`'s own test coverage (none dedicated; exercised via the component).
+
+## 4. Files touched
+
+| File | Change |
+|---|---|
+| `apps/web/src/features/analytics/api/analytics-coverage.types.ts` | + `CoverageConnectionRow`, `CoverageCategoryConnectionRows`, `AnalyticsCoverageByConnection` |
+| `apps/web/src/features/analytics/api/analytics-coverage.api.ts` | + `getCoverageByConnection` |
+| `apps/web/src/features/analytics/api/analytics-coverage.query-keys.ts` | + `byConnection` key factory |
+| `apps/web/src/features/analytics/hooks/use-coverage-by-connection-query.ts` | new file |
+| `apps/web/src/features/analytics/hooks/use-coverage-cross-reference-query.ts` | doc comment only |
+| `apps/web/src/features/analytics/lib/channel-exclusion-map.lib.ts` | `buildChannelExclusionMap` reshaped |
+| `apps/web/src/features/analytics/lib/channel-exclusion-map.test.ts` | new file (unit test) |
+| `apps/web/src/features/analytics/components/channel-sales-table.tsx` | swap call site, doc comment |
+| `apps/web/src/features/analytics/components/channel-sales-table.test.tsx` | `.excl-note` mocks updated |
+| `apps/web/src/test/test-utils.tsx` | + default `getCoverageByConnection` mock |
+
+No backend, no migration, no cross-package boundary change — `apps/web` never imports `@openlinker/core` (#591), consistent with the existing pattern.
+
+## 5. Step-by-step plan
+
+1. Add the three new types (§3.1).
+2. Add `getCoverageByConnection` to the API client + query keys (§3.2, §3.3).
+3. Add `useCoverageByConnectionQuery` (§3.4).
+4. Reshape `buildChannelExclusionMap` (§3.5); add its unit test.
+5. Swap `ChannelSalesTable`'s call site + doc comment (§3.6).
+6. Update `useCoverageCrossReferenceQuery`'s doc comment (§3.7).
+7. Update `channel-sales-table.test.tsx`'s `.excl-note` mocks (§3.8).
+8. Add the default `getCoverageByConnection` mock to `test-utils.tsx` (§3.8).
+9. `pnpm --filter @openlinker/web type-check` + lint on touched files.
+10. `pnpm --filter @openlinker/web test` (or the affected test files) — full FE suite is fast/no Docker, unlike backend `pnpm test:integration`.
+
+## 6. Risks & edge cases
+
+- **All-clear state**: when every cross-referenceable category has `affectedCount: 0` in the already-fetched `coverage` prop, the new hook is disabled entirely (`anyOpenCrossReferenceable` false) — zero network calls, matching current behavior's intent (previously: zero of the 4 per-category calls fired either, for the same reason).
+- **Partial category presence**: the backend `by-connection` response always includes all 4 categories (even with an empty `rows` array) per PR #2810's design — `rowsByCategory.get(category) ?? []` handles a hypothetically missing entry defensively anyway.
+- **`onOpenCategory`/`coverageFilters` optional**: unchanged gating (`crossRefEnabled`), so a caller that doesn't wire coverage in (e.g. some other page embedding `ChannelSalesTable`) still renders with zero exclusion notes and now literally zero related requests, not even the disabled-query bookkeeping across 4 hooks.
+- **No behavior change for `ProductSalesTable`**: explicitly out of scope; verified no shared mutable state or accidental coupling exists between the two tables' use of the old hook.
+
+## 7. Final validation checklist
+
+- [x] Dependency direction: `pages` never imports `features` internals directly; this stays within `features/analytics`
+- [x] No raw `fetch` from components — goes through `apiClient.analytics.*` via a hook, matching every sibling read
+- [x] Server state via TanStack Query (`useQuery`), no new local/global state
+- [x] No business logic duplicated from BE — the FE only reshapes an already-grouped response into a `Map`, same as before
+- [x] Naming: `use-*.ts` hook file, `*.lib.ts` pure helper, `*.types.ts` types, `*.api.ts` client — all match existing conventions in this feature
+- [x] Tests updated for the new API call shape; existing regression assertions preserved
+- [x] Plan is execution-ready
+
+## 8. Questions & Assumptions
+
+- **Assumption**: since PR #2810 (issue #2713) is not yet merged to `main`, this branch stacks on top of `2713-coverage-by-connection-reads` rather than `main` — consistent with how #2713 itself stacked on `2799-product-identity-coverage-rows`. If #2713 merges first, this branch rebases cleanly (no conflicts expected — disjoint file sets).
+- **Assumption**: `buildChannelExclusionMap`'s signature change (object → `AnalyticsCoverageByConnection | undefined`) is acceptable as an in-place reshape rather than a new function name, since it has exactly one caller and the issue explicitly anticipates this ("stays (or simplifies)").


### PR DESCRIPTION
## Summary
- Adds `GET /analytics/coverage/by-connection` FE client (`getCoverageByConnection`, types, query key), mirroring the existing `getCoverage` pattern.
- New `useCoverageByConnectionQuery` — one request instead of `useCoverageCrossReferenceQuery`'s 4 page-draining calls.
- `buildChannelExclusionMap` reshaped in place (single caller, grouping now happens server-side) rather than duplicated.
- `ChannelSalesTable` swapped to the new hook; `enabled` gating changed from "each category open" to "any cross-referenceable category open" (same all-clear optimization, now for one request instead of four).
- `ProductSalesTable` is explicitly untouched — confirmed it needs per-order `productId`/`lineRates`, which the connection-level aggregate doesn't carry, so it keeps `useCoverageCrossReferenceQuery`.

## Test plan
- [x] Existing `.excl-note` regression tests (`channel-sales-table.test.tsx`) ported to mock `getCoverageByConnection`, same rendered-output assertions
- [x] New unit test for `buildChannelExclusionMap`'s reshaped signature (5 cases)
- [x] `pnpm --filter @openlinker/web type-check`, lint, and `vitest run src/features/analytics` — 225/225 passing, including `product-sales-table.test.tsx` unchanged

Depends on #2713 (PR #2810, not yet merged) — this PR targets that branch.

Closes #2714