### PR TITLE
fix(analytics): Gross Median Order Value uses the same basis as AOV/Revenue

### DIFF
--- a/apps/api/test/integration/sales-analytics-aggregates.int-spec.ts
+++ b/apps/api/test/integration/sales-analytics-aggregates.int-spec.ts
@@ -250,34 +250,46 @@ describe('Sales analytics daily aggregates (integration, #1987)', () => {
     expect(median).toBeNull();
   });
 
-  it('getMedianOrderValue computes PERCENTILE_CONT over stamped, non-cancelled orders', async () => {
+  it('getMedianOrderValue computes PERCENTILE_CONT over stamped, non-cancelled orders, on the gross merchandise-only basis (#2906)', async () => {
     const day = new Date('2026-08-05T10:00:00.000Z');
-    await seedStampedOrder({
+    // Each order's `totalAmount` (shipping-INCLUSIVE) diverges from its
+    // merchandise-only line-item value by a flat 5 shipping charge, so a
+    // regression back to `reportingTotalAmount` would shift the median from
+    // 20 to 25 — the assertion below fails on that basis, not just on this
+    // one.
+    const order1 = await seedStampedOrder({
       placedAt: day,
-      totalAmount: 10,
+      totalAmount: 15,
       reportingCurrency: 'EUR',
-      reportingTotalAmount: 10,
+      reportingTotalAmount: 15,
     });
-    await seedStampedOrder({
+    await seedLineItem({ orderRecordId: order1, unitPrice: 10, quantity: 1 });
+
+    const order2 = await seedStampedOrder({
       placedAt: day,
-      totalAmount: 20,
+      totalAmount: 25,
       reportingCurrency: 'EUR',
-      reportingTotalAmount: 20,
+      reportingTotalAmount: 25,
     });
-    await seedStampedOrder({
+    await seedLineItem({ orderRecordId: order2, unitPrice: 20, quantity: 1 });
+
+    const order3 = await seedStampedOrder({
       placedAt: day,
-      totalAmount: 30,
+      totalAmount: 35,
       reportingCurrency: 'EUR',
-      reportingTotalAmount: 30,
+      reportingTotalAmount: 35,
     });
+    await seedLineItem({ orderRecordId: order3, unitPrice: 30, quantity: 1 });
+
     // Cancelled — must not enter the median.
-    await seedStampedOrder({
+    const cancelledOrder = await seedStampedOrder({
       placedAt: day,
       totalAmount: 1000,
       reportingCurrency: 'EUR',
       reportingTotalAmount: 1000,
       cancelledAt: new Date('2026-08-05T11:00:00.000Z'),
     });
+    await seedLineItem({ orderRecordId: cancelledOrder, unitPrice: 990, quantity: 1 });
 
     const median = await repository.getMedianOrderValue(
       {
@@ -288,6 +300,36 @@ describe('Sales analytics daily aggregates (integration, #1987)', () => {
     );
 
     expect(median).toBe(20);
+  });
+
+  it('getMedianOrderValue shares AOV/Revenue\'s gross, shipping-EXCLUDED basis instead of the shipping-inclusive order total (#2906)', async () => {
+    // Live-proven regression: for this exact shape (a shipping-inclusive
+    // order total of 300 against a merchandise-only line value of 200), the
+    // pre-#2906 implementation — PERCENTILE_CONT over `reportingTotalAmount`
+    // directly — returned 300. AOV/Revenue for the identical order set report
+    // 200 (`getSalesAndChannelAnalytics`/`getDailyOrderAggregates`, computed
+    // from `order_line_items` via `buildGrossRevenueOrderAmountSql`). The
+    // spec's own contract (`docs/specs/metrics-analytics-dashboard.md`)
+    // requires median and AOV to share the same value field.
+    const day = new Date('2026-08-05T10:00:00.000Z');
+    const orderId = await seedStampedOrder({
+      placedAt: day,
+      totalAmount: 300,
+      reportingCurrency: 'EUR',
+      reportingTotalAmount: 300,
+    });
+    await seedLineItem({ orderRecordId: orderId, unitPrice: 200, quantity: 1 });
+
+    const median = await repository.getMedianOrderValue(
+      {
+        from: new Date('2026-08-01T00:00:00.000Z'),
+        to: new Date('2026-08-08T00:00:00.000Z'),
+      },
+      'EUR'
+    );
+
+    expect(median).toBe(200);
+    expect(median).not.toBe(300);
   });
 
   describe('findCurrencyMismatchOrders (#2464)', () => {

--- a/libs/core/src/orders/infrastructure/persistence/repositories/__tests__/order-record.repository.spec.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/__tests__/order-record.repository.spec.ts
@@ -1541,6 +1541,26 @@ describe('OrderRecordRepository', () => {
         currentReportingCurrency: 'EUR',
       });
     });
+
+    it('computes PERCENTILE_CONT over the gross merchandise-only line-item basis, not the shipping-inclusive reportingTotalAmount (#2906)', async () => {
+      const select = jest.fn().mockReturnThis();
+      (ormRepository.createQueryBuilder as jest.Mock).mockReturnValue({
+        select,
+        andWhere: jest.fn().mockReturnThis(),
+        getRawOne: jest.fn().mockResolvedValue({ median: null }),
+      });
+
+      await repository.getMedianOrderValue(baseFilters, 'EUR');
+
+      const [selectSql, alias] = select.mock.calls[0] as [string, string];
+      expect(alias).toBe('median');
+      expect(selectSql).toContain('PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY');
+      // The gross-revenue scalar subquery reads from order_line_items —
+      // the same basis AOV/Revenue use — rather than reading
+      // `reportingTotalAmount` bare (the shipping-inclusive bug).
+      expect(selectSql).toContain('FROM order_line_items');
+      expect(selectSql).toContain('rec."reportingTotalAmount" / NULLIF(rec."totalAmount", 0)');
+    });
   });
 
   /**

--- a/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
@@ -1026,21 +1026,34 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
    * reports them in a separate column rather than omitting them). `null`
    * when no row matches (an empty ordered-set aggregate).
    *
-   * Currency correctness (#1987 review notes): computed over
-   * `reportingTotalAmount`, restricted to `reportingCurrency =
-   * currentReportingCurrency` — the same current-era stamped subset
-   * {@link getDailyOrderAggregates} uses for `revenue`, so the headline
-   * median stays comparable with the headline revenue/AOV figures rather
-   * than mixing a native-currency or prior-era distribution into the
-   * current one.
+   * Currency correctness (#1987 review notes): restricted to
+   * `reportingCurrency = currentReportingCurrency` — the same current-era
+   * stamped subset {@link getDailyOrderAggregates} uses for `revenue`, so
+   * the headline median stays comparable with the headline revenue/AOV
+   * figures rather than mixing a native-currency or prior-era distribution
+   * into the current one.
+   *
+   * Basis correctness (#2906): computed over the SAME gross, shipping-EXCLUDED
+   * per-order merchandise amount `revenue`/`averageOrderValue` use — see
+   * {@link buildGrossRevenueOrderAmountSql} — converted via the order's own
+   * already-stamped FX multiplier, exactly as `getDailyOrderAggregates`'s
+   * `revenue` column does. Previously ran `PERCENTILE_CONT` directly over
+   * `reportingTotalAmount`, the shipping-INCLUSIVE order total, which
+   * contradicted AOV/Revenue's merchandise-only basis and reported an
+   * inflated median whenever orders carried non-zero shipping.
    */
   async getMedianOrderValue(
     filters: SalesAnalyticsFilters,
     currentReportingCurrency: string
   ): Promise<number | null> {
+    const grossRevenueOrderAmount = this.buildGrossRevenueOrderAmountSql();
+
     const qb = this.repository
       .createQueryBuilder('rec')
-      .select(`PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY rec."reportingTotalAmount")`, 'median')
+      .select(
+        `PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY (${grossRevenueOrderAmount}) * (rec."reportingTotalAmount" / NULLIF(rec."totalAmount", 0)))`,
+        'median'
+      )
       .andWhere('rec."cancelledAt" IS NULL')
       .andWhere('rec."reportingCurrency" = :currentReportingCurrency', { currentReportingCurrency });
 


### PR DESCRIPTION
## Summary

`getMedianOrderValue` (`libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts`) ran `PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY rec."reportingTotalAmount")` directly over the shipping-inclusive order total. Meanwhile AOV/Revenue (post-#2892) are computed from `order_line_items` via `buildGrossRevenueOrderAmountSql` / `grossRevenueLineAmountSql` - the gross, shipping-EXCLUDED merchandise value. This contradicted `docs/specs/metrics-analytics-dashboard.md`, which requires median and AOV to share "the same value field", and inflated the reported median on any order set carrying non-zero shipping.

`getNetMedianOrderValue` (the Net-mode sibling) never had this bug - it already runs `PERCENTILE_CONT` over `buildNetSalesOrderFragments`'s per-order net amount, converted through the order's own stamped FX multiplier. This PR mirrors that exact pattern for the gross case, reusing `buildGrossRevenueOrderAmountSql` (no new SQL invented). `getNetMedianOrderValue` itself is untouched.

## The fix

```diff
- .select(`PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY rec."reportingTotalAmount")`, 'median')
+ .select(
+   `PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY (${grossRevenueOrderAmount}) * (rec."reportingTotalAmount" / NULLIF(rec."totalAmount", 0)))`,
+   'median'
+ )
```

where `grossRevenueOrderAmount` is `this.buildGrossRevenueOrderAmountSql()` - the identical per-order scalar subquery `getDailyOrderAggregates`'s `revenue` column already sums, converted the identical way (`* (reportingTotalAmount / NULLIF(totalAmount, 0))`, the order's own already-stamped FX multiplier, never a re-lookup).

## Before/after proof

Added a new integration test proving the exact live-observed regression:

> a single order with a shipping-inclusive total of **300** and a merchandise-only line value of **200** now reports a median of **200** (matching AOV/Revenue), instead of the old **300**.

```
✓ getMedianOrderValue shares AOV/Revenue's gross, shipping-EXCLUDED basis instead of the shipping-inclusive order total (#2906) (51 ms)
```

Also updated the pre-existing multi-order median test to seed line items with a flat shipping delta per order (so a regression back to `reportingTotalAmount` shifts the median from 20 to 25 and fails), and added a repository unit test asserting the `SELECT` SQL reads from `order_line_items` rather than the bare column.

## Test plan

- [x] `pnpm --filter @openlinker/core type-check` - passes
- [x] `pnpm --filter @openlinker/core test -- order-record` - 247/247 passed (both repo unit specs + service specs)
- [x] `pnpm --filter @openlinker/api test:integration -- sales-analytics-aggregates` (real Postgres via Testcontainers) - 20/20 passed, including the two new `#2906` cases

## Scope note

Per the task instructions, this PR is scoped ONLY to the gross median function. Four sibling issues (#2907 channel-table units, #2908 headline toggle scope, #2909 currency labelling, #2910 Cancelled Value net basis) are being fixed concurrently in isolated worktrees against overlapping files; conflicts at integration time are expected and not this PR's concern.

Closes #2906

🤖 Generated with [Claude Code](https://claude.com/claude-code)