### PR TITLE
docs(specs): Wave 3b — an operator can expedite a parcel (B5, D22)

### DIFF
--- a/docs/specs/product-spec-oms-wave3b-scan-pick-pack.md
+++ b/docs/specs/product-spec-oms-wave3b-scan-pick-pack.md
@@ -12,7 +12,7 @@
 No surface, copy or layout is specified yet; where a story would imply a control, it stops at the
 behaviour.
 
-The decision log (§ 6) is the substantive part. Twenty-one decisions, each with its reasoning, and
+The decision log (§ 6) is the substantive part. Twenty-two decisions, each with its reasoning, and
 several of them reverse an earlier draft of this document.
 
 ---
@@ -178,6 +178,17 @@ Terminals are **shared and roaming** (D15), but a person changes terminal only a
 **B4 — state is legible at a glance** *(P9)*
 - Given work in mixed states,
 - Then state is carried by colour and position as well as text, never by colour alone.
+
+**B5 — I can push one parcel to the front** *(D22)*
+- Given a parcel that must go out ahead of its deadline order — an angry customer, a courier
+  cut-off, a supervisor's call,
+- When someone with write access expedites it,
+- Then it sorts ahead of everything not expedited, and the bench shows *that* it was expedited
+  rather than silently reordering the list under the packer,
+- And it can be un-expedited, because a permanent override is a second deadline system.
+- *(Without this, the only lever on ordering is to HOLD everything else — destructive, and it
+  stops other work rather than advancing this one. Deadline order is a good default and a poor
+  only-answer: `dispatchByAt` cannot know that this particular buyer phoned twice.)*
 
 ### 2.3 Surface C — scanner-first operation *(W3b-3, #2416)*
 
@@ -401,4 +412,5 @@ does not exist yet.
 | D18 | **The parcel closes on the last verification**, with no confirmation step. | The field is near-unanimous (Peoplevox, Sellasist, Linnworks, ShipStation auto-advance; Sellasist markets the absent click). Overrides an earlier recommendation for a deliberate commit. |
 | D19 | **A closed parcel can be reopened**, attributed and audited; refused once shipped. | Load-bearing because of D18 — auto-close removes the pause in which a mis-scan would be caught, so reopening is the only correction path. Apilo attributes the un-pack too. |
 | D20 | **Manual confirmation is recorded identically to a scan.** | Marking it creates a stigma, and stigma drives the undetectable workaround (scan a second unit of the same SKU twice). Cost: weaker dispute evidence. |
+| D22 | **An operator can expedite a parcel ahead of deadline order**, visibly and reversibly. | Ordering is otherwise purely `dispatchByAt`, and the only lever on it is holding everything else — which stops work rather than advancing it. The expedite is shown, not silent, because a list that reorders itself under a packer is a list they stop trusting. **Routing a parcel to a bench BY HAND is a different and larger thing** — it adds a producer of work and must take #2395's single decision slot — and is #2869, not this wave. |
 | D21 | **A work changing underneath the packer interrupts**, naming the change. | The free behaviour — a 409 on the next scan — is an error at a moment the packer cannot interpret, which is how a correct guard becomes a support ticket. |


### PR DESCRIPTION
One story and one decision-log entry on the Wave 3b spec.

## The gap

Bench ordering is purely `dispatchByAt`, and nothing in the wave lets a person change it. `OPERATOR_INVOCABLE_ACTIONS` is `schedule, hold, release_hold, mark_in_progress, close, force_cancel` — there is no `prioritise` and nothing of that shape anywhere in the tree.

So today the only lever on ordering is to **hold everything else**, which stops other work rather than advancing this one.

At 1000 orders/day a supervisor will expedite — an angry customer, a courier cut-off in twenty minutes, a VIP. Deadline order is a good default and a poor only-answer, because `dispatchByAt` cannot know that this particular buyer phoned twice. This is the kind of absence that gets discovered in week one of real use and then bolted on badly.

## Two properties are load-bearing

- **The expedite is shown, not silent.** A list that reorders itself under a packer is a list they stop trusting.
- **It is reversible.** A permanent override is just a second deadline system with no rules.

Deliberately small: one flag on the work, one sort key ahead of `dispatchByAt`. It adds no concept to the model.

## What this is not

**Routing a parcel to a bench by hand is a different and much larger thing** — it adds a *producer* of work rather than reordering existing work, and must take #2395's single routing-decision slot, with real questions about overriding an existing decision and about work already dispatched to a 3PL holder. Filed separately as **#2869** against the routing context.

The distinction is the one that keeps the design intact: **manual control adds a producer, never a second list.** A second source of truth for "what is on this bench" would recreate exactly the derived-list problem the authoritative design exists to avoid.

## Gate

Docs only; `pnpm lint` (incl. `check:invariants`), `type-check` and `test` ran via the pre-commit hook under Node 22.

Refs #2422
Refs #2869

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QTQgzuUUzDWrkRcPUAra5f
