### PR TITLE
perf(f1): measure order ingestion, and fix six things that stopped it measuring

### DIFF
--- a/perf/openlinker-throughput/bootstrap.sh
+++ b/perf/openlinker-throughput/bootstrap.sh
@@ -187,7 +187,36 @@ step_module() {
 # junction the account is unbound and every WS call answers 503 "The PrestaShop
 # webservice is disabled" with PSWS-Version: 0, even with PS_WEBSERVICE on.
 # ---------------------------------------------------------------------------
-WS_RESOURCES="products combinations stock_availables orders order_details customers addresses carriers order_carriers order_states specific_prices product_options product_option_values tax_rules taxes"
+# Every resource `PrestashopOrderProcessorManagerAdapter.createOrder` touches,
+# plus the catalogue/stock ones the master-sync paths need.
+#
+# `countries`, `currencies` and `carts` were MISSING until #2847, and the
+# failure they produced is worth naming because it does not look like a
+# permission problem: PrestaShop answers an ungranted resource with
+# `Authentication failed: Invalid API key`, so the order create died reporting
+# a bad credential on a connection whose own `POST /connections/:id/test` had
+# just passed and whose `customers` writes were succeeding. The three are on
+# the create path exactly once each -
+#   countries   `PrestashopCountryResolver.resolveCountryId`, reached by
+#               address provisioning (24h per-connection cache, so it fires
+#               on the first order after a restart and then rarely)
+#   currencies  `readPrestashopCurrencyByIso`, once per order before the cart
+#   carts       `POST carts`, the cart every order is built on
+# - and each is a hard stop for the whole destination arm when absent.
+#
+# `configurations` is a FOURTH, and it fails differently, which is why it
+# survived the first three being added: the create path reads
+# `GET configurations?filter[name]=[PS_CURRENCY_DEFAULT]` and tolerates a
+# failure, so the order still completes. It is therefore not a hard stop - it
+# is a silent tax. Measured during F1's latency arm: 4 of 4 orders spent one
+# 401 there, i.e. roughly a tenth of the destination's whole 60/min rate-limit
+# budget per order, on a request that can never succeed. A tolerated error is
+# harder to find than a fatal one, so it is named here rather than left to be
+# rediscovered.
+#
+# The grant below is re-applied on EVERY bootstrap run (DELETE + re-INSERT),
+# so adding a name here repairs an existing stand rather than only a fresh one.
+WS_RESOURCES="products combinations stock_availables orders order_details customers addresses countries currencies carts configurations carriers order_carriers order_states specific_prices product_options product_option_values tax_rules taxes"
 
 step_webservice() {
   log "--- PrestaShop WebService key ---"
@@ -328,7 +357,39 @@ step_woocommerce() {
   WC_CK="$(printf '%s' "$json" | json_field consumer_key)"
   WC_CS="$(printf '%s' "$json" | json_field consumer_secret)"
   [ -n "$WC_CK" ] || die "WooCommerce key creation returned no consumer_key"
+  WC_KEY_ROTATED=1
   created "WooCommerce REST key (${WC_CK:0:10}...)"
+}
+
+# ---------------------------------------------------------------------------
+# Step 4b (#2847) - push a ROTATED WooCommerce key onto an existing connection.
+#
+# `ol_ensure_connection` is create-only, so it supplies credentials exactly
+# once, at creation. `step_woocommerce` above, meanwhile, ROTATES the key
+# whenever it cannot recover the plaintext from stand-ids.env - and the
+# plaintext is unrecoverable by construction, because WooCommerce stores the
+# consumer key hashed. So on any stand whose stand-ids.env was lost (a fresh
+# worktree is enough), the two halves silently disagree: WooCommerce holds a
+# new key and the OpenLinker connection still holds the old one, for ever, and
+# nothing repairs it because every later step reports FOUND.
+#
+# Found live by F1 (#2847), whose WooCommerce destination arm answered
+# `WooCommerce authentication failed - check consumer key and secret` on a
+# stand that every other check called healthy. Without this step that arm is
+# unrunnable and the failure looks like a stand fault rather than a bootstrap
+# one.
+#
+# Only fires when this run actually rotated: a reused key is already the one
+# the connection carries, and a needless credential write would rewrite the
+# encrypted row for nothing.
+step_woocommerce_credentials() {
+  [ "${WC_KEY_ROTATED:-0}" = "1" ] || return 0
+  [ -n "${WC_CONN_ID:-}" ] || { warn "WooCommerce key was rotated but no connection id resolved - the connection still carries the OLD key"; return 0; }
+  [ "$VERIFY_ONLY" = 1 ] && { gap "WooCommerce connection credentials (key was rotated this run)"; return 0; }
+  would "push the rotated WooCommerce key onto connection $WC_CONN_ID" && return 0
+  ol_api PUT "/v1/connections/$WC_CONN_ID/credentials" \
+    "$(jq -n --arg ck "$WC_CK" --arg cs "$WC_CS" '{credentials:{consumerKey:$ck, consumerSecret:$cs}}')" >/dev/null
+  created "WooCommerce connection credentials updated to the rotated key"
 }
 
 # ---------------------------------------------------------------------------
@@ -496,31 +557,92 @@ step_allegro_offer_manager() {
 # never reaches a destination create, and burns ten retry attempts over roughly
 # 30 hours. The offer-id space must match the stub's (#2856).
 # ---------------------------------------------------------------------------
+# AN OFFER MUST POINT AT A PRODUCT THE DESTINATION ACTUALLY HAS (#2847)
+#
+# The original seeder pointed every offer at any non-stale `product_variants`
+# row. That is not enough for a DESTINATION-CREATE path, and F1 found out the
+# expensive way: `seed-catalogue.sh` writes 10 000 OL products plus matching
+# `identifier_mappings` rows whose external ids are synthetic strings
+# (`PERFSEED-EXT-PROD-ps-*`, `PERFSEED-EXT-PROD-wc-*`) - it seeds OL's own
+# tables and the MAPPINGS, never a product in either shop. It was built for the
+# read-path scenarios, where nothing crosses to a shop and that is fine.
+#
+# An order whose line resolves to one of those products reaches the destination
+# adapter and dies there:
+#
+#   PrestaShop   GET products/PERFSEED-EXT-PROD-ps-10000 -> Resource not found
+#                (the tax-rate chain, before any order is created)
+#   WooCommerce  Corrupted mapping: "PERFSEED-EXT-PROD-wc-10000" is not a
+#                valid positive integer WC ID
+#
+# and because `OrderSyncService` fans out under `Promise.allSettled`, the job
+# still records `outcome: 'ok'` while the shop receives nothing.
+#
+# The target set is therefore variants whose product carries a NUMERIC
+# PrestaShop external id - a real `id_product` in the shop's own catalogue,
+# which on this stand is the six products bootstrap itself installs (20-25,
+# eleven non-stale positions). A numeric test rather than a hardcoded list, so
+# a stand that later grows a real catalogue picks it up automatically.
+#
+# Note what this means for #2856's seeded-mapping contract ("the offer pool and
+# the distinct-product count are the same number"): it CANNOT hold on a stand
+# with six real products, and the warning below says so with the real figure
+# rather than letting a reader assume 200. A destination-create measurement has
+# to state its true distinct-product count, because that is what the PrestaShop
+# tax chain's 24h per-(connection, product, country) cache decays against.
 seed_offer_mappings_for() {
-  local conn_id="$1" tenant="$2" existing
+  local conn_id="$1" tenant="$2" rows distinct usable want
   [ -n "$conn_id" ] || { warn "no connection id for tenant $tenant - skipping offer mappings"; return 0; }
-  existing="$(pg_sql "SELECT COUNT(*) FROM identifier_mappings WHERE \"entityType\"='Offer' AND \"connectionId\"='$conn_id'")"
-  if [ "${existing:-0}" -ge "$ALLEGRO_OFFER_POOL_SIZE" ]; then
-    found "Offer mappings for $tenant ($existing rows)"; return 0
+
+  # Variants whose product is REAL at the PrestaShop destination.
+  local real_clause=""
+  if [ -n "${PS_CONN_ID:-}" ]; then
+    real_clause="AND EXISTS (SELECT 1 FROM identifier_mappings m
+                             WHERE m.\"entityType\"='Product' AND m.\"connectionId\"='$PS_CONN_ID'
+                               AND m.\"internalId\"=pv.\"productId\" AND m.\"externalId\" ~ '^[0-9]+\$')"
   fi
-  if [ "$VERIFY_ONLY" = 1 ]; then gap "Offer mappings for $tenant (have ${existing:-0}, need $ALLEGRO_OFFER_POOL_SIZE)"; return 0; fi
-  would "seed $ALLEGRO_OFFER_POOL_SIZE Offer mappings for $tenant" && return 0
+  usable="$(pg_sql "SELECT COUNT(*) FROM product_variants pv WHERE pv.\"isStale\" = false $real_clause")"
+  [ "${usable:-0}" -gt 0 ] || die "no non-stale product_variants map to a real (numeric-id) PrestaShop product - install the module's catalogue before the offer mappings"
 
-  # Each mapping points at a live, non-stale ProductVariant. A stale one would
-  # resolve as 'source_deleted' rather than a usable item.
-  local variants
-  variants="$(pg_sql "SELECT COUNT(*) FROM product_variants WHERE \"isStale\" = false")"
-  [ "${variants:-0}" -gt 0 ] || die "no non-stale product_variants exist - seed the catalogue before the mappings"
+  # The most distinct targets this stand can support. Comparing against the
+  # pool size alone would report a permanent gap on a stand whose real
+  # catalogue is smaller than the pool, and a permanent gap trains people to
+  # ignore the summary.
+  want="$ALLEGRO_OFFER_POOL_SIZE"
+  [ "$usable" -ge "$want" ] || want="$usable"
 
+  rows="$(pg_sql "SELECT COUNT(*) FROM identifier_mappings WHERE \"entityType\"='Offer' AND \"connectionId\"='$conn_id'")"
+  distinct="$(pg_sql "SELECT COUNT(DISTINCT im.\"internalId\") FROM identifier_mappings im
+                      JOIN product_variants pv ON pv.id = im.\"internalId\"
+                      WHERE im.\"entityType\"='Offer' AND im.\"connectionId\"='$conn_id'
+                        AND pv.\"isStale\" = false $real_clause")"
+  if [ "${rows:-0}" -ge "$ALLEGRO_OFFER_POOL_SIZE" ] && [ "${distinct:-0}" -ge "$want" ]; then
+    found "Offer mappings for $tenant ($rows rows over $distinct destination-resolvable variant(s); stand supports $usable)"; return 0
+  fi
+  if [ "$VERIFY_ONLY" = 1 ]; then
+    gap "Offer mappings for $tenant (have ${rows:-0} rows over ${distinct:-0} destination-resolvable variant(s), need $ALLEGRO_OFFER_POOL_SIZE rows over $want)"; return 0
+  fi
+  would "seed/repair $ALLEGRO_OFFER_POOL_SIZE Offer mappings for $tenant over $want destination-resolvable variant(s)" && return 0
+
+  if [ "$usable" -lt "$ALLEGRO_OFFER_POOL_SIZE" ]; then
+    warn "only $usable variant(s) resolve to a real PrestaShop product, fewer than the offer pool $ALLEGRO_OFFER_POOL_SIZE - offers will SHARE targets and the distinct-product count will NOT equal the offer pool. Any destination-create measurement must record the real figure (#2856's seeded-mapping contract cannot hold here)."
+  fi
+
+  # DELETE-then-insert rather than ON CONFLICT DO NOTHING: the repair case has
+  # rows whose externalId already exists but whose internalId points somewhere
+  # unusable, and DO NOTHING would leave every one of them exactly as it was.
+  pg_sql "DELETE FROM identifier_mappings WHERE \"entityType\"='Offer' AND \"connectionId\"='$conn_id'" >/dev/null
   pg_sql "INSERT INTO identifier_mappings (id, \"entityType\", \"internalId\", \"externalId\", \"platformType\", \"connectionId\", \"createdAt\", \"updatedAt\")
           SELECT gen_random_uuid(), 'Offer', v.id, '${tenant}-offer-' || g.n, 'allegro', '$conn_id', NOW(), NOW()
           FROM generate_series(1, $ALLEGRO_OFFER_POOL_SIZE) AS g(n)
           JOIN LATERAL (
-            SELECT id FROM product_variants WHERE \"isStale\" = false
-            ORDER BY id OFFSET ((g.n - 1) % $variants) LIMIT 1
+            SELECT pv.id FROM product_variants pv
+            WHERE pv.\"isStale\" = false $real_clause
+            ORDER BY pv.id OFFSET ((g.n - 1) % $usable) LIMIT 1
           ) AS v ON true
           ON CONFLICT DO NOTHING" >/dev/null
-  created "$ALLEGRO_OFFER_POOL_SIZE Offer mappings for $tenant"
+  distinct="$(pg_sql "SELECT COUNT(DISTINCT \"internalId\") FROM identifier_mappings WHERE \"entityType\"='Offer' AND \"connectionId\"='$conn_id'")"
+  created "$ALLEGRO_OFFER_POOL_SIZE Offer mappings for $tenant over ${distinct} destination-resolvable variant(s)"
 }
 
 step_offer_mappings() {
@@ -613,6 +735,10 @@ main() {
   step_tax_group
   step_woocommerce
   step_connections
+  # After step_connections (the connection must exist to be patched) and
+  # before step_verify_connections (whose WooCommerce test is exactly what a
+  # stale credential fails) - #2847.
+  step_woocommerce_credentials
   step_allegro_offer_manager
   step_offer_mappings
   step_verify_connections

--- a/perf/openlinker-throughput/drivers/f1-summarize.py
+++ b/perf/openlinker-throughput/drivers/f1-summarize.py
@@ -1,0 +1,370 @@
+#!/usr/bin/env python3
+"""
+F1 summarizer (#2847, epic #2840).
+
+Two modes, because F1 measures two different things and reporting them with
+one shape would misdescribe both:
+
+  latency <samples.csv>     per-hop order statistics for the serial arm
+  throughput <progress.csv> completion rate + queue-growth verdict for one
+                            throughput arm
+
+WHY THIS REPORTS ORDER STATISTICS AND NAMES THEIR RANK
+------------------------------------------------------
+#2847's own acceptance criteria refuse "p50/p95/p99" as a reporting shape at
+this sample size, and say so in terms worth restating: at n in the tens,
+"p99" IS the maximum observation and "p95" is the second-highest - there is
+no distribution, only a handful of points. So every percentile printed here
+carries the 1-based RANK it actually resolved to, out of n. A reader can then
+see for themselves that a "p95" over 20 samples is the 19th of 20, and
+discount it accordingly, rather than being handed a number whose name implies
+a tail it cannot have.
+
+The rank rule is nearest-rank (ceil(p * n)), which is the only definition
+under which the printed rank is an actual observation rather than an
+interpolation between two of them. An interpolated percentile at n=20 would
+be a number that was never measured, presented beside numbers that were.
+
+TIMESTAMP HANDLING
+------------------
+Every column consumed here is Postgres text. `sync_jobs.createdAt` /
+`updatedAt` / `lockedAt` and `order_records.createdAt` are all declared
+`timestamptz` and carry their own `+00`. A value WITHOUT an offset is stamped
+UTC explicitly rather than left naive - F2's summarizer records the live bug
+this prevents: `datetime.timestamp()` on a naive object assumes the
+interpreting PROCESS's local timezone, which on this host is CEST, so a naive
+value mis-converts by exactly 7 200 000 ms and produces plausible-looking
+hop figures that are two hours wrong.
+"""
+import csv
+import datetime as _dt
+import math
+import sys
+from datetime import datetime, timezone
+
+
+def parse_pg_ts(s):
+    if s is None:
+        return None
+    s = s.strip()
+    if not s:
+        return None
+    s = s.replace(' ', 'T', 1)
+    # Postgres prints a 2-digit offset ("+00"); fromisoformat wants "+00:00"
+    # on older Pythons and tolerates it on newer ones either way.
+    if len(s) >= 3 and (s[-3] in '+-') and s[-3:] not in ('', None):
+        s = s + ':00'
+    try:
+        dt = datetime.fromisoformat(s)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def ms_between(a, b):
+    """Milliseconds from a to b, or None if either endpoint is missing.
+
+    A missing endpoint yields None and the row is EXCLUDED from that hop's
+    sample - never coerced to zero, which would silently report a hop that
+    was not observed as one that took no time.
+    """
+    ta, tb = parse_pg_ts(a), parse_pg_ts(b)
+    if ta is None or tb is None:
+        return None
+    return (tb - ta).total_seconds() * 1000.0
+
+
+def nearest_rank(values, p):
+    """(value, rank) at percentile p (0..1), nearest-rank. values must be sorted."""
+    n = len(values)
+    if n == 0:
+        return (None, None)
+    rank = max(1, min(n, math.ceil(p * n)))
+    return (values[rank - 1], rank)
+
+
+def stats_line(label, values, note=''):
+    vals = sorted(v for v in values if v is not None)
+    n = len(vals)
+    if n == 0:
+        return f'{label:<46} n=0    (never observed){("  " + note) if note else ""}'
+    p50, r50 = nearest_rank(vals, 0.50)
+    p95, r95 = nearest_rank(vals, 0.95)
+    return (
+        f'{label:<46} n={n:<4} '
+        f'min={vals[0]:>9.1f}  p50={p50:>9.1f} (rank {r50}/{n})  '
+        f'p95={p95:>9.1f} (rank {r95}/{n})  max={vals[-1]:>9.1f}'
+        + (f'  {note}' if note else '')
+    )
+
+
+# ---------------------------------------------------------------------------
+# latency
+# ---------------------------------------------------------------------------
+#
+# THE CLAIM INSTANT HAS TWO SOURCES, AND THIS SAYS WHICH ONE ANSWERED
+#
+# `SyncJobRepository.markSucceeded` sets `lockedAt: null` alongside
+# `status: 'succeeded'`, so the column is EMPTY on every job a completed
+# sample reads. The scenario therefore latches `lockedAt` while the job is
+# still running - a real observation, but one a job shorter than the 1-second
+# poll tick can slip past entirely.
+#
+# The fallback is `updatedAt - lastAttemptDurationMs`: the runner measures the
+# attempt itself (`Date.now() - attemptStartedAt`) and stamps it by the same
+# UPDATE that moves `updatedAt`, so on a single-attempt job this is exact and,
+# unlike the latch, immune to the 3-minute heartbeat rewrite as well. It is
+# NOT valid for a multi-attempt job, where the duration describes only the
+# last attempt - such rows are excluded from the derived path and counted.
+#
+# Every hop that depends on a claim instant reports the SPLIT, so a reader can
+# see how much of the figure is observed and how much reconstructed.
+
+
+def claim_instant(row, prefix):
+    """(datetime, source) for a job's claim instant, or (None, 'missing')."""
+    latched = parse_pg_ts(row.get(f'{prefix}_locked_utc'))
+    if latched is not None:
+        return (latched, 'latched')
+    updated = parse_pg_ts(row.get(f'{prefix}_updated_utc'))
+    dur = row.get(f'{prefix}_attempt_duration_ms')
+    attempts = row.get(f'{prefix}_attempts') or '1'
+    if updated is None or dur in (None, '', 'NULL'):
+        return (None, 'missing')
+    if attempts.isdigit() and int(attempts) > 1:
+        # lastAttemptDurationMs describes the LAST attempt only, so subtracting
+        # it from updatedAt lands inside the final retry rather than at the
+        # original claim. Reporting that as a claim instant would understate
+        # every hop it feeds.
+        return (None, 'multi-attempt')
+    try:
+        return (updated - _dt.timedelta(milliseconds=float(dur)), 'derived')
+    except ValueError:
+        return (None, 'missing')
+
+
+def hop_ms(row, frm, to):
+    """Milliseconds for one hop, where an endpoint may be a claim instant."""
+    def endpoint(name):
+        if name == 'poll_claim':
+            return claim_instant(row, 'poll')[0]
+        if name == 'child_claim':
+            return claim_instant(row, 'child')[0]
+        return parse_pg_ts(row.get(name))
+    a, b = endpoint(frm), endpoint(to)
+    if a is None or b is None:
+        return None
+    return (b - a).total_seconds() * 1000.0
+
+
+HOPS = [
+    # (label, from, to, note)
+    ('A  order pushed at stub -> poll enqueued',
+     'pushed_at_utc', 'poll_created_utc',
+     'HARNESS-CHOSEN, see report'),
+    ('B  poll enqueued -> poll claimed',
+     'poll_created_utc', 'poll_claim', ''),
+    ('C  poll claimed -> child enqueued',
+     'poll_claim', 'child_created_utc', ''),
+    ('D  child enqueued -> child claimed',
+     'child_created_utc', 'child_claim', ''),
+    ('E  child claimed -> order_records row written',
+     'child_claim', 'record_created_utc', ''),
+    ('F  order_records written -> destination syncedAt',
+     'record_created_utc', 'synced_at_utc', ''),
+    ('G  child claimed -> child terminal',
+     'child_claim', 'child_updated_utc', ''),
+    ('TOTAL  poll enqueued -> destination syncedAt',
+     'poll_created_utc', 'synced_at_utc',
+     'excludes hop A'),
+    ('TOTAL  order pushed -> destination syncedAt',
+     'pushed_at_utc', 'synced_at_utc',
+     'includes the harness-chosen hop A'),
+]
+
+
+def summarize_latency(path):
+    rows = []
+    with open(path, newline='') as f:
+        for row in csv.DictReader(f):
+            rows.append(row)
+
+    print(f'samples in file: {len(rows)}')
+    complete = [r for r in rows if r.get('synced_at_utc')]
+    print(f'samples reaching a destination create: {len(complete)}')
+    print()
+
+    for label, a, b, note in HOPS:
+        print(stats_line(label, [hop_ms(r, a, b) for r in rows], note))
+
+    # How much of the above is observed and how much reconstructed.
+    print()
+    for prefix, name in (('poll', 'poll job'), ('child', 'child job')):
+        counts = {}
+        for r in rows:
+            counts[claim_instant(r, prefix)[1]] = counts.get(claim_instant(r, prefix)[1], 0) + 1
+        parts = ', '.join(f'{k}={v}' for k, v in sorted(counts.items()))
+        print(f'{name} claim-instant source: {parts}   '
+              f'(latched = observed while running; derived = updatedAt - '
+              f'lastAttemptDurationMs; missing/multi-attempt rows are EXCLUDED '
+              f'from every hop that needs a claim)')
+
+    print()
+    # lastAttemptDurationMs is the runner's OWN measurement of the attempt
+    # (sync-job.runner.ts stamps Date.now() - attemptStartedAt on success), so
+    # it is the one figure here that is not a difference of two DB columns.
+    # It is what the lane-vs-destination crossover arithmetic in #2847 calls D.
+    durations = []
+    for r in rows:
+        v = r.get('child_attempt_duration_ms')
+        if v not in (None, '', 'NULL'):
+            try:
+                durations.append(float(v))
+            except ValueError:
+                pass
+    print(stats_line('D  child job duration (runner-measured)', durations,
+                     'sync_jobs.lastAttemptDurationMs'))
+
+    # The heartbeat rewrites lockedAt every 3 minutes (sync-job.runner.ts
+    # JOB_HEARTBEAT_INTERVAL_MS), so lockedAt is only the CLAIM instant for a
+    # job that finished inside that window. Rather than assert that, count it.
+    over = 0
+    checked = 0
+    for r in rows:
+        d = hop_ms(r, 'child_claim', 'child_updated_utc')
+        if d is None:
+            continue
+        checked += 1
+        if d >= 180_000:
+            over += 1
+    print()
+    print(f'heartbeat caveat: {over} of {checked} child jobs ran >= 180s, so a '
+          f'LATCHED lockedAt for them could be a heartbeat rewrite rather than '
+          f'the claim instant (0 means the caveat does not bite on this run; '
+          f'the DERIVED source is immune to it either way)')
+
+    attempts_over = sum(1 for r in rows
+                        if (r.get('child_attempts') or '1').isdigit()
+                        and int(r.get('child_attempts') or '1') > 1)
+    print(f'retry caveat:     {attempts_over} of {len(rows)} child jobs took more than one '
+          f'attempt (lastAttemptDurationMs reports the LAST attempt only)')
+
+
+# ---------------------------------------------------------------------------
+# throughput
+# ---------------------------------------------------------------------------
+def summarize_throughput(path):
+    rows = []
+    with open(path, newline='') as f:
+        for row in csv.DictReader(f):
+            rows.append(row)
+    if len(rows) < 2:
+        print('progress.csv carries fewer than 2 ticks - nothing to report')
+        return
+
+    def num(r, k, default=None):
+        v = r.get(k)
+        if v in (None, '', 'unknown'):
+            return default
+        try:
+            return float(v)
+        except ValueError:
+            return default
+
+    t0 = float(rows[0]['epoch'])
+    t1 = float(rows[-1]['epoch'])
+    elapsed = t1 - t0
+    done0 = num(rows[0], 'completed', 0.0)
+    done1 = num(rows[-1], 'completed', 0.0)
+    completed = done1 - done0
+
+    print(f'window elapsed:        {elapsed:.0f}s')
+    print(f'orders completed:      {int(completed)}')
+    if elapsed > 0:
+        print(f'sustained rate:        {completed / elapsed:.3f} orders/s '
+              f'= {completed / elapsed * 3600:.0f} orders/hour')
+
+    # QUEUE GROWTH, AND WHY IT IS NOT ITSELF THE KNEE ON A SATURATION ARM
+    #
+    # #2847 asks for "the orders/hour at which oldest-job age begins growing
+    # monotonically". On an arm that deliberately offers MORE than the system
+    # can take - which is what every throughput arm here does, because that is
+    # the only way to measure the service rate - the age grows by
+    # construction, on every run, at every rate. Reporting that as "past the
+    # knee" would be true and useless: it says the arm was configured the way
+    # it was configured.
+    #
+    # So this reports the OBSERVATION (did the age grow, and how steadily) and
+    # leaves the knee to be read off the SUSTAINED RATE above, which is the
+    # service rate mu. The knee is mu by definition: an arrival rate below it
+    # leaves the queue flat, one above it grows the queue without bound. A run
+    # whose age did NOT grow while saturated is the interesting case - it means
+    # the offered load never exceeded the system, so the sustained rate is a
+    # floor rather than the ceiling.
+    #
+    # Growth is measured over the SECOND HALF only: the first half is the ramp
+    # from an empty queue to steady state on any arm whose backlog was pushed
+    # before the window opened.
+    ages = [(float(r['epoch']), num(r, 'oldest_due_age_s')) for r in rows]
+    ages = [(t, a) for t, a in ages if a is not None]
+    half = len(ages) // 2
+    tail = ages[half:]
+    if len(tail) >= 4:
+        first_a = tail[0][1]
+        last_a = tail[-1][1]
+        rises = sum(1 for i in range(1, len(tail)) if tail[i][1] > tail[i - 1][1])
+        frac_rising = rises / (len(tail) - 1)
+        print(f'oldest due-job age:    {first_a:.0f}s -> {last_a:.0f}s over the window\'s '
+              f'second half ({frac_rising * 100:.0f}% of ticks rising)')
+        # Deliberately two conditions, not one: a queue can rise on most ticks
+        # while ending lower than it started (a sawtooth around a poll
+        # cadence), and it can end higher after a single spike without being
+        # unbounded. Both must hold before this reports growth.
+        growing = last_a > first_a and frac_rising > 0.6
+        if growing:
+            print('queue growth:          YES - the system was offered more than it took, '
+                  'so the sustained rate above IS the service rate, and therefore the knee')
+        else:
+            print('queue growth:          NO - the offered load did not exceed the system, '
+                  'so the sustained rate above is a FLOOR on the ceiling, not the knee. '
+                  'Offer more (deeper backlog or a faster poll cadence) and re-run')
+    else:
+        print('oldest due-job age:    too few ticks to judge growth')
+
+    backlogs = [num(r, 'feed_backlog') for r in rows]
+    known = [b for b in backlogs if b is not None]
+    if known:
+        print(f'stub feed backlog:     min={min(known):.0f} max={max(known):.0f} '
+              f'(reaching 0 here is NORMAL and not starvation - the poll pump '
+              f'converts upstream events into queued child jobs faster than '
+              f'they drain, so the upstream empties while the system is busiest)')
+    else:
+        print('stub feed backlog:     unknown on every tick')
+
+    # This, not the line above, is what post_guard_feed_starved consumes.
+    avail = [num(r, 'available_work') for r in rows]
+    known_avail = [a for a in avail if a is not None]
+    if known_avail:
+        m = min(known_avail)
+        print(f'available work:        min={m:.0f} max={max(known_avail):.0f} '
+              f'(upstream + due queue + running; min 0 means the system was IDLE '
+              f'for part of the window, so the achieved rate is a floor on the '
+              f'offered load rather than the system\'s ceiling)')
+    else:
+        print('available work:        unknown on every tick - the run cannot show '
+              'its instrument kept offering load')
+
+    peaks = [num(r, 'due_queued', 0.0) for r in rows]
+    print(f'due-queued peak:       {max(p for p in peaks if p is not None):.0f}')
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 3 or sys.argv[1] not in ('latency', 'throughput'):
+        print(__doc__)
+        sys.exit(2)
+    if sys.argv[1] == 'latency':
+        summarize_latency(sys.argv[2])
+    else:
+        summarize_throughput(sys.argv[2])

--- a/perf/openlinker-throughput/drivers/order-feed.sh
+++ b/perf/openlinker-throughput/drivers/order-feed.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+#
+# F1 driver library (#2847, epic #2840) - order-arrival primitives against the
+# Allegro upstream stub (#2856, wired onto the `lab` stand by #2935). Sourced
+# by scenarios/f1-order-ingestion.sh, never run standalone.
+#
+# Every generic guard/manifest/results primitive lives in lib.sh, per that
+# file's own rule; this library owns only what is specific to (a) pushing
+# orders into the stub, (b) asking OpenLinker to go and look, and (c) telling
+# whether the stub still had work left to hand over - none of which lib.sh
+# has a reason to know about.
+#
+# Requires the caller to have already sourced lib.sh (uses its pg_sql /
+# enqueue_perf_job / log / warn / die / iso_now / require_tools).
+#
+# ---------------------------------------------------------------------------
+# THE SHAPE OF "ARRIVAL RATE" ON THIS PATH, AND WHY IT IS NOT A k6 SCRIPT
+# ---------------------------------------------------------------------------
+# #2847 proposes `drivers/order-feed.js` driving a `ramping-arrival-rate`
+# executor. That shape does not describe this path, and adopting it would
+# have produced a number about the driver rather than about OpenLinker.
+#
+# OpenLinker never observes the instant an order appears at the marketplace.
+# It observes a PAGE, once per poll tick: `AllegroOrderSourceAdapter.
+# listOrderFeed` reads `GET /order/events?from={cursor}&limit=100` exactly
+# once per `marketplace.orders.poll` job - `OrderIngestionService.ingestOrders`
+# has no loop and no page budget. So an order pushed into the stub at
+# t=0.001s and one pushed at t=0.999s are, to OpenLinker, the same arrival:
+# both are simply rows in whatever page the next tick reads.
+#
+# The independent variable OpenLinker actually experiences is therefore
+#
+#     offered rate = min(page limit, backlog) / poll interval
+#
+# and both terms are things this driver sets explicitly: `of_push_orders`
+# controls the backlog, `of_enqueue_poll` controls the interval. A k6
+# arrival-rate executor firing `POST /__stub/tenants/{t}/orders` would vary
+# a third term that no OpenLinker code path can see.
+#
+# The consequence for the generator-saturation question (#2933, the F3
+# lesson) is that the k6-shaped guard has nothing to check here - a single
+# `POST .../orders` with `count: 400` mints the whole backlog in one request,
+# before the window even opens, so the pusher is structurally incapable of
+# being the bottleneck. The question that guard exists to answer -
+# "was the instrument, rather than the system, the ceiling?" - still applies
+# and is answered instead by `post_guard_feed_starved` (lib.sh, this issue):
+# a run whose stub RAN DRY offered less load than it could have, so its
+# achieved rate is a floor on the offered rate and not the system's ceiling.
+#
+set -euo pipefail
+
+# The stub's HOST-published address. The harness runs on the host, so this is
+# 127.0.0.1:19081 (docker-compose.lab.yml) and NOT the `http://allegro-stub:8080`
+# service address the api/worker containers use - same host-vs-network-namespace
+# distinction F3's TARGET_URL and F2's OL_API_INTERNAL_URL each carry.
+OF_STUB_URL="${OF_STUB_URL:-http://127.0.0.1:19081}"
+
+# The cursor row OpenLinker persists for an Allegro order feed. Fixed by the
+# scheduler task's own payload (`allegro-scheduler-tasks.ts`, generatePayload:
+# `cursorKey: 'allegro.orders.lastEventId'`), restated here because
+# `of_backlog` and the scenario's own reset both key on it.
+OF_CURSOR_KEY="${OF_CURSOR_KEY:-allegro.orders.lastEventId}"
+
+# The page limit the real scheduler task passes. Restated rather than invented:
+# `allegro-scheduler-tasks.ts` hardcodes `limit: 100` with no env var, so a run
+# that passed anything else would be measuring a configuration no deployment
+# can reach.
+OF_POLL_LIMIT="${OF_POLL_LIMIT:-100}"
+
+# ---------------------------------------------------------------------------
+# of_curl <method> <path> [json-body]
+# Dies on a non-2xx, printing the body - the same reasoning as lib.sh's
+# `ol_api`: a stub refusal is exactly where a scenario tends to fail, and
+# `curl -f` alone would hide the message that says why.
+# ---------------------------------------------------------------------------
+of_curl() {
+  local method="$1" path="$2" body="${3:-}" resp status resp_body
+  if [ -n "$body" ]; then
+    resp="$(curl -sS -w '\n%{http_code}' -X "$method" "$OF_STUB_URL$path" \
+      -H 'Content-Type: application/json' -d "$body")"
+  else
+    resp="$(curl -sS -w '\n%{http_code}' -X "$method" "$OF_STUB_URL$path")"
+  fi
+  status="${resp##*$'\n'}"
+  resp_body="${resp%$'\n'*}"
+  if [ "$status" -lt 200 ] || [ "$status" -ge 300 ]; then
+    die "stub $method $path -> HTTP $status: $resp_body"
+  fi
+  printf '%s' "$resp_body"
+}
+
+# of_config - the stub's own resolved configuration. Read into the manifest
+# rather than restated from docker-compose.lab.yml, so the manifest asserts
+# against the stub's RUNNING state (its own README makes this the point of
+# the endpoint) instead of against what somebody believed it was started with.
+of_config() { of_curl GET /__stub/config; }
+
+of_health() { of_curl GET /__stub/health; }
+
+# ---------------------------------------------------------------------------
+# of_new_run [run_id] - start a fresh stub run, resetting every tenant's
+# event/order history and counters.
+#
+# This is NOT optional housekeeping. The child job's Redis dedupe key is
+# `marketplace:{connectionId}:order:{eventKey}` with a 7-day TTL
+# (`order-ingestion.service.ts`, `redis-streams-job-enqueue.service.ts`), and
+# `eventKey` is the stub's own event id. Repeating this scenario inside that
+# window without a new run id re-mints the identical keys the previous run
+# already reserved, so every enqueue silently no-ops - `n = 0`, the cursor
+# still commits, and nothing in the result distinguishes a fully-deduped tick
+# from a fresh one (the stub's README states this in its own words).
+# ---------------------------------------------------------------------------
+of_new_run() {
+  local run_id="${1:-}" body='{}'
+  [ -z "$run_id" ] || body="$(jq -n --arg r "$run_id" '{runId:$r}')"
+  of_curl POST /__stub/run "$body" | jq -r '.runId'
+}
+
+# ---------------------------------------------------------------------------
+# of_push_orders <tenant> <count> [line_items_per_order] [events_per_order]
+# Echoes the number of orders the stub reports it minted.
+#
+# Minted orders sit in the stub's in-memory event list until something polls
+# for them; the stub never pushes. That is what makes backlog depth an
+# independent variable this scenario sets rather than a property it inherits.
+# ---------------------------------------------------------------------------
+of_push_orders() {
+  local tenant="$1" count="$2" lines="${3:-1}" events="${4:-1}" body resp minted
+  body="$(jq -n --argjson c "$count" --argjson l "$lines" --argjson e "$events" \
+    '{count:$c, lineItemsPerOrder:$l, eventsPerOrder:$e}')"
+  resp="$(of_curl POST "/__stub/tenants/$tenant/orders" "$body")"
+  # `.minted | length` rather than echoing the request's own `count` back -
+  # the stub answers with the list it ACTUALLY minted, and trusting the
+  # request would report a number the stub never confirmed. The field is
+  # `minted` (server.mjs), not `orders`; getting that wrong reads as "the stub
+  # minted 0" on a push that in fact succeeded, which is how it was found.
+  minted="$(printf '%s' "$resp" | jq -r '(.minted // []) | length')"
+  [ "${minted:-0}" -eq "$count" ] \
+    || warn "of_push_orders: asked for $count order(s) on $tenant, stub minted ${minted:-0}"
+  printf '%s' "${minted:-0}"
+}
+
+of_stats() { of_curl GET "/__stub/tenants/$1/stats"; }
+
+# of_request_count <tenant> <key> - one endpoint's served-request count, e.g.
+# `of_request_count perf-allegro-a 'GET /order/events'`. Absent means the
+# endpoint was never reached, which is 0 here (the stub only creates a key on
+# first use), NOT "unknown" - and that distinction is safe only because the
+# same call site always reads a key the stub is known to create.
+of_request_count() {
+  of_stats "$1" | jq -r --arg k "$2" '.requestCounts[$k] // 0'
+}
+
+# ---------------------------------------------------------------------------
+# of_seq <event_id> - the monotone per-tenant sequence number inside a stub
+# event id. Ids are `{runId}-{6-digit-seq}` (`server.mjs`, and deliberately
+# NOT a bare decimal so OpenLinker's own `compareOrderCursors` regression
+# guard reads them as `unrecognised` rather than as a regression).
+#
+# Echoes nothing for an id this function cannot parse. A caller must treat
+# that as UNKNOWN and never as 0 - reading an unparseable cursor as sequence
+# zero would report a fully-drained feed as a full backlog.
+# ---------------------------------------------------------------------------
+of_seq() {
+  local id="${1:-}"
+  case "$id" in
+    *-[0-9][0-9][0-9][0-9][0-9][0-9]) printf '%s' "$((10#${id##*-}))" ;;
+    *) printf '' ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# of_backlog <tenant> <connection_id>
+#
+# How many minted events OpenLinker has NOT yet consumed: the stub's own head
+# sequence minus the sequence OpenLinker's persisted `connection_cursors` row
+# has committed. Echoes `unknown` when either side cannot be parsed.
+#
+# Why this number is load-bearing rather than diagnostic: it is the whole
+# evidence for `post_guard_feed_starved`. A throughput arm whose backlog
+# reaches 0 while its window is still open stopped offering load, so its
+# achieved rate is a statement about this driver and not about OpenLinker -
+# the same failure that nearly published F3's generator ceiling as the
+# system's (#2933), arriving through a different door.
+#
+# `unknown` on a run whose stub has minted nothing yet is correct and
+# expected (there is no head to compare against); a caller in a measured
+# window must treat `unknown` as a reason to refuse, never as "fine".
+# ---------------------------------------------------------------------------
+of_backlog() {
+  local tenant="$1" conn="$2" head_id head_seq cur_id cur_seq
+  head_id="$(of_stats "$tenant" | jq -r '.currentCursor // empty')"
+  [ -n "$head_id" ] || { printf 'unknown'; return 0; }
+  head_seq="$(of_seq "$head_id")"
+  [ -n "$head_seq" ] || { printf 'unknown'; return 0; }
+
+  cur_id="$(pg_sql "SELECT COALESCE(value,'') FROM connection_cursors WHERE \"connectionId\"='$conn' AND \"cursorKey\"='$OF_CURSOR_KEY'" 2>/dev/null || printf '')"
+  # No cursor row at all is a REAL, meaningful state, not an error: nothing
+  # has been consumed, so the whole head is backlog.
+  [ -n "$cur_id" ] || { printf '%s' "$head_seq"; return 0; }
+  cur_seq="$(of_seq "$cur_id")"
+  [ -n "$cur_seq" ] || { printf 'unknown'; return 0; }
+
+  # A cursor from a PREVIOUS stub run compares meaninglessly against this
+  # run's head (each run restarts the sequence at 0), so a negative result is
+  # reported as unknown rather than clamped to 0 - clamping would silently
+  # claim a drained feed on exactly the run-mismatch this catches.
+  if [ "$cur_seq" -gt "$head_seq" ]; then printf 'unknown'; return 0; fi
+  printf '%s' "$((head_seq - cur_seq))"
+}
+
+# ---------------------------------------------------------------------------
+# of_enqueue_poll <connection_id> <tag>
+#
+# Enqueue one `marketplace.orders.poll` job by hand, with the payload the
+# real Allegro scheduler task generates (`allegro-scheduler-tasks.ts`:
+# `{schemaVersion: 1, cursorKey: 'allegro.orders.lastEventId', limit: 100}`).
+#
+# THE SCHEDULER IS DELIBERATELY NOT USED, and this is the single most
+# consequential methodology choice in F1. Turning `OL_SCHEDULER_ENABLED` on
+# would fire the Allegro poll cron - and, on this stand, every OTHER default-on
+# task with it, including the PrestaShop master sweeps, whose parents share
+# the `fan-out` lane with `marketplace.orders.poll` itself
+# (`handler-registration.service.ts`) at 8 total / 4 per scope. #2847's own
+# acceptance criteria name that co-tenancy as a contaminant to control for.
+#
+# So the harness owns the poll cadence outright. The cost is stated rather
+# than hidden: the poll-WAIT term this run reports is a cadence this script
+# chose, not one any deployment experiences, exactly as F2 reports its
+# t1->t2 hop as excluded-by-construction. The real cadences are recorded in
+# the manifest separately, as DERIVED figures read from the plugin defaults
+# and the worker's own environment.
+#
+# The idempotency key carries a caller-supplied tag plus a millisecond
+# timestamp. The real task's key is `marketplace:{id}:orders:poll:{ts}` at
+# second resolution; at the cadences a throughput arm drives, two polls can
+# legitimately land inside one second, and a colliding key would silently
+# dedupe the second one away (`isExisting: true`) while the run went on
+# believing it had offered another page.
+# ---------------------------------------------------------------------------
+of_enqueue_poll() {
+  local conn="$1" tag="${2:-f1}" key
+  key="marketplace:$conn:orders:poll:$tag:$(date +%s%3N)"
+  enqueue_perf_job 'marketplace.orders.poll' "$conn" \
+    "{\"schemaVersion\":1,\"cursorKey\":\"$OF_CURSOR_KEY\",\"limit\":$OF_POLL_LIMIT}" "$key" >/dev/null
+  printf '%s' "$key"
+}

--- a/perf/openlinker-throughput/lib-test.sh
+++ b/perf/openlinker-throughput/lib-test.sh
@@ -513,6 +513,128 @@ FAKE_PG[count]=1
 assert_contains "DISCARDED when a failed syncStatus entry exists" "$(post_guard_destination_creates '2026-01-01T00:00:00Z' '')" "DISCARDED"
 FAKE_PG[count]=0
 
+echo "--- reset_between_repeats SCAN loop (#2847) ---"
+# This function shipped with NO CALLER in any scenario, so its SCAN loop had
+# never executed. It used `redis-cli --no-raw`, whose reply renders as
+# `1) "8192"` - `head -1` then fed `1) "8192"` back as the cursor, Redis
+# answered `ERR invalid cursor`, that string is never `0`, and the loop spun
+# for ever. Observed live before the fix: a scenario stuck at 0% with a
+# `SCAN (error) ERR invalid cursor` child process.
+#
+# Both directions are asserted: a well-behaved raw reply terminates, and a
+# malformed cursor DIES rather than looping. The second is the one that
+# matters - the original failure was survivable only because it was silent.
+RESET_SCAN_CALLS_FILE="$(mktemp)"
+RESET_SCAN_MODE=raw
+# Only `redis_cli` is faked here. `pg_sql_write`'s own fake RECORDS the SQL it
+# was handed and a later cap_perf_job_attempts test asserts against those
+# recordings - replacing it with a no-op made three unrelated assertions fail
+# with an empty haystack.
+redis_cli() {
+  case "$1" in
+    SCAN)
+      printf '1\n' >> "$RESET_SCAN_CALLS_FILE"
+      if [ "$RESET_SCAN_MODE" = "noraw" ]; then
+        # Exactly what `--no-raw` produced, which is what caused the hang.
+        printf '1) "8192"\n2) 1) "jobdedup:x:conn-1:y"\n'
+      else
+        # Raw: bare cursor on line 1, one key per line after. Terminates on
+        # the second call by answering cursor 0.
+        if [ "$(wc -l < "$RESET_SCAN_CALLS_FILE")" -lt 2 ]; then
+          printf '8192\njobdedup:a:conn-1:1\njobdedup:a:conn-1:2\n'
+        else
+          printf '0\njobdedup:a:conn-1:3\n'
+        fi
+      fi ;;
+    DEL) printf '1' ;;
+    *) printf '' ;;
+  esac
+}
+assert_ok "a raw SCAN reply terminates the loop" \
+  reset_between_repeats "'conn-1'" "'allegro.orders.lastEventId'"
+assert_eq "and it issued exactly the two SCAN calls the fake scripted" "2" \
+  "$(wc -l < "$RESET_SCAN_CALLS_FILE" | tr -d ' ')"
+
+: > "$RESET_SCAN_CALLS_FILE"
+RESET_SCAN_MODE=noraw
+# Without the guard this call never returns, so a regression here hangs the
+# test suite rather than failing it - which is itself the signal.
+assert_dies "a non-numeric cursor dies instead of looping for ever" \
+  reset_between_repeats "'conn-1'" "'allegro.orders.lastEventId'"
+rm -f "$RESET_SCAN_CALLS_FILE"
+# Restore the stand-lock fake the later guard tests rely on.
+redis_cli() {
+  case "$1" in
+    SET) if [ -n "$(fake_redis_get)" ]; then printf ''; else fake_redis_set "$3"; printf 'OK'; fi ;;
+    GET) fake_redis_get ;;
+    DEL) fake_redis_set ""; printf '1' ;;
+    *) printf '' ;;
+  esac
+}
+
+echo "--- post_guard_feed_starved ---"
+# The counterpart to post_guard_generator_saturated for a scenario whose load
+# is a standing supply of work rather than an HTTP generator (#2847/F1).
+# Both answer "was the instrument, not the system, the ceiling?" and both
+# reach the same wrong conclusion when they cannot: an achieved rate reported
+# as a ceiling when it is a floor on what the instrument offered.
+#
+# The input is AVAILABLE WORK - upstream supply PLUS the due queue - not an
+# upstream backlog alone. A poll pump that drains its upstream into queued
+# child jobs empties the upstream while the system is at its busiest, so a
+# backlog-only reading would discard every valid run. See the guard's own
+# docblock; these assertions are worded in those terms so a later edit cannot
+# quietly narrow the input back.
+assert_eq "no standing supply is not applicable, and passes" "ok" \
+  "$(post_guard_feed_starved "")"
+assert_eq "work that was always available passes" "ok" \
+  "$(post_guard_feed_starved "137")"
+assert_eq "exactly 1 unit of available work still passes - it never ran dry" "ok" \
+  "$(post_guard_feed_starved "1")"
+assert_contains "available work reaching zero is discarded" \
+  "$(post_guard_feed_starved "0")" "DISCARDED"
+# Asserted on the SPECIFIC wording, not merely on DISCARDED: the refusal has
+# to say that the number is a floor on the OFFERED rate, or a reader takes the
+# discarded run's figure at face value anyway - which is exactly what nearly
+# happened to F3's ~600/s (#2933).
+assert_contains "the zero refusal names what the number actually is" \
+  "$(post_guard_feed_starved "0")" "floor on the OFFERED rate"
+assert_contains "the zero refusal names the remedy" \
+  "$(post_guard_feed_starved "0")" "deeper backlog"
+# It must name BOTH halves of the sum, or the next reader repeats the mistake
+# this guard's own first draft made and passes an upstream backlog alone.
+assert_contains "the zero refusal names both halves of available work" \
+  "$(post_guard_feed_starved "0")" "the due queue were BOTH empty"
+# `unknown` must never be read as "fine". A run that cannot show its
+# instrument kept offering load is not a run whose instrument behaved - the
+# same rule the generator guard applies to a missing k6 summary.
+assert_contains "unestablished available work is discarded, never skipped" \
+  "$(post_guard_feed_starved "unknown")" "DISCARDED"
+assert_contains "the unknown refusal says it could not be established" \
+  "$(post_guard_feed_starved "unknown")" "could not be established"
+# A malformed value must not fall through to the zero branch (which would give
+# the right verdict for the wrong reason) nor to "ok" (which would be silent).
+assert_contains "a non-numeric value is discarded as unreadable" \
+  "$(post_guard_feed_starved "3 orders")" "unreadable available-work value"
+assert_contains "a negative value is discarded as unreadable" \
+  "$(post_guard_feed_starved "-1")" "unreadable available-work value"
+
+echo "--- run_post_guards threads the feed guard through ---"
+# The 9th positional argument is the one a scenario can silently forget, which
+# is the failure mode the k6-summary argument already has a warning about in
+# run_post_guards' own docblock. These two assertions pin both directions.
+FAKE_PG[count]=0
+RPG_DIR="$(mktemp -d)"
+run_post_guards "$RPG_DIR" "'c1'" '2026-01-01T00:00:00Z' 0 9999999999 '' '' '' '' >/dev/null 2>&1 || true
+assert_eq "omitting the feed argument leaves the verdict VALID (not applicable)" \
+  "VALID" "$(verdict_read "$RPG_DIR" | head -1)"
+run_post_guards "$RPG_DIR" "'c1'" '2026-01-01T00:00:00Z' 0 9999999999 '' '' '' '0' >/dev/null 2>&1 || true
+assert_eq "a starved feed reaches the verdict as DISCARDED" \
+  "DISCARDED" "$(verdict_read "$RPG_DIR" | head -1)"
+assert_contains "and the verdict carries the feed guard's own reason" \
+  "$(verdict_read "$RPG_DIR")" "post_guard_feed_starved"
+rm -rf "$RPG_DIR"
+
 echo "--- post_guard_limiter_degraded ---"
 FAKE_LOG["degraded-container"]="Redis rate limiter unavailable for connection abc — falling back to per-process in-memory limiting (degraded, not unthrottled). timeout"
 WORKER_CONTAINERS="degraded-container"

--- a/perf/openlinker-throughput/lib.sh
+++ b/perf/openlinker-throughput/lib.sh
@@ -1152,12 +1152,37 @@ reset_between_repeats() {
   # order-ingestion.service.ts:239, redis-streams-job-enqueue.service.ts:23).
   # SCAN rather than KEYS - this runs against the shared redis-data volume,
   # never blocking, matching the #2590 finding of 37,500+ standing keys.
+  #
+  # RAW output, never `--no-raw`. This function shipped with `--no-raw` and had
+  # NO CALLER in any scenario until F1 (#2847) - F3 only names it in a comment
+  # explaining why it does not use it - so the flag had never executed. It
+  # cannot work: `--no-raw` asks redis-cli for its human-readable form, which
+  # renders the SCAN reply as
+  #
+  #     1) "8192"
+  #     2) 1) "jobdedup:..."
+  #
+  # so `head -1` yields `1) "8192"`, feeding `1) "8192"` back as the next
+  # cursor. Redis answers `ERR invalid cursor`, that string is not `0`, and the
+  # `while true` loop spins for ever issuing the same failing command. Observed
+  # live: a scenario sat at 0% progress with a `docker exec ... SCAN (error) ERR
+  # invalid cursor ...` child, indefinitely.
+  #
+  # Raw mode prints the cursor bare on line 1 and one key per line after it,
+  # which is exactly the shape the parsing below already assumed.
   for conn_id in $(printf '%s' "$conn_ids" | tr -d "'" | tr ',' ' '); do
     n=0
-    local cursor=0 batch
+    local cursor=0 batch guard=0
     while true; do
-      batch="$(redis_cli --no-raw SCAN "$cursor" MATCH "jobdedup:*:${conn_id}:*" COUNT 1000)"
+      batch="$(redis_cli SCAN "$cursor" MATCH "jobdedup:*:${conn_id}:*" COUNT 1000)"
       cursor="$(printf '%s' "$batch" | head -1)"
+      # FAIL FAST on a cursor that is not a plain integer. The bug above was
+      # survivable only because it was silent; a loop whose termination
+      # condition can never be met must abort rather than spin, so a future
+      # redis-cli output change is a loud failure and not another hang.
+      case "$cursor" in
+        ''|*[!0-9]*) die "reset_between_repeats: redis SCAN answered a non-numeric cursor [$cursor] - refusing to loop. Full reply: $batch" ;;
+      esac
       local keys
       keys="$(printf '%s' "$batch" | tail -n +2)"
       if [ -n "$keys" ]; then
@@ -1166,6 +1191,12 @@ reset_between_repeats() {
         n=$((n + $(printf '%s\n' "$keys" | wc -l)))
       fi
       [ "$cursor" != "0" ] || break
+      # A second belt: SCAN is guaranteed to terminate, but only against a
+      # server that keeps its promises. Bounding the iteration count turns a
+      # pathological server into a named failure instead of a hung campaign.
+      guard=$((guard + 1))
+      [ "$guard" -lt "${RESET_SCAN_MAX_ITERATIONS:-100000}" ] \
+        || die "reset_between_repeats: SCAN did not complete within ${RESET_SCAN_MAX_ITERATIONS:-100000} iterations for connection $conn_id"
     done
     [ "$n" -eq 0 ] || log "reset_between_repeats: deleted $n jobdedup:* key(s) for connection $conn_id"
   done
@@ -1383,6 +1414,64 @@ post_guard_generator_saturated() {
   ' "$summary_path" 2>/dev/null || echo "DISCARDED post_guard_generator_saturated: could not parse $summary_path"
 }
 
+# post_guard_feed_starved - the system must never have RUN OUT OF WORK inside
+# the window, or the run measured the driver rather than OpenLinker.
+#
+# This is `post_guard_generator_saturated`'s counterpart for a scenario whose
+# load does not arrive over HTTP from k6 (#2847/F1). There the instrument is a
+# request generator and the failure is "k6 was at its own ceiling"; here the
+# instrument is a supply of pending work and the failure is the mirror image -
+# "the supply ran dry and the system sat idle". Both produce the same wrong
+# conclusion, which #2933 records F3 nearly publishing: an achieved rate
+# reported as the system's ceiling when it is in fact a floor on what the
+# instrument offered.
+#
+# THE INPUT IS AVAILABLE WORK, NOT AN UPSTREAM BACKLOG, and the distinction is
+# the whole correctness of the guard. F1's first draft passed the ALLEGRO STUB's
+# own un-polled backlog, which is wrong in the dangerous direction: a poll pump
+# reading 100 events every 10 seconds drains a 900-order stub in 90 seconds and
+# turns every one of them into a queued child job, so the stub reads empty
+# while OpenLinker is at its busiest. That would have discarded every valid
+# throughput run. What the guard actually needs is the total the system could
+# still have worked on - upstream supply PLUS whatever is already queued and
+# due - and it is zero only when the system genuinely had nothing to do.
+#
+# It is deliberately a PURE function of one already-measured number rather
+# than a reader of anything, because the guard that cannot see is this
+# harness's other recurring failure (post_guard_limiter_degraded answered "ok"
+# on every scenario of this campaign while structurally unable to match a
+# line, #2851). The scenario samples available work on every observer tick and
+# passes the MINIMUM it saw; whether that sensor works is then provable
+# against the live stand by a scenario's own --smoke, not asserted here.
+#
+# Three inputs, told apart on purpose:
+#   ""        -> the scenario offers no standing supply (a serial,
+#                one-order-at-a-time latency arm deliberately runs the system
+#                dry between samples). Not applicable.
+#   "unknown" -> available work could not be established for at least one
+#                tick. DISCARDS: a run that cannot show its instrument was
+#                still offering load is not a run whose instrument behaved,
+#                which is the same rule post_guard_generator_saturated applies
+#                to a missing k6 summary.
+#   <integer> -> 0 discards, anything positive is ok.
+post_guard_feed_starved() {
+  local min_available="${1:-}"
+  [ -n "$min_available" ] || { echo "ok"; return 0; }
+  if [ "$min_available" = "unknown" ]; then
+    echo "DISCARDED post_guard_feed_starved: available work could not be established for at least one observer tick - a run that cannot show its instrument was still offering load cannot report a ceiling"
+    return 0
+  fi
+  if ! [ "$min_available" -ge 0 ] 2>/dev/null; then
+    echo "DISCARDED post_guard_feed_starved: unreadable available-work value '$min_available' - expected a non-negative integer, the empty string, or 'unknown'"
+    return 0
+  fi
+  if [ "$min_available" -eq 0 ]; then
+    echo "DISCARDED post_guard_feed_starved: the system ran out of work inside the window (upstream supply and the due queue were BOTH empty on at least one tick), so it was idle for part of the measurement - the achieved rate is a floor on the OFFERED rate, not the system's ceiling. Push a deeper backlog (or a shorter window) and re-run"
+    return 0
+  fi
+  echo "ok"
+}
+
 # ---------------------------------------------------------------------------
 # verdict - VALID / DISCARDED + reason, with a documented, machine-parseable
 # schema (--resume parses it, #2845). One `key=value` per line, LF-terminated,
@@ -1420,8 +1509,15 @@ verdict_read() {
 # genuinely has none (F2). Omitting it for a k6 scenario silently skips the
 # generator check, which is the shape post_guard_generator_saturated exists to
 # stop - so scenarios should pass it even when they expect it to pass.
+#
+# `min_available_work` (9th, #2847) carries the same "absence is meaningful"
+# rule one instrument over: pass the minimum AVAILABLE WORK observed across
+# the window (upstream supply plus the due queue - see post_guard_feed_starved
+# for why an upstream backlog alone is the wrong number) for any scenario
+# whose load is a standing supply, and leave it empty only for one that
+# deliberately runs the system dry between samples.
 run_post_guards() {
-  local dir="$1" conn_ids="$2" ws_iso="$3" ws_epoch="$4" we_epoch="$5" dest="${6:-}" k6_summary="${7:-}" k6_executor="${8:-ramping-arrival-rate}"
+  local dir="$1" conn_ids="$2" ws_iso="$3" ws_epoch="$4" we_epoch="$5" dest="${6:-}" k6_summary="${7:-}" k6_executor="${8:-ramping-arrival-rate}" min_available_work="${9:-}"
   local results=() r
   results+=("$(post_guard_attempts "$conn_ids" "$ws_iso")")
   results+=("$(post_guard_deferrals "$conn_ids" "$ws_iso")")
@@ -1429,6 +1525,7 @@ run_post_guards() {
   results+=("$(post_guard_destination_creates "$ws_iso" "$dest")")
   results+=("$(post_guard_limiter_degraded "$ws_epoch" "$we_epoch")")
   results+=("$(post_guard_generator_saturated "$k6_summary" "$k6_executor")")
+  results+=("$(post_guard_feed_starved "$min_available_work")")
 
   local reasons=()
   for r in "${results[@]}"; do

--- a/perf/openlinker-throughput/results-F1-2026-09-07.md
+++ b/perf/openlinker-throughput/results-F1-2026-09-07.md
@@ -1,0 +1,438 @@
+# F1 - order ingestion latency and throughput
+
+_Run 2026-09-07, image `af6802cbff9e1c53c1268e5a52b935e00d594fba`, stand `lab`._
+
+## Headline
+
+| Question | Answer | Status |
+|---|---|---|
+| How long does one order take to reach a real shop? | **p50 66 s** (idle system, excludes poll wait) | measured, verdict DISCARDED |
+| How many orders per hour, at the shipped defaults? | **182 orders/h** | measured, verdict DISCARDED |
+| ...with the destination rate limit lifted? | **262-295 orders/h** | measured, verdict DISCARDED |
+| What binds first? | the destination's declared rate limit - **through minimum inter-request SPACING, not through its budget** | measured |
+| What binds ABOVE that? | not established - the lane-cap arm never applied its own change | **not measured** |
+
+**Every window was DISCARDED.** Read the figures as provisional. The two
+causes, and the four things this run did not establish, are set out at the end
+- please read those before quoting anything here.
+
+**The single most actionable finding** is one component seen misbehaving in two
+different ways at once, and the two should be read together rather than as
+separate curiosities:
+
+1. `requestsPerMinute: 60` throttles by imposing a **1-second minimum gap
+   between requests**, not by spending a per-minute budget. The baseline never
+   exceeded 2 requests in any second across 118 sampled seconds while using
+   only **34 of its 60 req/min** - so 10-14 s of pacing was paid per order
+   with 43% of the budget unused.
+2. The same limiter burns its **full 1000 ms Redis timeout** roughly once a
+   minute and degrades to per-process limiting, against a Redis measured
+   healthy on every axis (0 ms latency, empty slowlog, 18 MB, plain string
+   keys).
+
+That reads as an implementation problem in the outbound rate limiter rather
+than a configuration choice.
+
+## Conditions
+
+- **Stand**: `lab` (`docker-compose.lab.yml`, #2854), a single developer
+  workstation sharing a host with two other OpenLinker docker-compose stacks
+  (`ol-demo-fresh-*`, `openlinker-*`). No CPU pinning, no memory limits on
+  `lab-api` or `lab-worker-1` (`containerLimits` in every manifest reads
+  `none`), and no isolation from host contention. Every figure below is
+  subject to that.
+- **Source**: the Allegro upstream stub (#2856/#2935) at
+  `http://allegro-stub:8080`, tenant `perf-allegro-a`, serving
+  `GET /order/events` at a configured **276 ms** and
+  `GET /order/checkout-forms/{id}` at **1106 ms** - the p50s #2861 measured
+  against the real Allegro sandbox. A stub answering instantly would measure
+  only OpenLinker's own local overhead; these two constants are what make the
+  run externally meaningful rather than merely self-consistent. Neither is a
+  distribution (both endpoints measured multi-modal), which remains a
+  documented limitation.
+- **Destination**: the real local PrestaShop (#2860), never #2846's stub. This
+  is #2847's own requirement for the headline figure.
+- **Runner**: ENABLED (`guard_runner_state enabled`). **Scheduler: OFF**
+  (`guard_scheduler_off`), so no master sweep shares the `fan-out` lane with
+  `marketplace.orders.poll` during any window - #2847's named co-tenancy
+  contaminant, controlled.
+- Lane caps as resolved by the runner itself:
+  `realtime=4/2 bulk=12/8 fiscal=2/1 fan-out=8/4`, **one worker replica**.
+  Every cap is per PROCESS (ADR-050 amendment #2594).
+- Postgres carries a live `statement_timeout=30000ms` on the `postgres` role
+  (the #2934 finding) and holds **1 000 000 pre-seeded `order_records`** from
+  the F5 dataset. That is a fixed dataset size, never an arrival rate.
+
+## Provenance of every latency point
+
+A **documented cross-table reconstruction**, not #2850 instrumentation
+(#2850 does not exist). #2847 requires that choice to be declared rather than
+made silently. Each of the caveats it names is handled rather than restated:
+
+| Caveat | Treatment |
+|---|---|
+| `lockedAt` is rewritten every 3 min by the heartbeat | Counted, not assumed - the summarizer prints how many sampled jobs ran >= 180 s |
+| `lastAttemptDurationMs` is the LAST attempt only | Counted - the summarizer prints how many children took more than one attempt, and those rows are excluded from the derived claim instant |
+| `syncStatus[].syncedAt` is biased late (stamped after the slowest of N parallel destination creates) | Removed STRUCTURALLY - each arm disables the other destination connection, so the fan-out has exactly one member |
+
+**A fourth caveat #2847 does not list, and it is the larger one.**
+`SyncJobRepository.markSucceeded` sets `lockedAt: null` alongside
+`status: 'succeeded'`, so a job read after it finishes carries no claim
+instant at all. A reconstruction that read the column at the end would report
+four of the seven hops as "never observed" on every sample. Two independent
+sources are captured instead, and the summarizer reports which answered for
+each row:
+
+- **latched** - the first non-empty `lockedAt` the sample's own 1 Hz poll saw
+  while the job was still running. A real observation, missable when a job
+  starts and finishes inside one tick.
+- **derived** - `updatedAt - lastAttemptDurationMs`. The runner measures the
+  attempt itself and stamps it by the same UPDATE that moves `updatedAt`, so
+  on a single-attempt job this is exact and, unlike the latch, immune to the
+  heartbeat rewrite.
+
+One point in #2847's own table has **no proxy and is not reported**: "the poll
+observed it". Nothing persists it. The two hops either side bracket it.
+
+## Poll wait is excluded by construction, not measured as fast
+
+The scheduler is off and the harness enqueues every `marketplace.orders.poll`
+itself, so **hop A is a cadence this script chose** and is not a figure any
+deployment experiences. This is the same shape F2 reports for its shop-cron
+hop. Turning the scheduler on would have fired the PrestaShop master sweeps
+with it, whose parents share the `fan-out` lane with the order poll.
+
+The real cadences, recorded in every manifest as **derived** (read from the
+worker environment falling back to the plugin literal - there is no running
+scheduler to read from):
+
+| Source | Cron | Mean poll wait | Retunable without a code change? |
+|---|---|---|---|
+| Allegro | `*/1 * * * *` | 30 s | yes - `OL_ALLEGRO_POLL_INTERVAL_CRON`, **on the worker** (#2279) |
+| PrestaShop | `0 */10 * * * *` | webhook-primary, poll is the backstop | yes - `OL_PRESTASHOP_POLL_INTERVAL_CRON` |
+| WooCommerce | `*/5 * * * *` | 2.5 min | **no** - string literal |
+| Erli | `*/5 * * * *` | 2.5 min | **no** - string literal |
+
+To reconstruct a real end-to-end figure, take the TOTAL that excludes hop A
+and add your own source's mean poll wait.
+
+## Latency - one order, end to end, on an otherwise idle system
+
+**MEASURED.** 25 serial samples, one order in flight at a time, real
+PrestaShop destination, WooCommerce disabled so the fan-out has one member.
+**25 of 25 reached a destination create.** Zero retries, zero jobs over the
+3-minute heartbeat window, and the claim instant was **latched (observed while
+running) on all 25 samples for both jobs** - the derived fallback was never
+needed, so every hop below rests on an observation rather than a
+reconstruction.
+
+Percentiles carry the rank they resolved to, because at n=25 a "p95" is the
+24th of 25 observations and calling it p95 implies a tail it cannot have.
+
+```
+                                                  n    min        p50 (rank)      p95 (rank)      max
+A  order pushed at stub -> poll enqueued          25    8.3       9.9 (13/25)     13.9 (24/25)    15.0     HARNESS-CHOSEN
+B  poll enqueued -> poll claimed                  25   54.5     430.2 (13/25)    992.7 (24/25)  1220.6
+C  poll claimed -> child enqueued                 25 8789.2    9629.6 (13/25)  10381.6 (24/25) 10419.2
+D  child enqueued -> child claimed                25    4.5     301.8 (13/25)    915.1 (24/25)  1003.6
+E  child claimed -> order_records row written     25 2122.0    2127.0 (13/25)   3782.0 (24/25)  3819.0
+F  order_records written -> destination syncedAt  25 47805    52902   (13/25)   58394   (24/25) 61974
+G  child claimed -> child terminal                25 49944    55120.7 (13/25)   60528.5 (24/25) 64114.6
+TOTAL  poll enqueued -> destination syncedAt      25 60095.6  65552.6 (13/25)   71299.0 (24/25) 75131.5
+TOTAL  order pushed -> destination syncedAt       25 60105    65561   (13/25)   71309   (24/25) 75141
+```
+
+**In operator units: a single order takes a p50 of 66 seconds from appearing
+at the marketplace to existing in the shop, on an idle system**, plus the
+source's own poll wait (30 s mean for Allegro) which this run excludes by
+construction.
+
+### The destination shop is responsible for almost none of it
+
+Hop F - the destination create - is 81% of the total, at a p50 of **52.9 s**.
+It is **not** the shop:
+
+- **PrestaShop answers every create-path webservice call in 11-20 ms**,
+  measured directly from a container on the same docker network, three
+  samples per endpoint, *while the measurement was running*
+  (`countries` 11.3/13.0/16.8 ms, `currencies` 11.0/11.5/11.7 ms,
+  `order_states` 13.2/14.7/15.6/17.1/19.8 ms, `products/{id}`
+  13.3/14.0/14.1 ms).
+- The create makes **~16 destination requests per order** (measured over the
+  17 orders in the first 25 minutes of the window: 239 `/api/` requests =
+  14.06 per order, plus 34 `POST /index.php` module calls = 2.00 per order).
+- 16 requests x ~15 ms is **~0.24 s of shop time** inside a 52.9 s hop.
+
+So roughly **99.5% of the destination hop is OpenLinker-side**, not the
+destination's. Whatever is slow here, the shop is not it.
+
+### Per-order destination request breakdown (measured, 17 orders)
+
+| Resource | Per order | Note |
+|---|---:|---|
+| `GET products` | 1.41 | tax chain + the cascade's `filter[cache_is_pack]` |
+| `GET order_states` | 1.35 | |
+| `GET currencies` | 1.18 | |
+| `GET countries` | 1.18 | |
+| `GET` + `POST customers` | 2.00 | a NEW customer every order - see below |
+| `GET` + `POST addresses` | 2.00 | |
+| `POST carts` | 1.00 | |
+| `GET orders` | 1.00 | the `filter[reference]` pre-check |
+| `GET carriers` | 1.00 | not cached, one per order |
+| `GET stock_availables` | 0.94 | **the cascade, not the create path** |
+| `GET configurations` | 0.94 | **always 401 - see "wasted budget" below** |
+| `POST /index.php` | 2.00 | module: `cartshipping` + `importorder` |
+
+Status mix: 172x200, 51x201 (the three creations per order), **16x401**.
+
+**`line_prices` was advertised for this arm.** There is not one
+`specific_prices` POST or DELETE in the window, so the warm-up did its job and
+this is the 7-requests-per-line path rather than the 27-request cold one that
+#2847 asks to be excluded. Two warm-up orders per worker replica preceded the
+window.
+
+**Buyer provisioning is 4 of the 14 webservice requests.** The stub's buyer
+pool is 50 slots, so the first 50 orders each mint a distinct customer; all 25
+samples were cold buyers. A warm-buyer deployment would pay 4 fewer requests
+per order.
+
+### Wasted rate-limit budget: the `configurations` 401
+
+`GET /api/configurations?filter[name]=[PS_CURRENCY_DEFAULT]` answered **401 on
+every order** (16 of 16 in the counted window) because that resource was never
+granted to the stand's webservice account. The create path tolerates the
+failure, so the order still completes - which is exactly why it survived three
+other missing resources being found and fixed. It is not free: the outbound
+limiter takes its slot before the call, so **~7% of the destination's whole
+60/min budget is spent on a request that can never succeed**. Fixed in
+`bootstrap.sh` for future runs; the figures above still carry it.
+
+## Throughput
+
+**MEASURED.** Three 300-second saturation windows, each preceded by a
+900-order backlog pushed in one request before the window opened and a poll
+pump enqueuing one `marketplace.orders.poll` every 10 s. The knee is read off
+the sustained rate, not off the queue-growth flag: on an arm that deliberately
+offers more than the system can take, the queue grows by construction, so what
+the growth flag confirms is that the offered load really did exceed the system
+and the sustained rate therefore IS the service rate.
+
+Available work (upstream backlog + due queue + running) never dropped below
+897 on any arm, so `post_guard_feed_starved` passed - the instrument was never
+the limit.
+
+| Arm | Destination `config.rateLimit` | Lane caps ACTUALLY in force | Completed / 300 s | Sustained |
+|---|---|---|---:|---:|
+| baseline | manifest default 60/min, 4 concurrent | `realtime=4/2` | 16 | **182 orders/h** |
+| destination raised | 6000/min, 32 concurrent | `realtime=4/2` | 23 | **262 orders/h** |
+| "lane raised" | 6000/min, 32 concurrent | `realtime=4/2` **(the raise did not apply - see below)** | 26 | **295 orders/h** |
+
+### Run-to-run variance, measured by accident
+
+Because the third arm's lane raise never took effect, it is an **exact repeat
+of the second arm's configuration**. That gives the only same-configuration
+repeatability figure in the run: **262 vs 295 orders/h, a 12.6% spread**.
+Worth stating because the scenario's own "did the number move" threshold was
+15% - close enough to the observed noise that a smaller effect would not have
+been distinguishable from it. The baseline-to-raised change is +44% (or +53%
+against the two raised arms' 278/h mean), comfortably outside that.
+
+### The falsification: the destination limit WAS binding, through SPACING
+
+#2847 asks whether the destination's rate limit or the lane cap binds first.
+Lifting the destination limit moved the rate from 182 to 262-295 orders/h, so
+**the destination's declared limit was binding at the shipped default** - but
+not for the reason the issue's arithmetic assumes, and this needs saying
+precisely because it changes what an operator should do about it.
+
+Counting requests per second at PrestaShop, inside each measured window:
+
+| | 1 req/s | 2 req/s | 3 req/s | 9 req/s |
+|---|---:|---:|---:|---:|
+| baseline (60/min) | 106 s | 12 s | - | - |
+| destination raised (6000/min) | 54 s | 42 s | 1 s | 2 s |
+
+**The baseline never put more than 2 requests into any second, across 118
+sampled seconds, while using only 34 of its 60 req/min.** That is not a budget
+being exhausted - it is a **minimum inter-request spacing of one second**,
+applied whether or not the budget is anywhere near spent. At the measured
+10-14 requests per order that is **10-14 seconds of pure pacing per order**,
+paid on every order regardless of headroom.
+
+**A correction to an earlier reading of this run.** Partway through, this
+scenario's author reported the opposite - that request pacing was unchanged by
+the 100x raise, and therefore that the configured limit was never the pacing
+term. That sample was taken during the raised arm's WARM-UP rather than inside
+either measured window, and it was wrong. The corrected measurement above
+inverts the conclusion. It is recorded here rather than only in the commit
+because the withdrawn claim was the more intuitive one, and a reader who
+reaches the same intuition should meet the evidence against it.
+
+### Where the ceiling actually sits
+
+With the destination limit effectively removed, throughput stopped at 262-295
+orders/h. The next constraint is therefore **not** the destination, and the
+obvious candidate is the `realtime` lane's per-scope cap of 2 - which this run
+did **not** measure, for the reason in the next section.
+
+Note that the source connection's two per-scope `realtime` slots are not
+reserved for order syncs. Each ingested order sets off a cascade -
+`master.inventory.syncByExternalId` (realtime, scope `perf-prestashop`) ->
+`inventory.propagateToMarketplaces` (fan-out) -> two
+`marketplace.offerQuantity.update` (realtime, scopes `perf-allegro-a` and
+`perf-allegro-b`) - and the `perf-allegro-a` one competes for the SAME two
+slots the order syncs need. That is real production behaviour on a stand where
+the destination shop is also the inventory master, not harness noise, but it
+means "2 concurrent orders" overstates what the lane actually grants.
+
+## The arm that measured the wrong thing, and why that matters most
+
+**The lane-cap arm never raised the lane cap.** `recreate_worker` wrote
+`OL_LANE_REALTIME_SCOPE_CAP=16` into `.env.lab` and recreated the worker. That
+does nothing: an env-file entry is available for `${VAR}` interpolation inside
+the compose file, and is passed to a container only if the service's own
+`environment:` block names it - which `docker-compose.lab.yml`'s worker
+service does not, for either lane variable. Verified live: `docker exec
+lab-worker-1 printenv OL_LANE_REALTIME_SCOPE_CAP` was empty and the runner's
+startup line still read `realtime=4/2`.
+
+**A scenario that silently measures a configuration it did not request is the
+worst failure mode this harness has**, and this is squarely the
+reported-versus-enforced gap the rest of the programme keeps closing (#2229's
+rule that a reported ceiling and an enforced one must be the same read). What
+caught it and what did not is the instructive part:
+
+- **Caught**: `guard_runner_state` parses the runner's OWN startup line, so
+  `manifest.laneCaps` correctly recorded `realtime=4/2`.
+- **Missed**: the arm's label was hand-written and asserted
+  `"+ lane scope cap 16"`. The manifest therefore contradicts itself, and only
+  the derived half is true. It was broken in the one place a claim was written
+  instead of a reading.
+
+Three fixes are in this change, in order of importance:
+
+1. `recreate_worker` now **verifies** (`assert_lane_caps`) that the caps the
+   runner reports are the caps that were requested, and dies naming the
+   forwarding trap if not. Asking is not getting.
+2. Lane caps are forwarded through a scenario-local compose override that
+   declares them on the worker service, leaving #2854's shared stand file
+   untouched.
+3. The arm label is derived from `MANIFEST_LANE_CAPS` rather than asserted.
+
+## Per-order upstream cost (satisfies #1134 AC2)
+
+Counted at the stub, which is the only place that can separate the two rates.
+The serial latency arm runs one poll per order so they coincide there; the
+saturation arm separates them cleanly:
+
+| Arm | `GET /order/events` | `GET /order/checkout-forms/{id}` |
+|---|---:|---:|
+| latency (25 orders, 25 polls) | 25 | 25 |
+| baseline (18 orders, 30 poll ticks) | **30** = exactly the 30 ticks (300 s / 10 s) | **18** = exactly one per ingested order |
+
+**One request per poll tick, one per ingested order, zero per line item** -
+#2856's cost model confirmed at two different ratios rather than asserted at
+one. The poll cost amortises across orders; hydration tracks them one-for-one.
+
+The latency arm additionally shows 24 `PUT /sale/offer-quantity-change-commands/{id}`
+for 25 orders - the cascade's marketplace write-back, roughly one per order per
+Allegro connection. Those are outbound marketplace writes caused by ingesting
+an order, and they are not free.
+
+## Verdicts: every window was DISCARDED
+
+| Arm | Verdict | Reasons |
+|---|---|---|
+| latency | DISCARDED | limiter degraded, 39 lines in window |
+| baseline | DISCARDED | limiter degraded (34); 2 orders lacked `syncedAt` |
+| destination raised | DISCARDED | limiter degraded (52); 2 orders lacked `syncedAt` |
+| "lane raised" | DISCARDED | limiter degraded (41); 2 orders lacked `syncedAt` |
+
+**Every figure in this report is therefore PROVISIONAL.** Two distinct causes,
+and they are not equally serious.
+
+### 1. The rate limiter degrades against a Redis that is measurably healthy
+
+`RedisRateLimiterAdapter` logged *"Redis rate-limiter call `checkPace` timed
+out after 1000ms - falling back to per-process in-memory limiting"* roughly
+once a minute throughout. `post_guard_limiter_degraded` discards on it, and
+correctly - but everything that would explain it was measured and ruled out:
+
+| Checked | Result |
+|---|---|
+| Redis server latency | `--latency-history` reports 0 / 0 / 0.00 |
+| Redis slow commands | `SLOWLOG GET` is **empty** |
+| Redis memory | 18.46 MB of a 2 GB `maxmemory` |
+| Key shape | `ratelimit:pace:*` are plain STRINGS, not large ZSETs |
+| Host CPU | load average 0.59 across 28 cores |
+| Worker log volume | 402 lines / 50 KB per minute |
+
+So the 1000 ms timeout is **client-side in the worker**, not the server, and
+this run cannot attribute it further without product-side instrumentation.
+
+**Read this together with the spacing finding above, not separately.** One
+component - the outbound rate limiter - is both (a) throttling by minimum
+inter-request spacing rather than by budget, costing 10-14 s per order while
+57% of its budget goes unused, and (b) burning its full 1000 ms Redis timeout
+about once a minute against a server that answers in 0 ms. Separately they
+read as two curiosities. Together they read as one component that needs
+looking at, and they are the most actionable thing F1 found.
+
+Incidental, noted while ruling Redis out: the shared Redis carries **78 325
+standing `webhook:prestashop:*` keys** from the F3 campaign.
+
+### 2. `post_guard_destination_creates` is not saturation-aware
+
+Each throughput arm was also discarded for *"2 orders lack `syncedAt` on the
+declared destination"*. Both were orders created inside the window and still
+mid-create when it closed - which is **structural to any saturation arm**,
+since the entire point of one is to end with work in flight. The guard is
+correct for F2's shape (one write, drain, observe) and will fire on every
+throughput window ever run. It needs either a bound at
+`window_stop - max_expected_duration`, or an explicit "in-flight is expected"
+input. Left as a finding rather than worked around, because silencing it in
+this scenario would hide it from the next one.
+
+## What this did not establish
+
+- **No valid verdict on any arm.** Every window was DISCARDED, chiefly on a
+  real limiter degradation whose cause this run localised to the worker but
+  could not identify. The figures are provisional and should not be quoted as
+  a published OpenLinker throughput number.
+- **No lane-cap arm.** The raise never reached the container (above), so the
+  `realtime` per-scope cap of 2 - the leading candidate for the ceiling above
+  262-295 orders/h - remains unmeasured. The fixes in this change are what let
+  the next run measure it; deliberately not re-run here rather than produced
+  in a hurry.
+- **No WooCommerce arm.** The stand carries 10 000 WooCommerce `Product`
+  mappings and **none** names a numeric WC product id - `seed-catalogue.sh`
+  seeds mappings, never real WooCommerce products, and
+  `WooCommerceOrderProcessorAdapter.resolveLineItems` needs a real id. The arm
+  refuses up front and reports not-run, rather than burning a window to
+  produce a table of failures that a reader could mistake for a WooCommerce
+  performance result.
+- **No `log`-level figure.** #2847 requires job duration measured with the
+  worker at `log` rather than `debug`. That is **unsatisfiable on this build**:
+  `apps/worker/src/main.ts:28` hardcodes
+  `logger: ['error','warn','log','debug','verbose']` and no env override
+  exists anywhere in the tree. `guard_log_level` checks
+  `OL_LOG_BODY_MAX_BYTES`, not the level, so nothing catches it. An acceptance
+  criterion that cannot be satisfied is a fact about the code, not a gap in
+  the run - but every worker-side figure in this campaign is a debug-level
+  figure, and the results-D campaign already flagged that as inflating
+  OL-side timings.
+- **No separation of `requestsPerMinute` from `maxConcurrent`.** The raised
+  arm lifted both at once (60 -> 6000 and 4 -> 32), so it shows the declared
+  limit was binding without saying which half did it. The per-second histogram
+  points at the rate floor rather than the concurrency, but that is inference,
+  not a controlled result.
+- **No production-representative poll wait.** Excluded by construction; add
+  your source's own cadence (30 s mean for Allegro) to the totals.
+- **A small, non-representative product pool.** Only 6 real PrestaShop
+  products (11 non-stale variants) exist, so all 200 stub offer ids
+  round-robin onto them. The PrestaShop tax chain caches 24 h per
+  connection+product+country, so it warms almost immediately here and a real
+  catalogue would pay more per order than these figures show.
+- **A single worker replica, and no CPU or memory limits** on `lab-api` or
+  `lab-worker-1`. Every lane cap is per process, so a multi-replica deployment
+  multiplies them.

--- a/perf/openlinker-throughput/scenarios/f1-order-ingestion.sh
+++ b/perf/openlinker-throughput/scenarios/f1-order-ingestion.sh
@@ -1,0 +1,1213 @@
+#!/usr/bin/env bash
+#
+# F1 - order ingestion latency and throughput (#2847, epic #2840).
+#
+# Answers the two questions an adopter asks first, and answers them
+# separately because they are different questions:
+#
+#   LATENCY     how long does ONE order take to get from the marketplace into
+#               a real shop, broken down hop by hop, on an idle system?
+#   THROUGHPUT  how many orders per hour can OpenLinker sustain, and what
+#               binds first?
+#
+# The chain measured, and where each timestamp comes from:
+#
+#   t0  an order exists at the source            harness clock, at the stub push
+#   t1  a poll job is enqueued                   sync_jobs.createdAt   (poll)
+#   t2  the runner claims the poll               sync_jobs.lockedAt    (poll)
+#   t3  a marketplace.order.sync child exists    sync_jobs.createdAt   (child)
+#   t4  the runner claims the child              sync_jobs.lockedAt    (child)
+#   t5  the order snapshot is persisted          order_records.createdAt
+#   t6  the destination order is created         order_records.syncStatus[].syncedAt
+#
+# ---------------------------------------------------------------------------
+# THE FOUR-POINT LATENCY IS A DOCUMENTED CROSS-TABLE RECONSTRUCTION
+# ---------------------------------------------------------------------------
+# #2847 requires this choice to be declared rather than made silently: either
+# real instrumentation (#2850) or a reconstruction carrying its caveats
+# explicitly. #2850 does not exist, so this is the reconstruction - and each
+# of the three caveats it names is handled here rather than restated:
+#
+#  - `lockedAt` is rewritten every 3 minutes by the runner's heartbeat
+#    (`sync-job.runner.ts` JOB_HEARTBEAT_INTERVAL_MS), so it is the CLAIM
+#    instant only for a job that finished inside that window. Not assumed:
+#    the summarizer COUNTS how many sampled jobs ran >= 180s and prints the
+#    figure beside the hops that depend on it.
+#
+#  - `lastAttemptDurationMs` is reset to `null` on every enqueue
+#    (`sync-job.repository.ts`) and reports the LAST attempt only. Again
+#    counted rather than assumed: the summarizer prints how many sampled
+#    children took more than one attempt.
+#
+#  - `syncStatus[].syncedAt` is stamped inside a `Promise.allSettled` over
+#    EVERY destination (`order-ingestion.service.ts`), so it is biased late -
+#    it records whichever destination finished last. This scenario removes
+#    the bias STRUCTURALLY rather than caveating it: each arm disables the
+#    other destination connection before its window opens, so the fan-out
+#    has exactly one member and "the slowest of N" is the one destination.
+#    That is also #2847's own acceptance criterion, met for two reasons at
+#    once.
+#
+# One point in the issue's own table has no proxy at all and is therefore NOT
+# reported: "the poll observed it". Nothing persists it. The two hops either
+# side of it (t1->t2 and t2->t3) are reported instead, which brackets it.
+#
+# ---------------------------------------------------------------------------
+# POLL WAIT IS EXCLUDED BY CONSTRUCTION, NOT MEASURED AS FAST
+# ---------------------------------------------------------------------------
+# The scheduler is OFF for this run and the harness enqueues every
+# `marketplace.orders.poll` itself (see drivers/order-feed.sh's
+# `of_enqueue_poll` for the full reasoning). So hop A below - "order pushed at
+# the stub -> poll enqueued" - is a cadence this script chose. It is NOT a
+# figure any deployment experiences, and the report says so in those words,
+# the way F2 reports its own shop-cron hop.
+#
+# The real cadences are recorded in the manifest separately, as DERIVED
+# values: Allegro's `*/1 * * * *` (`allegro-scheduler-tasks.ts`, tunable via
+# `OL_ALLEGRO_POLL_INTERVAL_CRON` on the WORKER since #2279) gives a 30s mean
+# poll wait; WooCommerce and Erli hardcode `*/5` string literals and are NOT
+# retunable without a code change. Because the scheduler is off, those are
+# read from the plugin defaults and the worker's own environment - never
+# claimed to be "read from a running scheduler", because there isn't one.
+#
+# Turning the scheduler on instead would have fired every other default-on
+# task with it, including the PrestaShop master sweeps whose parents share
+# the `fan-out` lane with `marketplace.orders.poll` itself
+# (`handler-registration.service.ts`, 8 total / 4 per scope) - the exact
+# co-tenancy #2847 names as a contaminant to control for.
+#
+# ---------------------------------------------------------------------------
+# THE HYPOTHESIS THIS RUN FALSIFIES
+# ---------------------------------------------------------------------------
+# #2847 argues the destination's own rate limit, not the lane cap, may be the
+# real ceiling - and that raising `OL_LANE_REALTIME_SCOPE_CAP` would then do
+# nothing, the opposite of what anyone tries first. The crossover arithmetic
+# it states:
+#
+#   lane ceiling per source connection = 120 / D orders/min   (perScope = 2)
+#   destination ceiling                = 60/min / ~7 req per order = ~8.6/min
+#   crossover                          = D ~= 14s
+#
+# Above D = 14s the lane binds whatever the destination allows; below it, the
+# destination can. This scenario runs three throughput arms in order and
+# reports which moved the number:
+#
+#   1. baseline                 defaults on both
+#   2. destination raised       config.rateLimit lifted well past 60/min
+#   3. lane raised              OL_LANE_REALTIME_SCOPE_CAP lifted too
+#
+# All three run, unconditionally. Arms 1 and 2 alone complete the
+# falsification (moved => the destination was binding; did not move => the
+# lane was), but they cannot answer the question that follows it - with the
+# destination lifted, what binds NEXT? Arm 3 either moves the number again,
+# naming the lane cap as the new ceiling, or it does not, in which case the
+# report has to name whatever else is. Each arm's settings are recorded in
+# its own manifest.
+#
+# Sources lib.sh (#2841) and drivers/order-feed.sh (this issue).
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+LIB_LOG_PREFIX="f1"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/../lib.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/../drivers/order-feed.sh"
+
+ENV_FILE="${ENV_FILE:-$REPO_ROOT/.env.lab}"
+
+# ---------------------------------------------------------------------------
+# Configuration (env-overridable, same convention as lib.sh/bootstrap.sh)
+# ---------------------------------------------------------------------------
+SOURCE_TENANT="${SOURCE_TENANT:-perf-allegro-a}"
+
+# Serial latency arm: one order in flight at a time, so no hop is contaminated
+# by queue wait behind another order. n is bounded by wall clock rather than
+# by choice - see the summarizer's header for why every percentile it prints
+# carries the rank it resolved to at this n.
+LATENCY_SAMPLES="${LATENCY_SAMPLES:-25}"
+
+# Throughput arms. The backlog is pushed in ONE request before the window
+# opens, so the pusher can never be the bottleneck; the offered rate is then
+# `min(OF_POLL_LIMIT, backlog) / POLL_CADENCE_SECS`.
+#
+# The backlog must outlast the window at the highest rate any arm might reach,
+# or post_guard_feed_starved discards the run - which is the guard working,
+# not an obstacle. Raise THROUGHPUT_BACKLOG and re-run if it fires.
+THROUGHPUT_BACKLOG="${THROUGHPUT_BACKLOG:-900}"
+THROUGHPUT_WINDOW_SECS="${THROUGHPUT_WINDOW_SECS:-300}"
+POLL_CADENCE_SECS="${POLL_CADENCE_SECS:-10}"
+PROGRESS_TICK_SECS="${PROGRESS_TICK_SECS:-5}"
+
+# The WooCommerce arm is a REAL-SHOP measurement, not a throughput figure
+# (#2847's own words), so it is deliberately small and serial - bounded by a
+# sample COUNT rather than by a window, exactly like the latency arm. There is
+# deliberately no WC_ARM_WINDOW_SECS knob: a knob that configures nothing is a
+# false statement about what an operator can change.
+WC_ARM_ORDERS="${WC_ARM_ORDERS:-12}"
+
+# At least one successful order per worker PROCESS before any measured window,
+# so the `line_prices` cold start is excluded. `PrestashopOpenlinkerModuleClient`
+# learns that capability from a previous `importorder` response into a
+# module-level Map keyed by connection id, so the first order after a worker
+# restart takes the 27-request legacy `specific_prices` path instead of the
+# 7-request one - a 3.4x difference, once per process
+# (`prestashop-openlinker-module.client.ts`, and the adapter's own comment).
+# Two per replica rather than one: the first also warms the currency, country
+# and order-state caches, so a single warm-up would leave the FIRST measured
+# order carrying the tail of that.
+WARMUP_ORDERS_PER_REPLICA="${WARMUP_ORDERS_PER_REPLICA:-2}"
+
+# The raised destination limit for the falsification arm. 6000/min and 32
+# concurrent sit just inside `ConnectionService.validateRateLimitConfig`'s
+# own bounds (1..6000 and 1..64) - deliberately far past anything the
+# destination can absorb, because the question is whether the limiter binds
+# at all, not where a second knee is.
+RAISED_RPM="${RAISED_RPM:-6000}"
+RAISED_CONCURRENT="${RAISED_CONCURRENT:-32}"
+# The raised lane cap for arm 3. `OL_LANE_REALTIME_SCOPE_CAP` defaults to 2
+# (`sync-job.runner.ts`); `OL_LANE_REALTIME_CAP` must rise with it or the
+# lane-wide cap of 4 becomes the new binding constraint one level up.
+RAISED_LANE_SCOPE_CAP="${RAISED_LANE_SCOPE_CAP:-16}"
+RAISED_LANE_CAP="${RAISED_LANE_CAP:-16}"
+
+# How much of a rate change counts as "the number moved". Two runs of the same
+# arm on a contended workstation do not repeat exactly, so a threshold is
+# needed; 15% is well outside the run-to-run spread this stand shows and well
+# inside the several-fold change a genuinely-binding limiter would produce.
+MOVED_THRESHOLD_PCT="${MOVED_THRESHOLD_PCT:-15}"
+
+MODE="strict"
+ARMS="all"
+for arg in "$@"; do
+  case "$arg" in
+    --smoke) MODE="smoke" ;;
+    --latency-only) ARMS="latency" ;;
+    --throughput-only) ARMS="throughput" ;;
+    -h|--help)
+      cat <<'USAGE'
+Usage: f1-order-ingestion.sh [--smoke | --latency-only | --throughput-only]
+
+  (no flag)          strict measurement - every applicable #2841 guard runs,
+                     the serial latency arm, three PrestaShop throughput arms
+                     (the third only if the second did not move the rate), a
+                     real-WooCommerce arm, and a dated report under results/.
+  --latency-only     the serial latency arm alone.
+  --throughput-only  the throughput arms alone.
+  --smoke            driver self-test: one order end to end, the reconstructed
+                     hops printed, the feed-backlog sensor exercised against
+                     the live stub. No manifest, no verdict, nothing written
+                     under results/.
+
+Every knob is an env var - see the Configuration block at the top of this file.
+USAGE
+      exit 0
+      ;;
+    *) die "unknown argument: $arg (use --smoke, --latency-only, --throughput-only, --help, or nothing)" ;;
+  esac
+done
+
+require_tools docker jq curl python3
+
+[ -n "${ALLEGRO_A_CONNECTION_ID:-}" ] || die "ALLEGRO_A_CONNECTION_ID is not set - source stand-ids.env (bootstrap.sh) or export it by hand"
+[ -n "${PS_CONNECTION_ID:-}" ] || die "PS_CONNECTION_ID is not set - source stand-ids.env"
+[ -n "${WC_CONNECTION_ID:-}" ] || die "WC_CONNECTION_ID is not set - source stand-ids.env"
+SOURCE_CONNECTION_ID="${SOURCE_CONNECTION_ID:-$ALLEGRO_A_CONNECTION_ID}"
+CONN_IDS="'$SOURCE_CONNECTION_ID'"
+
+# Claimed BEFORE any arrange step, not just before window_start: this scenario
+# mutates shared stand state (both destinations' enabledCapabilities, the
+# PrestaShop connection's rate limit, the worker's own runner posture and lane
+# caps) well before the first window opens, and a peer racing any of it is
+# exactly the failure guard_stand_exclusive exists to prevent (#2842/#2848).
+guard_stand_exclusive "f1-order-ingestion"
+
+ol_login
+
+# ===========================================================================
+# Stand posture captured for restore, and the single EXIT trap
+#
+# bash's EXIT trap is ONE slot, so a second `trap ... EXIT` REPLACES
+# guard_stand_exclusive's own release and leaves the stand locked for the full
+# TTL after any `die` - F7 found that the hard way and F4 records the fix.
+# Everything that must be undone is undone from this one function.
+# ===========================================================================
+ORIGINAL_REPLICAS="$(discover_worker_containers | wc -w | tr -d ' ')"
+[ "$ORIGINAL_REPLICAS" -ge 1 ] || ORIGINAL_REPLICAS=1
+# Read from the RUNNING container, not from .env.lab: the file is a request,
+# the container's environment is what is in force, and a peer may have flipped
+# one without the other.
+ORIGINAL_RUNNER_ENABLED="$(docker exec "$(discover_worker_containers | awk '{print $1}')" printenv WORKER_RUNNER_ENABLED 2>/dev/null || printf '')"
+[ -n "$ORIGINAL_RUNNER_ENABLED" ] || ORIGINAL_RUNNER_ENABLED=false
+
+connection_json() { ol_api GET "/v1/connections/$1"; }
+
+ORIGINAL_PS_CAPS="$(connection_json "$PS_CONNECTION_ID" | jq -c '.enabledCapabilities // []')"
+ORIGINAL_WC_CAPS="$(connection_json "$WC_CONNECTION_ID" | jq -c '.enabledCapabilities // []')"
+ORIGINAL_PS_CONFIG="$(connection_json "$PS_CONNECTION_ID" | jq -c '.config // {}')"
+ORIGINAL_WC_CONFIG="$(connection_json "$WC_CONNECTION_ID" | jq -c '.config // {}')"
+log "posture at start: replicas=$ORIGINAL_REPLICAS runner=$ORIGINAL_RUNNER_ENABLED"
+log "  perf-prestashop caps=$ORIGINAL_PS_CAPS rateLimit=$(printf '%s' "$ORIGINAL_PS_CONFIG" | jq -c '.rateLimit // null')"
+log "  perf-woocommerce caps=$ORIGINAL_WC_CAPS rateLimit=$(printf '%s' "$ORIGINAL_WC_CONFIG" | jq -c '.rateLimit // null')"
+
+# A restore that CANNOT abort itself.
+#
+# Every helper in lib.sh reaches `die` on failure, and `die` calls `exit` - so
+# `ol_login || true` does NOT contain it: the `||` sees a return code, and
+# there is none, the shell is already leaving. Inside an EXIT trap that skips
+# every later line, which here would be `release_stand_exclusive` and the
+# stand would stay locked for the full hour. So the cleanup path uses raw
+# curl, never `ol_login`/`ol_api`, and every call ends in `|| true`.
+restore_curl() {
+  local method="$1" path="$2" body="${3:-}"
+  [ -n "${RESTORE_TOKEN:-}" ] || return 0
+  curl -sS -o /dev/null -X "$method" "$OL_API_URL$path" \
+    -H "Authorization: Bearer $RESTORE_TOKEN" -H 'Content-Type: application/json' \
+    ${body:+-d "$body"} 2>/dev/null || true
+}
+
+# A RUN THAT CHANGED NOTHING MUST RESTORE NOTHING.
+#
+# These two flags exist because the restore below is not free: it PATCHes both
+# connections and runs `docker compose up --no-deps worker`, which RECREATES
+# the worker container. On a run that never got past `guard_stand_exclusive` -
+# the common case on a contended stand, where a peer holds the lock - firing
+# that would recreate the worker UNDERNEATH the scenario that legitimately
+# holds the stand, killing its in-flight jobs and resetting its runner. That
+# is precisely the cross-contamination the lock exists to prevent, arriving
+# through the refused run's own cleanup path.
+#
+# Learned the hard way on this stand: an earlier F1 attempt recreated `api` and
+# `worker` while a peer's F7 window was open.
+CONNECTIONS_TOUCHED=0
+WORKER_TOUCHED=0
+
+f1_on_exit() {
+  local rc=$?
+  if [ "$CONNECTIONS_TOUCHED" = "0" ] && [ "$WORKER_TOUCHED" = "0" ]; then
+    log "nothing was changed on the stand - no restore needed"
+    release_stand_exclusive
+    return $rc
+  fi
+  log "restoring stand posture"
+  RESTORE_TOKEN="$(curl -sS -X POST "$OL_API_URL/v1/auth/login" -H 'Content-Type: application/json' \
+    -d "{\"username\":\"$OL_ADMIN_USER\",\"password\":\"$OL_ADMIN_PASSWORD\"}" 2>/dev/null \
+    | jq -r '.access_token // .accessToken // empty' 2>/dev/null || printf '')"
+  [ -n "$RESTORE_TOKEN" ] || warn "could not log in to restore the connections - their capabilities/rateLimit are left as the last arm set them"
+  if [ "$CONNECTIONS_TOUCHED" = "1" ]; then
+    restore_curl PATCH "/v1/connections/$PS_CONNECTION_ID" \
+      "$(jq -n --argjson c "$ORIGINAL_PS_CAPS" --argjson g "$ORIGINAL_PS_CONFIG" '{enabledCapabilities:$c, config:$g}' 2>/dev/null || printf '')"
+    restore_curl PATCH "/v1/connections/$WC_CONNECTION_ID" \
+      "$(jq -n --argjson c "$ORIGINAL_WC_CAPS" --argjson g "$ORIGINAL_WC_CONFIG" '{enabledCapabilities:$c, config:$g}' 2>/dev/null || printf '')"
+  fi
+  if [ "$WORKER_TOUCHED" = "1" ]; then
+    if [ -f "$ENV_FILE" ]; then
+      sed -i "s/^WORKER_RUNNER_ENABLED=.*/WORKER_RUNNER_ENABLED=$ORIGINAL_RUNNER_ENABLED/" "$ENV_FILE" 2>/dev/null || true
+      # Left over from the pre-#2847 mechanism, which wrote the caps here and
+      # achieved nothing. Cleared so a stand never carries a dead knob that
+      # looks live.
+      sed -i '/^OL_LANE_REALTIME_CAP=/d; /^OL_LANE_REALTIME_SCOPE_CAP=/d' "$ENV_FILE" 2>/dev/null || true
+    fi
+    # The override must go BEFORE the recreate, or the restored worker keeps
+    # whatever lane caps the last arm asked for.
+    rm -f "$LANE_OVERRIDE_FILE"
+    ( cd "$REPO_ROOT" && docker compose -f docker-compose.lab.yml --env-file .env.lab -p lab \
+        up -d --no-deps --scale "worker=$ORIGINAL_REPLICAS" worker >/dev/null 2>&1 ) \
+      || warn "could not restore the worker posture - the stand is left at whatever the last arm set (replicas: [$(discover_worker_containers)])"
+  fi
+  release_stand_exclusive
+  return $rc
+}
+trap f1_on_exit EXIT
+
+# ===========================================================================
+# Arrange helpers
+# ===========================================================================
+
+# set_destination <connection_id> <on|off>
+#
+# Toggles `OrderProcessorManager` in `enabledCapabilities` rather than flipping
+# the connection's `status`. Both would work - `resolveDestinations` reads
+# `listCapabilityAdapters`, which is active-only AND capability-filtered - but
+# a status flip has a side effect this scenario does not want: transitioning a
+# connection back INTO `active` fires `ConnectionService`'s taxonomy-sync
+# bootstrap (#2084/#2085), enqueueing a `destination.taxonomy.sync` job into a
+# stand this run is trying to keep quiet. A capability edit has no such hook.
+set_destination() {
+  local conn="$1" state="$2" caps
+  caps="$(connection_json "$conn" | jq -c '.enabledCapabilities // []')"
+  if [ "$state" = "on" ]; then
+    caps="$(printf '%s' "$caps" | jq -c '. + ["OrderProcessorManager"] | unique')"
+  else
+    caps="$(printf '%s' "$caps" | jq -c 'map(select(. != "OrderProcessorManager"))')"
+  fi
+  CONNECTIONS_TOUCHED=1
+  ol_api PATCH "/v1/connections/$conn" "$(jq -n --argjson c "$caps" '{enabledCapabilities:$c}')" >/dev/null
+  log "set_destination $conn -> $state (caps now $caps)"
+}
+
+# set_rate_limit <connection_id> <rpm|"default"> [max_concurrent]
+#
+# `config` is patched as a WHOLE object, never as a partial: `ConnectionService`
+# shallow-spreads it (the #2016 note), so sending `{rateLimit: ...}` alone
+# would drop `baseUrl`/`shopId`/`siteUrl` and leave the connection unusable.
+# The current config is therefore read back and merged.
+#
+# "default" DELETES the key rather than writing some number that happens to
+# match the manifest's - the resolution order is `config.rateLimit ??
+# manifest.defaultRateLimit ?? {}` (`http-transport-factory.ts`), and an
+# explicit value that equals the default is a different persisted state from
+# an absent one, which is exactly the distinction the falsification depends on.
+set_rate_limit() {
+  local conn="$1" rpm="$2" concurrent="${3:-$RAISED_CONCURRENT}" cfg
+  cfg="$(connection_json "$conn" | jq -c '.config // {}')"
+  if [ "$rpm" = "default" ]; then
+    cfg="$(printf '%s' "$cfg" | jq -c 'del(.rateLimit)')"
+  else
+    cfg="$(printf '%s' "$cfg" | jq -c --argjson r "$rpm" --argjson c "$concurrent" \
+      '.rateLimit = {requestsPerMinute:$r, maxConcurrent:$c}')"
+  fi
+  CONNECTIONS_TOUCHED=1
+  ol_api PATCH "/v1/connections/$conn" "$(jq -n --argjson g "$cfg" '{config:$g}')" >/dev/null
+  log "set_rate_limit $conn -> $(printf '%s' "$cfg" | jq -c '.rateLimit // "manifest default"')"
+}
+
+# The compose override this scenario writes to carry lane-cap changes.
+#
+# WHY AN OVERRIDE FILE AND NOT `.env.lab` (#2847, found the hard way)
+#
+# The first version of `recreate_worker` wrote `OL_LANE_REALTIME_SCOPE_CAP=16`
+# into `.env.lab` and recreated the worker. That does NOTHING. An entry in an
+# env-file is available for `${VAR}` INTERPOLATION inside the compose file; it
+# is not passed to the container unless the service's own `environment:` block
+# names it, and `docker-compose.lab.yml`'s worker service does not name either
+# lane variable. Verified live: `docker exec lab-worker-1 printenv
+# OL_LANE_REALTIME_SCOPE_CAP` was empty and the runner's own startup line still
+# read `realtime=4/2` for an arm whose whole purpose was to raise it. The arm
+# silently measured the configuration it was supposed to be varying against.
+#
+# An override file declares the variables on the service, which is what
+# actually forwards them - and it lives in this scenario rather than in
+# `docker-compose.lab.yml`, so #2854's shared stand file is untouched and a
+# stand that never runs F1 never carries the knobs.
+LANE_OVERRIDE_FILE="${LANE_OVERRIDE_FILE:-$REPO_ROOT/.f1-lane-override.yml}"
+
+# recreate_worker <runner:true|false> [lane_scope_cap] [lane_cap]
+#
+# Same shape as F4's `scale_workers` (and for the same reasons - `--no-deps`
+# keeps the blast radius to the worker; the discovery cache in lib.sh is stale
+# by construction afterwards and must be re-resolved; `grep -c` not `grep -q`
+# on the startup line, because `-q` closes the pipe and `set -o pipefail` then
+# fails the whole pipeline even though the line matched).
+#
+# Passing an empty cap removes the override entirely, restoring the runner's
+# own defaults rather than pinning them to whatever this script believes they
+# are - the runner is the authority on its defaults.
+#
+# AND IT VERIFIES. See `assert_lane_caps` below: a scenario that silently
+# measures a configuration it did not request is the worst failure this
+# harness has, and it is exactly the reported-versus-enforced gap the rest of
+# the programme keeps closing (#2229's rule). Asking is not the same as
+# getting, so the runner's own reported caps are read back and compared.
+recreate_worker() {
+  local runner="$1" scope_cap="${2:-}" lane_cap="${3:-}" tries w hits found
+  WORKER_TOUCHED=1
+  [ -f "$ENV_FILE" ] || die "recreate_worker: $ENV_FILE not found - this scenario recreates the worker service, which needs the stand's own env file"
+  if grep -q '^WORKER_RUNNER_ENABLED=' "$ENV_FILE"; then
+    sed -i "s/^WORKER_RUNNER_ENABLED=.*/WORKER_RUNNER_ENABLED=$runner/" "$ENV_FILE"
+  else
+    printf 'WORKER_RUNNER_ENABLED=%s\n' "$runner" >> "$ENV_FILE"
+  fi
+
+  local compose_args=(-f docker-compose.lab.yml)
+  rm -f "$LANE_OVERRIDE_FILE"
+  if [ -n "$scope_cap" ]; then
+    cat > "$LANE_OVERRIDE_FILE" <<YAML
+# Written by scenarios/f1-order-ingestion.sh (#2847). Removed when the
+# scenario restores the worker. Declares the lane-cap variables on the worker
+# service so compose actually forwards them - an .env.lab entry alone does not.
+services:
+  worker:
+    environment:
+      OL_LANE_REALTIME_SCOPE_CAP: '$scope_cap'
+      OL_LANE_REALTIME_CAP: '${lane_cap:-$scope_cap}'
+YAML
+    compose_args+=(-f "$LANE_OVERRIDE_FILE")
+  fi
+
+  ( cd "$REPO_ROOT" && docker compose "${compose_args[@]}" --env-file .env.lab -p lab \
+      up -d --no-deps --scale "worker=$ORIGINAL_REPLICAS" worker >/dev/null 2>&1 ) \
+    || die "recreate_worker: compose refused to recreate the worker service"
+
+  WORKER_CONTAINERS=""
+  WORKER_CONTAINERS_RESOLVED=0
+  _ensure_worker_containers
+  found="$(discover_worker_containers | wc -w | tr -d ' ')"
+  [ "$found" -eq "$ORIGINAL_REPLICAS" ] || die "recreate_worker: expected $ORIGINAL_REPLICAS replica(s), discovery found $found"
+
+  if [ "$runner" = "true" ]; then
+    for w in $WORKER_CONTAINERS; do
+      tries=0
+      while true; do
+        hits="$(docker logs "$w" 2>&1 | grep -cF 'Starting sync job runner loop' || true)"
+        [ "${hits:-0}" -eq 0 ] || break
+        tries=$((tries + 1))
+        [ "$tries" -lt 90 ] || die "recreate_worker: $w never logged 'Starting sync job runner loop'"
+        sleep 1
+      done
+    done
+    assert_lane_caps "$scope_cap" "${lane_cap:-$scope_cap}"
+  else
+    sleep 5
+  fi
+  log "worker recreated: runner=$runner replicas=$ORIGINAL_REPLICAS lane scope cap=${scope_cap:-<runner default>}"
+}
+
+# assert_lane_caps <expected_scope_cap|""> <expected_lane_cap|"">
+#
+# Reads the caps the RUNNER ITSELF reports on its startup line and refuses to
+# continue unless they are the caps that were requested. Empty expectations
+# mean "the runner's own defaults", which cannot be asserted against a number
+# this script invents - so that case only records what was found.
+assert_lane_caps() {
+  local want_scope="$1" want_lane="$2" w line caps got_total got_scope
+  for w in $WORKER_CONTAINERS; do
+    line="$(docker logs "$w" 2>&1 | grep -F 'Starting sync job runner loop' | tail -1 || true)"
+    caps="$(printf '%s' "$line" | grep -oP 'realtime=\K[0-9]+/[0-9]+' || true)"
+    [ -n "$caps" ] || die "assert_lane_caps: could not parse realtime lane caps out of $w's startup line: $line"
+    got_total="${caps%%/*}"; got_scope="${caps##*/}"
+    if [ -n "$want_scope" ]; then
+      [ "$got_scope" = "$want_scope" ] || die \
+"assert_lane_caps: asked for OL_LANE_REALTIME_SCOPE_CAP=$want_scope but $w reports realtime=$caps.
+  The request did not reach the container. An .env.lab entry alone does NOT forward a
+  variable - the service's own \`environment:\` block must name it, which is what
+  \$LANE_OVERRIDE_FILE exists to do. Refusing to measure a configuration that was not applied."
+      [ "$got_total" = "$want_lane" ] || die \
+"assert_lane_caps: asked for OL_LANE_REALTIME_CAP=$want_lane but $w reports realtime=$caps"
+    fi
+    log "assert_lane_caps: $w reports realtime=$caps${want_scope:+ (requested $want_lane/$want_scope)}"
+  done
+}
+
+# ===========================================================================
+# Observation helpers - every one reads persisted state, never a log line
+# ===========================================================================
+
+# The sync_jobs projection every sample reads.
+#
+# No COALESCE on the nullable columns, deliberately: `psql -tA` renders NULL
+# as an EMPTY FIELD by default, which is exactly what the CSV and the
+# summarizer already treat as "not observed". An earlier draft wrapped each
+# one in `COALESCE(..., \x27\x27)` inside a single-quoted bash string, where
+# `\x27` is six literal characters rather than a quote - the SQL was malformed,
+# psql printed nothing, and every sample reported NO_POLL_ROW for a poll job
+# that had in fact succeeded. Fewer quotes is the fix, not better escaping.
+#
+# ---------------------------------------------------------------------------
+# `lockedAt` MUST BE LATCHED WHILE THE JOB RUNS - IT IS GONE AFTERWARDS
+# ---------------------------------------------------------------------------
+# `SyncJobRepository.markSucceeded` sets `lockedAt: null, lockedBy: null`
+# alongside `status: 'succeeded'`. So a job read after it finishes - which is
+# every job a latency sample cares about - carries NO claim instant at all.
+# #2847's own caveat table names the heartbeat rewrite as `lockedAt`'s problem
+# and does not mention this one, which is the larger of the two: a
+# reconstruction that read the column at the end would report hops B, D, E and
+# G as "never observed" on every single sample, and the run would look like a
+# rig fault rather than a wrong column.
+#
+# Two independent sources are therefore captured, and the summarizer reports
+# which one answered for each row:
+#
+#  (1) LATCHED - the sample's own poll loops record the first non-empty
+#      `lockedAt` they see while the job is still `running`. A real
+#      observation, but it can be missed entirely when a job starts and
+#      finishes inside one 1-second poll tick (the poll job, at ~300ms, often
+#      does).
+#  (2) DERIVED - `updatedAt - lastAttemptDurationMs`. `lastAttemptDurationMs`
+#      is the RUNNER's own measurement of the attempt (`Date.now() -
+#      attemptStartedAt`, stamped by the same UPDATE that sets `updatedAt`),
+#      so for a single-attempt job this is exact and, unlike `lockedAt`,
+#      immune to the 3-minute heartbeat rewrite as well.
+JOB_COLS='"createdAt", "lockedAt", "updatedAt", status, outcome, attempts, "lastAttemptDurationMs"'
+
+job_row_by_key() {
+  pg_sql "SELECT $JOB_COLS FROM sync_jobs WHERE \"idempotencyKey\"='$1'"
+}
+
+# The payload column is `payloadJson` (jsonb), NOT `payload` - there is no
+# column of that name and psql answers `ERROR: column "payload" does not
+# exist`. `pg_sql` does not die on a query error, so the row read simply came
+# back EMPTY and every sample reported NO_CHILD for a child job that existed
+# and had already created its order at the shop. A wrong column name is
+# indistinguishable from a missing row through this seam, which is why the
+# --smoke path exists.
+child_row_for_order() {
+  pg_sql "SELECT $JOB_COLS FROM sync_jobs
+          WHERE \"jobType\"='marketplace.order.sync'
+            AND \"connectionId\"='$SOURCE_CONNECTION_ID'
+            AND \"payloadJson\"->>'externalOrderId'='$1'
+          ORDER BY \"createdAt\" DESC LIMIT 1"
+}
+
+# The internal order id OpenLinker minted for a source-native checkout-form id.
+# Read through identifier_mappings rather than guessed - the mapping IS how
+# every other consumer resolves it.
+internal_order_id() {
+  pg_sql "SELECT \"internalId\" FROM identifier_mappings
+          WHERE \"entityType\"='Order' AND \"connectionId\"='$SOURCE_CONNECTION_ID' AND \"externalId\"='$1'"
+}
+
+# order_records.createdAt plus the declared destination's own syncedAt.
+# The syncStatus element is selected BY destinationConnectionId, never by
+# array position: `updateSyncStatus` rebuilds the array drop-then-append, so
+# position is not stable across destinations.
+record_row() {
+  local internal_id="$1" dest="$2"
+  pg_sql "SELECT \"createdAt\",
+                 COALESCE((SELECT e->>'syncedAt' FROM jsonb_array_elements(\"syncStatus\") e
+                           WHERE e->>'destinationConnectionId'='$dest' LIMIT 1),''),
+                 COALESCE((SELECT e->>'status' FROM jsonb_array_elements(\"syncStatus\") e
+                           WHERE e->>'destinationConnectionId'='$dest' LIMIT 1),''),
+                 \"recordStatus\"
+          FROM order_records WHERE \"internalOrderId\"='$internal_id'"
+}
+
+poll_until() {
+  local desc="$1" max_wait="$2"; shift 2
+  local waited=0 out
+  while [ "$waited" -lt "$max_wait" ]; do
+    out="$("$@" 2>/dev/null || true)"
+    if [ -n "$out" ]; then printf '%s' "$out"; return 0; fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+  return 1
+}
+
+# ===========================================================================
+# The serial latency arm
+# ===========================================================================
+# The POLL job carries its own attempts/duration columns for the same reason
+# the child does: without them the summarizer cannot DERIVE a claim instant
+# for it (`updatedAt - lastAttemptDurationMs`), and since `markSucceeded`
+# nulls `lockedAt`, a poll job whose ~300ms run slipped between two 1-second
+# latch polls would have no claim instant at all - leaving hops B and C
+# permanently n=0. Found by running the summarizer against a synthetic sample
+# set before the real run, which is exactly what that dry run was for.
+LATENCY_HEADER='sample,checkout_form_id,pushed_at_utc,poll_key,poll_created_utc,poll_locked_utc,poll_updated_utc,poll_status,poll_outcome,poll_attempts,poll_attempt_duration_ms,child_created_utc,child_locked_utc,child_updated_utc,child_status,child_outcome,child_attempts,child_attempt_duration_ms,internal_order_id,record_created_utc,record_status,synced_at_utc,dest_sync_status'
+
+SAMPLE_MAX_WAIT_SECS="${SAMPLE_MAX_WAIT_SECS:-120}"
+
+# run_one_sample <n> <dest_connection_id> <out_csv>
+run_one_sample() {
+  local n="$1" dest="$2" out="$3"
+  local pushed_at cf_id poll_key
+  local poll_created poll_locked poll_updated poll_status poll_outcome poll_attempts poll_dur
+  local child_created child_locked child_updated child_status child_outcome child_attempts child_dur
+  local internal_id rec_created synced_at dest_status rec_status
+
+  # Push ONE order and take the source-side instant from the stub's own
+  # response, not from before the call: the order does not exist until the
+  # stub says it minted it.
+  local resp
+  resp="$(of_curl POST "/__stub/tenants/$SOURCE_TENANT/orders" '{"count":1,"lineItemsPerOrder":1,"eventsPerOrder":1}')"
+  pushed_at="$(date -u +%Y-%m-%dT%H:%M:%S.%3NZ)"
+  cf_id="$(printf '%s' "$resp" | jq -r '.minted[0].checkoutFormId // empty')"
+  [ -n "$cf_id" ] || { warn "sample $n: stub minted no checkout form: $resp"; return 0; }
+
+  poll_key="$(of_enqueue_poll "$SOURCE_CONNECTION_ID" "lat$n")"
+
+  local row
+  row="$(poll_until "poll job row for $poll_key" 30 job_row_by_key "$poll_key")" || {
+    warn "sample $n: the poll job never produced a sync_jobs row (slow intake?)"
+    # 23 columns: 4 written, cols 5-7 empty, col 8 the marker, cols 9-23 empty.
+    printf '%s,%s,%s,%s,,,,NO_POLL_ROW,,,,,,,,,,,,,,,\n' "$n" "$cf_id" "$pushed_at" "$poll_key" >> "$out"
+    return 0
+  }
+  IFS='|' read -r poll_created poll_locked poll_updated poll_status poll_outcome poll_attempts poll_dur <<< "$row"
+  # LATCH: `markSucceeded` nulls lockedAt, so the value only exists while the
+  # job is running. First non-empty reading wins and is never overwritten -
+  # both because a later reading is a heartbeat rewrite rather than the claim,
+  # and because the terminal reading is NULL and would erase it.
+  local poll_locked_latched="$poll_locked"
+
+  # Wait for the poll to finish before reading its updatedAt - a read that
+  # lands while it is still `running` would report an unfinished hop C.
+  local waited=0
+  while [ "$waited" -lt 30 ] && [ "$poll_status" != "succeeded" ] && [ "$poll_status" != "dead" ]; do
+    sleep 1; waited=$((waited + 1))
+    row="$(job_row_by_key "$poll_key" 2>/dev/null || true)"
+    IFS='|' read -r poll_created poll_locked poll_updated poll_status poll_outcome poll_attempts poll_dur <<< "$row"
+    [ -n "$poll_locked_latched" ] || poll_locked_latched="$poll_locked"
+  done
+
+  row="$(poll_until "child job for $cf_id" 30 child_row_for_order "$cf_id")" || {
+    warn "sample $n: no marketplace.order.sync child for $cf_id - the poll did not discover it (a stale cursor, or the per-connection poll lock skipped this tick)"
+    # 23 columns: 11 written, cols 12-14 empty, col 15 the marker, 16-23 empty.
+    printf '%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,,,,NO_CHILD,,,,,,,,\n' \
+      "$n" "$cf_id" "$pushed_at" "$poll_key" "$poll_created" "$poll_locked_latched" "$poll_updated" \
+      "$poll_status" "$poll_outcome" "$poll_attempts" "$poll_dur" >> "$out"
+    return 0
+  }
+  IFS='|' read -r child_created child_locked child_updated child_status child_outcome child_attempts child_dur <<< "$row"
+  local child_locked_latched="$child_locked"
+
+  waited=0
+  while [ "$waited" -lt "$SAMPLE_MAX_WAIT_SECS" ] && [ "$child_status" != "succeeded" ] && [ "$child_status" != "dead" ]; do
+    sleep 1; waited=$((waited + 1))
+    row="$(child_row_for_order "$cf_id" 2>/dev/null || true)"
+    IFS='|' read -r child_created child_locked child_updated child_status child_outcome child_attempts child_dur <<< "$row"
+    [ -n "$child_locked_latched" ] || child_locked_latched="$child_locked"
+  done
+
+  internal_id="$(internal_order_id "$cf_id" 2>/dev/null || true)"
+  rec_created=""; synced_at=""; dest_status=""; rec_status=""
+  if [ -n "$internal_id" ]; then
+    row="$(record_row "$internal_id" "$dest" 2>/dev/null || true)"
+    IFS='|' read -r rec_created synced_at dest_status rec_status <<< "$row"
+  fi
+
+  printf '%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n' \
+    "$n" "$cf_id" "$pushed_at" "$poll_key" \
+    "$poll_created" "$poll_locked_latched" "$poll_updated" "$poll_status" "$poll_outcome" "$poll_attempts" "$poll_dur" \
+    "$child_created" "$child_locked_latched" "$child_updated" "$child_status" "$child_outcome" "$child_attempts" "$child_dur" \
+    "${internal_id:-}" "${rec_created:-}" "${rec_status:-}" "${synced_at:-}" "${dest_status:-}" >> "$out"
+
+  log "sample $n: cf=$cf_id child=$child_status/$child_outcome att=$child_attempts dur=${child_dur:-?}ms synced=${synced_at:-NONE}"
+}
+
+# ===========================================================================
+# The throughput arms
+# ===========================================================================
+PROGRESS_HEADER='epoch,iso,due_queued,running,completed,oldest_due_age_s,feed_backlog,available_work'
+
+# progress_tick <out_csv> <window_start_iso>
+#
+# `available_work` is `feed_backlog + due_queued + running`, and it is the
+# number post_guard_feed_starved consumes - NOT `feed_backlog` alone.
+#
+# The distinction is the guard's correctness, not bookkeeping. The poll pump
+# reads a page of 100 every POLL_CADENCE_SECS, so a 900-order stub backlog is
+# fully converted into queued child jobs inside about 90 seconds; from then on
+# the stub reads EMPTY while OpenLinker is at its busiest. Passing the stub's
+# backlog would discard every valid throughput run. `running` is included
+# because a tick can legitimately land with the queue momentarily drained and
+# every slot busy - that is a saturated system, the opposite of a starved one.
+progress_tick() {
+  local out="$1" ws_iso="$2" due running completed oldest backlog available
+  due="$(pg_sql "SELECT COUNT(*) FROM sync_jobs WHERE \"connectionId\"='$SOURCE_CONNECTION_ID' AND status='queued' AND \"nextRunAt\"<=NOW()" 2>/dev/null || printf 0)"
+  running="$(pg_sql "SELECT COUNT(*) FROM sync_jobs WHERE \"connectionId\"='$SOURCE_CONNECTION_ID' AND status='running'" 2>/dev/null || printf 0)"
+  completed="$(pg_sql "SELECT COUNT(*) FROM sync_jobs WHERE \"jobType\"='marketplace.order.sync' AND \"connectionId\"='$SOURCE_CONNECTION_ID' AND status='succeeded' AND \"createdAt\">='$ws_iso'" 2>/dev/null || printf 0)"
+  oldest="$(pg_sql "SELECT COALESCE(ROUND(EXTRACT(EPOCH FROM (NOW() - MIN(\"createdAt\")))),0) FROM sync_jobs WHERE \"connectionId\"='$SOURCE_CONNECTION_ID' AND status='queued' AND \"nextRunAt\"<=NOW()" 2>/dev/null || printf 0)"
+  backlog="$(of_backlog "$SOURCE_TENANT" "$SOURCE_CONNECTION_ID" 2>/dev/null || printf 'unknown')"
+  # An unreadable upstream makes AVAILABLE WORK unknown too, never just the
+  # queue depth: the guard's contract is that `unknown` discards rather than
+  # being read around, and silently substituting the queue depth here would
+  # route around it one layer down.
+  if [ "$backlog" = "unknown" ]; then
+    available="unknown"
+  else
+    available=$(( backlog + ${due:-0} + ${running:-0} ))
+  fi
+  printf '%s,%s,%s,%s,%s,%s,%s,%s\n' "$(epoch)" "$(iso_now)" "${due:-0}" "${running:-0}" "${completed:-0}" "${oldest:-0}" "${backlog:-unknown}" "$available" >> "$out"
+}
+
+# The two background loops a throughput arm runs. Kept as separate PIDs rather
+# than one interleaved loop because their cadences are independent - the poll
+# pump's interval is the OFFERED-RATE knob and the sampler's is observation
+# resolution, and folding them together would silently tie one to the other.
+PUMP_PID=""
+SAMPLER_PID=""
+
+start_pump() {
+  local tag="$1"
+  ( while true; do
+      # Called inside a COMMAND SUBSTITUTION, which is what contains a `die`.
+      # `of_enqueue_poll` reaches `ol_api`, and `ol_api` dies on any non-2xx;
+      # a direct call would take the pump's own subshell down with it and the
+      # window would silently stop offering load from that moment on - which
+      # post_guard_feed_starved would then correctly, but confusingly, discard.
+      # A substitution keeps the failure to one tick.
+      : "$(of_enqueue_poll "$SOURCE_CONNECTION_ID" "$tag" 2>/dev/null || printf '')"
+      sleep "$POLL_CADENCE_SECS"
+    done ) &
+  PUMP_PID=$!
+  log "poll pump started (pid=$PUMP_PID, every ${POLL_CADENCE_SECS}s)"
+}
+
+start_progress() {
+  local out="$1" ws_iso="$2"
+  printf '%s\n' "$PROGRESS_HEADER" > "$out"
+  ( while true; do
+      progress_tick "$out" "$ws_iso" || true
+      sleep "$PROGRESS_TICK_SECS"
+    done ) &
+  SAMPLER_PID=$!
+  log "progress sampler started (pid=$SAMPLER_PID, every ${PROGRESS_TICK_SECS}s)"
+}
+
+stop_background() {
+  local p
+  for p in "$PUMP_PID" "$SAMPLER_PID"; do
+    [ -n "$p" ] || continue
+    kill "$p" >/dev/null 2>&1 || true
+    wait "$p" 2>/dev/null || true
+  done
+  PUMP_PID=""; SAMPLER_PID=""
+}
+
+# min_available_work <progress_csv>
+#
+# The minimum AVAILABLE WORK observed across the window (column 8), or
+# `unknown` if ANY tick could not establish it. `unknown` wins over every
+# number deliberately: a single unreadable tick means the run cannot show its
+# instrument kept offering load, and post_guard_feed_starved treats that as a
+# discard rather than reading around it.
+min_available_work() {
+  awk -F, 'NR>1 { v=$8; if (v=="unknown" || v=="") { print "unknown"; exit }
+                  if (m=="" || v+0 < m) m=v+0 }
+           END { if (m=="") print "unknown"; else printf "%d\n", m }' "$1"
+}
+
+# ===========================================================================
+# --smoke
+# ===========================================================================
+run_smoke() {
+  log "=== --smoke: one order end to end against the real PrestaShop destination ==="
+  of_health | jq -c .
+  log "stub config: $(of_config | jq -c '{runId, offerPoolSize, buyerPoolSize, latency}')"
+
+  # The runner must be on for anything to happen. --smoke deliberately does
+  # NOT recreate the worker: it is a rig self-test, and a smoke run that
+  # rebuilds containers is not cheap enough to reach for casually.
+  local runner
+  runner="$(docker exec "$(discover_worker_containers | awk '{print $1}')" printenv WORKER_RUNNER_ENABLED 2>/dev/null || printf 'true')"
+  [ "$runner" != "false" ] || die "--smoke needs the runner ENABLED; this stand has WORKER_RUNNER_ENABLED=false.
+  Bring it up first:
+    sed -i 's/^WORKER_RUNNER_ENABLED=.*/WORKER_RUNNER_ENABLED=true/' $ENV_FILE
+    (cd $REPO_ROOT && docker compose -f docker-compose.lab.yml --env-file .env.lab -p lab up -d --no-deps worker)"
+
+  of_new_run >/dev/null
+  # RESETTING THE STUB'S RUN IS ONLY HALF OF IT - OL's own cursor must go too.
+  #
+  # `POST /__stub/run` restarts the stub's per-tenant sequence at 0 under a new
+  # run id, but `connection_cursors` still holds the LAST run's head. The stub
+  # cannot place a cursor from a run it no longer has, and its documented
+  # behaviour for an unplaceable `from` is to treat the caller as already
+  # caught up - so it answers with NO events and echoes the current head back.
+  # The poll then succeeds with `fetched=0, enqueued=0` and the sample reports
+  # NO_CHILD, which reads like a broken pipeline and is in fact a stale cursor.
+  # Observed live before this line existed.
+  reset_between_repeats "$CONN_IDS" "'$OF_CURSOR_KEY'"
+  local tmp
+  tmp="$(mktemp)"
+  printf '%s\n' "$LATENCY_HEADER" > "$tmp"
+  run_one_sample 0 "$PS_CONNECTION_ID" "$tmp"
+  log "=== sample row ==="
+  cat "$tmp"
+  log "=== reconstructed hops ==="
+  python3 "$SCRIPT_DIR/../drivers/f1-summarize.py" latency "$tmp" || true
+
+  # THE FEED-BACKLOG SENSOR IS EXERCISED HERE, ON PURPOSE.
+  # post_guard_feed_starved is a pure function of a number, so lib-test.sh can
+  # prove the guard; only a live stand can prove the SENSOR that feeds it is
+  # not structurally blind - which is this harness's other recurring failure
+  # (post_guard_limiter_degraded answered "ok" on every run of this campaign
+  # while unable to match a line, #2851). A sensor that reports a positive
+  # backlog after a push and a smaller one after a drain is one that can see.
+  log "=== feed-backlog sensor check ==="
+  local before after
+  before="$(of_backlog "$SOURCE_TENANT" "$SOURCE_CONNECTION_ID")"
+  of_push_orders "$SOURCE_TENANT" 5 >/dev/null
+  after="$(of_backlog "$SOURCE_TENANT" "$SOURCE_CONNECTION_ID")"
+  log "backlog before pushing 5: $before   after: $after"
+  case "$after" in
+    unknown) die "of_backlog answered 'unknown' after a push - the sensor post_guard_feed_starved depends on cannot see, and every throughput arm would discard" ;;
+  esac
+  [ "$after" -gt "${before:-0}" ] 2>/dev/null \
+    || die "of_backlog did not rise after pushing 5 orders ($before -> $after) - the sensor is blind, so post_guard_feed_starved would pass a starved run"
+  log "feed-backlog sensor OK (rose by $((after - before)) after a 5-order push)"
+
+  rm -f "$tmp"
+  log "--smoke complete. Nothing was written under $RESULTS_ROOT."
+}
+
+# ===========================================================================
+# strict
+# ===========================================================================
+
+# Everything a window needs that is not lib.sh's: the resolved poll cadences,
+# the stub's own config, the identity mode, and the destination posture.
+#
+# The Allegro cadence is DERIVED, and labelled so. The scheduler is off, so
+# nothing is "read from a running scheduler"; what is read is the worker's own
+# environment (where #2279 moved the scheduler, and therefore the only process
+# whose value would matter) falling back to the plugin's literal default.
+manifest_extra_json() {
+  local arm="$1" dest="$2" dest_label="$3" rate_limit="$4" extra="${5:-{\}}"
+  local allegro_cron warmup_total stub_cfg identity resolvable_variants resolvable_products
+  # What the offers can ACTUALLY reach at the destination, read from the
+  # database rather than taken from the stub's advertised pool size.
+  resolvable_variants="$(pg_sql "SELECT COUNT(DISTINCT im.\"internalId\") FROM identifier_mappings im
+    JOIN product_variants pv ON pv.id = im.\"internalId\"
+    WHERE im.\"entityType\"='Offer' AND im.\"connectionId\"='$SOURCE_CONNECTION_ID' AND pv.\"isStale\" = false" 2>/dev/null || printf 0)"
+  resolvable_products="$(pg_sql "SELECT COUNT(DISTINCT pv.\"productId\") FROM identifier_mappings im
+    JOIN product_variants pv ON pv.id = im.\"internalId\"
+    WHERE im.\"entityType\"='Offer' AND im.\"connectionId\"='$SOURCE_CONNECTION_ID' AND pv.\"isStale\" = false" 2>/dev/null || printf 0)"
+  allegro_cron="$(docker exec "$(discover_worker_containers | awk '{print $1}')" printenv OL_ALLEGRO_POLL_INTERVAL_CRON 2>/dev/null || printf '')"
+  local allegro_cron_source="worker environment"
+  [ -n "$allegro_cron" ] || { allegro_cron='*/1 * * * *'; allegro_cron_source="allegro-scheduler-tasks.ts default (unset on the worker)"; }
+  identity="$(docker exec "$(discover_worker_containers | awk '{print $1}')" printenv OL_CUSTOMER_IDENTITY_MODE 2>/dev/null || printf '')"
+  [ -n "$identity" ] || identity='email_fallback (unset - core default)'
+  warmup_total=$((WARMUP_ORDERS_PER_REPLICA * ORIGINAL_REPLICAS))
+  stub_cfg="$(of_config)"
+
+  jq -n \
+    --arg arm "$arm" \
+    --arg dest "$dest" \
+    --arg dest_label "$dest_label" \
+    --arg rate_limit "$rate_limit" \
+    --arg source_tenant "$SOURCE_TENANT" \
+    --arg source_conn "$SOURCE_CONNECTION_ID" \
+    --arg allegro_cron "$allegro_cron" \
+    --arg allegro_cron_source "$allegro_cron_source" \
+    --arg identity "$identity" \
+    --argjson warmup "$warmup_total" \
+    --argjson warmup_per_replica "$WARMUP_ORDERS_PER_REPLICA" \
+    --argjson replicas "$ORIGINAL_REPLICAS" \
+    --argjson poll_cadence "$POLL_CADENCE_SECS" \
+    --argjson poll_limit "$OF_POLL_LIMIT" \
+    --argjson stub "$stub_cfg" \
+    --argjson resolvable_variants "${resolvable_variants:-0}" \
+    --argjson resolvable_products "${resolvable_products:-0}" \
+    --argjson extra "$extra" \
+    '{
+      arm: $arm,
+      orderSource: {tenant: $source_tenant, connectionId: $source_conn},
+      destination: {label: $dest_label, connectionId: $dest, rateLimitInForce: $rate_limit},
+      arrivalRate: {
+        note: "the INDEPENDENT VARIABLE is the offered order rate, kept separate from any seeded row count: min(pollPageLimit, feedBacklog) / pollCadenceSeconds. The 1,000,000 pre-seeded order_records rows on this stand are a fixed dataset size, never an arrival rate.",
+        pollCadenceSecondsHarnessChosen: $poll_cadence,
+        pollPageLimit: $poll_limit
+      },
+      pollCadenceResolved: {
+        note: "DERIVED, not read from a running scheduler - the scheduler is OFF for this run and the harness enqueues every poll itself. #2279 moved the scheduler into the worker, so the worker environment is the only place a cron override would take effect.",
+        allegro: {cron: $allegro_cron, source: $allegro_cron_source, meanPollWaitSeconds: 30, retunable: true, envVar: "OL_ALLEGRO_POLL_INTERVAL_CRON"},
+        woocommerce: {cron: "*/5 * * * *", source: "woocommerce-scheduler-tasks.ts string literal", retunable: false},
+        erli: {cron: "*/5 * * * *", source: "erli-scheduler-tasks.ts string literal", retunable: false},
+        prestashop: {cron: "0 */10 * * * *", source: "prestashop-scheduler-tasks.ts", retunable: true, envVar: "OL_PRESTASHOP_POLL_INTERVAL_CRON", note: "webhook-primary; the poll is the backstop"}
+      },
+      buyerIdentityMode: $identity,
+      warmupOrders: {perReplica: $warmup_per_replica, replicas: $replicas, total: $warmup, reason: "excludes the line_prices cold start (27 requests vs 7 for the first order after any worker restart, prestashop-openlinker-module.client.ts) and warms the currency/country/order-state caches"},
+      stub: $stub,
+      stubOfferPoolSize: ($stub.offerPoolSize),
+      destinationResolvableVariants: $resolvable_variants,
+      destinationResolvableProducts: $resolvable_products,
+      productPoolNote: "THREE DIFFERENT NUMBERS, and the #2856 seeded-mapping contract (the offer pool and the distinct-product count being the same number) CANNOT hold on this stand. The stub mints stubOfferPoolSize distinct offer ids, but seed-catalogue.sh seeds mappings rather than real shop products, so only destinationResolvableProducts products actually exist at the destination and every offer round-robins onto destinationResolvableVariants variants. The PrestaShop tax chain caches 24h per connection+product+country, so it decays against the RESOLVABLE count - a small pool warms almost immediately and understates per-order destination cost for a real catalogue.",
+      fanOutCoTenancy: "controlled - the scheduler is OFF, so no master sweep parent shares the fan-out lane with marketplace.orders.poll during any window",
+      latencyPointProvenance: "documented cross-table reconstruction, NOT #2850 instrumentation. See the scenario header; the summarizer counts the heartbeat-rewrite and multi-attempt cases rather than assuming them away, and the single-destination arrange removes the syncedAt late-bias structurally."
+    } * $extra'
+}
+
+# arm_throughput <arm_name> <dest_conn> <dest_label> <rate_limit_label> <backlog> <window_secs>
+#
+# Reports through the GLOBALS `ARM_RATE` / `ARM_DIR`, deliberately, rather than
+# by echoing on stdout for the caller to capture. Half a dozen lib.sh calls in
+# this function's body (window_start, window_stop, manifest_write,
+# results_dir_init, reset_between_repeats, the sampler starts) write to stdout
+# through `log`, and a `$(...)` capture would swallow all of it into the
+# "rate" - silently, since `read -r rate dir` simply takes the first two words
+# of whatever arrives. Redirecting each of those to stderr one by one is a list
+# that goes stale the first time a line is added.
+ARM_RATE=""
+ARM_DIR=""
+
+arm_throughput() {
+  local arm="$1" dest="$2" dest_label="$3" rl_label="$4" backlog="$5" window="$6"
+  local dir run_group progress rate
+  ARM_RATE=""; ARM_DIR=""
+
+  log "=== arm $arm: backlog=$backlog window=${window}s destination=$dest_label rateLimit=$rl_label ==="
+
+  of_new_run >/dev/null
+  reset_between_repeats "$CONN_IDS" "'$OF_CURSOR_KEY'"
+  pg_sql_write "DELETE FROM sync_jobs WHERE \"connectionId\"='$SOURCE_CONNECTION_ID' AND status IN ('queued','running')" >/dev/null
+  guard_queue_empty "$CONN_IDS"
+
+  # Warm-up BEFORE the window, so the line_prices cold start and the
+  # currency/country/order-state caches are all warm when it opens.
+  local warm=$((WARMUP_ORDERS_PER_REPLICA * ORIGINAL_REPLICAS))
+  log "warm-up: $warm order(s) ($WARMUP_ORDERS_PER_REPLICA per replica x $ORIGINAL_REPLICAS)"
+  of_push_orders "$SOURCE_TENANT" "$warm" >/dev/null
+  of_enqueue_poll "$SOURCE_CONNECTION_ID" "warm-$arm" >/dev/null
+  cap_perf_job_attempts
+  drain_wait "$CONN_IDS" >/dev/null || warn "warm-up drain did not settle cleanly"
+
+  # Then the measured backlog, pushed in ONE request before the window opens.
+  of_push_orders "$SOURCE_TENANT" "$backlog" >/dev/null
+  log "pushed $backlog order(s); stub backlog now $(of_backlog "$SOURCE_TENANT" "$SOURCE_CONNECTION_ID")"
+
+  run_group="$arm-run$(date +%s)"
+  dir="$(results_dir_init f1-order-ingestion "$run_group")"
+  progress="$dir/progress.csv"
+
+  snapshot_jobs_before "$CONN_IDS"
+  window_start "$dir" f1-order-ingestion "$CONN_IDS" 0 \
+    "$(manifest_extra_json "$arm" "$dest" "$dest_label" "$rl_label" \
+       "$(jq -n --argjson b "$backlog" --argjson w "$window" '{feedBacklogPushed:$b, windowSeconds:$w}')")"
+  local ws_iso; ws_iso="$(date -u -d "@$WINDOW_START_EPOCH" +%Y-%m-%dT%H:%M:%SZ)"
+
+  local stub_before; stub_before="$(of_stats "$SOURCE_TENANT")"
+  start_progress "$progress" "$ws_iso"
+  start_pump "$arm"
+  sleep "$window"
+  stop_background
+  window_stop "$dir"
+  local stub_after; stub_after="$(of_stats "$SOURCE_TENANT")"
+
+  printf '%s' "$stub_before" > "$dir/stub-stats-before.json"
+  printf '%s' "$stub_after"  > "$dir/stub-stats-after.json"
+
+  local mb; mb="$(min_available_work "$progress")"
+  run_post_guards "$dir" "$CONN_IDS" "$ws_iso" "$WINDOW_START_EPOCH" "$WINDOW_STOP_EPOCH" "$dest" "" "" "$mb"
+
+  # DISCARD the undrained remainder rather than draining it.
+  #
+  # The backlog is deliberately sized to outlast the window (that is what
+  # post_guard_feed_starved requires), so a window that ends with the system
+  # still busy leaves hundreds of queued children behind BY DESIGN. Draining
+  # them would cost, at the rates this arm just measured, longer than the
+  # window itself - three arms of that is most of an hour spent executing work
+  # that is outside every measurement and contributes to none of them.
+  #
+  # Deleting a QUEUED row is safe: it was never claimed, so nothing partially
+  # happened for it, and the orders it would have created are the ones this
+  # arm already declined to count. `running` rows are left to finish and then
+  # waited on - killing a claimed job mid-flight would abandon a destination
+  # create halfway, which is a real side effect on a real shop.
+  local discarded
+  discarded="$(pg_sql "SELECT COUNT(*) FROM sync_jobs WHERE \"connectionId\"='$SOURCE_CONNECTION_ID' AND status='queued'" 2>/dev/null || printf 0)"
+  pg_sql_write "DELETE FROM sync_jobs WHERE \"connectionId\"='$SOURCE_CONNECTION_ID' AND status='queued'" >/dev/null
+  log "arm $arm: discarded ${discarded:-0} queued child job(s) that the window did not reach (never claimed, so nothing partially happened)"
+  pg_sql_write "UPDATE sync_jobs SET \"maxAttempts\"=$PERF_MAX_ATTEMPTS WHERE \"connectionId\"='$SOURCE_CONNECTION_ID' AND status='running'" >/dev/null
+  drain_wait "$CONN_IDS" >/dev/null || warn "arm $arm: drain timed out waiting for in-flight jobs"
+
+  {
+    printf '=== arm %s ===\n' "$arm"
+    python3 "$SCRIPT_DIR/../drivers/f1-summarize.py" throughput "$progress"
+    printf '\nstub upstream requests over the window:\n'
+    jq -n --argjson a "$stub_after" --argjson b "$stub_before" \
+      '($a.requestCounts // {}) as $A | ($b.requestCounts // {}) as $B
+       | [$A | keys[]] | map({key:., value: (($A[.] // 0) - ($B[.] // 0))}) | from_entries'
+  } > "$dir/summary.txt"
+  cat "$dir/summary.txt"
+
+  rate="$(awk -F'= *' '/orders\/hour/ {gsub(/ orders\/hour/,"",$2); print $2; exit}' "$dir/summary.txt")"
+  [ -n "$rate" ] || rate=0
+  ARM_RATE="$rate"
+  ARM_DIR="$dir"
+  log "arm $arm result: $ARM_RATE orders/hour ($ARM_DIR)"
+}
+
+run_strict() {
+  log "=== pre-flight guards ==="
+  guard_scheduler_off
+  guard_demo_mode_off
+  guard_log_level
+  guard_perf_max_attempts
+  guard_build
+
+  # The runner must be ON for F1 - the whole chain is unobservable otherwise.
+  # This stand's own default is OFF, so it is flipped here and restored by the
+  # EXIT trap. guard_runner_state then verifies the flip took AND captures the
+  # lane caps the runner actually resolved, which is what the falsification
+  # arms compare against.
+  recreate_worker true
+  guard_connection_budget
+  guard_pool_recorded
+  guard_runner_state enabled
+
+  local built_sha; built_sha="${MANIFEST_GIT_SHA}"
+  local report="$RESULTS_ROOT/results-F1-$(date -u +%Y-%m-%d).md"
+  local baseline_caps="$MANIFEST_LANE_CAPS"
+
+  local lat_dir="" lat_csv=""
+  local base_rate="" base_dir="" raised_rate="" raised_dir="" lane_rate="" lane_dir=""
+  local wc_dir="" wc_csv=""
+
+  # -------------------------------------------------------------------------
+  # PrestaShop is the headline destination (#2847: the REAL local shop, never
+  # the #2846 stub). WooCommerce is disabled for every PrestaShop arm so the
+  # unfiltered fan-out cannot reach both and bias syncedAt toward the slower.
+  # -------------------------------------------------------------------------
+  set_destination "$WC_CONNECTION_ID" off
+  set_destination "$PS_CONNECTION_ID" on
+  set_rate_limit  "$PS_CONNECTION_ID" default
+
+  if [ "$ARMS" = "all" ] || [ "$ARMS" = "latency" ]; then
+    log "=== arm latency: $LATENCY_SAMPLES serial samples, real PrestaShop destination ==="
+    of_new_run >/dev/null
+    reset_between_repeats "$CONN_IDS" "'$OF_CURSOR_KEY'"
+    pg_sql_write "DELETE FROM sync_jobs WHERE \"connectionId\"='$SOURCE_CONNECTION_ID' AND status IN ('queued','running')" >/dev/null
+    guard_queue_empty "$CONN_IDS"
+
+    local warm=$((WARMUP_ORDERS_PER_REPLICA * ORIGINAL_REPLICAS))
+    of_push_orders "$SOURCE_TENANT" "$warm" >/dev/null
+    of_enqueue_poll "$SOURCE_CONNECTION_ID" "warm-lat" >/dev/null
+    cap_perf_job_attempts
+    drain_wait "$CONN_IDS" >/dev/null || warn "latency warm-up drain did not settle cleanly"
+
+    lat_dir="$(results_dir_init f1-order-ingestion "latency-run$(date +%s)")"
+    lat_csv="$lat_dir/samples.csv"
+    printf '%s\n' "$LATENCY_HEADER" > "$lat_csv"
+
+    snapshot_jobs_before "$CONN_IDS"
+    window_start "$lat_dir" f1-order-ingestion "$CONN_IDS" 0 \
+      "$(manifest_extra_json latency "$PS_CONNECTION_ID" "real PrestaShop (#2860)" "manifest default (60/min, 4 concurrent)" \
+         "$(jq -n --argjson n "$LATENCY_SAMPLES" '{samples:$n, shape:"serial - one order in flight at a time, so no hop carries queue wait behind another order"}')")"
+    local lat_ws_iso; lat_ws_iso="$(date -u -d "@$WINDOW_START_EPOCH" +%Y-%m-%dT%H:%M:%SZ)"
+    local lat_stub_before; lat_stub_before="$(of_stats "$SOURCE_TENANT")"
+
+    local i
+    for i in $(seq 1 "$LATENCY_SAMPLES"); do
+      run_one_sample "$i" "$PS_CONNECTION_ID" "$lat_csv"
+    done
+
+    window_stop "$lat_dir"
+    printf '%s' "$lat_stub_before"        > "$lat_dir/stub-stats-before.json"
+    printf '%s' "$(of_stats "$SOURCE_TENANT")" > "$lat_dir/stub-stats-after.json"
+    # No feed backlog to starve here, deliberately: the arm drains the stub by
+    # design, one order at a time. That is post_guard_feed_starved's own
+    # "not applicable" case, and passing a number would discard every run.
+    run_post_guards "$lat_dir" "$CONN_IDS" "$lat_ws_iso" "$WINDOW_START_EPOCH" "$WINDOW_STOP_EPOCH" "$PS_CONNECTION_ID" "" "" ""
+    python3 "$SCRIPT_DIR/../drivers/f1-summarize.py" latency "$lat_csv" > "$lat_dir/summary.txt"
+    cat "$lat_dir/summary.txt"
+    drain_wait "$CONN_IDS" >/dev/null || true
+  fi
+
+  if [ "$ARMS" = "all" ] || [ "$ARMS" = "throughput" ]; then
+    arm_throughput throughput-baseline "$PS_CONNECTION_ID" \
+      "real PrestaShop (#2860)" "manifest default (60/min, 4 concurrent)" "$THROUGHPUT_BACKLOG" "$THROUGHPUT_WINDOW_SECS"
+    base_rate="$ARM_RATE"; base_dir="$ARM_DIR"
+
+    set_rate_limit "$PS_CONNECTION_ID" "$RAISED_RPM" "$RAISED_CONCURRENT"
+    arm_throughput throughput-destination-raised "$PS_CONNECTION_ID" \
+      "real PrestaShop (#2860)" "config.rateLimit $RAISED_RPM/min, $RAISED_CONCURRENT concurrent" "$THROUGHPUT_BACKLOG" "$THROUGHPUT_WINDOW_SECS"
+    raised_rate="$ARM_RATE"; raised_dir="$ARM_DIR"
+
+    # The falsification #2847 asks for is complete at this point either way:
+    # if the rate moved, the destination limit was binding at baseline; if it
+    # did not, the lane cap was.
+    local moved
+    moved="$(awk -v a="$base_rate" -v b="$raised_rate" -v t="$MOVED_THRESHOLD_PCT" \
+      'BEGIN { if (a <= 0) { print "unknown"; exit } d = (b - a) / a * 100; if (d < 0) d = -d; print (d > t) ? "yes" : "no" }')"
+    log "destination-limit falsification: baseline=$base_rate/h raised=$raised_rate/h -> moved=$moved (threshold ${MOVED_THRESHOLD_PCT}%)"
+
+    # Arm 3 runs UNCONDITIONALLY, and that is a change of mind worth recording.
+    # An earlier draft skipped it whenever arm 2 moved the number, on the
+    # grounds that the falsification was already answered. It is - but the
+    # question an operator actually has is "what binds NEXT", and a two-point
+    # ladder cannot answer it: with the destination lifted, either the lane cap
+    # is the new ceiling (arm 3 moves the number again) or something else
+    # entirely is (arm 3 does not, and the report has to name what). Skipping
+    # it saves one window and throws away the only measurement that tells those
+    # two apart.
+    log "raising OL_LANE_REALTIME_SCOPE_CAP to $RAISED_LANE_SCOPE_CAP on top of the raised destination limit"
+    recreate_worker true "$RAISED_LANE_SCOPE_CAP" "$RAISED_LANE_CAP"
+    guard_runner_state enabled
+    # The label is DERIVED from what the runner reported, never from what was
+    # requested. An earlier version asserted "+ lane scope cap 16" as a
+    # literal while the runner was in fact still on 4/2, producing a manifest
+    # that contradicted itself - honest in `laneCaps` (read from the runner)
+    # and false in the label (written by hand). A label is a claim; only a
+    # reading is evidence.
+    arm_throughput throughput-lane-raised "$PS_CONNECTION_ID" \
+      "real PrestaShop (#2860)" "config.rateLimit $RAISED_RPM/min, $RAISED_CONCURRENT concurrent + lane caps as reported by the runner: $MANIFEST_LANE_CAPS" \
+      "$THROUGHPUT_BACKLOG" "$THROUGHPUT_WINDOW_SECS"
+    lane_rate="$ARM_RATE"; lane_dir="$ARM_DIR"
+    recreate_worker true
+    guard_runner_state enabled
+
+    set_rate_limit "$PS_CONNECTION_ID" default
+  fi
+
+  # -------------------------------------------------------------------------
+  # The real-WooCommerce arm. Reported separately and labelled a real-shop
+  # measurement, never a throughput figure (#2847's own words): a real
+  # WooCommerce install carries its own unmeasured latency the way a sandbox
+  # would. PrestaShop is disabled for it, for the same single-destination
+  # reason the PrestaShop arms disable WooCommerce.
+  # -------------------------------------------------------------------------
+  # A DESTINATION ARM WITH NO REAL PRODUCTS BEHIND IT IS REFUSED, NOT RUN.
+  #
+  # `seed-catalogue.sh` writes 10 000 WooCommerce `Product` identifier
+  # mappings whose external ids are synthetic strings
+  # (`PERFSEED-EXT-PROD-wc-*`), and zero actual WooCommerce products - it was
+  # built for the read-path scenarios, where nothing crosses to a shop.
+  # `WooCommerceOrderProcessorAdapter.resolveLineItems` needs a numeric WC
+  # product id, so every order on this arm fails with
+  # `Corrupted mapping: "PERFSEED-EXT-PROD-wc-N" is not a valid positive
+  # integer WC ID`.
+  #
+  # Running it anyway would burn a window to produce a DISCARDED verdict and a
+  # table of failures, and - worse - would invite a reader to mistake a stand
+  # gap for a WooCommerce performance result. The refusal names what is
+  # missing and what would fix it.
+  local wc_real_products=0
+  if [ "$ARMS" = "all" ]; then
+    wc_real_products="$(pg_sql "SELECT COUNT(*) FROM identifier_mappings
+      WHERE \"entityType\"='Product' AND \"connectionId\"='$WC_CONNECTION_ID'
+        AND \"externalId\" ~ '^[0-9]+\$'" 2>/dev/null || printf 0)"
+  fi
+  if [ "$ARMS" = "all" ] && [ "${wc_real_products:-0}" -eq 0 ]; then
+    warn "SKIPPING the WooCommerce arm: the stand carries $(pg_sql "SELECT COUNT(*) FROM identifier_mappings WHERE \"entityType\"='Product' AND \"connectionId\"='$WC_CONNECTION_ID'" 2>/dev/null || printf '?') WooCommerce Product mappings and NONE of them names a numeric WC product id, so no order can resolve a line item there. seed-catalogue.sh seeds mappings, never real WooCommerce products - creating some (wp post create --post_type=product) and re-pointing those mappings is what this arm needs. Reported as not-run rather than run-and-discarded."
+  elif [ "$ARMS" = "all" ]; then
+    log "=== arm woocommerce: $WC_ARM_ORDERS serial samples against the real local WooCommerce ==="
+    set_destination "$PS_CONNECTION_ID" off
+    set_destination "$WC_CONNECTION_ID" on
+    of_new_run >/dev/null
+    reset_between_repeats "$CONN_IDS" "'$OF_CURSOR_KEY'"
+    pg_sql_write "DELETE FROM sync_jobs WHERE \"connectionId\"='$SOURCE_CONNECTION_ID' AND status IN ('queued','running')" >/dev/null
+    guard_queue_empty "$CONN_IDS"
+
+    of_push_orders "$SOURCE_TENANT" "$((WARMUP_ORDERS_PER_REPLICA * ORIGINAL_REPLICAS))" >/dev/null
+    of_enqueue_poll "$SOURCE_CONNECTION_ID" warm-wc >/dev/null
+    cap_perf_job_attempts
+    drain_wait "$CONN_IDS" >/dev/null || warn "woocommerce warm-up drain did not settle cleanly"
+
+    wc_dir="$(results_dir_init f1-order-ingestion "woocommerce-run$(date +%s)")"
+    wc_csv="$wc_dir/samples.csv"
+    printf '%s\n' "$LATENCY_HEADER" > "$wc_csv"
+    snapshot_jobs_before "$CONN_IDS"
+    window_start "$wc_dir" f1-order-ingestion "$CONN_IDS" 0 \
+      "$(manifest_extra_json woocommerce "$WC_CONNECTION_ID" "real WooCommerce behind wc-tls (#2854)" "manifest default (60/min, 4 concurrent)" \
+         "$(jq -n --argjson n "$WC_ARM_ORDERS" '{samples:$n, shape:"serial, low rate - a REAL-SHOP measurement, never a throughput figure"}')")"
+    local wc_ws_iso; wc_ws_iso="$(date -u -d "@$WINDOW_START_EPOCH" +%Y-%m-%dT%H:%M:%SZ)"
+    local j
+    for j in $(seq 1 "$WC_ARM_ORDERS"); do
+      run_one_sample "$j" "$WC_CONNECTION_ID" "$wc_csv"
+    done
+    window_stop "$wc_dir"
+    run_post_guards "$wc_dir" "$CONN_IDS" "$wc_ws_iso" "$WINDOW_START_EPOCH" "$WINDOW_STOP_EPOCH" "$WC_CONNECTION_ID" "" "" ""
+    python3 "$SCRIPT_DIR/../drivers/f1-summarize.py" latency "$wc_csv" > "$wc_dir/summary.txt"
+    cat "$wc_dir/summary.txt"
+    drain_wait "$CONN_IDS" >/dev/null || true
+  fi
+
+  log "=== every arm complete ==="
+  log "latency:                    ${lat_dir:-<not run>}"
+  log "throughput baseline:        ${base_dir:-<not run>} (${base_rate:-?} orders/h)"
+  log "throughput dest-raised:     ${raised_dir:-<not run>} (${raised_rate:-?} orders/h)"
+  log "throughput lane-raised:     ${lane_dir:-<not run>} (${lane_rate:-?} orders/h)"
+  log "woocommerce:                ${wc_dir:-<not run>}"
+  log "baseline lane caps:         $baseline_caps"
+  log "image revision:             $built_sha"
+  log "write the dated report at:  $report"
+}
+
+case "$MODE" in
+  smoke) run_smoke ;;
+  strict) run_strict ;;
+esac

--- a/perf/openlinker-throughput/stubs/allegro/server.mjs
+++ b/perf/openlinker-throughput/stubs/allegro/server.mjs
@@ -181,6 +181,39 @@ function priceForOffer(offerIndex) {
   return Number((9.99 + (offerIndex % 20) * 1.5).toFixed(2));
 }
 
+// A pool slot rendered as LETTERS ONLY - 1 -> 'a', 26 -> 'z', 27 -> 'aa'.
+//
+// This exists because of a real destination refusal, found live by F1 (#2847)
+// and worth stating precisely rather than leaving as a mystery constant. The
+// buyer's `firstName`/`lastName` travel all the way into
+// `PrestashopCustomerProvisioner`'s `POST /api/customers`, and PrestaShop
+// validates them with `Validate::isName`, which REJECTS digits outright. A
+// lastName of `Number42` therefore answered
+//
+//   HTTP 400  code 85  Validation error: "Property Customer->firstname is not valid"
+//
+// on every single order, so no stub order could reach a destination create at
+// all - and because `OrderSyncService` fans out under `Promise.allSettled`,
+// the job still recorded `outcome: 'ok'` while the shop received nothing.
+//
+// Distinctness per pool slot is preserved, which is the property the buyer
+// pool exists for (see the README's "buyer-identity decision"): letters are a
+// bijection with the slot number. The EMAIL keeps its digits deliberately -
+// it is the masked-email fixedPart the identity normalizer keys on, an email
+// is not name-validated anywhere, and changing it would change the axis the
+// pool is about. The street keeps its digits too: `Validate::isAddress`
+// allows them, as a street number must be.
+function poolSlotLetters(n) {
+  let s = '';
+  let v = n;
+  while (v > 0) {
+    const rem = (v - 1) % 26;
+    s = String.fromCharCode(97 + rem) + s;
+    v = Math.floor((v - 1) / 26);
+  }
+  return s || 'a';
+}
+
 function buyerFor(orderN) {
   const idx = orderN % CONFIG.buyerPoolSize; // 0-based
   const buyerNumber = idx + 1;
@@ -195,8 +228,11 @@ function buyerFor(orderN) {
     // and is deliberately included BECAUSE it must be irrelevant.
     email: `buyer${buyerNumber}+tx${orderN}@allegromail.pl`,
     login: `buyer${buyerNumber}`,
+    // Letters only - see poolSlotLetters above. Never re-introduce a digit
+    // here: it fails PrestaShop's Validate::isName and silently costs every
+    // destination create.
     firstName: 'Buyer',
-    lastName: `Number${buyerNumber}`,
+    lastName: `Testbuyer${poolSlotLetters(buyerNumber)}`,
     phoneNumber: '+48000000000',
     address: {
       street: `ul. Testowa ${buyerNumber}`,

--- a/perf/openlinker-throughput/stubs/allegro/test.mjs
+++ b/perf/openlinker-throughput/stubs/allegro/test.mjs
@@ -286,6 +286,49 @@ test('distinct buyers produce distinct masked-email fixed parts', async () => {
 });
 
 // ---------------------------------------------------------------------------
+// Buyer NAMES carry no digits, and are still distinct per pool slot
+//
+// Found live by F1 (#2847): PrestaShop validates a customer's firstname and
+// lastname with `Validate::isName`, which rejects digits outright, so a
+// lastName of `Number42` answered HTTP 400 code 85 on every destination
+// create - and because OrderSyncService fans out under Promise.allSettled the
+// job still recorded `outcome: 'ok'` while the shop received nothing. This
+// asserts both halves of the fix, because dropping the digits without keeping
+// the slots distinct would silently collapse the buyer pool the stub's own
+// identity decision depends on.
+// ---------------------------------------------------------------------------
+
+test('buyer names carry no digits and stay distinct per pool slot', async () => {
+  await resetRun('t-buyer-names');
+  await call('POST', `/__stub/tenants/${TENANT_A}/orders`, {
+    token: null,
+    body: { count: 30 },
+  });
+  const { body: eventsPage } = await call('GET', '/order/events?limit=50', { token: TOKEN_A });
+
+  const names = new Set();
+  for (const event of eventsPage.events) {
+    const { body: form } = await call(
+      'GET',
+      `/order/checkout-forms/${encodeURIComponent(event.order.checkoutForm.id)}`,
+      { token: TOKEN_A }
+    );
+    assert.ok(
+      !/[0-9]/.test(form.buyer.firstName),
+      `buyer.firstName must contain no digit (PrestaShop Validate::isName), got ${form.buyer.firstName}`
+    );
+    assert.ok(
+      !/[0-9]/.test(form.buyer.lastName),
+      `buyer.lastName must contain no digit (PrestaShop Validate::isName), got ${form.buyer.lastName}`
+    );
+    names.add(`${form.buyer.firstName} ${form.buyer.lastName}`);
+  }
+  // 30 orders against the default 50-slot pool: every slot is still distinct,
+  // so the letter encoding did not collapse the pool.
+  assert.equal(names.size, 30, 'each pool slot should still render a distinct name');
+});
+
+// ---------------------------------------------------------------------------
 // Offer ids: {tenant}-offer-{n}, n within the configured pool size
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Builds and runs **F1 - order ingestion latency and throughput**, the headline flow of the #2840 programme. It had never run and had no scenario file.

## Measured

Every window was **DISCARDED**, so these are provisional - the two causes are in the report and summarised below.

| Question | Answer |
|---|---|
| How long does one order take to reach a real shop? | **p50 66 s**, idle system, excludes poll wait. 25/25 samples reached PrestaShop. |
| How many orders per hour at the shipped defaults? | **182 orders/h** |
| ...with the destination rate limit lifted? | **262-295 orders/h** |
| Per-order upstream cost (#1134 AC2) | **1 per poll tick + 1 per ingested order + 0 per line item**, confirmed at two different ratios |
| What binds first? | the destination's declared rate limit - **through minimum inter-request spacing, not through its budget** |
| What binds above that? | **not established** - the lane-cap arm never applied its own change |

## The finding worth acting on

One component misbehaving two ways at once. Read together, not separately.

1. **`requestsPerMinute: 60` throttles by imposing a 1-second minimum gap between requests, not by spending a budget.** The baseline never exceeded 2 requests in any second across 118 sampled seconds while using only **34 of its 60 req/min**. At 10-14 requests per order that is 10-14 s of pacing paid per order with 43% of the budget unused.
2. **The same limiter burns its full 1000 ms Redis timeout roughly once a minute** and degrades to per-process limiting - against a Redis measured healthy on every axis (0 ms latency, empty `SLOWLOG`, 18 MB, plain string keys, host load 0.59/28 cores). The timeout is client-side in the worker; this run localised it but could not identify it.

The destination shop is not the bottleneck: **PrestaShop answers every create-path call in 11-20 ms**, measured directly while the run was in flight. ~16 requests per order is ~0.24 s of shop time inside a 52.9 s hop.

## An arm that measured the wrong thing

**The lane-cap arm never raised the lane cap.** `recreate_worker` wrote `OL_LANE_REALTIME_SCOPE_CAP` into `.env.lab`, which only enables `${VAR}` interpolation *inside* the compose file - the worker service names neither lane variable in its `environment:`, so compose never forwarded them.

A scenario that silently measures a configuration it did not request is the worst failure mode this harness has. What caught it and what did not is the point:

- **Caught** - `guard_runner_state` parses the runner's own startup line, so `manifest.laneCaps` correctly recorded `realtime=4/2`.
- **Missed** - the hand-written arm label asserted `"+ lane scope cap 16"`. Broken in the one place a claim was written instead of a reading.

Three fixes, in order of importance: `recreate_worker` now **verifies** the runner reports the caps requested and dies naming the trap otherwise; caps are forwarded via a scenario-local compose override leaving #2854's shared file untouched; the label is derived from `MANIFEST_LANE_CAPS`.

A genuine lane-cap arm was deliberately **not** run - the fixes let the next run measure it, and "not measured, here is the defect" beats a number produced in a hurry.

## Six defects fixed where they belong

1. **Allegro stub buyer names carried digits** - PrestaShop's `Validate::isName` rejects them, so every destination create answered HTTP 400 while the job still recorded `outcome: 'ok'` (the `Promise.allSettled` swallow). Red-first test added.
2. **`lib.sh`'s `reset_between_repeats` looped for ever** - `redis-cli --no-raw` renders the SCAN cursor as `1) "8192"`, which fed back gives `ERR invalid cursor`, never `0`. It had **no caller in any scenario** until F1, so it had never executed.
3. **Four PrestaShop webservice resources were never granted** (`countries`, `currencies`, `carts`, `configurations`). PrestaShop answers an ungranted resource with *"Invalid API key"*, so a create died blaming a credential on a connection whose own test had just passed. `configurations` is the subtle one: it is *tolerated*, so it merely burned ~7% of the rate-limit budget per order on a request that can never succeed.
4. **Offer mappings pointed at products that exist in neither shop** - `seed-catalogue.sh` seeds 10 000 mappings with synthetic ids and zero real products. The seeder now targets variants backed by a numeric PrestaShop id and warns with the real figure (6 real products here).
5. **The WooCommerce connection's credentials were permanently stale** - `ol_ensure_connection` is create-only while `step_woocommerce` rotates the key whenever it cannot recover the plaintext, which is always.
6. **Two bugs in this scenario itself**, both caught by a dry run before the real one: a malformed SQL column list, and `payload` where the column is `payloadJson`.

## New shared post-guard

`post_guard_feed_starved`, the counterpart to `post_guard_generator_saturated` for a scenario whose load is a standing supply rather than an HTTP generator. Its input is **available work** (upstream + due queue + running), not an upstream backlog - the poll pump drains a 900-order stub into queued children in ~90 s, so a backlog-only reading would have discarded every valid run.

## Recorded rather than worked around

- `post_guard_destination_creates` is **not saturation-aware** - orders still mid-create at window close discard every throughput arm, which is structural to a saturation window.
- `apps/worker/src/main.ts:28` hardcodes debug+verbose with no env override anywhere, so #2847's *"measure at `log` level"* criterion is **unsatisfiable on this build**. An AC that cannot be met is a fact about the code, not a gap in the run.
- **Run-to-run variance is 12.6%** for an identical configuration, measured by accident when arm 3 turned out to repeat arm 2.
- The WooCommerce arm refuses up front and reports not-run: the stand has 10 000 WC Product mappings and none names a numeric WC id.

## A correction carried in the report

Partway through the run I reported that request pacing was unchanged by the 100x limit raise, and therefore that the declared limit was never the pacing term. That sample came from the raised arm's **warm-up** rather than either measured window, and it was wrong. The corrected measurement inverts the conclusion. It is in the report where a reader meets it, because the withdrawn claim was the more intuitive one.

## Gate

`bash -n` clean, `lib-test.sh` **113 -> 133**, stub tests **16 -> 17**, `pnpm check:invariants` exit 0. Stand restored to the posture it was found in (runner off, scheduler off, one replica, connections untouched).

Deliberately dropped for time: re-running `bootstrap.sh` to apply the `configurations` grant to the live stand. The fix is committed; the next bootstrap run picks it up.

Closes #2847

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkKifZVwvZzHspxaQ7x396
