### PR TITLE
fix(web): stop calling the order-date display-currency figure accounting-grade

### DIFF
--- a/apps/web/src/features/analytics/components/analytics-settings-dialog.tsx
+++ b/apps/web/src/features/analytics/components/analytics-settings-dialog.tsx
@@ -196,8 +196,8 @@ export function AnalyticsSettingsDialog({
             <span>
               <strong>Rate on order date</strong>
               <span className="analytics-settings-dialog__rate-basis-desc">
-                A stable, accounting-grade figure — depends on whether this order&rsquo;s rate has
-                already been recalculated (see below).
+                Keeps each order at its own order-date rate. Showing a different currency converts
+                that total at today&rsquo;s rate - analytics only, not a figure for tax filings.
               </span>
             </span>
           </label>

--- a/docs/plans/mockups/analytics-display-currency-picker.html
+++ b/docs/plans/mockups/analytics-display-currency-picker.html
@@ -764,7 +764,7 @@ tr.total td { font-weight: 700; border-bottom: none; border-top: 2px solid var(-
         <input type="radio" name="rate-basis">
         <span class="rate-basis-option__title">Rate on order date</span>
       </div>
-      <span class="rate-basis-option__desc">A stable, accounting-grade figure — doesn’t change day to day. Depends on whether this order’s rate has already been updated (see Data coverage).</span>
+      <span class="rate-basis-option__desc">Keeps each order at its own order-date rate. Showing a different currency converts that total at today’s rate - analytics only, not a figure for tax filings.</span>
     </label>
   </div>
 


### PR DESCRIPTION
## Summary

The "Rate on order date" description in the analytics settings dialog called the resulting figure "a stable, accounting-grade figure" and claimed it "depends on whether this order's rate has already been recalculated." Both claims are wrong, and one of them is compliance-adjacent:

- **ADR-064** (`docs/architecture/adrs/064-analytics-display-currency-conversion.md`) uses the exact word "accounting-grade" to explicitly disclaim this property of the mode: it applies today's rate to a total mixing orders from many dates, and is "not an accounting-grade historical question."
- **ADR-040** (`docs/architecture/adrs/040-order-time-fx-stamping-against-a-system-reporting-currency.md`) states this class of FX figure "is analytics-only and must never supply a fiscal document's rate." Calling it "accounting-grade" invites exactly the misuse that rule exists to prevent.
- It is also factually wrong about the mechanism: `DisplayCurrencyConversionService.convertAtOrderDate` resolves the reporting-to-display leg at today's rate whenever the display currency differs from the reporting currency, so the figure is neither order-date-anchored nor stable in that case (`analytics-convert-note.tsx` already documents this correctly in a code comment). And no per-order rate lookup happens at all - one current rate is applied once to the already-summed total.

The same string originated in `docs/plans/mockups/analytics-display-currency-picker.html`, so it's fixed there too to avoid reseeding the bug for a future implementer.

## Change

Replaced the copy in both files with a description of the actual mechanism and the analytics-only boundary:

> Keeps each order at its own order-date rate. Showing a different currency converts that total at today's rate - analytics only, not a figure for tax filings.

No behavior change - `convertAtOrderDate` itself is untouched. No other strings in the dialog were touched (a sibling issue, #2815, covers a different string in the same file).

## Test plan

- [x] `pnpm --filter @openlinker/web exec vitest run src/features/analytics/components/analytics-settings-dialog.test.tsx` - 9 passed, no test pinned the old wording
- [x] `pnpm --filter @openlinker/web exec eslint src/features/analytics/components/analytics-settings-dialog.tsx` - clean
- [x] `pnpm --filter @openlinker/web type-check` - clean
- [x] Diff reviewed - only the target paragraph changed in each file

Closes #2814