### PR TITLE
fix(analytics): AOV/Median use the same order set as Number of Orders

### DIFF
--- a/apps/web/src/features/analytics/components/analytics-kpi-strip.test.tsx
+++ b/apps/web/src/features/analytics/components/analytics-kpi-strip.test.tsx
@@ -95,8 +95,10 @@ describe('AnalyticsKpiStrip', () => {
     renderWithProviders(<AnalyticsKpiStrip filters={FILTERS} connections={[]} />, { apiClient });
 
     expect(await screen.findByText('40')).toBeInTheDocument();
-    expect(screen.getByText('PLN 105.00')).toBeInTheDocument();
-    expect(screen.getByText('PLN 90.00')).toBeInTheDocument();
+    // AOV/Median render the GROSS headline fields (#2894) — same FX-stamped
+    // order set as Number of Orders, not the VAT-exclusive net-eligible ones.
+    expect(screen.getByText('PLN 120.00')).toBeInTheDocument();
+    expect(screen.getByText('PLN 100.00')).toBeInTheDocument();
     expect(screen.getByText('60')).toBeInTheDocument();
     expect(screen.getByText('PLN 200.00')).toBeInTheDocument();
   });
@@ -353,8 +355,8 @@ describe('AnalyticsKpiStrip', () => {
           analytics({
             revenue: 1000,
             netRevenue: 900,
-            netAverageOrderValue: 90,
-            netMedianOrderValue: 85,
+            averageOrderValue: 90,
+            medianOrderValue: 85,
             cancelledValue: 50,
             displayCurrencyConversion: {
               displayCurrency: 'EUR',
@@ -401,8 +403,8 @@ describe('AnalyticsKpiStrip', () => {
           analytics({
             revenue: 1000,
             netRevenue: 900,
-            netAverageOrderValue: 90,
-            netMedianOrderValue: 85,
+            averageOrderValue: 90,
+            medianOrderValue: 85,
             cancelledValue: 50,
             displayCurrencyConversion: {
               displayCurrency: 'EUR',
@@ -570,6 +572,8 @@ describe('AnalyticsKpiStrip', () => {
           analytics({
             revenue: 0,
             currency: null,
+            averageOrderValue: 0,
+            medianOrderValue: 0,
             netRevenue: 0,
             netAverageOrderValue: 0,
             netMedianOrderValue: 0,

--- a/apps/web/src/features/analytics/components/analytics-kpi-strip.tsx
+++ b/apps/web/src/features/analytics/components/analytics-kpi-strip.tsx
@@ -23,13 +23,20 @@
  *     FX-stamped orders (ADR-040) — `totalOrders` below adds back `headline.
  *     unconvertedCount` so Orders/Avg. daily/Units per order/Cancellation
  *     rate count every placed order.
- *   - Order value (AOV + median): renders `headline.netAverageOrderValue` /
- *     `netMedianOrderValue` (net-sales tax-rate epic), not the gross
- *     `averageOrderValue`/`medianOrderValue` — same VAT-exclusive basis as
- *     the Revenue card's headline figure, so a reader comparing "Revenue"
- *     against "Order value" isn't silently comparing net against gross.
- *     Both stay on the FX-stamped subset and disclose that gap explicitly,
- *     same as before.
+ *   - Order value (AOV + median, #2894 fix): renders the gross
+ *     `headline.averageOrderValue`/`medianOrderValue`, NOT the VAT-exclusive
+ *     `netAverageOrderValue`/`netMedianOrderValue`. The metrics spec requires
+ *     AOV/Median's numerator and denominator to "operate on exactly the same
+ *     set of orders as Number of Orders" — the net fields are additionally
+ *     restricted to `netExcludedCount`-eligible orders (a stored, resolved
+ *     per-line tax rate; see ADR-063), a restriction Number of Orders never
+ *     applies. AOV/Median need only the order's gross total
+ *     (`reportingTotalAmount`), so there is no principled reason to exclude
+ *     a tax-rate-unresolved order from them. The ONE restriction kept is the
+ *     FX-stamp one — a currency-denominated average genuinely cannot include
+ *     an order with no known amount in the reporting currency, and that is
+ *     the SAME restriction `revenue`/`orderCount` (Number of Orders) already
+ *     apply, disclosed via the same `STAMPED_GAP` gap mark as before.
  *   - Returns & refunds: no return/refund entity exists anywhere in the
  *     orders domain — fully planned.
  *   - Cancellations: `cancelledCount`/`cancelledValue` are real fields —
@@ -354,7 +361,7 @@ export function AnalyticsKpiStrip({
   const orderValueCurrenciesMatch =
     headline.currency !== null && headline.currency === previousHeadline?.currency;
   const orderValueDelta = orderValueCurrenciesMatch
-    ? buildDelta(headline.netAverageOrderValue, previousHeadline?.netAverageOrderValue, 'higher-is-better')
+    ? buildDelta(headline.averageOrderValue, previousHeadline?.averageOrderValue, 'higher-is-better')
     : null;
   const orderValueDeltaGapReason =
     !orderValueCurrenciesMatch && previousHeadline
@@ -458,12 +465,12 @@ export function AnalyticsKpiStrip({
         definitions={[
           {
             term: 'Average order value (AOV)',
-            text: 'Net sales divided by the number of FX-stamped, net-eligible orders it was computed from — not by every placed order.',
+            text: 'The gross value of every FX-stamped order placed in the period, divided by the number of FX-stamped orders it was computed from — the same order set as Number of Orders, minus the not-yet-stamped ones.',
             caveat: stampedGapVisible ? STAMPED_GAP : undefined,
           },
           {
             term: 'Median order value',
-            text: 'The middle net-sales value of every FX-stamped, net-eligible order in the range — less skewed by a handful of very large or very small orders than the average.',
+            text: 'The middle gross value of every FX-stamped order in the range — less skewed by a handful of very large or very small orders than the average.',
           },
         ]}
         metric={
@@ -476,11 +483,11 @@ export function AnalyticsKpiStrip({
           )
         }
         headlineUnavailable={currencyRecalculating}
-        value={currencyRecalculating ? <RecalculatingValue /> : formatAmount(convertToDisplay(headline.netAverageOrderValue), currency)}
+        value={currencyRecalculating ? <RecalculatingValue /> : formatAmount(convertToDisplay(headline.averageOrderValue), currency)}
         qualifiers={[
           {
             label: 'Median',
-            value: currencyRecalculating ? <RecalculatingValue /> : formatAmount(convertToDisplay(headline.netMedianOrderValue), currency),
+            value: currencyRecalculating ? <RecalculatingValue /> : formatAmount(convertToDisplay(headline.medianOrderValue), currency),
           },
         ]}
         delta={orderValueDelta}


### PR DESCRIPTION
Closes #2894

## Root cause

The Order value KPI card (AOV + Median) rendered `headline.netAverageOrderValue` / `netMedianOrderValue`. Those fields are restricted to net-sales-eligible orders — an order not `taxRateEra = 'pre-rollout'` and with every line's tax rate resolved (ADR-063, tracked by `netExcludedCount`). That restriction has nothing to do with FX stamping, and it is narrower than the cohort the "Number of Orders" card uses (every FX-stamped, non-cancelled order).

`docs/specs/metrics-analytics-dashboard.md` § Average Order Value / § Median Order Value is explicit: "The numerator and denominator must operate on exactly the same set of orders as Number of Orders and Median Order Value." AOV/Median only need an order's gross total (`reportingTotalAmount`, already FX-stamped on `order_records` at ingestion) to compute an average or a median — no per-line tax-rate resolution is required to average a gross total, so there was no principled reason to exclude a tax-rate-unresolved order from these two figures.

The backend already computes the correct, non-narrowed figures: `headline.averageOrderValue` / `medianOrderValue` are derived from exactly the same FX-stamped, non-cancelled cohort as `revenue`/`orderCount` (see `getDailyOrderAggregates`'s `stampedAndNotCancelled` predicate vs. the additional `netEligible` predicate used only for `netRevenue`/`netAverageOrderValue`/`netExcludedCount`). So this is a pure frontend fix — the KPI strip was pointed at the wrong pair of fields.

## What was kept vs. removed

- **Kept**: the FX-stamped-cohort restriction (`reportingCurrency IS NOT NULL`, non-cancelled). A currency-denominated average genuinely cannot include an order with no known amount in the reporting currency — this is the same restriction `revenue`/`orderCount` (GMV/Number of Orders) already apply, and it's still disclosed via the existing `STAMPED_GAP` gap mark on the card.
- **Removed**: the additional net-sales-eligibility (stored, resolved per-line tax rate) restriction. The card now reads the gross `headline.averageOrderValue` / `medianOrderValue` fields instead of the VAT-exclusive `netAverageOrderValue` / `netMedianOrderValue` fields — no backend change needed, since those gross fields already existed and already match the required cohort.

## Scope

Only `apps/web/src/features/analytics/components/analytics-kpi-strip.tsx` changed (the Order value card's value/qualifier/delta wiring, its tooltip copy, and the file's own doc comment), plus its test file (`analytics-kpi-strip.test.tsx`) to match the new expected values. GMV/revenue logic (#2892), Units Sold logic (#2893), Net Sales itself, and Cancellation logic are all untouched.

`features/analytics/components/channel-sales-table.tsx` has its own, deliberately net-eligible "AOV" column — that table's docblock explains it must stay net-eligible so it reconciles with the same row's "Net sales" figure. That is a separate, unrelated design decision for a different UI element and is not touched by this PR.

## Tooltip copy

Updated to describe the gross basis and the FX-stamp-only restriction, dropping the "net-eligible" wording that no longer applies. Kept consistent with the spec's own wording per `.claude/rules/analytics-metrics.md`.

## Testing

- `cd apps/web && npx vitest run src/features/analytics/components/analytics-kpi-strip.test.tsx` — 21/21 passed
- `npx tsc --noEmit` on the web app — no new errors in the changed file
- `npx eslint` on both changed files — 0 errors (2 pre-existing warnings unrelated to this change)
- No integration test exists for this frontend-only KPI-strip component; Docker was not needed/used since the fix is entirely in `apps/web` and required no backend change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)