### PR TITLE
perf(f7): close the blindness the re-run exposed, and re-measure against the fixed guard

### DIFF
--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -1190,3 +1190,43 @@ but still risks interleaving at the wrong offset.
 `perf/**/*.sh`, `scripts/*.sh`, CI wrappers.
 
 **Source**: #2851 (F4 claim-contention scenario).
+
+---
+
+## A lock that arbitrates SCENARIOS does not arbitrate the STAND - a peer's `docker compose up` invalidates a held window, silently
+
+**Context**: F7's re-run (#2852) held `guard_stand_exclusive` for its whole
+measurement. Seven and a half minutes into the window, `lab-api` and
+`lab-worker-1` were both recreated by a peer who had just finished rebuilding
+the images. Every guard still passed. The contamination was noticed only
+because a `docker logs | grep -c` of degraded-limiter lines was read twice by
+hand and went **down**, from 36 to 2.
+
+**Problem**: the stand lock is advisory and scenario-scoped. It stops a second
+*scenario* from starting; it cannot stop `docker compose up -d`, which is a
+routine thing to type on a shared multi-worktree checkout the moment a build
+finishes. Three consequences follow, and not one of them raises anything:
+
+- in-flight jobs are killed and their rows stay `running` for ever, so a
+  `COUNT(*) WHERE status='running'` lane-occupancy proxy is inflated by
+  phantoms for the rest of the run (observed: 16 concurrent against a
+  per-scope cap of 8);
+- `docker logs` starts over, so every log-derived post-guard silently loses
+  the part of the window before the recreate and reports a count for the
+  remainder as though it were the whole - which is the *same* blindness as the
+  `--since "@epoch"` defect, arrived at from the other direction;
+- probe timings straddle a cold start.
+
+**Rule**: a measurement window must record what it is measuring ON, not only
+what it measured. Capture each measured container's `.State.StartedAt` at
+window_start and re-check it in the post-guards; any change means a restart or
+a recreate and the window is void. `post_guard_containers_stable`
+(`perf/openlinker-throughput/lib.sh`) does this. A **missing** baseline must
+refuse too - it means the run cannot answer the question, and "stable" would be
+the same confident-but-blind pass the guard exists to remove. Do not reach for
+a longer lock TTL instead: the peer never took the lock.
+
+**Applies to**: every scenario in `perf/openlinker-throughput/`, and any future
+harness that measures a shared, human-reachable environment.
+
+**Source**: #2852 (found while re-running F7 against the fixed degraded-limiter guard).

--- a/perf/openlinker-throughput/campaign-2026-09-06.md
+++ b/perf/openlinker-throughput/campaign-2026-09-06.md
@@ -448,11 +448,24 @@ catalogue size. The throughput figure stands; the store-impact figure does not.
   next candidate.
 - **Cross-lane starvation.** ADR-050's lane model is not validated by any run
   here. F7 (#2852) addresses it and F4 (#2851) exercised the multi-replica
-  arm, but **F7's `degraded_mode_entries = 0` must not be quoted**: its
-  post-guard filtered `docker logs` with `--since "@epoch"`, a form Docker
-  accepts while matching nothing, so the guard could not see a degraded line on
-  ANY scenario in this campaign. Fixed in #2851; the first arm run afterwards
-  found two.
+  arm. **F7's original `degraded_mode_entries = 0` is WITHDRAWN and must not
+  be quoted**: its post-guard filtered `docker logs` with `--since "@epoch"`, a
+  form Docker accepts while matching nothing, so the guard could not see a
+  degraded line on ANY scenario in this campaign. Fixed in #2851/#2969.
+  **F7 was re-run on 2026-09-07 against the fixed guard** and recorded
+  **≥ 38 degraded-mode lines** inside its window - the run is `DISCARDED` for
+  that reason. Its structural findings reproduced (claim latency flat across
+  arms; realtime execution roughly 5-6x under load while the fiscal control
+  stayed flat; occupancy 76.1% at the per-scope cap, still short of the literal
+  95% bar), but the original's "32x/35x" queued-depth growth ratio did **not**
+  and should not be quoted either - it is dominated by a sub-0.1 ms depth-0
+  denominator. **§8 of that report carries an explicit may-travel / may-not
+  table**, because a `DISCARDED` verdict stops nothing mechanically here (this
+  report's own F4 throughput figure is appended with the verdict as a column) -
+  in short, the isolation and depth findings travel, every throughput-shaped
+  figure from that window does not. That re-run also found that a peer
+  recreating the stack mid-window tripped no guard at all; closed by
+  `post_guard_containers_stable`.
 - **Erli's 500-unread inbox cliff.** Unreachable without an Erli arm, which does
   not exist; the cap itself is unverified prose rather than an observed
   behaviour.

--- a/perf/openlinker-throughput/lib-test.sh
+++ b/perf/openlinker-throughput/lib-test.sh
@@ -545,12 +545,18 @@ FAKE_PG[count]=0
 DRAIN_DEFERRED_SEEN=0
 WORKER_CONTAINERS="lab-worker"
 RPGDIR="$(mktemp -d)"
+# window_start would have captured this; these tests call run_post_guards
+# directly, so they must establish the same baseline or
+# post_guard_containers_stable correctly refuses to certify a window it has no
+# "before" reading for.
+capture_container_starts "$RPGDIR"
 run_post_guards "$RPGDIR" "'c1'" '2026-01-01T00:00:00Z' 0 9999999999 ''
 assert_eq "every post-guard ok -> VALID" "VALID" "$(verdict_read "$RPGDIR" | head -1)"
 rm -rf "$RPGDIR"
 
 FAKE_PG[count]=1
 RPGDIR2="$(mktemp -d)"
+capture_container_starts "$RPGDIR2"
 run_post_guards "$RPGDIR2" "'c1'" '2026-01-01T00:00:00Z' 0 9999999999 ''
 assert_eq "any post-guard failing -> DISCARDED" "DISCARDED" "$(verdict_read "$RPGDIR2" | head -1)"
 rm -rf "$RPGDIR2"
@@ -560,6 +566,7 @@ FAKE_PG[count]=0
 # post_guard_generator_saturated: a fixed-pool-at-ceiling summary passed with
 # the constant-vus hint must still resolve VALID, never DISCARDED.
 RPGDIR3="$(mktemp -d)"
+capture_container_starts "$RPGDIR3"
 write_k6_summary "$RPGDIR3/k6-summary.json" 16 16 none 2000
 run_post_guards "$RPGDIR3" "'c1'" '2026-01-01T00:00:00Z' 0 9999999999 '' "$RPGDIR3/k6-summary.json" constant-vus
 assert_eq "run_post_guards threads the executor hint through to the generator guard" "VALID" \
@@ -876,6 +883,88 @@ docker() {
 assert_eq "no degraded line inside the window passes" \
   "ok" "$(post_guard_limiter_degraded 1788730000 1788734000)"
 rm -f "$DOCKER_LOGS_ARGS_FILE"
+
+# ---------------------------------------------------------------------------
+echo "--- post_guard_containers_stable (#2852) ---"
+# The stand lock arbitrates scenarios, not `docker compose up` typed by hand.
+# A recreate inside the window kills in-flight jobs (leaving phantom `running`
+# rows that inflate the lane-occupancy proxy) and resets `docker logs`, so
+# every log-derived guard silently measures only the tail of the window. This
+# was observed live and tripped NOTHING; these assertions exist so the failing
+# case is proved to fail, not merely hoped to.
+CS_DIR="$(mktemp -d)"
+declare -A FAKE_STARTED
+docker() {
+  case "$1" in
+    ps) printf '%s\n' "$FAKE_WORKER_PS" ;;
+    inspect)
+      local last="${@: -1}"
+      case "$*" in
+        *'{{.State.StartedAt}}'*)
+          if [ -z "${FAKE_STARTED[$last]+set}" ]; then return 1; fi
+          echo "${FAKE_STARTED[$last]}" ;;
+        *'{{.Id}}'*) echo "fake-id-$last" ;;
+        *) echo "" ;;
+      esac ;;
+    *) : ;;
+  esac
+}
+OL_API_CONTAINER="lab-api"
+PG_CONTAINER="lab-postgres"; REDIS_CONTAINER=""; PS_CONTAINER=""; WC_CONTAINER=""
+WORKER_CONTAINERS="lab-worker-1"; WORKER_CONTAINERS_RESOLVED=1
+FAKE_STARTED["lab-api"]="2026-09-07T00:33:00Z"
+FAKE_STARTED["lab-worker-1"]="2026-09-07T00:33:01Z"
+FAKE_STARTED["lab-postgres"]="2026-09-07T00:10:00Z"
+
+capture_container_starts "$CS_DIR"
+assert_eq "a stand nobody touched passes" "ok" "$(post_guard_containers_stable "$CS_DIR")"
+
+# THE case this guard exists for: a peer recreates the worker mid-window.
+FAKE_STARTED["lab-worker-1"]="2026-09-07T00:41:21Z"
+CS_OUT="$(post_guard_containers_stable "$CS_DIR")"
+assert_contains "a worker recreated mid-window DISCARDS the run" "$CS_OUT" "DISCARDED post_guard_containers_stable"
+assert_contains "the refusal names the offending container" "$CS_OUT" "lab-worker-1"
+assert_contains "the refusal quotes the before/after start times" "$CS_OUT" "was=2026-09-07T00:33:01Z"
+
+# The api half of the same recreate - F7's live incident restarted BOTH, and a
+# guard watching only the worker would have called that stand stable.
+FAKE_STARTED["lab-worker-1"]="2026-09-07T00:33:01Z"
+FAKE_STARTED["lab-api"]="2026-09-07T00:41:21Z"
+assert_contains "an api recreated mid-window DISCARDS the run" \
+  "$(post_guard_containers_stable "$CS_DIR")" "lab-api"
+
+# A container that vanished entirely must not read as stable.
+FAKE_STARTED["lab-api"]="2026-09-07T00:33:00Z"
+unset 'FAKE_STARTED[lab-postgres]'
+assert_contains "a container that disappeared DISCARDS the run" \
+  "$(post_guard_containers_stable "$CS_DIR")" "lab-postgres"
+
+# An absent baseline is a REFUSAL, never a pass: it means the run cannot answer
+# the question, and "stable" would be exactly the confident-but-blind reading
+# the degraded-limiter defect taught us to distrust.
+assert_contains "a missing baseline DISCARDS rather than passing" \
+  "$(post_guard_containers_stable "$(mktemp -d)")" "no container baseline"
+
+# measured_containers' STDOUT is its return value, and _ensure_worker_containers
+# logs "worker replicas: ..." on its FIRST call. Unredirected, every word of
+# that log line becomes a "container" - the guard then records rubbish like
+# `[lib]` and `(explicit)` as things to watch, and reports them as MISSING for
+# ever after. Caught by the real-docker red-first check, not by the stubbed
+# assertions above (which run with discovery already memoised, so nothing
+# logs). This resets the memo so the log path is actually exercised.
+FAKE_WORKER_PS="lab-worker-1"
+WORKER_CONTAINERS="lab-worker-1"; WORKER_CONTAINERS_RESOLVED=0
+FAKE_EXISTING_CONTAINERS="lab-worker-1"
+MC_OUT="$(measured_containers)"
+case "$MC_OUT" in
+  *'['*|*'('*|*'replicas'*)
+    FAIL=$((FAIL + 1))
+    FAILURES+=("measured_containers leaked _ensure_worker_containers' log into its return value: [$MC_OUT]") ;;
+  *) PASS=$((PASS + 1)) ;;
+esac
+assert_eq "measured_containers returns only the container names" \
+  "lab-api lab-worker-1 lab-postgres" "$MC_OUT"
+rm -rf "$CS_DIR"
 
 # ---------------------------------------------------------------------------
 echo

--- a/perf/openlinker-throughput/lib.sh
+++ b/perf/openlinker-throughput/lib.sh
@@ -1074,6 +1074,9 @@ window_start() {
   log "settling ${SETTLE_SECS}s before window_start (letting the build/rebuild's CPU and page-cache impact fade)"
   sleep "$SETTLE_SECS"
   sampler_start "$dir" "$conn_ids"
+  # AFTER the settle and any scenario-owned recreate, so the baseline is the
+  # stack the window actually measures (see post_guard_containers_stable).
+  capture_container_starts "$dir"
   WINDOW_START_EPOCH="$(epoch)"
   log "window_start at $(iso_now)"
 }
@@ -1265,6 +1268,86 @@ post_guard_destination_creates() {
   fi
 }
 
+# ---------------------------------------------------------------------------
+# Container stability across the measurement window (#2852).
+#
+# The stand lock (guard_stand_exclusive) arbitrates SCENARIOS. It cannot stop a
+# peer running `docker compose up -d` by hand, and on a shared multi-worktree
+# checkout that is a routine thing to do - a rebuild is finished, the operator
+# recreates the stack. Observed live during F7's re-run: `lab-api` and
+# `lab-worker-1` were both recreated 7.5 minutes into a held window.
+#
+# Every consequence of that is silent:
+#   - in-flight jobs are killed, and their rows sit `running` forever, so the
+#     `COUNT(*) WHERE status='running'` lane-occupancy proxy is inflated by
+#     phantoms for the rest of the run;
+#   - `docker logs` starts over, so every log-derived post-guard (the degraded
+#     limiter one above all) silently loses the part of the window that
+#     preceded the recreate and reports a count for the remainder as if it
+#     were the whole;
+#   - probe timings straddle a cold start.
+#
+# None of that trips any existing guard. It was found by noticing a degraded
+# line COUNT go DOWN between two reads, which is not a thing anyone should have
+# to notice. `.State.StartedAt` changes on both a restart and a recreate, which
+# is exactly the set of events that invalidates the window.
+#
+# Captured at window_start rather than at scenario start on purpose: a
+# scenario legitimately recreates the worker itself while setting up (F7 flips
+# WORKER_RUNNER_ENABLED), and those recreates happen BEFORE the window opens.
+container_stability_file() { printf '%s/.container-starts' "$1"; }
+
+# The containers whose behaviour a run measures. A destination is included when
+# the scenario declares one - a shop restarting mid-window invalidates a
+# throughput number as surely as the worker doing so.
+measured_containers() {
+  # `>&2`, because this function's STDOUT is its return value and
+  # `_ensure_worker_containers` logs "worker replicas: ..." on first call.
+  # Without the redirect that log line is captured by `$(measured_containers)`
+  # and every word of it becomes a "container" - which the real-docker
+  # red-first check for this guard caught on its first run, as
+  # `MISSING) [lib](was= now=MISSING)` noise in the refusal text.
+  _ensure_worker_containers >&2
+  local c out=""
+  for c in $OL_API_CONTAINER $WORKER_CONTAINERS "${PG_CONTAINER:-}" "${REDIS_CONTAINER:-}" "${PS_CONTAINER:-}" "${WC_CONTAINER:-}"; do
+    [ -n "$c" ] || continue
+    case " $out " in *" $c "*) continue ;; esac
+    out="$out $c"
+  done
+  printf '%s' "${out# }"
+}
+
+capture_container_starts() {
+  local dir="$1" c started
+  : > "$(container_stability_file "$dir")"
+  for c in $(measured_containers); do
+    started="$(docker inspect --format '{{.State.StartedAt}}' "$c" 2>/dev/null || printf 'MISSING')"
+    printf '%s %s\n' "$c" "$started" >> "$(container_stability_file "$dir")"
+  done
+}
+
+# A missing baseline is NOT "ok" - it means the run never recorded one, so the
+# question cannot be answered, and answering "stable" would be the same class
+# of confident-but-blind pass this guard exists to remove.
+post_guard_containers_stable() {
+  local dir="$1" f c was now changed=""
+  f="$(container_stability_file "$dir")"
+  if [ ! -s "$f" ]; then
+    echo "DISCARDED post_guard_containers_stable: no container baseline was captured at window_start - cannot tell whether the stand was recreated mid-window"
+    return 0
+  fi
+  while read -r c was; do
+    [ -n "$c" ] || continue
+    now="$(docker inspect --format '{{.State.StartedAt}}' "$c" 2>/dev/null || printf 'MISSING')"
+    [ "$now" = "$was" ] || changed="$changed $c(was=$was now=$now)"
+  done < "$f"
+  if [ -n "$changed" ]; then
+    echo "DISCARDED post_guard_containers_stable: container(s) restarted or recreated inside the measurement window -$changed"
+  else
+    echo "ok"
+  fi
+}
+
 # post_guard_limiter_degraded - greps the worker log for the Redis
 # rate-limiter's degraded-mode message (redis-rate-limiter.adapter.ts:563).
 # At three replicas a degraded episode turns a configured 60/min into an
@@ -1428,6 +1511,10 @@ run_post_guards() {
   results+=("$(post_guard_requeues "$conn_ids")")
   results+=("$(post_guard_destination_creates "$ws_iso" "$dest")")
   results+=("$(post_guard_limiter_degraded "$ws_epoch" "$we_epoch")")
+  # Runs alongside the others rather than first: every guard's answer is worth
+  # having, and a reader needs to see WHICH of them a mid-window recreate
+  # coincided with.
+  results+=("$(post_guard_containers_stable "$dir")")
   results+=("$(post_guard_generator_saturated "$k6_summary" "$k6_executor")")
 
   local reasons=()

--- a/perf/openlinker-throughput/results-F4-2026-09-06.md
+++ b/perf/openlinker-throughput/results-F4-2026-09-06.md
@@ -332,9 +332,13 @@ confirming the holder pid was gone.
   conservative local rate rather than the full per-process allowance, or
   surfacing degraded episodes on the connection health surface where an
   operator would see them (today they are an `error` log line and nothing else).
-- **Re-run F7's cross-lane starvation scenario now that its degraded-mode
-  post-guard works.** Its headline claim about lane isolation may well stand,
-  but one of its stated controls did not.
+- ~~**Re-run F7's cross-lane starvation scenario now that its degraded-mode
+  post-guard works.**~~ **DONE, 2026-09-07** (#2852) - and the headline claim
+  about lane isolation did stand: claim latency stayed flat across arms while
+  the `bulk` lane held 7-8 concurrent jobs. The control that did not stand is
+  now quantified - **>= 38 degraded-mode lines inside the re-run's window**,
+  so that run is `DISCARDED` too, exactly as both arms of this one are. See
+  `results-F7-2026-09-06.md` §8.
 - **A second `ProductMaster`/`InventoryMaster` connection on the stand** would
   let a future run reach the `bulk` lane's TOTAL cap and exercise cross-scope
   fairness - the same gap F7 named.

--- a/perf/openlinker-throughput/results-F7-2026-09-06.md
+++ b/perf/openlinker-throughput/results-F7-2026-09-06.md
@@ -4,6 +4,75 @@ Cross-flow report for epic #2840. Every number below carries a label —
 **measured**, **derived** or **extrapolated** — and the closing section
 states what this run did not establish.
 
+> ## Correction, 2026-09-07 - one published figure is withdrawn
+>
+> **Withdrawn.** §1 of the original report stated that the run recorded
+> "**zero** `post_guard_limiter_degraded` log lines (i.e.
+> `degraded_mode_entries = 0` - **measured**)". **That figure was never
+> supported by evidence and is withdrawn.**
+>
+> **Why.** The guard bounded its window with `docker logs --since "@$epoch"`.
+> Docker takes a bare Unix timestamp, an RFC3339 timestamp or a Go duration;
+> the `@` form is GNU `date` syntax, **not Docker's**, and Docker neither
+> rejects nor warns - it simply matches nothing. A *counting* guard whose count
+> is structurally always zero reads exactly like a clean run, so it answered
+> `ok` on every scenario in this campaign while unable to see the thing it
+> exists to detect. Found in #2851, fixed in #2969.
+>
+> **What is not recoverable.** Whether the ORIGINAL 2026-09-06 window contained
+> a degraded line cannot be recovered: that run is over and its container's log
+> is gone. The re-run below does not resurrect that answer - it replaces the
+> claim with a fresh measurement.
+>
+> **What replaced it.** §8 (added 2026-09-07) records the re-run. The short
+> version: **the limiter degraded at least 38 times inside the re-run's
+> window** - so the answer is emphatically not zero, and the original §3's
+> numbers must be read as measurements of a possibly-degraded system, the same
+> reading F4 gives its own. The re-run was itself **`DISCARDED`** for that
+> reason, which is the finding rather than a failure.
+>
+> Everything from §1 to §7 below is the ORIGINAL 2026-09-06 text, left in place
+> so the correction can be checked against what it corrects. Where a figure did
+> not survive, §8 says so by name.
+
+> ## Which figures from the 2026-09-07 re-run MAY travel, and which MAY NOT
+>
+> **The `DISCARDED` label stops nothing mechanically.** No scenario in this
+> harness refuses to emit a figure because its verdict discarded - F4 appends
+> its throughput number unconditionally with the verdict as a column, which is
+> how a discarded 2.77x reached an ADR. The re-run below is `DISCARDED` too, so
+> this section draws the line explicitly rather than trusting the label to
+> draw it.
+>
+> **The reason most of it survives is specific, not generous.** The Redis
+> limiter paces OUTBOUND requests per connection. Degraded, it falls back to
+> per-process pacing - and at **one replica**, which this run is, one process's
+> fallback is approximately the declared limit (F4's own words: "harmless
+> because one process's fallback ≈ the declared limit; the replica count is
+> what converts a harmless fallback into an exceeded limit"). The limiter also
+> does not touch *when* a job is claimed from `sync_jobs`, so it is orthogonal
+> to the claim-latency question outright.
+>
+> **May travel, and may be quoted:**
+>
+> | Figure | Why it holds |
+> |---|---|
+> | `degraded_mode_entries >= 38` | An observation OF the degradation, not affected by it. A **floor**, never a total (§8.2). |
+> | Claim latency flat across arms (no starvation signal) | All 48 probe jobs completed pre-incident on attempt 0; the limiter does not govern claim. A within-run contrast, both arms equally exposed. Quote with the 1 s resolution caveat. |
+> | Phase 1 depth-vs-claim table, and the 32x/35x withdrawal | Ran at 00:32, **before** `window_start`, runner disabled, isolated rolled-back SQL, zero outbound calls. Untouched by both the limiter and the recreate. |
+> | Realtime inflates under load while the fiscal control stays flat | A qualitative contrast whose control is a probe that makes no external call at all. Robust to pacing. |
+> | Occupancy 76.1% at the per-scope cap | Pre-incident subset only (n=197); the backlog never ran dry, so it is insensitive to pacing. Quote **with** the n and the pre-incident scoping. |
+>
+> **May NOT travel, and must not be quoted:**
+>
+> | Figure | Why it does not |
+> |---|---|
+> | Any throughput, jobs-per-second or drain-duration figure from this run | The window contains a stack recreate that killed 8 in-flight jobs. The 1 451 s elapsed is not a measurement of anything. |
+> | Any occupancy sample at or after 00:41:21Z (the 15-16 readings) | Physically impossible against a per-scope cap of 8; they are stranded rows, not concurrency (§8.3). |
+> | The guard's own "2 degraded-mode log lines" | A structural undercount - the container reset destroyed the earlier log. |
+> | The realtime execution medians as a statement about how long a product sync takes | They are a within-run contrast, not a system latency claim. |
+> | **The precise 5.70x multiple** | Usable as "roughly 5-6x, same as the original's 5.5x", not as a sharp figure: the degradation fell in the CONTROL arm and not the loaded one, so the two arms were not equally paced and the ratio carries an asymmetry neither run accounted for. The **direction** and the flat fiscal control are what survive. |
+
 **Read this first, same as every other report in this campaign**: the stand
 is a Docker Compose project on a developer workstation, not the isolated
 `lab` environment #2854 specifies (it does not exist). The host carried a
@@ -91,9 +160,17 @@ comment, alongside two real bugs found and fixed while building it (see §6).
 
 Post-window guards: **`VALID`** — no `attempts>1`, no `deferredTotalMs>0`, no
 `StuckJobRecoveryService` requeue signature, no failed `order_records`
-`syncStatus`, and **zero** `post_guard_limiter_degraded` log lines (i.e.
+`syncStatus`, and ~~**zero** `post_guard_limiter_degraded` log lines (i.e.
 `degraded_mode_entries = 0` — **measured**, the run never entered the
-rate-limiter's degraded per-process-fallback mode).
+rate-limiter's degraded per-process-fallback mode)~~.
+
+> **WITHDRAWN (2026-09-07).** The struck sentence is not supported by
+> evidence - the guard that produced it could not match a log line at all (see
+> the correction at the top, and §8). The `VALID` verdict is therefore also
+> withdrawn: the limiter-degradation input to it was never measured, and on the
+> re-run that same input **discards** the window. The other four post-guard
+> results in this paragraph stand; only the limiter one, and the overall
+> verdict that depended on it, do not.
 
 Runner posture: found `WORKER_RUNNER_ENABLED=false` at scenario start,
 flipped to `true` for the live-load phase, **restored to `false`** on exit
@@ -351,3 +428,254 @@ scale against a live worker before this run.
 - #2850 (metrics exporter) remains the single biggest gap in this whole
   campaign's ability to answer "slots or the loop?" with direct evidence
   instead of inference.
+
+---
+
+# 8. The 2026-09-07 re-run - what the fixed guard actually saw
+
+Everything above this line is the original 2026-09-06 report, left intact so
+the correction can be checked against what it corrects. This section is the
+re-run the correction requires. It supersedes the original §1 post-guard
+paragraph and its `VALID` verdict; it does **not** supersede §2–§5's structure,
+which reproduced closely. Where a number moved, it is named.
+
+**Run**: `results/f7-lane-starvation/run1788741154`. Window
+**2026-09-07T00:33:53Z → 00:58:04Z** (1 451 s). Image and working tree both at
+`af6802cbff9e1c53c1268e5a52b935e00d594fba` - `guard_build ok`, a real match
+this time: the stand's `ol-perf:api` / `ol-perf:worker` images were rebuilt to
+that sha and the containers recreated onto them before the run started. One
+replica (`lab-worker-1`). Lane caps read live from the worker's own boot log
+and **identical to the original run**: `realtime=4/2 bulk=12/8 fiscal=2/1
+fan-out=8/4`. 125 675 pre-existing `sync_jobs` rows. Same stand caveat as the
+top of this report, and the same one every report in this campaign carries: a
+Docker Compose project on a shared developer workstation, not an isolated lab.
+
+## 8.1 The fixed guard was proved able to FAIL before it was believed
+
+A guard that had answered zero on every run of this campaign was not taken on
+trust a second time. Against **real Docker** - not the stub `lib-test.sh`
+uses - with a throwaway container emitting one degraded-mode line at a known
+instant:
+
+| Check | Result |
+|---|---|
+| Fixed guard, window CONTAINING the line | `DISCARDED … 1 degraded-mode log line(s)` |
+| Fixed guard, window BEFORE the line | `ok` - window bounding is real, not match-everything |
+| OLD `@epoch` form, same container, same window | **0** |
+| Fixed bare-epoch form, same container, same window | **1** |
+
+The last two rows differ only in the `@`. `lib-test.sh` asserts the *arguments*
+handed to `docker logs` against a stub, and a stub answers regardless of how
+the window is spelled - which is exactly how the original defect survived its
+own test suite. Only an end-to-end check against real Docker closes that gap.
+
+## 8.2 `degraded_mode_entries` - **not zero. At least 38, and recurring.**
+
+**Measured.** The figure the original report could not supply:
+
+| Portion of the window | Degraded-mode lines |
+|---|---|
+| 00:34:09Z – 00:36:59Z (control arm) | **36**, one every 3–8 s |
+| 00:41:26Z – 00:41:31Z (worker boot, §8.3) | **2** |
+| **Total observed inside the window** | **≥ 38** |
+
+Every line is the condition F4 (#2851) reports: *"Redis rate limiter
+unavailable for connection `c4710417-…` - falling back to per-process in-memory
+limiting (degraded, not unthrottled). Redis rate-limiter call
+`claimConcurrency` timed out after 1000ms"*. Not Redis down - a call to it
+exceeding the limiter's own 1 s budget on a contended host.
+
+Two qualifications, both load-bearing:
+
+- **The 36 is a direct observation, not a guard reading.** The worker container
+  was recreated mid-window (§8.3), which reset `docker logs`, so
+  `post_guard_limiter_degraded` could only ever see the 2 lines after that
+  point - and `verdict.txt` accordingly records *"2 degraded-mode log line(s)
+  inside the window"*. The 36 were counted from the live log before the reset.
+  **The guard's own number for this window is an undercount, and `≥ 38` is the
+  honest total.**
+- **Degradation clustered in the CONTROL arm and at worker boot - not at
+  saturation.** The heaviest run of lines came while the lane carried only the
+  control arm's one-job-every-3-s trickle, and the loaded arm's sustained 7–8
+  concurrent jobs produced none. That is the opposite of the intuitive reading
+  and is worth stating plainly: on this stand the limiter's 1 s Redis budget is
+  breached during connection establishment and early load, not by sustained
+  concurrency.
+
+**Consequence for the original report.** Its §3 numbers were gathered under
+conditions that reproduce degradation readily, so they must be read - exactly
+as F4 reads its own - as **measurements of a possibly-degraded system**.
+Whether that particular 2026-09-06 window contained a degraded line remains
+unrecoverable; what is now established is that the condition is common here,
+not absent.
+
+## 8.3 The run was contaminated mid-window, and nothing in the harness said so
+
+At **00:41:21Z**, 7.5 minutes into a window whose stand lock this run held,
+`lab-api` and `lab-worker-1` were **both recreated** by a peer who had just
+finished rebuilding images. `guard_stand_exclusive` arbitrates *scenarios*; it
+cannot stop `docker compose up -d` typed by hand, which on a shared
+multi-worktree checkout is a routine thing to do.
+
+No guard fired. It was noticed only because a `docker logs | grep -c` happened
+to be read twice and the count went **down**, 36 → 2. The damage is quantified
+rather than asserted, and the lane-occupancy proxy - a `COUNT(*)` of
+`sync_jobs` rows in `status='running'` - shows it most clearly:
+
+| Loaded-arm samples | occ=6 | occ=7 | occ=8 | occ=15 | occ=16 |
+|---|---|---|---|---|---|
+| **Before** 00:41:21Z (n=197) | 0.5% | 23.4% | **76.1%** | - | - |
+| **After** 00:41:21Z (n=649) | - | - | 0.5% | 29.3% | **70.3%** |
+
+The per-scope cap is **8**. An occupancy of 15–16 is not merely high, it is
+**impossible**: it is the 8 rows the killed container stranded in `running`
+forever, plus the 8 the replacement is really executing. Had the restart gone
+unnoticed, this run would have published an apparent lane-cap violation - and
+plausibly an ADR-050 bug report against code that was behaving correctly.
+
+**Closed, with the failing case proved first.** `post_guard_containers_stable`
+(`lib.sh`) records every measured container's `.State.StartedAt` at
+`window_start` and re-checks it in the post-guards; any change is a restart or
+a recreate, and the window is void. A **missing** baseline discards too - it
+means the run cannot answer the question, and "stable" would be the same
+confident-but-blind pass the `@epoch` defect taught us to distrust. Verified
+against real Docker on the actual incident: a baseline carrying the
+pre-incident worker start discards and names
+`lab-worker-1(was=…00:33:01Z now=…00:41:21Z)`, while an untouched stand passes.
+Covered by 9 new `lib-test.sh` assertions - **125 passing, up from 116**.
+
+One of those assertions exists because the real-Docker check found a bug in the
+new guard *on its first run*: `measured_containers` was capturing
+`_ensure_worker_containers`' log line into its own return value, so every word
+of that line became a "container" to watch. The stubbed tests could not have
+caught it, because discovery is already memoised there. Same lesson as the one
+this whole re-run is about, one level down.
+
+## 8.4 What reproduced anyway
+
+The probe dataset is **uncontaminated**: all 48 probe jobs across both arms were
+enqueued between 00:33:53Z and 00:40:34Z (the last 47 s before the incident),
+all succeeded on **attempt 0**, and **none** completed after 00:41:21Z. The
+occupancy figures above are split at the incident for the same reason. So the
+following stands.
+
+Figures below are computed from the run's own artifacts (`realtime-probes.csv`,
+`fiscal-probes.csv`, `probe-claims.csv`, `sync_jobs`). The scenario's own
+`analyze_probes` step did not produce its CSVs: the process was killed by
+SIGPIPE from the wrapper driving it, after `window_stop` and after the verdict
+was written, so nothing measured was lost - but that is a harness-side
+annoyance worth naming rather than hiding.
+
+### Claim latency - no starvation signal, as before - **measured**
+
+| | realtime control | realtime loaded | fiscal control | fiscal loaded |
+|---|---|---|---|---|
+| Claim wait, median | 1 000 ms | 1 000 ms | 1 000 ms | 1 000 ms |
+| Claim wait, p95 | 3 000 ms | 2 000 ms | 3 000 ms | 2 000 ms |
+
+n=12 per cell. **Resolution caveat, and it matters more than the numbers**: the
+claim-wait instrument is a ~1 Hz poller, so every value is
+1-second-quantised and a sub-second difference between arms cannot be resolved
+by it at all. The original's "0–1.7 s band" and this "0–3 s at 1 s resolution"
+are the same finding taken with the same blunt instrument. What can honestly be
+said is what the original said: **no multi-second, lane-shaped delay appeared
+on either probe while the bulk lane held 7–8 concurrent real jobs**, and the
+loaded arm was not slower to be claimed than the control arm. Neither run
+supports a claim finer than "no starvation was visible".
+
+**So: the isolation band survives the degraded limiter being visible.** The
+degradation documented in §8.2 did not move claim latency.
+
+### Execution time - the destination-contention finding reproduces - **measured**
+
+| | control median | loaded median | ratio | control p95 | loaded p95 |
+|---|---|---|---|---|---|
+| **realtime** probe (real PrestaShop round trip) | 3 335 ms | 19 008 ms | **5.70×** | 8 703 ms | 29 033 ms |
+| **fiscal** probe (validates payload, no external call) | 436 ms | 560 ms | flat | 939 ms | 996 ms |
+
+Original: realtime 3 272 → 18 094 ms (5.5×), fiscal 650 → 516 ms (flat). **The
+reproduction is close on both probes**, and the fiscal probe again does the job
+the scenario needs of it: it is the control proving the realtime slowdown is
+not "everything is slow right now" but specifically *sharing one destination's
+capacity with the aggressor* - contention ADR-050's lane model does not address
+and was never designed to.
+
+**Quote the direction, not the sharp multiple.** The degradation of §8.2 fell
+in the CONTROL arm and not in the loaded one, so the two arms were not equally
+paced: a degraded limiter permits more outbound throughput, which would make
+the control arm artificially fast and the ratio correspondingly generous. At
+one replica that effect is small (per-process fallback is approximately the
+declared limit), so **"roughly 5-6x, agreeing with the original's 5.5x" is
+supportable and 5.70x as a sharp figure is not**. The qualitative finding is
+unaffected, because the fiscal control inflated by nothing at all.
+
+### Channel 2 (queued depth vs claim latency) - shape reproduces, **the ratio does not** - **measured**
+
+Phase 1 ran at 00:32, before the contamination, runner disabled, each point in
+its own rolled-back transaction:
+
+| Depth | Lane | Execution (ms) | Planning (ms) |
+|---|---|---|---|
+| 0 | realtime | 0.218 | 0.749 |
+| 0 | fiscal | 0.259 | 0.633 |
+| 1 000 | realtime | 0.366 | 0.600 |
+| 1 000 | fiscal | 0.400 | 0.627 |
+| 10 000 | realtime | 0.963 | 0.500 |
+| 10 000 | fiscal | 1.708 | 0.490 |
+
+Execution grows with depth, planning stays flat, absolute cost still **under
+2 ms at 10 000 queued rows** - all three as originally reported. But **the
+original's "roughly 32× / 35×" growth figure does not reproduce and should not
+be quoted**: the same span here is 4.4× (realtime) and 6.6× (fiscal). That
+ratio is dominated by its depth-0 denominator, a sub-0.1 ms measurement on a
+contended workstation which moved 5× between runs (0.044 → 0.218 ms), while the
+absolute values at depth agree closely (1.409 vs 0.963; 1.838 vs 1.708). **The
+reproducible claim is the shape and the magnitude, not the multiple.**
+
+### Occupancy - the literal-95% partial miss REPRODUCES - **measured**
+
+Restricted to the uncontaminated pre-incident portion (n=197): **76.1% exactly
+at the per-scope cap of 8**, 99.5% within one slot of it. The original measured
+66.4% / 96.5%. So this run sits at cap more often and **still misses the AC's
+literal "at cap for ≥95% of samples" bar**. Read against the intent - a lane
+genuinely under sustained pressure, backlog never dry - it is met. Both
+readings are reported and neither is chosen for the reader, as before. The
+original's structural caveat is unchanged and remains the honest cause: with
+one real bulk-capable connection this aggressor can only ever reach the lane's
+**per-scope** cap (8), never its **total** (12).
+
+## 8.5 Verdict, and what this re-run did NOT establish
+
+**`DISCARDED` - and that is the finding, not a failed run.**
+`verdict.txt` records the reason: *degraded-mode log lines inside the window*.
+A second, independent condition would also have discarded it had the guard
+existed when the window opened: the stand was recreated mid-window (§8.3).
+Both are precisely what a post-guard is for. The original run reported neither,
+because it could detect neither.
+
+Not established here:
+
+- **A clean, uncontaminated full-window measurement.** Probe and Phase-1 data
+  are clean, and occupancy is clean to 00:41:21Z, but no arm of this run covers
+  a whole window on an undisturbed stand. A repeat is owed - and is now
+  self-certifying, because `post_guard_containers_stable` makes a recurrence
+  loud instead of invisible. The stand passed to a peer's F8 run at 00:58:31Z,
+  so the repeat was not attempted here.
+- **Whether the ORIGINAL 2026-09-06 window was degraded.** Unrecoverable, as F4
+  already recorded. This section replaces the claim; it cannot answer the
+  original question.
+- **A true degraded-line count for the whole window.** The container reset
+  destroyed the first 7.5 minutes of log. `≥ 38` is a floor, not a total.
+- **Event-loop lag (Channel 1) directly** - #2850 still does not exist, so
+  "no starvation signal in claim latency" remains consistent with, but not
+  proof against, a loop blocked too briefly for a 1 Hz poller to see.
+- **Lane TOTAL cap saturation** - still one real bulk-capable connection on
+  this stand.
+- **The 3-replica arm** - deliberately out of scope. The occupancy proxy is
+  only valid at one replica (slot accounting is per process, ADR-050/#2302), so
+  measuring it at N replicas needs #2850's exporter rather than a bigger stand.
+  Note the reason recorded in the original §7 has expired: #2969 removed the
+  fixed `container_name` that used to block `--scale`, and F4 (#2851) runs the
+  multi-replica arm.
+- **A realtime BURST against a saturated lane** - probes were 15 s apart, a
+  distribution rather than a burst. Unchanged from the original.

--- a/perf/openlinker-throughput/scenarios/f7-lane-starvation.sh
+++ b/perf/openlinker-throughput/scenarios/f7-lane-starvation.sh
@@ -74,14 +74,22 @@
 #     and the transaction rollback means nothing measured here persists or
 #     interacts with the live-load arms.
 #
-# (5) The 3-replica arm is NOT RUN. `docker-compose.lab.yml`'s worker service
-#     declares a fixed `container_name: lab-worker` (confirmed by reading the
-#     file directly) - `docker compose up --scale worker=3` refuses to scale a
-#     service with a fixed container name, and lib.sh's own
-#     `WORKER_CONTAINERS` comment names this exact blocker ("A `--scale
-#     worker=3` stand (#2854) does not carry a fixed `container_name` per
-#     replica"). #2851 (the compose overlay this needs) does not exist in this
-#     worktree. This is reported as NOT ESTABLISHED, not silently skipped.
+# (5) The 3-replica arm is NOT RUN - but the ORIGINAL reason recorded here no
+#     longer holds, and is corrected rather than left standing. When this
+#     scenario was first written, `docker-compose.lab.yml`'s worker service
+#     declared a fixed `container_name: lab-worker`, and compose refuses to
+#     `--scale` such a service. #2969 REMOVED that pin (the replica is now
+#     compose-named `lab-worker-1`), so scaling works today and F4 (#2851)
+#     exercises the multi-replica arm.
+#
+#     F7 stays single-replica for a different and still-valid reason: its lane
+#     occupancy figure is proxied by `COUNT(*) FROM sync_jobs WHERE
+#     status='running' AND ...`, which #2852's own dependency list admits only
+#     "for lane occupancy only, and only on the 1-replica arm". Slot
+#     accounting is per PROCESS (ADR-050/#2302), so at N replicas that COUNT
+#     sums N independent lane budgets and stops meaning "this lane's
+#     occupancy" at all. Measuring it there needs #2850's exporter, not a
+#     bigger stand. Reported as NOT ESTABLISHED, not silently skipped.
 #
 # (6) #2850 (the metrics exporter) does not exist in this worktree. There is
 #     no `ol_lane_slots_in_use`, no `ol_event_loop_lag_seconds`, no
@@ -165,15 +173,68 @@ RUN_GROUP="run$(date +%s)"
 DIR="$(results_dir_init f7-lane-starvation "$RUN_GROUP")"
 log "results dir: $DIR"
 
+# Which compose file and env file does the RUNNING stand actually use?
+#
+# Asking the stand rather than assuming a path matters here: on a multi-
+# worktree checkout the stand is routinely brought up from a DIFFERENT
+# worktree than the one a scenario runs from (verified on this host - the
+# `lab` project's working_dir pointed at a sibling agent worktree, so the
+# hardcoded `$SCRIPT_DIR/../../../.env.lab` did not exist and the runner
+# toggle died). Compose stamps both paths onto every container it creates, so
+# the container is the authority on its own project's configuration; an
+# operator can still override either explicitly.
+#
+# `.env.lab` is deliberately NOT copied into this worktree: it is the STAND's
+# configuration, shared by every scenario, and a private copy would silently
+# diverge from the file the stand is really running on.
+_compose_label() {
+  local w
+  w="$(discover_worker_containers | awk '{print $1}')"
+  [ -n "$w" ] || return 0
+  docker inspect --format "{{index .Config.Labels \"$1\"}}" "$w" 2>/dev/null || true
+}
+LAB_ENV_FILE="${LAB_ENV_FILE:-$(_compose_label com.docker.compose.project.environment_file)}"
+[ -n "$LAB_ENV_FILE" ] || LAB_ENV_FILE="$SCRIPT_DIR/../../../.env.lab"
+LAB_COMPOSE_FILE="${LAB_COMPOSE_FILE:-$(_compose_label com.docker.compose.project.config_files)}"
+[ -n "$LAB_COMPOSE_FILE" ] || LAB_COMPOSE_FILE="$SCRIPT_DIR/../../../docker-compose.lab.yml"
+# A multi-file project stamps a comma-separated list; this scenario recreates
+# one service from one file and refuses to guess which.
+case "$LAB_COMPOSE_FILE" in
+  *,*) die "LAB_COMPOSE_FILE resolved to a multi-file compose project [$LAB_COMPOSE_FILE] - set LAB_COMPOSE_FILE explicitly to the file carrying the 'worker' service" ;;
+esac
+log "stand config: compose=$LAB_COMPOSE_FILE env=$LAB_ENV_FILE project=$LAB_COMPOSE_PROJECT"
+
+# Read the posture from the DISCOVERED replica, never from a hardcoded
+# `lab-worker`. #2969 removed the worker service's fixed `container_name` so
+# compose could `--scale` it, and the container is now `lab-worker-1`. The
+# old form did not error - `docker exec lab-worker` fails, `2>/dev/null`
+# swallows it, and `|| printf 'false'` supplies a confident answer nobody
+# measured. That happens to match this stand's real posture today, which is
+# precisely what makes it dangerous: it would silently restore `false` over
+# an `enabled` stand. An unreadable container falls back to the ENV FILE (the
+# F4 pattern), and an unreadable env file is fatal rather than assumed.
+_read_runner_posture() {
+  local w val
+  w="$(discover_worker_containers | awk '{print $1}')"
+  if [ -n "$w" ]; then
+    val="$(docker exec "$w" printenv WORKER_RUNNER_ENABLED 2>/dev/null || printf '')"
+    [ -z "$val" ] || { printf '%s' "$val"; return 0; }
+  fi
+  val="$(awk -F= '/^WORKER_RUNNER_ENABLED=/{print $2; exit}' "$LAB_ENV_FILE" 2>/dev/null || printf '')"
+  [ -n "$val" ] || die "_read_runner_posture: could not read WORKER_RUNNER_ENABLED from any running worker replica [$(discover_worker_containers)] or from $LAB_ENV_FILE - refusing to guess a posture this run must restore"
+  printf '%s' "$val"
+}
+
 # Capture the worker's CURRENT runner posture so it can be restored exactly,
 # whatever it was, at the end - the task's own instruction ("say what you
 # left it at").
-ORIGINAL_RUNNER_ENABLED="$(docker exec lab-worker printenv WORKER_RUNNER_ENABLED 2>/dev/null || printf 'false')"
+ORIGINAL_RUNNER_ENABLED="$(_read_runner_posture)"
 log "worker's runner posture at scenario start: WORKER_RUNNER_ENABLED=$ORIGINAL_RUNNER_ENABLED (will be restored on exit)"
 
 restore_runner_posture() {
   local current
-  current="$(docker exec lab-worker printenv WORKER_RUNNER_ENABLED 2>/dev/null || printf 'false')"
+  current="$(_read_runner_posture 2>/dev/null || printf '')"
+  [ -n "$current" ] || { warn "restore_runner_posture: could not read the current posture - leaving the stand as-is"; return 0; }
   if [ "$current" != "$ORIGINAL_RUNNER_ENABLED" ]; then
     log "restoring WORKER_RUNNER_ENABLED=$ORIGINAL_RUNNER_ENABLED (was $current)"
     set_runner_enabled "$ORIGINAL_RUNNER_ENABLED"
@@ -198,22 +259,52 @@ trap f7_on_exit EXIT
 # stand to itself, but a full `up -d` would still be a wider blast radius
 # than this scenario needs).
 set_runner_enabled() {
-  local want="$1" env_file="$SCRIPT_DIR/../../../.env.lab"
-  [ -f "$env_file" ] || die "set_runner_enabled: $env_file not found"
+  local want="$1" env_file="$LAB_ENV_FILE"
+  [ -f "$env_file" ] || die "set_runner_enabled: $env_file not found - set LAB_ENV_FILE to the .env.lab the running stand was created from (see LAB_ENV_FILE's own resolution note above)"
+  # `grep -q` on a plain FILE argument is safe - the SIGPIPE/pipefail trap
+  # docs/lessons.md records applies only when grep terminates a PIPE.
   if grep -q '^WORKER_RUNNER_ENABLED=' "$env_file"; then
     sed -i "s/^WORKER_RUNNER_ENABLED=.*/WORKER_RUNNER_ENABLED=$want/" "$env_file"
   else
     printf 'WORKER_RUNNER_ENABLED=%s\n' "$want" >> "$env_file"
   fi
-  ( cd "$SCRIPT_DIR/../../.." && docker compose -f docker-compose.lab.yml --env-file .env.lab up -d --no-deps worker >/dev/null )
+  # `-p lab` is REQUIRED. The worker service no longer carries a
+  # `container_name` (#2969), so without an explicit project name compose
+  # derives one from the directory and would bring up a SECOND, parallel
+  # worker against this same database rather than recreating the stand's.
+  # `--no-deps` plus an explicit service name bounds this to `worker`, so a
+  # compose file that knows about MORE services than the one the project was
+  # created from cannot start or alter any of them.
+  ( cd "$(dirname "$LAB_COMPOSE_FILE")" && docker compose -f "$LAB_COMPOSE_FILE" --env-file "$env_file" -p "$LAB_COMPOSE_PROJECT" up -d --no-deps worker >/dev/null )
   # Give the process a moment to actually boot and print its startup line
   # before any guard reads it.
   sleep 5
-  local tries=0
-  until docker logs lab-worker 2>&1 | grep -qF 'Starting sync job runner loop' || [ "$want" = "false" ]; do
-    tries=$((tries + 1))
-    [ "$tries" -lt 20 ] || die "set_runner_enabled: lab-worker never logged 'Starting sync job runner loop' after enabling"
-    sleep 1
+  # The recreate mints a NEW container, so lib.sh's memoised list is stale.
+  WORKER_CONTAINERS=""
+  WORKER_CONTAINERS_RESOLVED=0
+  _ensure_worker_containers
+  # Written as an `if`, not `[ ... ] && return 0`: that idiom is safe here
+  # only because a non-final member of an `&&` list is exempt from `set -e`,
+  # and it silently stops being safe the day it becomes the last statement.
+  if [ "$want" = "false" ]; then
+    return 0
+  fi
+  local tries w hits
+  for w in $WORKER_CONTAINERS; do
+    tries=0
+    # `grep -c`, never `grep -q`: `grep -q` exits on its first match, closing
+    # the pipe while `docker logs` is still writing, so `docker logs` dies of
+    # SIGPIPE (141) and `set -o pipefail` reports the pipeline as FAILED even
+    # though the line matched. It is length-dependent, so it passes while the
+    # log is short and starts failing once the worker has been up a while -
+    # the exact trap docs/lessons.md records from F4 (#2851).
+    while true; do
+      hits="$(docker logs "$w" 2>&1 | grep -cF 'Starting sync job runner loop' || true)"
+      [ "${hits:-0}" -eq 0 ] || break
+      tries=$((tries + 1))
+      [ "$tries" -lt 60 ] || die "set_runner_enabled: $w never logged 'Starting sync job runner loop' after enabling"
+      sleep 1
+    done
   done
 }
 
@@ -260,6 +351,19 @@ SQL
 
 run_depth_phase() {
   log "=== Phase 1: queued-depth vs. claim latency (runner disabled, isolated SQL) ==="
+  # ENSURE the posture this phase needs; do not merely assert it. This phase
+  # inserts synthetic queued rows inside a rolled-back transaction, so a live
+  # runner could claim against the table mid-EXPLAIN and put another process's
+  # work into the number. The original version asserted `disabled` and never
+  # set it, which silently depended on whatever posture the previous scenario
+  # happened to leave behind - it passed for as long as the stand was found
+  # idle and died the first time a peer left the runner enabled. The exit trap
+  # restores ORIGINAL_RUNNER_ENABLED either way, so setting it here is safe
+  # and symmetric with the live-load phase enabling it below.
+  if [ "$(_read_runner_posture)" != "false" ]; then
+    log "runner is enabled; disabling it for the isolated-SQL phase"
+    set_runner_enabled false
+  fi
   guard_runner_state disabled
   local depths="0 1000 10000"
   [ "$MODE" != "smoke" ] || depths="0 50"
@@ -333,7 +437,7 @@ extra_manifest="$(jq -n \
   --arg fiscal_probe_type "invoicing.issue (deliberately-invalid payload, business_failure by design)" \
   '{aggressorRoute:$aggressor_route, aggressorCount:$aggressor_count, probeCount:$probe_count, products:$products,
     realtimeProbeType:$realtime_probe_type, fiscalProbeType:$fiscal_probe_type,
-    replicaCount: 1, threeReplicaArm: "NOT RUN - docker-compose.lab.yml pins container_name: lab-worker, --scale refuses; #2851 compose overlay absent from this worktree",
+    replicaCount: 1, threeReplicaArm: "NOT RUN - out of scope for this scenario. The original blocker (docker-compose.lab.yml pinning container_name: lab-worker) was REMOVED by #2969, so --scale now works; F4 (#2851) runs the multi-replica arm. F7 stays single-replica because its lane-occupancy proxy (COUNT(*) over sync_jobs status='running') is only valid at one replica.",
     metricsExporter: "absent (#2850 not in this worktree) - lane occupancy proxied via sync_jobs COUNT(*), event-loop lag not directly measured"}')"
 
 window_start "$DIR" f7-lane-starvation "$CONN_IDS" "$([ "$MODE" = smoke ] && echo 1 || echo 0)" "$extra_manifest"


### PR DESCRIPTION
## A guard that could not see, and a contamination nothing could see

The brief was to re-run F7 because one of its stated controls did not work. The
re-run did that, but the more valuable finding is the second blindness it
uncovered on the way.

### A peer recreated the stack mid-window and no guard fired

Seven and a half minutes into a window whose stand lock this run held,
`lab-api` and `lab-worker-1` were **both recreated** by a peer who had just
finished rebuilding images. `guard_stand_exclusive` arbitrates *scenarios*; it
cannot stop `docker compose up -d` typed by hand, which on a shared
multi-worktree checkout is a routine thing to do.

The in-flight jobs were killed and their rows left stranded `running` for ever,
so the lane-occupancy proxy went from a coherent pre-incident distribution to a
physically impossible one:

| Loaded-arm samples | occ=6 | occ=7 | occ=8 | occ=15 | occ=16 |
|---|---|---|---|---|---|
| **Before** 00:41:21Z (n=197) | 0.5% | 23.4% | **76.1%** | - | - |
| **After** 00:41:21Z (n=649) | - | - | 0.5% | 29.3% | **70.3%** |

The per-scope cap is **8**. Occupancy 15-16 is not merely high, it is
impossible - 8 stranded rows plus 8 real ones. Published unnoticed that reads
as an ADR-050 lane-cap violation against code behaving perfectly correctly, and
it would have been believed, because every other number in the run looked
ordinary. It was caught only because a `docker logs | grep -c` happened to be
read twice and the count went the wrong way, 36 -> 2.

**Closed by `post_guard_containers_stable`** (`lib.sh`): every measured
container's `.State.StartedAt` is recorded at `window_start` and re-checked in
the post-guards; any change is a restart or recreate and the window is void. A
**missing** baseline discards too, because "stable" would be exactly the
confident-but-blind pass this whole PR is about. Verified against real Docker
on the actual incident.

That verification found a bug in the new guard **on its first run**:
`measured_containers` was capturing `_ensure_worker_containers`' log line into
its own return value, so every word of it became a "container" to watch. The
stubbed tests could not have caught it, because discovery is already memoised
there. That general lesson - a guard's first contact with the real system finds
what its stub cannot - is recorded in `docs/lessons.md` beside the `@epoch`
entry.

### The re-measurement it was opened for

`results-F7-2026-09-06.md` published `degraded_mode_entries = 0` as **measured**.
It never was: `post_guard_limiter_degraded` filtered logs with
`docker logs --since "@$epoch"`, a form Docker accepts while matching nothing,
so a counting guard whose count was structurally always zero read exactly like
a clean run. Fixed in #2969; this is the re-run it owed.

The figure is **withdrawn in place** - a correction at the top of the report, a
struck sentence at the original claim, and a §8 recording the replacement, so a
reader never has to compare two documents to learn which numbers to trust.

**The answer is `>= 38` degraded lines**, not zero. This run is `DISCARDED` for
it, which is the finding rather than a failure. Two qualifications carried in
the report: the 36 pre-restart lines are a direct observation rather than a
guard reading (the container reset destroyed that log, so the guard's own
number, 2, is a structural undercount), and the degradation clustered in the
**control** arm and at worker boot, not under saturation - the opposite of the
intuitive reading.

The fixed guard was proved able to **fail** before it was believed: against
real Docker, the old `@epoch` form returns 0 on the identical window where the
fixed form returns 1.

### Which figures may travel, and which may not

**A `DISCARDED` verdict stops nothing mechanically.** F4 appends its throughput
figure unconditionally with the verdict as column 20, which is how a discarded
2.77x reached an ADR. This run is `DISCARDED` too, so the report draws the line
itself rather than trusting the label. Full table at the top of the report;
in summary:

**May travel** - the `>= 38` floor; claim latency flat across arms (the limiter
paces *outbound* requests and does not govern *claim*, and at one replica a
per-process fallback is approximately the declared limit); the Phase 1 depth
table, which ran before `window_start` with the runner disabled and made no
outbound call at all; the realtime-inflates-while-fiscal-stays-flat contrast;
and occupancy 76.1% at cap **with** its n=197 pre-incident scoping.

**May not travel** - any throughput, jobs-per-second or drain-duration figure
from this window; any occupancy sample after the recreate; the guard's
undercounted "2"; the realtime medians as a statement about how long a product
sync takes; and the sharp **5.70x** multiple, because the degradation fell in
the control arm and not the loaded one, so the arms were not equally paced.
"Roughly 5-6x, agreeing with the original's 5.5x" is what is supportable.

### What reproduced

- **The isolation band survives.** Claim latency is flat across arms with the
  degraded limiter now visible - no starvation signal while the `bulk` lane
  held 7-8 concurrent real jobs.
- **The destination-contention finding reproduces**: realtime execution
  inflates roughly 5-6x under load while the fiscal control - a probe that
  makes no external call - stays flat (436 -> 560 ms).
- **The occupancy partial-miss reproduces**: 76.1% exactly at the per-scope cap
  against the original's 66.4%, so still short of the literal 95% bar.
- **The 32x/35x queued-depth growth ratio does NOT**, and is withdrawn although
  nobody asked. It is dominated by a sub-0.1 ms depth-0 denominator that moved
  5x between runs; the shape and the absolute magnitude reproduce, the multiple
  does not.

### Also in this change

The scenario needed #2969's worker rename applied before it would run at all:
it read the runner posture from a hardcoded `lab-worker` behind
`|| printf 'false'` (a silent wrong answer), waited on a `grep -qF` pipeline
that reports failure on a *successful* match under `pipefail`, resolved
`.env.lab` from its own worktree rather than the stand's, and asserted the
disabled-runner posture Phase 1 needs without ever setting it.

`lib-test.sh`: **116 -> 125** assertions, 0 failing. (The brief said 113; it was
116, and saying so beat quietly matching the number.)

### Gate

`bash -n` clean on all three scripts; `lib-test.sh` 125/125.
`pnpm check:invariants` passes 64 checks and **cannot complete the last one** -
`check-bundle-budgets.mjs` shells out to `vite build` and this worktree has no
`node_modules`. Installing them would have contended for CPU with a peer's live
measurement on the same host, which is the one thing a perf campaign must not
do, so it was deliberately declined rather than forgotten. No file under
`apps/`, `libs/`, `Dockerfile` or the lockfiles is touched, so that check has
nothing in this change to read.

### Still owed

A clean, uncontaminated full-window run. It is now self-certifying: a
recurrence of the contamination discards loudly instead of invisibly. The stand
passed to a peer's run at 00:58:31Z, so the repeat was not attempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UwqnrmELURfiSUu6898bsV
