### PR TITLE
fix(orders): exclude shipping from GMV/revenue on /analytics

### DIFF
--- a/apps/api/test/integration/sales-analytics-aggregates.int-spec.ts
+++ b/apps/api/test/integration/sales-analytics-aggregates.int-spec.ts
@@ -79,12 +79,13 @@ describe('Sales analytics daily aggregates (integration, #1987)', () => {
     // Tokyo) would truncate this to the FOLLOWING calendar day under a bare
     // date_trunc('day', placedAt); the explicit `AT TIME ZONE 'UTC'` pair
     // must keep it on 2026-08-02.
-    await seedStampedOrder({
+    const orderId = await seedStampedOrder({
       placedAt: new Date('2026-08-02T23:30:00.000Z'),
       totalAmount: 100,
       reportingCurrency: 'EUR',
       reportingTotalAmount: 100,
     });
+    await seedLineItem({ orderRecordId: orderId, unitPrice: 100, quantity: 1 });
 
     // Testcontainers Postgres boots with TimeZone = UTC, so this assertion
     // would pass identically with or without the `AT TIME ZONE 'UTC'` pair —
@@ -118,13 +119,14 @@ describe('Sales analytics daily aggregates (integration, #1987)', () => {
   it('folds a prior-era stamp into the unconverted bucket rather than mixing it into revenue (#1987 review notes, ported from #2172)', async () => {
     const day = new Date('2026-08-03T10:00:00.000Z');
     // Current-era stamp — the system reporting currency is EUR at read time.
-    await seedStampedOrder({
+    const currentEraOrderId = await seedStampedOrder({
       placedAt: day,
       currency: 'EUR',
       totalAmount: 100,
       reportingCurrency: 'EUR',
       reportingTotalAmount: 100,
     });
+    await seedLineItem({ orderRecordId: currentEraOrderId, unitPrice: 100, quantity: 1 });
     // A stamp taken while the operator's reporting-currency setting held a
     // different value (#2096) — `reportingCurrency` never moves once set
     // (ADR-040), so this row must NOT be summed into `revenue` alongside the
@@ -158,18 +160,20 @@ describe('Sales analytics daily aggregates (integration, #1987)', () => {
 
   it('reports the shared reportingCurrency when a bucket agrees', async () => {
     const day = new Date('2026-08-04T10:00:00.000Z');
-    await seedStampedOrder({
+    const orderIdA = await seedStampedOrder({
       placedAt: day,
       totalAmount: 50,
       reportingCurrency: 'EUR',
       reportingTotalAmount: 50,
     });
-    await seedStampedOrder({
+    await seedLineItem({ orderRecordId: orderIdA, unitPrice: 50, quantity: 1 });
+    const orderIdB = await seedStampedOrder({
       placedAt: day,
       totalAmount: 60,
       reportingCurrency: 'EUR',
       reportingTotalAmount: 60,
     });
+    await seedLineItem({ orderRecordId: orderIdB, unitPrice: 60, quantity: 1 });
 
     const rows = await repository.getDailyOrderAggregates(
       {
@@ -182,6 +186,56 @@ describe('Sales analytics daily aggregates (integration, #1987)', () => {
     expect(rows).toHaveLength(1);
     expect(rows[0].reportingCurrency).toBe('EUR');
     expect(rows[0].revenue).toBe(110);
+  });
+
+  it('excludes shipping from revenue (GMV) — the order total includes it, the line items do not (#2892)', async () => {
+    // Mirrors the live-confirmed defect shape: subtotal=44.97, shipping=10.95,
+    // total=55.92. Revenue must report the merchandise-only 44.97, never the
+    // shipping-inclusive order total.
+    const day = new Date('2026-08-05T10:00:00.000Z');
+    const orderId = await seedStampedOrder({
+      placedAt: day,
+      totalAmount: 55.92,
+      reportingCurrency: 'EUR',
+      reportingTotalAmount: 55.92,
+      taxTreatment: 'inclusive',
+    });
+    await seedLineItem({ orderRecordId: orderId, unitPrice: 44.97, quantity: 1, taxRate: '0' });
+
+    const rows = await repository.getDailyOrderAggregates(
+      {
+        from: new Date('2026-08-01T00:00:00.000Z'),
+        to: new Date('2026-08-08T00:00:00.000Z'),
+      },
+      'EUR'
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].revenue).toBeCloseTo(44.97, 5);
+  });
+
+  it('grosses up an exclusive (net-priced) line via its tax rate, rather than reporting the net value as revenue (#2892)', async () => {
+    const day = new Date('2026-08-06T10:00:00.000Z');
+    // Net-priced line: unitPrice is VAT-exclusive. 100 net at 23% VAT -> 123 gross.
+    const orderId = await seedStampedOrder({
+      placedAt: day,
+      totalAmount: 123,
+      reportingCurrency: 'EUR',
+      reportingTotalAmount: 123,
+      taxTreatment: 'exclusive',
+    });
+    await seedLineItem({ orderRecordId: orderId, unitPrice: 100, quantity: 1, taxRate: '23' });
+
+    const rows = await repository.getDailyOrderAggregates(
+      {
+        from: new Date('2026-08-01T00:00:00.000Z'),
+        to: new Date('2026-08-08T00:00:00.000Z'),
+      },
+      'EUR'
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].revenue).toBeCloseTo(123, 5);
   });
 
   it('getMedianOrderValue returns null when no stamped order matches the range', async () => {

--- a/libs/core/src/orders/domain/types/net-sales-tax-rate.types.spec.ts
+++ b/libs/core/src/orders/domain/types/net-sales-tax-rate.types.spec.ts
@@ -1,5 +1,6 @@
 import {
   deriveNetLineAmount,
+  grossRevenueLineAmountSql,
   netSalesEraEligibleSql,
   netSalesLineNetAmountSql,
   netSalesLineNetEligibleConditionSql,
@@ -137,6 +138,44 @@ describe('netSalesLineNetAmountSql', () => {
     );
     expect(sql).toContain("rec.\"taxTreatment\" = 'exclusive'");
     expect(sql).toContain('li."unitPrice" * li."quantity"');
+  });
+});
+
+describe('grossRevenueLineAmountSql (#2892)', () => {
+  it('branches on taxTreatment, passing an inclusive/absent-treatment line through unchanged', () => {
+    const sql = grossRevenueLineAmountSql(
+      'li."unitPrice"',
+      'li."quantity"',
+      'li."taxRate"',
+      'rec."taxTreatment"'
+    );
+    expect(sql).toContain("rec.\"taxTreatment\" = 'exclusive'");
+    expect(sql).toContain('li."unitPrice" * li."quantity"');
+    expect(sql).toContain('* (1 + COALESCE(');
+  });
+
+  it('never divides by (1 + rate) — that is the net-sales direction, not gross', () => {
+    const sql = grossRevenueLineAmountSql(
+      'li."unitPrice"',
+      'li."quantity"',
+      'li."taxRate"',
+      'rec."taxTreatment"'
+    );
+    expect(sql).not.toMatch(/\/\s*\(1 \+/);
+  });
+
+  it('falls back to the stored value (never NULL) when the rate is unresolvable, via COALESCE(...,0)', () => {
+    const sql = grossRevenueLineAmountSql(
+      'li."unitPrice"',
+      'li."quantity"',
+      'li."taxRate"',
+      'rec."taxTreatment"'
+    );
+    // An unresolvable rateFraction is SQL NULL; COALESCE(...,0) makes the
+    // exclusive-branch multiplier `1 + 0 = 1`, i.e. pass the stored value
+    // through as-is rather than propagating NULL through the whole SUM.
+    expect(sql).toContain('COALESCE((');
+    expect(sql).toContain('), 0))');
   });
 });
 

--- a/libs/core/src/orders/domain/types/net-sales-tax-rate.types.ts
+++ b/libs/core/src/orders/domain/types/net-sales-tax-rate.types.ts
@@ -163,6 +163,40 @@ export function netSalesRateFractionSql(taxRateColumnRef: string): string {
 }
 
 /**
+ * SQL for one line's GROSS (VAT-inclusive) amount, honoring the parent
+ * order's {@link PriceTaxTreatment} — the mirror image of
+ * {@link netSalesLineNetAmountSql}. This is the GMV/revenue building block
+ * (`docs/specs/metrics-analytics-dashboard.md`): "gross selling prices
+ * (incl. VAT)", computed from `order_line_items` so shipping (never
+ * itemized as a line) is structurally excluded — unlike the order's own
+ * `reportingTotalAmount`, which is `subtotal + tax + shipping` (#2892).
+ *
+ * An `exclusive`-priced line is grossed UP via `* (1 + rate)`; an
+ * `inclusive`/absent-treatment line is already gross and passes through
+ * unchanged. When an `exclusive` line's own rate does not resolve
+ * (`rateFraction` is NULL), this falls back to the line's stored value
+ * AS-IS rather than excluding the whole order from revenue — unlike Net
+ * Sales, GMV has no precedent for a silent per-order exclusion category,
+ * and a computable-but-slightly-understated figure (bounded by whatever
+ * rate would have applied to that one line) is preferable to a metric that
+ * can silently stop covering an order (#2892).
+ */
+export function grossRevenueLineAmountSql(
+  unitPriceColumnRef: string,
+  quantityColumnRef: string,
+  taxRateColumnRef: string,
+  taxTreatmentColumnRef: string
+): string {
+  const lineTotal = `${unitPriceColumnRef} * ${quantityColumnRef}`;
+  const rateFraction = netSalesRateFractionSql(taxRateColumnRef);
+  return `CASE
+      WHEN ${taxTreatmentColumnRef} = 'exclusive'
+        THEN ${lineTotal} * (1 + COALESCE((${rateFraction}), 0))
+      ELSE ${lineTotal}
+    END`;
+}
+
+/**
  * SQL for one line's VAT-exclusive amount, honoring the parent order's
  * {@link PriceTaxTreatment}. Mirrors {@link deriveNetLineAmount} — divides
  * the gross line total by `(1 + rate)` rather than multiplying by

--- a/libs/core/src/orders/infrastructure/persistence/repositories/__tests__/order-record.repository.spec.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/__tests__/order-record.repository.spec.ts
@@ -761,6 +761,37 @@ describe('OrderRecordRepository', () => {
       );
     });
 
+    it('computes revenue (GMV) from order_line_items, never the shipping-inclusive reportingTotalAmount directly (#2892)', async () => {
+      const addSelect = jest.fn().mockReturnThis();
+      (ormRepository.createQueryBuilder as jest.Mock).mockReturnValue({
+        select: jest.fn().mockReturnThis(),
+        addSelect,
+        groupBy: jest.fn().mockReturnThis(),
+        addGroupBy: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        setParameter: jest.fn().mockReturnThis(),
+        getRawMany: jest.fn().mockResolvedValue([]),
+      });
+
+      await repository.getDailyOrderAggregates(baseFilters, 'EUR');
+
+      const calls = addSelect.mock.calls as Array<[string, string]>;
+      const revenueCall = calls.find(([, alias]) => alias === 'revenue');
+      expect(revenueCall?.[0]).toContain('FROM order_line_items rev_li');
+      // The order's own stamped FX multiplier is still applied — this must
+      // never re-look-up a fresh rate, or the figure stops reconciling with
+      // every other reporting-currency figure on the page.
+      expect(revenueCall?.[0]).toContain(
+        'rec."reportingTotalAmount" / NULLIF(rec."totalAmount", 0)'
+      );
+      // The bare pre-#2892 fragment (shipping-inclusive, no line-item join)
+      // must not survive — a straight `SUM(rec."reportingTotalAmount")` with
+      // no line-item subquery is exactly the regression this test guards.
+      expect(revenueCall?.[0]).not.toBe(
+        `COALESCE(SUM(rec."reportingTotalAmount") FILTER (WHERE rec."cancelledAt" IS NULL AND rec."reportingCurrency" = :currentReportingCurrency), 0)`
+      );
+    });
+
     it('treats a bucket with an unrecorded native currency as not-uniform (#1987 review, suggestion 4)', async () => {
       const addSelect = jest.fn().mockReturnThis();
       (ormRepository.createQueryBuilder as jest.Mock).mockReturnValue({

--- a/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
@@ -48,6 +48,7 @@ import { isHoldReason, OrderLifecyclePhaseValues } from '@openlinker/core/order-
 import { SLA_AT_RISK_WINDOW_MS } from '../../../domain/types/order-sla.types';
 import type { FulfillmentRollupState } from '../../../domain/types/order-fulfillment.types';
 import {
+  grossRevenueLineAmountSql,
   netSalesLineNetAmountSql,
   netSalesOrderNetEligibleSql,
 } from '../../../domain/types/net-sales-tax-rate.types';
@@ -532,8 +533,13 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
    *
    * Currency correctness (#2049/ADR-040 follow-up): `order_count`/`revenue`
    * are further restricted to `reportingCurrency IS NOT NULL` — one
-   * comparable currency, `SUM(reportingTotalAmount)` — with the complementary
-   * unstamped slice reported separately as `unconverted_count`/
+   * comparable currency. `revenue` itself is GMV per
+   * `docs/specs/metrics-analytics-dashboard.md` — gross, shipping-EXCLUDED
+   * merchandise value summed from `order_line_items` and converted via the
+   * order's own stamped FX multiplier, never the shipping-inclusive
+   * `reportingTotalAmount` directly (#2892; see `buildGrossRevenueOrderAmountSql`)
+   * — with the complementary unstamped slice reported separately as
+   * `unconverted_count`/
    * `unconverted_value` (native `totalAmount`, informational only) rather
    * than silently mixed in or silently dropped. `cancelled_value` now follows
    * the SAME split (epic #2452): `SUM(reportingTotalAmount)` restricted to
@@ -577,6 +583,11 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
     const netAndNotCancelled = `${stampedAndNotCancelled} AND ${netEligible}`;
     const netExcludedAndNotCancelled = `${stampedAndNotCancelled} AND NOT ${netEligible}`;
 
+    // GMV/revenue (#2892) — gross, shipping-EXCLUDED merchandise value from
+    // `order_line_items`, never the shipping-inclusive `reportingTotalAmount`.
+    // See `buildGrossRevenueOrderAmountSql`.
+    const grossRevenueOrderAmount = this.buildGrossRevenueOrderAmountSql();
+
     // UTC day boundary made explicit (#1987 review, IMPORTANT 2): `placedAt`
     // is `timestamptz`, so a bare `date_trunc('day', ...)` truncates at local
     // midnight per the Postgres session `TimeZone` GUC — on a non-UTC server
@@ -593,7 +604,14 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
       .addSelect('rec.sourceConnectionId', 'source_connection_id')
       .addSelect(`COUNT(*) FILTER (WHERE ${stampedAndNotCancelled})`, 'order_count')
       .addSelect(
-        `COALESCE(SUM(rec."reportingTotalAmount") FILTER (WHERE ${stampedAndNotCancelled}), 0)`,
+        // Line-derived gross sum in the order's NATIVE currency, converted
+        // into the reporting currency via the order's own already-stamped
+        // FX multiplier (`reportingTotalAmount / totalAmount`) — the same
+        // trick `net_revenue` below already uses, so this never re-looks-up
+        // a rate and always reconciles with every other reporting-currency
+        // figure on the page (#2892, docs/specs/metrics-analytics-dashboard.md
+        // GMV: gross, excluding shipping).
+        `COALESCE(SUM((${grossRevenueOrderAmount}) * (rec."reportingTotalAmount" / NULLIF(rec."totalAmount", 0))) FILTER (WHERE ${stampedAndNotCancelled}), 0)`,
         'revenue'
       )
       .addSelect(`COUNT(*) FILTER (WHERE ${unconvertedAndNotCancelled})`, 'unconverted_count')
@@ -1105,6 +1123,34 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
       WHERE net_li."orderRecordId" = rec."internalOrderId"
     )`;
     return { netEligible, netOrderAmount };
+  }
+
+  /**
+   * GMV/revenue (#2892) scalar subquery: the order's gross, shipping-excluded
+   * merchandise value in its NATIVE currency, summed from `order_line_items`
+   * via {@link grossRevenueLineAmountSql}. Deliberately a scalar subquery
+   * rather than a join, for the same reason `buildNetSalesOrderFragments`
+   * uses one — joining `order_line_items` at the order-grain SELECT would
+   * multiply row cardinality and corrupt every `COUNT(*)`/`SUM` aggregate
+   * grouped at the order level.
+   *
+   * Unlike Net Sales, there is no eligibility gate here: revenue does not
+   * exclude an order for lacking a resolvable tax rate (see
+   * {@link grossRevenueLineAmountSql}'s per-line fallback) — every `'ready'`
+   * order carries line items (ADR-039), so this always has something to sum.
+   */
+  private buildGrossRevenueOrderAmountSql(): string {
+    const grossLineAmount = grossRevenueLineAmountSql(
+      'rev_li."unitPrice"',
+      'rev_li."quantity"',
+      'rev_li."taxRate"',
+      'rec."taxTreatment"'
+    );
+    return `(
+      SELECT COALESCE(SUM(${grossLineAmount}), 0)
+      FROM order_line_items rev_li
+      WHERE rev_li."orderRecordId" = rec."internalOrderId"
+    )`;
   }
 
   /**


### PR DESCRIPTION
## Summary

`OrderRecordRepository.getDailyOrderAggregates`'s `revenue` aggregate (rendered as GMV on the Revenue KPI card) summed `order_records.reportingTotalAmount`, which is the order's FX-stamped `subtotal + tax + shipping`. `docs/specs/metrics-analytics-dashboard.md` defines GMV as gross merchandise value **excluding shipping costs**. Confirmed live: order `ol_order_84171f85f7fe4204ac5e4af1c27305be` has `subtotal=44.97, tax=0, shipping=10.95, total=55.92` — the shipped code summed `55.92`. Matches a live-reported ~40% GMV overshoot vs Net Sales on a low-value catalog with flat shipping charges.

## Fix

Revenue is now summed from `order_line_items` (`unitPrice × quantity`), which never itemizes shipping and is therefore structurally shipping-free — no migration needed.

**Tax-treatment decision (stated explicitly per review request):** an `exclusive`-priced (net) line is grossed **up** via its own `taxRate` — the mirror image of the existing Net Sales gross-to-net division (`netSalesLineNetAmountSql`). When the rate is unresolvable for such a line, the fix **falls back to the stored value as-is** rather than excluding the whole order from revenue. Rationale: GMV has no precedent for a silent per-order exclusion category the way Net Sales does (`netExcludedCount`/`netExcludedValue`), and revenue should stay computable; the cost is a bounded understatement of that one line, never a vanished order. New pure function: `grossRevenueLineAmountSql` in `net-sales-tax-rate.types.ts`, unit-tested.

**FX decision (stated explicitly per review request):** the native-currency line sum is converted into the reporting currency by multiplying by the order's own already-stamped FX factor — `reportingTotalAmount / totalAmount` — the exact same technique the adjacent `net_revenue` aggregate already uses in this file. This never re-looks-up a fresh exchange rate, so the figure stays reconciled with every other reporting-currency number already on the page.

The stamped/unconverted cohort split (`unconvertedCount`/`unconvertedValue`, currency-era handling) is untouched — this only changes what constitutes the summed *value* for an already-stamped order, not which orders are in that cohort.

## Known, acknowledged limitation

`OrderTotals` carries no "discount" field anywhere in the ingestion pipeline (Allegro/PrestaShop/WooCommerce), so "before deducting discounts" (the other half of the spec's GMV definition) is not addressed here — there is no data to reconstruct it from. This fix closes the shipping-inclusion defect only, which is the one independently confirmed against live data.

## Testing

- `pnpm lint` — clean on all touched files.
- `pnpm --filter @openlinker/core` unit tests for `order-record.repository.spec.ts` + `net-sales-tax-rate.types.spec.ts` — 181/181 passing (added: `grossRevenueLineAmountSql` behavior, a repository-level regression guard that `revenue` no longer resolves to the bare pre-fix fragment).
- Integration test against real Postgres (`apps/api/test/integration/sales-analytics-aggregates.int-spec.ts`) — 19/19 passing, including two new cases: (1) the exact live-confirmed bug shape (subtotal 44.97 / shipping 10.95 / total 55.92 → revenue must read 44.97), and (2) an exclusive-priced line grossed up via its tax rate (100 net @ 23% → 123 gross revenue). Existing revenue-asserting cases in the same file were updated to seed matching `order_line_items` fixtures, since the old assertions relied on orders with no line items — a shape production never produces (ADR-039 writes line items for every `'ready'` order) but which the pre-fix code never required.

## Closes

Closes #2892

🤖 Generated with [Claude Code](https://claude.com/claude-code)
