### PR TITLE
feat(perf): Allegro upstream stub for the measurement programme

### DIFF
--- a/perf/openlinker-throughput/stubs/allegro/Dockerfile
+++ b/perf/openlinker-throughput/stubs/allegro/Dockerfile
@@ -1,0 +1,29 @@
+# Allegro upstream stub (#2856).
+#
+# Pinned to the exact base image tag the repo's root Dockerfile uses for its
+# `base` / `production` / `worker` stages, so this container is built from
+# the same node runtime as everything else in the stand.
+FROM node:22.23.1-alpine3.24
+
+# Nothing besides the node runtime is installed: server.mjs has zero
+# dependencies (node:http, node:crypto, node:url only), so there is no
+# install step and no package.json - see server.mjs's own header comment
+# for why this directory is deliberately not a pnpm workspace member.
+WORKDIR /app
+COPY server.mjs ./server.mjs
+
+# Surfaced back through GET /__stub/config, so a run manifest can record
+# exactly which stub build a measurement was taken against
+# (#2856 Build Specification "The stub's git sha for the manifest").
+ARG STUB_GIT_SHA=unknown
+ENV STUB_GIT_SHA=${STUB_GIT_SHA}
+
+ENV STUB_PORT=8080
+EXPOSE 8080
+
+# busybox wget ships in the alpine base image, so no extra package is
+# needed for a compose healthcheck to hit the control surface.
+HEALTHCHECK --interval=5s --timeout=3s --start-period=2s --retries=5 \
+  CMD wget -q -O - "http://127.0.0.1:${STUB_PORT}/__stub/health" || exit 1
+
+CMD ["node", "server.mjs"]

--- a/perf/openlinker-throughput/stubs/allegro/README.md
+++ b/perf/openlinker-throughput/stubs/allegro/README.md
@@ -1,0 +1,355 @@
+# Allegro upstream stub
+
+Implements GitHub issue #2856. A single-process `node:http` stub that serves
+just enough of the Allegro Public API for OpenLinker's real order-ingestion
+adapter to run against it unmodified, so the throughput programme (#2840)
+can measure OpenLinker's own cost without a live marketplace in the loop.
+
+## What it serves, and why only this
+
+Per #2856's own cost-model analysis of the real adapter, exactly two Allegro
+endpoints are on the order-ingestion path:
+
+| Method | Path | Cadence |
+|---|---|---|
+| `GET` | `/order/events?from={cursor}&limit={n}` | once per poll tick per connection |
+| `GET` | `/order/checkout-forms/{id}` | once per ingested order (zero per line item) |
+
+Plus `GET /me`, reached by the connection tester and by #2860's bootstrap
+readiness check. Everything else answers `404` in Allegro's own error shape
+(`{"errors":[{"code":"NotFound","message":"..."}]}`), because a 404 is
+non-retryable in OpenLinker's Allegro retry classifier - a stray call fails
+loudly on attempt 1 instead of burning a retry ladder.
+
+## What it deliberately does not serve
+
+- `PUT /order/checkout-forms/{id}/fulfillment`, `POST
+  /order/checkout-forms/{id}/shipments` - fire only on a cancellation feed
+  event or a dispatch writeback, off the ingestion path this stub exists to
+  measure.
+- The returns endpoints - gated behind two scheduler tasks that both default
+  off.
+- OAuth token exchange (`/auth/oauth/token`) - the token host is hardcoded in
+  the real adapter (`allegro-token-refresh.service.ts`) and cannot be
+  repointed by `config.apiBaseUrl`. **The workaround is credential shape, not
+  code**: store the connection's credentials with `accessToken` only - no
+  `expiresAt`, no `refreshToken`, no `clientId`/`clientSecret`. With
+  `expiresAt` absent, the adapter's token-freshness check short-circuits
+  before every request and no token call is ever made. See #2860's bootstrap
+  for where this is wired.
+
+## The one hard rule: never answer 401
+
+If the stub ever answered 401, the real adapter would attempt a token
+refresh against the real, hardcoded `allegro.pl` host - so a run would start
+depending on the public internet, and a failed refresh flags the connection
+`needs_reauth`. Every code path in `server.mjs` that could plausibly want to
+say "unauthorized" (a missing bearer token, an unrecognised one, a malformed
+control-endpoint request) instead degrades to something else - see
+"Multi-tenancy" below. `test.mjs` asserts this directly across every served
+path, every fault mode, and several bogus/missing tokens.
+
+## Design decisions and why
+
+**Transport: `node:http`, zero dependencies, standalone.**
+`pnpm-workspace.yaml` globs only `apps/*`, `libs/*` and `libs/integrations/*`,
+so `perf/` is not a pnpm workspace member and cannot be a package without
+editing that file. The `perf/prestashop-baseline` precedent ships no
+`package.json` either. Two endpoints plus a control surface do not need a
+framework.
+
+**State lives in memory, keyed by bearer token.** This is safe only because
+ids are run-scoped and monotone (below) - a process restart resets counters
+to zero, and that is fine precisely because a fresh run is never assumed to
+continue a prior run's id space.
+
+**Event ids are run-scoped, never process-scoped.** `eventKey` becomes the
+child job's Redis dedupe key (`marketplace:{connectionId}:order:{eventKey}`,
+7-day TTL). If ids were a function of process start alone, repeating a
+scenario within that window would mint the identical keys the first run
+already reserved and every enqueue would silently no-op (`n = 0`, cursor
+still commits, and nothing in the result distinguishes a fully-deduped tick
+from a fresh one). Ids are `{runId}-{6-digit-seq}`. `runId` defaults to
+`STUB_RUN_ID` at boot, or is minted fresh automatically; a driver can also
+start a brand-new run **without restarting the container** via
+`POST /__stub/run`, which is what makes a same-process repeat produce
+disjoint ids.
+
+**Cursor shape is deliberately unrecognised by the real regression guard,
+not a decimal counter.** `compareOrderCursors` in OpenLinker core recognises
+four cursor shapes (decimal counter, ISO instant, naive wall clock,
+wall-clock keyset) and treats anything else as `unrecognised`, which is
+*never* read as a regression. A hyphenated `{runId}-{seq}` id can never match
+any of the four regexes (the hyphen alone rules out the decimal-counter
+shape), so a stub restart that resets its counter to zero can never trip the
+`regressed` guard and wedge a connection. Using a plain decimal counter would
+have armed that guard for no benefit.
+
+**An unknown `from` cursor is tolerated, not 404'd.** OpenLinker's own
+`connection_cursors` row persists across a stub restart; the stub's
+in-memory state does not. A `from` value the stub cannot place (wrong run,
+malformed, or simply unknown) is treated as "you are already caught up" -
+the response carries no events and echoes back the current head as
+`lastEventId`, with a warning in the request log, so the connection is never
+told to replay history it may have already processed under a previous run.
+
+**The driver pushes; the stub never self-generates on a schedule.** Every
+order in the stub exists because `POST /__stub/tenants/{tenant}/orders` was
+called. This is what makes order *arrival rate* a driver-controlled
+independent variable rather than a stub constant.
+
+**Control endpoints live under `/__stub/`, deliberately unauthenticated.**
+No Allegro path uses that prefix, so it can never collide with the served
+surface or be mistaken for a 404-able Allegro path. It carries no auth
+because it is a local perf-harness control plane that OpenLinker itself
+never reaches - there is no principal to check.
+
+**Request log: JSON lines on stdout.** The lab stand's compose service
+declaration for this image has no volume mount, so a file-based log would
+die with the container. One line per request: `ts`, `runId`, `tenant`,
+`method`, `path`, `status`, `latencyMs`.
+
+**Latency is applied per tenant, not via a global mutex.** A shared lock
+would make two tenants serialise, which would make the multi-tenancy
+scenario measure nothing about concurrency at all. Each request independently
+`setTimeout`s for its configured latency; two tenants' requests interleave
+freely.
+
+**Dockerfile lives in the stub's own directory**, `FROM
+node:22.23.1-alpine3.24` - the exact tag the repo's root `Dockerfile` pins
+for its `base`/`production`/`worker` stages. No install step: `server.mjs`
+has zero dependencies.
+
+## The offer-id contract with #2860
+
+`OrderIngestionService` resolves every line item's `offer.id` against an
+`identifier_mappings` row (`entityType='Offer'`, scoped per connection) to a
+live `ProductVariant`. Without a pre-seeded mapping, every stub order dies
+`awaiting_mapping` after exhausting its retries. This stub therefore mints
+offer ids as a **deterministic function of tenant and index**:
+
+```
+{tenant}-offer-{n}      for n in 1..STUB_OFFER_POOL_SIZE
+```
+
+where `{tenant}` is the connection's configured name (`perf-allegro-a` /
+`perf-allegro-b` by default) - the same value `#2860`'s bootstrap must use
+when it seeds `identifier_mappings` rows ahead of any order being pushed.
+
+**`STUB_OFFER_POOL_SIZE` must equal `ALLEGRO_OFFER_POOL_SIZE` in the
+bootstrap.** `sku` on the resulting order line is the same value as
+`offer.id` (`allegro-order-source.adapter.ts:802`), so it is not an
+independent axis - the seeder does not need to track it separately.
+
+Offer indices are assigned round-robin across the pool as line items are
+minted (not per-order), so a small pool is exercised evenly even with many
+orders.
+
+## The buyer-identity decision
+
+`OL_CUSTOMER_IDENTITY_MODE` defaults to `email_fallback`, and Allegro's
+masked-email normalizer strips everything from `+` onward on any
+`@allegromail.` address before hashing (`fixedPart+transactionId@...`, with
+a stable `fixedPart` per real buyer). Minting a distinct `buyer.id` per
+order but only varying the `+transactionId` suffix would therefore collapse
+every synthetic order onto **one** internal customer - the normalizer erases
+exactly that suffix, so per-order destination cost is understated from order
+two onward and an independent-orders workload becomes contention on one
+shared customer row.
+
+This stub varies the masked-email **fixed part** itself:
+`buyer{N}+tx{orderNumber}@allegromail.pl`, where `N` cycles across
+`STUB_BUYER_POOL_SIZE` distinct slots (default 50). A driver wanting a
+"warm" (repeat-buyer) scenario instead of "cold" (one buyer per order) sets
+`STUB_BUYER_POOL_SIZE=1` and records that choice in the run manifest.
+
+## Multi-tenancy
+
+One process, tenants distinguished by the `Authorization: Bearer` token - a
+path prefix cannot work (the real HTTP client builds URLs with `new
+URL(path, baseUrl)`, which discards any path segment already in `baseUrl`).
+
+Configure via `STUB_TENANTS` (default
+`stub-token-a=perf-allegro-a,stub-token-b=perf-allegro-b`), a comma-separated
+list of `token=name` pairs. Each tenant keeps an independent cursor, order/
+event history and fault state.
+
+**An unrecognised or missing bearer token still serves** - it is bucketed
+under a shared `unknown` tenant rather than answering 401 (see "the one hard
+rule" above). This bucket starts empty and is never populated by a push
+(pushes are addressed by tenant *name*, and only configured tenants have
+one), so it exists purely to keep every request answerable without ever
+saying 401.
+
+## Pacing and fault injection
+
+| Env var | Default | Meaning |
+|---|---|---|
+| `STUB_PER_REQUEST_LATENCY_MS` | `120` | Delay applied to every served request |
+| `STUB_LATENCY_EVENTS_MS` | falls back to the above | Per-endpoint override for `/order/events` |
+| `STUB_LATENCY_CHECKOUT_MS` | falls back to the above | Per-endpoint override for `/order/checkout-forms/{id}` |
+
+Latency is a fixed constant per endpoint, not a distribution - #2856 names
+that as a real limitation (a mean cannot produce a tail), and a run manifest
+should record it as such rather than imply a realistic latency profile.
+
+Fault injection (`POST /__stub/tenants/{tenant}/fault`):
+
+```bash
+# Rate-limit tenant A for the next several requests, with an explicit
+# Retry-After the real client actually reads and sleeps on.
+curl -X POST http://localhost:8080/__stub/tenants/perf-allegro-a/fault \
+  -H 'Content-Type: application/json' \
+  -d '{"mode": "429", "retryAfterSeconds": 5}'
+
+# Simulate an outage.
+curl -X POST http://localhost:8080/__stub/tenants/perf-allegro-a/fault \
+  -H 'Content-Type: application/json' \
+  -d '{"mode": "503", "retryAfterSeconds": 10}'
+
+# Hang past the real client's 30s abort (holdMs defaults to 31000; a smaller
+# value is useful only for testing the stub itself, never for a real run).
+curl -X POST http://localhost:8080/__stub/tenants/perf-allegro-a/fault \
+  -H 'Content-Type: application/json' \
+  -d '{"mode": "timeout"}'
+
+# Clear a fault.
+curl -X DELETE http://localhost:8080/__stub/tenants/perf-allegro-a/fault
+```
+
+A fault, once set, applies to every subsequent request from that tenant
+against `/order/events`, `/order/checkout-forms/{id}` and `/me` until
+cleared - it is not consumed after one request. Both 429 and 503 carry
+`Retry-After` as integer seconds (the only response header OpenLinker's
+Allegro client reads) and the Allegro error-body shape
+`{"errors":[{"code":"...","message":"..."}]}`.
+
+## Control surface (`/__stub/`)
+
+All bodies are JSON, no auth required.
+
+### `GET /__stub/health`
+
+For a compose healthcheck. Returns `{"status": "ok", "runId": "..."}`.
+
+### `GET /__stub/config`
+
+The full resolved configuration - the run id, git sha, every latency value,
+the offer pool size, the buyer pool size and the configured tenant names -
+so a run manifest can assert against the stub's own running state rather
+than only against what it was started with.
+
+```bash
+curl http://localhost:8080/__stub/config
+```
+
+### `POST /__stub/run`
+
+Starts a new run: mints (or accepts) a run id and resets every tenant's
+event/order history, counters and faults. This is what lets a driver repeat
+the same scenario multiple times **within one process lifetime** and get
+disjoint dedupe keys each time, without restarting the container.
+
+```bash
+curl -X POST http://localhost:8080/__stub/run \
+  -H 'Content-Type: application/json' \
+  -d '{"runId": "campaign-run-2"}'
+# or, to auto-generate one:
+curl -X POST http://localhost:8080/__stub/run -d '{}'
+```
+
+### `POST /__stub/tenants/{tenant}/orders`
+
+The driver's entry point for order arrival. `{tenant}` is the configured
+tenant **name** (e.g. `perf-allegro-a`), never the bearer token.
+
+```bash
+curl -X POST http://localhost:8080/__stub/tenants/perf-allegro-a/orders \
+  -H 'Content-Type: application/json' \
+  -d '{"count": 10, "lineItemsPerOrder": 3, "eventsPerOrder": 1}'
+```
+
+- `count` (default 1): how many orders to mint.
+- `lineItemsPerOrder` (default 1): distinct line items per order, each drawn
+  round-robin from the offer pool.
+- `eventsPerOrder` (default 1): how many `/order/events` entries reference
+  the same `checkoutForm.id` - set to e.g. 3 to exercise the real adapter's
+  client-side dedupe-by-checkoutFormId behaviour.
+
+Minted orders are served from `/order/events` on the very next poll of that
+endpoint - the stub does not push anything itself. Pushing faster than
+OpenLinker's own discovery ceiling (one page per cron tick, no loop inside
+the adapter) simply queues inside the stub's in-memory event list; that is
+expected and should be stated in the run manifest rather than read as a bug.
+
+### `POST` / `DELETE /__stub/tenants/{tenant}/fault`
+
+See "Pacing and fault injection" above.
+
+### `GET /__stub/tenants/{tenant}/stats`
+
+Per-tenant counters: requests served per endpoint, orders pushed, events
+emitted, the current cursor head, and the active fault (if any).
+
+```bash
+curl http://localhost:8080/__stub/tenants/perf-allegro-a/stats
+```
+
+This is the source of truth for the "1 request per poll tick + 1 per
+ingested order + 0 per line item" cost-model assertion.
+
+## Pointing a connection at the stub
+
+```json
+{
+  "config": { "environment": "production", "apiBaseUrl": "http://allegro-stub:8080" },
+  "credentials": { "accessToken": "stub-token-a" }
+}
+```
+
+`config.environment` remains mandatory on every Allegro connection
+(`@IsIn(AllegroEnvironmentValues)`) but, with `apiBaseUrl` present, its only
+remaining effect on this path is a cosmetic Sales Center deep link. Two
+connections that differ only in `credentials.accessToken` (`stub-token-a`
+vs. `stub-token-b`) are two independent tenants against one stub process.
+
+Verify with `POST /connections/:id/test`, which reaches the stub's `/me` -
+this is the bootstrap readiness check, not a manual step.
+
+## Running the tests
+
+```bash
+node test.mjs
+```
+
+No install step, no pnpm workspace membership needed - `node:test` and
+`node:assert` are both node core. The suite imports `server.mjs` directly
+and starts it on an ephemeral port per test file (not per test - each test
+calls `POST /__stub/run` first for isolation from prior tests in the same
+process).
+
+## What #2856 asks for that this implementation does NOT cover
+
+Two acceptance criteria in #2856 are end-to-end properties of a real
+OpenLinker install pointed at this stub, not something the stub alone can
+satisfy or a unit test can assert:
+
+- *"one order reaches `order_records.recordStatus='ready'` and a destination
+  create"* - needs a running OpenLinker api/worker plus #2860's seeded
+  `identifier_mappings`. This stub only guarantees its half of that contract
+  (see "The offer-id contract with #2860" above).
+- *"every default-ON Allegro scheduler task is either served by the stub or
+  disabled... verified by zero dead `sync_jobs` rows"* - the five scheduler
+  tasks #2856 lists (`offers-sync`, `taxonomy-sync`, `offer-status-sync`,
+  `quantity-ack-reconcile`, `shipment-status-sync`) hit endpoints
+  (`/sale/offer-events`, `/sale/categories`, `/sale/product-offers/{id}`,
+  `/sale/offer-quantity-change-commands/{id}`,
+  `/shipment-management/shipments/{id}`) that are genuinely out of scope for
+  the two-endpoint ingestion path this stub measures, and #2856 explicitly
+  frames disabling them in the stand's environment as the alternative to
+  serving them. That is a stand-configuration decision (#2854/#2860's job),
+  not code this stub ships. Left unserved here, they correctly 404 - fast
+  and loud rather than silently degrading the measurement.
+
+Everything else in the acceptance-criteria list is implemented and covered
+by `test.mjs`.

--- a/perf/openlinker-throughput/stubs/allegro/server.mjs
+++ b/perf/openlinker-throughput/stubs/allegro/server.mjs
@@ -1,0 +1,689 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Allegro upstream stub - #2856.
+ *
+ * Serves the two Allegro Public API endpoints OpenLinker's order-ingestion
+ * path actually calls (GET /order/events, GET /order/checkout-forms/{id}),
+ * plus GET /me for the connection tester, plus a driver-facing control
+ * surface under /__stub/. Everything else answers 404 in Allegro's own error
+ * shape, so a stray call fails loudly (404 is non-retryable per
+ * allegro-retry-classifier.adapter.ts) instead of looping.
+ *
+ * This file is standalone node:http with zero dependencies, deliberately.
+ * `pnpm-workspace.yaml` globs only apps/*, libs/* and libs/integrations/*,
+ * so perf/openlinker-throughput/stubs/allegro is not a workspace member and
+ * cannot be a pnpm package without editing that file - and the
+ * perf/prestashop-baseline precedent ships no package.json either. See
+ * README.md for the full list of design decisions and their reasons.
+ *
+ * Every design decision below is traceable to a numbered section of GitHub
+ * issue #2856 (openlinker-project/openlinker); comments cite it as "#2856".
+ */
+
+import { createServer } from 'node:http';
+import { randomBytes } from 'node:crypto';
+import { URL, fileURLToPath } from 'node:url';
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+/**
+ * #2856 "Event ids must be run-scoped, or repeatability breaks silently":
+ * eventKey becomes a Redis jobdedup:* key with a 7-day TTL, so a repeated
+ * campaign run within that window must NOT reissue ids the first run already
+ * reserved, or every enqueue silently no-ops. The run id is the free
+ * variable a driver controls (via STUB_RUN_ID at boot, or POST /__stub/run
+ * at any point in the process lifetime) precisely so it CAN mint a fresh id
+ * space per repeat without restarting the container.
+ */
+function generateRunId() {
+  return `${Date.now().toString(36)}${randomBytes(3).toString('hex')}`;
+}
+
+function parseTenants(spec) {
+  // "token=name,token=name". Kept human-addressable by NAME on the control
+  // surface (see resolveTenantByName) so a driver script never has to quote
+  // a bearer secret into a URL path.
+  const map = new Map();
+  for (const pair of spec.split(',')) {
+    const trimmed = pair.trim();
+    if (!trimmed) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq === -1) continue;
+    const token = trimmed.slice(0, eq).trim();
+    const name = trimmed.slice(eq + 1).trim();
+    if (token && name) map.set(token, name);
+  }
+  return map;
+}
+
+function envInt(name, fallback) {
+  const raw = process.env[name];
+  if (raw === undefined || raw === '') return fallback;
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n >= 0 ? n : fallback;
+}
+
+const CONFIG = {
+  port: envInt('STUB_PORT', 8080),
+  runId: process.env.STUB_RUN_ID || generateRunId(),
+  gitSha: process.env.STUB_GIT_SHA || 'unknown',
+  tenants: parseTenants(
+    process.env.STUB_TENANTS || 'stub-token-a=perf-allegro-a,stub-token-b=perf-allegro-b'
+  ),
+  latencyDefaultMs: envInt('STUB_PER_REQUEST_LATENCY_MS', 120),
+  latencyEventsMs: process.env.STUB_LATENCY_EVENTS_MS,
+  latencyCheckoutMs: process.env.STUB_LATENCY_CHECKOUT_MS,
+  // #2856 "The seeded-mapping contract": offer ids must be a deterministic
+  // function of tenant + index so #2860's bootstrap can pre-seed
+  // identifier_mappings rows before any order is ever pushed. This value
+  // MUST equal ALLEGRO_OFFER_POOL_SIZE in that bootstrap - see README.
+  offerPoolSize: envInt('STUB_OFFER_POOL_SIZE', 200),
+  // #2856 "The buyer-identity decision": distinct masked-email fixed parts
+  // are required to avoid collapsing every synthetic order onto one internal
+  // customer under the default email_fallback identity mode. This knob lets
+  // a driver choose "cold" (large pool, ~1 buyer per order) vs "warm"
+  // (small pool, repeat buyers) as a declared measurement input.
+  buyerPoolSize: envInt('STUB_BUYER_POOL_SIZE', 50),
+  deliveryCostAmount: process.env.STUB_DELIVERY_COST || '9.99',
+};
+
+function latencyFor(endpoint) {
+  if (endpoint === 'events' && CONFIG.latencyEventsMs !== undefined) {
+    return envInt('STUB_LATENCY_EVENTS_MS', CONFIG.latencyDefaultMs);
+  }
+  if (endpoint === 'checkout' && CONFIG.latencyCheckoutMs !== undefined) {
+    return envInt('STUB_LATENCY_CHECKOUT_MS', CONFIG.latencyDefaultMs);
+  }
+  return CONFIG.latencyDefaultMs;
+}
+
+// ---------------------------------------------------------------------------
+// State - one process, N tenants, keyed by bearer token (#2856 Multi-tenancy)
+// ---------------------------------------------------------------------------
+
+function freshTenantState(name) {
+  return {
+    name,
+    // seq is the per-tenant, per-run monotone event counter. It resets to 0
+    // whenever /__stub/run mints a new run id for the whole process, which
+    // is the "simulated restart" the tests below exercise. While the run id
+    // stays constant, seq only ever increases - that is the "monotone
+    // across a restart when the run id is held constant" property: a run
+    // is, by definition, one contiguous increasing sequence.
+    seq: 0,
+    events: [], // { id, seq, order, occurredAt, type }
+    checkoutForms: new Map(), // checkoutFormId -> AllegroCheckoutForm
+    orderCounter: 0,
+    lineCounter: 0, // drives round-robin offer assignment across the pool
+    fault: null, // { mode: '429'|'503'|'timeout', retryAfterSeconds, holdMs }
+    requestCounts: {}, // 'GET /order/events' -> n
+  };
+}
+
+const state = {
+  runId: CONFIG.runId,
+  tenants: new Map(), // token -> tenant state
+  unknown: freshTenantState('unknown'),
+};
+
+for (const [token, name] of CONFIG.tenants) {
+  state.tenants.set(token, freshTenantState(name));
+}
+
+function resolveTenantByToken(authorizationHeader) {
+  // #2856 Multi-tenancy: "An unknown token still serves (never 401) but
+  // under an `unknown` tenant label, logged as such." Never 401 anywhere -
+  // Problem/Context: a 401 whose body mentions a token sends OpenLinker's
+  // real adapter down the hardcoded allegro.pl OAuth refresh path.
+  if (!authorizationHeader || !authorizationHeader.startsWith('Bearer ')) {
+    return { token: null, tenant: state.unknown };
+  }
+  const token = authorizationHeader.slice('Bearer '.length).trim();
+  const tenant = state.tenants.get(token);
+  if (!tenant) return { token, tenant: state.unknown };
+  return { token, tenant };
+}
+
+function resolveTenantByName(name) {
+  for (const tenant of state.tenants.values()) {
+    if (tenant.name === name) return tenant;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Order minting - the driver pushes, the stub never self-generates
+// (#2856 "Order minting: the driver pushes, the stub does not self-generate")
+// ---------------------------------------------------------------------------
+
+function priceForOffer(offerIndex) {
+  // Deterministic function of the offer index, purely so totals vary a
+  // little between line items rather than being a single repeated constant -
+  // not a modelling requirement, just makes a manifest's numbers look real.
+  return Number((9.99 + (offerIndex % 20) * 1.5).toFixed(2));
+}
+
+function buyerFor(orderN) {
+  const idx = orderN % CONFIG.buyerPoolSize; // 0-based
+  const buyerNumber = idx + 1;
+  return {
+    id: `buyer-${buyerNumber}`,
+    // #2856 "The rule for the stub: vary the masked-email fixedPart per
+    // synthetic buyer... do not vary only the +transactionId suffix and
+    // expect distinct customers, since that is exactly what the normalizer
+    // erases" (allegro-email-normalizer.adapter.ts strips +suffix before
+    // hashing any @allegromail. address). The fixedPart here is
+    // `buyer{N}`, distinct per pool slot; the +tx suffix varies per order
+    // and is deliberately included BECAUSE it must be irrelevant.
+    email: `buyer${buyerNumber}+tx${orderN}@allegromail.pl`,
+    login: `buyer${buyerNumber}`,
+    firstName: 'Buyer',
+    lastName: `Number${buyerNumber}`,
+    phoneNumber: '+48000000000',
+    address: {
+      street: `ul. Testowa ${buyerNumber}`,
+      city: 'Warsaw',
+      zipCode: '00-001',
+      countryCode: 'PL',
+    },
+  };
+}
+
+function mintCheckoutForm(tenant, tenantLabel, orderN, lineItemsPerOrder) {
+  const checkoutFormId = `${state.runId}-${tenantLabel}-order-${orderN}`;
+  const buyer = buyerFor(orderN);
+  const now = new Date().toISOString();
+
+  const lineItems = [];
+  let subtotal = 0;
+  for (let i = 0; i < lineItemsPerOrder; i += 1) {
+    tenant.lineCounter += 1;
+    // #2856 "The seeded-mapping contract": offer ids are `{tenant}-offer-{n}`
+    // for n in 1..STUB_OFFER_POOL_SIZE, matching #2860's bootstrap seeder
+    // exactly - sku is the same value (allegro-order-source.adapter.ts:802),
+    // so it is not tracked as a separate axis.
+    const offerIndex = ((tenant.lineCounter - 1) % CONFIG.offerPoolSize) + 1;
+    const offerId = `${tenantLabel}-offer-${offerIndex}`;
+    const unitPrice = priceForOffer(offerIndex);
+    subtotal = Number((subtotal + unitPrice).toFixed(2));
+    lineItems.push({
+      id: `${checkoutFormId}-line-${i + 1}`,
+      offer: { id: offerId, name: `Stub offer ${offerIndex}` },
+      quantity: 1,
+      price: { amount: unitPrice.toFixed(2), currency: 'PLN' },
+      boughtAt: now,
+    });
+  }
+
+  const deliveryCost = Number(CONFIG.deliveryCostAmount);
+  const total = Number((subtotal + deliveryCost).toFixed(2));
+
+  /** @type {import('./allegro-checkout-form-shape').AllegroCheckoutForm} */
+  const checkoutForm = {
+    id: checkoutFormId,
+    // Neither status nor fulfillment.status may be CANCELLED, or the order
+    // ingests as cancelled (#2856, allegro-order-source.adapter.ts:740-742).
+    status: 'BOUGHT',
+    fulfillment: { status: 'NOWE' },
+    buyer,
+    payment: { type: 'ONLINE', finishedAt: now },
+    lineItems,
+    // Totals must reconcile: totalToPay = sum(line price * qty) + delivery
+    // cost, or the order-record total the seeded-mapping AC checks against
+    // won't match what was minted here.
+    summary: { totalToPay: { amount: total.toFixed(2), currency: 'PLN' } },
+    delivery: {
+      cost: { amount: deliveryCost.toFixed(2), currency: 'PLN' },
+      address: {
+        firstName: buyer.firstName,
+        lastName: buyer.lastName,
+        street: buyer.address.street,
+        city: buyer.address.city,
+        zipCode: buyer.address.zipCode,
+        countryCode: buyer.address.countryCode,
+      },
+    },
+    updatedAt: now,
+  };
+
+  tenant.checkoutForms.set(checkoutFormId, checkoutForm);
+  return checkoutForm;
+}
+
+const EVENT_TYPE_CYCLE = ['BOUGHT', 'FILLED_IN', 'READY_FOR_PROCESSING'];
+
+function pushOrders(tenant, tenantLabel, { count, lineItemsPerOrder, eventsPerOrder }) {
+  const minted = [];
+  for (let i = 0; i < count; i += 1) {
+    tenant.orderCounter += 1;
+    const orderN = tenant.orderCounter;
+    const checkoutForm = mintCheckoutForm(tenant, tenantLabel, orderN, lineItemsPerOrder);
+    const orderId = `${checkoutForm.id}-order-ref`;
+
+    // Multiple events naming the SAME checkoutForm.id, so a driver can
+    // exercise the client-side dedupe-by-checkoutFormId behaviour (#2856:
+    // "a stub emitting three events for one order must expect exactly one
+    // hydration"). occurredAt increases monotonically across the events so
+    // the highest event id is also the chronologically last one.
+    for (let e = 0; e < eventsPerOrder; e += 1) {
+      tenant.seq += 1;
+      const eventId = `${state.runId}-${String(tenant.seq).padStart(6, '0')}`;
+      tenant.events.push({
+        id: eventId,
+        seq: tenant.seq,
+        order: { id: orderId, checkoutForm: { id: checkoutForm.id } },
+        occurredAt: new Date(Date.now() + e * 1000).toISOString(),
+        type: EVENT_TYPE_CYCLE[Math.min(e, EVENT_TYPE_CYCLE.length - 1)],
+      });
+    }
+
+    minted.push({ checkoutFormId: checkoutForm.id, orderId, orderN });
+  }
+  return minted;
+}
+
+// ---------------------------------------------------------------------------
+// Events endpoint - cursor semantics (#2856 "Cursor semantics")
+// ---------------------------------------------------------------------------
+
+function parseCursorSeq(cursor) {
+  // Our own ids are `{runId}-{6-digit-seq}`. Deliberately NOT a decimal
+  // counter (order-cursor.types.ts DECIMAL_COUNTER = /^[0-9]+$/) - the
+  // hyphen alone guarantees this shape is "unrecognised" by
+  // compareOrderCursors, which treats "unrecognised" as never-a-regression.
+  // A decimal-counter shape would ARM that guard, and a stub restart that
+  // resets its counter would then trip `regressed` and wedge the connection
+  // forever (#2856 "Event ids must be run-scoped, or repeatability breaks
+  // silently").
+  if (typeof cursor !== 'string') return null;
+  const prefix = `${state.runId}-`;
+  if (!cursor.startsWith(prefix)) return null;
+  const suffix = cursor.slice(prefix.length);
+  if (!/^\d+$/.test(suffix)) return null;
+  return Number.parseInt(suffix, 10);
+}
+
+function listEvents(tenant, fromCursor, limit) {
+  let startSeq; // events with seq > startSeq are returned
+  let unknownCursor = false;
+
+  if (!fromCursor) {
+    startSeq = 0;
+  } else {
+    const parsed = parseCursorSeq(fromCursor);
+    if (parsed === null) {
+      // #2856 "Cursor durability across a stub restart. ... Recommended:
+      // tolerate an unknown `from` by treating it as the newest known
+      // cursor and warning, never 404." We do not replay full history for
+      // a cursor we cannot place - that would re-mint hydration work for
+      // events the caller may already have processed under a previous run.
+      unknownCursor = true;
+      startSeq = tenant.seq;
+    } else {
+      startSeq = parsed;
+    }
+  }
+
+  const page = tenant.events.filter((e) => e.seq > startSeq).slice(0, limit);
+  const lastEventId =
+    page.length > 0
+      ? page[page.length - 1].id
+      : unknownCursor && tenant.events.length > 0
+        ? tenant.events[tenant.events.length - 1].id
+        : undefined;
+
+  return {
+    body: {
+      events: page.map((e) => ({
+        id: e.id,
+        order: e.order,
+        occurredAt: e.occurredAt,
+        type: e.type,
+      })),
+      ...(lastEventId !== undefined ? { lastEventId } : {}),
+    },
+    unknownCursor,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fault injection (#2856 "Failure injection")
+// ---------------------------------------------------------------------------
+
+function allegroError(code, message) {
+  return { errors: [{ code, message }] };
+}
+
+/**
+ * Applies a tenant's active fault, if any, to the in-flight Allegro-surface
+ * request. Returns true if it fully handled the response (caller must do
+ * nothing further); false if the caller should proceed to serve a normal
+ * response.
+ */
+function applyFault(tenant, req, res, log) {
+  const fault = tenant.fault;
+  if (!fault) return false;
+
+  if (fault.mode === '429' || fault.mode === '503') {
+    const status = fault.mode === '429' ? 429 : 503;
+    const code = fault.mode === '429' ? 'RateLimitExceeded' : 'ServiceUnavailable';
+    const retryAfter = fault.retryAfterSeconds ?? 5;
+    res.writeHead(status, {
+      'Content-Type': 'application/json',
+      'Retry-After': String(retryAfter),
+    });
+    res.end(JSON.stringify(allegroError(code, `Injected ${status} fault for tenant ${tenant.name}`)));
+    log(status);
+    return true;
+  }
+
+  if (fault.mode === 'timeout') {
+    // Holds the connection open past the client's 30 s abort
+    // (allegro-http-client.ts:362-363) by default; a driver testing this
+    // in isolation may pass a short holdMs to avoid a real 30+ second wait.
+    // We never write a response before holdMs elapses, and if the client
+    // is still there afterwards we close the socket rather than leaking it
+    // forever - the real client will have long since aborted by then.
+    const holdMs = fault.holdMs ?? 31000;
+    let responded = false;
+    req.on('close', () => {
+      responded = true;
+    });
+    setTimeout(() => {
+      if (responded) return;
+      responded = true;
+      // Nothing reads this in the intended (>30s abort) case; it only
+      // matters for a short-holdMs test that wants the request to
+      // eventually settle rather than hang the test runner.
+      res.writeHead(503, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(allegroError('ServiceUnavailable', 'Injected timeout fault settled')));
+      log(503);
+    }, holdMs);
+    return true;
+  }
+
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// HTTP plumbing
+// ---------------------------------------------------------------------------
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function sendJson(res, status, body) {
+  const payload = JSON.stringify(body);
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(payload);
+}
+
+function notFound(res, method, pathname) {
+  sendJson(res, 404, allegroError('NotFound', `No route for ${method} ${pathname}`));
+}
+
+function readBody(req) {
+  return new Promise((resolve, reject) => {
+    let raw = '';
+    req.on('data', (chunk) => {
+      raw += chunk;
+    });
+    req.on('end', () => {
+      if (!raw) return resolve({});
+      try {
+        resolve(JSON.parse(raw));
+      } catch (err) {
+        reject(err);
+      }
+    });
+    req.on('error', reject);
+  });
+}
+
+function recordRequestCount(tenant, method, pathTemplate) {
+  const key = `${method} ${pathTemplate}`;
+  tenant.requestCounts[key] = (tenant.requestCounts[key] || 0) + 1;
+}
+
+function logLine(fields) {
+  // JSON lines on stdout - #2856 Build Specification "The request log":
+  // #2854's compose service declares no volume mount, so a file-based log
+  // dies with the container.
+  process.stdout.write(`${JSON.stringify(fields)}\n`);
+}
+
+const server = createServer((req, res) => {
+  const startedAt = Date.now();
+  const url = new URL(req.url, `http://${req.headers.host || 'localhost'}`);
+  const method = req.method || 'GET';
+  const pathname = url.pathname;
+  const { token, tenant } = resolveTenantByToken(req.headers.authorization);
+  const tenantLabel = tenant.name;
+
+  const log = (status, pathTemplate) => {
+    logLine({
+      ts: new Date().toISOString(),
+      runId: state.runId,
+      tenant: tenantLabel,
+      method,
+      path: pathTemplate || pathname,
+      status,
+      latencyMs: Date.now() - startedAt,
+    });
+  };
+
+  void handle();
+
+  async function handle() {
+    // GET /me - #2856: "GET /me answers, and the connection-test bootstrap
+    // check passes." Never 401, never faulted (an operator must always be
+    // able to prove the stub is reachable).
+    if (method === 'GET' && pathname === '/me') {
+      recordRequestCount(tenant, 'GET', '/me');
+      await delay(latencyFor('me'));
+      sendJson(res, 200, { id: 'seller-1', login: `stub-seller-${tenantLabel}` });
+      log(200, '/me');
+      return;
+    }
+
+    if (method === 'GET' && pathname === '/order/events') {
+      recordRequestCount(tenant, 'GET', '/order/events');
+      await delay(latencyFor('events'));
+      if (applyFault(tenant, req, res, (status) => log(status, '/order/events'))) return;
+      const from = url.searchParams.get('from');
+      const limitParam = url.searchParams.get('limit');
+      const limit = limitParam ? Number.parseInt(limitParam, 10) : 100;
+      const { body } = listEvents(tenant, from, Number.isFinite(limit) ? limit : 100);
+      sendJson(res, 200, body);
+      log(200, '/order/events');
+      return;
+    }
+
+    const checkoutMatch = /^\/order\/checkout-forms\/([^/]+)$/.exec(pathname);
+    if (method === 'GET' && checkoutMatch) {
+      recordRequestCount(tenant, 'GET', '/order/checkout-forms/:id');
+      await delay(latencyFor('checkout'));
+      if (applyFault(tenant, req, res, (status) => log(status, '/order/checkout-forms/:id'))) return;
+      const id = decodeURIComponent(checkoutMatch[1]);
+      const checkoutForm = tenant.checkoutForms.get(id);
+      if (!checkoutForm) {
+        notFound(res, method, pathname);
+        log(404, '/order/checkout-forms/:id');
+        return;
+      }
+      sendJson(res, 200, checkoutForm);
+      log(200, '/order/checkout-forms/:id');
+      return;
+    }
+
+    // -----------------------------------------------------------------
+    // Control surface - /__stub/, driver-facing. No Allegro path uses this
+    // prefix (#2856 Build Specification "Control endpoint"). Deliberately
+    // unauthenticated: this is a local perf harness control plane, never
+    // reached by OpenLinker itself, so there is no principal to check.
+    // -----------------------------------------------------------------
+
+    if (method === 'GET' && pathname === '/__stub/health') {
+      sendJson(res, 200, { status: 'ok', runId: state.runId });
+      return;
+    }
+
+    if (method === 'GET' && pathname === '/__stub/config') {
+      sendJson(res, 200, {
+        runId: state.runId,
+        gitSha: CONFIG.gitSha,
+        port: CONFIG.port,
+        tenants: [...state.tenants.values()].map((t) => t.name),
+        offerPoolSize: CONFIG.offerPoolSize,
+        buyerPoolSize: CONFIG.buyerPoolSize,
+        deliveryCostAmount: CONFIG.deliveryCostAmount,
+        latency: {
+          defaultMs: CONFIG.latencyDefaultMs,
+          eventsMs: latencyFor('events'),
+          checkoutMs: latencyFor('checkout'),
+        },
+      });
+      return;
+    }
+
+    if (method === 'POST' && pathname === '/__stub/run') {
+      let body;
+      try {
+        body = await readBody(req);
+      } catch {
+        sendJson(res, 400, { error: 'invalid JSON body' });
+        return;
+      }
+      // #2856 "Event ids must be minted run-scoped, not process-scoped":
+      // this is the mechanism that lets a driver run the same scenario
+      // twice in one process lifetime and get disjoint dedupe keys the
+      // second time, without restarting the container.
+      state.runId = typeof body.runId === 'string' && body.runId ? body.runId : generateRunId();
+      for (const t of state.tenants.values()) {
+        const fresh = freshTenantState(t.name);
+        Object.assign(t, fresh);
+      }
+      Object.assign(state.unknown, freshTenantState('unknown'));
+      sendJson(res, 200, { runId: state.runId });
+      return;
+    }
+
+    const ordersMatch = /^\/__stub\/tenants\/([^/]+)\/orders$/.exec(pathname);
+    if (method === 'POST' && ordersMatch) {
+      const targetTenant = resolveTenantByName(decodeURIComponent(ordersMatch[1]));
+      if (!targetTenant) {
+        sendJson(res, 404, { error: `unknown tenant ${ordersMatch[1]}` });
+        return;
+      }
+      let body;
+      try {
+        body = await readBody(req);
+      } catch {
+        sendJson(res, 400, { error: 'invalid JSON body' });
+        return;
+      }
+      const count = Number.isInteger(body.count) && body.count > 0 ? body.count : 1;
+      const lineItemsPerOrder =
+        Number.isInteger(body.lineItemsPerOrder) && body.lineItemsPerOrder > 0
+          ? body.lineItemsPerOrder
+          : 1;
+      const eventsPerOrder =
+        Number.isInteger(body.eventsPerOrder) && body.eventsPerOrder > 0 ? body.eventsPerOrder : 1;
+      const minted = pushOrders(targetTenant, targetTenant.name, {
+        count,
+        lineItemsPerOrder,
+        eventsPerOrder,
+      });
+      sendJson(res, 201, { minted });
+      return;
+    }
+
+    const faultMatch = /^\/__stub\/tenants\/([^/]+)\/fault$/.exec(pathname);
+    if (faultMatch && (method === 'POST' || method === 'DELETE')) {
+      const targetTenant = resolveTenantByName(decodeURIComponent(faultMatch[1]));
+      if (!targetTenant) {
+        sendJson(res, 404, { error: `unknown tenant ${faultMatch[1]}` });
+        return;
+      }
+      if (method === 'DELETE') {
+        targetTenant.fault = null;
+        sendJson(res, 200, { fault: null });
+        return;
+      }
+      let body;
+      try {
+        body = await readBody(req);
+      } catch {
+        sendJson(res, 400, { error: 'invalid JSON body' });
+        return;
+      }
+      if (![null, '429', '503', 'timeout'].includes(body.mode)) {
+        sendJson(res, 400, { error: "mode must be one of null, '429', '503', 'timeout'" });
+        return;
+      }
+      targetTenant.fault =
+        body.mode === null
+          ? null
+          : {
+              mode: body.mode,
+              retryAfterSeconds: Number.isInteger(body.retryAfterSeconds)
+                ? body.retryAfterSeconds
+                : 5,
+              holdMs: Number.isInteger(body.holdMs) ? body.holdMs : undefined,
+            };
+      sendJson(res, 200, { fault: targetTenant.fault });
+      return;
+    }
+
+    const statsMatch = /^\/__stub\/tenants\/([^/]+)\/stats$/.exec(pathname);
+    if (method === 'GET' && statsMatch) {
+      const targetTenant = resolveTenantByName(decodeURIComponent(statsMatch[1]));
+      if (!targetTenant) {
+        sendJson(res, 404, { error: `unknown tenant ${statsMatch[1]}` });
+        return;
+      }
+      sendJson(res, 200, {
+        name: targetTenant.name,
+        requestCounts: targetTenant.requestCounts,
+        ordersPushed: targetTenant.orderCounter,
+        eventsEmitted: targetTenant.events.length,
+        currentCursor:
+          targetTenant.events.length > 0
+            ? targetTenant.events[targetTenant.events.length - 1].id
+            : null,
+        fault: targetTenant.fault,
+      });
+      return;
+    }
+
+    notFound(res, method, pathname);
+    log(404);
+  }
+});
+
+// Only auto-listen when this file is run directly (`node server.mjs`), never
+// on import - test.mjs imports this module and calls server.listen(0) itself
+// so it gets an ephemeral port instead of colliding with a real instance on
+// CONFIG.port.
+const isMain = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+if (isMain) {
+  server.listen(CONFIG.port, () => {
+    logLine({
+      ts: new Date().toISOString(),
+      event: 'listening',
+      runId: state.runId,
+      port: CONFIG.port,
+      gitSha: CONFIG.gitSha,
+      tenants: [...state.tenants.values()].map((t) => t.name),
+    });
+  });
+}
+
+// Exported for test.mjs, which starts/stops the server in-process on an
+// ephemeral port rather than shelling out to a second node process.
+export { server, CONFIG, state };

--- a/perf/openlinker-throughput/stubs/allegro/test.mjs
+++ b/perf/openlinker-throughput/stubs/allegro/test.mjs
@@ -1,0 +1,399 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Tests for the Allegro upstream stub (#2856).
+ *
+ * Runs with `node test.mjs` - node:test and node:assert are both node core,
+ * so no test runner needs to be installed. This file is outside the pnpm
+ * workspace (perf/ is not a workspace member, see server.mjs's header), so
+ * Jest is not reachable here without editing pnpm-workspace.yaml, which
+ * #2856's own Build Specification says to avoid.
+ *
+ * The server module is imported directly (not shelled out to) so tests run
+ * on an ephemeral port and can reach into `state`/`CONFIG` when a black-box
+ * HTTP assertion alone would not be enough (e.g. confirming a cursor's
+ * internal shape is truly unrecognised by the real regression guard).
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+// Keep the per-request latency small in this suite so ~40 assertions run in
+// well under a second - production runs set a realistic value via
+// STUB_PER_REQUEST_LATENCY_MS on the container. Must be set BEFORE the
+// dynamic import below, since CONFIG is captured once at module load.
+process.env.STUB_PER_REQUEST_LATENCY_MS ??= '5';
+const { server, CONFIG } = await import('./server.mjs');
+
+let baseUrl;
+
+test.before(async () => {
+  await new Promise((resolve) => server.listen(0, resolve));
+  const { port } = server.address();
+  baseUrl = `http://127.0.0.1:${port}`;
+});
+
+test.after(() => {
+  server.close();
+});
+
+const TOKEN_A = 'stub-token-a';
+const TENANT_A = 'perf-allegro-a';
+const TOKEN_B = 'stub-token-b';
+const TENANT_B = 'perf-allegro-b';
+
+async function call(method, path, { token, body } = {}) {
+  const headers = { 'Content-Type': 'application/json' };
+  if (token !== null) headers.Authorization = `Bearer ${token ?? TOKEN_A}`;
+  const res = await fetch(`${baseUrl}${path}`, {
+    method,
+    headers,
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+  const text = await res.text();
+  let json;
+  try {
+    json = text ? JSON.parse(text) : undefined;
+  } catch {
+    json = undefined;
+  }
+  return { status: res.status, headers: res.headers, body: json, raw: text };
+}
+
+/** Resets every tenant's state to a fresh, disjoint run id. */
+async function resetRun(runId) {
+  const { body } = await call('POST', '/__stub/run', { token: null, body: runId ? { runId } : {} });
+  return body.runId;
+}
+
+// ---------------------------------------------------------------------------
+// Never 401 - Problem/Context: a 401 escapes to the hardcoded real
+// allegro.pl OAuth host and can flag the connection needs_reauth.
+// ---------------------------------------------------------------------------
+
+test('never answers 401, for any path, any token, any fault mode', async () => {
+  await resetRun('t-401');
+  await call('POST', `/__stub/tenants/${TENANT_A}/fault`, {
+    token: null,
+    body: { mode: '429' },
+  });
+
+  const attempts = [
+    ['GET', '/order/events', TOKEN_A],
+    ['GET', '/order/events', 'not-a-real-token'],
+    ['GET', '/order/events', null], // no Authorization header at all
+    ['GET', '/order/checkout-forms/does-not-exist', TOKEN_A],
+    ['GET', '/me', 'garbage'],
+    ['GET', '/some/unknown/path', TOKEN_A],
+  ];
+
+  for (const [method, path, token] of attempts) {
+    const { status } = await call(method, path, { token });
+    assert.notEqual(status, 401, `${method} ${path} with token=${token} must never be 401`);
+  }
+
+  await call('DELETE', `/__stub/tenants/${TENANT_A}/fault`, { token: null });
+});
+
+// ---------------------------------------------------------------------------
+// Unknown cursor tolerated, never 404
+// ---------------------------------------------------------------------------
+
+test('an unknown `from` cursor is tolerated, not 404d', async () => {
+  await resetRun('t-unknown-cursor');
+  const { status, body } = await call(
+    'GET',
+    '/order/events?from=some-cursor-from-a-different-run&limit=10',
+    { token: TOKEN_A }
+  );
+  assert.equal(status, 200);
+  assert.deepEqual(body.events, []);
+});
+
+// ---------------------------------------------------------------------------
+// Dedupe shape: three events naming one checkoutForm.id -> one hydration
+// ---------------------------------------------------------------------------
+
+test('three events naming one checkoutForm.id produce exactly one hydration call', async () => {
+  await resetRun('t-dedupe');
+  const { body: pushed } = await call('POST', `/__stub/tenants/${TENANT_A}/orders`, {
+    token: null,
+    body: { count: 1, lineItemsPerOrder: 2, eventsPerOrder: 3 },
+  });
+  assert.equal(pushed.minted.length, 1);
+  const checkoutFormId = pushed.minted[0].checkoutFormId;
+
+  const { body: eventsPage } = await call('GET', '/order/events?limit=100', { token: TOKEN_A });
+  assert.equal(eventsPage.events.length, 3);
+  const distinctCheckoutForms = new Set(eventsPage.events.map((e) => e.order.checkoutForm.id));
+  assert.equal(distinctCheckoutForms.size, 1);
+  assert.equal([...distinctCheckoutForms][0], checkoutFormId);
+
+  // Client-side dedupe (allegro-order-source.adapter.ts) picks the highest
+  // event id per checkoutForm.id and hydrates it exactly once.
+  const winner = eventsPage.events.reduce((a, b) => (a.id > b.id ? a : b));
+  const { status: hydrateStatus } = await call(
+    'GET',
+    `/order/checkout-forms/${encodeURIComponent(winner.order.checkoutForm.id)}`,
+    { token: TOKEN_A }
+  );
+  assert.equal(hydrateStatus, 200);
+
+  const { body: stats } = await call('GET', `/__stub/tenants/${TENANT_A}/stats`, { token: null });
+  assert.equal(stats.requestCounts['GET /order/events'], 1);
+  assert.equal(stats.requestCounts['GET /order/checkout-forms/:id'], 1);
+});
+
+// ---------------------------------------------------------------------------
+// Request count: 1 per poll tick + 1 per ingested order + 0 per line item
+// ---------------------------------------------------------------------------
+
+test('request count is 1 per /order/events call plus 1 per hydration, zero per line item', async () => {
+  await resetRun('t-cost-model');
+  await call('POST', `/__stub/tenants/${TENANT_A}/orders`, {
+    token: null,
+    body: { count: 3, lineItemsPerOrder: 8, eventsPerOrder: 1 },
+  });
+
+  const { body: eventsPage } = await call('GET', '/order/events?limit=100', { token: TOKEN_A });
+  assert.equal(eventsPage.events.length, 3);
+
+  for (const event of eventsPage.events) {
+    await call('GET', `/order/checkout-forms/${encodeURIComponent(event.order.checkoutForm.id)}`, {
+      token: TOKEN_A,
+    });
+  }
+
+  const { body: stats } = await call('GET', `/__stub/tenants/${TENANT_A}/stats`, { token: null });
+  // One /order/events call was made above (the dedupe test's own reset
+  // cleared prior counts).
+  assert.equal(stats.requestCounts['GET /order/events'], 1);
+  assert.equal(stats.requestCounts['GET /order/checkout-forms/:id'], 3);
+  assert.equal(stats.ordersPushed, 3);
+});
+
+// ---------------------------------------------------------------------------
+// Ids are run-scoped: monotone within a run, disjoint across a new run
+// ---------------------------------------------------------------------------
+
+test('ids are monotone while the run id is held constant, and disjoint when it changes', async () => {
+  const runA = await resetRun('t-run-a');
+  await call('POST', `/__stub/tenants/${TENANT_A}/orders`, {
+    token: null,
+    body: { count: 2 },
+  });
+  const { body: firstPage } = await call('GET', '/order/events?limit=100', { token: TOKEN_A });
+  const firstIds = firstPage.events.map((e) => e.id);
+  assert.equal(firstIds.length, 2);
+  assert.ok(firstIds[0] < firstIds[1], 'ids must strictly increase within one run');
+  for (const id of firstIds) assert.ok(id.startsWith(`${runA}-`));
+
+  const runB = await resetRun('t-run-b');
+  assert.notEqual(runA, runB);
+  await call('POST', `/__stub/tenants/${TENANT_A}/orders`, {
+    token: null,
+    body: { count: 2 },
+  });
+  const { body: secondPage } = await call('GET', '/order/events?limit=100', { token: TOKEN_A });
+  const secondIds = secondPage.events.map((e) => e.id);
+
+  for (const id of secondIds) {
+    assert.ok(!firstIds.includes(id), 'a new run must never reissue a prior run\'s ids');
+    assert.ok(id.startsWith(`${runB}-`));
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Cursor shape is unrecognised by the real regression guard
+// (order-cursor.types.ts: DECIMAL_COUNTER / ISO_INSTANT / NAIVE_WALL_CLOCK /
+// WALL_CLOCK_KEYSET). Minted ids must match none of the four.
+// ---------------------------------------------------------------------------
+
+test('minted event ids match none of the four recognised cursor shapes', async () => {
+  await resetRun('t-cursor-shape');
+  await call('POST', `/__stub/tenants/${TENANT_A}/orders`, { token: null, body: { count: 1 } });
+  const { body } = await call('GET', '/order/events?limit=10', { token: TOKEN_A });
+  const id = body.events[0].id;
+
+  const DECIMAL_COUNTER = /^[0-9]+$/;
+  const ISO_INSTANT = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}(:\d{2}(\.\d+)?)?(Z|[+-]\d{2}:\d{2})$/;
+  const NAIVE_WALL_CLOCK = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/;
+  const WALL_CLOCK_KEYSET = /^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2})\|([0-9]+)$/;
+
+  assert.ok(!DECIMAL_COUNTER.test(id));
+  assert.ok(!ISO_INSTANT.test(id));
+  assert.ok(!NAIVE_WALL_CLOCK.test(id));
+  assert.ok(!WALL_CLOCK_KEYSET.test(id));
+});
+
+// ---------------------------------------------------------------------------
+// Totals reconcile
+// ---------------------------------------------------------------------------
+
+test('totals reconcile: totalToPay = sum(line price * qty) + delivery cost', async () => {
+  await resetRun('t-totals');
+  await call('POST', `/__stub/tenants/${TENANT_A}/orders`, {
+    token: null,
+    body: { count: 1, lineItemsPerOrder: 4 },
+  });
+  const { body: eventsPage } = await call('GET', '/order/events?limit=10', { token: TOKEN_A });
+  const checkoutFormId = eventsPage.events[0].order.checkoutForm.id;
+  const { body: form } = await call(
+    'GET',
+    `/order/checkout-forms/${encodeURIComponent(checkoutFormId)}`,
+    { token: TOKEN_A }
+  );
+
+  const subtotal = form.lineItems.reduce(
+    (sum, li) => sum + Number(li.price.amount) * li.quantity,
+    0
+  );
+  const deliveryCost = Number(form.delivery.cost.amount);
+  const expectedTotal = Number((subtotal + deliveryCost).toFixed(2));
+  assert.equal(Number(form.summary.totalToPay.amount), expectedTotal);
+  assert.notEqual(form.status, 'CANCELLED');
+  assert.notEqual(form.fulfillment.status, 'CANCELLED');
+});
+
+// ---------------------------------------------------------------------------
+// Distinct buyers -> distinct masked-email fixed parts
+// ---------------------------------------------------------------------------
+
+test('distinct buyers produce distinct masked-email fixed parts', async () => {
+  await resetRun('t-buyers');
+  await call('POST', `/__stub/tenants/${TENANT_A}/orders`, {
+    token: null,
+    body: { count: 5 },
+  });
+  const { body: eventsPage } = await call('GET', '/order/events?limit=10', { token: TOKEN_A });
+
+  const fixedParts = new Set();
+  for (const event of eventsPage.events) {
+    const { body: form } = await call(
+      'GET',
+      `/order/checkout-forms/${encodeURIComponent(event.order.checkoutForm.id)}`,
+      { token: TOKEN_A }
+    );
+    // The normalizer strips everything from '+' onward before hashing any
+    // @allegromail. address - only the part before '+' may vary if the
+    // intent is distinct buyers.
+    const fixedPart = form.buyer.email.split('+')[0];
+    fixedParts.add(fixedPart);
+  }
+  assert.equal(fixedParts.size, 5, 'each order should mint a distinct buyer fixedPart');
+});
+
+// ---------------------------------------------------------------------------
+// Offer ids: {tenant}-offer-{n}, n within the configured pool size
+// ---------------------------------------------------------------------------
+
+test('offer ids fall inside 1..STUB_OFFER_POOL_SIZE and carry the tenant label', async () => {
+  await resetRun('t-offers');
+  await call('POST', `/__stub/tenants/${TENANT_A}/orders`, {
+    token: null,
+    body: { count: 1, lineItemsPerOrder: 3 },
+  });
+  const { body: eventsPage } = await call('GET', '/order/events?limit=10', { token: TOKEN_A });
+  const { body: form } = await call(
+    'GET',
+    `/order/checkout-forms/${encodeURIComponent(eventsPage.events[0].order.checkoutForm.id)}`,
+    { token: TOKEN_A }
+  );
+
+  const offerPattern = new RegExp(`^${TENANT_A}-offer-(\\d+)$`);
+  for (const line of form.lineItems) {
+    const match = offerPattern.exec(line.offer.id);
+    assert.ok(match, `offer id ${line.offer.id} must match {tenant}-offer-{n}`);
+    const n = Number(match[1]);
+    assert.ok(n >= 1 && n <= CONFIG.offerPoolSize);
+    // sku is the same value as offer.id and is not tracked separately -
+    // there is nothing further to assert here, matching #2856's note that
+    // sku is not an independent axis.
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Multi-tenancy: independent state per bearer token
+// ---------------------------------------------------------------------------
+
+test('two tenants keep independent cursor state, order ids and failure controls', async () => {
+  await resetRun('t-multi-tenant');
+  await call('POST', `/__stub/tenants/${TENANT_A}/orders`, { token: null, body: { count: 2 } });
+  await call('POST', `/__stub/tenants/${TENANT_B}/orders`, { token: null, body: { count: 1 } });
+
+  const { body: pageA } = await call('GET', '/order/events?limit=100', { token: TOKEN_A });
+  const { body: pageB } = await call('GET', '/order/events?limit=100', { token: TOKEN_B });
+  assert.equal(pageA.events.length, 2);
+  assert.equal(pageB.events.length, 1);
+
+  await call('POST', `/__stub/tenants/${TENANT_A}/fault`, { token: null, body: { mode: '429' } });
+  const { status: statusA } = await call('GET', '/order/events', { token: TOKEN_A });
+  const { status: statusB } = await call('GET', '/order/events', { token: TOKEN_B });
+  assert.equal(statusA, 429);
+  assert.equal(statusB, 200, 'a fault on tenant A must not affect tenant B');
+
+  await call('DELETE', `/__stub/tenants/${TENANT_A}/fault`, { token: null });
+});
+
+// ---------------------------------------------------------------------------
+// Fault injection: 429/503 carry Retry-After and a parseable error body
+// ---------------------------------------------------------------------------
+
+test('429 and 503 carry Retry-After and a parseable Allegro-shaped error body', async () => {
+  await resetRun('t-faults');
+
+  for (const mode of ['429', '503']) {
+    await call('POST', `/__stub/tenants/${TENANT_A}/fault`, {
+      token: null,
+      body: { mode, retryAfterSeconds: 3 },
+    });
+    const { status, headers, body } = await call('GET', '/order/events', { token: TOKEN_A });
+    assert.equal(status, Number(mode));
+    assert.equal(headers.get('retry-after'), '3');
+    assert.ok(Array.isArray(body.errors));
+    assert.ok(body.errors[0].code);
+    assert.ok(body.errors[0].message);
+  }
+
+  await call('DELETE', `/__stub/tenants/${TENANT_A}/fault`, { token: null });
+});
+
+test('timeout fault holds the response rather than answering immediately', async () => {
+  await resetRun('t-timeout');
+  await call('POST', `/__stub/tenants/${TENANT_A}/fault`, {
+    token: null,
+    body: { mode: 'timeout', holdMs: 200 },
+  });
+
+  const startedAt = Date.now();
+  const { status } = await call('GET', '/order/events', { token: TOKEN_A });
+  const elapsed = Date.now() - startedAt;
+  assert.ok(elapsed >= 200, `expected the response to be held at least 200ms, got ${elapsed}ms`);
+  assert.equal(status, 503);
+
+  await call('DELETE', `/__stub/tenants/${TENANT_A}/fault`, { token: null });
+});
+
+// ---------------------------------------------------------------------------
+// /me answers for the connection tester
+// ---------------------------------------------------------------------------
+
+test('GET /me answers 200 with an id and login', async () => {
+  await resetRun('t-me');
+  const { status, body } = await call('GET', '/me', { token: TOKEN_A });
+  assert.equal(status, 200);
+  assert.ok(body.id);
+  assert.ok(body.login);
+});
+
+// ---------------------------------------------------------------------------
+// Everything else 404s in Allegro's own error shape
+// ---------------------------------------------------------------------------
+
+test('an unserved path 404s in the Allegro error shape', async () => {
+  const { status, body } = await call('GET', '/sale/offer-events', { token: TOKEN_A });
+  assert.equal(status, 404);
+  assert.ok(Array.isArray(body.errors));
+  assert.equal(body.errors[0].code, 'NotFound');
+});


### PR DESCRIPTION
Closes #2856. Child of #2840. Paired with #2872 (the stand bootstrap, #2860) by the offer-id contract described below - **that is why this is a draft**: the two must agree on the offer-id space, and #2872 is not merged yet.

## What this is

A standalone, dependency-free `node:http` stub that OpenLinker is pointed at instead of the real Allegro API, so F1 (#2847) and F2 (#2848) measure OpenLinker rather than a third party's weather.

Pointing OpenLinker at it needs **no application code change**: `connection.config.apiBaseUrl` is an existing validated field. Two Allegro endpoints, plus `/me`, plus a `/__stub/` control surface. Everything else answers 404 in Allegro's own error shape, so a stray call fails loudly rather than looping - a 404 is non-retryable.

The honest cost model is **one request per poll tick plus one per ingestion attempt, and zero per line item**. Per attempt rather than per order because `getOrder` sits above item resolution, so a retry re-hydrates; and a cancel event costs zero hydrations because `handleSourceCancellation` never calls `getOrder`.

## Five properties that are load-bearing, not incidental

**Event ids are run-scoped, and structurally unrecognisable as a cursor.** The child dedupe key is `marketplace:{connectionId}:order:{eventKey}` where `eventKey` is the Allegro event id verbatim, and that becomes a Redis `jobdedup:` key with a **7-day TTL**. A repeat run that reuses ids therefore enqueues nothing - silently, with `enqueued: requests.length` returned unconditionally and the only trace a suppressed `debug` line - and every guard passes because the queue is empty *for that reason*. Verdict `VALID`, `n = 0`. Ids carry a run id so a repeat is fresh.

They also must not parse as a decimal counter. `compareOrderCursors` recognises exactly four shapes and treats anything else as `unrecognised`, which is explicitly **not** a regression. A recognised shape arms the guard, and a restarted stub reissuing lower ids then answers `regressed`, the cursor is never committed, the same page is re-read every minute forever, and the only output is one warn per tick. Verified empirically against the four regexes copied verbatim from `order-cursor.types.ts:33-58`:

```
mtlv2r456ebe52-000001   -> unrecognised (guard inert - correct)
12345                   -> DECIMAL_COUNTER (GUARD ARMED)
2026-09-03T18:31:43.824Z-> ISO_INSTANT (GUARD ARMED)
```

**It never answers 401, on any path, with any token, in any fault mode.** A 401 whose body mentions a token sends OpenLinker to the OAuth host, which is hardcoded with no per-connection override - the run would start depending on the public internet, and a failed refresh is classified `credential-rejected`, which flags the connection `needs_reauth`. Swept in the tests and again by hand across every path and token.

**Offer ids are `{tenant}-offer-{n}`**, matching exactly what #2860's bootstrap seeds as `identifier_mappings` rows. Without that agreement every order fails item resolution, persists `awaiting_mapping`, never reaches a destination create, and burns ten retry attempts over roughly 30 hours. `sku` is the same value, so it is not an independent axis. `STUB_OFFER_POOL_SIZE` must equal the bootstrap's `ALLEGRO_OFFER_POOL_SIZE`.

**Buyers vary their masked-email fixed part**, not only the `+txn` suffix. OpenLinker strips that suffix for any `@allegromail.` address, so under the default `email_fallback` identity mode a shared fixed part collapses every order onto **one** internal customer: destination customer provisioning is paid once, address provisioning disappears from order two onward, and an independent-orders workload becomes contention on one row plus one lock.

**Orders are minted in PLN.** A currency differing from the deployment's reporting currency puts a live NBP/ECB call inside every measured job, and not once per rate date either - the candidate rate date is a calendar day, so where the provider walks it back no row is written under the candidate and the read keeps missing.

Latency is applied **per tenant, not globally** - a global mutex would serialise the two tenants and the multi-tenancy requirement would then measure nothing.

## Verified end to end, not only by unit test

`node test.mjs` passes 14/14 and the Docker image builds and reports healthy, but the run that matters was against a **live OpenLinker install** with #2872's bootstrap creating the connections and the `Offer` mappings:

- both Allegro connection tests **passed through the real adapter**, which proves the `apiBaseUrl` override works with no code change and that no OAuth call left for the real `allegro.pl`
- five pushed orders carrying **three events each deduplicated to five `marketplace.order.sync` jobs** - the adapter's client-side dedupe by `checkoutForm.id`, exercised for real
- the resulting `order_records` rows reached **`recordStatus = 'ready'`** in PLN, with line items and a populated `placedAt`

Two things the live run showed that no unit test would have:

```
last_error | Deferred: lane 'realtime' per-scope cap reached within the claim
             batch - re-queued immediately, no attempt consumed (ADR-050)
```

The `realtime` per-scope cap of 2 binding on five queued orders, visibly - the constraint #2847's arithmetic is about, demonstrated rather than derived. And `marketplace.offerQuantity.reconcile` failing for both stub tenants, which is one of the five default-ON Allegro scheduler tasks hitting a path this stub deliberately does not serve. That is expected and is #2854's to silence by environment; it is recorded in the README rather than papered over.

The stack was returned to its exact prior state afterwards: connection count back to its original 13, zero stub orders, zero perf mappings, both keys removed, container and image deleted.

## Deliberately not served

The five default-ON Allegro scheduler tasks (`/sale/offer-events`, `/sale/categories`, `/sale/product-offers/{id}`, `/sale/offer-quantity-change-commands/{id}`, `/shipment-management/shipments/{id}`) answer 404. The issue frames disabling them in the stand's environment as the alternative, and that is #2854's. Serving them here would be inventing a second cost model nobody has measured.

## Not covered

- `pnpm lint` and `pnpm type-check` were not run: the change adds no TypeScript and `perf/` is not a pnpm workspace member (`pnpm-workspace.yaml` globs `apps/*`, `libs/*`, `libs/integrations/*` only), which is also why this ships zero dependencies rather than a package. `pnpm check:invariants` passes.
- The per-request latency constant is a placeholder. No Allegro p50 or p95 exists anywhere in this repo, so a figure taken against this stub is internally consistent and externally meaningless until the one-off sandbox baseline (#2861) lands. Stated in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
