### PR TITLE
fix(orders): let a PrestaShop order's total be evaluated by an orderTotalGross sales-document rule

### DIFF
--- a/apps/api/src/migrations/1870000000000-add-order-record-total-tax-treatment.ts
+++ b/apps/api/src/migrations/1870000000000-add-order-record-total-tax-treatment.ts
@@ -1,0 +1,69 @@
+/**
+ * Add `order_records.totalTaxTreatment` and backfill it for PrestaShop (#2829/#2832).
+ *
+ * `order_records.taxTreatment` (#1985/#2440) describes the LINE prices /
+ * subtotal — for PrestaShop those are net (`order_details.product_price`),
+ * so the column reads `'exclusive'`. But PrestaShop's order TOTAL
+ * (`total_paid_tax_incl`) genuinely is gross, and the `orderTotalGross`
+ * sales-document rule condition reads `taxTreatment` to decide whether it may
+ * trust the total as gross at all — so no PrestaShop order could ever match
+ * that condition, regardless of its real tax setup.
+ *
+ * `taxTreatment` cannot simply be flipped to `'inclusive'`: it also drives
+ * `PrestashopOrderProcessorManagerAdapter.convertGrossToNet` (destination-side
+ * line pinning) and the ADR-063 net-sales tax-rate resolution path
+ * (`deriveNetLineAmount` + its SQL twins), both of which need the LINE-level
+ * fact to stay `'exclusive'`. `totalTaxTreatment` is the narrower, additive
+ * column describing the total's own inclusivity alone — `null` means "same as
+ * `taxTreatment`" (see `OrderRecord.totalTaxTreatment` and
+ * `SalesDocumentViewService.toOrderFacts`, which reads
+ * `totalTaxTreatment ?? taxTreatment`, the same fallback the live-`Order`
+ * gate applies via `toSalesDocumentOrderFacts`).
+ *
+ * The adapter fix (companion PR) only reaches orders ingested from now on.
+ * This migration backfills history for PrestaShop, following the exact
+ * platform-scoped join precedent set by
+ * `1841000000006-backfill-order-records-tax-treatment.ts` (itself following
+ * `1840000000000-reset-fx-stamp-for-mislabelled-prestashop-orders.ts`).
+ *
+ * Idempotent by construction (`WHERE "totalTaxTreatment" IS NULL`) — a re-run
+ * touches only rows a later fix hasn't already reached, matching the house
+ * convention documented on `1818000000004-backfill-ksef-provider-invoice-number.ts`.
+ *
+ * Deliberately does NOT touch WooCommerce, despite the identical structural
+ * split (net line prices + `total_tax` decomposed separately, but `total` is
+ * genuinely gross) — tracked as a follow-up (#2836) and cited from
+ * `OrderTotals.totalTaxTreatment`'s doc comment. A connection whose platform
+ * this migration does not assert stays `totalTaxTreatment IS NULL`, i.e.
+ * "same as `taxTreatment`", which is the existing (net-priced) behaviour —
+ * never a guess.
+ *
+ * Generated: 2026-09-03 (synthetic sequential prefix per docs/migrations.md
+ * rule 3; 1869000000900 is #2385's `automation_runs` retry-attempt column).
+ */
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddOrderRecordTotalTaxTreatment1870000000000 implements MigrationInterface {
+  name = 'AddOrderRecordTotalTaxTreatment1870000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "order_records" ADD COLUMN IF NOT EXISTS "totalTaxTreatment" varchar`
+    );
+
+    await queryRunner.query(`
+      UPDATE "order_records" o
+      SET "totalTaxTreatment" = 'inclusive'
+      FROM "connections" c
+      WHERE c."id" = o."sourceConnectionId"
+        AND c."platformType" = 'prestashop'
+        AND o."totalTaxTreatment" IS NULL
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "order_records" DROP COLUMN IF EXISTS "totalTaxTreatment"`
+    );
+  }
+}

--- a/apps/api/src/migrations/1870000000000-add-order-record-total-tax-treatment.ts
+++ b/apps/api/src/migrations/1870000000000-add-order-record-total-tax-treatment.ts
@@ -62,6 +62,9 @@ export class AddOrderRecordTotalTaxTreatment1870000000000 implements MigrationIn
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {
+    // Unlike 1841000000006's down() (a deliberate no-op — that migration only
+    // SET a pre-existing column), this one ADDS the column, so dropping it is
+    // the only sound reversal.
     await queryRunner.query(
       `ALTER TABLE "order_records" DROP COLUMN IF EXISTS "totalTaxTreatment"`
     );

--- a/libs/core/src/invoicing/application/mappers/order-to-sales-document-order-facts.mapper.spec.ts
+++ b/libs/core/src/invoicing/application/mappers/order-to-sales-document-order-facts.mapper.spec.ts
@@ -201,4 +201,32 @@ describe('toSalesDocumentOrderFacts (#2173)', () => {
 
     expect(toSalesDocumentOrderFacts(order)?.taxTreatment).toBe('exclusive');
   });
+
+  it('should honour totalTaxTreatment even when it disagrees downward from taxTreatment', () => {
+    // The fallback is `totalTaxTreatment ?? taxTreatment`, which must win in
+    // BOTH directions — the sibling test above only proves the
+    // exclusive→inclusive override; a regression to `||` or a truthiness
+    // check would still pass that one but silently ignore an explicit
+    // `'exclusive'` here (a falsy-looking-but-defined string is never the
+    // failure mode of `??`, so this guards the direction `||` would break).
+    const order = makeOrder({
+      shippingAddress: {
+        address1: 'ul. Testowa 1',
+        city: 'Poznań',
+        postalCode: '60-001',
+        country: 'PL',
+      },
+      totals: {
+        subtotal: 20,
+        tax: 0,
+        shipping: 0,
+        total: 20,
+        currency: 'PLN',
+        taxTreatment: 'inclusive',
+        totalTaxTreatment: 'exclusive',
+      },
+    });
+
+    expect(toSalesDocumentOrderFacts(order)?.taxTreatment).toBe('exclusive');
+  });
 });

--- a/libs/core/src/invoicing/application/mappers/order-to-sales-document-order-facts.mapper.spec.ts
+++ b/libs/core/src/invoicing/application/mappers/order-to-sales-document-order-facts.mapper.spec.ts
@@ -153,4 +153,52 @@ describe('toSalesDocumentOrderFacts (#2173)', () => {
     expect(facts?.currency).toBe('EUR');
     expect(facts?.totalGross).toBe(100);
   });
+
+  it('should prefer totalTaxTreatment over taxTreatment when a source asserts total is gross despite net line prices (#2829)', () => {
+    const order = makeOrder({
+      shippingAddress: {
+        address1: 'ul. Testowa 1',
+        city: 'Poznań',
+        postalCode: '60-001',
+        country: 'PL',
+      },
+      totals: {
+        subtotal: 83.32,
+        tax: 16.67,
+        shipping: 5,
+        total: 99.99,
+        currency: 'PLN',
+        // PrestaShop-shaped: line prices/subtotal are net, but the order
+        // total is genuinely gross.
+        taxTreatment: 'exclusive',
+        totalTaxTreatment: 'inclusive',
+      },
+    });
+
+    const facts = toSalesDocumentOrderFacts(order);
+
+    expect(facts?.taxTreatment).toBe('inclusive');
+    expect(facts?.totalGross).toBe(99.99);
+  });
+
+  it('should fall back to taxTreatment when totalTaxTreatment is absent', () => {
+    const order = makeOrder({
+      shippingAddress: {
+        address1: 'ul. Testowa 1',
+        city: 'Poznań',
+        postalCode: '60-001',
+        country: 'PL',
+      },
+      totals: {
+        subtotal: 20,
+        tax: 0,
+        shipping: 0,
+        total: 20,
+        currency: 'PLN',
+        taxTreatment: 'exclusive',
+      },
+    });
+
+    expect(toSalesDocumentOrderFacts(order)?.taxTreatment).toBe('exclusive');
+  });
 });

--- a/libs/core/src/invoicing/application/mappers/order-to-sales-document-order-facts.mapper.ts
+++ b/libs/core/src/invoicing/application/mappers/order-to-sales-document-order-facts.mapper.ts
@@ -14,10 +14,18 @@
  *   caller treats this exactly like "no rule-engine configuration for this
  *   order" and falls back to the pre-#2170 single-primary resolver rather than
  *   guessing a jurisdiction.
- * - `totalGross` / `currency` / `taxTreatment` — read verbatim from
- *   `order.totals`. The evaluator itself is what turns an `exclusive`
- *   treatment into the terminal `net-priced-order` signal; this mapper never
- *   re-derives or converts anything.
+ * - `totalGross` / `currency` — read verbatim from `order.totals`.
+ * - `taxTreatment` — `order.totals.totalTaxTreatment ?? order.totals.taxTreatment`
+ *   (#2829). `totals.taxTreatment` is source-uniform and also governs the
+ *   per-line/subtotal net-conversion path (`convertGrossToNet`, the ADR-063
+ *   net-sales tax-rate resolution), so a source whose line prices are net but
+ *   whose `total` is genuinely gross (PrestaShop, WooCommerce) cannot flip it
+ *   without breaking those. `totalTaxTreatment` is the narrower, `total`-only
+ *   signal such a source may set instead; every other source leaves it unset
+ *   and falls back to `taxTreatment` unchanged. The evaluator itself is what
+ *   turns an `exclusive` (or absent) result into the terminal
+ *   `net-priced-order` signal; this mapper never re-derives or converts
+ *   anything.
  * - `buyerHasTaxId` - read from the order's own buyer tax id (#2599), which
  *   closed the prerequisite ADR-041 decision 5 was waiting on. It stays
  *   `undefined` whenever the source asserted nothing, and is `false` only when
@@ -54,7 +62,7 @@ export function toSalesDocumentOrderFacts(order: Order): SalesDocumentOrderFacts
     country,
     totalGross: order.totals.total,
     currency: order.totals.currency,
-    taxTreatment: order.totals.taxTreatment,
+    taxTreatment: order.totals.totalTaxTreatment ?? order.totals.taxTreatment,
     // Stays `undefined` when the source asserted nothing — see the module doc
     // comment. Never defaulted to `false`.
     buyerHasTaxId: buyerHasTaxId(readBuyerTaxId(order)),

--- a/libs/core/src/orders/application/services/order-record.service.ts
+++ b/libs/core/src/orders/application/services/order-record.service.ts
@@ -288,7 +288,8 @@ export class OrderRecordService implements IOrderRecordService {
       null,
       [],
       buyerTaxId,
-      shippingAddressHash
+      shippingAddressHash,
+      analyticsScalars.totalTaxTreatment
     );
 
     // #1985: persist the order record AND its order_line_items rows in one

--- a/libs/core/src/orders/application/services/sales-document-view.service.spec.ts
+++ b/libs/core/src/orders/application/services/sales-document-view.service.spec.ts
@@ -255,6 +255,39 @@ describe('SalesDocumentViewService', () => {
     },
   );
 
+  it('should prefer totalTaxTreatment over taxTreatment in the routing facts (#2829/#2832)', async () => {
+    // Must match `toSalesDocumentOrderFacts`'s `totalTaxTreatment ?? taxTreatment`
+    // fallback exactly: a PrestaShop order (line prices net, total gross)
+    // routed as gross by the gate must not be reported net-priced here.
+    orderRecords.findByIds.mockResolvedValue([
+      orderRecord({ taxTreatment: 'exclusive', totalTaxTreatment: 'inclusive' }),
+    ]);
+    rules.resolveRoutingBatch.mockResolvedValue([
+      { kind: 'unresolved', reason: 'no-configuration-for-country' },
+    ]);
+
+    await service.getForOrders(['ol_order_1']);
+
+    expect(rules.resolveRoutingBatch).toHaveBeenCalledWith([
+      expect.objectContaining({ taxTreatment: 'inclusive' }),
+    ]);
+  });
+
+  it('should fall back to taxTreatment when totalTaxTreatment is absent from the record', async () => {
+    orderRecords.findByIds.mockResolvedValue([
+      orderRecord({ taxTreatment: 'exclusive', totalTaxTreatment: null }),
+    ]);
+    rules.resolveRoutingBatch.mockResolvedValue([
+      { kind: 'unresolved', reason: 'no-configuration-for-country' },
+    ]);
+
+    await service.getForOrders(['ol_order_1']);
+
+    expect(rules.resolveRoutingBatch).toHaveBeenCalledWith([
+      expect.objectContaining({ taxTreatment: 'exclusive' }),
+    ]);
+  });
+
   it('should keep an order with no document in the map, with the kind routing resolves', async () => {
     orderRecords.findByIds.mockResolvedValue([orderRecord()]);
     connections.list.mockResolvedValue([connection()]);

--- a/libs/core/src/orders/application/services/sales-document-view.service.ts
+++ b/libs/core/src/orders/application/services/sales-document-view.service.ts
@@ -266,17 +266,27 @@ function toDocumentKind(decision: SalesDocumentDecision | null): SalesDocumentKi
  * source asserted the buyer has none) - `buyerTaxIdState` is the only intended
  * read of the column, because a bare `!== null` test reports true for the
  * asserted-none row.
+ *
+ * `taxTreatment` reads `record.totalTaxTreatment ?? record.taxTreatment`
+ * (#2829/#2832), the SAME fallback `toSalesDocumentOrderFacts` applies from
+ * the live `Order` - this is the `totalGross` field's own inclusivity, which
+ * can diverge from the line-price/subtotal `taxTreatment` (a PrestaShop order
+ * prices lines net but its total gross). Reading `record.taxTreatment` alone
+ * here would report every PrestaShop order as `net-priced` to the operator
+ * while the gate itself resolves it as gross, and the two must agree - see
+ * the country-address comment above, whose argument binds identically here.
  */
 function toOrderFacts(record: OrderRecord): SalesDocumentOrderFacts | null {
   const country = readDeliveryCountry(record.orderSnapshot);
   if (country === null || record.totalAmount === null || record.currency === null) {
     return null;
   }
+  const totalTaxTreatment = record.totalTaxTreatment ?? record.taxTreatment;
   return {
     country,
     totalGross: record.totalAmount,
     currency: record.currency,
-    ...(isTaxTreatment(record.taxTreatment) ? { taxTreatment: record.taxTreatment } : {}),
+    ...(isTaxTreatment(totalTaxTreatment) ? { taxTreatment: totalTaxTreatment } : {}),
     buyerHasTaxId: buyerHasTaxId(record.buyerTaxIdState),
   };
 }

--- a/libs/core/src/orders/domain/entities/order-record.entity.ts
+++ b/libs/core/src/orders/domain/entities/order-record.entity.ts
@@ -358,7 +358,21 @@ export class OrderRecord {
      * positional constructor, so a field inserted mid-list would silently
      * shift every argument after it at each construction site.
      */
-    public readonly shippingAddressHash: string | null = null
+    public readonly shippingAddressHash: string | null = null,
+    /**
+     * How `totalAmount` ALONE expresses tax, when that diverges from
+     * `taxTreatment` (#2829/#2832). Mirrors `OrderTotals.totalTaxTreatment` -
+     * see that field's doc comment for the full rationale (a PrestaShop order
+     * prices its LINES net but its TOTAL gross, so one flag cannot describe
+     * both). `null` means "same as `taxTreatment`"; every reader of the total's
+     * own inclusivity (today: `SalesDocumentViewService.toOrderFacts`, feeding
+     * the `orderTotalGross` sales-document rule condition) MUST read
+     * `totalTaxTreatment ?? taxTreatment`, exactly as `toSalesDocumentOrderFacts`
+     * does from the live `Order` - the gate and this projection must agree, or
+     * a PrestaShop order would be routed as gross while the operator-facing
+     * surface still reports it `net-priced`.
+     */
+    public readonly totalTaxTreatment: PriceTaxTreatment | null = null
   ) {}
 
   /**

--- a/libs/core/src/orders/domain/order-analytics-projection.spec.ts
+++ b/libs/core/src/orders/domain/order-analytics-projection.spec.ts
@@ -28,7 +28,7 @@ describe('orderAnalyticsProjection', () => {
   });
 
   describe('deriveOrderAnalyticsScalars', () => {
-    it('derives all 4 scalars when the order carries them', () => {
+    it('derives all 5 scalars when the order carries them', () => {
       const order = { ...baseOrder(), placedAt: new Date('2026-08-01T09:00:00.000Z') };
 
       expect(deriveOrderAnalyticsScalars(order)).toEqual({
@@ -36,7 +36,26 @@ describe('orderAnalyticsProjection', () => {
         currency: 'PLN',
         taxTreatment: 'inclusive',
         totalAmount: 32,
+        totalTaxTreatment: null,
       });
+    });
+
+    it('derives totalTaxTreatment when the source scopes it to the total alone (#2829)', () => {
+      const order = baseOrder();
+      order.totals.taxTreatment = 'exclusive';
+      order.totals.totalTaxTreatment = 'inclusive';
+
+      expect(deriveOrderAnalyticsScalars(order)).toMatchObject({
+        taxTreatment: 'exclusive',
+        totalTaxTreatment: 'inclusive',
+      });
+    });
+
+    it('returns totalTaxTreatment: null when the source did not diverge from taxTreatment', () => {
+      const order = baseOrder();
+      expect(order.totals.totalTaxTreatment).toBeUndefined();
+
+      expect(deriveOrderAnalyticsScalars(order).totalTaxTreatment).toBeNull();
     });
 
     it('returns placedAt: null when the order does not carry one', () => {

--- a/libs/core/src/orders/domain/order-analytics-projection.ts
+++ b/libs/core/src/orders/domain/order-analytics-projection.ts
@@ -3,8 +3,8 @@
  *
  * Pure derivation (no I/O): called by `OrderRecordService.persistOrder` at the
  * moment a `ready` order is persisted, to populate the denormalized
- * `OrderRecord` scalars (`placedAt`/`currency`/`taxTreatment`/`totalAmount`)
- * and the `order_line_items` rows — see ADR-039 for the persistence-strategy
+ * `OrderRecord` scalars (`placedAt`/`currency`/`taxTreatment`/`totalAmount`/
+ * `totalTaxTreatment`) and the `order_line_items` rows — see ADR-039 for the persistence-strategy
  * decision. Deliberately never throws: a malformed/partial `Order` degrades to
  * `null` scalars or an empty item list rather than failing the whole ingest.
  *
@@ -20,10 +20,16 @@ export interface OrderAnalyticsScalars {
   currency: string | null;
   taxTreatment: PriceTaxTreatment | null;
   totalAmount: number | null;
+  /**
+   * How `totalAmount` ALONE expresses tax, when that diverges from
+   * `taxTreatment` (#2829/#2832) — see `OrderTotals.totalTaxTreatment` and
+   * `OrderRecord.totalTaxTreatment`. `null` means "same as `taxTreatment`".
+   */
+  totalTaxTreatment: PriceTaxTreatment | null;
 }
 
 /**
- * Derive the 4 order-level scalars from an already-resolved {@link Order}.
+ * Derive the 5 order-level scalars from an already-resolved {@link Order}.
  * Pure function of its own argument — no I/O, never throws.
  */
 export function deriveOrderAnalyticsScalars(order: Order): OrderAnalyticsScalars {
@@ -32,6 +38,7 @@ export function deriveOrderAnalyticsScalars(order: Order): OrderAnalyticsScalars
     currency: order.totals?.currency ?? null,
     taxTreatment: order.totals?.taxTreatment ?? null,
     totalAmount: typeof order.totals?.total === 'number' ? order.totals.total : null,
+    totalTaxTreatment: order.totals?.totalTaxTreatment ?? null,
   };
 }
 

--- a/libs/core/src/orders/domain/order-from-ready-snapshot.ts
+++ b/libs/core/src/orders/domain/order-from-ready-snapshot.ts
@@ -226,6 +226,13 @@ function readTotals(value: unknown): OrderTotals {
   if (raw.taxTreatment === 'inclusive' || raw.taxTreatment === 'exclusive') {
     totals.taxTreatment = raw.taxTreatment;
   }
+  // #2829/#2832 — same allowlist, same failure mode as the per-line tax
+  // fields above: an omitted field here is silently dropped from every
+  // rehydrated `Order`, and a PrestaShop order's total-only gross assertion
+  // would vanish on any manual-issuance path that reaches this function.
+  if (raw.totalTaxTreatment === 'inclusive' || raw.totalTaxTreatment === 'exclusive') {
+    totals.totalTaxTreatment = raw.totalTaxTreatment;
+  }
   return totals;
 }
 

--- a/libs/core/src/orders/domain/types/incoming-order.types.ts
+++ b/libs/core/src/orders/domain/types/incoming-order.types.ts
@@ -208,6 +208,12 @@ export interface IncomingOrderTotals {
    * not assert it.
    */
   taxTreatment?: PriceTaxTreatment;
+
+  /**
+   * How `total` ALONE expresses tax, when it diverges from `taxTreatment`. See
+   * {@link OrderTotals.totalTaxTreatment} (#2829).
+   */
+  totalTaxTreatment?: PriceTaxTreatment;
 }
 
 export interface IncomingOrderAddress {

--- a/libs/core/src/orders/domain/types/order.types.ts
+++ b/libs/core/src/orders/domain/types/order.types.ts
@@ -343,6 +343,26 @@ export interface OrderTotals {
    * source-uniform, and it stays here.
    */
   taxTreatment?: PriceTaxTreatment;
+
+  /**
+   * How `total` ALONE expresses tax, when that diverges from `taxTreatment`
+   * (#2829). `taxTreatment` is source-uniform by design (it also governs
+   * per-line/`subtotal` net-conversion, e.g. PrestaShop's `specific_price`
+   * pinning and the ADR-063 net-sales tax-rate resolution) and MUST NOT be
+   * repurposed to describe `total` alone — a source whose line prices are
+   * genuinely net but whose `total` is genuinely gross (PrestaShop:
+   * `order_details.product_price` is net per #2440, `total_paid_tax_incl` is
+   * gross) cannot express that with one flag.
+   *
+   * Absent means "same as `taxTreatment`" — every consumer of `total`'s own
+   * inclusivity (today, only the sales-document `orderTotalGross` rule
+   * condition via `toSalesDocumentOrderFacts`) falls back to `taxTreatment`
+   * when this is unset, so a source that doesn't set it behaves exactly as
+   * before. Never read by `convertGrossToNet` or the net-sales tax-rate path —
+   * those describe the per-line/subtotal treatment and must keep reading
+   * `taxTreatment`.
+   */
+  totalTaxTreatment?: PriceTaxTreatment;
 }
 
 export interface Address {

--- a/libs/core/src/orders/domain/types/order.types.ts
+++ b/libs/core/src/orders/domain/types/order.types.ts
@@ -355,12 +355,19 @@ export interface OrderTotals {
    * gross) cannot express that with one flag.
    *
    * Absent means "same as `taxTreatment`" — every consumer of `total`'s own
-   * inclusivity (today, only the sales-document `orderTotalGross` rule
-   * condition via `toSalesDocumentOrderFacts`) falls back to `taxTreatment`
-   * when this is unset, so a source that doesn't set it behaves exactly as
-   * before. Never read by `convertGrossToNet` or the net-sales tax-rate path —
-   * those describe the per-line/subtotal treatment and must keep reading
+   * inclusivity (today: the sales-document `orderTotalGross` rule condition
+   * via `toSalesDocumentOrderFacts`, and its operator-facing projection
+   * counterpart `SalesDocumentViewService.toOrderFacts`, both of which read
+   * `totalTaxTreatment ?? taxTreatment` — the two must agree, or an order
+   * could be ROUTED as gross while the surface that reports which document it
+   * gets still evaluates it as net-priced) falls back to `taxTreatment` when
+   * this is unset, so a source that doesn't set it behaves exactly as before.
+   * Never read by `convertGrossToNet` or the net-sales tax-rate path — those
+   * describe the per-line/subtotal treatment and must keep reading
    * `taxTreatment`.
+   *
+   * WooCommerce has the identical structural split (net line prices, genuinely
+   * gross `total`) and does not yet set this field — tracked as #2836.
    */
   totalTaxTreatment?: PriceTaxTreatment;
 }

--- a/libs/core/src/orders/infrastructure/persistence/entities/order-record.orm-entity.ts
+++ b/libs/core/src/orders/infrastructure/persistence/entities/order-record.orm-entity.ts
@@ -244,6 +244,14 @@ export class OrderRecordOrmEntity {
   totalAmount!: number | null;
 
   /**
+   * How `totalAmount` ALONE expresses tax, when that diverges from
+   * `taxTreatment` (#2829/#2832) — see `OrderRecord.totalTaxTreatment`.
+   * `null` means "same as `taxTreatment`"; never defaulted by a consumer.
+   */
+  @Column({ type: 'varchar', nullable: true })
+  totalTaxTreatment!: string | null;
+
+  /**
    * Buyer tax identifier as the source reported it (#2599), denormalized off
    * the snapshot's billing address so a routing or gating query never has to
    * expand JSONB - and so the value survives `OL_STORE_PII=false`, under which

--- a/libs/core/src/orders/infrastructure/persistence/repositories/__tests__/order-record.repository.spec.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/__tests__/order-record.repository.spec.ts
@@ -1347,6 +1347,7 @@ describe('OrderRecordRepository', () => {
       expect(sql).toContain('"currency"');
       expect(sql).toContain('"taxTreatment"');
       expect(sql).toContain('"totalAmount"');
+      expect(sql).toContain('"totalTaxTreatment"');
       expect(params).toEqual(
         expect.arrayContaining([new Date('2025-01-01T09:00:00Z'), 'PLN', 'inclusive', 199.99])
       );
@@ -2012,7 +2013,7 @@ describe('OrderRecordRepository', () => {
         expectColumnAbsentFromUpsert('fxIntendedCurrency');
       });
 
-      it('should NOT name the four analytics scalars (#1985 review, finding 1) in the upsert() statement', async () => {
+      it('should NOT name the five analytics scalars (#1985 review, finding 1; #2832) in the upsert() statement', async () => {
         // upsert() is reached by persistIncomingSnapshot, whose OrderRecord
         // never carries a resolved analytics figure. Mapping these columns
         // here would NULL out an already-`ready` order's figures on every
@@ -2029,6 +2030,7 @@ describe('OrderRecordRepository', () => {
         expectColumnAbsentFromUpsert('currency');
         expectColumnAbsentFromUpsert('taxTreatment');
         expectColumnAbsentFromUpsert('totalAmount');
+        expectColumnAbsentFromUpsert('totalTaxTreatment');
       });
 
       it('should NOT write the analytics scalars via upsert() even when the domain record carries them', async () => {
@@ -2062,6 +2064,7 @@ describe('OrderRecordRepository', () => {
         expectColumnAbsentFromUpsert('currency');
         expectColumnAbsentFromUpsert('taxTreatment');
         expectColumnAbsentFromUpsert('totalAmount');
+        expectColumnAbsentFromUpsert('totalTaxTreatment');
       });
     });
 

--- a/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
@@ -1885,8 +1885,8 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
    * `cancelledAt` (#1984), the three `salesDocument*` columns (#2100), the six
    * FX snapshot columns (#2124), the two packed columns (#2287), the two
    * amendment columns `lastAmendedAt` / `lastAmendmentChanges` (#2283) and the
-   * four analytics scalars (#1985 - `placedAt` / `currency` / `taxTreatment` /
-   * `totalAmount`) are deliberately outside the write set - see the
+   * five analytics scalars (#1985/#2832 - `placedAt` / `currency` / `taxTreatment` /
+   * `totalAmount` / `totalTaxTreatment`) are deliberately outside the write set - see the
    * {@link toOrm} comments. A consequence is that the returned record reports
    * all of them as empty (`[]` / `null`) regardless of what the row holds,
    * because none of those columns was part of the statement; callers needing
@@ -1938,9 +1938,9 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
     // `omsAttention` (#2352 -
     // sole writer `updateOmsAttention`, whose whole contract is that it edits
     // ONE producer's entry; a round-trip here would drop every producer's entry
-    // on every ingestion and then re-add none), and the four #1985
+    // on every ingestion and then re-add none), and the five #1985/#2832
     // analytics scalars (`placedAt` / `currency` / `taxTreatment` /
-    // `totalAmount`, which only `upsertWithLineItems` writes). Do not add one
+    // `totalAmount` / `totalTaxTreatment`, which only `upsertWithLineItems` writes). Do not add one
     // of them to either half of this statement - each has a narrow, atomic
     // out-of-band writer that owns it. This list is illustrative only:
     // `fromRawRow` DERIVES the reset from the statement's write set, so it
@@ -1976,7 +1976,7 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
    * - `createdAt` is never updated: it records the first write.
    *
    * `includeReadyPathColumns` adds the columns only `upsertWithLineItems`
-   * resolves — the four #1985 analytics scalars and the #2599 `buyerTaxId`.
+   * resolves — the five #1985/#2832 analytics scalars and the #2599 `buyerTaxId`.
    * `persistIncomingSnapshot`, which reaches `upsert`, has no figure or resolved
    * billing address to offer yet and must not null them out. They are appended
    * after the shared tuple so the shared placeholders — including the
@@ -2047,6 +2047,8 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
       add('currency', entity.currency ?? null);
       add('taxTreatment', entity.taxTreatment ?? null);
       add('totalAmount', entity.totalAmount ?? null);
+      // #2829/#2832 — same ready-path-only reasoning as `taxTreatment` above.
+      add('totalTaxTreatment', entity.totalTaxTreatment ?? null);
       // #2599, and it MUST be added here rather than left to the caller's
       // `entity.buyerTaxId = ...`: this statement enumerates its columns, so a
       // column the caller stamps on the entity but never adds here is simply
@@ -2088,7 +2090,7 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
    * `order_records` that the statement did not write is reset. A hand-kept
    * list is what let six columns brought forward from main
    * (`salesDocumentBlockedAt` / `salesDocumentBlockReleasedAt`, plus
-   * `placedAt` / `currency` / `taxTreatment` / `totalAmount` on the
+   * `placedAt` / `currency` / `taxTreatment` / `totalAmount` / `totalTaxTreatment` on the
    * analytics-free `upsert` path) escape the guarantee the docblock states —
    * the same drift argument {@link buildFrozenAttributionUpsert} makes about
    * forked statements, one layer up. Deriving it means a column added to the
@@ -2129,13 +2131,13 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
    * the same transactional `EntityManager`, so a failure on either side rolls
    * back both (no order_records/order_line_items desync).
    *
-   * The sole writer of the four analytics scalars (#1985) - stamped onto the
+   * The sole writer of the five analytics scalars (#1985/#2832) - stamped onto the
    * entity here, not in the shared {@link toOrm}, because `upsert()` above
    * reaches the same conversion from `persistIncomingSnapshot`, which has no
    * resolved figure to offer yet (see its comment there).
    *
    * The order-record half is {@link buildFrozenAttributionUpsert}, the SAME
-   * statement `upsert` runs, with the four scalars parameterised on. It used to
+   * statement `upsert` runs, with the five scalars parameterised on. It used to
    * be a full-object `manager.save()` - the exact shape #2282 abandoned - which
    * UPDATEd `sourceConnectionId` and so let a re-ingestion from a second
    * connection silently rewrite an order's origin, bypassing a freeze the other
@@ -2151,7 +2153,8 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
     entity.currency = orderRecord.currency;
     entity.taxTreatment = orderRecord.taxTreatment;
     entity.totalAmount = orderRecord.totalAmount;
-    // Same reason the four scalars above are stamped here rather than in the
+    entity.totalTaxTreatment = orderRecord.totalTaxTreatment;
+    // Same reason the five scalars above are stamped here rather than in the
     // shared toOrm: `upsert()` is also reached by `persistIncomingSnapshot`,
     // which has no resolved billing address to read a tax id off, so mapping
     // the column there would NULL a value a previous ready-path write settled.
@@ -2366,7 +2369,8 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
       // is the same call the two reason guards above make.
       readAuthorityAttentionEntries(entity.omsAttention),
       entity.buyerTaxId ?? null,
-      entity.shippingAddressHash ?? null
+      entity.shippingAddressHash ?? null,
+      (entity.totalTaxTreatment as PriceTaxTreatment | null) ?? null
     );
   }
 
@@ -2442,8 +2446,8 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
    *   very upsert is about to overwrite, so mapping them here would have the
    *   detecting re-poll erase its own finding. No source payload carries them
    *   either - they are OpenLinker's observation, not the source's report.
-   * - The four analytics scalars (#1985) - `placedAt` / `currency` /
-   *   `taxTreatment` / `totalAmount` - are mapped by {@link upsertWithLineItems}
+   * - The five analytics scalars (#1985/#2832) - `placedAt` / `currency` /
+   *   `taxTreatment` / `totalAmount` / `totalTaxTreatment` - are mapped by {@link upsertWithLineItems}
    *   directly, NOT here, because this shared conversion also backs
    *   `upsert()`, reached by `persistIncomingSnapshot` with no resolved figure
    *   to offer. Mapping them in this shared method would NULL an
@@ -2474,7 +2478,7 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
     entity.recordStatus = orderRecord.recordStatus;
     entity.mappingFailureReason = orderRecord.mappingFailureReason;
     entity.dispatchByAt = orderRecord.dispatchByAt;
-    // The four analytics scalars (#1985) are deliberately NOT mapped here -
+    // The five analytics scalars (#1985/#2832) are deliberately NOT mapped here -
     // see the class comment above and `upsertWithLineItems`, their sole writer.
     // The six FX snapshot columns (#2124) are deliberately NOT mapped here,
     // for the strongest version of the reason documented above for

--- a/libs/integrations/prestashop/src/infrastructure/mappers/__tests__/prestashop-order.mapper.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/mappers/__tests__/prestashop-order.mapper.spec.ts
@@ -122,6 +122,9 @@ describe('PrestashopOrderMapper', () => {
       expect(result.totals).not.toHaveProperty('currency');
       // Line prices (`order_details.product_price`) are net (#2440).
       expect(result.totals.taxTreatment).toBe('exclusive');
+      // `total` (`total_paid_tax_incl`) is genuinely gross, independent of the
+      // (net) line-price treatment above (#2829).
+      expect(result.totals.totalTaxTreatment).toBe('inclusive');
     });
 
     it('should parse dates correctly', () => {

--- a/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-order.mapper.ts
+++ b/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-order.mapper.ts
@@ -90,6 +90,9 @@ export class PrestashopOrderMapper implements IPrestashopOrderMapper {
       // PrestaShop's line prices (`order_details.product_price`, mapped onto
       // `OrderItem.price` above) are net — `specific_price` and every catalogue
       // read this adapter does elsewhere already treat them that way (#2440).
+      // This governs `convertGrossToNet` (destination-side line pinning) and
+      // the ADR-063 net-sales tax-rate path — do NOT flip it to describe
+      // `total`, which is a different, genuinely gross figure (#2829).
       //
       // #2835: this net-priced-lines fact is why `invoicing`/`fiscalization`
       // permanently refuse a PrestaShop order (`describeNetPricedOrderRefusal`,
@@ -97,6 +100,12 @@ export class PrestashopOrderMapper implements IPrestashopOrderMapper {
       // (below) does not change that the LINES this guard cares about are net,
       // and core may never compute tax to convert them.
       taxTreatment: 'exclusive',
+      // `total` (above, from `total_paid_tax_incl`) IS genuinely gross —
+      // unlike `subtotal`/line prices, it is never net for a PrestaShop order.
+      // Asserted independently of `taxTreatment` so an `orderTotalGross`
+      // sales-document rule condition can trust it without also relabeling
+      // the (still net) line prices as gross (#2829).
+      totalTaxTreatment: 'inclusive',
     };
 
     return {


### PR DESCRIPTION
## Problem

`PrestashopOrderMapper` sets `taxTreatment: 'exclusive'` unconditionally on every order it maps — correct for line prices/subtotal (`order_details.product_price`, `total_paid_tax_excl`), per #2440. But `evaluateSalesDocumentRules`'s `orderTotalGross` condition reads that same flag to decide whether it may trust `SalesDocumentOrderFacts.totalGross` as a real gross figure, and refuses (`net-priced` data problem) unless it reads `'inclusive'`.

A PrestaShop order's total (`total_paid_tax_incl`) genuinely IS gross even though its line prices/subtotal are net — so no PrestaShop-sourced order could ever match an `orderTotalGross` sales-document rule condition, regardless of the order's actual tax setup.

## Why not just flip the flag

Audited every consumer of `OrderTotals.taxTreatment` per the issue's acceptance criteria. Flipping it to `'inclusive'` for PrestaShop is unsafe:

- **`PrestashopOrderProcessorManagerAdapter.convertGrossToNet`** (destination-side line pinning): reads `taxTreatment !== 'exclusive'` to decide whether line prices need gross→net conversion before pinning. For a PrestaShop-sourced order later routed to another PrestaShop destination (a live path — `OrderSyncService`'s default unfiltered fan-out sends to every `OrderProcessorManager`-capable connection except the source), flipping the flag would make this treat already-net line prices as gross and double-convert them.
- **The ADR-063 net-sales tax-rate resolution path** (`net-sales-tax-rate.types.ts`, `deriveNetLineAmount` + its SQL twins): reads `taxTreatment === 'exclusive'` to mean "line `unitPrice` is already net, no rate-based conversion needed" — the whole net-sales analytics feature for PrestaShop orders depends on this staying `'exclusive'`. Flipping it would silently understate net revenue for every PrestaShop order (double VAT stripping).
- WooCommerce's order mapper has the **identical structural split** (net line prices + `total_tax` decomposed separately, but `total` is genuinely gross) — same reasoning applies there, out of scope for this PR but worth a follow-up issue.

## Fix

Added a narrower `OrderTotals.totalTaxTreatment` field describing only the **total's own** inclusivity, independent of `taxTreatment` (which stays scoped to line-price/subtotal treatment, unchanged in meaning and behavior for every existing consumer). `toSalesDocumentOrderFacts` now reads `totalTaxTreatment ?? taxTreatment` — every source that doesn't set the new field falls back exactly as before. `PrestashopOrderMapper` sets `totalTaxTreatment: 'inclusive'` alongside the unchanged `taxTreatment: 'exclusive'`.

Mirrored onto `IncomingOrderTotals` (the mapper-output shape consumed by `PrestashopOrderSourceAdapter.getOrder()`) so the field survives the source→`Order` build in `OrderIngestionService.buildUnifiedOrder`.

## Testing

- `prestashop-order.mapper.spec.ts`: asserts `totalTaxTreatment: 'inclusive'` alongside the unchanged `taxTreatment: 'exclusive'`.
- `order-to-sales-document-order-facts.mapper.spec.ts`: new cases for the `totalTaxTreatment` override and the fallback-to-`taxTreatment` path when unset.
- Full `pnpm type-check` (all packages) and `pnpm lint` (all invariant checks) pass.
- Ran the full affected-consumer test suites: PrestaShop order-source adapter + order-processor-manager adapter (151 tests), net-sales-tax-rate / evaluate-sales-document-rules / order-record.service / order-ingestion (214 tests) — all pass, confirming `convertGrossToNet` and the net-sales path are unaffected.

Not done (per scope discussion): the issue's live e2e verification step on ol-demo-fresh — deferred as a manual follow-up check, not blocking this PR given the unit-level coverage above.

Closes #2829