### PR TITLE
DX: run the Allegro stub on the lab network, measure F2's marketplace-write hop

### DIFF
--- a/.env.lab.example
+++ b/.env.lab.example
@@ -47,6 +47,15 @@ WOOCOMMERCE_MYSQL_HOST_PORT=19307
 PRESTASHOP_HOST_PORT=19080
 WOOCOMMERCE_HOST_PORT=19082
 API_HOST_PORT=19000
+ALLEGRO_STUB_HOST_PORT=19081
+
+# --- Allegro stub (#2856, wired onto this stand by #2935) - per-endpoint
+# latency, measured against the real Allegro sandbox (#2861, see
+# perf/openlinker-throughput/results-allegro-latency-2026-09-05.md). Both
+# default to that report's p50 figures; override only to deliberately
+# re-run F1/F2 against a different pacing assumption. ---
+ALLEGRO_STUB_LATENCY_EVENTS_MS=276
+ALLEGRO_STUB_LATENCY_CHECKOUT_MS=1106
 
 # --- Measurement-hygiene posture (perf/openlinker-throughput/lib.sh's guard
 # table). F3 needs the runner OFF; a mixed-workload campaign flips this back

--- a/docker-compose.lab.yml
+++ b/docker-compose.lab.yml
@@ -277,6 +277,74 @@ services:
     # No published port - reachable only on the `lab` compose network, at
     # https://wc-tls (the OpenLinker WooCommerce connection's siteUrl).
 
+  # Allegro upstream stub (#2856, wired onto this stand by #2935) - a
+  # single-process node:http stand-in for the two Allegro Public API
+  # endpoints on the order-ingestion path, so `bootstrap.sh`'s
+  # `perf-allegro-a` / `perf-allegro-b` connections have something real to
+  # reach instead of a DNS name nothing answers. Built locally (not reused
+  # from `ol-perf:*`) - `perf/openlinker-throughput/stubs/allegro` carries
+  # its own Dockerfile and zero dependencies (node:http/crypto/url only), so
+  # there is nothing to gain from routing it through the multi-stage root
+  # build. Reachable from `lab-api`/`lab-worker` at `http://allegro-stub:8080`
+  # (`bootstrap.sh`'s `ALLEGRO_STUB_URL` default) - service name, not
+  # container name, is what compose's embedded DNS resolves.
+  allegro-stub:
+    build:
+      context: ./perf/openlinker-throughput/stubs/allegro
+      args:
+        # Best-effort only - a `docker build` outside a git checkout (or a
+        # dirty tree) still succeeds; the stub's own `/__stub/config`
+        # reports whatever this resolves to, `unknown` included.
+        STUB_GIT_SHA: '${STUB_GIT_SHA:-unknown}'
+    container_name: lab-allegro-stub
+    environment:
+      STUB_PORT: '8080'
+      # Matches bootstrap.sh's ALLEGRO_A_ID / ALLEGRO_B_ID connection
+      # credentials (`stub-token-a` / `stub-token-b`) and tenant names
+      # (`perf-allegro-a` / `perf-allegro-b`) - this is also server.mjs's own
+      # default, restated here rather than omitted so the pairing is visible
+      # in one file instead of two.
+      STUB_TENANTS: 'stub-token-a=perf-allegro-a,stub-token-b=perf-allegro-b'
+      # Must equal bootstrap.sh's ALLEGRO_OFFER_POOL_SIZE (default 200) -
+      # see stubs/allegro/README.md "The offer-id contract with #2860".
+      STUB_OFFER_POOL_SIZE: '${ALLEGRO_OFFER_POOL_SIZE:-200}'
+      # Per-endpoint latency, set from the real Allegro sandbox measurement
+      # (#2861, perf/openlinker-throughput/results-allegro-latency-2026-09-05.md
+      # Result 1/2, p50 - never the mean, see that report for why). A stub
+      # answering instantly would measure only OpenLinker's own local
+      # overhead; these two constants are what makes a run against it
+      # externally meaningful rather than merely self-consistent. Neither
+      # value is a distribution (both endpoints were measured as
+      # multi-modal, not a single spread) - this remains a known,
+      # documented limitation of a single constant per endpoint, not a
+      # claim of a realistic latency profile.
+      STUB_LATENCY_EVENTS_MS: '${ALLEGRO_STUB_LATENCY_EVENTS_MS:-276}'
+      STUB_LATENCY_CHECKOUT_MS: '${ALLEGRO_STUB_LATENCY_CHECKOUT_MS:-1106}'
+      # `STUB_LATENCY_QUANTITY_MS` (the #2935 write-path endpoint) is
+      # DELIBERATELY left unset here, not merely undocumented - #2861 never
+      # measured this endpoint (its scope was order-ingestion only), so
+      # there is no defensible sandbox p50 to cite the way the two above
+      # have. Setting a number anyway would be exactly the "the mock is now
+      # the model" trap #2840 names by name. Leaving it unset makes the
+      # stub fall back to its own generic `STUB_PER_REQUEST_LATENCY_MS`
+      # default (120ms) and reports that honestly via
+      # `/__stub/config`'s `latency.quantityMsMeasured: false` - set the env
+      # var explicitly only if a future sandbox probe (a #2861-shaped
+      # follow-up) actually measures this endpoint.
+    ports:
+      # Published so a scenario/driver script (running on the HOST, not
+      # inside a container) can reach the `/__stub/*` control surface
+      # directly - e.g. `POST /__stub/tenants/perf-allegro-a/orders` to push
+      # a synthetic order. `lab-api`/`lab-worker` never use this published
+      # port; they resolve the service name on the internal network.
+      - '127.0.0.1:${ALLEGRO_STUB_HOST_PORT:-19081}:8080'
+    healthcheck:
+      test: ['CMD', 'wget', '-q', '-O', '-', 'http://127.0.0.1:8080/__stub/health']
+      interval: 5s
+      timeout: 3s
+      retries: 5
+      start_period: 2s
+
   # One-shot schema bootstrap. Runs the SAME compiled data-source the api/
   # worker processes use (apps/api/dist/apps/api/src/database/data-source.js),
   # invoked directly through the typeorm CLI binary already in

--- a/perf/openlinker-throughput/bootstrap.sh
+++ b/perf/openlinker-throughput/bootstrap.sh
@@ -387,13 +387,36 @@ JSON
   # so ensureFreshToken short-circuits and no request is ever made to the
   # hardcoded real allegro.pl token host (#2856).
   #
-  # enabledCapabilities is OrderSource only. Adding OfferManager would arm
-  # marketplace.offers.sync, whose task declares no requiredCapability, turning
-  # a clean 404 into a retryable CapabilityNotEnabledException that burns ten
-  # attempts (#2856).
+  # enabledCapabilities carries OfferManager too, since #2935 (the stub is now
+  # a real service on this stand - ALLEGRO_STUB_URL resolves). This is safe
+  # under exactly ONE precondition, which this stand's own default already
+  # satisfies and F2/F1/F6 must each verify for themselves via
+  # `guard_scheduler_off`: the scheduler must stay OFF (remedy 1 of the two
+  # #2935 names).
+  #
+  # Why that precondition is load-bearing - verified against the actual code,
+  # not assumed: `allegro-offers-sync`'s scheduler task (jobType
+  # marketplace.offers.sync) declares no `requiredCapability`, so it is
+  # enqueued for every ACTIVE allegro connection on every tick regardless of
+  # `enabledCapabilities` - capability is checked only once the job runs, via
+  # `getCapabilityAdapter`. With OfferManager DISABLED, that throws the core
+  # `CapabilityNotEnabledException`, which no platform retry classifier
+  # recognises (each one only owns its own platform's exception hierarchy -
+  # `retry-classifier-registry.service.ts`) - so it is retryable BY DEFAULT
+  # and burns the full ten-attempt ladder, every tick, for ever. With
+  # OfferManager ENABLED the capability check passes and the job actually
+  # reaches the stub - which does not serve `/sale/offer-events` (#2856 scoped
+  # the stub to the two order-ingestion endpoints only) - and gets a fast,
+  # zero-latency, Allegro-shaped 404, which Allegro's OWN classifier already
+  # treats as non-retryable (`allegro-retry-classifier.adapter.ts`,
+  # `NON_RETRYABLE_STATUS_CODES`). So the capability state does not decide
+  # whether a burn-ten-attempts failure CAN happen here - the scheduler does:
+  # with it off (this stand's default, `OL_SCHEDULER_ENABLED=false` on every
+  # worker container), the task is never enqueued at all and neither branch
+  # above is ever reached, whatever `enabledCapabilities` says.
   ol_ensure_connection ALLEGRO_A_ID 'perf-allegro-a' "$(cat <<JSON
 {"name":"perf-allegro-a","platformType":"allegro",
- "enabledCapabilities":["OrderSource"],
+ "enabledCapabilities":["OrderSource","OfferManager"],
  "config":{"environment":"production","apiBaseUrl":"$ALLEGRO_STUB_URL"},
  "credentials":{"accessToken":"stub-token-a"}}
 JSON
@@ -401,7 +424,7 @@ JSON
 
   ol_ensure_connection ALLEGRO_B_ID 'perf-allegro-b' "$(cat <<JSON
 {"name":"perf-allegro-b","platformType":"allegro",
- "enabledCapabilities":["OrderSource"],
+ "enabledCapabilities":["OrderSource","OfferManager"],
  "config":{"environment":"production","apiBaseUrl":"$ALLEGRO_STUB_URL"},
  "credentials":{"accessToken":"stub-token-b"}}
 JSON
@@ -431,6 +454,38 @@ JSON
  "credentials":{"webserviceApiKey":"${PS_WS_KEY:-}"}}
 JSON
 )"
+}
+
+# ---------------------------------------------------------------------------
+# Step 5b (#2935) - ensure OfferManager on Allegro connections created by an
+# EARLIER bootstrap run.
+#
+# `ol_ensure_connection` is create-only (see its own docblock) - it never
+# updates an existing row, so a connection created before #2935 landed
+# (`enabledCapabilities: ["OrderSource"]` only) would otherwise never gain
+# OfferManager just because this script was re-run. This step is the PATCH
+# half: idempotent, and safe under the same precondition step_connections'
+# own comment states - the scheduler must stay off (verified independently
+# by every scenario's own `guard_scheduler_off`, not by this script, which
+# has no container access to check it).
+# ---------------------------------------------------------------------------
+ensure_offer_manager() {
+  local conn_id="$1" tenant="$2" caps has_it
+  [ -n "$conn_id" ] || { warn "no connection id for tenant $tenant - skipping OfferManager check"; return 0; }
+  caps="$(ol_api GET "/v1/connections/$conn_id" | jq -r '(.enabledCapabilities // []) | join(",")')"
+  has_it="$(printf '%s' "$caps" | grep -c '\bOfferManager\b' || true)"
+  if [ "${has_it:-0}" -ge 1 ]; then found "OfferManager on $tenant"; return 0; fi
+  if [ "$VERIFY_ONLY" = 1 ]; then gap "OfferManager not enabled on $tenant (has: ${caps:-<none>})"; return 0; fi
+  would "enable OfferManager on $tenant (has: ${caps:-<none>})" && return 0
+  ol_api PATCH "/v1/connections/$conn_id" "$(jq -cn --arg caps "$caps" \
+    '{enabledCapabilities: (($caps | split(",") | map(select(length > 0))) + ["OfferManager"])}')" >/dev/null
+  created "OfferManager enabled on $tenant"
+}
+
+step_allegro_offer_manager() {
+  log "--- Allegro OfferManager capability ---"
+  ensure_offer_manager "${ALLEGRO_A_ID:-}" 'perf-allegro-a'
+  ensure_offer_manager "${ALLEGRO_B_ID:-}" 'perf-allegro-b'
 }
 
 # ---------------------------------------------------------------------------
@@ -558,6 +613,7 @@ main() {
   step_tax_group
   step_woocommerce
   step_connections
+  step_allegro_offer_manager
   step_offer_mappings
   step_verify_connections
 

--- a/perf/openlinker-throughput/drivers/f2-summarize.py
+++ b/perf/openlinker-throughput/drivers/f2-summarize.py
@@ -12,8 +12,10 @@ verified live against this stand to run UTC (matches Postgres NOW() and the
 host's own `date -u`) - so it is parsed as naive-UTC. Every OL-side
 timestamp (`webhook_delivery_created_utc`, `inv_job_created_utc`,
 `inventory_items_max_updated_utc`, `propagate_job_created_utc`,
-`offer_child_created_utc`) is a Postgres `timestamptz` string and carries
-its own `+00` offset. `outbox_created_local` (PHP `date()`) is Europe/Paris
+`offer_child_created_utc`, `offer_child_completed_utc`) is a Postgres
+`timestamptz` string (`sync_jobs.createdAt`/`updatedAt` are both declared
+`type: 'timestamptz'`) and carries its own `+00` offset.
+`outbox_created_local` (PHP `date()`) is Europe/Paris
 and is NOT used for any hop math here - see the scenario script's own
 header for why comparing it against the UTC columns without correction
 would be off by the DST offset.
@@ -117,7 +119,7 @@ def main():
         for product, cycle, count in contaminated_rows:
             print(f"  product={product} cycle={cycle} offer_children_count={count}")
 
-    hopA, hopB, hopC, hopD, hopE, hopF, total_to_ol, total_to_enqueue = [], [], [], [], [], [], [], []
+    hopA, hopB, hopC, hopD, hopE, hopF, hopG, total_to_ol, total_to_enqueue, total_to_answer = [], [], [], [], [], [], [], [], [], []
     inv_counts = []
     offer_children = []
     inv_job_terminal = {}
@@ -135,6 +137,10 @@ def main():
         inv_max_updated = parse_pg_ts(r.get('inventory_items_max_updated_utc'))
         prop_created = parse_pg_ts(r.get('propagate_job_created_utc'))
         offer_created = parse_pg_ts(r.get('offer_child_created_utc'))
+        # Absent on a CSV produced before #2935 (the column did not exist) -
+        # parse_pg_ts(None) returns None, so hopG/total_to_answer simply have
+        # n=0 on an old file rather than raising.
+        offer_completed = parse_pg_ts(r.get('offer_child_completed_utc'))
 
         if t0 is not None and t1 is not None:
             hopA.append(t1 - t0)
@@ -162,13 +168,28 @@ def main():
             pass
         if contaminated:
             offer_created = None
+            offer_completed = None
 
         if prop_created is not None and offer_created is not None:
             hopF.append(ms(offer_created) - ms(prop_created))
+        # Hop G (#2935): child enqueued -> child reached a terminal status
+        # (succeeded or dead). This is the hop that used to be entirely
+        # absent ("not measured") because both Allegro connections had
+        # OfferManager disabled, so the child died at capability resolution
+        # before any network call. See the scenario script's own comment
+        # at this hop for exactly what it does and does not establish -
+        # in short, real dispatch + HTTP-client + network overhead against
+        # a marketplace-shaped upstream, NOT a genuine marketplace
+        # acknowledgement (the stub's quantity-write endpoint is
+        # deliberately unserved, so every child in this sample failed).
+        if offer_created is not None and offer_completed is not None:
+            hopG.append(ms(offer_completed) - ms(offer_created))
         if t0 is not None and inv_max_updated is not None:
             total_to_ol.append(ms(inv_max_updated) - t0)
         if t0 is not None and offer_created is not None:
             total_to_enqueue.append(ms(offer_created) - t0)
+        if t0 is not None and offer_completed is not None:
+            total_to_answer.append(ms(offer_completed) - t0)
 
         if r.get('inventory_items_updated_count'):
             try:
@@ -193,9 +214,11 @@ def main():
     report_hop("Hop D  OL commit -> inventory_items updated (job pickup + PS webservice re-read + write)", hopD)
     report_hop("Hop E  inventory_items updated -> inventory.propagateToMarketplaces enqueued", hopE)
     report_hop("Hop F  propagate enqueued -> marketplace.offerQuantity.update child enqueued", hopF)
+    report_hop("Hop G  child enqueued -> child reached a terminal status (dispatch + HTTP round-trip to the Allegro stub's write endpoint - see Hop 5 section for what this does/does not establish)", hopG)
     print()
     report_hop("TOTAL  stock write -> landed in OL's own inventory_items", total_to_ol)
-    report_hop("TOTAL  stock write -> marketplace.offerQuantity.update child enqueued (NOT delivered - see Hop 5 section)", total_to_enqueue)
+    report_hop("TOTAL  stock write -> marketplace.offerQuantity.update child enqueued", total_to_enqueue)
+    report_hop("TOTAL  stock write -> marketplace.offerQuantity.update child answered (stub ACCEPT, not a genuine sandbox round-trip - see Hop 5 section)", total_to_answer)
     print()
     if inv_counts:
         print(f"inventory_items rows touched per event: n={len(inv_counts)} min={min(inv_counts)} max={max(inv_counts)} (1 for simple products, up to the combination count for 22/23/24)")

--- a/perf/openlinker-throughput/results-F2-2026-09-06.md
+++ b/perf/openlinker-throughput/results-F2-2026-09-06.md
@@ -1,0 +1,198 @@
+# F2 - stock propagation latency
+
+_generated 2026-09-06T21:33:12Z, run group run1788730196_
+
+## Conditions
+
+- Stand: `lab` (docker-compose.lab.yml, #2854), a single developer workstation shared with two other OpenLinker docker-compose stacks (`ol-demo-fresh-*`, `openlinker-*`) - no CPU pinning, no isolation from host contention. Every figure below is subject to that.
+- `guard_build` PASSED: running images and the working tree both resolve to `7d4a4fa70116de1b6827c12c022ff45e233ef860`.
+- Runner: ENABLED for this scenario (`guard_runner_state enabled`) - the whole chain is unobservable otherwise. Scheduler: OFF (`guard_scheduler_off`) - the inventory sweep is a second, competing path to the same rows and was deliberately excluded so every observed job is attributable to this scenario's own webhook-triggered writes.
+- 6 products x 1 cycles = 6 stock-write attempts.
+
+## Headline finding: hop t1->t2 is EXCLUDED from this measurement, not measured as fast
+
+This scenario force-drains the outbox after every single write (calls the module's cron controller immediately). That is a deliberate experimental choice - it isolates OpenLinker's OWN work from the shop's delivery cadence, which is the more actionable half of the chain to an operator - but it means **the t1->t2 hop below is NOT a measurement of anything a real deployment experiences; it is excluded by construction.** On a stand shaped exactly like this one, hop t2 in production is bounded below by whatever external cron interval an operator (or a hosting provider's crontab) configures for the module's cron controller - commonly minutes, not the sub-second figure this run reports for it. To reconstruct a real "shop to OpenLinker" figure from the numbers below: take Hop A + Hop C + Hop D + Hop E (+ Hop F/Hop G if you also want the marketplace-write hop, which is a real network round-trip against a stub with an unmeasured-for-this-endpoint latency, never a genuine sandbox figure - see the Hop 5 section) and ADD your own PrestaShop cron interval on top. That addition is the dominant term for almost any real deployment, and this run cannot supply it: nothing on this container's crontab calls the cron controller at all (`crontab -l` is empty), and the module's own response-flush fast path (#2624), which WOULD close this gap automatically, never fires on this image - its SAPI is `apache2handler`/mod_php, and `fastcgi_finish_request()` does not exist there (confirmed live via a throwaway PHP probe served over a real HTTP request: `PHP_SAPI` reports `apache2handler`, `function_exists('fastcgi_finish_request')` reports `false`). **If a deployment runs behind php-fpm instead, hop t2 collapses toward zero automatically via the fast path** - that is a real, actionable, deployment-shape-dependent fact this stand happens to be positioned to demonstrate, precisely because it is NOT running php-fpm.
+
+## Why the earlier 2-of-25 trial undercounted (root-caused, not guessed)
+
+Two independent, verified mechanisms explain it, and the webservice-API attempt made it worse than either alone would:
+
+1. **The PrestaShop REST webservice cannot fire the hook at all on this PrestaShop version.** `stock_availables` PUT is dispatched generically onto `ObjectModel::update()` (`classes/webservice/WebserviceRequest.php:332`), never through the static `StockAvailable::setQuantity()` helper that is the only call site of `Hook::exec('actionUpdateQuantity', ...)` in PrestaShop 9.0.2 core (`classes/stock/StockAvailable.php:454-455`). Verified live on this stand: a real webservice `PUT` with a genuinely changed quantity returns HTTP 200 and inserts zero outbox rows.
+2. **A dedup key survives until the row is CLAIMED, not until it is delivered.** `OutboxRepository::enqueueEvent` derives `dedup_key` from `(provider, connectionId, eventType, objectType, externalId)` - it does not include the timestamp or the new quantity - and `INSERT IGNORE` collides on it. The key is cleared only when the drainer *claims* a row (moves it to `processing`), not when it is delivered. Verified live: two `StockAvailable::setQuantity()` calls for the SAME product id, made before any drain, produced exactly ONE outbox row; the second call silently no-opped. With only 6 distinct products on this catalogue, a burst of writes made faster than the drain cadence collapses onto at most 6 rows - independent of how many individual stock_available rows (combinations) were actually touched.
+
+This scenario avoids both: it drives t0 through `StockAvailable::setQuantity()` directly (drivers/ps-set-quantity.php), and it drains after every single write, so every cycle claims its own row before the next write for that product can be silently swallowed.
+
+## Root-caused: `drain_http_status` reads 500 on every cycle, and the hop timings do not depend on it
+
+Every cycle's cron-drain call returns HTTP 500 - verified NOT to be a delivery failure, and not trusted on faith: the same request that returns 500 also carries a fully-formed, ACCURATE JSON body (`{"processed":1,"delivered":1,"failed":0,...}`), and the outbox row it was meant to deliver reaches `delivered_at` at that exact same second, every time. The cause is unrelated to the module entirely: PrestaShop's `FrontController::display()` runs its normal asset-pipeline step AFTER the module's own `initContent()` has already echoed the JSON body (the controller never calls `exit`), and that step throws `MatthiasMullie\Minify\Exceptions\IOException: The file "/var/www/html/themes/classic/assets/cache/theme-3f744e.css" could not be opened for writing` - a container filesystem-permission gap on the theme asset cache directory, confirmed by matching the Apache error-log timestamp to the exact same request's access-log line and to the outbox row's own `delivered_at`. **Because of this, no hop in this report is computed from `drain_http_status` or from the cron controller's HTTP response at all** - every hop is computed from PrestaShop's own `ps_openlinker_webhook_outbox.delivered_at` column (the ground truth of whether delivery happened) and from OpenLinker's own `webhook_deliveries`/`sync_jobs`/`inventory_items` timestamps, never from a status line. `drain_http_status` is still recorded verbatim in `cycles.csv` as a data point, precisely so this claim is checkable rather than asserted.
+
+## Per-hop latency (measured, ms; sample sizes stated per row)
+
+**Hop G is a real network round-trip against a marketplace-shaped upstream, not a genuine Allegro-sandbox figure.** See the Hop 5 section below for exactly what it does and does not establish, and see the Headline Finding above for why Hop B is an excluded floor, not a shop-cron estimate.
+
+```
+total rows: 6
+rows with NO outbox row at all (guard/dedup swallowed the write, or hook did not fire): 0 / 6
+
+Hop A  write (StockAvailable::setQuantity) -> outbox row inserted (same PHP call): n=6 min=97ms p50=138ms max=187ms p95=177ms
+Hop B  outbox created -> outbox delivered (cron-drain call, harness-controlled cadence): n=6 min=-589ms p50=-302ms max=147ms p95=137ms
+Hop C  outbox delivered -> OL commits webhook_deliveries+sync_jobs (#2280 gate): n=6 min=96ms p50=562ms max=926ms p95=896ms
+Hop D  OL commit -> inventory_items updated (job pickup + PS webservice re-read + write): n=6 min=2689ms p50=3378ms max=8713ms p95=8510ms
+Hop E  inventory_items updated -> inventory.propagateToMarketplaces enqueued: n=6 min=-15ms p50=256ms max=2955ms p95=2448ms
+Hop F  propagate enqueued -> marketplace.offerQuantity.update child enqueued: n=6 min=5013ms p50=5018ms max=5085ms p95=5068ms
+Hop G  child enqueued -> child reached a terminal status (dispatch + HTTP round-trip to the Allegro stub's write endpoint - see Hop 5 section for what this does/does not establish): n=6 min=10033ms p50=10111ms max=10137ms p95=10135ms
+
+TOTAL  stock write -> landed in OL's own inventory_items: n=6 min=3147ms p50=3751ms max=9132ms p95=8922ms
+TOTAL  stock write -> marketplace.offerQuantity.update child enqueued: n=6 min=8664ms p50=9005ms max=16260ms p95=15731ms
+TOTAL  stock write -> marketplace.offerQuantity.update child answered (stub ACCEPT, not a genuine sandbox round-trip - see Hop 5 section): n=6 min=18792ms p50=19085ms max=26355ms p95=25824ms
+
+inventory_items rows touched per event: n=6 min=1 max=3 (1 for simple products, up to the combination count for 22/23/24)
+offerQuantity.update children enqueued per event: n=6 min=2 max=2 (see report's amplification section)
+master.inventory.syncByExternalId terminal status distribution: {'succeeded': 6}
+```
+
+## A methodology bug found and fixed mid-run: writing `id_product_attribute=0` on a product WITH combinations silently changes nothing
+
+An earlier draft of this run wrote every product at `id_product_attribute=0`, uniformly. For the three simple products (20/21/25) that IS the product's only stock position, but for the three products WITH combinations (22/23/24), PrestaShop treats that row as an AGGREGATE it recomputes from the combinations - `PrestashopInventoryMasterAdapter.listInventory` says so directly in its own source: "the id_product_attribute=0 aggregate is ignored - the per-combination rows [are read instead]" (`prestashop-inventory-master.adapter.ts:291-295`), and a separate comment on the SAME file states a direct write there "would be discarded" (`:1011-1012`). So a write to attribute 0 on those three products fired the webhook and re-synced the product (`inv_job outcome: ok`, looking perfectly healthy) while touching NO position OpenLinker's InventoryMaster read actually consults. On the FIRST cycle propagation still fired for every position (every `inventory_items` row was a fresh insert, which the no-change guard always treats as a change); from the SECOND cycle onward, the three unaffected combination products stopped propagating entirely - not a lane-contention stall, a wrong write target. **Fixed** by writing products 22/23/24 at one of their real combination attribute ids instead (22->40, 23->43, 24->45, `product_attr_for()` in this script) - this run's own numbers reflect the fix, and a comment above `product_attr_for()` records the finding for whoever edits this scenario next.
+
+## Enqueue amplification (measured, after the fix above)
+
+- One webhook event per stock-changed **product** (the hook always attributes the event to the product id - `openlinker.php`, "Always use product ID as externalId"), one `master.inventory.syncByExternalId` job per event, one `inventory_items` row upserted per non-stale `ProductVariant` under the product that GENUINELY changed value (`inventory_items_updated_count` in `cycles.csv`).
+- Per changed VARIANT, one `inventory.propagateToMarketplaces` job, which enqueued exactly **2** `marketplace.offerQuantity.update` children (one per Allegro connection) - never 36 (18 synthetic Offer mappings x 2 connections that this stand's bootstrap seed data maps onto every variant, purely so the F1 order-synthesis stub has enough distinct external offer ids to reference), because the enqueue idempotency key (`inventory:{connectionId}:{productId}:{variantId}:{quantity}:{observedAt}`, `inventory-propagate-to-marketplaces.handler.ts`) omits the target offer id and collapses every mapping sharing connection+variant+quantity+timestamp onto one winning enqueue. One variant : one live offer per connection is the guarded production norm (#1837), so the 18->1 collapse is an artifact of reusing F1's seed data for a question it was not built to answer, not a newly-discovered defect.
+
+## Located vs. pooled position shapes
+
+Not applicable on this stand as configured: PrestaShop reports no location dimension for any of the six products (`ps_stock_available.location` is empty on every row, and the adapter never populates `Inventory.locationId` for it), so every position OpenLinker holds for this master is POOLED (`locationId IS NULL`) by construction - there is no #2324/#2325 located-position collapse to observe here, and none is claimed.
+
+## Hop 5 (destination write) - MEASURED as of #2935, and what the figure does and does not mean
+
+`OfferManager` is now ENABLED on both Allegro connections (`perf-allegro-a`/`perf-allegro-b`), and `config.apiBaseUrl` points at a real `allegro-stub:8080` service on this stand's own compose network (#2856/#2876, wired onto `lab` by #2935) - `marketplace.offerQuantity.update` no longer fails at capability resolution before any network call. It reaches the adapter's one synchronous write, `PUT /sale/offer-quantity-change-commands/{id}`, which the stub answers `{id, status: 'ACCEPTED'}` - so Hop G (child enqueued -> child reached a terminal status) below is a REAL measurement of dispatch + HTTP-client + network overhead against a marketplace-shaped upstream, not a job dying at a capability check. **What it still is not**: a genuine Allegro sandbox round-trip - the stub's `/sale/offer-quantity-change-commands/{id}` latency has no #2861-shaped measurement behind it (that probe covered `/order/events` and `/order/checkout-forms/{id}` only), so this hop reports the stub's configured default (120ms, unmeasured for this endpoint - see `stubs/allegro/README.md`), not a real sandbox distribution. It also never learns whether Allegro's OWN eventual, asynchronous application of the quantity change succeeds - #2621 made `updateOfferQuantity` return on ACCEPT rather than a terminal status, and the terminal-status poll is a separate, optional job (`marketplace.offerQuantity.reconcile`) this scenario does not exercise. So "Hop G" / the "child answered" TOTAL below mean exactly that: OpenLinker submitted the write and received a definitive ACCEPT from a marketplace-shaped upstream, in the time that upstream took to answer - never that Allegro's catalogue has actually updated.
+
+## Addendum - Hop G's 10.1s explained (not the stub, not adapter polling)
+
+Hop G's own p50 (10 111 ms) is roughly 9x the 1 106 ms configured for
+`/order/checkout-forms/{id}` and 35x the 276 ms for `/order/events`, which
+is too large to be "one paced request" and needed explaining rather than
+being reported as-is. Investigated directly against the stub's own request
+log and the worker's job log for the same jobs, rather than guessed at:
+
+- **Ruled out: the stub is paced slowly.** The stub's own JSON request log
+  for these exact two calls reads `"latencyMs":120` and `"latencyMs":121` -
+  its configured `STUB_PER_REQUEST_LATENCY_MS` default, applied exactly as
+  designed (this endpoint has no #2861 measurement, see the Hop 5 section
+  above). The stub answered fast; it is not the source of the 10.1s.
+- **Ruled out: the adapter polls the command status repeatedly.** Both the
+  worker's log and the stub's own request log show exactly ONE `PUT` per
+  connection for each event, no `GET` at all - #2621's "returns on ACCEPT,
+  never polls for a terminal status" holds on this path.
+- **What the worker's own log shows instead**: for product 20's pair, the
+  handler logged `Executing marketplace.offerQuantity.update job` at
+  `21:31:15`, but `AllegroOfferManagerAdapter`'s own
+  `Updating Allegro offer quantity` line (immediately before the `PUT`) does
+  not appear until `21:31:20` - a ~5s gap with no log output at all for
+  EITHER connection's job, followed by the ~1.1-1.2s HTTP round-trip
+  (client-measured, consistent with the stub's 120ms server-side answer
+  plus network/event-loop overhead), followed by a further ~4s gap between
+  the adapter logging `status=accepted` and the job's own `sync_jobs` row
+  reaching its terminal timestamp. The two gaps, not the HTTP call, account
+  for essentially all of the 10.1s.
+- **Not resolved to a single named internal step.** Neither connection
+  carries a `config.rateLimit`, and the Allegro manifest declares no
+  `defaultRateLimit` either, so an explicit configured pacing gate is an
+  unlikely explanation; `OFFER_QUANTITY_WRITE_LOCK_TTL_MS` (30s,
+  `offer-quantity-write-order.types.ts`) bounds a possible lock wait but
+  nothing in `InventorySyncService.updateOfferQuantities` sleeps or retries
+  on contention before calling the adapter. The investigation could not go
+  further: the `lab-worker` container was destroyed and recreated (under a
+  compose-generated `lab-worker-1` name, then back to `lab-worker`) by a
+  concurrent agent's own `docker compose` operation on this shared stand
+  partway through, taking its scrollback log history with it before a
+  fuller, unfiltered capture could be taken.
+- **A plausible, disclosed, but unconfirmed contributor**: both of this
+  report's F2 measurement windows (`21:12:59-21:16:23` and
+  `21:30:58-21:33:11` UTC) fall inside a window (`~21:11-23:12` UTC) during
+  which another agent ran `EXPLAIN ANALYZE` against `lab-postgres`'s
+  1M-row table without holding `guard_stand_exclusive` (it hit a sandbox
+  restriction that stopped it sourcing `lib.sh`, and disclosed the fact
+  independently). Every step between the two log lines above - Controls
+  resolution, the per-offer `SyncLockPort` acquire, and the job's own
+  status write - shares that same Postgres instance, so contention there is
+  a plausible contributor to an otherwise-unaccounted, uniformly-sized gap.
+  It is **not confirmed**: `pg_stat_statements` on this instance shows
+  nothing over 1000ms mean/max at the time of writing, which is consistent
+  with either no real contention or with stats having been reset since (a
+  sibling scenario resets stats per its own run). The very tight clustering
+  across all 6 samples (10 033-10 137 ms, ~100ms spread) argues weakly
+  against ad-hoc, variably-timed lock contention and weakly for something
+  closer to a fixed internal wait, but neither reading is verified.
+
+**So: Hop G is reported as an OBSERVED artifact of this stand under
+concurrent load, not a paced-stub figure and not a demonstrated adapter
+behaviour** - the honest middle case the investigation above was asked to
+distinguish. Whoever revisits this hop should re-run it on an otherwise-idle
+stand with `NestLoggerAdapter` at `debug` for `InventorySyncService` and
+`SyncLockPort`, and should NOT quote the p50 above as "the marketplace
+write takes 10 seconds."
+
+## Cleanup and stand state
+
+- **Two stray `marketplace.offerQuantity.update` rows** (one per Allegro
+  connection), created by an earlier `--smoke` invocation before the stub's
+  write endpoint existed, were found retrying (`status=queued`,
+  `attempts=4`) against a deterministic 404 and were marked `dead` by hand
+  rather than left to burn the remaining six attempts over ~30h - see "A
+  real, separate finding" in `stubs/allegro/README.md` for why a 404 on
+  this specific path is retryable rather than failing fast on attempt 1 (a
+  core retry-classification gap, not a stub defect, and out of scope for
+  this change). Every child this run itself created was already cleaned up
+  automatically by the scenario's own end-of-window `DELETE` (unconditional
+  on status, so it removes successes and failures alike) - `sync_jobs`
+  carries none of this run's own `marketplace.offerQuantity.update` rows by
+  design, not by omission.
+- **`WORKER_RUNNER_ENABLED`** was found `false` on this stand (matching
+  `.env.lab.example`'s documented default) and is `false` again now - it
+  was flipped to `true` only for the two F2 measurement windows (F2's own
+  `guard_runner_state enabled` requires it) and restored afterward. Because
+  another agent's own compose operation destroyed and recreated the
+  `lab-worker` container mid-session (see the addendum above), the
+  restoration is a property of the CURRENT container's observed state
+  (verified by `docker exec lab-worker printenv WORKER_RUNNER_ENABLED` ->
+  `false`) rather than of one continuous container this report can trace
+  start to finish.
+
+## F1 (#2847) and F6 (#2844) - are they unblocked, and by how much
+
+**F1 is meaningfully closer to runnable, not merely "in principle."** F1's
+own proposed throughput arm is explicitly "stub source feeding orders at a
+`ramping-arrival-rate`" - exactly the Allegro stub's
+`POST /__stub/tenants/{tenant}/orders` control endpoint, now reachable from
+`lab-worker` by service name with `OrderSource` enabled and per-endpoint
+latencies from #2861 applied. What F1 still needs and this change does not
+supply: its own scenario script (none exists yet under `scenarios/`), the
+four-point-latency reconstruction it names as a precondition
+(`sync_jobs.lockedAt`/`lastAttemptDurationMs` caveats), the WooCommerce
+destination arm's own isolation logic, and - separately - #2846 (a
+mutable-stock PrestaShop stub), which F1 treats as an optional control arm
+rather than a hard blocker. None of those are Allegro-stub-shaped gaps.
+
+**F6 is NOT unblocked by this change, and #2935's own framing overstates
+its dependency.** Read in full, #2844 is entirely about the PrestaShop
+master-sweep jobs (`master.product.syncAll` / `master.inventory.syncAll`,
+their `fan-out`/`bulk` lane occupancy, cursor advance rate) - it crosses
+the PrestaShop adapter boundary, never the Allegro one, and its own
+Dependencies section names #2841/#2849/#2854, not this stub. Nothing in
+F6's problem statement, proposed solution or acceptance criteria touches
+Allegro, `OfferManager`, or order ingestion. Whoever picks up #2935's
+result should not assume F6 needs anything this change provides; it was
+already fully runnable (module-wise) before this branch and remains
+gated on its own listed dependencies alone, chiefly #2849's set-based
+seeders for the inventory-sweep arm.
+
+## What this did not establish
+
+- **No genuine Allegro-sandbox hop-5 latency, and none is claimed** - the stub's quantity-write endpoint answers at its configured default (unmeasured for this endpoint, see the Hop 5 section), not at a figure taken against a real marketplace. What IS established is the real network + adapter dispatch cost against a marketplace-shaped upstream.
+- **No confirmation that Allegro's own eventual application of the quantity change succeeds** - #2621's async-ACK design means a `QUEUED`/`ACCEPTED` submission is reconciled later by a separate, optional job this scenario does not run; this report measures submission, never eventual application.
+- **No production-representative t1->t2 (shop cron cadence) figure - by deliberate exclusion, not by omission.** See the Headline Finding: this run forces an immediate drain specifically to isolate OpenLinker's own work, and a real deployment must ADD its own external cron interval on top of every total this report quotes. What IS established is that the interval is unbounded absent an external caller on a stand shaped like this one, and that it would collapse toward zero automatically on a php-fpm deployment via the #2624 fast path - both operationally actionable facts, neither a production interval.
+- Only 6 distinct products exist in this catalogue, so the dedup-collapse mechanism (root-caused above) caps the number of INDEPENDENT per-product outbox chains available on this stand at 6 per drain cycle - repeated over 1 cycles for 6 total attempts, never a larger independent N.
+- No sustained-load / concurrent-write figure: every cycle in this run drains after a single write, so nothing here characterises what happens under a BURST of writes across many products landing between drains (the dedup-collapse section above describes the mechanism, not a measured collapse RATE under load). A related, real observation an earlier draft of this run DID surface and this final run's own `cycles.csv` should be checked for: under several back-to-back cycles, `inventory.propagateToMarketplaces` for a multi-variant product can queue for longer than this scenario's 15s poll (the realtime lane's per-scope cap is 2, and a 3-4-variant product's own propagate jobs can exceed it) - a real lane-saturation signal under sustained sequential writes, distinct from the attribute-0 methodology bug, and worth a dedicated sustained-load scenario rather than this one's single-write-per-cycle shape.
+- No multi-replica or multi-location figure (single worker replica on this stand; PrestaShop reports no location dimension at all, see above).

--- a/perf/openlinker-throughput/scenarios/f2-stock-propagation.sh
+++ b/perf/openlinker-throughput/scenarios/f2-stock-propagation.sh
@@ -317,26 +317,61 @@ run_one_cycle() {
     IFS='|' read -r prop_status prop_outcome <<< "$prop_row"
   done
 
-  # marketplace.offerQuantity.update children - hop t5. Reported, never
-  # counted as a successful destination write: both Allegro connections on
-  # this stand have OfferManager DISABLED by bootstrap.sh's own design (F1's
-  # concern, not this scenario's to override), and no #2856 Allegro-stub
-  # container exists in this compose file even if it were enabled - so this
-  # hop fails deterministically before any network call, and that is
-  # reported as a job DISPATCHED, never as a marketplace write.
+  # marketplace.offerQuantity.update children - hop t5, now REACHABLE
+  # (#2935): OfferManager is enabled on both Allegro connections and the
+  # #2856 stub sits at `allegro-stub:8080` on this stand's network, so the
+  # job actually attempts the write instead of failing at capability
+  # resolution before any network call. It still does not measure a
+  # genuine marketplace ACKNOWLEDGEMENT of the quantity change - the stub
+  # was scoped to the two order-INGESTION endpoints only (#2856's own
+  # README, "What it deliberately does not serve") and answers `PUT
+  # /sale/offer-quantity-change-commands/{id}` with its unserved-route
+  # catch-all: a fast, zero-configured-latency, Allegro-shaped 404
+  # (`notFound()` in server.mjs never calls `delay()`), which Allegro's own
+  # retry classifier already treats as non-retryable (404 is in
+  # `NON_RETRYABLE_STATUS_CODES`) - so the job dies on attempt 1 rather
+  # than burning ten. What this DOES measure honestly: the wall-clock time
+  # from the child job's own enqueue to the runner picking it up, making
+  # the real outbound HTTP call, and recording the (failed) terminal
+  # outcome - i.e. OpenLinker's own dispatch + adapter + HTTP-client
+  # overhead against a marketplace-shaped upstream, dominated by the
+  # runner's own poll-tick cadence (jobs are claimed on a ~1s loop, not
+  # pushed), not by anything the stub does. See the report's Hop 5 section
+  # for the honest reading; #2861 never measured this endpoint's real
+  # sandbox latency (its probe covered `/order/events` and
+  # `/order/checkout-forms/{id}` only), so there is no external figure to
+  # compare this against.
   #
   # Bounded on both sides, same reasoning as the propagate query above (and
   # for the same live-found reason: an unbounded upper edge let a later
   # cycle's children leak into an earlier cycle's count under sustained
   # load).
-  local offer_count offer_status offer_err offer_created
+  local offer_count offer_status offer_err offer_created offer_completed
   local offer_where="\"jobType\"='marketplace.offerQuantity.update' AND \"connectionId\" IN ('$ALLEGRO_A_CONNECTION_ID','$ALLEGRO_B_CONNECTION_ID') AND \"createdAt\" BETWEEN '${inv_job_created:-1970-01-01}'::timestamptz - interval '1 second' AND '${inv_job_created:-1970-01-01}'::timestamptz + interval '${PROP_WINDOW_SECS} second'"
   offer_count="$(pg_sql "SELECT COUNT(*) FROM sync_jobs WHERE $offer_where" 2>/dev/null || printf 0)"
   offer_created="$(pg_sql "SELECT \"createdAt\" FROM sync_jobs WHERE $offer_where ORDER BY \"createdAt\" ASC LIMIT 1" 2>/dev/null || true)"
+
+  # Wait for every counted child to reach a terminal status before reading
+  # its final status/error/updatedAt - the same reason the propagate job
+  # above is awaited by id: a read that lands mid-flight (`queued` or
+  # `running`) would under-report the dispatch->terminal latency this hop
+  # exists to measure.
+  local offer_waited=0 offer_pending
+  offer_pending="$(pg_sql "SELECT COUNT(*) FROM sync_jobs WHERE $offer_where AND status NOT IN ('succeeded','dead')" 2>/dev/null || printf 0)"
+  while [ "${offer_pending:-0}" -gt 0 ] && [ "$offer_waited" -lt "$POLL_MAX_WAIT_SECS" ]; do
+    sleep 1; offer_waited=$((offer_waited + 1))
+    offer_pending="$(pg_sql "SELECT COUNT(*) FROM sync_jobs WHERE $offer_where AND status NOT IN ('succeeded','dead')" 2>/dev/null || printf 0)"
+  done
+
   offer_status="$(pg_sql "SELECT status FROM sync_jobs WHERE $offer_where ORDER BY \"createdAt\" DESC LIMIT 1" 2>/dev/null || true)"
   offer_err="$(pg_sql "SELECT COALESCE(\"lastError\",'') FROM sync_jobs WHERE $offer_where ORDER BY \"createdAt\" DESC LIMIT 1" 2>/dev/null | tr ',' ';' || true)"
+  # MAX(updatedAt), not the last-created row's own updatedAt - several
+  # children can finish out of creation order under the runner's own
+  # concurrency, and the hop this measures is "every dispatched child has
+  # answered", not "whichever child was created last".
+  offer_completed="$(pg_sql "SELECT MAX(\"updatedAt\") FROM sync_jobs WHERE $offer_where" 2>/dev/null || true)"
 
-  printf '%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n' \
+  printf '%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n' \
     "$product" "$cycle" "$t0_ms" "$t1_ms" "$created_local" \
     "$drain_status" "$drain_before" "$drain_after" "${delivered_utc:-}" \
     "${wd_status:-}" "${wd_created:-}" \
@@ -344,6 +379,7 @@ run_one_cycle() {
     "${inv_count:-0}" "${inv_max_updated:-}" \
     "${prop_created:-}" "${prop_status:-}" "${prop_outcome:-}" \
     "${offer_count:-0}" "${offer_created:-}" "${offer_status:-}" "${offer_err:-}" \
+    "${offer_completed:-}" \
     >> "$out_csv"
 
   log "product=$product cycle=$cycle qty=$new_qty -> outbox=$outbox_id ($outbox_status) drain_http=$drain_status inv_job=$inv_job_status/$inv_job_outcome inv_rows=$inv_count propagate=$prop_status/$prop_outcome offer_children=$offer_count"
@@ -356,7 +392,7 @@ run_smoke() {
   local tmp_csv
   tmp_csv="$(mktemp)"
   trap "rm -f '$tmp_csv'" EXIT
-  printf 'product,cycle,t0_ms,t1_ms,outbox_created_local,drain_http_status,drain_before_ms,drain_after_ms,outbox_delivered_utc,webhook_delivery_status,webhook_delivery_created_utc,inv_job_created_utc,inv_job_status,inv_job_outcome,inventory_items_updated_count,inventory_items_max_updated_utc,propagate_job_created_utc,propagate_job_status,propagate_job_outcome,offer_children_count,offer_child_created_utc,offer_child_status,offer_child_last_error\n' > "$tmp_csv"
+  printf 'product,cycle,t0_ms,t1_ms,outbox_created_local,drain_http_status,drain_before_ms,drain_after_ms,outbox_delivered_utc,webhook_delivery_status,webhook_delivery_created_utc,inv_job_created_utc,inv_job_status,inv_job_outcome,inventory_items_updated_count,inventory_items_max_updated_utc,propagate_job_created_utc,propagate_job_status,propagate_job_outcome,offer_children_count,offer_child_created_utc,offer_child_status,offer_child_last_error,offer_child_completed_utc\n' > "$tmp_csv"
   local p
   p="$(printf '%s\n' $PRODUCTS | head -1)"
   run_one_cycle "$p" 0 "$tmp_csv"
@@ -393,7 +429,7 @@ run_strict() {
   run_group="run$(date +%s)"
   dir="$(results_dir_init f2-stock-propagation "$run_group")"
   local csv="$dir/cycles.csv"
-  printf 'product,cycle,t0_ms,t1_ms,outbox_created_local,drain_http_status,drain_before_ms,drain_after_ms,outbox_delivered_utc,webhook_delivery_status,webhook_delivery_created_utc,inv_job_created_utc,inv_job_status,inv_job_outcome,inventory_items_updated_count,inventory_items_max_updated_utc,propagate_job_created_utc,propagate_job_status,propagate_job_outcome,offer_children_count,offer_child_created_utc,offer_child_status,offer_child_last_error\n' > "$csv"
+  printf 'product,cycle,t0_ms,t1_ms,outbox_created_local,drain_http_status,drain_before_ms,drain_after_ms,outbox_delivered_utc,webhook_delivery_status,webhook_delivery_created_utc,inv_job_created_utc,inv_job_status,inv_job_outcome,inventory_items_updated_count,inventory_items_max_updated_utc,propagate_job_created_utc,propagate_job_status,propagate_job_outcome,offer_children_count,offer_child_created_utc,offer_child_status,offer_child_last_error,offer_child_completed_utc\n' > "$csv"
 
   snapshot_jobs_before "$CONN_IDS"
   local extra_manifest
@@ -445,7 +481,7 @@ write_dated_report() {
     printf -- '- %s products x %s cycles = %s stock-write attempts.\n\n' "$(printf '%s' "$PRODUCTS" | wc -w)" "$CYCLES" "$(($(printf '%s' "$PRODUCTS" | wc -w) * CYCLES))"
 
     printf '## Headline finding: hop t1->t2 is EXCLUDED from this measurement, not measured as fast\n\n'
-    printf -- 'This scenario force-drains the outbox after every single write (calls the module'"'"'s cron controller immediately). That is a deliberate experimental choice - it isolates OpenLinker'"'"'s OWN work from the shop'"'"'s delivery cadence, which is the more actionable half of the chain to an operator - but it means **the t1->t2 hop below is NOT a measurement of anything a real deployment experiences; it is excluded by construction.** On a stand shaped exactly like this one, hop t2 in production is bounded below by whatever external cron interval an operator (or a hosting provider'"'"'s crontab) configures for the module'"'"'s cron controller - commonly minutes, not the sub-second figure this run reports for it. To reconstruct a real "shop to OpenLinker" figure from the numbers below: take Hop A + Hop C + Hop D + Hop E (+ Hop F if you also want "job dispatched to the destination", which is NOT "reached the marketplace" - see the Hop 5 section) and ADD your own PrestaShop cron interval on top. That addition is the dominant term for almost any real deployment, and this run cannot supply it: nothing on this container'"'"'s crontab calls the cron controller at all (`crontab -l` is empty), and the module'"'"'s own response-flush fast path (#2624), which WOULD close this gap automatically, never fires on this image - its SAPI is `apache2handler`/mod_php, and `fastcgi_finish_request()` does not exist there (confirmed live via a throwaway PHP probe served over a real HTTP request: `PHP_SAPI` reports `apache2handler`, `function_exists(\x27fastcgi_finish_request\x27)` reports `false`). **If a deployment runs behind php-fpm instead, hop t2 collapses toward zero automatically via the fast path** - that is a real, actionable, deployment-shape-dependent fact this stand happens to be positioned to demonstrate, precisely because it is NOT running php-fpm.\n\n'
+    printf -- 'This scenario force-drains the outbox after every single write (calls the module'"'"'s cron controller immediately). That is a deliberate experimental choice - it isolates OpenLinker'"'"'s OWN work from the shop'"'"'s delivery cadence, which is the more actionable half of the chain to an operator - but it means **the t1->t2 hop below is NOT a measurement of anything a real deployment experiences; it is excluded by construction.** On a stand shaped exactly like this one, hop t2 in production is bounded below by whatever external cron interval an operator (or a hosting provider'"'"'s crontab) configures for the module'"'"'s cron controller - commonly minutes, not the sub-second figure this run reports for it. To reconstruct a real "shop to OpenLinker" figure from the numbers below: take Hop A + Hop C + Hop D + Hop E (+ Hop F/Hop G if you also want the marketplace-write hop, which is a real network round-trip against a stub with an unmeasured-for-this-endpoint latency, never a genuine sandbox figure - see the Hop 5 section) and ADD your own PrestaShop cron interval on top. That addition is the dominant term for almost any real deployment, and this run cannot supply it: nothing on this container'"'"'s crontab calls the cron controller at all (`crontab -l` is empty), and the module'"'"'s own response-flush fast path (#2624), which WOULD close this gap automatically, never fires on this image - its SAPI is `apache2handler`/mod_php, and `fastcgi_finish_request()` does not exist there (confirmed live via a throwaway PHP probe served over a real HTTP request: `PHP_SAPI` reports `apache2handler`, `function_exists(\x27fastcgi_finish_request\x27)` reports `false`). **If a deployment runs behind php-fpm instead, hop t2 collapses toward zero automatically via the fast path** - that is a real, actionable, deployment-shape-dependent fact this stand happens to be positioned to demonstrate, precisely because it is NOT running php-fpm.\n\n'
 
     printf '## Why the earlier 2-of-25 trial undercounted (root-caused, not guessed)\n\n'
     printf -- 'Two independent, verified mechanisms explain it, and the webservice-API attempt made it worse than either alone would:\n\n'
@@ -457,7 +493,7 @@ write_dated_report() {
     printf -- 'Every cycle'"'"'s cron-drain call returns HTTP 500 - verified NOT to be a delivery failure, and not trusted on faith: the same request that returns 500 also carries a fully-formed, ACCURATE JSON body (`{"processed":1,"delivered":1,"failed":0,...}`), and the outbox row it was meant to deliver reaches `delivered_at` at that exact same second, every time. The cause is unrelated to the module entirely: PrestaShop'"'"'s `FrontController::display()` runs its normal asset-pipeline step AFTER the module'"'"'s own `initContent()` has already echoed the JSON body (the controller never calls `exit`), and that step throws `MatthiasMullie\\Minify\\Exceptions\\IOException: The file \x22/var/www/html/themes/classic/assets/cache/theme-3f744e.css\x22 could not be opened for writing` - a container filesystem-permission gap on the theme asset cache directory, confirmed by matching the Apache error-log timestamp to the exact same request'"'"'s access-log line and to the outbox row'"'"'s own `delivered_at`. **Because of this, no hop in this report is computed from `drain_http_status` or from the cron controller'"'"'s HTTP response at all** - every hop is computed from PrestaShop'"'"'s own `ps_openlinker_webhook_outbox.delivered_at` column (the ground truth of whether delivery happened) and from OpenLinker'"'"'s own `webhook_deliveries`/`sync_jobs`/`inventory_items` timestamps, never from a status line. `drain_http_status` is still recorded verbatim in `cycles.csv` as a data point, precisely so this claim is checkable rather than asserted.\n\n'
 
     printf '## Per-hop latency (measured, ms; sample sizes stated per row)\n\n'
-    printf -- '**None of these is a "reached the marketplace" figure.** The chain measured stops at the point where OpenLinker DISPATCHES a `marketplace.offerQuantity.update` job - see the Hop 5 section below for why the write itself is unmeasurable on this stand, and see the Headline Finding above for why Hop B is an excluded floor, not a shop-cron estimate.\n\n'
+    printf -- '**Hop G is a real network round-trip against a marketplace-shaped upstream, not a genuine Allegro-sandbox figure.** See the Hop 5 section below for exactly what it does and does not establish, and see the Headline Finding above for why Hop B is an excluded floor, not a shop-cron estimate.\n\n'
     printf '```\n%s\n```\n\n' "$summary"
 
     printf '## A methodology bug found and fixed mid-run: writing `id_product_attribute=0` on a product WITH combinations silently changes nothing\n\n'
@@ -470,11 +506,12 @@ write_dated_report() {
     printf '## Located vs. pooled position shapes\n\n'
     printf -- 'Not applicable on this stand as configured: PrestaShop reports no location dimension for any of the six products (`ps_stock_available.location` is empty on every row, and the adapter never populates `Inventory.locationId` for it), so every position OpenLinker holds for this master is POOLED (`locationId IS NULL`) by construction - there is no #2324/#2325 located-position collapse to observe here, and none is claimed.\n\n'
 
-    printf '## Hop 5 (destination write) - NOT MEASURABLE on this stand, and why enabling OfferManager would not fix that\n\n'
-    printf -- 'Both Allegro connections (`perf-allegro-a`/`perf-allegro-b`) have `OfferManager` DISABLED by `bootstrap.sh`'"'"'s own design - deliberately, for a DIFFERENT scenario'"'"'s (F1) benefit, to keep `marketplace.offers.sync` from burning retries against no live stub. `marketplace.offerQuantity.update` therefore fails after 3 attempts with the deterministic, structural error `Connection <id> has capability OfferManager disabled` - BEFORE any network call is attempted, confirmed against every observed job'"'"'s `lastError` in `cycles.csv`. **This scenario deliberately did NOT enable the capability to force a real write**, and checked first rather than assuming: no `allegro-stub` hostname resolves anywhere on this stand'"'"'s docker network at all (`getent hosts allegro-stub` inside the worker container: not found) - the #2856 Allegro stub is a separate, not-yet-integrated worktree. Enabling `OfferManager` would only trade one deterministic non-write failure (capability disabled, fails in milliseconds) for another (DNS resolution failure, fails after a connect timeout) - neither is a marketplace WRITE, so flipping the flag would not have produced a real number, only a slower fake one, and would have touched a connection shared with other scenarios for no measurement gain. So every "Hop F" / "TOTAL ... offer child enqueued" figure above means exactly that: a job was DISPATCHED toward the marketplace. None of them means the marketplace was updated, and the report'"'"'s own hop labels say "enqueued", never "delivered", for this reason.\n\n'
+    printf '## Hop 5 (destination write) - MEASURED as of #2935, and what the figure does and does not mean\n\n'
+    printf -- '`OfferManager` is now ENABLED on both Allegro connections (`perf-allegro-a`/`perf-allegro-b`), and `config.apiBaseUrl` points at a real `allegro-stub:8080` service on this stand'"'"'s own compose network (#2856/#2876, wired onto `lab` by #2935) - `marketplace.offerQuantity.update` no longer fails at capability resolution before any network call. It reaches the adapter'"'"'s one synchronous write, `PUT /sale/offer-quantity-change-commands/{id}`, which the stub answers `{id, status: \x27ACCEPTED\x27}` - so Hop G (child enqueued -> child reached a terminal status) below is a REAL measurement of dispatch + HTTP-client + network overhead against a marketplace-shaped upstream, not a job dying at a capability check. **What it still is not**: a genuine Allegro sandbox round-trip - the stub'"'"'s `/sale/offer-quantity-change-commands/{id}` latency has no #2861-shaped measurement behind it (that probe covered `/order/events` and `/order/checkout-forms/{id}` only), so this hop reports the stub'"'"'s configured default (120ms, unmeasured for this endpoint - see `stubs/allegro/README.md`), not a real sandbox distribution. It also never learns whether Allegro'"'"'s OWN eventual, asynchronous application of the quantity change succeeds - #2621 made `updateOfferQuantity` return on ACCEPT rather than a terminal status, and the terminal-status poll is a separate, optional job (`marketplace.offerQuantity.reconcile`) this scenario does not exercise. So "Hop G" / the "child answered" TOTAL below mean exactly that: OpenLinker submitted the write and received a definitive ACCEPT from a marketplace-shaped upstream, in the time that upstream took to answer - never that Allegro'"'"'s catalogue has actually updated.\n\n'
 
     printf '## What this did not establish\n\n'
-    printf -- '- **No hop-5 (destination) latency, and none is claimed** - reachability of an Allegro-side write is a prerequisite this stand does not currently supply (no `allegro-stub` host, capability deliberately left disabled - see the Hop 5 section). Every figure this report calls a "total" stops at job dispatch, not delivery.\n'
+    printf -- '- **No genuine Allegro-sandbox hop-5 latency, and none is claimed** - the stub'"'"'s quantity-write endpoint answers at its configured default (unmeasured for this endpoint, see the Hop 5 section), not at a figure taken against a real marketplace. What IS established is the real network + adapter dispatch cost against a marketplace-shaped upstream.\n'
+    printf -- '- **No confirmation that Allegro'"'"'s own eventual application of the quantity change succeeds** - #2621'"'"'s async-ACK design means a `QUEUED`/`ACCEPTED` submission is reconciled later by a separate, optional job this scenario does not run; this report measures submission, never eventual application.\n'
     printf -- '- **No production-representative t1->t2 (shop cron cadence) figure - by deliberate exclusion, not by omission.** See the Headline Finding: this run forces an immediate drain specifically to isolate OpenLinker'"'"'s own work, and a real deployment must ADD its own external cron interval on top of every total this report quotes. What IS established is that the interval is unbounded absent an external caller on a stand shaped like this one, and that it would collapse toward zero automatically on a php-fpm deployment via the #2624 fast path - both operationally actionable facts, neither a production interval.\n'
     printf -- '- Only 6 distinct products exist in this catalogue, so the dedup-collapse mechanism (root-caused above) caps the number of INDEPENDENT per-product outbox chains available on this stand at 6 per drain cycle - repeated over %s cycles for %s total attempts, never a larger independent N.\n' "$CYCLES" "$(($(printf '%s' "$PRODUCTS" | wc -w) * CYCLES))"
     printf -- '- No sustained-load / concurrent-write figure: every cycle in this run drains after a single write, so nothing here characterises what happens under a BURST of writes across many products landing between drains (the dedup-collapse section above describes the mechanism, not a measured collapse RATE under load). A related, real observation an earlier draft of this run DID surface and this final run'"'"'s own `cycles.csv` should be checked for: under several back-to-back cycles, `inventory.propagateToMarketplaces` for a multi-variant product can queue for longer than this scenario'"'"'s 15s poll (the realtime lane'"'"'s per-scope cap is 2, and a 3-4-variant product'"'"'s own propagate jobs can exceed it) - a real lane-saturation signal under sustained sequential writes, distinct from the attribute-0 methodology bug, and worth a dedicated sustained-load scenario rather than this one'"'"'s single-write-per-cycle shape.\n'

--- a/perf/openlinker-throughput/stubs/allegro/README.md
+++ b/perf/openlinker-throughput/stubs/allegro/README.md
@@ -16,10 +16,55 @@ endpoints are on the order-ingestion path:
 | `GET` | `/order/checkout-forms/{id}` | once per ingested order (zero per line item) |
 
 Plus `GET /me`, reached by the connection tester and by #2860's bootstrap
-readiness check. Everything else answers `404` in Allegro's own error shape
+readiness check.
+
+**#2935 adds one write-path endpoint**, once the F2 stock-propagation
+scenario needed `OfferManager` reachable rather than disabled:
+
+| Method | Path | Cadence |
+|---|---|---|
+| `PUT` | `/sale/offer-quantity-change-commands/{id}` | once per `inventory.propagateToMarketplaces` fan-out child |
+
+This is the ONE synchronous call `AllegroOfferManagerAdapter.
+updateOfferQuantity` makes - #2621 made it return on Allegro's ACCEPT rather
+than polling for a terminal status, so there is no second rung to serve
+here. It always answers `{id, status: 'ACCEPTED'}` - this stub has no
+concept of a genuinely invalid quantity modification to reject, and
+inventing one would be exactly the "the mock is now the model" trap #2840
+names by name. The async status-poll rung (`GET
+/sale/offer-quantity-change-commands/{id}`, consumed only by the separate,
+optional `marketplace.offerQuantity.reconcile` job) is deliberately **not**
+served - nothing on the path this stub measures ever calls it.
+
+**Its latency has no #2861 measurement behind it.** #2856's scope, and
+#2861's probe, both covered order-ingestion only; `STUB_LATENCY_QUANTITY_MS`
+exists as a knob (falls back to `STUB_PER_REQUEST_LATENCY_MS` like the other
+two) but `/__stub/config`'s `latency.quantityMsMeasured` is `false` unless a
+driver sets it explicitly, so a manifest reading the config can tell
+"measured" apart from "unmeasured default" rather than trusting a number
+that was never taken against a real sandbox.
+
+**A real, separate finding surfaced while wiring this up, recorded here
+rather than silently worked around**: `MarketplaceOfferQuantityUpdateHandler`
+(`apps/worker/src/sync/handlers/marketplace-offer-quantity-update.handler.ts`)
+constructs its `SyncJobExecutionError` with `cause: undefined` for any
+non-contention failure in `result.failed[]` - the original
+`AllegroApiException` (and its `statusCode`) never reaches
+`isNonRetryableError`, so even a *genuinely* deterministic 4xx from a real
+Allegro sandbox would retry the full ten-attempt ladder rather than failing
+fast on attempt 1, the same way every OTHER Allegro call in this repo does.
+This stub therefore always answers `ACCEPTED` rather than `REJECTED` for a
+second, independent reason beyond the one above: routing through that code
+path at all would measure a 30-hour retry storm neither this stub nor F2 is
+about. Fixing the classification gap is core product code, out of scope for
+a stub change - filed as its own follow-up rather than patched here.
+
+Everything else answers `404` in Allegro's own error shape
 (`{"errors":[{"code":"NotFound","message":"..."}]}`), because a 404 is
-non-retryable in OpenLinker's Allegro retry classifier - a stray call fails
-loudly on attempt 1 instead of burning a retry ladder.
+non-retryable in OpenLinker's Allegro retry classifier for every OTHER call
+site that reaches this stub's default 404 path with its `statusCode`
+intact - a stray call fails loudly on attempt 1 instead of burning a retry
+ladder.
 
 ## What it deliberately does not serve
 

--- a/perf/openlinker-throughput/stubs/allegro/server.mjs
+++ b/perf/openlinker-throughput/stubs/allegro/server.mjs
@@ -77,6 +77,17 @@ const CONFIG = {
   latencyDefaultMs: envInt('STUB_PER_REQUEST_LATENCY_MS', 120),
   latencyEventsMs: process.env.STUB_LATENCY_EVENTS_MS,
   latencyCheckoutMs: process.env.STUB_LATENCY_CHECKOUT_MS,
+  // #2935: PUT /sale/offer-quantity-change-commands/{id}, the ONE
+  // synchronous call updateOfferQuantity makes (allegro-offer-manager.
+  // adapter.ts - #2621 made it return on Allegro's ACCEPT rather than
+  // waiting for a terminal status, so no second call happens here). UNLIKE
+  // latencyEventsMs/latencyCheckoutMs, this has no #2861 sandbox
+  // measurement behind it - #2856's own scope was order-ingestion only, and
+  // #2861 measured exactly the two endpoints above and no others. There is
+  // therefore no defensible p50 to cite, and CONFIG.quantityLatencyKnown
+  // records that fact for /__stub/config so a manifest can tell "measured"
+  // apart from "fell back to the generic default" at a glance.
+  latencyQuantityMs: process.env.STUB_LATENCY_QUANTITY_MS,
   // #2856 "The seeded-mapping contract": offer ids must be a deterministic
   // function of tenant + index so #2860's bootstrap can pre-seed
   // identifier_mappings rows before any order is ever pushed. This value
@@ -97,6 +108,9 @@ function latencyFor(endpoint) {
   }
   if (endpoint === 'checkout' && CONFIG.latencyCheckoutMs !== undefined) {
     return envInt('STUB_LATENCY_CHECKOUT_MS', CONFIG.latencyDefaultMs);
+  }
+  if (endpoint === 'quantity' && CONFIG.latencyQuantityMs !== undefined) {
+    return envInt('STUB_LATENCY_QUANTITY_MS', CONFIG.latencyDefaultMs);
   }
   return CONFIG.latencyDefaultMs;
 }
@@ -521,6 +535,43 @@ const server = createServer((req, res) => {
       return;
     }
 
+    // #2935: the ONE synchronous call `AllegroOfferManagerAdapter.
+    // updateOfferQuantity` makes - see allegro-api.types.ts's
+    // `AllegroOfferQuantityChangeCommandResponse` for the exact, narrow
+    // contract this echoes (`{id, status, errors?}`, status one of
+    // 'QUEUED'|'ACCEPTED'|'REJECTED'). Added so the F2 stock-propagation
+    // scenario's last hop (job dispatched -> marketplace write) is
+    // measurable at all, rather than failing at capability resolution
+    // before any network call - see docs/architecture-overview.md's own
+    // "#2621" note for why no further call happens synchronously here: the
+    // adapter does not poll for a terminal status, it returns as soon as
+    // Allegro acknowledges the submission. Always answers ACCEPTED - this
+    // stub has no notion of a genuinely invalid modification to reject, and
+    // synthesising one would be exactly the invented-semantics trap #2840
+    // warns against; the async status-poll rung
+    // (GET .../offer-quantity-change-commands/{id}, consumed only by the
+    // OPTIONAL, separate marketplace.offerQuantity.reconcile job) is
+    // deliberately NOT served - nothing on the path this scenario measures
+    // ever calls it.
+    const quantityMatch = /^\/sale\/offer-quantity-change-commands\/([^/]+)$/.exec(pathname);
+    if (method === 'PUT' && quantityMatch) {
+      recordRequestCount(tenant, 'PUT', '/sale/offer-quantity-change-commands/:id');
+      await delay(latencyFor('quantity'));
+      if (applyFault(tenant, req, res, (status) => log(status, '/sale/offer-quantity-change-commands/:id')))
+        return;
+      const commandId = decodeURIComponent(quantityMatch[1]);
+      try {
+        await readBody(req);
+      } catch {
+        sendJson(res, 400, allegroError('InvalidRequest', 'invalid JSON body'));
+        log(400, '/sale/offer-quantity-change-commands/:id');
+        return;
+      }
+      sendJson(res, 200, { id: commandId, status: 'ACCEPTED' });
+      log(200, '/sale/offer-quantity-change-commands/:id');
+      return;
+    }
+
     // -----------------------------------------------------------------
     // Control surface - /__stub/, driver-facing. No Allegro path uses this
     // prefix (#2856 Build Specification "Control endpoint"). Deliberately
@@ -546,6 +597,13 @@ const server = createServer((req, res) => {
           defaultMs: CONFIG.latencyDefaultMs,
           eventsMs: latencyFor('events'),
           checkoutMs: latencyFor('checkout'),
+          quantityMs: latencyFor('quantity'),
+          // #2935: false unless the driver set STUB_LATENCY_QUANTITY_MS
+          // explicitly - there is no #2861 sandbox measurement behind this
+          // endpoint, so a manifest reading this field can tell "measured"
+          // apart from "fell back to the generic (also unmeasured-for-this-
+          // endpoint) default" rather than silently trusting a number.
+          quantityMsMeasured: CONFIG.latencyQuantityMs !== undefined,
         },
       });
       return;

--- a/perf/openlinker-throughput/stubs/allegro/test.mjs
+++ b/perf/openlinker-throughput/stubs/allegro/test.mjs
@@ -86,6 +86,7 @@ test('never answers 401, for any path, any token, any fault mode', async () => {
     ['GET', '/order/checkout-forms/does-not-exist', TOKEN_A],
     ['GET', '/me', 'garbage'],
     ['GET', '/some/unknown/path', TOKEN_A],
+    ['PUT', '/sale/offer-quantity-change-commands/does-not-matter', TOKEN_A],
   ];
 
   for (const [method, path, token] of attempts) {
@@ -385,6 +386,33 @@ test('GET /me answers 200 with an id and login', async () => {
   assert.equal(status, 200);
   assert.ok(body.id);
   assert.ok(body.login);
+});
+
+// ---------------------------------------------------------------------------
+// #2935 - the one synchronous write updateOfferQuantity makes
+// ---------------------------------------------------------------------------
+
+test('PUT /sale/offer-quantity-change-commands/{id} echoes the id back as ACCEPTED', async () => {
+  await resetRun('t-quantity');
+  const { status, body } = await call('PUT', '/sale/offer-quantity-change-commands/abc-123', {
+    token: TOKEN_A,
+    body: {
+      modification: { changeType: 'FIXED', value: 7 },
+      offerCriteria: [{ offers: [{ id: 'perf-allegro-a-offer-1' }], type: 'CONTAINS_OFFERS' }],
+    },
+  });
+  assert.equal(status, 200);
+  assert.equal(body.id, 'abc-123');
+  assert.equal(body.status, 'ACCEPTED');
+});
+
+test('PUT /sale/offer-quantity-change-commands/{id} accepts an empty body too (no body sent)', async () => {
+  await resetRun('t-quantity-nobody');
+  const { status, body } = await call('PUT', '/sale/offer-quantity-change-commands/xyz-789', {
+    token: TOKEN_A,
+  });
+  assert.equal(status, 200);
+  assert.equal(body.id, 'xyz-789');
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #2935.

- Wires the #2856 Allegro stub onto `docker-compose.lab.yml` as a real `allegro-stub` service, reachable from `lab-worker`/`lab-api` by service name (`http://allegro-stub:8080`) and from the host at a published port for driver control (`/__stub/*`).
- Points `bootstrap.sh`'s `perf-allegro-a`/`perf-allegro-b` connections at it (already the case via `ALLEGRO_STUB_URL`) and enables `OfferManager` on both, plus a new idempotent `step_allegro_offer_manager` step so a connection created before this change also gets the capability without a manual PATCH.
- **Remedy used**: keep the scheduler OFF (`guard_scheduler_off`, this stand's own default) - `marketplace.offers.sync`'s scheduler task has no `requiredCapability` gate, so it is capability-state-independent; the scheduler being off is what actually prevents it from ever enqueuing, not the capability flag.
- Extended the stub with `PUT /sale/offer-quantity-change-commands/{id}` (the one synchronous call `updateOfferQuantity` makes per #2621) after discovering the original order-ingestion-only surface left F2's marketplace-write hop 404ing - it always answers `ACCEPTED`; the optional async status-poll rung stays unserved since nothing on the measured path calls it. Its latency is honestly unmeasured (no #2861-shaped probe exists for this endpoint) and reports that via `/__stub/config`'s `quantityMsMeasured: false`.
- A real, separate finding surfaced along the way and is recorded (not fixed) in `stubs/allegro/README.md`: `MarketplaceOfferQuantityUpdateHandler` drops the original exception's `statusCode` for a non-contention failure, so a deterministic 404 on this job type retries the full ten-attempt ladder instead of failing fast like every other Allegro call site.
- F2 re-ran twice against the extended stub - both Allegro connections' quantity-write jobs succeeded, replacing the "not measured" Hop 5 with a real figure. The duration was investigated (stub's own request log confirms 120ms server-side, not a paced-stub artifact; exactly one PUT per connection, no adapter-side polling) and reported as an **observed stand artifact under concurrent load**, not a clean marketplace-write latency - both windows overlapped a disclosed period of unrelated heavy Postgres load on this shared stand.
- Two stray retrying jobs from an earlier smoke test (pre-dating the stub extension) were found and marked `dead` rather than left to burn the remaining retry attempts.

## F1 / F6 status

- **F1 (#2847)** is meaningfully closer to runnable: its own proposed throughput arm is exactly this stub's `POST /__stub/tenants/{tenant}/orders` push endpoint, now reachable with `OrderSource` enabled and #2861's latencies applied. It still needs its own scenario script, the four-point-latency reconstruction, and the WooCommerce-arm isolation logic - none of which this change supplies.
- **F6 (#2844)** is unaffected by this change. Read in full, it measures the PrestaShop master sweeps only and never crosses the Allegro adapter boundary - #2935's own framing overstated this dependency.

## Report

`perf/openlinker-throughput/results-F2-2026-09-06.md` - see "Addendum - Hop G's 10.1s explained", "Cleanup and stand state", and "F1 (#2847) and F6 (#2844)" for the full write-up.

## Test plan

- [x] `bash -n` on every changed shell script
- [x] `node --check` on the stub
- [x] `perf/openlinker-throughput/lib-test.sh` - 96/96 passed
- [x] `stubs/allegro/test.mjs` - 16/16 passed (added 3 new cases for the write endpoint)
- [x] `pnpm check:invariants` - exit 0
- [x] F2 scenario run end-to-end against the extended stub on the `lab` stand, twice - both Allegro `marketplace.offerQuantity.update` jobs succeeded

🤖 Generated with [Claude Code](https://claude.com/claude-code)