### PR TITLE
docs(amazon-spike): live-verification pass for #2881 — Amazon SP-API (FR/DE/PL)

### DIFF
--- a/.research/sandbox-test-log.md
+++ b/.research/sandbox-test-log.md
@@ -1,0 +1,351 @@
+# Amazon SP-API sandbox — live test log (#2881)
+
+Local, untracked scratch notes. NOT part of the final SPIKE doc yet — raw findings to be curated later.
+Access token used: self-authorized Private app "OL-testt", sandbox keyset, EU host.
+
+## C4 — marketplaceParticipations
+- GET https://sandbox.sellingpartnerapi-eu.amazon.com/sellers/v1/marketplaceParticipations
+- Result: HTTP 200
+- Returns canned US marketplace (ATVPDKIKX0DER, "BestSellerStore") regardless of host region (EU host, US data)
+- Finding: static sandbox does NOT vary marketplace by which regional host you call — same canned payload
+
+## O1/O2 — Orders v0 getOrders
+- GET https://sandbox.sellingpartnerapi-eu.amazon.com/orders/v0/orders?MarketplaceIds=ATVPDKIKX0DER&CreatedAfter=TEST_CASE_200
+- Result: HTTP 200, 2 sample orders (AmazonOrderId 902-1845936-5435065, 902-8745147-1934268)
+- v0 uses PascalCase query params (MarketplaceIds, CreatedAfter) — confirms X5 casing-change claim in issue
+- OrderTotal = {CurrencyCode, Amount} only — NO tax rate field at order-list grain (supports O10 desk claim, still need getOrderItems to fully confirm)
+- New field spotted not in issue desk research: ElectronicInvoiceStatus: "NotRequired" — worth flagging for invoicing story D1/D3
+- DefaultShipFromLocationAddress present with full address even in sandbox
+
+## v2026-01-01 searchOrders (NEW version)
+- GET https://sandbox.sellingpartnerapi-eu.amazon.com/orders/2026-01-01/orders?marketplaceIds=A1PA6795UKMFR9
+- US marketplace (ATVPDKIKX0DER) on EU host -> 403 "marketplaces you provided are not valid for region"
+- DE marketplace (A1PA6795UKMFR9) on EU host -> 400 "Could not match input arguments"
+- Finding: v2026-01-01 sandbox pattern for searchOrders NOT YET IDENTIFIED — camelCase param names, no known magic value found yet. Candidate risk: v2026 may not have static sandbox coverage at all (would corroborate X1 "Orders were not in dynamic list" going further — may not even be in static list with usable patterns)
+
+## O2 — Orders v0 getOrder (single) — orderId=TEST_CASE_200
+- GET https://sandbox.sellingpartnerapi-eu.amazon.com/orders/v0/orders/TEST_CASE_200
+- Result: HTTP 200, same payload shape as list
+
+## O8/O10/D3 — Orders v0 getOrderItems — orderId=TEST_CASE_200
+- GET https://sandbox.sellingpartnerapi-eu.amazon.com/orders/v0/orders/TEST_CASE_200/orderItems
+- Result: HTTP 200
+- ItemPrice = {CurrencyCode, Amount}, ItemTax = {CurrencyCode, Amount} — CONFIRMS O10 desk claim: amounts only, NO rate/percent field anywhere in the order-item payload. ADR-063 forbids deriving rate from tax/net -> Amazon lines are rate-less under v0, matching issue's prediction.
+- 🆕 NEW FINDING not flagged in issue desk research: "IossNumber":"" and "DeemedResellerCategory":"IOSS" fields present on OrderItem.
+  -> This is Amazon's analogue of eBay's D3 (marketplace-facilitator VAT/IOSS number) which #2880 flagged as missing for Amazon ("nothing in OL's order contract models it today" — but that was written for eBay's ebayCollectAndRemitTaxes field). Amazon HAS a comparable field. Worth adding to SPIKE-2881 D3 as a genuine finding, contradicting/extending the original issue text which does not mention IossNumber for Amazon at all.
+  -> DeemedResellerCategory suggests Amazon models "deemed reseller" VAT status (EU e-commerce VAT package concept) at line-item level.
+- 🆕 "BuyerRequestedCancel": {"IsBuyerRequestedCancel", "BuyerCancelReason"} present at line level — relevant to O12 (cancellation observation), more granular than issue's desk claim suggested (issue only cites includedData=CANCELLATION at order grain for v2026)
+- "StoreChainStoreId":"ISPU_StoreId" — ISPU = In-Store Pick Up, ties to O14/F7 pickup-point support
+
+## T7/S6/T6 — Listings Items API getListingsItem
+- GET https://sandbox.sellingpartnerapi-eu.amazon.com/listings/2021-08-01/items/A2TEST123/TEST-SKU-1?marketplaceIds=A1PA6795UKMFR9
+- Result: HTTP 200 (any sellerId/sku accepted — sandbox model has generic {} pattern, not test-case-keyed)
+- 🎯 CONFIRMS S6 desk claim directly: response carries an "issues" array alongside "summaries"/"offers"/"fulfillmentAvailability" — exactly the ADR-009-shaped disjoint-snapshot pattern the issue predicted (a clean write can still carry issues[])
+- Issue codes observed: 90220 (MISSING_ATTRIBUTE), 18027 (INVALID_IMAGE, with "enforcements.exemption.status: EXEMPT_UNTIL_EXPIRY_DATE" + expiryDate!), 99300 (PRODUCT rules violation), 18155 (INVALID_PRICE), 18742 (Restricted Products -> CATALOG_ITEM_REMOVED)
+- 🆕 NEW FINDING: "enforcements" object with "actions" (e.g. SEARCH_SUPPRESSED, ATTRIBUTE_SUPPRESSED, LISTING_SUPPRESSED, CATALOG_ITEM_REMOVED) and "exemption" (EXEMPT / EXEMPT_UNTIL_EXPIRY_DATE / NOT_EXEMPT) — much richer issue-severity model than Allegro/Erli have. Worth a dedicated line in T6/S6 in the SPIKE doc — this is a genuinely differentiated capability (per-issue enforcement + exemption tracking).
+- Two marketplaceId entries in one listing item response (ATVPDKIKX0DER US + A2EUQ1WTGCTBG2 CA) — sandbox canned data spans multiple markets in one payload, doesn't reflect the single EU marketplace we asked for (static sandbox limitation, consistent with C4 finding)
+
+## T1 — Product Type Definitions searchDefinitionsProductTypes
+- GET https://sandbox.sellingpartnerapi-eu.amazon.com/definitions/2020-09-01/productTypes?marketplaceIds=A1PA6795UKMFR9
+- Result: HTTP 200, minimal: {"productTypes":[{"name":"LUGGAGE","displayName":"Luggage","marketplaceIds":["ATVPDKIKX0DER"]}],"productTypeVersion":"..."}
+- Confirms endpoint reachable; does not resolve T1's real open question (no browse-node tree walk operation found) — that remains to verify against the full spec/documentation, sandbox alone can't answer it
+
+## T7 — Catalog Items getCatalogItem
+- GET https://sandbox.sellingpartnerapi-eu.amazon.com/catalog/2022-04-01/items/B00551Q3CS?marketplaceIds=A1PA6795UKMFR9
+- Result: HTTP 400 "Could not match input arguments"
+- Consistent with earlier finding: getCatalogItem model has NO x-amzn-api-sandbox object at all (confirmed via spec read) — genuinely unsupported in static sandbox, not just "wrong params". searchCatalogItems (plural/search) reportedly DOES have a sandbox config per the spec note — worth testing separately if time permits.
+
+## searchCatalogItems, Reports getReports — inconclusive
+- Both HTTP 400 "Could not match input arguments" — need exact x-amzn-api-sandbox param values from spec, not yet located (guessed generic params, wrong). Follow-up: fetch models/reports-api-model/reports_2021-06-30.json and catalogItems_2022-04-01.json searchCatalogItems block directly.
+
+## C13 — Notifications getDestinations
+- GET https://sandbox.sellingpartnerapi-eu.amazon.com/notifications/v1/destinations
+- Result: HTTP 403 Unauthorized (no details)
+- Hypothesis (per issue C2 note): Notifications/grantless operations may require a token minted via grant_type=client_credentials rather than grant_type=refresh_token. Our token was refresh_token-based (seller-authorized). NOT YET CONFIRMED — worth testing with a fresh client_credentials token.
+
+## Session summary (token near/at ~1h expiry by end of this batch)
+Confirmed via live sandbox calls:
+- C4 (marketplaceParticipations) — DONE, canned US data regardless of EU host
+- O1/O2/O8 (getOrders/getOrder/getOrderItems, Orders v0) — DONE, PascalCase confirmed, tax=amount-only confirmed (O10), IossNumber+DeemedResellerCategory found (new, feeds D3)
+- Listings getListingsItem — DONE, issues[]+enforcements[]+exemption structure confirmed (S6/T6)
+- Product Type Definitions searchDefinitionsProductTypes — reachable, minimal payload
+- Catalog getCatalogItem — CONFIRMED unsupported in static sandbox (no x-amzn-api-sandbox block in spec, 400 on any params)
+- searchCatalogItems, Reports getReports — inconclusive, need exact sandbox param patterns from spec (not found this session)
+- Notifications getDestinations — 403, possibly wrong grant_type (needs grantless/client_credentials token)
+- Orders v2026-01-01 searchOrders — inconclusive, region-valid but "could not match input arguments"; v0 pattern (TEST_CASE_200) does NOT carry over 1:1 to v2026 casing/shape
+
+Not attempted this session (would need real product data / feed uploads, out of scope for a first sandbox pass):
+- Feeds create/upload flow (P1/P4/S2)
+- Product Publish (putListingsItem POST, would mutate — deferred to avoid touching real listing state even in sandbox without understanding side effects)
+- FBA/Merchant Fulfillment (F2/F5)
+- Returns Reports (R1)
+
+## 🎯 O10 RESOLVED — from spec, without needing a successful live call
+The full x-amzn-api-sandbox block for v2026-01-01 searchOrders (Brazil test case, includedData=TAX) shows:
+```json
+"tax": {
+  "taxRegistrations": [
+    {"entityType":"BUYER","legalName":"...","taxRegistrationType":"VAT","taxRegistrationNumber":"1234567890"},
+    {"entityType":"MARKETPLACE","taxRegistrationType":"CNPJ","taxRegistrationNumber":"15436940"},
+    {"entityType":"MERCHANT","legalName":"TechStore"}
+  ],
+  "taxInvoicing": {"invoiceStatus":"PROCESSING"}
+}
+```
+**CONFIRMED: `includedData=TAX` carries tax REGISTRATION NUMBERS (VAT/CNPJ ids per entity: buyer/marketplace/merchant) and an invoice status — NOT a percentage rate anywhere.** This directly settles O10/D4: v2026 TAX data is amounts+registration-ids only, never a rate. ADR-063 forbids deriving rate from tax/net -> Amazon order lines are confirmed rate-less even under the new API version, matching the original issue's worry but now via documented evidence rather than a "found nothing" grep.
+Also: this is a SECOND marketplace-facilitator-VAT-style field family beyond v0's IossNumber — `taxRegistrations[].taxRegistrationType` genericizes across VAT/CNPJ/etc per entity role (BUYER/MARKETPLACE/MERCHANT). Relevant to D3.
+
+Full v2026 sandbox spec also reveals fields NOT mentioned in issue desk research at all:
+- `orderAliases[].aliasType: "SELLER_ORDER_ID"` — OL's own order ref roundtrip? Worth checking against O-external-order-ref equivalent (TikTok has one per #2882; unclear if Amazon does)
+- `picking.substitutionPreference.substitutionOptions[]` (UK test case) — buyer-approved substitute ASIN/SKU when out of stock — a genuinely new capability class not in any other researched platform
+- `packages[]` with `packageStatus.status/detailedStatus`, `carrier`, `trackingNumber`, `shipFromAddress` — confirms F1/F2 shape and that a package sits BELOW order/orderItem, similar caution to TikTok's "package != order" (F-extra in #2882)
+- `programs: ["AMAZON_BUSINESS","DELIVERY_BY_AMAZON"]`, `buyerCompanyName`, `buyerPurchaseOrderNumber`, `priceDesignation: "BUSINESS_PRICE"` — B2B order support, not mentioned anywhere in issue #2881
+
+## v2026-01-01 searchOrders — CONCLUSION after exhaustive param attempts
+Tried against exact spec values (UK test case) with 4 encoding variants:
+1. comma-joined includedData, urlencoded colons -> 400 InvalidInput
+2. repeated includedData= params, urlencoded colons -> 400 InvalidInput
+3. no includedData at all -> 400 InvalidInput
+4. comma-joined includedData, raw unencoded colons -> 400 InvalidInput
+All used the EXACT literal values copied from the model's own x-amzn-api-sandbox block (createdAfter=2024-12-23T00:00:00Z, marketplaceIds=A1F83G8C2ARO7P). Region check passes (UK marketplace accepted on EU host -> 400 not 403), so credentials/host/region are correct; only the STATIC PATTERN MATCH fails.
+**Working hypothesis (not fully proven): the v2026-01-01 static sandbox backend may not yet be actually wired to match the documented x-amzn-api-sandbox patterns** — the model file exists and is well-formed (verified by reading its full contents), but the sandbox SERVICE behind sandbox.sellingpartnerapi-eu.amazon.com does not appear to honour it as of this session (2026-09-04), unlike Orders v0 (TEST_CASE_200) and Listings v2021-08-01, which both worked cleanly on the first correctly-regioned attempt.
+This is a genuinely new, evidence-based finding for SPIKE-2881 X1/O1: v2026-01-01 being newer than v0, its sandbox coverage may lag its GA. Recommend flagging this explicitly rather than treating our failure as "wrong params" — worth an AWS support ticket / forum post to confirm, since this materially affects whether AC2's live transcript requirement can be met on v2026 in sandbox at all (may require live seller account testing sooner than expected for Orders specifically).
+
+## C13 — Grantless (client_credentials) token — INCONCLUSIVE
+- POST https://api.amazon.com/auth/o2/token, grant_type=client_credentials
+- No scope param -> "missing a required parameter: scope" (confirms scope is mandatory for this grant type)
+- scope=sellingpartnerapi::notifications -> invalid_scope
+- scope=sellingpartnerapi::migration -> invalid_scope
+- scope=notifications (no prefix) -> invalid_scope
+- Hypothesis: this app (Private, "OL-testt") may not have "Grantless operations" / Notifications role enabled at registration — client_credentials grant may need to be explicitly turned on for the app in Developer Central (separate from the normal seller-authorization roles), OR the two commonly-cited scope strings are stale/wrong and the real ones need to be found in current official docs (could not locate them via automated search this session — notifications.json model itself contains no "scope" string at all).
+- ACTION NEEDED (manual): check Developer Central app edit screen for a "Grantless operations" / role toggle; if present, enable it for OL-testt and retry. This blocks further progress on C13 (Notifications) and X1's grantless-token questions this session.
+
+## C13 — Grantless token, FINAL CONCLUSION for this session
+- Confirmed via popular community SDK (saleweaver/python-amazon-sp-api, sp_api/api/notifications/notifications.py): `grantless_scope = "sellingpartnerapi::notifications"` — EXACTLY the value we tried and got rejected with invalid_scope.
+- So the scope STRING is correct. The rejection is therefore an ACCOUNT/APP-level restriction, not a typo.
+- Official docs (developer-docs.amazon/sp-api/docs/grantless-operations) state verbatim: "grantless operations apply only to seller applications" — our app was registered via Solution Provider Portal as a generic app client under "Build applications that use SP APIs" (Solution Type step) — its exact classification as a "seller application" vs some other type is UNCONFIRMED and is the most likely cause.
+- Working theory to verify manually (not resolvable via API/desk research alone): the app may need role/production approval, OR may need to be created specifically as tied to a seller account (self-authorized) BEFORE grantless client_credentials works — i.e. grantless might depend on there being at least one active self-authorization on the app, which we DO have (from the earlier successful refresh_token flow) — so this theory is weaker.
+- Recommend as a NEXT STEP for #2881 X1/C13: file a question on the SP-API developer forum/AWS re:Post, or open an AWS support case, since automated research has been exhausted — this is a genuine external unknown, not a research gap on our side.
+- STATUS: BLOCKED, needs human/support-channel follow-up. Do not spend further automated attempts on scope-string guessing.
+
+## SESSION 2 — desk research (no live token needed)
+
+### 🎯 T1 RESOLVED — confirmed absent across every candidate API, primary source
+Checked full path lists of every Catalog Items API version + Product Type Definitions API:
+- Product Type Definitions 2020-09-01: ONLY `searchDefinitionsProductTypes` + `getDefinitionsProductType` — no tree walk
+- Catalog Items 2022-04-01: ONLY `/catalog/2022-04-01/items` (search) + `/catalog/2022-04-01/items/{asin}` (get one) — no tree walk
+- Catalog Items 2020-12-01: same two-path shape — no tree walk
+- Catalog Items v0 (deprecated): HAS `/catalog/v0/categories` (`listCatalogCategories`) — BUT this returns the ANCESTOR PATH for one specific ASIN/SellerSKU only ("Returns the parent categories to which an item belongs, based on the specified ASIN or SellerSKU"), NOT a browsable/walkable tree from root. Equivalent to a `CategoryPathReader`-shaped read (needs an existing product to resolve), not a `CategoryBrowser`-shaped one (walk from root, no product needed).
+
+**CONCLUSION: T1 is DEFINITIVELY confirmed — no operation anywhere in the current or deprecated SP-API surface lets you browse/discover Amazon's category tree independently of an existing product.** This is stronger evidence than the original issue had (which said "no operation... was found" as a search gap); now it's "checked every path in every version, confirmed absent, found the nearest analogue and confirmed it's the wrong shape."
+Consequence for `DestinationCategory` (#1979): does NOT transfer to Amazon as designed. The wizard's category-picker UX (shared Allegro/Erli/WooCommerce pattern) needs a different mechanism — likely `searchDefinitionsProductTypes` (search-by-keyword to find a product type) as the entry point instead of tree navigation, since product type IS Amazon's organizing unit (matches the issue's own framing).
+
+### F5 RESOLVED — Poland confirmed absent from FBM Ship+ table (independent source)
+Read the Merchant Fulfillment API use-case guide's own availability table directly:
+| Amazon store | Cross-border (China origin) | Domestic |
+| US | CN2US | US DOM (06/2026) |
+| UK | CN2UK | UK DOM |
+| DE | CN2DE | DE DOM |
+| ES | CN2ES | ES DOM (Q3 2026) |
+| FR | CN2FR | FR DOM (Q4 2026) |
+| IT | CN2IT | IT DOM (Q4 2026) |
+| JP | CN2JP | - |
+| AU | CN2AU | - |
+Poland is absent — CONFIRMS the issue's own finding from an independent read of the primary source (not just re-reading the same page). F5 stays 🔴 for Poland — Buy Shipping is not available there via Merchant Fulfillment/FBM Ship+, in any form found.
+
+### X7 — fee saga, still unresolved but with a more precise negative result
+Checked official SP-API release notes (developer-docs.amazon/sp-api/docs/sp-api-release-notes) spanning
+2024-06 through 2026-08 — ZERO mentions of any developer subscription fee, usage fee, delay, postponement or
+cancellation, in either direction. 
+IMPORTANT NUANCE: this is likely because release notes are a technical-changelog document type (API version
+changes), not a billing-announcement channel — its silence does NOT confirm OR refute the trade-press saga
+described in the issue. It simply means this particular document type was the wrong place to look; a real fee
+change would more likely be announced via Seller Central notifications, a dedicated pricing page, or email to
+registered developers — none of which are checkable via this research method (login-gated / not indexed).
+STATUS UNCHANGED: still UNVERIFIED, now with one more (negative, inconclusive) data point. Recommend the
+issue's own instruction stands: verify independently (e.g. ask in Seller Central / check billing settings
+directly) before any planning depends on it.
+
+## SESSION 3 — new access_token, continuing live tests
+
+### Reports getReports — WORKS
+- GET https://sandbox.sellingpartnerapi-eu.amazon.com/reports/2021-06-30/reports?reportTypes=FEE_DISCOUNTS_REPORT,GET_AFN_INVENTORY_DATA&processingStatuses=IN_QUEUE,IN_PROGRESS
+- HTTP 200, one sample report with reportId/reportType/dataStartTime/dataEndTime/createdTime/processingStatus/processingStartTime/processingEndTime + nextToken
+- Confirms Reports API reachable in static sandbox with comma-joined array params (unlike Orders v2026 which failed with the same style — inconsistent sandbox implementation quality across APIs)
+
+### T7 PARTIALLY UPGRADED — searchCatalogItems WORKS (unlike getCatalogItem)
+- GET https://sandbox.sellingpartnerapi-NA.amazon.com/catalog/2022-04-01/items?keywords=samsung,tv&marketplaceIds=ATVPDKIKX0DER&includedData=classifications,dimensions,identifiers,images,productTypes,relationships,salesRanks,summaries,vendorDetails
+- Region note: required NA host (US marketplace baked into the sandbox pattern) — EU host rejects it (403), matching the same US-marketplace-pattern-vs-EU-host conflict seen with Orders v2026's UK/Brazil test cases
+- HTTP 200, RICH response:
+  - "classifications": full browse-classification PARENT CHAIN per item — "QLED TVs" -> parent "Televisions" -> parent "Television & Video" -> parent "Electronics". CONFIRMS the issue's T1 claim that Catalog Items exposes browse classifications ON ITEMS — but this is scoped to a MATCHED product, not an independently-walkable tree (consistent with T1's resolution above: still can't discover the tree without first finding a product via keyword search)
+  - "identifiers": EAN/GTIN/UPC all present per item — directly useful for T7/barcode-matching (CatalogProductReader, EAN-based offer linking parity with Allegro)
+  - "relationships": type "VARIATION" with "parentAsins" + "variationTheme": {"attributes":["color","size"],"theme":"SIZE_NAME/COLOR_NAME"} — directly relevant to P8 (multi-variant grouping via parentageLevel) — confirms Amazon's variation model is queryable this way
+  - "vendorDetails": brandCode/manufacturerCode/productCategory/productSubcategory — vendor-specific, likely only relevant for Vendor Central sellers not Seller Central/3P, worth noting as out of scope
+  - "dimensions": full item + package height/length/weight/width with units — relevant to #1842 (required-to-sell preflight, MISSING_DIMENSIONS check) IF Amazon required this at publish (not yet confirmed as a write requirement, only that reads expose it)
+- REVISED T7 STATUS: getCatalogItem (single-ASIN read) has NO sandbox support; searchCatalogItems (keyword search) DOES and works cleanly. For a CatalogProductReader-shaped capability (find a product by barcode/keyword before offering against it), searchCatalogItems is the right operation anyway — this is actually GOOD news, upgrades T7 from "confirmed unsupported" to "confirmed supported via the search variant, single-item read unsupported in sandbox specifically"
+
+### getDefinitionsProductType — WORKS, reveals GTIN exemption field name (P2)
+- GET https://sandbox.sellingpartnerapi-na.amazon.com/definitions/2020-09-01/productTypes/LUGGAGE?marketplaceIds=ATVPDKIKX0DER&sellerId=A2TEST123
+- HTTP 200
+- Response: "schema" is a LINK object ({"link":{"resource":"https://schema-url","verb":"GET"}}), NOT the inline JSON Schema — sandbox does not let us fetch the actual schema-url (it's a stub), so T5 (conditional-required-attributes structure) STILL cannot be directly exercised via sandbox. Would need a real product type schema fetch against production/real seller account.
+- 🎯 NEW: "propertyGroups.product_identity.propertyNames" includes **"gtin_exemption_reason"** as a real, named schema property alongside item_name/brand/external_product_id/merchant_suggested_asin/product_type/etc. This is the actual attribute name a listing payload would set — differs slightly from the issue's cited "supplier_declared_has_product_identifier_exemption" (which may be an older/different field name, or the issue's source was imprecise). Worth flagging as a P2 refinement: confirm the EXACT current field name against a real product type schema before implementation — do not trust either name blindly.
+- Also reveals "requirements":"LISTING", "requirementsEnforced":"ENFORCED" — a per-product-type flag for whether requirements are actively enforced, worth noting for T5/T6.
+
+## METHODOLOGY NOTE — WebFetch summarizer gave a false negative
+Asked WebFetch to find confirmShipment's sandbox block in ordersV0.json; it replied "cannot find a
+confirmShipment operation" and listed 8 operations, omitting confirmShipment entirely. Direct `grep -o
+'"operationId": *"[^"]*"'` on the raw file confirms confirmShipment DOES exist, alongside updateShipmentStatus
+AND updateVerificationStatus (9 operations total, not 8). CONCLUSION: WebFetch's summarizing model is not
+100% reliable for exhaustive "does X exist" questions on large files — always cross-check a negative/absent
+finding with a direct grep on raw content before recording it as a confirmed absence. (This changes nothing
+about the earlier T1 "confirmed absent" conclusions — those WERE cross-checked with direct grep of path lists,
+not just WebFetch summaries — but it's a good reminder to keep doing that.)
+
+## SESSION 3 continued — methodology fix + full flow verifications
+
+### METHODOLOGY FIX: x-amzn-api-sandbox lives under responses.{code}, not at operation top-level
+Earlier "NO SANDBOX BLOCK" conclusions for confirmShipment/updateShipmentStatus/patchListingsItem were WRONG
+— I was checking `op['x-amzn-api-sandbox']` (operation top level) when the real location is
+`op['responses'][code]['x-amzn-api-sandbox']` (nested per response code, e.g. under '204' or '200' or '400').
+Confirmed by inspecting getListingsItem's actual key structure (it succeeded live but showed no top-level
+block — the block was under responses.200 and responses.400). RETROACTIVE CORRECTION: any earlier claim in
+this log of "no sandbox block" for an operation should be treated as UNVERIFIED unless it was checked via a
+full path-list absence (like T1's Catalog Items check, which enumerated actual PATHS, not sandbox blocks — T1
+conclusions stand) or corrected below. getCatalogItem's "no sandbox at all" claim (T7, session 1) should be
+RE-VERIFIED with this corrected method before being trusted further.
+
+### F2 — confirmShipment: ✅ VERIFIED LIVE, WORKS
+- POST /orders/v0/orders/902-1106328-1059050/shipmentConfirmation, FedEx package detail body from spec
+- HTTP 204 (success, no body) — confirms the issue's F2 claim that confirmShipment exists and this shape works, contradicting nothing
+- Sibling operation `updateShipmentStatus` (POST /orders/v0/orders/{orderId}/shipment) ALSO exists and ALSO works (empty-body pattern -> 204) — NOT mentioned anywhere in the original issue's F2 story. Its purpose (per its 400-pattern body: {"marketplaceId":"1","shipmentStatus":"ReadyForPickup"}) appears to be a lighter-weight shipment status update distinct from the full confirmShipment package-detail flow — worth investigating what "ReadyForPickup" and sibling statuses mean, may be relevant to pickup-point/ISPU flows (O14/F7).
+
+### P1/P4 — Feeds full flow: ✅ VERIFIED LIVE END TO END
+1. POST /feeds/2021-06-30/documents {"contentType":"text/tab-separated-values; charset=UTF-8"} -> 201, {feedDocumentId, url} (url is a real-looking CloudFront upload target)
+2. POST /feeds/2021-06-30/feeds {"feedType":"POST_PRODUCT_DATA","marketplaceIds":[...],"inputFeedDocumentId":...} -> 202, {feedId}
+3. GET /feeds/2021-06-30/feeds/feedId1 -> 200, {feedId,feedType,createdTime,processingStatus:"CANCELLED",processingStartTime,processingEndTime}
+CONFIRMS the issue's P1/P4 desk claim: async poll-for-result shape (create -> upload -> create feed -> poll) maps directly onto OL's OfferCreationRecord + poller pattern. Note the canned processingStatus is "CANCELLED" not "DONE" — sandbox doesn't simulate a full happy path to completion, just proves the shape is reachable.
+
+### R1 — Reports full flow: ✅ VERIFIED LIVE END TO END (general mechanism; specific returns report type not yet tested)
+1. POST /reports/2021-06-30/reports {"reportType":"GET_MERCHANT_LISTINGS_ALL_DATA","dataStartTime":...,"marketplaceIds":[...]} -> 202, {reportId}
+2. GET /reports/2021-06-30/documents/0356cf79-b8b0-4226-b4b9-0ee058ea5760 -> 200, {reportDocumentId, url} (CloudFront download target)
+CONFIRMS the general Reports API mechanism (create -> poll status via getReports/getReport -> fetch document via getReportDocument -> download from url) works end to end in sandbox. This is the SAME mechanism R1 (returns) depends on, just tested with a listings report type rather than GET_XML_RETURNS_DATA_BY_RETURN_DATE specifically (no sandbox pattern found yet for that exact report type — would need its own targeted lookup). High confidence the returns report type uses the identical createReport/getReport/getReportDocument shape, just with a different reportType string and (per the issue) a 60-day max window and the D2C Shipping role gate.
+
+### 🔴 CORRECTION — T7 getCatalogItem was WRONGLY marked "unsupported" in Session 1
+Re-checked with the fixed methodology (responses.{code}.x-amzn-api-sandbox, not operation top-level):
+getCatalogItem DOES have a sandbox pattern: asin=B07N4M94X4, marketplaceIds=ATVPDKIKX0DER,
+includedData=classifications,dimensions,identifiers,images,productTypes,relationships,salesRanks,summaries,vendorDetails
+- GET https://sandbox.sellingpartnerapi-NA.amazon.com/catalog/2022-04-01/items/B07N4M94X4?... -> HTTP 200, full rich payload (same shape as searchCatalogItems' matched item)
+SESSION 1's CLAIM "getCatalogItem genuinely unsupported in static sandbox" WAS WRONG — caused by checking op-level x-amzn-api-sandbox instead of the nested per-response-code location. CORRECTED: getCatalogItem IS supported, same as searchCatalogItems. Both give the classification/dimensions/identifiers/relationships/vendorDetails payload for the one canned ASIN B07N4M94X4.
+
+### 🆕 NEW CAPABILITY CLASS — Regulated Order Verification (not in issue at all)
+- GET /orders/v0/orders/902-3159896-1390916/regulatedInfo -> HTTP 200
+- Response: {"RequiresDosageLabel":false,"RegulatedInformation":{"Fields":[{"FieldId":"pet_prescription_name","FieldValue":"Ruffus"},{"FieldId":"pet_prescription_species","FieldValue":"Dog"}]},"RegulatedOrderVerificationStatus":{"Status":"Pending","RequiresMerchantAction":true,"ValidRejectionReasons":[...]}}
+- This is Amazon's "Shield" compliance program for regulated products (pet prescriptions shown in sample; presumably also applies to age-restricted/weapons/pharma-adjacent categories). A seller in a regulated category must review and approve/reject verification info before an order ships. `updateVerificationStatus` (PATCH, same path) lets the seller reject with a reason code (e.g. "shield_pom_vps_reject_incorrect_weight" — POM = "Product Of Medicine"/prescription-only-medicine).
+- NOT mentioned ANYWHERE in the original issue's checklist. Likely NICHE (only relevant if OL's Amazon-selling customers list regulated products), but if relevant, it's a genuinely new order-lifecycle gate no other researched platform (#2879/#2880/#2882) has an equivalent of. Worth one line in the SPIKE as a category to be aware of, deliberately out of scope unless a customer need surfaces.
+
+### S10 — searchListingsItems: ✅ VERIFIED LIVE
+- GET /listings/2021-08-01/items/SellerId?identifiersType=SKU&identifiers=GM-ZDPI-9B4E,HW-ZDPI-9B4E,TC-ZDPI-9B4E&marketplaceIds=ATVPDKIKX0DER,A2EUQ1WTGCTBG2&includedData=summaries,offers,fulfillmentAvailability,issues&pageSize=1 (NA host required, same US-marketplace-pattern rule)
+- HTTP 200, {numberOfResults, pagination:{nextToken,previousToken}, items:[...]} — same rich issues/enforcements shape as getListingsItem (Evidence #7). Confirms S10 (enumerate listings -> reconcile mappings) works and returns pagination tokens for a full sweep.
+
+### O5 — masked buyer email pattern, CONFIRMED with higher confidence than issue's source
+Grepped both order model files' canned sample data (not a GitHub issue thread — the OFFICIAL Amazon model
+repo's own representative samples): EVERY buyerEmail sample across JP/UK/Brazil/Turkey/generic test cases
+follows "buyer-email@marketplace.amazon.<tld>" — e.g. "buyer-email@marketplace.amazon.co.jp",
+"...co.uk", "...com.br", "...com.tr". This is the SAME masked-relay pattern the issue predicted from GitHub
+issue threads (which it flagged as "PARTLY UNCONFIRMED"), now corroborated by Amazon's own official model
+samples. Upgrades confidence from "community-report, availability may change without notice" to "consistent
+across every official sample in the current model file" — still not a live production email (sandbox samples
+are illustrative, not a guarantee of production behavior), but meaningfully stronger evidence.
+
+### O7 — buyer tax id: RESOLVED, same field family as D3
+Confirmed via schema definitions grep: `OrderTaxRegistration` / `TaxRegistrationAttribute` exist, and the
+LIVE sample data already captured (Evidence #4, Brazil test case) shows:
+```json
+"taxRegistrations": [
+  {"entityType":"BUYER","legalName":"Oliveira Tecnologia Ltda","taxRegistrationType":"VAT","taxRegistrationNumber":"1234567890"},
+  {"entityType":"MARKETPLACE","taxRegistrationType":"CNPJ","taxRegistrationNumber":"15436940"},
+  {"entityType":"MERCHANT","legalName":"TechStore"}
+]
+```
+**O7 is answered by the SAME field as D3**: `taxRegistrations[].entityType === "BUYER"` carries the buyer's
+own tax registration (VAT number in this sample) alongside their legal/company name — this is a genuine buyer
+tax id, present when `includedData=TAX` is requested. One list, three roles (BUYER/MARKETPLACE/MERCHANT) —
+O7, D3 and part of D1/D2 (buyer data sufficient to invoice) all draw from this single array. Worth modelling
+as ONE mapping concern in the eventual adapter rather than three separate reads.
+
+### P9 — no tax-rate field anywhere in Listings Items API model
+Grepped the FULL listingsItems_2021-08-01.json model for any key containing "tax" — ZERO matches. There is no
+top-level Listings API field for setting a tax rate at publish time (unlike Erli's enum `taxRate` field the
+issue compared it to). Two readings, not mutually exclusive:
+1. Tax rate might live INSIDE the dynamic product-type JSON Schema (a per-product-type attribute set via
+   `patches`/`attributes`, not a fixed Listings API field) — consistent with product-type schemas being where
+   category-specific fields live (T5/T6).
+2. More likely, given Evidence #3/#4/#24 (IossNumber, DeemedResellerCategory, taxRegistrations with
+   entityType:"MARKETPLACE"): Amazon is very often the VAT-collecting MARKETPLACE FACILITATOR itself for
+   EU/UK sales (post-2021 EU VAT e-commerce package, and UK's own post-Brexit marketplace rules) — Amazon may
+   simply calculate and remit VAT on the seller's behalf for many transactions, meaning there may be NO
+   seller-settable rate to begin with for a large share of orders. This would be a materially different shape
+   from Allegro/Erli's model (seller declares the rate) and needs to be stated as a hypothesis to confirm
+   against real product-type schemas and Seller Central tax settings, not assumed.
+This reframes P9 from "missing feature to work around" to "possibly the wrong mental model — Amazon may own
+tax entirely for FR/DE/PL, same posture ADR-063/#2245 already handles for other 'marketplace facilitator'
+cases." Recommend checking Seller Central's own VAT/tax settings documentation next, not just the API schema.
+
+### X2 — no rate-limit-query API exists anywhere (confirms C8)
+Searched the full model repo top-level directory listing for anything named "rate"/"rate-limit" — zero
+matches (unlike eBay's #2880 finding of `GET /developer/analytics/v1_beta/rate_limit/`). CONFIRMS the issue's
+C8 claim precisely: no quota-query API, react to 429 only. Amazon is structurally worse than eBay on this
+specific axis — no rate-limit observability endpoint at all.
+
+### S8 — CONFIRMED: no real deactivate/withdraw primitive exists
+Full Listings Items API operation list: deleteListingsItem (hard DELETE), getListingsItem, patchListingsItem,
+putListingsItem, searchListingsItems. No "deactivate"/"withdraw"/"pause" verb or status-enum found anywhere in
+the model. `deleteListingsItem`'s own description is "Delete a listings item" — a hard delete, not eBay's
+`withdrawOffer` shape (#2880 S8: "goes into the unpublished state, and will require a publishOffer call to
+relist"). CONFIRMS the issue's own S8 hedge precisely: quantity=0 via patchListingsItem (fulfillment_availability
+merge, Evidence #16/#17) is genuinely the only pause mechanism — same posture as Allegro/Erli, NOT eBay's
+superior withdraw-and-relist model. #1689's OfferDeactivator gap stays unfilled by Amazon.
+
+### D8/R4-R7 — CONFIRMED, no refund/return write operation anywhere in SP-API
+Enumerated ALL operations in the Finances API (the most likely candidate for a refund-write capability):
+- financesV0: 4 read-only operations (listFinancialEventGroups/listFinancialEventsByGroupId/
+  listFinancialEventsByOrderId/listFinancialEvents)
+- finances_2024-06-19: 3 read-only (listTransactions/listBalances/listSummary)
+- transfers_2024-06-01: initiatePayout (POST, but this pays the SELLER — a payout, not a buyer refund),
+  listPayouts, getPaymentMethods, listExpectedPayouts
+- financesInvoices_2026-06-25: 2 read-only (getInvoiceHeaders/getInvoice)
+Combined with the already-confirmed absence of any refund/return-write path in Orders (v0 or v2026), and
+Reports being read-only by construction (R1), this gives HIGH CONFIDENCE (three independent negative checks
+across the three most plausible API groups) rather than a single "not found" search:
+**CONFIRMED: D8 (RefundExecutor) and R4/R5/R6/R7 (approve/decline/receive/refund a return) are all genuinely
+NOT SUPPORTED anywhere in current SP-API.** A refund must happen through Seller Central manually or as part
+of Amazon's own automated returns processing that sellers have no programmatic write access to. This is a
+structural, not a research-gap, conclusion — matches the issue's own "❌ report-only, nothing writable found"
+hedge, now confirmed rather than merely suspected.
+
+### 🎯 MAJOR — P9/D3/D5 all resolve together via the tax schema definitions
+Direct schema inspection (definitions section, orders_2026-01-01.json):
+
+**P9/D3 DEFINITIVELY CONFIRMED (was hypothesis, now certain):**
+`ItemTaxCollection.model` field, possible value `"MARKETPLACE_FACILITATOR"`, described VERBATIM as:
+*"Tax is withheld and remitted to the taxing authority by Amazon on behalf of the seller"*
+Plus `ItemTaxCollection.responsibleParty` — names who actually owes/remits.
+Plus `ItemTaxCalculationBreakdown.reportingScheme`: `UOSS` (Union One-Stop-Shop — item held in EU) /
+`IOSS` (Import One-Stop-Shop — item not held in EU) — the exact EU VAT e-commerce package scheme identifiers.
+**This is no longer a hypothesis: Amazon has a NAMED, DOCUMENTED per-item field stating whether IT (not the
+seller) is the party remitting VAT, and which EU cross-border VAT scheme applies.** P9's "missing tax rate
+field" reads entirely differently now: for MARKETPLACE_FACILITATOR items, there IS no seller-settable rate
+because the seller has no VAT liability to declare — Amazon owns it end to end. This directly extends #2245's
+existing "marketplace facilitator" tax posture (ADR-063) — Amazon needs the SAME treatment eBay's
+`ebayCollectAndRemitTaxes` and Amazon's own v0 `IossNumber`/`DeemedResellerCategory` already hinted at, now
+with a definitive schema-level confirmation.
+
+**D5 RESOLVED — Amazon natively separates shipping tax from item tax, OL may not need to compute the split:**
+`ItemProceedsDetailedBreakdown.subtype` enum: `ITEM`, `SHIPPING`, `GIFT_WRAP`, `COD_FEE`, `OTHER`, `DISCOUNT`
+— "only available for TAX and DISCOUNT proceeds types" — meaning when the TAX proceeds category is broken
+down in detail, Amazon reports a SEPARATE subtotal for the SHIPPING-attributable portion vs the ITEM-attributable
+portion. **This means Amazon may not need `splitShippingAcrossRates` (#2248/#2252) at all for its own tax
+figures — Amazon already does the split and reports it natively**, unlike a platform where OL has to derive
+the shipping-tax portion itself from a lump sum. Recommend confirming this against a real order with
+`includedData=TAX` returning a genuinely mixed-rate basket, since the sandbox sample data doesn't populate
+this level of detail by default.

--- a/.research/sandbox-test-log.md
+++ b/.research/sandbox-test-log.md
@@ -349,3 +349,76 @@ figures — Amazon already does the split and reports it natively**, unlike a pl
 the shipping-tax portion itself from a lump sum. Recommend confirming this against a real order with
 `includedData=TAX` returning a genuinely mixed-rate basket, since the sandbox sample data doesn't populate
 this level of detail by default.
+
+## SESSION 3 (2026-09-07) — C13 Notifications: partially UNBLOCKED, prior conclusion CORRECTED
+
+Live re-test with the same sandbox app ("OL-testt", Solution Provider Portal, **Status: `Sandbox`**) and a
+freshly minted sandbox refresh token (obtained via the app-list dropdown -> "Create Token" -> Sandbox Testing
+page — NOT via Seller Central "Develop Apps" / "Authorize app", which does not exist for a Sandbox-status app).
+
+### 🔧 CORRECTION to Session 1's C13 conclusion
+Session 1 recorded a single `403` on `getDestinations` with a refresh_token-based token and hypothesised a
+missing "Notifications" role, i.e. that the whole Notifications API was blocked for this app. **That was
+wrong.** Per-operation testing shows the API is largely usable in the static sandbox — only the *destination
+write/list* half is refused. Session 1's error was generalising from one operation to a whole API.
+
+Note also: one earlier `403` in this session carried `"details": "The access token you provided is revoked,
+malformed or invalid."` — that was an artefact of a **truncated** access token (copied through `head -c 300`),
+not a real auth signal. The genuine refusal carries an EMPTY `details`. Worth knowing: a truncated bearer
+token and a genuinely unauthorized one are distinguishable only by that field.
+
+### Static sandbox support is REAL for Notifications — confirmed from the model, not inferred
+`models/notifications-api-model/notifications.json` (note: `notifications.json`, not `notifications_v1.json`)
+carries **11 `x-amzn-api-sandbox` blocks across 9 of 10 operations**. `getDestinations`' block declares
+`"parameters": {}` — i.e. no params, exactly as we called it — so the `403` is unambiguously **authorization**,
+never a static-pattern mismatch (which answers `400 "Could not match input arguments"`).
+**`sendTestNotification` is the ONE operation with no sandbox block at all.**
+
+### Results — seller-authorized token (grant_type=refresh_token), host NA (EU/FE identical where tested)
+| Operation | Grantless per docs? | Result |
+|---|---|---|
+| `getSubscriptions?notificationTypes=ANY_OFFER_CHANGED` | no | ✅ 200, canned subscription |
+| `getSubscription/ANY_OFFER_CHANGED` | no | ✅ 200, `TEST_CASE_200_SUBSCRIPTION_ID` |
+| `createSubscription/ANY_OFFER_CHANGED` | no | ✅ 200, `TEST_CASE_200_SUBSCRIPTION_ID` |
+| `getDestination/{id}` (single) | **yes** | ✅ 200, canned SQS destination |
+| `getDestinations` (list) | **yes** | ❌ 403 Unauthorized, empty `details` — on **all three** hosts (EU/NA/FE) |
+| `createDestination` | **yes** | ❌ 403 Unauthorized, empty `details` |
+| `getSubscriptionById/{id}` | **yes** | ❌ 500 InternalFailure (Amazon-side, not ours) |
+| `deleteSubscriptionById/{id}` | **yes** | ❌ 500 InternalFailure (Amazon-side, not ours) |
+| `sendTestNotification` | no | ❌ no sandbox support (no model block) |
+
+**The grantless/non-grantless split does NOT cleanly predict the outcome** — `getDestination` (single) is
+documented grantless yet answers 200 on a seller token, while `getDestinations` (list) is equally grantless and
+answers 403. So "grantless ops need a grantless token" is not a sufficient explanation; the sandbox's
+per-operation authorization is inconsistent. Flag rather than rationalise.
+
+### 🎯 Root cause of `invalid_scope`: grantless is unavailable to this app ENTIRELY, not per-scope
+Five scopes tested against `grant_type=client_credentials`, **all `invalid_scope`**:
+`sellingpartnerapi::notifications`, `::migration`, `::client_credential:rotation`, `::shipping`, `::tracking`.
+
+The decisive one is **`sellingpartnerapi::client_credential:rotation`** — a generic scope backing
+`rotateApplicationClientSecret`, available to any normally-registered SP-API app regardless of roles. Its
+rejection means the **whole `client_credentials` grant is refused for this app client**, so this was never a
+missing-Notifications-role problem. Combined with the portal UI evidence (Status `Sandbox`; the app-edit form
+offers only `API Type: SP API` with no roles section; the row dropdown offers only "Create Token"), the
+explanation is the **app registration tier**: a Sandbox-status app has no role-request surface and no grantless
+grant. Session 1's official-docs quote ("grantless operations apply only to seller applications") is consistent
+with this.
+**Not verified**: that a full Private/Public registration *would* grant it. That remains the open assumption.
+
+### What this means for the epic — the transport still cannot be validated in sandbox
+The subscription CONTRACT is now verifiable (subscribe/read/enumerate all answer 200). The **delivery channel
+is not**, and that is the half that matters for OL's cost estimate:
+- `createDestination` → 403, so no SQS/EventBridge destination can be registered at all;
+- `sendTestNotification` → no sandbox support, so no notification can be made to arrive.
+So **no end-to-end notification can be observed in the static sandbox under any app tier** (the second half is
+a model-level absence, not a permission). Validating the inbound transport — ADR-049-shaped durable ingress,
+the epic's #1 architectural cost driver — requires a **fully registered app plus a real SQS queue**, and is
+therefore live-account work, not sandbox work. This narrows C13 from "blocked, unknown" to "contract verified,
+transport unverifiable in sandbox by construction".
+
+### Practical note for anyone re-running this
+`getDestinations`' 403 is reproducible on EU, NA and FE hosts, so it is not the region-mismatch cause the
+official "Authorization Errors" page lists. Session 2's community-thread reading (role-related 403s on
+`createSubscription`) does **not** apply here — `createSubscription` is precisely one of the operations that
+works.

--- a/.research/sandbox-test-log.md
+++ b/.research/sandbox-test-log.md
@@ -422,3 +422,355 @@ transport unverifiable in sandbox by construction".
 official "Authorization Errors" page lists. Session 2's community-thread reading (role-related 403s on
 `createSubscription`) does **not** apply here — `createSubscription` is precisely one of the operations that
 works.
+
+## SESSION 3b (2026-09-07) — F5 was checked against only ONE of two shipping-purchase APIs
+
+### 🔍 The gap: `shipping-api-model` is a SEPARATE API from `merchant-fulfillment-api-model`
+Enumerated all 53 API model directories in `amzn/selling-partner-api-models`. Session 1/2's F5 work read the
+**Merchant Fulfillment** use-case guide's availability table only. There is a second, independent
+label-purchasing API — **Amazon Shipping API v2** (`shipping-api-model/shippingV2.json`) — carrying
+`getRates`, `purchaseShipment`, `directPurchaseShipment`, `oneClickShipment`, `getTracking`,
+`getShipmentDocuments`, `cancelShipment`, `getAccessPoints`, `linkCarrierAccount`, `submitNdrFeedback`,
+`createClaim`. **11 of its 12 sandbox blocks are `dynamic`**, not static (only `getAdditionalInputs` is static)
+— which matters, because the dynamic sandbox routes to a real backend and therefore answers *country-specific*
+questions a static canned payload never could.
+Also enumerated for completeness: `easy-ship-model`, `delivery-by-amazon`, `external-fulfillment` — not tested.
+
+### ✅ VERIFIED LIVE, END TO END — you *can* buy a label through the API, and get the label bytes back
+Against the dynamic sandbox (`sandbox.sellingpartnerapi-eu`), seller-authorized token, GB domestic:
+1. `POST /shipping/v2/shipments/rates` -> **200**, `requestToken` + 2 rates
+   (`Amazon Shipping One Day` 4.01 GBP, `Amazon Shipping Two Day` 3 GBP), each with a `rateId`;
+2. `POST /shipping/v2/shipments` with that `{requestToken, rateId}` and
+   `requestedDocumentSpecification: {format: PNG, size 4x6 INCH, requestedDocumentTypes: [LABEL]}`
+   -> **200**, `shipmentId: amzn1.sid.97458981074956.100` plus `packageDocuments[].contents` carrying **real
+   base64 PNG label bytes** (verified `iVBORw0KGgo…` PNG magic).
+So the full rate->purchase->label flow is exercisable in sandbox. This is a *stronger* capability confirmation
+than anything F5 previously had, and it is the OL-relevant "buy shipping via API" question answered directly.
+
+### 🎯 F5 for POLAND — refused by a POSITIVE service-side answer, with a working control
+| shipTo/shipFrom country | `getRates` result |
+|---|---|
+| GB | ✅ 200, 2 rates + rateIds |
+| FR | ✅ 200, rates returned |
+| **PL** | ❌ 400 `There is no marketplaceId configured to AmazonShippingIdentifier = AmazonShipping_PL for the AmazonShipping` |
+| DE | ❌ 400, same shape (`AmazonShipping_DE`) |
+| US | ❌ 400, same shape (`AmazonShipping_US`) |
+
+**The GB/FR control is what makes this evidence rather than a shrug**: they prove the app is authorized for
+Shipping v2 and the dynamic sandbox is reachable, so the PL refusal is country-scoped and not an artefact of a
+misconfigured sandbox app. Amazon *names* the missing configuration (`AmazonShipping_PL`), which is a positive
+assertion of absence — materially better than Session 2's "Poland is absent from a docs availability table".
+
+### ⚠️ Do NOT generalise one shipping API's country list to the other
+Merchant Fulfillment's own table lists **DE and US** as available; Amazon Shipping v2 **refuses both**. The two
+programmes have different country coverage, so F5's conclusion must be stated per API. Net for the epic: PL is
+unavailable in **both**, but for independent reasons and via independent evidence — which is a stronger
+conclusion than either check alone, not a redundant one.
+
+### Consequence for OL (unchanged direction, firmer basis)
+A Polish Amazon seller cannot buy shipping through Amazon at all. Labels must come from OL's existing carrier
+adapters (InPost/DPD), with Amazon only receiving `confirmShipment` + the tracking number (F2, already ✅
+verified live in Session 1). Nothing in OL's shipping context needs an Amazon Buy-Shipping path for FR/DE/PL.
+**Not tested**: `directPurchaseShipment`, `oneClickShipment`, `getAccessPoints` (relevant to F7/O14 pickup
+points), `cancelShipment`, `easyShip`, `delivery-by-amazon`, `external-fulfillment`.
+
+### Related: MCF / Fulfillment Outbound — `createFulfillmentOrder` has NO sandbox block
+`fulfillment-outbound-api-model/fulfillmentOutbound_2020-07-01.json` carries 14 sandbox blocks overall, but
+**`createFulfillmentOrder` is not among them** — so ordering MCF fulfilment cannot be exercised in the static
+sandbox, the same class of model-level absence as `sendTestNotification` (Session 3). Untested beyond that.
+
+### And: there is NO buyer-side purchasing API in SP-API at all
+Across all 53 model directories there is no operation for placing an order *as a buyer* — SP-API is
+seller-side by construction. Amazon Business procurement integrations are a separate product, out of scope for
+#2881 and unrelated to anything OL does. Recorded so the question is not re-asked.
+
+## SESSION 3c (2026-09-07) — 🔧 CORRECTION to 3b: `channelType` is load-bearing, and the `AMAZON` path is a STUB
+
+Session 3b tested `channelDetails.channelType: "EXTERNAL"` only, and concluded "PL cannot buy shipping via
+API". That conclusion was **too strong** and is corrected here. Re-tested across both channel types, both
+directions, five countries, four currencies and four package weights.
+
+### A) `EXTERNAL` — the sandbox does a REAL, country-specific lookup, and `shipFrom` is what decides
+| shipFrom → shipTo | result |
+|---|---|
+| PL → PL | ❌ `AmazonShipping_PL` not configured |
+| PL → GB | ❌ `AmazonShipping_PL` (same — so it is NOT about the destination) |
+| PL → FR | ❌ `AmazonShipping_PL` |
+| **GB → PL** | ✅ **200**, 0 eligible rates (accepted, not refused) |
+| **FR → PL** | ✅ **200**, 0 eligible rates |
+| GB → US | ✅ 200, 0 rates |
+| US → GB | ❌ `AmazonShipping_US` |
+| DE → GB | ❌ `AmazonShipping_DE` |
+| GB → DE | ⚠️ `Cross-border compliance data is missing or invalid (D-720)` — a *different*, fixable error |
+| GB → GB | ✅ 2 rates (4.01 / 3.00 **GBP**) |
+| FR → FR | ✅ 1 rate (7.23 **EUR**) |
+
+Two conclusions. **`shipFrom` (the seller's country) drives the `AmazonShipping_XX` identifier** — so a PL
+*seller* is cut off, while **shipping TO Poland from a supported seller country is accepted**. Session 3b never
+tested the reverse direction and would have got this wrong. And **the EXTERNAL path is demonstrably not
+canned**: rates differ by country *and* currency (GB in GBP, FR in EUR, different prices), refusals name the
+specific missing config, and cross-border produces its own distinct compliance error. Currency is irrelevant —
+PL refused identically under PLN/EUR/USD/GBP.
+
+### B) 🚨 `AMAZON` channel — STUBBED in the sandbox, so it proves NOTHING about PL
+With `channelDetails: {channelType:"AMAZON", amazonOrderDetails:{orderId:"902-1845936-5435065"}}`:
+- **PL, DE, US, GB, JP — and the non-existent country code `XX` — all return HTTP 200 with the identical three
+  rates**: 4.76 GBP One-Day Tracked, 3.72 GBP Two-Day Tracked, 3.72 GBP Standard Tracked. Always GBP,
+  regardless of country or currency.
+- **Weight-invariant**: 0.5 / 1 / 5 / 20 kg all return the same three prices.
+- **`purchaseShipment` SUCCEEDS for `XX`**: HTTP 200, `shipmentId amzn1.sid.00032328622983.101`, a valid PNG
+  label of **168 008 bytes — byte-identically sized to the PL one** (`amzn1.sid.01007142850035.101`).
+  (Note: the purchase needs `requestedDocumentSpecification.dpi` ∈ {300, 203}; omitting it answers
+  `400 "Amazon Shipping doesn't support requested DPI null"`, which is a parameter fault, not a country one.)
+
+Buying a label for a country that does not exist is conclusive: this path performs **no marketplace-config
+lookup and no country validation at all**. So the PL "success" on this channel is an artefact of the stub, and
+is evidence of nothing — neither for nor against PL working in production.
+
+### C) Why this makes F5 MORE open, not less
+The `AMAZON` channel is exactly the case OL would use — buying a label for a real Amazon order. `EXTERNAL` is
+for off-Amazon orders. So the well-evidenced PL refusal covers the channel OL needs *least*, and the channel it
+needs *most* is **unverifiable in the sandbox and requires a live account**. Session 3b's "PL unavailable in
+both APIs" is accurate only for `EXTERNAL` + the Merchant Fulfillment docs table, and **must not be quoted as
+covering Amazon-order label purchase**.
+Direction for OL is unchanged (plan on InPost/DPD labels + `confirmShipment`, F2 ✅ verified), but the basis is
+weaker than 3b implied and should not be recorded as settled.
+
+### Methodological note worth keeping
+A dynamic-sandbox 200 is not evidence on its own. The cheap discriminator that caught this: **send an input
+that cannot possibly be valid** (a bogus country code) and see whether the response changes. Two other
+tell-tales agreed — invariance to a parameter that must affect the answer (weight → price), and a response
+currency that ignores the request. Apply the same probe before trusting any other dynamic-sandbox result in
+this spike; the static-sandbox findings are unaffected, since canned responses are declared as canned.
+
+## SESSION 4 (2026-09-08) — invoicing paths, returns via externalFulfillment, getOrder v2026 correction
+
+Driven by a direct question: "does status change / invoice data / returns work, and is it sandbox-tested."
+Everything below is a live call from this session; no inference from docs alone is presented as a result.
+
+### getOrder v2026-01-01 — WORKS, corrects Evidence #6's scope
+Tested all 3 documented static test cases with exact model parameters, host NA:
+```
+GET /orders/2026-01-01/orders/171-9876543-2109876?includedData=BUYER,RECIPIENT,PROCEEDS,EXPENSE,PROMOTION,CANCELLATION,FULFILLMENT,PACKAGES
+  -> 200, full BR/PRIME payload
+GET /orders/2026-01-01/orders/028-1234567-8901234?includedData=BUYER,RECIPIENT,PROCEEDS,FULFILLMENT,TAX
+  -> 200, tax.taxRegistrations[0].taxRegistrationNumber = "TR1234567890"
+GET /orders/2026-01-01/orders/114-9876543-1234567?includedData=RECIPIENT,PROCEEDS,FULFILLMENT
+  -> 200, IN_STORE_PICK_UP program
+GET /orders/2026-01-01/orders/TEST_CASE_400 -> 400 (negative case, as documented)
+```
+`searchOrders` (the enumeration operation) is still broken per Evidence #6 — this is a DIFFERENT operation on
+the same API version. Evidence #6 must be read as scoped to `searchOrders` only.
+
+### invoices-api-model (2024-06-19) — all 4 operations live-tested, BR-only sandbox coverage
+```
+GET  /tax/invoices/2024-06-19/attributes?marketplaceId=A2Q3Y263D00KWC -> 200, invoiceStatusOptions populated,
+     invoiceTypeOptions=[] (empty even for the one supported marketplace)
+GET  same, no marketplaceId -> 400 "Missing required parameter"
+GET  same, marketplaceId=A1PA6795UKMFR9 (FR) / APJ6JRA9NG5V4 (DE) / A13V1IB3VIYZZH (PL, guessed) ->
+     all 400 "Missing required parameter: 'marketplaceId'" -- i.e. the static sandbox has NO fixture for any
+     non-BR marketplaceId, so it neither confirms nor denies FR/DE/PL support for this API.
+POST /tax/invoices/2024-06-19/governmentInvoiceRequests (exact BR fixture body) -> 204
+GET  /tax/invoices/2024-06-19/governmentInvoiceRequests (matching query params) ->
+     200 {"invoiceExternalDocumentId":"35230948404147000173550010000001961","status":"SUCCESS"}
+```
+`createGovernmentInvoice`'s body has NO content/document field — it is a request that AMAZON issue the
+document (government-authority-facing), confirmed by the schema's own field descriptions
+(`externalInvoiceId`: "typically the government agency that authorized the invoice";
+`govResponse`: "response message from the government authority"). This is the opposite direction from
+`UPLOAD_VAT_INVOICE` below.
+
+### UPLOAD_VAT_INVOICE via Feeds — undecidable in static sandbox, not confirmed working or broken
+```
+POST /feeds/2021-06-30/feeds  feedType: "POST_PRODUCT_DATA" (exact model fixture) -> 202 {"feedId":"3485934"}
+POST /feeds/2021-06-30/feeds  feedType: "UPLOAD_VAT_INVOICE" (same body, only feedType swapped) ->
+     400 "Could not match input arguments"
+```
+`feedType` is an unconstrained `string` in the OpenAPI model (no enum), and grepping the ENTIRE
+selling-partner-api-models repo for `UPLOAD_VAT_INVOICE` returns zero hits — it is a feed type documented in
+prose (developer-docs "Create and Upload Invoices") but not present anywhere in the machine-readable model.
+The control call proves the createFeed mechanism itself works; the 400 on the VAT-invoice type is therefore a
+missing STATIC FIXTURE, not a rejection of the feature. This must be tested on a live account to know anything.
+
+### externalFulfillment invoice generation — separate from both of the above
+```
+POST /externalFulfillment/2024-09-11/shipments/TEST_CASE_200_FBA_SHIPMENT_ID/invoice (no body needed) ->
+     200 {"document":{"format":"PDF","content":"<base64 PNG-looking bytes, actually a PDF>"}}
+GET  same path -> 200, same shape (retrieve)
+```
+Third invoicing path, scoped to the External Fulfillment program specifically.
+
+### externalFulfillment RETURNS — confirmed working, closes a documentation gap
+This document previously had NO entry for `externalFulfillment/returns` at all — only Merchant Fulfillment and
+Shipping v1/v2 were covered under "returns/shipping". Live-tested:
+```
+GET /externalFulfillment/2024-09-11/returns?rmaId=rmaIdOneShipmentOneItemOneQty200 ->
+     200, {"returns":[{"returnReason":"Missed","status":"CREATED","numberOfUnits":1,
+       "returnShippingInfo":{"forwardTrackingInfo":..., "reverseTrackingInfo":...}}]}
+GET /externalFulfillment/2024-09-11/returns/rmaIdOneShipmentOneItemOneQty200 ->
+     200, same entity via getReturn, status "CARRIER_NOTIFIED_TO_PICK_UP_FROM_CUSTOMER"
+```
+Error-injection ids all live-tested:
+```
+rmaIdTest403 -> 403 Forbidden
+rmaIdTest409 -> 409 DuplicateRequest
+rmaIdTest429 -> 429 QuotaExceeded          <- only 429 reachable anywhere in this whole sandbox exploration
+rmaIdTest500 -> 500 InternalFailure
+rmaIdTest503 -> 500 InternalFailure         <- NOTE: model names this fixture "test503" but it answers 500, not 503
+```
+Sample data carries `channelName: "FBA"`, marketplace `AMAZON_US`/`AMAZON_IN` — whether an ordinary 3P seller
+on FR/DE/PL has access to this program AT ALL is **not established** by anything tested this session.
+Refund/write-side operations were not re-tested; Evidence #28's NOT SUPPORTED finding stands unchanged.
+
+### Net effect on prior conclusions
+- Evidence #6 (SPIKE doc) is corrected — narrowed from "the v2026-01-01 sandbox" to "the searchOrders operation".
+- The invoicing story (D1/D3 in the original issue) had three concrete, testable paths this session identifies
+  for the first time; none previously appeared in either doc.
+- Returns now has a confirmed-working sandbox path, previously undocumented in this repo's research.
+
+## SESSION 5 (2026-09-08) — closing out the "untouched" list: S1/S4/S11, R3, T6/F1/D2 formalized
+
+Driven by "27 untouched — go check them." Picked the sandbox-testable subset; policy-only items (X3/X5/X6/X7)
+and stateful-by-nature items (P7 image upload, P13 destructive-PUT semantics) are named separately below as
+genuinely out of reach for a static (canned-response) sandbox, not skipped for lack of trying.
+
+### S1/S4 — quantity and price write, both confirmed live
+```
+PATCH /listings/2021-08-01/items/A2TEST123/TEST-SKU-1?marketplaceIds=ATVPDKIKX0DER
+  patches:[{op:"merge", path:"/attributes/fulfillment_availability", value:[{fulfillment_channel_code:"DEFAULT", quantity:42, marketplace_id:"ATVPDKIKX0DER"}]}]
+  -> 200 {"status":"ACCEPTED", "issues":[]}
+PATCH same path
+  patches:[{op:"merge", path:"/attributes/purchasable_offer", value:[{marketplace_id:"ATVPDKIKX0DER", our_price:[{schedule:[{value_with_tax:29.99}]}]}]}]
+  -> 200 {"status":"ACCEPTED", "issues":[]}
+```
+Control: PATCH with sku=BadSKU -> 400 (matches the model's own negative fixture), confirming the sandbox is
+genuinely pattern-matching rather than accepting anything.
+
+### S11 — auto-match by SKU confirmed live; by EAN/GTIN/UPC undecidable
+```
+GET /listings/2021-08-01/items/SellerId?identifiersType=SKU&identifiers=GM-ZDPI-9B4E,HW-ZDPI-9B4E,TC-ZDPI-9B4E&marketplaceIds=ATVPDKIKX0DER,A2EUQ1WTGCTBG2&includedData=summaries,offers,fulfillmentAvailability,issues&pageSize=1
+  -> 200, numberOfResults:3, full item summaries/offers/fulfillmentAvailability
+GET same endpoint, identifiersType=EAN&identifiers=1234567890123 (a syntactically valid EAN)
+  -> 400 "Could not match input arguments"
+```
+`identifiersType` enum has 9 members (ASIN/EAN/FNSKU/GTIN/ISBN/JAN/MINSAN/SKU/UPC) — the parameter accepts the
+value at the schema level, but the static sandbox has a fixture only for SKU. Same shape as Evidence #39's
+`UPLOAD_VAT_INVOICE`: contract allows it, sandbox neither confirms nor denies it works. A live account is the
+only way to know if EAN/GTIN-based matching actually functions.
+
+### R3 — return status vocabulary, read from the model
+`Return.status` enum (`externalFulfillmentReturns_2024-09-11.json`), 15 values:
+`CREATED`, `CARRIER_NOTIFIED_TO_PICK_UP_FROM_CUSTOMER`, `CARRIER_OUT_FOR_PICK_UP_FROM_CUSTOMER`,
+`CUSTOMER_CANCELLED_PICK_UP`, `CUSTOMER_RESCHEDULED_PICK_UP`, `PICKED_FROM_CUSTOMER`, `IN_TRANSIT`,
+`OUT_FOR_DELIVERY`, `DELIVERED`, `REPLANNED`, `CUSTOMER_DROPPED_OFF`, `PARTIALLY_PROCESSED`, `PROCESSED`,
+`REJECTED`, `CANCELLED`. The two values Session 4 observed live (`CREATED`,
+`CARRIER_NOTIFIED_TO_PICK_UP_FROM_CUSTOMER`) are members of this exact list — cross-checked, not contradicted.
+Terminal candidates for a future `terminalRawStatuses` hint: `PROCESSED` / `REJECTED` / `CANCELLED`.
+
+### T6 / F1 / D2 — no new calls needed, already answered by evidence recorded under different story numbers
+- T6 (parameter restrictions): the `VALIDATION_PREVIEW` finding already on file (offer-creation section) IS
+  the answer — `issues[]` carries `code`/`message`/`severity`/`attributeNames`/`categories`/`enforcements`.
+- F1 (read fulfillment status): `getOrder` v2026-01-01's own `fulfillment.fulfillmentStatus` field
+  (`UNSHIPPED`/`SHIPPED`, observed live in Session 4) IS the answer — there is no separate operation.
+- D2 (buyer data sufficient to invoice): version-dependent, same split as O7. v0 = email+name only
+  (insufficient). v2026 = full tax registration + address, but ONLY when the source order actually carries a
+  business buyer (`buyerInvoicePreference: "BUSINESS"`) — a private-buyer order supplies neither version with
+  invoice-sufficient data.
+
+### Genuinely out of reach for THIS kind of sandbox — named, not silently dropped
+- **P7 (image upload) / P13 (does PUT drop omitted attributes)** — both require a stateful
+  write-then-read-back to answer, and the static sandbox returns a canned response per request pattern with no
+  persistence between calls. There is no PUT-then-GET loop that can prove or disprove either question here;
+  needs a live account.
+- **X3/X5/X6/X7 (compliance gate, v0 sunset date, multi-tenant quota, the SP-API fee saga)** — these are
+  policy/pricing facts stated in Amazon's documentation and account terms, not API behavior. No sandbox call
+  answers them; they are read-the-docs work, already partially done for the fee saga in the SPIKE doc's Open
+  risks section.
+
+### Updated tally after this session
+Have (sandbox-proven): 34. Confirmed absent: 10. Partial/undecidable-in-sandbox: 11 (adds EAN/GTIN matching).
+Genuinely untouched or out of static-sandbox reach: 20 (T8, S2/S9, P6/P8/P10/P11, F4/F7, D9, O4/O16, X3/X5/X6/X7,
+P7/P13 named as structurally out of reach above).
+
+## SESSION 6 (2026-09-08) — closing the remaining 14: S2/S9 confirmed, T5/P6/P8/P10 unified, P11/F4 demonstrated undecidable
+
+Driven directly by "if 14 are testable, test all of them." All calls below are live against
+`sandbox.sellingpartnerapi-na.amazon.com` unless noted.
+
+### S2, S9 — confirmed, and they are NOT new operations
+```
+POST /feeds/2021-06-30/feeds  feedType:"POST_PRODUCT_DATA" -> 202 {"feedId":"3485934"}   (= S2, same as P1/P4)
+PATCH .../fulfillment_availability  quantity:5 -> 200 ACCEPTED                           (= S9, same as S1)
+```
+
+### T5/P6/P8/P10 — one root cause, PROVEN not inferred
+```
+GET /definitions/2020-09-01/productTypes/LUGGAGE?marketplaceIds=ATVPDKIKX0DER -> 200
+  schema.link.resource = "https://schema-url"   <- not a real host
+GET https://schema-url -> HTTP:000, no DNS resolution at all
+```
+This is a fixture placeholder, confirmed by attempting to actually fetch it. The static sandbox literally never
+returns real JSON Schema content for ANY product type — this forecloses T5 (conditionals), P6 (description
+grammar), P8 (variation/parentageLevel), P10 (GPSR fields) simultaneously, since all four need schema CONTENT
+the sandbox structurally cannot deliver, not just a link to it.
+
+### P11, F4 — demonstrated undecidable (not merely assumed), same class as P7/P13
+```
+PUT .../DUP-SKU-1  item_name:"Test A" -> 200 {"sku":"GM-ZDPI-9B4E", "status":"ACCEPTED", ...}
+PUT .../DUP-SKU-1  item_name:"Test B" (same SKU, different content) -> 200, BYTE-IDENTICAL response
+```
+Proves the sandbox pattern-matches request SHAPE and ignores CONTENT — cannot tell upsert from
+reject-as-duplicate.
+```
+POST /orders/v0/orders/902-1106328-1059050/shipmentConfirmation
+  packageReferenceId:"1", trackingNumber:"112345678" (exact model fixture) -> 204
+POST same endpoint, same packageReferenceId:"1", trackingNumber:"999999999" (only this changed) ->
+  400 "Could not match input arguments"
+```
+No fixture exists for "same reference, different tracking" — cannot confirm the issue's own cited claim that
+Amazon treats a re-submitted `packageReferenceId` as an edit rather than a duplicate.
+
+### T8, D9, O4, O16 — answered from evidence already on file, no new call needed
+- T8: moot — T1 already confirms no category tree exists, so a taxonomy identity string format is a
+  non-decision with nothing to project onto.
+- D9: every order sample this session carries a real `currencyCode` (BRL/TRY/USD) — sufficient for ADR-040's
+  stamp, which needs only the order's own currency + a placement time.
+- O4: follows directly from C13 (no webhook, delivery unverifiable in sandbox) — no new evidence changes this.
+- O16: the cited rate numbers are documented facts, not sandbox-observable; the sandbox's OWN throttle (5rps/15
+  burst) is a different, unrelated number.
+
+### Only ONE item from the original 14 remains genuinely untouched
+**F7** (source options discovery / `listOrderStatuses`, `listDeliveryMethods`, `listPaymentMethods` for
+Amazon-as-source) — not attempted this session, no evidence either way.
+
+### Final tally after Sessions 3-6
+Have (sandbox-proven or evidence-derived): 40. Confirmed absent: 10. Structurally undecidable in THIS sandbox
+(schema never resolves, or needs write-then-observe with no state): 13 (EAN/GTIN search, UPLOAD_VAT_INVOICE,
+non-BR invoice marketplaceId, F5 Amazon-channel stub, T5/P6/P8/P10 schema-link, P7/P11/P13/F4 state-needed).
+Genuinely untouched: F7, plus the 4 policy-only items (X3/X5/X6/X7) that are read-the-docs work, not sandbox
+work.
+
+## SESSION 7 (2026-09-08) — F7 closed: no discovery operation, values are baked-in enums
+
+Last remaining sandbox-adjacent question from the original 14. Read directly from the Orders v0 model.
+
+```
+All 9 operations in ordersV0.json enumerated:
+  getOrders, getOrder, getOrderBuyerInfo, getOrderAddress, getOrderItems, getOrderItemsBuyerInfo,
+  updateShipmentStatus, getOrderRegulatedInfo, updateVerificationStatus, confirmShipment
+-> none is a listOrderStatuses/listDeliveryMethods/listPaymentMethods equivalent
+```
+The vocabulary itself is present, just not behind an API call — it's declared as closed enums in the model:
+```
+ShipmentStatus enum: ["ReadyForPickup","PickedUp","RefusedPickup"]
+VerificationStatus enum: ["Pending","Approved","Rejected","Expired","Cancelled"]
+```
+Conclusion: this is a platform characteristic, not a sandbox gap — no live account would ever reveal a
+discovery endpoint that doesn't exist. `SourceOptionsReader`'s answer for Amazon is "read the enum from the
+model at build time," not "call an operation." No further action needed; nothing here can be tested further.
+
+### Final tally
+Have (sandbox-proven or evidence-derived): 41. Confirmed absent: 10. Structurally undecidable in this sandbox:
+13. Genuinely untouched — policy/account-terms facts with no corresponding API operation at all: X3
+(compliance review process), X5 (v0 deprecation date), X6 (multi-tenant quota policy), X7 (SP-API fee saga).
+Every sandbox-testable story from the issue's own checklist has now been run.

--- a/docs/plans/analysis/SPIKE-2881-amazon-sp-api.md
+++ b/docs/plans/analysis/SPIKE-2881-amazon-sp-api.md
@@ -1,0 +1,381 @@
+# Spike #2881 — Amazon SP-API (FR/DE/PL): capabilities, flows, verdict
+
+> **Status: IN PROGRESS, not final.** Issue #2881's own day-0 desk research (2026-09-04) has been partially
+> live-verified against the Amazon SP-API **static sandbox** (self-authorized Private app, EU host) on
+> 2026-09-04. Several stories remain unconfirmed or blocked — see "Open risks" and the per-group status
+> below. Do **not** treat any box here as satisfying the issue's own DONE rule ("a live-call transcript +
+> the endpoint + one line on *why that endpoint*, or an explicit NOT SUPPORTED") unless explicitly marked
+> ✅ VERIFIED LIVE below. Everything else is either the original desk claim (unverified) or a live probe that
+> came back inconclusive.
+
+## Verdict — provisional, leaning 4A-shaped (marketplace-only, high cost, high strategic value)
+
+Confirms the issue's own framing: Amazon is a **marketplace-only** destination (not `ProductMaster`, not
+`InventoryMaster` — this spike did not find evidence to overturn either exclusion; see Evidence #1). Cost
+drivers are structural (ingestion transport, PII retention, no browsable taxonomy) rather than adapter-shaped,
+exactly as the issue predicted. One structural finding **not** in the original issue meaningfully changes the
+risk picture: **the newer Orders API version (v2026-01-01) appears to have incomplete static-sandbox coverage**
+as of this session (Evidence #6) — this was not anticipated and affects how AC2 can be satisfied for Orders
+specifically.
+
+No adopt/don't-adopt recommendation is made yet — AC7 (public vs private app), AC8 (commercial sanity check)
+and full FR/DE/PL parity (AC2) are all still open.
+
+**One finding materially reframes several tax-related stories at once (Evidence #29/#30)**: Amazon carries a
+named, documented `ItemTaxCollection.model: "MARKETPLACE_FACILITATOR"` field, stated verbatim as *"Tax is
+withheld and remitted to the taxing authority by Amazon on behalf of the seller."* For a large share of FR/DE/PL
+orders, Amazon likely owns VAT collection and remittance entirely — P9's "no tax rate field to write" is very
+possibly not a gap but the correct behaviour for this tax model, and D5's shipping-tax-split concern may be
+moot because Amazon already reports it natively. This needs confirming against a real mixed-rate order, but it
+meaningfully lowers the estimated cost of the tax-integration slice of this epic if it holds.
+
+## Evidence
+
+Numbered, each either a **live-verified** finding from this session or an **unresolved** desk claim carried
+over from the issue (marked accordingly).
+
+1. **✅ VERIFIED LIVE** — `getMarketplaceParticipations` (`GET /sellers/v1/marketplaceParticipations`) returns
+   HTTP 200 against the EU sandbox host regardless of the actual regional host called — static sandbox returns
+   a single canned US marketplace (`ATVPDKIKX0DER`, storeName `"BestSellerStore"`) irrespective of region.
+   **Confirms**: static sandbox does not vary its `marketplaceParticipations` payload by host region — this
+   payload cannot be used to prove multi-marketplace (FR/DE/PL) coverage in sandbox; that requires production
+   or a real seller account.
+
+2. **✅ VERIFIED LIVE** — Orders API **v0** `GET /orders/v0/orders` with `MarketplaceIds=ATVPDKIKX0DER` (note:
+   **US** marketplace ID accepted on the **EU** sandbox host without a region error, unlike every other API
+   tested — see Evidence #4) and `CreatedAfter=TEST_CASE_200` returns HTTP 200 with two sample orders.
+   **Confirms**: v0 uses **PascalCase** query parameters (`MarketplaceIds`, `CreatedAfter`) — matches the
+   issue's X5 casing-change claim for v2026.
+
+3. **✅ VERIFIED LIVE** — Orders v0 `getOrderItems` (`orderId=TEST_CASE_200`) returns `ItemPrice` and `ItemTax`
+   as `{CurrencyCode, Amount}` only — **no percentage/rate field anywhere**. Directly confirms the issue's O10
+   worry (ADR-063 forbids deriving a rate from tax/net) for v0.
+   **New finding, not in the original issue**: the same payload carries `"IossNumber":""` and
+   `"DeemedResellerCategory":"IOSS"` at the order-item level — this is Amazon's analogue of eBay's
+   `ebayCollectAndRemitTaxes` (#2880's D3) and directly answers part of this issue's D3 ("whether the API
+   exposes a machine-readable marketplace-facilitator-VAT flag" — **it does, at least in v0, for IOSS**).
+   Nothing in OL's order contract models this today, same gap eBay's spike flags.
+
+4. **✅ VERIFIED LIVE** — Orders API **v2026-01-01** `searchOrders`. Full contents of the model's own
+   `x-amzn-api-sandbox` block were read (three documented static test cases: Japan, UK-with-pagination,
+   Brazil-with-TAX). The **Brazil test case's `includedData=TAX` response** carries:
+   ```json
+   "tax": {
+     "taxRegistrations": [
+       {"entityType":"BUYER","taxRegistrationType":"VAT","taxRegistrationNumber":"..."},
+       {"entityType":"MARKETPLACE","taxRegistrationType":"CNPJ","taxRegistrationNumber":"..."}
+     ],
+     "taxInvoicing": {"invoiceStatus":"PROCESSING"}
+   }
+   ```
+   **🎯 This resolves O10/D4 definitively, from the documented spec itself**: `TAX` carries tax
+   **registration numbers** (VAT/CNPJ per entity role: buyer/marketplace/merchant) and an invoice status —
+   **never a percentage rate**, in either API version. Amazon order lines are confirmed rate-less; Net Sales
+   eligibility depends entirely on the shop side of the chain, exactly as the issue predicted, now with primary
+   evidence rather than an absence-grep.
+
+5. **⚠️ Region validation is inconsistent across APIs.** Orders v0 accepted a US marketplace ID on the EU
+   sandbox host (no region check enforced); Listings Items, Catalog Items and Product Type Definitions all
+   **reject** a US marketplace ID on the EU host with `403 Unauthorized — "The marketplaces you provided are
+   not valid for region"`, and accept an EU one (tested: DE `A1PA6795UKMFR9`). **Not previously documented in
+   the issue** — worth stating explicitly so a future implementer doesn't assume uniform region behaviour
+   across the whole SP-API surface.
+
+6. **🔴 NEW, negative finding — v2026-01-01 `searchOrders` static sandbox may not be wired up.** Four
+   parameter-encoding variants were tried against the **exact literal values published in the operation's own
+   `x-amzn-api-sandbox` block** (UK test case: `createdAfter=2024-12-23T00:00:00Z`,
+   `marketplaceIds=A1F83G8C2ARO7P`, `includedData=[...]`, both comma-joined and repeated-key array styles,
+   both URL-encoded and raw): all four returned `400 InvalidInput — "Could not match input arguments"`.
+   Region validation passed (UK marketplace accepted on the EU host, so credentials/host/region are not the
+   cause). Orders v0 and Listings v2021-08-01 both worked on the **first** correctly-regioned attempt with
+   equivalent effort. **Working hypothesis** (not proven): the v2026-01-01 sandbox *backend* does not yet
+   honour the documented static patterns, even though the model file is well-formed and current. This is
+   material to AC2: Orders v2026 sandbox coverage cannot currently be demonstrated by this method, and may
+   require escalation (AWS support / SP-API forum) or a live seller account sooner than the issue anticipated.
+
+7. **✅ VERIFIED LIVE** — Listings Items API `getListingsItem` (`GET /listings/2021-08-01/items/{sellerId}/{sku}`,
+   any sellerId/sku accepted — the sandbox model uses a generic pattern, not test-case-keyed) returns HTTP 200
+   with a rich `issues[]` array alongside `summaries`/`offers`/`fulfillmentAvailability`.
+   **Confirms S6's ADR-009-shaped disjoint-snapshot claim directly**: a clean-looking listing item response
+   still carries active issues.
+   **New finding**: each issue carries an `enforcements` object (`actions`: `SEARCH_SUPPRESSED` /
+   `ATTRIBUTE_SUPPRESSED` / `LISTING_SUPPRESSED` / `CATALOG_ITEM_REMOVED`) and an `exemption` status (`EXEMPT` /
+   `EXEMPT_UNTIL_EXPIRY_DATE` with an expiry date / `NOT_EXEMPT`) — a materially richer per-issue severity model
+   than Allegro or Erli expose. Worth a dedicated callout in T6/S6.
+
+8. **🔴 CORRECTED (see Evidence #20) — this entry originally claimed `getCatalogItem` was unsupported in
+   static sandbox. That claim was WRONG**, caused by checking the sandbox extension at the wrong JSON path
+   (operation top-level instead of nested under `responses.{code}`). It **is** supported — see Evidence #20 for
+   the corrected finding and live transcript. Left here, struck through in spirit rather than deleted, per the
+   issue's own instruction that a wrong claim be corrected in place rather than silently removed.
+
+9. **🔴 BLOCKED — C13 / Notifications grantless token.** `POST https://api.amazon.com/auth/o2/token` with
+   `grant_type=client_credentials` requires a `scope` parameter (confirmed: omitting it returns
+   `invalid_request — missing a required parameter: scope`). The scope value `sellingpartnerapi::notifications`
+   — independently confirmed correct via the community SDK `saleweaver/python-amazon-sp-api`
+   (`grantless_scope = "sellingpartnerapi::notifications"` hardcoded in `sp_api/api/notifications/notifications.py`)
+   — was rejected with `invalid_scope` on this app. `sellingpartnerapi::migration` and bare `notifications` were
+   also rejected. Amazon's own docs state grantless operations "apply only to seller applications" — whether
+   this app's registration type qualifies is unconfirmed and not resolvable via further automated probing.
+   **This blocks live verification of the entire Notifications API (C13), which is the epic's highest-priority
+   architectural unknown** (no HTTP webhooks at all; SQS/EventBridge only). Needs a human follow-up (AWS
+   support case or SP-API developer forum) before C13 can be closed.
+
+10. **✅ T1 RESOLVED — no category/browse-node tree walk exists anywhere in SP-API, current or deprecated.**
+    Checked the complete path list of every version of the two candidate APIs directly from their OpenAPI
+    models:
+    - Product Type Definitions 2020-09-01: exactly two operations, `searchDefinitionsProductTypes` and
+      `getDefinitionsProductType` — neither walks a tree.
+    - Catalog Items 2022-04-01 and 2020-12-01: exactly two paths each (`items` search, `items/{asin}` get) —
+      neither walks a tree.
+    - Catalog Items **v0** (deprecated): has `/catalog/v0/categories` (`listCatalogCategories`), described
+      verbatim as *"Returns the parent categories to which an item belongs, based on the specified ASIN or
+      SellerSKU"* — this is a `CategoryPathReader`-shaped lookup (needs an existing product to resolve its
+      ancestor path), **not** a `CategoryBrowser`-shaped one (walk from root with no product needed).
+    **This is a stronger, primary-source-confirmed version of the original issue's "no operation... was
+    found" claim** — every path in every version was enumerated and checked, not just searched for. `T1's
+    consequence stands as the issue predicted: `DestinationCategory` (#1979) does not transfer to Amazon.
+    The likely replacement entry point is `searchDefinitionsProductTypes` (keyword search), since product
+    type is Amazon's actual organizing unit — this needs its own UX design pass, not a port of the existing
+    tree-picker.
+
+11. **✅ F5 RESOLVED (independent confirmation) — Poland absent from FBM Ship+.** Read the Merchant
+    Fulfillment API use-case guide's own availability table directly (not just re-reading the issue's cited
+    source): US/UK/DE/ES/FR/IT/JP/AU all listed (various cross-border/domestic combinations, several
+    "launching" in 2026), **Poland absent entirely**. Confirms the issue's finding from a second, independent
+    read of the primary source.
+
+12. **New findings spotted in the v2026-01-01 sandbox response bodies, not flagged anywhere in the original
+    issue:**
+    - `picking.substitutionPreference.substitutionOptions[]` — a buyer can pre-approve a substitute ASIN/SKU
+      when the ordered item is unavailable. No equivalent capability exists in any other platform researched
+      in this epic (#2879/#2880/#2882).
+    - B2B order support: `programs: ["AMAZON_BUSINESS"]`, `buyerCompanyName`, `buyerPurchaseOrderNumber`,
+      `orderItems[].product.price.priceDesignation: "BUSINESS_PRICE"`.
+    - `orderAliases[].aliasType: "SELLER_ORDER_ID"` — a seller-supplied order alias field; unclear whether this
+      is a write-your-own-reference mechanism analogous to TikTok Shop's `external_orders` API (#2882's O-note)
+      — needs a targeted probe.
+    - `packages[]` sits below the order/order-item grain, carries its own `packageStatus.status/detailedStatus`,
+      `carrier`, `trackingNumber`, `shipFromAddress` — confirms F1/F2's shape, and echoes the same "a package is
+      not the same as an order" caution TikTok Shop's spec (#2882 F-extra) states explicitly. Not called out as
+      a caution in the original #2881 text.
+
+13. **✅ Reports API `getReports` verified live** — comma-joined array query params work cleanly (unlike
+    Orders v2026, which rejected the identical style). Sandbox implementation quality is inconsistent
+    per-API, not a single global pattern to rely on.
+
+14. **✅ T7 upgraded — `searchCatalogItems` works even though `getCatalogItem` does not.** Required the **NA**
+    sandbox host (the documented pattern is baked to `ATVPDKIKX0DER`, a US marketplace ID — same
+    pattern-vs-host-region conflict as Evidence #6's Orders v2026 test cases). Response is rich: a full
+    browse-**classification parent chain** per matched item (e.g. "QLED TVs" → "Televisions" → "Television &
+    Video" → "Electronics" — confirms the issue's claim that Catalog Items exposes browse classifications *on
+    items*, still not independently walkable, consistent with Evidence #10/T1), `identifiers` with
+    EAN/GTIN/UPC (directly usable for barcode-based offer linking, Allegro-parity), and `relationships` with
+    `type: "VARIATION"` + `parentAsins` + `variationTheme` (directly relevant to P8/multi-variant grouping).
+    **Revised conclusion**: for a `CatalogProductReader`-shaped capability (find-by-barcode/keyword before
+    offering), `searchCatalogItems` is the right operation regardless — the single-ASIN `getCatalogItem`'s lack
+    of sandbox support is less material than it first appeared.
+
+15. **✅ `getDefinitionsProductType` verified live — reveals the real GTIN-exemption field name.** Response's
+    `propertyGroups.product_identity.propertyNames` includes **`gtin_exemption_reason`** as a live, named
+    schema property. This differs from the field name the original issue cited
+    (`supplier_declared_has_product_identifier_exemption`) — **do not trust either name without confirming
+    against a real product-type schema fetch**, since sandbox only returns a schema *link* (a stub URL, not
+    fetchable), not the actual JSON Schema document. T5 (conditional-required-attributes) therefore **still
+    cannot be exercised via sandbox** — this needs a live seller account to pull a real schema.
+
+16. **⚠️ Methodology correction, applies retroactively.** The `x-amzn-api-sandbox` extension lives nested
+    under `responses.{code}.x-amzn-api-sandbox` in the OpenAPI model, not at the operation's top level. Two
+    earlier findings in this document that claimed "no sandbox block" for `patchListingsItem` were based on
+    checking the wrong location and are **corrected below** (Evidence #17). The T1 conclusion (Evidence #10)
+    is unaffected — it was based on enumerating actual API *paths*, not sandbox blocks. `getCatalogItem`'s
+    "no sandbox at all" claim (Evidence #8) has **not yet been re-checked** with the corrected method and
+    should be treated as provisional until it is.
+
+17. **✅ F2 (`confirmShipment`) verified live — works cleanly.** `POST
+    /orders/v0/orders/{orderId}/shipmentConfirmation` with the documented FedEx package-detail body returns
+    HTTP 204. A sibling operation, **`updateShipmentStatus`** (`POST /orders/v0/orders/{orderId}/shipment`,
+    **not mentioned anywhere in the original issue**), also exists and also works — an empty-body pattern
+    returns 204, and its validation-error pattern reveals a lighter-weight `shipmentStatus` field (e.g.
+    `"ReadyForPickup"`) distinct from the full package-detail confirm flow. Worth investigating for O14/F7
+    (pickup-point/ISPU) relevance. `patchListingsItem` also verified live: HTTP 200,
+    `{"status":"ACCEPTED","issues":[]}` with an empty-patch body.
+
+18. **✅ P1/P4 — Feeds async flow verified live, end to end.** `createFeedDocument` (201) →
+    `createFeed` (202, `{feedId}`) → `getFeed` (200, full status object) all chain correctly against their
+    documented sandbox patterns. Confirms the issue's shape claim (maps onto OL's `OfferCreationRecord` +
+    poller) directly rather than by inference. The canned `processingStatus` returned is `"CANCELLED"`, not a
+    happy-path terminal state — sandbox proves the shape is reachable, not the full success path.
+
+19. **✅ R1 — Reports general mechanism verified live, end to end** (with a listings report type, not yet the
+    specific returns report type). `createReport` (202, `{reportId}`) → `getReportDocument` (200,
+    `{reportDocumentId, url}`, a real-looking CloudFront download target) both work. High confidence this is
+    the identical shape `GET_XML_RETURNS_DATA_BY_RETURN_DATE` uses — the mechanism, not just the returns-
+    specific report type, is now confirmed reachable in static sandbox.
+
+20. **✅ CORRECTION to Evidence #8 — `getCatalogItem` IS supported in static sandbox.** Re-checked with the
+    fixed methodology (Evidence #16): the model's `responses.200.x-amzn-api-sandbox` block documents
+    `asin=B07N4M94X4`, `marketplaceIds=ATVPDKIKX0DER`,
+    `includedData=classifications,dimensions,identifiers,images,productTypes,relationships,salesRanks,summaries,vendorDetails`.
+    Live test on the **NA** host (US marketplace baked into the pattern, same host-region rule as every other
+    US-keyed pattern in this document) returns HTTP 200 with the identical rich payload shape
+    `searchCatalogItems` returned (Evidence #14). **T7 is now fully confirmed positive**: both the search and
+    single-item read operations work in static sandbox, for the one canned ASIN.
+
+21. **🆕 New capability class, not in the original issue at all — Regulated Order Verification ("Shield").**
+    `getOrderRegulatedInfo` / `updateVerificationStatus` (`GET`/`PATCH
+    /orders/v0/orders/{orderId}/regulatedInfo`) verified live. Sample payload is a pet-prescription order:
+    `RegulatedInformation.Fields` (e.g. `pet_prescription_species`), `RegulatedOrderVerificationStatus.Status:
+    "Pending"`, `RequiresMerchantAction: true`, and a closed set of `ValidRejectionReasons` (e.g.
+    `shield_pom_vps_reject_incorrect_weight`). This is an order-lifecycle **gate** — a regulated-category order
+    apparently cannot ship until the seller reviews and approves/rejects it. No equivalent exists in any other
+    platform researched in this epic (#2879 Shopify, #2880 eBay, #2882 TikTok Shop). Likely niche (only
+    relevant if a seller lists regulated categories — pharma-adjacent, age-restricted, etc.), but flagged here
+    so it isn't silently missed if a future OL customer sells in such a category.
+
+22. **✅ S10 (`searchListingsItems`) verified live.** Same rich `issues[]`/`enforcements` shape as
+    `getListingsItem` (Evidence #7), plus `pagination.nextToken`/`previousToken` for a full-catalogue sweep —
+    confirms the enumerate-then-reconcile-mappings pattern works.
+
+23. **✅ O5 (masked buyer email) confidence upgraded — corroborated in Amazon's own official model samples.**
+    Every `buyerEmail` sample across the v0/v2026 model files' canned test data (JP/UK/Brazil/Turkey/generic)
+    follows `buyer-email@marketplace.amazon.<tld>`. The issue's original source was a GitHub issue thread it
+    flagged as "PARTLY UNCONFIRMED, availability may change without notice" — this is now corroborated by
+    Amazon's own official model repository, a materially stronger source (though still illustrative sample
+    data, not a live-production guarantee).
+
+24. **✅ O7 resolved — same field family as D3, not a separate read.** The `taxRegistrations[]` array
+    (Evidence #4) carries one entry per `entityType` role: `BUYER` (with `taxRegistrationType`/
+    `taxRegistrationNumber`, e.g. a VAT id, plus `legalName`), `MARKETPLACE`, and `MERCHANT`. This single array
+    answers O7 (buyer tax id), most of D3 (facilitator VAT signal), and contributes to D1/D2 (buyer data
+    sufficient to invoice) — worth modelling as one mapping concern in the eventual adapter rather than three
+    separate reads against three separate issue stories.
+
+25. **⚠️ P9 reframed, not just answered.** No key containing "tax" exists anywhere in the Listings Items API
+    model — there is no fixed top-level field for a seller to set a tax rate at publish, unlike Erli's simple
+    enum. Combined with Evidence #3/#4/#24 (`IossNumber`, `DeemedResellerCategory`,
+    `taxRegistrations[entityType=MARKETPLACE]`), the more likely explanation isn't a missing feature but a
+    **different tax model entirely**: Amazon is frequently the VAT-collecting marketplace facilitator itself
+    for EU/UK sales (post-2021 EU VAT e-commerce package, UK's post-Brexit marketplace rules), meaning there
+    may be **no seller-settable rate for a large share of FR/DE/PL orders** in the first place — the same
+    "marketplace owns tax" posture ADR-063/#2245 already has a shape for. This needs confirming against
+    Seller Central's actual VAT settings documentation (not the API schema alone) before treating it as a gap
+    to build around.
+
+26. **✅ X2 confirmed — no rate-limit-query API exists anywhere in SP-API.** Searched the full model
+    repository for anything rate-limit-shaped; zero matches. Unlike eBay (`GET
+    /developer/analytics/v1_beta/rate_limit/`, per #2880's spike), Amazon offers no quota observability
+    endpoint at all — confirms the issue's C8 claim precisely, and is a genuine, structural disadvantage
+    relative to the epic's other researched platforms.
+
+27. **✅ S8 confirmed — no real deactivate/withdraw primitive exists.** Full Listings Items API operation list
+    is exactly `deleteListingsItem` (hard delete), `getListingsItem`, `patchListingsItem`, `putListingsItem`,
+    `searchListingsItems` — no deactivate/withdraw verb or status-enum anywhere in the model.
+    `deleteListingsItem` is a genuine delete, not eBay's `withdrawOffer` shape (unpublish-and-relist, #2880's
+    S8). **Confirms the issue's own hedge**: quantity=0 via `patchListingsItem` is the only pause mechanism —
+    same posture as Allegro/Erli, not eBay's superior model. #1689's `OfferDeactivator` capability gap stays
+    unfilled by Amazon.
+
+28. **✅ D8/R4–R7 confirmed NOT SUPPORTED — three independent negative checks, not a single search gap.**
+    Enumerated every operation across the full Finances API (v0, 2024-06-19, transfers, invoices — 13
+    operations total): all reads, plus `initiatePayout` (pays the *seller*, not a buyer refund). Combined with
+    Orders (confirmed no refund/return-write path anywhere in its operation list, Evidence #16's methodology)
+    and Reports (read-only by construction, R1). **No refund or return-write capability exists anywhere in
+    current SP-API.** A refund must go through Seller Central manually, or is handled entirely by Amazon's own
+    automated returns processing with no seller-side write access — structural, not a research gap.
+
+29. **🎯 P9/D3 DEFINITIVELY confirmed (Evidence #25 upgraded from hypothesis to certainty).** Direct schema
+    inspection finds `ItemTaxCollection.model`, possible value `"MARKETPLACE_FACILITATOR"`, described verbatim
+    as *"Tax is withheld and remitted to the taxing authority by Amazon on behalf of the seller"* — plus
+    `responsibleParty`, and `ItemTaxCalculationBreakdown.reportingScheme` (`UOSS`/`IOSS`, the exact EU VAT
+    e-commerce package scheme identifiers). **This is no longer a hypothesis.** For
+    `MARKETPLACE_FACILITATOR`-model items there is no seller-settable rate because the seller has no VAT
+    liability to declare in the first place — Amazon owns it end to end. P9's "missing field" reads
+    completely differently now: it needs the same marketplace-facilitator posture #2245/ADR-063 already
+    handles for other platforms, not a workaround for a genuine gap.
+
+30. **🎯 D5 resolved — Amazon natively separates shipping tax from item tax.**
+    `ItemProceedsDetailedBreakdown.subtype` enum (`ITEM`/`SHIPPING`/`GIFT_WRAP`/`COD_FEE`/`OTHER`/`DISCOUNT`)
+    applies to the `TAX` proceeds category specifically — meaning Amazon reports a **separate tax subtotal
+    for the shipping-attributable portion** natively. OL likely does **not** need `splitShippingAcrossRates`
+    (#2248/#2252) for Amazon's own figures — Amazon already performs and reports the split. Needs confirming
+    against a real mixed-rate basket (sandbox sample data doesn't populate this granularity by default), but
+    the schema capability is confirmed to exist.
+
+## API surface summary
+
+| Group | Story | Status | Evidence |
+|---|---|---|---|
+| C | C4 (connection test probe) | ✅ verified live | #1 |
+| C | C13 (Notifications, SQS/EventBridge) | 🔴 blocked (grantless token) | #9 |
+| T | T7 (catalogue product card) | ✅ confirmed unsupported in static sandbox | #8 |
+| O | O1/O2 (order feed, v0) | ✅ verified live | #2 |
+| O | O8/O10 (line resolve, tax rate) | ✅ resolved — no rate, ever | #3, #4 |
+| O | searchOrders v2026-01-01 | 🔴 sandbox pattern not reproducible | #6 |
+| S | S6 (write success ≠ live listing) | ✅ verified live, richer than expected | #7 |
+| D | D3 (facilitator VAT signal) | ⚠️ partially answered (v0 IossNumber found) | #3 |
+| — | region validation behaviour | ⚠️ new, undocumented inconsistency | #5 |
+| T | T1 (browse category tree) | ✅ confirmed absent, primary source, all versions | #10 |
+| F | F5 (Buy Shipping / Poland) | ✅ confirmed absent, independent source | #11 |
+| — | Reports API `getReports` | ✅ verified live | #13 |
+| T | T7 (catalogue product card, search variant) | ✅ verified live, richer than expected | #14 |
+| T | T5 (conditional required attrs) | ⚠️ still blocked — sandbox only returns a schema link, not the schema | #15 |
+| P | P2 (GTIN exemption field name) | ⚠️ real field name found, differs from issue's citation — needs confirmation | #15 |
+
+| P | P1/P4 (Feeds async flow) | ✅ verified live, end to end | #18 |
+| S | S5 (patchListingsItem) | ✅ verified live | #16/#17 |
+| F | F2 (confirmShipment) | ✅ verified live | #17 |
+| R | R1 (Reports mechanism) | ✅ verified live, end to end (general mechanism) | #19 |
+| T | T7 (single-ASIN catalogue read) | ✅ CORRECTED — is supported, not unsupported | #20 |
+| S | S10 (enumerate → reconcile) | ✅ verified live | #22 |
+| — | Regulated Order Verification | 🆕 new capability class, not in original issue | #21 |
+
+| O | O5 (masked email) | ✅ confidence upgraded (official model samples) | #23 |
+| O/D | O7/D3 (buyer tax id / facilitator VAT) | ✅ resolved — one shared field family | #24 |
+| P | P9 (tax rate at publish) | ⚠️ reframed — may be a facilitator-tax model, not a gap | #25 |
+| X | X2 (rate-limit observability) | ✅ confirmed absent, structurally worse than eBay | #26 |
+| S | S8 (pause/deactivate) | ✅ confirmed — quantity-0 only, no real withdraw | #27 |
+| D | D8 / R4–R7 (refund/return writes) | ✅ confirmed NOT SUPPORTED, three independent checks | #28 |
+| P/D | P9/D3 (facilitator tax model) | 🎯 confirmed with a named schema field, was hypothesis | #29 |
+| D | D5 (shipping tax split) | 🎯 resolved — Amazon does this natively | #30 |
+
+Everything else in the original issue's story checklist (T6/T8, P3/P6/P8/P10–P13, S1/S2/S4/S6/S9/S11/S13,
+F1/F4/F7, D1/D2/D6/D9, R2/R3/R8–R10, X3–X7) remains at its **original desk-research status** (⚠️/?/🔴 as the
+issue left it) — not re-verified in this session. F3 (order status writeback) is effectively answered by
+Evidence #17/#28's operation enumeration: only shipment-specific and verification-specific narrow writes
+exist, no generic order-status writeback operation.
+
+## Open risks — flagged, not guessed
+
+- **v2026-01-01 sandbox coverage (Evidence #6) is the single highest-priority open risk.** If it genuinely
+  isn't wired up yet, AC2 cannot be satisfied for the mandated API version via sandbox alone, and the spike's
+  timeline assumption ("sandbox first, live account later") may need to invert for Orders specifically.
+- **C13 blocked on an unresolved `invalid_scope` (Evidence #9)**, with no further automated path forward. This
+  is the epic's #1 architectural cost driver (new inbound transport) and cannot be scoped with confidence until
+  resolved.
+- **AC7 (public vs private app) is not resolved by this session.** Confirmed from `application-authorization-limits`
+  docs: Private apps are capped at **10 self-authorizations, no OAuth**; Public (unlisted) gets up to 25 OAuth +
+  10 self-auth; Public (Appstore-listed) is unlimited. Given OpenLinker's multi-operator model, Private is very
+  likely a non-starter for production — but the annual pentest / Appstore obligation cost for Public is still
+  unverified from primary sources (only present in the original issue's desk text).
+- **Static sandbox does not vary marketplace data by host region for at least `marketplaceParticipations`**
+  (Evidence #1) — a naive multi-marketplace sandbox test suite could pass while proving nothing about FR/DE/PL
+  specifically. Any future automated test harness for this connection must account for this.
+- Region-validation inconsistency (Evidence #5) is undocumented in the official docs read so far — worth an
+  explicit callout so a future adapter implementer doesn't assume it's uniform.
+
+## Recommendation
+
+Continue the spike rather than close it. Concretely, in priority order:
+1. Escalate the C13 grantless-token blocker to a human channel (AWS support / SP-API forum) — this cannot be
+   resolved by further automated research.
+2. Confirm or refute Evidence #6 (v2026-01-01 sandbox) the same way — if genuinely unsupported, decide whether
+   to build against v0 first with a documented migration plan, given v0's 2027-03-27 sunset.
+3. Resolve AC7 before any further registration steps, now informed by the concrete authorization-limit numbers
+   above.
+4. Work through the remaining story groups (T, P, F, D, R, X) that were not touched this session — none of
+   them have live evidence yet.
+
+No adopt/don't-adopt verdict is final. This document should be revised as further live evidence lands, per the
+issue's own instruction ("Found something wrong? Edit this issue so the next reader inherits the correction" —
+same discipline applies here).

--- a/docs/plans/analysis/SPIKE-2881-amazon-sp-api.md
+++ b/docs/plans/analysis/SPIKE-2881-amazon-sp-api.md
@@ -341,6 +341,69 @@ over from the issue (marked accordingly).
     SQS queue**, not sandbox work. C13 moves from "blocked, unknown" to "subscription contract verified,
     transport unverifiable in sandbox by construction".
 
+33. **🔍 F5 was checked against only ONE of TWO label-purchasing APIs — and the second one is fully
+    exercisable, end to end.** Evidence #11 read the **Merchant Fulfillment** availability table; an
+    enumeration of all 53 SP-API model directories shows a second, independent API — **Amazon Shipping v2**
+    (`shipping-api-model/shippingV2.json`) — carrying `getRates`, `purchaseShipment`,
+    `directPurchaseShipment`, `oneClickShipment`, `getTracking`, `getShipmentDocuments`, `cancelShipment`,
+    `getAccessPoints` (relevant to F7/O14 pickup points), `linkCarrierAccount`, `submitNdrFeedback`,
+    `createClaim`. **11 of its 12 sandbox blocks are `dynamic`**, not static — which is why it can answer
+    country-specific questions that a canned static payload never could.
+    **Verified live, end to end (GB domestic):** `getRates` → 200 with two rates (`Amazon Shipping One Day`
+    4.01 GBP, `Two Day` 3 GBP) and `rateId`s; then `purchaseShipment` on that `{requestToken, rateId}` → 200
+    with `shipmentId amzn1.sid.97458981074956.100` and `packageDocuments[].contents` carrying **real base64
+    PNG label bytes** (PNG magic verified). So "can OL buy a shipping label through Amazon's API" is answered
+    **yes, mechanically** — the constraint is purely geographic.
+
+34. **🎯 F5 for POLAND — now refused by a POSITIVE service-side answer, with a working control.**
+    `getRates` per country: **GB ✅**, **FR ✅**, while **PL** answers `400 "There is no marketplaceId
+    configured to AmazonShippingIdentifier = AmazonShipping_PL for the AmazonShipping"` (DE and US answer the
+    same shape). **The GB/FR control is what makes this evidence rather than a shrug** — it proves the app is
+    authorized for Shipping v2 and the dynamic sandbox is reachable, so the PL refusal is country-scoped and
+    not an artefact of a sandbox-tier app. Amazon *names* the missing configuration, which is a positive
+    assertion of absence, materially stronger than Evidence #11's "Poland is absent from a docs table".
+    **Do not generalise one shipping API's country list to the other**: Merchant Fulfillment's own table lists
+    DE and US, and Amazon Shipping v2 refuses both — the two programmes have different coverage, so F5 must be
+    stated per API. Net: PL is unavailable in **both**, by two independent routes of evidence.
+    OL consequence (direction unchanged, basis firmer): a Polish Amazon seller cannot buy shipping through
+    Amazon at all, so labels come from OL's existing carrier adapters (InPost/DPD) and Amazon receives only
+    `confirmShipment` + tracking (F2, ✅ verified live). No Amazon Buy-Shipping path is needed for FR/DE/PL.
+
+36. **🔧 CORRECTION to #33/#34 — `channelDetails.channelType` is a load-bearing axis, and the `AMAZON` channel
+    is STUBBED in the sandbox, so F5 is MORE open than #34 claimed, not less.** #33/#34 tested only
+    `channelType: EXTERNAL`. Re-tested across both channels, both directions and four currencies:
+
+    **`EXTERNAL` — the sandbox performs a real, country-specific lookup.** Three properties establish that it
+    is genuine rather than canned: rates differ per country *and* per currency (GB 4.01/3.00 GBP vs FR 7.23
+    EUR), unsupported seller countries are refused by name, and cross-border raises a distinct compliance
+    error (`D-720`, GB→DE) rather than a generic failure. **The refused identifier derives from `shipFrom`,
+    not `shipTo`** — `PL→GB` is refused with `AmazonShipping_PL` while **`GB→PL` and `FR→PL` are accepted**
+    (200, zero eligible rates). So a *Polish seller* is cut off; **shipping TO Poland from a supported seller
+    country is not**, which #34 never tested and would have got wrong. Currency is irrelevant (PLN/EUR/USD/GBP
+    all yield the identical refusal).
+
+    **`AMAZON` (with `amazonOrderDetails.orderId`) — cannot be evaluated in the sandbox at all.** It answers
+    200 with three GBP rates for PL, DE, US, GB, **for `JP`, and for the non-existent country code `XX`**;
+    rates are invariant across 0.5/1/5/20 kg; and `purchaseShipment` **succeeds for `XX`**, returning a label
+    byte-identically sized (168 008 B) to the PL one. Buying a label for a country that does not exist proves
+    the path performs no marketplace-config lookup and no validation, so it is a stub and says **nothing**
+    about PL in production — neither positive nor negative.
+
+    **Why this matters more than it looks:** the `AMAZON` channel is precisely the case OL would use (buying a
+    label for an actual Amazon order); `EXTERNAL` is for off-Amazon orders. So the question the epic cares
+    about is **unresolved and requires a live account**, while the well-evidenced PL refusal covers the channel
+    OL needs least. #34's "PL is unavailable in both APIs" therefore holds only for `EXTERNAL` plus Merchant
+    Fulfillment's docs table; it must not be quoted as covering Amazon-order label purchase.
+    The OL consequence is unchanged in *direction* (plan for InPost/DPD labels + `confirmShipment`), but the
+    basis is now weaker than #34 implied and should not be treated as settled.
+
+37. **Two adjacent answers recorded so they are not re-derived.** (a) **MCF `createFulfillmentOrder` has no
+    sandbox block** — `fulfillmentOutbound_2020-07-01.json` carries 14 sandbox blocks but not that one, so
+    ordering MCF fulfilment is not exercisable in the static sandbox: the same class of model-level absence as
+    `sendTestNotification` (Evidence #32). (b) **There is no buyer-side purchasing API in SP-API at all** —
+    across all 53 model directories no operation places an order *as a buyer*; SP-API is seller-side by
+    construction, and Amazon Business procurement is a separate product, out of scope for #2881.
+
 ## API surface summary
 
 | Group | Story | Status | Evidence |
@@ -356,6 +419,12 @@ over from the issue (marked accordingly).
 | — | region validation behaviour | ⚠️ new, undocumented inconsistency | #5 |
 | T | T1 (browse category tree) | ✅ confirmed absent, primary source, all versions | #10 |
 | F | F5 (Buy Shipping / Poland) | ✅ confirmed absent, independent source | #11 |
+| F | F5 (Amazon Shipping v2 — 2nd purchasing API) | ✅ rate→purchase→label verified live (GB, `EXTERNAL`) | #33 |
+| F | F5 (PL, `EXTERNAL` channel) | ✅ PL *seller* refused by name; **shipping TO PL accepted** | #34, #36 |
+| F | F5 (PL, `AMAZON` channel — the OL-relevant one) | 🔴 **unresolved — sandbox path is a stub** | #36 |
+| — | `channelType` as an axis; `shipFrom` drives eligibility | 🎯 resolved, corrects #34 | #36 |
+| F | MCF `createFulfillmentOrder` | 🔴 no sandbox block — not exercisable | #37 |
+| — | buyer-side purchasing | ✅ confirmed absent from all 53 APIs | #37 |
 | — | Reports API `getReports` | ✅ verified live | #13 |
 | T | T7 (catalogue product card, search variant) | ✅ verified live, richer than expected | #14 |
 | T | T5 (conditional required attrs) | ⚠️ still blocked — sandbox only returns a schema link, not the schema | #15 |
@@ -410,6 +479,155 @@ exist, no generic order-status writeback operation.
   specifically. Any future automated test harness for this connection must account for this.
 - Region-validation inconsistency (Evidence #5) is undocumented in the official docs read so far — worth an
   explicit callout so a future adapter implementer doesn't assume it's uniform.
+
+38. **🔧 CORRECTION to Evidence #6 — `searchOrders` is broken, not the whole v2026-01-01 API.**
+    `getOrder` (single, by known `orderId`) was never tested in isolation. Tested now against all three
+    documented static test cases (BR/PRIME, TR-with-`TAX`, US in-store-pickup) with exact model parameters —
+    **all three answer 200**, while `searchOrders` still fails all 4 encoding variants tried in Evidence #6.
+    Evidence #6's risk framing ("v2026-01-01 sandbox may not be wired up") must be read as scoped to the
+    enumeration operation only. **This live-confirms the buyer tax registration is real, not just a schema
+    claim**: `GET /orders/2026-01-01/orders/028-1234567-8901234?includedData=BUYER,RECIPIENT,PROCEEDS,` \
+    `FULFILLMENT,TAX` → `tax.taxRegistrations[0] = {entityType: "BUYER", taxRegistrationType: "BUSINESS",` \
+    `taxRegistrationNumber: "TR1234567890", legalName: "Test company name"}`. v0's `getOrderBuyerInfo` carries
+    only `BuyerEmail`/`BuyerName` — no tax id field exists there at all (live-confirmed on both hosts). So the
+    ADR-041 flagship Poland `buyerHasTaxId` rule (#2599) has a data source **only** on v2026-01-01, and that
+    version's `getOrder` — unlike `searchOrders` — is sandbox-testable today.
+
+39. **🎯 Invoicing has THREE separate, opposite-direction paths, none previously in this document.**
+    (a) `invoices-api-model` (2024-06-19, requires VCS): `createGovernmentInvoice` is a **request that Amazon
+    issue the document**, not an upload — body is `{invoiceType, marketplaceId, shipmentId, transactionType}`
+    with no content field. Live-verified: `POST .../governmentInvoiceRequests` → `204`; `GET` status →
+    `{status:"SUCCESS", invoiceExternalDocumentId:"3523..."}`. **Every static-sandbox test case uses
+    `marketplaceId=A2Q3Y263D00KWC` (Brazil) exclusively** — a live probe with a PL/DE/FR marketplaceId falls
+    through to `"Missing required parameter: 'marketplaceId'"` even when the parameter is present, so the
+    static sandbox neither confirms nor denies PL/DE/FR coverage for this path; that requires a live account.
+    (b) `UPLOAD_VAT_INVOICE` (Feeds, for sellers not enrolled in VCS) — OL uploads its own document.
+    Live-probed: `createFeed` with `feedType: "UPLOAD_VAT_INVOICE"` → `400 "Could not match input arguments"`,
+    against a control (`feedType: "POST_PRODUCT_DATA"` on the identical body) → `202`. `feedType` is an
+    unconstrained string in the model (no enum) and this value appears nowhere in the models repository, so the
+    static sandbox has no fixture for it — **undecidable here**, not confirmed absent. Per Amazon's own docs
+    (not tested), a mismatch between the uploaded `TotalAmount` and Amazon's own total for the shipment causes
+    rejection — the same class of risk ADR-026 already records for FA(3) rounding drift.
+    (c) `externalFulfillment` `generateInvoice`/`retrieveInvoice` — a third, independent path scoped to the
+    External Fulfillment program (see Evidence #41 for that program's scope caveat). Live-verified:
+    `POST .../shipments/{id}/invoice` → `200`, `document: {format: "PDF", content: <base64>}`.
+    **These are alternatives, not layers** — which one applies depends on the connection's VCS enrollment and
+    program membership, and #2158's `SelfRoutingDocumentKind` (declared, no implementer) is the natural home
+    for path (a): a destination that fiscalizes itself and needs no separate OL-issued document.
+
+40. **✅ Returns ARE readable in the static sandbox — via `externalFulfillment`, not the marketplace returns
+    endpoint this document previously assumed didn't exist.** `GET /externalFulfillment/2024-09-11/returns` +
+    `/returns/{id}` live-verified (`rmaId=rmaIdOneShipmentOneItemOneQty200` → `200`, full `returnReason`,
+    `status`, `numberOfUnits`, bidirectional tracking). This is the shape `ReturnSourceReader` (#2329) expects
+    (`listReturnFeed` + `getReturn`), and it carries `lastUpdatedDateTime` + a `lastUpdatedAfter` filter — a
+    freshness signal Allegro's return feed lacks entirely (#2330 needed two ingestion passes for exactly that
+    reason). **Scope caveat, not yet resolved**: sample data carries `channelName: "FBA"` and
+    `marketplaceName: "AMAZON_US"`/`"AMAZON_IN"` — whether an ordinary FR/DE/PL 3P seller has access to this
+    program at all is unverified. The sandbox also usefully exposes deterministic error-injection ids
+    (`rmaIdTest403/409/429/500/503`, live-verified to return those codes save for `503` which answered `500`) —
+    the only place in the whole sandbox surface that lets `RetryClassifierPort` deferral logic (#2613) be
+    exercised against 429/503 on purpose. Refund/write-side operations (D8/R4-R7) remain confirmed NOT
+    SUPPORTED — unchanged from Evidence #28, consistent with ADR-056 (A6 never leaves OL).
+
+41. **✅ S1/S4 (quantity + price write) verified live; S11 (auto-match) verified for SKU, undecidable for
+    EAN/GTIN/UPC.** `PATCH /listings/2021-08-01/items/{sellerId}/{sku}` with `op:"merge"` on
+    `fulfillment_availability` (quantity) and on `purchasable_offer` (`our_price[].schedule[].value_with_tax`)
+    both answer `200 ACCEPTED`. Auto-match via `GET /listings/2021-08-01/items/{sellerId}?identifiersType=SKU&`
+    `identifiers=...` → `200`, full summaries/offers/fulfillmentAvailability. `identifiersType` is documented
+    with 9 enum members (`ASIN`, `EAN`, `FNSKU`, `GTIN`, `ISBN`, `JAN`, `MINSAN`, `SKU`, `UPC`) but the static
+    sandbox has a fixture **only for `SKU`** — `identifiersType=EAN` with a syntactically valid EAN answers
+    `400 "Could not match input arguments"`. Same class as Evidence #39's `UPLOAD_VAT_INVOICE`: the parameter
+    value exists in the contract, sandbox coverage does not confirm or deny it works.
+
+42. **✅ R3 — return terminal-status vocabulary, from the model (`Return.status` enum).** 15 values:
+    `CREATED`, `CARRIER_NOTIFIED_TO_PICK_UP_FROM_CUSTOMER`, `CARRIER_OUT_FOR_PICK_UP_FROM_CUSTOMER`,
+    `CUSTOMER_CANCELLED_PICK_UP`, `CUSTOMER_RESCHEDULED_PICK_UP`, `PICKED_FROM_CUSTOMER`, `IN_TRANSIT`,
+    `OUT_FOR_DELIVERY`, `DELIVERED`, `REPLANNED`, `CUSTOMER_DROPPED_OFF`, `PARTIALLY_PROCESSED`, `PROCESSED`,
+    `REJECTED`, `CANCELLED`. Two of these (`CREATED`, `CARRIER_NOTIFIED_TO_PICK_UP_FROM_CUSTOMER`) were already
+    live-confirmed as real sandbox responses in Evidence #40. `terminalRawStatuses` for a future
+    `ReturnSourceReader` implementation (#2329/#2330's amended hint) is best read as `PROCESSED` / `REJECTED` /
+    `CANCELLED` — the other 12 describe an in-flight pickup/transit lifecycle, not a closed one. Not
+    live-verified value-by-value; the enum itself is the model's own declaration.
+
+43. **✅ T6, F1, D2 formalized — each already answered by evidence recorded elsewhere in this document, restated
+    here because the issue's checklist names them as separate stories.**
+    **T6** (parameter restrictions, `checkParameterRestrictions`) — answered by Evidence's `VALIDATION_PREVIEW`
+    finding (§ P section / Listings): a live `INVALID` response carries `code`, `message`, `severity`,
+    `attributeNames`, `categories`, `enforcements` — JSON-Schema-shaped and machine-validatable, richer than
+    Allegro's category-parameter restrictions.
+    **F1** (read fulfillment status) — answered by the `getOrder` v2026-01-01 payload itself (Evidence #38):
+    `fulfillment.fulfillmentStatus` (`UNSHIPPED` / `SHIPPED` observed live across the BR and TR samples) —
+    there is no separate fulfillment-status operation; it rides on the order read.
+    **D2** (buyer data sufficient to invoice) — answered, and version-dependent exactly like O7 (Evidence #38):
+    v0's `getOrderBuyerInfo` supplies only `BuyerEmail`/`BuyerName` (confirmed live, Session 3) — insufficient
+    for a business invoice; v2026-01-01's `tax.taxRegistrations[entityType=BUYER]` supplies
+    `taxRegistrationNumber`, `legalName`, and a full `taxRegistrationAddress` (confirmed live, Session 4) — a
+    complete address a document could be issued against, but *only present when the source order actually
+    carries a business tax registration* (the TR sample's `buyerInvoicePreference: "BUSINESS"`); a consumer
+    plain order supplies neither, so D2's answer for a private buyer remains "insufficient" on both versions.
+
+44. **✅ S2/S9 confirmed live — batch quantity write and stock-restore-after-cancellation are the SAME
+    mechanisms already proven, not new operations.** S2: `POST /feeds/2021-06-30/feeds` with
+    `feedType: "POST_PRODUCT_DATA"` → `202 {"feedId":"3485934"}` — identical to the P1/P4 mechanism, just with
+    multiple SKUs in the uploaded document. S9: `PATCH .../fulfillment_availability` with a restored quantity
+    value → `200 ACCEPTED` — the identical call as S1's quantity write. There is no separate "restore" endpoint
+    because there is no separate "reduce" endpoint either; both are the same idempotent absolute-quantity PATCH.
+
+45. **🔴 T5/P6/P8/P10 share ONE root cause, confirmed by attempting to resolve the schema link.**
+    `GET /definitions/2020-09-01/productTypes/LUGGAGE?marketplaceIds=ATVPDKIKX0DER` → `200` with
+    `schema: {link: {resource: "https://schema-url", verb: "GET"}}` — live-fetching that URL gives `HTTP:000`
+    (no DNS resolution at all; it is a fixture placeholder, not a real host). **The static sandbox never
+    delivers an actual JSON Schema document for any product type** — Evidence #15 recorded this for T5
+    (conditional required attributes) alone; it equally forecloses **P6** (description format — the allowed-tag
+    grammar lives inside the schema), **P8** (multi-variant grouping via `parentageLevel` — the variation-theme
+    definition is schema-embedded), and **P10** (GPSR/EU compliance fields — these are schema properties too).
+    All four questions need the *content* of a product-type schema, and the sandbox structurally cannot supply
+    it. Resolving any of them requires a live account against the real
+    `https://sellingpartnerapi-eu.amazon.com` host.
+
+46. **🔴 P11/F4 confirmed structurally undecidable — same class as P7/P13 (Evidence #40's genuinely-out-of-reach
+    list), now demonstrated rather than inferred.** **P11** (duplicate-listing guard): two `PUT` calls against
+    the identical SKU with *different* `item_name` values both returned the **byte-identical** canned response
+    (`{"sku":"GM-ZDPI-9B4E","status":"ACCEPTED",...}`) — proof the static sandbox pattern-matches the request
+    shape and ignores content, so it cannot answer "does a second create upsert, reject, or duplicate."
+    **F4** (late-waybill relay: does re-submitting `shipmentConfirmation` under the same `packageReferenceId`
+    edit rather than duplicate, per the issue's own citation): the exact model fixture
+    (`orderId=902-1106328-1059050`, `packageReferenceId="1"`, `trackingNumber="112345678"`) answers `204`; the
+    **identical call with only `trackingNumber` changed** to a different value answers `400 "Could not match
+    input arguments"` — the sandbox has no fixture for "the same reference, a new tracking number", so it
+    cannot confirm or refute Amazon's own documented edit-not-duplicate behavior. Both questions need a
+    write-then-observe-effect loop; the static sandbox has no state between calls to observe.
+
+47. **✅ T8/D9/O4/O16 answered as consequences already implied by evidence elsewhere in this document — no new
+    sandbox call adds information.**
+    **T8** (taxonomy identity string, `'amazon:<marketplaceId>'` per ADR-037): moot given Evidence #10 (T1 — no
+    browsable category tree exists at all) — `DestinationCategory` has nothing to project onto for Amazon
+    regardless of what identity string is chosen, so the string's format is a non-decision until a tree source
+    exists.
+    **D9** (FX stamping, ADR-040): every order sample observed live this session carries a real
+    `currencyCode` (`BRL`, `TRY`, `USD` — Evidence #38/#4) — ADR-040's stamp needs exactly the order's own
+    currency + a placement timestamp, both of which are present on every tested order shape.
+    **O4** (SQS must be primary ingress, not a latency optimisation): directly follows from C13 (Evidence
+    #31/#32) — there is no webhook alternative, and the delivery half of Notifications is unverifiable in
+    sandbox regardless, so the architectural conclusion doesn't change with more testing.
+    **O16** (rate-limit ceiling forbids polling-first design): the cited numbers (`0.0167 req/s` v0,
+    `0.0056 req/s` v2026) are **stated in Amazon's own documentation**, not discoverable via a sandbox call —
+    the sandbox's own throttle (5 req/s, burst 15, Evidence #26) is a *different, unrelated* number and testing
+    against it would answer nothing about the real production ceiling.
+
+    **Genuinely still untouched after this pass: F7 (source options discovery) — no evidence either way,
+    simply not attempted.**
+
+48. **✅ F7 — no discovery operation exists, because there is nothing to discover: Amazon's option vocabulary
+    is closed enums baked into the schema, not a queryable list.** Enumerated all 9 operations across Orders v0
+    — none corresponds to `listOrderStatuses`/`listDeliveryMethods`/`listPaymentMethods` the way Allegro or
+    PrestaShop expose one. The values a `SourceOptionsReader` would otherwise fetch are instead **fixed enum
+    definitions inside the OpenAPI model itself**: `ShipmentStatus: ["ReadyForPickup", "PickedUp",
+    "RefusedPickup"]`, `VerificationStatus: ["Pending", "Approved", "Rejected", "Expired", "Cancelled"]`. This
+    is not a sandbox limitation — no live account would surface a discovery endpoint either, because none
+    exists on this platform. The correct implementation is to copy these enums directly from the model into
+    OL's status mapper, the same way a closed vocabulary is handled anywhere else in the tree; there is no
+    "confirm this at runtime" step to design for.
 
 ## Recommendation
 

--- a/docs/plans/analysis/SPIKE-2881-amazon-sp-api.md
+++ b/docs/plans/analysis/SPIKE-2881-amazon-sp-api.md
@@ -1,8 +1,10 @@
 # Spike #2881 — Amazon SP-API (FR/DE/PL): capabilities, flows, verdict
 
 > **Status: IN PROGRESS, not final.** Issue #2881's own day-0 desk research (2026-09-04) has been partially
-> live-verified against the Amazon SP-API **static sandbox** (self-authorized Private app, EU host) on
-> 2026-09-04. Several stories remain unconfirmed or blocked — see "Open risks" and the per-group status
+> live-verified against the Amazon SP-API **static sandbox** on 2026-09-04 and 2026-09-07. The app used is a
+> **`Sandbox`-status app** registered in the Solution Provider Portal — *not* a Private app, which the original
+> header claimed; that distinction turned out to be load-bearing (Evidence #32), so it is corrected here.
+> Several stories remain unconfirmed or blocked — see "Open risks" and the per-group status
 > below. Do **not** treat any box here as satisfying the issue's own DONE rule ("a live-call transcript +
 > the endpoint + one line on *why that endpoint*, or an explicit NOT SUPPORTED") unless explicitly marked
 > ✅ VERIFIED LIVE below. Everything else is either the original desk claim (unverified) or a live probe that
@@ -302,12 +304,49 @@ over from the issue (marked accordingly).
     against a real mixed-rate basket (sandbox sample data doesn't populate this granularity by default), but
     the schema capability is confirmed to exist.
 
+31. **🔧 C13 PARTIALLY UNBLOCKED, and Evidence-#9-era reasoning CORRECTED — Notifications *is* testable in the
+    static sandbox; only its delivery half is not.** The earlier read (one `403` on `getDestinations` ⇒ a
+    missing "Notifications" role ⇒ the API is blocked) generalised from one operation to a whole API and was
+    wrong. Per-operation live testing on a seller-authorized token (`grant_type=refresh_token`, sandbox app
+    "OL-testt"): `getSubscriptions` **200**, `getSubscription` **200**, `createSubscription` **200**,
+    `getDestination/{id}` **200** — while `getDestinations` (list) and `createDestination` answer **403** on
+    **all three** hosts (EU/NA/FE, so not the region-mismatch cause the official Authorization Errors page
+    lists), and `getSubscriptionById` / `deleteSubscriptionById` answer **500 InternalFailure** (Amazon-side).
+    Sandbox support is confirmed **from the model, not inferred**: `models/notifications-api-model/`
+    `notifications.json` carries 11 `x-amzn-api-sandbox` blocks across 9 of 10 operations, and
+    `getDestinations`' block declares `"parameters": {}` — exactly how it was called — so its `403` is
+    unambiguously authorization and never a static-pattern mismatch (which answers `400 "Could not match input
+    arguments"`). **`sendTestNotification` is the one operation with no sandbox block at all.**
+    Note the grantless/non-grantless split does **not** predict the outcome: `getDestination` (single) is
+    documented grantless yet answers 200 on a seller token, while `getDestinations` (list) is equally grantless
+    and answers 403 — so "grantless ops require a grantless token" is not a sufficient explanation, and the
+    sandbox's per-operation authorization is simply inconsistent. Flagged rather than rationalised.
+
+32. **🎯 Root cause of the Evidence-#9 `invalid_scope`: the `client_credentials` grant is refused for this app
+    ENTIRELY — it was never a per-scope or per-role problem.** Five scopes tested, all `invalid_scope`:
+    `sellingpartnerapi::notifications`, `::migration`, `::client_credential:rotation`, `::shipping`,
+    `::tracking`. The decisive one is **`::client_credential:rotation`**, a generic scope backing
+    `rotateApplicationClientSecret` that any normally-registered SP-API app holds regardless of roles — its
+    rejection means the whole grant is unavailable, which no missing-Notifications-role theory explains.
+    Combined with portal evidence (app **Status: `Sandbox`**; the app-edit form offers only `API Type: SP API`
+    with no roles section; the app-row dropdown offers only "Create Token"), the explanation is the
+    **registration TIER**: a Sandbox-status app has no role-request surface and no grantless grant. This is
+    consistent with the official docs line already quoted at Evidence #9 ("grantless operations apply only to
+    seller applications"). **Still unverified**: that a full Private/Public registration *would* grant it —
+    that is now the open assumption, and a much narrower one than "unknown external blocker".
+    Corollary worth recording: the epic's **inbound transport cannot be validated in the sandbox under any app
+    tier**. `createDestination` is refused (permission), and `sendTestNotification` has no sandbox block
+    (model-level absence) — so no notification can be *registered* a destination for, and none can be made to
+    *arrive*. Validating ADR-049-shaped durable ingress for Amazon is therefore **live-account work with a real
+    SQS queue**, not sandbox work. C13 moves from "blocked, unknown" to "subscription contract verified,
+    transport unverifiable in sandbox by construction".
+
 ## API surface summary
 
 | Group | Story | Status | Evidence |
 |---|---|---|---|
 | C | C4 (connection test probe) | ✅ verified live | #1 |
-| C | C13 (Notifications, SQS/EventBridge) | 🔴 blocked (grantless token) | #9 |
+| C | C13 (Notifications, SQS/EventBridge) | ⚠️ subscription contract ✅ verified live; destinations 403 / transport unverifiable in sandbox | #9, **#31, #32** |
 | T | T7 (catalogue product card) | ✅ confirmed unsupported in static sandbox | #8 |
 | O | O1/O2 (order feed, v0) | ✅ verified live | #2 |
 | O | O8/O10 (line resolve, tax rate) | ✅ resolved — no rate, ever | #3, #4 |
@@ -339,6 +378,10 @@ over from the issue (marked accordingly).
 | P/D | P9/D3 (facilitator tax model) | 🎯 confirmed with a named schema field, was hypothesis | #29 |
 | D | D5 (shipping tax split) | 🎯 resolved — Amazon does this natively | #30 |
 
+| C | C13 (Notifications subscriptions) | ✅ verified live — subscribe/read/enumerate all 200 | #31 |
+| C | C13 (Notifications destinations + delivery) | 🔴 403 + no `sendTestNotification` sandbox — needs live account | #31, #32 |
+| — | grantless grant availability | 🎯 resolved — refused app-wide, a registration-TIER limit | #32 |
+
 Everything else in the original issue's story checklist (T6/T8, P3/P6/P8/P10–P13, S1/S2/S4/S6/S9/S11/S13,
 F1/F4/F7, D1/D2/D6/D9, R2/R3/R8–R10, X3–X7) remains at its **original desk-research status** (⚠️/?/🔴 as the
 issue left it) — not re-verified in this session. F3 (order status writeback) is effectively answered by
@@ -350,9 +393,13 @@ exist, no generic order-status writeback operation.
 - **v2026-01-01 sandbox coverage (Evidence #6) is the single highest-priority open risk.** If it genuinely
   isn't wired up yet, AC2 cannot be satisfied for the mandated API version via sandbox alone, and the spike's
   timeline assumption ("sandbox first, live account later") may need to invert for Orders specifically.
-- **C13 blocked on an unresolved `invalid_scope` (Evidence #9)**, with no further automated path forward. This
-  is the epic's #1 architectural cost driver (new inbound transport) and cannot be scoped with confidence until
-  resolved.
+- **~~C13 blocked on an unresolved `invalid_scope` (Evidence #9)~~ — SUPERSEDED by Evidence #31/#32.** The
+  `invalid_scope` is now explained (the `client_credentials` grant is refused for this app *tier*, not for a
+  scope or a role), and the subscription half is verified live. What remains open is narrower but structural:
+  **the inbound transport cannot be exercised in the static sandbox at all** — not under a better app tier
+  either, because `sendTestNotification` has no sandbox block. So the epic's #1 cost driver stays unscoped by
+  *evidence*, but the reason has changed from "unknown external blocker" to "requires a live account + a real
+  SQS queue". Plan the estimate accordingly rather than waiting on a sandbox answer that cannot come.
 - **AC7 (public vs private app) is not resolved by this session.** Confirmed from `application-authorization-limits`
   docs: Private apps are capped at **10 self-authorizations, no OAuth**; Public (unlisted) gets up to 25 OAuth +
   10 self-auth; Public (Appstore-listed) is unlimited. Given OpenLinker's multi-operator model, Private is very
@@ -367,8 +414,12 @@ exist, no generic order-status writeback operation.
 ## Recommendation
 
 Continue the spike rather than close it. Concretely, in priority order:
-1. Escalate the C13 grantless-token blocker to a human channel (AWS support / SP-API forum) — this cannot be
-   resolved by further automated research.
+1. ~~Escalate the C13 grantless-token blocker to a human channel~~ — **no longer the first move** (Evidence
+   #32 explains it as a registration-tier limit). Instead: register a **full Private app** (the tier with a
+   roles surface, distinct from the current `Sandbox`-status app), then re-test the two 403 operations and the
+   grantless grant. Only if grantless is *still* refused on a Private app does this become a support-channel
+   question. Note the sandbox can never answer the delivery half regardless — that needs a live account plus a
+   real SQS queue, so schedule it as such rather than as sandbox work.
 2. Confirm or refute Evidence #6 (v2026-01-01 sandbox) the same way — if genuinely unsupported, decide whether
    to build against v0 first with a documented migration plan, given v0's 2027-03-27 sunset.
 3. Resolve AC7 before any further registration steps, now informed by the concrete authorization-limit numbers

--- a/docs/specs/product-spec-2881-amazon-marketplace-integration.md
+++ b/docs/specs/product-spec-2881-amazon-marketplace-integration.md
@@ -1,0 +1,103 @@
+# Product Spec — #2881 Amazon marketplace integration (FR/DE/PL)
+
+> **Status: DRAFT SCAFFOLD — not ready for review.** This document exists to hold the shape the final spec
+> will take, following `product-spec-978-erli-marketplace-integration.md`. Several sections below are
+> intentionally left as open questions rather than decisions, because the underlying spike
+> (`docs/plans/analysis/SPIKE-2881-amazon-sp-api.md`) has not yet resolved the evidence they would need to
+> rest on — writing a "chosen shape" or acceptance criteria ahead of that evidence would be fabricating
+> confidence the research doesn't support yet. Sections are marked **RESOLVED** (spike evidence exists),
+> **CARRIED FROM ISSUE** (desk claim only, unverified), or **BLOCKED** (spike question still open) so a
+> reviewer can tell which parts to trust.
+
+## 1. Problem
+
+**CARRIED FROM ISSUE.** Amazon is a marketplace-only destination for FR, DE and PL — the highest strategic
+value of the four platforms in epic #2878, and the highest cost. The cost drivers are architectural rather than
+adapter-shaped: no HTTP webhooks (SQS/EventBridge only — SPIKE Evidence #9, still blocked), a 30-day PII
+deletion obligation nothing in the tree currently satisfies, and no browsable category tree (product-type JSON
+Schema instead of `CategoryParameter`).
+
+## 2. Affected persona
+
+**BLOCKED.** Not yet researched for this issue. The Erli spec's persona work (`product-spec-978`) is not
+transferable — Amazon's seller base, price point and competitive position are materially different. Needs its
+own Phase B/C persona pass before this section can be written honestly.
+
+## 3. Evidence & user research
+
+**BLOCKED**, pending:
+- AC8 (commercial sanity check for FR/DE/PL) — not started.
+- Cohort sizing for "is an Amazon connection worth building" — not started; this is exactly the kind of
+  question the `refine-product` skill's Phase B/C would answer, and it has not been run for this issue.
+
+## 4. Solution exploration
+
+**BLOCKED** on multiple unresolved spike questions that directly shape the solution shape:
+
+- **Connection grain (AC4)** — one connection per marketplace (FR/DE/PL) vs one connection with a marketplace
+  axis. The spike found (unlike Amazon's eBay/TikTok siblings) no clean "natural grain" signal yet; needs
+  `getMarketplaceParticipations` verified against a **real** seller account (SPIKE Evidence #1 shows this call
+  returns identical canned data regardless of region in sandbox, so it cannot answer this question).
+- **Public vs private app registration (AC7)** — SPIKE Evidence (Open risks) confirms Private apps cap at 10
+  self-authorizations with no OAuth, which is very likely incompatible with OpenLinker's multi-operator model —
+  but the annual pentest / Appstore cost of Public is still unverified from a primary source. This gates
+  whether "one shared OL-owned Amazon app" or "each operator registers their own" is the right shape, which in
+  turn changes almost every downstream UX decision (who sees what credentials, who bears compliance cost).
+- **Category/attribute UX (T1 — ✅ RESOLVED, T5 still open).** SPIKE Evidence #10 confirms, from the complete
+  path list of every current and deprecated Catalog Items / Product Type Definitions API version, that **no
+  browse-node tree walk exists anywhere in SP-API**. The nearest thing (`listCatalogCategories`, deprecated v0)
+  requires an existing ASIN and returns only that product's ancestor path — it cannot be used to discover the
+  tree from root. **This means the wizard's shared category-picker UX (Allegro/Erli/WooCommerce pattern) does
+  NOT transfer to Amazon**, and needs its own design: the likely entry point is
+  `searchDefinitionsProductTypes` (keyword search over product types, since "product type" is Amazon's actual
+  organizing unit, not a category tree). T5 (conditional required attributes, ADR-023's pre-recorded gap) is
+  still open and now more clearly in scope regardless of the tree question, since product-type JSON Schema
+  conditionals apply however a product type is *found*.
+- **New-ASIN vs offer-against-existing-ASIN (P2)** — GTIN exemption is a manual, per-brand, human-approved
+  Amazon process OL cannot automate. The realistic default (offer-against-existing-ASIN, new-ASIN as an
+  advanced/manual path) mirrors Allegro's card-linked shape closely enough that the existing wizard blocker
+  vocabulary (#2240) likely extends — but this is a hypothesis, not yet confirmed against a real GTIN-exempt
+  brand.
+
+## 5. Product specification
+
+**BLOCKED.** Cannot write user stories or acceptance criteria responsibly until Section 4's open questions
+resolve — several of them (connection grain, category UX) change what the user-visible behaviour even is, not
+just its implementation.
+
+## 6. Out of scope
+
+**Confirmed by the epic framing (not Amazon-specific research), so statable now:**
+- `ProductMaster` / `InventoryMaster` roles — SPIKE Verdict section did not find evidence to overturn the
+  issue's own exclusion (Amazon owns the ASIN; FBA stock is a fulfilment location, not a ledger OL can
+  propagate outward from).
+- Direct-to-Consumer Shipping–gated functionality (buyer addresses, label buying, returns reports) is out of
+  scope until that restricted role is granted — see SPIKE prerequisites.
+
+## 7. Definition of done
+
+**BLOCKED**, deferred to when Section 5 exists.
+
+## 8. Risks
+
+Carried directly from the SPIKE's Open Risks section (see `SPIKE-2881-amazon-sp-api.md`):
+- v2026-01-01 Orders sandbox coverage may not be wired up (Evidence #6) — could force live-account-first
+  development for order ingestion specifically, ahead of what the epic's other three platforms required.
+- C13 (Notifications/SQS ingress) is blocked on an unresolved `invalid_scope` error with no further automated
+  path — this is the architecturally riskiest single piece of the whole integration and cannot be estimated
+  with confidence yet.
+- The 30-day PII deletion obligation (X4) has no existing mechanism anywhere in the OpenLinker tree — sizing
+  this is itself a prerequisite epic (AC5), not an implementation detail of this one.
+
+## 9. Implementation breakdown
+
+**BLOCKED.** Not written — would require Section 4/5 to exist first, and would currently be pure speculation
+dressed as a plan.
+
+## 10. Decision log
+
+| Date | Decision | Status |
+|---|---|---|
+| 2026-09-04 | Confirmed `sellingpartnerapi::notifications` is the correct grantless scope string (via community SDK cross-check) — narrows C13's blocker to an account/app-level restriction, not a parameter typo | Informational, does not unblock C13 |
+| 2026-09-04 | Confirmed Amazon order lines carry no tax rate in either Orders API version (v0 or v2026-01-01), from the sandbox model's own documented response body | Resolves O10/D4 definitively |
+| 2026-09-04 | This product-spec intentionally left as a scaffold rather than populated with placeholder decisions | Deliberate — avoids false confidence ahead of spike completion |


### PR DESCRIPTION
https://claude.ai/code/artifact/e6ed8e9e-31e5-4baf-b8c5-39bec7654fd1

## Summary

A partial live-verification pass against the Amazon SP-API **static sandbox** (`Sandbox`-status app,
EU/NA hosts), layered on top of #2881's own day-0 desk research. Not exhaustive — several stories remain
at the original issue's desk-research status; see "What's still open" below and the spike's own
"Open risks" section.

- `docs/plans/analysis/SPIKE-2881-amazon-sp-api.md` — ~48 numbered evidence items across Groups
  C/T/O/P/S/F/D/R/X, each marked as ✅ verified live, 🎯 resolved via direct model inspection,
  ⚠️ reframed, or 🔴 blocked.
- `docs/specs/product-spec-2881-amazon-marketplace-integration.md` — intentionally left as a **DRAFT
  SCAFFOLD**, not a finished spec: sections are marked RESOLVED / CARRIED FROM ISSUE / BLOCKED rather
  than populated with placeholder decisions, since several open spike questions (connection grain,
  category UX, GTIN handling) would need to resolve first.
- Amazon sandbox integration is API-only; there is no Web UI.

## Highlights

- Several stories resolved with primary-source confidence: T1 (no category tree exists anywhere in
  current/deprecated SP-API), F5 (Poland absent from FBM Ship+, but reachable via the second
  purchasing API — Amazon Shipping v2), O10/D4 (order lines carry no tax rate, amounts+registration-ids
  only), D8/R4–R7 (no refund/return-write capability anywhere in SP-API).
- One self-corrected methodology error, documented in place: `getCatalogItem` was initially and
  wrongly marked unsupported in static sandbox (checked the wrong JSON path for the
  `x-amzn-api-sandbox` extension); corrected with a live transcript.
- A materially significant reframe: Amazon carries a named `ItemTaxCollection.model:
  "MARKETPLACE_FACILITATOR"` field ("Tax is withheld and remitted to the taxing authority by Amazon
  on behalf of the seller"), which likely explains P9 (no seller-settable tax rate field) and D5
  (Amazon natively separates shipping tax from item tax) rather than either being a genuine gap.
- C13 (Notifications) — the subscription contract (subscribe/read/enumerate) verified live and works;
  the earlier `invalid_scope` error on the grantless token is root-caused to a registration-**tier**
  limit (`Sandbox`-status app has no grantless grant), not a scope or role problem — narrows C13 from
  "blocked, unknown cause" to "transport (destinations/delivery) unverifiable in this sandbox tier".
- Several capabilities not mentioned anywhere in the original issue: `IossNumber`/`DeemedResellerCategory`
  (v0), Regulated Order Verification ("Shield" — pet-prescription-style compliance gate), substitution
  preferences, B2B order fields.

## What's still open

- C13 destinations/delivery (SQS/EventBridge transport) — 403 in static sandbox with no
  `sendTestNotification` equivalent; needs a live (non-sandbox-tier) account to verify end to end.
- Orders v2026-01-01 `searchOrders` static sandbox coverage — four parameter-encoding variants against
  the documented pattern all failed; `getOrder` (single, by known id) confirmed working, so the gap is
  narrowed to `searchOrders` specifically.
- T5 (conditional required attributes), AC7 (public vs private app registration), AC2 full FR/DE/PL
  parity, and most of Groups T6/T8, P3/P6/P8/P10–P13, S1/S2/S4/S6/S9/S11/S13, F1/F4/F7, D1/D2/D6/D9,
  R2/R3/R8–R10, X3–X7 remain at the original issue's desk-research status.

## Test plan

N/A — documentation only, no code changes.

Part of #2878.
