### PR TITLE
fix(prestashop-module): load WebhookSender before scheduleFastPathDrain() calls it (#2962)

### DIFF
--- a/apps/prestashop-module/openlinker/openlinker.php
+++ b/apps/prestashop-module/openlinker/openlinker.php
@@ -2243,17 +2243,9 @@ class OpenLinker extends CarrierModule
 
         $classesDir = dirname(__FILE__) . '/classes/';
 
-        // #2962 - this call site referenced WebhookSender without the same
-        // class_exists/require_once guard every OTHER WebhookSender call site
-        // in this module uses, and $classesDir was computed only AFTER the
-        // static call. On a request where nothing had already pulled the class
-        // in, that is a fatal "Class WebhookSender not found" raised straight
-        // out of hookActionValidateOrderAfter / hookActionUpdateQuantity -
-        // aborting the shop's own order validation and stock-change hooks, not
-        // merely OpenLinker's outbox drain, and invisible from OpenLinker's
-        // side (no job, no delivery row). Whether it fires depends on autoload
-        // state, which is why it is route- and load-dependent rather than
-        // deterministic.
+        // #2962 - without this guard, a request where nothing has autoloaded
+        // WebhookSender yet fatals here, aborting hookActionValidateOrderAfter/
+        // hookActionUpdateQuantity; $classesDir must stay hoisted above this call.
         if (!class_exists('WebhookSender')) {
             require_once($classesDir . 'WebhookSender.php');
         }

--- a/apps/prestashop-module/openlinker/openlinker.php
+++ b/apps/prestashop-module/openlinker/openlinker.php
@@ -2241,11 +2241,26 @@ class OpenLinker extends CarrierModule
         }
         self::$fastPathDrainScheduled = true;
 
+        $classesDir = dirname(__FILE__) . '/classes/';
+
+        // #2962 - this call site referenced WebhookSender without the same
+        // class_exists/require_once guard every OTHER WebhookSender call site
+        // in this module uses, and $classesDir was computed only AFTER the
+        // static call. On a request where nothing had already pulled the class
+        // in, that is a fatal "Class WebhookSender not found" raised straight
+        // out of hookActionValidateOrderAfter / hookActionUpdateQuantity -
+        // aborting the shop's own order validation and stock-change hooks, not
+        // merely OpenLinker's outbox drain, and invisible from OpenLinker's
+        // side (no job, no delivery row). Whether it fires depends on autoload
+        // state, which is why it is route- and load-dependent rather than
+        // deterministic.
+        if (!class_exists('WebhookSender')) {
+            require_once($classesDir . 'WebhookSender.php');
+        }
+
         if (!WebhookSender::fastPathAvailable()) {
             return;
         }
-
-        $classesDir = dirname(__FILE__) . '/classes/';
 
         register_shutdown_function(function () use ($classesDir) {
             // Flush and close the buyer's connection now. Everything below

--- a/apps/prestashop-module/openlinker/tests/Unit/FastPathDrainWebhookSenderGuardTest.php
+++ b/apps/prestashop-module/openlinker/tests/Unit/FastPathDrainWebhookSenderGuardTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Regression test for #2962: scheduleFastPathDrain() referenced
+ * WebhookSender::fastPathAvailable() without the class_exists/require_once
+ * guard every other WebhookSender call site in openlinker.php uses. On a
+ * request where nothing had already autoloaded the class, that fataled
+ * straight out of hookActionValidateOrderAfter / hookActionUpdateQuantity -
+ * silent at runtime, so (like ModuleHookRegistrationTest) this reads the
+ * source rather than executing the module.
+ */
+class FastPathDrainWebhookSenderGuardTest extends TestCase
+{
+    /** @var string */
+    private static $source;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$source = file_get_contents(dirname(__DIR__, 2) . '/openlinker.php');
+    }
+
+    private function methodBody(string $signature): string
+    {
+        $start = strpos(self::$source, $signature);
+        self::assertNotFalse($start, $signature . ' not found');
+
+        return substr(self::$source, $start, 2000);
+    }
+
+    public function testScheduleFastPathDrainLoadsWebhookSenderBeforeFirstStaticReference(): void
+    {
+        $body = $this->methodBody('public static function scheduleFastPathDrain()');
+
+        $guardPos = strpos($body, "class_exists('WebhookSender')");
+        $callPos = strpos($body, 'WebhookSender::');
+
+        self::assertNotFalse($guardPos, 'scheduleFastPathDrain() no longer guards WebhookSender with class_exists');
+        self::assertNotFalse($callPos, 'scheduleFastPathDrain() no longer references WebhookSender::');
+        self::assertLessThan(
+            $callPos,
+            $guardPos,
+            'WebhookSender is referenced before the class_exists guard in scheduleFastPathDrain() - this fatals on any request where nothing has autoloaded it yet (#2962)'
+        );
+    }
+
+    public function testScheduleFastPathDrainComputesClassesDirBeforeUsingIt(): void
+    {
+        $body = $this->methodBody('public static function scheduleFastPathDrain()');
+
+        $classesDirPos = strpos($body, '$classesDir = dirname(__FILE__)');
+        $usePos = strpos($body, '$classesDir . ');
+
+        self::assertNotFalse($classesDirPos, '$classesDir assignment not found in scheduleFastPathDrain()');
+        self::assertNotFalse($usePos, '$classesDir is never used in scheduleFastPathDrain()');
+        self::assertLessThan(
+            $usePos,
+            $classesDirPos,
+            '$classesDir is used before it is assigned in scheduleFastPathDrain() (#2962)'
+        );
+    }
+}


### PR DESCRIPTION
## What changed and why

`OpenLinker::scheduleFastPathDrain()` called `WebhookSender::fastPathAvailable()` without the
`class_exists` / `require_once` guard **every other** `WebhookSender` call site in the module uses,
and computed `$classesDir` only *after* the static call.

On any request where nothing had already autoloaded the class, that is a fatal
`Class "WebhookSender" not found` raised straight out of `hookActionValidateOrderAfter` and
`hookActionUpdateQuantity` — so it aborts the **shop's own** order validation and stock-change
hooks, not merely OpenLinker's outbox drain. It is invisible from OpenLinker's side: no job, no
webhook delivery row, nothing in the OL UI.

Whether it fires depends on autoload state, which is why it is route- and load-dependent rather
than deterministic — and why it survived review.

The fix hoists `$classesDir` above the call and adds the same guard. 12 added lines, no behaviour
change beyond the guard.

## How to test

```
pnpm test:php
```

Or exercise a checkout on a shop with the module installed and confirm `hookActionValidateOrderAfter`
completes.

## Provenance

Found while reviewing #2809 and originally written on that branch. Split out here on the reviewer's
request: a PHP fatal in the order hook deserves its own reviewable change rather than riding inside
a frontend PR.

## Related issues

Closes #2962.

🤖 Generated with [Claude Code](https://claude.com/claude-code)