### PR TITLE
perf(seed): make the stand's dataset realistic, and re-measure on it

### DIFF
--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -1301,3 +1301,38 @@ ADDING arms until this is fixed.
 knob (`ARM_SPECS`, `CAPS`, `WORKER_CONTAINERS`, `BUILD_RELEVANT_PATHS`).
 
 **Source**: #2840 (limiter A/B).
+
+---
+
+## A seeder that sets a target distribution needs a TWO-SIDED assertion - a one-sided one passes while the dataset is silently wrong
+
+**Context**: re-seeding the #2840 measurement stand (#2949). `rebalance-sync-status.sh` sets the
+share of `order_records` matching `GET /orders?health=needs_attention`
+(`syncStatus @> '[{"status":"failed"}]'`) to a realistic figure, replacing the 27.7% the earlier
+seed produced. Target 0.6%.
+
+**Problem**: the first draft only ever HEALED - it turned a seeded `failed` entry into `synced`
+for rows outside the kept hash fraction, on the reasoning that a seeder should never manufacture
+a needs-attention row. So a row survived as failed only if it was ALREADY failed **and** its hash
+fell in the kept fraction, and the realised share was the PRODUCT of the two: `27.686% x 0.6% =
+0.166%`. Measured 0.158%, **3.8x below target**. The run's own assertion passed, because it tested
+only `realised > target * 1.10`. Nothing downstream could have caught it either: 0.158% is still
+"a fraction of a percent", the dataset still looks plausible, and no other part of the harness
+knows what the share was supposed to be. This is the same family as *An "authenticates" assertion
+is not a "works" assertion* and the red-first rule under *A zero-rows assertion about what a
+MIGRATION does is vacuous* - a test passing for a reason it did not claim.
+
+**Rule**: an assertion over a quantity a script SETS must bound it on both sides, and the low side
+is the one that matters - an undershoot is invisible in every downstream figure, whereas an
+overshoot usually announces itself. Prefer a RELATIVE band (`+/-10%`) over an absolute
+percentage-point tolerance when the target is small: `check_share`'s 5pp tolerance, correct for
+its 60-90% targets, is vacuous at 0.6% and would pass anything under 5.6%. And a seeder whose
+whole job is to set a distribution must be able to set it in BOTH directions - a monotone
+"only ever heal" primitive cannot reach a target above its current value, and the arithmetic that
+makes that a multiplication rather than an assignment is easy to miss when reading the code.
+Verify red-first: run it once against a deliberately wrong target and watch the assertion fail.
+
+**Applies to**: `perf/openlinker-throughput/seed/*.sh`, and any fixture/seeder asserting a
+proportion rather than a count.
+
+**Source**: #2949 (dataset re-seed), building on #2840.

--- a/perf/openlinker-throughput/results-reseed-2026-09-07.md
+++ b/perf/openlinker-throughput/results-reseed-2026-09-07.md
@@ -1,0 +1,751 @@
+# Re-measuring on a realistic dataset (epic #2840)
+
+_Stand: `lab` (docker-compose.lab.yml, #2854). **Every figure here is measured unless
+it is explicitly labelled `derived`** - there is exactly one derived conclusion in the
+report (§ 7, why the catalogue was inserted rather than replicated) and nothing is
+extrapolated. § 10 states what this pass did not establish._
+
+---
+
+## 0. Two corrections to figures already in circulation
+
+**Read these first. Both are corrections to numbers from
+`results-F5-2026-09-06.md` that have been quoted since, and both change a decision
+somebody could be making now.**
+
+### Correction 1: the sub-linear scaling was a one-off. Do not size on it.
+
+F5 reported that 10x the rows cost only **3.6x** the time on the needs-attention
+`COUNT`, and explained it as Postgres switching to a `Parallel Seq Scan` - real, and
+correctly diagnosed. It has since been repeated as though it described the curve.
+
+**It described a boundary, and the boundary has been crossed.** A fourth point at 2M
+rows:
+
+| Step | rows | filtered COUNT | ratio |
+|---|---:|---:|---:|
+| 100k -> 1M (previous pass) | 10x | 39.64 -> 141.89 ms | **3.58x** |
+| **1M -> 2M (this pass)** | **2x** | 148.55 -> 273.18 ms | **1.84x** |
+
+Fitting a power law to the first row gives an exponent of 0.55, predicting `2^0.55 =
+1.47x` for a doubling. The measured figure is **1.84x** - the prediction is low by
+about 25%, and the unfiltered `COUNT` on the same table behaves identically
+(36.25 -> 64.61 ms, 1.78x). The parallel plan was already in use at 1M, so there was
+no further plan change left to absorb the growth.
+
+**Anyone sizing hardware past 1M orders should assume linear.** Detail in § 3.5.
+
+### Correction 2: "`product_detail` is flat" is scoped to ORDER growth only
+
+F5 states that *"`order_detail` and `product_detail` are flat across three orders of
+magnitude ... both are primary-key point lookups, unaffected by table growth"*. The
+claim is not wrong - it is **narrower than it reads**, because the only thing that
+grew in that campaign was `order_records`.
+
+Grow the **catalogue** instead, holding orders and their distribution fixed:
+
+| Route | 10 006 products | 60 006 products | |
+|---|---:|---:|---:|
+| `product_detail` | 5.58 ms | **14.49 ms** | **2.60x** |
+| `products_list` | 9.53 ms | **36.21 ms** | **3.80x** |
+| `order_detail` (control) | 5.07 ms | 5.28 ms | 1.04 |
+
+`product_detail` is not a lone point lookup: it fans out to the product's variants,
+its inventory positions and its identifier mappings. `order_detail` has no such
+fan-out and stays flat, so the original claim holds for it. **Quote the claim with
+its axis, or it becomes a wrong decision.** Detail in § 3.4.
+
+---
+
+## 0b. And two things about method that carried the rest
+
+**A prediction failed, and the reason is the finding.** § 6.1 predicted the order path
+would slow down on a diverse catalogue, because PrestaShop's tax-rate cache is
+per-product. **Requests per order fell on both arms instead** - arm A 11.22 -> 11.09,
+arm BD 10.16 -> 10.08 - even though a BD window now touches **92-94 distinct
+products** where the old dataset's entire offer pool resolved to **six**.
+
+The mechanism is the useful part: exactly **one line of the per-order request budget
+is product-keyed**, about 9% of it, and everything else is per-order or per-buyer (a
+new customer and address every order, carriers uncached, currencies, countries, order
+states). **Catalogue size structurally cannot reach this flow** - a stronger statement
+than the slowdown would have been, and arm BD is the clean test of it because its
+cache is genuinely cold for most of a window (§ 6.5).
+
+**The dataset is credible because of a control, not because of a row count.** The
+seeded products resolve through the shop's own webservice (**200**) and the old
+synthetic mappings do not (**404**). That pair only means something because the
+control - an id nothing holds - 404s in the same run: two earlier versions of that
+probe answered `000` and then `301` for **every** id, including known-good ones, and
+either would have read as "the seeded data is broken" (§ 4).
+
+_Everything here is measured on a contended single-workstation stand. These are
+floors, not ceilings, and § 10 lists what the pass did not establish._
+
+_One process note, so a reader is not surprised by the ordering: the repository gate
+(`pnpm check:invariants`, `lib-test.sh`) was run **after** the measurement windows
+closed, not before. That was deliberate - both walk the tree and would have added CPU
+to the host during a window, and this report's whole subject is a stand whose figures
+are already qualified by host contention. `bash -n` on the changed scripts ran
+throughout._
+
+**One more read-path conclusion was tested and SURVIVED**: "the page is fast, the
+total is slow" holds at a realistic 0.591% needs-attention share, even though the old
+seed had been flattering exactly the half that conclusion exonerated (§ 3.3).
+
+---
+
+## 1. Why this pass exists
+
+The campaign's figures were taken against a dataset thin enough that a reader could
+reasonably ask whether they meant anything. OpenLinker's own tables held ~10 000
+products and ~1 000 000 orders, but **the shop behind them held six products**, and
+the seeded order population put **27.7%** of all orders in the needs-attention bucket.
+
+Both distortions are load-bearing rather than cosmetic, and they push in opposite
+directions.
+
+- **The six-product shop makes the order path look FASTER than it is.** PrestaShop's
+  tax-rate resolution caches per `(connection, product, country)` for 24 h, so a
+  window touching six products warms the cache after six orders and every later order
+  pays a cheaper request count. `results-limiter-ab-2026-09-07.md` § 5 establishes
+  that the order path's ceiling is `(requestsPerMinute / requests-per-order) x 60`
+  orders per hour - so requests-per-order is not one input among many, it is a direct
+  divisor of the throughput.
+- **The 27.7% failure rate flatters the read path's PAGE query.** The needs-attention
+  COUNT is a non-sargable full scan whose cost barely moves with selectivity, but the
+  page beside it walks `IDX_order_records_createdAt` backwards applying the same
+  filter until twenty rows pass - so its cost is inversely proportional to the match
+  rate.
+
+`bootstrap.sh` already knew about the first one. Its offer-mapping step points every
+offer at a variant whose product carries a **numeric** PrestaShop external id, warns
+that the 200-offer pool cannot hold on a six-product shop, and names the remedy in
+its own comment: *"A numeric test rather than a hardcoded list, so a stand that later
+grows a real catalogue picks it up automatically."* This pass grows that catalogue.
+
+---
+
+## 2. The dataset: what it is, and how each side was populated
+
+**Read this before any figure below.** The provenance is what makes the numbers
+interpretable, and its absence is what made the previous ones questionable.
+
+| | Before | After |
+|---|---:|---:|
+| PrestaShop `ps_product` | **6** | **50 006** |
+| PrestaShop `ps_product_attribute` (combinations) | 8 | 66 675 |
+| PrestaShop `ps_stock_available` | 25 | 116 692 |
+| PrestaShop distinct default categories | **1** | **7** (seeded set; 8 shop-wide) |
+| PrestaShop distinct product prices | **6** | **50 000** (seeded set) |
+| OL `products` | 10 006 | 60 006 |
+| OL `product_variants` | 20 011 | 111 678 |
+| OL `inventory_items` | 40 011 | 131 678 |
+| OL `identifier_mappings` | 65 644 | 207 311 * |
+| OL `order_records` | 1 002 561 | 2 002 561 |
+| OL `order_line_items` | 2 501 874 | 5 001 312 |
+| OL `sync_jobs` (held constant) | 137 708 | 137 708 |
+| needs-attention share | **27.686%** | **0.591%** |
+| 200-offer pool -> distinct destination-resolvable variants | **11** | **200** |
+| 200-offer pool -> distinct destination-resolvable **products** | **6** | **110** |
+
+\* **Every count in this table is as at the F5 runs (§ 3), which is when they were
+taken and what they describe.** Two of them are not static afterwards: the order-path
+scenario in § 6 creates real orders, so it adds a few hundred to `order_records` and a
+handful of `identifier_mappings` per order. `identifier_mappings` in particular reads
+207 406 mid-§ 6 against the 207 311 above; the figure is cross-checked against run C's
+own plan (`Parallel Seq Scan`, 69 104 rows per worker x 3 = 207 312). The catalogue
+counts and the needs-attention share are static throughout.
+
+**How each side was populated, plainly:**
+
+- **The PrestaShop catalogue was INSERTED, not replicated.** `seed-shop-catalogue.sh`
+  writes MySQL rows directly, cloning round-robin from the six products the shop
+  already had - three simple and three multi-variant - and then varying price,
+  category, manufacturer, name and stock per row by deterministic arithmetic on the
+  ordinal. So the seeded catalogue inherits the shop's own structural mix rather than
+  one hand-picked shape, and re-running with the same count and template set
+  reproduces it exactly.
+- **The OpenLinker projection was INSERTED too, keyed to the shop's real ids.** It did
+  **not** come through `master.product.syncAll`. The external ids are the adapter's
+  own shapes - `String(id_product)` for a product, `String(id_product_attribute)` for
+  a combination, and `'product:' || id_product` for a simple product's synthetic
+  variant - so a mapping lookup lands on a row the shop can serve, which is the
+  property the previous dataset lacked.
+- **Why not replicate through the real sweeps** (derived, see § 7 for the arithmetic):
+  the request cost is affordable but the sweep's own pacing is not - one full cycle
+  over 50 000 products is **~33 hours** at the shipped budget and cadence.
+- **The orders were inserted by `seed-orders.sh`** (the existing seeder), grown from
+  1 000 000 to 2 000 000 seeded rows, the new generation at a realistic per-destination
+  failure rate. The pre-existing 1 000 000 had their `syncStatus` rewritten in place by
+  `rebalance-sync-status.sh`.
+- **2 561 orders on the stand are real**, created by earlier order-path runs against
+  the live PrestaShop. They are not seeded and `rebalance-sync-status.sh` does not
+  rewrite them. They are the newest rows by `createdAt` and are almost all synced
+  (7 failed of 2 561), which turns out to matter to exactly one measurement - § 3.3
+  explains where, and why it is realistic rather than a stand artefact.
+
+**The 0.591% needs-attention share is a CHOSEN stand-in, not a measured industry
+figure.** The reasoning: a healthy install retries a failed destination create, so the
+steady-state backlog of orders stuck failed is small; 27.7% describes an install in
+the middle of an incident. Nothing in this report depends on 0.6% being the right
+number - what it depends on is that it is a fraction of a percent rather than a third.
+
+**Scale reasoning, and it is a judgement rather than a survey.** 50 000 products is
+the size of a large specialist retailer or a mid-size distributor. It was chosen for
+three reasons that can be checked: it is 8 333x the shop the campaign had been
+measuring; it takes `identifier_mappings` to 207 311 rows, which is past the point
+where the unindexed partition scan #2219 documents stops being free (§ 3.4 shows the
+plan change it triggers); and it stays within a range a single PrestaShop install
+plausibly serves, so the stand is a stress test rather than an outlier. Nobody
+surveyed real installs for it.
+
+2 000 000 orders is ~5.5 years of history at ~1 000 orders/day. It was chosen to add
+a **fourth** point to the previous pass's 10k/100k/1M curve specifically to test
+whether that curve's sub-linear step continues (§ 3.5 - it does not), not because
+2M is a threshold anything special happens at.
+
+**Cost (measured):** see § 7.
+
+---
+
+## 3. F5, the operator read path
+
+Four runs, each changing **one** thing, so no figure below confounds two changes.
+Every run VALID, zero non-2xx, same load shape (`TARGET_RATE=20`, 60 s plateau).
+
+| Run | orders | needs-attention share | shop |
+|---|---:|---:|---:|
+| **A** baseline | 1 002 561 | 27.686% | 6 products |
+| **B** distribution only | 1 002 561 | 0.591% | 6 products |
+| **C** catalogue added | 1 002 561 | 0.591% | 50 000 products |
+| **D** orders grown | 2 002 561 | 0.591% | 50 000 products |
+
+### 3.1 The machine drifted, so read the ratios, not the wall clock
+
+The stand itself moved between runs. The plain unfiltered
+`COUNT(*) FROM order_records` - which touches no jsonb, no catalogue and no index -
+went **29.24 -> 36.87 ms** between runs A and B, on an unchanged table. That is a
+26% shift with no change under test.
+
+So **no wall-clock delta across these runs is attributable on its own**, and every
+claim below is carried either by a ratio against that unfiltered COUNT (the machine
+control) or by a plan-level counter (`Rows Removed by Filter`, `Buffers`) that
+machine drift cannot move. Where only a wall-clock figure exists, it is labelled as
+such and not leaned on.
+
+### 3.2 Per-route medians (measured, ms)
+
+| Route | A | B | C | D |
+|---|---:|---:|---:|---:|
+| `orders_list` | 36.34 | 44.71 | 43.79 | 69.60 |
+| `orders_list_needs_attention` | 141.73 | 164.57 | 164.18 | **286.15** |
+| `order_detail` | 5.48 | 5.07 | 5.28 | 5.76 |
+| **`products_list`** | **9.58** | **9.53** | **36.21** | 39.19 |
+| **`product_detail`** | **5.87** | **5.58** | **14.49** | 15.89 |
+| `sync_jobs_list` | 36.50 | 44.30 | 44.41 | 46.11 |
+| `page_shell_total` | 55.00 | 62.00 | 56.00 | 84.00 |
+| _machine control:_ unfiltered `COUNT(*)` | 29.24 | 36.87 | 36.25 | 64.61 |
+
+Every run VALID with zero non-2xx responses.
+
+### 3.3 The distribution fix (A -> B): the page's work doubled, and F5's conclusion survives
+
+Taking the needs-attention share from 27.686% to 0.591% - a **47-fold** change in
+selectivity - moves the two halves of that route in opposite directions once the
+machine's own drift is divided out, exactly as the mechanism predicts.
+
+| | A (27.686%) | B (0.591%) | ratio |
+|---|---:|---:|---:|
+| filtered `COUNT` mean, ms | 131.31 | 150.36 | 1.15 |
+| _same, against the machine control_ | 4.49x | 4.08x | **0.91** |
+| paged `SELECT`, mean ms | 2.85 | 4.68 | 1.64 |
+| paged `SELECT`, `Rows Removed by Filter` | 2 589 | 5 728 | **2.21** |
+| paged `SELECT`, `Buffers: shared hit` | 2 978 | 5 330 | **1.79** |
+
+**The COUNT did not get cheaper when its filter became 47x more selective** - against
+the machine control it is fractionally cheaper (4.49 -> 4.08 times an unfiltered
+count of the same table), which is what a non-sargable full scan should do: it
+evaluates the jsonb containment on every row either way and only the aggregate's
+input shrinks.
+
+**The page's work roughly doubled**, on two counters that machine drift cannot touch.
+And it stayed a rounding error against the route: 2.0% of the route's median in A,
+2.8% in B. **So F5's headline - "the page is fast, the total is slow" - holds on the
+realistic distribution.** That is a robustness result rather than a null: the
+conclusion was reached on a dataset that flattered exactly the half it exonerated,
+and it survives when the flattery is removed.
+
+**Why the page's cost grew only 2.2x when selectivity changed 47x**, and why that is
+realistic rather than a stand artefact: the page walks `IDX_order_records_createdAt`
+**backwards**, so it meets the newest rows first - and the newest 2 561 rows on this
+stand are the real orders earlier runs created, of which only 7 are failed. That
+block is a fixed floor of ~2 554 rows the scan crosses before it reaches any seeded
+history. The arithmetic checks out almost exactly for A: 13 hits still needed after
+the real block, at 27.686%, is ~34 further rows removed, for ~2 588 - **measured
+2 589**. This is not a distortion to correct. On any real install the newest orders
+are the ones most likely to have synced, so a needs-attention page always pays a
+walk past recent healthy traffic; the stand reproduces that by accident.
+
+### 3.4 The catalogue (B -> C): two routes the previous pass called flat are not
+
+B -> C changed the catalogue only - orders, their distribution and the load shape
+are identical, and the machine control barely moved (36.87 -> 36.25 ms). The three
+order-side routes are correspondingly flat. Two catalogue routes are not:
+
+| Route | B | C | ratio |
+|---|---:|---:|---:|
+| `products_list` | 9.53 | **36.21** | **3.80x** |
+| `product_detail` | 5.58 | **14.49** | **2.60x** |
+| `orders_list` | 44.71 | 43.79 | 0.98 |
+| `orders_list_needs_attention` | 164.57 | 164.18 | 1.00 |
+| `sync_jobs_list` | 44.30 | 44.41 | 1.00 |
+| `order_detail` | 5.07 | 5.28 | 1.04 |
+
+**This qualifies a claim the previous report made.** `results-F5-2026-09-06.md`
+states that *"`order_detail` and `product_detail` are flat across three orders of
+magnitude ... both are primary-key point lookups, unaffected by table growth"*. That
+was true of the growth it measured, which was **orders only**. Grow the **catalogue**
+and `product_detail` moves 2.6x, because it is not a lone point lookup - it fans out
+to the product's variants, its inventory positions and its identifier mappings.
+`order_detail`, which has no such fan-out, stays flat here and the claim holds for it.
+
+Three plan-level mechanisms carry it (all measured, from `explain.txt`):
+
+- **`products` list is a `Seq Scan` plus a top-N sort, with no index on
+  `createdAt`**: 10 006 rows / 1.08 ms at A, **60 006 rows / 10.17 ms** at C, buffers
+  191 -> 1 095. The `COUNT(*) FROM products` beside it went 0.78 -> 4.25 ms.
+- **`identifier_mappings` paged by `externalId` is unindexed for that partition**
+  (#2219's own accepted cost) and at 207 311 rows Postgres **switched it to a
+  `Parallel Seq Scan` with two workers**: 8.81 ms -> 16.82 ms. The table grew 3.2x
+  (65 644 -> 207 311) and the partition the query actually matches grew 6.0x
+  (10 006 -> 60 006 `Product` rows on that connection), so 1.9x the time is well
+  under either - the parallel plan is absorbing most of it. This is the same partial
+  self-healing F5 documented for the order COUNT, and it carries the same caveat -
+  it depends on workers being available, which is exactly what a loaded install does
+  not guarantee.
+- The `/products` list's per-row `getExternalIds` fan-out is unchanged in shape; it
+  is the base scan underneath it that grew.
+
+### 3.5 Orders 1M -> 2M (C -> D): the sub-linear scaling was a one-off, not a trend
+
+The previous report's most quoted result is that naive linear extrapolation
+**over-predicted** the needs-attention COUNT at 1M by 2.8x - 10x the rows cost only
+3.6x the time, because Postgres switched that COUNT to a `Parallel Seq Scan` with two
+workers somewhere between 100k and 1M rows.
+
+The fourth point says that headroom is now spent:
+
+| Step | rows | filtered COUNT | ratio | unfiltered COUNT | ratio |
+|---|---:|---:|---:|---:|---:|
+| 100k -> 1M (previous pass) | **10x** | 39.64 -> 141.89 ms | **3.58x** | 6.90 -> 30.52 ms | 4.42x |
+| 1M -> 2M (this pass) | **2x** | 148.55 -> 273.18 ms | **1.84x** | 36.25 -> 64.61 ms | 1.78x |
+
+**Past 1M it is linear again**, on both the filtered and the unfiltered count, and the
+route follows: `orders_list_needs_attention` 164.18 -> **286.15 ms** for twice the
+rows. The parallel plan was already in use at 1M, so there was no further plan change
+left to absorb the growth - the sub-linear step was a **transition** between two
+regimes, not a property of the curve.
+
+This matters because the previous report's own framing invites the extrapolation it
+warns against elsewhere. Fitting a power law to "3.6x for 10x rows" gives an exponent
+of 0.55, which predicts `2^0.55 = 1.47x` for a doubling; the measured figure is
+**1.84x**, so that prediction is low by about 25%. **The honest reading is that the
+degradation is linear in row count except across the one plan boundary**, and that
+the boundary has already been crossed - so a reader sizing for growth past 1M should
+assume linear, not the flattering exponent.
+
+The page query is unchanged by this step, as it should be - selectivity did not move,
+so `Rows Removed by Filter` stayed flat (5 728 at C, 5 302 at D) even though the
+table doubled.
+
+---
+
+## 4. The property that makes the rest of it meaningful: the mappings resolve
+
+A row count proves nothing here. The defect being removed was a **full** mapping
+table every one of whose external ids named a product that did not exist, so the
+only check worth running is to take the ids OpenLinker holds and ask the shop's own
+**webservice** - the same `GET products/{id}` the tax-rate chain issues.
+
+Measured, from inside the stand, with the control run **first** so a probe that
+cannot reach the shop at all is not mistaken for a pass:
+
+| Probe | HTTP | |
+|---|---|---|
+| `products/999999` - **control, an id nothing holds** | **404** | the probe can fail |
+| `products/20` - a pre-existing real product | **200** | |
+| `products/200002` - **a seeded product** | **200** | `id_category_default: 6`, `manufacturer_name: "Studio Design"`, `type: simple` |
+| `combinations/200002` - a seeded combination | **200** | `ean13: 6100000000001`, `reference: PERFSHOP-000002-V1` |
+| `stock_availables?filter[id_product]=200002` | **200** | `quantity: 37` |
+| `products/PERFSEED-EXT-PROD-ps-1` - **the OLD synthetic mapping** | **404** | the original defect, measured rather than asserted |
+
+The control earned its place twice over. The first two attempts at this probe
+returned `000` for **every** id including the known-good one (no `curl` in the api
+container) and then `301` for every id (the shop redirects away from `localhost`);
+without a control that must 404, both of those runs would have read as "the seeded
+products do not resolve" and sent this pass chasing a data bug that did not exist.
+
+The seeder asserts the same property structurally on every run - it samples 500
+Product mappings and refuses to finish unless PrestaShop holds all 500 - and reported
+`500 of a 500-mapping sample resolve to a real ps_product row`.
+
+---
+
+## 5. Diversity, quantified
+
+"Realistic" is not only a row count. The previous catalogue had **one** distinct
+default category and **six** distinct prices across the whole shop, so category
+breadth, payload-size spread and cache-miss behaviour were not merely unmeasured -
+they were unmeasurable.
+
+| | Before | After |
+|---|---:|---:|
+| distinct default categories | 1 | **7** across the seeded set (8 shop-wide, adding the templates' own) |
+| distinct product prices | 6 | **50 000** (5.06 - 3 004.95) |
+| manufacturer slots assigned | not varied | 3 - the shop's 2, plus "none" |
+| product name vocabulary | 6 fixed names | 120 adjective x noun pairs + ordinal |
+| simple vs multi-variant products | 3 / 3 | **25 000 / 25 000** |
+| combinations per multi-variant product | 2-3 | 2-3 (inherited from the templates) |
+| per-variant stock values | 25 rows | 116 667 rows, varied per row |
+
+The simple/multi-variant split is the one worth calling out: cloning a single
+template - the shape the existing `perf/prestashop-baseline/seed-products.sh` uses -
+would have produced a catalogue that is uniformly one or the other, leaving either
+the synthetic-variant path or the real-combination path completely untouched.
+
+---
+
+## 6. The order path (limiter-ab arms A and BD)
+
+### 6.1 What changed underneath it, and why it should matter
+
+`bootstrap.sh` points each Allegro tenant's 200-offer pool at variants whose product
+carries a numeric PrestaShop external id. On the six-product shop that collapsed the
+pool onto **11 variants across 6 products**, and the bootstrap said so in a warning
+rather than hiding it. Re-run against the grown catalogue - the same statement,
+unchanged - the same 200 offers now span **200 distinct variants across 110 distinct
+products**, an 18x increase on both axes.
+
+The mechanism that makes this a throughput question rather than a tidiness one is
+already established in `results-limiter-ab-2026-09-07.md` § 5: the order path's
+ceiling is `(requestsPerMinute / requests-per-order) x 60` orders per hour, so
+anything that changes requests-per-order changes the ceiling inversely and
+proportionally. PrestaShop's tax-rate
+resolution caches per `(connection, product, country)` for 24 h. With six products a
+window warms that cache after six orders; with 110, an arm-A window that completes
+~19 orders **never** warms it.
+
+**Prediction stated before the run, so it can be wrong:** both arms slow down, and
+requests-per-order rises.
+
+### 6.2 The comparison, and how verdicts are handled
+
+The baseline is the committed `results-limiter-ab-2026-09-07.md`, taken on the same
+stand on the same day with the same script and the same arm specs
+(`A:60:4:::false`, `BD:600:4:::true`, `REPEATS=2`, `WINDOW_SECS=300`, `BACKLOG=900`).
+The only thing that differs is the dataset.
+
+**Three of these four windows are labelled `DISCARDED`, as was every window in the
+baseline** - that report's § 9 says so and explains why, and the same two causes
+recur unchanged:
+
+- `post_guard_destination_creates` fires structurally on any saturation window,
+  because the point of one is to end with work in flight, so an order created inside
+  the window and still mid-create at close necessarily lacks `syncedAt`.
+- `post_guard_limiter_degraded` fires on arm A **by construction**: the shared Redis
+  client's degradation is the very condition arm A exists to characterise, and the
+  dedicated-client arms are the ones that answer zero.
+
+So the discard label is not a difference between this run and the baseline, and the
+comparison is like for like. It does mean **no figure in this section is a
+publishable throughput number**, which was already true of the baseline.
+
+The exception is **BD r2, which came back `VALID`** - the first valid window in this
+scenario's history, since the baseline records all thirteen of its own as discarded.
+It cleared both guards: zero degraded-limiter lines, and no order left mid-create when
+the window closed.
+
+### 6.3 First, the check that has to pass before any throughput number means anything
+
+The campaign's own recorded trap: a `marketplace.order.sync` job reports
+`outcome: 'ok'` **even when every destination create failed**, because
+`OrderSyncService` fans out under `Promise.allSettled` and records
+`syncStatus[].status = 'failed'` without failing the job. A throughput figure taken
+on a dataset whose creates all 400 is a measurement of the failure path.
+
+Sampled live part-way through the first arm-A window - a 30-minute lookback, so it
+covers that window's warm-up orders as well as the first of its measured ones
+(measured):
+
+| Check | Result |
+|---|---|
+| PrestaShop `ps_orders` | 2 560 -> **2 569** - the shop really received them |
+| `syncStatus` of the 9 orders ingested in that period | **9 synced, 0 failed** |
+| destination `Order` identifier mappings written | **9** |
+| **distinct PRODUCTS those 9 orders touched** | **9** |
+| job outcomes | `marketplace.order.sync` 9 succeeded / `ok`, 0 dead |
+
+The fourth row is the one that says the re-seed did its job: nine orders reached nine
+**different** products. On the old dataset the entire 200-offer pool resolved to six.
+
+The scenario's own `post_guard_destination_creates` then confirmed it independently
+for every window it ran, not just the sampled one: **`0 order(s) carry a failed
+syncStatus entry`** in each. The only thing that guard objected to was 1-2 orders
+still mid-create at window close, which is the structural artefact of saturating a
+window rather than a create failure.
+
+### 6.4 Results
+
+| Arm | dataset | orders/h | mean | vs thin | orders | **requests/order** | mean | degraded |
+|---|---|---|---:|---:|---:|---|---:|---:|
+| A | thin (n=3) | 218, 231, 230 | **226.3** | - | 18-19 | 11.28, 11.16 | 11.22 | 34-58 |
+| **A** | **realistic (n=2)** | **221, 208** | **214.5** | **-5.2%** | 19, 18 | **11.00, 11.17** | **11.09** | 54, 40 |
+| BD | thin (n=2) | 2 255, 2 303 | **2 279.0** | - | 186, 190 | 10.19, 10.13 | 10.16 | 0, 0 |
+| **BD** | **realistic (n=2)** | **2 204, 2 174** | **2 189.0** | **-3.9%** | 191, 189 | **10.05, 10.11** | **10.08** | 0, 0 |
+
+**And the diversity really was exercised** - measured per window, by joining each
+window's orders through their `Offer` mappings to the products behind them:
+
+| Window | orders created | **distinct products touched** |
+|---|---:|---:|
+| A r1 | 21 | **19** |
+| A r2 | 20 | **15** |
+| **BD r1** | **191** | **92** |
+| **BD r2** | **191** | **94** |
+
+On the old dataset the entire 200-offer pool resolved to **six** products, so a
+191-order window touched at most six, most of them dozens of times. It now touches
+**92-94 distinct products**, nearly all of them once. That is a ~15x increase in the
+cache-miss surface within a single window - and **requests per order still went
+DOWN**, on both arms.
+
+**Neither arm moved in the direction predicted, and neither moved much at all.** Arm
+A's 5.2% sits inside the 5.7% spread it shows against *itself* on the baseline: at
+18-19 orders per window the instrument's resolution is one order, which is 5.4% of the
+rate, so two windows differing by one completed order differ by more than this entire
+effect. Arm BD's 3.9% is larger than that arm's own 2.1% baseline spread and so may
+be real - but it is **not attributable to the catalogue through the request budget**,
+because requests per order fell (10.16 -> 10.08) rather than rose. A slower, larger
+Postgres (2M orders, 207k mappings) and ordinary host drift are both live candidates
+and this pass separates neither.
+
+**One window came back `VALID`** - BD r2, the first in this campaign's limiter-ab
+history; the baseline report records all thirteen of its own windows as `DISCARDED`.
+It cleared both post-guards: zero degraded-limiter lines *and* no order left
+mid-create at window close.
+
+Independent confirmation that the creates were real throughout: **0 orders with a
+failed `syncStatus` entry in any window, 0 dead jobs, and PrestaShop's own order count
+rose to 2 995.**
+
+### 6.5 The prediction failed. Here is the mechanism, which is the better answer.
+
+§ 6.1 predicted, before the run, that both arms would slow and requests-per-order
+would rise. **Arm A did neither**, and the reason is more useful than the prediction
+would have been, because it says *why catalogue size cannot reach this flow* rather
+than *how much it costs*.
+
+The prediction rests on the tax-rate cache being a material share of the order's
+request budget. `results-F1-2026-09-07.md` measures that budget per resource, and it
+does not support the premise:
+
+| Resource | per order | keyed on |
+|---|---:|---|
+| `GET`+`POST customers`, `GET`+`POST addresses` | 4.00 | **the buyer** - a new one every order |
+| `POST /index.php` (`cartshipping` + `importorder`) | 2.00 | the order |
+| `GET order_states` / `currencies` / `countries` | 3.71 | small reference tables, per order |
+| **`GET products`** | **1.41** | **the product** - tax chain + the cascade |
+| `GET carriers` / `orders` / `carts` | 3.00 | per order ("`carriers` not cached") |
+| `GET stock_availables` / `configurations` | 1.88 | the cascade / an always-401 waste |
+
+Those lines sum to **16.0 requests per order**, which is F1's own accounting for its
+own arm; limiter-ab counts 11.0-11.3 for this arm, over a narrower set (`/api/` plus
+`POST /index.php` inside the window). The two totals are not the same measurement and
+are not mixed here - what carries the argument is the **proportion**, which is a
+property of the mix rather than of either total.
+
+**Exactly one line in that table is product-keyed, and it is 1.41 of 16.0 - about
+9%.** So even a total cache miss on every product can only add on the order of one
+request per order. At arm A's resolution, where a window completes 18-19 orders and a
+single order is 5.4% of the rate, an effect that size is at or below the noise floor
+by construction - and the measured requests-per-order moved 1.2% the other way.
+
+That is the honest read of the null: not "product diversity does not matter", but
+**the order path's request cost is dominated by per-order and per-buyer lookups, and
+the catalogue is a small term in it.** The six-product shop was flattering the
+*catalogue-side read path* substantially (§ 3.4) and the order path barely at all.
+
+The comparison that makes this drift-proof is the **fraction of the pace-gate ceiling
+each window reached**, since the ceiling itself is computed from that window's own
+measured requests-per-order:
+
+| Window | req/order | ceiling = `60 / req-per-order x 60` | achieved | fraction |
+|---|---:|---:|---:|---:|
+| baseline A r1 (thin) | 11.28 | 319 /h | 218 | **68.3%** |
+| baseline A r2 (thin) | 11.16 | 323 /h | 231 | **71.6%** |
+| **this run, A r1 (realistic)** | **11.00** | **327 /h** | **221** | **67.5%** |
+| **this run, A r2 (realistic)** | **11.17** | **322 /h** | **208** | **64.5%** |
+
+Mean fraction 70.0% thin against 66.0% realistic. That difference is **not** claimed
+as an effect: it is 4 percentage points on an instrument whose quantum is 5.4
+points, from two windows per arm. What the table does support is the negative -
+**the requests per order did not rise**, and since the ceiling is computed from that
+number, the catalogue did not narrow the ceiling either.
+
+Arm BD is the stronger version of the same test, and it is the one that settles it.
+Its windows touch **92-94 distinct products** rather than arm A's 15-19, so the
+tax-rate cache is genuinely cold for most of the window - the condition the prediction
+needed. Requests per order there is **10.05 / 10.11 against a thin-catalogue 10.19 /
+10.13**. If a per-product cache miss were a material term in that budget, this is
+where it would show, and it does not.
+
+---
+
+## 7. What the dataset cost
+
+| | Measured |
+|---|---|
+| PrestaShop catalogue, 50 000 products (MySQL, direct insert) | **9 s** |
+| OpenLinker projection of it (Postgres, via `COPY`) | **6 s** |
+| `rebalance-sync-status.sh` over 1 000 000 orders | **1 s** |
+| Orders 1M -> 2M: 1 000 000 records + 2 499 438 line items | **95 s** |
+| **Total seeding wall clock** | **under 2.5 minutes** |
+
+Disk, by table, both sides measured (`pg_total_relation_size`, includes indexes):
+
+| Table | Before | After |
+|---|---:|---:|
+| `order_line_items` | 1 183 MB | **2 359 MB** |
+| `order_records` | 1 167 MB | **2 014 MB** |
+| `identifier_mappings` | 51 MB | **147 MB** |
+| `inventory_items` | 16 MB | **49 MB** |
+| `product_variants` | 5.9 MB | **31 MB** |
+| Postgres database total | not measured before | **4 801 MB** |
+| PrestaShop MySQL schema total | not measured before | **211 MB** |
+
+**~2.2 GB of growth across the tables measured on both sides**, against 848 GB free.
+
+The whole dataset is cheap enough that its size was never the constraint - which is
+worth saying plainly, because it means a future campaign has no reason to measure on
+a thin one.
+
+**Why the catalogue was inserted rather than replicated (derived).** The request cost
+alone would have been affordable: at ADR-048's post-#2593/#2648 batched cost of
+**0.058 requests/SKU**, 50 000 SKUs is ~2 900 platform requests, and at the ~277
+req/min the #2594 lane-caps A/B sustained that is ~10.5 minutes of request time. What
+makes it infeasible is the sweep's own **pacing**, not its request count:
+`BATCHED_SWEEP_BUDGET_DEFAULT` is 500 items per run against a 20-minute cron, so one
+full cycle over 50 000 products is `ceil(50000/500) = 100` ticks - **~33 hours**.
+
+Both input figures (0.058 req/SKU, 277 req/min) are carried from earlier
+measurements and were **not** re-taken here, which is why the conclusion is labelled
+derived. Against 15 seconds of direct insert, the margin is wide enough that a
+re-measurement could not change the decision.
+
+The consequence is stated rather than hidden: **this dataset did not exercise the
+replication path.** Nothing here says anything about how long a real catalogue sync
+takes, and no figure in this report should be read as though it did.
+
+---
+
+## 8. What became measurable that was not before
+
+Five things, each previously blocked by a specific absence rather than by a missing
+scenario:
+
+1. **Catalogue-side read degradation.** `products_list` and `product_detail` were
+   flat across the previous campaign because only the order table ever grew. With a
+   6x catalogue they move 3.8x and 2.6x, and `product_detail`'s movement contradicts
+   a stated conclusion of the previous report (§ 3.4).
+2. **The `identifier_mappings` unindexed partition scan at a realistic size.** The
+   previous pass measured it at 65 644 rows and observed a plain `Seq Scan`. At
+   273 481 rows Postgres switches it to a parallel plan - a plan change that could
+   not be observed on the smaller table (§ 3.4).
+3. **Order-path product diversity - and the answer is a NULL, which is itself the
+   result.** With six products the tax-rate cache was warm after six orders, so the
+   question "does catalogue size reach this flow?" could not be put. With 110
+   products it could be, and the answer is no: requests-per-order is unchanged, and
+   § 6.5 shows why from the request mix rather than leaving it as a bare null. A null
+   you can explain is worth more than an unmeasurable.
+4. **Inventory contention across distinct positions.** A 900-order window previously
+   drove the post-sale `setInventory` cascade into **11** `inventory_items` rows; it
+   now spreads across 200. **This pass did not isolate it** - it changed together
+   with everything else in § 6 and no arm holds it fixed - so all that is claimed
+   here is that the condition now exists to be measured, where before it did not.
+5. **Whether the read-path conclusions were artefacts of the seed.** Two of them
+   survive (§ 3.3), one needs qualifying (§ 3.4) and one must not be extrapolated
+   (§ 3.5) - and none of those three answers was available on the old dataset.
+
+---
+
+## 9. Reproducing this dataset
+
+Every step is a committed script under `perf/openlinker-throughput/seed/`, and every
+one is deterministic - the RNG seed and the ordinal arithmetic are both fixed, so the
+same invocations regenerate the identical dataset.
+
+```bash
+# 1. the shop, and the OpenLinker projection keyed to its real ids
+SHOP_PRODUCT_COUNT=50000 ./seed/seed-shop-catalogue.sh
+
+# 2. the orders, at a realistic per-destination failure rate
+TARGET_ORDERS=2000000 SYNC_FAILED_RATE=0.003 ./seed/seed-orders.sh
+
+# 3. only if an earlier generation was seeded at the old 0.15 rate
+NEEDS_ATTENTION_PCT=0.6 ./seed/rebalance-sync-status.sh
+
+# 4. re-point the offer pool at the grown catalogue (bootstrap is idempotent)
+./bootstrap.sh
+
+# and to undo all of it - matches only this seed family's own tags
+./seed/cleanup.sh
+```
+
+Two properties are worth knowing before re-running. `seed-shop-catalogue.sh` refuses
+a second generation under the same prefix unless given `FORCE_SEED=1` **and** a
+`SHOP_SEED_OFFSET`, because a repeat would mint duplicate references and duplicate
+`ean13` barcodes - and a duplicate barcode is exactly what offer linking refuses to
+resolve. And `cleanup.sh` now removes both sides: the `PERFSHOP-` reference prefix in
+MySQL and the prefix-tagged `internalId` in Postgres, the latter because
+shop-aligned mappings carry the shop's own numeric external ids and no `externalId`
+pattern could find them without risking a row this seed never wrote.
+
+---
+
+## 10. What this did not establish
+
+- **The catalogue was inserted, not replicated.** See § 7. No figure here bears on
+  `master.product.syncAll`, `master.inventory.syncAll` or the deletion audit.
+- **10 006 of the 60 006 OpenLinker products still name nothing in either shop.**
+  The pre-existing `seed-catalogue.sh` generation was left in place rather than
+  deleted, so it still carries `PERFSEED-EXT-PROD-*` mappings that 404 - proven
+  live, § 4. They cannot contaminate the order path, because `bootstrap.sh`'s offer
+  seeder filters on a numeric external id and excludes them by construction, and they
+  are legitimate load on the `identifier_mappings` scan. But "60 006 products" is not
+  "60 006 resolvable products", and the resolvable figure is **50 000**.
+- **WooCommerce is still empty and still capability-less.** `wp_posts` holds zero
+  products and the `perf-woocommerce` connection carries `enabledCapabilities: []`,
+  so nothing in this pass measures a WooCommerce destination or a second
+  `InventoryMaster` scope. The WC-side mappings from the earlier seeder remain
+  synthetic and dangling.
+- **0.591% is a chosen stand-in.** No install was surveyed for it.
+- **The order-path arm does not separate catalogue SIZE from product DIVERSITY.** A
+  50 000-row PrestaShop is slower at its own reads than a six-row one, and the
+  tax-rate cache misses more often; both changed together, deliberately, because both
+  are what a realistic install has. Attributing the movement between them would need
+  a third arm holding one fixed.
+- **`offer_mappings` ILIKE search and `destination_categories` trigram search remain
+  unmeasured**, unchanged from the previous pass - neither table has rows, and this
+  pass did not seed them.
+- **Product content is still a floor.** Seeded names are short synthetic strings and
+  descriptions are cloned from six templates, so per-row payload sizes understate a
+  real catalogue exactly as the previous pass's `orderSnapshot` did.
+- **The stand is a contended developer workstation** sharing a host with two other
+  OpenLinker stacks. Figures are floors, not ceilings.
+- **No arrival rate is assumed**, so no "days until N orders" figure is derived.
+- **`bootstrap.sh` was not re-run in full.** Only its offer-mapping step was reproduced
+  (verbatim), because the same script also owns the PrestaShop module, the webservice
+  account, the tax group and the WooCommerce setup - and WooCommerce here is empty
+  with a capability-less connection, so a full run could legitimately have decided to
+  repair it and changed the dataset mid-campaign.

--- a/perf/openlinker-throughput/seed/cleanup.sh
+++ b/perf/openlinker-throughput/seed/cleanup.sh
@@ -24,8 +24,16 @@ pg_sql_write "DELETE FROM order_records WHERE \"internalOrderId\" LIKE '${PREFIX
 log "deleting perfseed sync_jobs"
 pg_sql_write "DELETE FROM sync_jobs WHERE \"idempotencyKey\" LIKE '${PREFIX}:g%'" >/dev/null
 
-log "deleting perfseed identifier_mappings"
+log "deleting perfseed identifier_mappings (synthetic external ids)"
 pg_sql_write "DELETE FROM identifier_mappings WHERE \"externalId\" LIKE '${PREFIX^^}-EXT-%'" >/dev/null
+
+# seed-shop-catalogue.sh's mappings carry the SHOP's own external ids (a bare
+# `id_product` / `id_product_attribute`), so no externalId pattern can find
+# them - matching one would risk deleting a mapping this seed never wrote.
+# They are identified by the prefix-tagged internalId instead, which keeps the
+# "only rows this seed could have written" property intact.
+log "deleting perfseed identifier_mappings (shop-aligned, matched on internalId)"
+pg_sql_write "DELETE FROM identifier_mappings WHERE \"internalId\" LIKE '${PREFIX}\\_product\\_%' ESCAPE '\\'" >/dev/null
 
 log "deleting perfseed inventory_items"
 pg_sql_write "DELETE FROM inventory_items WHERE id LIKE '${PREFIX}\\_inv\\_%' ESCAPE '\\'" >/dev/null
@@ -37,5 +45,38 @@ log "deleting perfseed products"
 pg_sql_write "DELETE FROM products WHERE id LIKE '${PREFIX}\\_product\\_%' ESCAPE '\\'" >/dev/null
 
 vacuum_analyze_reset order_records order_line_items sync_jobs identifier_mappings inventory_items product_variants products
+
+# ---------------------------------------------------------------------------
+# PrestaShop side (seed-shop-catalogue.sh). Matches ONLY the PERFSHOP-
+# reference prefix, exactly as the OpenLinker half matches only the perfseed
+# id prefix, so neither can reach the shop's own catalogue.
+#
+# Children before parents: ps_product_attribute_* key on the combination id,
+# which stops resolving once ps_product_attribute is gone.
+# ---------------------------------------------------------------------------
+SHOP_PREFIX="PERFSHOP-"
+SHOP_MATCHING="$(ps_sql "SELECT COUNT(*) FROM ps_product WHERE reference LIKE '${SHOP_PREFIX}%'" | tail -1)"
+log "deleting $SHOP_MATCHING PrestaShop product(s) carrying the ${SHOP_PREFIX} prefix"
+if [ "${SHOP_MATCHING:-0}" != "0" ]; then
+  ps_sql_write "
+    CREATE TEMPORARY TABLE perf_del AS SELECT id_product FROM ps_product WHERE reference LIKE '${SHOP_PREFIX}%';
+    CREATE TEMPORARY TABLE perf_del_pa AS SELECT id_product_attribute FROM ps_product_attribute WHERE reference LIKE '${SHOP_PREFIX}%';
+    DELETE pac FROM ps_product_attribute_combination pac JOIN perf_del_pa d ON d.id_product_attribute = pac.id_product_attribute;
+    DELETE pas FROM ps_product_attribute_shop pas JOIN perf_del_pa d ON d.id_product_attribute = pas.id_product_attribute;
+    DELETE pa FROM ps_product_attribute pa JOIN perf_del_pa d ON d.id_product_attribute = pa.id_product_attribute;
+    DELETE sa FROM ps_stock_available sa JOIN perf_del d ON d.id_product = sa.id_product;
+    DELETE cp FROM ps_category_product cp JOIN perf_del d ON d.id_product = cp.id_product;
+    DELETE pl FROM ps_product_lang pl JOIN perf_del d ON d.id_product = pl.id_product;
+    DELETE psh FROM ps_product_shop psh JOIN perf_del d ON d.id_product = psh.id_product;
+    DELETE p FROM ps_product p JOIN perf_del d ON d.id_product = p.id_product;
+  "
+fi
+# The handback is a real table by necessity (two processes, two databases), so
+# a seeder that died between writing and dropping it leaves one behind.
+ps_sql "DROP TABLE IF EXISTS perf_shop_handback" >/dev/null
+pg_sql_write "DROP TABLE IF EXISTS perf_shop_handback" >/dev/null
+
+SHOP_REMAINING="$(ps_sql "SELECT COUNT(*) FROM ps_product WHERE reference LIKE '${SHOP_PREFIX}%'" | tail -1)"
+log "PrestaShop products remaining with the ${SHOP_PREFIX} prefix: ${SHOP_REMAINING:-?}"
 
 log "cleanup done"

--- a/perf/openlinker-throughput/seed/rebalance-sync-status.sh
+++ b/perf/openlinker-throughput/seed/rebalance-sync-status.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+#
+# Re-point the seeded orders' `syncStatus` at a realistic per-destination
+# failure rate, in place.
+#
+# WHY THIS IS NOT COSMETIC. `GET /orders?health=needs_attention` filters on
+# `syncStatus @> '[{"status":"failed"}]'::jsonb`. The first three size steps
+# were seeded at a 15% per-destination failure rate over two destinations, so
+# 27.7% of all orders match - an install in the middle of an incident, not one
+# in steady state. Two separate measurements read differently because of it:
+#
+#   * the COUNT is a full non-sargable scan either way, so its cost barely
+#     moves with selectivity - but
+#   * the PAGE walks `IDX_order_records_createdAt` backwards applying the
+#     filter row by row until 20 rows pass. At a 27.7% match rate it finds
+#     twenty within about seventy rows. At 0.6% it has to walk thousands.
+#
+# So the seeded distortion made the page look cheap and left the count as the
+# only visible problem. A realistic rate is expected to move the page, and
+# that movement is a finding rather than an artefact.
+#
+# The rewrite is deterministic (`hashtext` on the order id, not random()), so
+# re-running is idempotent and a later campaign can reproduce the identical
+# split.
+#
+# IT SETS THE SHARE IN BOTH DIRECTIONS, and the first draft did not - that is
+# worth recording, because the failure was silent and is the exact class of
+# defect this whole pass exists to remove. That draft only ever HEALED, on the
+# reasoning that a seeder should never manufacture a needs-attention row. But
+# a row survived as failed only if it was ALREADY failed AND its hash fell in
+# the kept fraction, so the realised share was the PRODUCT of the two:
+# 27.686% x 0.6% = 0.166%, not 0.6%. Measured live at 0.158%, 3.8x below
+# target, and the run's own assertion passed because it only tested for
+# overshoot. A seeder whose entire job is to set a distribution has to be able
+# to set it in both directions, and has to assert both sides of it.
+#
+# Touches only rows carrying the seed prefix.
+#
+# Usage: NEEDS_ATTENTION_PCT=0.6 ./rebalance-sync-status.sh
+#
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/seed-lib.sh"
+LIB_LOG_PREFIX="rebalance-sync-status"
+
+# Share of ALL seeded orders that should match the needs-attention predicate.
+# 0.6% is the campaign's stated stand-in for a healthy install: destination
+# creates fail occasionally (a disabled connection, a rejected payload, a
+# throttled shop) and are then retried, so a steady-state backlog of orders
+# stuck failed is small. It is a CHOSEN figure, not a measured industry one,
+# and the report says so.
+NEEDS_ATTENTION_PCT="${NEEDS_ATTENTION_PCT:-0.6}"
+awk -v p="$NEEDS_ATTENTION_PCT" 'BEGIN{exit !(p >= 0 && p <= 100)}' \
+  || die "NEEDS_ATTENTION_PCT must be between 0 and 100, got '$NEEDS_ATTENTION_PCT'"
+
+# Resolution of the hash bucket. 100000 buckets lets a rate as low as 0.001%
+# be expressed exactly rather than rounded to zero.
+BUCKETS=100000
+KEEP_BUCKETS="$(awk -v p="$NEEDS_ATTENTION_PCT" -v b="$BUCKETS" 'BEGIN{printf "%d", (p/100)*b}')"
+
+require_connections
+
+BEFORE_TOTAL="$(pg_sql "SELECT COUNT(*) FROM order_records WHERE \"internalOrderId\" LIKE '${PREFIX}\\_ord\\_%' ESCAPE '\\'")"
+BEFORE_FAILED="$(pg_sql "SELECT COUNT(*) FROM order_records WHERE \"internalOrderId\" LIKE '${PREFIX}\\_ord\\_%' ESCAPE '\\' AND \"syncStatus\" @> '[{\"status\": \"failed\"}]'::jsonb")"
+[ "${BEFORE_TOTAL:-0}" -gt 0 ] || die "no seeded order_records found - nothing to rebalance"
+
+BEFORE_PCT="$(pg_sql "SELECT round(100.0*${BEFORE_FAILED}/NULLIF(${BEFORE_TOTAL},0), 3)")"
+log "before: $BEFORE_FAILED of $BEFORE_TOTAL seeded orders match needs-attention (${BEFORE_PCT}%)"
+log "target: ${NEEDS_ATTENTION_PCT}% (keep bucket < $KEEP_BUCKETS of $BUCKETS)"
+
+# `abs(hashtext(id)) % BUCKETS` is stable for a given id, so the SAME rows are
+# failed on every run - which is what makes this idempotent and reproducible.
+# hashtext can return the minimum int32, whose abs() overflows; the modulo is
+# taken on the bigint cast first so that value cannot raise.
+KEEP_PREDICATE="(abs(hashtext(\"internalOrderId\")::bigint) % ${BUCKETS}) < ${KEEP_BUCKETS}"
+IS_FAILED="o.\"syncStatus\" @> '[{\"status\": \"failed\"}]'::jsonb"
+
+START="$(epoch)"
+
+# Two narrow UPDATEs over the DISAGREEING rows only, never a blanket rewrite of
+# the whole table: at a million rows the blanket form rewrites 1.1 GB and
+# doubles the table's bloat to change a few thousand rows.
+#
+# jsonb_agg over the array rewrites the entries in place and preserves their
+# order and their destinationConnectionId, so a row keeps its real
+# per-destination shape rather than being replaced by a synthesised one.
+seed_sql <<SQL
+-- (1) Heal: currently failed, should not be.
+UPDATE order_records o
+SET "syncStatus" = (
+  SELECT jsonb_agg(
+           CASE WHEN e->>'status' = 'failed' THEN jsonb_set(e, '{status}', '"synced"'::jsonb) ELSE e END
+           ORDER BY ord)
+  FROM jsonb_array_elements(o."syncStatus") WITH ORDINALITY AS t(e, ord)
+)
+WHERE o."internalOrderId" LIKE '${PREFIX}\\_ord\\_%' ESCAPE '\\'
+  AND ${IS_FAILED}
+  AND NOT ${KEEP_PREDICATE};
+
+-- (2) Fail: should be failed, currently is not. WHICH destination fails is
+-- itself hashed, so the population keeps a mix of first-destination and
+-- second-destination failures rather than every minted failure landing on the
+-- same connection - an all-one-destination population would make any
+-- per-destination read look artificially clean.
+UPDATE order_records o
+SET "syncStatus" = (
+  SELECT jsonb_agg(
+           CASE WHEN ord = 1 + (abs(hashtext(o."internalOrderId" || ':dest')::bigint) % 2)
+                THEN jsonb_set(e, '{status}', '"failed"'::jsonb) ELSE e END
+           ORDER BY ord)
+  FROM jsonb_array_elements(o."syncStatus") WITH ORDINALITY AS t(e, ord)
+)
+WHERE o."internalOrderId" LIKE '${PREFIX}\\_ord\\_%' ESCAPE '\\'
+  AND NOT ${IS_FAILED}
+  AND ${KEEP_PREDICATE};
+SQL
+
+ELAPSED=$(( $(epoch) - START ))
+
+vacuum_analyze_reset order_records
+
+AFTER_FAILED="$(pg_sql "SELECT COUNT(*) FROM order_records WHERE \"internalOrderId\" LIKE '${PREFIX}\\_ord\\_%' ESCAPE '\\' AND \"syncStatus\" @> '[{\"status\": \"failed\"}]'::jsonb")"
+AFTER_TOTAL="$(pg_sql "SELECT COUNT(*) FROM order_records WHERE \"internalOrderId\" LIKE '${PREFIX}\\_ord\\_%' ESCAPE '\\'")"
+AFTER_PCT="$(pg_sql "SELECT round(100.0*${AFTER_FAILED}/NULLIF(${AFTER_TOTAL},0), 3)")"
+
+log "after: $AFTER_FAILED of $AFTER_TOTAL seeded orders match needs-attention (${AFTER_PCT}%) in ${ELAPSED}s"
+
+# TWO-SIDED, and the low side is the one that matters. A one-sided check is
+# what let the first draft land 3.8x below target and report success: an
+# undershoot is invisible in every downstream figure, because the resulting
+# dataset still looks plausible and nothing else in the harness knows what the
+# share was supposed to be.
+#
+# The realised share is over ALL order_records while the rewrite only reaches
+# the seeded ones, so a stand carrying unseeded rows lands slightly under
+# target by exactly their share; the tolerance absorbs that and the log states
+# both populations.
+UNSEEDED="$(pg_sql "SELECT COUNT(*) FROM order_records WHERE \"internalOrderId\" NOT LIKE '${PREFIX}\\_ord\\_%' ESCAPE '\\'")"
+SEEDED_PCT="$(pg_sql "SELECT round(100.0 * (SELECT COUNT(*) FROM order_records WHERE \"internalOrderId\" LIKE '${PREFIX}\\_ord\\_%' ESCAPE '\\' AND \"syncStatus\" @> '[{\"status\": \"failed\"}]'::jsonb)
+                     / NULLIF((SELECT COUNT(*) FROM order_records WHERE \"internalOrderId\" LIKE '${PREFIX}\\_ord\\_%' ESCAPE '\\'),0), 3)")"
+log "seeded population alone: ${SEEDED_PCT}% (target ${NEEDS_ATTENTION_PCT}%); ${UNSEEDED} unseeded row(s) are not rewritten and dilute the whole-table figure"
+
+awk -v a="$SEEDED_PCT" -v t="$NEEDS_ATTENTION_PCT" \
+  'BEGIN{ lo = t*0.9; hi = t*1.1;
+          if (a < lo || a > hi) { printf "realised %.3f%% is outside [%.3f, %.3f]\n", a, lo, hi; exit 1 } }' \
+  || die "rebalance: the seeded share is ${SEEDED_PCT}%, outside 10% of the ${NEEDS_ATTENTION_PCT}% target - the keep predicate did not do what it says"
+
+log "rebalance-sync-status done"

--- a/perf/openlinker-throughput/seed/seed-orders.sh
+++ b/perf/openlinker-throughput/seed/seed-orders.sh
@@ -35,6 +35,21 @@ source "$SCRIPT_DIR/seed-lib.sh"
 LIB_LOG_PREFIX="seed-orders"
 
 TARGET_ORDERS="${TARGET_ORDERS:?TARGET_ORDERS is required, e.g. TARGET_ORDERS=10000}"
+
+# Per-DESTINATION probability that a seeded order's syncStatus entry reads
+# 'failed'. There are two destinations, so the share of orders matching the
+# `/orders?health=needs_attention` predicate (`syncStatus @> '[{"status":
+# "failed"}]'`) is 1 - (1 - rate)^2, NOT the rate itself.
+#
+# The default 0.15 is the value the first three size steps were seeded with,
+# kept so an unaware caller reproduces that dataset exactly. It puts 27.75% of
+# orders in the needs-attention bucket, which is an install in an incident
+# rather than one in steady state - see rebalance-sync-status.sh, which exists
+# to correct it, and pass SYNC_FAILED_RATE explicitly for a realistic seed.
+SYNC_FAILED_RATE="${SYNC_FAILED_RATE:-0.15}"
+awk -v r="$SYNC_FAILED_RATE" 'BEGIN{exit !(r >= 0 && r <= 1)}' \
+  || die "SYNC_FAILED_RATE must be between 0 and 1, got '$SYNC_FAILED_RATE'"
+
 require_connections
 
 EXISTING_TOTAL="$(pg_sql "SELECT COUNT(*) FROM order_records WHERE \"internalOrderId\" LIKE '${PREFIX}\\_ord\\_%' ESCAPE '\\'" 2>/dev/null || printf 0)"
@@ -100,6 +115,8 @@ ALTER TABLE perfseed_orders_stage ADD COLUMN tax_rate_era varchar(16);
 --   taxTreatment: inclusive 80% / exclusive 20%
 --   reportingCurrency stamped (of 'ready' rows): 80%
 --   taxRateEra: NULL 30% (not-yet-checked) / 'pre-rollout' 10% / 'standard' 60%
+--   syncStatus 'failed', PER DESTINATION: SYNC_FAILED_RATE (see the header).
+--     The needs-attention share is 1-(1-rate)^2 across the two destinations.
 UPDATE perfseed_orders_stage SET
   conn_id = CASE WHEN r_conn < 0.6 THEN '${PS_CONNECTION_ID}' ELSE '${WC_CONNECTION_ID}' END,
   record_status = CASE WHEN r_status < 0.90 THEN 'ready' WHEN r_status < 0.95 THEN 'awaiting_mapping' ELSE 'source_deleted' END,
@@ -122,8 +139,8 @@ SELECT
     'items', COALESCE((SELECT jsonb_agg(jsonb_build_object('sku', 'ITEM-' || g)) FROM generate_series(1, s.line_count) g), '[]'::jsonb)
   ),
   jsonb_build_array(
-    jsonb_build_object('destinationConnectionId', '${PS_CONNECTION_ID}', 'status', CASE WHEN s.r_sync_ps < 0.85 THEN 'synced' ELSE 'failed' END),
-    jsonb_build_object('destinationConnectionId', '${WC_CONNECTION_ID}', 'status', CASE WHEN s.r_sync_wc < 0.85 THEN 'synced' ELSE 'failed' END)
+    jsonb_build_object('destinationConnectionId', '${PS_CONNECTION_ID}', 'status', CASE WHEN s.r_sync_ps >= ${SYNC_FAILED_RATE} THEN 'synced' ELSE 'failed' END),
+    jsonb_build_object('destinationConnectionId', '${WC_CONNECTION_ID}', 'status', CASE WHEN s.r_sync_wc >= ${SYNC_FAILED_RATE} THEN 'synced' ELSE 'failed' END)
   ),
   s.placed_at, s.placed_at + interval '1 minute',
   s.record_status, '[]'::jsonb,
@@ -178,6 +195,20 @@ check_share "recordStatus=ready" "\"recordStatus\"='ready'" 90
 check_share "sourceConnectionId=PS" "\"sourceConnectionId\"='${PS_CONNECTION_ID}'" 60
 check_share "currency=PLN" "currency='PLN'" 70
 check_share "reportingCurrency stamped (of ready)" "\"recordStatus\"='ready' AND \"reportingCurrency\" IS NOT NULL" 72
+
+# The needs-attention share is the compound of two independent destination
+# draws, not SYNC_FAILED_RATE itself - asserting the rate here would pass a
+# dataset carrying nearly twice the intended proportion.
+#
+# Note what this check is and is not. `check_share`'s tolerance is an ABSOLUTE
+# number of percentage points, shared with the four checks above whose targets
+# are 60-90%, so at a realistic failure rate of well under one percent it is
+# only a coarse net: it catches the 27.7%-instead-of-0.6% class of error - which
+# is the one this campaign actually hit - and would not notice 0.3% instead of
+# 0.6%. `rebalance-sync-status.sh` asserts the same quantity with a RELATIVE
+# +/-10% band, and is the tighter of the two.
+NEEDS_ATTENTION_PCT="$(awk -v r="$SYNC_FAILED_RATE" 'BEGIN{printf "%.2f", (1-(1-r)*(1-r))*100}')"
+check_share "syncStatus contains failed" "\"syncStatus\" @> '[{\"status\": \"failed\"}]'::jsonb" "$NEEDS_ATTENTION_PCT"
 
 N_ORDERS="$(pg_sql "SELECT COUNT(*) FROM order_records WHERE \"internalOrderId\" LIKE '${PREFIX}\\_ord\\_%' ESCAPE '\\'")"
 N_LINES="$(pg_sql "SELECT COUNT(*) FROM order_line_items oli JOIN order_records o ON o.\"internalOrderId\"=oli.\"orderRecordId\" WHERE o.\"internalOrderId\" LIKE '${PREFIX}\\_ord\\_%' ESCAPE '\\'")"

--- a/perf/openlinker-throughput/seed/seed-shop-catalogue.sh
+++ b/perf/openlinker-throughput/seed/seed-shop-catalogue.sh
@@ -1,0 +1,469 @@
+#!/usr/bin/env bash
+#
+# Shop-side catalogue seeder, and the OpenLinker projection that RESOLVES
+# against it.
+#
+# Why this exists, stated plainly, because the distinction is the whole point:
+# `seed-catalogue.sh` seeds OpenLinker's OWN tables and mints
+# `identifier_mappings` rows whose `externalId` is a synthetic string
+# (`PERFSEED-EXT-PROD-ps-1`). No such product exists in PrestaShop. Every
+# measurement that resolves such a mapping into the shop therefore exercises
+# the NOT-FOUND path - and `OrderSyncService` fans out under
+# `Promise.allSettled`, so the job still reports `outcome: 'ok'` while the shop
+# receives nothing (bootstrap.sh's own note, "Offer identifier mappings").
+#
+# bootstrap.sh works around that by pointing every Offer mapping at a variant
+# whose product carries a NUMERIC PrestaShop external id, and warns that on a
+# six-product shop the 200-offer pool collapses onto eleven variants. Its own
+# comment names the fix: "A numeric test rather than a hardcoded list, so a
+# stand that later grows a real catalogue picks it up automatically." This
+# script grows that catalogue.
+#
+# The external-id shapes are the ADAPTER's, not this script's invention:
+#   Product        -> String(id_product)              prestashop-product-master.adapter.ts:538
+#   ProductVariant -> String(id_product_attribute)    :678
+#   ProductVariant -> 'product:' || id_product        :633   (SIMPLE product, synthetic)
+# The synthetic form is not cosmetic: the inventory sweep filters synthetic ids
+# by that exact prefix, so a simple product mapped under a bare numeric id
+# would be swept as though it had a real combination.
+#
+# DIVERSITY is the other half of "realistic". Cloning ONE template N times
+# (the perf/prestashop-baseline/seed-products.sh shape) gives structurally
+# complete rows and no variety at all - one price, one category, one
+# combination count - so cache-miss behaviour, payload-size spread and
+# category breadth stay unmeasurable. This clones round-robin from EVERY
+# template the shop has (a mix of simple and multi-variant) and then varies
+# price, category, manufacturer, name and stock per row.
+#
+# Variation is DETERMINISTIC arithmetic on the ordinal, never RAND(): re-running
+# with the same count, offset and template set reproduces the identical
+# catalogue, which is what lets a later campaign regenerate this dataset. The
+# multipliers (1, 31, 13, 7919, 37, 17) are chosen coprime to the rotation
+# lengths so the rotations do not phase-lock - a product's category is not a
+# function of its template.
+#
+# Every PrestaShop row carries the `PERFSHOP-` reference prefix and every
+# OpenLinker row carries the `perfseed_product_s` id prefix, so cleanup.sh can
+# remove the whole generation by tag alone and can never touch demo data.
+#
+# Usage: SHOP_PRODUCT_COUNT=50000 ./seed-shop-catalogue.sh
+#
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/seed-lib.sh"
+LIB_LOG_PREFIX="seed-shop-catalogue"
+
+SHOP_PRODUCT_COUNT="${SHOP_PRODUCT_COUNT:-50000}"
+SHOP_SEED_OFFSET="${SHOP_SEED_OFFSET:-0}"
+SHOP_PREFIX="PERFSHOP-"
+# OL-side id stem. Deliberately shares the `perfseed_product_` stem with
+# seed-catalogue.sh so cleanup.sh's existing products / product_variants
+# patterns already match it; the trailing `s` distinguishes this generation.
+OL_STEM="${PREFIX}_product_s"
+CEILING_SECS="${CEILING_SECS:-900}"
+
+require_connections
+ps_mysql_pwd
+
+# A strict MySQL runner. lib.sh's ps_sql ends in `|| true` - correct for a
+# lenient probe, fatal for a seeder: a failed INSERT would print an ERROR line,
+# exit 0, and the script would carry on and assert a distribution over rows
+# that were never written. This captures the output instead of piping it, so
+# neither the exit status nor an ERROR line can be lost to a pipeline.
+ps_seed_sql() {
+  local out rc=0
+  out="$(docker exec -i -e MYSQL_PWD="$PS_MYSQL_PWD" "$PS_MYSQL_CONTAINER" \
+          mysql -uroot -N -B "$PS_DB" 2>&1)" || rc=$?
+  # No `grep -q` and no pipe: under `set -o pipefail` a grep that closes the
+  # pipe early SIGPIPEs the writer and reports failure on success.
+  case "$out" in
+    *"ERROR "*) printf '%s\n' "$out" >&2; die "PrestaShop seed SQL reported an ERROR (above)" ;;
+  esac
+  [ "$rc" -eq 0 ] || { printf '%s\n' "$out" >&2; die "PrestaShop seed SQL exited $rc (above)"; }
+  printf '%s\n' "$out" | sed '/^mysql: \[Warning\]/d'
+}
+
+# ---------------------------------------------------------------------------
+# Template and category discovery. Whatever real rows the shop already has
+# become the clone templates, so the seeded catalogue inherits the shop's OWN
+# structural mix rather than one hand-picked shape.
+# ---------------------------------------------------------------------------
+TEMPLATE_IDS="${TEMPLATE_IDS:-}"
+if [ -z "$TEMPLATE_IDS" ]; then
+  TEMPLATE_IDS="$(ps_sql "SELECT GROUP_CONCAT(id_product ORDER BY id_product) FROM ps_product WHERE active=1 AND reference NOT LIKE '${SHOP_PREFIX}%'" | tail -1)"
+fi
+[ -n "$TEMPLATE_IDS" ] || die "no template products in ps_product - this script clones from what the shop already has"
+TEMPLATE_COUNT="$(printf '%s' "$TEMPLATE_IDS" | tr ',' '\n' | grep -c . || true)"
+[ "${TEMPLATE_COUNT:-0}" -gt 0 ] || die "could not count templates from [$TEMPLATE_IDS]"
+
+LEAF_CATEGORIES="${LEAF_CATEGORIES:-}"
+if [ -z "$LEAF_CATEGORIES" ]; then
+  LEAF_CATEGORIES="$(ps_sql "SELECT GROUP_CONCAT(id_category ORDER BY id_category) FROM ps_category WHERE active=1 AND id_category > 2" | tail -1)"
+fi
+[ -n "$LEAF_CATEGORIES" ] || die "no leaf categories (id_category > 2) found"
+LEAF_COUNT="$(printf '%s' "$LEAF_CATEGORIES" | tr ',' '\n' | grep -c . || true)"
+
+MANU_COUNT="$(ps_sql "SELECT COUNT(*) FROM ps_manufacturer" | tail -1)"
+MANU_COUNT="${MANU_COUNT:-0}"
+MANU_SLOTS=$(( MANU_COUNT + 1 ))   # slot 0 = no manufacturer
+
+log "templates=[$TEMPLATE_IDS] ($TEMPLATE_COUNT) leaf_categories=[$LEAF_CATEGORIES] ($LEAF_COUNT) manufacturers=$MANU_COUNT"
+
+EXISTING_SHOP="$(ps_sql "SELECT COUNT(*) FROM ps_product WHERE reference LIKE '${SHOP_PREFIX}%'" | tail -1)"
+EXISTING_SHOP="${EXISTING_SHOP:-0}"
+if [ "$EXISTING_SHOP" != "0" ] && [ "${FORCE_SEED:-0}" != "1" ]; then
+  die "refuse: $EXISTING_SHOP PrestaShop product(s) already carry the '${SHOP_PREFIX}' prefix.
+  A second generation under one prefix makes cleanup counts and 'which generation is this'
+  both stop meaning anything, and would mint duplicate references and duplicate ean13
+  barcodes - a duplicate barcode is exactly what offer linking refuses to resolve.
+  Run seed/cleanup.sh first, or FORCE_SEED=1 with SHOP_SEED_OFFSET=$EXISTING_SHOP."
+fi
+
+# ---------------------------------------------------------------------------
+# Column lists, read from information_schema so a PrestaShop upgrade that adds
+# a column does not silently drop it from the clone.
+# ---------------------------------------------------------------------------
+cols_except() {
+  local table="$1" skip="$2"
+  ps_sql "SELECT GROUP_CONCAT(CONCAT(CHAR(96),COLUMN_NAME,CHAR(96)) ORDER BY ORDINAL_POSITION)
+          FROM information_schema.COLUMNS
+          WHERE TABLE_SCHEMA='$PS_DB' AND TABLE_NAME='$table' AND COLUMN_NAME NOT IN ($skip)" | tail -1
+}
+qualify() { printf '%s' "$1" | sed 's/`[^`]*`/p.&/g'; }
+
+PROD_COLS=$(cols_except ps_product '"id_product","reference","ean13","date_add","date_upd","id_category_default","id_manufacturer","price","wholesale_price","cache_default_attribute"')
+SHOP_COLS=$(cols_except ps_product_shop '"id_product","id_category_default","price","wholesale_price","cache_default_attribute","date_add","date_upd"')
+LANG_COLS=$(cols_except ps_product_lang '"id_product","name","link_rewrite"')
+PA_COLS=$(cols_except ps_product_attribute '"id_product_attribute","id_product","reference","ean13","price"')
+PAS_COLS=$(cols_except ps_product_attribute_shop '"id_product_attribute","id_product"')
+PAC_COLS=$(cols_except ps_product_attribute_combination '"id_product_attribute"')
+STOCK_COLS=$(cols_except ps_stock_available '"id_stock_available","id_product","id_product_attribute","quantity","physical_quantity"')
+
+for v in PROD_COLS SHOP_COLS LANG_COLS PA_COLS PAS_COLS PAC_COLS STOCK_COLS; do
+  [ -n "${!v}" ] || die "could not read column list for $v"
+done
+
+log "seeding $SHOP_PRODUCT_COUNT PrestaShop products (offset=$SHOP_SEED_OFFSET, prefix=${SHOP_PREFIX})"
+START="$(epoch)"
+
+# ---------------------------------------------------------------------------
+# PrestaShop side.
+#
+# The combination-id arithmetic differs from the single-template precedent:
+# with several templates the combinations-per-product is NOT constant, so
+# `@pabase + (n-1)*@vcount + rnk` does not hold. A materialised map assigns
+# every (clone, template-combination) pair a global ROW_NUMBER instead, and
+# every child table JOINS that map rather than recomputing an id - which also
+# makes the assignment auditable after the fact.
+#
+# Each temporary table is referenced at most once per statement: MySQL cannot
+# reopen a TEMPORARY table within one query, and that limitation is the reason
+# the plan is materialised rather than expressed as repeated subqueries.
+# ---------------------------------------------------------------------------
+ps_seed_sql <<SQL
+SET SESSION sql_mode='';
+SET SESSION cte_max_recursion_depth = 2000000;
+
+SET @base   := (SELECT GREATEST(MAX(id_product), 200000) + 1 FROM ps_product);
+SET @pabase := (SELECT GREATEST(MAX(id_product_attribute), 200000) + 1 FROM ps_product_attribute);
+
+CREATE TEMPORARY TABLE perf_tplmap (slot INT PRIMARY KEY, tpl INT);
+INSERT INTO perf_tplmap (slot, tpl)
+SELECT ROW_NUMBER() OVER (ORDER BY id_product) - 1, id_product
+FROM ps_product WHERE FIND_IN_SET(id_product, '${TEMPLATE_IDS}');
+
+CREATE TEMPORARY TABLE perf_catmap (slot INT PRIMARY KEY, cat INT);
+INSERT INTO perf_catmap (slot, cat)
+SELECT ROW_NUMBER() OVER (ORDER BY id_category) - 1, id_category
+FROM ps_category WHERE FIND_IN_SET(id_category, '${LEAF_CATEGORIES}');
+
+-- Slot 0 is deliberately "no manufacturer": a real catalogue has unbranded
+-- rows, and a NOT NULL id_manufacturer on every product is its own distortion.
+CREATE TEMPORARY TABLE perf_manumap (slot INT PRIMARY KEY, manu INT);
+INSERT INTO perf_manumap (slot, manu) VALUES (0, 0);
+INSERT INTO perf_manumap (slot, manu)
+SELECT ROW_NUMBER() OVER (ORDER BY id_manufacturer), id_manufacturer FROM ps_manufacturer;
+
+CREATE TEMPORARY TABLE perf_seq (n INT PRIMARY KEY);
+INSERT INTO perf_seq
+WITH RECURSIVE s(n) AS (SELECT 1 UNION ALL SELECT n+1 FROM s WHERE n < ${SHOP_PRODUCT_COUNT})
+SELECT n + ${SHOP_SEED_OFFSET} FROM s;
+
+CREATE TEMPORARY TABLE perf_plan (
+  n INT PRIMARY KEY, id_new INT, tpl INT, cat INT, manu INT,
+  price DECIMAL(20,6), wholesale DECIMAL(20,6), qty INT,
+  UNIQUE KEY (id_new), KEY (tpl)
+);
+INSERT INTO perf_plan (n, id_new, tpl, cat, manu, price, wholesale, qty)
+SELECT q.n, @base + q.n, t.tpl, c.cat, m.manu,
+       ROUND(4.99 + ((q.n * 7919) % 300000) / 100.0, 2),
+       ROUND((4.99 + ((q.n * 7919) % 300000) / 100.0) * 0.55, 2),
+       (q.n * 37) % 250
+FROM perf_seq q
+JOIN perf_tplmap t ON t.slot = q.n % ${TEMPLATE_COUNT}
+JOIN perf_catmap c ON c.slot = (q.n * 31) % ${LEAF_COUNT}
+JOIN perf_manumap m ON m.slot = (q.n * 13) % ${MANU_SLOTS};
+
+INSERT INTO ps_product (id_product, reference, ean13, date_add, date_upd, id_category_default, id_manufacturer, price, wholesale_price, cache_default_attribute, ${PROD_COLS})
+SELECT k.id_new,
+       CONCAT('${SHOP_PREFIX}', LPAD(k.n, 6, '0')),
+       LPAD(6000000000000 + k.n, 13, '0'),
+       NOW(), NOW(), k.cat, k.manu, k.price, k.wholesale, 0, $(qualify "$PROD_COLS")
+FROM perf_plan k JOIN ps_product p ON p.id_product = k.tpl;
+
+INSERT INTO ps_product_shop (id_product, id_category_default, price, wholesale_price, cache_default_attribute, date_add, date_upd, ${SHOP_COLS})
+SELECT k.id_new, k.cat, k.price, k.wholesale, 0, NOW(), NOW(), $(qualify "$SHOP_COLS")
+FROM perf_plan k JOIN ps_product_shop p ON p.id_product = k.tpl;
+
+-- Names from a small vocabulary crossed with the ordinal: varied enough that a
+-- name search has something to discriminate on, and stable across re-runs.
+INSERT INTO ps_product_lang (id_product, name, link_rewrite, ${LANG_COLS})
+SELECT k.id_new,
+       CONCAT(
+         ELT(1 + (k.n % 12), 'Bawelniana','Skorzana','Ceramiczna','Drewniana','Stalowa','Szklana','Lniana','Welniana','Plastikowa','Aluminiowa','Jedwabna','Bambusowa'),
+         ' ',
+         ELT(1 + ((k.n DIV 12) % 10), 'koszulka','torba','kubek','lampa','krzeslo','zegar','doniczka','poduszka','ramka','koszyk'),
+         ' ', LPAD(k.n, 6, '0')),
+       CONCAT('perfshop-', LPAD(k.n, 6, '0')),
+       $(qualify "$LANG_COLS")
+FROM perf_plan k JOIN ps_product_lang p ON p.id_product = k.tpl;
+
+-- Assigned leaf category, plus the shop home category (2) every product keeps.
+INSERT INTO ps_category_product (id_category, id_product, position)
+SELECT k.cat, k.id_new, 0 FROM perf_plan k;
+INSERT INTO ps_category_product (id_category, id_product, position)
+SELECT 2, k.id_new, 0 FROM perf_plan k WHERE k.cat <> 2;
+
+-- One row per (clone, template combination). A clone of a SIMPLE template
+-- contributes nothing here, which is what keeps the catalogue a genuine mix
+-- rather than uniformly multi-variant.
+CREATE TEMPORARY TABLE perf_pa_map (
+  new_pa INT PRIMARY KEY, n INT, id_new INT, tpl INT, tpl_pa INT, rnk INT,
+  qty INT, KEY (id_new), KEY (tpl_pa)
+);
+INSERT INTO perf_pa_map (new_pa, n, id_new, tpl, tpl_pa, rnk, qty)
+SELECT @pabase + ROW_NUMBER() OVER (ORDER BY k.n, pa.id_product_attribute),
+       k.n, k.id_new, k.tpl, pa.id_product_attribute,
+       ROW_NUMBER() OVER (PARTITION BY k.n ORDER BY pa.id_product_attribute),
+       0
+FROM perf_plan k
+JOIN ps_product_attribute pa ON pa.id_product = k.tpl;
+
+UPDATE perf_pa_map SET qty = ((n * 17) + rnk * 11) % 180;
+
+INSERT INTO ps_product_attribute (id_product_attribute, id_product, reference, ean13, price, ${PA_COLS})
+SELECT m.new_pa, m.id_new,
+       CONCAT('${SHOP_PREFIX}', LPAD(m.n, 6, '0'), '-V', m.rnk),
+       LPAD(6100000000000 + (m.new_pa - @pabase), 13, '0'),
+       ROUND((m.rnk - 1) * 5, 2),
+       $(qualify "$PA_COLS")
+FROM perf_pa_map m JOIN ps_product_attribute p ON p.id_product_attribute = m.tpl_pa;
+
+INSERT INTO ps_product_attribute_shop (id_product_attribute, id_product, ${PAS_COLS})
+SELECT m.new_pa, m.id_new, $(qualify "$PAS_COLS")
+FROM perf_pa_map m JOIN ps_product_attribute_shop p ON p.id_product_attribute = m.tpl_pa;
+
+INSERT INTO ps_product_attribute_combination (id_product_attribute, ${PAC_COLS})
+SELECT m.new_pa, $(qualify "$PAC_COLS")
+FROM perf_pa_map m JOIN ps_product_attribute_combination p ON p.id_product_attribute = m.tpl_pa;
+
+-- cache_default_attribute must point at the CLONE's own combination. The
+-- single-template precedent copies the template's value verbatim, leaving
+-- every clone pointing at a combination that belongs to another product -
+-- harmless in SQL, wrong in every read that resolves a default combination.
+-- These templates all carry default_on = NULL, so "lowest combination" is the
+-- rule, which is what PrestaShop itself falls back to.
+CREATE TEMPORARY TABLE perf_default_pa (id_new INT PRIMARY KEY, pa INT);
+INSERT INTO perf_default_pa (id_new, pa)
+SELECT id_new, MIN(new_pa) FROM perf_pa_map GROUP BY id_new;
+
+UPDATE ps_product pr JOIN perf_default_pa d ON d.id_new = pr.id_product
+SET pr.cache_default_attribute = d.pa;
+
+CREATE TEMPORARY TABLE perf_default_pa2 (id_new INT PRIMARY KEY, pa INT);
+INSERT INTO perf_default_pa2 SELECT id_new, pa FROM perf_default_pa;
+UPDATE ps_product_shop pr JOIN perf_default_pa2 d ON d.id_new = pr.id_product
+SET pr.cache_default_attribute = d.pa;
+
+-- Product-level stock row, then one per combination. Quantities vary per row
+-- so an availability read sees a spread rather than one constant.
+INSERT INTO ps_stock_available (id_product, id_product_attribute, quantity, physical_quantity, ${STOCK_COLS})
+SELECT k.id_new, 0, k.qty, k.qty, $(qualify "$STOCK_COLS")
+FROM perf_plan k JOIN ps_stock_available p ON p.id_product = k.tpl AND p.id_product_attribute = 0;
+
+INSERT INTO ps_stock_available (id_product, id_product_attribute, quantity, physical_quantity, ${STOCK_COLS})
+SELECT m.id_new, m.new_pa, m.qty, m.qty, $(qualify "$STOCK_COLS")
+FROM perf_pa_map m JOIN ps_stock_available p ON p.id_product = m.tpl AND p.id_product_attribute = m.tpl_pa;
+
+-- Handback: the (id_product, id_product_attribute) pairs the OpenLinker
+-- projection must key on. A REAL table, not a temporary one, because the
+-- OpenLinker half runs in a different process against a different database.
+DROP TABLE IF EXISTS perf_shop_handback;
+CREATE TABLE perf_shop_handback (
+  n INT NOT NULL, id_product INT NOT NULL, id_product_attribute INT NOT NULL,
+  rnk INT NOT NULL, is_synthetic TINYINT NOT NULL, ean13 VARCHAR(13) NOT NULL,
+  price DECIMAL(20,6) NOT NULL, qty INT NOT NULL,
+  PRIMARY KEY (id_product, id_product_attribute)
+) ENGINE=InnoDB;
+
+INSERT INTO perf_shop_handback (n, id_product, id_product_attribute, rnk, is_synthetic, ean13, price, qty)
+SELECT m.n, m.id_new, m.new_pa, m.rnk, 0,
+       LPAD(6100000000000 + (m.new_pa - @pabase), 13, '0'),
+       k.price + ((m.rnk - 1) * 5), m.qty
+FROM perf_pa_map m JOIN perf_plan k ON k.id_new = m.id_new;
+
+-- A simple product contributes ONE synthetic variant. id_product_attribute is
+-- 0 here; the OpenLinker half maps it to the adapter's 'product:<id>' form.
+INSERT INTO perf_shop_handback (n, id_product, id_product_attribute, rnk, is_synthetic, ean13, price, qty)
+SELECT k.n, k.id_new, 0, 1, 1, LPAD(6000000000000 + k.n, 13, '0'), k.price, k.qty
+FROM perf_plan k
+LEFT JOIN perf_default_pa d ON d.id_new = k.id_new
+WHERE d.id_new IS NULL;
+
+SELECT CONCAT('seeded_products=', COUNT(*)) FROM ps_product WHERE reference LIKE '${SHOP_PREFIX}%';
+SELECT CONCAT('seeded_combinations=', COUNT(*)) FROM ps_product_attribute WHERE reference LIKE '${SHOP_PREFIX}%';
+SELECT CONCAT('handback_rows=', COUNT(*)) FROM perf_shop_handback;
+SQL
+
+PS_ELAPSED=$(( $(epoch) - START ))
+log "PrestaShop side done in ${PS_ELAPSED}s"
+
+N_SHOP="$(ps_sql "SELECT COUNT(*) FROM ps_product WHERE reference LIKE '${SHOP_PREFIX}%'" | tail -1)"
+[ "${N_SHOP:-0}" -gt 0 ] || die "PrestaShop seed produced 0 products - see the SQL output above"
+
+# ---------------------------------------------------------------------------
+# OpenLinker side. Every row is derived from the handback, so a mapping can
+# only ever name an id PrestaShop actually holds.
+#
+# Streamed through COPY rather than generated from an ordinal: combination ids
+# come from a ROW_NUMBER over the shop's own tables and are not derivable, so
+# Postgres has to be told what they are.
+# ---------------------------------------------------------------------------
+log "exporting handback and building the OpenLinker projection"
+OL_START="$(epoch)"
+
+HANDBACK_TSV="$(mktemp)"
+trap 'rm -f "$HANDBACK_TSV"' EXIT
+
+docker exec -i -e MYSQL_PWD="$PS_MYSQL_PWD" "$PS_MYSQL_CONTAINER" \
+  mysql -uroot -N -B "$PS_DB" -e \
+  "SELECT n, id_product, id_product_attribute, rnk, is_synthetic, ean13, price, qty FROM perf_shop_handback ORDER BY id_product, id_product_attribute" \
+  2>/dev/null > "$HANDBACK_TSV"
+
+HANDBACK_LINES="$(wc -l < "$HANDBACK_TSV")"
+[ "$HANDBACK_LINES" -gt 0 ] || die "handback export is empty - the PrestaShop half wrote nothing this script can project"
+log "handback rows exported: $HANDBACK_LINES"
+
+pg_sql_write "DROP TABLE IF EXISTS perf_shop_handback;
+CREATE UNLOGGED TABLE perf_shop_handback (
+  n int NOT NULL, id_product int NOT NULL, id_product_attribute int NOT NULL,
+  rnk int NOT NULL, is_synthetic int NOT NULL, ean13 text NOT NULL,
+  price numeric(20,6) NOT NULL, qty int NOT NULL)" >/dev/null
+
+docker exec -i "$PG_CONTAINER" psql -U "$PG_USER" -d "$PG_DB" -v ON_ERROR_STOP=1 \
+  -c "\\copy perf_shop_handback FROM STDIN" < "$HANDBACK_TSV" >/dev/null \
+  || die "COPY of the handback into Postgres failed"
+
+COPIED="$(pg_sql "SELECT COUNT(*) FROM perf_shop_handback")"
+[ "$COPIED" = "$HANDBACK_LINES" ] \
+  || die "handback COPY landed $COPIED of $HANDBACK_LINES rows - refusing to project a partial catalogue"
+
+pg_sql_write "CREATE INDEX ON perf_shop_handback (id_product); ANALYZE perf_shop_handback" >/dev/null
+
+seed_sql <<SQL
+BEGIN;
+
+INSERT INTO products (id, name, sku, price, currency, "taxRate", "taxRateCountry", "taxRateReadAt", "createdAt", "updatedAt")
+SELECT DISTINCT ON (h.id_product)
+  '${OL_STEM}' || h.id_product,
+  'Perfshop product ' || h.n,
+  '${SHOP_PREFIX}' || lpad(h.n::text, 6, '0'),
+  h.price, 'PLN', '23', 'PL', now(), now(), now()
+FROM perf_shop_handback h
+ORDER BY h.id_product, h.id_product_attribute;
+
+INSERT INTO product_variants (id, "productId", sku, attributes, ean, price, "taxRate", "taxRateCountry", "taxRateReadAt", "createdAt", "updatedAt")
+SELECT
+  '${OL_STEM}' || h.id_product || '_v' || h.id_product_attribute,
+  '${OL_STEM}' || h.id_product,
+  '${SHOP_PREFIX}' || lpad(h.n::text, 6, '0') || '-V' || h.rnk,
+  jsonb_build_object('size', (ARRAY['S','M','L','XL'])[1 + (h.rnk % 4)]),
+  h.ean13,
+  h.price, '23', 'PL', now(), now(), now()
+FROM perf_shop_handback h;
+
+-- inventory_items keyed to the canonical variant (#822), quantity taken from
+-- the shop's own stock row rather than invented.
+INSERT INTO inventory_items (id, "productId", "productVariantId", "availableQuantity", "sourceConnectionId", "updatedAt")
+SELECT
+  '${PREFIX}_inv_ps_s' || h.id_product || '_v' || h.id_product_attribute,
+  '${OL_STEM}' || h.id_product,
+  '${OL_STEM}' || h.id_product || '_v' || h.id_product_attribute,
+  h.qty,
+  '${PS_CONNECTION_ID}',
+  now()
+FROM perf_shop_handback h;
+
+-- identifier_mappings on the PrestaShop connection, external ids in the
+-- ADAPTER's own shapes. This is the row set that makes the catalogue
+-- resolvable, and the whole reason this script exists.
+INSERT INTO identifier_mappings ("entityType", "internalId", "externalId", "platformType", "connectionId", "createdAt", "updatedAt")
+SELECT DISTINCT ON (h.id_product)
+  'Product', '${OL_STEM}' || h.id_product, h.id_product::text,
+  'prestashop', '${PS_CONNECTION_ID}'::uuid, now(), now()
+FROM perf_shop_handback h
+ORDER BY h.id_product, h.id_product_attribute;
+
+INSERT INTO identifier_mappings ("entityType", "internalId", "externalId", "platformType", "connectionId", "createdAt", "updatedAt")
+SELECT
+  'ProductVariant',
+  '${OL_STEM}' || h.id_product || '_v' || h.id_product_attribute,
+  CASE WHEN h.is_synthetic = 1 THEN 'product:' || h.id_product ELSE h.id_product_attribute::text END,
+  'prestashop', '${PS_CONNECTION_ID}'::uuid, now(), now()
+FROM perf_shop_handback h;
+
+COMMIT;
+SQL
+
+pg_sql_write "DROP TABLE IF EXISTS perf_shop_handback" >/dev/null
+ps_sql "DROP TABLE IF EXISTS perf_shop_handback" >/dev/null
+
+OL_ELAPSED=$(( $(epoch) - OL_START ))
+ELAPSED=$(( $(epoch) - START ))
+seed_check_ceiling "shop catalogue ($SHOP_PRODUCT_COUNT products, both sides)" "$ELAPSED" "$CEILING_SECS"
+
+vacuum_analyze_reset products product_variants inventory_items identifier_mappings
+
+# ---------------------------------------------------------------------------
+# Post-seed assertions. The last one is the one that matters: a count of
+# mappings proves nothing, since the whole defect this script exists to fix
+# was a full mapping table every one of whose external ids named nothing.
+# ---------------------------------------------------------------------------
+N_OL_PROD="$(pg_sql "SELECT COUNT(*) FROM products WHERE id LIKE '${OL_STEM}%'")"
+N_OL_VAR="$(pg_sql "SELECT COUNT(*) FROM product_variants WHERE id LIKE '${OL_STEM}%'")"
+N_OL_INV="$(pg_sql "SELECT COUNT(*) FROM inventory_items WHERE \"productId\" LIKE '${OL_STEM}%'")"
+N_OL_MAP="$(pg_sql "SELECT COUNT(*) FROM identifier_mappings WHERE \"internalId\" LIKE '${OL_STEM}%'")"
+N_MULTI="$(pg_sql "SELECT COUNT(*) FROM (SELECT \"productId\" FROM product_variants WHERE id LIKE '${OL_STEM}%' GROUP BY 1 HAVING COUNT(*) > 1) t")"
+N_SIMPLE=$(( N_OL_PROD - N_MULTI ))
+N_PS_COMBOS="$(ps_sql "SELECT COUNT(*) FROM ps_product_attribute WHERE reference LIKE '${SHOP_PREFIX}%'" | tail -1)"
+N_PS_STOCK="$(ps_sql "SELECT COUNT(*) FROM ps_stock_available s JOIN ps_product p ON p.id_product=s.id_product WHERE p.reference LIKE '${SHOP_PREFIX}%'" | tail -1)"
+N_DISTINCT_CAT="$(ps_sql "SELECT COUNT(DISTINCT id_category_default) FROM ps_product WHERE reference LIKE '${SHOP_PREFIX}%'" | tail -1)"
+PRICE_RANGE="$(ps_sql "SELECT CONCAT(MIN(price),'..',MAX(price),' distinct=',COUNT(DISTINCT price)) FROM ps_product WHERE reference LIKE '${SHOP_PREFIX}%'" | tail -1)"
+
+log "PrestaShop: products=$N_SHOP combinations=$N_PS_COMBOS stock_rows=$N_PS_STOCK distinct_default_categories=$N_DISTINCT_CAT price=$PRICE_RANGE"
+log "OpenLinker: products=$N_OL_PROD variants=$N_OL_VAR (multi-variant=$N_MULTI simple=$N_SIMPLE) inventory_items=$N_OL_INV identifier_mappings=$N_OL_MAP"
+
+# The referential check, done the only way that proves anything: take the
+# external ids OpenLinker holds and ask PrestaShop how many of them exist.
+DANGLING="$(pg_sql "SELECT COUNT(*) FROM identifier_mappings WHERE \"internalId\" LIKE '${OL_STEM}%' AND \"entityType\"='Product' AND \"externalId\" !~ '^[0-9]+\$'")"
+[ "$DANGLING" = "0" ] || die "referential check: $DANGLING Product mapping(s) carry a non-numeric externalId - those name no PrestaShop product"
+
+MAPPED_IDS="$(pg_sql "SELECT string_agg(\"externalId\", ',') FROM (SELECT \"externalId\" FROM identifier_mappings WHERE \"internalId\" LIKE '${OL_STEM}%' AND \"entityType\"='Product' ORDER BY \"externalId\" LIMIT 500) t")"
+RESOLVED="$(ps_sql "SELECT COUNT(*) FROM ps_product WHERE FIND_IN_SET(id_product, '${MAPPED_IDS}')" | tail -1)"
+SAMPLED="$(pg_sql "SELECT COUNT(*) FROM (SELECT 1 FROM identifier_mappings WHERE \"internalId\" LIKE '${OL_STEM}%' AND \"entityType\"='Product' ORDER BY \"externalId\" LIMIT 500) t")"
+log "referential check: $RESOLVED of a $SAMPLED-mapping sample resolve to a real ps_product row"
+[ "$RESOLVED" = "$SAMPLED" ] \
+  || die "referential check FAILED: only $RESOLVED of $SAMPLED sampled Product mappings name a product PrestaShop holds"
+
+log "seed-shop-catalogue done in ${ELAPSED}s (prestashop ${PS_ELAPSED}s, openlinker ${OL_ELAPSED}s)"


### PR DESCRIPTION
The campaign's figures were taken against a dataset thin enough that a reader could reasonably ask whether they meant anything. OpenLinker's tables carried 10 006 products and 1 000 000 orders, but **the shop behind them held six**, the 200-offer pool resolved to **eleven variants across six products**, and **27.7%** of orders sat in the needs-attention bucket - an install mid-incident rather than one in steady state.

This rebuilds the dataset and re-measures on it.

## Two corrections to figures already in circulation

**The sub-linear scaling was a one-off. Do not size on it.** `results-F5-2026-09-06.md` reported 10x rows costing only **3.6x** time on the needs-attention `COUNT`, correctly diagnosed as Postgres switching to a `Parallel Seq Scan`. It has since been quoted as though it described the curve. A fourth point at 2M rows shows it described a *boundary*, and the boundary has been crossed: **1M -> 2M is 1.84x for 2x the rows**, and the unfiltered `COUNT` on the same table behaves identically (1.78x). A power law fitted to the old figure predicts 1.47x and is low by ~25%. **Past 1M, assume linear.**

**"`product_detail` is flat" is scoped to ORDER growth only.** The original claim is not wrong, it is narrower than it reads - the only thing that grew in that campaign was `order_records`. Holding orders fixed and growing the catalogue 6x moves `product_detail` **2.60x** and `products_list` **3.80x**, while `order_detail` (the control, with no fan-out) stays flat at 1.04x. `product_detail` is not a lone point lookup: it fans out to variants, inventory positions and identifier mappings.

## A prediction failed, and the reason is the finding

I predicted a diverse catalogue would slow the order path, because PrestaShop's tax-rate cache is per-product. **Requests per order fell on both arms instead** - A 11.22 -> 11.09, BD 10.16 -> 10.08.

And the diversity really was exercised. Measured per window, by joining each window's orders through their `Offer` mappings to the products behind them:

| Window | orders | distinct products touched |
|---|---:|---:|
| A r1 / r2 | 21 / 20 | 19 / 15 |
| **BD r1 / r2** | **191 / 191** | **92 / 94** |

On the old dataset the entire pool resolved to **six**, so a 191-order window hit six products dozens of times each. It now hits 92-94, nearly all once - a ~15x increase in the cache-miss surface inside one window, with requests per order going *down*.

The mechanism is the useful part: **exactly one line of the per-order request budget is product-keyed**, about 9% of it. Everything else is per-order or per-buyer (a new customer and address every order, carriers uncached, currencies, countries, order states). So catalogue size structurally cannot reach this flow - a stronger statement than the slowdown would have been, and arm BD is the clean test because its cache is genuinely cold for most of a window.

Throughput: A 226.3 -> 214.5 (-5.2%, inside that arm's own 5.7% spread), BD 2 279.0 -> 2 189.0 (-3.9%). BD's gap is larger than its own 2.1% spread so may be real, but it is **not attributable to the catalogue through the request budget**, since requests/order fell. A larger Postgres and host drift are both live candidates and this pass separates neither.

**One window came back `VALID`** - BD r2, the first in this campaign's limiter-ab history; the baseline records all thirteen of its own windows as `DISCARDED`.

## What makes the dataset credible

Not the row count - a **control**. The seeded products resolve through the shop's own webservice (**HTTP 200**, with real category, manufacturer and stock) and the old synthetic mappings do not (**404**). That pair only means anything because an id nothing holds also 404s in the same run: two earlier versions of that probe answered `000` and then `301` for **every** id including known-good ones, and either would have read as "the seeded data is broken".

The seeder asserts the same property on every run, sampling 500 mappings and refusing to finish unless the shop holds all 500.

## The dataset

| | Before | After |
|---|---:|---:|
| PrestaShop products | **6** | **50 006** |
| distinct categories / prices | 1 / 6 | 7 / 50 000 |
| simple vs multi-variant | 3 / 3 | 25 000 / 25 000 |
| OL products / variants | 10 006 / 20 011 | 60 006 / 111 678 |
| `identifier_mappings` | 65 644 | 207 311 |
| `order_records` | 1 002 561 | 2 002 561 |
| needs-attention share | **27.686%** | **0.591%** |
| offer pool -> distinct products | **6** | **110** |

**Under 2.5 minutes to seed, ~2.2 GB.** The catalogue was **inserted, not replicated**, and the report says so plainly: the request cost would have been affordable (~2 900 requests at ADR-048's 0.058 req/SKU) but the sweep's pacing is not - 500 items per run against a 20-minute cron is ~33 hours for one cycle over 50 000 products.

## A bug in my own seeder, and a lessons entry

`rebalance-sync-status.sh`'s first draft only ever *healed*, so a row stayed failed only if it was already failed **and** its hash fell in the kept fraction - making the realised share the **product** of the two: 27.686% x 0.6% = 0.166%. Measured 0.158%, **3.8x below target**, and its own assertion passed because it tested only for overshoot.

That is the fifth instance in this campaign of a test passing for a reason it did not claim, so `docs/lessons.md` gains an entry: an assertion over a quantity a script *sets* must bound it on both sides, the low side matters more (an undershoot is invisible downstream), and a relative band beats an absolute percentage-point tolerance when the target is small - `check_share`'s 5pp, correct for its 60-90% targets, is vacuous at 0.6%.

## Notes

- **The gate was run after the measurement windows closed, deliberately.** `pnpm check:invariants` and `lib-test.sh` both walk the tree and would have added CPU to the host mid-window, and this report's whole subject is a stand whose figures are already qualified by host contention. `bash -n` ran throughout. Results: `lib-test.sh` **165 passed / 1 failed, identical to the pre-change baseline** (the failure is in `run_post_guards`, a file this PR does not touch). `check:invariants` passed every guard up to and including `check-css-structure` (the chain is `&&`-joined, so reaching the last one means all ~70 before it passed), and could not complete its final `check-bundle-budgets.mjs`, which shells out to `vite build` - this git worktree has no `node_modules`.

  Rather than assert that is harmless, here is the proof: `apps/web`'s tree hash at this commit is `e72a7e3c32ae3a40dc9a9f9f0ce7396a18bf4dba`, **identical to `perf-programme-2840`'s**. The bundle this check would build is byte-for-byte the one CI already validated on the base, so the check cannot produce a different answer here. CI will run it anyway.
- **Three of four limiter-ab windows are `DISCARDED`, as was every window in the baseline** - `results-limiter-ab-2026-09-07.md` § 9 explains why, and the same two causes recur unchanged. `post_guard_destination_creates` fires structurally on any saturation window (its point is to end with work in flight); `post_guard_limiter_degraded` fires on arm A by construction, because the shared-Redis degradation is the condition arm A exists to characterise. Like for like, and no figure here is a publishable throughput number. BD r2 is the exception and came back `VALID`.
- `cleanup.sh` removes both new row sets by tag alone, so a reset stays possible.

Full report, provenance and limitations: `perf/openlinker-throughput/results-reseed-2026-09-07.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkKifZVwvZzHspxaQ7x396
