### PR TITLE
fix(web): guard the 14 remaining degraded-data crashes (#2926 follow-up)

### DIFF
--- a/apps/web/src/features/connections/components/ConnectionCapabilitiesPanel.test.tsx
+++ b/apps/web/src/features/connections/components/ConnectionCapabilitiesPanel.test.tsx
@@ -25,6 +25,21 @@ describe('ConnectionCapabilitiesPanel', () => {
     expect(screen.getByText(/1 of 2 enabled/)).toBeInTheDocument();
   });
 
+  it('does not crash and renders zero-of-zero when `supportedCapabilities`/`enabledCapabilities` are missing', () => {
+    // A degraded response (a 500 handled into an empty object, a partial
+    // payload) can arrive as a successful query whose `data` is truthy but
+    // these arrays are missing entirely.
+    const degraded = { ...sampleConnection } as Partial<Connection>;
+    delete degraded.supportedCapabilities;
+    delete degraded.enabledCapabilities;
+
+    renderWithProviders(
+      <ConnectionCapabilitiesPanel connection={degraded as unknown as Connection} />,
+    );
+
+    expect(screen.getByText(/0 of 0 enabled/)).toBeInTheDocument();
+  });
+
   it('calls update mutation with new set when a capability is toggled', async () => {
     const update = vi.fn().mockResolvedValue({ ...sampleConnection });
     const apiClient = createMockApiClient({ connections: { update } });

--- a/apps/web/src/features/connections/components/ConnectionCapabilitiesPanel.tsx
+++ b/apps/web/src/features/connections/components/ConnectionCapabilitiesPanel.tsx
@@ -51,8 +51,11 @@ export function ConnectionCapabilitiesPanel({
   // also has a non-core capability enabled (e.g. a plugin-registered
   // ShippingProviderManager) silently drops that capability from the saved
   // list. Tracked under the same #576 follow-up.
-  const supported = connection.supportedCapabilities.filter(isCoreCapability);
-  const enabled = new Set(connection.enabledCapabilities.filter(isCoreCapability));
+  // A degraded response (a 500 handled into an empty object, a partial
+  // payload) can arrive as a successful query whose `data` is truthy but
+  // these arrays are missing — treat that as "none known" rather than crash.
+  const supported = (connection.supportedCapabilities ?? []).filter(isCoreCapability);
+  const enabled = new Set((connection.enabledCapabilities ?? []).filter(isCoreCapability));
 
   // Deliberately keyed on SUPPORTED, not ENABLED (#1949). MCP tool registration
   // reads `enabledCapabilities`, so gating the hint on that would make it vanish

--- a/apps/web/src/features/connections/components/EditConnectionForm.test.tsx
+++ b/apps/web/src/features/connections/components/EditConnectionForm.test.tsx
@@ -86,6 +86,20 @@ describe('EditConnectionForm', () => {
     expect(screen.getByText('Rotate webservice key')).toBeInTheDocument();
   });
 
+  it('does not crash when the connection response has no `config` or `enabledCapabilities`', () => {
+    // A degraded response (a 500 handled into an empty object, a partial
+    // payload) can arrive as a successful query whose `data` is truthy but
+    // `config`/`enabledCapabilities` are missing entirely — every read in
+    // this form goes through `connection.config`/`connection.enabledCapabilities`.
+    const degraded = { ...sampleConnection } as Partial<Connection>;
+    delete degraded.config;
+    delete degraded.enabledCapabilities;
+
+    renderWithProviders(<EditConnectionForm connection={degraded as unknown as Connection} />);
+
+    expect(screen.getByDisplayValue(sampleConnection.name)).toBeInTheDocument();
+  });
+
   it('shows platform type as disabled and credentials behind a rotate button', () => {
     renderWithProviders(<EditConnectionForm connection={sampleConnection} />);
 

--- a/apps/web/src/features/connections/components/EditConnectionForm.tsx
+++ b/apps/web/src/features/connections/components/EditConnectionForm.tsx
@@ -382,6 +382,12 @@ export function EditConnectionForm({ connection }: EditConnectionFormProps): Rea
   const demoMode = useDemoMode();
   const write = useWriteAccess('connections:write', demoMode);
   const [showRawJson, setShowRawJson] = useState(false);
+  // A degraded response (a 500 handled into an empty object, a partial
+  // payload) can arrive as a successful query whose `data` is truthy but
+  // `config` is missing — every read below goes through this normalized
+  // local rather than `connection.config` directly.
+  const config = connection.config ?? {};
+  const enabledCapabilities = connection.enabledCapabilities ?? [];
   const plugin = usePlatform(connection.platformType);
   // #1330 — the platform's non-render structured-config half: Zod schema
   // fragment, read-side hydration, write-side assembly. Memoized on the plugin
@@ -396,68 +402,68 @@ export function EditConnectionForm({ connection }: EditConnectionFormProps): Rea
   const form = useForm<EditConnectionFormValues, undefined, EditConnectionFormSubmission>({
     defaultValues: {
       name: connection.name,
-      baseUrl: readConfigString(connection.config, 'baseUrl'),
-      siteUrl: readConfigString(connection.config, 'siteUrl'),
-      shopId: readConfigString(connection.config, 'shopId'),
-      storefrontBaseUrl: readConfigString(connection.config, 'storefrontBaseUrl'),
+      baseUrl: readConfigString(config, 'baseUrl'),
+      siteUrl: readConfigString(config, 'siteUrl'),
+      shopId: readConfigString(config, 'shopId'),
+      storefrontBaseUrl: readConfigString(config, 'storefrontBaseUrl'),
       // #168 — pre-fill OL callback URL via the platform plugin when the
       // connection has none yet. Browser-context value, not server-trusted; the
       // BE doesn't derive this from request headers (host-header injection risk),
       // so the FE owns the convenience default. Operator can override for dev
       // (e.g. http://host.docker.internal:3000) by editing the field.
       openlinkerCallbackBaseUrl:
-        readConfigString(connection.config, 'openlinkerCallbackBaseUrl') ||
+        readConfigString(config, 'openlinkerCallbackBaseUrl') ||
         plugin?.getCallbackUrlDefault?.() ||
         '',
       // Erli's own callback-URL config key (#1454 follow-up) — same
       // pre-fill convenience as PrestaShop's `openlinkerCallbackBaseUrl`.
       callbackBaseUrl:
-        readConfigString(connection.config, 'callbackBaseUrl') ||
+        readConfigString(config, 'callbackBaseUrl') ||
         plugin?.getCallbackUrlDefault?.() ||
         '',
-      masterCatalogConnectionId: readConfigString(connection.config, 'masterCatalogConnectionId'),
+      masterCatalogConnectionId: readConfigString(config, 'masterCatalogConnectionId'),
       // PS `defaultCarrierId` is persisted as a number; the form keeps it
       // as a string so the same `<Select>` primitive serves both this
       // field and the per-method mapping dropdown (#517).
       defaultCarrierId:
-        typeof connection.config.defaultCarrierId === 'number'
-          ? String(connection.config.defaultCarrierId)
+        typeof config.defaultCarrierId === 'number'
+          ? String(config.defaultCarrierId)
           : '',
       // WC `inventory.unmanagedStockQuantity` is persisted as a number nested
       // under `config.inventory`; the form keeps it as a string (#969 §7.3).
-      unmanagedStockQuantity: readUnmanagedStockQuantity(connection.config),
+      unmanagedStockQuantity: readUnmanagedStockQuantity(config),
       inpostPsModuleType:
-        connection.config.inpostPsModuleType === 'official_inpost' ? 'official_inpost' : '',
-      configText: JSON.stringify(connection.config, null, 2),
+        config.inpostPsModuleType === 'official_inpost' ? 'official_inpost' : '',
+      configText: JSON.stringify(config, null, 2),
       adapterKey: connection.adapterKey ?? '',
-      sellerDefaults: readSellerDefaults(connection.config),
+      sellerDefaults: readSellerDefaults(config),
       // #759 — symmetric read-side hydration for the Subiekt fields, or an
       // existing connection renders empty and an unrelated save blanks the
       // persisted state (reverting the live getInvoiceTriggerModel consumer to 'manual').
-      subiektBridgeUrl: readConfigString(connection.config, 'subiektBridgeUrl'),
-      subiektTriggerModel: readTriggerModel(connection.config),
-      subiektCapabilities: readSubiektCapabilities(connection.config),
+      subiektBridgeUrl: readConfigString(config, 'subiektBridgeUrl'),
+      subiektTriggerModel: readTriggerModel(config),
+      subiektCapabilities: readSubiektCapabilities(config),
       // InPost structured fields (#771) — read from `config.{environment,
       // organizationId,senderAddress}`. Symmetric read-side hydration so an
       // unrelated save doesn't blank the persisted InPost config.
-      inpostEnvironment: readInpostEnvironment(connection.config),
-      inpostOrganizationId: readConfigString(connection.config, 'organizationId'),
-      inpostSenderAddress: readInpostSenderAddress(connection.config),
+      inpostEnvironment: readInpostEnvironment(config),
+      inpostOrganizationId: readConfigString(config, 'organizationId'),
+      inpostSenderAddress: readInpostSenderAddress(config),
       // Infakt default payment method (#1303) — `config.defaultPaymentMethod`.
-      infaktPaymentMethod: readInfaktPaymentMethod(connection.config),
-      infaktBankAccount: readInfaktBankAccount(connection.config),
+      infaktPaymentMethod: readInfaktPaymentMethod(config),
+      infaktBankAccount: readInfaktBankAccount(config),
       // Infakt environment (#2174) — `config.environment`. Symmetric read-side
       // hydration so an unrelated save doesn't blank the persisted choice.
-      infaktEnvironment: readInfaktEnvironment(connection.config),
+      infaktEnvironment: readInfaktEnvironment(config),
       // Per-connection outbound rate limit (#1810) — platform-neutral.
-      rateLimit: readRateLimit(connection.config),
+      rateLimit: readRateLimit(config),
       // Per-connection stock publish policy + pricing rule (#2610) — platform-neutral.
-      stockPolicy: readStockPolicy(connection.config),
-      pricingRule: readPricingRuleForm(connection.config),
+      stockPolicy: readStockPolicy(config),
+      pricingRule: readPricingRuleForm(config),
       // Plugin-owned structured fields (#1330) — the platform's contribution
       // hydrates its own field slice (e.g. KSeF seller/payment) so an
       // unrelated save doesn't blank the persisted platform config.
-      ...(connectionConfig?.readConfigToForm(connection.config) ?? {}),
+      ...(connectionConfig?.readConfigToForm(config) ?? {}),
     },
     resolver: zodResolver(resolverSchema),
   });
@@ -478,9 +484,9 @@ export function EditConnectionForm({ connection }: EditConnectionFormProps): Rea
   // master-catalog product data (name/description/images/price) through
   // `masterCatalogConnectionId` — `OfferBuilderService` and
   // `ProductPublishBuilderService` share the same requirement.
-  const isMarketplace = connection.enabledCapabilities.includes('OfferManager');
+  const isMarketplace = enabledCapabilities.includes('OfferManager');
   const needsMasterCatalog =
-    isMarketplace || connection.enabledCapabilities.includes('ProductPublisher');
+    isMarketplace || enabledCapabilities.includes('ProductPublisher');
   const hasStructuredInputs = StructuredSection !== undefined || needsMasterCatalog;
 
   // Tracks whether the raw JSON currently parses. When it doesn't, we lock the
@@ -497,7 +503,7 @@ export function EditConnectionForm({ connection }: EditConnectionFormProps): Rea
   const localAutoSelectId = candidates.length === 1 ? candidates[0].id : undefined;
 
   const masterCatalogValue = form.watch('masterCatalogConnectionId') ?? '';
-  const storedMasterRaw = connection.config.masterCatalogConnectionId;
+  const storedMasterRaw = config.masterCatalogConnectionId;
   const hasStoredMaster = typeof storedMasterRaw === 'string';
   const isStaleMaster =
     masterCatalogValue !== '' && !candidates.some((c) => c.id === masterCatalogValue);
@@ -798,8 +804,8 @@ export function EditConnectionForm({ connection }: EditConnectionFormProps): Rea
           issue a sales document (invoice OR fiscal receipt) shows its routing
           status here, read-only. Editing lives ONLY at Settings → Sales
           documents — see `SalesDocumentStatusSection`'s doc comment for why. */}
-      {connection.enabledCapabilities.includes('Invoicing') ||
-      connection.enabledCapabilities.includes('Fiscalization') ? (
+      {enabledCapabilities.includes('Invoicing') ||
+      enabledCapabilities.includes('Fiscalization') ? (
         <SalesDocumentStatusSection
           connection={connection}
           allConnections={connectionsQuery.data ?? []}

--- a/apps/web/src/features/connections/components/create-connection-form.test.tsx
+++ b/apps/web/src/features/connections/components/create-connection-form.test.tsx
@@ -26,6 +26,23 @@ describe('CreateConnectionForm', () => {
     captureDemoEvent.mockClear();
   });
 
+  it('does not crash when GET /adapters returns a shapeless envelope instead of an array', async () => {
+    // A degraded response (a 500 handled into an empty object, a partial
+    // payload) can arrive as a successful query whose `data` is truthy but
+    // not actually an array — `adaptersQuery.data?.filter` alone only
+    // guards `undefined`, not a truthy non-array value.
+    const list = vi.fn().mockResolvedValue({ data: [], total: 0 });
+    const apiClient = createMockApiClient({ adapters: { list } });
+
+    renderWithProviders(<CreateConnectionForm />, { apiClient });
+
+    await waitFor(() => {
+      expect(list).toHaveBeenCalled();
+    });
+    // The form must still be there — a crash would unmount the whole tree.
+    expect(screen.getByLabelText('Config JSON')).toBeInTheDocument();
+  });
+
   it('shows validation feedback for invalid JSON configuration', async () => {
     const view = renderWithProviders(<CreateConnectionForm />);
 

--- a/apps/web/src/features/connections/components/create-connection-form.tsx
+++ b/apps/web/src/features/connections/components/create-connection-form.tsx
@@ -92,8 +92,14 @@ export function CreateConnectionForm(): ReactElement {
   // Prefer the platform DEFAULT, because that is what the backend resolves when
   // the form omits `adapterKey` (`getDefaultAdapterKey`). First-match-wins would
   // read a non-default sibling if a platform ever ships two adapters.
-  const platformAdapters =
-    adaptersQuery.data?.filter((adapter) => adapter.platformType === watchedPlatformType) ?? [];
+  //
+  // A degraded response (a 500 handled into an empty object, a partial
+  // payload) can arrive as a successful query whose `data` is truthy but not
+  // actually an array — `?.` alone only guards `undefined`, not a truthy
+  // non-array value, and `.filter` on that throws.
+  const platformAdapters = Array.isArray(adaptersQuery.data)
+    ? adaptersQuery.data.filter((adapter) => adapter.platformType === watchedPlatformType)
+    : [];
   const selectedAdapter =
     platformAdapters.find((adapter) => adapter.isDefault === true) ?? platformAdapters[0];
   const requiresCredentials = selectedAdapter?.requiresCredentials !== false;

--- a/apps/web/src/features/mappings/lib/platform-label.test.ts
+++ b/apps/web/src/features/mappings/lib/platform-label.test.ts
@@ -42,6 +42,15 @@ describe('resolvePlatformLabel', () => {
   it('returns an empty string rather than throwing on an empty platformType', () => {
     expect(resolvePlatformLabel(PLATFORMS, '')).toBe('');
   });
+
+  it('returns "unknown" rather than throwing when a connection-shaped object carries no `platformType` at all', () => {
+    // A degraded response (a 500 handled into an empty object, a partial
+    // payload, a field dropped by version skew) can arrive as a truthy
+    // connection-shaped object with `platformType` genuinely undefined at
+    // runtime, despite the declared `ConnectionLike.platformType: string`.
+    const degraded = {} as unknown as { platformType: string };
+    expect(resolvePlatformLabel(PLATFORMS, degraded)).toBe('unknown');
+  });
 });
 
 describe('findPlatformDisplayName', () => {
@@ -59,5 +68,10 @@ describe('findPlatformDisplayName', () => {
 
   it('returns undefined when the plugin list is empty', () => {
     expect(findPlatformDisplayName([], 'allegro')).toBeUndefined();
+  });
+
+  it('returns undefined rather than throwing when a connection-shaped object carries no `platformType` at all', () => {
+    const degraded = {} as unknown as { platformType: string };
+    expect(findPlatformDisplayName(PLATFORMS, degraded)).toBeUndefined();
   });
 });

--- a/apps/web/src/features/mappings/lib/platform-label.ts
+++ b/apps/web/src/features/mappings/lib/platform-label.ts
@@ -51,7 +51,15 @@ export function findPlatformDisplayName(
   platforms: readonly PlatformLike[],
   platform: string | ConnectionLike,
 ): string | undefined {
-  const platformType = typeof platform === 'string' ? platform : platform.platformType;
+  // `platform` is documented as `string | ConnectionLike`, but a connection
+  // sourced from a degraded response (a 500 handled into an empty object, a
+  // partial payload, a field dropped by version skew) can carry
+  // `platformType: undefined` at runtime despite the declared type — `?.`
+  // guards that without asserting a platform we don't actually know, and
+  // `resolvePlatformLabel` below relies on this to forward a possibly-empty
+  // value safely.
+  const platformType = typeof platform === 'string' ? platform : platform?.platformType;
+  if (!platformType) return undefined;
   return platforms.find((p) => p.platformType === platformType)?.displayName;
 }
 
@@ -80,6 +88,10 @@ export function resolvePlatformLabel(
   platforms: readonly PlatformLike[],
   platform: string | ConnectionLike,
 ): string {
-  const platformType = typeof platform === 'string' ? platform : platform.platformType;
-  return findPlatformDisplayName(platforms, platformType) ?? platformType;
+  // Forward the original `platform`, not a pre-extracted `platformType` —
+  // `findPlatformDisplayName` above already guards a missing field, so
+  // re-deriving it here (`platform?.platformType`) is only for the final
+  // fallback string, never passed on as a bare (possibly-undefined) value.
+  const platformType = typeof platform === 'string' ? platform : platform?.platformType;
+  return findPlatformDisplayName(platforms, platform) ?? platformType ?? 'unknown';
 }

--- a/apps/web/src/features/mcp-tokens/components/mcp-tokens-panel.test.tsx
+++ b/apps/web/src/features/mcp-tokens/components/mcp-tokens-panel.test.tsx
@@ -4,7 +4,7 @@
  * Covers the four async UX states plus the security-critical behaviours:
  * the raw token is revealed exactly once and never re-rendered afterwards.
  */
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor, waitForElementToBeRemoved } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 import {
@@ -54,6 +54,36 @@ describe('McpTokensPanel', () => {
     });
 
     expect(await screen.findByText('No MCP tokens')).toBeInTheDocument();
+  });
+
+  it('should not crash when the list response is a shapeless envelope instead of an array', async () => {
+    // A degraded response (a 500 handled into an empty object, a partial
+    // payload) can arrive as a successful query whose `data` is truthy but
+    // not actually an array — `Array.isArray` guards that.
+    const apiClient = createMockApiClient({
+      mcpTokens: {
+        list: vi.fn().mockResolvedValue({ data: [], total: 0 } as unknown as (typeof TOKEN)[]),
+      },
+    });
+
+    renderWithProviders(<McpTokensPanel />, {
+      apiClient,
+      sessionAdapter: createAuthenticatedSessionAdapter(),
+    });
+
+    // Wait for the loading state to actually APPEAR first, then disappear —
+    // a bare `queryByText(...).not.toBeInTheDocument()` with no prior
+    // `findBy` can pass trivially on the pre-fetch render, before the mocked
+    // promise even resolves, proving nothing about the crash this guards.
+    await screen.findByText('Loading tokens');
+    await waitForElementToBeRemoved(() => screen.queryByText('Loading tokens'));
+    // Asserted immediately after the removal settles: an uncaught render
+    // exception with no error boundary unmounts the WHOLE tree, so this
+    // sibling heading disappearing too is what tells a crash apart from a
+    // successful settle where only the loading state cleared.
+    expect(screen.getByRole('heading', { name: 'New MCP token' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'MCP tokens' })).toBeInTheDocument();
+    expect(screen.queryByText('Claude Desktop')).not.toBeInTheDocument();
   });
 
   it('should render an error state when the list fails', async () => {

--- a/apps/web/src/features/mcp-tokens/components/mcp-tokens-panel.tsx
+++ b/apps/web/src/features/mcp-tokens/components/mcp-tokens-panel.tsx
@@ -78,7 +78,11 @@ export function McpTokensPanel(): ReactElement {
         {tokensQuery.isError ? (
           <ErrorState title="Could not load tokens" message={tokensQuery.error.message} />
         ) : null}
-        {tokensQuery.data ? (
+        {/* A degraded response (a 500 handled into an empty object, a
+            partial payload) can arrive as a successful query whose `data`
+            is truthy but not actually an array — `Array.isArray` guards
+            that, matching the McpTokensTile fix for the same query. */}
+        {Array.isArray(tokensQuery.data) ? (
           <McpTokenList
             tokens={tokensQuery.data}
             isRevoking={revokeMutation.isPending}

--- a/apps/web/src/features/sales-documents/components/sales-document-country-index.test.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-country-index.test.tsx
@@ -150,4 +150,21 @@ describe('SalesDocumentCountryIndex', () => {
 
     expect(await screen.findByText(/No countries configured yet/i)).toBeInTheDocument();
   });
+
+  it('should degrade to the empty state, not crash, when the countries response is a shapeless envelope instead of an array', async () => {
+    // A degraded response (a 500 handled into an empty object, a partial
+    // payload) can arrive as a successful query whose `data` is truthy but
+    // not actually an array.
+    const apiClient = createMockApiClient({
+      connections: { list: vi.fn().mockResolvedValue([]) },
+      salesDocumentRules: {
+        listConfiguredCountries: vi
+          .fn()
+          .mockResolvedValue({ data: [], total: 0 } as unknown as SalesDocumentCountrySummary[]),
+      },
+    });
+    renderWithProviders(<SalesDocumentCountryIndex onSelectCountry={vi.fn()} />, { apiClient });
+
+    expect(await screen.findByText(/No countries configured yet/i)).toBeInTheDocument();
+  });
 });

--- a/apps/web/src/features/sales-documents/components/sales-document-country-index.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-country-index.tsx
@@ -83,7 +83,12 @@ export function SalesDocumentCountryIndex({
     return <span>{name}</span>;
   };
 
-  const rows = orderSalesDocumentCountries(countriesQuery.data ?? []);
+  // A degraded response (a 500 handled into an empty object, a partial
+  // payload) can arrive as a successful query whose `data` is truthy but
+  // not actually an array — `?? []` alone only guards `undefined`.
+  const rows = orderSalesDocumentCountries(
+    Array.isArray(countriesQuery.data) ? countriesQuery.data : [],
+  );
 
   function submitAddCountry(): void {
     const normalized = draftCountry.trim().toUpperCase();

--- a/apps/web/src/features/sales-documents/components/sales-document-template-screen.test.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-template-screen.test.tsx
@@ -1,0 +1,96 @@
+/**
+ * SalesDocumentTemplateScreen tests
+ *
+ * @module apps/web/src/features/sales-documents/components
+ */
+import { screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { createMockApiClient, renderWithProviders } from '../../../test/test-utils';
+import { SalesDocumentTemplateScreen } from './sales-document-template-screen';
+import type { SalesDocumentStarterTemplate } from '../api/sales-document-rules.types';
+
+const REAL_TEMPLATE: SalesDocumentStarterTemplate = {
+  country: 'PL',
+  sourceLabel: 'Ministry of Finance',
+  sourceUrl: 'https://example.com/pl-vat',
+  disclaimer: 'Not legal advice.',
+  rules: [
+    {
+      slot: 'invoice',
+      label: 'Invoice for a business buyer',
+      requiredCapability: 'Invoicing',
+      documentKind: 'invoice',
+      effectiveFrom: '2026-01-01',
+      effectiveTo: null,
+      usesBuyerHasTaxId: true,
+    },
+  ],
+};
+
+describe('SalesDocumentTemplateScreen', () => {
+  it('renders the starter template card when the API resolves one', async () => {
+    const apiClient = createMockApiClient({
+      salesDocumentRules: { getTemplate: vi.fn().mockResolvedValue(REAL_TEMPLATE) },
+    });
+    renderWithProviders(<SalesDocumentTemplateScreen country="PL" />, { apiClient });
+
+    expect(await screen.findByText('Suggested starter template')).toBeInTheDocument();
+  });
+
+  it('renders nothing when no curated template exists for the country', async () => {
+    const apiClient = createMockApiClient({
+      salesDocumentRules: { getTemplate: vi.fn().mockResolvedValue(null) },
+    });
+    // Wrapped in a probe element rather than asserting on the render
+    // `container` directly — `renderWithProviders`' own wrapper chrome
+    // (the toast region, etc.) means the outer container is never truly
+    // empty, crash or not. The probe isolates "did OUR component render
+    // anything" from that chrome.
+    renderWithProviders(
+      <div data-testid="probe">
+        <SalesDocumentTemplateScreen country="DE" />
+      </div>,
+      { apiClient },
+    );
+
+    // Wait for the loading state to clear AND the probe to be empty in the
+    // SAME check — the query being called is not the same as it having
+    // settled and re-rendered, and checking the two outside one retrying
+    // `waitFor` risks observing the still-loading DOM as if it were final.
+    await waitFor(() => {
+      expect(screen.queryByText(/Checking for a starter template/i)).not.toBeInTheDocument();
+      expect(screen.getByTestId('probe')).toBeEmptyDOMElement();
+    });
+  });
+
+  it('degrades to rendering nothing, not a crash, when the response is truthy but has no `rules` array', async () => {
+    // A degraded response (a 500 handled into an empty object, a partial
+    // payload, a field dropped by version skew) can arrive as a successful
+    // query whose `data` is truthy but not shaped like a real template —
+    // `rules` in particular must be an array, since it is `.map`-ped.
+    // `null` already means "no curated template for this country" here, so
+    // an unreadable response degrades into that same, already-handled state.
+    // An uncaught render exception with no error boundary unmounts the
+    // WHOLE tree, so the probe disappearing entirely (rather than merely
+    // being empty) is what would tell a crash apart from a clean render.
+    const apiClient = createMockApiClient({
+      salesDocumentRules: {
+        getTemplate: vi
+          .fn()
+          .mockResolvedValue({ country: 'PL' } as unknown as SalesDocumentStarterTemplate),
+      },
+    });
+    renderWithProviders(
+      <div data-testid="probe">
+        <SalesDocumentTemplateScreen country="PL" />
+      </div>,
+      { apiClient },
+    );
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Checking for a starter template/i)).not.toBeInTheDocument();
+      expect(screen.getByTestId('probe')).toBeEmptyDOMElement();
+    });
+    expect(screen.queryByText('Suggested starter template')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/sales-documents/components/sales-document-template-screen.tsx
+++ b/apps/web/src/features/sales-documents/components/sales-document-template-screen.tsx
@@ -41,7 +41,14 @@ export function SalesDocumentTemplateScreen({
     return <LoadingState title="Checking for a starter template" message="" />;
   }
 
-  const template = templateQuery.data ?? null;
+  // A degraded response (a 500 handled into an empty object, a partial
+  // payload) can arrive as a successful query whose `data` is truthy but
+  // not shaped like a real template — `rules` in particular must be an
+  // array, since it's `.map`-ped below. `null` already has a meaning here
+  // ("no curated template for this country"), so an unreadable response
+  // degrades into that same, already-handled state rather than crashing.
+  const rawTemplate = templateQuery.data ?? null;
+  const template = rawTemplate !== null && Array.isArray(rawTemplate.rules) ? rawTemplate : null;
   if (template === null || dismissed) {
     return null;
   }

--- a/apps/web/src/pages/ai-provider-settings/ai-provider-settings-page.test.tsx
+++ b/apps/web/src/pages/ai-provider-settings/ai-provider-settings-page.test.tsx
@@ -149,6 +149,30 @@ describe('AiProviderSettingsPage', () => {
     expect(openaiActivate).toBeDisabled();
   });
 
+  it('shows an error, not a crash, when the response has no `providers` array', async () => {
+    // A degraded response (a 500 handled into an empty object, a partial
+    // payload) can arrive as a successful query whose `data` is truthy but
+    // `providers` is missing — `hasAnyKeyConfigured(query.data.providers)`
+    // would otherwise throw reading `.some` off `undefined`.
+    const getAll = vi.fn().mockResolvedValue({
+      activeProvider: 'anthropic',
+      activeUpdatedAt: null,
+      activeUpdatedBy: null,
+    } as unknown as AiProviderSettingsView);
+    const apiClient = createMockApiClient({ aiProviderSettings: { getAll } });
+
+    renderWithProviders(<AiProviderSettingsPage />, {
+      apiClient,
+      sessionAdapter: adminAdapter,
+    });
+
+    expect(
+      await screen.findByText(
+        'The response did not carry the provider list this page needs. Try again in a moment.',
+      ),
+    ).toBeInTheDocument();
+  });
+
   it('renders the ErrorState with retry when the query fails', async () => {
     const getAll = vi.fn().mockRejectedValue(new Error('Network down'));
     const apiClient = createMockApiClient({ aiProviderSettings: { getAll } });

--- a/apps/web/src/pages/ai-provider-settings/ai-provider-settings-page.tsx
+++ b/apps/web/src/pages/ai-provider-settings/ai-provider-settings-page.tsx
@@ -58,7 +58,7 @@ export function AiProviderSettingsPage(): ReactElement {
             </Button>
           }
         />
-      ) : query.data ? (
+      ) : query.data && Array.isArray(query.data.providers) ? (
         <>
           {!hasAnyKeyConfigured(query.data.providers) ? (
             <Alert tone="warning" title="No AI provider configured">
@@ -69,6 +69,22 @@ export function AiProviderSettingsPage(): ReactElement {
           ) : null}
           <AiProviderTable view={query.data} />
         </>
+      ) : query.data ? (
+        // A degraded response (a 500 handled into an empty object, a
+        // partial payload) can arrive as a successful query whose `data`
+        // is truthy but `providers` is missing — this is one indivisible
+        // answer (which providers exist and which is active), so an
+        // unreadable envelope is reported as unreadable rather than
+        // rendered with the list silently empty.
+        <ErrorState
+          title="Unable to load provider settings"
+          message="The response did not carry the provider list this page needs. Try again in a moment."
+          action={
+            <Button tone="secondary" onClick={() => void query.refetch()}>
+              Retry
+            </Button>
+          }
+        />
       ) : null}
     </PageLayout>
   );

--- a/apps/web/src/pages/connections/connection-category-mappings-page.test.tsx
+++ b/apps/web/src/pages/connections/connection-category-mappings-page.test.tsx
@@ -13,6 +13,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createMockApiClient, renderWithProviders, sampleConnection } from '../../test/test-utils';
 import { ConnectionCategoryMappingsPage } from './connection-category-mappings-page';
 import type { Connection } from '../../features/connections/api/connections.types';
+import type { CategoryMapping } from '../../features/mappings/api/mappings.types';
 import type * as DemoModule from '../../features/demo';
 
 const captureDemoEvent = vi.fn();
@@ -61,6 +62,27 @@ describe('ConnectionCategoryMappingsPage', () => {
       mappedCountBucket: '0',
     });
     expect(captureDemoEvent).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not crash when the category-mappings response is a shapeless envelope instead of an array', async () => {
+    // A degraded response (a 500 handled into an empty object, a partial
+    // payload) can arrive as a successful query whose `data` is truthy but
+    // not actually an array.
+    const apiClient = createMockApiClient({
+      connections: {
+        list: vi.fn().mockResolvedValue([sampleConnection, ALLEGRO_CONNECTION]),
+      },
+      mappings: {
+        getCategoryMappings: vi
+          .fn()
+          .mockResolvedValue({ data: [], total: 0 } as unknown as CategoryMapping[]),
+        getPrestashopCategories: vi.fn().mockResolvedValue(PS_CATEGORIES),
+      },
+    });
+
+    renderWithProviders(<ConnectionCategoryMappingsPage />, { apiClient });
+
+    expect(await screen.findByText('Men')).toBeInTheDocument();
   });
 
   it('captures demo_category_source_selected when the marketplace select changes (#1789)', async () => {

--- a/apps/web/src/pages/connections/connection-category-mappings-page.tsx
+++ b/apps/web/src/pages/connections/connection-category-mappings-page.tsx
@@ -99,7 +99,10 @@ export function ConnectionCategoryMappingsPage(): ReactElement {
   const upsertMutation = useUpsertCategoryMapping(connectionId);
   const deleteMutation = useDeleteCategoryMapping(connectionId);
 
-  const mappings = mappingsQuery.data ?? [];
+  // A degraded response (a 500 handled into an empty object, a partial
+  // payload) can arrive as a successful query whose `data` is truthy but not
+  // actually an array — `?? []` alone only guards `undefined`.
+  const mappings = Array.isArray(mappingsQuery.data) ? mappingsQuery.data : [];
   const categories = prestashopCategoriesQuery.data ?? [];
 
   const mappedCount = useMemo(() => {

--- a/apps/web/src/pages/connections/connection-detail-page.test.tsx
+++ b/apps/web/src/pages/connections/connection-detail-page.test.tsx
@@ -324,6 +324,29 @@ describe('ConnectionDetailPage', () => {
       expect(await screen.findByText('Product catalog not linked')).toBeInTheDocument();
       expect(screen.queryByText('Product catalog auto-linked')).toBeNull();
     });
+
+    it('does not crash when the connection response has no `enabledCapabilities` or `config`', async () => {
+      // A degraded response (a 500 handled into an empty object, a partial
+      // payload) can arrive as a successful query whose `data` is truthy but
+      // does not carry `enabledCapabilities`/`config` at all.
+      const degraded = { id: ALLEGRO_UUID, name: 'Degraded connection', platformType: 'allegro' };
+      const apiClient = createMockApiClient({
+        connections: {
+          getById: vi.fn().mockResolvedValue(degraded as unknown as Connection),
+          list: vi.fn().mockResolvedValue([]),
+        },
+      });
+      renderWithProviders(
+        <Routes>
+          <Route path="/connections/:connectionId" element={<ConnectionDetailPage />} />
+        </Routes>,
+        { apiClient, route: `/connections/${ALLEGRO_UUID}` },
+      );
+
+      expect(await screen.findByRole('heading', { name: 'Overview' })).toBeInTheDocument();
+      expect(screen.queryByText('Product catalog auto-linked')).toBeNull();
+      expect(screen.queryByText('Product catalog not linked')).toBeNull();
+    });
   });
 
   describe('Health tab access for a demo read-only viewer (#1614)', () => {

--- a/apps/web/src/pages/connections/connection-detail-page.tsx
+++ b/apps/web/src/pages/connections/connection-detail-page.tsx
@@ -134,14 +134,19 @@ function ProductCatalogLinkBanner({
   isLoading,
   hasError,
 }: ProductCatalogLinkBannerProps): ReactElement | null {
+  // A degraded response (a 500 handled into an empty object, a partial
+  // payload) can arrive as a successful query whose `data` is truthy but
+  // `enabledCapabilities` is missing — treat that as "no capabilities
+  // known" rather than crash.
+  const enabledCapabilities = connection.enabledCapabilities ?? [];
   if (
-    !connection.enabledCapabilities.includes('OfferManager') &&
-    !connection.enabledCapabilities.includes('ProductPublisher')
+    !enabledCapabilities.includes('OfferManager') &&
+    !enabledCapabilities.includes('ProductPublisher')
   ) {
     return null;
   }
 
-  const rawMaster = connection.config.masterCatalogConnectionId;
+  const rawMaster = connection.config?.masterCatalogConnectionId;
   const explicitMaster = typeof rawMaster === 'string' ? rawMaster : null;
   const editHref = `/connections/${connection.id}/edit`;
 
@@ -226,7 +231,12 @@ export function ConnectionDetailPage(): ReactElement {
       eyebrow="Integration detail"
       title={
         connection ? (
-          <EntityLabel id={connection.id} name={connection.name} />
+          // A degraded response (a 500 handled into an empty object, a
+          // partial payload) can arrive as a successful query whose `data`
+          // is truthy but `id` is missing — fall back to the route's own
+          // `connectionId`, the same value a well-formed response echoes
+          // back, rather than pass `EntityLabel` an id it cannot shorten.
+          <EntityLabel id={connection.id || connectionId} name={connection.name} />
         ) : (
           `Connection ${connectionId}`
         )
@@ -242,7 +252,7 @@ export function ConnectionDetailPage(): ReactElement {
             <Link className="button button--secondary" to={`/connections/${connectionId}/mappings`}>
               Mappings
             </Link>
-            {connection.enabledCapabilities.includes('ProductMaster') ? (
+            {(connection.enabledCapabilities ?? []).includes('ProductMaster') ? (
               <Link className="button button--secondary" to={`/connections/${connectionId}/mappings/categories`}>
                 Category Mappings
               </Link>
@@ -349,7 +359,7 @@ export function ConnectionDetailPage(): ReactElement {
           <TabsContent value="health">
             <ConnectionDiagnosticsPanel connectionId={connection.id} />
             <ConnectionSyncStatusPanel connectionId={connection.id} />
-            {connection.enabledCapabilities.includes('ProductMaster') ? (
+            {(connection.enabledCapabilities ?? []).includes('ProductMaster') ? (
               <CatalogTrustPanel connectionId={connection.id} />
             ) : null}
             {/* #2407 — install-wide precondition, rendered here because this is

--- a/apps/web/src/pages/insights/insights-page.test.tsx
+++ b/apps/web/src/pages/insights/insights-page.test.tsx
@@ -9,6 +9,7 @@ import {
 } from '../../test/test-utils';
 import { InsightsPage } from './insights-page';
 import type { Connection } from '../../features/connections/api/connections.types';
+import type { DevStackHealth } from '../../features/health/api/health.types';
 import type {
   JobType,
   SyncJob,
@@ -114,6 +115,38 @@ describe('InsightsPage', () => {
     expect(await within(container).findByText('PostgreSQL')).toBeInTheDocument();
     expect(within(container).getByText('Redis')).toBeInTheDocument();
     expect(within(container).getByText('PrestaShop')).toBeInTheDocument();
+  });
+
+  it('does not crash and omits the service list when the health response has no `services` field', async () => {
+    // A degraded response (a 500 handled into an empty object, a partial
+    // payload) can arrive as a successful query whose `data` is truthy but
+    // `services` is missing entirely.
+    const apiClient = createMockApiClient({
+      health: {
+        getDevStackHealth: vi.fn().mockResolvedValue({
+          status: 'ok',
+          timestamp: '2026-04-06T00:00:00.000Z',
+        } as unknown as DevStackHealth),
+      },
+    });
+    const { container } = renderWithProviders(<InsightsPage />, { apiClient });
+
+    // Wait for the health query to actually settle (the KPI shows the
+    // top-level `status`, which this degraded payload does carry) before
+    // asserting on what the (missing-`services`) render produced — a bare
+    // synchronous `queryByText` here would pass trivially before the mocked
+    // promise even resolves, proving nothing about the crash this guards.
+    await waitFor(() => {
+      const card = findCardByLabel(container, 'System health');
+      expect(within(card).getByText('OK')).toBeInTheDocument();
+    });
+
+    expect(
+      within(container).getByRole('heading', { name: 'Operations overview' })
+    ).toBeInTheDocument();
+    expect(within(container).queryByText('PostgreSQL')).not.toBeInTheDocument();
+    expect(within(container).queryByText('Redis')).not.toBeInTheDocument();
+    expect(within(container).queryByText('PrestaShop')).not.toBeInTheDocument();
   });
 
   it('lists an infra-bearing connection (e.g. WooCommerce) in the Infrastructure panel (#1619)', async () => {

--- a/apps/web/src/pages/insights/insights-page.tsx
+++ b/apps/web/src/pages/insights/insights-page.tsx
@@ -109,7 +109,11 @@ function buildInfraNodeLabels(
 ): string[] {
   if (!data) return [];
   const labels = ['Postgres', 'Redis', 'PrestaShop'];
-  if (data.services.worker) {
+  // A degraded response (a 500 handled into an empty object, a partial
+  // payload) can arrive as a successful query whose `data` is truthy but
+  // `services` is missing entirely — `?.` guards that without asserting the
+  // worker is absent when we simply don't know.
+  if (data.services?.worker) {
     labels.push('Worker');
   }
   for (const connection of data.connections ?? []) {
@@ -617,7 +621,11 @@ export function InsightsPage(): ReactElement {
               action={<Button onClick={() => void healthQuery.refetch()}>Retry</Button>}
             />
           )}
-          {healthQuery.data && (
+          {/* A degraded response can arrive as a successful query whose
+              `data` is truthy but `services` is missing entirely — render
+              nothing rather than claim a status for a service we have no
+              data for. */}
+          {healthQuery.data?.services && (
             <ul className="check-list">
               <ServiceHealthRow name="PostgreSQL" health={healthQuery.data.services.postgres} />
               <ServiceHealthRow name="Redis" health={healthQuery.data.services.redis} />

--- a/apps/web/src/pages/prompt-templates/prompt-template-detail-page.test.tsx
+++ b/apps/web/src/pages/prompt-templates/prompt-template-detail-page.test.tsx
@@ -86,6 +86,27 @@ describe('PromptTemplateDetailPage', () => {
     expect(screen.getByRole('button', { name: /retry/i })).toBeInTheDocument();
   });
 
+  it('shows an error, not a crash, when the response has no `variables` array', async () => {
+    // A degraded response (a 500 handled into an empty object, a partial
+    // payload) can arrive as a successful query whose `data` is truthy but
+    // does not carry the fields this page seeds into local state (in
+    // particular `variables`, later `.map`-ped by `collectUndeclared`).
+    renderPage({
+      promptTemplates: {
+        get: vi.fn().mockResolvedValue({
+          id: 'tmpl-1',
+          key: 'offer.description.suggest',
+        } as unknown as PromptTemplate),
+      },
+    });
+
+    expect(
+      await screen.findByText(
+        'The response did not carry the fields this page needs. Try again in a moment.',
+      ),
+    ).toBeInTheDocument();
+  });
+
   it('shows the state-appropriate actions for a draft', async () => {
     renderPage({
       promptTemplates: {

--- a/apps/web/src/pages/prompt-templates/prompt-template-detail-page.tsx
+++ b/apps/web/src/pages/prompt-templates/prompt-template-detail-page.tsx
@@ -55,6 +55,33 @@ function channelLabel(channel: string | null): string {
   return channel === null ? 'master' : channel;
 }
 
+/**
+ * A degraded response (a 500 handled into an empty object, a partial
+ * payload, a field dropped by version skew) can arrive as a successful
+ * query whose `data` is truthy but not shaped like `PromptTemplate` — every
+ * field below is read unguarded throughout this page (including
+ * `variables`, seeded into local state and then `.map`-ped), so a response
+ * that did not actually carry them would crash rather than render. This is
+ * a whole-envelope check: the template is one indivisible answer, and a
+ * page that "renders" with some of it silently missing would let an
+ * operator edit and save a template built from placeholder blanks.
+ */
+function isPromptTemplate(data: unknown): data is PromptTemplate {
+  if (typeof data !== 'object' || data === null) return false;
+  const candidate = data as Partial<PromptTemplate>;
+  return (
+    typeof candidate.id === 'string' &&
+    typeof candidate.key === 'string' &&
+    typeof candidate.version === 'number' &&
+    typeof candidate.systemPrompt === 'string' &&
+    typeof candidate.userPromptTemplate === 'string' &&
+    Array.isArray(candidate.variables) &&
+    typeof candidate.state === 'string' &&
+    typeof candidate.createdAt === 'string' &&
+    typeof candidate.updatedAt === 'string'
+  );
+}
+
 export function PromptTemplateDetailPage(): ReactElement {
   const { id } = useParams<{ id: string }>();
   const { session } = useSession();
@@ -63,7 +90,8 @@ export function PromptTemplateDetailPage(): ReactElement {
   const isMobile = useMediaQuery('(max-width: 1023.98px)');
 
   const detailQuery = usePromptTemplateQuery(id);
-  const template = detailQuery.data;
+  const template = isPromptTemplate(detailQuery.data) ? detailQuery.data : undefined;
+  const isUnreadable = !detailQuery.isLoading && !detailQuery.error && detailQuery.data !== undefined && template === undefined;
   const versionsQuery = usePromptTemplateVersionsQuery(template?.key, template?.channel ?? null);
 
   const updateMutation = useUpdatePromptTemplateDraftMutation();
@@ -200,6 +228,22 @@ export function PromptTemplateDetailPage(): ReactElement {
         <ErrorState
           title="Unable to load prompt template"
           message={detailQuery.error instanceof Error ? detailQuery.error.message : 'Unknown error'}
+          action={
+            <Button tone="secondary" onClick={() => void detailQuery.refetch()}>
+              Retry
+            </Button>
+          }
+        />
+      </PageLayout>
+    );
+  }
+
+  if (isUnreadable) {
+    return (
+      <PageLayout eyebrow="Settings" title="Prompt template">
+        <ErrorState
+          title="Unable to load prompt template"
+          message="The response did not carry the fields this page needs. Try again in a moment."
           action={
             <Button tone="secondary" onClick={() => void detailQuery.refetch()}>
               Retry

--- a/apps/web/src/pages/prompt-templates/prompt-templates-list-page.test.tsx
+++ b/apps/web/src/pages/prompt-templates/prompt-templates-list-page.test.tsx
@@ -68,6 +68,24 @@ describe('PromptTemplatesListPage', () => {
     expect(await screen.findByText(/No prompt templates yet/i)).toBeInTheDocument();
   });
 
+  it('degrades to the empty state, not a crash, when the response is a shapeless envelope instead of an array', async () => {
+    // A degraded response (a 500 handled into an empty object, a partial
+    // payload) can arrive as a successful query whose `data` is truthy but
+    // not actually an array — `?? []` alone only guards `undefined`.
+    const client = createMockApiClient({
+      promptTemplates: {
+        list: vi
+          .fn()
+          .mockResolvedValue({ data: [], total: 0 } as unknown as PromptTemplateSummary[]),
+      },
+    });
+    renderWithProviders(<PromptTemplatesListPage />, {
+      apiClient: client,
+      sessionAdapter: adminAdapter,
+    });
+    expect(await screen.findByText(/No prompt templates yet/i)).toBeInTheDocument();
+  });
+
   it('renders error state with retry affordance', async () => {
     const client = createMockApiClient({
       promptTemplates: { list: vi.fn().mockRejectedValue(new Error('Network error')) },

--- a/apps/web/src/pages/prompt-templates/prompt-templates-list-page.tsx
+++ b/apps/web/src/pages/prompt-templates/prompt-templates-list-page.tsx
@@ -214,7 +214,10 @@ export function PromptTemplatesListPage(): ReactElement {
     });
   };
 
-  const allRows = query.data ?? [];
+  // A degraded response (a 500 handled into an empty object, a partial
+  // payload) can arrive as a successful query whose `data` is truthy but
+  // not actually an array — `?? []` alone only guards `undefined`.
+  const allRows = Array.isArray(query.data) ? query.data : [];
   const rows = allRows.filter((row) => matchesStatusFilter(row, statusFilter));
 
   const columns: DataTableColumn<PromptTemplateSummary>[] = [

--- a/apps/web/src/pages/settings/operational-settings-page.test.tsx
+++ b/apps/web/src/pages/settings/operational-settings-page.test.tsx
@@ -128,6 +128,24 @@ describe('OperationalSettingsPage', () => {
     expect(screen.getAllByText('100 (default)').length).toBeGreaterThan(0);
   });
 
+  it('should show an error, not crash, when the response has none of the pacing fields', async () => {
+    // A degraded response (a 500 handled into an empty object, a partial
+    // payload) can arrive as a successful query whose `data` is truthy but
+    // does not carry the five pacing values this page reads via `.value`.
+    renderPage({
+      get: vi.fn().mockResolvedValue({
+        deletionAuditAlwaysEnabled: true,
+        cadenceAppliesAt: 'next-scheduler-start',
+        updatedAt: null,
+        updatedBy: null,
+      }),
+    });
+
+    expect(
+      await screen.findByRole('heading', { name: 'Unable to load sync pacing' }),
+    ).toBeInTheDocument();
+  });
+
   it('should keep the save button inert until something changes', async () => {
     renderPage();
 

--- a/apps/web/src/pages/settings/operational-settings-page.tsx
+++ b/apps/web/src/pages/settings/operational-settings-page.tsx
@@ -80,6 +80,26 @@ const NUMERIC_FIELDS: readonly OperationalSettingKey[] = [
   'deletionAuditBudget',
 ];
 
+/**
+ * A degraded response (a 500 handled into an empty object, a partial
+ * payload, a field dropped by version skew) can arrive as a successful
+ * query whose `data` is truthy but not shaped like `OperationalSettingsView`
+ * — every numeric field below is read via `.value`, so a query result that
+ * did not actually carry them would crash rather than render. This is a
+ * whole-envelope check, matching how the who-decides status read treats an
+ * unreadable response: the five pacing values are one indivisible answer,
+ * so a page that "renders" with some of them silently missing would assert
+ * settings the operator never confirmed exist.
+ */
+function isOperationalSettingsView(data: unknown): data is OperationalSettingsView {
+  if (typeof data !== 'object' || data === null) return false;
+  const candidate = data as Partial<OperationalSettingsView>;
+  return (
+    NUMERIC_FIELDS.every((key) => typeof candidate[key]?.value === 'number') &&
+    typeof candidate.deletionAuditCadence?.value === 'string'
+  );
+}
+
 function toValues(view: OperationalSettingsView): SyncPacingValues {
   return {
     catalogueSweepBudget: view.catalogueSweepBudget.value,
@@ -123,7 +143,8 @@ export function OperationalSettingsPage(): ReactElement {
    */
   const [acknowledged, setAcknowledged] = useState<Record<string, boolean>>({});
 
-  const view = query.data ?? null;
+  const view = isOperationalSettingsView(query.data) ? query.data : null;
+  const isUnreadable = !query.isPending && !query.error && query.data !== undefined && view === null;
   const savedStamp = view === null ? null : `${view.updatedAt ?? 'none'}:${view.deletionAuditCadence.value}`;
 
   // Adopt the server's values once, and again whenever the saved row changes
@@ -306,6 +327,16 @@ export function OperationalSettingsPage(): ReactElement {
         <ErrorState
           title="Unable to load sync pacing"
           message={query.error instanceof Error ? query.error.message : 'Unknown error'}
+          action={
+            <Button tone="secondary" onClick={() => void query.refetch()}>
+              Retry
+            </Button>
+          }
+        />
+      ) : isUnreadable ? (
+        <ErrorState
+          title="Unable to load sync pacing"
+          message="The response did not carry the values this page needs. Try again in a moment."
           action={
             <Button tone="secondary" onClick={() => void query.refetch()}>
               Retry

--- a/scripts/lighthouse/smoke-check.mjs
+++ b/scripts/lighthouse/smoke-check.mjs
@@ -18,14 +18,23 @@
  * platform type to resolve meaningfully and are not part of the generic
  * authenticated surface this check establishes coverage over.
  *
- * `REGRESSION_GUARD_ROUTES` are the two routes #2926 fixed
- * (`analytics-page.tsx`, `settings-page.tsx` and their tiles) — this script
- * exits non-zero if EITHER of them regresses to an error-boundary or a
- * thrown page error, so the fix stays fixed. Every other route is reported
- * but does NOT fail the process: the point of extending coverage to all of
- * them is to make the extent of the "unguarded `.length`/`.find`/`.filter`
- * read" class of bug visible, not to silently gate on fixing every one of
- * them in this change.
+ * `REGRESSION_GUARD_ROUTES` covers every route in `ROUTES` (widened from the
+ * original 2 — `/` and `/settings`, #2926 — once the remaining 14 crashing
+ * routes were fixed): this script exits non-zero if ANY of them regresses
+ * to an error-boundary or a thrown page error, so the fixed set stays
+ * fixed.
+ *
+ * Crash detection deliberately does NOT match on arbitrary "something went
+ * wrong"-shaped body text. An early version did, and it misclassified
+ * `/settings/who-decides` as crashed: that page's own `WhoDecidesPanel`
+ * validates its response and renders a genuine, designed `ErrorState`
+ * ("We could not load this page…") when the shape is unreadable — exactly
+ * the behaviour this check wants pages to have, not a bug. The one marker
+ * that reliably distinguishes a real unhandled render exception is React
+ * Router's own default `ErrorBoundary` heading, "Unexpected Application
+ * Error!" (verified against the shipped `react-router-dom` bundle) — no
+ * page-authored copy renders that exact string, so it is used instead of a
+ * broader regex.
  */
 import { chromium } from '@playwright/test';
 
@@ -71,7 +80,7 @@ const ROUTES = [
   '/dev/ui',
 ];
 
-const REGRESSION_GUARD_ROUTES = ['/', '/settings'];
+const REGRESSION_GUARD_ROUTES = ROUTES;
 
 async function main() {
   const browser = await chromium.launch();
@@ -98,9 +107,12 @@ async function main() {
     }
     await page.waitForTimeout(500);
     const bodyText = await page.locator('body').innerText();
-    const hasErrorBoundary = /something went wrong|unexpected error|application error/i.test(
-      bodyText,
-    );
+    // React Router's own default `ErrorBoundary` fallback title — the one
+    // marker that means an unhandled render exception, as opposed to a
+    // page's own designed `ErrorState` for an unreadable response (which
+    // uses its own copy, e.g. "We could not load this page…", and must not
+    // be misclassified as a crash — see the header comment).
+    const hasErrorBoundary = /unexpected application error!/i.test(bodyText);
     const crashed = hasErrorBoundary || pageErrors.length > 0;
     const title = await page.title();
     results.push({ route, crashed });
@@ -126,7 +138,7 @@ async function main() {
   const regressed = REGRESSION_GUARD_ROUTES.filter((route) => crashedRoutes.includes(route));
   if (regressed.length > 0) {
     console.error(
-      `\nREGRESSION: ${regressed.join(', ')} crashed against the degraded-data stub — #2926 fixed this.`,
+      `\nREGRESSION: ${regressed.join(', ')} crashed against the degraded-data stub.`,
     );
     process.exitCode = 1;
   }


### PR DESCRIPTION
## Summary

#2926 fixed `/` and `/settings` against the degraded-data stub and left 14 routes crashing the same way, gated behind a smoke-check exit code scoped to just those two. All 14 now render a degraded state instead of throwing, and the exit-code guard is widened to cover all 34 routes.

**Two shared root causes account for most of the count, not fourteen independent bugs.**

- `platform-label.ts`'s `resolvePlatformLabel` extracted a possibly-`undefined` `platformType` and forwarded *that* value (not the original connection-shaped object) into `findPlatformDisplayName`, whose non-string branch then read `.platformType` off `undefined`. Fixed once, in the utility — it's what `/connections/:id/mappings` hit via `MappingPairingBar`, and it would have hit every other caller passing a connection-shaped object with a missing `platformType`.
- `ConnectionCapabilitiesPanel`'s unguarded `supportedCapabilities`/`enabledCapabilities` reads were a second bug stacked directly behind `connection-detail-page.tsx`'s own — fixing the page's reads revealed the panel crashing next, the identical "fix one, the next stacked bug surfaces" shape #2926 hit on `/settings`.

Everything else is one repeated pattern (`Array.isArray(x) ? x : []`, since `?? []` alone only guards `undefined`, not a truthy non-array envelope) applied at five more sites, plus three pages (`operational-settings-page.tsx`, `ai-provider-settings-page.tsx`, `prompt-template-detail-page.tsx`) that needed a genuine "unreadable whole envelope" branch rather than a per-field default — each response is one indivisible answer, and a partial render would assert settings/values/a template the operator never confirmed exist.

**The smoke-check regex fix deserves calling out on its own.** The old crash-detection pattern matched any "something went wrong"-shaped body text, and it was flagging `/settings/who-decides` as crashed — the one page in the set already doing this *correctly*, rendering a designed `ErrorState` for an unreadable response rather than throwing. A guard that reports a correct implementation as broken teaches people to ignore it, which is worse than no guard. Narrowed to React Router's own default-boundary heading ("Unexpected Application Error!", verified against the shipped `react-router-dom` bundle — no page-authored copy can produce that exact string), which is what makes the widened 34-route coverage trustworthy rather than noisy.

Every fix was verified red-first: reverted, confirmed the paired test failed on the real crash trace, restored. That process caught a false pass in my own first attempt at the mcp-tokens test — a synchronous assertion was satisfied before the mocked query had actually settled, so the test passed identically with the bug present or fixed. Rewritten against a state the crash genuinely distinguishes (the loading indicator appearing then clearing, checked in one retrying assertion alongside a sibling element that a crash would also unmount). `docs/lessons.md`'s "a new assertion must be verified red-first" entry now has a fifth instance from this repo.

## Test plan

- [x] 14 previously-crashing routes render a degraded state (verified live against the #2866 mock stub, before and after)
- [x] `scripts/lighthouse/smoke-check.mjs`: 14 crashed → 0 crashed, `REGRESSION_GUARD_ROUTES` widened from `['/', '/settings']` to all 34 `ROUTES`
- [x] One regression test per fix, each verified red-first against the reverted code
- [x] `pnpm --filter @openlinker/web lint` — 0 errors, no new warnings on touched files
- [x] `pnpm --filter @openlinker/web type-check` — clean
- [x] `pnpm check:invariants` — clean
- [x] Scoped `vitest run` across every touched test file (186 tests) plus the full affected feature/page directories (830 tests) — all passing

Closes #2926

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UwqnrmELURfiSUu6898bsV