### PR TITLE
perf(harness): share the pre-signed pool across k6 VUs

### DIFF
--- a/perf/openlinker-throughput/drivers/presign-webhooks.mjs
+++ b/perf/openlinker-throughput/drivers/presign-webhooks.mjs
@@ -27,13 +27,24 @@
  *   node --experimental-strip-types perf/openlinker-throughput/drivers/presign-webhooks.mjs [flags]
  *
  * Output: a `pool.json` shaped
- *   { meta: {...}, generations: [ { timestampMs, entries: [ { eventId, body, signature } ] } ] }
+ *   { meta: {...},
+ *     generationIndex: [ { timestampMs, startIndex, count }, ... ],
+ *     entries: [ { timestampMs, eventId, body, signature }, ... ] }
+ *
+ * `entries` is FLAT - one array, no nesting - and `generationIndex` is a
+ * small side table of slice boundaries into it (#2931). This replaces the
+ * earlier `generations: [{ timestampMs, entries: [...] }]` shape, which grouped
+ * entries by generation. That shape is what k6's `webhook-burst.js` used to
+ * `JSON.parse` once PER VIRTUAL USER, and separately, deep nesting defeats
+ * `SharedArray`'s sharing even when it IS used - see that driver's own header
+ * comment for the measurements behind both changes.
  *
  * @module perf/openlinker-throughput/drivers
  */
 import { signWebhook } from '../../../apps/e2e/src/support/webhooks.ts';
 import { writeFileSync, readFileSync } from 'node:fs';
 import { randomUUID } from 'node:crypto';
+import { freemem } from 'node:os';
 
 // ---------------------------------------------------------------------------
 // Arg parsing - flags only, no positional args, no external dep.
@@ -102,6 +113,13 @@ Optional:
   --verify-live <apiBaseUrl>      after building the pool, POST its first entry
                                    for real and confirm a 2xx (never a DB check -
                                    this script has no psql dependency)
+  --skip-memory-check             skip the pre-flight memory-budget refusal
+                                   (#2931) and build the pool regardless of
+                                   how much host memory is free
+  --memory-safety-fraction <n>    fraction of currently-free host memory the
+                                   projected pool is allowed to use, default
+                                   0.7 - leaves headroom for the api/worker
+                                   containers and anything else on the host
   --help                          this text
 `);
 }
@@ -243,41 +261,121 @@ function nextEventId(i) {
 }
 
 // ---------------------------------------------------------------------------
-// Build the pool. Entries are distributed evenly across generations (the
-// last generation may carry a partial share when count is not an exact
-// multiple) - the exact distribution is not load-bearing (any generation
-// with any remaining entries can serve any request), only that the TOTAL
-// legitimately covers `count`.
+// One real entry, built the exact same way the main loop below builds one -
+// used ONLY to measure the actual serialized byte cost of an entry before
+// committing to signing `count` of them. Kept as its own function rather
+// than inlined so the pre-flight estimate below and the main loop can never
+// silently drift into building two different shapes.
+// ---------------------------------------------------------------------------
+function buildEntry(i, timestampMs) {
+  const eventId = nextEventId(i);
+  const envelope = {
+    schemaVersion: 1,
+    eventId,
+    eventType,
+    occurredAt: new Date(timestampMs).toISOString(),
+    object: { type: objectType, externalId: `${externalIdPrefix}-order-${i}` },
+    payload,
+  };
+  const signed = signWebhook(secret, envelope, timestampMs);
+  return { timestampMs, eventId, body: signed.rawBody, signature: signed.headers['X-OpenLinker-Signature'] };
+}
+
+// ---------------------------------------------------------------------------
+// Pre-flight memory budget (#2931). Refuse to sign `count` entries at all
+// when the pool that would result is bigger than this host can hold once
+// k6 loads it - discovered live as two OOM kills mid-run, confirmed by
+// `dmesg`, in results-F3-2026-09-06.md.
+//
+// The multiplier and fixed overhead below are NOT a guess - they are read
+// off a live measurement of the ACTUAL webhook-burst.js driver (the
+// double-SharedArray design that replaced per-VU JSON.parse; see that
+// file's own header comment), holding a real ~63 MB flat pool, at both 5
+// and 150 virtual users:
+//
+//   5 VUs:   peak container RSS ~517 MB  (~8.2x the 62.8 MB pool file)
+//   150 VUs: peak container RSS ~501 MB  (~8.0x the 62.8 MB pool file)
+//
+// (a 2 GB cgroup limit; the pre-#2931 per-VU-parse driver, same pool, same
+// limit, was OOM-killed with only 5/20 VUs initialized.) i.e. the dominant
+// cost is the ONE-TIME cost of parsing the file twice (once per
+// SharedArray) into JS-object form, not the VU count - which is exactly the
+// property this issue exists to buy: 5 VUs and 150 VUs land within 3% of
+// each other. `PARSE_MEMORY_MULTIPLIER` rounds the observed ~8x up to 9x so
+// the estimate holds a margin rather than reporting a number that already
+// assumes the best case, and `RUNTIME_FIXED_OVERHEAD_BYTES` is slack for a
+// smaller pool's fixed k6/goja baseline (which the multiplier alone
+// under-covers once the pool itself gets small) and for a bigger box's own
+// baseline.
+// ---------------------------------------------------------------------------
+const PARSE_MEMORY_MULTIPLIER = 9;
+const RUNTIME_FIXED_OVERHEAD_BYTES = 100 * 1024 * 1024;
+const memorySafetyFraction = Number(args['memory-safety-fraction'] ?? 0.7);
+if (!Number.isFinite(memorySafetyFraction) || memorySafetyFraction <= 0 || memorySafetyFraction > 1) {
+  die(`--memory-safety-fraction must be in (0, 1], got '${args['memory-safety-fraction']}'`);
+}
+
+function mb(bytes) {
+  return (bytes / (1024 * 1024)).toFixed(1);
+}
+
+if (args['skip-memory-check']) {
+  log('skipping the pre-flight memory-budget check (--skip-memory-check)');
+} else {
+  const sample = buildEntry(0, windowStartMs);
+  // +1 per entry for the array-element comma; generationIndex + meta are a
+  // few hundred bytes total regardless of count and are folded into the
+  // fixed overhead instead of measured per-generation.
+  const projectedEntriesBytes = (JSON.stringify(sample).length + 1) * count;
+  const requiredBytes = Math.round(projectedEntriesBytes * PARSE_MEMORY_MULTIPLIER) + RUNTIME_FIXED_OVERHEAD_BYTES;
+  const availableBytes = freemem();
+  const budgetBytes = Math.floor(availableBytes * memorySafetyFraction);
+  log(
+    `memory budget: pool would be ~${mb(projectedEntriesBytes)} MB on disk -> an estimated ` +
+      `~${mb(requiredBytes)} MB resident in the k6 process (${PARSE_MEMORY_MULTIPLIER}x measured parse ` +
+      `overhead, #2931, + ${mb(RUNTIME_FIXED_OVERHEAD_BYTES)} MB fixed baseline); this host currently has ` +
+      `${mb(availableBytes)} MB free, budgeted at ${Math.round(memorySafetyFraction * 100)}% = ${mb(budgetBytes)} MB`
+  );
+  if (requiredBytes > budgetBytes) {
+    die(
+      `refusing to build a pool this host cannot hold: need an estimated ~${mb(requiredBytes)} MB resident, ` +
+        `only ${mb(budgetBytes)} MB budgeted (${mb(availableBytes)} MB free x ${memorySafetyFraction} safety ` +
+        `margin). Lower --count, free memory on the host (stop an idle stack), raise the budget with ` +
+        `--memory-safety-fraction, or pass --skip-memory-check to try anyway and risk an OOM kill.`
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Build the pool. Entries are FLAT (#2931 - see the header comment) and
+// distributed evenly across generations (the last generation may carry a
+// partial share when count is not an exact multiple) - the exact
+// distribution is not load-bearing (any generation with any remaining
+// entries can serve any request), only that the TOTAL legitimately covers
+// `count`. `generationIndex` records, per generation, the contiguous slice
+// of `entries` it owns (`startIndex`/`count`) so the k6 driver can pick a
+// generation's entries in O(1) without scanning the flat array.
 // ---------------------------------------------------------------------------
 const perGeneration = Math.ceil(count / nGenerations);
-const generations = [];
+const generationIndex = [];
+const entries = [];
 let built = 0;
 for (let g = 0; g < nGenerations && built < count; g++) {
   const timestampMs = windowStartMs + g * genIntervalMs;
-  const entries = [];
   const take = Math.min(perGeneration, count - built);
+  const startIndex = built;
   for (let k = 0; k < take; k++) {
-    const eventId = nextEventId(built);
-    const envelope = {
-      schemaVersion: 1,
-      eventId,
-      eventType,
-      occurredAt: new Date(timestampMs).toISOString(),
-      object: { type: objectType, externalId: `${externalIdPrefix}-order-${built}` },
-      payload,
-    };
-    const signed = signWebhook(secret, envelope, timestampMs);
-    entries.push({ eventId, body: signed.rawBody, signature: signed.headers['X-OpenLinker-Signature'] });
+    entries.push(buildEntry(built, timestampMs));
     built++;
   }
-  generations.push({ timestampMs, entries });
+  generationIndex.push({ timestampMs, startIndex, count: take });
 }
 
 if (built < count) {
   die(`internal error: only built ${built} of ${count} requested entries`);
 }
 
-const sampleBytes = generations[0]?.entries[0]?.body?.length ?? 0;
+const sampleBytes = entries[0]?.body?.length ?? 0;
 
 const pool = {
   meta: {
@@ -298,11 +396,12 @@ const pool = {
     externalIdPrefix,
     // Never the secret. Never anything the secret could be recovered from.
   },
-  generations,
+  generationIndex,
+  entries,
 };
 
 writeFileSync(out, JSON.stringify(pool));
-log(`wrote ${out} (${built} entries across ${generations.length} generation(s), sample entry ${sampleBytes} bytes)`);
+log(`wrote ${out} (${built} entries across ${generationIndex.length} generation(s), sample entry ${sampleBytes} bytes)`);
 
 // ---------------------------------------------------------------------------
 // § 4.3 acceptance - "a unit-ish self-check asserts that a pool entry,
@@ -313,8 +412,8 @@ log(`wrote ${out} (${built} entries across ${generations.length} generation(s), 
 // ---------------------------------------------------------------------------
 if (args['verify-live']) {
   const apiBaseUrl = String(args['verify-live']).replace(/\/$/, '');
-  const first = generations[0].entries[0];
-  const firstGenTimestamp = generations[0].timestampMs;
+  const first = entries[0];
+  const firstGenTimestamp = first.timestampMs;
   const url = `${apiBaseUrl}/webhooks/${provider}/${connectionId}`;
   log(`--verify-live: POSTing entry eventId=${first.eventId} to ${url}`);
   const res = await fetch(url, {

--- a/perf/openlinker-throughput/drivers/webhook-burst.js
+++ b/perf/openlinker-throughput/drivers/webhook-burst.js
@@ -36,6 +36,7 @@ import http from 'k6/http';
 import { check } from 'k6';
 import { Trend, Counter } from 'k6/metrics';
 import exec from 'k6/execution';
+import { SharedArray } from 'k6/data';
 
 function readEnv(name, fallback) {
   const v = __ENV[name];
@@ -60,19 +61,55 @@ const RAMP_DOWN_SECS = Number(readEnv('RAMP_DOWN_SECS', '5'));
 const PRE_ALLOCATED_VUS = Number(readEnv('PRE_ALLOCATED_VUS', '20'));
 const MAX_VUS = Number(readEnv('MAX_VUS', '100'));
 
-// `open()` only works in the init context (top-level module scope) - loaded
-// once per VU. A `SharedArray` would dedupe this across VUs, but the pool
-// object here is `{ meta, generations: [...] }`, not a flat array, and
-// SharedArray requires a flat-array-returning function; keeping the plain
-// per-VU parse is a stated, honest limitation (see the scenario README
-// section this driver is documented under) rather than a silent one - on the
-// PRE_ALLOCATED_VUS/MAX_VUS scale this scenario runs at, the duplication cost
-// is bytes-of-JSON times tens of VUs, not a real constraint.
-const pool = JSON.parse(open(POOL_FILE));
+// Loaded ONCE, not once per VU (#2931). Two things had to change together to
+// get there, both verified live against the pinned grafana/k6:1.0.0 image:
+//
+// 1. `SharedArray` - k6's own answer to "parse this once, share it read-only
+//    across every VU". A plain `JSON.parse(open(POOL_FILE))` here (the
+//    pre-#2931 shape) gave every VU its OWN parsed copy of the whole pool,
+//    so memory grew as pool-bytes times VU count - confirmed as the cause of
+//    two real OOM kills at the 1000/s tier (results-F3-2026-09-06.md).
+//
+// 2. A FLAT entries array. `SharedArray` genuinely shares a flat array of
+//    plain objects, but the pre-#2931 pool shape was
+//    `{ meta, generations: [ { timestampMs, entries: [...] } ] }` - an array
+//    of objects each holding a NESTED array. Measured live: wrapping that
+//    nested shape in a `SharedArray` did NOT hold memory flat as VU count
+//    rose (5 VUs -> ~730 MB; 50 VUs -> ~5.2 GB; 150 VUs -> OOM-killed at a
+//    3 GB cgroup limit) - each VU still ends up materializing its own copy
+//    of every nested sub-array it indexes into. Flattening `entries` (one
+//    array, no nesting - `timestampMs` denormalized onto EACH entry instead
+//    of living once on a wrapping generation object) and sharing THAT
+//    measured flat regardless of VU count (5 VUs and 150 VUs both landed
+//    within a few percent of each other - see presign-webhooks.mjs's own
+//    pre-flight-budget comment for the exact figures this drove).
+//
+// `generationIndex` stays a SEPARATE, small `SharedArray` rather than being
+// folded into a per-entry field, because a VU still needs O(1) access to
+// "which contiguous slice of `entries` belongs to generation g" on every
+// single request - scanning 90 000 entries by `timestampMs` per HTTP call
+// would spend k6's own CPU on work this driver exists specifically to avoid
+// (see the file header: k6 must never contend with the api for CPU).
+//
+// Both `SharedArray` constructors read `POOL_FILE` independently rather than
+// sharing one parse - each is a self-contained, one-time cost (not
+// VU-scaled), which is simpler and safer than trying to smuggle a second
+// value out of one SharedArray's constructor via a closure side effect.
+const generationIndex = new SharedArray('webhook_burst_generation_index', function () {
+  const pool = JSON.parse(open(POOL_FILE));
+  if (!pool.generationIndex || pool.generationIndex.length === 0) {
+    throw new Error(`webhook-burst.js: pool at ${POOL_FILE} carries no generationIndex`);
+  }
+  return pool.generationIndex;
+});
 
-if (!pool.generations || pool.generations.length === 0) {
-  throw new Error(`webhook-burst.js: pool at ${POOL_FILE} carries no generations`);
-}
+const entries = new SharedArray('webhook_burst_entries', function () {
+  const pool = JSON.parse(open(POOL_FILE));
+  if (!pool.entries || pool.entries.length === 0) {
+    throw new Error(`webhook-burst.js: pool at ${POOL_FILE} carries no entries`);
+  }
+  return pool.entries;
+});
 
 // One Trend per ARM (plan § 3.3 - "never averaged": `unique`, `replay-committed`
 // and `replay-concurrent` measure different things - one lock-free, one fully
@@ -121,19 +158,21 @@ export const options = {
 };
 
 /**
- * Pick the generation whose timestamp is legal for THIS moment in the run
- * (plan § 3.2). Elapsed time is measured against RUN_START_MS - the same
+ * Pick the generation slice whose timestamp is legal for THIS moment in the
+ * run (plan § 3.2). Elapsed time is measured against RUN_START_MS - the same
  * instant the pre-signer used to build generation 0's timestamp - so a
  * request fired at elapsed=90s picks generation 1 (timestamp = start + 60s),
  * which is within the ±120s default skew window of "now" for the whole time
- * generation 1 is in use.
+ * generation 1 is in use. Returns `{ timestampMs, startIndex, count }` - a
+ * slice into the flat `entries` SharedArray (#2931), not an object holding
+ * its own copy of the entries.
  */
 function pickGeneration() {
   const elapsedMs = Date.now() - RUN_START_MS;
   let g = Math.floor(elapsedMs / GEN_INTERVAL_MS);
   if (g < 0) g = 0;
-  if (g >= pool.generations.length) g = pool.generations.length - 1;
-  return pool.generations[g];
+  if (g >= generationIndex.length) g = generationIndex.length - 1;
+  return generationIndex[g];
 }
 
 export default function () {
@@ -141,16 +180,16 @@ export default function () {
   // `iterationInTest` is a monotonically increasing counter across every VU
   // for this scenario (k6/execution) - a global sequential index with no
   // shared mutable state to race on, which is exactly what "replay bytes,
-  // compute nothing" needs. Modulo into the CURRENT generation's own entry
-  // list - not the whole pool - so an entry is never replayed from a
+  // compute nothing" needs. Modulo into the CURRENT generation's own slice
+  // of `entries` - not the whole pool - so an entry is never replayed from a
   // generation whose timestamp is not the one legal for this moment.
-  const idx = exec.scenario.iterationInTest % gen.entries.length;
-  const entry = gen.entries[idx];
+  const idx = gen.startIndex + (exec.scenario.iterationInTest % gen.count);
+  const entry = entries[idx];
 
   const res = http.post(TARGET_URL, entry.body, {
     headers: {
       'Content-Type': 'application/json',
-      'X-OpenLinker-Timestamp': String(gen.timestampMs),
+      'X-OpenLinker-Timestamp': String(entry.timestampMs),
       'X-OpenLinker-Signature': entry.signature,
     },
     tags: { arm: ARM },


### PR DESCRIPTION
Closes #2931. Based on **`2842-f3-webhook-burst`** (#2922) - review against the stack tip.

## Why this blocks the sweep

The F3 driver `open()`s a JSON pool of pre-signed webhook payloads at init scope, and **every virtual user parsed its own copy**. At the 1 000/s tier the pool reaches 40 MB and the run needs ~132 VUs; two runs were OOM-killed, confirmed in `dmesg`.

That is why F3's ceiling is reported as *"at least ~600/s"* rather than a number - the generator ran out of memory before the system ran out of throughput, and the two could not be separated.

## `SharedArray` alone was not the fix

This is the useful part. Wrapping the existing nested shape (`{generations: [{timestampMs, entries: [...]}]}`) in a `SharedArray` **still grew with VU count**:

```
5 VUs   -> ~730 MB
50 VUs  -> ~5.2 GB
150 VUs -> OOM against a 3 GB limit
```

goja does not share nested sub-arrays. The pool had to be **flattened** as well: one flat `entries` array with the timestamp denormalised onto each entry, plus a small `generationIndex` of `{timestampMs, startIndex, count}` slice boundaries. The driver loads both as independent `SharedArray`s and does an O(1) slice lookup instead of scanning.

## Measured, not asserted

Real driver, real 62.8 MB / 90 000-entry pool, against a dead port so the figure isolates pool memory from network behaviour:

| VUs | Peak container RSS |
|---|---|
| 5 | ~517 MB |
| **150** | **~501 MB** |

**Flat within 3% across a 30x change in VU count** - which is the property #2931 asks for. A single successful run would only have shown the symptom gone, not the cause. For contrast, the pre-change driver with the same pool and a 2 GB limit was OOM-killed with 5 of 20 VUs initialised.

## The pre-flight refusal

The harness now projects the pool's resident size from one real signed sample and **refuses before doing any signing work** if that exceeds a margined fraction of free host memory, naming both numbers:

```
need ~636.1 MB resident, only 1.0 MB budgeted
```

Discovering the limit through the OOM killer gives an operator nothing to act on. A refusal that states the shortfall does.

## Both load-bearing properties survive

Neither was negotiable:

- signing still goes through `apps/e2e/src/support/webhooks.ts` rather than restating the HMAC scheme
- `grep -c 'hmac\|crypto'` on the k6 driver is still **0**, so the generator does not contend with the API it measures for CPU on an unpinned host

## What this does not do

**The harness-level 1 000/s re-run is not done.** It was blocked by `guard_build`, correctly - another agent's uncommitted `apps/api` changes were in the tree, so the running image no longer matched it and the guard refused to measure. The driver-level measurements above establish the memory physics; re-taking the F3 sweep and updating its report remains open and is called out rather than folded in quietly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UWquhyubMheRRqdq7hDsZ7
