### PR TITLE
fix(web): make headline Revenue card track the Net/Gross toggle

### DIFF
--- a/apps/web/src/features/analytics/components/analytics-kpi-strip.test.tsx
+++ b/apps/web/src/features/analytics/components/analytics-kpi-strip.test.tsx
@@ -157,6 +157,52 @@ describe('AnalyticsKpiStrip', () => {
     expect(screen.queryByText('PLN 100.00')).not.toBeInTheDocument(); // medianOrderValue
   });
 
+  it('should render GMV as the primary Revenue figure and Net sales as its qualifier under the gross basis (#2908 fix)', async () => {
+    // Under `netGrossBasis="gross"` (the default), the headline Revenue
+    // card's primary figure must swap to GMV — matching the channel/product
+    // tables' own `revenueLabel`/`revenueOf` primary-column choice for the
+    // same basis — while Net sales moves to the qualifier row. Neither
+    // figure is dropped; only which one is primary changes.
+    const apiClient = createMockApiClient({
+      analytics: { getSales: vi.fn().mockResolvedValue(analytics()) },
+    });
+
+    renderWithProviders(
+      <AnalyticsKpiStrip filters={FILTERS} connections={[]} netGrossBasis="gross" />,
+      { apiClient }
+    );
+
+    const primaryValue = await screen.findByText('PLN 4,800.00'); // headline.revenue (GMV)
+    expect(primaryValue.closest('.kpi-card__value')).not.toBeNull();
+    expect(screen.getByText('GMV').closest('.kpi-card__metric')).not.toBeNull();
+
+    const qualifierValue = screen.getByText('PLN 4,200.00'); // headline.netRevenue (Net sales)
+    expect(qualifierValue.closest('.kpi-card__qualifier-value')).not.toBeNull();
+    expect(screen.getByText('Net sales').closest('.kpi-card__qualifier-label')).not.toBeNull();
+  });
+
+  it('should render Net sales as the primary Revenue figure and GMV as its qualifier under the net basis (#2908 fix)', async () => {
+    // The mirror-image case: under `netGrossBasis="net"`, Net sales stays
+    // primary (byte-identical to this card's pre-#2908 rendering) and GMV
+    // becomes the qualifier.
+    const apiClient = createMockApiClient({
+      analytics: { getSales: vi.fn().mockResolvedValue(analytics()) },
+    });
+
+    renderWithProviders(
+      <AnalyticsKpiStrip filters={FILTERS} connections={[]} netGrossBasis="net" />,
+      { apiClient }
+    );
+
+    const primaryValue = await screen.findByText('PLN 4,200.00'); // headline.netRevenue (Net sales)
+    expect(primaryValue.closest('.kpi-card__value')).not.toBeNull();
+    expect(screen.getByText('Net sales').closest('.kpi-card__metric')).not.toBeNull();
+
+    const qualifierValue = screen.getByText('PLN 4,800.00'); // headline.revenue (GMV)
+    expect(qualifierValue.closest('.kpi-card__qualifier-value')).not.toBeNull();
+    expect(screen.getByText('GMV').closest('.kpi-card__qualifier-label')).not.toBeNull();
+  });
+
   it('should count unconverted-order units into Units sold and Units per order, matching the Orders card population', async () => {
     // 40 stamped orders + 10 unconverted = 50 total orders (same population
     // the Orders card renders, per `totalOrders = orderCount +

--- a/apps/web/src/features/analytics/components/analytics-kpi-strip.tsx
+++ b/apps/web/src/features/analytics/components/analytics-kpi-strip.tsx
@@ -11,14 +11,20 @@
  *   - Revenue: the spec's "Net Sales" is NOV (net order value, VAT-exclusive)
  *     minus the value of returns (`docs/specs/metrics-analytics-dashboard.md`
  *     § Net Sales). The net-sales tax-rate epic made NOV real
- *     (`headline.netRevenue`) — per the reference design mockup this renders
- *     as a normal, complete "Net sales" headline (no gap badge on the card
- *     face); the still-open returns caveat and the tax-rate exclusion count
- *     (`headline.netExcludedCount` — pre-rollout orders, or an order with an
- *     unresolvable line-level tax rate) live only in the (i) tooltip's
- *     definition, never as a second qualifier row. Its GMV qualifier
- *     (`headline.revenue`, real, FX-stamped, in `headline.currency`) renders
- *     normally, unchanged.
+ *     (`headline.netRevenue`); the still-open returns caveat and the
+ *     tax-rate exclusion count (`headline.netExcludedCount` — pre-rollout
+ *     orders, or an order with an unresolvable line-level tax rate) live
+ *     only in the (i) tooltip's definition, never as a second qualifier row.
+ *     Both Net sales and GMV (`headline.revenue`, real, FX-stamped, in
+ *     `headline.currency`) always render — one as the primary headline
+ *     figure, the other as the qualifier below it — and which one is
+ *     primary is driven by `netGrossBasis` (#2908 fix): `'net'` (the
+ *     default) shows Net sales primary / GMV qualifier; `'gross'` shows GMV
+ *     primary / Net sales qualifier, matching the channel/product tables'
+ *     own basis-driven primary column (`channel-sales-table.tsx`'s
+ *     `revenueLabel`/`revenueOf`). Neither figure is ever hidden — the
+ *     toggle only decides which one is labelled and rendered as the
+ *     headline.
  *   - Orders, Units: fully real. `headline.orderCount` only counts
  *     FX-stamped orders (ADR-040) — `totalOrders` below adds back `headline.
  *     unconvertedCount` so Orders/Avg. daily/Units per order/Cancellation
@@ -46,10 +52,8 @@
  *     `netGrossBasis="net"` — an operator's own explicit choice to view the
  *     page net-of-VAT — the card instead reads `netAverageOrderValue`/
  *     `netMedianOrderValue`, whose narrower net-eligible cohort is disclosed
- *     via `netExcludedNote` instead. The Revenue card is deliberately NOT
- *     gated on this prop: it already shows Net Sales (primary) and GMV
- *     (qualifier) unconditionally, both bases visible at once, so there is
- *     nothing for a basis toggle to add there.
+ *     via `netExcludedNote` instead. The Revenue card now ALSO reads this
+ *     prop (#2908 fix), for the primary/qualifier swap described above.
  *   - Returns & refunds: no return/refund entity exists anywhere in the
  *     orders domain — fully planned.
  *   - Cancellations: `cancelledCount`/`cancelledValue` are real fields —
@@ -61,8 +65,10 @@
  *     (never a lopsided comparison) unless that ENTIRE previous window is
  *     covered by ingested order history (`isPreviousPeriodCovered`, keyed
  *     off `GET /analytics/trust`'s per-connection `earliestOrderDate`,
- *     #2083) — see the per-card `deltaFor*` helpers below. Revenue's
- *     headline and Returns & refunds are both already `unavailable`/
+ *     #2083) — see the per-card `deltaFor*` helpers below. Revenue carries
+ *     no delta today (confirmed still true by #2908 — nothing here compares
+ *     a toggled current figure against a fixed-basis previous one, since
+ *     there is no comparison to begin with); Returns & refunds stays
  *     `planned`, so a delta there would compare against nothing real.
  *
  * Currency (#1987/#2049/ADR-040): there is exactly ONE system-wide reporting
@@ -350,6 +356,67 @@ export function AnalyticsKpiStrip({
     netExcludedGapOpen && netExcludedTaxRow && onOpenCategory
       ? () => onOpenCategory(netExcludedTaxRow.category)
       : undefined;
+  // Headline Revenue card (#2908 fix): the primary rendered value/label now
+  // tracks `netGrossBasis` the same way the channel/product tables do
+  // (`revenueLabel` / `revenueOf` there) — under `'gross'` GMV is primary
+  // and Net sales is the qualifier; under `'net'` (the default) it's the
+  // reverse, byte-identical to this card's pre-#2908 rendering. Both
+  // figures still always render — this only swaps which one is primary.
+  function renderNetSalesLabel(): ReactElement | string {
+    return netExcludedGapOpen ? (
+      <>
+        Net sales{' '}
+        <GapMark title={netExcludedGapTitle ?? netExcludedNote} onActivate={onOpenNetExcludedGap} />
+      </>
+    ) : (
+      'Net sales'
+    );
+  }
+  const netRevenue = headline.netRevenue;
+  function renderNetSalesValue(): ReactElement {
+    return currencyRecalculating ? (
+      <RecalculatingValue />
+    ) : (
+      <>{formatAmount(convertToDisplay(netRevenue), currency)}</>
+    );
+  }
+  function renderGmvLabel(): ReactElement | string {
+    return stampedGapVisible ? (
+      <>
+        GMV <GapMark title={currencyGapTitle} onActivate={onOpenCurrencyGap} />
+      </>
+    ) : (
+      'GMV'
+    );
+  }
+  function renderGmvValue(): ReactElement {
+    return currencyRecalculating ? (
+      <RecalculatingValue />
+    ) : (
+      <>
+        {formatAmount(gmvValue, gmvCurrency)}
+        {gmvProvenanceDefinitions.length > 0 ? (
+          <span className="kpi-card__qualifier-rate">
+            {gmvInlineRate
+              ? formatAppliedRateLine(gmvInlineRate, rateFormat)
+              : "today's rate(s)"}
+            <AnalyticsInfotip
+              ariaLabel="About this conversion"
+              definitions={gmvProvenanceDefinitions}
+              align="end"
+            />
+          </span>
+        ) : null}
+      </>
+    );
+  }
+  const revenuePrimaryLabel = netGrossBasis === 'gross' ? renderGmvLabel() : renderNetSalesLabel();
+  const revenuePrimaryValue = netGrossBasis === 'gross' ? renderGmvValue() : renderNetSalesValue();
+  const revenueQualifierLabel =
+    netGrossBasis === 'gross' ? renderNetSalesLabel() : renderGmvLabel();
+  const revenueQualifierValue =
+    netGrossBasis === 'gross' ? renderNetSalesValue() : renderGmvValue();
+
   const trendDays = rangeDays(filters.from, filters.to);
   const trendRangeLabel = trendDays === 1 ? 'the selected day' : `the last ${trendDays} days`;
 
@@ -455,27 +522,9 @@ export function AnalyticsKpiStrip({
               : 'Cancelled orders and cancelled items are excluded. Returned/refunded items remain included.',
           },
         ]}
-        metric={
-          netExcludedGapOpen ? (
-            <>
-              Net sales{' '}
-              <GapMark
-                title={netExcludedGapTitle ?? netExcludedNote}
-                onActivate={onOpenNetExcludedGap}
-              />
-            </>
-          ) : (
-            'Net sales'
-          )
-        }
+        metric={revenuePrimaryLabel}
         headlineUnavailable={currencyRecalculating}
-        value={
-          currencyRecalculating ? (
-            <RecalculatingValue />
-          ) : (
-            formatAmount(convertToDisplay(headline.netRevenue), currency)
-          )
-        }
+        value={revenuePrimaryValue}
         trend={{
           values: revenueTrend,
           tone: trendTone(revenueTrend),
@@ -483,32 +532,8 @@ export function AnalyticsKpiStrip({
         }}
         qualifiers={[
           {
-            label: stampedGapVisible ? (
-              <>
-                GMV <GapMark title={currencyGapTitle} onActivate={onOpenCurrencyGap} />
-              </>
-            ) : (
-              'GMV'
-            ),
-            value: currencyRecalculating ? (
-              <RecalculatingValue />
-            ) : (
-              <>
-                {formatAmount(gmvValue, gmvCurrency)}
-                {gmvProvenanceDefinitions.length > 0 ? (
-                  <span className="kpi-card__qualifier-rate">
-                    {gmvInlineRate
-                      ? formatAppliedRateLine(gmvInlineRate, rateFormat)
-                      : "today's rate(s)"}
-                    <AnalyticsInfotip
-                      ariaLabel="About this conversion"
-                      definitions={gmvProvenanceDefinitions}
-                      align="end"
-                    />
-                  </span>
-                ) : null}
-              </>
-            ),
+            label: revenueQualifierLabel,
+            value: revenueQualifierValue,
           },
         ]}
       />


### PR DESCRIPTION
## Summary

The KPI-strip headline Revenue card in `analytics-kpi-strip.tsx` always rendered `headline.netRevenue` labeled "Net sales" as primary, with `headline.revenue` (GMV) as a fixed qualifier - it never read `netGrossBasis` for this card at all. The channel and product tables below it correctly flip their primary money column (and AOV) based on the toggle, so setting the toggle to Gross left the page internally inconsistent: tables show GMV as primary while the headline still said "Net sales".

## Fix

- The headline Revenue card's primary rendered value/label now tracks `netGrossBasis` the same way `channel-sales-table.tsx`'s `revenueLabel`/`revenueOf` already do: under `'gross'` (the default) GMV becomes primary with Net sales as the qualifier; under `'net'` Net sales stays primary as it was before this fix.
- Both figures still always render - the toggle only swaps which one is primary/labelled as such, not which values are shown.
- Checked the AOV/Median card (#2894/#2903) as the reference for basis-driven rendering, and mirrored its approach for the Revenue card.
- Checked the delta logic: the Revenue card has never carried a period-over-period delta (confirmed in the component's own doc comment and code), so there was no fixed-basis-vs-toggled-current comparison to fix there.

## Test plan

- [x] `pnpm --filter @openlinker/web type-check` - clean
- [x] `pnpm --filter @openlinker/web test -- analytics-kpi-strip` - 26/26 passing (24 pre-existing + 2 new)
- [x] Added two component tests asserting the primary/qualifier swap at both toggle states (checking the value's placement in `.kpi-card__value` vs `.kpi-card__qualifier-value`, and label placement in `.kpi-card__metric` vs `.kpi-card__qualifier-label`)

Closes #2908

🤖 Generated with [Claude Code](https://claude.com/claude-code)