### PR TITLE
perf(orders): batch and dedupe the tax coverage detection reads

### DIFF
--- a/libs/core/src/orders/application/services/tax-coverage-detection.service.spec.ts
+++ b/libs/core/src/orders/application/services/tax-coverage-detection.service.spec.ts
@@ -12,7 +12,7 @@ describe('TaxCoverageDetectionService (#2465)', () => {
   let recordRepository: jest.Mocked<
     Pick<OrderRecordRepositoryPort, 'findNetExcludedOrderCandidates'>
   >;
-  let lineItemRepository: jest.Mocked<Pick<OrderLineItemRepositoryPort, 'findByOrderId'>>;
+  let lineItemRepository: jest.Mocked<Pick<OrderLineItemRepositoryPort, 'findByOrderIds'>>;
   let productsService: jest.Mocked<Pick<IProductsService, 'getEffectiveTaxRate'>>;
 
   const baseFilters = {
@@ -53,9 +53,20 @@ describe('TaxCoverageDetectionService (#2465)', () => {
   const noRate: StoredTaxRate = { code: null, countryIso2: 'PL', readAt: new Date('2026-08-24T00:00:00Z') };
   const notChecked: StoredTaxRate = { code: null, countryIso2: null, readAt: null };
 
+  /** Groups lines by `orderRecordId` into the `Map` shape `findByOrderIds` returns. */
+  const linesMap = (...lines: OrderLineItem[]): Map<string, OrderLineItem[]> => {
+    const map = new Map<string, OrderLineItem[]>();
+    for (const line of lines) {
+      const existing = map.get(line.orderRecordId) ?? [];
+      existing.push(line);
+      map.set(line.orderRecordId, existing);
+    }
+    return map;
+  };
+
   beforeEach(() => {
     recordRepository = { findNetExcludedOrderCandidates: jest.fn() };
-    lineItemRepository = { findByOrderId: jest.fn() };
+    lineItemRepository = { findByOrderIds: jest.fn().mockResolvedValue(new Map()) };
     productsService = { getEffectiveTaxRate: jest.fn() };
 
     service = new TaxCoverageDetectionService(
@@ -77,16 +88,16 @@ describe('TaxCoverageDetectionService (#2465)', () => {
       expect(result['tax-b'][0].internalOrderId).toBe('order-post-rollout');
       expect(result['tax-a']).toHaveLength(0);
       expect(result['tax-c']).toHaveLength(0);
-      expect(lineItemRepository.findByOrderId).not.toHaveBeenCalled();
+      expect(lineItemRepository.findByOrderIds).toHaveBeenCalledWith([]);
     });
 
     it('reports tax-a when a pre-rollout order already has every line resolved (backfill already ran)', async () => {
       recordRepository.findNetExcludedOrderCandidates.mockResolvedValue([
         candidate({ internalOrderId: 'order-a', taxRateEra: 'pre-rollout' }),
       ]);
-      lineItemRepository.findByOrderId.mockResolvedValue([
-        makeLine({ orderRecordId: 'order-a', taxRate: '23' }),
-      ]);
+      lineItemRepository.findByOrderIds.mockResolvedValue(
+        linesMap(makeLine({ orderRecordId: 'order-a', taxRate: '23' }))
+      );
 
       const result = await service.classify(baseFilters, 'EUR');
 
@@ -99,9 +110,9 @@ describe('TaxCoverageDetectionService (#2465)', () => {
       recordRepository.findNetExcludedOrderCandidates.mockResolvedValue([
         candidate({ internalOrderId: 'order-a', taxRateEra: 'pre-rollout' }),
       ]);
-      lineItemRepository.findByOrderId.mockResolvedValue([
-        makeLine({ orderRecordId: 'order-a', productId: 'ol_product_x', taxRate: null }),
-      ]);
+      lineItemRepository.findByOrderIds.mockResolvedValue(
+        linesMap(makeLine({ orderRecordId: 'order-a', productId: 'ol_product_x', taxRate: null }))
+      );
       productsService.getEffectiveTaxRate.mockResolvedValue(known('23'));
 
       const result = await service.classify(baseFilters, 'EUR');
@@ -116,9 +127,9 @@ describe('TaxCoverageDetectionService (#2465)', () => {
       recordRepository.findNetExcludedOrderCandidates.mockResolvedValue([
         candidate({ internalOrderId: 'order-b', taxRateEra: 'pre-rollout' }),
       ]);
-      lineItemRepository.findByOrderId.mockResolvedValue([
-        makeLine({ orderRecordId: 'order-b', taxRate: null }),
-      ]);
+      lineItemRepository.findByOrderIds.mockResolvedValue(
+        linesMap(makeLine({ orderRecordId: 'order-b', taxRate: null }))
+      );
       productsService.getEffectiveTaxRate.mockResolvedValue(noRate);
 
       const result = await service.classify(baseFilters, 'EUR');
@@ -132,9 +143,9 @@ describe('TaxCoverageDetectionService (#2465)', () => {
       recordRepository.findNetExcludedOrderCandidates.mockResolvedValue([
         candidate({ internalOrderId: 'order-c', taxRateEra: 'pre-rollout' }),
       ]);
-      lineItemRepository.findByOrderId.mockResolvedValue([
-        makeLine({ orderRecordId: 'order-c', taxRate: null }),
-      ]);
+      lineItemRepository.findByOrderIds.mockResolvedValue(
+        linesMap(makeLine({ orderRecordId: 'order-c', taxRate: null }))
+      );
       productsService.getEffectiveTaxRate.mockResolvedValue(notChecked);
 
       const result = await service.classify(baseFilters, 'EUR');
@@ -148,13 +159,27 @@ describe('TaxCoverageDetectionService (#2465)', () => {
       recordRepository.findNetExcludedOrderCandidates.mockResolvedValue([
         candidate({ internalOrderId: 'order-mixed', taxRateEra: 'pre-rollout' }),
       ]);
-      lineItemRepository.findByOrderId.mockResolvedValue([
-        makeLine({ id: 'line-1', lineNumber: 0, productId: 'p1', taxRate: null }),
-        makeLine({ id: 'line-2', lineNumber: 1, productId: 'p2', taxRate: null }),
-      ]);
-      productsService.getEffectiveTaxRate
-        .mockResolvedValueOnce(noRate)
-        .mockResolvedValueOnce(notChecked);
+      lineItemRepository.findByOrderIds.mockResolvedValue(
+        linesMap(
+          makeLine({
+            id: 'line-1',
+            orderRecordId: 'order-mixed',
+            lineNumber: 0,
+            productId: 'p1',
+            taxRate: null,
+          }),
+          makeLine({
+            id: 'line-2',
+            orderRecordId: 'order-mixed',
+            lineNumber: 1,
+            productId: 'p2',
+            taxRate: null,
+          })
+        )
+      );
+      productsService.getEffectiveTaxRate.mockImplementation((productId: string) =>
+        Promise.resolve(productId === 'p1' ? noRate : notChecked)
+      );
 
       const result = await service.classify(baseFilters, 'EUR');
 
@@ -166,15 +191,35 @@ describe('TaxCoverageDetectionService (#2465)', () => {
       recordRepository.findNetExcludedOrderCandidates.mockResolvedValue([
         candidate({ internalOrderId: 'order-fail', taxRateEra: 'pre-rollout' }),
       ]);
-      lineItemRepository.findByOrderId.mockResolvedValue([
-        makeLine({ orderRecordId: 'order-fail', taxRate: null }),
-      ]);
+      lineItemRepository.findByOrderIds.mockResolvedValue(
+        linesMap(makeLine({ orderRecordId: 'order-fail', taxRate: null }))
+      );
       productsService.getEffectiveTaxRate.mockRejectedValue(new Error('catalogue unavailable'));
 
       const result = await service.classify(baseFilters, 'EUR');
 
       expect(result['tax-c']).toHaveLength(1);
       expect(result['tax-b']).toHaveLength(0);
+    });
+
+    it('resolves the catalogue rate ONCE per distinct (productId, variantId) pair, even when several orders/lines share it (#2826)', async () => {
+      recordRepository.findNetExcludedOrderCandidates.mockResolvedValue([
+        candidate({ internalOrderId: 'order-x', taxRateEra: 'pre-rollout' }),
+        candidate({ internalOrderId: 'order-y', taxRateEra: 'pre-rollout' }),
+      ]);
+      lineItemRepository.findByOrderIds.mockResolvedValue(
+        linesMap(
+          makeLine({ id: 'line-x1', orderRecordId: 'order-x', productId: 'shared-product', taxRate: null }),
+          makeLine({ id: 'line-x2', orderRecordId: 'order-x', lineNumber: 1, productId: 'shared-product', taxRate: null }),
+          makeLine({ id: 'line-y1', orderRecordId: 'order-y', productId: 'shared-product', taxRate: null })
+        )
+      );
+      productsService.getEffectiveTaxRate.mockResolvedValue(known('23'));
+
+      const result = await service.classify(baseFilters, 'EUR');
+
+      expect(productsService.getEffectiveTaxRate).toHaveBeenCalledTimes(1);
+      expect(result['tax-a']).toHaveLength(2);
     });
 
     it('partitions a mixed candidate set with categories summing to the full candidate count (regression guard)', async () => {
@@ -184,12 +229,12 @@ describe('TaxCoverageDetectionService (#2465)', () => {
         candidate({ internalOrderId: 'order-3', taxRateEra: 'pre-rollout' }),
       ];
       recordRepository.findNetExcludedOrderCandidates.mockResolvedValue(candidates);
-      lineItemRepository.findByOrderId.mockImplementation((orderRecordId: string) => {
-        if (orderRecordId === 'order-2') {
-          return Promise.resolve([makeLine({ orderRecordId, taxRate: '23' })]);
-        }
-        return Promise.resolve([makeLine({ orderRecordId, taxRate: null })]);
-      });
+      lineItemRepository.findByOrderIds.mockResolvedValue(
+        linesMap(
+          makeLine({ orderRecordId: 'order-2', productId: 'p-order-2', taxRate: '23' }),
+          makeLine({ orderRecordId: 'order-3', productId: 'p-order-3', taxRate: null })
+        )
+      );
       productsService.getEffectiveTaxRate.mockResolvedValue(notChecked);
 
       const result = await service.classify(baseFilters, 'EUR');
@@ -240,9 +285,9 @@ describe('TaxCoverageDetectionService (#2465)', () => {
         candidate({ internalOrderId: 'order-2', taxRateEra: 'pre-rollout' }),
       ];
       recordRepository.findNetExcludedOrderCandidates.mockResolvedValue(candidates);
-      lineItemRepository.findByOrderId.mockResolvedValue([
-        makeLine({ orderRecordId: 'order-2', taxRate: '23' }),
-      ]);
+      lineItemRepository.findByOrderIds.mockResolvedValue(
+        linesMap(makeLine({ orderRecordId: 'order-2', taxRate: '23' }))
+      );
 
       const pages = await service.getAllCategoryPages(baseFilters, 'EUR', {
         limit: 10,

--- a/libs/core/src/orders/application/services/tax-coverage-detection.service.spec.ts
+++ b/libs/core/src/orders/application/services/tax-coverage-detection.service.spec.ts
@@ -222,6 +222,45 @@ describe('TaxCoverageDetectionService (#2465)', () => {
       expect(result['tax-a']).toHaveLength(2);
     });
 
+    it('never runs more than the bounded concurrency ceiling of catalogue lookups in flight at once (#2826)', async () => {
+      const KEY_COUNT = 12; // comfortably above RATE_LOOKUP_CONCURRENCY (5)
+      recordRepository.findNetExcludedOrderCandidates.mockResolvedValue(
+        Array.from({ length: KEY_COUNT }, (_, i) =>
+          candidate({ internalOrderId: `order-${i}`, taxRateEra: 'pre-rollout' })
+        )
+      );
+      lineItemRepository.findByOrderIds.mockResolvedValue(
+        linesMap(
+          ...Array.from({ length: KEY_COUNT }, (_, i) =>
+            makeLine({
+              id: `line-${i}`,
+              orderRecordId: `order-${i}`,
+              productId: `distinct-product-${i}`,
+              taxRate: null,
+            })
+          )
+        )
+      );
+
+      let inFlight = 0;
+      let maxInFlight = 0;
+      productsService.getEffectiveTaxRate.mockImplementation(async () => {
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        // Yield so every worker gets a chance to start before any resolves —
+        // otherwise a purely-synchronous mock would never let the bound show up.
+        await new Promise((resolve) => setImmediate(resolve));
+        inFlight -= 1;
+        return known('23');
+      });
+
+      await service.classify(baseFilters, 'EUR');
+
+      expect(productsService.getEffectiveTaxRate).toHaveBeenCalledTimes(KEY_COUNT);
+      expect(maxInFlight).toBeLessThanOrEqual(5);
+      expect(maxInFlight).toBeGreaterThan(1); // proves it actually ran concurrently, not sequentially
+    });
+
     it('partitions a mixed candidate set with categories summing to the full candidate count (regression guard)', async () => {
       const candidates = [
         candidate({ internalOrderId: 'order-1', taxRateEra: null }),

--- a/libs/core/src/orders/application/services/tax-coverage-detection.service.ts
+++ b/libs/core/src/orders/application/services/tax-coverage-detection.service.ts
@@ -56,6 +56,7 @@ import { Logger } from '@openlinker/shared/logging';
 import type { ITaxCoverageDetectionService } from './tax-coverage-detection.service.interface';
 import { OrderRecordRepositoryPort } from '../../domain/ports/order-record-repository.port';
 import { OrderLineItemRepositoryPort } from '../../domain/ports/order-line-item-repository.port';
+import type { OrderLineItem } from '../../domain/entities/order-line-item.entity';
 import { ORDER_RECORD_REPOSITORY_TOKEN, ORDER_LINE_ITEM_REPOSITORY_TOKEN } from '../../orders.tokens';
 import { resolveNetSalesTaxRate } from '../../domain/types/net-sales-tax-rate.types';
 import type { SalesAnalyticsFilters } from '../../domain/types/order-sales-analytics.types';
@@ -70,6 +71,15 @@ import {
 } from '../../domain/types/coverage-detection.types';
 
 const PRE_ROLLOUT_ERA = 'pre-rollout';
+
+/**
+ * Bounded fan-out ceiling for the catalogue rate lookup (#2826) — mirrors
+ * the `resolveBatchConcurrency` precedent (ADR-047/#2229): bound the number
+ * of concurrent `getEffectiveTaxRate` calls rather than either running them
+ * fully sequentially (the pre-#2826 behaviour) or fanning out an unbounded
+ * `Promise.all` over the whole deduplicated key set.
+ */
+const RATE_LOOKUP_CONCURRENCY = 5;
 
 @Injectable()
 export class TaxCoverageDetectionService implements ITaxCoverageDetectionService {
@@ -95,6 +105,48 @@ export class TaxCoverageDetectionService implements ITaxCoverageDetectionService
       includeBackfilledPreRollout
     );
 
+    // Only a pre-rollout candidate needs a line-item read at all — every
+    // other candidate is unconditionally 'tax-b' (see `classifyOne`'s doc
+    // comment). Narrowing here means neither the batched line-item read nor
+    // the catalogue check below does any work for the non-pre-rollout
+    // majority (#2826).
+    const preRolloutCandidates = candidates.filter(
+      (candidate) => candidate.taxRateEra === PRE_ROLLOUT_ERA
+    );
+
+    // ONE query for every pre-rollout candidate's lines, instead of one
+    // `findByOrderId` call per candidate (#2826) — the N+1 this method used
+    // to make.
+    const linesByOrderId = await this.orderLineItemRepository.findByOrderIds(
+      preRolloutCandidates.map((candidate) => candidate.internalOrderId)
+    );
+
+    // Every unresolved line across every pre-rollout candidate, deduplicated
+    // by (productId, variantId) — many lines across many orders reference
+    // the same catalogue entry, so this collapses what used to be one
+    // `getEffectiveTaxRate` call per UNRESOLVED LINE into one call per
+    // distinct product/variant pair (#2826).
+    const unresolvedLinesByOrderId = new Map<string, OrderLineItem[]>();
+    const uniqueRateKeys = new Map<string, { productId: string; variantId?: string }>();
+    for (const candidate of preRolloutCandidates) {
+      const lines = linesByOrderId.get(candidate.internalOrderId) ?? [];
+      const unresolved = lines.filter(
+        (line) => resolveNetSalesTaxRate(line.taxRate).kind === 'unknown'
+      );
+      unresolvedLinesByOrderId.set(candidate.internalOrderId, unresolved);
+      for (const line of unresolved) {
+        uniqueRateKeys.set(this.rateKey(line.productId, line.variantId), {
+          productId: line.productId,
+          variantId: line.variantId ?? undefined,
+        });
+      }
+    }
+
+    // Bounded-concurrency fan-out over the DEDUPLICATED key set — never one
+    // sequential `await` per line, and never an unbounded `Promise.all`
+    // either (#2826).
+    const rateByKey = await this.resolveRates([...uniqueRateKeys.values()]);
+
     const result: TaxCoverageClassification = {
       'tax-a': [],
       'tax-b': [],
@@ -102,11 +154,65 @@ export class TaxCoverageDetectionService implements ITaxCoverageDetectionService
     };
 
     for (const candidate of candidates) {
-      const category = await this.classifyOne(candidate);
+      const category = this.classifyOne(
+        candidate,
+        unresolvedLinesByOrderId.get(candidate.internalOrderId) ?? [],
+        rateByKey
+      );
       result[category].push(this.toRow(candidate));
     }
 
     return result;
+  }
+
+  /** Stable dedup key for a (productId, variantId) catalogue lookup. */
+  private rateKey(productId: string, variantId: string | null | undefined): string {
+    return `${productId}::${variantId ?? ''}`;
+  }
+
+  /**
+   * Resolve the effective tax rate for every distinct (productId, variantId)
+   * pair, with bounded concurrency (#2826) — mirrors the
+   * `resolveBatchConcurrency` precedent used for the EAN-resolve batch path
+   * (ADR-047/#2229): a caller that only needs the whole map back gains
+   * nothing from an unbounded fan-out while spending more of the catalogue
+   * read path at once. A failed lookup is recorded as `null` rather than
+   * rejecting the batch — `classifyOne` treats a missing/`null` entry
+   * exactly like the pre-#2826 catch block did (logged, folded into
+   * 'not-checked').
+   */
+  private async resolveRates(
+    keys: Array<{ productId: string; variantId?: string }>
+  ): Promise<Map<string, StoredTaxRate | null>> {
+    const rateByKey = new Map<string, StoredTaxRate | null>();
+    let cursor = 0;
+
+    const worker = async (): Promise<void> => {
+      for (;;) {
+        const index = cursor++;
+        if (index >= keys.length) {
+          return;
+        }
+        const { productId, variantId } = keys[index];
+        try {
+          const rate = await this.productsService.getEffectiveTaxRate(productId, variantId);
+          rateByKey.set(this.rateKey(productId, variantId), rate);
+        } catch (error) {
+          // A catalogue read failure tells us nothing about the rate's
+          // existence — treat like 'not-checked' rather than assuming the
+          // worst (a permanent 'no-rate' claim this order does not support).
+          this.logger.warn(
+            `Tax coverage classification: catalogue read failed for ` +
+              `[productId=${productId}, variantId=${variantId ?? 'none'}]: ${(error as Error).message}`
+          );
+          rateByKey.set(this.rateKey(productId, variantId), null);
+        }
+      }
+    };
+
+    const workerCount = Math.min(RATE_LOOKUP_CONCURRENCY, keys.length);
+    await Promise.all(Array.from({ length: workerCount }, () => worker()));
+    return rateByKey;
   }
 
   async getCategoryPage(
@@ -176,19 +282,24 @@ export class TaxCoverageDetectionService implements ITaxCoverageDetectionService
   }
 
   /**
-   * Classify one candidate. A non-pre-rollout candidate is always `'tax-b'`
-   * — the A/C split only applies to the pre-rollout blanket-exclusion case
-   * (see the class doc comment).
+   * Classify one candidate, given its already-fetched unresolved lines and
+   * the already-resolved catalogue rate per (productId, variantId) key
+   * (#2826 — both are batched/deduplicated once per `classify()` call rather
+   * than fetched here, so this method does no I/O of its own). A
+   * non-pre-rollout candidate is always `'tax-b'` — the A/C split only
+   * applies to the pre-rollout blanket-exclusion case (see the class doc
+   * comment). A `null` map entry means the catalogue read for that key
+   * failed — treated exactly like 'not-checked', matching the pre-#2826
+   * per-line catch block.
    */
-  private async classifyOne(candidate: NetExcludedOrderCandidate): Promise<TaxCoverageCategory> {
+  private classifyOne(
+    candidate: NetExcludedOrderCandidate,
+    unresolvedLines: OrderLineItem[],
+    rateByKey: Map<string, StoredTaxRate | null>
+  ): TaxCoverageCategory {
     if (candidate.taxRateEra !== PRE_ROLLOUT_ERA) {
       return 'tax-b';
     }
-
-    const lines = await this.orderLineItemRepository.findByOrderId(candidate.internalOrderId);
-    const unresolvedLines = lines.filter(
-      (line) => resolveNetSalesTaxRate(line.taxRate).kind === 'unknown'
-    );
 
     // Every line already resolves (e.g. the backfill sweep already wrote a
     // rate to each one) — the order is fully resolvable, just blocked by
@@ -201,20 +312,11 @@ export class TaxCoverageDetectionService implements ITaxCoverageDetectionService
     let anyNotChecked = false;
 
     for (const line of unresolvedLines) {
-      let rate: StoredTaxRate;
-      try {
-        rate = await this.productsService.getEffectiveTaxRate(
-          line.productId,
-          line.variantId ?? undefined
-        );
-      } catch (error) {
-        // A catalogue read failure tells us nothing about the rate's
-        // existence — treat like 'not-checked' rather than assuming the
-        // worst (a permanent 'no-rate' claim this order does not support).
-        this.logger.warn(
-          `Tax coverage classification: catalogue read failed for order ${candidate.internalOrderId} ` +
-            `line [productId=${line.productId}, variantId=${line.variantId ?? 'none'}]: ${(error as Error).message}`
-        );
+      const rate = rateByKey.get(this.rateKey(line.productId, line.variantId));
+      if (!rate) {
+        // Absent (shouldn't happen — every unresolved line's key was
+        // collected before the lookup) or `null` (the catalogue read for
+        // this key failed) — treat like 'not-checked'.
         anyNotChecked = true;
         continue;
       }

--- a/libs/core/src/orders/domain/ports/order-line-item-repository.port.ts
+++ b/libs/core/src/orders/domain/ports/order-line-item-repository.port.ts
@@ -34,6 +34,18 @@ export interface OrderLineItemRepositoryPort {
   findByOrderId(orderRecordId: string): Promise<OrderLineItem[]>;
 
   /**
+   * Batch read: every line item for the given order ids, in ONE query,
+   * grouped into a `Map` keyed by `orderRecordId` (each value ordered by
+   * `lineNumber`, mirroring {@link findByOrderId}) — the real batch a
+   * cross-cutting read needs, as opposed to a `Promise.all` fan-out over
+   * {@link findByOrderId} (#2826, mirrors `RefundRecordRepositoryPort
+   * .summarizeByOrderIds`'s doc comment). An order id with no line items is
+   * simply absent from the returned Map. Returns an empty `Map` immediately
+   * for an empty `orderRecordIds` input, without issuing a query.
+   */
+  findByOrderIds(orderRecordIds: string[]): Promise<Map<string, OrderLineItem[]>>;
+
+  /**
    * Units sold per source connection for the sales & channel analytics read
    * (#1987) — `SUM(quantity)` grouped by `sourceConnectionId`, joined back to
    * the parent `order_records` row to apply the same `recordStatus = 'ready'

--- a/libs/core/src/orders/infrastructure/persistence/repositories/__tests__/order-line-item.repository.spec.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/__tests__/order-line-item.repository.spec.ts
@@ -6,7 +6,7 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import type { Repository } from 'typeorm';
+import { In, type Repository } from 'typeorm';
 import { OrderLineItemRepository } from '../order-line-item.repository';
 import { OrderLineItemOrmEntity } from '../../entities/order-line-item.orm-entity';
 
@@ -131,6 +131,42 @@ describe('OrderLineItemRepository', () => {
       const result = await repository.findByOrderId('order-without-items');
 
       expect(result).toEqual([]);
+    });
+  });
+
+  describe('findByOrderIds (#2826)', () => {
+    it('returns an empty Map without a DB round-trip for an empty input', async () => {
+      const result = await repository.findByOrderIds([]);
+
+      expect(result.size).toBe(0);
+      expect(ormRepository.find).not.toHaveBeenCalled();
+    });
+
+    it('issues ONE query for the whole id set and groups the results by orderRecordId', async () => {
+      ormRepository.find.mockResolvedValue([
+        createOrmEntity({ id: 'line-1', orderRecordId: 'order-a', lineNumber: 0 }),
+        createOrmEntity({ id: 'line-2', orderRecordId: 'order-a', lineNumber: 1 }),
+        createOrmEntity({ id: 'line-3', orderRecordId: 'order-b', lineNumber: 0 }),
+      ]);
+
+      const result = await repository.findByOrderIds(['order-a', 'order-b']);
+
+      expect(ormRepository.find).toHaveBeenCalledTimes(1);
+      expect(ormRepository.find).toHaveBeenCalledWith({
+        where: { orderRecordId: In(['order-a', 'order-b']) },
+        order: { orderRecordId: 'ASC', lineNumber: 'ASC' },
+      });
+      expect(result.get('order-a')).toHaveLength(2);
+      expect(result.get('order-b')).toHaveLength(1);
+    });
+
+    it('omits an order id with no line items from the returned Map', async () => {
+      ormRepository.find.mockResolvedValue([]);
+
+      const result = await repository.findByOrderIds(['order-without-items']);
+
+      expect(result.has('order-without-items')).toBe(false);
+      expect(result.size).toBe(0);
     });
   });
 

--- a/libs/core/src/orders/infrastructure/persistence/repositories/__tests__/order-record.repository.spec.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/__tests__/order-record.repository.spec.ts
@@ -788,25 +788,33 @@ describe('OrderRecordRepository', () => {
       to: new Date('2026-08-08T00:00:00.000Z'),
     };
 
-    const createCandidateEntity = (
-      overrides: Partial<OrderRecordOrmEntity>
-    ): OrderRecordOrmEntity => {
-      const entity = createOrmEntity();
-      Object.assign(entity, overrides);
-      return entity;
-    };
+    /** A raw row shape as `getRawMany` returns it (#2826 — no longer `getMany`). */
+    const rawCandidateRow = (overrides: {
+      internal_order_id: string;
+      source_connection_id: string;
+      placed_at: Date | null;
+      tax_rate_era: string | null;
+    }): typeof overrides => overrides;
 
-    it('applies the non-cancelled, current-era-stamped, NOT-net-eligible predicate', async () => {
+    it('selects only the four candidate columns and applies the non-cancelled, current-era-stamped, NOT-net-eligible predicate (#2826)', async () => {
+      const select = jest.fn().mockReturnThis();
+      const addSelect = jest.fn().mockReturnThis();
       const andWhere = jest.fn().mockReturnThis();
       const orderBy = jest.fn().mockReturnThis();
       (ormRepository.createQueryBuilder as jest.Mock).mockReturnValue({
+        select,
+        addSelect,
         andWhere,
         orderBy,
-        getMany: jest.fn().mockResolvedValue([]),
+        getRawMany: jest.fn().mockResolvedValue([]),
       });
 
       await repository.findNetExcludedOrderCandidates(baseFilters, 'EUR');
 
+      expect(select).toHaveBeenCalledWith('rec."internalOrderId"', 'internal_order_id');
+      expect(addSelect).toHaveBeenCalledWith('rec."sourceConnectionId"', 'source_connection_id');
+      expect(addSelect).toHaveBeenCalledWith('rec."placedAt"', 'placed_at');
+      expect(addSelect).toHaveBeenCalledWith('rec."taxRateEra"', 'tax_rate_era');
       expect(andWhere).toHaveBeenCalledWith(
         expect.stringContaining('rec."cancelledAt" IS NULL AND rec."reportingCurrency" = :currentReportingCurrency AND NOT'),
         { currentReportingCurrency: 'EUR' }
@@ -816,10 +824,14 @@ describe('OrderRecordRepository', () => {
 
     it('is unpaged — no take/skip call on the query builder', async () => {
       const qb: Record<string, jest.Mock> = {
+        select: jest.fn(),
+        addSelect: jest.fn(),
         andWhere: jest.fn(),
         orderBy: jest.fn(),
-        getMany: jest.fn().mockResolvedValue([]),
+        getRawMany: jest.fn().mockResolvedValue([]),
       };
+      qb.select.mockReturnValue(qb);
+      qb.addSelect.mockReturnValue(qb);
       qb.andWhere.mockReturnValue(qb);
       qb.orderBy.mockReturnValue(qb);
       (ormRepository.createQueryBuilder as jest.Mock).mockReturnValue(qb);
@@ -831,16 +843,18 @@ describe('OrderRecordRepository', () => {
     });
 
     it('maps a pre-rollout candidate to the row shape, including taxRateEra', async () => {
-      const entity = createCandidateEntity({
-        internalOrderId: 'order-pre-rollout',
-        sourceConnectionId: 'conn-a',
-        placedAt: new Date('2026-08-02T00:00:00.000Z'),
-        taxRateEra: 'pre-rollout',
+      const row = rawCandidateRow({
+        internal_order_id: 'order-pre-rollout',
+        source_connection_id: 'conn-a',
+        placed_at: new Date('2026-08-02T00:00:00.000Z'),
+        tax_rate_era: 'pre-rollout',
       });
       (ormRepository.createQueryBuilder as jest.Mock).mockReturnValue({
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
         orderBy: jest.fn().mockReturnThis(),
-        getMany: jest.fn().mockResolvedValue([entity]),
+        getRawMany: jest.fn().mockResolvedValue([row]),
       });
 
       const result = await repository.findNetExcludedOrderCandidates(baseFilters, 'EUR');
@@ -849,23 +863,25 @@ describe('OrderRecordRepository', () => {
         {
           internalOrderId: 'order-pre-rollout',
           sourceConnectionId: 'conn-a',
-          placedAt: entity.placedAt,
+          placedAt: row.placed_at,
           taxRateEra: 'pre-rollout',
         },
       ]);
     });
 
     it('maps a non-pre-rollout candidate with taxRateEra: null', async () => {
-      const entity = createCandidateEntity({
-        internalOrderId: 'order-post-rollout',
-        sourceConnectionId: 'conn-a',
-        placedAt: new Date('2026-08-03T00:00:00.000Z'),
-        taxRateEra: null,
+      const row = rawCandidateRow({
+        internal_order_id: 'order-post-rollout',
+        source_connection_id: 'conn-a',
+        placed_at: new Date('2026-08-03T00:00:00.000Z'),
+        tax_rate_era: null,
       });
       (ormRepository.createQueryBuilder as jest.Mock).mockReturnValue({
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
         andWhere: jest.fn().mockReturnThis(),
         orderBy: jest.fn().mockReturnThis(),
-        getMany: jest.fn().mockResolvedValue([entity]),
+        getRawMany: jest.fn().mockResolvedValue([row]),
       });
 
       const result = await repository.findNetExcludedOrderCandidates(baseFilters, 'EUR');
@@ -874,7 +890,7 @@ describe('OrderRecordRepository', () => {
         {
           internalOrderId: 'order-post-rollout',
           sourceConnectionId: 'conn-a',
-          placedAt: entity.placedAt,
+          placedAt: row.placed_at,
           taxRateEra: null,
         },
       ]);
@@ -883,9 +899,11 @@ describe('OrderRecordRepository', () => {
     it('scopes to the sourceConnectionId filter when provided (via the shared analytics scope)', async () => {
       const andWhere = jest.fn().mockReturnThis();
       (ormRepository.createQueryBuilder as jest.Mock).mockReturnValue({
+        select: jest.fn().mockReturnThis(),
+        addSelect: jest.fn().mockReturnThis(),
         andWhere,
         orderBy: jest.fn().mockReturnThis(),
-        getMany: jest.fn().mockResolvedValue([]),
+        getRawMany: jest.fn().mockResolvedValue([]),
       });
 
       await repository.findNetExcludedOrderCandidates(

--- a/libs/core/src/orders/infrastructure/persistence/repositories/order-line-item.repository.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/order-line-item.repository.ts
@@ -12,7 +12,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import type { SelectQueryBuilder } from 'typeorm';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 import { OrderLineItemOrmEntity } from '../entities/order-line-item.orm-entity';
 import { OrderRecordOrmEntity } from '../entities/order-record.orm-entity';
 import type { OrderLineItemRepositoryPort } from '../../../domain/ports/order-line-item-repository.port';
@@ -46,6 +46,27 @@ export class OrderLineItemRepository implements OrderLineItemRepositoryPort {
       order: { lineNumber: 'ASC' },
     });
     return entities.map((e) => this.toDomain(e));
+  }
+
+  async findByOrderIds(orderRecordIds: string[]): Promise<Map<string, OrderLineItem[]>> {
+    if (orderRecordIds.length === 0) {
+      return new Map();
+    }
+
+    // One query for the whole id set — the real batch a cross-cutting read
+    // needs, as opposed to an N-call fan-out over `findByOrderId` (#2826).
+    const entities = await this.repository.find({
+      where: { orderRecordId: In(orderRecordIds) },
+      order: { orderRecordId: 'ASC', lineNumber: 'ASC' },
+    });
+
+    const grouped = new Map<string, OrderLineItem[]>();
+    for (const entity of entities) {
+      const lines = grouped.get(entity.orderRecordId) ?? [];
+      lines.push(this.toDomain(entity));
+      grouped.set(entity.orderRecordId, lines);
+    }
+    return grouped;
   }
 
   /**

--- a/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
@@ -771,6 +771,13 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
    * EXACTLY (non-cancelled, current-era stamped, `NOT` net-eligible) so
    * `candidates.length` is always the same figure as `netExcludedCount`
    * for the identical filters/currency.
+   *
+   * Reads only the four columns {@link NetExcludedOrderCandidate} needs via
+   * `getRawMany`, not `getMany` (#2826) — the full `OrderRecordOrmEntity`
+   * additionally carries `orderSnapshot` (an arbitrary-size JSONB column)
+   * that this classification pass never reads, so hydrating it for every
+   * candidate in the window was pure waste on top of an already-unpaged
+   * read (unpaged by design — see this method's port-level doc comment).
    */
   async findNetExcludedOrderCandidates(
     filters: SalesAnalyticsFilters,
@@ -782,18 +789,27 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
 
     const qb = this.repository
       .createQueryBuilder('rec')
+      .select('rec."internalOrderId"', 'internal_order_id')
+      .addSelect('rec."sourceConnectionId"', 'source_connection_id')
+      .addSelect('rec."placedAt"', 'placed_at')
+      .addSelect('rec."taxRateEra"', 'tax_rate_era')
       .andWhere(netExcludedAndNotCancelled, { currentReportingCurrency })
       .orderBy('rec."placedAt"', 'DESC');
 
     this.applySalesAnalyticsScope(qb, filters);
 
-    const entities = await qb.getMany();
+    const rows = await qb.getRawMany<{
+      internal_order_id: string;
+      source_connection_id: string;
+      placed_at: Date | null;
+      tax_rate_era: string | null;
+    }>();
 
-    return entities.map((entity) => ({
-      internalOrderId: entity.internalOrderId,
-      sourceConnectionId: entity.sourceConnectionId,
-      placedAt: entity.placedAt,
-      taxRateEra: entity.taxRateEra,
+    return rows.map((row) => ({
+      internalOrderId: row.internal_order_id,
+      sourceConnectionId: row.source_connection_id,
+      placedAt: row.placed_at,
+      taxRateEra: row.tax_rate_era,
     }));
   }
 


### PR DESCRIPTION
## Summary
- `findNetExcludedOrderCandidates` now selects only the four columns `TaxCoverageDetectionService` needs via `getRawMany`, instead of hydrating the full `OrderRecordOrmEntity` row (including the `orderSnapshot` JSONB column) via `getMany`.
- Added `OrderLineItemRepositoryPort.findByOrderIds` — one batched `IN (...)` query for a set of order ids, replacing the per-candidate `findByOrderId` N+1 in `TaxCoverageDetectionService.classify`.
- `classify()` now filters to pre-rollout candidates before doing any line-item I/O, batches that line-item read, deduplicates the catalogue rate check by `(productId, variantId)` (many lines/orders share a product), and resolves rates with bounded concurrency (5 workers) instead of one sequential `getEffectiveTaxRate` call per unresolved line.

This closes a live performance issue: `GET /analytics/coverage` is hit unconditionally on `/analytics` page mount, and on a fresh deployment (zero catalogue tax coverage is ADR-063's stated day-one state) the old unbounded read plus double N+1 could mean tens of thousands of hydrated rows and hundreds of thousands of sequential queries per page load.

Base branch is `epic/2452-analytics-currency-coverage` because this code (from PR #2668) hasn't landed on `main` yet.

## Test plan
- [x] `pnpm --filter @openlinker/core exec tsc -p tsconfig.json --noEmit` — clean
- [x] `npx eslint` on all touched files — 0 errors (3 pre-existing, unrelated warnings)
- [x] `npx jest` on the three affected spec files — 140/140 passing, including new tests for `findByOrderIds` and for rate-lookup deduplication
- [x] `tax-coverage-net-excluded.int-spec.ts` run live against real Postgres (Testcontainers) post-review — 2/2 passing, confirming the `getRawMany` raw-SQL rewrite behaves correctly against a real server, not just the mocked query-builder unit specs

## Scope note (post-review)

This PR closes two of #2826's three acceptance criteria (batched line-item read, bounded-concurrency catalogue check). It does **not** close the third: `findNetExcludedOrderCandidates`'s base query is still unbounded — no `LIMIT`/`OFFSET` — so row count returned still scales linearly with total order history for the filter window, even though each row is now cheap. That remaining piece is split out as its own follow-up: #2834.

Progresses #2826 (not "Closes" — see #2834 for the remainder).