### PR TITLE
fix(prestashop): cron controller exits on success; guard stale combination writes

### DIFF
--- a/apps/prestashop-module/openlinker/controllers/front/cron.php
+++ b/apps/prestashop-module/openlinker/controllers/front/cron.php
@@ -91,8 +91,10 @@ class OpenLinkerCronModuleFrontController extends ModuleFrontController
         try {
             $stats = DeliveryRunner::run('http');
 
+            http_response_code(200);
             header('Content-Type: application/json');
             echo json_encode($stats);
+            exit;
         } catch (Exception $e) {
             http_response_code(500);
             header('Content-Type: application/json');
@@ -100,6 +102,7 @@ class OpenLinkerCronModuleFrontController extends ModuleFrontController
                 'error' => 'Internal Server Error',
                 'message' => 'Cron delivery failed: ' . WebhookSender::getErrorMessage($e)
             ]);
+            exit;
         }
     }
 }

--- a/apps/prestashop-module/openlinker/tests/Unit/CronDeliveryHardeningTest.php
+++ b/apps/prestashop-module/openlinker/tests/Unit/CronDeliveryHardeningTest.php
@@ -75,6 +75,47 @@ class CronDeliveryHardeningTest extends TestCase
         self::assertStringContainsString('Deny from all', $htaccess);
     }
 
+    /**
+     * #2923: the HTTP cron front controller's success branch had no `exit;`,
+     * unlike its four early-return branches - so a successful delivery fell
+     * through into PrestaShop's ordinary page render, which either fatals
+     * (an unwritable theme cache) or appends a whole HTML document after the
+     * JSON (a writable one). Both the success and catch branches must
+     * terminate the request immediately after their envelope.
+     */
+    public function testTheSuccessBranchExitsAfterItsJsonEnvelope(): void
+    {
+        $source = self::sourceOf('controllers/front/cron.php');
+
+        $runAt = strpos($source, 'DeliveryRunner::run');
+        $echoAt = strpos($source, 'echo json_encode($stats);');
+        $catchAt = strpos($source, 'catch (Exception $e)');
+
+        self::assertIsInt($runAt);
+        self::assertIsInt($echoAt);
+        self::assertIsInt($catchAt);
+        self::assertGreaterThan($runAt, $echoAt);
+        self::assertLessThan($catchAt, $echoAt);
+
+        $betweenEchoAndCatch = substr($source, $echoAt, $catchAt - $echoAt);
+        self::assertStringContainsString('exit;', $betweenEchoAndCatch);
+    }
+
+    public function testTheCatchBranchAlsoExitsAfterItsJsonEnvelope(): void
+    {
+        $source = self::sourceOf('controllers/front/cron.php');
+
+        $catchAt = strpos($source, 'catch (Exception $e)');
+        self::assertIsInt($catchAt);
+
+        $afterCatch = substr($source, $catchAt);
+        $echoAt = strpos($afterCatch, 'echo json_encode([');
+        self::assertIsInt($echoAt);
+
+        $afterEcho = substr($afterCatch, $echoAt);
+        self::assertStringContainsString('exit;', $afterEcho);
+    }
+
     private static function sourceOf(string $relativePath): string
     {
         $path = __DIR__ . '/../../' . $relativePath;

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -23,6 +23,46 @@ When a lesson hardens into a rule, **graduate it** to the canonical doc and leav
 
 ---
 
+## A raw stock write to `id_product_attribute=0` on a PrestaShop combination product is a silent no-op
+
+**Context**: raising stock across a demo catalogue for the #2848 measurement, via 25 raw
+`stock_availables` PUTs through the PrestaShop webservice. Only 2 produced a `stock.changed` outbox
+row; the other 23 were product-level writes (`id_product_attribute=0`) against products that have
+combinations.
+
+**Problem**: PrestaShop treats the `id_product_attribute=0` row on a combination product as an
+aggregate it recomputes from the combination rows, not as a real, independently-writable row. A PUT
+against it is accepted (200, no error) and silently discarded - the quantity does not change, and
+nothing in PrestaShop or in a naive caller reports that. Seeding or correcting stock by writing the
+product-level row is indistinguishable, from the outside, between "it worked" and "it was thrown
+away".
+
+`PrestashopInventoryMasterAdapter.adjustInventory` already guards the OpenLinker write path against
+this (`resolveTargetAttributeId` refuses with `PrestashopNotSupportedException` rather than writing
+attribute 0 on a product it can see has combinations) - but that guard only covered the *caller
+named no variant* case. A second, narrower gap survived: a variant minted while its product was
+still simple keeps a synthetic `product:<id>` external-id mapping until the product's next full
+variant sync replaces it with real per-combination mappings; a caller handing in that variant id
+between "the shop admin adds the first combination" and "that re-sync completes" reached the same
+silent no-op through a resolved `variantId` instead of an absent one. Fixed in #2925 by running the
+same "does this product currently have combinations" probe whenever the resolved target is the
+product-level row, whichever branch resolved it there.
+
+**Rule**: when writing PrestaShop stock at product grain, never trust a cached/mapped "this is a
+simple product" fact without re-checking it against a live combinations read at write time - a
+product can gain combinations after the mapping that named it was minted, and the shop will accept
+and discard the write with no signal. A tool seeding stock for measurement or QA should always write
+at the resolved combination (`id_product_attribute`) level, never at `0`, unless it has just verified
+the product carries no combinations.
+
+**Applies to**: any script or adapter path that writes `stock_availables` directly or via
+`InventoryMasterPort.adjustInventory` — `libs/integrations/prestashop/src/infrastructure/adapters/prestashop-inventory-master.adapter.ts`,
+and any `perf/**` seeding/correction tooling that raises stock through the raw webservice.
+
+**Source**: #2925, found during the #2848 measurement.
+
+---
+
 ## Before a surface asserts a behaviour, read the code that implements it
 
 **Context**: redesigning the three sales-document surfaces (#2513). The design was worked out from

--- a/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-inventory-master.adapter.spec.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/__tests__/prestashop-inventory-master.adapter.spec.ts
@@ -1161,6 +1161,42 @@ describe('PrestashopInventoryMasterAdapter', () => {
       );
     });
 
+    it('should refuse rather than silently no-op when a variant carries a stale pre-combination mapping (#2925)', async () => {
+      // The variant was mapped as `product:<id>` before the shop admin added
+      // combinations. The next full variant sync would replace that mapping
+      // with a real per-combination one, but until it does, this write must
+      // never reach the recomputed-aggregate row silently.
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- test mock: narrowing dynamic spy / fixture / response shape
+      mockIdentifierMapping.getExternalIds = jest
+        .fn()
+        .mockImplementation((entityType: string) =>
+          entityType === 'ProductVariant'
+            ? Promise.resolve([
+                {
+                  connectionId: connection.id,
+                  externalId: `product:${PS_PRODUCT_ID}`,
+                  entityType: 'ProductVariant',
+                },
+              ])
+            : Promise.resolve([
+                { connectionId: connection.id, externalId: PS_PRODUCT_ID, entityType: 'Product' },
+              ])
+        );
+      respondWithRows([
+        simpleStockRow(10),
+        { ...simpleStockRow(4), id: '202', id_product_attribute: '77' },
+      ]);
+
+      await expect(
+        adapter.adjustInventory({
+          productId: PRODUCT_ID,
+          variantId: 'internal-variant-now-stale',
+          quantity: 1,
+        })
+      ).rejects.toThrow(PrestashopNotSupportedException);
+      expect(mockHttpClient.updateResource).not.toHaveBeenCalled();
+    });
+
     describe('refusals', () => {
       it('should refuse and name shopId when several shops match the row', async () => {
         respondWithRows([

--- a/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-inventory-master.adapter.ts
+++ b/libs/integrations/prestashop/src/infrastructure/adapters/prestashop-inventory-master.adapter.ts
@@ -1007,17 +1007,31 @@ export class PrestashopInventoryMasterAdapter implements InventoryMasterPort, Bu
    * GAP, not a master deletion — same carve-out, and same reasoning, as
    * {@link resolvePrestashopProductId}.
    *
-   * With no variant named, the target is the product-level row — but only once
-   * the product is known to have no combinations. On a combination product that
-   * row is an aggregate PrestaShop recomputes from its combinations, so writing
-   * it would be discarded; and picking a combination on the caller's behalf
-   * would move stock the caller never named. Mirrors the WooCommerce refusal to
-   * adjust a variable product without a `variantId`.
+   * With no variant named, the target is the product-level row. Either way,
+   * once the resolved target IS the product-level row (`0`), it is refused
+   * unless the product is currently known to have no combinations — never
+   * written silently. On a combination product that row is an aggregate
+   * PrestaShop recomputes from its combinations and discards any write to it
+   * (#2925); and picking a combination on the caller's behalf would move stock
+   * the caller never named. Mirrors the WooCommerce refusal to adjust a
+   * variable product without a `variantId`.
+   *
+   * The same refusal also covers a STALE synthetic mapping: a variant minted
+   * while its product was still simple keeps its `product:<id>` externalId
+   * until the next full variant sync of that product replaces it with real
+   * per-combination mappings ({@link PrestashopProductMasterAdapter.getProductVariants}
+   * deletes it "once combinations exist"). Between the shop admin adding the
+   * first combination and that re-sync completing, a caller could still hand
+   * in the old variant id — this check is what turns that narrow staleness
+   * window into a loud refusal instead of a silent no-op.
    */
   private async resolveTargetAttributeId(
     adjustment: InventoryAdjustment,
     psProductId: string
   ): Promise<string> {
+    let attributeId = '0';
+    let resolvedViaStaleSyntheticMapping = false;
+
     if (adjustment.variantId) {
       const externalIds = await this.identifierMapping.getExternalIds(
         CORE_ENTITY_TYPE.ProductVariant,
@@ -1040,7 +1054,15 @@ export class PrestashopInventoryMasterAdapter implements InventoryMasterPort, Bu
         );
       }
 
-      return mapping.externalId.startsWith('product:') ? '0' : mapping.externalId;
+      if (mapping.externalId.startsWith('product:')) {
+        resolvedViaStaleSyntheticMapping = true;
+      } else {
+        attributeId = mapping.externalId;
+      }
+    }
+
+    if (attributeId !== '0') {
+      return attributeId;
     }
 
     const allRows = await this.listStockRecords(adjustment.productId, {
@@ -1050,11 +1072,19 @@ export class PrestashopInventoryMasterAdapter implements InventoryMasterPort, Bu
 
     if (hasCombinations) {
       throw new PrestashopNotSupportedException(
-        `Inventory adjustment is ambiguous: product ${psProductId} has combinations, so an ` +
-          `adjustment must name which variant it applies to. The product-level stock row is an ` +
-          `aggregate PrestaShop recomputes from its combinations, so writing it would be discarded.`,
+        resolvedViaStaleSyntheticMapping
+          ? `Inventory adjustment refused: variant ${adjustment.variantId} is mapped to the ` +
+              `pre-combination product-level row of product ${psProductId}, but that product now ` +
+              `has combinations in PrestaShop. The product-level row is an aggregate PrestaShop ` +
+              `recomputes from its combinations, so writing it would be discarded.`
+          : `Inventory adjustment is ambiguous: product ${psProductId} has combinations, so an ` +
+              `adjustment must name which variant it applies to. The product-level stock row is an ` +
+              `aggregate PrestaShop recomputes from its combinations, so writing it would be discarded.`,
         'adjustInventory',
-        'Supply adjustment.variantId to target a specific combination'
+        resolvedViaStaleSyntheticMapping
+          ? 'Re-run the product/variant sync for this connection so OpenLinker maps to the real ' +
+              'combination rows, then retry the adjustment'
+          : 'Supply adjustment.variantId to target a specific combination'
       );
     }
 


### PR DESCRIPTION
## Summary

Two self-contained PrestaShop-module defects found by the #2848 measurement campaign.

**#2923** - the module's HTTP cron front controller (`controllers/front/cron.php`) ended its success branch (and its catch branch) without `exit;`, unlike the four early-return branches above it. Control therefore fell through into PrestaShop's ordinary front-controller page render after the JSON was echoed. On a shop whose theme cache is unwritable this fatals into a 500 over a correct success payload; on one whose cache is writable, the response body becomes the JSON payload followed by an entire HTML document, which breaks any strict JSON parser watching the endpoint. Both branches now `exit;` immediately after their envelope, matching the pattern already used by the four refusal branches.

**#2925** - `PrestashopInventoryMasterAdapter.adjustInventory` already refused to write the product-level (`id_product_attribute=0`) row when no variant was named and the product has combinations, since PrestaShop treats that row as an aggregate it silently recomputes from the combination rows (a write there is accepted and discarded with no signal). That guard had a narrower gap: a variant minted while its product was still simple keeps a synthetic `product:<id>` external-id mapping until the product's next full variant sync replaces it with real per-combination mappings. A caller handing in that variant id during the window between a shop admin adding the product's first combination and OpenLinker's next re-sync of that product's variants would reach the same silent no-op through a resolved `variantId`, bypassing the existing check. The "does this product currently have combinations" probe now runs whenever the resolved target is the product-level row, whichever branch resolved it there - refusing loudly (`PrestashopNotSupportedException`) instead of writing silently.

## Verification

**#2923**, live against the `lab-prestashop` (PrestaShop 9.0.2) stand:
- Before the fix, with the theme cache genuinely writable (it was previously owned by `root`; re-chowned to `www-data` to exercise the real render path rather than mask it behind a permissions fatal): the request still 500s, now failing further into the render pipeline (a Smarty "Missing `$template`" fatal) - confirming the missing `exit;` is the defect regardless of which downstream render step trips first.
- After the fix: `HTTP 200`, `Content-Length: 278`, body verified byte-exact to the 278-byte JSON payload with nothing appended.
- Both branches (`echo json_encode(...)` in the try, and the catch) now carry `exit;`, asserted by two new source-level tests in `CronDeliveryHardeningTest.php` (the module has no PrestaShop runtime available to phpunit for a live controller test, matching the existing tests in that file and in `EndpointHardeningTest.php`).
- Ran the module's own PHPUnit `Unit` suite (207 -> 209 tests) inside the `lab-prestashop` container (`composer install` + `vendor/bin/phpunit --testsuite=Unit`): both new tests pass. Two unrelated, pre-existing failures in `CronHealthTest` reproduce on this environment regardless of this change - the container's PHP default timezone is `Europe/Paris`, and `CronHealth::assess`'s `strtotime()` call interprets a UTC-labelled `gmdate()` string in that local zone, producing a systematic one-hour offset. Untouched by this PR; out of scope for #2923/#2925.

**#2925**: established from the code, not by inference, per the acceptance criteria - traced the one production caller of `adjustInventory` (`ReturnCustodyService.writeMasterStock`, in `libs/core/src/returns`) and confirmed `variantId` is always a variant id freshly resolved via `IProductsService.getVariantsBySkus`, never omitted. The pre-existing guard already covered the "no variantId" branch (tested at `should refuse when a combination product is adjusted without a variantId`). The narrower gap was the resolved-but-stale-mapping case above, closed by the change; a new test (`should refuse rather than silently no-op when a variant carries a stale pre-combination mapping (#2925)`) pins it. Added a `docs/lessons.md` entry recording the shape.

## Test plan

- [x] `pnpm check:invariants` - exit 0
- [x] `libs/integrations/prestashop` package lint (`eslint`) - clean
- [x] Module's own PHPUnit `Unit` suite run live in the `lab-prestashop` container - 209 tests, 2 pre-existing unrelated failures (timezone-dependent `CronHealthTest`, untouched by this PR)
- [x] Live end-to-end verification of #2923 against `lab-prestashop` (PrestaShop 9.0.2), both before/after the fix, with the theme cache genuinely writable
- [x] Traced the one production caller of `adjustInventory` to establish #2925's reachability, per its acceptance criteria

Closes #2923
Closes #2925

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018vj6hpCBnLJZL1geCE1qzv