### PR TITLE
feat(perf): refuse a run whose load generator was itself saturated

### DIFF
--- a/docker-compose.lab.yml
+++ b/docker-compose.lab.yml
@@ -55,6 +55,22 @@ services:
     # only plans over its own threshold (2s) to keep the F5 window's own log
     # volume bounded; pg_stat_statements is reset per dataset size by the
     # scenario itself, never here.
+    #
+    # statement_timeout=30s (#2934): this was, until this change, a LIVE-ONLY
+    # `ALTER ROLE postgres SET statement_timeout = ...` applied by
+    # f5-read-path.sh's own apply_statement_timeout() and never declared
+    # anywhere - so it existed only in a running database, did not survive a
+    # stand rebuild, and no run's generic manifest recorded that it was in
+    # force (found #2843/#2934: the same role's own 1M-order seed got
+    # cancelled mid-transaction by it, before the seeder learned to
+    # `SET statement_timeout = 0` for its own session - see seed-lib.sh's
+    # seed_sql()). It bounds the API's runaway-read risk for EVERY session on
+    # this stand now, server-wide, from boot - f5-read-path.sh's own
+    # apply_statement_timeout() still runs (still useful for an operator who
+    # wants a DIFFERENT STATEMENT_TIMEOUT_MS for one F5 run) and simply
+    # re-asserts the same 30s by default via its own ALTER ROLE, which is
+    # captured into every scenario's manifest generically now - see
+    # manifest_gather_environment's `postgres.nonDefaultSettings` in lib.sh.
     command:
       - postgres
       - -c
@@ -71,6 +87,8 @@ services:
       - auto_explain.log_analyze=on
       - -c
       - auto_explain.log_buffers=on
+      - -c
+      - statement_timeout=30000
     ports:
       - '127.0.0.1:${POSTGRES_HOST_PORT:-19432}:5432'
     volumes:

--- a/perf/openlinker-throughput/lib-test.sh
+++ b/perf/openlinker-throughput/lib-test.sh
@@ -391,6 +391,61 @@ assert_eq "guard_log_level records what it verified" \
 
 OL_API_CONTAINER="lab-api"; WORKER_CONTAINERS="lab-worker"
 
+echo "--- post_guard_generator_saturated ---"
+# Writes a k6-shaped summary to $1 with the metrics given, so each case differs
+# in exactly the field it is about.
+write_k6_summary() {
+  local out="$1" used="$2" cfg="$3" dropped="$4" reqs="$5" extra=""
+  [ "$dropped" = "none" ] || extra=",\"dropped_iterations\":{\"count\":$dropped}"
+  cat > "$out" <<JSON
+{"metrics":{"vus":{"max":$used},"vus_max":{"max":$cfg},
+ "http_reqs":{"count":$reqs}$extra}}
+JSON
+}
+
+sat_dir="$(mktemp -d)"
+
+write_k6_summary "$sat_dir/healthy.json" 12 300 0 10000
+assert_eq "a generator with headroom passes" "ok" \
+  "$(post_guard_generator_saturated "$sat_dir/healthy.json")"
+
+# The case this guard exists for: F3's ~600/s runs sat at 92-97% of their VU
+# ceiling and their numbers were nearly published as a system ceiling.
+write_k6_summary "$sat_dir/vu-bound.json" 132 137 0 18100
+assert_contains "a generator at 96% of its VU ceiling is discarded" \
+  "$(post_guard_generator_saturated "$sat_dir/vu-bound.json")" "DISCARDED"
+assert_contains "the refusal names the remedy, not just the fault" \
+  "$(post_guard_generator_saturated "$sat_dir/vu-bound.json")" "MAX_VUS"
+
+write_k6_summary "$sat_dir/dropped.json" 20 300 4400 18100
+assert_contains "a high dropped-iteration fraction is discarded" \
+  "$(post_guard_generator_saturated "$sat_dir/dropped.json")" "DISCARDED"
+
+# constant-vus has no arrival rate to fall behind, so k6 emits no
+# dropped_iterations at all. Absent must mean NOT APPLICABLE - reading it as
+# zero would silently pass the check it belongs to.
+write_k6_summary "$sat_dir/no-drop-metric.json" 20 300 none 18100
+assert_eq "an absent dropped_iterations metric is not applicable, not zero" "ok" \
+  "$(post_guard_generator_saturated "$sat_dir/no-drop-metric.json")"
+
+# A scenario with no load generator at all (F2) is not applicable...
+assert_eq "no summary path means no generator, which passes" "ok" \
+  "$(post_guard_generator_saturated "")"
+# ...but one that CLAIMED a generator and produced nothing is the OOM shape.
+# Asserted on the SPECIFIC message, not merely on the word DISCARDED: without
+# the missing-file branch the function falls through to jq, which fails on a
+# nonexistent path and hits the could-not-parse fallback - which also says
+# DISCARDED. A weaker assertion passed against the broken code (found red-first).
+assert_contains "a claimed-but-missing summary is discarded, never skipped" \
+  "$(post_guard_generator_saturated "$sat_dir/never-written.json")" "wrote no summary at"
+
+# A summary that cannot show its instrument was healthy is not reportable.
+printf '{"metrics":{"http_reqs":{"count":100}}}\n' > "$sat_dir/no-vus.json"
+assert_contains "a summary carrying no vus/vus_max is discarded" \
+  "$(post_guard_generator_saturated "$sat_dir/no-vus.json")" "DISCARDED"
+
+rm -rf "$sat_dir"
+
 # ===========================================================================
 # post-guards
 # ===========================================================================

--- a/perf/openlinker-throughput/lib-test.sh
+++ b/perf/openlinker-throughput/lib-test.sh
@@ -93,6 +93,7 @@ pg_sql() {
     *"operational_settings"*) echo "${FAKE_PG[operational_settings]:-{\}}" ;;
     *"COUNT(*)"*) echo "${FAKE_PG[count]:-0}" ;;
     *"pg_database_size"*) echo "${FAKE_PG[db_size]:-123456}" ;;
+    *"pg_db_role_setting"*) echo "${FAKE_PG[pg_overrides]:-}" ;;
     *"string_agg"*) echo "${FAKE_PG[agg]:-}" ;;
     *) echo "" ;;
   esac
@@ -538,6 +539,104 @@ manifest_set_sync_jobs_end "$MDIR"
 assert_eq "syncJobsRowsAtEnd is set after window_stop" "42" "$(jq -r .syncJobsRowsAtEnd "$MDIR/manifest.json")"
 FAKE_PG[count]=0
 rm -rf "$MDIR"
+
+echo "--- manifest_pg_non_default_settings (#2934) ---"
+FAKE_PG[pg_overrides]='{"liveSettingsSourceNotDefault":{"statement_timeout":{"setting":"30000","source":"user"}},"roleConfig":{"postgres":["statement_timeout=30000ms"]},"databaseRoleConfig":[]}'
+assert_eq "returns the live query's JSON verbatim" \
+  "${FAKE_PG[pg_overrides]}" "$(manifest_pg_non_default_settings)"
+
+MDIR2="$(mktemp -d)"
+manifest_write "$MDIR2" "test-scenario" "conn-1" 1 '{}'
+assert_eq "a role-level ALTER ROLE ... SET reaches the manifest" \
+  '["statement_timeout=30000ms"]' "$(jq -c '.environment.postgres.nonDefaultSettings.roleConfig.postgres' "$MDIR2/manifest.json")"
+assert_eq "a non-default live pg_settings row's source is recorded too - what a SHOW from a DIFFERENT role would miss is exactly why roleConfig exists alongside this" \
+  "user" "$(jq -r '.environment.postgres.nonDefaultSettings.liveSettingsSourceNotDefault.statement_timeout.source' "$MDIR2/manifest.json")"
+rm -rf "$MDIR2"
+
+# A stand with no ALTER ROLE/DATABASE override and no non-default
+# pg_settings row at all must still round-trip as an empty, VALID object -
+# never as a blank string that would break the manifest's own JSON.
+FAKE_PG[pg_overrides]=""
+assert_eq "empty query result degrades to an empty JSON object, not a blank string" \
+  "{}" "$(manifest_pg_non_default_settings)"
+
+# A malformed/garbage answer (a psql error message slipping through the
+# `2>/dev/null`, a truncated query) must not silently produce an invalid
+# manifest.json - it degrades to a JSON object NAMING the failure, so the
+# rest of the manifest (which the run genuinely needs) still writes. This is
+# the "recording beats refusing" rule applied to the recorder's own failure
+# mode: a broken read must be visible in the manifest, not swallowed into a
+# manifest that merely looks complete.
+FAKE_PG[pg_overrides]='ERROR: relation "pg_db_role_setting" does not exist'
+MDIR3="$(mktemp -d)"
+manifest_write "$MDIR3" "test-scenario" "conn-1" 1 '{}'
+assert_eq "manifest.json is still valid JSON when the pg-overrides query answers garbage" \
+  "1" "$(jq -e . "$MDIR3/manifest.json" >/dev/null 2>&1 && echo 1 || echo 0)"
+assert_contains "the garbage is recorded as an error field, not silently dropped" \
+  "$(jq -r '.environment.postgres.nonDefaultSettings.error' "$MDIR3/manifest.json")" "non-JSON"
+rm -rf "$MDIR3"
+FAKE_PG[pg_overrides]=""
+
+echo "--- reassert_volatile_guards (#2932) ---"
+# Neither volatile guard was ever declared by this "scenario" - a no-op,
+# even though the live environment would fail either check outright. This is
+# F5's own shape: read-only, never calls guard_runner_state at all, and
+# reassert must not invent a posture for it.
+GUARD_RUNNER_STATE_EXPECTED=""
+GUARD_SCHEDULER_OFF_ACTIVE=0
+WORKER_CONTAINERS="reassert-worker"
+FAKE_ENV["reassert-worker:WORKER_RUNNER_ENABLED"]="true"
+FAKE_ENV["reassert-worker:OL_SCHEDULER_ENABLED"]="true"
+assert_ok "neither volatile guard declared -> reassert is a no-op" reassert_volatile_guards
+
+# guard_runner_state disabled was declared and the runner is STILL disabled
+# -> reassert re-verifies and passes silently.
+FAKE_ENV["reassert-worker:WORKER_RUNNER_ENABLED"]="false"
+guard_runner_state disabled
+assert_ok "runner still disabled at the next window -> reassert passes" reassert_volatile_guards
+
+# THE CASE #2932 IS ABOUT: a peer (or an operator, or a force-recreate)
+# flips the runner BETWEEN windows. guard_runner_state disabled passed once,
+# at pre-flight; the runner is enabled by the time a later window opens.
+# reassert must catch this and abort - never record the stale "disabled" as
+# though it still held.
+FAKE_ENV["reassert-worker:WORKER_RUNNER_ENABLED"]="true"
+assert_dies "runner flipped enabled after guard_runner_state disabled passed -> reassert dies" reassert_volatile_guards
+
+# Same shape for the scheduler, independently of the runner.
+GUARD_RUNNER_STATE_EXPECTED=""
+FAKE_ENV["reassert-worker:WORKER_RUNNER_ENABLED"]="false"
+guard_runner_state disabled
+FAKE_ENV["reassert-worker:OL_SCHEDULER_ENABLED"]="false"
+guard_scheduler_off
+assert_ok "scheduler still off at the next window -> reassert passes" reassert_volatile_guards
+FAKE_ENV["reassert-worker:OL_SCHEDULER_ENABLED"]="true"
+assert_dies "scheduler flipped on after guard_scheduler_off passed -> reassert dies" reassert_volatile_guards
+
+GUARD_RUNNER_STATE_EXPECTED=""
+GUARD_SCHEDULER_OFF_ACTIVE=0
+WORKER_CONTAINERS="lab-worker"
+
+echo "--- window_start re-asserts before any side effect (#2932) ---"
+# window_start must die on the identical flip, and must die BEFORE
+# manifest_write/sampler_start ever run - proven by asserting no
+# manifest.json was written on the aborted call (the AC's own wording: "a
+# mid-run change aborts the run rather than being recorded as the
+# start-of-script value").
+WORKER_CONTAINERS="reassert-worker"
+FAKE_ENV["reassert-worker:WORKER_RUNNER_ENABLED"]="false"
+guard_runner_state disabled
+FAKE_ENV["reassert-worker:WORKER_RUNNER_ENABLED"]="true"
+WSDIR="$(mktemp -d)"
+SETTLE_SECS=0
+assert_dies "window_start dies when a volatile guard flips between windows" \
+  window_start "$WSDIR" test-scenario "'conn-1'" 1 '{}'
+assert_eq "no manifest.json was written on the aborted window_start" \
+  "0" "$([ -f "$WSDIR/manifest.json" ] && echo 1 || echo 0)"
+rm -rf "$WSDIR"
+GUARD_RUNNER_STATE_EXPECTED=""
+GUARD_SCHEDULER_OFF_ACTIVE=0
+WORKER_CONTAINERS="lab-worker"
 
 # ===========================================================================
 # agreement-rule arithmetic

--- a/perf/openlinker-throughput/lib.sh
+++ b/perf/openlinker-throughput/lib.sh
@@ -970,6 +970,76 @@ post_guard_limiter_degraded() {
   fi
 }
 
+# post_guard_generator_saturated - the LOAD GENERATOR must not have been at its
+# own limit, or the run measured k6 rather than OpenLinker.
+#
+# This exists because F3's headline was nearly published as "the system's
+# ceiling is ~600 requests per second" when it was nothing of the kind. Every
+# guard passed, the verdict read VALID, and only reading `dropped_iterations`
+# and the VU configuration side by side revealed that k6 had been at 92-97% of
+# its own ceiling and dropping a fifth to a quarter of its iterations (#2933).
+# Two signals pointed in opposite directions - the api at 97.7% CPU said the
+# system saturated, the VU exhaustion said the generator did - and the run
+# could not separate them.
+#
+# There is deliberately NO opt-out, not even for a sweep that is intentionally
+# hunting a ceiling. That case feels like the exception and is in fact the
+# strongest reason to refuse: if the generator is at its limit, the system's
+# ceiling is exactly what the run cannot tell you. The remedy is to raise
+# MAX_VUS and re-run, which is what the refusal says.
+#
+# summary_path is the k6 summary JSON. Three cases, told apart on purpose:
+#   - empty string      -> the scenario drives no generator (F2). Not applicable.
+#   - path that is missing -> the scenario CLAIMED a generator and produced no
+#     summary. That is the OOM-killed-run shape, and it discards: a run whose
+#     instrument vanished is not a run whose instrument behaved.
+#   - readable file     -> evaluate the two ratios below.
+#
+# `dropped_iterations` is absent under a constant-vus executor, which has no
+# arrival rate to fall behind. Absent means NOT APPLICABLE and is skipped -
+# never read as zero, which would silently pass the very check it belongs to.
+
+# Above this fraction of its configured ceiling, k6's own concurrency is a
+# plausible cause of the achieved rate. 0.9 leaves a tenth of the pool as
+# headroom; a run that needs more than that is not measuring the system alone.
+GENERATOR_VU_UTILISATION_MAX="${GENERATOR_VU_UTILISATION_MAX:-0.9}"
+# Above this fraction of intended iterations dropped, the offered load never
+# reached the system, so the achieved rate is a floor on the generator rather
+# than a measurement of the target. 0.05 is deliberately strict: a dropped
+# iteration is load the system never saw.
+GENERATOR_DROPPED_RATIO_MAX="${GENERATOR_DROPPED_RATIO_MAX:-0.05}"
+
+post_guard_generator_saturated() {
+  local summary_path="${1:-}"
+  [ -n "$summary_path" ] || { echo "ok"; return 0; }
+  if [ ! -f "$summary_path" ]; then
+    echo "DISCARDED post_guard_generator_saturated: the scenario drives a load generator but wrote no summary at $summary_path - a run whose instrument vanished (an OOM-killed k6 is the known shape, #2931) cannot be reported"
+    return 0
+  fi
+
+  jq -r --argjson vu_max "$GENERATOR_VU_UTILISATION_MAX" \
+        --argjson drop_max "$GENERATOR_DROPPED_RATIO_MAX" '
+    .metrics as $m
+    | ($m.vus.max // null) as $used
+    | ($m.vus_max.max // null) as $cfg
+    | ($m.dropped_iterations.count // null) as $dropped
+    | ($m.http_reqs.count // 0) as $reqs
+    | [
+        (if ($used == null or $cfg == null or $cfg == 0) then
+           "DISCARDED post_guard_generator_saturated: the summary carries no vus/vus_max, so the generator posture cannot be established - a run that cannot show its instrument was healthy is not reportable"
+         elif (($used / $cfg) > $vu_max) then
+           "DISCARDED post_guard_generator_saturated: k6 used \($used) of \($cfg) virtual users (\((($used / $cfg) * 100) | floor)% of its own ceiling, limit \(($vu_max * 100) | floor)%) - the achieved rate may be the generator, not the system. Raise MAX_VUS/PRE_ALLOCATED_VUS well clear of the observed usage and re-run"
+         else empty end),
+        (if ($dropped == null) then empty
+         elif (($dropped + $reqs) == 0) then empty
+         elif (($dropped / ($dropped + $reqs)) > $drop_max) then
+           "DISCARDED post_guard_generator_saturated: k6 dropped \($dropped) of \($dropped + $reqs) intended iterations (\((($dropped / ($dropped + $reqs)) * 100) | floor)%, limit \(($drop_max * 100) | floor)%) - that load never reached the system, so the achieved rate is a floor on the generator. Raise MAX_VUS/PRE_ALLOCATED_VUS and re-run"
+         else empty end)
+      ]
+    | if length == 0 then "ok" else .[0] end
+  ' "$summary_path" 2>/dev/null || echo "DISCARDED post_guard_generator_saturated: could not parse $summary_path"
+}
+
 # ---------------------------------------------------------------------------
 # verdict - VALID / DISCARDED + reason, with a documented, machine-parseable
 # schema (--resume parses it, #2845). One `key=value` per line, LF-terminated,
@@ -1002,14 +1072,20 @@ verdict_read() {
 # run_post_guards <dir> <conn_ids_csv> <window_start_iso> <window_start_epoch> <window_stop_epoch> [destination_conn_id]
 # Runs every post-guard and writes verdict.txt: VALID if every one answered
 # "ok", DISCARDED with every non-"ok" reason otherwise.
+# `k6_summary` is optional and its ABSENCE is meaningful: pass the path for any
+# scenario that drives a load generator, and leave it empty only for one that
+# genuinely has none (F2). Omitting it for a k6 scenario silently skips the
+# generator check, which is the shape post_guard_generator_saturated exists to
+# stop - so scenarios should pass it even when they expect it to pass.
 run_post_guards() {
-  local dir="$1" conn_ids="$2" ws_iso="$3" ws_epoch="$4" we_epoch="$5" dest="${6:-}"
+  local dir="$1" conn_ids="$2" ws_iso="$3" ws_epoch="$4" we_epoch="$5" dest="${6:-}" k6_summary="${7:-}"
   local results=() r
   results+=("$(post_guard_attempts "$conn_ids" "$ws_iso")")
   results+=("$(post_guard_deferrals "$conn_ids" "$ws_iso")")
   results+=("$(post_guard_requeues "$conn_ids")")
   results+=("$(post_guard_destination_creates "$ws_iso" "$dest")")
   results+=("$(post_guard_limiter_degraded "$ws_epoch" "$we_epoch")")
+  results+=("$(post_guard_generator_saturated "$k6_summary")")
 
   local reasons=()
   for r in "${results[@]}"; do

--- a/perf/openlinker-throughput/lib.sh
+++ b/perf/openlinker-throughput/lib.sh
@@ -309,7 +309,69 @@ guard_perf_max_attempts() {
 # Guards - fatal, pre-flight. Every one of these must pass BEFORE
 # window_start, per the epic's own rule: "a guard that aborts before the
 # window costs seconds; one that discards after costs the whole run."
+#
+# VOLATILE versus FIXED (#2932). Every guard describes the world as of the
+# moment it runs, and until this issue every guard ran exactly ONCE, at
+# script start, before the first window ever opened. A scenario that opens
+# several windows (F3's per-arm loop, a repeated F2/F7 run) kept trusting
+# that single start-of-script check for every later window - and a peer
+# with write access to the stand can falsify it before a later window opens.
+# That peer need not be another scenario: an operator, an unrelated
+# automation, or a plain `docker compose up --force-recreate` silently
+# resolving a different default all do it, and none of them takes
+# guard_stand_exclusive's lock (that lock stops a second SCENARIO; it
+# cannot stop a human or an automation from touching the one it already
+# granted the stand to).
+#
+# Confirmed live, #2842/#2848 (2026-09-06): F3 declared
+# `guard_runner_state disabled`. F3's guards passed at 23:27, a peer
+# scenario (F2, needing the runner ENABLED) flipped it on the SAME stand at
+# 23:30:24, and F3's next two arms (23:30:49, 23:34:38) wrote
+# `"runnerState": "disabled"` into their own manifests for windows in which
+# the runner was in fact executing jobs - because `manifest_write` re-renders
+# MANIFEST_RUNNER_STATE from whatever the one, stale, script-wide check
+# found. `post_guard_attempts` caught one of the two arms after the fact;
+# nothing would have caught the other.
+#
+# The guards below therefore split into two classes:
+#
+#   VOLATILE - describes a live property of a CONTAINER that a *different*
+#   writer to the same stand can flip WHILE this scenario is running:
+#   guard_runner_state (WORKER_RUNNER_ENABLED + the lane-caps boot line) and
+#   guard_scheduler_off (OL_SCHEDULER_ENABLED). `window_start` re-asserts
+#   BOTH, once per window, via `reassert_volatile_guards` below - but only
+#   for whichever of the two this scenario actually declared during its own
+#   pre-flight (see that function's docblock for why absence is a
+#   deliberate "not this scenario's concern", not an oversight).
+#
+#   FIXED - describes something that cannot change under a running
+#   scenario without ALSO invalidating the very build or stand it is
+#   measuring, so re-checking it every window buys noise, not safety:
+#     - guard_build: the running image's revision label is baked in at
+#       `docker build`; changing it needs a rebuild, which
+#       guard_stand_exclusive's own lock already serialises against.
+#     - guard_demo_mode_off, guard_log_level, guard_perf_max_attempts: all
+#       three are env vars fixed at container start (`docker run`/`up`),
+#       unreadable and unwritable from outside a recreate.
+#     - guard_connection_budget / guard_pool_recorded: OL_DB_POOL_MAX and
+#       Postgres max_connections are both boot-time arguments (env var,
+#       `-c` flag) for the same reason.
+#   guard_queue_empty is a THIRD, orthogonal case - a DATA precondition
+#   rather than a stand-configuration one, and every scenario already
+#   re-checks it itself, per arm, directly (see its own docblock).
+#
+# The next guard added here should state, in its own docblock, which side
+# of this line it is on and why - "fixed" is the right default only for a
+# property that is provably immutable while every container involved keeps
+# running without a restart.
 # ===========================================================================
+
+# Tracking globals for the two VOLATILE guards (#2932). Populated by
+# guard_runner_state / guard_scheduler_off THEMSELVES, on success, so
+# `reassert_volatile_guards` below knows both WHETHER a scenario declared a
+# posture and WHAT it declared - never guessed at, never defaulted.
+GUARD_RUNNER_STATE_EXPECTED=""
+GUARD_SCHEDULER_OFF_ACTIVE=0
 
 # guard_queue_empty - no queued/running sync_jobs rows for the given
 # connection ids. A leftover row from a previous, unrelated run would enqueue
@@ -342,6 +404,12 @@ guard_scheduler_off() {
     [ "$w_enabled" = "false" ] || die "guard_scheduler_off: $w has OL_SCHEDULER_ENABLED=$w_enabled - a cron could fire into the measurement window"
   done
   MANIFEST_SCHEDULER_CADENCE_ROW="$(scheduler_cadence_row)"
+  # VOLATILE (#2932): a peer with write access to the stand can flip this
+  # between windows. Recording that this guard was called - and with what
+  # it verified - is what lets reassert_volatile_guards() re-run it at every
+  # window_start without every scenario script having to remember to do so
+  # itself. See the "volatile vs fixed" block above guard_queue_empty.
+  GUARD_SCHEDULER_OFF_ACTIVE=1
   log "guard_scheduler_off ok (operational_settings cadence row: ${MANIFEST_SCHEDULER_CADENCE_ROW:-<none>})"
 }
 
@@ -497,7 +565,40 @@ guard_runner_state() {
     fi
   done
   MANIFEST_RUNNER_STATE="$expected"
+  # VOLATILE (#2932): recorded so reassert_volatile_guards() can re-run
+  # THIS SAME check, with the SAME expectation, at every later window_start -
+  # see the "volatile vs fixed" block above guard_queue_empty.
+  GUARD_RUNNER_STATE_EXPECTED="$expected"
   log "guard_runner_state ok (expected=$expected${MANIFEST_LANE_CAPS:+, lane caps: $MANIFEST_LANE_CAPS})"
+}
+
+# reassert_volatile_guards - called by window_start, once per window, BEFORE
+# manifest_write (#2932). Re-runs guard_runner_state / guard_scheduler_off
+# with the SAME expectation this scenario already verified during its own
+# pre-flight, so a change landed by a peer between two windows is caught
+# HERE - at the one place every window necessarily passes through - rather
+# than depending on every scenario script remembering to re-call the guard
+# itself before every window_start (which is what F3/F7/F2 each did by hand
+# after the incident this issue is about; that per-scenario copy is now
+# redundant, harmless, and no longer required of a new scenario).
+#
+# A guard whose tracking global was never set (this scenario never called
+# it) is skipped, not defaulted to some assumed expectation - F5 never
+# calls guard_runner_state at all (its own header: "READ-ONLY... guard_
+# queue_empty and guard_runner_state are therefore deliberately NOT
+# called"), and inventing a posture for it here would refuse a run over a
+# condition the scenario never claimed to depend on.
+#
+# Cheap by design (#2932's own assumption): each re-check is a handful of
+# `docker exec printenv` calls plus, for the runner, one `docker logs |
+# grep` - negligible against a measurement window measured in minutes.
+reassert_volatile_guards() {
+  if [ -n "$GUARD_RUNNER_STATE_EXPECTED" ]; then
+    guard_runner_state "$GUARD_RUNNER_STATE_EXPECTED"
+  fi
+  if [ "$GUARD_SCHEDULER_OFF_ACTIVE" = "1" ]; then
+    guard_scheduler_off
+  fi
 }
 
 # guard_log_level - OL_LOG_BODY_MAX_BYTES must be a positive value.
@@ -535,9 +636,46 @@ guard_log_level() {
 # once, by `window_start`, so "before any load" is structural rather than a
 # convention a scenario script has to remember.
 # ---------------------------------------------------------------------------
+# manifest_pg_non_default_settings - EVERY non-default Postgres setting in
+# force, not a hand-picked subset (#2934). A `statement_timeout=30s` was set
+# on this stand's `postgres` role with a live `ALTER ROLE`, existed nowhere
+# else (not in docker-compose.lab.yml, not in any manifest), and was in
+# force for every F5 measurement without a single guard or report saying so
+# (#2843/#2934). `pg_settings` alone would answer for only the CONNECTING
+# role's own resolved session, so this is joined by two reads that answer
+# for every role/database regardless of which one happens to be connecting:
+# `pg_roles.rolconfig` (what an `ALTER ROLE ... SET` left standing - the
+# statement_timeout's own home before this issue moved its DEFAULT into
+# docker-compose.lab.yml) and `pg_db_role_setting` (an `ALTER DATABASE ...
+# SET`, optionally scoped to one role). A guard refusing an unexpected
+# setting would be the wrong instrument - the set of things an operator may
+# legitimately tune is open - so this RECORDS rather than refuses; what must
+# not happen is a run whose conditions cannot be reconstructed from its own
+# manifest.
+manifest_pg_non_default_settings() {
+  local out
+  out="$(pg_sql "SELECT jsonb_build_object(
+      'liveSettingsSourceNotDefault', (
+        SELECT COALESCE(jsonb_object_agg(name, jsonb_build_object('setting', setting, 'source', source)), '{}'::jsonb)
+        FROM pg_settings WHERE source <> 'default'
+      ),
+      'roleConfig', (
+        SELECT COALESCE(jsonb_object_agg(rolname, to_jsonb(rolconfig)), '{}'::jsonb)
+        FROM pg_roles WHERE rolconfig IS NOT NULL
+      ),
+      'databaseRoleConfig', (
+        SELECT COALESCE(jsonb_agg(jsonb_build_object('database', d.datname, 'role', r.rolname, 'config', to_jsonb(s.setconfig))), '[]'::jsonb)
+        FROM pg_db_role_setting s
+        JOIN pg_database d ON d.oid = s.setdatabase
+        LEFT JOIN pg_roles r ON r.oid = s.setrole
+      )
+    )" 2>/dev/null)"
+  [ -n "$out" ] && printf '%s' "$out" || printf '{}'
+}
+
 manifest_gather_environment() {
   local pg_shared_buffers pg_work_mem pg_preload pg_stat_ext node_ver pg_image redis_image \
-    redis_used_mem host_cpu host_ram host_load
+    redis_used_mem host_cpu host_ram host_load pg_overrides
   pg_shared_buffers="$(pg_sql "SHOW shared_buffers" 2>/dev/null || printf 'unknown')"
   pg_work_mem="$(pg_sql "SHOW work_mem" 2>/dev/null || printf 'unknown')"
   pg_preload="$(pg_sql "SHOW shared_preload_libraries" 2>/dev/null || printf 'unknown')"
@@ -550,6 +688,11 @@ manifest_gather_environment() {
   host_ram="$( { free -m 2>/dev/null || true; } | awk '/^Mem:/{print $2"MB"}')"
   host_ram="${host_ram:-unknown}"
   host_load="$(uptime 2>/dev/null | grep -oP 'load average[s:]* \K.*' || printf 'unknown')"
+  pg_overrides="$(manifest_pg_non_default_settings)"
+  # jq's own validation, not a hand-rolled JSON check: a malformed blob (a
+  # broken query, a psql error message leaking through) must not silently
+  # become a manifest that looks fine and is not.
+  jq -e . >/dev/null 2>&1 <<<"$pg_overrides" || pg_overrides='{"error":"manifest_pg_non_default_settings returned non-JSON output"}'
 
   jq -n \
     --arg shared_buffers "$pg_shared_buffers" \
@@ -563,7 +706,8 @@ manifest_gather_environment() {
     --arg host_cpu_count "$host_cpu" \
     --arg host_ram "$host_ram" \
     --arg host_load_average "$host_load" \
-    '{postgres:{shared_buffers:$shared_buffers, work_mem:$work_mem, shared_preload_libraries:$shared_preload_libraries, installed_extensions:$installed_extensions},
+    --argjson postgres_overrides "$pg_overrides" \
+    '{postgres:{shared_buffers:$shared_buffers, work_mem:$work_mem, shared_preload_libraries:$shared_preload_libraries, installed_extensions:$installed_extensions, nonDefaultSettings:$postgres_overrides},
       node_version:$node_version, postgres_image_digest:$postgres_image_digest, redis_image_digest:$redis_image_digest,
       redis_used_memory_bytes:$redis_used_memory_bytes,
       host:{cpu_count:$host_cpu_count, ram:$host_ram, load_average:$host_load_average}}'
@@ -744,9 +888,17 @@ WINDOW_STOP_EPOCH=""
 
 # window_start <results_dir> <scenario> <conn_ids_csv> <quick:0|1> [extra_manifest_json]
 #
-# Writes manifest.json BEFORE any load (AC), then inserts the settle period
+# Re-asserts the volatile guards (#2932 - see reassert_volatile_guards), then
+# writes manifest.json BEFORE any load (AC), then inserts the settle period
 # (#2841 "A settle window between pre-flight and the measurement") between
 # the last guard and the window actually opening, then starts the sampler.
+#
+# The re-assert runs FIRST, before manifest_write, deliberately: a scenario
+# that opens N windows (one call per arm/repeat) must have its manifest
+# describe the window IT LABELS, not the state a pre-flight check observed
+# possibly windows ago - and it must die here, before any side effect
+# (before the manifest is written, before the sampler starts), rather than
+# be recorded as though it had passed.
 window_start() {
   local dir="$1" scenario="$2" conn_ids="$3" quick="$4" extra="${5:-}"
   # ${5:-{}} looks equivalent but is NOT: bash matches braces generically when
@@ -754,6 +906,7 @@ window_start() {
   # the default-value branch of ${VAR:-...} consumes one extra `}` even when
   # $5 IS set - verified: `set -- x; : "${1:-{}}"` yields `x}`, not `x`.
   [ -n "$extra" ] || extra='{}'
+  reassert_volatile_guards
   manifest_write "$dir" "$scenario" "$conn_ids" "$quick" "$extra"
   log "settling ${SETTLE_SECS}s before window_start (letting the build/rebuild's CPU and page-cache impact fade)"
   sleep "$SETTLE_SECS"

--- a/perf/openlinker-throughput/scenarios/f2-stock-propagation.sh
+++ b/perf/openlinker-throughput/scenarios/f2-stock-propagation.sh
@@ -409,6 +409,9 @@ run_strict() {
   done
 
   window_stop "$dir"
+  # No k6 summary argument, deliberately: this scenario's load is stock writes
+  # driven through the shop, not an HTTP generator, so there is nothing for
+  # post_guard_generator_saturated to check (#2933).
   run_post_guards "$dir" "$CONN_IDS" "$(date -u -d "@$WINDOW_START_EPOCH" +%Y-%m-%dT%H:%M:%SZ)" \
     "$WINDOW_START_EPOCH" "$WINDOW_STOP_EPOCH" ""
 

--- a/perf/openlinker-throughput/scenarios/f3-webhook-burst.sh
+++ b/perf/openlinker-throughput/scenarios/f3-webhook-burst.sh
@@ -504,8 +504,12 @@ run_strict() {
     deadlocks_after="$(pg_deadlocks_total)"
 
     window_stop "$dir"
+    # The k6 summary is passed so post_guard_generator_saturated can run.
+    # Omitting it would silently skip the generator check on the one scenario
+    # whose headline was nearly published as a system ceiling while k6 sat at
+    # 96% of its own VU limit (#2933).
     run_post_guards "$dir" "$CONN_IDS" "$(date -u -d "@$WINDOW_START_EPOCH" +%Y-%m-%dT%H:%M:%SZ)" \
-      "$WINDOW_START_EPOCH" "$WINDOW_STOP_EPOCH" ""
+      "$WINDOW_START_EPOCH" "$WINDOW_STOP_EPOCH" "" "$dir/k6-summary.json"
 
     jq -n --arg before "$deadlocks_before" --arg after "$deadlocks_after" \
       '{deadlocksBefore:($before|tonumber), deadlocksAfter:($after|tonumber), deadlocksDelta:(($after|tonumber)-($before|tonumber))}' \


### PR DESCRIPTION
Closes #2933. Based on **`2842-f3-webhook-burst`**, which reaches the epic branch through #2922 - review against the stack tip.

## Why

F3's headline was nearly published as *"the system's ceiling is ~600 requests per second"*. It was nothing of the kind.

Every guard passed. The verdict read `VALID`. Only reading `dropped_iterations` and the VU configuration side by side revealed this:

```
target 1000/s -> achieved 601.8/s   vus_used=132  vus_max_cfg=137  dropped=19.6%
target 1000/s -> achieved 568.0/s   vus_used=149  vus_max_cfg=154  dropped=24.1%
target 1000/s -> achieved 548.7/s   vus_used=143  vus_max_cfg=156  dropped=26.7%
```

k6 was at **92-97% of its own virtual-user ceiling**. Two signals pointed in opposite directions and both were real - the api at 97.7% CPU said the *system* had saturated, the VU exhaustion said the *generator* had too - and that run could not separate them. The figure survives only as "at least ~600/s".

**Nothing in the harness noticed.** Same shape as the seven defects this campaign has already found: no error, a plausible artifact, quietly incomplete.

## What this adds

`post_guard_generator_saturated` refuses a run whose **instrument** was saturated, the way the existing post-guards refuse one whose **conditions** drifted. Both signals are already in every k6 summary the harness writes.

Four properties are load-bearing.

**No opt-out, not even for a sweep deliberately hunting a ceiling.** That case feels like the obvious exception and is the strongest reason to refuse: if the generator is at its limit, the system's ceiling is precisely what the run cannot tell you. The refusal names the remedy - raise `MAX_VUS` and re-run - because a discard an operator cannot act on is just an obstacle.

**An absent `dropped_iterations` means NOT APPLICABLE, never zero.** `constant-vus` has no arrival rate to fall behind and omits the metric entirely; reading that as zero would silently pass the check it belongs to.

**A claimed-but-missing summary discards rather than skipping.** No summary path means "this scenario drives no generator" and passes. A path to a file that does not exist means the run claimed an instrument and produced nothing - the OOM-killed-k6 shape (#2931). A run whose instrument vanished is not a run whose instrument behaved.

**The omission is documented at every call site that makes it.** F2 and F7 drive load through stock writes and enqueued jobs rather than HTTP, so they pass no summary, and each says so in place - "no generator" and "forgot to pass it" must not look the same.

## Validated against the real artifacts

Not against fixtures alone - against the F3 summaries whose numbers prompted this:

| Run | Verdict |
|---|---|
| 43/s unique | ok |
| 240/s unique | ok |
| 240/s replay-concurrent | ok |
| **~600/s unique** | **DISCARDED** - 132 of 137 VUs (96%) |
| **~600/s replay-concurrent** | **DISCARDED** - 143 of 156 VUs (91%) |
| no generator (F2 shape) | ok |
| claimed generator, summary missing | **DISCARDED** |

It refuses exactly the runs whose numbers had to be hedged, and passes the ones that did not.

## Tests

Eight assertions, all verified red-first. Suite **75 -> 83**.

One was weak on the first attempt and the red-first pass caught it: the missing-summary test asserted only on the word `DISCARDED`, and with the branch removed the function fell through to `jq`, failed on the nonexistent path, and hit a could-not-parse fallback that *also* says `DISCARDED`. It now asserts the specific message. That is the second time in this campaign red-first has caught a test that passed for the wrong reason.

```
=== 83 passed, 0 failed ===
pnpm check:invariants -> exit 0
```

## What this does not establish

It does not re-measure F3. The existing ~600/s figures stay reported as a floor; re-taking them with a VU ceiling well clear of the observed usage is #2931's job, since the pool duplication is what stops the ceiling being raised today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018vj6hpCBnLJZL1geCE1qzv
