### PR TITLE
perf(2840): measure a weak PrestaShop and raise its rate-limit default 60 -> 300/min

### DIFF
--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -1336,3 +1336,62 @@ Verify red-first: run it once against a deliberately wrong target and watch the 
 proportion rather than a count.
 
 **Source**: #2949 (dataset re-seed), building on #2840.
+
+## `docker update` cannot take a container back to "unconstrained" - restore by recreating from the compose spec
+
+**Context**: a perf scenario that sweeps CPU/memory profiles over the `lab` stand's PrestaShop
+container needs to apply a limit and then put the stand back exactly as it found it
+(`perf/openlinker-throughput/scenarios/weak-shop-ramp.sh`).
+
+**Problem**: `docker update` applies a limit fine and **cannot remove one**. Measured on this host
+(Docker 29.5.2, cgroup v1) against a throwaway container: after
+`docker update --cpus 0.25 --memory 512m --memory-swap 512m`, the documented reset
+`docker update --cpus 0 --memory 0 --memory-swap -1` **exits 0 and changes nothing** -
+`HostConfig.NanoCpus` stays `250000000`, `HostConfig.Memory` stays `536870912`, and the container's
+own `memory.limit_in_bytes` is untouched. `--cpu-quota -1` does clear the CPU cgroup but leaves
+`HostConfig.NanoCpus` stale, so `docker inspect` then **reports a limit the container no longer
+has**. Either way a stand "restored" that way lies about itself, and `manifest_container_limits`
+(`perf/openlinker-throughput/lib.sh`) reads exactly those two fields into every subsequent run's
+manifest - so the next scenario records the lie rather than catching it.
+
+**Rule**: apply a container limit with `docker update` when you need the container to survive (an
+opcache and page cache that stay warm are what make a multi-profile sweep a single-variable
+experiment), but **restore by recreating the service from the unmodified compose spec** - a fresh
+container is the only thing that genuinely reads back `NanoCpus=0 Memory=0`. Verify the restore by
+reading both fields back and say so loudly if they are not zero; never infer "restored" from the
+reset command's exit status. Keep the profile table monotonically TIGHTENING within one
+invocation, since no step can loosen. Before recreating a stateful service, read its image's
+entrypoint and confirm the already-installed guard fires (PrestaShop's `/tmp/docker_run.sh` skips
+its installer, and `PS_ERASE_DB`, only because `app/config/parameters.php` exists) - a recreate
+that silently reinstalls would destroy a peer's seeded catalogue.
+
+**Applies to**: `perf/openlinker-throughput/**`, and any script that constrains a shared container.
+
+**Source**: #2840 (weak-shop rate-limit gate,
+`perf/openlinker-throughput/results-weak-shop-2026-09-07.md`).
+
+## A scenario-local env knob must not reuse a name `lib.sh` already defaults - the library wins silently
+
+**Context**: `perf/openlinker-throughput/scenarios/weak-shop-ramp.sh` wanted a 10 s pause between
+rate steps and wrote the usual `SETTLE_SECS="${SETTLE_SECS:-10}"` after sourcing `lib.sh`.
+
+**Problem**: `lib.sh:159` already declares `SETTLE_SECS="${SETTLE_SECS:-60}"` for a completely
+different purpose (the settle between the last guard and `window_start`). Sourcing runs first, so
+by the time the scenario's line executes the variable is already `60` and the `:-10` **never
+applies**. Nothing warns: the script says 10, does 60, and the only symptom is a run that takes
+longer than planned. It was caught by reading the child process's `/proc/<pid>/environ` and
+cross-checking against the probe's own window timestamps (a real 63.5 s gap), not by reading the
+code - re-reading the assignment looks correct in isolation, which is exactly why this survives
+review.
+
+**Rule**: after `source lib.sh`, treat every name that library defaults as taken. A scenario's own
+knob gets a scenario-scoped name (`RAMP_SETTLE_SECS`, not `SETTLE_SECS`) and is passed explicitly
+to whatever it configures. The general form: `${VAR:-default}` in a sourcing script is not a
+default, it is a default *only if nothing upstream already set it*, and a shared library is
+upstream. When a knob's effective value matters to a measurement, assert it - read it back from the
+child rather than trusting the assignment.
+
+**Applies to**: `perf/openlinker-throughput/scenarios/**`, and any script sourcing a shared
+`lib.sh` that declares `${VAR:-...}` defaults at top level.
+
+**Source**: #2840 (weak-shop rate-limit gate).

--- a/libs/integrations/inpost/src/__tests__/inpost-plugin.spec.ts
+++ b/libs/integrations/inpost/src/__tests__/inpost-plugin.spec.ts
@@ -13,8 +13,9 @@
  *
  *   - No manifest `defaultRateLimit` is passed, because InPost deliberately
  *     ships none (see the rationale on `inpostAdapterManifest`). PrestaShop's
- *     60/4 is calibrated for an operator's own shop webserver; guessing the
- *     same figure for a carrier platform would cap bulk dispatch at 1 req/s.
+ *     default is calibrated - and, since #2840, measured - for an operator's
+ *     own shop webserver; guessing the same figure for a carrier platform
+ *     would have capped bulk dispatch at 1 req/s under the old 60/min.
  *
  * @module libs/integrations/inpost/src/__tests__
  */

--- a/libs/integrations/inpost/src/inpost-plugin.ts
+++ b/libs/integrations/inpost/src/inpost-plugin.ts
@@ -36,8 +36,10 @@ export const inpostAdapterManifest: AdapterMetadata = {
   displayName: 'InPost ShipX v1',
   version: '1.0.0',
   isDefault: true,
-  // Deliberately NO `defaultRateLimit` (#1810 Phase 5). PrestaShop's 60/4 — the
-  // only manifest default in the repo — is calibrated for an operator's OWN shop
+  // Deliberately NO `defaultRateLimit` (#1810 Phase 5). PrestaShop's default —
+  // 300/min since #2840 measured it on constrained hardware, and no longer the
+  // only manifest default in the repo now that WooCommerce and Subiekt carry
+  // their own — is calibrated for an operator's OWN shop
   // webserver (#1815), which is both the throughput bottleneck and busy serving
   // customers. ShipX is a carrier platform whose quota OL has no documented
   // figure for, and `requestsPerMinute` is minimum-interval spacing (capacity

--- a/libs/integrations/ksef/src/ksef-plugin.ts
+++ b/libs/integrations/ksef/src/ksef-plugin.ts
@@ -61,8 +61,9 @@ export const ksefAdapterManifest: AdapterMetadata = {
   // No `defaultRateLimit` yet (#1810 Phase 5). Unlike every other adopter, KSeF
   // is a platform where one WOULD be justified — MF publishes API limits and the
   // client already models 429 + `Retry-After` — but the figure must be cited
-  // from that documentation, not copied from PrestaShop's 60/4, which is
-  // calibrated for an operator's own shop webserver (#1815). Until it is,
+  // from that documentation, not copied from PrestaShop's default (300/4 since
+  // #2840 measured it; 60/4 before that), which is calibrated — and now
+  // measured — for an operator's own shop webserver (#1815). Until it is,
   // `forConnection(connection)` is called without a fallback: unlimited unless
   // the operator sets `config.rateLimit`, with the transport's `Retry-After`
   // feedback as the reactive backstop. Adding it later is one line here plus

--- a/libs/integrations/prestashop/src/prestashop-plugin.ts
+++ b/libs/integrations/prestashop/src/prestashop-plugin.ts
@@ -76,12 +76,53 @@ export const prestashopAdapterManifest: AdapterMetadata = {
   displayName: 'PrestaShop WebService v1',
   version: '1.0.0',
   isDefault: true,
-  // Conservative resolution-time fallback for a connection with no
-  // explicit config.rateLimit (#1810/#1772) — a shared-hosting PrestaShop
-  // VPS is the platform this issue's reporter hit an abuse block on.
-  // Placeholder values pending the reporter's actual abuse-notice text
-  // (see #1810's own open question); never written into stored config.
-  defaultRateLimit: { requestsPerMinute: 60, maxConcurrent: 4 },
+  // Resolution-time fallback for a connection with no explicit
+  // config.rateLimit (#1810/#1772); never written into stored config. A
+  // self-hosted PrestaShop is the operator's OWN webserver - simultaneously
+  // the throughput bottleneck and busy serving customers - which is why a
+  // default belongs here at all (#1815).
+  //
+  // 300/min is one request every 200 ms. `requestsPerMinute` is strict
+  // minimum-interval spacing with NO burst, CAS'd in Redis across every
+  // replica (#2015), so the shop sees an evenly spaced 5 req/s and never a
+  // spike. Peak concurrency stays at ~1, which is why `maxConcurrent: 4` is
+  // not binding at this rate and is left alone.
+  //
+  // MEASURED, not inherited (#2840,
+  // perf/openlinker-throughput/results-weak-shop-2026-09-07.md). PrestaShop
+  // 9.0.2 with a 50 000-product catalogue, driven at 1-10 req/s of
+  // create-path reads across six CPU profiles, with the database squeezed
+  // alongside the shop on the small ones. Every constraint was read back from
+  // both the daemon and the container's own cgroup:
+  //
+  //   5 req/s (this default) is FREE down to 0.5 cpu (p99 78 ms), and
+  //   DEGRADES but never fails at 0.25 cpu (p99 143 ms; 3000/3000 ok over a
+  //   sustained 10 min with the tail flat). NOTHING refused at any profile or
+  //   rate - a constrained shop QUEUES, it does not shed.
+  //
+  // THE BOUND: this is not support for 600. 10 req/s is free at 1.0 cpu
+  // (p99 20 ms) and collapses below it - p99 617 ms at 0.5 cpu, 2126 ms at
+  // 0.25 cpu. The knee for THIS value sits between 0.5 and 0.25 cpu.
+  //
+  // AND DO NOT RAISE `maxConcurrent` ON THE STRENGTH OF THIS. The limiter is
+  // WEIGHT-BLIND: it admits five requests per second whether each costs 11 ms
+  // (a create-path read) or 1021 ms (a `display=full` catalogue page on a
+  // quarter-core shop - both measured). Pacing bounds ARRIVAL; `maxConcurrent`
+  // bounds SIMULTANEOUS WORK, and it is the latter that stops a sweep's heavy
+  // pages from swamping a small shop. It is deliberately left at 4.
+  //
+  // WHAT IT DOES NOT COVER: synthetic cgroup limits on one host are not a
+  // hosting provider's abuse policy. #1810's report was an abuse NOTICE, and
+  // a rule counting requests per hour is not reproducible this way - a busy
+  // install really can send ~5x more per hour at this ceiling. If that
+  // notice's text ever surfaces a request quota, re-derive from the quota
+  // rather than from this measurement.
+  //
+  // Deliberately NOT copied to any other manifest: WooCommerce and Subiekt
+  // carry their own, still unmeasured, 60/4, and moving them on the strength
+  // of a PrestaShop measurement is the mistake docs/lessons.md exists to
+  // prevent ("Never copy another platform's `defaultRateLimit` figure").
+  defaultRateLimit: { requestsPerMinute: 300, maxConcurrent: 4 },
 };
 
 /**

--- a/libs/integrations/subiekt/src/subiekt-plugin.ts
+++ b/libs/integrations/subiekt/src/subiekt-plugin.ts
@@ -40,9 +40,16 @@ export const subiektAdapterManifest: AdapterMetadata = {
   version: '1.0.0',
   isDefault: true,
   // #1810 §1 — the Sfera bridge runs on the operator's own machine alongside
-  // Subiekt nexo, the same merchant-hosted profile PrestaShop's 60/4 (#1815)
-  // was calibrated for (not a borrowed number — Subiekt genuinely fits that
-  // rationale, unlike a carrier/marketplace platform). Both call sites already
+  // Subiekt nexo, the same merchant-hosted RATIONALE (#1815) PrestaShop's
+  // default was calibrated for (not a borrowed number — Subiekt genuinely fits
+  // that rationale, unlike a carrier/marketplace platform).
+  //
+  // The shared rationale is all that is shared: the two are no longer the same
+  // FIGURE. #2840 measured PrestaShop on constrained hardware and moved it to
+  // 300/min; this 60 was deliberately left where it is, because that
+  // measurement is evidence about PrestaShop and not about a Sfera bridge on
+  // an operator's desktop. It remains an UNMEASURED, conservative default —
+  // raise it only with a measurement of this platform. Both call sites already
   // pass this to `host.http.forConnection` (see `createCapabilityAdapter` below
   // and `SubiektConnectionTesterAdapter`, injected via constructor — never via
   // an import of this module, which would cycle back into it).

--- a/libs/integrations/woocommerce/src/woocommerce-plugin.ts
+++ b/libs/integrations/woocommerce/src/woocommerce-plugin.ts
@@ -93,10 +93,24 @@ export const woocommerceAdapterManifest: AdapterMetadata = {
   // locked default any undeclared adapter resolves to.
   variantGrouping: 'parent-child',
   // #1810 Phase 5 (#1970): WooCommerceHttpClient now goes through
-  // `HttpTransportFactoryPort`, so this default is real — mirrors
-  // PrestaShop's conservative merchant-hosted default (the same "no
-  // documented req/min cap" home.pl scenario applies to any self-hosted
-  // WooCommerce install).
+  // `HttpTransportFactoryPort`, so this default is real. It was originally
+  // copied from PrestaShop's, on the reasoning that the same "no documented
+  // req/min cap" self-hosted scenario applies to any WooCommerce install.
+  //
+  // IT NO LONGER MIRRORS PRESTASHOP, and that is deliberate (#2840). #2840
+  // measured PrestaShop on constrained hardware and raised its default to
+  // 300/min on the strength of that measurement; this figure was NOT moved
+  // with it, because a PrestaShop measurement is not evidence about
+  // WooCommerce - copying a figure across platforms is precisely the mistake
+  // docs/lessons.md records ("Never copy another platform's
+  // `defaultRateLimit` figure"), and it is how this 60 arrived here in the
+  // first place. So 60 stands as an UNMEASURED, conservative default.
+  //
+  // Measuring it is a well-defined follow-up: the `lab` stand already runs a
+  // WooCommerce, and `perf/openlinker-throughput/scenarios/weak-shop-ramp.sh`
+  // is the shape of the sweep - it needs a WooCommerce endpoint mix in place
+  // of the PrestaShop create-path one. Raise this only with that measurement,
+  // or with a documented quota.
   defaultRateLimit: { requestsPerMinute: 60, maxConcurrent: 4 },
 };
 

--- a/perf/openlinker-throughput/probes/ps-heavy-request-cost.sh
+++ b/perf/openlinker-throughput/probes/ps-heavy-request-cost.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# ps-heavy-request-cost.sh <outdir> <label> - what ONE catalogue-sweep request
+# costs on the shop, at whatever resource profile is currently in force.
+#
+# WHY THIS EXISTS BESIDE THE RAMP
+#
+# `drivers/ps-latency-probe.mjs` offers the create path's GET half - eight
+# cheap, mostly single-row reads. That is the right mix for "can the shop take
+# orders at this rate", and it is the WRONG mix for the biggest consumer of a
+# raised rate limit, which is the catalogue and inventory sweeps. Those issue
+# `display=full` pages of 100 products: #2593 measured one such page at 1.33 MB
+# and roughly a third of a second on an unconstrained shop, against ~11 ms for
+# a single-row read. A ramp built from cheap reads therefore says nothing
+# directly about the rate at which heavy reads are safe.
+#
+# Running a full RATE ramp of heavy pages was rejected: at 5 req/s of 1.33 MB
+# responses against a quarter-core shop the probe would simply saturate it, and
+# "we saturated it" is a fact about the probe's chosen rate, not a bound anyone
+# can use. What an operator needs instead is the per-request SERVICE COST at
+# each profile, from which the safe rate follows arithmetically - a shop can
+# sustain at most 1/service_time requests per second of a given shape, and the
+# report can then say plainly whether 5 req/s of catalogue pages is inside or
+# outside that, per profile, rather than leaving the heavy path unmeasured.
+#
+# So this is deliberately SEQUENTIAL and small: N requests one after another,
+# no concurrency, no offered rate. It measures cost, not capacity.
+#
+# It status-checks every sample for the same reason the ramp does - the
+# campaign has already withdrawn one figure to an instrument that did not
+# (ADR-066 correction 1). A non-200 is counted, reported, and excluded from the
+# timing aggregate rather than folded in as a fast sample.
+#
+# The offsets VARY per request. A repeated identical query would be answered
+# increasingly from MySQL's buffer pool and the measurement would drift
+# downwards for a reason that has nothing to do with the resource profile.
+#
+set -euo pipefail
+
+OUTDIR="${1:?usage: ps-heavy-request-cost.sh <outdir> <label>}"
+LABEL="${2:?label required}"
+SAMPLES="${HEAVY_SAMPLES:-8}"
+PAGE="${HEAVY_PAGE_SIZE:-100}"
+PS_BASE_URL="${PS_BASE_URL:-http://prestashop}"
+PS_NETWORK="${PS_NETWORK:-lab_default}"
+CURL_IMAGE="${CURL_IMAGE:-curlimages/curl:8.11.1}"
+: "${PS_WEBSERVICE_KEY:?ps-heavy-request-cost.sh: PS_WEBSERVICE_KEY required}"
+
+mkdir -p "$OUTDIR"
+OUT="$OUTDIR/heavy-$LABEL.csv"
+printf 'label,shape,offset,status,expected,ok,latency_ms,bytes\n' >"$OUT"
+
+log() { printf '[heavy] %s\n' "$*" >&2; }
+
+# The three shapes a catalogue/inventory sweep really issues, read off
+# PrestaShop's own access log and the adapter's query builder:
+#   ids   - the enumeration `listExternalIds` pages through
+#   full  - the batched product prefetch (#2593), the expensive one
+#   stock - the batched inventory prefetch (#2648)
+# `sort` is explicit on all three because an unsorted offset read has no tiling
+# guarantee at all (#2593 property 4 / #2648).
+shape_path() {
+  local shape="$1" off="$2"
+  case "$shape" in
+    ids)   printf '/api/products?display=[id]&limit=%s&offset=%s&sort=[id_ASC]' "$PAGE" "$off" ;;
+    full)  printf '/api/products?display=full&limit=%s&offset=%s&sort=[id_ASC]' "$PAGE" "$off" ;;
+    stock) printf '/api/stock_availables?display=full&limit=%s&offset=%s&sort=[id_ASC]' "$PAGE" "$off" ;;
+  esac
+}
+
+run_one() {
+  local shape="$1" off="$2" path out status ms bytes ok
+  path="$(shape_path "$shape" "$off")"
+  # `-o /dev/null` would discard the body without measuring it; the sweep pays
+  # for those bytes, so they are counted (`size_download`) and the body is
+  # still fully drained by curl before `time_total` is reported.
+  # Pinned, and pinned to a tag ALREADY PRESENT on this host - a probe that
+  # pulls an image mid-measurement spends host bandwidth and CPU inside the
+  # window it is measuring.
+  # `-g` / --globoff is REQUIRED, not defensive. PrestaShop's webservice syntax
+  # puts square brackets in the query string (`display=[id]`, `sort=[id_ASC]`,
+  # `filter[id]=[1|2|3]`), and curl treats `[...]` as a glob RANGE - without
+  # this every request dies with exit 3 "URL malformed" before a socket is
+  # opened. That is how this probe first ran: 18 samples, all status `000`.
+  # They were reported as non-ok rather than as fast successes, which is the
+  # whole reason every sample carries its status.
+  out="$(docker run --rm --network "$PS_NETWORK" "$CURL_IMAGE" \
+        -s -g -o /dev/null \
+        -u "$PS_WEBSERVICE_KEY:" \
+        -H 'Accept: application/xml' \
+        -H 'User-Agent: olperf-heavy-cost' \
+        -w '%{http_code} %{time_total} %{size_download}' \
+        "$PS_BASE_URL$path" 2>/dev/null || printf '000 0 0')"
+  status="$(printf '%s' "$out" | awk '{print $1}')"
+  ms="$(printf '%s' "$out" | awk '{printf "%.1f", $2*1000}')"
+  bytes="$(printf '%s' "$out" | awk '{print $3}')"
+  ok=0; [ "$status" = "200" ] && ok=1
+  printf '%s,%s,%s,%s,200,%s,%s,%s\n' "$LABEL" "$shape" "$off" "$status" "$ok" "$ms" "$bytes" >>"$OUT"
+}
+
+for shape in ids full stock; do
+  i=0
+  while [ "$i" -lt "$SAMPLES" ]; do
+    run_one "$shape" $(( i * PAGE * 7 ))
+    i=$(( i + 1 ))
+  done
+done
+
+log "wrote $OUT"
+awk -F, 'NR>1 && $6==1 {n[$2]++; s[$2]+=$7; b[$2]+=$8; if($7>m[$2]) m[$2]=$7}
+         NR>1 && $6!=1 {bad[$2]++}
+         END{for (k in n) printf "  %-6s n=%d ok  mean %.1f ms  max %.1f ms  mean %.0f KiB  non-ok=%d\n",
+             k, n[k], s[k]/n[k], m[k], (b[k]/n[k])/1024, bad[k]+0}' "$OUT" >&2

--- a/perf/openlinker-throughput/probes/weak-shop-verdict.sh
+++ b/perf/openlinker-throughput/probes/weak-shop-verdict.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+#
+# weak-shop-verdict.sh <run-dir> - render one markdown table per profile from a
+# `scenarios/weak-shop-ramp.sh` run, and apply the verdict rule to each.
+#
+# WHY THE VERDICT IS COMPUTED AND NOT EYEBALLED
+#
+# The rule it applies is written down in the run's own
+# `threshold-fixed-in-advance.md`, before any constrained profile produced a
+# sample. Computing it here rather than reading the tables and deciding means
+# the same arithmetic is applied to every profile, including the ones whose
+# answer is inconvenient - which is the whole reason for fixing a threshold in
+# advance rather than after.
+#
+# It reads the `#` summary block `drivers/ps-latency-probe.mjs` writes, exactly
+# as `ps-latency-table.sh` does, so no percentile is re-derived here. One
+# implementation of the arithmetic, not two.
+#
+# The comparison rate defaults to 5 req/s - what a `requestsPerMinute: 300`
+# default offers - and the profile's OWN 1 req/s step is its idle control, so
+# a slow box is judged against itself rather than against the 28-core baseline.
+set -euo pipefail
+
+DIR="${1:?usage: weak-shop-verdict.sh <run-dir>}"
+JUDGE_RATE="${JUDGE_RATE:-5}"
+IDLE_RATE="${IDLE_RATE:-1}"
+RATIO_FREE="${RATIO_FREE:-2}"       # p99 <= 2x own idle p99
+ABS_FREE_MS="${ABS_FREE_MS:-250}"   # ...and <= 250 ms absolute
+RATIO_UNSAFE="${RATIO_UNSAFE:-10}"
+ABS_UNSAFE_MS="${ABS_UNSAFE_MS:-1000}"
+
+# field <file> <regex-with-one-group>
+field() { sed -nE "s/$2/\1/p" "$1" | head -n 1; }
+
+summary_row() {
+  local f="$1" base off ach okn p50 p90 p99 mx st
+  base="$(basename "$f" .summary)"
+  off="$(field "$f" '^# offered rps *: (.*)')"
+  ach="$(field "$f" '^# achieved rps *: ([0-9.]+).*')"
+  okn="$(field "$f" '^# samples ok *: (.*)')"; okn="${okn// /}"
+  p50="$(field "$f" '^# latency ok.*p50 ([0-9.]+).*')"
+  p90="$(field "$f" '^# latency ok.*p90 ([0-9.]+).*')"
+  p99="$(field "$f" '^# latency ok.*p99 ([0-9.]+).*')"
+  mx="$(field "$f"  '^# latency ok.*max ([0-9.]+).*')"
+  st="$(field "$f"  '^# status mix *: (.*)')"
+  printf '%s|%s|%s|%s|%s|%s|%s|%s|%s\n' \
+    "$base" "${off:-?}" "${ach:-?}" "${okn:-?}" "${p50:-n/a}" "${p90:-n/a}" "${p99:-n/a}" "${mx:-n/a}" "${st:-?}"
+}
+
+# Integer-only comparison in tenths of a millisecond, so no bc dependency and
+# no float drift. `n/a` (every sample non-ok) propagates rather than becoming 0.
+tenths() {
+  case "$1" in
+    ''|n/a|'?') printf 'na' ;;
+    *) printf '%s' "$(awk -v v="$1" 'BEGIN{printf "%d", v*10}')" ;;
+  esac
+}
+
+shopt -s nullglob
+any=0
+for prof_dir in "$DIR"/*/; do
+  prof="$(basename "$prof_dir")"
+  case "$prof" in warmup-*) continue ;; esac
+  files=("$prof_dir"step-*.summary)
+  [ "${#files[@]}" -gt 0 ] || continue
+  any=1
+
+  printf '\n#### %s\n\n' "$prof"
+  printf '| offered req/s | achieved | ok/total | p50 | p90 | p99 | max | status mix |\n'
+  printf '|---:|---:|---:|---:|---:|---:|---:|---|\n'
+
+  # Glob order is LEXICOGRAPHIC, which puts `step-drift-1` first and
+  # `step-rate-10` between `step-rate-1` and `step-rate-2`. A latency curve
+  # printed in that order is not a curve, and the drift control - whose whole
+  # meaning is "this rate again, LAST" - would be read as the opening
+  # measurement. So the rows are sorted by offered rate, with the drift step
+  # forced last whatever its rate.
+  ordered="$(
+    for f in "${files[@]}"; do
+      b="$(basename "$f" .summary)"
+      case "$b" in
+        step-drift-*) printf '999999\t%s\n' "$f" ;;
+        *)            printf '%s\t%s\n' "${b#step-rate-}" "$f" ;;
+      esac
+    done | sort -g -k1,1
+  )"
+
+  idle_p99=''; judge_p99=''; judge_ok=''; judge_off=''; judge_ach=''; refused=''; ratio_na=0
+  for f in $(printf '%s\n' "$ordered" | cut -f2-); do
+    # A step still being written has no summary block yet. Rendering it would
+    # put a row of `?` in the table, which reads as a measurement that failed
+    # rather than one that has not happened - so it is skipped, and the missing
+    # step shows up as the verdict saying it was NOT MEASURED.
+    grep -Eq '^# latency ok' "$f" || continue
+    IFS='|' read -r base off ach okn p50 p90 p99 mx st <<<"$(summary_row "$f")"
+    # `$base` is the file stem, i.e. `step-drift-1` / `step-rate-5` - matching
+    # on `drift-*` silently never fires and the drift control renders as an
+    # ordinary row indistinguishable from the opening one.
+    drift_tag=''
+    case "$base" in step-drift-*) drift_tag=' **(drift, run last)**' ;; esac
+    printf '| %s%s | %s | %s | %s | %s | %s | %s | %s |\n' \
+      "$off" "$drift_tag" "$ach" "$okn" "$p50" "$p90" "$p99" "$mx" "$st"
+    case "$base" in
+      "step-rate-$IDLE_RATE")  idle_p99="$p99" ;;
+    esac
+    case "$base" in
+      "step-rate-$JUDGE_RATE") judge_p99="$p99"; judge_ok="$okn"; judge_off="$off"; judge_ach="$ach" ;;
+    esac
+    # Any status other than the two the mix legitimately contains (200 for
+    # every endpoint, 401 for the `configurations` probe, which EXPECTS it) is
+    # a refusal signal and is reported separately from latency.
+    case "$st" in
+      *'"429"'*|*'"503"'*|*'"500"'*|*'"502"'*|*'"504"'*|*'"0"'*) refused="$refused $base:$st" ;;
+    esac
+  done
+
+  # --- verdict -------------------------------------------------------------
+  if [ -z "$judge_p99" ]; then
+    printf '\n**Verdict at %s req/s: NOT MEASURED** (no `step-rate-%s` in this profile).\n' "$JUDGE_RATE" "$JUDGE_RATE"
+  else
+    v='FREE'; why=''
+    ok_n="${judge_ok%%/*}"; ok_d="${judge_ok##*/}"
+    [ "$ok_n" = "$ok_d" ] || { v='UNSAFE'; why="$why not every sample returned its expected status ($judge_ok);"; }
+
+    jp="$(tenths "$judge_p99")"; ip="$(tenths "$idle_p99")"
+    # An ABSENT idle control and an UNCOMPUTABLE judged p99 are different
+    # facts and must not share a verdict. A soak directory legitimately holds
+    # only the judged rate, so it has no 1 req/s step to be its own control -
+    # collapsing that into "no p99 could be computed (every sample non-ok)"
+    # reported the 10-minute sustained window as UNSAFE while every one of its
+    # 3000 samples had in fact succeeded. The ratio half of the rule is simply
+    # not applicable there; the absolute half still is, and is applied.
+    if [ "$jp" = "na" ]; then
+      v='UNSAFE'; why="$why no p99 could be computed (every sample non-ok);"
+    elif [ "$ip" = "na" ]; then
+      ratio_na=1
+      [ "$jp" -le "$(( ABS_UNSAFE_MS * 10 ))" ] || { v='UNSAFE'; why="$why p99 ${judge_p99} ms is over the ${ABS_UNSAFE_MS} ms absolute ceiling;"; }
+      if [ "$v" = 'FREE' ] && [ "$jp" -gt "$(( ABS_FREE_MS * 10 ))" ]; then
+        v='DEGRADING'; why="$why p99 ${judge_p99} ms is over the ${ABS_FREE_MS} ms free ceiling;"
+      fi
+    else
+      [ "$jp" -le "$(( ABS_UNSAFE_MS * 10 ))" ] || { v='UNSAFE'; why="$why p99 ${judge_p99} ms is over the ${ABS_UNSAFE_MS} ms absolute ceiling;"; }
+      [ "$ip" -eq 0 ] || [ "$jp" -le "$(( ip * RATIO_UNSAFE ))" ] || { v='UNSAFE'; why="$why p99 is over ${RATIO_UNSAFE}x its own idle p99 (${idle_p99} ms);"; }
+      if [ "$v" = 'FREE' ]; then
+        if [ "$jp" -gt "$(( ABS_FREE_MS * 10 ))" ]; then
+          v='DEGRADING'; why="$why p99 ${judge_p99} ms is over the ${ABS_FREE_MS} ms free ceiling;"
+        elif [ "$ip" -gt 0 ] && [ "$jp" -gt "$(( ip * RATIO_FREE ))" ]; then
+          v='DEGRADING'; why="$why p99 ${judge_p99} ms is over ${RATIO_FREE}x its own idle p99 (${idle_p99} ms);"
+        fi
+      fi
+    fi
+
+    # The achieved-rate condition: a probe that could not deliver the offered
+    # rate mislabelled its own x-axis, so the row is not evidence about that
+    # rate at all.
+    ja="$(tenths "$judge_ach")"; jo="$(tenths "$judge_off")"
+    if [ "$ja" != "na" ] && [ "$jo" != "na" ] && [ "$jo" -gt 0 ]; then
+      [ "$(( ja * 100 / jo ))" -ge 95 ] || { v='UNSAFE'; why="$why achieved ${judge_ach} against ${judge_off} offered - the rate was not delivered;"; }
+    fi
+
+    printf '\n**Verdict at %s req/s: %s**' "$JUDGE_RATE" "$v"
+    [ -n "$why" ] && printf ' -%s' "${why% }"
+    printf '\n'
+    if [ "$ratio_na" = "1" ]; then
+      printf '\nNo %s req/s step in this directory, so the profile has no idle control of its own: the\nRATIO half of the rule is not applicable and only the absolute ceiling was applied.\n%s req/s p99 %s ms.\n' \
+        "$IDLE_RATE" "$JUDGE_RATE" "$judge_p99"
+    else
+      printf '\nidle (%s req/s) p99 %s ms -> %s req/s p99 %s ms.\n' \
+        "$IDLE_RATE" "${idle_p99:-n/a}" "$JUDGE_RATE" "$judge_p99"
+    fi
+  fi
+
+  if [ -n "$refused" ]; then
+    printf '\n**REFUSED** (a status the mix should never contain):%s\n' "$refused"
+  else
+    printf '\nNo refusal at any step: every status was 200 or the `configurations` probe'\''s expected 401.\n'
+  fi
+done
+
+[ "$any" = "1" ] || { echo "weak-shop-verdict.sh: no profile directories with step-*.summary under $DIR" >&2; exit 1; }

--- a/perf/openlinker-throughput/results-weak-shop-2026-09-07.md
+++ b/perf/openlinker-throughput/results-weak-shop-2026-09-07.md
@@ -1,0 +1,641 @@
+# Is 300 req/min safe on a WEAK PrestaShop? (epic #2840)
+
+**Run**: `results/weak-shop/run-a1d53-sweep`, 2026-09-07 20:18:19Z - 21:43:11Z,
+one 85-minute window held under `guard_stand_exclusive` throughout.
+**Scenario**: `scenarios/weak-shop-ramp.sh`. **Six profiles + one sustained
+window, 38 measurement steps, 10 800 status-checked samples.**
+**Instrument**: `probes/ps-latency-ramp.sh` + `drivers/ps-latency-probe.mjs`,
+reused **verbatim** from #2977, so every number here is directly comparable to
+that report's curve.
+
+---
+
+## Before the numbers: why a "FREE" verdict here is worth believing
+
+This report concludes that the change we were hoping to make is safe. That is
+exactly the situation in which a reader should be suspicious, so the two things
+that guard against it are stated first rather than buried in § 2.
+
+**The verdict rule was written down and timestamped BEFORE any constrained
+profile produced a sample.** It is committed at
+`results/weak-shop/run-a1d53-sweep/threshold-fixed-in-advance.md`, written
+20:12Z; the sweep it governs started at 20:18Z, and at the moment of writing the
+only samples in existence anywhere were from the **unconstrained** control.
+`probes/weak-shop-verdict.sh` then applies it mechanically to every profile,
+including the ones whose answer is inconvenient - and **that classifier was
+itself validated against ten synthetic known-answer fixtures** (free, degrading
+by ratio, degrading by absolute, unsafe by ratio / absolute / non-ok-status /
+undelivered-rate, free-but-refusing, and two soak-shaped directories) before it
+was ever pointed at real data.
+
+**And the threshold was NOT retightened when its own rationale turned out to be
+wrong.** The 250 ms bar was justified by "~8 destination requests per order";
+F1 actually measured ~16, which makes the bar twice as permissive as intended
+(§ 2.1). Moving a pre-registered threshold after seeing the data is precisely
+what pre-registration exists to prevent, so it was left alone and the
+robustness check was published instead: **at the stricter bar the corrected
+arithmetic implies, the headline answer does not move** - the boundary still
+sits between half a core and a quarter core.
+
+Nothing else in this campaign carries that guarantee.
+
+---
+
+## 0. The answers, in one page
+
+| Question | Answer | Label |
+|---|---|---|
+| **Weakest profile at which 5 req/s is FREE** | **0.5 cpu with the database squeezed to 0.5 cpu beside it** (`P3-shared`) - p99 78.1 ms, 300/300 samples ok | measured |
+| **Weakest profile at which it is NOT** | **0.25 cpu** (`P4-shared-min`) - p99 143.2 ms, **DEGRADING, never UNSAFE** | measured |
+| **Does a constrained shop REFUSE or DEGRADE?** | **Degrades.** 100% expected status at every step of every profile - including 0.1 cpu at 10 req/s, where p99 was 4.1 s. Zero 429, 503, resets or timeouts anywhere. | measured |
+| **Did the CPU limit actually engage?** | Yes, and provably: **0** throttle events at 1.0 cpu and above, first engagement at 0.5 cpu, scaling with the tail to 38 events at 0.1 cpu | measured |
+| **Sustained, not just a 60 s step?** | 2 x 5 min at exactly 5 req/s on the quarter-core profile: **3000/3000 ok**, p99 186.6 then **166.3** - it got *better*, so no accumulation | measured |
+| **Does this license 600 req/min?** | **No.** 10 req/s is free at >= 1.0 cpu (p99 20.0 ms) but p99 **616.7 ms** at 0.5 cpu and **2125.6 ms** at 0.25 cpu | measured |
+| **What about the heavy catalogue reads?** | A `display=full` page costs **395 ms** unconstrained and **1021 ms** at a quarter core - ~70x a create-path read. The limiter is **weight-blind**; what bounds the damage is `maxConcurrent: 4`, which this change leaves alone | measured |
+| **Recommendation** | **Raise PrestaShop's `requestsPerMinute` 60 -> 300. Only PrestaShop's.** | judgement, from the above |
+
+---
+
+## 1. The question, and why #2977 does not settle it
+
+`libs/integrations/prestashop/src/prestashop-plugin.ts:79-84` declares
+
+```ts
+  // Conservative resolution-time fallback for a connection with no
+  // explicit config.rateLimit (#1810/#1772) - a shared-hosting PrestaShop
+  // VPS is the platform this issue's reporter hit an abuse block on.
+  // Placeholder values pending the reporter's actual abuse-notice text
+  // (see #1810's own open question); never written into stored config.
+  defaultRateLimit: { requestsPerMinute: 60, maxConcurrent: 4 },
+```
+
+Somebody hit an abuse block on shared hosting, a provisional number was written
+pending details, and the details never arrived. `docs/lessons.md:301` names the
+failure mode - *"an uncalibrated manifest default is a silent throughput
+regression"* - and rules that such a default should exist only with a
+documented quota to calibrate against.
+
+#2977 measured the shop free to ~6.5 req/s with the tail moving at 10 req/s.
+300 req/min is 5 req/s, inside that. But it was measured on a **28-core host
+with an unconstrained container**, and the shop the block came from was on
+shared hosting. A default is for everyone, so the figure that decides it has to
+come from the weakest shop a real operator runs, not the strongest one we own.
+
+### 1.1 What `requestsPerMinute` does, because it decides both the instrument and the risk
+
+It is **strict minimum-interval spacing, not a token bucket**.
+`libs/shared/src/rate-limit/rate-limiter.ts:196-199` advances a single
+`nextAvailableAt` by `60000/rpm` on each admission, and
+`redis-rate-limiter.adapter.ts:12-24` does the same through a CAS'd
+`ratelimit:pace:{connectionId}` key using Redis's own `TIME`. Since #2015 that
+key is shared by every process and replica, so it is the **aggregate** cap.
+
+**So 300/min means the shop sees an evenly spaced 5 req/s and never a burst.**
+That is a materially safer shape than "300 requests in a minute" sounds:
+OpenLinker at 300/min *cannot* send 300 requests in the first second, or 10 in
+any one second. Anyone reading this change as a fivefold increase in peak load
+is reading it wrong - peak load is unchanged at one concurrent request; only
+the interval between requests shortens, from 1000 ms to 200 ms.
+
+It is also why the instrument is right: the probe offers requests on a fixed
+arrival schedule (`start + n/rate`), which is that same shape.
+
+`maxConcurrent: 4` is not binding at these rates - with an ~11 ms shop and
+200 ms spacing, in-flight is ~1 - and is neither changed nor measured here.
+
+### 1.2 Blast radius
+
+`libs/shared/src/http/http-transport-factory.ts:148` resolves
+`connection.config?.rateLimit ?? defaultRateLimit ?? {}`, so the manifest value
+applies to **every PrestaShop connection with no explicit `config.rateLimit`** -
+on an untouched install, all of them. This is not opt-in.
+
+The operator override already exists
+(`apps/web/src/features/connections/components/rate-limit-section.tsx` renders
+`Default: 60` and accepts 1-6000), which is the asymmetry shaping the
+recommendation: **an operator who knows their shop can already raise it, so the
+default's job is to be safe rather than fast.**
+
+---
+
+## 2. Method
+
+### 2.1 The verdict rule was fixed and timestamped BEFORE any constrained profile produced a sample
+
+`results/weak-shop/run-a1d53-sweep/threshold-fixed-in-advance.md`, written
+20:12Z. At that moment the only samples in existence were from the
+**unconstrained** control of an aborted first attempt; no constrained profile
+had produced a single sample, and none had when the sweep this report covers
+was launched at 20:18Z. This is pre-registration, and it is the reason a reader
+has grounds to believe the verdicts below rather than merely the numbers.
+
+A profile is judged at its **5 req/s** step against **its own 1 req/s step** as
+the idle control, so a weak box is judged against itself:
+
+* **FREE** - 100% expected status; achieved within 5% of offered with no
+  in-flight-cap skips; p99 <= 2x the profile's own idle p99; **and** p99 <=
+  250 ms absolute. Both p99 conditions are required, because a box whose idle
+  p99 is already 300 ms passes a ratio test while being unusable.
+* **DEGRADING** - status and rate hold, but p99 is 2-10x idle, or 250 ms - 1 s.
+* **UNSAFE** - any unexpected status, an undelivered rate, p99 > 10x idle, or
+  p99 > 1 s.
+* **REFUSING** is reported *separately* and is not a latency judgement: any
+  429, 503, reset or timeout. A shop that stays fast and then blocks you is a
+  different failure from one that slows down, and it is the one the original
+  abuse notice describes.
+
+`probes/weak-shop-verdict.sh` computes it, so the same arithmetic reaches every
+profile including the ones whose answer is inconvenient. **The classifier was
+itself checked against ten synthetic known-answer fixtures** - free, degrading
+by ratio, degrading by absolute, unsafe by ratio / absolute / non-ok-status /
+undelivered-rate, free-but-refusing, and two soak-shaped directories with no
+idle control - before being pointed at real data.
+
+#### A correction to the rule's own rationale, which I am NOT using to move the rule
+
+The 250 ms figure was justified in the pre-registered text by *"F1 measured ~8
+destination requests per order, so a 250 ms p99 is a ~2 s worst-case shop-side
+contribution"*. **That count is wrong.** F1 measured **~16** requests per order
+(`results-F1-2026-09-07.md:161-163`: 14.06 `/api/` + 2.00 module POSTs), so a
+250 ms p99 is really a ~4 s worst case, and the absolute bar is **twice as
+permissive as its own rationale intended**.
+
+The threshold is left at 250 ms anyway, because silently retightening a
+pre-registered rule after seeing the data destroys the only thing
+pre-registration buys. What is owed instead is the robustness check: **at the
+125 ms bar the corrected arithmetic would have produced, the headline answer
+does not move.** P3 (78.1 ms) is still FREE and P4 (143.2 ms) is still not - the
+boundary sits between half a core and a quarter core either way. The one
+verdict that *would* flip is the quarter-core **soak** (186.6 ms), from FREE to
+DEGRADING, and § 3.3 states that explicitly rather than resting on it.
+
+### 2.2 Two mechanisms for the constraint, and why neither alone is enough
+
+Applied with `docker update`, removed with a compose recreate. That split is a
+measured necessity.
+
+`docker update` keeps the container alive, so PHP's opcache, the Apache worker
+pool and every warm page survive the whole sweep and the **only** thing
+differing between two profiles is the cgroup quota. A recreate per profile
+would hand each one a cold shop and confound the constraint with the warm-up.
+
+But **`docker update` cannot undo itself.** Measured here (Docker 29.5.2,
+cgroup v1) on a throwaway container:
+
+| command | `HostConfig.NanoCpus` | `HostConfig.Memory` | `memory.limit_in_bytes` | exit |
+|---|---:|---:|---:|---:|
+| `--cpus 0.25 --memory 512m --memory-swap 512m` | 250000000 | 536870912 | 536870912 | 0 |
+| `--cpus 0 --memory 0 --memory-swap -1` | **250000000** | **536870912** | **536870912** | **0** |
+| `--cpu-quota -1` | **250000000** (stale) | 536870912 | 536870912 | 0 |
+
+Row two is the point: the documented reset **exits 0 and changes nothing**. Row
+three clears the CPU cgroup but leaves `HostConfig.NanoCpus` reporting a limit
+the container no longer has - and `manifest_container_limits` (`lib.sh`) reads
+exactly those fields into every later run's manifest, so the next scenario
+would record the lie. Only a fresh container from the unmodified compose spec
+returns both to zero. Hence `stand/weak-shop.override.yml` as a scenario-local
+override (#2854 owns `docker-compose.lab.yml`; it is untouched) and a restore
+that recreates from the base spec and **verifies** the result.
+
+**That restore path then survived the measuring process being KILLED mid-run,
+which is unusual evidence and worth stating plainly.** The agent driving this
+sweep was terminated partway through by an unrelated spend limit. The sweep
+itself continued in the background, completed all six profiles, ran its
+restore, and logged `restore verified: lab-prestashop NanoCpus=0 Memory=0` /
+`restore verified: lab-mysql NanoCpus=0 Memory=0` plus `restored_ok=yes`. The
+stand was then re-checked **independently, by a third party, before this agent
+was resumed**, and again by the agent on resumption: `docker inspect` reporting
+`NanoCpus 0 / Memory 0 / CpuQuota 0`, the containers' own
+`cpu.cfs_quota_us = -1`, the stand lock free, and the peer-seeded catalogue
+intact at 50 006 products.
+
+Given the table immediately above - that `docker update` **cannot** restore
+this host, and that its documented reset exits 0 while changing nothing - a
+restore that holds through the death of the process that scheduled it is worth
+considerably more than one that runs on a tidy exit. The trap handling
+(`EXIT` plus explicit `INT`/`TERM`, since a default-disposition SIGTERM does
+not run an EXIT trap) is what makes that true by construction rather than by
+luck.
+
+Before recreating anything, PrestaShop's own entrypoint (`/tmp/docker_run.sh`)
+was read in the running container to confirm the already-installed guard fires:
+the install branch requires `settings.inc.php`, `app/config/parameters.php` and
+`install.lock` to be **all** absent, and `parameters.php` exists - so a recreate
+falls straight through to *"PrestaShop Core already installed"* and cannot reach
+`PS_ERASE_DB`. A recreate that silently reinstalled would have destroyed a
+peer's 50 000-product catalogue.
+
+### 2.3 Every applied constraint is read back from two independent places
+
+`docker update` exiting 0 is not evidence the kernel accepted the value. Each
+profile is verified against **both** the daemon's `HostConfig` **and** the
+container's own cgroup files, and any disagreement is fatal. All six profiles
+passed both; the log carries lines such as
+`verified lab-prestashop: HostConfig NanoCpus=250000000 Memory=1073741824;
+cgroup quota=25000/100000 limit=1073741824`.
+
+### 2.4 A third, mechanistic axis: did the quota engage at all?
+
+Latency alone cannot separate *"this box had headroom"* from *"the limit was
+never reached"*. `cpu.stat`'s `nr_throttled` / `throttled_time` answer it
+directly, sampled every 5 s **from the host's own cgroup filesystem**
+(`/sys/fs/cgroup/cpu/docker/<id>/cpu.stat`) rather than with `docker exec` - an
+exec spawns a process inside the container being measured and, at a 0.1-cpu
+quota, would consume a visible share of the very quota it observes. Counters
+are differenced across each step's own window, taken from the probe's own
+`# window` timestamps, so throttling is attributed to a profile rather than
+reported as one meaningless cumulative total.
+
+### 2.5 The profiles
+
+CPU is the swept variable. **Memory is held realistic and non-binding, and that
+is a decision**: measured before the sweep, the PrestaShop container's whole
+cgroup usage is 117 MiB and MySQL's 416 MiB (`innodb_buffer_pool_size`
+128 MiB), so a limit tight enough to bind would OOM-kill a container rather
+than slow it - and an OOM-kill is an artefact of the container, not a property
+of shared hosting, since a real host selling a 512 MB account does not also
+hand PHP a 512 MB per-request `memory_limit`, which this image does. (The
+first attempt at this sweep was aborted before it constrained anything, for
+exactly this reason: the originally planned 512m database limit sat only
+~76 MiB above MySQL's measured footprint.)
+
+| profile | PrestaShop | MySQL | represents |
+|---|---|---|---|
+| `P0-baseline` | unconstrained | unconstrained | control - #2977's conditions on today's 50k catalogue |
+| `P1-vps2` | 2.0 cpu / 2 GiB | unconstrained | small dedicated VPS |
+| `P2-vps1` | 1.0 cpu / 1 GiB | unconstrained | entry VPS, 1 vCPU |
+| `P3-shared` | 0.5 cpu / 1 GiB | 0.5 cpu / 1 GiB | shared hosting: half a core, PHP and database on one squeezed box |
+| `P4-shared-min` | 0.25 cpu / 1 GiB | 0.25 cpu / 1 GiB | worst realistic shared hosting |
+| `P5-boundary` | 0.1 cpu / 1 GiB | 0.1 cpu / 1 GiB | **below any real hosting plan** - to locate a boundary the realistic profiles might not reach |
+
+A sweep in which every profile passes has not located a boundary, which is why
+the ladder ends below anything a customer buys.
+
+### 2.6 Stand condition
+
+* Host: 28 cores, 15.5 GiB, Docker 29.5.2, **cgroup v1**, WSL2.
+* **Host load over the measurement window: p50 0.13, p90 0.37, p99 1.00,
+  max 1.02** across 490 samples on 28 cores - quieter than #2977's own
+  clean-window run (p50 0.56).
+* Catalogue: **50 006 products**, 2 847 orders, 116 692 stock rows, read
+  immediately before the window (a peer had reseeded the stand to 50k). Every
+  profile is preceded by its own warm-up, so no curve is measured against a
+  cold cache, and each profile's drift control confirms the shop was not left
+  degraded.
+* **The dataset did not move under the measurement.** Re-read afterwards:
+  products and stock rows **identical** (50 006 / 116 692); the order count had
+  drifted to 3 030 through peer activity *outside* the locked window, and is
+  not load-bearing here (the probe's `orders` call is a deliberate
+  filter-miss). The exclusive stand lock was held for the whole 85 minutes, and
+  the per-profile drift controls are the direct empirical check that nothing
+  shifted mid-run.
+* **#2949's reseed, which landed on the epic branch during this work, does not
+  touch these numbers.** That pass rebalances the `syncStatus` distribution of
+  OpenLinker's own `order_records` in **Postgres**; this report drives
+  PrestaShop's webservice in **MySQL** directly and reads no OpenLinker table
+  at all. Stated because both changes touch `perf/openlinker-throughput/` on
+  the same day and a reader is right to ask which dataset these curves are on.
+* Shop: `prestashop/prestashop:9.0.2-2.0-classic-8.4`, Apache **mpm_prefork**,
+  PHP `memory_limit=512M`. CFS period 100 ms.
+* The `lab` project was brought up from a sibling agent worktree, so the
+  scenario resolves compose file, env file and project directory from the
+  running container's own labels - recreating from a different checkout would
+  bind different module sources in.
+
+---
+
+## 3. Results
+
+All **measured**. 60 s per step, ~60 s settling between (see § 6), one shared
+instrument. `ok/total` counts samples returning the status their endpoint
+expects; the 401s are the `configurations` probe, which is *supposed* to answer
+401.
+
+### 3.1 The curve, per profile, at the rate the question is about
+
+| profile | shop cpu | idle p99 (1 req/s) | **p50 @ 5** | **p90 @ 5** | **p99 @ 5** | ok/total @ 5 | throttle events in that window | **verdict** |
+|---|---|---:|---:|---:|---:|---:|---:|---|
+| `P0-baseline` | unconstrained | 51.4 | 11.0 | 14.2 | **19.8** | 300/300 | 0 | **FREE** |
+| `P1-vps2` | 2.0 | 51.2 | 11.7 | 15.4 | **18.5** | 300/300 | 0 | **FREE** |
+| `P2-vps1` | 1.0 | 62.4 | 10.8 | 14.4 | **18.5** | 300/300 | 0 | **FREE** |
+| `P3-shared` | 0.5 + db 0.5 | 46.4 | 10.9 | 15.0 | **78.1** | 300/300 | 1 (354 ms) | **FREE** |
+| `P4-shared-min` | 0.25 + db 0.25 | 49.8 | 10.7 | 14.8 | **143.2** | 300/300 | 5 (1.3 s) | **DEGRADING** |
+| `P5-boundary` | 0.1 + db 0.1 | 179.2 | 10.7 | 93.3 | **598.1** | 300/300 | 38 (14.9 s) | **DEGRADING** |
+
+**So: 5 req/s is free down to half a core with the database squeezed alongside
+it, and stops being free at a quarter core.** P4 is flagged by the *ratio*
+half of the rule (143.2 > 2 x 49.8) and is still **under** the 250 ms absolute
+bar; it is DEGRADING, never UNSAFE.
+
+Five readings, in order of how much they matter.
+
+**1. Nothing ever refused.** `ok/total` is **100% at every step of every
+profile** - 10 800 samples, including 600/600 at 0.1 cpu and 10 req/s where p99
+was 4069 ms and the worst single sample 6.8 s. No 429, no 503, no reset, no
+timeout, no in-flight-cap skip. **A constrained PrestaShop queues; it does not
+shed.** That distinction is only available because the probe checks status per
+sample - the instrument the campaign built after ADR-066's store-impact figure
+was withdrawn for not doing so.
+
+**2. The quota provably engaged, and only where the latency says it did.**
+Zero throttle events at 1.0 cpu and above, so "FREE" there means genuine
+headroom rather than a limit that was never reached. First engagement at
+0.5 cpu (one event, 354 ms), then 5, then 38 as the tail grows. The
+`throttled_time` column and the p99 column are two independent instruments
+telling the same story.
+
+**3. The median never moves.** p50 is 10.7-11.7 ms at 5 req/s on *every*
+profile, from 28 unconstrained cores down to a tenth of a core. Even at 0.1 cpu
+and 10 req/s, p50 is 74.4 ms. The cost of a constrained shop is entirely in the
+tail, which is the shape CFS throttling predicts: a request arriving after its
+period's quota is spent waits for the next 100 ms period.
+
+**4. The x-axis is real.** Achieved rate matched offered to within 0.4% at
+every step of every profile, so no point is a rate the probe failed to deliver
+and then mislabelled.
+
+**5. The drift controls hold.** Every profile's repeat of 1 req/s, run last,
+comes back at or below its opening value (P0 45.9 vs 51.4; P2 55.1 vs 62.4; P3
+47.4 vs 46.4; P4 54.5 vs 49.8; P5 94.9 vs 179.2). The ramps measured rate, not
+cumulative damage, and no profile left the shop degraded for the next.
+
+A note on the idle column: at 60 samples, p99 *is* the maximum, so those
+figures are inflated by a single cold outlier apiece - which is why several
+profiles read *slower* at 1 req/s than at 5. It makes the ratio test lenient,
+and is the reason the absolute ceiling is the half that actually binds.
+
+### 3.2 What this says about 600 req/min, which is a different question and a different answer
+
+#2977 concluded *"600 req/min is supportable **on this shop**"*. The italics
+were load-bearing, and this sweep shows why:
+
+| profile | p99 @ 10 req/s | worst sample |
+|---|---:|---:|
+| `P0-baseline` | 19.6 ms | 2 094 ms |
+| `P1-vps2` | 47.7 ms | 2 585 ms |
+| `P2-vps1` | **20.0 ms** | 63.5 ms |
+| `P3-shared` | **616.7 ms** | 2 623 ms |
+| `P4-shared-min` | **2 125.6 ms** | 2 227 ms |
+| `P5-boundary` | **4 069.0 ms** | 6 768 ms |
+
+**10 req/s is free at 1.0 cpu and above and collapses below it.** So #2977's
+conclusion does not transfer to a small shop, and nothing in this report should
+be read as support for 600 as a default. The knee for 600/min sits between one
+core and half a core; the knee for 300/min sits between half a core and a
+quarter.
+
+### 3.3 The sustained window - the result that matters most for an abuse rule
+
+A 60 s step cannot see an accumulating problem, and the condition this whole
+question is about is accumulating by nature. So the worst *realistic* profile
+was held at exactly the proposed rate for two back-to-back five-minute windows:
+
+| window | offered | achieved | ok/total | p50 | p90 | p99 | max |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| soak, first 5 min | 5 | 5.00 | **1500/1500** | 10.6 | 14.3 | 186.6 | 240.5 |
+| soak, second 5 min | 5 | 5.00 | **1500/1500** | 10.4 | 14.3 | **166.3** | 204.8 |
+
+**3000 consecutive requests at 5 req/s against a quarter-core shop with a
+quarter-core database, and the tenth minute was *better* than the first.** No
+accumulation, no leak, no degradation, and nothing resembling a refusal. The
+worst single sample in ten minutes was 240 ms.
+
+Two honest qualifications. First, sustained load *is* worse than a 60 s step -
+p99 186.6 against the ramp's 143.2 - which is precisely why the soak was worth
+running rather than inferring. Second, under my pre-registered rule the soak is
+FREE only because the absolute ceiling is the only applicable half (a soak
+directory has no idle control of its own); and under the **corrected** 125 ms
+bar of § 2.1 it would be DEGRADING. I am not claiming the quarter-core shop is
+comfortable at 5 req/s. I am claiming it never fails, never refuses, and does
+not get worse with time.
+
+### 3.4 The heavy path: a catalogue page costs 70x a create-path read, and the limiter is weight-blind
+
+The mix above is the create path's single-row reads. The biggest consumer of a
+raised limit is the catalogue/inventory sweep, which issues `display=full`
+pages. `probes/ps-heavy-request-cost.sh` measures the per-request cost of the
+three shapes a sweep really sends - sequentially, no offered rate, because what
+is needed here is service COST, not capacity - at the unconstrained baseline
+and at the quarter-core profile. Run `results/weak-shop/run-a1d53-heavy2`,
+4 samples per shape, offsets varied so nothing is answered from a warm repeat
+of the identical query, **12/12 ok at each profile**.
+
+| request shape | P0 unconstrained | P4 0.25 cpu | response |
+|---|---:|---:|---:|
+| `products?display=full&limit=100` (the batched prefetch, #2593) | **394.8 ms** | **1020.9 ms** | 627 KiB |
+| `products?display=[id]&limit=100` (the enumeration) | 129.4 ms | 360.1 ms | 5 KiB |
+| `stock_availables?display=full&limit=100` (#2648) | 25.7 ms | **25.3 ms** | 50 KiB |
+
+Three readings.
+
+**1. A catalogue page is ~70x a create-path read** (395 ms against ~11 ms) even
+unconstrained, and 1021 ms at a quarter core. So `5 req/s` is not one workload:
+five catalogue pages per second would demand 5.1 s of service per second of
+wall clock on the quarter-core shop, which is impossible.
+
+**2. What stops that being a disaster is `maxConcurrent: 4`, not the pacing.**
+The two knobs bound different things - pacing bounds ARRIVAL, concurrency
+bounds SIMULTANEOUS WORK - and the limiter is **weight-blind**: it admits five
+requests per second whether each costs 11 ms or 1021 ms. With 1021 ms pages and
+an in-flight cap of 4, OpenLinker's own throughput self-limits to roughly four
+pages in flight and the shop is never asked for five per second. Raising the
+pacing therefore does not let OL push heavy pages five times faster at a weak
+shop; it removes an artificial 1 req/s floor on the cheap requests that are the
+overwhelming majority of the traffic.
+
+**3. The inventory prefetch is genuinely insensitive to the constraint**
+(25.7 -> 25.3 ms), so #2648's batched stock read is not a concern at any
+profile measured.
+
+**The remaining gap is now narrow and specific rather than open**: every
+measurement in this report is at an in-flight concurrency of about one. Four
+*concurrent* 1021 ms catalogue pages against a quarter core were not measured,
+and that is the one shape where the raised pacing could plausibly bite. It is
+bounded by `maxConcurrent: 4`, which this change does not touch.
+
+### 3.5 Two instrument bugs found and fixed in this analysis
+
+**The verdict tool reported a false UNSAFE.** Its first run over the soak said
+`UNSAFE - no p99 could be computed (every sample non-ok)`, which was wrong in
+both halves: all 3000 samples succeeded and the p99 was perfectly computable.
+The cause was that a soak directory has no `step-rate-1`, so an *absent idle
+control* and an *uncomputable p99* had been collapsed into one branch. The fix
+separates them, applies the absolute half of the rule alone when there is no
+control, and says so in the output; two soak-shaped fixtures were added and the
+original eight still classify identically.
+
+**The heavy-cost probe failed completely on its first run, and said so.** All
+18 samples came back status `000`. curl exits 3 (*URL malformed*) on
+PrestaShop's own webservice syntax, because `display=[id]` and `sort=[id_ASC]`
+put square brackets in the query string and curl reads `[...]` as a glob range;
+`--globoff` is required, and no socket was ever opened without it. **The run
+produced no plausible-looking numbers to be misread** - every sample was
+recorded non-ok and every aggregate was empty - which is the entire reason each
+sample carries its status and each endpoint declares the status it expects.
+This is the second instrument in this campaign to be caught by that discipline
+and the first that would otherwise have produced *silence* rather than
+flattering data.
+
+---
+
+## 4. Recommendation
+
+**Raise `requestsPerMinute` from 60 to 300 in
+`libs/integrations/prestashop/src/prestashop-plugin.ts`. Change nothing else's
+value.**
+
+The reasoning, with the uncomfortable parts included:
+
+**1. The load argument for 60 is gone at every realistic profile.** 5 req/s is
+free down to half a core with a squeezed database, and at a quarter core the
+shop degrades in the tail while remaining under the absolute usability bar,
+never refusing, and holding steady for ten minutes.
+
+**2. Even on the weakest realistic profile the change makes orders faster, and
+by a wide margin.** F1 measured ~16 destination requests per order. Pacing
+alone costs `16 x 1000 ms = 16 s` per order at 60/min and `16 x 200 ms = 3.2 s`
+at 300/min. The quarter-core shop's own p99 contribution rises from
+`16 x 49.8 ms = 0.8 s` to `16 x 143.2 ms = 2.3 s`. **Net: about 11 s faster per
+order**, on the worst realistic shop. The limiter dominates the shop by an
+order of magnitude; this is not a trade of throughput against shop health.
+
+**3. The shape is safer than the number sounds.** 300/min is strict spacing
+with no burst, shared across replicas - one request every 200 ms, never a
+spike. Peak concurrency is unchanged.
+
+**4. The heavy path does not overturn this, and the reason is the OTHER knob.**
+The limiter is weight-blind, and a catalogue page costs 1021 ms at a quarter
+core against ~11 ms for a create-path read (§ 3.4). Five of those per second is
+arithmetically impossible on that shop - but `maxConcurrent: 4` bounds
+simultaneous work independently of pacing, so OpenLinker's own throughput
+self-limits there and the shop is never asked for five per second. That knob is
+deliberately left at 4. Anyone later tempted to raise `maxConcurrent` should
+read § 3.4 first: it, not the pacing, is what protects a weak shop from the
+heavy path.
+
+**5. The failure mode, if we are wrong, is visible and recoverable.** The shop
+queues rather than refusing; the transport already honours `Retry-After`
+reactively; and the operator can set `config.rateLimit` on the connection.
+
+**What I am NOT claiming, and what would change my mind.** This measures load,
+not policy. The original report was an **abuse notice** - a hosting provider's
+policy action - and no CPU cgroup can reproduce a rule that counts requests per
+hour. Worse, raising the ceiling genuinely raises sustained volume for a busy
+install: a 20-minute catalogue tick admits at most `60 x 20 = 1200` requests at
+the old limit and `300 x 20 = 6000` at the new one, so an install with enough
+queued work really can send ~5x more per hour. (It will not always: #2977's arm
+BD used only 378 of its 600 req/min because lane caps and work availability
+bound it first - but 378 > 300, so at 300 the limiter *is* still the binding
+constraint for a busy install, which is exactly why 5 req/s was the right rate
+to test.) **If the reporter's abuse-notice text ever arrives and names a
+request-count quota, this number should be re-derived from that quota and not
+from this measurement.**
+
+### 4.1 Scope: only PrestaShop's value may move
+
+The identical `{ requestsPerMinute: 60, maxConcurrent: 4 }` appears in three
+manifests - `prestashop-plugin.ts:84`, `woocommerce-plugin.ts:100` and
+`subiekt-plugin.ts:49` - and is cited by name in two more comments
+(`inpost-plugin.ts:39`, `ksef-plugin.ts:64`). `docs/lessons.md:301` exists to
+forbid exactly that copying; it stopped the figure reaching InPost and KSeF and
+did not stop WooCommerce and Subiekt.
+
+**WooCommerce and Subiekt are therefore left at an unmeasured 60, and that is
+the correct outcome rather than an omission.** Moving them on the strength of a
+PrestaShop measurement would be the very mistake that lesson records - a guess
+about someone else's platform dressed as evidence. What the change *must* do is
+correct the comments that will otherwise become false: WooCommerce's says it
+"mirrors PrestaShop's conservative merchant-hosted default", and InPost's
+describes PrestaShop's 60/4 as "the only manifest default in the repo", which
+has been untrue since WooCommerce and Subiekt added theirs. Measuring
+WooCommerce on this stand is a well-defined follow-up - `lab-woocommerce` is
+already running - and is out of scope here.
+
+### 4.2 The replacement comment
+
+```ts
+  // Resolution-time fallback for a connection with no explicit
+  // config.rateLimit (#1810/#1772). A self-hosted PrestaShop is the operator's
+  // OWN webserver - simultaneously the throughput bottleneck and busy serving
+  // customers - which is why a default belongs here at all (#1815).
+  //
+  // 300/min is one request every 200 ms. `requestsPerMinute` is strict
+  // minimum-interval spacing with NO burst, CAS'd in Redis across every
+  // replica (#2015), so the shop sees an evenly spaced 5 req/s and never a
+  // spike; peak concurrency stays at ~1 and `maxConcurrent` is not binding.
+  //
+  // MEASURED, not inherited (#2840, perf/openlinker-throughput/
+  // results-weak-shop-2026-09-07.md). PrestaShop 9.0.2, 50 000-product
+  // catalogue, driven at 1-10 req/s of create-path reads across six CPU
+  // profiles with the database squeezed alongside the shop on the small ones:
+  //
+  //   5 req/s (this default) is FREE down to 0.5 cpu (p99 78 ms), and
+  //   DEGRADES but never fails at 0.25 cpu (p99 143 ms; 3000/3000 ok over a
+  //   sustained 10 min, tail flat). Nothing refused at any profile or rate -
+  //   a constrained shop QUEUES, it does not shed.
+  //
+  // THE BOUND: do NOT read this as support for 600. 10 req/s is free at
+  // 1.0 cpu (p99 20 ms) and collapses below it - p99 617 ms at 0.5 cpu,
+  // 2126 ms at 0.25. The knee for this value sits between 0.5 and 0.25 cpu.
+  //
+  // WHAT IT DOES NOT COVER: synthetic cgroup limits on one host are not a
+  // hosting provider's abuse policy. The original report (#1810) was an abuse
+  // NOTICE, and a rule counting requests per hour is not reproducible here -
+  // a busy install really can send ~5x more per hour at this ceiling. If that
+  // notice's text ever surfaces a request quota, re-derive from the quota.
+  //
+  // Deliberately NOT copied to any other manifest: WooCommerce and Subiekt
+  // carry their own unmeasured 60/4, and moving them on a PrestaShop
+  // measurement is the mistake docs/lessons.md:301 exists to prevent.
+  defaultRateLimit: { requestsPerMinute: 300, maxConcurrent: 4 },
+```
+
+---
+
+## 5. What this did NOT establish
+
+* **Whether a hosting provider refuses.** A CPU/memory cgroup is not shared
+  hosting. A real provider adds concurrent-process caps, I/O throttling,
+  per-account request accounting and an abuse rule that may key on request
+  *count* rather than on load. This measures how a small box **degrades**; it
+  cannot measure whether a provider **blocks**. That is the single largest gap,
+  and it is the same gap 60 was chosen under.
+* **Memory pressure.** Memory was deliberately held above measured usage (§ 2.5)
+  so the CPU sweep had one variable. No reading here is evidence about a
+  memory-starved shop.
+* **The write path.** The mix is the create path's **GET half** only
+  (`ps-latency-probe.mjs` explains why: the POSTs mint real rows). A GET-only
+  mix under-represents a write-heavy create path, so a flat curve here is
+  necessary and not sufficient.
+* **Heavy catalogue reads AT CONCURRENCY.** § 3.4 measured the per-request cost
+  of a `display=full` page (395 ms unconstrained, 1021 ms at a quarter core),
+  so the weight-blindness of the limiter is now quantified rather than
+  hand-waved. What is still unmeasured is four such pages **concurrently**
+  against a quarter core - the one shape where raised pacing could plausibly
+  bite, bounded by the `maxConcurrent: 4` this change does not touch.
+* **WooCommerce, Subiekt, or any other platform.** One shop, one image, one
+  host.
+* **Concurrency above ~1.** Strict pacing at these rates never puts more than
+  about one request in flight, so `maxConcurrent` is untested.
+
+---
+
+## 6. Two process findings, both now in `docs/lessons.md`
+
+**`docker update` cannot restore "unconstrained"** - § 2.2's table. This is the
+seventh instance in this campaign of a command succeeding while doing nothing,
+and the reason the restore path recreates and verifies rather than trusting an
+exit status.
+
+**A scenario-local env knob silently inherited `lib.sh`'s default.** The
+scenario wrote `SETTLE_SECS="${SETTLE_SECS:-10}"` *after* sourcing `lib.sh`,
+which already declares `SETTLE_SECS="${SETTLE_SECS:-60}"` for the unrelated
+guard-to-window settle. The library wins: the script said 10 and did 60. It is
+harmless here - a longer settle is *more* isolation between steps, not less, so
+no figure above is affected, only the run's length - but the script said one
+thing and did another, which is the defect regardless of its sign. Found by
+reading the child's `/proc/<pid>/environ` and cross-checking against the
+probe's own window timestamps (a real 63.5 s gap), not by re-reading the code,
+where the assignment looks correct in isolation. The knob is renamed
+`RAMP_SETTLE_SECS`; **the steps in § 3 ran with a ~60 s settle**, which is
+stated here rather than silently corrected in the scenario.

--- a/perf/openlinker-throughput/scenarios/weak-shop-ramp.sh
+++ b/perf/openlinker-throughput/scenarios/weak-shop-ramp.sh
@@ -1,0 +1,528 @@
+#!/usr/bin/env bash
+#
+# weak-shop-ramp.sh - is 300 req/min safe on a WEAK PrestaShop? (epic #2840)
+#
+# ---------------------------------------------------------------------------
+# THE QUESTION, AND WHY THE EXISTING ANSWER DOES NOT SETTLE IT
+# ---------------------------------------------------------------------------
+#
+# `libs/integrations/prestashop/src/prestashop-plugin.ts` declares
+# `defaultRateLimit: { requestsPerMinute: 60, maxConcurrent: 4 }` and says in
+# its own comment: "Placeholder values pending the reporter's actual
+# abuse-notice text". Somebody hit an abuse block on shared hosting; the
+# details never arrived; 60 stayed.
+#
+# #2977 then measured the shop's latency against offered rate and found it
+# free to ~6.5 req/s, with the tail moving at 10 req/s. 300 req/min is 5 req/s,
+# comfortably inside that. But that measurement was taken on a 28-core host
+# with an UNCONSTRAINED PrestaShop container, and the shop the original abuse
+# block came from was on shared hosting. A default is for everyone, so the
+# figure that decides it has to come from the weakest shop a real operator
+# runs, not the strongest one we happen to own.
+#
+# `docs/lessons.md` (2026-09-06) names the failure in both directions: an
+# uncalibrated `defaultRateLimit` is a silent throughput regression, and such a
+# default should only exist with a documented quota to calibrate against.
+# Raising it on one measurement from one well-resourced shop would repeat that
+# mistake with the sign flipped.
+#
+# So: re-run #2977's ramp against a deliberately constrained shop, at several
+# profiles, and find where 5 req/s stops being free.
+#
+# ---------------------------------------------------------------------------
+# TWO MECHANISMS, AND WHY NEITHER ALONE IS ENOUGH
+# ---------------------------------------------------------------------------
+#
+# The constraint is APPLIED with `docker update` and REMOVED with a compose
+# recreate, and that split is a measured necessity rather than a preference.
+#
+#   * `docker update` keeps the container - and therefore PHP's opcache, the
+#     Apache worker pool and every warm page - alive across the whole sweep, so
+#     the ONLY thing that differs between two profiles is the cgroup quota. A
+#     recreate per profile would hand every profile a cold shop and confound
+#     the constraint with the warm-up.
+#
+#   * `docker update` cannot undo itself. Measured on this host (Docker 29.5.2,
+#     cgroup v1), on a throwaway container:
+#
+#         docker update --cpus 0.25 --memory 512m --memory-swap 512m C
+#         docker update --cpus 0     --memory 0    --memory-swap -1   C   # exit 0
+#         -> HostConfig.NanoCpus  250000000   (unchanged)
+#         -> HostConfig.Memory    536870912   (unchanged)
+#         -> memory.limit_in_bytes 536870912  (unchanged)
+#
+#     `--cpu-quota -1` does clear the CPU cgroup, but leaves
+#     `HostConfig.NanoCpus` stale - so `docker inspect` then REPORTS a limit the
+#     container no longer has. Either way a stand "restored" with
+#     `docker update` lies about itself, and the next scenario to read those
+#     fields (`manifest_container_limits` reads exactly them) records the lie.
+#     A fresh container from the unmodified compose spec is the only thing that
+#     genuinely returns both to zero, and this script verifies that it did.
+#
+# Every applied profile is READ BACK from two independent places - the
+# daemon's `HostConfig` and the container's own cgroup files - and a mismatch
+# is fatal. One arm of this campaign silently measured the default under a
+# label claiming a constraint; a set value is not an applied value.
+#
+# ---------------------------------------------------------------------------
+# WHAT THIS DOES NOT ESTABLISH
+# ---------------------------------------------------------------------------
+#
+# A CPU and memory cgroup is not shared hosting. A real provider applies
+# concurrent-process caps, I/O throttling, per-account request accounting and
+# an abuse rule that may trigger on request COUNT rather than on load - none of
+# which a cgroup reproduces, and the last of which is precisely what the
+# original reporter hit. This measures how a small box DEGRADES; it cannot
+# measure whether a provider REFUSES. The report says so in those words.
+#
+# The mix is also GET-only, inherited from `drivers/ps-latency-probe.mjs` -
+# see that file for why (the create path's POSTs mint real rows). A flat curve
+# here is necessary, not sufficient.
+#
+# Usage:
+#   weak-shop-ramp.sh <outdir> [profile ...]
+#
+# With no profiles named, runs the full table below. Profiles may be run in
+# separate invocations (each takes and releases the stand lock) so a long sweep
+# can be split across lock windows.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_LOG_PREFIX="weak-shop"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+
+OUTDIR="${1:?usage: weak-shop-ramp.sh <outdir> [profile ...]}"
+shift || true
+
+require_tools docker jq
+
+PS_CONTAINER="${PS_CONTAINER:-lab-prestashop}"
+PS_MYSQL_CONTAINER="${PS_MYSQL_CONTAINER:-lab-mysql}"
+: "${PS_WEBSERVICE_KEY:?weak-shop-ramp.sh: PS_WEBSERVICE_KEY required}"
+
+# ---------------------------------------------------------------------------
+# THE PROFILE TABLE
+#
+#   id|ps_cpus|ps_mem|db_cpus|db_mem|what it is meant to represent
+#
+# `-` means "leave this container unconstrained". The database is squeezed
+# only on the profiles that claim to be shared hosting: on a VPS a small but
+# dedicated database is the realistic arrangement, and constraining it there
+# would make the profile represent something nobody runs.
+#
+# The ladder BRACKETS what a customer runs rather than flattering the answer -
+# it goes below the smallest plausible VPS, and its last rung is deliberately
+# below any real hosting plan, because a sweep in which every profile passes
+# has not located a boundary and cannot say where one is.
+#
+# CPU IS THE SWEPT VARIABLE; MEMORY IS HELD REALISTIC AND NON-BINDING, and
+# that is a decision rather than an oversight. Measured on this stand before
+# the sweep: the PrestaShop container's whole cgroup usage is 117 MiB and
+# MySQL's is 416 MiB (`innodb_buffer_pool_size` 128 MiB), so a limit tight
+# enough to bind would OOM-kill a container rather than slow it, and an
+# OOM-kill is an artefact of the container, not a property of shared hosting -
+# a real host that sells a 512 MB account does not also hand PHP a 512 MB
+# per-request `memory_limit`, which this image does. The figures below are
+# chosen to sit above measured usage with headroom. The consequence is stated
+# in the report's "What this did not establish": memory pressure is NOT tested
+# here, and no reading from this sweep may be quoted as evidence about it.
+# ---------------------------------------------------------------------------
+PROFILES=(
+  'P0-baseline|-|-|-|-|control: unconstrained, i.e. #2977 conditions re-measured today against the 50k catalogue'
+  'P1-vps2|2.0|2g|-|-|small dedicated VPS, 2 vCPU, dedicated database'
+  'P2-vps1|1.0|1g|-|-|entry VPS, 1 vCPU - the smallest box PrestaShop 9 is normally put on'
+  'P3-shared|0.5|1g|0.5|1g|shared hosting: half a core, PHP and database on the same squeezed box'
+  'P4-shared-min|0.25|1g|0.25|1g|worst realistic shared hosting: a quarter core, PHP and database'
+  'P5-boundary|0.1|1g|0.1|1g|BELOW any real hosting plan - included only to locate the boundary if the realistic profiles all pass'
+)
+
+# The rate ladder. 5 req/s IS the question (300 req/min); 6.4 is the rate
+# #2977's arm BD was measured to sustain, so one step is directly comparable to
+# that report; 10 is where #2977 saw the unconstrained shop's tail start to
+# move, so it shows whether a weak shop has any headroom past the proposal.
+RATES="${WEAK_SHOP_RATES:-1 2 5 6.4 10}"
+STEP_SECS="${STEP_SECS:-60}"
+# RAMP_SETTLE_SECS, deliberately NOT `SETTLE_SECS`. `lib.sh` already declares
+# `SETTLE_SECS="${SETTLE_SECS:-60}"` at top level for an unrelated purpose (the
+# settle between the last guard and `window_start`), and sourcing runs first -
+# so a `SETTLE_SECS="${SETTLE_SECS:-10}"` here is already 60 by the time it
+# executes and the `:-10` never applies. That is not hypothetical: the
+# 2026-09-07 sweep ran with a ~60 s settle while this file said 10, verified
+# from the child's own environment. Harmless there (a longer settle is more
+# isolation between steps, not less) but the script must not say one thing and
+# do another. See docs/lessons.md.
+RAMP_SETTLE_SECS="${RAMP_SETTLE_SECS:-10}"
+# Warm-up before each profile's ramp. The container survives `docker update`,
+# so the shop is already warm - this re-warms after the quota change (the
+# first requests under a new quota pay for scheduler adjustment) and, on the
+# first profile, after a cold start.
+# Note the ramp probe always appends its own drift step, so a warm-up costs
+# 2 x WARMUP_SECS of traffic, not one.
+WARMUP_SECS="${WARMUP_SECS:-30}"
+WARMUP_RPS="${WARMUP_RPS:-2}"
+
+# ---------------------------------------------------------------------------
+# Stand discovery. The container is the authority on its own compose project:
+# on this host the `lab` project was brought up from a sibling agent worktree,
+# so the prestashop service's relative bind mounts resolve against THAT tree
+# and recreating from any other checkout would change what is bound in.
+# ---------------------------------------------------------------------------
+_ps_label() { docker inspect --format "{{index .Config.Labels \"$1\"}}" "$PS_CONTAINER" 2>/dev/null || true; }
+STAND_DIR="${STAND_DIR:-$(_ps_label com.docker.compose.project.working_dir)}"
+STAND_COMPOSE="${STAND_COMPOSE:-$(_ps_label com.docker.compose.project.config_files)}"
+STAND_ENV="${STAND_ENV:-$(_ps_label com.docker.compose.project.environment_file)}"
+STAND_PROJECT="${STAND_PROJECT:-$(_ps_label com.docker.compose.project)}"
+OVERRIDE_FILE="${OVERRIDE_FILE:-$SCRIPT_DIR/../stand/weak-shop.override.yml}"
+
+[ -n "$STAND_DIR" ]     || die "could not resolve the stand's compose working_dir from $PS_CONTAINER's labels - export STAND_DIR"
+[ -n "$STAND_COMPOSE" ] || die "could not resolve the stand's compose file from $PS_CONTAINER's labels - export STAND_COMPOSE"
+[ -f "$STAND_COMPOSE" ] || die "stand compose file [$STAND_COMPOSE] does not exist"
+[ -f "$OVERRIDE_FILE" ] || die "override file [$OVERRIDE_FILE] does not exist"
+case "$STAND_COMPOSE" in
+  *,*) die "the stand is a multi-file compose project [$STAND_COMPOSE]; set STAND_COMPOSE to the file carrying the prestashop service" ;;
+esac
+[ -n "$STAND_ENV" ] && [ -f "$STAND_ENV" ] || die "stand env file [$STAND_ENV] not found - export STAND_ENV"
+
+log "stand: project=$STAND_PROJECT dir=$STAND_DIR compose=$STAND_COMPOSE env=$STAND_ENV"
+
+# ---------------------------------------------------------------------------
+# Guards
+# ---------------------------------------------------------------------------
+guard_stand_exclusive weak-shop-ramp
+
+# Refuse to start against an already-constrained container. If the stand is
+# already carrying somebody else's limit then "restore" has no defined
+# meaning: recreating would silently drop THEIR constraint, and leaving it
+# would mix two profiles. This is also the check that catches a previous run
+# of this script that died before restoring.
+guard_shop_unconstrained() {
+  local c cpus mem
+  for c in "$PS_CONTAINER" "$PS_MYSQL_CONTAINER"; do
+    cpus="$(docker inspect --format '{{.HostConfig.NanoCpus}}' "$c")"
+    mem="$(docker inspect --format '{{.HostConfig.Memory}}' "$c")"
+    if [ "$cpus" != "0" ] || [ "$mem" != "0" ]; then
+      die "guard_shop_unconstrained: $c already carries a limit (NanoCpus=$cpus Memory=$mem).
+  This script's restore path recreates from the unmodified compose spec, which
+  would DROP that limit rather than put it back. Find out who set it. If it is
+  a dead run of this script, restore it yourself with:
+    cd $STAND_DIR && docker compose -f $STAND_COMPOSE --env-file $STAND_ENV -p $STAND_PROJECT up -d --no-deps --force-recreate ${c#lab-}"
+    fi
+  done
+  log "guard_shop_unconstrained ok ($PS_CONTAINER and $PS_MYSQL_CONTAINER carry no cpu/memory limit)"
+}
+guard_shop_unconstrained
+
+mkdir -p "$OUTDIR"
+RESTORE_NEEDED=0
+
+# The compose form of a profile, rendered and checked but not applied. This
+# runs on EVERY invocation and touches no container: `docker compose config`
+# only merges and prints. It exists because `stand/weak-shop.override.yml` is
+# the declarative record a future run reproduces a profile from, and a
+# declaration nothing exercises is a declaration nobody has checked - a typo
+# in a key name would sit there, render as an unknown field, and be discovered
+# by the person who needed it. Applying it for real is the separate
+# WEAK_SHOP_VERIFY_OVERRIDE mode below; this is the cheap half that can run
+# every time.
+compose_with_override() {
+  local ps_cpus="$1" ps_mem="$2" db_cpus="$3" db_mem="$4"
+  shift 4
+  ( cd "$STAND_DIR" && WEAK_SHOP_PS_CPUS="$ps_cpus" WEAK_SHOP_PS_MEM="$ps_mem" \
+      WEAK_SHOP_DB_CPUS="$db_cpus" WEAK_SHOP_DB_MEM="$db_mem" \
+      docker compose \
+        --project-directory "$STAND_DIR" \
+        -f "$STAND_COMPOSE" \
+        -f "$OVERRIDE_FILE" \
+        --env-file "$STAND_ENV" \
+        -p "$STAND_PROJECT" "$@" )
+}
+
+validate_override_merge() {
+  local rendered
+  rendered="$(compose_with_override 0.25 1g 0.25 1g config 2>&1)" \
+    || die "validate_override_merge: \`docker compose config\` failed with $OVERRIDE_FILE merged in:
+$rendered"
+  # Both services must carry all three keys at the values asked for. Grepping
+  # the RENDERED spec, not the file, is the point: it proves compose parsed the
+  # variables and placed them on the right services.
+  local want_bytes k
+  want_bytes="$(to_bytes 1g)"
+  for k in "cpus: 0.25" "mem_limit: \"$want_bytes\"" "memswap_limit: \"$want_bytes\""; do
+    [ "$(printf '%s\n' "$rendered" | grep -cF "$k")" -ge 2 ] \
+      || die "validate_override_merge: the merged spec does not carry [$k] on both prestashop and mysql.
+  Rendered spec written to $OUTDIR/override-merge.yml"
+  done
+  printf '%s\n' "$rendered" >"$OUTDIR/override-merge.yml"
+  log "validate_override_merge ok ($OVERRIDE_FILE renders cpus/mem_limit/memswap_limit onto both services)"
+}
+
+# ---------------------------------------------------------------------------
+# Apply / verify / restore
+# ---------------------------------------------------------------------------
+
+# to_bytes 768m -> 805306368. Only the suffixes the profile table uses.
+to_bytes() {
+  case "$1" in
+    *g|*G) printf '%s' $(( ${1%[gG]} * 1024 * 1024 * 1024 )) ;;
+    *m|*M) printf '%s' $(( ${1%[mM]} * 1024 * 1024 )) ;;
+    *)     printf '%s' "$1" ;;
+  esac
+}
+
+# cpus_to_nanocpus 0.25 -> 250000000, without bc (0.05 resolution is enough
+# for this table and an integer expression cannot drift the way a float can).
+cpus_to_nanocpus() {
+  local whole frac
+  whole="${1%%.*}"
+  case "$1" in
+    *.*) frac="${1#*.}" ;;
+    *)   frac="" ;;
+  esac
+  frac="${frac}00"; frac="${frac:0:2}"
+  printf '%s' $(( 10#$whole * 1000000000 + 10#$frac * 10000000 ))
+}
+
+apply_limit() {
+  local container="$1" cpus="$2" mem="$3"
+  [ "$cpus" = "-" ] && return 0
+  log "applying to $container: cpus=$cpus mem=$mem (swap disabled)"
+  docker update --cpus "$cpus" --memory "$mem" --memory-swap "$mem" "$container" >/dev/null
+  RESTORE_NEEDED=1
+}
+
+# Reads the limit back from BOTH the daemon's view and the container's own
+# cgroup, and dies on any disagreement with what was asked for. `docker update`
+# exiting 0 is not evidence the kernel accepted the value.
+verify_limit() {
+  local container="$1" cpus="$2" mem="$3" want_nano want_bytes got_nano got_mem got_quota got_period got_limit
+  if [ "$cpus" = "-" ]; then
+    got_nano="$(docker inspect --format '{{.HostConfig.NanoCpus}}' "$container")"
+    got_mem="$(docker inspect --format '{{.HostConfig.Memory}}' "$container")"
+    [ "$got_nano" = "0" ] && [ "$got_mem" = "0" ] \
+      || die "verify_limit: profile asks for $container UNCONSTRAINED but it reads NanoCpus=$got_nano Memory=$got_mem.
+  \`docker update\` cannot remove a limit (see this file's header), so the
+  profile table must only ever tighten within one invocation. Run the
+  unconstrained profiles FIRST, or run them in a separate invocation after
+  this one has restored the stand."
+    log "verified $container: unconstrained (NanoCpus=0 Memory=0)"
+    return 0
+  fi
+
+  want_nano="$(cpus_to_nanocpus "$cpus")"
+  want_bytes="$(to_bytes "$mem")"
+
+  got_nano="$(docker inspect --format '{{.HostConfig.NanoCpus}}' "$container")"
+  got_mem="$(docker inspect --format '{{.HostConfig.Memory}}' "$container")"
+  [ "$got_nano" = "$want_nano" ] || die "verify_limit: $container HostConfig.NanoCpus is $got_nano, asked for $want_nano ($cpus cpus)"
+  [ "$got_mem" = "$want_bytes" ] || die "verify_limit: $container HostConfig.Memory is $got_mem, asked for $want_bytes ($mem)"
+
+  # The daemon's own record is not the kernel's. cgroup v1 paths; a v2 host
+  # would need cpu.max / memory.max and this would fail loudly rather than
+  # silently skip the second opinion.
+  got_quota="$(docker exec "$container" cat /sys/fs/cgroup/cpu/cpu.cfs_quota_us 2>/dev/null </dev/null || printf 'unreadable')"
+  got_period="$(docker exec "$container" cat /sys/fs/cgroup/cpu/cpu.cfs_period_us 2>/dev/null </dev/null || printf 'unreadable')"
+  got_limit="$(docker exec "$container" cat /sys/fs/cgroup/memory/memory.limit_in_bytes 2>/dev/null </dev/null || printf 'unreadable')"
+  [ "$got_quota" != "unreadable" ] || die "verify_limit: could not read $container's own cpu cgroup - cannot confirm the limit was applied"
+  # quota/period must equal the requested cpus, to the same 0.01 resolution.
+  [ $(( got_nano / 10000000 )) -eq $(( 10#$got_quota * 100 / 10#$got_period )) ] \
+    || die "verify_limit: $container cgroup says quota=$got_quota period=$got_period, which is not $cpus cpus"
+  [ "$got_limit" = "$want_bytes" ] \
+    || die "verify_limit: $container cgroup memory.limit_in_bytes is $got_limit, asked for $want_bytes"
+
+  log "verified $container: HostConfig NanoCpus=$got_nano Memory=$got_mem; cgroup quota=$got_quota/$got_period limit=$got_limit"
+}
+
+# The ONLY thing that returns HostConfig to genuine zeros - see the header.
+restore_stand() {
+  [ "$RESTORE_NEEDED" = "1" ] || { log "restore: nothing was constrained, nothing to restore"; return 0; }
+  local svc rc=0
+  # MYSQL FIRST. `--no-deps` means compose will not restart prestashop for us,
+  # so recreating the shop before the database it talks to leaves a live
+  # PHP container pointed at a database that is mid-restart. Nothing is being
+  # measured at this point so it is not a correctness problem, but the stand is
+  # handed to the next scenario in a better state if the database is already up
+  # when the shop comes back.
+  log "restore: recreating mysql and prestashop from the UNMODIFIED compose spec"
+  for svc in mysql prestashop; do
+    ( cd "$STAND_DIR" && docker compose \
+        --project-directory "$STAND_DIR" \
+        -f "$STAND_COMPOSE" \
+        --env-file "$STAND_ENV" \
+        -p "$STAND_PROJECT" \
+        up -d --no-deps --force-recreate "$svc" ) >>"$OUTDIR/restore.log" 2>&1 || rc=1
+  done
+  [ "$rc" = "0" ] || warn "restore: compose reported an error - see $OUTDIR/restore.log"
+
+  # Verify, loudly. A restore that did not restore is the single worst thing
+  # this script could leave behind, so it is checked rather than assumed.
+  local c cpus mem bad=0
+  for c in "$PS_CONTAINER" "$PS_MYSQL_CONTAINER"; do
+    cpus="$(docker inspect --format '{{.HostConfig.NanoCpus}}' "$c" 2>/dev/null || printf 'ERR')"
+    mem="$(docker inspect --format '{{.HostConfig.Memory}}' "$c" 2>/dev/null || printf 'ERR')"
+    if [ "$cpus" = "0" ] && [ "$mem" = "0" ]; then
+      log "restore verified: $c NanoCpus=0 Memory=0"
+    else
+      bad=1
+      warn "RESTORE FAILED: $c still reads NanoCpus=$cpus Memory=$mem - THE STAND IS LEFT THROTTLED"
+    fi
+  done
+  [ "$bad" = "0" ] && RESTORE_NEEDED=0
+  printf 'restored_ok=%s\n' "$([ "$bad" = "0" ] && printf 'yes' || printf 'NO')" >>"$OUTDIR/restore.log"
+}
+
+# Restore runs on ANY exit, before the stand lock is released, so a crash mid
+# sweep cannot leave a throttled shop behind for the next scenario. lib.sh's
+# own EXIT trap releases the lock; this one is installed after it, and bash
+# replaces rather than appends - so it calls the release explicitly.
+#
+# INT/TERM are trapped as well, and that is load-bearing rather than tidy:
+# bash runs an EXIT trap when the script ends, but a default-disposition
+# SIGTERM terminates the shell without running it. An operator (or an agent's
+# task-stop) killing a long sweep is the MOST likely way this script ever
+# ends early, and it is exactly the path that must not leave a throttled shop
+# behind. The handler re-raises with the default disposition so the exit
+# status still reports the signal.
+on_exit() {
+  local rc=$?
+  trap - EXIT INT TERM
+  restore_stand || true
+  release_stand_exclusive || true
+  exit "$rc"
+}
+on_signal() {
+  local sig="$1"
+  trap - EXIT INT TERM
+  warn "caught SIG$sig - restoring the stand before exiting"
+  restore_stand || true
+  release_stand_exclusive || true
+  trap - "$sig"
+  kill "-$sig" $$
+}
+trap on_exit EXIT
+trap 'on_signal INT' INT
+trap 'on_signal TERM' TERM
+
+validate_override_merge
+
+# ---------------------------------------------------------------------------
+# WEAK_SHOP_VERIFY_OVERRIDE=1 - apply a profile the COMPOSE way, for real, and
+# read it back. Not part of the sweep, because a recreate per profile would
+# hand every profile a cold shop (see the header). Run once so the override
+# file has evidence behind it and not only a rendered merge: a future run
+# reproducing a profile from a clean boot uses this path, and "it renders" is
+# weaker than "it applied".
+# ---------------------------------------------------------------------------
+if [ "${WEAK_SHOP_VERIFY_OVERRIDE:-0}" = "1" ]; then
+  log "verify-override: recreating prestashop and mysql WITH the override at 0.25 cpu / 1g"
+  compose_with_override 0.25 1g 0.25 1g up -d --no-deps --force-recreate prestashop mysql \
+    >"$OUTDIR/override-apply.log" 2>&1 || die "verify-override: compose up failed - see $OUTDIR/override-apply.log"
+  RESTORE_NEEDED=1
+  verify_limit "$PS_CONTAINER" 0.25 1g
+  verify_limit "$PS_MYSQL_CONTAINER" 0.25 1g
+  docker inspect \
+    --format '{{.Name}} NanoCpus={{.HostConfig.NanoCpus}} Memory={{.HostConfig.Memory}} MemorySwap={{.HostConfig.MemorySwap}}' \
+    "$PS_CONTAINER" "$PS_MYSQL_CONTAINER" >"$OUTDIR/override-applied.txt" 2>&1
+  log "verify-override: applied and read back; the EXIT trap now restores from the unmodified spec"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Load
+# ---------------------------------------------------------------------------
+warm_shop() {
+  local label="$1"
+  log "warming the shop for ${WARMUP_SECS}s at ${WARMUP_RPS} req/s ($label)"
+  STEP_SECS="$WARMUP_SECS" SETTLE_SECS=0 \
+    "$SCRIPT_DIR/../probes/ps-latency-ramp.sh" "$OUTDIR/warmup-$label" "$WARMUP_RPS" >/dev/null 2>&1 || true
+  # The warm-up's own samples are kept but named so they can never be read as
+  # a measurement step - ps-latency-table.sh globs step-*.summary, and these
+  # live in their own directory.
+}
+
+run_profile() {
+  local spec="$1"
+  local id ps_cpus ps_mem db_cpus db_mem represents
+  IFS='|' read -r id ps_cpus ps_mem db_cpus db_mem represents <<<"$spec"
+
+  log "=============================================================="
+  log "profile $id - $represents"
+  log "  prestashop: cpus=$ps_cpus mem=$ps_mem   mysql: cpus=$db_cpus mem=$db_mem"
+  log "=============================================================="
+
+  apply_limit "$PS_CONTAINER" "$ps_cpus" "$ps_mem"
+  apply_limit "$PS_MYSQL_CONTAINER" "$db_cpus" "$db_mem"
+  verify_limit "$PS_CONTAINER" "$ps_cpus" "$ps_mem"
+  verify_limit "$PS_MYSQL_CONTAINER" "$db_cpus" "$db_mem"
+
+  # The applied constraint, recorded beside the samples rather than only in
+  # this script's stdout, so a reader of the results directory can see what
+  # each curve was measured under.
+  docker inspect \
+    --format '{{.Name}} NanoCpus={{.HostConfig.NanoCpus}} Memory={{.HostConfig.Memory}} MemorySwap={{.HostConfig.MemorySwap}}' \
+    "$PS_CONTAINER" "$PS_MYSQL_CONTAINER" >"$OUTDIR/$id.applied" 2>&1
+
+  warm_shop "$id"
+
+  # WEAK_SHOP_HEAVY_ONLY=1 - skip the rate ramp and measure only the per-request
+  # cost of a catalogue-sweep page at this profile. It is a separate mode rather
+  # than an extra step because the two answer different questions and the ramp
+  # is what makes a run take an hour: this mode exists so the heavy-read cost can
+  # be bounded in a few minutes, reusing this scenario's guards, its two-place
+  # constraint verification and - the reason it is not a standalone script - its
+  # restore path.
+  if [ "${WEAK_SHOP_HEAVY_ONLY:-0}" = "1" ]; then
+    log "heavy-only: measuring catalogue-page cost at $id"
+    HEAVY_SAMPLES="${HEAVY_SAMPLES:-6}" \
+      "$SCRIPT_DIR/../probes/ps-heavy-request-cost.sh" "$OUTDIR" "$id"
+    return 0
+  fi
+
+  # shellcheck disable=SC2086
+  STEP_SECS="$STEP_SECS" SETTLE_SECS="$RAMP_SETTLE_SECS" \
+    "$SCRIPT_DIR/../probes/ps-latency-ramp.sh" "$OUTDIR/$id" $RATES
+
+  log "profile $id done - table:"
+  "$SCRIPT_DIR/../probes/ps-latency-table.sh" "$OUTDIR/$id" | tee "$OUTDIR/$id.table"
+
+  # A SUSTAINED window at the proposed rate, on the profile named by
+  # WEAK_SHOP_SOAK_PROFILE. It runs here, inside the profile, because the
+  # constraint can only ever tighten within one invocation (`docker update`
+  # cannot loosen) - so a soak appended after the whole sweep could not get
+  # back to a middle profile's quota.
+  #
+  # It exists because a 60 s step cannot see an accumulating problem, and the
+  # condition this whole measurement is about - the reporter's abuse block - is
+  # by nature accumulating: a host that counts requests per hour, a PHP-FPM
+  # pool that fills, a connection table that grows. Two back-to-back windows at
+  # the same rate (the probe's own drift step supplies the second) answer
+  # "does the tenth minute look like the first", which one short step cannot.
+  if [ "$id" = "${WEAK_SHOP_SOAK_PROFILE:-}" ]; then
+    local soak_secs="${WEAK_SHOP_SOAK_SECS:-300}" soak_rps="${WEAK_SHOP_SOAK_RPS:-5}"
+    log "soak: $id at ${soak_rps} req/s for 2 x ${soak_secs}s (the probe appends its own repeat)"
+    STEP_SECS="$soak_secs" SETTLE_SECS="$RAMP_SETTLE_SECS" \
+      "$SCRIPT_DIR/../probes/ps-latency-ramp.sh" "$OUTDIR/$id-soak" "$soak_rps"
+    log "soak $id done - table:"
+    "$SCRIPT_DIR/../probes/ps-latency-table.sh" "$OUTDIR/$id-soak" | tee "$OUTDIR/$id-soak.table"
+  fi
+}
+
+# ---------------------------------------------------------------------------
+# Sweep
+# ---------------------------------------------------------------------------
+WANTED=("$@")
+ran=0
+for spec in "${PROFILES[@]}"; do
+  id="${spec%%|*}"
+  if [ "${#WANTED[@]}" -gt 0 ]; then
+    match=0
+    for w in "${WANTED[@]}"; do [ "$w" = "$id" ] && match=1; done
+    [ "$match" = "1" ] || continue
+  fi
+  run_profile "$spec"
+  ran=$(( ran + 1 ))
+done
+[ "$ran" -gt 0 ] || die "no profile matched [${WANTED[*]}] - known ids: $(for s in "${PROFILES[@]}"; do printf '%s ' "${s%%|*}"; done)"
+
+log "sweep complete: $ran profile(s) under $OUTDIR"

--- a/perf/openlinker-throughput/stand/weak-shop.override.yml
+++ b/perf/openlinker-throughput/stand/weak-shop.override.yml
@@ -1,0 +1,68 @@
+# Weak-shop resource profiles for the `lab` stand's PrestaShop (epic #2840).
+#
+# WHY THIS FILE EXISTS SEPARATELY FROM docker-compose.lab.yml
+#
+# #2854 owns `docker-compose.lab.yml` and every scenario shares it. A profile
+# that constrains the shop belongs to ONE measurement and must not become the
+# stand's posture, so it lives here and is composed on top:
+#
+#   docker compose --project-directory "$STAND_DIR" \
+#     -f "$STAND_DIR/docker-compose.lab.yml" \
+#     -f perf/openlinker-throughput/stand/weak-shop.override.yml \
+#     --env-file "$STAND_DIR/.env.lab" -p lab \
+#     up -d --no-deps --force-recreate prestashop
+#
+# `--project-directory` and the stand's OWN compose file are both load-bearing:
+# on this host the `lab` project was brought up from a sibling agent worktree,
+# so the prestashop service's relative bind mounts
+# (`./apps/prestashop-module/openlinker`, `./docker/prestashop/post-install`)
+# resolve against THAT tree. Composing from a different checkout would recreate
+# the container with different sources bound in, which is a change to the stand
+# rather than a change to its CPU quota. `scenarios/weak-shop-ramp.sh` resolves
+# both paths from the running container's own compose labels rather than
+# assuming them.
+#
+# WHY THE VALUES ARE PARAMETERS AND NOT SEVERAL SERVICE BLOCKS
+#
+# One profile is in force at a time, and a file carrying every variant would
+# need one service name per container per profile. The sweep sets the four
+# variables below per profile; the profile TABLE - and what each profile is
+# meant to represent - lives in `scenarios/weak-shop-ramp.sh`, which is also
+# what applies them, so there is one list rather than two that can disagree.
+#
+# WHAT `memswap_limit` IS DOING HERE
+#
+# Left unset, Docker allows a container to swap up to 2x its memory limit, so
+# `mem_limit: 512m` would really mean "512m of RAM plus 512m of swap" and the
+# profile would not represent the box it claims to. Setting it EQUAL to
+# `mem_limit` disables swap for the container, which is the honest reading of
+# a small hosting plan.
+#
+# BOTH SERVICES, BECAUSE A SHARED-HOSTING SHOP DOES NOT HAVE A SPARE DATABASE
+#
+# Constraining only the PHP container would leave MySQL with all 28 host cores
+# and overstate what a small plan can serve. The sweep applies the `mysql`
+# limits only on the profiles that claim to represent shared hosting and leaves
+# the database unconstrained on the VPS-shaped ones, where a dedicated (if
+# small) database is the realistic arrangement.
+#
+# RESTORING
+#
+# Removing this `-f` and recreating is what restores the stand: a fresh
+# container from the unmodified spec carries `HostConfig.NanoCpus = 0` and
+# `HostConfig.Memory = 0`. `docker update` CANNOT do this - measured on this
+# host, Docker 29.5.2 / cgroup v1: `docker update --cpus 0 --memory 0` leaves
+# `HostConfig.NanoCpus` and the memory cgroup at their constrained values and
+# still exits 0, so a stand "restored" that way reports a limit it no longer
+# has, or keeps one it claims to have dropped. See the report's
+# "Two mechanisms, and why neither alone is enough" section.
+services:
+  prestashop:
+    cpus: ${WEAK_SHOP_PS_CPUS:-0.5}
+    mem_limit: ${WEAK_SHOP_PS_MEM:-768m}
+    memswap_limit: ${WEAK_SHOP_PS_MEM:-768m}
+
+  mysql:
+    cpus: ${WEAK_SHOP_DB_CPUS:-0.5}
+    mem_limit: ${WEAK_SHOP_DB_MEM:-512m}
+    memswap_limit: ${WEAK_SHOP_DB_MEM:-512m}


### PR DESCRIPTION
PrestaShop's `defaultRateLimit` said so in its own words - *"Placeholder values
pending the reporter's actual abuse-notice text"*. Somebody hit an abuse block
on shared hosting, `60/min` was written pending details, and the details never
arrived. #2977 then measured the shop free to ~6.5 req/s, but on a 28-core host
with an **unconstrained** container - and a default is for everyone, so the
figure has to come from the weakest shop an operator runs, not the strongest one
we happen to own.

This re-runs #2977's ramp against a deliberately constrained PrestaShop at six
CPU profiles down to a tenth of a core, with the database squeezed alongside it
on the small ones. **38 steps, 10 800 status-checked samples, one 85-minute
window under the stand lock.**

Full report: `perf/openlinker-throughput/results-weak-shop-2026-09-07.md`.

---

## Read this before the numbers

This concludes that the change we were hoping to make is safe, which is exactly
when a reader should be suspicious. Two things guard against that.

**The verdict rule was written down and timestamped BEFORE any constrained
profile produced a sample** - committed at
`results/weak-shop/run-a1d53-sweep/threshold-fixed-in-advance.md`, written
20:12Z against a sweep that started 20:18Z, when the only samples in existence
were from the *unconstrained* control. `probes/weak-shop-verdict.sh` applies it
mechanically to every profile including the inconvenient ones, and **that
classifier was validated against ten synthetic known-answer fixtures before it
was pointed at real data.** Nothing else in this campaign carries that
guarantee.

**The threshold was NOT retightened when its own rationale turned out to be
wrong.** The 250 ms absolute bar was justified by *"F1 measured ~8 destination
requests per order"*; F1 actually measured **~16**, making the bar twice as
permissive as intended. Moving a pre-registered threshold after seeing the data
is precisely what pre-registration exists to prevent - so it was left alone and
the robustness check published instead: **at the stricter bar the corrected
arithmetic implies, the headline answer does not move.** The boundary still sits
between half a core and a quarter core. The only verdict that would flip is the
quarter-core soak, and the report says so rather than resting on it.

---

## The answer

| profile | shop cpu | idle p99 | p50 | p90 | **p99 @ 5 req/s** | ok/total | CFS throttle events | verdict |
|---|---|---:|---:|---:|---:|---:|---:|---|
| `P0-baseline` | unconstrained | 51.4 | 11.0 | 14.2 | **19.8** | 300/300 | 0 | FREE |
| `P1-vps2` | 2.0 | 51.2 | 11.7 | 15.4 | **18.5** | 300/300 | 0 | FREE |
| `P2-vps1` | 1.0 | 62.4 | 10.8 | 14.4 | **18.5** | 300/300 | 0 | FREE |
| **`P3-shared`** | **0.5 + db 0.5** | 46.4 | 10.9 | 15.0 | **78.1** | 300/300 | 1 | **FREE** |
| **`P4-shared-min`** | **0.25 + db 0.25** | 49.8 | 10.7 | 14.8 | **143.2** | 300/300 | 5 | **DEGRADING** |
| `P5-boundary` | 0.1 + db 0.1 | 179.2 | 10.7 | 93.3 | **598.1** | 300/300 | 38 | DEGRADING |

**Weakest profile at which 5 req/s is FREE: half a core with the database
squeezed alongside it. The weakest at which it is not: a quarter core** -
DEGRADING, never UNSAFE, and still under the 250 ms absolute bar; only the
ratio half of the rule flags it.

**Does a constrained shop refuse, or degrade? It degrades.** 100% expected
status at every step of every profile - 10 800 samples, including 600/600 at
0.1 cpu and 10 req/s where p99 was 4.1 s and the worst sample 6.8 s. Zero 429,
503, resets or timeouts anywhere. **A constrained PrestaShop queues; it does not
shed.**

**The quota provably engaged** rather than the shop merely being fast: zero CFS
throttle events at 1.0 cpu and above, first engagement at 0.5 cpu, scaling to 38
at 0.1 cpu. Latency and `cpu.stat` are two independent instruments telling one
story. Counters are read from the **host's** cgroup fs, not via `docker exec` -
an exec at a 0.1-cpu quota would consume a visible share of the quota it
observes.

**Sustained, not just a 60 s step:** quarter core, 2 x 5 min at exactly 5 req/s.
**3000/3000 ok**, p99 186.6 then **166.3** - the tenth minute better than the
first - worst single sample 240 ms. No accumulation, no leak, nothing resembling
a refusal.

---

## Recommendation: raise 60 -> 300

Even on the worst realistic profile the change makes orders **faster**. F1
measured ~16 destination requests per order, so pacing alone costs
`16 x 1000 ms = 16 s` per order at 60/min and `16 x 200 ms = 3.2 s` at 300/min,
while the quarter-core shop's own p99 contribution rises from 0.8 s to 2.3 s -
**about 11 s faster per order**. The limiter dominates the shop by an order of
magnitude; this is not a trade of throughput against shop health.

And the shape is safer than the number sounds: `requestsPerMinute` is **strict
minimum-interval spacing with no burst**, CAS'd in Redis across every replica
(#2015), so **the shop sees an evenly spaced 5 req/s and never a spike**. Peak
concurrency is unchanged at ~1. Anyone reading this as a fivefold increase in
peak load is reading it wrong - only the interval shortens, 1000 ms to 200 ms.

### Two bounds, as prominent as the recommendation

**1. This is NOT support for 600/min.** 10 req/s is free at 1.0 cpu (p99
20.0 ms) and collapses below it - **p99 616.7 ms at 0.5 cpu, 2125.6 ms at
0.25 cpu**. #2977's *"600 req/min is supportable on this shop"* is a statement
about that host only and does not transfer down. The knee for 600 sits between
one core and half a core; the knee for 300 sits between half and a quarter.

**2. The limiter is WEIGHT-BLIND.** It admits five requests per second whether
each costs 11 ms or 1021 ms. A `display=full` catalogue page (the batched
prefetch, #2593) costs **394.8 ms unconstrained and 1020.9 ms at a quarter
core** - roughly **70x** a create-path read - so five per second is
arithmetically impossible on that shop. What bounds the damage is
**`maxConcurrent: 4`**, not the pacing: pacing bounds ARRIVAL, concurrency
bounds SIMULTANEOUS WORK. That knob is deliberately left at 4, and the manifest
comment warns explicitly against raising it on the strength of this measurement.
(#2648's batched stock read is insensitive to the constraint: 25.7 -> 25.3 ms.)

---

## Scope: exactly one value moves

`git diff` shows a **single** changed `defaultRateLimit:` line. The identical
copied `{ requestsPerMinute: 60, maxConcurrent: 4 }` also sits in
`woocommerce-plugin.ts:100` and `subiekt-plugin.ts:49`, and is cited by name in
`inpost-plugin.ts` and `ksef-plugin.ts`. `docs/lessons.md` exists to forbid
exactly that copying; it stopped the figure reaching InPost and KSeF and did not
stop WooCommerce and Subiekt.

**WooCommerce and Subiekt are therefore left at an unmeasured 60, and that is
the correct outcome rather than an omission** - moving them on the strength of a
PrestaShop measurement is the very mistake that lesson records, and is how the
figure reached them. What this PR *does* do is correct the four citations that
would otherwise become quietly false (WooCommerce's "mirrors PrestaShop's
default", InPost's "the only manifest default in the repo", Subiekt's and
KSeF's "PrestaShop's 60/4"), each now stating why it was not moved and what
would justify moving it. Measuring WooCommerce on this stand is a well-defined
follow-up - `lab-woocommerce` is already running.

---

## Two instrument bugs, reported rather than quietly patched

**A false UNSAFE.** The verdict tool's first pass reported the soak as
`UNSAFE - no p99 could be computed (every sample non-ok)`. Wrong in both halves:
all 3000 samples succeeded and the p99 was computable. It had collapsed *absent
idle control* and *uncomputable p99* into one branch. Fixed; two soak-shaped
fixtures added; the original eight still classify identically.

**An all-`000` probe.** The heavy-cost probe's first run failed completely - 18
samples, every one status `000` - because curl exits 3 (*URL malformed*) on
PrestaShop's own webservice syntax: `display=[id]` and `sort=[id_ASC]` put
square brackets in the query string and curl reads `[...]` as a glob range.
`--globoff` is required and no socket was ever opened without it.

That second one is the strongest available argument for per-sample status
checks: **it produced no plausible-looking numbers to be misread.** Every sample
was recorded non-ok and every aggregate came back empty. Compare the failure
mode this campaign has met repeatedly in the other direction - a plausible
artifact with nothing wrong on its face, which is what withdrew ADR-066's
store-impact figure.

---

## Method notes

**`docker update` cannot restore "unconstrained" on this host.** Measured
(Docker 29.5.2, cgroup v1): after applying a limit, the documented reset
`--cpus 0 --memory 0 --memory-swap -1` **exits 0 and changes nothing**;
`--cpu-quota -1` clears the CPU cgroup but leaves `HostConfig.NanoCpus`
reporting a limit the container no longer has - and `manifest_container_limits`
reads exactly those fields into every later run's manifest. So constraints are
**applied** with `docker update` (the container survives, so opcache and page
cache stay warm and the quota is the only variable between profiles) and
**removed** by recreating from the unmodified compose spec, verified afterwards.
Every applied profile is read back from **two independent places** - the
daemon's `HostConfig` and the container's own cgroup files - and a mismatch is
fatal.

**That restore path survived the measuring process being killed mid-run.** The
agent driving the sweep was terminated partway through by an unrelated spend
limit; the sweep completed in the background, ran its restore, and logged
`restored_ok=yes`. The stand was then verified **independently by a third party
before the agent was resumed** - `HostConfig` zeros, `cpu.cfs_quota_us = -1`
from inside the container, lock free, peer-seeded catalogue intact at 50 006
products. Given the finding immediately above, a restore that holds through the
death of the process that scheduled it is worth more than one that holds through
a clean exit. It is true by construction rather than luck: the scenario traps
`INT`/`TERM` as well as `EXIT`, because a default-disposition SIGTERM does not
run an EXIT trap.

Before recreating anything, PrestaShop's entrypoint was read **in the running
container** to confirm its already-installed guard fires - the install branch
needs `settings.inc.php`, `parameters.php` and `install.lock` all absent, and
`parameters.php` exists - so a recreate cannot reach `PS_ERASE_DB`. A recreate
that silently reinstalled would have destroyed a peer's 50 000-product
catalogue.

`docker-compose.lab.yml` (#2854) is untouched; the profiles live in a
scenario-local `stand/weak-shop.override.yml`, validated on every run by
rendering it through `docker compose config` and asserting the keys land on both
services.

---

## What this did NOT establish

- **Whether a hosting provider refuses.** A cgroup is not shared hosting. A real
  provider adds concurrent-process caps, I/O throttling, per-account request
  accounting and an abuse rule that may key on request **count**. #1810's report
  was an abuse **notice** - a policy action - and raising the ceiling genuinely
  raises sustained volume (a 20-min catalogue tick admits 1200 requests at
  60/min, 6000 at 300/min). **If that notice's text ever surfaces a request
  quota, re-derive from the quota, not from this measurement.** This is the
  largest gap, and it is the same gap 60 was chosen under.
- **Memory pressure.** Deliberately held above measured usage so CPU was the one
  variable; a tighter limit would OOM-kill rather than slow, which is an
  artefact of the container rather than a property of shared hosting.
- **The write path.** GET-only mix (the create path's POSTs mint real rows), so
  a flat curve here is necessary and not sufficient.
- **Heavy catalogue reads at CONCURRENCY.** Per-request cost is now measured;
  four *concurrent* 1021 ms pages against a quarter core is not, and is the one
  shape where raised pacing could plausibly bite - bounded by the
  `maxConcurrent: 4` this PR does not touch.
- **WooCommerce, Subiekt, or any other platform.** One shop, one image, one host.

---

## Gate

`bash -n` clean on all three new scripts; `bash perf/openlinker-throughput/lib-test.sh`
**165 passed / 1 failed** - identical to the pre-change baseline on the branch
tip, that failure pre-existing; `pnpm check:invariants` exit 0; `pnpm type-check`
exit 0. Per campaign convention `pnpm test` was not run locally.

Both process findings (`docker update` cannot restore; a scenario-local
`SETTLE_SECS` silently inheriting `lib.sh`'s default, so the script said 10 and
did 60) are appended to `docs/lessons.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkKifZVwvZzHspxaQ7x396
