### PR TITLE
fix(orders): reject a non-numeric tax-rate string instead of silently coercing it in the net-sales resolver

### DIFF
--- a/libs/core/src/orders/domain/types/net-sales-tax-rate.types.spec.ts
+++ b/libs/core/src/orders/domain/types/net-sales-tax-rate.types.spec.ts
@@ -38,6 +38,34 @@ describe('resolveNetSalesTaxRate', () => {
   it('resolves a garbage string to unknown', () => {
     expect(resolveNetSalesTaxRate('not-a-rate')).toEqual({ kind: 'unknown' });
   });
+
+  it('resolves a non-numeric-prefixed string to unknown rather than coercing a leading digit (#2813)', () => {
+    // `Number.parseFloat` is prefix-lenient and would read '0x10' as `0`,
+    // silently confirming a 0% VAT rate for a value that never parsed as a
+    // number at all - exactly what this file's contract forbids.
+    expect(resolveNetSalesTaxRate('0x10')).toEqual({ kind: 'unknown' });
+  });
+
+  it('resolves a European decimal-comma string to unknown rather than dropping the comma (#2813)', () => {
+    // `Number.parseFloat('23,5')` reads as `23`, silently accepting a locale
+    // notation the SQL half's `^[0-9]+(\.[0-9]+)?$` predicate would reject.
+    expect(resolveNetSalesTaxRate('23,5')).toEqual({ kind: 'unknown' });
+  });
+
+  it('resolves a percent-suffixed string to unknown rather than stripping the sign (#2813)', () => {
+    expect(resolveNetSalesTaxRate('23%')).toEqual({ kind: 'unknown' });
+  });
+
+  it('resolves scientific notation to unknown rather than evaluating the exponent (#2813)', () => {
+    // `Number.parseFloat('1e2')` reads as `100`; the SQL shape predicate has
+    // no exponent notation, so this must resolve to unknown to keep the two
+    // halves aligned.
+    expect(resolveNetSalesTaxRate('1e2')).toEqual({ kind: 'unknown' });
+  });
+
+  it('still resolves a genuine "0" to a known 0% rate (#2813 regression guard)', () => {
+    expect(resolveNetSalesTaxRate('0')).toEqual({ kind: 'known', rateFraction: 0 });
+  });
 });
 
 describe('netSalesRateFractionSql', () => {
@@ -54,6 +82,27 @@ describe('netSalesRateFractionSql', () => {
     expect(resolveNetSalesTaxRate('0.23')).toEqual({ kind: 'unknown' });
     const sql = netSalesRateFractionSql('li."taxRate"');
     expect(sql).toContain('NOT (li."taxRate"::numeric > 0 AND li."taxRate"::numeric < 1)');
+  });
+
+  it.each(['0x10', '23,5', '23%', '1e2'])(
+    'declares the shape predicate that excludes %s from ever reaching ::numeric (#2813)',
+    (taxRate) => {
+      // Pin the literal Postgres shape predicate the CASE expression uses -
+      // `^[0-9]+(\.[0-9]+)?$` - so a future edit to netSalesRateFractionSql
+      // that widens or narrows it is caught here, not just by inspection.
+      const sql = netSalesRateFractionSql('li."taxRate"');
+      expect(sql).toContain(String.raw`li."taxRate" ~ '^[0-9]+(\.[0-9]+)?$'`);
+      // The equivalent JS regex (same anchors, same digit-only shape) must
+      // reject the same string resolveNetSalesTaxRate rejects, keeping both
+      // halves aligned on these four inputs.
+      expect(/^[0-9]+(\.[0-9]+)?$/.test(taxRate)).toBe(false);
+      expect(resolveNetSalesTaxRate(taxRate)).toEqual({ kind: 'unknown' });
+    }
+  );
+
+  it('the shape predicate still accepts a genuine "0" (#2813 regression guard)', () => {
+    expect(/^[0-9]+(\.[0-9]+)?$/.test('0')).toBe(true);
+    expect(resolveNetSalesTaxRate('0')).toEqual({ kind: 'known', rateFraction: 0 });
   });
 });
 

--- a/libs/core/src/orders/domain/types/net-sales-tax-rate.types.ts
+++ b/libs/core/src/orders/domain/types/net-sales-tax-rate.types.ts
@@ -77,7 +77,19 @@ export function resolveNetSalesTaxRate(
   if ((NetSalesExemptTaxRateCodeValues as readonly string[]).includes(trimmed)) {
     return { kind: 'known', rateFraction: 0 };
   }
-  const parsed = Number.parseFloat(trimmed);
+  // Require the same numeric shape the SQL half enforces
+  // (`~ '^[0-9]+(\.[0-9]+)?$'`) before converting to a number.
+  // `Number.parseFloat` is prefix-lenient - it reads '0x10' as `0` and
+  // '23,5' as `23`, silently confirming a rate for a value the SQL
+  // predicate would reject outright as `NULL` - exactly the "0% VAT" false
+  // claim this file's contract forbids. Anything not matching this shape
+  // resolves to `unknown`, same as the SQL predicate; `Number()` is used
+  // afterwards rather than `parseFloat` so nothing with trailing garbage
+  // past a leading number can slip through even once the shape is confirmed.
+  if (!/^\d+(\.\d+)?$/.test(trimmed)) {
+    return { kind: 'unknown' };
+  }
+  const parsed = Number(trimmed);
   if (!Number.isFinite(parsed)) {
     return { kind: 'unknown' };
   }


### PR DESCRIPTION
## Summary

`libs/core/src/orders/domain/types/net-sales-tax-rate.types.ts` documents that its TypeScript half (`resolveNetSalesTaxRate`) and its SQL half (`netSalesRateFractionSql`) must change together and must agree on which `order_line_items.taxRate` strings are resolvable. They had drifted apart.

The TS half used `Number.parseFloat`, which is prefix-lenient. The SQL half anchors on `^[0-9]+(\.[0-9]+)?$`. As a result:

- `"0x10"` resolved in TS to a rate of `0` - a confirmed 0% VAT claim for a value that never actually parsed as a number, which is exactly the false claim this file's own contract forbids (`'unknown'` must never be silently coerced to a rate).
- `"23,5"` (a European decimal-comma notation) silently resolved to a 23% rate instead of being rejected as unknown, disagreeing with the SQL predicate which would reject it as `NULL`.

## Fix

`resolveNetSalesTaxRate` now requires the trimmed string to match the same digit-only shape the SQL half enforces (`^\d+(\.\d+)?$`) before converting to a number, and uses `Number()` rather than `parseFloat` once the shape is confirmed so nothing with trailing garbage past a leading number can slip through even after the regex gate. The exemption-code handling (`zw`/`np`/`oo`) and the fractional-notation / out-of-range rejection are untouched.

## Tests

Added to `net-sales-tax-rate.types.spec.ts`:
- `"0x10"` -> `unknown`
- `"23,5"` -> `unknown`
- `"23%"` -> `unknown`
- `"1e2"` -> `unknown`
- `"0"` still resolves to a known 0% rate (regression guard)
- Existing `zw`/`np`/`oo` exemption-code cases untouched and still pass
- Pinned the same four strings against the literal SQL shape predicate extracted from `netSalesRateFractionSql`, so both halves are covered identically (no other spec file references `netSalesRateFractionSql`, so this is the only test file needing the parallel coverage)

## Verification

- `pnpm --filter @openlinker/core exec jest net-sales-tax-rate.types.spec.ts` - 41/41 passing
- `pnpm --filter @openlinker/core lint` - no errors (pre-existing warnings elsewhere, none in touched files)
- `pnpm --filter @openlinker/core type-check` - clean

Closes #2813