### PR TITLE
fix(analytics): reconcile channel table Units Sold with unconverted orders

### DIFF
--- a/apps/web/src/features/analytics/components/channel-sales-table.test.tsx
+++ b/apps/web/src/features/analytics/components/channel-sales-table.test.tsx
@@ -167,6 +167,31 @@ describe('ChannelSalesTable', () => {
     expect(screen.queryByText('PLN 108.00')).not.toBeInTheDocument();
   });
 
+  it('should add back unconverted units into both the row and the Total row (#2907)', async () => {
+    const apiClient = createMockApiClient({
+      analytics: {
+        getSales: vi
+          .fn()
+          .mockResolvedValue(analytics([channel({ unitsSold: 40, unconvertedUnitsSold: 5 })])),
+      },
+      connections: {
+        list: vi
+          .fn()
+          .mockResolvedValue([{ id: 'conn-1', name: 'Allegro — main', platformType: 'allegro' }]),
+      },
+    });
+
+    renderWithProviders(<ChannelSalesTable netGrossBasis="net" filters={FILTERS} />, { apiClient });
+
+    await screen.findByRole('link', { name: 'Allegro — main' });
+
+    // 40 unitsSold + 5 unconvertedUnitsSold = 45, on both the channel row and
+    // the Total row it fully composes — reconciling with the headline KPI's
+    // own unitsSold + unconvertedUnitsSold add-back (#2893).
+    expect(screen.getAllByText('45')).toHaveLength(2);
+    expect(screen.queryByText('40')).not.toBeInTheDocument();
+  });
+
   it('should render a partial-history channel with a coverage flag', async () => {
     const apiClient = createMockApiClient({
       analytics: {

--- a/apps/web/src/features/analytics/components/channel-sales-table.tsx
+++ b/apps/web/src/features/analytics/components/channel-sales-table.tsx
@@ -478,7 +478,11 @@ export function ChannelSalesTable({
       header: 'Units',
       align: 'right',
       cell: (row) =>
-        intFormat.format(row.kind === 'total' ? row.total.unitsSold : row.channel.unitsSold),
+        intFormat.format(
+          row.kind === 'total'
+            ? row.total.unitsSold
+            : row.channel.unitsSold + row.channel.unconvertedUnitsSold,
+        ),
       hideBelow: 1024,
     },
     {

--- a/apps/web/src/features/analytics/lib/sales-analytics-view-model.test.ts
+++ b/apps/web/src/features/analytics/lib/sales-analytics-view-model.test.ts
@@ -149,6 +149,33 @@ describe('groupChannelTotalsByCurrency', () => {
     ]);
   });
 
+  it('should add back unconverted units into the Total row unitsSold (#2907)', () => {
+    const totals = groupChannelTotalsByCurrency([
+      channel({
+        sourceConnectionId: 'a',
+        revenue: 3000,
+        orderCount: 25,
+        unitsSold: 40,
+        unconvertedUnitsSold: 5,
+        revenueShare: 0.6,
+        netRevenue: 2400,
+        netExcludedCount: 5,
+      }),
+      channel({
+        sourceConnectionId: 'b',
+        revenue: 2000,
+        orderCount: 15,
+        unitsSold: 20,
+        unconvertedUnitsSold: 3,
+        revenueShare: 0.4,
+        netRevenue: 1600,
+        netExcludedCount: 0,
+      }),
+    ]);
+
+    expect(totals[0]?.unitsSold).toBe(40 + 5 + 20 + 3);
+  });
+
   it('should never emit a total row for unconverted-currency evidence — no matter how many channels share it', () => {
     const totals = groupChannelTotalsByCurrency([
       channel({ sourceConnectionId: 'a', revenue: 3000, orderCount: 25, revenueShare: 1 }),

--- a/apps/web/src/features/analytics/lib/sales-analytics-view-model.ts
+++ b/apps/web/src/features/analytics/lib/sales-analytics-view-model.ts
@@ -157,7 +157,7 @@ export function groupChannelTotalsByCurrency(channels: ChannelSalesAnalytics[]):
       revenue,
       orderCount,
       averageOrderValue: orderCount === 0 ? 0 : revenue / orderCount,
-      unitsSold: sum(contributing, (c) => c.unitsSold),
+      unitsSold: sum(contributing, (c) => c.unitsSold + c.unconvertedUnitsSold),
       revenueShare: sum(contributing, (c) => c.revenueShare),
       netRevenue,
       netAverageOrderValue: netOrderCount === 0 ? 0 : netRevenue / netOrderCount,


### PR DESCRIPTION
## Summary

The headline KPI-strip fix for #2893 correctly computes `unitsSold + unconvertedUnitsSold`. `channel-sales-table.tsx` read `channel.unitsSold` directly with no add-back, and the table's own Total row (`groupChannelTotalsByCurrency` in `sales-analytics-view-model.ts`) summed the same un-reconciled field. Whenever a channel has unconverted orders, the channel table's units under-counted relative to the headline card, and channel rows did not sum to the headline total.

This mirrors the headline fix in both places:
- `channel-sales-table.tsx`: the per-row Units cell now renders `channel.unitsSold + channel.unconvertedUnitsSold`
- `sales-analytics-view-model.ts`: `groupChannelTotalsByCurrency`'s Total-row `unitsSold` now sums `c.unitsSold + c.unconvertedUnitsSold` across contributing channels

## Test plan

- [x] `pnpm --filter @openlinker/web type-check` — clean
- [x] `pnpm --filter @openlinker/web test` — 5460 passed, 1 skipped (full suite; no `-- filter` support in this repo's vitest wrapper, ran everything)
- [x] New test in `channel-sales-table.test.tsx` asserts a channel with `unitsSold: 40, unconvertedUnitsSold: 5` renders `45` on both the channel row and the Total row it composes
- [x] New test in `sales-analytics-view-model.test.ts` asserts the Total row's `unitsSold` sums `unitsSold + unconvertedUnitsSold` across two contributing channels

Closes #2907

🤖 Generated with [Claude Code](https://claude.com/claude-code)