### PR TITLE
fix(invoicing,fiscalization): name the actual constraint when refusing a net-priced order

### DIFF
--- a/libs/core/src/fiscalization/application/mappers/errors/unsupported-fiscal-price-treatment.error.ts
+++ b/libs/core/src/fiscalization/application/mappers/errors/unsupported-fiscal-price-treatment.error.ts
@@ -9,6 +9,10 @@
  * silently mis-state the registered sale, which is why this fails loud instead
  * of degrading.
  *
+ * This is a PERMANENT limitation of a net-line-price source (PrestaShop,
+ * WooCommerce), not a gap #2829/#2832's `totalTaxTreatment` signal relaxes -
+ * see `describeNetPricedOrderRefusal` (#2835) for why.
+ *
  * @module libs/core/src/fiscalization/application/mappers/errors
  */
 export class UnsupportedFiscalPriceTreatmentError extends Error {

--- a/libs/core/src/fiscalization/application/mappers/order-to-register-transaction-command.mapper.spec.ts
+++ b/libs/core/src/fiscalization/application/mappers/order-to-register-transaction-command.mapper.spec.ts
@@ -151,6 +151,27 @@ describe('toRegisterTransactionCommand', () => {
     ).toThrow(UnsupportedFiscalPriceTreatmentError);
   });
 
+  it('net-priced order: the refusal names the actual constraint (#2835)', () => {
+    expect(() =>
+      toRegisterTransactionCommand({
+        order: order({
+          totals: {
+            subtotal: 40,
+            tax: 9.2,
+            shipping: 0,
+            total: 40,
+            currency: 'PLN',
+            taxTreatment: 'exclusive',
+          },
+        }),
+        connectionId: 'conn-1',
+        idempotencyKey: 'k',
+      }),
+    ).toThrow(
+      /ol_order_1 cannot be fiscally registered: its source reports net \(tax-exclusive\) line prices/,
+    );
+  });
+
   it('should accept an order whose treatment is absent (the documented gross assumption)', () => {
     expect(() =>
       toRegisterTransactionCommand({

--- a/libs/core/src/fiscalization/application/mappers/order-to-register-transaction-command.mapper.ts
+++ b/libs/core/src/fiscalization/application/mappers/order-to-register-transaction-command.mapper.ts
@@ -13,7 +13,11 @@
  * @module libs/core/src/fiscalization/application/mappers
  */
 import type { Order, OrderItem } from '@openlinker/core/orders';
-import { minorUnitExponentFor, splitShippingAcrossRates } from '@openlinker/core/sales-documents';
+import {
+  describeNetPricedOrderRefusal,
+  minorUnitExponentFor,
+  splitShippingAcrossRates,
+} from '@openlinker/core/sales-documents';
 
 import type {
   FiscalRecipient,
@@ -101,11 +105,13 @@ export function toRegisterTransactionCommand(
   // and core may not convert (it never computes or defaults a tax rate). Fail
   // loud. An ABSENT treatment is the documented gross assumption - marketplaces
   // report buyer-paid gross - so it is accepted.
-  if (order.totals.taxTreatment === 'exclusive') {
-    throw new UnsupportedFiscalPriceTreatmentError(
-      `Order ${order.id} is net-priced (taxTreatment "exclusive"); ` +
-        `only gross-priced orders can be registered`,
-    );
+  //
+  // This checks LINE-level `taxTreatment`, never `totals.totalTaxTreatment`
+  // (#2829/#2832) — see `describeNetPricedOrderRefusal`'s doc comment
+  // (#2835) for why the latter cannot relax this guard.
+  const refusal = describeNetPricedOrderRefusal(order, 'fiscally registered');
+  if (refusal !== null) {
+    throw new UnsupportedFiscalPriceTreatmentError(refusal);
   }
 
   const lines = order.items.map((item) => toFiscalLine(item, order.id));

--- a/libs/core/src/invoicing/application/mappers/errors/unsupported-price-treatment.error.ts
+++ b/libs/core/src/invoicing/application/mappers/errors/unsupported-price-treatment.error.ts
@@ -7,6 +7,10 @@
  * Rather than mislabel net as gross (silent totals corruption), the mapper fails
  * loud. Messages cite ONLY `order.id`. No country/document-type vocabulary.
  *
+ * This is a PERMANENT limitation of a net-line-price source (PrestaShop,
+ * WooCommerce), not a gap #2829/#2832's `totalTaxTreatment` signal relaxes —
+ * see `describeNetPricedOrderRefusal` (#2835) for why.
+ *
  * @module libs/core/src/invoicing/application/mappers/errors
  */
 export class UnsupportedPriceTreatmentError extends Error {

--- a/libs/core/src/invoicing/application/mappers/order-to-issue-invoice-command.mapper.spec.ts
+++ b/libs/core/src/invoicing/application/mappers/order-to-issue-invoice-command.mapper.spec.ts
@@ -42,7 +42,14 @@ function makeOrder(overrides: Partial<Order> = {}): Order {
     id: 'order-1',
     status: 'processing',
     items: [makeItem()],
-    totals: { subtotal: 100, tax: 23, shipping: 0, total: 123, currency: 'PLN', taxTreatment: 'inclusive' },
+    totals: {
+      subtotal: 100,
+      tax: 23,
+      shipping: 0,
+      total: 123,
+      currency: 'PLN',
+      taxTreatment: 'inclusive',
+    },
     billingAddress: makeAddress(),
     createdAt: new Date('2026-06-22T10:00:00.000Z'),
     updatedAt: new Date('2026-06-22T10:00:00.000Z'),
@@ -90,11 +97,25 @@ describe('toIssueInvoiceCommand', () => {
 
   it('multi-line: items -> lines, currency from totals.currency, name fallback to sku then productId', () => {
     const order = makeOrder({
-      totals: { subtotal: 0, tax: 0, shipping: 0, total: 0, currency: 'EUR', taxTreatment: 'inclusive' },
+      totals: {
+        subtotal: 0,
+        tax: 0,
+        shipping: 0,
+        total: 0,
+        currency: 'EUR',
+        taxTreatment: 'inclusive',
+      },
       items: [
         makeItem({ id: 'a', name: 'Named', price: 10, quantity: 2 }),
         makeItem({ id: 'b', name: undefined, sku: 'SKU-9', price: 20, quantity: 1 }),
-        makeItem({ id: 'c', name: undefined, sku: undefined, productId: 'PID-5', price: 30, quantity: 3 }),
+        makeItem({
+          id: 'c',
+          name: undefined,
+          sku: undefined,
+          productId: 'PID-5',
+          price: 30,
+          quantity: 3,
+        }),
       ],
     });
 
@@ -123,12 +144,15 @@ describe('toIssueInvoiceCommand', () => {
     ['zero', 0],
     ['negative', -2],
     ['NaN', Number.NaN],
-  ])('should throw InvalidInvoiceLineError for a %s item quantity (#1525 review)', (_label, quantity) => {
-    const order = makeOrder({ items: [makeItem({ quantity })] });
-    expect(() => toIssueInvoiceCommand({ order, connectionId: 'conn-1' })).toThrow(
-      InvalidInvoiceLineError,
-    );
-  });
+  ])(
+    'should throw InvalidInvoiceLineError for a %s item quantity (#1525 review)',
+    (_label, quantity) => {
+      const order = makeOrder({ items: [makeItem({ quantity })] });
+      expect(() => toIssueInvoiceCommand({ order, connectionId: 'conn-1' })).toThrow(
+        InvalidInvoiceLineError
+      );
+    }
+  );
 
   it('InvalidInvoiceLineError is PII-clean: cites only the order id', () => {
     const order = makeOrder({ items: [makeItem({ quantity: 0, name: 'SECRET_ITEM' })] });
@@ -169,11 +193,15 @@ describe('toIssueInvoiceCommand', () => {
 
   it('name derivation: firstName+lastName absent AND no company -> throws InvalidBuyerProfileError (no "undefined undefined")', () => {
     const order = makeOrder({
-      billingAddress: makeAddress({ firstName: undefined, lastName: undefined, company: undefined }),
+      billingAddress: makeAddress({
+        firstName: undefined,
+        lastName: undefined,
+        company: undefined,
+      }),
     });
 
     expect(() => toIssueInvoiceCommand({ order, connectionId: 'conn-1' })).toThrow(
-      InvalidBuyerProfileError,
+      InvalidBuyerProfileError
     );
   });
 
@@ -191,7 +219,11 @@ describe('toIssueInvoiceCommand', () => {
       billingAddress: makeAddress({ firstName: 'Jan', lastName: 'Kowalski', company: 'Big Corp' }),
     });
 
-    const cmd = toIssueInvoiceCommand({ order, connectionId: 'conn-1', buyerTaxId: { scheme: 'eu-vat', value: 'PL1' } });
+    const cmd = toIssueInvoiceCommand({
+      order,
+      connectionId: 'conn-1',
+      buyerTaxId: { scheme: 'eu-vat', value: 'PL1' },
+    });
     expect(cmd.buyer.name).toBe('Big Corp');
   });
 
@@ -199,7 +231,7 @@ describe('toIssueInvoiceCommand', () => {
     const order = makeOrder({ billingAddress: undefined, shippingAddress: undefined });
 
     expect(() => toIssueInvoiceCommand({ order, connectionId: 'conn-1' })).toThrow(
-      InvalidBuyerProfileError,
+      InvalidBuyerProfileError
     );
   });
 
@@ -227,7 +259,11 @@ describe('toIssueInvoiceCommand', () => {
       shippingAddress: undefined,
     });
     // Force the name-derivation failure path.
-    order.billingAddress = makeAddress({ firstName: undefined, lastName: undefined, address1: 'SecretStreet 42' });
+    order.billingAddress = makeAddress({
+      firstName: undefined,
+      lastName: undefined,
+      address1: 'SecretStreet 42',
+    });
 
     try {
       toIssueInvoiceCommand({ order, connectionId: 'conn-1' });
@@ -242,7 +278,14 @@ describe('toIssueInvoiceCommand', () => {
   it('price treatment: totals.taxTreatment "inclusive" -> unitPriceGross = item.price', () => {
     const order = makeOrder({
       items: [makeItem({ price: 49.99 })],
-      totals: { subtotal: 0, tax: 0, shipping: 0, total: 0, currency: 'PLN', taxTreatment: 'inclusive' },
+      totals: {
+        subtotal: 0,
+        tax: 0,
+        shipping: 0,
+        total: 0,
+        currency: 'PLN',
+        taxTreatment: 'inclusive',
+      },
     });
 
     const cmd = toIssueInvoiceCommand({ order, connectionId: 'conn-1' });
@@ -261,22 +304,36 @@ describe('toIssueInvoiceCommand', () => {
 
   it('price treatment: totals.taxTreatment "exclusive" -> throws UnsupportedPriceTreatmentError', () => {
     const order = makeOrder({
-      totals: { subtotal: 0, tax: 0, shipping: 0, total: 0, currency: 'PLN', taxTreatment: 'exclusive' },
+      totals: {
+        subtotal: 0,
+        tax: 0,
+        shipping: 0,
+        total: 0,
+        currency: 'PLN',
+        taxTreatment: 'exclusive',
+      },
     });
 
     expect(() => toIssueInvoiceCommand({ order, connectionId: 'conn-1' })).toThrow(
-      UnsupportedPriceTreatmentError,
+      UnsupportedPriceTreatmentError
     );
   });
 
   it('price treatment: "exclusive" -> the refusal names the actual constraint (#2835)', () => {
     const order = makeOrder({
       id: 'ol_order_abc',
-      totals: { subtotal: 0, tax: 0, shipping: 0, total: 0, currency: 'PLN', taxTreatment: 'exclusive' },
+      totals: {
+        subtotal: 0,
+        tax: 0,
+        shipping: 0,
+        total: 0,
+        currency: 'PLN',
+        taxTreatment: 'exclusive',
+      },
     });
 
     expect(() => toIssueInvoiceCommand({ order, connectionId: 'conn-1' })).toThrow(
-      /ol_order_abc cannot be invoiced: its source reports net \(tax-exclusive\) line prices/,
+      /ol_order_abc cannot be invoiced: its source reports net \(tax-exclusive\) line prices/
     );
   });
 
@@ -316,7 +373,14 @@ describe('toIssueInvoiceCommand', () => {
     // shipping line is still EMITTED (dropping it would understate the total)
     // and still carries an empty rate, and the gate refuses the whole document.
     const order = makeOrder({
-      totals: { subtotal: 100, tax: 0, shipping: 15, total: 115, currency: 'PLN', taxTreatment: 'inclusive' },
+      totals: {
+        subtotal: 100,
+        tax: 0,
+        shipping: 15,
+        total: 115,
+        currency: 'PLN',
+        taxTreatment: 'inclusive',
+      },
     });
 
     const cmd = toIssueInvoiceCommand({ order, connectionId: 'conn-1' });
@@ -328,10 +392,15 @@ describe('toIssueInvoiceCommand', () => {
 
   it('shipping: inherits the basket rate when every line carries the same one (#2248)', () => {
     const order = makeOrder({
-      items: [
-        { id: 'i1', productId: 'p1', quantity: 1, price: 100, taxRate: '23' },
-      ],
-      totals: { subtotal: 100, tax: 0, shipping: 15, total: 115, currency: 'PLN', taxTreatment: 'inclusive' },
+      items: [{ id: 'i1', productId: 'p1', quantity: 1, price: 100, taxRate: '23' }],
+      totals: {
+        subtotal: 100,
+        tax: 0,
+        shipping: 15,
+        total: 115,
+        currency: 'PLN',
+        taxTreatment: 'inclusive',
+      },
     });
 
     const cmd = toIssueInvoiceCommand({ order, connectionId: 'conn-1' });
@@ -349,7 +418,14 @@ describe('toIssueInvoiceCommand', () => {
   ])('shipping: totals.shipping %s -> no phantom shipping line (#1517)', (_label, shipping) => {
     const order = makeOrder({
       items: [makeItem({ price: 100, quantity: 1 })],
-      totals: { subtotal: 100, tax: 0, shipping, total: 100, currency: 'PLN', taxTreatment: 'inclusive' },
+      totals: {
+        subtotal: 100,
+        tax: 0,
+        shipping,
+        total: 100,
+        currency: 'PLN',
+        taxTreatment: 'inclusive',
+      },
     });
 
     const cmd = toIssueInvoiceCommand({ order, connectionId: 'conn-1' });
@@ -360,7 +436,14 @@ describe('toIssueInvoiceCommand', () => {
 
   it('shipping: caller-supplied shippingLineName overrides the neutral default label (#1517)', () => {
     const order = makeOrder({
-      totals: { subtotal: 100, tax: 0, shipping: 15, total: 115, currency: 'PLN', taxTreatment: 'inclusive' },
+      totals: {
+        subtotal: 100,
+        tax: 0,
+        shipping: 15,
+        total: 115,
+        currency: 'PLN',
+        taxTreatment: 'inclusive',
+      },
     });
 
     const cmd = toIssueInvoiceCommand({
@@ -382,13 +465,20 @@ describe('toIssueInvoiceCommand', () => {
     'shipping: %s shippingLineName override falls back to the neutral default label (#1517)',
     (_label, shippingLineName) => {
       const order = makeOrder({
-        totals: { subtotal: 100, tax: 0, shipping: 15, total: 115, currency: 'PLN', taxTreatment: 'inclusive' },
+        totals: {
+          subtotal: 100,
+          tax: 0,
+          shipping: 15,
+          total: 115,
+          currency: 'PLN',
+          taxTreatment: 'inclusive',
+        },
       });
 
       const cmd = toIssueInvoiceCommand({ order, connectionId: 'conn-1', shippingLineName });
 
       const shippingLine = cmd.lines.find((l) => l.unitPriceGross === 15 && l.quantity === 1);
       expect(shippingLine?.name).toBe('Shipping');
-    },
+    }
   );
 });

--- a/libs/core/src/invoicing/application/mappers/order-to-issue-invoice-command.mapper.spec.ts
+++ b/libs/core/src/invoicing/application/mappers/order-to-issue-invoice-command.mapper.spec.ts
@@ -269,6 +269,17 @@ describe('toIssueInvoiceCommand', () => {
     );
   });
 
+  it('price treatment: "exclusive" -> the refusal names the actual constraint (#2835)', () => {
+    const order = makeOrder({
+      id: 'ol_order_abc',
+      totals: { subtotal: 0, tax: 0, shipping: 0, total: 0, currency: 'PLN', taxTreatment: 'exclusive' },
+    });
+
+    expect(() => toIssueInvoiceCommand({ order, connectionId: 'conn-1' })).toThrow(
+      /ol_order_abc cannot be invoiced: its source reports net \(tax-exclusive\) line prices/,
+    );
+  });
+
   it('shipping: totals.shipping > 0 -> appends one gross shipping line after the item lines (#1517)', () => {
     const order = makeOrder({
       items: [makeItem({ price: 499.99, quantity: 1 })],

--- a/libs/core/src/invoicing/application/mappers/order-to-issue-invoice-command.mapper.ts
+++ b/libs/core/src/invoicing/application/mappers/order-to-issue-invoice-command.mapper.ts
@@ -22,7 +22,11 @@ import type {
 import { InvalidBuyerProfileError } from './errors/invalid-buyer-profile.error';
 import { InvalidInvoiceLineError } from './errors/invalid-invoice-line.error';
 import { UnsupportedPriceTreatmentError } from './errors/unsupported-price-treatment.error';
-import { minorUnitExponentFor, splitShippingAcrossRates } from '@openlinker/core/sales-documents';
+import {
+  describeNetPricedOrderRefusal,
+  minorUnitExponentFor,
+  splitShippingAcrossRates,
+} from '@openlinker/core/sales-documents';
 
 /**
  * Default carrier-neutral label for the shipping invoice line (#1517). Core is
@@ -93,13 +97,16 @@ export function toIssueInvoiceCommand(
     taxRateEra,
   } = input;
 
-  // GROSS-only MVP: an `exclusive` (net) order would mislabel net as gross.
-  // Fail loud rather than corrupt totals. Absent treatment = documented gross
+  // GROSS-only: an `exclusive` (net) order would mislabel net as gross. Fail
+  // loud rather than corrupt totals. Absent treatment = documented gross
   // assumption (marketplaces report buyer-paid gross), so it is accepted.
-  if (order.totals.taxTreatment === 'exclusive') {
-    throw new UnsupportedPriceTreatmentError(
-      `Order ${order.id} is net-priced (taxTreatment "exclusive"); only gross-priced orders are supported`,
-    );
+  //
+  // This checks LINE-level `taxTreatment`, never `totals.totalTaxTreatment`
+  // (#2829/#2832) — see `describeNetPricedOrderRefusal`'s doc comment
+  // (#2835) for why the latter cannot relax this guard.
+  const refusal = describeNetPricedOrderRefusal(order, 'invoiced');
+  if (refusal !== null) {
+    throw new UnsupportedPriceTreatmentError(refusal);
   }
 
   const buyer = buildBuyerProfile(order, buyerTaxId ?? null);

--- a/libs/core/src/sales-documents/domain/types/gross-price-eligibility.types.spec.ts
+++ b/libs/core/src/sales-documents/domain/types/gross-price-eligibility.types.spec.ts
@@ -1,0 +1,43 @@
+/**
+ * Gross-price Eligibility Tests (#2835)
+ *
+ * @module libs/core/src/sales-documents/domain/types
+ */
+import { describeNetPricedOrderRefusal } from './gross-price-eligibility.types';
+
+describe('describeNetPricedOrderRefusal', () => {
+  it('should return null when taxTreatment is "inclusive" (gross line prices)', () => {
+    expect(
+      describeNetPricedOrderRefusal({ id: 'ol_order_1', totals: { taxTreatment: 'inclusive' } }, 'invoiced')
+    ).toBeNull();
+  });
+
+  it('should return null when taxTreatment is absent (the documented gross assumption)', () => {
+    expect(
+      describeNetPricedOrderRefusal({ id: 'ol_order_1', totals: {} }, 'invoiced')
+    ).toBeNull();
+  });
+
+  it('should name the order and the action when taxTreatment is "exclusive"', () => {
+    const refusal = describeNetPricedOrderRefusal(
+      { id: 'ol_order_1', totals: { taxTreatment: 'exclusive' } },
+      'invoiced'
+    );
+
+    expect(refusal).toBe(
+      'Order ol_order_1 cannot be invoiced: its source reports net (tax-exclusive) line prices, ' +
+        'and OpenLinker never computes or infers tax to convert them to gross for a fiscal document — ' +
+        'only a source that reports gross (tax-inclusive) line prices can be invoiced today.'
+    );
+  });
+
+  it('should thread a different action through both clauses (fiscalization)', () => {
+    const refusal = describeNetPricedOrderRefusal(
+      { id: 'ol_order_2', totals: { taxTreatment: 'exclusive' } },
+      'fiscally registered'
+    );
+
+    expect(refusal).toContain('ol_order_2 cannot be fiscally registered:');
+    expect(refusal).toContain('can be fiscally registered today.');
+  });
+});

--- a/libs/core/src/sales-documents/domain/types/gross-price-eligibility.types.spec.ts
+++ b/libs/core/src/sales-documents/domain/types/gross-price-eligibility.types.spec.ts
@@ -8,14 +8,15 @@ import { describeNetPricedOrderRefusal } from './gross-price-eligibility.types';
 describe('describeNetPricedOrderRefusal', () => {
   it('should return null when taxTreatment is "inclusive" (gross line prices)', () => {
     expect(
-      describeNetPricedOrderRefusal({ id: 'ol_order_1', totals: { taxTreatment: 'inclusive' } }, 'invoiced')
+      describeNetPricedOrderRefusal(
+        { id: 'ol_order_1', totals: { taxTreatment: 'inclusive' } },
+        'invoiced'
+      )
     ).toBeNull();
   });
 
   it('should return null when taxTreatment is absent (the documented gross assumption)', () => {
-    expect(
-      describeNetPricedOrderRefusal({ id: 'ol_order_1', totals: {} }, 'invoiced')
-    ).toBeNull();
+    expect(describeNetPricedOrderRefusal({ id: 'ol_order_1', totals: {} }, 'invoiced')).toBeNull();
   });
 
   it('should name the order and the action when taxTreatment is "exclusive"', () => {
@@ -27,7 +28,7 @@ describe('describeNetPricedOrderRefusal', () => {
     expect(refusal).toBe(
       'Order ol_order_1 cannot be invoiced: its source reports net (tax-exclusive) line prices, ' +
         'and OpenLinker never computes or infers tax to convert them to gross for a fiscal document — ' +
-        'only a source that reports gross (tax-inclusive) line prices can be invoiced today.'
+        'only a source that reports gross (tax-inclusive) line prices can be invoiced.'
     );
   });
 
@@ -38,6 +39,6 @@ describe('describeNetPricedOrderRefusal', () => {
     );
 
     expect(refusal).toContain('ol_order_2 cannot be fiscally registered:');
-    expect(refusal).toContain('can be fiscally registered today.');
+    expect(refusal).toContain('can be fiscally registered.');
   });
 });

--- a/libs/core/src/sales-documents/domain/types/gross-price-eligibility.types.ts
+++ b/libs/core/src/sales-documents/domain/types/gross-price-eligibility.types.ts
@@ -1,0 +1,77 @@
+/**
+ * Gross-price eligibility for document issuance (#2835)
+ *
+ * `invoicing` and `fiscalization` each compose a document whose lines are
+ * GROSS by contract (`InvoiceLine.unitPriceGross`,
+ * `FiscalTransactionLine.unitPriceGross`) directly from `OrderItem.price`, so
+ * both refuse an order whose LINE prices are net
+ * (`OrderTotals.taxTreatment === 'exclusive'`) rather than compose a document
+ * that mislabels a net figure as gross. Converting a net line price to gross
+ * would mean computing `net * (1 + rate)` — arithmetic that computes tax, which
+ * ADR-063 § 5 forbids core from doing ("Core may group and divide amounts; it
+ * may never compute tax"). So this is a genuine, structural refusal, not an
+ * oversight: it holds even though the per-line tax rate is often already known
+ * (`OrderItem.taxRate`, ADR-063), because knowing the rate does not make
+ * *computing* an amount with it any less forbidden for a figure that feeds a
+ * legal document.
+ *
+ * **#2829/#2832's `OrderTotals.totalTaxTreatment` does NOT relax this.** That
+ * field describes `total` ALONE — PrestaShop's `total` genuinely is gross
+ * while its line prices (`order_details.product_price`, #2440) stay net — and
+ * both write paths compose `unitPriceGross` from the per-item price, never
+ * from the order total. Reading `totalTaxTreatment` here would let a
+ * PrestaShop order pass this guard and then silently mislabel its still-net
+ * line prices as gross on the composed document: the exact corruption this
+ * guard exists to prevent, just moved one level down. So the guard correctly
+ * keeps reading `taxTreatment` (the LINE-level signal) and ignores
+ * `totalTaxTreatment` entirely.
+ *
+ * This is a PERMANENT limitation of a net-line-price source (PrestaShop,
+ * WooCommerce — both hardcode `taxTreatment: 'exclusive'`) under the current
+ * architecture, not a gap waiting for this refusal to be relaxed. It clears
+ * only if the source adapter itself starts reporting gross line prices (a
+ * platform-specific mapper change, out of scope for `libs/core`) — never by
+ * teaching core to convert.
+ *
+ * WHY HERE. Both document contexts need the identical answer and the
+ * identical operator-facing wording, and a fiscal receipt is not an invoice,
+ * so neither `invoicing` nor `fiscalization` could own it for the other — the
+ * same reason `shipping-tax-split.types` and `tax-rate-enforcement.types` live
+ * in this leaf. Import-free, like both of those.
+ *
+ * @module libs/core/src/sales-documents/domain/types
+ * @see docs/architecture/adrs/063-per-line-tax-rate-resolution-and-provenance.md
+ */
+
+/** The narrow order shape this check needs — never the full `Order` entity. */
+export interface GrossPriceEligibilityOrder {
+  id: string;
+  totals: {
+    taxTreatment?: string;
+  };
+}
+
+/**
+ * `null` when the order's line prices are gross-eligible for document
+ * issuance; otherwise an actionable, operator-facing sentence naming the
+ * actual constraint — never the unqualified "only gross-priced orders are
+ * supported", which gave an operator no way to tell whether their own order
+ * or their own connection was the problem.
+ *
+ * `action` names what the caller was trying to do, in a form that reads
+ * naturally both as "cannot be {action}" and as "can be {action} today" —
+ * e.g. `'invoiced'`, `'fiscally registered'`.
+ */
+export function describeNetPricedOrderRefusal(
+  order: GrossPriceEligibilityOrder,
+  action: string
+): string | null {
+  if (order.totals.taxTreatment !== 'exclusive') {
+    return null;
+  }
+  return (
+    `Order ${order.id} cannot be ${action}: its source reports net (tax-exclusive) line prices, ` +
+    `and OpenLinker never computes or infers tax to convert them to gross for a fiscal document — ` +
+    `only a source that reports gross (tax-inclusive) line prices can be ${action} today.`
+  );
+}

--- a/libs/core/src/sales-documents/domain/types/gross-price-eligibility.types.ts
+++ b/libs/core/src/sales-documents/domain/types/gross-price-eligibility.types.ts
@@ -52,6 +52,16 @@ export interface GrossPriceEligibilityOrder {
 }
 
 /**
+ * The two document kinds this guard serves. Closed rather than a bare
+ * `string` — both current call sites (`invoicing`, `fiscalization`) are the
+ * whole of what this leaf's two document contexts are, so a third value
+ * would be a compile-time signal that a new caller showed up, not silent
+ * wording drift.
+ */
+export const NetPricedOrderRefusalActionValues = ['invoiced', 'fiscally registered'] as const;
+export type NetPricedOrderRefusalAction = (typeof NetPricedOrderRefusalActionValues)[number];
+
+/**
  * `null` when the order's line prices are gross-eligible for document
  * issuance; otherwise an actionable, operator-facing sentence naming the
  * actual constraint — never the unqualified "only gross-priced orders are
@@ -59,12 +69,11 @@ export interface GrossPriceEligibilityOrder {
  * or their own connection was the problem.
  *
  * `action` names what the caller was trying to do, in a form that reads
- * naturally both as "cannot be {action}" and as "can be {action} today" —
- * e.g. `'invoiced'`, `'fiscally registered'`.
+ * naturally both as "cannot be {action}" and as "can be {action} today".
  */
 export function describeNetPricedOrderRefusal(
   order: GrossPriceEligibilityOrder,
-  action: string
+  action: NetPricedOrderRefusalAction
 ): string | null {
   if (order.totals.taxTreatment !== 'exclusive') {
     return null;

--- a/libs/core/src/sales-documents/domain/types/gross-price-eligibility.types.ts
+++ b/libs/core/src/sales-documents/domain/types/gross-price-eligibility.types.ts
@@ -43,7 +43,19 @@
  * @see docs/architecture/adrs/063-per-line-tax-rate-resolution-and-provenance.md
  */
 
-/** The narrow order shape this check needs — never the full `Order` entity. */
+/**
+ * The narrow order shape this check needs — never the full `Order` entity.
+ *
+ * `taxTreatment` is deliberately `string`, not the domain `PriceTaxTreatment`
+ * union (`@openlinker/core/orders/types`): importing it would add a fourth
+ * type-only exception to this leaf's zero-outbound-core-edge barrel-purity
+ * allowlist for a one-field narrowing that buys nothing today — every real
+ * caller passes an `Order` whose field is already `PriceTaxTreatment`, and
+ * structural typing keeps them honest. The guard below fails open on any
+ * unrecognised value (returns `null`, i.e. "eligible"), which is latent, not
+ * live, for exactly that reason. Do not "tighten" this to close the latent
+ * gap without first re-reading the leaf-purity tradeoff above.
+ */
 export interface GrossPriceEligibilityOrder {
   id: string;
   totals: {
@@ -69,7 +81,11 @@ export type NetPricedOrderRefusalAction = (typeof NetPricedOrderRefusalActionVal
  * or their own connection was the problem.
  *
  * `action` names what the caller was trying to do, in a form that reads
- * naturally both as "cannot be {action}" and as "can be {action} today".
+ * naturally both as "cannot be {action}" and as "can be {action}". The
+ * message deliberately does not say "today" — the constraint is permanent
+ * under the current architecture (see the module docblock above) and names
+ * the source platform as the thing that would have to change, not a future
+ * OpenLinker release.
  */
 export function describeNetPricedOrderRefusal(
   order: GrossPriceEligibilityOrder,
@@ -81,6 +97,6 @@ export function describeNetPricedOrderRefusal(
   return (
     `Order ${order.id} cannot be ${action}: its source reports net (tax-exclusive) line prices, ` +
     `and OpenLinker never computes or infers tax to convert them to gross for a fiscal document — ` +
-    `only a source that reports gross (tax-inclusive) line prices can be ${action} today.`
+    `only a source that reports gross (tax-inclusive) line prices can be ${action}.`
   );
 }

--- a/libs/core/src/sales-documents/index.ts
+++ b/libs/core/src/sales-documents/index.ts
@@ -87,3 +87,9 @@ export * from './domain/types/tax-rate-enforcement.types';
 // receipt is not an invoice, so neither context could own the shape for the
 // other. Visibility only - it changes no lease and no guarantee.
 export * from './domain/types/sales-document-in-flight.types';
+// Whether an order's LINE prices are gross-eligible for document issuance
+// (#2835). Here for the same reason the vocabularies above are: both document
+// contexts refuse a net-priced order identically, and this leaf imports
+// nothing so both can value-import it without either owning the other's
+// wording.
+export * from './domain/types/gross-price-eligibility.types';

--- a/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-order.mapper.ts
+++ b/libs/integrations/prestashop/src/infrastructure/mappers/prestashop-order.mapper.ts
@@ -90,6 +90,12 @@ export class PrestashopOrderMapper implements IPrestashopOrderMapper {
       // PrestaShop's line prices (`order_details.product_price`, mapped onto
       // `OrderItem.price` above) are net — `specific_price` and every catalogue
       // read this adapter does elsewhere already treat them that way (#2440).
+      //
+      // #2835: this net-priced-lines fact is why `invoicing`/`fiscalization`
+      // permanently refuse a PrestaShop order (`describeNetPricedOrderRefusal`,
+      // `@openlinker/core/sales-documents`) — `total` being genuinely gross
+      // (below) does not change that the LINES this guard cares about are net,
+      // and core may never compute tax to convert them.
       taxTreatment: 'exclusive',
     };
 

--- a/libs/integrations/woocommerce/src/infrastructure/adapters/woocommerce-order-source.adapter.ts
+++ b/libs/integrations/woocommerce/src/infrastructure/adapters/woocommerce-order-source.adapter.ts
@@ -316,6 +316,12 @@ function mapTotals(order: WooCommerceOrder): IncomingOrderTotals {
     // `line_items[].price` (mapped onto `OrderItem.price`) is net — WooCommerce
     // reports `total_tax` as a separate amount rather than folding it into the
     // line price (#2440).
+    //
+    // #2835 audit: this identically makes every WooCommerce order refused by
+    // `invoicing`/`fiscalization`'s net-priced-order guard
+    // (`describeNetPricedOrderRefusal`, `@openlinker/core/sales-documents`) —
+    // the same permanent limitation PrestaShop's net line prices hit, for the
+    // same reason (core may never compute tax to convert net to gross).
     taxTreatment: 'exclusive',
   };
 }


### PR DESCRIPTION
## Summary

Closes #2835.

The invoice and fiscal-registration write-path guards refused a net-priced order (PrestaShop, WooCommerce) with `only gross-priced orders are supported` - true, but not actionable, and easy to misread as fixed by #2829/#2832's new `totalTaxTreatment` signal.

They aren't. `totalTaxTreatment` describes the order **total** alone; `unitPriceGross` is composed from each item's `price`, which stays net regardless of what `total` is. Converting a net line price to gross would be *computing* tax (`net * (1 + rate)`), which ADR-063 forbids core from doing even though the rate is often already known - so this is decided as a genuine, permanent limitation of a net-line-price source, not a gap #2832 closes. Full reasoning + decision recorded on the issue and in the new helper's doc comment.

## Changes

- New shared pure helper `describeNetPricedOrderRefusal` (`libs/core/src/sales-documents/domain/types/gross-price-eligibility.types.ts`) - the single place both document contexts (invoicing, fiscalization) state the constraint identically.
- Both mapper guards (`order-to-issue-invoice-command.mapper.ts`, `order-to-register-transaction-command.mapper.ts`) now compose their thrown message from it, instead of the unqualified string.
- Both error-class docblocks cross-reference this decision so a future reader isn't misled by #2829/#2832 into thinking the guard should relax.
- Audit comments added at PrestaShop's and WooCommerce's `taxTreatment: 'exclusive'` sites, confirming both hit the identical permanent limitation (AC #4).
- Tests: new spec for the helper, plus a message-content assertion added to both existing mapper specs.

## Test plan

- [x] `pnpm --filter @openlinker/core lint` - 0 errors
- [x] `pnpm --filter @openlinker/core type-check` - clean
- [x] `pnpm --filter @openlinker/integrations-prestashop lint && type-check` - clean
- [x] `pnpm --filter @openlinker/integrations-woocommerce lint && type-check` - clean
- [ ] `pnpm test` - not run locally (frozen this machine before); covered by CI