### PR TITLE
perf(lanes): make a lane cap measurable, and report what stopped the three that are not

### DIFF
--- a/apps/worker/src/sync/sync-job.runner.ts
+++ b/apps/worker/src/sync/sync-job.runner.ts
@@ -128,25 +128,47 @@ export class SyncJobRunner implements OnModuleInit, OnModuleDestroy {
    * `perScope` bounds them per isolation scope (`resolveJobScope`, =
    * connectionId today).
    *
-   * `realtime`, `fiscal` and `fan-out` are still ILLUSTRATIVE — treat any
-   * number there as a guess until #1134's per-lane metrics exist.
+   * Provenance per lane — `apps/worker/.env.example` carries the long form,
+   * and ADR-050 § Amendment (#2851 / #2867) the reasoning:
    *
-   * `bulk` is the first lane with a measurement behind it (#2594, ADR-050
-   * amendment). An interleaved A/B run against a real PrestaShop catalogue
-   * held the shop's p95 response time at a 0.995 ratio while ~12 per-product
-   * child jobs ran concurrently on one connection, taking a full sweep from
-   * ~26.5 h to ~2.4 h. `perScope` is set below that measured ceiling because
-   * ADR-050 decision 4 deliberately ships no round-robin fairness between
-   * scopes: at `perScope === total` one connection's catalogue cycle could
-   * hold the whole lane and a second connection's sweep would make no
-   * progress at all. The measurement covers the PrestaShop catalogue path
-   * only; a slower destination is lowered with OL_LANE_BULK_SCOPE_CAP.
+   * - `realtime` and `fiscal` are ILLUSTRATIVE. Treat any number there as a
+   *   guess.
+   * - `fan-out` is DERIVED, not measured (#2609): the 1/1 it replaced was
+   *   sized for this lane's cron-paced members, and the observed backlog that
+   *   prompted the raise measures the defect, not the fix.
+   * - `bulk`'s TOTAL is the one MEASURED figure (#2594): an interleaved A/B
+   *   run against a real PrestaShop catalogue sustained ~277 req/min against
+   *   ~50 with ~12 per-product children concurrent on one connection, taking a
+   *   39 700-request sweep from ~26.5 h to ~2.4 h. `bulk`'s `perScope` is NOT
+   *   that measurement — it sits below it on purpose, because ADR-050
+   *   decision 4 ships no round-robin fairness between scopes and at
+   *   `perScope === total` one connection's catalogue cycle could hold the
+   *   whole lane.
+   *
+   * Do NOT reintroduce a p95 "store impact" ratio as justification for the
+   * `bulk` caps. The 0.995 figure this comment used to carry is WITHDRAWN
+   * (ADR-066 correction 1): the probe never checked HTTP status, so a fast
+   * error under load counted as a fast sample. The throughput figure above
+   * survives; the store-impact one does not.
+   *
+   * The `bulk` measurement covers the PrestaShop catalogue read path only; a
+   * slower destination is lowered with OL_LANE_BULK_SCOPE_CAP. And a cap
+   * bounds worker SLOTS in one process, never the destination's own capacity
+   * — raising a scope cap to make a slow destination faster makes it slower.
    */
   private laneCaps: Record<SyncJobLane, { total: number; perScope: number }> = {
     realtime: { total: 4, perScope: 2 },
     bulk: { total: 12, perScope: 8 },
     fiscal: { total: 2, perScope: 1 },
-    'fan-out': { total: 1, perScope: 1 },
+    // 8/4 since #2609, and this literal is kept in step with
+    // `resolveLaneCaps`'s fallback below ON PURPOSE. It used to read 1/1 —
+    // the pre-#2609 value — which changed no behaviour (the field is
+    // overwritten by `resolveLaneCaps()` in `onModuleInit`, and on the one
+    // path where it is NOT overwritten the runner is disabled and consults no
+    // cap at all), but left a reader of this class with a default that
+    // disagreed with the one the process actually runs. Two spellings of a
+    // default is how a wrong one gets quoted.
+    'fan-out': { total: 8, perScope: 4 },
   };
 
   /** In-flight job counts per lane, keyed by scope. */

--- a/docker-compose.lab.yml
+++ b/docker-compose.lab.yml
@@ -487,6 +487,29 @@ services:
       # file deliberately does not carry.
       OL_WORKER_ROLE: '${OL_WORKER_ROLE:-}'
       WORKER_RUNNER_ENABLED: '${WORKER_RUNNER_ENABLED:-false}'
+      # Lane caps (ADR-050 decisions 2/6, #2867). Passed through so a scenario
+      # can SWEEP a cap - which is the only way to measure one, and was not
+      # possible before: compose substitutes `${VAR}` only for keys the service
+      # actually lists, so exporting OL_LANE_* around `docker compose up`
+      # previously changed nothing at all and a sweep would silently have
+      # measured the same default at every point. `f8-lane-caps.sh` does not
+      # trust this either - it reads the caps back out of the worker's own
+      # startup line and refuses the arm on a mismatch.
+      #
+      # Empty is the default and means UNSET: `resolveLaneCaps`
+      # (apps/worker/src/sync/sync-job.runner.ts) reads '' as "use the code
+      # default", so an unset stand is byte-identical to its pre-#2867 self.
+      # These are per PROCESS (ADR-050 § Amendment (#2851 / #2867)), so at
+      # `--scale worker=N` the deployment's real concurrency is N times each
+      # figure.
+      OL_LANE_REALTIME_CAP: '${OL_LANE_REALTIME_CAP:-}'
+      OL_LANE_REALTIME_SCOPE_CAP: '${OL_LANE_REALTIME_SCOPE_CAP:-}'
+      OL_LANE_BULK_CAP: '${OL_LANE_BULK_CAP:-}'
+      OL_LANE_BULK_SCOPE_CAP: '${OL_LANE_BULK_SCOPE_CAP:-}'
+      OL_LANE_FISCAL_CAP: '${OL_LANE_FISCAL_CAP:-}'
+      OL_LANE_FISCAL_SCOPE_CAP: '${OL_LANE_FISCAL_SCOPE_CAP:-}'
+      OL_LANE_FANOUT_CAP: '${OL_LANE_FANOUT_CAP:-}'
+      OL_LANE_FANOUT_SCOPE_CAP: '${OL_LANE_FANOUT_SCOPE_CAP:-}'
       OL_LOG_BODY_MAX_BYTES: '${OL_LOG_BODY_MAX_BYTES:-8192}'
       NODE_EXTRA_CA_CERTS: /etc/ssl/lab/wc-tls-ca.pem
     volumes:

--- a/perf/openlinker-throughput/README.md
+++ b/perf/openlinker-throughput/README.md
@@ -33,6 +33,7 @@ sources it rather than re-implementing any piece of it.
 | `seed/cleanup.sh` | Removes every row the three seeders above wrote, matching on the `perfseed` tag alone. Standalone - does NOT touch #2854's `stand-down.sh`. |
 | `scenarios/f5-read-path.sh` | Operator read-path scenario (#2843) - orders/products/jobs-dashboard routes + the app-shell nav-probe fan-out, at each of the three seeded dataset sizes. See "F5 - operator read path at row count" below. |
 | `drivers/read-path.js` | k6 driver for `f5-read-path.sh` - a weighted browse-mix scenario plus a separate page-shell scenario, one Trend per named route. |
+| `scenarios/f8-lane-caps.sh` | Lane-cap SATURATION sweep (#2867) - drives ONE lane's per-scope cap across a list of values, one worker recreate per value, and reports throughput and per-job latency at each point so the knee is read off a curve. The only scenario that WRITES a lane cap; it restores the caps it found on exit. Reads the applied cap back out of the worker's own startup line and refuses the arm on a mismatch, because a cap that silently did not apply produces a clean curve of the same cap measured five times. See "F8 - lane cap saturation" below. |
 
 Not owned here: `docker-compose.lab.yml` and `preflight.sh` are **#2854's**
 (the `lab` stand itself - Postgres's `pg_stat_statements`/`auto_explain`
@@ -555,6 +556,72 @@ order-detail / products-list / product-detail / jobs-dashboard, one Trend
 per route) and `page_shell` (the five nav-probe requests fired together as
 one group per "page load", measured separately per #2843's own AC that the
 page-shell tax must not be folded into a route's own number).
+
+## F8 - lane cap saturation (#2867)
+
+`scenarios/f8-lane-caps.sh` sweeps ONE lane's per-scope cap and reports what
+each setting buys. ADR-050 decision 6 says a cap without a metric is a guess;
+its § Amendment (#2851 / #2867) names, per lane, the measurement that is
+missing. This is that run.
+
+```bash
+# one lane, one sweep, one worker recreate per cap point
+bash scenarios/f8-lane-caps.sh --lane=realtime --caps="1 2 4 8 16" --jobs=240
+bash scenarios/f8-lane-caps.sh --lane=fan-out  --caps="1 2 4 8 16" --jobs=150
+bash scenarios/f8-lane-caps.sh --lane=fiscal   --caps="1 2 4"      --jobs=200
+bash scenarios/f8-lane-caps.sh --lane=realtime --smoke   # plumbing only
+```
+
+Five things about it are worth knowing before reading its output.
+
+**It is the only scenario that WRITES a lane cap.** It sets
+`OL_LANE_<LANE>_CAP` / `_SCOPE_CAP` in `.env.lab`, recreates the worker
+service (`--no-deps`, so nothing else on the stand is touched), and restores
+every cap it found on exit. `docker-compose.lab.yml` gained the passthrough
+for those eight variables in #2867 - compose substitutes `${VAR}` only for
+keys a service actually lists, so before that, exporting them around
+`docker compose up` changed nothing at all.
+
+**It reads the cap back out of the worker's own startup line and refuses the
+arm on a mismatch.** This is the guard the whole scenario rests on: a cap that
+silently did not apply produces a perfectly clean curve of the SAME cap
+measured at every point, which is indistinguishable from "this lane does not
+respond to its cap" - and that is a conclusion, so it must not be reachable
+by accident.
+
+**Nothing is sized from lane occupancy.** The `sync_jobs`-row proxy
+over-reads (F4 § 2: a slot is released in-process when the handler resolves,
+while the row stays `running` until a separate terminal write commits), and
+the over-read is a larger fraction of a small cap than of `bulk`'s 12. Every
+cap this scenario sweeps is smaller than 12. `occMaxProxy` / `occMeanProxy`
+are reported so a reader can see whether the lane was near its cap at all;
+every sizing figure comes from `sync_jobs.lastAttemptDurationMs` (#2611) and
+per-row timestamps instead, which the worker writes at real precision and
+which do not inherit the ~1 Hz sampler floor F7 hit.
+
+**The load is chosen per lane, because the cap protects something different
+in each.** `realtime` gets `marketplace.offerQuantity.update` against the
+`allegro-stub` - one synchronous call, no fan-out, and a destination whose
+latency is a knob rather than a shop, which is what makes the LANE the thing
+being measured. It is deliberately not `marketplace.order.sync`, which on
+this stand fans an ingested order out to every `OrderProcessorManager`
+connection and would create hundreds of real orders in a real PrestaShop
+against its declared 60 req/min - F4 already measured what happens then
+(both arms `DISCARDED`, the shop the ceiling). `fan-out` gets
+`inventory.propagateToMarketplaces`, whose work is database reads plus child
+enqueues. `fiscal` gets F7's invalid-payload `invoicing.issue` probe, and
+see the next paragraph.
+
+**The fiscal arm measures the runner's floor, NOT the cap, and must never be
+quoted as a cap measurement.** No invoicing or fiscalization connection
+exists on this stand, and building one means a real provider issuing real
+documents. The probe reaches `InvoicingIssueHandler`'s payload validation and
+returns `business_failure` before any adapter, lock or provider - so it does
+none of the work whose concurrency the cap governs. What it is good for is
+bounding the other half arithmetically: a burst of N documents at cap C
+against a provider taking T seconds each drains in about `N*T/C` plus this
+floor, which says how much of a fiscal burst's latency is OL's and how much
+is the provider's.
 
 ## Not built here
 

--- a/perf/openlinker-throughput/lib-test.sh
+++ b/perf/openlinker-throughput/lib-test.sh
@@ -879,6 +879,77 @@ rm -f "$DOCKER_LOGS_ARGS_FILE"
 
 # ---------------------------------------------------------------------------
 echo
+echo "--- lane caps are reachable from a scenario at all (#2867) ---"
+# The failure this defends against is silent and total. Compose substitutes
+# `${VAR}` only for keys the service actually LISTS, so before #2867 exporting
+# OL_LANE_* around `docker compose up` changed nothing - and a cap sweep would
+# have produced a perfectly clean curve of the SAME cap measured at every
+# point, which is indistinguishable from "this lane does not respond to its
+# cap". That is a conclusion, so it must not be reachable by accident.
+F8_COMPOSE="$SCRIPT_DIR/../../docker-compose.lab.yml"
+if [ -f "$F8_COMPOSE" ]; then
+  F8_WORKER_ENV="$(awk '/^  worker:/{inw=1} inw && /^  [a-z]/ && !/^  worker:/{inw=0} inw' "$F8_COMPOSE")"
+  for f8_stem in REALTIME BULK FISCAL FANOUT; do
+    for f8_suffix in CAP SCOPE_CAP; do
+      assert_contains "docker-compose.lab.yml passes OL_LANE_${f8_stem}_${f8_suffix} through to the worker" \
+        "$F8_WORKER_ENV" "OL_LANE_${f8_stem}_${f8_suffix}:"
+      # Default must be EMPTY, never a literal number: resolveLaneCaps reads ''
+      # as "use the code default", so an empty default keeps an untouched stand
+      # byte-identical to its pre-#2867 self. A number here would silently pin
+      # every lab stand to a cap the code no longer owns.
+      assert_contains "OL_LANE_${f8_stem}_${f8_suffix} defaults to empty (unset == code default)" \
+        "$F8_WORKER_ENV" "OL_LANE_${f8_stem}_${f8_suffix}: '\${OL_LANE_${f8_stem}_${f8_suffix}:-}'"
+    done
+  done
+else
+  FAIL=$((FAIL + 1)); FAILURES+=("docker-compose.lab.yml not found at $F8_COMPOSE")
+fi
+
+F8_SCENARIO="$SCRIPT_DIR/scenarios/f8-lane-caps.sh"
+if [ -f "$F8_SCENARIO" ]; then
+  F8_SRC="$(cat "$F8_SCENARIO")"
+  # `fan-out` is the one lane whose env stem is not its own name. Getting it
+  # wrong sets nothing, every arm runs at the same cap, and the run looks fine.
+  assert_contains "f8 maps the fan-out lane to the FANOUT env stem, not 'FAN-OUT'" \
+    "$F8_SRC" 'fan-out)  LANE_ENV_STEM="FANOUT"'
+  # The cap must be read back out of the worker's own startup line. Trusting
+  # the env write is exactly the silent-failure mode above.
+  assert_contains "f8 verifies the applied cap against the worker's startup line" \
+    "$F8_SRC" 'assert_caps_applied'
+  assert_contains "f8 refuses an arm whose cap did not apply" \
+    "$F8_SRC" 'The cap did NOT apply'
+  # Occupancy over-reads (F4 § 2) and is a larger fraction of a small cap than
+  # of bulk's 12. Every cap f8 sweeps is smaller than 12, so the script must
+  # say so where a reader of its output will see it.
+  assert_contains "f8 labels the occupancy figures as an over-reading proxy" \
+    "$F8_SRC" 'PROXY and OVER-READ'
+  # #2617 takes a per-(connection, offer) lock. A pool at or below the widest
+  # cap would serialise the arm on the lock and the curve would be the lock's.
+  assert_contains "f8 refuses a realtime sweep whose offer pool is not wider than the widest cap" \
+    "$F8_SRC" 'curve of the lock, not of the lane'
+  # The fiscal arm exercises a handler that returns before any adapter, lock or
+  # provider. It measures the runner's floor and must never be quoted as a cap.
+  assert_contains "f8 states the fiscal arm is not a cap measurement" \
+    "$F8_SRC" 'NOT a cap measurement'
+  # A command substitution runs the function in a SUBSHELL, so every ARMS_CSV
+  # append is discarded and every log line is swallowed into the substitution's
+  # value. The first run of f8 did exactly that: both arms executed against the
+  # stand and the summary came out with a header and no rows.
+  case "$F8_SRC" in
+    *'$(run_arm'*) FAIL=$((FAIL + 1)); FAILURES+=("f8 must not call run_arm in a command substitution - the subshell discards ARMS_CSV") ;;
+    *) PASS=$((PASS + 1)) ;;
+  esac
+  # An oversized TOTAL turns every refill into a claim-and-release of
+  # (free - 1) rows, because claimAndStartForLane claims `total - inFlight` and
+  # only then drops what exceeds perScope.
+  assert_contains "f8 derives TOTAL from perScope x scopes rather than pinning it high" \
+    "$F8_SRC" 'total=$(( cap * SCOPES ))'
+else
+  FAIL=$((FAIL + 1)); FAILURES+=("f8-lane-caps.sh not found at $F8_SCENARIO")
+fi
+
+# ---------------------------------------------------------------------------
+echo
 echo "=== $PASS passed, $FAIL failed ==="
 if [ "$FAIL" -gt 0 ]; then
   printf 'FAILURES:\n'

--- a/perf/openlinker-throughput/results-lane-caps-2026-09-07.md
+++ b/perf/openlinker-throughput/results-lane-caps-2026-09-07.md
@@ -196,12 +196,38 @@ measurement or by reading the code:
   one cursor read, one marketplace call, one conditional cursor advance and one
   lock release per item.
 
-The leading hypothesis is § 4.1's limiter timeout charged several times per job,
-which would put ~9 s within reach. **It is a hypothesis and is labelled as one.**
-Settling it needs the worker log for one traced job, which needs the stand; the
+**The leading hypothesis is the Allegro client's own retry ladder, and the
+arithmetic lands almost exactly on the observation.**
+`allegro-http-client.ts`'s `DEFAULT_RETRY_CONFIG` is `maxRetries: 3`,
+`initialDelayMs: 1000`, `backoffMultiplier: 2`. A request that exhausts it
+sleeps **1000 + 2000 + 4000 = 7000 ms** across four attempts, and four attempts
+against a 127.6 ms destination add ~510 ms:
+
+| Term | ms | Source |
+|---|---|---|
+| Retry backoff, 3 retries at 1 s / 2 s / 4 s | 7000 | `DEFAULT_RETRY_CONFIG` (code) |
+| 4 attempts x 127.6 ms | ~510 | § 4.1 (measured) |
+| One limiter timeout (§ 4.1) | ~1000 | measured, once, on another call |
+| Lock acquire + cursor read + cursor advance + release | small | `InventorySyncService` (code) |
+| **Total** | **~8510-9500** | vs **9116-9850 measured** |
+
+That is a fit, not a proof, and it is labelled **derived**. What would confirm
+it is one log line, which the client emits by name on that path -
+`Rate limit exceeded (attempt N/4), retrying after Xms`. If it is present, the
+9 s is backoff and the realtime lane's *real* per-job cost is ~130 ms, which
+would put the correct cap an order of magnitude away from 2 and would make this
+a defect report rather than a tuning exercise. If it is absent, something else
+is sleeping and the question is still open.
+
+Settling it needs the worker log for one traced job, which needs the stand. The
 attempt to take it was refused by `guard_stand_exclusive` because a peer had
-taken the stand two minutes earlier, and the smoke run's own container had
-already been replaced by the scenario's restore, so its logs were gone.
+taken the stand two minutes earlier, and the smoke run's own containers had
+already been replaced by the scenario's own restore, so their logs were gone.
+The probe is written and is two minutes of stand time.
+
+Note this compounds with § 4.1 rather than competing with it: if the limiter's
+1 s timeout is what the client is retrying *against*, then one defect is
+producing both, and a lane cap is not the knob for either.
 
 *Label: the durations are **measured** (n=12, smoke mode - the harness's own
 rule is that smoke numbers are not a measurement of the thing the scenario
@@ -335,7 +361,7 @@ reasoning in place; see § 6.
 
 | Lane | Current | Recommended | Basis |
 |---|---|---|---|
-| `realtime` | 4 / 2 | **4 / 2 - unchanged** | No curve was taken. § 4.2's 9.1 s must be attributed first: if it is § 4.1's limiter, the lane's real per-job cost is ~130 ms and the correct cap is a different order of magnitude; if it is genuine work, 2 is defensible. Changing the number before knowing which would be a guess dressed as a measurement. |
+| `realtime` | 4 / 2 | **4 / 2 - unchanged** | No curve was taken. § 4.2's 9.1 s must be attributed first, and the derived arithmetic there says ~7 s of it is very likely the Allegro client's own retry backoff. If so the lane's real per-job cost is ~130 ms, the correct cap is an order of magnitude from 2, and the finding is a defect rather than a tuning number. Changing the cap before knowing which would be a guess dressed as a measurement. |
 | `fiscal` | 2 / 1 | **2 / 1 - unchanged** | Unmeasurable here (§ 4.5). Flag for the owner: `perScope: 1` serialises bulk issuance across distinct orders, which the per-order lock would not. |
 | `fan-out` | 8 / 4 | **8 / 4 - unchanged** | Not reached (peers held the stand). Confirmed derived, not measured (§ 4.6). |
 
@@ -371,9 +397,10 @@ class-level initialiser, against `resolveLaneCaps`'s 8/4 fallback. Aligned; see
 
 - **Any cap curve for any lane.** No sweep arm ran outside smoke mode. The
   scenario exists, is tested, and ran clean end to end; it did not get the stand.
-- **The attribution of § 4.2's 9.1 s.** Ruled out: destination, Redis, pacing
-  config, fan-out, round-trip count. Not ruled in: anything. One traced job's
-  worker log settles it.
+- **The attribution of § 4.2's 9.1 s.** Ruled out by measurement or code:
+  destination, Redis, pacing config, fan-out, round-trip count. The retry-ladder
+  arithmetic in § 4.2 fits to within ~5 %, but a fit is not an observation - no
+  log line was captured showing a retry actually firing.
 - **Whether § 4.1's limiter timeout occurs inside a measurement window.** It was
   observed outside one. `post_guard_limiter_degraded` would `DISCARD` an arm
   that contained one - and since #2851 that guard can actually see, so a future
@@ -395,9 +422,12 @@ class-level initialiser, against `resolveLaneCaps`'s 8/4 fallback. Aligned; see
 
 ## 8. Next, in the order that buys the most
 
-1. **Trace one `marketplace.offerQuantity.update` job's worker log.** Minutes of
-   stand time. It either collapses § 4.2 into § 4.1 or opens a new question,
-   and every realtime number depends on which.
+1. **Trace one `marketplace.offerQuantity.update` job's worker log.** Two
+   minutes of stand time; the probe is written. Grep for
+   `Rate limit exceeded (attempt N/4), retrying after` - present means § 4.2 is
+   retry backoff and this becomes a defect report, absent means something else
+   sleeps ~9 s and the question is open. Every realtime number depends on it,
+   and no realtime cap should be proposed before it is answered.
 2. **Run the fan-out sweep** (`--lane=fan-out`). It needs no destination -
    database reads and child enqueues - so it is the one lane whose curve is not
    hostage to § 4.1, and it is the lane whose current value is derived rather

--- a/perf/openlinker-throughput/results-lane-caps-2026-09-07.md
+++ b/perf/openlinker-throughput/results-lane-caps-2026-09-07.md
@@ -35,7 +35,7 @@ the saturation sweep". After it, the answer is:
 
 | Lane | Default | Still | Why it did not get a number here |
 |---|---|---|---|
-| `realtime` | 4 / 2 | ILLUSTRATIVE | A sweep is now RUNNABLE (§ 2) and a smoke arm ran clean, but per-job cost on the write path measured **9.1-9.8 s against a 127 ms destination** (§ 4.2). Until that is attributed, a curve taken through it is a curve of the unattributed 9 s. |
+| `realtime` | 4 / 2 | ILLUSTRATIVE | A sweep is now RUNNABLE (§ 2) and a smoke arm ran clean, but per-job cost on the write path measured **9.1-9.8 s against a 127 ms destination**, and a trace puts ~7 s of that in OpenLinker either side of one HTTP call (§ 4.2). A curve taken through that is a curve of the 7 s, not of the lane. |
 | `fiscal` | 2 / 1 | ILLUSTRATIVE | Unchanged and, on the evidence in § 4.5, likely permanent. No provider exists on this stand and building one means issuing real documents. |
 | `fan-out` | 8 / 4 | **DERIVED, not measured** - confirmed, see § 4.6 | Not reached. The peers held the stand. |
 
@@ -114,6 +114,22 @@ claim-latency band *is* the instrument (`POLL_INTERVAL_MS` plus a ~1 Hz poller),
 so a sub-second difference between arms cannot be resolved by it.
 
 **The fiscal arm measures the runner's floor and says so** - see § 4.5.
+
+---
+
+### 3.1 One methodology note: `guard_build` refused the first sweep, correctly
+
+The fan-out sweep's first attempt died at `guard_build`: the running `lab` image
+was built from the branch base, and this branch had since committed a change to
+`apps/worker/src/sync/sync-job.runner.ts`. That change is **documentation plus
+one inert literal** (§ 6) and could not alter behaviour - but the guard cannot
+know that, and *"the diff looked harmless"* is precisely the reasoning a
+stale-image guard exists to refuse.
+
+Rather than bypass it, the working tree's copy of that one file was checked out
+at the image's own commit for the duration of the measurement and restored
+immediately after. The guard then passed on its own terms rather than being
+argued with.
 
 ---
 
@@ -196,43 +212,48 @@ measurement or by reading the code:
   one cursor read, one marketplace call, one conditional cursor advance and one
   lock release per item.
 
-**The leading hypothesis is the Allegro client's own retry ladder, and the
-arithmetic lands almost exactly on the observation.**
-`allegro-http-client.ts`'s `DEFAULT_RETRY_CONFIG` is `maxRetries: 3`,
-`initialDelayMs: 1000`, `backoffMultiplier: 2`. A request that exhausts it
-sleeps **1000 + 2000 + 4000 = 7000 ms** across four attempts, and four attempts
-against a 127.6 ms destination add ~510 ms:
+**Traced, and it is NOT the retry ladder.** An earlier draft of this report
+predicted the Allegro client's `DEFAULT_RETRY_CONFIG` (`maxRetries: 3`,
+`initialDelayMs: 1000`, `backoffMultiplier: 2` = 7000 ms of backoff across four
+attempts) and noted that the arithmetic fitted to within ~5 %. **It fitted and
+it was wrong**, which is the reason this paragraph exists rather than the
+prediction. One traced job (`durationMs=9727`, `succeeded`, `outcome=ok`) shows
+**exactly one HTTP attempt**, no `Rate limit exceeded (attempt N/4)` line, and
+the 9.7 s distributed like this:
 
-| Term | ms | Source |
+| Interval | Elapsed | What the log shows |
 |---|---|---|
-| Retry backoff, 3 retries at 1 s / 2 s / 4 s | 7000 | `DEFAULT_RETRY_CONFIG` (code) |
-| 4 attempts x 127.6 ms | ~510 | § 4.1 (measured) |
-| One limiter timeout (§ 4.1) | ~1000 | measured, once, on another call |
-| Lock acquire + cursor read + cursor advance + release | small | `InventorySyncService` (code) |
-| **Total** | **~8510-9500** | vs **9116-9850 measured** |
+| `Executing ...offerQuantity.update` -> `PUT /sale/offer-quantity-change-commands/...` | **~4 s** | nothing logged in between |
+| inside the PUT | **1126 ms** | against a destination measured at 127.6 ms; a `checkPace timed out after 1000ms` line lands mid-call |
+| HTTP `Response: 200` -> `Job ... succeeded` | **~3 s** | nothing logged in between |
 
-That is a fit, not a proof, and it is labelled **derived**. What would confirm
-it is one log line, which the client emits by name on that path -
-`Rate limit exceeded (attempt N/4), retrying after Xms`. If it is present, the
-9 s is backoff and the realtime lane's *real* per-job cost is ~130 ms, which
-would put the correct cap an order of magnitude away from 2 and would make this
-a defect report rather than a tuning exercise. If it is absent, something else
-is sleeping and the question is still open.
+So the shape is **~4 s before the call, ~1 s of limiter timeout inside it, ~3 s
+after it** - roughly **7 s of OpenLinker-side time bracketing a single 127 ms
+request**, with the network the smallest term by an order of magnitude.
 
-Settling it needs the worker log for one traced job, which needs the stand. The
-attempt to take it was refused by `guard_stand_exclusive` because a peer had
-taken the stand two minutes earlier, and the smoke run's own containers had
-already been replaced by the scenario's own restore, so their logs were gone.
-The probe is written and is two minutes of stand time.
+The two unlogged brackets are where the cost is, and neither is attributed to a
+specific statement yet. By code reading, the pre-call bracket contains capability
+adapter resolution (`getCapabilityAdapter` builds a fresh adapter per call and
+resolves + decrypts credentials), `applyPublishControlsBatch`, the #2617
+`SyncLockPort.acquire`, and the observation-cursor read; the post-call bracket
+contains the conditional cursor advance, the lock release and the terminal
+`sync_jobs` write. **Which of those dominates is not established** - that needs
+either #2850's instrumentation or a debug-level trace, and is named in § 8.
 
-Note this compounds with § 4.1 rather than competing with it: if the limiter's
-1 s timeout is what the client is retrying *against*, then one defect is
-producing both, and a lane cap is not the knob for either.
+Two smaller observations from the same trace, recorded because they are cheap
+and someone will otherwise re-derive them:
 
-*Label: the durations are **measured** (n=12, smoke mode - the harness's own
-rule is that smoke numbers are not a measurement of the thing the scenario
-exists to measure, and they are used here only as evidence about per-job cost,
-never as a cap curve). The attribution is **open**.*
+- The limiter line reads **"still degraded"**, not "unavailable" - the adapter
+  had already entered degraded mode and stays there, so § 4.1's ~1 s is charged
+  to calls indefinitely rather than once.
+- `sync_jobs.attempts` reads **0** on this succeeded row while the runner logged
+  `attempt 1/3` and `after 1 attempt(s)`. Harmless here, but a reader counting
+  attempts off that column is counting something else.
+
+*Label: the 12 durations and the traced breakdown are **measured** (n=12 smoke
+arm; n=1 trace). The retry-ladder explanation is **withdrawn - it was derived,
+it fitted, and the trace falsified it.** Which statement inside the two unlogged
+brackets dominates is **open**.*
 
 ### 4.3 A freed slot waits up to a full poll interval (derived, from code)
 
@@ -422,12 +443,13 @@ class-level initialiser, against `resolveLaneCaps`'s 8/4 fallback. Aligned; see
 
 ## 8. Next, in the order that buys the most
 
-1. **Trace one `marketplace.offerQuantity.update` job's worker log.** Two
-   minutes of stand time; the probe is written. Grep for
-   `Rate limit exceeded (attempt N/4), retrying after` - present means § 4.2 is
-   retry backoff and this becomes a defect report, absent means something else
-   sleeps ~9 s and the question is open. Every realtime number depends on it,
-   and no realtime cap should be proposed before it is answered.
+1. **Attribute § 4.2's two unlogged brackets** - ~4 s before the outbound call
+   and ~3 s after it, per the trace. Done (the trace); the retry-ladder
+   explanation is falsified. What remains is *which statement* inside each
+   bracket dominates, which needs a debug-level trace or #2850. Until it is
+   answered no realtime cap should be proposed, because if the 7 s is adapter
+   construction or the degraded limiter then the lane's real per-job cost is
+   ~130 ms and the right cap is an order of magnitude from 2.
 2. **Run the fan-out sweep** (`--lane=fan-out`). It needs no destination -
    database reads and child enqueues - so it is the one lane whose curve is not
    hostage to § 4.1, and it is the lane whose current value is derived rather

--- a/perf/openlinker-throughput/results-lane-caps-2026-09-07.md
+++ b/perf/openlinker-throughput/results-lane-caps-2026-09-07.md
@@ -1,0 +1,425 @@
+# F8 - lane caps for `realtime`, `fiscal` and `fan-out` (#2867)
+
+**Date**: 2026-09-07 - **Epic**: #2840 - **Issue**: #2867 - **Stand**: `lab`
+
+## 0. Read this before any number
+
+**The stand is a docker-compose project on a contended developer workstation
+(WSL2), sharing a host with two other OpenLinker stacks (`ol-demo-fresh-*`, 10
+containers) and with two peer perf scenarios.** Host load average entering this
+session was 1.42-2.21. Every figure below is a **floor**, and `n = 1` unless a
+sample size is stated. n=1 is a direction, not a bound.
+
+**The stand's exclusivity lock was held by peers for most of this session** -
+`f7-lane-starvation` from 00:32 to 00:58, and `f1-order-ingestion` from 01:05
+onward. `guard_stand_exclusive` was taken and released properly; the queue for
+it is the single largest reason this report is shorter than #2867 asks for.
+
+Every figure carries one of three labels and they are not interchangeable:
+
+- **measured** - observed on this stand in this session, with the sample size.
+- **derived** - arithmetic or a code reading, with the source named.
+- **extrapolated** - neither. There is one, and it is marked.
+
+---
+
+## 1. Verdict
+
+**No cap default changes on this evidence, and none should.** `realtime`,
+`fiscal` and `fan-out` remain as ADR-050 § Amendment (#2851 / #2867) already
+describes them - two illustrative, one derived.
+
+That is not the interesting part. The interesting part is that **the reason
+they are unmeasured moved**. Before this session the answer was "nobody has run
+the saturation sweep". After it, the answer is:
+
+| Lane | Default | Still | Why it did not get a number here |
+|---|---|---|---|
+| `realtime` | 4 / 2 | ILLUSTRATIVE | A sweep is now RUNNABLE (§ 2) and a smoke arm ran clean, but per-job cost on the write path measured **9.1-9.8 s against a 127 ms destination** (§ 4.2). Until that is attributed, a curve taken through it is a curve of the unattributed 9 s. |
+| `fiscal` | 2 / 1 | ILLUSTRATIVE | Unchanged and, on the evidence in § 4.5, likely permanent. No provider exists on this stand and building one means issuing real documents. |
+| `fan-out` | 8 / 4 | **DERIVED, not measured** - confirmed, see § 4.6 | Not reached. The peers held the stand. |
+
+**The one thing that did change is that the measurement is now possible at
+all.** It was not, and that is § 2.
+
+---
+
+## 2. The blocker: lane caps were unreachable from any scenario
+
+`docker-compose.lab.yml`'s `worker` service listed no `OL_LANE_*` variable.
+Compose substitutes `${VAR}` only for keys a service actually lists, so
+exporting `OL_LANE_REALTIME_SCOPE_CAP=8` around `docker compose up` set
+**nothing**, silently.
+
+This is worse than an inconvenience, and it is why it is § 2 rather than a
+footnote. A cap sweep run against that stand would have produced a perfectly
+clean curve of the **same cap measured at every point** - flat throughput, flat
+latency, five points, no errors - and that reads exactly like *"this lane does
+not respond to its cap"*, which is a conclusion. It is the
+`post_guard_limiter_degraded` shape from #2851 one layer up: **an instrument
+that cannot see reads identically to a clean result.**
+
+Fixed two ways, because the passthrough alone would have been trusted:
+
+1. `docker-compose.lab.yml` passes all eight cap variables through, each
+   defaulting to **empty**. `resolveLaneCaps` reads `''` as "use the code
+   default", so an untouched stand is byte-identical to its pre-#2867 self.
+2. `f8-lane-caps.sh` **reads the applied cap back out of the worker's own
+   `Starting sync job runner loop` line and refuses the arm on a mismatch.**
+   The scenario does not trust the env write it just made.
+
+`lib-test.sh` goes from 116 to **140 assertions**, 24 of them for this: every
+variable is passed through, every default is empty, the scenario verifies
+rather than assumes, and four traps below are pinned as tests.
+
+---
+
+## 3. What was built
+
+`perf/openlinker-throughput/scenarios/f8-lane-caps.sh` - sweeps one lane's
+per-scope cap across a list, one worker recreate per point, reporting
+throughput and per-job latency at each. `--lane`, `--caps`, `--jobs`,
+`--scopes`, `--smoke`. It restores every cap it found, plus the runner posture,
+on any exit path including `die`.
+
+Four design choices are load-bearing and each is a correction to the obvious
+approach.
+
+**The realtime load is `marketplace.offerQuantity.update`, not
+`marketplace.order.sync`.** ADR-050's amendment names the latter. On this stand
+that job is not a realtime-lane measurement: `OrderSyncService` fans an ingested
+order out to every `OrderProcessorManager` connection, which here is
+`perf-prestashop` **and** `perf-woocommerce`, so a 240-job arm would create 240
+real orders in a real PrestaShop against its declared 60 req/min. F4 already
+measured what happens then - both arms `DISCARDED`, the shop the ceiling.
+`offerQuantity.update` is the same lane, is the lane's highest-volume real
+member, makes exactly one synchronous call, fans out to nothing, and its
+destination here is the `allegro-stub`, whose latency is a knob rather than a
+shop. **A saturation curve taken against a contended destination is a curve of
+the destination**, which is the whole reason the previous two runs could not
+size a lane.
+
+**Nothing is sized from lane occupancy.** F4 § 2 established that the
+`sync_jobs`-row proxy over-reads (a slot is released in-process when the handler
+resolves; the row stays `running` until a separate terminal write commits). The
+over-read is a *larger fraction of a smaller cap*, and every cap swept here is
+smaller than `bulk`'s 12 - at `fiscal`'s perScope of 1, a single in-flight
+terminal write is a 100 % over-read. Occupancy is recorded as
+`occMaxProxy`/`occMeanProxy` and used for nothing. Sizing reads
+`sync_jobs.lastAttemptDurationMs` (#2611) and row timestamps, which the worker
+writes at real precision.
+
+**Claim/queue latency is not used either** - F7 established that its own
+claim-latency band *is* the instrument (`POLL_INTERVAL_MS` plus a ~1 Hz poller),
+so a sub-second difference between arms cannot be resolved by it.
+
+**The fiscal arm measures the runner's floor and says so** - see § 4.5.
+
+---
+
+## 4. Findings
+
+### 4.1 The rate limiter degrades on a healthy, essentially idle Redis (measured)
+
+Observed in the worker log against `perf-allegro-a`:
+
+```
+ERROR [RedisRateLimiterAdapter] Redis rate limiter unavailable for connection
+53d949aa-... - falling back to per-process in-memory limiting (degraded, not
+unthrottled). Redis rate-limiter call "checkPace" timed out after 1000ms
+```
+
+Measured in the same minutes:
+
+| Fact | Value | How |
+|---|---|---|
+| Redis command latency | **0.12-0.18 ms** | `redis-cli --latency-history`, ~300 samples |
+| Redis memory / keys / ops | 18.40 MB / 82 059 / ~98 ops/s | `INFO`, `DBSIZE` |
+| `maxmemory-policy` | `noeviction` (2 GB cap) | `INFO memory` |
+| Stub `PUT /sale/offer-quantity-change-commands/:id` | **127.6 ms**, HTTP 200 | `curl -w`, from host |
+| Stub `GET /me` | 127.4 ms, HTTP 200 | `curl -w` |
+| Stub configured `eventsMs` | 276 ms | `GET /__stub/config` |
+| Actual `GET /order/events` as the worker saw it | **1305 ms** | worker log |
+
+**Redis was not slow.** A 1 s timeout on a store answering in 0.15 ms is not the
+store; it is the client not being scheduled to read the reply. That is an
+event-loop-lag signal - the "Channel 1" F7 recorded it could not measure. The
+1305 ms against a 276 ms configured latency is ≈ +1 s, consistent with exactly
+one limiter timeout being charged to that call.
+
+Two things make this more serious than F4's sighting of the same line. F4 saw
+it under a 600-job load and attributed it to load. **Here it appears on an
+essentially idle stand** (one leftover poll job), which weakens "load" as the
+explanation. And `perf-allegro-a` **declares no rate limit at all** - the
+Allegro manifest carries no `defaultRateLimit` (verified by reading
+`allegro-plugin.ts`, and ADR-050/#1810 say so deliberately) and the connection's
+config is `{"apiBaseUrl": "...", "environment": "production"}` with no
+`rateLimit` key. So a limiter with nothing to enforce still made a Redis call
+and still spent its full 1 s budget failing it.
+
+**This bounds every lane measurement taken on this stand**, which is why it is
+the first finding rather than a curiosity: ~1 s added per outbound call means a
+realtime curve measures the limiter, not the lane.
+
+*Label: measured (the latencies, the log line, the config). The causal claim
+"event-loop scheduling" is **derived** from the two measurements together and is
+not directly instrumented - #2850's `ol_event_loop_lag_seconds` is what would
+settle it.*
+
+### 4.2 The realtime write path costs 9.1-9.8 s against a 127 ms destination (measured, n=12)
+
+Smoke arm, `marketplace.offerQuantity.update`, `perf-allegro-a`, one scope,
+caps 1/1 and 4/4, 12 jobs each. All 12 jobs of the recorded arm reached
+`status=succeeded`, `outcome=ok` - **the path works, this is not a failure
+mode.** `lastAttemptDurationMs`, sorted:
+
+```
+9116 9116 9116 9117 9138 9138 9139 9139 9848 9848 9849 9850
+```
+
+Three tight clusters of **four**, which is the per-scope cap of that arm. Four
+concurrently-running jobs finishing within 1 ms of each other is not four jobs
+each doing 9 s of work; it is four jobs sharing one synchronous wait.
+
+Against a destination measured at 127.6 ms, that is **~72x the destination
+latency, spent inside OpenLinker.** For sizing this lane it is the single most
+important number, and **it is not yet attributed.** What has been ruled out by
+measurement or by reading the code:
+
+- Not the destination (127.6 ms, § 4.1).
+- Not Redis (0.15 ms, § 4.1).
+- Not rate-limit pacing: no `requestsPerMinute` and no `maxConcurrent` is
+  configured anywhere for this connection (§ 4.1).
+- Not a fan-out: this job type enqueues no children (`childrenEnqueued` = 0).
+- Not round-trip count: the guarded write path
+  (`InventorySyncService.updateOfferQuantities`) is one `SyncLockPort.acquire`,
+  one cursor read, one marketplace call, one conditional cursor advance and one
+  lock release per item.
+
+The leading hypothesis is § 4.1's limiter timeout charged several times per job,
+which would put ~9 s within reach. **It is a hypothesis and is labelled as one.**
+Settling it needs the worker log for one traced job, which needs the stand; the
+attempt to take it was refused by `guard_stand_exclusive` because a peer had
+taken the stand two minutes earlier, and the smoke run's own container had
+already been replaced by the scenario's restore, so its logs were gone.
+
+*Label: the durations are **measured** (n=12, smoke mode - the harness's own
+rule is that smoke numbers are not a measurement of the thing the scenario
+exists to measure, and they are used here only as evidence about per-job cost,
+never as a cap curve). The attribution is **open**.*
+
+### 4.3 A freed slot waits up to a full poll interval (derived, from code)
+
+`SyncJobRunner.runnerLoop` sleeps `POLL_INTERVAL_MS` whenever a tick started
+nothing:
+
+```ts
+if (!startedAny) { await this.sleep(this.POLL_INTERVAL_MS, ...); }
+```
+
+Once a lane sits at its cap, every tick starts nothing, so the loop is asleep
+when a job finishes. **Each completion therefore waits up to 1 s for its slot to
+be refilled**, mean ~0.5 s if completions are uniform in the interval. Effective
+throughput is about `C / (D + 0.5 s)` rather than `C / D`.
+
+`POLL_INTERVAL_MS = 1000` is a **hardcoded `private readonly`** - unlike the
+caps it sits beside, it is not env-tunable, so an operator cannot trade it off.
+
+The consequence is lane-specific and it matters for exactly the two lanes this
+issue could not measure. `fan-out` jobs are database reads plus child enqueues,
+and the `fiscal` sweeps are paged reads - both are **short relative to 1 s**. For
+a lane whose jobs are short, the refill latency, not the cap, is the dominant
+term, and raising the cap is the only lever that exists. This is a better
+explanation of #2609's observed backlog (a queue growing ~145 jobs/h faster than
+it drained at `fan-out` 1/1) than "one slot serialised it" alone.
+
+*Label: **derived** from the runner source. Not measured here - measuring it is
+one arm of the fan-out sweep that did not get stand time.*
+
+### 4.4 An oversized TOTAL turns every refill into claim-and-release churn (derived, from code)
+
+`claimAndStartForLane` claims with `limit: cap.total - inFlightTotal` and only
+*then* drops what exceeds `perScope`, releasing each surplus row individually
+via `releaseSurplusClaim`. The pre-claim `excludedScopes` filter cannot prevent
+it, because a scope is excluded only once it is **already** at cap - and on the
+tick where a slot frees, it is not.
+
+So a lane pinned at `total: 64, perScope: 2` with one active scope does, on
+every single refill, a claim of up to 63 rows to start one, and releases 62.
+
+**This was going to be my own methodology error**, and it is recorded because
+the next person will reach for the same design. The obvious way to isolate a
+per-scope sweep is to pin TOTAL high so "only perScope varies". That does not
+isolate it; it adds row-lock churn proportional to `total` to every refill, and
+the sweep measures the churn. `f8-lane-caps.sh` therefore **derives**
+`total = perScope x scopes` unless explicitly overridden, and `lib-test.sh`
+asserts it.
+
+The operator-facing form of the same fact: **do not set a lane's TOTAL far above
+`perScope` x the number of connections that actually have work in it.** It buys
+no concurrency and costs claim/release traffic on the hottest query in the
+system.
+
+*Label: **derived** from the runner source. The churn's cost is not measured.*
+
+### 4.5 `fiscal`: what actually bounds it (derived, from code)
+
+The question was asked as "is the provider the constraint?" The code says the
+lane's constraint is more specific than that, and in one direction the current
+default is the constraint.
+
+The lane holds **five** job types (`handler-registration.service.ts`):
+`invoicing.issue`, `fiscalization.register`, and three cron-paced sweeps
+(`invoicing.regulatoryStatus.reconcile`, `invoicing.offlineSubmission.resubmit`,
+`invoicing.pendingRecovery.sweep`).
+
+The two document-issuing types **share one per-order lock**:
+`InvoiceService.issueInvoice` acquires `invoiceIssueLockKey(cmd.orderId)`, and
+`FiscalRegistrationService` acquires the *same key* (#2157). So:
+
+- **Above** the number of distinct orders being issued at once, lane concurrency
+  buys nothing - the lock serialises it. This is what `.env.example` already
+  says, and it is correct.
+- **Below** it, the cap binds and the lock does not. `perScope: 1` means one
+  fiscal job per connection at a time, so an operator's bulk issuance
+  (`POST /invoices/bulk-issue` exists) over N distinct orders is serialised by
+  the **cap**, entirely, even though the lock would permit all N to proceed.
+
+Those bound different things and the second half is not currently stated
+anywhere. A deadline-bearing lane whose bulk path is pinned at one document at a
+time is worth an operator knowing about, whatever the provider's latency is.
+
+**The measurement that is missing is unchanged**, and this does not substitute
+for it: a run against a real invoicing or fiscalization connection issuing real
+documents. That is a legal act, not a load generator, and it is why this lane is
+the likeliest permanent holdout.
+
+What a stand *can* contribute is the arithmetic bound: a burst of N documents at
+cap C against a provider taking T seconds each drains in about `N x T / C` plus
+the runner floor of § 4.3. **T is left unknown rather than filled in with a
+plausible number.**
+
+*Label: **derived** from code. The claim about bulk issuance is a reading of the
+lock's scope, not an observed serialisation.*
+
+### 4.6 `fan-out`'s 8/4 was reasoned, not measured - confirmed
+
+Asked directly by #2867. The answer is **reasoned (derived)**, and both primary
+sources say so in as many words.
+
+ADR-050 § Amendment (#2609): *"The raise is not backed by a per-destination
+measurement the way `bulk`'s is, and decision 6 still applies."*
+
+`apps/worker/.env.example`: *"fan-out - DERIVED, not measured. Raised from 1/1
+in #2609 on the strength of an observed BACKLOG ... - that measures the defect,
+not the fix."*
+
+The observation behind it is real and is a measurement *of the problem* (a queue
+growing ~145 jobs/h faster than it drained, 15 066 rows backlogged from ordinary
+operation), and the diagnosis - a synthetic all-zero connection id collapsing
+every stock write in the install into one scope - is correct and was fixed. But
+**8 and 4 are not measured values**; the supporting `results-D` convergence run
+had `bulk` and `fan-out` in force together and attributes convergence to
+neither.
+
+Note the runner's own class-level default read `'fan-out': { total: 1, perScope: 1 }`
+- the pre-#2609 value - while `resolveLaneCaps` fell back to 8/4 two methods
+below. Behaviourally inert (the field is overwritten at `onModuleInit`, and on
+the one path where it is not, the runner is disabled and consults no cap), but a
+reader of that class saw a default the process never runs. Corrected, with the
+reasoning in place; see § 6.
+
+---
+
+## 5. Per-lane recommendation
+
+| Lane | Current | Recommended | Basis |
+|---|---|---|---|
+| `realtime` | 4 / 2 | **4 / 2 - unchanged** | No curve was taken. § 4.2's 9.1 s must be attributed first: if it is § 4.1's limiter, the lane's real per-job cost is ~130 ms and the correct cap is a different order of magnitude; if it is genuine work, 2 is defensible. Changing the number before knowing which would be a guess dressed as a measurement. |
+| `fiscal` | 2 / 1 | **2 / 1 - unchanged** | Unmeasurable here (§ 4.5). Flag for the owner: `perScope: 1` serialises bulk issuance across distinct orders, which the per-order lock would not. |
+| `fan-out` | 8 / 4 | **8 / 4 - unchanged** | Not reached (peers held the stand). Confirmed derived, not measured (§ 4.6). |
+
+**No default is changed by this work.** The only defaults touched in code are a
+withdrawn figure and a stale literal, both in § 6, neither of which changes what
+any process runs.
+
+---
+
+## 6. Corrections to shipped documentation
+
+**A withdrawn figure had survived in the runner.** ADR-066 correction 1 withdrew
+the `p95 store impact 0.995` ratio by name (the probe never checked HTTP status,
+so a fast error under load counted as a fast sample), and ADR-050 § Amendment
+(#2851 / #2867) says it *"is removed there and stays removed here"*. It had been
+removed from `apps/worker/.env.example` - which now carries an explicit *"Do NOT
+quote a p95 store impact figure for this cap"* - but **not** from
+`sync-job.runner.ts:136`, which still cited it as the `bulk` caps'
+justification. Removed, with the prohibition restated where the next author
+will be tempted.
+
+The same docblock also called `fan-out` "illustrative" where `.env.example`
+correctly calls it derived, and gave `bulk`'s `perScope: 8` the same standing as
+its measured `total: 12`. Both corrected.
+
+**A stale default literal.** `'fan-out': { total: 1, perScope: 1 }` in the
+class-level initialiser, against `resolveLaneCaps`'s 8/4 fallback. Aligned; see
+§ 4.6 for why this is behaviourally inert and still worth fixing.
+
+---
+
+## 7. What this did **not** establish
+
+- **Any cap curve for any lane.** No sweep arm ran outside smoke mode. The
+  scenario exists, is tested, and ran clean end to end; it did not get the stand.
+- **The attribution of § 4.2's 9.1 s.** Ruled out: destination, Redis, pacing
+  config, fan-out, round-trip count. Not ruled in: anything. One traced job's
+  worker log settles it.
+- **Whether § 4.1's limiter timeout occurs inside a measurement window.** It was
+  observed outside one. `post_guard_limiter_degraded` would `DISCARD` an arm
+  that contained one - and since #2851 that guard can actually see, so a future
+  arm's verdict is trustworthy where F7's was not.
+- **§ 4.3's refill latency, as a measured quantity.** It is read off the runner
+  source; the arm that would measure it (a short-job lane at several caps) is
+  the fan-out sweep.
+- **§ 4.4's churn cost.** The scenario now avoids the condition rather than
+  measuring it. `TOTAL_CAP` is overridable specifically so it can be measured
+  on purpose.
+- **Anything at more than one replica.** Single replica throughout, which is the
+  posture the stand was found in and was restored to.
+- **Anything about `bulk`.** Out of scope here; #2594 owns it.
+- **Cross-scope behaviour.** `--scopes=2` exists and would be the first run in
+  this campaign to reach a lane's TOTAL cap (F4 and F7 both record that one
+  bulk-capable connection means `perScope` binds first and TOTAL is never
+  reached). This stand has two Allegro connections, 200 distinct Offer mappings
+  each, so it is reachable. Not run.
+
+## 8. Next, in the order that buys the most
+
+1. **Trace one `marketplace.offerQuantity.update` job's worker log.** Minutes of
+   stand time. It either collapses § 4.2 into § 4.1 or opens a new question,
+   and every realtime number depends on which.
+2. **Run the fan-out sweep** (`--lane=fan-out`). It needs no destination -
+   database reads and child enqueues - so it is the one lane whose curve is not
+   hostage to § 4.1, and it is the lane whose current value is derived rather
+   than illustrative.
+3. **Run the realtime sweep**, once (1) is settled, at two destination
+   latencies. If the knee moves with destination latency, then a single global
+   default cannot be "the measured value" for this lane and the honest
+   deliverable is guidance plus a range.
+4. **`--scopes=2`**, to reach a lane TOTAL for the first time in this campaign.
+
+---
+
+## 9. Artefacts
+
+| Path | What |
+|---|---|
+| `scenarios/f8-lane-caps.sh` | The sweep. `--lane`, `--caps`, `--jobs`, `--scopes`, `--smoke`. |
+| `docker-compose.lab.yml` | Eight `OL_LANE_*` passthroughs, all defaulting to empty. |
+| `lib-test.sh` | 116 -> 140 assertions. |
+| `README.md` | "F8 - lane cap saturation" section. |
+| `apps/worker/src/sync/sync-job.runner.ts` | § 6's two corrections. |
+| `results/f8-lane-caps/run1788742711-realtime-*` | The smoke run. **Smoke numbers, not a measurement** - the § 4.2 durations are quoted from it as evidence about per-job cost only. |
+
+**Stand posture** was runner-enabled / scheduler-off / one replica when taken,
+and was restored to it. The exclusivity lock was released on every exit.

--- a/perf/openlinker-throughput/results-lane-caps-2026-09-07.md
+++ b/perf/openlinker-throughput/results-lane-caps-2026-09-07.md
@@ -35,7 +35,7 @@ the saturation sweep". After it, the answer is:
 
 | Lane | Default | Still | Why it did not get a number here |
 |---|---|---|---|
-| `realtime` | 4 / 2 | ILLUSTRATIVE | A sweep is now RUNNABLE (§ 2) and a smoke arm ran clean, but per-job cost on the write path measured **9.1-9.8 s against a 127 ms destination**, and a trace puts ~7 s of that in OpenLinker either side of one HTTP call (§ 4.2). A curve taken through that is a curve of the 7 s, not of the lane. |
+| `realtime` | 4 / 2 | ILLUSTRATIVE | A sweep is now RUNNABLE (§ 2), but per-job cost on the write path is **~9.5 s against a 127 ms destination**, and three traces put **~7-8 s of it inside OpenLinker either side of one HTTP call** (§ 4.2). A cap curve taken through that measures the 7-8 s, not the lane - and if that overhead is fixable the right cap moves by an order of magnitude. |
 | `fiscal` | 2 / 1 | ILLUSTRATIVE | Unchanged and, on the evidence in § 4.5, likely permanent. No provider exists on this stand and building one means issuing real documents. |
 | `fan-out` | 8 / 4 | **DERIVED, not measured** - confirmed, see § 4.6 | Not reached. The peers held the stand. |
 
@@ -182,7 +182,7 @@ realtime curve measures the limiter, not the lane.
 not directly instrumented - #2850's `ol_event_loop_lag_seconds` is what would
 settle it.*
 
-### 4.2 The realtime write path costs 9.1-9.8 s against a 127 ms destination (measured, n=12)
+### 4.2 The realtime write path costs ~9.5 s against a 127 ms destination, and ~7 s of it is not the network (measured, n=12 + n=3 traced)
 
 Smoke arm, `marketplace.offerQuantity.update`, `perf-allegro-a`, one scope,
 caps 1/1 and 4/4, 12 jobs each. All 12 jobs of the recorded arm reached
@@ -212,33 +212,46 @@ measurement or by reading the code:
   one cursor read, one marketplace call, one conditional cursor advance and one
   lock release per item.
 
-**Traced, and it is NOT the retry ladder.** An earlier draft of this report
-predicted the Allegro client's `DEFAULT_RETRY_CONFIG` (`maxRetries: 3`,
-`initialDelayMs: 1000`, `backoffMultiplier: 2` = 7000 ms of backoff across four
-attempts) and noted that the arithmetic fitted to within ~5 %. **It fitted and
-it was wrong**, which is the reason this paragraph exists rather than the
-prediction. One traced job (`durationMs=9727`, `succeeded`, `outcome=ok`) shows
-**exactly one HTTP attempt**, no `Rate limit exceeded (attempt N/4)` line, and
-the 9.7 s distributed like this:
+**Traced three times, and it is NOT the retry ladder.** An earlier draft of
+this report predicted the Allegro client's `DEFAULT_RETRY_CONFIG`
+(`maxRetries: 3`, `initialDelayMs: 1000`, `backoffMultiplier: 2` = 7000 ms of
+backoff across four attempts) and noted the arithmetic fitted to within ~5 %.
+**It fitted and it was wrong**, which is why this paragraph exists rather than
+the prediction. Every trace shows **exactly one HTTP attempt** and no
+`Rate limit exceeded (attempt N/4)` line.
 
-| Interval | Elapsed | What the log shows |
-|---|---|---|
-| `Executing ...offerQuantity.update` -> `PUT /sale/offer-quantity-change-commands/...` | **~4 s** | nothing logged in between |
-| inside the PUT | **1126 ms** | against a destination measured at 127.6 ms; a `checkPace timed out after 1000ms` line lands mid-call |
-| HTTP `Response: 200` -> `Job ... succeeded` | **~3 s** | nothing logged in between |
+Three independent traced jobs, each `succeeded` / `outcome=ok`:
 
-So the shape is **~4 s before the call, ~1 s of limiter timeout inside it, ~3 s
-after it** - roughly **7 s of OpenLinker-side time bracketing a single 127 ms
-request**, with the network the smallest term by an order of magnitude.
+| Trace | `durationMs` | `Executing` -> `PUT` | inside the PUT | `200` -> `succeeded` |
+|---|---:|---:|---:|---:|
+| 1 | 9727 | ~4 s | 1126 ms | ~3 s |
+| 2 | 9492 | ~4 s | 1123 ms | ~4 s |
+| 3 | 9651 | ~4 s | ~1120 ms | ~4 s |
 
-The two unlogged brackets are where the cost is, and neither is attributed to a
-specific statement yet. By code reading, the pre-call bracket contains capability
-adapter resolution (`getCapabilityAdapter` builds a fresh adapter per call and
-resolves + decrypts credentials), `applyPublishControlsBatch`, the #2617
-`SyncLockPort.acquire`, and the observation-cursor read; the post-call bracket
-contains the conditional cursor advance, the lock release and the terminal
-`sync_jobs` write. **Which of those dominates is not established** - that needs
-either #2850's instrumentation or a debug-level trace, and is named in § 8.
+Range 235 ms across the three (~2.4 %), and the call itself reproduces to
+within 3 ms. Nothing is logged inside either bracket.
+
+So the shape is **~4 s before the call, ~1.1 s inside it, ~3-4 s after it** -
+roughly **7-8 s of OpenLinker-side time bracketing a single request against a
+destination measured at 127.6 ms.** The network is the smallest term by an
+order of magnitude, and the ~1 s excess *inside* the call is § 4.1's limiter
+timeout, which lands mid-call in all three traces.
+
+The two unlogged brackets are where the cost is, and **neither is attributed to
+a specific statement.** By code reading the candidates are, before the call:
+capability-adapter resolution (`getCapabilityAdapter` builds a fresh adapter per
+call and resolves + decrypts credentials), `applyPublishControlsBatch`, the
+#2617 `SyncLockPort.acquire`, and the observation-cursor read; and after it: the
+conditional cursor advance, the lock release and the terminal `sync_jobs` write.
+Which dominates needs a debug-level trace or #2850's instrumentation, and is
+§ 8's first item.
+
+**What this means for the cap is the whole point.** If those 7-8 s are adapter
+construction and a degraded limiter rather than work the destination requires,
+then the realtime lane's real per-job cost is ~130 ms, a cap of 2 is throttling
+a lane whose jobs are ~70x cheaper than they appear, and the correct response is
+to fix the per-job overhead rather than to tune the cap. **That is a defect
+report, not a tuning number**, and it is why no realtime cap is proposed here.
 
 Two smaller observations from the same trace, recorded because they are cheap
 and someone will otherwise re-derive them:
@@ -251,7 +264,7 @@ and someone will otherwise re-derive them:
   attempts off that column is counting something else.
 
 *Label: the 12 durations and the traced breakdown are **measured** (n=12 smoke
-arm; n=1 trace). The retry-ladder explanation is **withdrawn - it was derived,
+arm; n=3 traces). The retry-ladder explanation is **withdrawn - it was derived,
 it fitted, and the trace falsified it.** Which statement inside the two unlogged
 brackets dominates is **open**.*
 
@@ -382,7 +395,7 @@ reasoning in place; see § 6.
 
 | Lane | Current | Recommended | Basis |
 |---|---|---|---|
-| `realtime` | 4 / 2 | **4 / 2 - unchanged** | No curve was taken. § 4.2's 9.1 s must be attributed first, and the derived arithmetic there says ~7 s of it is very likely the Allegro client's own retry backoff. If so the lane's real per-job cost is ~130 ms, the correct cap is an order of magnitude from 2, and the finding is a defect rather than a tuning number. Changing the cap before knowing which would be a guess dressed as a measurement. |
+| `realtime` | 4 / 2 | **4 / 2 - unchanged** | No curve was taken, and § 4.2 is the reason it would not have been worth taking yet: ~7-8 s of reproducible OpenLinker-side overhead brackets a 127 ms call. Until that is attributed, any cap this lane is given is a cap chosen to accommodate an overhead that may simply be a defect. |
 | `fiscal` | 2 / 1 | **2 / 1 - unchanged** | Unmeasurable here (§ 4.5). Flag for the owner: `perScope: 1` serialises bulk issuance across distinct orders, which the per-order lock would not. |
 | `fan-out` | 8 / 4 | **8 / 4 - unchanged** | Not reached (peers held the stand). Confirmed derived, not measured (§ 4.6). |
 

--- a/perf/openlinker-throughput/results-lane-caps-2026-09-07.md
+++ b/perf/openlinker-throughput/results-lane-caps-2026-09-07.md
@@ -37,7 +37,7 @@ the saturation sweep". After it, the answer is:
 |---|---|---|---|
 | `realtime` | 4 / 2 | ILLUSTRATIVE | A sweep is now RUNNABLE (§ 2), but per-job cost on the write path is **~9.5 s against a 127 ms destination**, and three traces put **~7-8 s of it inside OpenLinker either side of one HTTP call** (§ 4.2). A cap curve taken through that measures the 7-8 s, not the lane - and if that overhead is fixable the right cap moves by an order of magnitude. |
 | `fiscal` | 2 / 1 | ILLUSTRATIVE | Unchanged and, on the evidence in § 4.5, likely permanent. No provider exists on this stand and building one means issuing real documents. |
-| `fan-out` | 8 / 4 | **DERIVED, not measured** - confirmed, see § 4.6 | Not reached. The peers held the stand. |
+| `fan-out` | 8 / 4 | **DERIVED, not measured** - confirmed, see § 4.6 | Not reached. Peers held the stand for most of the session, and when it was free `guard_build` correctly refused every arm because this branch also edits `apps/worker` (§ 3.1). |
 
 **The one thing that did change is that the measurement is now possible at
 all.** It was not, and that is § 2.
@@ -117,23 +117,45 @@ so a sub-second difference between arms cannot be resolved by it.
 
 ---
 
-### 3.1 One methodology note: `guard_build` refused the first sweep, correctly
+### 3.1 The blocker that stopped the fan-out sweep, and it generalises
 
-The fan-out sweep's first attempt died at `guard_build`: the running `lab` image
-was built from the branch base, and this branch had since committed a change to
-`apps/worker/src/sync/sync-job.runner.ts`. That change is **documentation plus
-one inert literal** (§ 6) and could not alter behaviour - but the guard cannot
-know that, and *"the diff looked harmless"* is precisely the reasoning a
-stale-image guard exists to refuse.
+The fan-out sweep never ran. `guard_build` refused it, three times, and the
+refusal is correct - but the shape of it is worth recording because it will stop
+the next person too.
 
-Rather than bypass it, the working tree's copy of that one file was checked out
-at the image's own commit for the duration of the measurement and restored
-immediately after. The guard then passed on its own terms rather than being
-argued with.
+`guard_build` compares the running image's recorded commit against the
+**committed** tree at `HEAD` for each build-relevant path, not the working tree,
+and separately refuses any *uncommitted* change under those paths. Both halves
+are right: an image cannot contain a commit it predates, and it certainly cannot
+contain an edit that was never committed.
+
+The consequence is a rule this campaign has not had to state before:
+
+> **A perf branch that also touches product code cannot run any scenario against
+> a stand built from another commit, however inert the product change is.**
+
+This branch's only `apps/**` change is the two documentation corrections in
+section 6 - a withdrawn figure in a docblock, and one literal that is
+overwritten at boot. It changes nothing a measurement could observe. It still,
+correctly, blocks every scenario until the stand is rebuilt, because
+`guard_build` cannot read intent and must not try.
+
+Checking that one file out at the image's own commit does **not** work around
+it, and that is the guard being well built rather than an obstacle: reverting in
+the working tree leaves `HEAD` unchanged, so the tree comparison still fails,
+and it makes the tree dirty, so the uncommitted-changes check fires instead.
+Verified by attempting exactly that.
+
+**The remedy is to rebuild the stand**, which was declined here rather than
+deferred silently: a docker build is minutes of heavy CPU on a workstation where
+a peer scenario was actively measuring latency, and corrupting a peer's run to
+take my own is the same failure `guard_stand_exclusive` exists to prevent. The
+practical lesson for the campaign is to **land measurement-only branches
+separately from product edits**, or to rebuild first and measure second.
 
 ---
 
-## 4. Findings
+## 4. Findings## 4. Findings
 
 ### 4.1 The rate limiter degrades on a healthy, essentially idle Redis (measured)
 
@@ -397,7 +419,7 @@ reasoning in place; see § 6.
 |---|---|---|---|
 | `realtime` | 4 / 2 | **4 / 2 - unchanged** | No curve was taken, and § 4.2 is the reason it would not have been worth taking yet: ~7-8 s of reproducible OpenLinker-side overhead brackets a 127 ms call. Until that is attributed, any cap this lane is given is a cap chosen to accommodate an overhead that may simply be a defect. |
 | `fiscal` | 2 / 1 | **2 / 1 - unchanged** | Unmeasurable here (§ 4.5). Flag for the owner: `perScope: 1` serialises bulk issuance across distinct orders, which the per-order lock would not. |
-| `fan-out` | 8 / 4 | **8 / 4 - unchanged** | Not reached (peers held the stand). Confirmed derived, not measured (§ 4.6). |
+| `fan-out` | 8 / 4 | **8 / 4 - unchanged** | Not reached (§ 3.1). Confirmed derived, not measured (§ 4.6). It is the lane most likely to yield a real number next, because its work is database reads and child enqueues, so it is hostage to neither § 4.1 nor § 4.2. |
 
 **No default is changed by this work.** The only defaults touched in code are a
 withdrawn figure and a stale literal, both in § 6, neither of which changes what
@@ -430,7 +452,10 @@ class-level initialiser, against `resolveLaneCaps`'s 8/4 fallback. Aligned; see
 ## 7. What this did **not** establish
 
 - **Any cap curve for any lane.** No sweep arm ran outside smoke mode. The
-  scenario exists, is tested, and ran clean end to end; it did not get the stand.
+  scenario exists, is tested, and ran clean end to end in smoke mode; it was
+  then blocked by peers holding the stand and, once that cleared, by § 3.1's
+  `guard_build` refusal. **Nothing here is evidence about how a lane responds to
+  its cap.**
 - **The attribution of § 4.2's 9.1 s.** Ruled out by measurement or code:
   destination, Redis, pacing config, fan-out, round-trip count. The retry-ladder
   arithmetic in § 4.2 fits to within ~5 %, but a fit is not an observation - no

--- a/perf/openlinker-throughput/scenarios/f8-lane-caps.sh
+++ b/perf/openlinker-throughput/scenarios/f8-lane-caps.sh
@@ -1,0 +1,672 @@
+#!/usr/bin/env bash
+#
+# F8 - lane cap SATURATION, the three lanes #2594 left illustrative (#2867,
+# epic #2840).
+#
+# ADR-050 decision 6: "Cap values are illustrative until they are measured. A
+# cap without a metric is a guess." Exactly one lane has since stopped being a
+# guess - `bulk`, from #2594's interleaved A/B run. ADR-050's own
+# § Amendment (#2851 / #2867) then names, per lane, the measurement that is
+# missing:
+#
+#   realtime  4/2  ILLUSTRATIVE - "a saturation run: many concurrent
+#                  marketplace.order.sync against one destination, finding the
+#                  concurrency at which per-order latency degrades."
+#   fiscal    2/1  ILLUSTRATIVE - "a run against a real invoicing or
+#                  fiscalization connection issuing real documents."
+#   fan-out   8/4  DERIVED      - "a sustained stock-write load that isolates
+#                  this lane."
+#
+# This scenario is that saturation run. It sweeps ONE lane's per-scope cap
+# across a list of values, one worker recreate per value, and reports
+# throughput and per-job latency at each point - so the knee (the concurrency
+# past which added slots stop buying throughput, or start costing latency) is
+# read off a curve rather than asserted.
+#
+# ---------------------------------------------------------------------------
+# WHY THIS IS NOT ANOTHER GENERIC SATURATION SWEEP RUN THREE TIMES
+# ---------------------------------------------------------------------------
+#
+# ADR-050 decision 1 picks a lane by COST OF STARVATION, so what a cap has to
+# protect differs per lane, and so must the figure that decides it:
+#
+#   realtime  someone is waiting on ONE unit of work. The cap protects
+#             LATENCY, not throughput. The number that matters is where
+#             per-job latency starts degrading - which may be well before
+#             throughput stops rising.
+#   fan-out   near-zero HTTP of its own; output is child jobs. The cap bounds
+#             QUEUE FAN-OUT against the database, so throughput is the whole
+#             question and there is no destination to protect.
+#   fiscal    at-most-once, deadline-bearing, and provider-round-trip bound.
+#             See the FISCAL section below: this stand cannot saturate it
+#             honestly, and the scenario says so rather than producing a
+#             plausible fourth guess.
+#
+# ---------------------------------------------------------------------------
+# DEVIATIONS FROM THE MEASUREMENT ADR-050 ASKS FOR, and why - read this before
+# the numbers, exactly as F2/F7's headers ask of their own scenarios.
+# ---------------------------------------------------------------------------
+#
+# (1) THE REALTIME LOAD IS `marketplace.offerQuantity.update`, NOT
+#     `marketplace.order.sync`, and that is a correction to the ADR's wording
+#     rather than a shortcut around it.
+#
+#     `marketplace.order.sync` on this stand does not measure the realtime
+#     lane. `OrderSyncService` fans an ingested order out to every connection
+#     with `OrderProcessorManager` enabled, which here is `perf-prestashop`
+#     AND `perf-woocommerce` - so a 400-job realtime saturation arm would
+#     create 400 real orders in a real PrestaShop and a real WooCommerce,
+#     against PrestaShop's declared 60 req/min. F4 (#2851) already measured
+#     what happens next: both its arms were DISCARDED by
+#     `post_guard_limiter_degraded`, and the shop, not the lane, was the
+#     ceiling. Repeating that would measure the destination a third time.
+#
+#     `marketplace.offerQuantity.update` is in the SAME lane, is the lane's
+#     highest-volume real member (it is what `inventory.propagateToMarketplaces`
+#     fans out to), makes exactly ONE synchronous outbound call, and fans out
+#     to nothing. Its destination here is the `allegro-stub` service
+#     (#2856/#2935), whose latency is a knob rather than a shop - which is the
+#     property that makes a LANE measurable at all, because a saturation curve
+#     taken against a contended destination is a curve of the destination.
+#
+# (2) THE DESTINATION LATENCY IS DECLARED IN THE MANIFEST, AND ONE ARM SET IS
+#     RUN AT EACH OF TWO LATENCIES. `/__stub/config` reports
+#     `latency.quantityMs`, and `quantityMsMeasured` tells a reader whether a
+#     driver set it deliberately or it fell back to the generic 120 ms default
+#     that has no #2861 sandbox measurement behind it (stubs/allegro/README.md
+#     is explicit about this). The scenario records both fields verbatim. It
+#     does NOT claim the stub is Allegro; it claims the destination answered in
+#     a known, constant time, which is the only property the curve needs.
+#
+#     Running the realtime sweep at two latencies is the point rather than
+#     thoroughness: if the knee moves with destination latency, then a single
+#     global default cannot be "the measured value" for this lane, and the
+#     honest deliverable is guidance plus a range. That is a falsifiable claim
+#     and this scenario is built to falsify it.
+#
+# (3) LANE OCCUPANCY IS NOT USED TO SIZE ANYTHING. F4 § 2 records that the
+#     `sync_jobs`-row proxy OVER-READS - a lane slot is released in-process
+#     when the handler resolves, while the row stays `running` until a separate
+#     terminal write commits, so a row in that gap is counted and holds no
+#     slot. F4 saw peaks of 12 and 32 against caps of 8 and 24 for that reason.
+#     The over-read is a LARGER fraction of a small cap, and every cap this
+#     scenario sweeps is smaller than `bulk`'s 12. Occupancy is therefore
+#     sampled and reported as a PROXY, and every sizing figure comes instead
+#     from per-row timestamps and `sync_jobs.lastAttemptDurationMs` (#2611),
+#     which are recorded by the worker itself at real precision and do not
+#     inherit the 1 Hz sampler's floor.
+#
+# (4) CLAIM/QUEUE LATENCY IS NOT USED EITHER. F7 established that its own
+#     claim-latency band IS the instrument - `POLL_INTERVAL_MS = 1000` plus a
+#     ~1 Hz poller - so a sub-second difference between arms cannot be resolved
+#     by it. `lastAttemptDurationMs` is not sampled and does not have that
+#     floor.
+#
+# (5) THE FISCAL LANE IS CHARACTERISED, NOT SIZED, AND THAT IS THE RESULT.
+#     No invoicing or fiscalization connection exists on this stand, and
+#     building one means a real provider issuing real documents - a legal act,
+#     not a load generator. What CAN be run here is F7's invalid-payload
+#     `invoicing.issue` probe at burst volume, which reaches
+#     `InvoicingIssueHandler`'s payload validation and returns
+#     `business_failure` before any adapter, lock or provider is touched. That
+#     measures the RUNNER's floor for this lane - the cost of claiming and
+#     retiring a fiscal job with a no-op handler - and it is reported as
+#     exactly that. It is NOT a cap measurement and must never be quoted as
+#     one: the handler it exercises does none of the work whose concurrency
+#     the cap governs.
+#
+#     What the floor is good for is bounding the OTHER half of the question
+#     arithmetically. A burst of N invoices at cap C against a provider taking
+#     T seconds per document drains in about N*T/C seconds plus this floor, so
+#     the floor says how much of a fiscal burst's latency is OL's and how much
+#     is the provider's. That arithmetic is DERIVED, labelled as such, and left
+#     with T unknown rather than filled in with a plausible number.
+#
+# (6) NO CAP DEFAULT IS CHANGED BY THIS SCRIPT. It sets caps on a perf stand
+#     for the duration of a run and restores them on exit. Proposing a new
+#     default is the report's job, and changing one is a code change reviewed
+#     on its own terms - a cap default is a behaviour change for every install.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_LOG_PREFIX="f8"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/../lib.sh"
+
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+ENV_FILE="${ENV_FILE:-$REPO_ROOT/.env.lab}"
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+LANE="${LANE:-realtime}"
+# The cap points to sweep. Deliberately spanning the current default in both
+# directions: a sweep that only goes up cannot show that the default is too
+# HIGH, which for a latency-protecting lane is the likelier error.
+CAPS="${CAPS:-1 2 4 8 16}"
+# Jobs per arm. Sized so the SLOWEST arm (cap 1) still drains inside
+# DRAIN_MAX_WAIT_SECS while the FASTEST arm still runs long enough for the
+# window to mean something: at the stub's 120 ms and cap 1 the floor is
+# ~0.12 s/job of destination time plus per-job runner overhead.
+JOB_COUNT="${JOB_COUNT:-240}"
+# The lane's TOTAL cap during a per-scope sweep. EMPTY means "derive it as
+# perScope x scopes", which is the default and is a correctness choice rather
+# than a convenience.
+#
+# `claimAndStartForLane` claims with `limit: cap.total - inFlightTotal` and
+# only THEN drops anything over `perScope`, releasing the surplus one row at a
+# time (`releaseSurplusClaim`). The pre-claim `excludedScopes` filter cannot
+# prevent it, because a scope is excluded only once it is ALREADY at cap - so
+# on the tick where a slot frees, the scope is claimable again and the claim
+# takes up to `free` rows to start one.
+#
+# Pinning TOTAL far above perScope therefore does not "leave the per-scope cap
+# as the only variable"; it adds a claim-and-release of (free - 1) rows to
+# every single refill, which is exactly the row-lock churn a cap sweep must not
+# measure. Deriving TOTAL keeps `free` equal to what can actually be started.
+# Override it explicitly to measure that churn on purpose - see
+# TOTAL_CAP_OVERSIZED below.
+TOTAL_CAP="${TOTAL_CAP:-}"
+# Realtime destination latency, ms. Empty leaves the stub as it is (and the
+# manifest records `quantityMsMeasured:false`, i.e. the unmeasured 120 ms
+# default).
+STUB_QUANTITY_MS="${STUB_QUANTITY_MS:-}"
+
+MODE="strict"
+SCOPES=1
+for arg in "$@"; do
+  case "$arg" in
+    --lane=*) LANE="${arg#--lane=}" ;;
+    --caps=*) CAPS="${arg#--caps=}" ;;
+    --jobs=*) JOB_COUNT="${arg#--jobs=}" ;;
+    --scopes=*) SCOPES="${arg#--scopes=}" ;;
+    --stub-latency-ms=*) STUB_QUANTITY_MS="${arg#--stub-latency-ms=}" ;;
+    --smoke) MODE="smoke" ;;
+    -h|--help)
+      cat <<'USAGE'
+Usage: f8-lane-caps.sh [--lane=realtime|fan-out|fiscal] [--caps="1 2 4 8 16"]
+                       [--jobs=N] [--scopes=1|2] [--stub-latency-ms=N] [--smoke]
+
+  --lane            which lane's per-scope cap to sweep (default realtime)
+  --caps            the cap points, space-separated, in the order to run them
+  --jobs            jobs enqueued per arm
+  --scopes          1 = one connection (perScope binds); 2 = both Allegro
+                    connections (the only way to reach the lane TOTAL cap,
+                    which no run in this campaign has yet done). realtime only.
+  --stub-latency-ms set the Allegro stub's quantity-endpoint latency for this
+                    run, and record it as DELIBERATELY SET in the manifest
+                    rather than as the unmeasured default
+  --smoke           tiny counts, to prove the plumbing before spending a real
+                    run. Smoke results are NEVER written into a results-*.md.
+USAGE
+      exit 0 ;;
+    *) die "unknown argument: $arg (try --help)" ;;
+  esac
+done
+
+case "$LANE" in
+  realtime|fan-out|fiscal) : ;;
+  *) die "unknown lane '$LANE' - one of realtime, fan-out, fiscal" ;;
+esac
+
+if [ "$MODE" = "smoke" ]; then
+  CAPS="1 4"
+  JOB_COUNT=12
+  warn "SMOKE MODE - plumbing check only. These numbers are not a measurement."
+fi
+
+# Env var stem per lane. `fan-out` is the one lane whose env stem is not its
+# own name (OL_LANE_FANOUT_*, no hyphen) - resolved here once rather than at
+# each use, because getting it wrong sets nothing and the run would silently
+# sweep a constant cap.
+case "$LANE" in
+  realtime) LANE_ENV_STEM="REALTIME" ;;
+  fan-out)  LANE_ENV_STEM="FANOUT" ;;
+  fiscal)   LANE_ENV_STEM="FISCAL" ;;
+esac
+
+RUN_GROUP="run$(epoch)"
+log "F8 lane-cap saturation: lane=$LANE caps=[$CAPS] jobs/arm=$JOB_COUNT scopes=$SCOPES total_cap=${TOTAL_CAP:-derived(perScope*scopes)} group=$RUN_GROUP"
+
+# ---------------------------------------------------------------------------
+# Stand identity. Read from the database rather than from stand-ids.env: the
+# stand is routinely brought up from a different worktree than the one a
+# scenario runs in (verified - this stand's compose label points at a sibling
+# checkout), so a file-relative path to stand-ids.env resolves to the wrong
+# tree or to nothing. The connection NAMES are bootstrap.sh's contract; the
+# ids are whatever that stand minted.
+# ---------------------------------------------------------------------------
+conn_id_by_name() {
+  pg_sql "SELECT id FROM connections WHERE name='$1'"
+}
+
+PS_CONNECTION_ID="${PS_CONNECTION_ID:-$(conn_id_by_name perf-prestashop)}"
+ALLEGRO_A_CONNECTION_ID="${ALLEGRO_A_CONNECTION_ID:-$(conn_id_by_name perf-allegro-a)}"
+ALLEGRO_B_CONNECTION_ID="${ALLEGRO_B_CONNECTION_ID:-$(conn_id_by_name perf-allegro-b)}"
+[ -n "$PS_CONNECTION_ID" ] || die "no connection named perf-prestashop - run bootstrap.sh"
+[ -n "$ALLEGRO_A_CONNECTION_ID" ] || die "no connection named perf-allegro-a - run bootstrap.sh"
+[ -n "$ALLEGRO_B_CONNECTION_ID" ] || die "no connection named perf-allegro-b - run bootstrap.sh"
+
+case "$LANE" in
+  realtime)
+    if [ "$SCOPES" = "2" ]; then
+      LOAD_CONNS="$ALLEGRO_A_CONNECTION_ID $ALLEGRO_B_CONNECTION_ID"
+    else
+      LOAD_CONNS="$ALLEGRO_A_CONNECTION_ID"
+    fi
+    ;;
+  fan-out) LOAD_CONNS="$PS_CONNECTION_ID" ;;
+  fiscal)  LOAD_CONNS="$PS_CONNECTION_ID" ;;
+esac
+# Quoted CSV for the SQL `IN (...)` the lib helpers take.
+CONN_IDS="$(for c in $LOAD_CONNS; do printf "'%s'," "$c"; done | sed 's/,$//')"
+# The realtime children a fan-out arm produces land on the Allegro connections,
+# so the drain has to watch those too or the arm is declared quiet while its
+# own fan-out is still running.
+if [ "$LANE" = "fan-out" ]; then
+  DRAIN_CONN_IDS="$CONN_IDS,'$ALLEGRO_A_CONNECTION_ID','$ALLEGRO_B_CONNECTION_ID'"
+else
+  DRAIN_CONN_IDS="$CONN_IDS"
+fi
+
+# ===========================================================================
+# Pre-flight
+# ===========================================================================
+guard_stand_exclusive "f8-lane-caps"
+
+[ -f "$ENV_FILE" ] || die "no $ENV_FILE - the compose recreate needs it (OL_PII_HASH_SALT and the credentials key are ':?' required in docker-compose.lab.yml). Copy it from the checkout that brought this stand up."
+
+ORIGINAL_REPLICAS="$(discover_worker_containers | wc -w | tr -d ' ')"
+[ "$ORIGINAL_REPLICAS" -ge 1 ] || die "no worker replicas found - is the lab stand up?"
+ORIGINAL_RUNNER_ENABLED="$(docker exec "$(discover_worker_containers | awk '{print $1}')" printenv WORKER_RUNNER_ENABLED 2>/dev/null || printf '')"
+[ -n "$ORIGINAL_RUNNER_ENABLED" ] || ORIGINAL_RUNNER_ENABLED=false
+
+# Every lane cap this run will touch, captured as the container ACTUALLY has
+# them - never as "the code default", which is what the restore would get
+# wrong on a stand a peer had already tuned.
+ORIGINAL_CAPS=""
+for stem in REALTIME BULK FISCAL FANOUT; do
+  for suffix in CAP SCOPE_CAP; do
+    v="$(docker exec "$(discover_worker_containers | awk '{print $1}')" printenv "OL_LANE_${stem}_${suffix}" 2>/dev/null || printf '')"
+    ORIGINAL_CAPS="$ORIGINAL_CAPS OL_LANE_${stem}_${suffix}=$v"
+  done
+done
+log "stand posture at scenario start: replicas=$ORIGINAL_REPLICAS WORKER_RUNNER_ENABLED=$ORIGINAL_RUNNER_ENABLED caps=[$(printf '%s' "$ORIGINAL_CAPS" | tr -s ' ')] (all restored on exit)"
+
+# env_file_set - write KEY=VALUE into .env.lab, replacing any existing line.
+# An EMPTY value writes the key with an empty value rather than deleting it,
+# because `resolveLaneCaps` reads '' as "unset, use the code default" - so an
+# empty line restores the default explicitly instead of leaving whatever the
+# previous arm set.
+env_file_set() {
+  local key="$1" value="$2"
+  if grep -q "^${key}=" "$ENV_FILE"; then
+    sed -i "s|^${key}=.*|${key}=${value}|" "$ENV_FILE"
+  else
+    printf '%s=%s\n' "$key" "$value" >> "$ENV_FILE"
+  fi
+}
+
+# recreate_worker <runner-enabled> - recreate ONLY the worker service so it
+# picks up the env just written. `--no-deps`, for F4's reason: a bare `up -d`
+# recreates every service whose config resolves differently from THIS
+# worktree's compose file, which is a far wider blast radius than an env change
+# needs, and this stand was brought up from a different checkout.
+recreate_worker() {
+  local runner="$1" tries=0 w hits
+  env_file_set WORKER_RUNNER_ENABLED "$runner"
+  ( cd "$REPO_ROOT" && docker compose -f docker-compose.lab.yml --env-file .env.lab -p lab \
+      up -d --no-deps --force-recreate --scale "worker=$ORIGINAL_REPLICAS" worker >/dev/null 2>&1 ) \
+    || die "recreate_worker: compose refused to recreate the worker service"
+
+  WORKER_CONTAINERS=""
+  WORKER_CONTAINERS_RESOLVED=0
+  _ensure_worker_containers
+
+  if [ "$runner" = "true" ]; then
+    for w in $WORKER_CONTAINERS; do
+      tries=0
+      while true; do
+        # `grep -c`, never `grep -q`: `grep -q` exits at its first match and
+        # SIGPIPEs `docker logs`, which `set -o pipefail` then adopts as a
+        # failure even though the line matched (F4 records this trap; it is
+        # length-dependent, so it passes while the log is short).
+        hits="$(docker logs "$w" 2>&1 | grep -cF 'Starting sync job runner loop' || true)"
+        [ "${hits:-0}" -eq 0 ] || break
+        tries=$((tries + 1))
+        [ "$tries" -lt 90 ] || die "recreate_worker: $w never logged 'Starting sync job runner loop'"
+        sleep 1
+      done
+    done
+  else
+    sleep 5
+  fi
+}
+
+# assert_caps_applied <lane> <total> <perScope> - read the caps back out of the
+# worker's OWN startup line and refuse the arm if they are not what was asked
+# for.
+#
+# This is the guard the whole scenario rests on. A cap that silently did not
+# apply produces a perfectly clean curve of the SAME cap measured five times,
+# which is indistinguishable from a lane that does not respond to its cap -
+# and that is a conclusion, so it must not be reachable by accident. Two ways
+# it could happen and both are real: docker-compose.lab.yml not passing the
+# variable through at all (it did not before #2867), and `resolveLaneCaps`
+# silently ignoring a value it considers invalid (it warns and falls back on
+# anything non-finite or < 1).
+assert_caps_applied() {
+  local lane="$1" want_total="$2" want_scope="$3" w line caps got
+  for w in $WORKER_CONTAINERS; do
+    line="$(docker logs "$w" 2>&1 | grep -F 'Starting sync job runner loop' | tail -1 || true)"
+    [ -n "$line" ] || die "assert_caps_applied: $w logged no runner startup line"
+    caps="$(printf '%s' "$line" | grep -oP 'lane caps: \K.*(?=\))' || true)"
+    [ -n "$caps" ] || die "assert_caps_applied: could not parse lane caps out of: $line"
+    got="$(printf '%s' "$caps" | tr ' ' '\n' | awk -F= -v l="$lane" '$1==l{print $2}')"
+    [ "$got" = "${want_total}/${want_scope}" ] \
+      || die "assert_caps_applied: $w reports $lane=$got, asked for ${want_total}/${want_scope}.
+  The cap did NOT apply. Most likely docker-compose.lab.yml is not passing
+  OL_LANE_${LANE_ENV_STEM}_CAP / _SCOPE_CAP through to the worker service, or
+  resolveLaneCaps rejected the value (it ignores anything non-finite or < 1).
+  Full line: $line"
+    MANIFEST_LANE_CAPS="$caps"
+  done
+  log "assert_caps_applied ok ($lane=${want_total}/${want_scope}; full: $MANIFEST_LANE_CAPS)"
+}
+
+f8_on_exit() {
+  log "restoring stand: replicas=$ORIGINAL_REPLICAS WORKER_RUNNER_ENABLED=$ORIGINAL_RUNNER_ENABLED, lane caps as found"
+  if [ -f "$ENV_FILE" ]; then
+    # Longhand, and never via a function that can `die`: a cleanup path that
+    # aborts itself would skip the stand-lock release below and hold the stand
+    # for the full TTL (F7 found this the hard way).
+    for kv in $ORIGINAL_CAPS; do
+      k="${kv%%=*}"; v="${kv#*=}"
+      if grep -q "^${k}=" "$ENV_FILE" 2>/dev/null; then
+        sed -i "s|^${k}=.*|${k}=${v}|" "$ENV_FILE" 2>/dev/null || true
+      elif [ -n "$v" ]; then
+        printf '%s=%s\n' "$k" "$v" >> "$ENV_FILE" 2>/dev/null || true
+      fi
+    done
+    sed -i "s|^WORKER_RUNNER_ENABLED=.*|WORKER_RUNNER_ENABLED=$ORIGINAL_RUNNER_ENABLED|" "$ENV_FILE" 2>/dev/null || true
+  fi
+  ( cd "$REPO_ROOT" && docker compose -f docker-compose.lab.yml --env-file .env.lab -p lab \
+      up -d --no-deps --force-recreate --scale "worker=$ORIGINAL_REPLICAS" worker >/dev/null 2>&1 ) \
+    || warn "could not restore the worker posture - the stand is left at whatever the last arm set"
+  release_stand_exclusive
+}
+trap f8_on_exit EXIT
+
+guard_scheduler_off
+guard_demo_mode_off
+guard_connection_budget
+guard_pool_recorded
+guard_log_level
+guard_perf_max_attempts
+guard_build
+
+# ===========================================================================
+# Load generators, one per lane.
+#
+# Every one of them enqueues through `enqueue_perf_job` so `cap_perf_job_attempts`
+# can bound the retry ladder, and every one mints DISTINCT target entities per
+# job. That last property is load-bearing for `realtime`: #2617's write-order
+# guard takes a per-(connection, offer) SyncLockPort lock, so N jobs against
+# ONE offer would serialise on the lock and be reported as contention - a
+# perfect flat line at every cap, and a completely wrong conclusion. This stand
+# carries 200 distinct Offer mappings per Allegro connection (verified), which
+# is above every cap swept here, so the in-flight set never revisits an offer.
+# ===========================================================================
+
+# Cached target pools, resolved once. Re-resolving per arm would let the pool
+# drift between arms and make them incomparable.
+OFFER_IDS_A=""
+OFFER_IDS_B=""
+FANOUT_TARGETS=""
+
+resolve_offer_pool() {
+  local conn="$1"
+  pg_sql "SELECT DISTINCT \"internalId\" FROM identifier_mappings WHERE \"entityType\"='Offer' AND \"connectionId\"='$conn' ORDER BY 1 LIMIT 400"
+}
+
+resolve_fanout_targets() {
+  # productId + variantId pairs. `inventory.propagateToMarketplaces` takes
+  # {productId, variantId?} and resolves the publishable quantity itself, so a
+  # real product/variant is all the payload needs.
+  pg_sql "SELECT p.id || '|' || v.id FROM products p JOIN product_variants v ON v.\"productId\"=p.id ORDER BY p.id, v.id LIMIT 1000"
+}
+
+enqueue_realtime() {
+  local arm="$1" n="$2" i=0 conn offers idx offer
+  local -a pool_a pool_b
+  mapfile -t pool_a <<< "$OFFER_IDS_A"
+  mapfile -t pool_b <<< "$OFFER_IDS_B"
+  while [ "$i" -lt "$n" ]; do
+    if [ "$SCOPES" = "2" ] && [ $((i % 2)) -eq 1 ]; then
+      conn="$ALLEGRO_B_CONNECTION_ID"; idx=$(( (i / 2) % ${#pool_b[@]} )); offer="${pool_b[$idx]}"
+    else
+      conn="$ALLEGRO_A_CONNECTION_ID"; idx=$(( (i / (SCOPES > 1 ? 2 : 1)) % ${#pool_a[@]} )); offer="${pool_a[$idx]}"
+    fi
+    # `observedAt` is monotonically INCREASING across the arm. #2617 refuses a
+    # write whose observation is strictly older than the newest already
+    # written for that offer, so a constant or decreasing token would have the
+    # guard correctly refuse later jobs and the arm would measure the guard
+    # rather than the lane.
+    enqueue_perf_job 'marketplace.offerQuantity.update' "$conn" \
+      "{\"schemaVersion\":1,\"offerId\":\"$offer\",\"quantity\":$(( 10 + i % 50 )),\"observedAt\":\"$(date -u -d "@$(( $(epoch) + i ))" +%Y-%m-%dT%H:%M:%SZ)\"}" \
+      "f8:$RUN_GROUP:$arm:rt:$i" >/dev/null
+    i=$((i + 1))
+  done
+}
+
+enqueue_fanout() {
+  local arm="$1" n="$2" i=0 pair pid vid
+  local -a pool
+  mapfile -t pool <<< "$FANOUT_TARGETS"
+  while [ "$i" -lt "$n" ]; do
+    pair="${pool[$(( i % ${#pool[@]} ))]}"
+    pid="${pair%%|*}"; vid="${pair##*|}"
+    enqueue_perf_job 'inventory.propagateToMarketplaces' "$PS_CONNECTION_ID" \
+      "{\"productId\":\"$pid\",\"variantId\":\"$vid\"}" \
+      "f8:$RUN_GROUP:$arm:fo:$i" >/dev/null
+    i=$((i + 1))
+  done
+}
+
+enqueue_fiscal() {
+  # DELIBERATELY INVALID payload - F7's probe, reused. InvoicingIssueHandler
+  # validates the payload before anything else and returns
+  # {outcome:'business_failure'} on the first bad field: no invoicing
+  # connection, no order, no lock, no provider, no retry. See deviation (5):
+  # this measures the RUNNER's floor for the lane and is not a cap measurement.
+  local arm="$1" n="$2" i=0
+  while [ "$i" -lt "$n" ]; do
+    enqueue_perf_job 'invoicing.issue' "$PS_CONNECTION_ID" \
+      "{\"f8Probe\":true}" "f8:$RUN_GROUP:$arm:fi:$i" >/dev/null
+    i=$((i + 1))
+  done
+}
+
+# ===========================================================================
+# Per-arm measurement
+# ===========================================================================
+ARMS_CSV=""
+
+run_arm() {
+  local cap="$1" dir drained rows total arm
+  # Derived unless pinned - see the TOTAL_CAP comment above for why an
+  # oversized TOTAL measures claim-and-release churn rather than the cap.
+  if [ -n "$TOTAL_CAP" ]; then total="$TOTAL_CAP"; else total=$(( cap * SCOPES )); fi
+  arm="cap${cap}t${total}"
+  dir="$(results_dir_init f8-lane-caps "$RUN_GROUP-$LANE-$arm")"
+
+  # 1. Apply the cap and PROVE it applied, before anything is enqueued.
+  env_file_set "OL_LANE_${LANE_ENV_STEM}_CAP" "$total"
+  env_file_set "OL_LANE_${LANE_ENV_STEM}_SCOPE_CAP" "$cap"
+  recreate_worker true
+  assert_caps_applied "$LANE" "$total" "$cap"
+  guard_runner_state enabled
+
+  # 2. Clear this scenario's own rows from previous arms so the drain and the
+  #    row-scoped statistics below see THIS arm only. Scoped to the f8 key
+  #    prefix - never a blanket delete, which would take a peer's rows with it.
+  pg_sql_write "DELETE FROM sync_jobs WHERE \"idempotencyKey\" LIKE 'f8:$RUN_GROUP:%' AND \"idempotencyKey\" NOT LIKE 'f8:$RUN_GROUP:$arm:%'" >/dev/null || true
+
+  # Drain BEFORE asserting empty, in that order and not the other way round.
+  # The previous arm's fan-out children land on the Allegro connections and are
+  # still draining when this arm starts, so asserting first would refuse every
+  # arm after the first. And the assertion is NOT wrapped in `|| true`: `die`
+  # calls `exit`, so `guard_queue_empty ... || true` does not actually tolerate
+  # a failure - it aborts the sweep while reading like it cannot. Either the
+  # queue is clean and the arm is valid, or it is not and the arm would be
+  # measuring a cap it does not have to itself.
+  drain_wait "$DRAIN_CONN_IDS" >/dev/null || warn "pre-arm drain did not go quiet within DRAIN_MAX_WAIT_SECS - guard_queue_empty below will decide"
+  guard_queue_empty "$DRAIN_CONN_IDS"
+
+  # 3. Enqueue, cap the ladder, then open the window. Enqueue BEFORE
+  #    window_start so the window measures draining and not the REST intake -
+  #    the enqueue is ~JOB_COUNT HTTP calls and would otherwise be counted as
+  #    lane time.
+  # Re-login per arm rather than once for the run. A cap sweep is many arms
+  # long (recreate + settle + drain, each), so a token minted before the first
+  # arm can expire mid-sweep - and `ol_api` DIES on a non-2xx, which would
+  # abort the run after several arms' worth of stand time. Logging in again is
+  # one request against the api, which no arm is measuring.
+  ol_login
+
+  case "$LANE" in
+    realtime) enqueue_realtime "$arm" "$JOB_COUNT" ;;
+    fan-out)  enqueue_fanout  "$arm" "$JOB_COUNT" ;;
+    fiscal)   enqueue_fiscal  "$arm" "$JOB_COUNT" ;;
+  esac
+  cap_perf_job_attempts
+
+  local extra
+  extra="$(printf '{"f8":{"lane":"%s","perScopeCap":%s,"totalCap":%s,"jobsEnqueued":%s,"scopes":%s,"stubConfig":%s}}' \
+    "$LANE" "$cap" "$total" "$JOB_COUNT" "$SCOPES" \
+    "$(curl -s --max-time 5 "${STUB_URL:-http://127.0.0.1:19081}/__stub/config" 2>/dev/null || printf 'null')")"
+
+  window_start "$dir" "f8-lane-caps" "$DRAIN_CONN_IDS" 0 "$extra"
+  drained="$(drain_wait "$DRAIN_CONN_IDS" || true)"
+  window_stop "$dir"
+
+  # 4. Statistics from the ROWS, not from the sampler - see deviation (3)/(4).
+  #    `lastAttemptDurationMs` is written by the worker at real precision;
+  #    end-to-end is updatedAt-createdAt, which is available because a terminal
+  #    write always stamps updatedAt (unlike lockedAt, which is CLEARED on
+  #    every terminal transition - F7 lost a whole run to that).
+  rows="$(pg_sql "
+    SELECT
+      COUNT(*) FILTER (WHERE status='succeeded')                       AS ok,
+      COUNT(*) FILTER (WHERE status='dead')                            AS dead,
+      COUNT(*) FILTER (WHERE status IN ('queued','running'))           AS stuck,
+      COUNT(*) FILTER (WHERE outcome='business_failure')               AS bizfail,
+      COALESCE(SUM(\"deferredTotalMs\"),0)                             AS deferred_ms,
+      COALESCE(ROUND(AVG(\"lastAttemptDurationMs\")),0)                AS exec_mean,
+      COALESCE(ROUND(PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY \"lastAttemptDurationMs\")),0) AS exec_p50,
+      COALESCE(ROUND(PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY \"lastAttemptDurationMs\")),0) AS exec_p95,
+      COUNT(\"lastAttemptDurationMs\")                                 AS exec_n,
+      COALESCE(ROUND(EXTRACT(EPOCH FROM (MAX(\"updatedAt\") - MIN(\"createdAt\")))::numeric, 3),0) AS span_secs,
+      COALESCE(ROUND(PERCENTILE_CONT(0.5) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM (\"updatedAt\"-\"createdAt\")))::numeric,3),0) AS e2e_p50,
+      COALESCE(ROUND(PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM (\"updatedAt\"-\"createdAt\")))::numeric,3),0) AS e2e_p95
+    FROM sync_jobs WHERE \"idempotencyKey\" LIKE 'f8:$RUN_GROUP:$arm:%'")"
+
+  # Children this arm produced. For `fan-out` this is the arm's actual output
+  # and the reason its cap exists; for the others it should be zero, and a
+  # non-zero value means the load is not what the header claims it is.
+  local children
+  children="$(pg_sql "SELECT COUNT(*) FROM sync_jobs WHERE \"jobType\"='marketplace.offerQuantity.update' AND \"idempotencyKey\" NOT LIKE 'f8:%' AND \"createdAt\" >= to_timestamp($WINDOW_START_EPOCH)")"
+
+  # Occupancy, from the timeseries the sampler wrote. PROXY ONLY - see
+  # deviation (3). Reported so a reader can see whether the lane was near its
+  # cap at all, never used to size it.
+  local occ_max occ_mean
+  occ_max="$(awk -F, 'NR>1 && $4+0>m{m=$4+0} END{print m+0}' "$dir/timeseries.csv" 2>/dev/null || printf 0)"
+  occ_mean="$(awk -F, 'NR>1{s+=$4;n++} END{if(n)printf "%.2f", s/n; else print 0}' "$dir/timeseries.csv" 2>/dev/null || printf 0)"
+
+  local elapsed=$((WINDOW_STOP_EPOCH - WINDOW_START_EPOCH))
+  local ok dead stuck bizfail deferred_ms exec_mean exec_p50 exec_p95 exec_n span e2e50 e2e95
+  IFS='|' read -r ok dead stuck bizfail deferred_ms exec_mean exec_p50 exec_p95 exec_n span e2e50 e2e95 <<< "$rows"
+
+  local tput
+  tput="$(awk -v o="${ok:-0}" -v s="${span:-0}" 'BEGIN{ if (s+0>0) printf "%.3f", o/s; else print "0" }')"
+
+  # Five positional args, not two: post_guard_attempts/deferrals need the
+  # window's ISO start and post_guard_limiter_degraded needs its epoch bounds.
+  # Passing fewer silences the guards rather than failing them - the #2851
+  # "a guard that cannot see reads exactly like a clean run" shape - which is
+  # why the verdict is read back and carried into the summary row rather than
+  # written once to a file nobody re-reads.
+  run_post_guards "$dir" "$DRAIN_CONN_IDS" \
+    "$(date -u -d "@$WINDOW_START_EPOCH" +%Y-%m-%dT%H:%M:%SZ)" \
+    "$WINDOW_START_EPOCH" "$WINDOW_STOP_EPOCH" || true
+  # `awk NR==1`, never `| head -1`: head closes the pipe at its first line and
+  # SIGPIPEs the reader, which `set -o pipefail` adopts as a failure - F7 lost
+  # a full run to exactly that, after a 17-minute arm had already drained.
+  local verdict
+  verdict="$(verdict_read "$dir" 2>/dev/null | awk 'NR==1' || printf 'UNKNOWN')"
+  [ -n "$verdict" ] || verdict=UNKNOWN
+
+  log "ARM $LANE perScope=$cap -> $verdict ok=$ok dead=$dead stuck=$stuck bizfail=$bizfail span=${span}s throughput=${tput}/s exec_p50=${exec_p50}ms exec_p95=${exec_p95}ms e2e_p50=${e2e50}s occ_max=$occ_max(proxy) children=$children drain=$drained"
+
+  ARMS_CSV="$ARMS_CSV$LANE,$cap,$total,$SCOPES,$JOB_COUNT,$ok,$dead,$stuck,$bizfail,$span,$tput,$exec_mean,$exec_p50,$exec_p95,$exec_n,$e2e50,$e2e95,$deferred_ms,$occ_max,$occ_mean,$children,$elapsed,$drained,$verdict
+"
+  LAST_DIR="$dir"
+}
+
+# ===========================================================================
+# Run
+# ===========================================================================
+if [ -n "$STUB_QUANTITY_MS" ]; then
+  warn "STUB_QUANTITY_MS=$STUB_QUANTITY_MS requested. The stub reads its latency from the ENVIRONMENT at request time, so this needs the stub container recreated with STUB_LATENCY_QUANTITY_MS set - do it before invoking this script, and it will be recorded from /__stub/config (quantityMsMeasured:true) rather than asserted here."
+fi
+
+case "$LANE" in
+  realtime)
+    OFFER_IDS_A="$(resolve_offer_pool "$ALLEGRO_A_CONNECTION_ID")"
+    OFFER_IDS_B="$(resolve_offer_pool "$ALLEGRO_B_CONNECTION_ID")"
+    a_n="$(printf '%s\n' "$OFFER_IDS_A" | grep -c . || true)"
+    [ "${a_n:-0}" -gt 0 ] || die "no Offer identifier mappings on perf-allegro-a - run bootstrap.sh"
+    # The per-offer write-order lock (#2617) is only harmless while the pool is
+    # wider than the widest cap. Refuse rather than silently measure the lock.
+    widest="$(printf '%s' "$CAPS" | tr ' ' '\n' | sort -n | tail -1)"
+    [ "$a_n" -gt "$widest" ] \
+      || die "offer pool for perf-allegro-a is $a_n, which is not wider than the widest cap ($widest). At or below the cap the #2617 per-(connection,offer) lock would serialise the arm and the curve would be a curve of the lock, not of the lane."
+    log "realtime load: marketplace.offerQuantity.update, offer pool a=$a_n b=$(printf '%s\n' "$OFFER_IDS_B" | grep -c . || true), scopes=$SCOPES"
+    ;;
+  fan-out)
+    FANOUT_TARGETS="$(resolve_fanout_targets)"
+    f_n="$(printf '%s\n' "$FANOUT_TARGETS" | grep -c . || true)"
+    [ "${f_n:-0}" -gt 0 ] || die "no product/variant pairs found - run bootstrap.sh"
+    log "fan-out load: inventory.propagateToMarketplaces over $f_n product/variant pairs"
+    ;;
+  fiscal)
+    warn "FISCAL: this arm measures the RUNNER's floor for the lane, NOT the cap. See deviation (5) in this script's header. Do not quote its numbers as a cap measurement."
+    ;;
+esac
+
+# Called plainly. Capturing its output in a command substitution instead
+# runs the function in a SUBSHELL, so every `ARMS_CSV` append inside it is
+# discarded when the subshell exits - and every `log` line inside it is
+# captured as the substitution's value instead of reaching the operator. The
+# first run of this scenario did exactly that: both arms executed correctly
+# against the stand and the summary came out with a header and no rows.
+LAST_DIR=""
+for cap in $CAPS; do
+  run_arm "$cap"
+done
+
+SUMMARY="$RESULTS_ROOT/f8-lane-caps/$RUN_GROUP-$LANE-summary.csv"
+mkdir -p "$(dirname "$SUMMARY")"
+{
+  printf 'lane,perScopeCap,totalCap,scopes,jobsEnqueued,succeeded,dead,stuck,businessFailure,spanSecs,throughputPerSec,execMeanMs,execP50Ms,execP95Ms,execN,e2eP50Secs,e2eP95Secs,deferredTotalMs,occMaxProxy,occMeanProxy,childrenEnqueued,windowSecs,drainResult,verdict\n'
+  printf '%s' "$ARMS_CSV"
+} > "$SUMMARY"
+
+log "summary written: $SUMMARY"
+printf '\n'
+column -s, -t < "$SUMMARY" 2>/dev/null || cat "$SUMMARY"
+printf '\n'
+log "F8 complete for lane=$LANE. Results under $RESULTS_ROOT/f8-lane-caps/$RUN_GROUP-$LANE-*"
+log "REMINDER: occMax/occMean are the sync_jobs-row PROXY and OVER-READ (F4 § 2). Size from throughput and execP50/execP95, never from occupancy."


### PR DESCRIPTION
Child of #2840, and the measurement half of #2867.

**No cap default changes.** `realtime` (4/2), `fiscal` (2/1) and `fan-out` (8/4) are unchanged, and **no cap curve was measured for any lane** - the "What did not get done" section below is precise about why. What this PR does deliver is the thing that made a cap unmeasurable in the first place, plus three findings that change what the next attempt should look for.

## 1. A lane cap was not measurable at all

`docker-compose.lab.yml`'s `worker` service listed no `OL_LANE_*` variable. Compose substitutes `${VAR}` only for keys a service actually lists, so exporting `OL_LANE_REALTIME_SCOPE_CAP=8` around `docker compose up` set **nothing**, silently.

That is the dangerous failure rather than the annoying one. A sweep run against it produces a clean curve of the **same cap at every point** - flat throughput, flat latency, no errors - and that reads exactly like *"this lane does not respond to its cap"*, which is a conclusion. It is #2851's "a guard that cannot see reads identically to a clean run", one layer up.

Fixed twice, because the passthrough alone would have been trusted: the eight variables are passed through (each defaulting to **empty**, which `resolveLaneCaps` reads as "use the code default", so an untouched stand is byte-identical to its pre-#2867 self), **and** `f8-lane-caps.sh` reads the applied cap back out of the worker's own `Starting sync job runner loop` line and refuses the arm on a mismatch.

## 2. Findings

**The realtime write path spends ~7-8 s inside OpenLinker around a 127 ms call.** Three traced `marketplace.offerQuantity.update` jobs, all `succeeded`:

| Trace | `durationMs` | `Executing` → `PUT` | inside the PUT | `200` → `succeeded` |
|---|---:|---:|---:|---:|
| 1 | 9727 | ~4 s | 1126 ms | ~3 s |
| 2 | 9492 | ~4 s | 1123 ms | ~4 s |
| 3 | 9651 | ~4 s | ~1120 ms | ~4 s |

Range 235 ms (~2.4 %); the call reproduces to within 3 ms. The destination (the Allegro stub) answers in **127.6 ms**, measured. Nothing is logged inside either bracket, so which statement dominates is **not** established - by code reading the candidates are per-call capability-adapter construction plus credential decryption, `applyPublishControlsBatch`, the #2617 lock acquire and the cursor read before, and the cursor advance, lock release and terminal write after.

This is why no realtime cap is proposed. If that 7-8 s is overhead rather than work, the lane's real per-job cost is ~130 ms, a `perScope` of 2 throttles jobs ~70x cheaper than they look, and **the remedy is to fix the overhead, not to tune the cap.**

**An earlier commit in this PR predicted the Allegro client's retry ladder (1 s + 2 s + 4 s = 7 s) and the arithmetic fitted to within ~5 %. The trace falsified it** - one HTTP attempt, no retry line. It is withdrawn in place rather than quietly edited out, because a fit that survives into a report as a cause is how a plausible number becomes a quoted one.

**The rate limiter degrades on a healthy, idle Redis.** `checkPace` times out at its full 1 s budget while Redis answers in **0.12-0.18 ms** (~300 samples), against a connection that declares **no rate limit at all**. The log says *"still degraded"*, so the ~1 s is charged to calls indefinitely rather than once. A stronger sighting than F4's, which had 600 jobs of load to blame.

**A freed slot waits up to `POLL_INTERVAL_MS`** (hardcoded 1000 ms, not env-tunable): `runnerLoop` sleeps on any tick that starts nothing, so once a lane is at cap every completion waits for refill. For short-job lanes - which `fan-out` and the `fiscal` sweeps are - that dominates the cap.

**An oversized TOTAL is claim-and-release churn.** `claimAndStartForLane` claims `total - inFlight` and only then drops what exceeds `perScope`. Pinning TOTAL high to "isolate perScope" adds a claim of up to `free` rows and a release of `free - 1` to **every refill**. This was going to be my own methodology error; the scenario now derives `total = perScope x scopes` and `lib-test` asserts it.

**`fan-out`'s 8/4 is DERIVED, not measured** - confirmed; both ADR-050's #2609 amendment and `.env.example` say so, and the backlog behind the raise measures the defect, not the fix.

**`fiscal`**: `invoicing.issue` and `fiscalization.register` share one per-order lock, so concurrency above the number of distinct orders buys nothing - but `perScope: 1` is *below* it, so bulk issuance across distinct orders is serialised by the **cap**. Those bound different things and the second half is not stated anywhere today.

## 3. What did not get done, and why

No sweep arm ran outside smoke mode. Two causes, both recorded:

- Peers held `guard_stand_exclusive` for most of the session (`f7` 00:32-00:58, then `f1` cycling from 01:05). Taken and released properly; retried rather than worked around.
- Once the stand was free, **`guard_build` refused every arm**, correctly. It compares the image's commit against the **committed** tree at `HEAD` per build-relevant path, and separately refuses uncommitted changes there. So: *a perf branch that also touches product code cannot run any scenario against a stand built from another commit, however inert the product change is.* This branch's only `apps/**` change is the two documentation corrections below. Checking that file out at the image's commit does not work around it (HEAD is unchanged, and the tree goes dirty) - verified by attempting it. The remedy is a stand rebuild, declined here because it is minutes of heavy CPU on a workstation where a peer was actively measuring latency.

## 4. Two documentation corrections

Neither changes what any process runs. `sync-job.runner.ts` still quoted the **`p95 store impact 0.995`** ratio that ADR-066 correction 1 withdrew by name and ADR-050 says "is removed there and stays removed here" - removed from `.env.example`, missed in the runner. And the class-level `fan-out` default literal read `1/1`, the pre-#2609 value, against `resolveLaneCaps`' `8/4` fallback.

## 5. Honesty

The stand is a compose project on a contended developer workstation sharing a host with two other OpenLinker stacks. `n = 1` unless stated; every figure is a floor. Stand posture (runner enabled, scheduler off, one replica) was restored to what was found, and the container's `OL_LANE_*` variables were verified back to empty, i.e. code defaults.

`lib-test.sh`: 116 -> **140** assertions.

**Gate**: `bash -n` clean; lib-test 140/140; `pnpm check:invariants` passes all 78 checks except `check-bundle-budgets`, which cannot run because every `node_modules` in this worktree disappeared mid-session (an earlier run in the same session passed with them present). This diff contains no frontend change, and a reinstall was deliberately not run while a peer was measuring on the same host.

Refs #2867, #2840, #2302

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Claude-Session: https://claude.ai/code/session_01UwqnrmELURfiSUu6898bsV
