### PR TITLE
feat(analytics): net/gross VAT-basis toggle with settings-persisted default (#2895)

### DIFF
--- a/apps/api/src/analytics/http/analytics-coverage.controller.spec.ts
+++ b/apps/api/src/analytics/http/analytics-coverage.controller.spec.ts
@@ -51,6 +51,7 @@ describe('AnalyticsCoverageController (#2466)', () => {
       displayCurrency: null,
       rateBasis: 'current',
       includeBackfilledTaxRatesInNetSales,
+      netGrossBasis: 'gross',
       updatedAt: null,
       updatedByUserId: null,
     }),

--- a/apps/api/src/analytics/http/analytics-settings.controller.spec.ts
+++ b/apps/api/src/analytics/http/analytics-settings.controller.spec.ts
@@ -91,6 +91,7 @@ describe('AnalyticsSettingsController', () => {
         displayCurrency: 'PLN',
         rateBasis: 'order-date',
         includeBackfilledTaxRatesInNetSales: true,
+        netGrossBasis: 'net',
         updatedAt: new Date('2026-08-01T00:00:00Z'),
         updatedByUserId: 'admin-1',
       };
@@ -103,6 +104,7 @@ describe('AnalyticsSettingsController', () => {
       expect(dto.displayCurrencySource).toBe('setting');
       expect(dto.rateBasis).toBe('order-date');
       expect(dto.includeBackfilledTaxRatesInNetSales).toBe(true);
+      expect(dto.netGrossBasis).toBe('net');
       expect(dto.updatedAt).toBe('2026-08-01T00:00:00.000Z');
       expect(dto.updatedByUserId).toBe('admin-1');
       expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-store');
@@ -113,6 +115,7 @@ describe('AnalyticsSettingsController', () => {
         displayCurrency: null,
         rateBasis: 'current',
         includeBackfilledTaxRatesInNetSales: false,
+        netGrossBasis: 'gross',
         updatedAt: null,
         updatedByUserId: null,
       };
@@ -134,6 +137,7 @@ describe('AnalyticsSettingsController', () => {
         displayCurrency: 'PLN',
         rateBasis: 'order-date',
         includeBackfilledTaxRatesInNetSales: true,
+        netGrossBasis: 'net',
       };
 
       await controller.update(dto, user, res as unknown as Response);
@@ -143,6 +147,7 @@ describe('AnalyticsSettingsController', () => {
           displayCurrency: 'PLN',
           rateBasis: 'order-date',
           includeBackfilledTaxRatesInNetSales: true,
+          netGrossBasis: 'net',
         },
         'admin-1'
       );

--- a/apps/api/src/analytics/http/analytics-settings.controller.ts
+++ b/apps/api/src/analytics/http/analytics-settings.controller.ts
@@ -95,6 +95,7 @@ export class AnalyticsSettingsController {
         displayCurrency: dto.displayCurrency,
         rateBasis: dto.rateBasis,
         includeBackfilledTaxRatesInNetSales: dto.includeBackfilledTaxRatesInNetSales,
+        netGrossBasis: dto.netGrossBasis,
       },
       user?.id
     );

--- a/apps/api/src/analytics/http/dto/analytics-settings-response.dto.ts
+++ b/apps/api/src/analytics/http/dto/analytics-settings-response.dto.ts
@@ -24,8 +24,10 @@
  */
 import { ApiProperty } from '@nestjs/swagger';
 import {
+  NetGrossBasisValues,
   RateBasisValues,
   type AnalyticsDisplaySettingsView,
+  type NetGrossBasis,
   type RateBasis,
 } from '@openlinker/core/analytics';
 
@@ -61,6 +63,13 @@ export class AnalyticsSettingsResponseDto {
   includeBackfilledTaxRatesInNetSales!: boolean;
 
   @ApiProperty({
+    enum: NetGrossBasisValues,
+    description:
+      "Default VAT basis a view opens in when no `?netGrossBasis=` URL override is present: `gross` (VAT-inclusive) or `net` (VAT-exclusive, NOV).",
+  })
+  netGrossBasis!: NetGrossBasis;
+
+  @ApiProperty({
     type: String,
     nullable: true,
     description: 'When the settings row was last written. `null` when no row exists yet.',
@@ -86,6 +95,7 @@ export class AnalyticsSettingsResponseDto {
     dto.displayCurrencySource = hasExplicitOverride ? 'setting' : 'default';
     dto.rateBasis = input.view.rateBasis;
     dto.includeBackfilledTaxRatesInNetSales = input.view.includeBackfilledTaxRatesInNetSales;
+    dto.netGrossBasis = input.view.netGrossBasis;
     dto.updatedAt = input.view.updatedAt ? input.view.updatedAt.toISOString() : null;
     dto.updatedByUserId = input.view.updatedByUserId;
     return dto;

--- a/apps/api/src/analytics/http/dto/update-analytics-settings.dto.ts
+++ b/apps/api/src/analytics/http/dto/update-analytics-settings.dto.ts
@@ -18,7 +18,12 @@
  */
 import { ApiProperty } from '@nestjs/swagger';
 import { IsBoolean, IsIn, ValidateIf } from 'class-validator';
-import { RateBasisValues, type RateBasis } from '@openlinker/core/analytics';
+import {
+  NetGrossBasisValues,
+  RateBasisValues,
+  type NetGrossBasis,
+  type RateBasis,
+} from '@openlinker/core/analytics';
 import { SUPPORTED_REPORTING_CURRENCIES } from '@openlinker/core/currency';
 
 export class UpdateAnalyticsSettingsDto {
@@ -46,4 +51,12 @@ export class UpdateAnalyticsSettingsDto {
   })
   @IsBoolean()
   includeBackfilledTaxRatesInNetSales!: boolean;
+
+  @ApiProperty({
+    enum: NetGrossBasisValues,
+    description:
+      "Default VAT basis a view opens in when no `?netGrossBasis=` URL override is present: `gross` (VAT-inclusive) or `net` (VAT-exclusive, NOV).",
+  })
+  @IsIn(NetGrossBasisValues as unknown as string[])
+  netGrossBasis!: NetGrossBasis;
 }

--- a/apps/api/src/analytics/http/sales-analytics.controller.spec.ts
+++ b/apps/api/src/analytics/http/sales-analytics.controller.spec.ts
@@ -83,6 +83,7 @@ describe('SalesAnalyticsController', () => {
       displayCurrency: null,
       rateBasis: 'current',
       includeBackfilledTaxRatesInNetSales,
+      netGrossBasis: 'gross',
       updatedAt: null,
       updatedByUserId: null,
     }),

--- a/apps/api/src/analytics/http/top-products.controller.spec.ts
+++ b/apps/api/src/analytics/http/top-products.controller.spec.ts
@@ -27,6 +27,7 @@ describe('TopProductsController', () => {
       displayCurrency: null,
       rateBasis: 'current',
       includeBackfilledTaxRatesInNetSales,
+      netGrossBasis: 'gross',
       updatedAt: null,
       updatedByUserId: null,
     }),

--- a/apps/api/src/migrations/1870000000200-add-analytics-net-gross-basis.ts
+++ b/apps/api/src/migrations/1870000000200-add-analytics-net-gross-basis.ts
@@ -1,0 +1,28 @@
+/**
+ * Add `analytics_display_settings.net_gross_basis` (#2895)
+ *
+ * A fourth operator preference on the existing singleton row (#2461): the
+ * default VAT basis (`'gross'` | `'net'`) a view opens in when no
+ * `?netGrossBasis=` URL override is present — mirrors `rate_basis` exactly
+ * (same singleton row, same default-then-URL-override shape).
+ *
+ * @module apps/api/src/migrations
+ */
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddAnalyticsNetGrossBasis1870000000200 implements MigrationInterface {
+  name = 'AddAnalyticsNetGrossBasis1870000000200';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "analytics_display_settings"
+      ADD COLUMN "net_gross_basis" text NOT NULL DEFAULT 'gross'
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "analytics_display_settings" DROP COLUMN "net_gross_basis"
+    `);
+  }
+}

--- a/apps/web/src/features/analytics/api/analytics-settings.types.ts
+++ b/apps/web/src/features/analytics/api/analytics-settings.types.ts
@@ -16,6 +16,10 @@
 export const RATE_BASIS_VALUES = ['current', 'order-date'] as const;
 export type RateBasis = (typeof RATE_BASIS_VALUES)[number];
 
+/** Default VAT basis a view opens in when no `?netGrossBasis=` URL override is present. */
+export const NET_GROSS_BASIS_VALUES = ['gross', 'net'] as const;
+export type NetGrossBasis = (typeof NET_GROSS_BASIS_VALUES)[number];
+
 export const ANALYTICS_DISPLAY_CURRENCY_SOURCES = ['setting', 'default'] as const;
 export type AnalyticsDisplayCurrencySource = (typeof ANALYTICS_DISPLAY_CURRENCY_SOURCES)[number];
 
@@ -28,15 +32,18 @@ export interface AnalyticsSettingsView {
   rateBasis: RateBasis;
   /** Org-wide opt-in: admit a backfilled pre-rollout order into Net Sales. Never mutates any `order_records` row. */
   includeBackfilledTaxRatesInNetSales: boolean;
+  /** Default basis a view opens in when no `?netGrossBasis=` URL override is present. */
+  netGrossBasis: NetGrossBasis;
   /** ISO timestamp of the last write to the settings row. `null` when no row exists yet. */
   updatedAt: string | null;
   /** Id of the user who last wrote the settings row. `null` when no row exists yet. */
   updatedByUserId: string | null;
 }
 
-/** Request body for `PUT /analytics/settings` — all three fields are required; `displayCurrency: null` clears the override. */
+/** Request body for `PUT /analytics/settings` — all four fields are required; `displayCurrency: null` clears the override. */
 export interface UpdateAnalyticsSettingsInput {
   displayCurrency: string | null;
   rateBasis: RateBasis;
   includeBackfilledTaxRatesInNetSales: boolean;
+  netGrossBasis: NetGrossBasis;
 }

--- a/apps/web/src/features/analytics/components/analytics-net-gross-toggle.test.tsx
+++ b/apps/web/src/features/analytics/components/analytics-net-gross-toggle.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { AnalyticsNetGrossToggle } from './analytics-net-gross-toggle';
+
+describe('AnalyticsNetGrossToggle', () => {
+  it('renders both options and highlights the current value', () => {
+    render(<AnalyticsNetGrossToggle value="gross" onChange={vi.fn()} />);
+
+    expect(screen.getByRole('radio', { name: 'Gross' })).toHaveAttribute('aria-checked', 'true');
+    expect(screen.getByRole('radio', { name: 'Net' })).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('calls onChange with the selected basis', async () => {
+    const onChange = vi.fn();
+    render(<AnalyticsNetGrossToggle value="gross" onChange={onChange} />);
+
+    await userEvent.click(screen.getByRole('radio', { name: 'Net' }));
+
+    expect(onChange).toHaveBeenCalledWith('net');
+  });
+});

--- a/apps/web/src/features/analytics/components/analytics-net-gross-toggle.tsx
+++ b/apps/web/src/features/analytics/components/analytics-net-gross-toggle.tsx
@@ -1,0 +1,39 @@
+/**
+ * Analytics Net/Gross Toggle
+ *
+ * Toolbar control for the VAT basis a view is read in — `gross` (VAT-inclusive,
+ * the default) or `net` (VAT-exclusive). Mirrors `AnalyticsCurrencyPicker`'s
+ * shape: the current choice lives in the URL (`?netGrossBasis=`), same as the
+ * date range and the display currency, so it is shareable and reversible with
+ * no persisted side effect. Rendered directly below the currency picker in
+ * the toolbar's trailing slot — same column, second row — since both are
+ * "how to read this view" preferences and the currency picker is the taller,
+ * more consequential choice of the pair.
+ *
+ * @module apps/web/src/features/analytics/components
+ */
+import type { ReactElement } from 'react';
+import { SegmentedControl } from '../../../shared/ui';
+import type { NetGrossBasis } from '../api/analytics-settings.types';
+
+interface AnalyticsNetGrossToggleProps {
+  value: NetGrossBasis;
+  onChange: (value: NetGrossBasis) => void;
+}
+
+const OPTIONS: readonly { value: NetGrossBasis; label: string }[] = [
+  { value: 'gross', label: 'Gross' },
+  { value: 'net', label: 'Net' },
+];
+
+export function AnalyticsNetGrossToggle({
+  value,
+  onChange,
+}: AnalyticsNetGrossToggleProps): ReactElement {
+  return (
+    <div className="analytics-toolbar__field analytics-net-gross-toggle">
+      <span className="sr-only">VAT basis</span>
+      <SegmentedControl aria-label="VAT basis" options={OPTIONS} value={value} onChange={onChange} />
+    </div>
+  );
+}

--- a/apps/web/src/features/analytics/components/analytics-settings-dialog.test.tsx
+++ b/apps/web/src/features/analytics/components/analytics-settings-dialog.test.tsx
@@ -139,6 +139,7 @@ describe('AnalyticsSettingsDialog', () => {
           displayCurrencySource: 'setting',
           rateBasis: 'current',
           includeBackfilledTaxRatesInNetSales: false,
+          netGrossBasis: 'gross',
           updatedAt: null,
           updatedByUserId: null,
         }),
@@ -161,6 +162,7 @@ describe('AnalyticsSettingsDialog', () => {
         displayCurrency: 'EUR',
         rateBasis: 'current',
         includeBackfilledTaxRatesInNetSales: true,
+        netGrossBasis: 'gross',
       });
     });
   });
@@ -174,6 +176,7 @@ describe('AnalyticsSettingsDialog', () => {
           displayCurrencySource: 'default',
           rateBasis: 'current',
           includeBackfilledTaxRatesInNetSales: false,
+          netGrossBasis: 'gross',
           updatedAt: null,
           updatedByUserId: null,
         }),
@@ -196,6 +199,7 @@ describe('AnalyticsSettingsDialog', () => {
         displayCurrency: null,
         rateBasis: 'current',
         includeBackfilledTaxRatesInNetSales: true,
+        netGrossBasis: 'gross',
       });
     });
   });

--- a/apps/web/src/features/analytics/components/analytics-settings-dialog.tsx
+++ b/apps/web/src/features/analytics/components/analytics-settings-dialog.tsx
@@ -14,14 +14,19 @@
  *      `rateBasis` (the persisted, admin-only DEFAULT those fields resolve
  *      from when no URL override is present) — a different axis, never
  *      written by this section.
- *   2. "Currency — recalculation" / "Tax rates" — real, persisted actions.
- *      Recalculating enqueues a real remediation run
+ *   2. "Currency — recalculation" / "Tax rates" / "Default VAT basis" — real,
+ *      persisted actions. Recalculating enqueues a real remediation run
  *      (`POST /analytics/coverage/currency/recalculate`, #2468); the tax
- *      toggle writes `includeBackfilledTaxRatesInNetSales` via
- *      `useUpdateAnalyticsSettingsMutation` (#2471), preserving whatever
- *      `displayCurrency`/`rateBasis` defaults are already persisted, since
- *      this dialog must never overwrite an admin default with an ephemeral
- *      view preference.
+ *      toggle and the VAT-basis default both write via
+ *      `useUpdateAnalyticsSettingsMutation` (#2471, #2895), preserving
+ *      whatever `displayCurrency`/`rateBasis`/other fields are already
+ *      persisted, since this dialog must never overwrite an admin default
+ *      with an ephemeral view preference. "Default VAT basis" is the
+ *      save-as-default counterpart to the toolbar's `AnalyticsNetGrossToggle`
+ *      (rendered stacked directly below the currency picker, #2895): the
+ *      toggle is the URL-encoded session choice — see (1) — while this
+ *      section is what a returning operator's future visits fall back to
+ *      when no session override is present.
  *
  * The "automatically recalculate" toggle from the reference mockup has no
  * backend counterpart yet (no persisted setting exists for it) — rendered
@@ -53,6 +58,7 @@ import { useRecalculateCurrencyMutation } from '../hooks/use-recalculate-currenc
 import { DISPLAY_CURRENCY_OPTIONS } from '../lib/display-currency.lib';
 import type { AnalyticsCoverageFilters } from '../api/analytics-coverage.types';
 import type { DisplayCurrencyRateBasis } from '../api/sales-analytics.types';
+import type { NetGrossBasis } from '../api/analytics-settings.types';
 
 interface AnalyticsSettingsDialogProps {
   open: boolean;
@@ -149,6 +155,34 @@ export function AnalyticsSettingsDialog({
             : null,
         rateBasis: settingsQuery.data.rateBasis,
         includeBackfilledTaxRatesInNetSales: nextInclude,
+        netGrossBasis: settingsQuery.data.netGrossBasis,
+      },
+      {
+        onError: (error) => {
+          showToast({ tone: 'error', description: error.message });
+        },
+      }
+    );
+  }
+
+  // Persists the ORG-WIDE default a view opens in when no `?netGrossBasis=`
+  // URL override is present — the save-as-default counterpart to the
+  // toolbar's `AnalyticsNetGrossToggle`, exactly mirroring how the tax-rate
+  // toggle above is this dialog's one already-shipped immediate-write
+  // pattern (Apply only ever pushes a URL param, never a persisted write).
+  function handleNetGrossBasisDefaultChange(next: NetGrossBasis): void {
+    if (!settingsQuery.data) {
+      return;
+    }
+    updateSettings.mutate(
+      {
+        displayCurrency:
+          settingsQuery.data.displayCurrencySource === 'setting'
+            ? settingsQuery.data.displayCurrency
+            : null,
+        rateBasis: settingsQuery.data.rateBasis,
+        includeBackfilledTaxRatesInNetSales: settingsQuery.data.includeBackfilledTaxRatesInNetSales,
+        netGrossBasis: next,
       },
       {
         onError: (error) => {
@@ -221,6 +255,51 @@ export function AnalyticsSettingsDialog({
             </span>
           </label>
         </fieldset>
+
+        <section className="analytics-settings-dialog__section">
+          <h3 className="analytics-settings-dialog__section-title">Default VAT basis</h3>
+          <p className="analytics-settings-dialog__status">
+            Saved immediately and applies to every future visit that doesn&rsquo;t pick its own basis
+            via the toolbar toggle.
+          </p>
+          {write.visible && (
+            <ReadOnlyLock active={write.demoReadOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
+              <fieldset className="analytics-settings-dialog__field">
+                <legend className="sr-only">Default VAT basis</legend>
+                <label className="analytics-settings-dialog__rate-basis-option">
+                  <input
+                    type="radio"
+                    name="net-gross-basis-default"
+                    checked={(settingsQuery.data?.netGrossBasis ?? 'gross') === 'gross'}
+                    disabled={!settingsQuery.data || updateSettings.isPending || write.demoReadOnly}
+                    onChange={() => handleNetGrossBasisDefaultChange('gross')}
+                  />
+                  <span>
+                    <strong>Gross</strong>
+                    <span className="analytics-settings-dialog__rate-basis-desc">
+                      VAT-inclusive figures, by default.
+                    </span>
+                  </span>
+                </label>
+                <label className="analytics-settings-dialog__rate-basis-option">
+                  <input
+                    type="radio"
+                    name="net-gross-basis-default"
+                    checked={settingsQuery.data?.netGrossBasis === 'net'}
+                    disabled={!settingsQuery.data || updateSettings.isPending || write.demoReadOnly}
+                    onChange={() => handleNetGrossBasisDefaultChange('net')}
+                  />
+                  <span>
+                    <strong>Net</strong>
+                    <span className="analytics-settings-dialog__rate-basis-desc">
+                      VAT-exclusive figures, by default.
+                    </span>
+                  </span>
+                </label>
+              </fieldset>
+            </ReadOnlyLock>
+          )}
+        </section>
 
         <section className="analytics-settings-dialog__section">
           <h3 className="analytics-settings-dialog__section-title">Currency — recalculation</h3>

--- a/apps/web/src/features/analytics/hooks/use-analytics-settings-query.test.tsx
+++ b/apps/web/src/features/analytics/hooks/use-analytics-settings-query.test.tsx
@@ -27,6 +27,7 @@ const mockSettings: AnalyticsSettingsView = {
   displayCurrencySource: 'setting',
   rateBasis: 'order-date',
   includeBackfilledTaxRatesInNetSales: true,
+  netGrossBasis: 'gross',
   updatedAt: '2026-08-01T00:00:00.000Z',
   updatedByUserId: 'user_1',
 };

--- a/apps/web/src/features/analytics/hooks/use-update-analytics-settings-mutation.test.tsx
+++ b/apps/web/src/features/analytics/hooks/use-update-analytics-settings-mutation.test.tsx
@@ -34,12 +34,14 @@ describe('useUpdateAnalyticsSettingsMutation', () => {
       displayCurrency: 'PLN',
       rateBasis: 'current',
       includeBackfilledTaxRatesInNetSales: true,
+      netGrossBasis: 'gross',
     });
 
     expect(updateSettings).toHaveBeenCalledWith({
       displayCurrency: 'PLN',
       rateBasis: 'current',
       includeBackfilledTaxRatesInNetSales: true,
+      netGrossBasis: 'gross',
     });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
   });
@@ -59,6 +61,7 @@ describe('useUpdateAnalyticsSettingsMutation', () => {
       displayCurrency: null,
       rateBasis: 'order-date',
       includeBackfilledTaxRatesInNetSales: false,
+      netGrossBasis: 'gross',
     });
 
     await waitFor(() =>
@@ -81,6 +84,7 @@ describe('useUpdateAnalyticsSettingsMutation', () => {
         displayCurrency: 'PLN',
         rateBasis: 'current',
         includeBackfilledTaxRatesInNetSales: false,
+        netGrossBasis: 'gross',
       })
     ).rejects.toThrow('boom');
   });

--- a/apps/web/src/features/analytics/index.ts
+++ b/apps/web/src/features/analytics/index.ts
@@ -32,13 +32,15 @@ export type {
 
 export { useAnalyticsSettingsQuery } from './hooks/use-analytics-settings-query';
 export { useUpdateAnalyticsSettingsMutation } from './hooks/use-update-analytics-settings-mutation';
-export { RATE_BASIS_VALUES } from './api/analytics-settings.types';
+export { RATE_BASIS_VALUES, NET_GROSS_BASIS_VALUES } from './api/analytics-settings.types';
 export type {
   AnalyticsDisplayCurrencySource,
   AnalyticsSettingsView,
+  NetGrossBasis,
   RateBasis,
   UpdateAnalyticsSettingsInput,
 } from './api/analytics-settings.types';
+export { AnalyticsNetGrossToggle } from './components/analytics-net-gross-toggle';
 
 export { useAnalyticsCoverageQuery } from './hooks/use-analytics-coverage-query';
 export { useRecalculateCurrencyMutation } from './hooks/use-recalculate-currency-mutation';

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -19274,6 +19274,20 @@ textarea.bulk-editor__input { resize: vertical; min-height: 66px; font-family: i
   font-weight: 600;
 }
 
+/* ── Trailing toolbar stack (#2895) ──
+   The currency picker and the VAT-basis toggle are both "how to read this
+   view" preferences, stacked in one column — the toggle sits directly
+   below the picker rather than beside it, since the currency choice is the
+   taller and more consequential of the two. This div is the ONE child of
+   the trailing `.toolbar__group` (a flex row), so it becomes a single flex
+   item that switches its own children to a column. */
+.analytics-toolbar__trailing-stack {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: var(--space-2);
+}
+
 /* The † gap marker on the "Order date" chip — a real <button> opening a
    Popover on click, not a Tooltip, so it's reachable on touch devices
    (Radix Tooltip ignores pointerType === 'touch'). */

--- a/apps/web/src/pages/analytics/analytics-page.test.tsx
+++ b/apps/web/src/pages/analytics/analytics-page.test.tsx
@@ -243,6 +243,7 @@ describe('AnalyticsPage', () => {
           displayCurrencySource: 'setting',
           rateBasis: 'current',
           includeBackfilledTaxRatesInNetSales: false,
+          netGrossBasis: 'gross',
           updatedAt: null,
           updatedByUserId: null,
         }),

--- a/apps/web/src/pages/analytics/analytics-page.tsx
+++ b/apps/web/src/pages/analytics/analytics-page.tsx
@@ -24,6 +24,7 @@ import {
   AnalyticsDegradationBanner,
   AnalyticsKpiStrip,
   AnalyticsNeedsAttention,
+  AnalyticsNetGrossToggle,
   AnalyticsSettingsDialog,
   AnalyticsTrustHeader,
   ChannelSalesTable,
@@ -31,10 +32,12 @@ import {
   computePresetRange,
   toExclusiveEndInstant,
   useAnalyticsCoverageQuery,
+  useAnalyticsSettingsQuery,
   useAnalyticsTrustQuery,
   useSalesAnalyticsQuery,
   type CoverageCategory,
   type DisplayCurrencyRateBasis,
+  type NetGrossBasis,
   type SalesAnalyticsFilters,
 } from '../../features/analytics';
 import { Button, EmptyState, ErrorState, LoadingState, PageLayout } from '../../shared/ui';
@@ -106,6 +109,24 @@ export function AnalyticsPage(): ReactElement {
     setSearchParams(next);
   }
 
+  // Reads the operator-saved default basis (`AnalyticsSettingsView.
+  // netGrossBasis`) so a returning operator sees their own default without
+  // reselecting it via the toolbar toggle — the same dual mechanism as
+  // `displayCurrency`/`rateBasis`: a URL override always wins for the
+  // current view/session; absent one, the persisted default applies.
+  const settingsQuery = useAnalyticsSettingsQuery();
+  const netGrossBasisParam = searchParams.get('netGrossBasis');
+  const netGrossBasis: NetGrossBasis =
+    netGrossBasisParam === 'net' || netGrossBasisParam === 'gross'
+      ? netGrossBasisParam
+      : (settingsQuery.data?.netGrossBasis ?? 'gross');
+
+  function handleNetGrossBasisChange(next: NetGrossBasis): void {
+    const nextParams = new URLSearchParams(searchParams);
+    nextParams.set('netGrossBasis', next);
+    setSearchParams(nextParams);
+  }
+
   // Built once per from/to/displayCurrency/rateBasis so `AnalyticsKpiStrip`,
   // `ChannelSalesTable` and `AnalyticsConvertNote` share a byte-identical
   // query key and therefore one network request — and so a channel-table
@@ -166,11 +187,14 @@ export function AnalyticsPage(): ReactElement {
         to={to}
         onApply={handleApply}
         trailing={
-          <AnalyticsCurrencyPicker
-            reportingCurrency={reportingCurrency}
-            displayCurrency={displayCurrency}
-            onChange={handleDisplayCurrencyChange}
-          />
+          <div className="analytics-toolbar__trailing-stack">
+            <AnalyticsCurrencyPicker
+              reportingCurrency={reportingCurrency}
+              displayCurrency={displayCurrency}
+              onChange={handleDisplayCurrencyChange}
+            />
+            <AnalyticsNetGrossToggle value={netGrossBasis} onChange={handleNetGrossBasisChange} />
+          </div>
         }
       />
       <AnalyticsConvertNote

--- a/apps/web/src/test/test-utils.tsx
+++ b/apps/web/src/test/test-utils.tsx
@@ -256,6 +256,7 @@ export function createMockApiClient(
         displayCurrencySource: 'default',
         rateBasis: 'current',
         includeBackfilledTaxRatesInNetSales: false,
+        netGrossBasis: 'gross',
         updatedAt: null,
         updatedByUserId: null,
       }),

--- a/libs/core/src/analytics/application/services/analytics-display-settings.service.spec.ts
+++ b/libs/core/src/analytics/application/services/analytics-display-settings.service.spec.ts
@@ -39,6 +39,7 @@ describe('AnalyticsDisplaySettingsService', () => {
         displayCurrency: null,
         rateBasis: 'current',
         includeBackfilledTaxRatesInNetSales: false,
+        netGrossBasis: 'gross',
         updatedAt: null,
         updatedByUserId: null,
       });
@@ -47,7 +48,7 @@ describe('AnalyticsDisplaySettingsService', () => {
     it('returns the persisted row verbatim', async () => {
       const updatedAt = new Date('2026-08-20T10:00:00Z');
       repository.findSettings.mockResolvedValue(
-        new AnalyticsDisplaySettings('EUR', 'order-date', true, updatedAt, 'user-9')
+        new AnalyticsDisplaySettings('EUR', 'order-date', true, 'net', updatedAt, 'user-9')
       );
 
       const view = await service.getSettings();
@@ -56,6 +57,7 @@ describe('AnalyticsDisplaySettingsService', () => {
         displayCurrency: 'EUR',
         rateBasis: 'order-date',
         includeBackfilledTaxRatesInNetSales: true,
+        netGrossBasis: 'net',
         updatedAt,
         updatedByUserId: 'user-9',
       });
@@ -65,33 +67,49 @@ describe('AnalyticsDisplaySettingsService', () => {
   describe('updateSettings', () => {
     it('delegates to the repository with the resolved actor', async () => {
       repository.upsertSettings.mockResolvedValue(
-        new AnalyticsDisplaySettings('PLN', 'current', false, new Date(), 'user-1')
+        new AnalyticsDisplaySettings('PLN', 'current', false, 'gross', new Date(), 'user-1')
       );
 
       await service.updateSettings(
-        { displayCurrency: 'PLN', rateBasis: 'current', includeBackfilledTaxRatesInNetSales: false },
+        {
+          displayCurrency: 'PLN',
+          rateBasis: 'current',
+          includeBackfilledTaxRatesInNetSales: false,
+          netGrossBasis: 'gross',
+        },
         'user-1'
       );
 
       expect(repository.upsertSettings).toHaveBeenCalledWith(
-        { displayCurrency: 'PLN', rateBasis: 'current', includeBackfilledTaxRatesInNetSales: false },
+        {
+          displayCurrency: 'PLN',
+          rateBasis: 'current',
+          includeBackfilledTaxRatesInNetSales: false,
+          netGrossBasis: 'gross',
+        },
         'user-1'
       );
     });
 
     it('passes a null actor for a system-driven write', async () => {
       repository.upsertSettings.mockResolvedValue(
-        new AnalyticsDisplaySettings(null, 'current', false, new Date(), null)
+        new AnalyticsDisplaySettings(null, 'current', false, 'gross', new Date(), null)
       );
 
       await service.updateSettings({
         displayCurrency: null,
         rateBasis: 'current',
         includeBackfilledTaxRatesInNetSales: false,
+        netGrossBasis: 'gross',
       });
 
       expect(repository.upsertSettings).toHaveBeenCalledWith(
-        { displayCurrency: null, rateBasis: 'current', includeBackfilledTaxRatesInNetSales: false },
+        {
+          displayCurrency: null,
+          rateBasis: 'current',
+          includeBackfilledTaxRatesInNetSales: false,
+          netGrossBasis: 'gross',
+        },
         null
       );
     });

--- a/libs/core/src/analytics/application/services/analytics-display-settings.service.ts
+++ b/libs/core/src/analytics/application/services/analytics-display-settings.service.ts
@@ -44,6 +44,7 @@ export class AnalyticsDisplaySettingsService implements IAnalyticsDisplaySetting
         displayCurrency: null,
         rateBasis: 'current',
         includeBackfilledTaxRatesInNetSales: false,
+        netGrossBasis: 'gross',
         updatedAt: null,
         updatedByUserId: null,
       };
@@ -53,6 +54,7 @@ export class AnalyticsDisplaySettingsService implements IAnalyticsDisplaySetting
       displayCurrency: row.displayCurrency,
       rateBasis: row.rateBasis,
       includeBackfilledTaxRatesInNetSales: row.includeBackfilledTaxRatesInNetSales,
+      netGrossBasis: row.netGrossBasis,
       updatedAt: row.updatedAt,
       updatedByUserId: row.updatedByUserId,
     };
@@ -64,6 +66,7 @@ export class AnalyticsDisplaySettingsService implements IAnalyticsDisplaySetting
       displayCurrency: input.displayCurrency,
       rateBasis: input.rateBasis,
       includeBackfilledTaxRatesInNetSales: input.includeBackfilledTaxRatesInNetSales,
+      netGrossBasis: input.netGrossBasis,
       actor: actorUserId ?? 'system',
     });
   }

--- a/libs/core/src/analytics/domain/entities/analytics-display-settings.entity.ts
+++ b/libs/core/src/analytics/domain/entities/analytics-display-settings.entity.ts
@@ -9,7 +9,7 @@
  *
  * @module libs/core/src/analytics/domain/entities
  */
-import type { RateBasis } from '../types/analytics-display-settings.types';
+import type { NetGrossBasis, RateBasis } from '../types/analytics-display-settings.types';
 
 export const ANALYTICS_DISPLAY_SETTINGS_SINGLETON_ID = 'singleton';
 
@@ -18,6 +18,7 @@ export class AnalyticsDisplaySettings {
     public readonly displayCurrency: string | null,
     public readonly rateBasis: RateBasis,
     public readonly includeBackfilledTaxRatesInNetSales: boolean,
+    public readonly netGrossBasis: NetGrossBasis,
     public readonly updatedAt: Date,
     public readonly updatedByUserId: string | null
   ) {}

--- a/libs/core/src/analytics/domain/types/analytics-display-settings.types.ts
+++ b/libs/core/src/analytics/domain/types/analytics-display-settings.types.ts
@@ -21,6 +21,21 @@ export const RateBasisValues = ['current', 'order-date'] as const;
 export type RateBasis = (typeof RateBasisValues)[number];
 
 /**
+ * Which basis a currency-denominated figure is shown in.
+ *
+ * - `'gross'` — VAT-inclusive (the pre-existing default; every figure's
+ *   raw, as-charged amount).
+ * - `'net'` — VAT-exclusive (NOV — see `SalesAnalyticsHeadline.netRevenue`).
+ *
+ * This is a read-time DISPLAY preference only, same as `rateBasis` — it
+ * never changes which figures the backend computes (both are already
+ * returned on every headline/channel row), only which one a view treats as
+ * primary.
+ */
+export const NetGrossBasisValues = ['gross', 'net'] as const;
+export type NetGrossBasis = (typeof NetGrossBasisValues)[number];
+
+/**
  * Non-secret settings fields, as written by `PUT /analytics/settings` (#2462).
  */
 export interface AnalyticsDisplaySettingsInput {
@@ -38,6 +53,8 @@ export interface AnalyticsDisplaySettingsInput {
    * unchanged from the pre-#2456 exclusion until an operator opts in.
    */
   includeBackfilledTaxRatesInNetSales: boolean;
+  /** Default basis a view opens in when no `?netGrossBasis=` URL override is present. Default `'gross'`. */
+  netGrossBasis: NetGrossBasis;
 }
 
 /**

--- a/libs/core/src/analytics/index.ts
+++ b/libs/core/src/analytics/index.ts
@@ -26,9 +26,10 @@ export {
   ANALYTICS_DISPLAY_SETTINGS_SINGLETON_ID,
 } from './domain/entities/analytics-display-settings.entity';
 export type { AnalyticsDisplaySettingsRepositoryPort } from './domain/ports/analytics-display-settings-repository.port';
-export { RateBasisValues } from './domain/types/analytics-display-settings.types';
+export { RateBasisValues, NetGrossBasisValues } from './domain/types/analytics-display-settings.types';
 export type {
   RateBasis,
+  NetGrossBasis,
   AnalyticsDisplaySettingsInput,
   AnalyticsDisplaySettingsView,
 } from './domain/types/analytics-display-settings.types';

--- a/libs/core/src/analytics/infrastructure/persistence/entities/analytics-display-settings.orm-entity.ts
+++ b/libs/core/src/analytics/infrastructure/persistence/entities/analytics-display-settings.orm-entity.ts
@@ -28,6 +28,9 @@ export class AnalyticsDisplaySettingsOrmEntity {
   })
   includeBackfilledTaxRatesInNetSales!: boolean;
 
+  @Column({ type: 'text', name: 'net_gross_basis', default: 'gross' })
+  netGrossBasis!: string;
+
   @UpdateDateColumn({ type: 'timestamptz', name: 'updated_at' })
   updatedAt!: Date;
 

--- a/libs/core/src/analytics/infrastructure/persistence/repositories/analytics-display-settings.repository.spec.ts
+++ b/libs/core/src/analytics/infrastructure/persistence/repositories/analytics-display-settings.repository.spec.ts
@@ -16,6 +16,7 @@ function ormRow(
     displayCurrency: 'PLN',
     rateBasis: 'current',
     includeBackfilledTaxRatesInNetSales: false,
+    netGrossBasis: 'gross',
     updatedAt: new Date('2026-08-14T06:00:00Z'),
     updatedByUserId: 'user-1',
     ...overrides,
@@ -61,6 +62,7 @@ describe('AnalyticsDisplaySettingsRepository', () => {
         displayCurrency: 'PLN',
         rateBasis: 'current',
         includeBackfilledTaxRatesInNetSales: false,
+        netGrossBasis: 'gross',
         updatedAt: new Date('2026-08-14T06:00:00Z'),
         updatedByUserId: 'user-1',
       });
@@ -96,6 +98,7 @@ describe('AnalyticsDisplaySettingsRepository', () => {
           displayCurrency: 'EUR',
           rateBasis: 'order-date',
           includeBackfilledTaxRatesInNetSales: true,
+          netGrossBasis: 'net',
         },
         'user-2'
       );
@@ -106,6 +109,7 @@ describe('AnalyticsDisplaySettingsRepository', () => {
           displayCurrency: 'EUR',
           rateBasis: 'order-date',
           includeBackfilledTaxRatesInNetSales: true,
+          netGrossBasis: 'net',
           updatedByUserId: 'user-2',
         }),
         { conflictPaths: ['id'] }
@@ -122,6 +126,7 @@ describe('AnalyticsDisplaySettingsRepository', () => {
           displayCurrency: null,
           rateBasis: 'current',
           includeBackfilledTaxRatesInNetSales: false,
+          netGrossBasis: 'gross',
         },
         null
       );

--- a/libs/core/src/analytics/infrastructure/persistence/repositories/analytics-display-settings.repository.ts
+++ b/libs/core/src/analytics/infrastructure/persistence/repositories/analytics-display-settings.repository.ts
@@ -19,14 +19,19 @@ import {
 } from '../../../domain/entities/analytics-display-settings.entity';
 import type { AnalyticsDisplaySettingsRepositoryPort } from '../../../domain/ports/analytics-display-settings-repository.port';
 import {
+  NetGrossBasisValues,
   RateBasisValues,
   type AnalyticsDisplaySettingsInput,
+  type NetGrossBasis,
   type RateBasis,
 } from '../../../domain/types/analytics-display-settings.types';
 import { AnalyticsDisplaySettingsOrmEntity } from '../entities/analytics-display-settings.orm-entity';
 
 const isRateBasis = (value: string): value is RateBasis =>
   (RateBasisValues as readonly string[]).includes(value);
+
+const isNetGrossBasis = (value: string): value is NetGrossBasis =>
+  (NetGrossBasisValues as readonly string[]).includes(value);
 
 @Injectable()
 export class AnalyticsDisplaySettingsRepository implements AnalyticsDisplaySettingsRepositoryPort {
@@ -52,6 +57,7 @@ export class AnalyticsDisplaySettingsRepository implements AnalyticsDisplaySetti
         displayCurrency: input.displayCurrency,
         rateBasis: input.rateBasis,
         includeBackfilledTaxRatesInNetSales: input.includeBackfilledTaxRatesInNetSales,
+        netGrossBasis: input.netGrossBasis,
         updatedByUserId,
         // TypeORM's upsert() only includes explicitly-passed columns in the
         // ON CONFLICT DO UPDATE SET clause — @UpdateDateColumn()'s auto-touch
@@ -77,10 +83,16 @@ export class AnalyticsDisplaySettingsRepository implements AnalyticsDisplaySetti
       // silently — same posture as `PosthogSettingsRepository.toDomain`.
       throw new Error(`analytics_display_settings.rate_basis has an unknown value '${entity.rateBasis}'`);
     }
+    if (!isNetGrossBasis(entity.netGrossBasis)) {
+      throw new Error(
+        `analytics_display_settings.net_gross_basis has an unknown value '${entity.netGrossBasis}'`
+      );
+    }
     return new AnalyticsDisplaySettings(
       entity.displayCurrency,
       entity.rateBasis,
       entity.includeBackfilledTaxRatesInNetSales,
+      entity.netGrossBasis,
       entity.updatedAt,
       entity.updatedByUserId
     );


### PR DESCRIPTION
## Summary
- Adds a Net/Gross VAT-basis toggle to the Analytics page, rendered **stacked directly below** the display-currency picker in the toolbar (same column, second row) rather than beside it.
- The current choice is URL-encoded (`?netGrossBasis=gross|net`), the same session-scoped mechanism `displayCurrency`/`rateBasis` already use.
- Adds a fourth field, `netGrossBasis`, to the singleton `analytics_display_settings` row (mirroring `rateBasis` end to end: entity, ORM entity, repository, service, DTOs, controller, migration), and a "Default VAT basis" section in `AnalyticsSettingsDialog` that persists it immediately via `useUpdateAnalyticsSettingsMutation` — the same real-write pattern the existing tax-rate toggle uses. A returning operator's saved default applies automatically when no session URL override is present.

## Test plan
- [x] `pnpm type-check` (whole workspace, after building `libs/*`) — green
- [x] Targeted `vitest` runs for the new toggle, the settings dialog, both settings hooks, and the analytics page — 30/30 passing
- [x] Backend unit specs for the settings entity/repository/service updated and passing (`libs/core` jest run for the `analytics` scope, excluding one pre-existing, unrelated env failure — missing `sanitize-html` dependency in this sandbox, not caused by this change)

Closes #2895

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019auBcLpYvAQ1Mr6qyB3Bj3