### PR TITLE
fix(web): stop claiming the net-sales tax toggle leaves already-shown figures unaffected

### DIFF
--- a/apps/web/src/features/analytics/components/analytics-settings-dialog.test.tsx
+++ b/apps/web/src/features/analytics/components/analytics-settings-dialog.test.tsx
@@ -41,6 +41,23 @@ describe('AnalyticsSettingsDialog', () => {
     ).toBeInTheDocument();
   });
 
+  it('should describe the tax-rate toggle truthfully: org-wide/every-date-range scope, and reverting removes the orders again (#2815)', async () => {
+    renderWithProviders(<AnalyticsSettingsDialog {...baseProps} />, {
+      sessionAdapter: createAuthenticatedSessionAdapter(),
+    });
+
+    const toggleDescription = await screen.findByText(/Trust a tax rate found retroactively/);
+    // Must not claim already-shown figures survive turning the setting off —
+    // it is a query-time gate, so reverting removes those orders from Net
+    // Sales again at the next query.
+    expect(toggleDescription).not.toHaveTextContent(/does not undo/);
+    expect(toggleDescription).toHaveTextContent(/removes these orders from Net Sales again/);
+    // Must state the change is org-wide and applies to every date range, not
+    // just the one currently being viewed.
+    expect(toggleDescription).toHaveTextContent(/everyone/);
+    expect(toggleDescription).toHaveTextContent(/every date range/);
+  });
+
   it('should render the reporting currency as the default "Show amounts in" option', () => {
     renderWithProviders(<AnalyticsSettingsDialog {...baseProps} />);
 

--- a/apps/web/src/features/analytics/components/analytics-settings-dialog.tsx
+++ b/apps/web/src/features/analytics/components/analytics-settings-dialog.tsx
@@ -257,8 +257,9 @@ export function AnalyticsSettingsDialog({
                   <strong>Use the rate found in the product catalog</strong>
                   <span className="analytics-settings-dialog__toggle-desc">
                     Trust a tax rate found retroactively in the catalog and include such orders in Net
-                    Sales automatically. This is reversible — turning it off does not undo any figure
-                    already shown.
+                    Sales automatically. This applies to everyone and to every date range, not just the
+                    one you&rsquo;re viewing - turning it off removes these orders from Net Sales again
+                    the next time the figures are queried.
                   </span>
                 </span>
               </label>


### PR DESCRIPTION
## Summary

The "Use the rate found in the product catalog" tax-toggle description in `analytics-settings-dialog.tsx` told the operator:

> This is reversible - turning it off does not undo any figure already shown.

That is the opposite of what actually happens. Per `docs/architecture-overview.md` (§ Order analytics read model / the currency-stamp doc), the include-backfilled-tax-rates setting is a pure query-time gate: no `order_records` row is mutated when it is flipped. Turning it off reverts every Net Sales, AOV and median figure at the very next query - it does not leave previously-shown figures standing.

## Fix

- Replaced the false claim with copy that says what actually happens: turning it off removes those orders from Net Sales again the next time the figures are queried.
- Also stated the two facts the misleading sentence obscured: the change is organisation-wide and applies to every date range, not just the one currently being viewed (the toggle fires immediately on change via `handleTaxToggleChange`, with no confirm step).
- Did not add a confirm-dialog or debounce to `handleTaxToggleChange` - out of scope per the issue; this PR is a copy fix, not a behavior change. Did not add an explicit `Alert` warning (like the currency-recalculation section above it) since that would require new component structure beyond a copy fix.
- Left the "Rate on order date" / accounting-grade paragraph (#2814, already merged) untouched.

## Test plan

- [x] `pnpm --filter @openlinker/web lint` - 0 errors (pre-existing warnings only)
- [x] `pnpm --filter @openlinker/web type-check` - clean
- [x] `vitest run src/features/analytics/components/analytics-settings-dialog.test.tsx` - 10/10 passing, including a new regression test pinning the corrected wording (asserts it no longer claims already-shown figures are unaffected, and asserts the org-wide/every-date-range scope is stated)

Closes #2815