### PR TITLE
fix(api): re-prefix analytics migrations past the current main tail

### DIFF
--- a/apps/api/src/migrations/1851000000000-add-analytics-display-settings.ts
+++ b/apps/api/src/migrations/1851000000000-add-analytics-display-settings.ts
@@ -21,8 +21,8 @@
  */
 import type { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class AddAnalyticsDisplaySettings1842000000000 implements MigrationInterface {
-  name = 'AddAnalyticsDisplaySettings1842000000000';
+export class AddAnalyticsDisplaySettings1851000000000 implements MigrationInterface {
+  name = 'AddAnalyticsDisplaySettings1851000000000';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`

--- a/apps/api/src/migrations/1851000000001-add-analytics-remediation-runs.ts
+++ b/apps/api/src/migrations/1851000000001-add-analytics-remediation-runs.ts
@@ -41,8 +41,8 @@
  */
 import type { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class AddAnalyticsRemediationRuns1843000000000 implements MigrationInterface {
-  name = 'AddAnalyticsRemediationRuns1843000000000';
+export class AddAnalyticsRemediationRuns1851000000001 implements MigrationInterface {
+  name = 'AddAnalyticsRemediationRuns1851000000001';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`


### PR DESCRIPTION
Re-prefixes `1842000000000-add-analytics-display-settings.ts` and `1843000000000-add-analytics-remediation-runs.ts` to `1851000000000` / `1851000000001`.

Both sorted below the newest migration already on `main` (`1850000000000`), which `scripts/check-migration-timestamps.mjs` rejects under `pnpm lint`. This was blocking finding 2 of the multi-lens review on PR #2668.

Note: a separately stacked PR chain (#2778 through #2714, i.e. #2785 onward) already carries this same rename on its own branch, but that chain is not yet merged into `epic/2452-analytics-currency-coverage`. This PR fixes it directly on the epic branch so `pnpm lint` is green regardless of when that stack lands. When the stack does merge, `git merge` will see identical renames on both sides and should resolve cleanly.

No behavior change: class name and `name` field renamed to match, no other reference to the old names anywhere in the tree.
