### PR TITLE
fix(web): guard the degraded-data reads that crashed / and /settings

### DIFF
--- a/apps/web/src/features/currency-settings/components/currency-coverage-dialog.test.tsx
+++ b/apps/web/src/features/currency-settings/components/currency-coverage-dialog.test.tsx
@@ -74,4 +74,19 @@ describe('CurrencyCoverageDialog', () => {
     fireEvent.click(await screen.findByRole('button', { name: 'Close' }));
     expect(onClose).toHaveBeenCalled();
   });
+
+  it('degrades to the zero-state rather than throwing when `stampedOrders` is missing (#2926)', async () => {
+    // A degraded API response (a 500 handled into an empty object, a partial
+    // payload, a field dropped by version skew) can arrive as a resolved
+    // query whose shape doesn't match the contract.
+    const degradedView = {
+      ...baseView,
+      stampedOrders: undefined,
+    } as unknown as CurrencySettingsView;
+
+    renderWithProviders(<CurrencyCoverageDialog open view={degradedView} onClose={vi.fn()} />);
+
+    expect(await screen.findByText('Analytics coverage')).toBeInTheDocument();
+    expect(screen.getByText(/No orders have been stamped yet/)).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/features/currency-settings/components/currency-coverage-dialog.tsx
+++ b/apps/web/src/features/currency-settings/components/currency-coverage-dialog.tsx
@@ -41,8 +41,16 @@ export function CurrencyCoverageDialog({
   view,
   onClose,
 }: CurrencyCoverageDialogProps): ReactElement {
-  const total = view.stampedOrders.reduce((sum, entry) => sum + entry.count, 0);
-  const hasMultipleEras = view.stampedOrders.length > 1;
+  // `view` reflects whatever the API returned; a degraded response (a
+  // partial payload, a field dropped by version skew) can arrive as a
+  // successful query with `stampedOrders` missing. Defaulting to empty
+  // degrades into "no orders stamped yet" rather than crashing — the same
+  // no-positive-claim-from-absent-data convention documented for the
+  // returns surfaces in docs/architecture-overview.md.
+  const stampedOrders = view.stampedOrders ?? [];
+
+  const total = stampedOrders.reduce((sum, entry) => sum + entry.count, 0);
+  const hasMultipleEras = stampedOrders.length > 1;
 
   const items: KeyValueItem[] = [
     {
@@ -52,7 +60,7 @@ export function CurrencyCoverageDialog({
       mono: true,
     },
     ...(hasMultipleEras
-      ? view.stampedOrders.map((entry) => ({
+      ? stampedOrders.map((entry) => ({
           id: entry.reportingCurrency,
           label: `— stamped in ${entry.reportingCurrency}`,
           value: <span className="tabular">{entry.count}</span>,

--- a/apps/web/src/features/currency-settings/components/currency-settings-dialog.test.tsx
+++ b/apps/web/src/features/currency-settings/components/currency-settings-dialog.test.tsx
@@ -107,4 +107,25 @@ describe('CurrencySettingsDialog', () => {
     fireEvent.change(select, { target: { value: 'PLN' } });
     expect(liveRegion().textContent).toBe('');
   });
+
+  it('does not throw when `view` arrives with array fields missing (#2926)', async () => {
+    // The tile mounts this dialog unconditionally (`open` merely controls
+    // Radix's own visibility), so the component body runs on every render of
+    // the settings page — a degraded API response (a 500 handled into an
+    // empty object, a partial payload, a field dropped by version skew)
+    // must not crash it even while closed.
+    const degradedView = {
+      reportingCurrency: 'PLN',
+      source: 'setting',
+      updatedAt: null,
+      updatedBy: null,
+      rateSource: 'nbp',
+      rateDateRule: 'prev-business-day',
+      // coverage / stampedOrders / supportedCurrencies deliberately absent
+    } as unknown as CurrencySettingsView;
+
+    expect(() => {
+      renderWithProviders(<CurrencySettingsDialog open={false} view={degradedView} onClose={vi.fn()} />);
+    }).not.toThrow();
+  });
 });

--- a/apps/web/src/features/currency-settings/components/currency-settings-dialog.tsx
+++ b/apps/web/src/features/currency-settings/components/currency-settings-dialog.tsx
@@ -57,9 +57,21 @@ export function CurrencySettingsDialog({
   view,
   onClose,
 }: CurrencySettingsDialogProps): ReactElement {
+  // `view` reflects whatever the API returned; a degraded response (a
+  // partial payload, a field dropped by version skew) can arrive as a
+  // successful query with these fields missing. Defaulting the arrays to
+  // empty and the currency to `''` degrades into "no coverage gap known" /
+  // "nothing else stamped" / "nothing selected yet" rather than crashing —
+  // the same no-positive-claim-from-absent-data convention documented for
+  // the returns surfaces in docs/architecture-overview.md.
+  const reportingCurrency = view.reportingCurrency ?? '';
+  const coverage = view.coverage ?? [];
+  const stampedOrders = view.stampedOrders ?? [];
+  const supportedCurrencies = view.supportedCurrencies ?? [];
+
   const { showToast } = useToast();
   const mutation = useSetReportingCurrencyMutation();
-  const [selected, setSelected] = useState(view.reportingCurrency);
+  const [selected, setSelected] = useState(reportingCurrency);
   const [acknowledged, setAcknowledged] = useState(false);
 
   // Reset whenever the dialog opens, matching the ai-provider-key-dialog /
@@ -73,17 +85,17 @@ export function CurrencySettingsDialog({
   const { reset: resetMutation } = mutation;
   useEffect(() => {
     if (open) {
-      setSelected(view.reportingCurrency);
+      setSelected(reportingCurrency);
       setAcknowledged(false);
       resetMutation();
     }
   }, [open, resetMutation]);
 
-  const selectedCoverage = view.coverage.find((entry) => entry.reportingCurrency === selected);
+  const selectedCoverage = coverage.find((entry) => entry.reportingCurrency === selected);
   const hasCoverageGap = (selectedCoverage?.uncoverableCurrencies.length ?? 0) > 0;
 
-  const otherEraStamped = view.stampedOrders.filter((entry) => entry.reportingCurrency !== selected);
-  const willSplitHistory = selected !== view.reportingCurrency && otherEraStamped.length > 0;
+  const otherEraStamped = stampedOrders.filter((entry) => entry.reportingCurrency !== selected);
+  const willSplitHistory = selected !== reportingCurrency && otherEraStamped.length > 0;
 
   const canSubmit = selected.length > 0 && (!hasCoverageGap || acknowledged);
 
@@ -175,7 +187,7 @@ export function CurrencySettingsDialog({
                 setAcknowledged(false);
               }}
             >
-              {view.supportedCurrencies.map((code) => (
+              {supportedCurrencies.map((code) => (
                 <option key={code} value={code}>
                   {code}
                 </option>

--- a/apps/web/src/features/mcp-tokens/components/mcp-tokens-tile.test.tsx
+++ b/apps/web/src/features/mcp-tokens/components/mcp-tokens-tile.test.tsx
@@ -1,0 +1,63 @@
+/**
+ * MCP Tokens Tile — Tests
+ *
+ * Covers the tile's loading/success/degraded-shape states. Rendered under an
+ * admin session throughout — non-admin visibility is asserted at the page
+ * level in `settings-page.test.tsx`, since gating lives there, not in this
+ * component.
+ *
+ * @module apps/web/src/features/mcp-tokens/components
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, screen } from '@testing-library/react';
+import {
+  createAuthenticatedSessionAdapter,
+  createMockApiClient,
+  renderWithProviders,
+} from '../../../test/test-utils';
+import type { McpToken } from '../api/mcp-tokens.types';
+import { McpTokensTile } from './mcp-tokens-tile';
+
+afterEach(cleanup);
+
+const adminSessionAdapter = createAuthenticatedSessionAdapter();
+
+const tokens: McpToken[] = [
+  { id: 'tok-1', name: 'agent-1', isActive: true } as McpToken,
+  { id: 'tok-2', name: 'agent-2', isActive: false } as McpToken,
+];
+
+describe('McpTokensTile', () => {
+  it('shows a loading placeholder while the tokens query is in flight', async () => {
+    const apiClient = createMockApiClient({
+      mcpTokens: { list: vi.fn(() => new Promise<McpToken[]>(() => {})) },
+    });
+    renderWithProviders(<McpTokensTile />, { sessionAdapter: adminSessionAdapter, apiClient });
+
+    expect(await screen.findByText('MCP tokens')).toBeInTheDocument();
+    expect(screen.getByText('…')).toBeInTheDocument();
+  });
+
+  it('counts only active tokens once the list resolves', async () => {
+    const apiClient = createMockApiClient({ mcpTokens: { list: vi.fn().mockResolvedValue(tokens) } });
+    renderWithProviders(<McpTokensTile />, { sessionAdapter: adminSessionAdapter, apiClient });
+
+    expect(await screen.findByText('1')).toBeInTheDocument();
+  });
+
+  it('degrades to "—" rather than throwing when the tokens query resolves to a non-array shape (#2926)', async () => {
+    // A degraded API response (a 500 handled into an empty object, a
+    // partial payload, a field dropped by version skew) can arrive as a
+    // resolved query whose `data` is truthy but not an array — `?? null`
+    // alone only guards `undefined`, and `.filter` on a plain object
+    // throws. This must render the same "unknown" dash a failed/pending
+    // read renders, never crash.
+    const degraded = { data: [], total: 0 } as unknown as McpToken[];
+    const apiClient = createMockApiClient({ mcpTokens: { list: vi.fn().mockResolvedValue(degraded) } });
+
+    renderWithProviders(<McpTokensTile />, { sessionAdapter: adminSessionAdapter, apiClient });
+
+    expect(await screen.findByText('MCP tokens')).toBeInTheDocument();
+    expect(await screen.findByText('—')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/mcp-tokens/components/mcp-tokens-tile.tsx
+++ b/apps/web/src/features/mcp-tokens/components/mcp-tokens-tile.tsx
@@ -12,7 +12,17 @@ import { useMcpTokensQuery } from '../hooks/use-mcp-tokens-query';
 
 export function McpTokensTile(): ReactElement {
   const tokensQuery = useMcpTokensQuery();
-  const activeCount = tokensQuery.data?.filter((token) => token.isActive).length ?? null;
+  // A degraded response (a 500 handled into an empty object, a partial
+  // payload) can arrive as a successful query whose `data` is not actually
+  // an array — `?? null` alone only guards `undefined`, not a truthy
+  // non-array value, and `.filter` on that throws. Treating anything but a
+  // real array as "unknown" (`null`, rendered as `—`) rather than crashing
+  // or claiming zero matches the no-positive-claim-from-absent-data
+  // convention documented for the returns surfaces in
+  // docs/architecture-overview.md.
+  const activeCount = Array.isArray(tokensQuery.data)
+    ? tokensQuery.data.filter((token) => token.isActive).length
+    : null;
 
   return (
     <article className="panel panel--dense">

--- a/apps/web/src/pages/analytics/analytics-page.test.tsx
+++ b/apps/web/src/pages/analytics/analytics-page.test.tsx
@@ -40,6 +40,26 @@ describe('AnalyticsPage', () => {
     ).toBeInTheDocument();
   });
 
+  it('should degrade to the empty-instance state, not crash, when the trust snapshot arrives with no `connections` field (#2926)', async () => {
+    // A malformed/degraded response (a 500 handled into an empty object, a
+    // partial payload, a field dropped by version skew) can arrive as a
+    // resolved query whose shape doesn't match the contract. This must
+    // degrade into the same "connect a channel" empty state a genuinely
+    // connection-less install renders, never throw.
+    const degraded = { generatedAt: '2026-08-14T14:32:00.000Z', worstStatus: 'fresh' };
+    const apiClient = createMockApiClient({
+      analyticsTrust: {
+        getTrust: vi.fn().mockResolvedValue(degraded as unknown as AnalyticsTrustSnapshot),
+      },
+    });
+
+    renderWithProviders(<AnalyticsPage />, { apiClient, route: ROUTE });
+
+    expect(
+      await screen.findByText('Connect a sales channel to see figures here'),
+    ).toBeInTheDocument();
+  });
+
   it('should show the "still arriving" card when every connection is never-ingested', async () => {
     const apiClient = createMockApiClient({
       analyticsTrust: {

--- a/apps/web/src/pages/analytics/analytics-page.tsx
+++ b/apps/web/src/pages/analytics/analytics-page.tsx
@@ -68,6 +68,16 @@ export function AnalyticsPage(): ReactElement {
   // render independently even though they fetch from the same cache entry.
   const salesFilters: SalesAnalyticsFilters = useMemo(() => ({ from, to }), [from, to]);
 
+  // A degraded response (a 500 handled into an empty object, a partial
+  // payload, a field dropped by version skew) can arrive as a successful
+  // query with `data` present but `connections` missing. Defaulting to an
+  // empty array here — rather than reading `trustQuery.data.connections`
+  // directly at each use below — degrades into the same "connect a channel"
+  // empty state a genuinely connection-less install renders, matching the
+  // no-positive-claim-from-absent-data convention documented for the
+  // returns surfaces in docs/architecture-overview.md.
+  const connections = trustQuery.data?.connections ?? [];
+
   return (
     <PageLayout
       eyebrow="Operations"
@@ -88,7 +98,7 @@ export function AnalyticsPage(): ReactElement {
             </Button>
           }
         />
-      ) : trustQuery.data && trustQuery.data.connections.length === 0 ? (
+      ) : trustQuery.data && connections.length === 0 ? (
         <EmptyState
           title="Connect a sales channel to see figures here"
           message="This page reports the orders OpenLinker has ingested. Once a marketplace or shop is connected and its first orders arrive, figures appear here without further setup."
@@ -100,8 +110,8 @@ export function AnalyticsPage(): ReactElement {
         />
       ) : trustQuery.data ? (
         <>
-          <AnalyticsDegradationBanner connections={trustQuery.data.connections} />
-          {trustQuery.data.connections.every((entry) => entry.status === 'never-ingested') ? (
+          <AnalyticsDegradationBanner connections={connections} />
+          {connections.every((entry) => entry.status === 'never-ingested') ? (
             <EmptyState
               title="First orders are still arriving"
               message="Nothing is missing; it is not here yet. Figures will appear as orders land."
@@ -113,7 +123,7 @@ export function AnalyticsPage(): ReactElement {
             />
           ) : (
             <>
-              <AnalyticsKpiStrip filters={salesFilters} connections={trustQuery.data.connections} />
+              <AnalyticsKpiStrip filters={salesFilters} connections={connections} />
               <ChannelSalesTable filters={salesFilters} />
               <ProductSalesTable filters={salesFilters} />
             </>
@@ -125,7 +135,7 @@ export function AnalyticsPage(): ReactElement {
               section and the data-coverage header below it render
               unconditionally, after the order-derived figures above. */}
           <AnalyticsNeedsAttention />
-          <AnalyticsTrustHeader connections={trustQuery.data.connections} />
+          <AnalyticsTrustHeader connections={connections} />
         </>
       ) : null}
     </PageLayout>

--- a/scripts/lighthouse/smoke-check.mjs
+++ b/scripts/lighthouse/smoke-check.mjs
@@ -1,40 +1,135 @@
 #!/usr/bin/env node
 /**
- * Renders each Lighthouse target route with Playwright and reports whether
- * it produced a real render (heading text found, no error-boundary marker)
- * before any Lighthouse score is trusted for it. Not part of the CI gate —
- * a one-off verification step, kept so the check is reproducible.
+ * Renders every authenticated `apps/web` route with Playwright and reports
+ * whether it produced a real render (no error-boundary marker, no thrown
+ * page error) against the same generic network stub Lighthouse audits
+ * against — before any Lighthouse score is trusted, and independent of it.
+ * Not part of the CI gate — a one-off verification step, kept so the check
+ * is reproducible.
+ *
+ * `ROUTES` is the full authenticated route list from `root.route.tsx`'s
+ * `coreChildren` (#2926) — every top-level route the sidebar links to, plus
+ * one representative parameterised detail route per list page (a
+ * `SMOKE_CHECK_PLACEHOLDER_ID` id, which resolves to nothing under the mock
+ * stub — visiting an unknown id in a URL is itself a real, reachable case
+ * an operator can hit, e.g. a stale bookmark after a connection is
+ * deleted). Plugin-contributed routes (Allegro/Erli category browsers,
+ * etc.) are out of scope here — they require a real connection of that
+ * platform type to resolve meaningfully and are not part of the generic
+ * authenticated surface this check establishes coverage over.
+ *
+ * `REGRESSION_GUARD_ROUTES` are the two routes #2926 fixed
+ * (`analytics-page.tsx`, `settings-page.tsx` and their tiles) — this script
+ * exits non-zero if EITHER of them regresses to an error-boundary or a
+ * thrown page error, so the fix stays fixed. Every other route is reported
+ * but does NOT fail the process: the point of extending coverage to all of
+ * them is to make the extent of the "unguarded `.length`/`.find`/`.filter`
+ * read" class of bug visible, not to silently gate on fixing every one of
+ * them in this change.
  */
 import { chromium } from '@playwright/test';
 
 const BASE = 'http://localhost:4173';
-const ROUTES = ['/connections', '/customers', '/listings', '/shipments', '/settings'];
+const SMOKE_CHECK_PLACEHOLDER_ID = 'smoke-check-placeholder';
+
+const ROUTES = [
+  // Post-login landing page (#2740) — also reachable at the legacy
+  // `/analytics` redirect, checked alongside it.
+  '/',
+  '/analytics',
+  '/insights',
+  '/orders',
+  '/products',
+  '/cursors',
+  '/customers',
+  '/listings',
+  '/shipments',
+  '/returns',
+  '/fulfillment',
+  '/automations',
+  '/invoices',
+  '/connections',
+  `/connections/${SMOKE_CHECK_PLACEHOLDER_ID}`,
+  `/connections/${SMOKE_CHECK_PLACEHOLDER_ID}/mappings`,
+  `/connections/${SMOKE_CHECK_PLACEHOLDER_ID}/mappings/categories`,
+  `/connections/${SMOKE_CHECK_PLACEHOLDER_ID}/edit`,
+  '/connections/new',
+  '/connections/new/advanced',
+  '/adapters',
+  '/jobs-logs',
+  '/webhook-deliveries',
+  '/settings',
+  '/settings/sync-pacing',
+  '/settings/sales-documents',
+  '/settings/who-decides',
+  '/settings/mcp-tokens',
+  '/settings/prompt-templates', // legacy redirect -> /ai/prompt-templates
+  '/ai/provider-settings',
+  '/ai/prompt-templates',
+  `/ai/prompt-templates/${SMOKE_CHECK_PLACEHOLDER_ID}`,
+  '/users',
+  '/dev/ui',
+];
+
+const REGRESSION_GUARD_ROUTES = ['/', '/settings'];
 
 async function main() {
   const browser = await chromium.launch();
   const page = await browser.newPage();
   const consoleErrors = [];
+  const pageErrors = [];
   page.on('console', (msg) => {
     if (msg.type() === 'error') consoleErrors.push(msg.text());
   });
-  page.on('pageerror', (err) => consoleErrors.push(`pageerror: ${err.message}`));
+  page.on('pageerror', (err) => pageErrors.push(err.message));
+
+  const results = [];
 
   for (const route of ROUTES) {
     consoleErrors.length = 0;
-    await page.goto(`${BASE}${route}`, { waitUntil: 'networkidle', timeout: 30000 });
+    pageErrors.length = 0;
+    try {
+      await page.goto(`${BASE}${route}`, { waitUntil: 'networkidle', timeout: 30000 });
+    } catch (err) {
+      results.push({ route, crashed: true, reason: `navigation failed: ${err.message}` });
+      console.log(`\n=== ${route} ===`);
+      console.log('NAVIGATION FAILED:', err.message);
+      continue;
+    }
     await page.waitForTimeout(500);
     const bodyText = await page.locator('body').innerText();
-    const hasErrorBoundary = /something went wrong|unexpected error|application error/i.test(bodyText);
+    const hasErrorBoundary = /something went wrong|unexpected error|application error/i.test(
+      bodyText,
+    );
+    const crashed = hasErrorBoundary || pageErrors.length > 0;
     const title = await page.title();
+    results.push({ route, crashed });
+
     console.log(`\n=== ${route} ===`);
     console.log('title:', title);
     console.log('body text length:', bodyText.length);
     console.log('error-boundary text present:', hasErrorBoundary);
+    console.log('page errors:', pageErrors.length ? pageErrors.slice(0, 3) : 'none');
     console.log('console errors:', consoleErrors.length ? consoleErrors.slice(0, 5) : 'none');
     console.log('body snippet:', bodyText.slice(0, 300).replace(/\n+/g, ' | '));
   }
 
   await browser.close();
+
+  const crashedRoutes = results.filter((r) => r.crashed).map((r) => r.route);
+  console.log(`\n=== summary ===`);
+  console.log(`${results.length} routes checked, ${crashedRoutes.length} crashed`);
+  if (crashedRoutes.length > 0) {
+    console.log('crashed routes:', crashedRoutes.join(', '));
+  }
+
+  const regressed = REGRESSION_GUARD_ROUTES.filter((route) => crashedRoutes.includes(route));
+  if (regressed.length > 0) {
+    console.error(
+      `\nREGRESSION: ${regressed.join(', ')} crashed against the degraded-data stub — #2926 fixed this.`,
+    );
+    process.exitCode = 1;
+  }
 }
 
 main().catch((err) => {


### PR DESCRIPTION
Closes #2926. Based on **`2842-f3-webhook-burst`** (#2922) - review against the stack tip.

## The crash is in page code, and `/settings` had two of them

Reproduced live with Playwright against a sourcemap-decoded stack, not inferred from the six routes that degraded cleanly.

**`/`** - `analytics-page.tsx:91`, `trustQuery.data.connections.length`. The trust snapshot arrived truthy but shapeless and `.connections` was `undefined`.

**`/settings`** - two independent bugs stacked behind each other, and the second is the one worth remembering.

`CurrencySettingsDialog` is mounted **unconditionally** by its tile - `open` only controls Radix visibility, so the component body runs whether or not the dialog is shown - and it read `view.coverage.find(...)` on an undefined array.

Fixing that revealed `McpTokensTile`'s `tokensQuery.data?.filter(...)`:

> **Optional chaining guards `undefined`, not a truthy value of the wrong type.**

`.filter` on an envelope object throws `is not a function`. A `?.` reads like a defensive measure and is not one against a shape mismatch. Worth knowing before writing the next one.

## The fixes are in the pages, deliberately

Widening the test stub to model real domain shapes would turn a network stub into a second copy of the API and hide the class rather than close it. And these shapes are what a degraded API really produces: a 500 handled into an empty object, a partial payload, a field removed by version skew.

The degraded states follow the convention the app already has for the returns surfaces - **never render a positive claim from an absent value**, because a page that says "no shortfalls" when it merely could not load is a worse bug than one that crashes.

## The extent is now established, and it is larger than the issue assumed

`smoke-check.mjs` grows from 5 routes to **34** - every `coreChildren` entry. **14 crash**:

`/insights`, four `/connections/:id...` variants, `/connections/new/advanced`, `/settings/sync-pacing`, `/settings/sales-documents`, `/settings/who-decides`, `/settings/mcp-tokens`, `/settings/prompt-templates`, `/ai/provider-settings`, and both `/ai/prompt-templates` variants.

Those are **untouched here** and raised for triage rather than fixed in passing. The check's exit-code regression guard is scoped to `/` and `/settings`, so it fails if what this PR fixed regresses, without turning fourteen known-open cases into a permanently red gate that everyone learns to ignore.

## Tests

Four regression cases, one on a component that had no test file at all (`McpTokensTile`).

```
vitest run (7 affected/new files) -> 43/43 passing
pnpm --filter @openlinker/web type-check -> clean
pnpm --filter @openlinker/web lint -> 0 errors, 116 pre-existing warnings, none in touched files
pnpm check:invariants -> exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018vj6hpCBnLJZL1geCE1qzv
