### PR TITLE
feat(web): move Data Coverage to the bottom, add a title-adjacent attention badge

### DIFF
--- a/apps/web/src/features/analytics/components/analytics-coverage-alert-badge.test.tsx
+++ b/apps/web/src/features/analytics/components/analytics-coverage-alert-badge.test.tsx
@@ -1,0 +1,70 @@
+import { screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { renderWithProviders } from '../../../test/test-utils';
+import { AnalyticsCoverageAlertBadge, ANALYTICS_DATA_COVERAGE_ANCHOR_ID } from './analytics-coverage-alert-badge';
+import type { CoverageCategoryRow } from '../api/analytics-coverage.types';
+
+function makeRow(overrides: Partial<CoverageCategoryRow> = {}): CoverageCategoryRow {
+  return {
+    category: 'currency',
+    status: 'open',
+    affectedCount: 0,
+    sampleOrderIds: [],
+    ...overrides,
+  };
+}
+
+describe('AnalyticsCoverageAlertBadge', () => {
+  it('should render nothing when categories is undefined', () => {
+    renderWithProviders(<AnalyticsCoverageAlertBadge categories={undefined} />);
+
+    expect(screen.queryByText('Needs attention')).not.toBeInTheDocument();
+  });
+
+  it('should render nothing when no row is actionable', () => {
+    renderWithProviders(
+      <AnalyticsCoverageAlertBadge
+        categories={[
+          makeRow({ category: 'tax-b', affectedCount: 3 }),
+          makeRow({ category: 'currency', affectedCount: 0 }),
+        ]}
+      />
+    );
+
+    expect(screen.queryByText('Needs attention')).not.toBeInTheDocument();
+  });
+
+  it('should render the badge when an Action-labelled row has affected orders', () => {
+    renderWithProviders(
+      <AnalyticsCoverageAlertBadge categories={[makeRow({ category: 'currency', affectedCount: 5 })]} />
+    );
+
+    expect(screen.getByText('Needs attention')).toBeInTheDocument();
+  });
+
+  it('should render the badge when a row failed, even with zero affected orders', () => {
+    renderWithProviders(
+      <AnalyticsCoverageAlertBadge
+        categories={[makeRow({ category: 'currency', status: 'failed', affectedCount: 0 })]}
+      />
+    );
+
+    expect(screen.getByText('Needs attention')).toBeInTheDocument();
+  });
+
+  it('should open a popover with a CTA to scroll to the coverage panel', () => {
+    const target = document.createElement('div');
+    target.id = ANALYTICS_DATA_COVERAGE_ANCHOR_ID;
+    target.scrollIntoView = (): void => {};
+    document.body.appendChild(target);
+
+    renderWithProviders(
+      <AnalyticsCoverageAlertBadge categories={[makeRow({ category: 'currency', affectedCount: 5 })]} />
+    );
+
+    fireEvent.click(screen.getByText('Needs attention'));
+    const cta = screen.getByRole('button', { name: 'Go to Data Coverage' });
+    expect(cta).toBeInTheDocument();
+    expect(() => fireEvent.click(cta)).not.toThrow();
+  });
+});

--- a/apps/web/src/features/analytics/components/analytics-coverage-alert-badge.tsx
+++ b/apps/web/src/features/analytics/components/analytics-coverage-alert-badge.tsx
@@ -1,0 +1,57 @@
+/**
+ * Analytics Coverage Alert Badge
+ *
+ * A page-title-adjacent warning, visible only while the Data Coverage
+ * panel (rendered at the bottom of the page) has something actionable —
+ * see `hasCoverageAttention`. Renders nothing otherwise, so a healthy
+ * install shows no badge at all.
+ *
+ * The panel itself lives at the very bottom of the page (moved there so the
+ * order-derived figures read first), so an operator scanning only the title
+ * area needs a way back to it without scrolling past everything else — the
+ * popover's CTA does exactly that.
+ *
+ * @module apps/web/src/features/analytics/components
+ */
+import type { ReactElement } from 'react';
+import { Button, Popover, PopoverContent, PopoverTrigger, StatusBadge } from '../../../shared/ui';
+import { hasCoverageAttention } from '../lib/data-coverage-copy.lib';
+import type { CoverageCategoryRow } from '../api/analytics-coverage.types';
+
+export const ANALYTICS_DATA_COVERAGE_ANCHOR_ID = 'analytics-data-coverage';
+
+interface AnalyticsCoverageAlertBadgeProps {
+  categories: CoverageCategoryRow[] | undefined;
+}
+
+export function AnalyticsCoverageAlertBadge({
+  categories,
+}: AnalyticsCoverageAlertBadgeProps): ReactElement | null {
+  if (!categories || !hasCoverageAttention(categories)) {
+    return null;
+  }
+
+  function scrollToCoverage(): void {
+    document
+      .getElementById(ANALYTICS_DATA_COVERAGE_ANCHOR_ID)
+      ?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  }
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button type="button" className="analytics-coverage-alert-badge__trigger">
+          <StatusBadge tone="warning" withDot compact>
+            Needs attention
+          </StatusBadge>
+        </button>
+      </PopoverTrigger>
+      <PopoverContent className="analytics-coverage-alert-badge__content">
+        <p>Some Data Coverage checks need action — reporting figures on this page may be incomplete.</p>
+        <Button type="button" tone="secondary" onClick={scrollToCoverage}>
+          Go to Data Coverage
+        </Button>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/src/features/analytics/index.ts
+++ b/apps/web/src/features/analytics/index.ts
@@ -44,6 +44,10 @@ export { useAnalyticsCoverageQuery } from './hooks/use-analytics-coverage-query'
 export { useRecalculateCurrencyMutation } from './hooks/use-recalculate-currency-mutation';
 export { AnalyticsSettingsDialog } from './components/analytics-settings-dialog';
 export { AnalyticsDataCoveragePanel } from './components/analytics-data-coverage-panel';
+export {
+  AnalyticsCoverageAlertBadge,
+  ANALYTICS_DATA_COVERAGE_ANCHOR_ID,
+} from './components/analytics-coverage-alert-badge';
 export type {
   AnalyticsCoverage,
   AnalyticsCoverageFilters,

--- a/apps/web/src/features/analytics/lib/data-coverage-copy.lib.ts
+++ b/apps/web/src/features/analytics/lib/data-coverage-copy.lib.ts
@@ -102,6 +102,24 @@ export function deriveCoverageRowCopy(row: CoverageCategoryRow): DataCoverageRow
 
 export const DATA_COVERAGE_CHECK_COUNT = 5;
 
+/**
+ * Whether the Data Coverage panel currently has something an operator needs
+ * to act on — either a row this panel labels `'Action'` (currently
+ * `currency`, `tax-a`) with at least one affected order, or a row whose
+ * remediation run itself ended `'failed'`. An `'Info'`-labelled row
+ * (`tax-b`, `tax-c`, `product-matching`) is deliberately excluded — those
+ * are informational per `deriveCoverageRowCopy`, not something the panel
+ * asks the operator to do, so surfacing them as a page-level warning would
+ * overstate what is actually wrong.
+ */
+export function hasCoverageAttention(categories: CoverageCategoryRow[]): boolean {
+  return categories.some((row) => {
+    if (row.status === 'failed') return true;
+    const copy = deriveCoverageRowCopy(row);
+    return copy.badgeLabel === 'Action' && row.affectedCount > 0;
+  });
+}
+
 /** Human-language label for a `product-matching` row's record status. Never rendered raw. */
 export function describeMatchingRecordStatus(status: ProductMatchingRecordStatus): string {
   switch (status) {

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -5522,6 +5522,30 @@ a.kpi-card:focus-visible {
   z-index: 50;
 }
 
+/* ── Analytics coverage alert badge (title-adjacent) ─────────────────── */
+.analytics-coverage-alert-badge__trigger {
+  display: inline-flex;
+  align-items: center;
+  vertical-align: middle;
+  margin-left: var(--space-2);
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+}
+
+.analytics-coverage-alert-badge__content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  max-width: 280px;
+}
+
+.analytics-coverage-alert-badge__content p {
+  margin: 0;
+  color: var(--text-secondary);
+}
+
 /* ── Command Palette (#333) ──────────────────────────────────────────
  * Overlay mounted via Radix Dialog; cmdk handles keyboard navigation.
  * The .dialog__content card is overridden to top-centre positioning so

--- a/apps/web/src/pages/analytics/analytics-page.tsx
+++ b/apps/web/src/pages/analytics/analytics-page.tsx
@@ -15,7 +15,9 @@
 import { useEffect, useMemo, useRef, useState, type ReactElement } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import {
+  ANALYTICS_DATA_COVERAGE_ANCHOR_ID,
   AnalyticsConvertNote,
+  AnalyticsCoverageAlertBadge,
   AnalyticsCurrencyPicker,
   AnalyticsDataCoveragePanel,
   AnalyticsDateRangeToolbar,
@@ -147,7 +149,11 @@ export function AnalyticsPage(): ReactElement {
   return (
     <PageLayout
       eyebrow="Operations"
-      title="Analytics"
+      title={
+        <>
+          Analytics <AnalyticsCoverageAlertBadge categories={coverageQuery.data?.categories} />
+        </>
+      }
       description="Sales across connected channels, with clear data coverage."
       actions={
         <Button type="button" tone="secondary" onClick={() => setSettingsDialogOpen(true)}>
@@ -233,17 +239,24 @@ export function AnalyticsPage(): ReactElement {
           {/* Coverage gaps and stock-at-risk are listing facts, not order
               facts, so they render regardless of ingestion status — a fresh
               install with a full catalogue and no orders yet is exactly
-              when they matter most (#2120 review, SUGGESTION). Both this
-              section and the data-coverage header below it render
-              unconditionally, after the order-derived figures above. */}
+              when they matter most (#2120 review, SUGGESTION). This section
+              and the Data Coverage panel below render unconditionally,
+              after the order-derived figures above. */}
           <AnalyticsNeedsAttention />
-          <AnalyticsDataCoveragePanel
-            filters={coverageFilters}
-            onOpenSettings={() => setSettingsDialogOpen(true)}
-            openCategory={openCoverageCategory}
-            onOpenCategoryChange={setOpenCoverageCategory}
-          />
           <AnalyticsTrustHeader connections={trustQuery.data.connections} />
+          {/* Deliberately the LAST section on the page: an operator reads
+              revenue/channel/product figures first, and only then the
+              detail behind any coverage gap. The title-adjacent
+              `AnalyticsCoverageAlertBadge` is the way back here without
+              scrolling past everything above when something needs action. */}
+          <div id={ANALYTICS_DATA_COVERAGE_ANCHOR_ID}>
+            <AnalyticsDataCoveragePanel
+              filters={coverageFilters}
+              onOpenSettings={() => setSettingsDialogOpen(true)}
+              openCategory={openCoverageCategory}
+              onOpenCategoryChange={setOpenCoverageCategory}
+            />
+          </div>
         </>
       ) : null}
 


### PR DESCRIPTION
## Summary
- Data Coverage panel is now the LAST section on `/analytics` (below Top Products, Needs Attention, Synchronization) — figures read first, gap detail second.
- A "Needs attention" badge renders next to the "Analytics" page title whenever the panel has something actionable (an `'Action'`-labelled category with affected orders, or a `'failed'` remediation run). Info-only rows (tax-b, tax-c, product-matching) don't trigger it.
- Clicking the badge opens a popover with a "Go to Data Coverage" CTA that smooth-scrolls to the panel.
- Renders nothing when there's nothing to act on.

## Screenshots
Placeholder — attach here:

1. No attention (healthy state, no badge): [ATTACH SCREENSHOT]
2. Needs attention (badge visible next to title): [ATTACH SCREENSHOT]
3. Popover open (CTA visible): [ATTACH SCREENSHOT]
4. Full page scrolled to bottom (Data Coverage panel in its new position): [ATTACH SCREENSHOT]

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on all touched files
- [x] New unit tests for `AnalyticsCoverageAlertBadge` (5 cases: undefined categories, no actionable row, action row with count, failed row, popover CTA)
- [x] Existing `analytics-page.test.tsx` still green (11 tests)
- [x] Manually verified against a live stack: badge appears/disappears correctly as coverage state changes, CTA scrolls to the panel, panel confirmed at the bottom of the page

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019auBcLpYvAQ1Mr6qyB3Bj3