### PR TITLE
perf(2978): F10 - behaviour under dependency failure

### DIFF
--- a/perf/openlinker-throughput/results-F10-2026-09-07.md
+++ b/perf/openlinker-throughput/results-F10-2026-09-07.md
@@ -1,0 +1,297 @@
+# F10 - behaviour under dependency failure
+
+_Run 2026-09-07 on the `lab` stand. Scenario `scenarios/f10-dependency-failure.sh` (#2978, epic #2840)._
+
+> **STATUS: METHOD AND CONDITIONS ONLY.** The measurement sections below are
+> not yet filled. Nothing in this file may be quoted as a result until this
+> banner is gone.
+
+---
+
+## 0. Why this run exists
+
+Every one of the six flows the #2840 campaign measured ran against a stand
+where **nothing ever failed**. PrestaShop answered every call, the Allegro stub
+answered every call, Redis stayed up, the worker stayed up. A system that is
+fast when everything works but loses orders when the shop hiccups is worse than
+a slow one, and until this run the campaign knew nothing about which OpenLinker
+is.
+
+The campaign has already met a **failure reported as a success** twice, and
+both times by accident rather than by design:
+
+- the Allegro stub generated buyer names containing digits, PrestaShop's
+  `Validate::isName` rejected every one, and the job still recorded
+  `outcome: 'ok'` because `Promise.allSettled` swallowed it;
+- `MarketplaceOfferQuantityUpdateHandler` drops the original exception's
+  `statusCode` for non-contention failures, so a deterministic 404 walks the
+  full ten-attempt retry ladder instead of dying on attempt 1.
+
+Finding that shape a third time by accident is not a method. This run goes
+looking for it.
+
+---
+
+## 1. The question, and what counts as an answer
+
+Per fault, one thing:
+
+> **is the order LOST, RETRIED, or SILENTLY MARKED DONE?**
+
+Each is **stated from a reading, never inferred from a rate that looks
+plausible**. The four readings, per window:
+
+| Source | What it answers |
+|---|---|
+| `sync_jobs` | what the job says happened - `status`, `outcome`, `outcomeReason`, `attempts`, `deferredTotalMs`, `lastError` |
+| `order_records` | what the order snapshot says happened |
+| `order_records.syncStatus[]` | what the destination fan-out says happened, and the destination-native order id it CLAIMS to have created |
+| `ps_orders` / `ps_cart` | whether that order actually exists |
+
+**Ground truth is the shop, not OpenLinker.** "Silently marked done" cannot be
+established from OpenLinker's own tables, because a system that believes it
+succeeded says so consistently everywhere it writes. The sharp test is
+therefore the last two rows read together: for every `syncStatus` entry with
+`status: 'synced'`, does its `externalOrderId` name a row in `ps_orders`? A
+claimed id with no row behind it is a success report over a failure.
+
+That detector was **proven able to fire before the run**, against live data on
+this stand, rather than assumed: three genuinely-claimed order ids answered
+3 present (missing 0), and the same query with one id replaced by a fabricated
+`999999` answered 2 present (missing 1). A detector nobody has watched go red
+is a detector that reports zero for the wrong reason.
+
+An orphaned cart is the second ground-truth signal: `psCartsCreated > 0`
+alongside `psOrdersCreated == 0` is work done at the destination that produced
+no order.
+
+---
+
+## 2. Conditions
+
+_(Filled from the run's own manifests - see § 8.)_
+
+- **Stand**: `lab` (`docker-compose.lab.yml`, #2854), a single developer
+  workstation shared with two other OpenLinker docker-compose stacks
+  (`ol-demo-fresh-*`, `openlinker-*`). No CPU pinning, no memory limits.
+- **Peer activity**: TBD - stated per chunk, because two peers were active on
+  this stand during the preparation of this run and the stand lock was
+  contended twice before the first window opened.
+- **Image**: TBD (`guard_build` records the image commit, not `HEAD`).
+- **Destination**: the **real local PrestaShop**, reached through the
+  fault-injection proxy. Never a mock - see § 3.
+- **Source**: the Allegro upstream stub (#2856/#2935) at
+  `http://allegro-stub:8080`, tenant `perf-allegro-a`, at its configured
+  276 ms / 1106 ms per-endpoint latencies.
+- **Runner**: ENABLED. The lab stand ships `WORKER_RUNNER_ENABLED=false`, so
+  the scenario recreates the worker with it on and restores it on exit - a
+  fault injected into a system that executes no jobs measures the injector.
+- **Scheduler**: OFF (`guard_scheduler_off`), so no master sweep shares a lane
+  with this run's jobs.
+- **Retry ladder**: capped at `PERF_MAX_ATTEMPTS=3`, against a shipped default
+  of 10. **This is a measurement input, not a detail**: every retry-cost figure
+  below is against this cap and any extrapolation to the shipped 10 is marked
+  as such.
+
+### Two declared deviations from the harness defaults
+
+Both are recorded in every window's manifest rather than taken silently.
+
+| Deviation | Default | Here | Why |
+|---|---|---|---|
+| `SETTLE_SECS` | 60 | 30 | The 60s default is sized to let a **rebuild's** CPU and page-cache impact fade. Nothing is rebuilt between these windows, so 60 x 13 would be thirteen minutes of held lock spent waiting for an effect that is not present. |
+| stand-lock TTL | 3600 s | 9000 s | The library TTL is a **crash** bound - the longest a dead holder can block the stand - not a run bound, and thirteen settle-plus-window-plus-drain cycles do not fit inside it. Letting it expire mid-run would let a peer take the stand underneath an open window. |
+
+---
+
+## 3. How the faults are injected
+
+### The PrestaShop side: a proxy, not a mock
+
+`stubs/ps-fault-proxy` is a transparent reverse proxy in front of the **real**
+local PrestaShop. Replacing the shop with a mock would change two variables at
+once - the fault, and the destination - so every request not selected for a
+fault reaches the same shop, gets the same answer, and takes the same time as
+it does in every other window of the campaign.
+
+It is started as a plain `docker run` on the lab network, and the
+`perf-prestashop` connection's `config.baseUrl` is PATCHed to point at it.
+Nothing in `docker-compose.lab.yml` changes and **no existing container is
+recreated by the injection**, so `post_guard_containers_stable` still means
+what it means everywhere else. A fresh adapter is built per capability
+resolution (`integrations.service.ts`), so the repoint takes effect on the next
+job with no restart.
+
+`wc-tls` is the precedent #2978 names for putting something in front of a stand
+dependency, and nginx was tried against that precedent and rejected: without a
+Lua build it cannot do a per-request **probability**, cannot match request path
+**and** method together, and cannot hold a connection open without answering
+while still counting it.
+
+**The proxy's own overhead is measured, not assumed away.** Every window in
+this scenario, the baseline included, routes PrestaShop traffic through it, so
+no fault window is ever credited with the proxy's cost.
+
+### The marketplace side: the stub's own fault surface, extended
+
+The Allegro stub already had `429` / `503` / `timeout`. #2978 added
+per-endpoint targeting, a per-request fraction, and three modes.
+
+Targeting is not a convenience. *"The source times out during hydration"* is a
+fault on `checkout` while `events` keeps working; a tenant-wide timeout instead
+stops the feed being read at all, so no order is ever hydrated and the window
+measures nothing about hydration.
+
+The three new modes are chosen for **where they fail**, not for variety:
+
+| Mode | Wire behaviour | Which layer breaks |
+|---|---|---|
+| `malformed` | HTTP 200, `Content-Type: application/json`, body is an HTML fatal-error page | the parse |
+| `truncated` | HTTP 200, honest `Content-Length`, half the body, socket destroyed | the transport |
+| `reject-quantity` | **HTTP 200** carrying `{status: 'REJECTED', errors: [...]}` | neither - the transport succeeded |
+
+`reject-quantity` is the sharpest available test of this issue's central
+question, precisely because a caller that reads only the status code has no
+reason to look further.
+
+### Infrastructure
+
+Neither injector applies. Redis is paused with `CLIENT PAUSE` - **not**
+`DEBUG SLEEP`, which is disabled by default on Redis 7+ and was verified
+refused on this stand - because pausing command processing for every client
+reproduces the **blocked-client** shape #2975 found (the shared `'REDIS_CLIENT'`
+occupied while the rate limiter waits out its own 1000 ms budget) rather than a
+server that is merely slower. Redis is dropped with `docker stop`; the worker is
+killed with `SIGKILL` and started again.
+
+### Every fault is declared, and its delivery is counted
+
+`manifest.json` carries a `faultInjection` object for **every** window,
+baseline included - the baseline's says `injected: false`, so "no fault" is a
+positive statement rather than an absent key.
+
+The rule is **read back from the injector** rather than echoed from what the
+script asked for, and the **delivered** fault count is read back after the
+window. Both matter: a fractional rule's delivered count is not its requested
+fraction, and a rule that installed but never matched would otherwise look
+identical to a system that shrugged the fault off.
+
+### The injectors were proven correct before any window was spent
+
+Both are tested in isolation, in-process, against a throwaway upstream, so the
+suites run while a peer holds `guard_stand_exclusive`:
+
+- `stubs/ps-fault-proxy/test.mjs` - 49 checks
+- `stubs/allegro/test.mjs` - 27 tests (17 pre-existing, all still green)
+
+That earned itself immediately. The proxy's own self-test caught that a default
+`429` sent **no `Retry-After` header at all** while the control surface, and
+therefore the manifest, both claimed one was being sent - which would have made
+the D2a and D2b arms measure the same thing under two different labels. Fixed
+by resolving the default at rule-install time, so what is reported and what
+goes on the wire cannot disagree.
+
+---
+
+## 4. Why the standard post-guard set is not used wholesale
+
+`run_post_guards` is right for every other scenario and wrong for this one,
+because three of its eight members are **inverted** by a fault window:
+
+| Guard | Elsewhere | Here |
+|---|---|---|
+| `post_guard_destination_creates` | a failed `syncStatus` entry discards the run | a failed entry is **the measurement**; zero of them would mean the fault never reached the destination path |
+| `post_guard_attempts` | `attempts > 1` discards the run | `attempts > 1` is **the retry cost** #2978 asks for |
+| `post_guard_deferrals` | any `deferredTotalMs > 0` discards the run | a 429 carrying `Retry-After` is **supposed** to defer |
+
+Skipping them silently would be the campaign sin. Each guard is therefore run
+individually and routed to one of two lists - a **stand** guard still discards
+the window, a **fault** guard's answer is recorded in `fault-observations.txt`
+as a measurement. Both are printed. Nothing is dropped.
+
+Of the eight, six run. The two that do not are named rather than left as an
+absence: `post_guard_generator_saturated` (there is no k6 generator on this
+path, as with F2) and `post_guard_feed_starved` (it needs a min-available-work
+series this scenario does not sample - the property it protects is checked
+directly instead, by reading the upstream backlog at window stop and flagging a
+drained feed).
+
+The one deliberate exemption: the **I2 and I3 windows stop a container on
+purpose**, so `post_guard_containers_stable` tripping there is the injected
+fault. It is recorded as `EXPECTED-BY-FAULT` rather than silently exempted.
+
+### The harness's own cleanup was made unable to forge a finding
+
+`drain_wait` is not a passive observer: on timeout it marks every still-queued
+or still-running row `dead` with its own `lastError`. Running it before the
+settled-state ledger read would make a job **the harness killed**
+indistinguishable from one the system dead-lettered - in the one scenario where
+leftover rows are the finding - and the recovery loop that followed would then
+read zero jobs in flight and report a clean unattended recovery that never
+happened.
+
+So the order is: observe recovery, read the ledger, and only then let
+`drain_wait` clean up for the next window. Its answer and the ids it killed are
+recorded in `recovery.json`, labelled as the harness's doing, and every ledger
+carries a `killed_by_harness` count that should be zero everywhere - it exists
+so that if this ordering is ever broken the contamination shows up in the data
+rather than only in a comment.
+
+---
+
+## 5. The fault catalogue
+
+Every fault class #2978 names, and where it is exercised.
+
+| id | #2978 class | Injector | Rule | Load path |
+|---|---|---|---|---|
+| `baseline` | none (reference) | ps-fault-proxy, transparent | none | order ingestion |
+| `D1` | PrestaShop 500 on a fraction of create-path calls | ps-fault-proxy | `500`, fraction 0.3, all paths | order ingestion |
+| `D2a` | PrestaShop 429 **with** `Retry-After` | ps-fault-proxy | `429`, fraction 0.5, `Retry-After: 5` | order ingestion |
+| `D2b` | PrestaShop 429 **without** `Retry-After` | ps-fault-proxy | `429`, fraction 0.5, header suppressed | order ingestion |
+| `D3` | PrestaShop stops responding mid-order | ps-fault-proxy | `hang`, fraction 0.3, 45 000 ms | order ingestion |
+| `D4` | partial create: cart succeeds, `importorder` fails | ps-fault-proxy | `500`, fraction 1, path `controller=importorder` | order ingestion |
+| `M1` | the source times out during hydration | allegro-stub | `timeout`, endpoint `checkout`, 35 000 ms | order ingestion |
+| `M2` | the source returns a malformed payload | allegro-stub | `malformed`, endpoint `checkout`, fraction 0.5 | order ingestion |
+| `M2t` | the source returns a truncated payload | allegro-stub | `truncated`, endpoint `events`, fraction 0.5 | order ingestion |
+| `M3` | the source rejects the offer-quantity write | allegro-stub | `reject-quantity` | `marketplace.offerQuantity.update` |
+| `I1` | Redis becomes slow (a blocked client, not an outage) | `CLIENT PAUSE` | 3 000 ms every 6 s | order ingestion |
+| `I2` | Redis drops entirely mid-window | `docker stop` / `start` | at t+35 s, back 20 s later | order ingestion |
+| `I3` | the worker is killed mid-job | `docker kill -s KILL` / `start` | at t+35 s, back 10 s later | order ingestion |
+
+Two notes on the choice of rule:
+
+- **`D3`'s 45 000 ms** exceeds the webservice client's own 30 s per-attempt
+  `AbortController` timeout and stays under the OL module HMAC's +/- 5 minute
+  skew window, so a held request fails as a timeout rather than as a signature
+  rejection.
+- **`D1`, `D2a`, `D2b` and `D3` use a fraction rather than every call.** A shop
+  that fails everything is an outage, and an outage is a less interesting
+  question than a shop that hiccups - the hiccup is what produces a *partially*
+  completed order, which is where a swallowed failure hides.
+
+---
+
+## 6. Results
+
+_TBD._
+
+---
+
+## 7. Findings
+
+_TBD. Any path found reporting success on a failure belongs at the top of this
+section with a reproduction._
+
+---
+
+## 8. What this did not establish
+
+_TBD. This section is mandatory and must not be empty._
+
+---
+
+## 9. Fault classes not exercised, and why
+
+_TBD. A class that could not be exercised is recorded here with its reason,
+never quietly dropped._

--- a/perf/openlinker-throughput/results-F10-2026-09-08.md
+++ b/perf/openlinker-throughput/results-F10-2026-09-08.md
@@ -1,6 +1,6 @@
 # F10 - behaviour under dependency failure
 
-_Run 2026-09-07 on the `lab` stand. Scenario `scenarios/f10-dependency-failure.sh` (#2978, epic #2840)._
+_Run 2026-09-08 on the `lab` stand. Scenario `scenarios/f10-dependency-failure.sh` (#2978, epic #2840)._
 
 > **STATUS: METHOD AND CONDITIONS ONLY.** The measurement sections below are
 > not yet filled. Nothing in this file may be quoted as a result until this
@@ -74,9 +74,9 @@ _(Filled from the run's own manifests - see § 8.)_
 - **Stand**: `lab` (`docker-compose.lab.yml`, #2854), a single developer
   workstation shared with two other OpenLinker docker-compose stacks
   (`ol-demo-fresh-*`, `openlinker-*`). No CPU pinning, no memory limits.
-- **Peer activity**: TBD - stated per chunk, because two peers were active on
-  this stand during the preparation of this run and the stand lock was
-  contended twice before the first window opened.
+- **Peer activity**: see § 2.1. Two windows were **discarded** before the
+  measured run began, one of them because a peer wrote into this run's own
+  connection while this run held the stand lock.
 - **Image**: TBD (`guard_build` records the image commit, not `HEAD`).
 - **Destination**: the **real local PrestaShop**, reached through the
   fault-injection proxy. Never a mock - see § 3.
@@ -92,6 +92,72 @@ _(Filled from the run's own manifests - see § 8.)_
   of 10. **This is a measurement input, not a detail**: every retry-cost figure
   below is against this cap and any extrapolation to the shipped 10 is marked
   as such.
+
+### 2.1 Two discarded windows, and a gap in the stand lock
+
+Neither is a product finding. Both are recorded because a run that quietly
+re-took its own measurements is not one anybody should believe.
+
+**Discarded #1 - `DISCARDED-calibration-backlog120`.** The first baseline
+window offered 120 orders, on the saturation rule every other scenario in this
+campaign uses. Against a stand whose measured baseline is ~207 orders/h that
+leaves ~115 children queued at window close, so no window could observe its own
+recovery - the run would have reported "not drained" in all thirteen windows
+whether the system healed or not. The window injected no fault and was thrown
+away rather than kept; the batch is 12 now. Two instrumentation bugs were fixed
+in the same pass - see the commit *"the load shape was borrowed from the wrong
+kind of measurement"*.
+
+**Discarded #2 - `DISCARDED-peer-collision-2026-09-08`. The name is wrong and
+the reason was wrong, and this is a retraction.**
+
+That window was stopped mid-run on a diagnosis of peer contamination:
+`marketplace.offerQuantity.update` rows keyed `inventory:{connectionId}:...`
+were appearing on `perf-allegro-a`, the connection under measurement, inside a
+window holding `guard_stand_exclusive`, while a peer's processes were visible
+in the process table. It looked like a peer writing through the lock.
+
+**It was not. Those rows were this run's own downstream cascade.** A contamination
+watcher armed on the *next* run flagged the identical pattern within ninety
+seconds of a clean start, and the key that settles it is
+`order:{internalOrderId}:inventory:sync:{prestashopConnectionId}` - an order id
+that belongs to an `order_records` row created by this run's own source
+connection inside its own window. The full chain, all of it caused by the load
+this scenario offers:
+
+1. the order is created in PrestaShop, so the shop's stock changed;
+2. `master.inventory.syncByExternalId` is enqueued against the destination;
+3. its write fires `inventory.propagateToMarketplaces`;
+4. which fans out one `marketplace.offerQuantity.update` per Allegro
+   connection - two, matching F2's own documented finding for this stand.
+
+The peer processes that seemed to corroborate it were host-load and CPU
+samplers, which write no rows at all. There was never any positive evidence of
+a peer enqueue, and **the earlier claim that "the stand lock is blind to a peer
+that does not take it" is withdrawn** - nothing in this run supports it. On the
+one occasion a peer genuinely was on the stand, it had taken the lock and
+`guard_stand_exclusive` refused F10 by name, before any side effect, leaving
+the connection at `http://prestashop` and starting no proxy. The lock behaved
+correctly every time it was exercised.
+
+Two things are worth keeping from the mistake.
+
+**A real property of the system, measured rather than assumed: one order on
+this path produces roughly three further jobs**, and they land in the same
+`realtime` lane, on the same connection, against `perScope = 2`. Order
+ingestion and stock propagation are not independent workloads here - they
+compete for the same two slots. That is most of why a 12-order batch drains at
+roughly two orders per minute rather than at the ~3.4/min a naive reading of
+the 207 orders/h baseline suggests, and it is a fact any fault window's timing
+has to be read against.
+
+**And a caution about detectors.** The watcher that produced the false positive
+(`watch-peer-contamination.sh`) classified every job it did not personally mint
+as foreign, which is wrong on a system whose whole job is to enqueue further
+work in response to work. A detector that cannot tell the system's own
+consequences from a third party's writes will cry contamination on a healthy
+run - and, worse, would have been believed here if its output had not been
+opened and read. It is kept, unused and labelled, rather than quietly deleted.
 
 ### Two declared deviations from the harness defaults
 
@@ -280,8 +346,194 @@ _TBD._
 
 ## 7. Findings
 
-_TBD. Any path found reporting success on a failure belongs at the top of this
-section with a reproduction._
+### F10-1 (top finding) - the job ledger reports total success over an order that never reached the shop, and nothing ever retries it
+
+**The pair is the finding, and neither half is it alone.** OpenLinker records
+the destination failure *accurately*, surfaces it *well* to a human, and then
+**never acts on it** - while every row in `sync_jobs`, the table an automated
+monitor watches, says the work succeeded. Read on its own the first half is
+reassurance and the second is alarm; together they say an unattended
+deployment loses orders while its job metrics stay green.
+
+#### Reproduction
+
+Window `D4`, run `f10-final-2026-09-08`, window start `2026-09-08T01:46:09Z`.
+Fault as recorded in that window's own manifest, read back from the injector:
+
+```json
+{"mode":"500","fraction":1,"pathIncludes":"controller=importorder",
+ "methods":null,"retryAfterSeconds":5}
+```
+
+That faults **only** the OL module's `importorder` front controller. Every
+webservice call that builds the cart passes through to the real PrestaShop
+untouched - the proxy's per-bucket counters show `api:carts`,
+`api:products`, `module:cartshipping` all proxied and unfaulted.
+
+#### The rows
+
+**1. What `order_records.syncStatus[]` says** - five orders, each carrying a
+failed entry with a real error and no destination order id:
+
+| `internalOrderId` | `sourceEventId` | entry status | dest order id |
+|---|---|---|---|
+| `ol_order_e682e504be2f4c93a1f50fffac8ead3a` | `f10-D4-…-000004` | `failed` | *(none)* |
+| `ol_order_d6d54b915eea467da39c467da25f1ca0` | `f10-D4-…-000002` | `failed` | *(none)* |
+| `ol_order_105b520d3bbd4ece8bc27c514c86d789` | `f10-D4-…-000007` | `failed` | *(none)* |
+| `ol_order_7b19326163554253bb6224510324d974` | `f10-D4-…-000009` | `failed` | *(none)* |
+| `ol_order_34cd70488ea94169bec51f93d5519160` | `f10-D4-…-000011` | `failed` | *(none)* |
+
+One entry in full. **This is an accurate, specific, well-formed record of the
+failure** - it names the connection, the cart, and the exact status:
+
+```json
+{
+  "error": "Failed to create PrestaShop order: OpenLinker module call failed for
+            connection=c4710417-5876-40cf-a0a6-bdbef38e823a idCart=3103:
+            HTTP 500 (reason: http-500)",
+  "status": "failed",
+  "destinationConnectionId": "c4710417-5876-40cf-a0a6-bdbef38e823a"
+}
+```
+
+**2. What `sync_jobs` says about those same five orders**, joined on
+`idempotencyKey = marketplace:{sourceConnectionId}:order:{sourceEventId}`:
+
+| job id | `jobType` | `status` | `outcome` | `attempts` | `lastError` |
+|---|---|---|---|---|---|
+| `8881a8b9-2413-40fc-a066-77b9c6d752a1` | `marketplace.order.sync` | `succeeded` | `ok` | **0** | `NULL` |
+| `551514c9-61d0-4351-a08c-d87421730baa` | `marketplace.order.sync` | `succeeded` | `ok` | **0** | `NULL` |
+| `44e6db33-3a86-441a-b9ac-0d098d905af1` | `marketplace.order.sync` | `succeeded` | `ok` | **0** | `NULL` |
+| `3666c5e9-2301-4a06-b5c8-232f74b743aa` | `marketplace.order.sync` | `succeeded` | `ok` | **0** | `NULL` |
+| `8d4aad4e-ca01-4feb-97aa-70493f929147` | `marketplace.order.sync` | `succeeded` | `ok` | **0** | `NULL` |
+
+**3. What the shop says.** Cart `3103` - the cart OpenLinker's own error
+message names - exists in `ps_cart` with `orders_for_cart = 0`. Across the D4
+window PrestaShop created **18 carts, 5 of them orphaned**, matching the five
+failed entries exactly.
+
+#### The parent/child objection, ruled out explicitly
+
+The obvious rebuttal is that `marketplace.order.sync` is a *parent* reporting
+an aggregate while a per-destination *child* recorded the failure correctly -
+a materially less serious defect. **It is not the case here.** Every job of
+every type on **every connection** in the D4 window, including the destination
+connection, which this run's own ledger does not scope to:
+
+| connection | `jobType` | status | outcome | n | Σ attempts |
+|---|---|---|---|---|---|
+| `53d949aa` (source) | `marketplace.order.sync` | succeeded | `ok` | 24 | **0** |
+| `53d949aa` (source) | `marketplace.orders.poll` | succeeded | `ok` | 20 | **0** |
+| `53d949aa` (source) | `marketplace.offerQuantity.update` | succeeded | `ok` | 11 | **0** |
+| `b20b8275` (allegro b) | `marketplace.offerQuantity.update` | succeeded | `ok` | 11 | **0** |
+| `c4710417` (**destination**) | `inventory.propagateToMarketplaces` | succeeded | `ok` | 11 | **0** |
+| `c4710417` (**destination**) | `master.inventory.syncByExternalId` | succeeded | `ok` | 11 | **0** |
+
+There is **no child job for the destination create** - it happens in-process
+inside `marketplace.order.sync`. Not one row anywhere carries `failed`,
+`dead`, `business_failure`, a non-zero attempts count, or a `lastError`. The
+two job types on the destination connection are the downstream cascade of the
+orders that *did* succeed.
+
+#### Mechanism
+
+Already documented, now confirmed end to end under load.
+`OrderSyncService.dispatchToDestinations` collects per-destination failures
+from `Promise.allSettled` and **returns them as data rather than raising**, so
+`MarketplaceOrderSyncHandler` returns `{outcome: 'ok'}`.
+`post_guard_destination_creates`'s own docblock in `lib.sh` names this exact
+shape - this run supplies the measurement behind it.
+
+#### Nothing retries it, and that is a positive finding rather than an absence
+
+Established by reading the code, not inferred from the window:
+
+- **No scheduler task reads `syncStatus` at all** - zero non-test hits for it
+  under `apps/worker/src`. Every registered core and integration task was
+  enumerated; none re-attempts a destination create.
+- **`OrderDestinationRetryService` has exactly one caller**, the HTTP route
+  `POST /orders/:internalOrderId/destinations/:connectionId/retry`. No sweep,
+  no cron, no handler constructs it. Its own header says it is
+  "operator-driven".
+- **A re-poll cannot re-drive it.** The child's dedupe key is
+  `marketplace:{connectionId}:order:{eventKey}`; the Redis reservation carries
+  a 7-day TTL, and past that the Postgres unique constraint on
+  `sync_jobs.idempotencyKey` makes `createIfNotExistsByIdempotencyKey` return
+  the existing **already-succeeded** row. The dedup is effectively permanent.
+  The connection cursor has also advanced past the event, because the *enqueue*
+  succeeded - the failure happened later, inside the child.
+- **No sweep scans `order_records` for failed entries.** The only SQL
+  predicate on one (`HAS_FAILED`) has six uses and all six are read-only
+  reporting: the KPI counts, the analytics "Stuck" row, a sort ordinal, and
+  the `?health=` filter.
+
+So the order is retried only if a human clicks Retry, an operator releases a
+hold, or the marketplace happens to emit a **new** event for that order - the
+last being incidental, not a mechanism.
+
+#### What the operator sees - good, and that is what bounds the severity
+
+This is **not** a data-loss defect. The failure is well surfaced:
+
+- the `/orders` row renders a `Sync failed` badge **and the raw error string
+  inline**;
+- a clickable **"Needs attention"** KPI card counts them without opening
+  anything;
+- the analytics panel carries a **"Stuck"** row with an age;
+- the order detail page renders an error alert per failed destination;
+- there are **three** Retry buttons (list row, mobile card, detail).
+
+So an *attended* deployment sees red. The defect is that (a) the **job**
+record is a false success, so anything monitoring `sync_jobs` - the natural
+thing to alert on - sees green; and (b) recovery is **manual, one click per
+order per destination, with no bulk action**.
+
+#### Severity, stated plainly
+
+At an injected 30% 500-rate on the destination (`D1`), **2 of the ~5 orders
+that executed inside the window** were stranded this way. At a 50% 429-rate
+with no `Retry-After` (`D2b`), 3. Under a total `importorder` outage (`D4`),
+5. In every case the job ledger reported unbroken success.
+
+---
+
+### F10-2 - `Retry-After` changes the outcome, not just the timing
+
+Same status code, same 50% rate, same window length, same batch:
+
+| window | `Retry-After` | reached the shop | failed entries | orphaned carts |
+|---|---|---|---|---|
+| `D2a` | **sent** (5 s) | **12 of 12** | 0 | 0 |
+| `D2b` | **suppressed** | 9 of 12 | 3 | 3 |
+
+A 429 that carries the header is absorbed completely. The same 429 without it
+strands three orders into the F10-1 state. Worth knowing because a shop behind
+a proxy or a WAF may well return one without the other.
+
+---
+
+### F10-3 - a failed destination create leaves an orphaned cart at the shop, and nothing cleans it up
+
+Every destination-fault window created **12 carts** and fewer orders. The
+difference is work performed at the destination that produced nothing, left
+behind: `D1` 2, `D2b` 3, `D3` 1, `D4` 5 - each count matching that window's
+failed-entry count exactly, and confirmed against `ps_cart` by id. OpenLinker's
+own error string even names the cart (`idCart=3103`), so the evidence needed to
+clean up is recorded and unused.
+
+---
+
+### F10-4 (minor) - the detail page's "View failed orders" link does not list orders with failed syncStatus
+
+The order-detail failure alert offers a **"View failed orders"** link to
+`/orders/failed?connectionId=…`. That page is titled *Awaiting Mapping* and
+filters `recordStatus: 'awaiting_mapping'` - a different condition entirely. An
+operator following the link from a sync failure is shown a list that by
+construction excludes it.
+
+Related, and the reason the mis-targeting is avoidable: a `?syncStatus=failed`
+list filter **is** supported end to end in the API and the client function, and
+no page passes it.
 
 ---
 

--- a/perf/openlinker-throughput/run-f10-until-claimed.sh
+++ b/perf/openlinker-throughput/run-f10-until-claimed.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# Retries the F10 run until it wins `guard_stand_exclusive` (#2978).
+#
+# A peer on this stand cycles the lock in short holds - take, run a profile,
+# release, repeat - so a single-shot launch loses the race more often than it
+# wins it. This retries rather than working around the guard: it never deletes
+# the lock, never passes a force flag, and never starts while somebody else
+# holds it. It simply asks again.
+#
+# It distinguishes the two ways the scenario can stop early, because they need
+# opposite responses:
+#
+#   refused by the lock   ->  retry, this is expected contention
+#   anything else         ->  stop and surface it, because a real failure
+#                             retried in a loop is a real failure repeated
+#
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+ATTEMPTS="${ATTEMPTS:-40}"
+RETRY_SECS="${RETRY_SECS:-20}"
+PROFILE="${1:-all}"
+LOG_BASE="${LOG_BASE:-$HERE/results/f10-run}"
+
+for i in $(seq 1 "$ATTEMPTS"); do
+  log="${LOG_BASE}-attempt${i}.log"
+  printf '[launcher] attempt %s/%s -> %s\n' "$i" "$ATTEMPTS" "$log"
+  set +e
+  bash "$HERE/run-f10.sh" "$PROFILE" > "$log" 2>&1
+  rc=$?
+  set -e
+  if [ "$rc" -eq 0 ]; then
+    printf '[launcher] run completed (attempt %s)\n' "$i"
+    exit 0
+  fi
+  if grep -qF 'guard_stand_exclusive: the stand is already being measured' "$log"; then
+    printf '[launcher] refused by the stand lock; retrying in %ss\n' "$RETRY_SECS"
+    rm -f "$log"
+    sleep "$RETRY_SECS"
+    continue
+  fi
+  printf '[launcher] attempt %s failed for a reason that is NOT lock contention (rc=%s) - stopping so it is not retried into the ground:\n' "$i" "$rc"
+  tail -25 "$log"
+  exit "$rc"
+done
+
+printf '[launcher] gave up after %s attempts - the stand was never free\n' "$ATTEMPTS"
+exit 1

--- a/perf/openlinker-throughput/run-f10.sh
+++ b/perf/openlinker-throughput/run-f10.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+#
+# F10 run wrapper (#2978). Chunked deliberately: thirteen windows in one
+# invocation is roughly an hour of held lock, and a failure at window eleven
+# would cost the ten before it. Each chunk takes and releases the stand lock
+# on its own and shares one RUN_LABEL, so the results land in one directory.
+#
+#   ./run-f10.sh destination   baseline D1 D2a D2b D3 D4
+#   ./run-f10.sh marketplace   M1 M2 M2t M3
+#   ./run-f10.sh infra         I1 I2 I3
+#
+set -euo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+export PS_CONTAINER=lab-prestashop PS_MYSQL_CONTAINER=lab-mysql WC_CONTAINER=lab-woocommerce
+export PG_CONTAINER=lab-postgres REDIS_CONTAINER=lab-redis OL_API_CONTAINER=lab-api
+export WORKER_CONTAINERS=lab-worker-1 OL_API_URL=http://127.0.0.1:19000
+export OL_ADMIN_USER=admin OL_ADMIN_PASSWORD=admin
+# shellcheck disable=SC1091
+source "$HERE/stand-ids.env"
+export PS_CONNECTION_ID WC_CONNECTION_ID ALLEGRO_A_CONNECTION_ID ALLEGRO_B_CONNECTION_ID
+
+export RUN_LABEL="${RUN_LABEL:-f10-2026-09-07}"
+
+case "${1:?usage: run-f10.sh destination|marketplace|infra|all}" in
+  destination) FAULTS="baseline,D1,D2a,D2b,D3,D4" ;;
+  marketplace) FAULTS="M1,M2,M2t,M3" ;;
+  infra)       FAULTS="I1,I2,I3" ;;
+  all)         FAULTS="baseline,D1,D2a,D2b,D3,D4,M1,M2,M2t,M3,I1,I2,I3" ;;
+  *)           FAULTS="$1" ;;
+esac
+
+exec bash "$HERE/scenarios/f10-dependency-failure.sh" --faults="$FAULTS"

--- a/perf/openlinker-throughput/scenarios/f10-dependency-failure.sh
+++ b/perf/openlinker-throughput/scenarios/f10-dependency-failure.sh
@@ -337,8 +337,18 @@ ORIGINAL_PS_CONFIG="$(connection_json "$PS_CONNECTION_ID" | jq -c '.config // {}
 ORIGINAL_PS_BASE_URL="$(printf '%s' "$ORIGINAL_PS_CONFIG" | jq -r '.baseUrl // empty')"
 [ -n "$ORIGINAL_PS_BASE_URL" ] || die "perf-prestashop carries no config.baseUrl - nothing to repoint, and nothing to restore"
 ORIGINAL_ALLEGRO_CAPS="$(connection_json "$SOURCE_CONNECTION_ID" | jq -c '.enabledCapabilities // []')"
+
+ORIGINAL_REPLICAS="$(discover_worker_containers | wc -w | tr -d ' ')"
+[ "$ORIGINAL_REPLICAS" -ge 1 ] || ORIGINAL_REPLICAS=1
+# Read from the RUNNING container, never from an env file: the file is a
+# request, the container's environment is what is in force, and on a
+# multi-worktree checkout the file that was used may not even be this one.
+ORIGINAL_RUNNER_ENABLED="$(docker exec "$(discover_worker_containers | awk '{print $1}')" printenv WORKER_RUNNER_ENABLED 2>/dev/null || printf '')"
+[ -n "$ORIGINAL_RUNNER_ENABLED" ] || ORIGINAL_RUNNER_ENABLED=false
+
 log "posture at start: perf-prestashop baseUrl=$ORIGINAL_PS_BASE_URL"
 log "                  perf-allegro-a caps=$ORIGINAL_ALLEGRO_CAPS"
+log "                  worker replicas=$ORIGINAL_REPLICAS runner=$ORIGINAL_RUNNER_ENABLED"
 
 # A restore that CANNOT abort itself. Every lib.sh helper reaches `die` on
 # failure and `die` calls `exit`; inside an EXIT trap that skips every later
@@ -357,6 +367,18 @@ restore_curl() {
 # that legitimately holds the stand (the F1 lesson).
 CONNECTION_TOUCHED=0
 PROXY_STARTED=0
+WORKER_TOUCHED=0
+
+# Declared HERE, above the trap, and not beside the function that fills them
+# in. `set -u` is on, and an unset variable read inside an EXIT trap aborts
+# the trap - which would skip `release_stand_exclusive` and leave the stand
+# locked for the whole TTL after any early `die`. The trap must be able to run
+# at every point after it is installed, including before any of this is
+# resolved.
+COMPOSE_WORKDIR=""
+COMPOSE_FILE=""
+COMPOSE_ENV_FILE=""
+COMPOSE_PROJECT=""
 
 f10_on_exit() {
   local rc=$?
@@ -365,7 +387,7 @@ f10_on_exit() {
   # behind - a peer's next window would measure OUR fault as their result.
   clear_all_faults || true
 
-  if [ "$CONNECTION_TOUCHED" = "0" ] && [ "$PROXY_STARTED" = "0" ]; then
+  if [ "$CONNECTION_TOUCHED" = "0" ] && [ "$PROXY_STARTED" = "0" ] && [ "$WORKER_TOUCHED" = "0" ]; then
     log "nothing was changed on the stand - no restore needed"
     release_stand_exclusive
     return $rc
@@ -390,6 +412,18 @@ f10_on_exit() {
     log "  $PROXY_CONTAINER removed"
   fi
 
+  # The runner posture is put back the way it was found. A stand left with the
+  # runner ENABLED that shipped it disabled is a changed stand, and the next
+  # scenario's `guard_runner_state disabled` would refuse against a state this
+  # run created.
+  if [ "$WORKER_TOUCHED" = "1" ] && [ "$ORIGINAL_RUNNER_ENABLED" != "true" ]; then
+    log "  restoring WORKER_RUNNER_ENABLED=$ORIGINAL_RUNNER_ENABLED"
+    local args=(-f "$COMPOSE_FILE" -p "$COMPOSE_PROJECT")
+    [ -z "$COMPOSE_ENV_FILE" ] || args+=(--env-file "$COMPOSE_ENV_FILE")
+    ( cd "$COMPOSE_WORKDIR" && WORKER_RUNNER_ENABLED="$ORIGINAL_RUNNER_ENABLED" \
+        docker compose "${args[@]}" up -d --no-deps --scale "worker=$ORIGINAL_REPLICAS" worker >/dev/null 2>&1 ) || true
+  fi
+
   # Redis and the worker are restored inside their own arms rather than here,
   # because a window that stopped them must not run its ledger read against a
   # stopped stand. This is the belt-and-braces pass for an abort mid-arm.
@@ -409,6 +443,106 @@ f10_on_exit() {
   return $rc
 }
 trap 'f10_on_exit' EXIT
+
+# ===========================================================================
+# The worker's runner posture
+#
+# The lab stand ships WORKER_RUNNER_ENABLED=false (docker-compose.lab.yml's
+# own default), so a scenario that needs jobs to actually execute has to
+# recreate the worker - the variable is read at boot. F1 and F4 do the same.
+#
+# WHERE THE RECREATE IS RUN FROM IS A CORRECTNESS QUESTION, NOT A DETAIL.
+#
+# This repository is checked out as several worktrees, and the running stack
+# was brought up from ONE of them - not necessarily this one. Two things
+# differ between worktrees and both would silently change the container:
+#
+#   - docker-compose.lab.yml itself. The tree that launched this stand is on
+#     an older commit whose worker service does not carry the #2867 lane-cap
+#     passthrough keys; recreating from here would add eight of them.
+#   - the wc-tls certificate the worker bind-mounts. `certs/` is gitignored,
+#     so it exists only in the worktree that generated it. Recreating from a
+#     worktree without it makes docker CREATE AN EMPTY DIRECTORY at the
+#     bind-mount path, and the worker then starts with a directory where
+#     NODE_EXTRA_CA_CERTS expects a file.
+#
+# So the compose context is READ BACK from the running container's own
+# labels rather than assumed to be this checkout - the same
+# verify-what-is-in-force rule the rest of this harness applies to
+# configuration. The recreated worker is then byte-identical to the running
+# one except for the single variable being changed.
+#
+# That variable is passed in the SHELL ENVIRONMENT, not by editing the
+# stand's .env.lab: compose's interpolation precedence puts the shell above
+# --env-file, and a scenario has no business rewriting a file that belongs to
+# another worktree. It is verified rather than trusted - the value is read
+# back out of the recreated container before anything is measured.
+# ===========================================================================
+resolve_compose_context() {
+  _ensure_worker_containers
+  local w
+  w="$(printf '%s' "$WORKER_CONTAINERS" | awk '{print $1}')"
+  COMPOSE_WORKDIR="$(docker inspect "$w" --format '{{index .Config.Labels "com.docker.compose.project.working_dir"}}' 2>/dev/null || printf '')"
+  COMPOSE_FILE="$(docker inspect "$w" --format '{{index .Config.Labels "com.docker.compose.project.config_files"}}' 2>/dev/null || printf '')"
+  COMPOSE_ENV_FILE="$(docker inspect "$w" --format '{{index .Config.Labels "com.docker.compose.project.environment_file"}}' 2>/dev/null || printf '')"
+  COMPOSE_PROJECT="$(docker inspect "$w" --format '{{index .Config.Labels "com.docker.compose.project"}}' 2>/dev/null || printf 'lab')"
+  [ -n "$COMPOSE_WORKDIR" ] && [ -d "$COMPOSE_WORKDIR" ] \
+    || die "resolve_compose_context: $w carries no usable com.docker.compose.project.working_dir label (got '$COMPOSE_WORKDIR') - this stand was not brought up by compose, and recreating the worker from a guess would change more than the runner flag"
+  [ -f "$COMPOSE_FILE" ] \
+    || die "resolve_compose_context: the compose file this stand was brought up with ($COMPOSE_FILE) does not exist"
+  log "compose context (read from $w's own labels, never assumed to be this checkout):"
+  log "  workdir=$COMPOSE_WORKDIR"
+  log "  file=$COMPOSE_FILE"
+  log "  envFile=${COMPOSE_ENV_FILE:-<none>} project=$COMPOSE_PROJECT"
+}
+
+# recreate_worker <runner:true|false>
+recreate_worker() {
+  local runner="$1" tries hits w found
+  WORKER_TOUCHED=1
+  local args=(-f "$COMPOSE_FILE" -p "$COMPOSE_PROJECT")
+  [ -z "$COMPOSE_ENV_FILE" ] || args+=(--env-file "$COMPOSE_ENV_FILE")
+  ( cd "$COMPOSE_WORKDIR" && WORKER_RUNNER_ENABLED="$runner" \
+      docker compose "${args[@]}" up -d --no-deps --scale "worker=$ORIGINAL_REPLICAS" worker >/dev/null 2>&1 ) \
+    || die "recreate_worker: compose refused to recreate the worker service from $COMPOSE_WORKDIR"
+
+  # The discovery cache in lib.sh is stale by construction after a recreate.
+  WORKER_CONTAINERS=""
+  WORKER_CONTAINERS_RESOLVED=0
+  _ensure_worker_containers
+  found="$(discover_worker_containers | wc -w | tr -d ' ')"
+  [ "$found" -eq "$ORIGINAL_REPLICAS" ] || die "recreate_worker: expected $ORIGINAL_REPLICAS replica(s), discovery found $found"
+
+  # ASKED IS NOT GOT. The shell-over-env-file interpolation precedence this
+  # relies on is read back out of the container rather than trusted - a
+  # scenario that measured a runner posture it did not get would be the
+  # reported-versus-enforced gap this campaign keeps closing.
+  for w in $WORKER_CONTAINERS; do
+    local got
+    got="$(docker exec "$w" printenv WORKER_RUNNER_ENABLED 2>/dev/null || printf '<unset>')"
+    [ "$got" = "$runner" ] \
+      || die "recreate_worker: asked for WORKER_RUNNER_ENABLED=$runner, $w reports '$got' - compose did not take the shell override, so this run would have measured the wrong posture"
+  done
+
+  if [ "$runner" = "true" ]; then
+    for w in $WORKER_CONTAINERS; do
+      tries=0
+      while true; do
+        # `grep -c`, never `grep -q`: -q closes the pipe on the first match
+        # and `set -o pipefail` then fails the pipeline on the very reading
+        # that succeeded.
+        hits="$(docker logs "$w" 2>&1 | grep -cF 'Starting sync job runner loop' || true)"
+        [ "${hits:-0}" -eq 0 ] || break
+        tries=$((tries + 1))
+        [ "$tries" -lt 90 ] || die "recreate_worker: $w never logged 'Starting sync job runner loop'"
+        sleep 1
+      done
+    done
+  else
+    sleep 5
+  fi
+  log "worker recreated: runner=$runner (verified from the container), replicas=$ORIGINAL_REPLICAS"
+}
 
 # ===========================================================================
 # Injector control surfaces
@@ -1115,6 +1249,19 @@ guard_perf_max_attempts
 guard_connection_budget
 guard_pool_recorded
 guard_scheduler_off
+
+# The runner has to be ON for any of this to mean anything - a fault injected
+# into a system that executes no jobs measures the injector. The lab stand
+# ships it OFF, so it is turned on here rather than declared as a
+# precondition an operator has to arrange, and turned back off on exit if
+# that is how it was found.
+resolve_compose_context
+if [ "$ORIGINAL_RUNNER_ENABLED" = "true" ]; then
+  log "the runner is already enabled - not recreating the worker"
+else
+  log "the runner is disabled on this stand; recreating the worker with it enabled"
+  recreate_worker true
+fi
 guard_runner_state enabled
 
 of_health >/dev/null || die "the Allegro stub is not answering at $OF_STUB_URL"

--- a/perf/openlinker-throughput/scenarios/f10-dependency-failure.sh
+++ b/perf/openlinker-throughput/scenarios/f10-dependency-failure.sh
@@ -195,6 +195,24 @@ export DRAIN_MAX_WAIT_SECS
 # and how late" measurement.
 RECOVERY_WAIT_SECS="${RECOVERY_WAIT_SECS:-180}"
 
+# Thirteen windows in one lock hold. The library default TTL (3600s) is a
+# CRASH bound, not a run bound - it is the longest a dead holder can block the
+# stand - and thirteen settle-plus-window-plus-drain cycles do not fit inside
+# it. Raised here rather than left to expire mid-run, which would let a peer
+# take the stand underneath an open window.
+OL_STAND_LOCK_TTL_SECS="${OL_STAND_LOCK_TTL_SECS:-9000}"
+export OL_STAND_LOCK_TTL_SECS
+STAND_LOCK_TTL_SECS="$OL_STAND_LOCK_TTL_SECS"
+
+# The library default is 60s, sized to let a REBUILD's CPU and page-cache
+# impact fade. Nothing is rebuilt between these windows and the load is
+# modest, so 60s x 13 would be thirteen minutes of the lock spent waiting for
+# an effect that is not present. 30s still covers the previous window's drain
+# tail, which is the only carry-over this scenario actually has. Declared as a
+# deviation rather than silently taken - it is recorded in every manifest by
+# manifest_gather_environment.
+SETTLE_SECS="${SETTLE_SECS:-30}"
+
 PROXY_CONTAINER="${PROXY_CONTAINER:-lab-ps-fault-proxy}"
 PROXY_IMAGE="${PROXY_IMAGE:-ol-perf:ps-fault-proxy}"
 PROXY_NETWORK="${PROXY_NETWORK:-lab_default}"
@@ -548,6 +566,7 @@ install_fault() {
 REDIS_PAUSE_MS="${REDIS_PAUSE_MS:-3000}"
 REDIS_PAUSE_EVERY_SECS="${REDIS_PAUSE_EVERY_SECS:-6}"
 MIDWINDOW_AT_SECS="${MIDWINDOW_AT_SECS:-35}"
+WORKER_RUNNER_LINES_BEFORE_KILL=0
 
 # ===========================================================================
 # The mid-window infrastructure actions. Each runs as a background job whose
@@ -575,6 +594,15 @@ start_midwindow_action() {
       log "  redis will be stopped ${MIDWINDOW_AT_SECS}s into the window and started again 20s later (pid=$MIDWINDOW_PID)"
       ;;
     I3)
+      # Counted BEFORE the kill so `restore_infrastructure` can wait for a NEW
+      # runner-loop line rather than for the presence of one - `docker start`
+      # preserves the log, so the old line is still there and a mere `grep -q`
+      # would answer "ready" the instant the container was started.
+      WORKER_RUNNER_LINES_BEFORE_KILL=0
+      local wc
+      for wc in $WORKER_CONTAINERS; do
+        WORKER_RUNNER_LINES_BEFORE_KILL=$(( WORKER_RUNNER_LINES_BEFORE_KILL + $(docker logs "$wc" 2>&1 | grep -cF 'Starting sync job runner loop' || true) ))
+      done
       ( sleep "$MIDWINDOW_AT_SECS"
         local w
         for w in $WORKER_CONTAINERS; do docker kill -s KILL "$w" >/dev/null 2>&1 || true; done
@@ -625,8 +653,25 @@ restore_infrastructure() {
     I3)
       local w
       for w in $WORKER_CONTAINERS; do docker start "$w" >/dev/null 2>&1 || true; done
-      sleep 5
-      log "  worker(s) started again"
+      # Waited for by its own startup line, never by a fixed sleep. The NEXT
+      # window's `window_start` calls `reassert_volatile_guards`, which runs
+      # `guard_runner_state enabled` and DIES if the runner loop line is not
+      # in the log - so a worker that is merely `Running` but has not booted
+      # yet would abort the whole remaining run at the next window rather
+      # than at this one. `docker start` preserves the log, so the line this
+      # greps for may be the previous boot's; it is the readiness of the
+      # PROCESS that the count below establishes.
+      local want_lines have_lines
+      want_lines="$WORKER_RUNNER_LINES_BEFORE_KILL"
+      while [ "$waited" -lt 120 ]; do
+        have_lines=0
+        for w in $WORKER_CONTAINERS; do
+          have_lines=$(( have_lines + $(docker logs "$w" 2>&1 | grep -cF 'Starting sync job runner loop' || true) ))
+        done
+        [ "$have_lines" -le "${want_lines:-0}" ] || break
+        sleep 2; waited=$((waited + 2))
+      done
+      log "  worker(s) started again and re-announced the runner loop after ${waited}s (runner lines ${want_lines:-0} -> ${have_lines:-0})"
       ;;
   esac
 }
@@ -706,6 +751,13 @@ read_ledger() {
              COUNT(*)::int AS n,
              SUM(attempts)::int AS attempts_total,
              MAX(attempts)::int AS attempts_max,
+             -- A `dead` row the HARNESS produced must never read as one the
+             -- system dead-lettered. drain_wait stamps its own lastError when
+             -- it times out; the ledger below is read before that runs, so
+             -- this should be 0 everywhere - it is carried so that if the
+             -- ordering is ever broken, the contamination is visible in the
+             -- data rather than only in a comment.
+             COUNT(*) FILTER (WHERE \"lastError\" LIKE '%perf harness drain_wait timeout%')::int AS killed_by_harness,
              COUNT(*) FILTER (WHERE COALESCE(\"deferredTotalMs\",0) > 0)::int AS deferred_rows,
              COALESCE(SUM(\"deferredTotalMs\"),0)::bigint AS deferred_ms_total,
              COALESCE(SUM(\"lastAttemptDurationMs\"),0)::bigint AS attempt_ms_total,
@@ -750,6 +802,12 @@ read_ledger() {
     #    This is the only reconciliation in the campaign whose witness is not
     #    OpenLinker, and it is the whole answer to "does any surface report
     #    success on a failed path".
+    #
+    #    PROVEN ABLE TO FIRE before the run, against live data on this stand,
+    #    rather than assumed: three genuinely-claimed ids answered 3 present
+    #    (missing 0), and the same query with one id replaced by a fabricated
+    #    999999 answered 2 present (missing 1). A detector nobody has seen go
+    #    red is a detector that reports zero for the wrong reason.
     local claimed_ids
     claimed_ids="$(pg_sql "SELECT string_agg(DISTINCT e->>'externalOrderId', ',')
       FROM order_records o, jsonb_array_elements(o.\"syncStatus\") e
@@ -909,7 +967,16 @@ run_fault() {
   if [ "$load" = "order" ]; then
     start_order_pump "$id"
   else
-    log "  enqueued $(enqueue_quantity_jobs "$id") quantity job(s)"
+    # Assigned, not interpolated into a `log` argument. `enqueue_quantity_jobs`
+    # calls `enqueue_perf_job`, which RECORDS each key it enqueued into
+    # `PERF_ENQUEUED_KEYS_FILE` - and `cap_perf_job_attempts` reads that file
+    # to apply the attempt cap. Running the whole loop inside a command
+    # substitution would keep the file path (it is exported from main below)
+    # but would lose any assignment the helper made to the variable itself,
+    # so the path is minted once in main rather than lazily in a subshell.
+    local qn
+    qn="$(enqueue_quantity_jobs "$id")"
+    log "  enqueued $qn quantity job(s)"
     cap_perf_job_attempts
   fi
 
@@ -957,24 +1024,47 @@ run_fault() {
   clear_all_faults
   restore_infrastructure "$id"
   log "  fault cleared; waiting up to ${RECOVERY_WAIT_SECS}s for unattended recovery"
-  local drain_result
-  drain_result="$(drain_wait "$CONN_IDS" || true)"
-  log "  drain_wait: $drain_result"
 
+  # THE RECOVERY WAIT RUNS BEFORE `drain_wait`, AND THE ORDER IS LOAD-BEARING.
+  #
+  # `drain_wait` is not a passive observer: on timeout it marks every
+  # still-queued or still-running row `dead` with its own `lastError`
+  # (lib.sh). Running it first would make a job the HARNESS killed
+  # indistinguishable from one the system dead-lettered - and a fault window
+  # is exactly the window where leftover rows are the finding. It would also
+  # make the recovery loop that followed it read zero still-in-flight jobs and
+  # report a clean recovery that never happened.
+  #
+  # So: observe recovery, read the settled ledger, and only then let
+  # `drain_wait` clean up for the next window. Its answer is still recorded.
+  local recovered_at="" still
   waited=0
   while [ "$waited" -lt "$RECOVERY_WAIT_SECS" ]; do
-    sleep 15; waited=$((waited + 15))
-    local still
     still="$(pg_sql "SELECT COUNT(*) FROM sync_jobs WHERE \"connectionId\" IN ($CONN_IDS) AND status IN ('queued','running') AND \"createdAt\">='$ws_iso'" 2>/dev/null || printf 0)"
-    log "    recovery t+${waited}s: ${still} job(s) from this window still queued/running"
-    [ "${still:-0}" -gt 0 ] || break
+    log "    recovery t+${waited}s: ${still:-?} job(s) from this window still queued/running"
+    if [ "${still:-1}" -eq 0 ]; then recovered_at="$waited"; break; fi
+    sleep 15; waited=$((waited + 15))
   done
 
-  # (c) the settled state
+  # (c) the settled state, read BEFORE any harness cleanup touches a row.
   read_ledger "$dir" "$ws_iso" "$ps_order_before" "$ps_cart_before" "$load"
   mv "$dir/ledger.json" "$dir/ledger-after-recovery.json"
+
+  local drain_result
+  drain_result="$(drain_wait "$CONN_IDS" || true)"
+  log "  drain_wait (cleanup for the next window, AFTER the ledger was read): $drain_result"
+
   jq -n --arg d "$drain_result" --argjson w "$waited" \
-    '{drainResult:$d, recoveryWaitedSecs:$w}' > "$dir/recovery.json"
+    --arg r "${recovered_at:-never}" --argjson still "${still:-0}" \
+    --arg killed "${DRAIN_DEAD_IDS:-}" \
+    '{
+       recoveredWithoutAHumanAfterSecs: (if $r == "never" then null else ($r|tonumber) end),
+       recoveryObservedForSecs: $w,
+       jobsStillInFlightWhenObservationEnded: $still,
+       drainResult: $d,
+       rowsTheHARNESSMarkedDeadDuringCleanup: $killed,
+       note: "recoveredWithoutAHumanAfterSecs is null when this window still had queued/running jobs when the observation window ended - that is NOT a claim that recovery never happens, only that it had not happened within recoveryObservedForSecs. rowsTheHARNESSMarkedDeadDuringCleanup names rows drain_wait killed AFTER the ledger above was read, so they are absent from it."
+     }' > "$dir/recovery.json"
 
   run_f10_guards "$dir" "$ws_iso" "$WINDOW_START_EPOCH" "$WINDOW_STOP_EPOCH" "$id" "$backlog_at_stop"
   log "  verdict: $(verdict_read "$dir" 2>/dev/null | head -1 || true)"
@@ -1055,6 +1145,14 @@ printf '%s' "$PROXY_TEST" | jq -e '.success == true' >/dev/null \
 # The quantity arm's targets, materialised BEFORE any loop that runs
 # `docker exec` - see enqueue_quantity_jobs for why.
 QUANTITY_OFFER_IDS="$(resolve_quantity_offer_ids)"
+[ -n "$QUANTITY_OFFER_IDS" ] || warn "no seeded Offer mappings on $SOURCE_CONNECTION_ID - the M3 quantity arm will enqueue nothing and must be recorded as NOT EXERCISED"
+
+# Minted in THIS shell, not lazily inside `enqueue_perf_job`'s first call: that
+# call happens inside a command substitution for the quantity arm, and a
+# variable assigned in a subshell does not survive it - so the cap would then
+# read an unset path and silently cap nothing.
+PERF_ENQUEUED_KEYS_FILE="$(mktemp)"
+export PERF_ENQUEUED_KEYS_FILE
 
 for f in $FAULTS; do
   run_fault "$f"

--- a/perf/openlinker-throughput/scenarios/f10-dependency-failure.sh
+++ b/perf/openlinker-throughput/scenarios/f10-dependency-failure.sh
@@ -426,7 +426,25 @@ f10_on_exit() {
 
   if [ "$CONNECTION_TOUCHED" = "1" ]; then
     restore_curl PATCH "/v1/connections/$PS_CONNECTION_ID" "$(jq -n --argjson c "$ORIGINAL_PS_CONFIG" '{config:$c}')"
-    log "  perf-prestashop config restored to baseUrl=$ORIGINAL_PS_BASE_URL"
+    # READ IT BACK. This line used to log "restored" unconditionally, and on
+    # the one run where it mattered it said so while restoring nothing: the
+    # API had exited (the I2 window's Redis outage killed it), `restore_curl`
+    # returned early with no token, and the stand was left with
+    # `config.baseUrl` pointing at a proxy container that had just been
+    # removed - every PrestaShop call on the stand would have failed, for the
+    # next scenario as much as for this one. A cleanup that reports success it
+    # did not achieve is worse than one that fails loudly.
+    local now_url
+    now_url="$(curl -sS "$OL_API_URL/v1/connections/$PS_CONNECTION_ID" \
+      -H "Authorization: Bearer ${RESTORE_TOKEN:-}" 2>/dev/null | jq -r '.config.baseUrl // empty' 2>/dev/null || printf '')"
+    if [ "$now_url" = "$ORIGINAL_PS_BASE_URL" ]; then
+      log "  perf-prestashop config restored and VERIFIED (baseUrl=$now_url)"
+    else
+      warn "  perf-prestashop was NOT restored - it reads [${now_url:-<unreadable>}], expected [$ORIGINAL_PS_BASE_URL].
+  THE STAND IS LEFT BROKEN FOR THE NEXT SCENARIO. Restore by hand:
+    curl -X PATCH $OL_API_URL/v1/connections/$PS_CONNECTION_ID \\
+      -H 'Content-Type: application/json' -d '{\"config\":$ORIGINAL_PS_CONFIG}'"
+    fi
   fi
 
   if [ "$WC_TOUCHED" = "1" ]; then
@@ -807,12 +825,34 @@ restore_infrastructure() {
         sleep 1; waited=$((waited + 1))
       done
       log "  redis answered PING after ${waited}s"
+      # THE LOCK IS RE-ESTABLISHED, AND A RIVAL HOLDER IS FATAL.
+      #
+      # Stopping Redis can destroy the lock this run holds, and the window in
+      # which it is gone is a window a peer can claim the stand in. Three
+      # cases, and only the first two are survivable:
+      #   gone            -> re-take it and carry on
+      #   still ours      -> nothing to do (RDB persistence restored it)
+      #   held by someone -> ABORT. Every later window would be measuring a
+      #                      stand somebody else is also driving, and the
+      #                      whole point of the lock is that this never
+      #                      silently happens. The previous version tested
+      #                      only for "gone", so a rival holder was passed
+      #                      over in silence.
       local holder
       holder="$(redis_cli GET "$STAND_LOCK_KEY" 2>/dev/null || printf '')"
-      if [ -z "$holder" ]; then
-        warn "  the stand lock did not survive the redis restart - re-taking it"
-        redis_cli SET "$STAND_LOCK_KEY" "f10-dependency-failure:pid$$@$(hostname):$(iso_now)" NX EX "$STAND_LOCK_TTL_SECS" >/dev/null 2>&1 || true
-      fi
+      case "$holder" in
+        "")
+          warn "  the stand lock did not survive the redis restart - re-taking it"
+          redis_cli SET "$STAND_LOCK_KEY" "f10-dependency-failure:pid$$@$(hostname):$(iso_now)" NX EX "$STAND_LOCK_TTL_SECS" >/dev/null 2>&1 || true
+          ;;
+        *":pid$$@"*)
+          log "  the stand lock survived the redis restart and is still ours"
+          ;;
+        *)
+          die "restore_infrastructure: the stand lock is now held by [$holder] - it was lost when redis stopped and a peer claimed it.
+  Every remaining window would measure a stand two scenarios are driving. Stopping here."
+          ;;
+      esac
       ;;
     I3)
       local w
@@ -915,7 +955,7 @@ read_ledger() {
              COUNT(*)::int AS n,
              SUM(attempts)::int AS attempts_total,
              MAX(attempts)::int AS attempts_max,
-             -- A `dead` row the HARNESS produced must never read as one the
+             -- A dead row the HARNESS produced must never read as one the
              -- system dead-lettered. drain_wait stamps its own lastError when
              -- it times out; the ledger below is read before that runs, so
              -- this should be 0 everywhere - it is carried so that if the

--- a/perf/openlinker-throughput/scenarios/f10-dependency-failure.sh
+++ b/perf/openlinker-throughput/scenarios/f10-dependency-failure.sh
@@ -78,18 +78,22 @@
 #   post_guard_generator_saturated   there is no k6 generator on this path.
 #                                    The same is true of F2, which is why the
 #                                    argument is optional in the first place.
-#   post_guard_feed_starved          it takes a min-available-work series this
-#                                    scenario does not sample. The property it
-#                                    protects is checked directly instead: the
-#                                    upstream backlog is read at window stop
-#                                    and recorded per window, and a window
-#                                    that ended with a drained feed is flagged
-#                                    in fault-observations.txt. At the offered
-#                                    load here (a 120-order backlog against a
-#                                    baseline that clears roughly five orders
-#                                    in a 90s window) the feed cannot run dry,
-#                                    but that is asserted from a reading, not
-#                                    from the arithmetic.
+#   post_guard_feed_starved          it protects a SATURATION measurement -
+#                                    it asks whether a standing supply ever
+#                                    ran dry, because a throughput figure
+#                                    taken while the generator was empty
+#                                    measures the generator. F10 offers a
+#                                    FIXED BATCH on purpose, so a drained feed
+#                                    is the expected end state and that guard
+#                                    would flag every window for doing what it
+#                                    was told. The property that DOES matter
+#                                    here is checked instead, and it is a
+#                                    different one: did every order pushed at
+#                                    the stub become a child job? If not, every
+#                                    per-order figure in the window is against
+#                                    the wrong denominator. See the
+#                                    offered_work observation in
+#                                    run_f10_guards.
 #
 # The two stand guards keep their full force, and they are the ones that
 # matter for trusting a window at all: `post_guard_containers_stable` (a peer
@@ -169,10 +173,29 @@ SOURCE_TENANT="${SOURCE_TENANT:-perf-allegro-a}"
 FAULT_WINDOW_SECS="${FAULT_WINDOW_SECS:-90}"
 POLL_CADENCE_SECS="${POLL_CADENCE_SECS:-10}"
 
-# Enough backlog that the feed cannot run dry inside a window at any rate this
-# scenario reaches. Pushed once, before the window, so the pusher is never the
-# bottleneck.
-WINDOW_BACKLOG="${WINDOW_BACKLOG:-120}"
+# THIS SCENARIO OFFERS A FIXED BATCH, NOT A STANDING SUPPLY, AND THE SIZE IS
+# CHOSEN AGAINST THE RECOVERY QUESTION RATHER THAN AGAINST SATURATION.
+#
+# The first calibration run used 120, on the saturation reasoning every other
+# scenario in this campaign uses: offer more than the window can consume so the
+# feed can never run dry. That is the right rule for a throughput measurement
+# and the wrong one here. This stand's measured baseline is ~207 orders/h -
+# roughly five orders in a 90 s window - so a batch of 120 leaves ~115 children
+# queued when the window closes, and NO window can then observe its own
+# recovery: every one reports "still not drained" whether the system healed or
+# not. The single most important question after "was the order lost" would have
+# been unanswerable in all thirteen windows.
+#
+# A batch is sized instead so that a HEALTHY window finishes inside the window
+# plus the recovery observation, which is what makes "did it recover on its
+# own, and how late" a readable number. 12 orders against ~3.3 orders/min over
+# 90 s + 240 s is comfortable at baseline and merely late under a fault - and
+# late is exactly the answer this run wants to be able to give.
+#
+# It is still far more than enough fault deliveries: the baseline window
+# measured ~11 PrestaShop requests per order, so 12 orders is ~130 requests and
+# a fraction of 0.3 delivers ~40 faults.
+WINDOW_BACKLOG="${WINDOW_BACKLOG:-12}"
 
 # The retry ladder is capped so a window's cost is bounded and comparable
 # across faults. `enqueue_perf_job` + `cap_perf_job_attempts` apply it. THIS
@@ -193,7 +216,7 @@ export DRAIN_MAX_WAIT_SECS
 # After the fault is cleared, how long to give the system to finish the work
 # it was struggling with. This is the "does recovery happen without a human,
 # and how late" measurement.
-RECOVERY_WAIT_SECS="${RECOVERY_WAIT_SECS:-180}"
+RECOVERY_WAIT_SECS="${RECOVERY_WAIT_SECS:-240}"
 
 # Thirteen windows in one lock hold. The library default TTL (3600s) is a
 # CRASH bound, not a run bound - it is the longest a dead holder can block the
@@ -911,8 +934,12 @@ read_ledger() {
 
   if [ "$load" = "order" ]; then
     # 2. order_records created in the window.
+    # `SUM(c)`, not `COUNT(*)`. The first calibration run had `COUNT(*)` here,
+    # which counts the rows of the SUBQUERY - the number of distinct
+    # recordStatus values - and duly reported `created: 1` beside four orders
+    # claimed synced.
     orders_json="$(pg_sql "SELECT jsonb_build_object(
-        'created', COUNT(*)::int,
+        'created', COALESCE(SUM(c),0)::int,
         'recordStatus', COALESCE(jsonb_object_agg(rs, c) FILTER (WHERE rs IS NOT NULL), '{}'::jsonb))
       FROM (SELECT \"recordStatus\" AS rs, COUNT(*)::int AS c
             FROM order_records
@@ -997,7 +1024,7 @@ read_ledger() {
 # is not used wholesale.
 # ===========================================================================
 run_f10_guards() {
-  local dir="$1" ws_iso="$2" ws_epoch="$3" we_epoch="$4" fault_id="$5" backlog_at_stop="$6"
+  local dir="$1" ws_iso="$2" ws_epoch="$3" we_epoch="$4" fault_id="$5" load="$6"
   local stand_reasons=() observations=() answer
 
   # --- STAND guards: these still discard --------------------------------
@@ -1021,16 +1048,38 @@ run_f10_guards() {
   observations+=("$(post_guard_destination_creates "$ws_iso" "$PS_CONNECTION_ID")")
   observations+=("$(post_guard_limiter_degraded "$ws_epoch" "$we_epoch")")
 
-  # The feed-starvation property, checked from a reading rather than from the
-  # arithmetic (see the header for why post_guard_feed_starved itself is not
-  # used). `unknown` is NOT read around: an unreadable upstream means the
-  # window cannot show it kept offering load, which is the whole point of the
-  # guard this replaces.
-  case "$backlog_at_stop" in
-    unknown) observations+=("UNKNOWN feed_backlog_at_stop: the upstream backlog could not be read - this window cannot show it kept offering load") ;;
-    0)       observations+=("STARVED feed_backlog_at_stop=0: the feed was drained at window stop, so the offered load was bounded by supply and not by the fault") ;;
-    *)       observations+=("ok feed_backlog_at_stop=$backlog_at_stop (the feed never ran dry)") ;;
-  esac
+  # WAS THE INTENDED LOAD ACTUALLY OFFERED?
+  #
+  # This replaces `post_guard_feed_starved`, and it is a different question
+  # rather than a cheaper version of the same one. That guard protects a
+  # SATURATION measurement: it asks whether a standing supply ever ran dry,
+  # because a throughput figure taken while the generator was empty measures
+  # the generator. F10 offers a FIXED BATCH on purpose (see WINDOW_BACKLOG), so
+  # the upstream feed draining is the expected and desired end state - the
+  # first calibration run's check would have flagged STARVED on every window
+  # for doing exactly what it was told to do.
+  #
+  # What has to be true here instead is that every order pushed at the stub
+  # became a child job. If it did not, the window offered less work than it
+  # claims and every count below is against the wrong denominator.
+  if [ "$load" = "order" ]; then
+    local children
+    children="$(pg_sql "SELECT COUNT(*) FROM sync_jobs
+      WHERE \"jobType\" IN ('marketplace.order.sync')
+        AND \"connectionId\" IN ($CONN_IDS) AND \"createdAt\" >= '$ws_iso'" 2>/dev/null || printf 'unknown')"
+    case "$children" in
+      unknown) observations+=("UNKNOWN offered_work: the child-job count could not be read, so this window cannot show the intended load was offered") ;;
+      *)
+        if [ "${children:-0}" -lt "$WINDOW_BACKLOG" ]; then
+          observations+=("UNDER-OFFERED offered_work: $children of $WINDOW_BACKLOG pushed order(s) became a marketplace.order.sync child - every per-order figure in this window is against a smaller denominator than the manifest's offeredBacklog")
+        else
+          observations+=("ok offered_work: $children child job(s) for $WINDOW_BACKLOG pushed order(s) - the intended load reached the queue")
+        fi
+        ;;
+    esac
+  else
+    observations+=("n/a offered_work: the quantity-write path enqueues its jobs directly and pushes nothing at the stub")
+  fi
 
   printf '%s\n' "${observations[@]}" > "$dir/fault-observations.txt"
   log "  fault observations:"
@@ -1123,14 +1172,6 @@ run_fault() {
   stop_order_pump
   stop_midwindow_action
 
-  # Read BEFORE window_stop's own bookkeeping, while the window's own state is
-  # still what the fault produced. On the quantity path there is no feed, so
-  # the reading is `n/a` rather than a fabricated number.
-  local backlog_at_stop='n/a'
-  if [ "$load" = "order" ]; then
-    backlog_at_stop="$(of_backlog "$SOURCE_TENANT" "$SOURCE_CONNECTION_ID" 2>/dev/null || printf 'unknown')"
-  fi
-
   window_stop "$dir"
 
   # The delivered fault count, read back from the injector. A rule that
@@ -1200,7 +1241,7 @@ run_fault() {
        note: "recoveredWithoutAHumanAfterSecs is null when this window still had queued/running jobs when the observation window ended - that is NOT a claim that recovery never happens, only that it had not happened within recoveryObservedForSecs. rowsTheHARNESSMarkedDeadDuringCleanup names rows drain_wait killed AFTER the ledger above was read, so they are absent from it."
      }' > "$dir/recovery.json"
 
-  run_f10_guards "$dir" "$ws_iso" "$WINDOW_START_EPOCH" "$WINDOW_STOP_EPOCH" "$id" "$backlog_at_stop"
+  run_f10_guards "$dir" "$ws_iso" "$WINDOW_START_EPOCH" "$WINDOW_STOP_EPOCH" "$id" "$load"
   log "  verdict: $(verdict_read "$dir" 2>/dev/null | head -1 || true)"
 }
 

--- a/perf/openlinker-throughput/scenarios/f10-dependency-failure.sh
+++ b/perf/openlinker-throughput/scenarios/f10-dependency-failure.sh
@@ -1,0 +1,1083 @@
+#!/usr/bin/env bash
+#
+# F10 - behaviour under dependency failure (#2978, epic #2840).
+#
+# Every other flow in this campaign ran against a stand where nothing ever
+# failed: PrestaShop answered every call, the Allegro stub answered every
+# call, Redis stayed up, the worker stayed up. This scenario is the one that
+# breaks things on purpose and reads what OpenLinker did about it.
+#
+# ---------------------------------------------------------------------------
+# THE QUESTION, AND WHY IT IS NOT A THROUGHPUT QUESTION
+# ---------------------------------------------------------------------------
+# For each injected fault, exactly one thing has to be established and it is
+# not a rate:
+#
+#     is the order LOST, RETRIED, or SILENTLY MARKED DONE?
+#
+# The third is the finding. This campaign has already met it twice, both
+# times by accident: the Allegro stub's digit-bearing buyer names, which
+# PrestaShop's Validate::isName rejected on every order while the job still
+# recorded outcome='ok' because Promise.allSettled swallowed it; and
+# MarketplaceOfferQuantityUpdateHandler dropping the original exception's
+# statusCode, so a deterministic 404 walks the full ten-attempt ladder. There
+# is no reason to think those are the only two, and looking for them by
+# accident a third time is not a method.
+#
+# So the windows here are short and the offered load is modest. The numbers
+# that matter are counts of rows in four ledgers, not orders per hour.
+#
+# ---------------------------------------------------------------------------
+# GROUND TRUTH IS THE SHOP, NOT OPENLINKER
+# ---------------------------------------------------------------------------
+# "Silently marked done" cannot be established from OpenLinker's own tables,
+# because a system that believes it succeeded says so consistently everywhere
+# it writes. The only witness that is not the accused is PrestaShop's own
+# database:
+#
+#   sync_jobs             what the job says happened
+#   order_records         what the order snapshot says happened
+#   syncStatus[]          what the destination fan-out says happened, and
+#                         the destination-native order id it CLAIMS to have
+#                         created
+#   ps_orders / ps_cart   whether that order actually exists
+#
+# The sharp test is the last two read together: for every syncStatus entry
+# with status='synced', does its externalOrderId name a row in ps_orders? A
+# claimed id with no row behind it is a success report over a failure, and it
+# is stated as a count rather than inferred from a rate that looks low.
+#
+# ---------------------------------------------------------------------------
+# WHY THE STANDARD POST-GUARD SET IS NOT USED WHOLESALE
+# ---------------------------------------------------------------------------
+# `run_post_guards` is right for every other scenario and wrong for this one,
+# because three of its members are INVERTED here:
+#
+#   post_guard_destination_creates   a failed syncStatus entry is the
+#                                    measurement, not a contaminant. Under a
+#                                    destination fault, zero of them would
+#                                    mean the fault never reached the
+#                                    destination path and the window is
+#                                    worthless.
+#   post_guard_attempts              attempts>1 is the RETRY COST this issue
+#                                    asks for ("a deterministic 404 burning
+#                                    ten attempts is measurable waste").
+#   post_guard_deferrals             a 429 carrying Retry-After is SUPPOSED
+#                                    to produce a penalty-free deferral.
+#
+# Skipping them silently would be the campaign sin. Instead every guard is
+# run individually by `run_f10_guards` and its answer is routed to one of two
+# places: a STAND guard still discards the window, and a FAULT guard's answer
+# is written to fault-observations.txt as a measurement. Both sets are
+# printed. Nothing is dropped.
+#
+# Of `run_post_guards`'s eight members, six run here - four as STAND or FAULT
+# guards above plus `post_guard_limiter_degraded`. The two that do not run,
+# and why, stated rather than left as an absence:
+#
+#   post_guard_generator_saturated   there is no k6 generator on this path.
+#                                    The same is true of F2, which is why the
+#                                    argument is optional in the first place.
+#   post_guard_feed_starved          it takes a min-available-work series this
+#                                    scenario does not sample. The property it
+#                                    protects is checked directly instead: the
+#                                    upstream backlog is read at window stop
+#                                    and recorded per window, and a window
+#                                    that ended with a drained feed is flagged
+#                                    in fault-observations.txt. At the offered
+#                                    load here (a 120-order backlog against a
+#                                    baseline that clears roughly five orders
+#                                    in a 90s window) the feed cannot run dry,
+#                                    but that is asserted from a reading, not
+#                                    from the arithmetic.
+#
+# The two stand guards keep their full force, and they are the ones that
+# matter for trusting a window at all: `post_guard_containers_stable` (a peer
+# recreated a container underneath the window) and `post_guard_requeues` (the
+# stuck-job recovery pass moved rows we are about to count). Note the ONE
+# deliberate exception: the I3 window kills the worker itself, so a container
+# restart there is the injected fault and is declared as such in the manifest
+# rather than discarding the window.
+#
+# ---------------------------------------------------------------------------
+# EVERY FAULT IS DECLARED, AND ITS DELIVERY IS COUNTED
+# ---------------------------------------------------------------------------
+# #2978's first acceptance criterion. `manifest.json` carries a
+# `faultInjection` object for every window, baseline included - the baseline's
+# says `injected: false`, so "no fault" is a positive statement rather than an
+# absent key. A reader six weeks from now can tell an injected 500 from a real
+# one without reading this file.
+#
+# The rule as INSTALLED is read back from the injector rather than echoed from
+# what this script asked for, and the DELIVERED fault count is read back after
+# the window. Both matter: a fractional rule's delivered count is not its
+# requested fraction, and a rule that installed but never matched would
+# otherwise look identical to a system that shrugged off the fault.
+#
+# ---------------------------------------------------------------------------
+# THE TWO INJECTORS
+# ---------------------------------------------------------------------------
+#   ps-fault-proxy   a transparent reverse proxy in front of the REAL local
+#                    PrestaShop, started by this script as a plain
+#                    `docker run` on the lab network and torn down on exit.
+#                    Nothing in docker-compose.lab.yml changes and no existing
+#                    container is recreated, so `post_guard_containers_stable`
+#                    still means what it means everywhere else. The
+#                    `perf-prestashop` connection's `config.baseUrl` is
+#                    PATCHed to point at it and PATCHed back on exit; a fresh
+#                    adapter is built per capability resolution
+#                    (`integrations.service.ts`), so that takes effect on the
+#                    next job with no restart.
+#   allegro-stub     already on the stand. #2978 extended its fault surface
+#                    with per-endpoint targeting, a fraction and three new
+#                    modes; see stubs/allegro/server.mjs applyFault.
+#
+# Infrastructure faults use neither - Redis is paused with CLIENT PAUSE
+# (DEBUG SLEEP is disabled on Redis 7+ by default, verified on this stand) and
+# stopped with `docker stop`; the worker is killed with SIGKILL and started
+# again.
+#
+# ---------------------------------------------------------------------------
+# WHAT THIS SCENARIO DOES NOT DO
+# ---------------------------------------------------------------------------
+# It does not fix anything it finds. A fix landing in the window that scores
+# it is how a campaign stops being believable (#2977 §2). Findings are
+# reported with a reproduction and nothing else.
+#
+# Sources lib.sh (#2841) and drivers/order-feed.sh (#2847).
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+LIB_LOG_PREFIX="f10"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/../lib.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/../drivers/order-feed.sh"
+
+ENV_FILE="${ENV_FILE:-$REPO_ROOT/.env.lab}"
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+SOURCE_TENANT="${SOURCE_TENANT:-perf-allegro-a}"
+
+# Short by design - see the header. A fault window has to be long enough for
+# the fault to be delivered many times and for the retry ladder to take at
+# least one visible step, and no longer.
+FAULT_WINDOW_SECS="${FAULT_WINDOW_SECS:-90}"
+POLL_CADENCE_SECS="${POLL_CADENCE_SECS:-10}"
+
+# Enough backlog that the feed cannot run dry inside a window at any rate this
+# scenario reaches. Pushed once, before the window, so the pusher is never the
+# bottleneck.
+WINDOW_BACKLOG="${WINDOW_BACKLOG:-120}"
+
+# The retry ladder is capped so a window's cost is bounded and comparable
+# across faults. `enqueue_perf_job` + `cap_perf_job_attempts` apply it. THIS
+# IS A MEASUREMENT INPUT, not a detail: the "ten attempts on a deterministic
+# failure" cost #2978 asks about is reported as observed-attempts against
+# THIS cap, and extrapolated to the shipped 10 explicitly rather than
+# silently.
+PERF_MAX_ATTEMPTS="${PERF_MAX_ATTEMPTS:-3}"
+export PERF_MAX_ATTEMPTS
+
+# How long to wait for the queue to settle after a window before reading the
+# ledger. Bounded: a fault window legitimately leaves rows behind (that IS the
+# finding), so a drain that runs to its timeout is an expected outcome here
+# rather than an error, and its result is recorded per window.
+DRAIN_MAX_WAIT_SECS="${DRAIN_MAX_WAIT_SECS:-180}"
+export DRAIN_MAX_WAIT_SECS
+
+# After the fault is cleared, how long to give the system to finish the work
+# it was struggling with. This is the "does recovery happen without a human,
+# and how late" measurement.
+RECOVERY_WAIT_SECS="${RECOVERY_WAIT_SECS:-180}"
+
+PROXY_CONTAINER="${PROXY_CONTAINER:-lab-ps-fault-proxy}"
+PROXY_IMAGE="${PROXY_IMAGE:-ol-perf:ps-fault-proxy}"
+PROXY_NETWORK="${PROXY_NETWORK:-lab_default}"
+PROXY_SERVICE_HOST="${PROXY_SERVICE_HOST:-ps-fault-proxy}"
+PROXY_HOST_PORT="${PROXY_HOST_PORT:-19083}"
+PROXY_URL="http://127.0.0.1:$PROXY_HOST_PORT"
+
+# The offer the M3 quantity-write arm targets. A seeded mapping on
+# perf-allegro-a (bootstrap.sh's ALLEGRO_OFFER_POOL_SIZE pool); resolved live
+# rather than hardcoded, because the internal id is a bootstrap artefact.
+QUANTITY_JOBS="${QUANTITY_JOBS:-12}"
+
+# ---------------------------------------------------------------------------
+# The fault catalogue. One row per #2978 fault class.
+#
+# Format: id|class|injector|description
+# The rule itself lives in `install_fault`, which is the single place a rule
+# is built - so what the manifest records and what the injector was told
+# cannot come from two different expressions.
+# ---------------------------------------------------------------------------
+ALL_FAULTS="baseline D1 D2a D2b D3 D4 M1 M2 M2t M3 I1 I2 I3"
+
+fault_class() {
+  case "$1" in
+    baseline) printf 'none (reference window - the proxy is in the path and transparent)' ;;
+    D1)  printf 'destination: PrestaShop returns 500 on a fraction of calls' ;;
+    D2a) printf 'destination: PrestaShop returns 429 WITH Retry-After' ;;
+    D2b) printf 'destination: PrestaShop returns 429 WITHOUT Retry-After' ;;
+    D3)  printf 'destination: PrestaShop stops responding mid-order (connection held open past the client timeout)' ;;
+    D4)  printf 'destination: partial create - the cart succeeds and importorder fails' ;;
+    M1)  printf 'marketplace: the source times out during hydration' ;;
+    M2)  printf 'marketplace: the source returns a malformed payload' ;;
+    M2t) printf 'marketplace: the source returns a truncated payload' ;;
+    M3)  printf 'marketplace: the source rejects the offer-quantity write' ;;
+    I1)  printf 'infrastructure: Redis becomes slow (a blocked client, not an outage)' ;;
+    I2)  printf 'infrastructure: Redis drops entirely mid-window' ;;
+    I3)  printf 'infrastructure: the worker is killed mid-job' ;;
+    *)   printf 'unknown' ;;
+  esac
+}
+
+fault_load() {
+  # Which load path a fault is exercised under. Only M3 uses the quantity
+  # write; everything else uses order ingestion, which is the only path that
+  # touches both a source and a destination.
+  case "$1" in
+    M3) printf 'quantity' ;;
+    *)  printf 'order' ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+FAULTS="$ALL_FAULTS"
+MODE="strict"
+for arg in "$@"; do
+  case "$arg" in
+    --smoke) MODE="smoke" ;;
+    --list)
+      for f in $ALL_FAULTS; do printf '%-8s %s\n' "$f" "$(fault_class "$f")"; done
+      exit 0
+      ;;
+    --faults=*) FAULTS="${arg#--faults=}"; FAULTS="${FAULTS//,/ }" ;;
+    -h|--help)
+      cat <<'USAGE'
+Usage: f10-dependency-failure.sh [--faults=ID[,ID...]] [--smoke] [--list]
+
+  (no flag)      every fault in the catalogue, in order, each in its own
+                 declared window, with a dated report under results/.
+  --faults=D1,M1 only these faults (the baseline is NOT added implicitly -
+                 name it if you want it).
+  --list         print the catalogue and exit.
+  --smoke        bring the proxy up, prove it is transparent against the real
+                 PrestaShop, install and clear one rule of every mode, tear
+                 everything down. No window, no manifest, nothing written
+                 under results/. Takes the stand lock, because it repoints a
+                 shared connection.
+
+Every knob is an env var - see the Configuration block at the top of this file.
+USAGE
+      exit 0
+      ;;
+    *) die "unknown argument: $arg (use --faults=..., --smoke, --list, --help, or nothing)" ;;
+  esac
+done
+
+require_tools docker jq curl python3
+
+[ -n "${ALLEGRO_A_CONNECTION_ID:-}" ] || die "ALLEGRO_A_CONNECTION_ID is not set - source stand-ids.env (bootstrap.sh) or export it by hand"
+[ -n "${PS_CONNECTION_ID:-}" ] || die "PS_CONNECTION_ID is not set - source stand-ids.env"
+[ -n "${WC_CONNECTION_ID:-}" ] || die "WC_CONNECTION_ID is not set - source stand-ids.env"
+SOURCE_CONNECTION_ID="${SOURCE_CONNECTION_ID:-$ALLEGRO_A_CONNECTION_ID}"
+CONN_IDS="'$SOURCE_CONNECTION_ID'"
+
+for f in $FAULTS; do
+  case " $ALL_FAULTS " in
+    *" $f "*) ;;
+    *) die "unknown fault id '$f' - run --list for the catalogue" ;;
+  esac
+done
+
+# Claimed before ANY side effect. This scenario repoints a shared connection,
+# starts a container on the shared network, pauses the shared Redis and kills
+# the shared worker - every one of which would silently invalidate a peer's
+# window (#2842/#2848).
+guard_stand_exclusive "f10-dependency-failure"
+
+ol_login
+
+# ===========================================================================
+# Posture captured for restore, and the SINGLE EXIT trap
+#
+# bash's EXIT trap is one slot, so a second `trap ... EXIT` REPLACES
+# guard_stand_exclusive's own release and leaves the stand locked for the full
+# TTL after any `die` (F7 found that the hard way; F1 records the fix).
+# Everything this scenario changes is undone from this one function.
+# ===========================================================================
+connection_json() { ol_api GET "/v1/connections/$1"; }
+
+ORIGINAL_PS_CONFIG="$(connection_json "$PS_CONNECTION_ID" | jq -c '.config // {}')"
+ORIGINAL_PS_BASE_URL="$(printf '%s' "$ORIGINAL_PS_CONFIG" | jq -r '.baseUrl // empty')"
+[ -n "$ORIGINAL_PS_BASE_URL" ] || die "perf-prestashop carries no config.baseUrl - nothing to repoint, and nothing to restore"
+ORIGINAL_ALLEGRO_CAPS="$(connection_json "$SOURCE_CONNECTION_ID" | jq -c '.enabledCapabilities // []')"
+log "posture at start: perf-prestashop baseUrl=$ORIGINAL_PS_BASE_URL"
+log "                  perf-allegro-a caps=$ORIGINAL_ALLEGRO_CAPS"
+
+# A restore that CANNOT abort itself. Every lib.sh helper reaches `die` on
+# failure and `die` calls `exit`; inside an EXIT trap that skips every later
+# line, which here would be `release_stand_exclusive`. So the cleanup path
+# uses raw curl and every call ends in `|| true`.
+restore_curl() {
+  local method="$1" path="$2" body="${3:-}"
+  [ -n "${RESTORE_TOKEN:-}" ] || return 0
+  curl -sS -o /dev/null -X "$method" "$OL_API_URL$path" \
+    -H "Authorization: Bearer $RESTORE_TOKEN" -H 'Content-Type: application/json' \
+    ${body:+-d "$body"} 2>/dev/null || true
+}
+
+# A run that changed nothing must restore nothing - a refused run's own
+# cleanup path must never recreate or repoint anything underneath the peer
+# that legitimately holds the stand (the F1 lesson).
+CONNECTION_TOUCHED=0
+PROXY_STARTED=0
+
+f10_on_exit() {
+  local rc=$?
+  # Clear injector state first: it is cheap, idempotent, and leaving a fault
+  # armed on a shared stub is the single worst thing this script could leave
+  # behind - a peer's next window would measure OUR fault as their result.
+  clear_all_faults || true
+
+  if [ "$CONNECTION_TOUCHED" = "0" ] && [ "$PROXY_STARTED" = "0" ]; then
+    log "nothing was changed on the stand - no restore needed"
+    release_stand_exclusive
+    return $rc
+  fi
+
+  log "restoring stand posture"
+  RESTORE_TOKEN="$(curl -sS -X POST "$OL_API_URL/v1/auth/login" -H 'Content-Type: application/json' \
+    -d "{\"username\":\"$OL_ADMIN_USER\",\"password\":\"$OL_ADMIN_PASSWORD\"}" 2>/dev/null \
+    | jq -r '.access_token // .accessToken // empty' 2>/dev/null || printf '')"
+  [ -n "$RESTORE_TOKEN" ] || warn "could not log in to restore perf-prestashop - its config.baseUrl is left pointing at the proxy. Restore by hand: PATCH /v1/connections/$PS_CONNECTION_ID with config=$ORIGINAL_PS_CONFIG"
+
+  if [ "$CONNECTION_TOUCHED" = "1" ]; then
+    restore_curl PATCH "/v1/connections/$PS_CONNECTION_ID" "$(jq -n --argjson c "$ORIGINAL_PS_CONFIG" '{config:$c}')"
+    log "  perf-prestashop config restored to baseUrl=$ORIGINAL_PS_BASE_URL"
+  fi
+
+  # The proxy container is removed LAST, after the connection has been
+  # repointed away from it - the other order leaves a window in which
+  # OpenLinker is pointed at a host that no longer resolves.
+  if [ "$PROXY_STARTED" = "1" ]; then
+    docker rm -f "$PROXY_CONTAINER" >/dev/null 2>&1 || true
+    log "  $PROXY_CONTAINER removed"
+  fi
+
+  # Redis and the worker are restored inside their own arms rather than here,
+  # because a window that stopped them must not run its ledger read against a
+  # stopped stand. This is the belt-and-braces pass for an abort mid-arm.
+  if [ "$(docker inspect -f '{{.State.Running}}' "$REDIS_CONTAINER" 2>/dev/null || printf true)" != "true" ]; then
+    warn "  $REDIS_CONTAINER is not running - starting it"
+    docker start "$REDIS_CONTAINER" >/dev/null 2>&1 || true
+  fi
+  local w
+  for w in $WORKER_CONTAINERS; do
+    if [ "$(docker inspect -f '{{.State.Running}}' "$w" 2>/dev/null || printf true)" != "true" ]; then
+      warn "  $w is not running - starting it"
+      docker start "$w" >/dev/null 2>&1 || true
+    fi
+  done
+
+  release_stand_exclusive
+  return $rc
+}
+trap 'f10_on_exit' EXIT
+
+# ===========================================================================
+# Injector control surfaces
+# ===========================================================================
+
+# --- the PrestaShop fault proxy -------------------------------------------
+pfp_curl() {
+  local method="$1" path="$2" body="${3:-}" resp status resp_body
+  if [ -n "$body" ]; then
+    resp="$(curl -sS -w '\n%{http_code}' -X "$method" "$PROXY_URL$path" \
+      -H 'Content-Type: application/json' -d "$body")"
+  else
+    resp="$(curl -sS -w '\n%{http_code}' -X "$method" "$PROXY_URL$path")"
+  fi
+  status="${resp##*$'\n'}"
+  resp_body="${resp%$'\n'*}"
+  if [ "$status" -lt 200 ] || [ "$status" -ge 300 ]; then
+    die "ps-fault-proxy $method $path -> HTTP $status: $resp_body"
+  fi
+  printf '%s' "$resp_body"
+}
+
+pfp_start() {
+  docker rm -f "$PROXY_CONTAINER" >/dev/null 2>&1 || true
+  docker image inspect "$PROXY_IMAGE" >/dev/null 2>&1 \
+    || die "image $PROXY_IMAGE does not exist - build it first:
+  cd $SCRIPT_DIR/../stubs/ps-fault-proxy && docker build -t $PROXY_IMAGE --build-arg PROXY_GIT_SHA=\$(git rev-parse HEAD) ."
+  docker run -d --name "$PROXY_CONTAINER" \
+    --network "$PROXY_NETWORK" --network-alias "$PROXY_SERVICE_HOST" \
+    -p "127.0.0.1:$PROXY_HOST_PORT:8080" \
+    -e PROXY_UPSTREAM_HOST=prestashop -e PROXY_UPSTREAM_PORT=80 \
+    -e PROXY_UPSTREAM_HOST_HEADER=prestashop \
+    "$PROXY_IMAGE" >/dev/null \
+    || die "could not start $PROXY_CONTAINER on network $PROXY_NETWORK"
+  PROXY_STARTED=1
+  local waited=0
+  while [ "$waited" -lt 30 ]; do
+    if curl -sSf "$PROXY_URL/__fault/health" >/dev/null 2>&1; then
+      log "$PROXY_CONTAINER up: $(pfp_curl GET /__fault/health | jq -c .)"
+      return 0
+    fi
+    sleep 1; waited=$((waited + 1))
+  done
+  die "$PROXY_CONTAINER did not answer /__fault/health within 30s
+$(docker logs "$PROXY_CONTAINER" 2>&1 | tail -20)"
+}
+
+pfp_rule_clear() { pfp_curl DELETE /__fault >/dev/null; }
+pfp_stats_reset() { pfp_curl POST /__fault/reset '{}' >/dev/null; }
+pfp_stats() { pfp_curl GET /__fault/stats; }
+
+# --- the Allegro stub ------------------------------------------------------
+stub_fault_set() { of_curl POST "/__stub/tenants/$SOURCE_TENANT/fault" "$1"; }
+stub_fault_clear() { of_curl DELETE "/__stub/tenants/$SOURCE_TENANT/fault" >/dev/null; }
+stub_stats() { of_curl GET "/__stub/tenants/$SOURCE_TENANT/stats"; }
+
+clear_all_faults() {
+  curl -sS -X DELETE "$PROXY_URL/__fault" >/dev/null 2>&1 || true
+  curl -sS -X DELETE "$OF_STUB_URL/__stub/tenants/$SOURCE_TENANT/fault" >/dev/null 2>&1 || true
+}
+
+# ===========================================================================
+# install_fault <id> - installs the rule and ECHOES the rule as the injector
+# stored it, as a JSON object. The single place a rule is expressed.
+#
+# The echoed value is read back from the injector, never echoed from what was
+# asked for: the two can differ (a default resolved at install time, a field
+# the injector normalised) and the manifest must record what is in force.
+# ===========================================================================
+install_fault() {
+  local id="$1"
+  case "$id" in
+    baseline)
+      jq -n '{injected:false, note:"no rule installed; the proxy is in the request path and transparent"}'
+      ;;
+    D1)
+      # A fraction rather than every call: a shop that 500s on everything is
+      # an outage, and an outage is a less interesting question than a shop
+      # that hiccups - the hiccup is what produces a PARTIALLY completed
+      # order, which is where a swallowed failure hides.
+      jq -n --argjson r "$(pfp_curl POST /__fault '{"mode":"500","fraction":0.3}')" \
+        '{injected:true, injector:"ps-fault-proxy", rule:$r.rule}'
+      ;;
+    D2a)
+      jq -n --argjson r "$(pfp_curl POST /__fault '{"mode":"429","fraction":0.5,"retryAfterSeconds":5}')" \
+        '{injected:true, injector:"ps-fault-proxy", rule:$r.rule}'
+      ;;
+    D2b)
+      # An explicit null, not an omitted field - the stored rule must say
+      # "send no Retry-After", which is a different measurement from the
+      # arm above and not merely an unset default.
+      jq -n --argjson r "$(pfp_curl POST /__fault '{"mode":"429","fraction":0.5,"retryAfterSeconds":null}')" \
+        '{injected:true, injector:"ps-fault-proxy", rule:$r.rule}'
+      ;;
+    D3)
+      # 45s exceeds the webservice client's own 30s per-attempt AbortController
+      # timeout (prestashop-webservice.client.ts) and stays under the module
+      # HMAC's +/-5 minute skew window, so a held request fails as a timeout
+      # rather than as a signature rejection.
+      jq -n --argjson r "$(pfp_curl POST /__fault '{"mode":"hang","fraction":0.3,"hangMs":45000}')" \
+        '{injected:true, injector:"ps-fault-proxy", rule:$r.rule}'
+      ;;
+    D4)
+      # The partial create. `controller=importorder` is the OL module's own
+      # front-controller path (prestashop-openlinker-module.client.ts's
+      # IMPORTORDER_PATH); every webservice call that builds the cart before
+      # it passes through untouched, and the proxy's per-bucket counters
+      # prove that rather than assuming it.
+      jq -n --argjson r "$(pfp_curl POST /__fault '{"mode":"500","fraction":1,"pathIncludes":"controller=importorder"}')" \
+        '{injected:true, injector:"ps-fault-proxy", rule:$r.rule}'
+      ;;
+    M1)
+      # `checkout` only. A tenant-wide timeout would stop the FEED being read
+      # too, so no order would ever be hydrated and the window would measure
+      # nothing about hydration at all.
+      jq -n --argjson r "$(stub_fault_set '{"mode":"timeout","endpoints":["checkout"],"holdMs":35000}')" \
+        '{injected:true, injector:"allegro-stub", rule:$r.fault}'
+      ;;
+    M2)
+      jq -n --argjson r "$(stub_fault_set '{"mode":"malformed","endpoints":["checkout"],"fraction":0.5}')" \
+        '{injected:true, injector:"allegro-stub", rule:$r.fault}'
+      ;;
+    M2t)
+      jq -n --argjson r "$(stub_fault_set '{"mode":"truncated","endpoints":["events"],"fraction":0.5}')" \
+        '{injected:true, injector:"allegro-stub", rule:$r.fault}'
+      ;;
+    M3)
+      jq -n --argjson r "$(stub_fault_set '{"mode":"reject-quantity","endpoints":["quantity"]}')" \
+        '{injected:true, injector:"allegro-stub", rule:$r.fault}'
+      ;;
+    I1)
+      # CLIENT PAUSE, not DEBUG SLEEP: DEBUG is disabled by default on Redis
+      # 7+ (verified refused on this stand). PAUSE stalls command processing
+      # for every client, which is the blocked-client shape #2975 found -
+      # the shared 'REDIS_CLIENT' occupied while the rate limiter waits on
+      # its own 1000ms budget - rather than a server that is merely slower.
+      jq -n --arg ms "$REDIS_PAUSE_MS" --arg every "$REDIS_PAUSE_EVERY_SECS" \
+        '{injected:true, injector:"redis:CLIENT PAUSE",
+          rule:{pauseMs:($ms|tonumber), everySecs:($every|tonumber), scope:"ALL"}}'
+      ;;
+    I2)
+      jq -n --arg at "$MIDWINDOW_AT_SECS" \
+        '{injected:true, injector:"docker stop/start",
+          rule:{target:"redis", atSecondsIntoWindow:($at|tonumber), action:"docker stop, then docker start"}}'
+      ;;
+    I3)
+      jq -n --arg at "$MIDWINDOW_AT_SECS" \
+        '{injected:true, injector:"docker kill -s KILL / docker start",
+          rule:{target:"worker", atSecondsIntoWindow:($at|tonumber), signal:"SIGKILL"}}'
+      ;;
+    *) die "install_fault: unknown fault id $id" ;;
+  esac
+}
+
+REDIS_PAUSE_MS="${REDIS_PAUSE_MS:-3000}"
+REDIS_PAUSE_EVERY_SECS="${REDIS_PAUSE_EVERY_SECS:-6}"
+MIDWINDOW_AT_SECS="${MIDWINDOW_AT_SECS:-35}"
+
+# ===========================================================================
+# The mid-window infrastructure actions. Each runs as a background job whose
+# pid is recorded, so a window can always stop it.
+# ===========================================================================
+MIDWINDOW_PID=""
+
+start_midwindow_action() {
+  local id="$1"
+  case "$id" in
+    I1)
+      ( while true; do
+          docker exec -i "$REDIS_CONTAINER" redis-cli CLIENT PAUSE "$REDIS_PAUSE_MS" ALL >/dev/null 2>&1 || true
+          sleep "$REDIS_PAUSE_EVERY_SECS"
+        done ) &
+      MIDWINDOW_PID=$!
+      log "  redis CLIENT PAUSE ${REDIS_PAUSE_MS}ms every ${REDIS_PAUSE_EVERY_SECS}s (pid=$MIDWINDOW_PID)"
+      ;;
+    I2)
+      ( sleep "$MIDWINDOW_AT_SECS"
+        docker stop "$REDIS_CONTAINER" >/dev/null 2>&1 || true
+        sleep 20
+        docker start "$REDIS_CONTAINER" >/dev/null 2>&1 || true ) &
+      MIDWINDOW_PID=$!
+      log "  redis will be stopped ${MIDWINDOW_AT_SECS}s into the window and started again 20s later (pid=$MIDWINDOW_PID)"
+      ;;
+    I3)
+      ( sleep "$MIDWINDOW_AT_SECS"
+        local w
+        for w in $WORKER_CONTAINERS; do docker kill -s KILL "$w" >/dev/null 2>&1 || true; done
+        sleep 10
+        for w in $WORKER_CONTAINERS; do docker start "$w" >/dev/null 2>&1 || true; done ) &
+      MIDWINDOW_PID=$!
+      log "  worker(s) [$WORKER_CONTAINERS] will be SIGKILLed ${MIDWINDOW_AT_SECS}s into the window and started again 10s later (pid=$MIDWINDOW_PID)"
+      ;;
+    *) MIDWINDOW_PID="" ;;
+  esac
+}
+
+stop_midwindow_action() {
+  [ -n "$MIDWINDOW_PID" ] || return 0
+  kill "$MIDWINDOW_PID" >/dev/null 2>&1 || true
+  wait "$MIDWINDOW_PID" 2>/dev/null || true
+  MIDWINDOW_PID=""
+}
+
+# Brings the stand back after an infrastructure arm, and RE-ASSERTS the stand
+# lock. Redis holds that lock, so stopping Redis can lose it - and a lost lock
+# on a shared stand means a peer can start measuring on top of this run.
+# Re-taking it is not optional housekeeping.
+restore_infrastructure() {
+  local id="$1" waited=0
+  case "$id" in
+    I2)
+      docker start "$REDIS_CONTAINER" >/dev/null 2>&1 || true
+      local pong
+      while [ "$waited" -lt 60 ]; do
+        # Captured into a variable and then tested, never piped into
+        # `grep -q`: `grep -q` closes the pipe on its first match, the slow
+        # `docker exec` producer takes SIGPIPE, and under `pipefail` the
+        # pipeline then reports FAILURE on the very reading that succeeded.
+        # This campaign has been bitten by that shape already.
+        pong="$(docker exec -i "$REDIS_CONTAINER" redis-cli PING 2>/dev/null || printf '')"
+        case "$pong" in *PONG*) break ;; esac
+        sleep 1; waited=$((waited + 1))
+      done
+      log "  redis answered PING after ${waited}s"
+      local holder
+      holder="$(redis_cli GET "$STAND_LOCK_KEY" 2>/dev/null || printf '')"
+      if [ -z "$holder" ]; then
+        warn "  the stand lock did not survive the redis restart - re-taking it"
+        redis_cli SET "$STAND_LOCK_KEY" "f10-dependency-failure:pid$$@$(hostname):$(iso_now)" NX EX "$STAND_LOCK_TTL_SECS" >/dev/null 2>&1 || true
+      fi
+      ;;
+    I3)
+      local w
+      for w in $WORKER_CONTAINERS; do docker start "$w" >/dev/null 2>&1 || true; done
+      sleep 5
+      log "  worker(s) started again"
+      ;;
+  esac
+}
+
+# ===========================================================================
+# Load
+# ===========================================================================
+PUMP_PID=""
+
+start_order_pump() {
+  local tag="$1"
+  ( while true; do
+      # Inside a command substitution: of_enqueue_poll reaches ol_api, which
+      # dies on any non-2xx, and a direct call would take the pump's subshell
+      # down with it - so the window would silently stop offering load from
+      # that moment on. Under an infrastructure fault a non-2xx from the API
+      # is EXPECTED, which makes this containment load-bearing here rather
+      # than merely defensive.
+      : "$(of_enqueue_poll "$SOURCE_CONNECTION_ID" "$tag" 2>/dev/null || printf '')"
+      sleep "$POLL_CADENCE_SECS"
+    done ) &
+  PUMP_PID=$!
+}
+
+stop_order_pump() {
+  [ -n "$PUMP_PID" ] || return 0
+  kill "$PUMP_PID" >/dev/null 2>&1 || true
+  wait "$PUMP_PID" 2>/dev/null || true
+  PUMP_PID=""
+}
+
+resolve_quantity_offer_ids() {
+  pg_sql "SELECT \"internalId\" FROM identifier_mappings
+          WHERE \"entityType\"='Offer' AND \"connectionId\"='$SOURCE_CONNECTION_ID'
+          ORDER BY \"externalId\" LIMIT $QUANTITY_JOBS"
+}
+
+enqueue_quantity_jobs() {
+  local tag="$1" n=0 offer
+  while IFS= read -r offer; do
+    [ -n "$offer" ] || continue
+    n=$((n + 1))
+    : "$(enqueue_perf_job 'marketplace.offerQuantity.update' "$SOURCE_CONNECTION_ID" \
+        "$(jq -n --arg o "$offer" --argjson q $((10 + n)) '{schemaVersion:1, offerId:$o, quantity:$q}')" \
+        "f10:$tag:qty:$offer:$(date +%s%3N)" 2>/dev/null || printf '')"
+    # `docker exec -i` inside a `while read` loop drains the loop's own stdin
+    # and silently reduces a multi-row iteration to ONE row - this campaign
+    # has been bitten by it twice. `resolve_quantity_offer_ids` is therefore
+    # materialised into a here-string BEFORE the loop (see the caller) and
+    # nothing inside the body reads stdin.
+  done <<< "$QUANTITY_OFFER_IDS"
+  printf '%s' "$n"
+}
+
+# ===========================================================================
+# The ledger read - four tables, one JSON document, per window.
+# ===========================================================================
+
+# ps_max_ids - PrestaShop's own highest order and cart ids, so the window's
+# creates can be counted without trusting a clock shared across two engines.
+ps_max_order_id() { ps_sql "SELECT COALESCE(MAX(id_order),0) FROM ps_orders" | tr -d '[:space:]'; }
+ps_max_cart_id()  { ps_sql "SELECT COALESCE(MAX(id_cart),0)  FROM ps_cart"   | tr -d '[:space:]'; }
+
+read_ledger() {
+  local dir="$1" ws_iso="$2" ps_order_before="$3" ps_cart_before="$4" load="$5"
+  local jobs_json orders_json ss_json claimed_total claimed_missing
+  local ps_order_after ps_cart_after
+
+  ps_order_after="$(ps_max_order_id)"
+  ps_cart_after="$(ps_max_cart_id)"
+
+  # 1. sync_jobs, grouped exactly as the runner writes them. `outcome` and
+  #    `outcomeReason` are read, never derived from `status`: ADR-007 splits
+  #    them precisely because a succeeded job can carry a business failure.
+  jobs_json="$(pg_sql "SELECT COALESCE(jsonb_agg(r), '[]'::jsonb) FROM (
+      SELECT \"jobType\" AS job_type, status, outcome, \"outcomeReason\" AS outcome_reason,
+             COUNT(*)::int AS n,
+             SUM(attempts)::int AS attempts_total,
+             MAX(attempts)::int AS attempts_max,
+             COUNT(*) FILTER (WHERE COALESCE(\"deferredTotalMs\",0) > 0)::int AS deferred_rows,
+             COALESCE(SUM(\"deferredTotalMs\"),0)::bigint AS deferred_ms_total,
+             COALESCE(SUM(\"lastAttemptDurationMs\"),0)::bigint AS attempt_ms_total,
+             COUNT(*) FILTER (WHERE \"lastAttemptDurationMs\" IS NOT NULL)::int AS attempt_ms_rows
+      FROM sync_jobs
+      WHERE \"connectionId\" IN ($CONN_IDS) AND \"createdAt\" >= '$ws_iso'
+      GROUP BY 1,2,3,4 ORDER BY 1,2,3,4) r" 2>/dev/null || printf '[]')"
+
+  # A sample of the distinct error texts, so the report can quote what the
+  # system actually said rather than paraphrase it.
+  local errors_json
+  errors_json="$(pg_sql "SELECT COALESCE(jsonb_agg(r), '[]'::jsonb) FROM (
+      SELECT left(\"lastError\", 300) AS last_error, COUNT(*)::int AS n
+      FROM sync_jobs
+      WHERE \"connectionId\" IN ($CONN_IDS) AND \"createdAt\" >= '$ws_iso' AND \"lastError\" IS NOT NULL
+      GROUP BY 1 ORDER BY 2 DESC LIMIT 8) r" 2>/dev/null || printf '[]')"
+
+  if [ "$load" = "order" ]; then
+    # 2. order_records created in the window.
+    orders_json="$(pg_sql "SELECT jsonb_build_object(
+        'created', COUNT(*)::int,
+        'recordStatus', COALESCE(jsonb_object_agg(rs, c) FILTER (WHERE rs IS NOT NULL), '{}'::jsonb))
+      FROM (SELECT \"recordStatus\" AS rs, COUNT(*)::int AS c
+            FROM order_records
+            WHERE \"sourceConnectionId\"='$SOURCE_CONNECTION_ID' AND \"createdAt\" >= '$ws_iso'
+            GROUP BY 1) s" 2>/dev/null || printf '{}')"
+
+    # 3. the destination fan-out, per status. An order with an EMPTY
+    #    syncStatus is counted separately from one carrying a 'failed' entry:
+    #    they are different failures (never attempted vs attempted and
+    #    refused) and collapsing them would hide the first.
+    ss_json="$(pg_sql "SELECT jsonb_build_object(
+        'ordersWithNoSyncStatus', COUNT(*) FILTER (WHERE jsonb_array_length(\"syncStatus\") = 0)::int,
+        'entriesSynced', COALESCE(SUM((SELECT COUNT(*) FROM jsonb_array_elements(\"syncStatus\") e WHERE e->>'status'='synced')),0)::int,
+        'entriesFailed', COALESCE(SUM((SELECT COUNT(*) FROM jsonb_array_elements(\"syncStatus\") e WHERE e->>'status'='failed')),0)::int,
+        'entriesOther',  COALESCE(SUM((SELECT COUNT(*) FROM jsonb_array_elements(\"syncStatus\") e WHERE e->>'status' NOT IN ('synced','failed'))),0)::int)
+      FROM order_records
+      WHERE \"sourceConnectionId\"='$SOURCE_CONNECTION_ID' AND \"createdAt\" >= '$ws_iso'" 2>/dev/null || printf '{}')"
+
+    # 4. GROUND TRUTH. Every destination-native order id OpenLinker CLAIMS to
+    #    have created in this window, checked against PrestaShop's own table.
+    #    This is the only reconciliation in the campaign whose witness is not
+    #    OpenLinker, and it is the whole answer to "does any surface report
+    #    success on a failed path".
+    local claimed_ids
+    claimed_ids="$(pg_sql "SELECT string_agg(DISTINCT e->>'externalOrderId', ',')
+      FROM order_records o, jsonb_array_elements(o.\"syncStatus\") e
+      WHERE o.\"sourceConnectionId\"='$SOURCE_CONNECTION_ID' AND o.\"createdAt\" >= '$ws_iso'
+        AND e->>'status'='synced' AND e->>'destinationConnectionId'='$PS_CONNECTION_ID'
+        AND e->>'externalOrderId' IS NOT NULL" 2>/dev/null | tr -d '[:space:]' || printf '')"
+    if [ -n "$claimed_ids" ]; then
+      claimed_total="$(printf '%s' "$claimed_ids" | tr ',' '\n' | grep -c . || true)"
+      # `grep -c` under `pipefail` returns 1 when it matches nothing, which
+      # would abort the run on a legitimately empty set - hence `|| true`
+      # above, and hence reading the count rather than testing the exit code.
+      local present
+      present="$(ps_sql "SELECT COUNT(DISTINCT id_order) FROM ps_orders WHERE id_order IN ($claimed_ids)" | tr -d '[:space:]')"
+      claimed_missing=$(( ${claimed_total:-0} - ${present:-0} ))
+    else
+      claimed_total=0
+      claimed_missing=0
+    fi
+  else
+    orders_json='{"created":0,"recordStatus":{},"note":"quantity-write load path - no orders are ingested"}'
+    ss_json='{"note":"quantity-write load path - no destination fan-out"}'
+    claimed_total=0
+    claimed_missing=0
+  fi
+
+  jq -n \
+    --argjson jobs "$jobs_json" \
+    --argjson errors "$errors_json" \
+    --argjson orders "$orders_json" \
+    --argjson syncStatus "$ss_json" \
+    --argjson claimedSynced "${claimed_total:-0}" \
+    --argjson claimedMissingAtDestination "${claimed_missing:-0}" \
+    --argjson psOrdersCreated "$(( ${ps_order_after:-0} - ${ps_order_before:-0} ))" \
+    --argjson psCartsCreated "$(( ${ps_cart_after:-0} - ${ps_cart_before:-0} ))" \
+    '{
+      syncJobs: $jobs,
+      lastErrors: $errors,
+      orderRecords: $orders,
+      destinationFanOut: $syncStatus,
+      groundTruth: {
+        psOrdersCreated: $psOrdersCreated,
+        psCartsCreated: $psCartsCreated,
+        claimedSyncedToPrestashop: $claimedSynced,
+        claimedButAbsentFromPsOrders: $claimedMissingAtDestination,
+        note: "claimedButAbsentFromPsOrders > 0 is a success report over a failure: OpenLinker recorded syncStatus.status=synced with an externalOrderId that names no row in the shop.\nA nonzero psCartsCreated alongside a zero psOrdersCreated is an orphaned cart - work done at the destination that produced no order."
+      }
+    }' > "$dir/ledger.json"
+  log "  ledger: $(jq -c '{orders:.orderRecords.created, psOrders:.groundTruth.psOrdersCreated, psCarts:.groundTruth.psCartsCreated, claimedSynced:.groundTruth.claimedSyncedToPrestashop, claimedMissing:.groundTruth.claimedButAbsentFromPsOrders}' "$dir/ledger.json")"
+}
+
+# ===========================================================================
+# The verdict, split by guard ROLE - see the header for why the standard set
+# is not used wholesale.
+# ===========================================================================
+run_f10_guards() {
+  local dir="$1" ws_iso="$2" ws_epoch="$3" we_epoch="$4" fault_id="$5" backlog_at_stop="$6"
+  local stand_reasons=() observations=() answer
+
+  # --- STAND guards: these still discard --------------------------------
+  answer="$(post_guard_requeues "$CONN_IDS")"
+  [ "$answer" = "ok" ] || stand_reasons+=("$answer")
+
+  answer="$(post_guard_containers_stable "$dir")"
+  if [ "$answer" != "ok" ]; then
+    if [ "$fault_id" = "I3" ] || [ "$fault_id" = "I2" ]; then
+      # The restart IS the declared fault. Recorded as an observation so the
+      # window is not silently exempted from a guard it genuinely tripped.
+      observations+=("EXPECTED-BY-FAULT $answer")
+    else
+      stand_reasons+=("$answer")
+    fi
+  fi
+
+  # --- FAULT guards: their answers ARE the measurement -------------------
+  observations+=("$(post_guard_attempts "$CONN_IDS" "$ws_iso")")
+  observations+=("$(post_guard_deferrals "$CONN_IDS" "$ws_iso")")
+  observations+=("$(post_guard_destination_creates "$ws_iso" "$PS_CONNECTION_ID")")
+  observations+=("$(post_guard_limiter_degraded "$ws_epoch" "$we_epoch")")
+
+  # The feed-starvation property, checked from a reading rather than from the
+  # arithmetic (see the header for why post_guard_feed_starved itself is not
+  # used). `unknown` is NOT read around: an unreadable upstream means the
+  # window cannot show it kept offering load, which is the whole point of the
+  # guard this replaces.
+  case "$backlog_at_stop" in
+    unknown) observations+=("UNKNOWN feed_backlog_at_stop: the upstream backlog could not be read - this window cannot show it kept offering load") ;;
+    0)       observations+=("STARVED feed_backlog_at_stop=0: the feed was drained at window stop, so the offered load was bounded by supply and not by the fault") ;;
+    *)       observations+=("ok feed_backlog_at_stop=$backlog_at_stop (the feed never ran dry)") ;;
+  esac
+
+  printf '%s\n' "${observations[@]}" > "$dir/fault-observations.txt"
+  log "  fault observations:"
+  local o; for o in "${observations[@]}"; do log "    $o"; done
+
+  if [ "${#stand_reasons[@]}" -eq 0 ]; then
+    verdict_write "$dir" VALID
+  else
+    verdict_write "$dir" DISCARDED "${stand_reasons[@]}"
+  fi
+}
+
+# ===========================================================================
+# One fault, one window.
+# ===========================================================================
+run_fault() {
+  local id="$1" load dir ws_iso ps_order_before ps_cart_before fault_json
+  load="$(fault_load "$id")"
+  dir="$(results_dir_init f10-dependency-failure "$RUN_LABEL/$id")"
+  log "=== $id - $(fault_class "$id") ==="
+  log "  load path: $load, window ${FAULT_WINDOW_SECS}s"
+
+  # Clean slate: a fresh stub run id (the jobdedup 7-day TTL would otherwise
+  # silently no-op every enqueue in a repeated campaign), the cursor cleared,
+  # and both injectors' counters zeroed.
+  of_new_run "f10-$id-$(date +%s)" >/dev/null
+  reset_between_repeats "$CONN_IDS" "'$OF_CURSOR_KEY'"
+  pfp_stats_reset
+  clear_all_faults
+
+  if [ "$load" = "order" ]; then
+    local minted
+    minted="$(of_push_orders "$SOURCE_TENANT" "$WINDOW_BACKLOG")"
+    log "  pushed $minted order(s) at the stub"
+  fi
+
+  ps_order_before="$(ps_max_order_id)"
+  ps_cart_before="$(ps_max_cart_id)"
+  snapshot_jobs_before "$CONN_IDS"
+
+  # Installed BEFORE window_start, so no request inside the window ever
+  # reaches an un-faulted dependency and the manifest describes the whole
+  # window rather than most of it.
+  fault_json="$(install_fault "$id")"
+  log "  fault installed: $(printf '%s' "$fault_json" | jq -c .)"
+
+  window_start "$dir" "f10-dependency-failure" "$CONN_IDS" 0 \
+    "$(jq -n --arg id "$id" --arg cls "$(fault_class "$id")" --arg load "$load" \
+       --argjson fault "$fault_json" \
+       --argjson window "$FAULT_WINDOW_SECS" --argjson backlog "$WINDOW_BACKLOG" \
+       --argjson maxAttempts "$PERF_MAX_ATTEMPTS" \
+       --arg psBaseUrl "http://$PROXY_SERVICE_HOST:8080" \
+       '{
+          faultId: $id,
+          faultClass: $cls,
+          faultInjection: $fault,
+          loadPath: $load,
+          windowSecs: $window,
+          offeredBacklog: $backlog,
+          perfMaxAttempts: $maxAttempts,
+          perfMaxAttemptsNote: "The shipped default is 10 (sync_jobs entity). This run caps it so a window is bounded and comparable; a retry-cost figure here must be read against THIS cap and extrapolated explicitly, never quoted as the shipped cost.",
+          prestashopBaseUrlDuringWindow: $psBaseUrl,
+          prestashopBaseUrlNote: "Every window in this scenario, baseline included, routes PrestaShop traffic through the ps-fault-proxy container. The baseline window measures that proxy overhead so no fault window is credited with it."
+        }')"
+  ws_iso="$(date -u -d "@$WINDOW_START_EPOCH" +%Y-%m-%dT%H:%M:%SZ)"
+
+  start_midwindow_action "$id"
+  if [ "$load" = "order" ]; then
+    start_order_pump "$id"
+  else
+    log "  enqueued $(enqueue_quantity_jobs "$id") quantity job(s)"
+    cap_perf_job_attempts
+  fi
+
+  local waited=0
+  while [ "$waited" -lt "$FAULT_WINDOW_SECS" ]; do
+    sleep 10; waited=$((waited + 10))
+    log "  t+${waited}s queued=$(pg_sql "SELECT COUNT(*) FROM sync_jobs WHERE \"connectionId\" IN ($CONN_IDS) AND status='queued'" 2>/dev/null || printf '?') running=$(pg_sql "SELECT COUNT(*) FROM sync_jobs WHERE \"connectionId\" IN ($CONN_IDS) AND status='running'" 2>/dev/null || printf '?') dead=$(pg_sql "SELECT COUNT(*) FROM sync_jobs WHERE \"connectionId\" IN ($CONN_IDS) AND status='dead' AND \"createdAt\">='$ws_iso'" 2>/dev/null || printf '?')"
+  done
+
+  stop_order_pump
+  stop_midwindow_action
+
+  # Read BEFORE window_stop's own bookkeeping, while the window's own state is
+  # still what the fault produced. On the quantity path there is no feed, so
+  # the reading is `n/a` rather than a fabricated number.
+  local backlog_at_stop='n/a'
+  if [ "$load" = "order" ]; then
+    backlog_at_stop="$(of_backlog "$SOURCE_TENANT" "$SOURCE_CONNECTION_ID" 2>/dev/null || printf 'unknown')"
+  fi
+
+  window_stop "$dir"
+
+  # The delivered fault count, read back from the injector. A rule that
+  # installed and never matched must not read the same as a system that
+  # absorbed the fault.
+  local delivered='{}'
+  case "$id" in
+    D1|D2a|D2b|D3|D4) delivered="$(pfp_stats | jq -c '{proxyCounters: .counters}')" ;;
+    M1|M2|M2t|M3)     delivered="$(stub_stats | jq -c '{stubFaultsApplied: .faultsApplied, stubRequestCounts: .requestCounts}')" ;;
+    baseline)         delivered="$(pfp_stats | jq -c '{proxyCounters: .counters}')" ;;
+    I1|I2|I3)         delivered="$(jq -n '{note:"an infrastructure fault has no per-request delivery count; its delivery is the container action itself, recorded in faultInjection.rule"}')" ;;
+  esac
+  jq --argjson d "$delivered" '.faultInjection = (.faultInjection + {delivered: $d})' "$dir/manifest.json" > "$dir/manifest.json.tmp"
+  mv "$dir/manifest.json.tmp" "$dir/manifest.json"
+  log "  delivered: $(printf '%s' "$delivered" | jq -c .)"
+
+  # --- the ledger read, at three points ---------------------------------
+  # (a) with the fault still in force, immediately after the window
+  read_ledger "$dir" "$ws_iso" "$ps_order_before" "$ps_cart_before" "$load"
+  mv "$dir/ledger.json" "$dir/ledger-at-window-stop.json"
+
+  # (b) after the fault is cleared and the system is given time to recover on
+  #     its own. This is #2978's "does recovery happen without a human, and
+  #     how late" - measured as the delta between (a) and (c), never asserted.
+  clear_all_faults
+  restore_infrastructure "$id"
+  log "  fault cleared; waiting up to ${RECOVERY_WAIT_SECS}s for unattended recovery"
+  local drain_result
+  drain_result="$(drain_wait "$CONN_IDS" || true)"
+  log "  drain_wait: $drain_result"
+
+  waited=0
+  while [ "$waited" -lt "$RECOVERY_WAIT_SECS" ]; do
+    sleep 15; waited=$((waited + 15))
+    local still
+    still="$(pg_sql "SELECT COUNT(*) FROM sync_jobs WHERE \"connectionId\" IN ($CONN_IDS) AND status IN ('queued','running') AND \"createdAt\">='$ws_iso'" 2>/dev/null || printf 0)"
+    log "    recovery t+${waited}s: ${still} job(s) from this window still queued/running"
+    [ "${still:-0}" -gt 0 ] || break
+  done
+
+  # (c) the settled state
+  read_ledger "$dir" "$ws_iso" "$ps_order_before" "$ps_cart_before" "$load"
+  mv "$dir/ledger.json" "$dir/ledger-after-recovery.json"
+  jq -n --arg d "$drain_result" --argjson w "$waited" \
+    '{drainResult:$d, recoveryWaitedSecs:$w}' > "$dir/recovery.json"
+
+  run_f10_guards "$dir" "$ws_iso" "$WINDOW_START_EPOCH" "$WINDOW_STOP_EPOCH" "$id" "$backlog_at_stop"
+  log "  verdict: $(verdict_read "$dir" 2>/dev/null | head -1 || true)"
+}
+
+# ===========================================================================
+# --smoke
+# ===========================================================================
+run_smoke() {
+  log "=== --smoke: proxy transparency and every injector mode, no window ==="
+  pfp_start
+  log "pointing perf-prestashop at the proxy"
+  ol_api PATCH "/v1/connections/$PS_CONNECTION_ID" \
+    "$(jq -n --argjson c "$ORIGINAL_PS_CONFIG" --arg u "http://$PROXY_SERVICE_HOST:8080" '{config: ($c + {baseUrl:$u})}')" >/dev/null
+  CONNECTION_TOUCHED=1
+
+  log "connection test through the proxy (a real PrestaShop round trip):"
+  ol_api POST "/v1/connections/$PS_CONNECTION_ID/test" '{}' | jq -c '{success, message}'
+  log "proxy counters after the test: $(pfp_stats | jq -c '.counters')"
+
+  local m
+  for m in '{"mode":"500","fraction":0.5}' '{"mode":"429","retryAfterSeconds":5}' '{"mode":"429","retryAfterSeconds":null}' '{"mode":"hang","hangMs":1000}' '{"mode":"reset"}'; do
+    log "  proxy rule $m -> $(pfp_curl POST /__fault "$m" | jq -c '.rule')"
+  done
+  pfp_rule_clear
+
+  for m in '{"mode":"503","endpoints":["checkout"]}' '{"mode":"timeout","endpoints":["checkout"],"holdMs":1000}' '{"mode":"malformed","endpoints":["checkout"]}' '{"mode":"truncated","endpoints":["events"]}' '{"mode":"reject-quantity"}'; do
+    log "  stub rule $m -> $(stub_fault_set "$m" | jq -c '.fault')"
+  done
+  stub_fault_clear
+
+  log "redis CLIENT PAUSE probe: $(docker exec -i "$REDIS_CONTAINER" redis-cli CLIENT PAUSE 1 2>&1)"
+  log "smoke ok - every injector answered; nothing was measured"
+}
+
+# ===========================================================================
+# Main
+# ===========================================================================
+RUN_LABEL="${RUN_LABEL:-run$(epoch)}"
+
+log "F10 - behaviour under dependency failure (#2978)"
+log "faults: $FAULTS"
+
+guard_build
+guard_demo_mode_off
+guard_log_level
+guard_perf_max_attempts
+guard_connection_budget
+guard_pool_recorded
+guard_scheduler_off
+guard_runner_state enabled
+
+of_health >/dev/null || die "the Allegro stub is not answering at $OF_STUB_URL"
+log "stub config: $(of_config | jq -c '{runId, gitSha, latency}')"
+
+if [ "$MODE" = "smoke" ]; then
+  run_smoke
+  exit 0
+fi
+
+pfp_start
+log "pointing perf-prestashop config.baseUrl at http://$PROXY_SERVICE_HOST:8080 (was $ORIGINAL_PS_BASE_URL)"
+ol_api PATCH "/v1/connections/$PS_CONNECTION_ID" \
+  "$(jq -n --argjson c "$ORIGINAL_PS_CONFIG" --arg u "http://$PROXY_SERVICE_HOST:8080" '{config: ($c + {baseUrl:$u})}')" >/dev/null
+CONNECTION_TOUCHED=1
+
+# Proved, not assumed: a connection test through the proxy must reach the real
+# PrestaShop before any window opens. A proxy that silently could not reach
+# upstream would make every window read as a total destination outage and the
+# whole run would report a fault that was never injected.
+log "verifying the proxy reaches the real PrestaShop before any window opens"
+PROXY_TEST="$(ol_api POST "/v1/connections/$PS_CONNECTION_ID/test" '{}' | jq -c '{success, message}')"
+log "  connection test through the proxy: $PROXY_TEST"
+printf '%s' "$PROXY_TEST" | jq -e '.success == true' >/dev/null \
+  || die "the connection test through the proxy did not succeed: $PROXY_TEST
+  Every window would have measured a destination outage that this scenario did not inject."
+
+# The quantity arm's targets, materialised BEFORE any loop that runs
+# `docker exec` - see enqueue_quantity_jobs for why.
+QUANTITY_OFFER_IDS="$(resolve_quantity_offer_ids)"
+
+for f in $FAULTS; do
+  run_fault "$f"
+done
+
+# ===========================================================================
+# Summary
+# ===========================================================================
+SUMMARY_DIR="$RESULTS_ROOT/f10-dependency-failure/$RUN_LABEL"
+{
+  printf 'fault\tclass\tverdict\tps_orders\tclaimed_synced\tclaimed_missing\tps_carts\tdead\n'
+  for f in $FAULTS; do
+    d="$SUMMARY_DIR/$f"
+    [ -d "$d" ] || continue
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+      "$f" "$(fault_class "$f" | cut -c1-40)" \
+      "$(verdict_read "$d" 2>/dev/null | head -1 || true)" \
+      "$(jq -r '.groundTruth.psOrdersCreated' "$d/ledger-after-recovery.json" 2>/dev/null || printf '?')" \
+      "$(jq -r '.groundTruth.claimedSyncedToPrestashop' "$d/ledger-after-recovery.json" 2>/dev/null || printf '?')" \
+      "$(jq -r '.groundTruth.claimedButAbsentFromPsOrders' "$d/ledger-after-recovery.json" 2>/dev/null || printf '?')" \
+      "$(jq -r '.groundTruth.psCartsCreated' "$d/ledger-after-recovery.json" 2>/dev/null || printf '?')" \
+      "$(jq -r '[.syncJobs[] | select(.status=="dead") | .n] | add // 0' "$d/ledger-after-recovery.json" 2>/dev/null || printf '?')"
+  done
+} | column -t -s $'\t' | tee "$SUMMARY_DIR/summary.txt"
+
+log "done - $SUMMARY_DIR"

--- a/perf/openlinker-throughput/scenarios/f10-dependency-failure.sh
+++ b/perf/openlinker-throughput/scenarios/f10-dependency-failure.sh
@@ -360,6 +360,7 @@ ORIGINAL_PS_CONFIG="$(connection_json "$PS_CONNECTION_ID" | jq -c '.config // {}
 ORIGINAL_PS_BASE_URL="$(printf '%s' "$ORIGINAL_PS_CONFIG" | jq -r '.baseUrl // empty')"
 [ -n "$ORIGINAL_PS_BASE_URL" ] || die "perf-prestashop carries no config.baseUrl - nothing to repoint, and nothing to restore"
 ORIGINAL_ALLEGRO_CAPS="$(connection_json "$SOURCE_CONNECTION_ID" | jq -c '.enabledCapabilities // []')"
+ORIGINAL_WC_CAPS="$(connection_json "$WC_CONNECTION_ID" | jq -c '.enabledCapabilities // []')"
 
 ORIGINAL_REPLICAS="$(discover_worker_containers | wc -w | tr -d ' ')"
 [ "$ORIGINAL_REPLICAS" -ge 1 ] || ORIGINAL_REPLICAS=1
@@ -391,6 +392,7 @@ restore_curl() {
 CONNECTION_TOUCHED=0
 PROXY_STARTED=0
 WORKER_TOUCHED=0
+WC_TOUCHED=0
 
 # Declared HERE, above the trap, and not beside the function that fills them
 # in. `set -u` is on, and an unset variable read inside an EXIT trap aborts
@@ -410,7 +412,7 @@ f10_on_exit() {
   # behind - a peer's next window would measure OUR fault as their result.
   clear_all_faults || true
 
-  if [ "$CONNECTION_TOUCHED" = "0" ] && [ "$PROXY_STARTED" = "0" ] && [ "$WORKER_TOUCHED" = "0" ]; then
+  if [ "$CONNECTION_TOUCHED" = "0" ] && [ "$PROXY_STARTED" = "0" ] && [ "$WORKER_TOUCHED" = "0" ] && [ "$WC_TOUCHED" = "0" ]; then
     log "nothing was changed on the stand - no restore needed"
     release_stand_exclusive
     return $rc
@@ -425,6 +427,11 @@ f10_on_exit() {
   if [ "$CONNECTION_TOUCHED" = "1" ]; then
     restore_curl PATCH "/v1/connections/$PS_CONNECTION_ID" "$(jq -n --argjson c "$ORIGINAL_PS_CONFIG" '{config:$c}')"
     log "  perf-prestashop config restored to baseUrl=$ORIGINAL_PS_BASE_URL"
+  fi
+
+  if [ "$WC_TOUCHED" = "1" ]; then
+    restore_curl PATCH "/v1/connections/$WC_CONNECTION_ID" "$(jq -n --argjson c "$ORIGINAL_WC_CAPS" '{enabledCapabilities:$c}')"
+    log "  perf-woocommerce enabledCapabilities restored to $ORIGINAL_WC_CAPS"
   fi
 
   # The proxy container is removed LAST, after the connection has been
@@ -1028,8 +1035,42 @@ run_f10_guards() {
   local stand_reasons=() observations=() answer
 
   # --- STAND guards: these still discard --------------------------------
-  answer="$(post_guard_requeues "$CONN_IDS")"
-  [ "$answer" = "ok" ] || stand_reasons+=("$answer")
+  #
+  # A NARROWED post_guard_requeues, and the narrowing is a correction rather
+  # than a relaxation.
+  #
+  # lib.sh's version matches "was running+locked in the snapshot, is unlocked
+  # now, attempts unchanged". It has no filter on the job's CURRENT status -
+  # and `SyncJobRepository.markSucceeded` sets `lockedAt: null` while leaving
+  # `attempts` alone, so an ordinary job that was simply RUNNING when the
+  # snapshot was taken and has since SUCCEEDED matches the signature exactly.
+  #
+  # Every other scenario snapshots a quiet queue, so it never sees this. F10
+  # cannot: its windows run back to back, and one order on this path spawns
+  # roughly three downstream jobs (master.inventory.syncByExternalId ->
+  # inventory.propagateToMarketplaces -> one marketplace.offerQuantity.update
+  # per marketplace connection), so there is essentially always something
+  # running when the next window's snapshot is taken. The first measured
+  # baseline was DISCARDED on four such rows, all of which had merely
+  # finished.
+  #
+  # Adding `j.status IN ('queued','running')` keeps the case the guard exists
+  # to catch - a row the recovery pass moved that this window is about to
+  # count - and drops the case it cannot distinguish and does not care about,
+  # a row that completed. It is deliberately still imperfect and says so: a
+  # requeue followed by a success is invisible to both versions, because
+  # `requeueStuckJobs` touches neither `attempts` nor anything else that
+  # would separate it from an ordinary completion. Fixing the shared guard is
+  # a follow-up, not something to do inside the run it would score.
+  answer="$(pg_sql "SELECT COUNT(*) FROM _perf_sync_jobs_snapshot s
+      JOIN sync_jobs j ON j.id = s.id
+      WHERE s.status='running' AND s.\"lockedAt\" IS NOT NULL
+        AND j.\"lockedAt\" IS NULL AND j.attempts = s.attempts
+        AND j.status IN ('queued','running')" 2>/dev/null || printf 0)"
+  if [ "${answer:-0}" -gt 0 ]; then
+    stand_reasons+=("DISCARDED f10_post_guard_requeues: $answer non-terminal job(s) show StuckJobRecoveryService's requeue signature")
+  fi
+  pg_sql_write "DROP TABLE IF EXISTS _perf_sync_jobs_snapshot" >/dev/null
 
   answer="$(post_guard_containers_stable "$dir")"
   if [ "$answer" != "ok" ]; then
@@ -1323,6 +1364,32 @@ CONNECTION_TOUCHED=1
 # PrestaShop before any window opens. A proxy that silently could not reach
 # upstream would make every window read as a total destination outage and the
 # whole run would report a fault that was never injected.
+# THE DESTINATION FAN-OUT IS NARROWED TO ONE MEMBER, STRUCTURALLY.
+#
+# `perf-woocommerce` also carries `OrderProcessorManager`, so every ingested
+# order fans out to it as well - and on this stand it fails EVERY time, with
+# "No WC product mapping for OL product ...", because the WC connection has no
+# product mappings seeded. The first measured baseline showed it plainly: 12
+# orders, 12 synced entries against PrestaShop, and 12 FAILED entries against
+# WooCommerce, in a window with no fault injected at all.
+#
+# That is fatal to this scenario's primary signal rather than merely noisy. The
+# question every destination window asks is "did the injected fault produce a
+# failed syncStatus entry", and it cannot be asked while a second destination
+# contributes one to every order unconditionally. It also puts a doomed HTTP
+# call on the critical path of each order.
+#
+# F1 removes the same contaminant the same way and for a related reason (its
+# `syncedAt` is stamped after the slowest of N destinations). Removing it
+# structurally beats caveating it: with one member in the fan-out, a failed
+# entry means the fault did it.
+log "narrowing the destination fan-out: disabling OrderProcessorManager on perf-woocommerce for the run"
+WC_CAPS_WITHOUT_ORDERS="$(printf '%s' "$ORIGINAL_WC_CAPS" | jq -c '[.[] | select(. != "OrderProcessorManager")]')"
+ol_api PATCH "/v1/connections/$WC_CONNECTION_ID" \
+  "$(jq -n --argjson c "$WC_CAPS_WITHOUT_ORDERS" '{enabledCapabilities:$c}')" >/dev/null
+WC_TOUCHED=1
+log "  perf-woocommerce caps $ORIGINAL_WC_CAPS -> $WC_CAPS_WITHOUT_ORDERS"
+
 log "verifying the proxy reaches the real PrestaShop before any window opens"
 PROXY_TEST="$(ol_api POST "/v1/connections/$PS_CONNECTION_ID/test" '{}' | jq -c '{success, message}')"
 log "  connection test through the proxy: $PROXY_TEST"

--- a/perf/openlinker-throughput/stubs/allegro/server.mjs
+++ b/perf/openlinker-throughput/stubs/allegro/server.mjs
@@ -133,7 +133,12 @@ function freshTenantState(name) {
     checkoutForms: new Map(), // checkoutFormId -> AllegroCheckoutForm
     orderCounter: 0,
     lineCounter: 0, // drives round-robin offer assignment across the pool
-    fault: null, // { mode: '429'|'503'|'timeout', retryAfterSeconds, holdMs }
+    // { mode, retryAfterSeconds, holdMs, endpoints, fraction } - see
+    // applyFault and the POST /__stub/tenants/:t/fault handler. `endpoints`
+    // and `fraction` were added by #2978; a rule that names neither behaves
+    // exactly as a pre-#2978 rule did (every endpoint, every request).
+    fault: null,
+    faultsApplied: 0, // #2978: how many requests this tenant's rule ACTUALLY faulted
     requestCounts: {}, // 'GET /order/events' -> n
   };
 }
@@ -413,10 +418,94 @@ function allegroError(code, message) {
  * request. Returns true if it fully handled the response (caller must do
  * nothing further); false if the caller should proceed to serve a normal
  * response.
+ *
+ * `endpoint` is one of 'events' | 'checkout' | 'quantity' and is what makes a
+ * rule targetable (#2978). Two of that issue's fault classes are meaningless
+ * without it: "the source times out during HYDRATION" is a fault on
+ * `checkout` while `events` keeps working - a tenant-wide timeout instead
+ * stops the feed being read at all, so no order is ever hydrated and the
+ * fault measures nothing about hydration. Likewise "the source REJECTS the
+ * offer-quantity write" is meaningless anywhere but `quantity`.
+ *
+ * A rule that names no `endpoints` still applies to all three, so every
+ * pre-#2978 caller and rule behaves exactly as before.
  */
-function applyFault(tenant, req, res, log) {
+function applyFault(tenant, req, res, log, endpoint) {
   const fault = tenant.fault;
   if (!fault) return false;
+
+  // Endpoint targeting first, then the coin flip - a request excluded by
+  // endpoint must not consume a draw, or the delivered fraction would depend
+  // on how much unrelated traffic shared the window.
+  if (Array.isArray(fault.endpoints) && fault.endpoints.length > 0 && !fault.endpoints.includes(endpoint)) {
+    return false;
+  }
+  if (Math.random() >= (fault.fraction ?? 1)) return false;
+
+  tenant.faultsApplied += 1;
+
+  // A malformed body: HTTP 200, the right content type, and a body that is
+  // not JSON at all. This is the shape a shop behind a broken gateway or a
+  // PHP fatal actually returns, and it is deliberately a 2xx - the question
+  // is what OpenLinker does with a SUCCESSFUL response it cannot parse.
+  if (fault.mode === 'malformed') {
+    const body = '<!DOCTYPE html><html><body><b>Fatal error</b>: upstream returned no data</body></html>';
+    res.writeHead(200, { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) });
+    res.end(body);
+    log(200);
+    return true;
+  }
+
+  // A truncated body: a Content-Length that promises the whole document, a
+  // prefix of valid JSON on the wire, and then the socket dies. Distinct
+  // from `malformed` because the client fails at a different layer - a
+  // premature close rather than a parse error - and an adapter can plausibly
+  // handle one and not the other.
+  if (fault.mode === 'truncated') {
+    const full = JSON.stringify({ events: [], truncatedBy: 'the #2978 fault injector' });
+    res.writeHead(200, { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(full) });
+    res.write(full.slice(0, Math.max(1, Math.floor(full.length / 2))));
+    try {
+      res.destroy();
+    } catch {
+      /* the socket may already be gone */
+    }
+    log(200);
+    return true;
+  }
+
+  // Allegro's own synchronous rejection of a quantity command: HTTP 200 with
+  // `status: 'REJECTED'` in the body (allegro-api.types.ts's
+  // AllegroOfferQuantityChangeCommandResponse). This is the sharpest
+  // available test of #2978's central question, because the TRANSPORT
+  // succeeded - a caller that only inspects the status code sees a 2xx and
+  // has no reason to look further.
+  //
+  // Only meaningful on the quantity endpoint; elsewhere the rule does not
+  // match and the request is served normally, rather than the stub
+  // inventing a rejection shape for an endpoint that has none.
+  if (fault.mode === 'reject-quantity') {
+    if (endpoint !== 'quantity') {
+      tenant.faultsApplied -= 1;
+      return false;
+    }
+    const commandId = decodeURIComponent((req.url || '').split('/').pop().split('?')[0]);
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(
+      JSON.stringify({
+        id: commandId,
+        status: 'REJECTED',
+        errors: [
+          {
+            code: 'OfferQuantityChangeCommandRejected',
+            message: 'Injected synchronous REJECTED for tenant ' + tenant.name,
+          },
+        ],
+      }),
+    );
+    log(200);
+    return true;
+  }
 
   if (fault.mode === '429' || fault.mode === '503') {
     const status = fault.mode === '429' ? 429 : 503;
@@ -544,7 +633,7 @@ const server = createServer((req, res) => {
     if (method === 'GET' && pathname === '/order/events') {
       recordRequestCount(tenant, 'GET', '/order/events');
       await delay(latencyFor('events'));
-      if (applyFault(tenant, req, res, (status) => log(status, '/order/events'))) return;
+      if (applyFault(tenant, req, res, (status) => log(status, '/order/events'), 'events')) return;
       const from = url.searchParams.get('from');
       const limitParam = url.searchParams.get('limit');
       const limit = limitParam ? Number.parseInt(limitParam, 10) : 100;
@@ -558,7 +647,7 @@ const server = createServer((req, res) => {
     if (method === 'GET' && checkoutMatch) {
       recordRequestCount(tenant, 'GET', '/order/checkout-forms/:id');
       await delay(latencyFor('checkout'));
-      if (applyFault(tenant, req, res, (status) => log(status, '/order/checkout-forms/:id'))) return;
+      if (applyFault(tenant, req, res, (status) => log(status, '/order/checkout-forms/:id'), 'checkout')) return;
       const id = decodeURIComponent(checkoutMatch[1]);
       const checkoutForm = tenant.checkoutForms.get(id);
       if (!checkoutForm) {
@@ -593,7 +682,9 @@ const server = createServer((req, res) => {
     if (method === 'PUT' && quantityMatch) {
       recordRequestCount(tenant, 'PUT', '/sale/offer-quantity-change-commands/:id');
       await delay(latencyFor('quantity'));
-      if (applyFault(tenant, req, res, (status) => log(status, '/sale/offer-quantity-change-commands/:id')))
+      if (
+        applyFault(tenant, req, res, (status) => log(status, '/sale/offer-quantity-change-commands/:id'), 'quantity')
+      )
         return;
       const commandId = decodeURIComponent(quantityMatch[1]);
       try {
@@ -706,6 +797,7 @@ const server = createServer((req, res) => {
       }
       if (method === 'DELETE') {
         targetTenant.fault = null;
+        targetTenant.faultsApplied = 0;
         sendJson(res, 200, { fault: null });
         return;
       }
@@ -716,10 +808,35 @@ const server = createServer((req, res) => {
         sendJson(res, 400, { error: 'invalid JSON body' });
         return;
       }
-      if (![null, '429', '503', 'timeout'].includes(body.mode)) {
-        sendJson(res, 400, { error: "mode must be one of null, '429', '503', 'timeout'" });
+      // #2978 added 'malformed', 'truncated' and 'reject-quantity' alongside
+      // the original three. The list is spelled out rather than derived so an
+      // unrecognised mode is refused here, at the control surface, instead of
+      // silently installing a rule applyFault will never match - a fault that
+      // was configured and never delivered is worse than one that was
+      // refused, because the window still gets spent.
+      const MODES = [null, '429', '503', 'timeout', 'malformed', 'truncated', 'reject-quantity'];
+      if (!MODES.includes(body.mode)) {
+        sendJson(res, 400, {
+          error: `mode must be one of ${MODES.map((m) => (m === null ? 'null' : `'${m}'`)).join(', ')}`,
+        });
         return;
       }
+      const ENDPOINTS = ['events', 'checkout', 'quantity'];
+      if (body.endpoints !== undefined && body.endpoints !== null) {
+        if (!Array.isArray(body.endpoints) || body.endpoints.some((e) => !ENDPOINTS.includes(e))) {
+          sendJson(res, 400, { error: `endpoints must be an array drawn from ${ENDPOINTS.join(', ')}` });
+          return;
+        }
+      }
+      const fraction = body.fraction === undefined ? 1 : Number(body.fraction);
+      if (!Number.isFinite(fraction) || fraction < 0 || fraction > 1) {
+        sendJson(res, 400, { error: 'fraction must be a number in [0,1]' });
+        return;
+      }
+      // Reset on every install, so a scenario reading `faultsApplied` after a
+      // window is reading THIS rule's delivery count and not an accumulation
+      // across every rule the process has ever carried.
+      targetTenant.faultsApplied = 0;
       targetTenant.fault =
         body.mode === null
           ? null
@@ -729,6 +846,8 @@ const server = createServer((req, res) => {
                 ? body.retryAfterSeconds
                 : 5,
               holdMs: Number.isInteger(body.holdMs) ? body.holdMs : undefined,
+              endpoints: Array.isArray(body.endpoints) && body.endpoints.length > 0 ? body.endpoints : null,
+              fraction,
             };
       sendJson(res, 200, { fault: targetTenant.fault });
       return;
@@ -746,6 +865,10 @@ const server = createServer((req, res) => {
         requestCounts: targetTenant.requestCounts,
         ordersPushed: targetTenant.orderCounter,
         eventsEmitted: targetTenant.events.length,
+        // #2978: how many requests the ACTIVE rule actually faulted. A
+        // fractional rule's delivered count is not its requested fraction,
+        // so a scenario must read this rather than assume one.
+        faultsApplied: targetTenant.faultsApplied,
         currentCursor:
           targetTenant.events.length > 0
             ? targetTenant.events[targetTenant.events.length - 1].id

--- a/perf/openlinker-throughput/stubs/allegro/test.mjs
+++ b/perf/openlinker-throughput/stubs/allegro/test.mjs
@@ -468,3 +468,161 @@ test('an unserved path 404s in the Allegro error shape', async () => {
   assert.ok(Array.isArray(body.errors));
   assert.equal(body.errors[0].code, 'NotFound');
 });
+
+// ---------------------------------------------------------------------------
+// #2978 fault-injection extensions: endpoint targeting, a fraction, and the
+// three new modes. Every one of these is a measurement input for F10, so a
+// rule that installs but never fires would spend a window and report nothing.
+// ---------------------------------------------------------------------------
+
+/** Installs a fault rule on tenant A and returns the rule the stub stored. */
+async function setFault(faultBody) {
+  const { body } = await call('POST', `/__stub/tenants/${TENANT_A}/fault`, { token: null, body: faultBody });
+  return body.fault;
+}
+async function clearFault() {
+  await call('DELETE', `/__stub/tenants/${TENANT_A}/fault`, { token: null });
+}
+async function statsA() {
+  const { body } = await call('GET', `/__stub/tenants/${TENANT_A}/stats`, { token: null });
+  return body;
+}
+
+test('a rule naming no endpoints still faults every endpoint (pre-#2978 behaviour is unchanged)', async () => {
+  await resetRun('t-2978-allends');
+  const rule = await setFault({ mode: '503' });
+  assert.equal(rule.endpoints, null, 'an unnamed endpoints list is stored as null, not as an empty array');
+  assert.equal(rule.fraction, 1, 'an unnamed fraction defaults to 1');
+  assert.equal((await call('GET', '/order/events', { token: TOKEN_A })).status, 503);
+  assert.equal((await call('GET', '/order/checkout-forms/x', { token: TOKEN_A })).status, 503);
+  assert.equal((await call('PUT', '/sale/offer-quantity-change-commands/x', { token: TOKEN_A })).status, 503);
+  await clearFault();
+});
+
+test('endpoint targeting faults ONLY the named endpoint - the hydration-fault shape', async () => {
+  await resetRun('t-2978-targeted');
+  // This is exactly F10's "the source times out during hydration": the feed
+  // must keep answering or nothing is ever hydrated and the fault measures
+  // nothing at all.
+  await setFault({ mode: '503', endpoints: ['checkout'] });
+  assert.equal((await call('GET', '/order/events', { token: TOKEN_A })).status, 200, 'the feed still answers');
+  assert.equal(
+    (await call('GET', '/order/checkout-forms/nope', { token: TOKEN_A })).status,
+    503,
+    'hydration is faulted',
+  );
+  assert.equal(
+    (await call('PUT', '/sale/offer-quantity-change-commands/x', { token: TOKEN_A })).status,
+    200,
+    'an unnamed endpoint is untouched',
+  );
+  const s = await statsA();
+  assert.equal(s.faultsApplied, 1, 'only the targeted request counts as a delivered fault');
+  await clearFault();
+});
+
+test('an endpoint excluded by targeting does not consume a fraction draw', async () => {
+  await resetRun('t-2978-nodraw');
+  // fraction 1 on `quantity` only: 20 feed reads must all succeed AND must
+  // leave faultsApplied at 0. If the draw ran before the endpoint test this
+  // would still pass on status, so the counter is the real assertion.
+  await setFault({ mode: '503', endpoints: ['quantity'], fraction: 1 });
+  for (let i = 0; i < 20; i += 1) {
+    assert.equal((await call('GET', '/order/events', { token: TOKEN_A })).status, 200);
+  }
+  assert.equal((await statsA()).faultsApplied, 0, 'no draw was consumed by an untargeted endpoint');
+  await clearFault();
+});
+
+test('fraction is a per-request coin flip, and the DELIVERED count is reported', async () => {
+  await resetRun('t-2978-fraction');
+  await setFault({ mode: '503', endpoints: ['events'], fraction: 0.5 });
+  let faulted = 0;
+  for (let i = 0; i < 200; i += 1) {
+    if ((await call('GET', '/order/events', { token: TOKEN_A })).status === 503) faulted += 1;
+  }
+  // A wide band on purpose - this asserts the flip is a flip, not that 200
+  // draws land near the mean. It catches "always" and "never" immediately.
+  assert.ok(faulted > 70 && faulted < 130, `fraction 0.5 faulted ${faulted} of 200 (expected 70..130)`);
+  assert.equal((await statsA()).faultsApplied, faulted, 'the reported delivered count matches what was served');
+  await clearFault();
+});
+
+test('installing a rule resets the delivered-fault counter', async () => {
+  await resetRun('t-2978-counterreset');
+  await setFault({ mode: '503', endpoints: ['events'] });
+  await call('GET', '/order/events', { token: TOKEN_A });
+  assert.equal((await statsA()).faultsApplied, 1);
+  await setFault({ mode: '429', endpoints: ['events'] });
+  assert.equal((await statsA()).faultsApplied, 0, 'the counter belongs to the ACTIVE rule, not to the process');
+  await clearFault();
+  assert.equal((await statsA()).faultsApplied, 0, 'DELETE clears it too');
+});
+
+test("the 'malformed' mode answers 200 with a body that is not JSON", async () => {
+  await resetRun('t-2978-malformed');
+  await setFault({ mode: 'malformed', endpoints: ['checkout'] });
+  const r = await call('GET', '/order/checkout-forms/anything', { token: TOKEN_A });
+  assert.equal(r.status, 200, 'the transport succeeds - that is the point of this fault');
+  assert.equal(r.headers.get('content-type'), 'application/json', 'it still CLAIMS to be JSON');
+  assert.equal(r.body, undefined, 'the body did not parse as JSON');
+  assert.ok(r.raw.includes('Fatal error'), 'the body is the html-error shape a broken PHP upstream returns');
+  await clearFault();
+});
+
+test("the 'truncated' mode closes the socket mid-body", async () => {
+  await resetRun('t-2978-truncated');
+  await setFault({ mode: 'truncated', endpoints: ['events'] });
+  // fetch surfaces a premature close as a thrown TypeError rather than as a
+  // short body, which is precisely the difference from `malformed`.
+  await assert.rejects(
+    async () => {
+      const res = await fetch(`${baseUrl}/order/events`, { headers: { Authorization: `Bearer ${TOKEN_A}` } });
+      await res.text();
+    },
+    (err) => err instanceof Error,
+    'a truncated response must fail at the transport layer, not parse as a short document',
+  );
+  await clearFault();
+});
+
+test("the 'reject-quantity' mode answers HTTP 200 carrying status REJECTED", async () => {
+  await resetRun('t-2978-reject');
+  await setFault({ mode: 'reject-quantity' });
+  const r = await call('PUT', '/sale/offer-quantity-change-commands/cmd-7', { token: TOKEN_A });
+  assert.equal(r.status, 200, 'the HTTP layer succeeds - a caller reading only the status sees success');
+  assert.equal(r.body.status, 'REJECTED');
+  assert.equal(r.body.id, 'cmd-7', 'the command id is echoed, as the real response does');
+  assert.ok(Array.isArray(r.body.errors) && r.body.errors.length > 0, 'a rejection carries errors');
+  await clearFault();
+});
+
+test("'reject-quantity' does not match a non-quantity endpoint, and does not count as delivered", async () => {
+  await resetRun('t-2978-reject-scope');
+  await setFault({ mode: 'reject-quantity' });
+  const r = await call('GET', '/order/events', { token: TOKEN_A });
+  assert.equal(r.status, 200);
+  assert.ok(Array.isArray(r.body.events), 'the feed is served normally, not given an invented rejection shape');
+  assert.equal((await statsA()).faultsApplied, 0, 'a non-matching endpoint is not counted as a delivered fault');
+  await clearFault();
+});
+
+test('the control surface refuses an unknown mode, a bad endpoint and a bad fraction', async () => {
+  const bad = await call('POST', `/__stub/tenants/${TENANT_A}/fault`, { token: null, body: { mode: 'nonsense' } });
+  assert.equal(bad.status, 400);
+  const badEndpoint = await call('POST', `/__stub/tenants/${TENANT_A}/fault`, {
+    token: null,
+    body: { mode: '503', endpoints: ['orders'] },
+  });
+  assert.equal(badEndpoint.status, 400, 'an endpoint this stub does not serve is refused, not silently ignored');
+  const badFraction = await call('POST', `/__stub/tenants/${TENANT_A}/fault`, {
+    token: null,
+    body: { mode: '503', fraction: 1.5 },
+  });
+  assert.equal(badFraction.status, 400);
+  assert.equal(
+    (await call('GET', `/__stub/tenants/${TENANT_A}/stats`, { token: null })).body.fault,
+    null,
+    'none of the refused rules was installed',
+  );
+});

--- a/perf/openlinker-throughput/stubs/ps-fault-proxy/Dockerfile
+++ b/perf/openlinker-throughput/stubs/ps-fault-proxy/Dockerfile
@@ -1,0 +1,25 @@
+# PrestaShop fault-injection proxy (#2978).
+#
+# Same base tag as the Allegro stub next door and as the repo's root
+# Dockerfile, so every process on the `lab` stand runs one node runtime.
+FROM node:22.23.1-alpine3.24
+
+# Zero dependencies (node:http / node:crypto only) - no package.json, no
+# install step. See server.mjs's header for what this container is for.
+WORKDIR /app
+COPY server.mjs ./server.mjs
+
+# Surfaced through GET /__fault/health so a run manifest records which proxy
+# build the measurement was taken against.
+ARG PROXY_GIT_SHA=unknown
+ENV PROXY_GIT_SHA=${PROXY_GIT_SHA}
+
+ENV PROXY_PORT=8080
+ENV PROXY_UPSTREAM_HOST=prestashop
+ENV PROXY_UPSTREAM_PORT=80
+EXPOSE 8080
+
+HEALTHCHECK --interval=5s --timeout=3s --start-period=2s --retries=5 \
+  CMD wget -q -O - "http://127.0.0.1:${PROXY_PORT}/__fault/health" || exit 1
+
+CMD ["node", "server.mjs"]

--- a/perf/openlinker-throughput/stubs/ps-fault-proxy/server.mjs
+++ b/perf/openlinker-throughput/stubs/ps-fault-proxy/server.mjs
@@ -1,0 +1,429 @@
+/**
+ * PrestaShop fault-injection proxy (#2978, epic #2840).
+ *
+ * A transparent HTTP reverse proxy that sits between OpenLinker and the real
+ * local PrestaShop on the `lab` stand, and can be told - at runtime, from a
+ * scenario script - to break a chosen slice of the traffic passing through
+ * it.
+ *
+ * WHY A PROXY AND NOT A STUB
+ * --------------------------
+ * #2978 measures behaviour under dependency failure, and every other flow in
+ * the #2840 campaign measured the REAL PrestaShop (#2860's own requirement
+ * for a destination figure). Replacing it with a mock for this one issue
+ * would change two variables at once: the fault, and the destination. A proxy
+ * changes exactly one - every request that is not selected for a fault
+ * reaches the same PrestaShop, gets the same answer, and takes the same time
+ * as it does in every other window of the campaign.
+ *
+ * The `wc-tls` nginx service on this stand is the precedent #2978 names for
+ * putting something in front of a stand dependency. nginx is not used here
+ * for three reasons it cannot satisfy without a Lua build: a per-request
+ * PROBABILITY, matching on request path AND method together, and holding a
+ * connection open without answering (the timeout fault) while still counting
+ * it.
+ *
+ * WHAT IT IS NOT
+ * --------------
+ * It is not a load balancer, not a cache, and not a rate limiter. It adds one
+ * TCP hop and nothing else. Its own overhead is measured and reported by the
+ * scenario's baseline window - a window with a rule installed at
+ * `fraction: 0` - so the proxy's cost is never confused with a fault's cost.
+ *
+ * HOW OPENLINKER IS POINTED AT IT
+ * -------------------------------
+ * The `perf-prestashop` connection's `config.baseUrl` is PATCHed from
+ * `http://prestashop` to `http://ps-fault-proxy:8080` for the duration of the
+ * run, and PATCHed back on exit. Nothing in docker-compose.lab.yml changes,
+ * no existing container is recreated, and `post_guard_containers_stable`
+ * therefore still means what it means in every other scenario.
+ *
+ * THE HOST HEADER IS REWRITTEN, DELIBERATELY
+ * ------------------------------------------
+ * Outgoing requests carry `Host: prestashop`, not `Host: ps-fault-proxy`, so
+ * PrestaShop sees byte-identical requests to the ones it serves in every
+ * other window. PrestaShop generates absolute URLs from the host it is given
+ * and can redirect on a mismatch; leaving the proxy's own host in place would
+ * have introduced a second difference alongside the fault.
+ *
+ * CONTROL SURFACE (never proxied)
+ * -------------------------------
+ *   GET    /__fault/health          -> {ok, upstream, runId}
+ *   GET    /__fault/stats           -> counters, per path bucket
+ *   POST   /__fault/reset           -> zero the counters, keep the rule
+ *   GET    /__fault                 -> the active rule (or null)
+ *   POST   /__fault                 -> install a rule
+ *   DELETE /__fault                 -> remove the rule
+ *
+ * A rule:
+ *   {
+ *     mode: '500' | '429' | 'hang' | 'reset',
+ *     fraction: 0..1,              // per-request probability, default 1
+ *     pathIncludes: string | null, // substring of the request path
+ *     methods: string[] | null,    // e.g. ["POST"]; null = any
+ *     retryAfterSeconds: n | null, // '429' only; null OMITS the header
+ *     hangMs: n                    // 'hang' only, default 45000
+ *   }
+ *
+ * `fraction` is a per-request coin flip, not a deterministic every-Nth. A
+ * deterministic selector would interact with OpenLinker's own retry ladder in
+ * a way that is hard to reason about (a request retried immediately would
+ * land on a different slot and succeed by construction), and the question
+ * #2978 asks is about a shop that hiccups, which is probabilistic. The
+ * consequence is that the DELIVERED fault count is not the requested
+ * fraction - so the proxy counts what it actually did and the scenario reads
+ * that number rather than assuming it.
+ *
+ * `retryAfterSeconds: null` is a distinct, meaningful state and not merely
+ * "unset": #2978 asks for 429 both WITH and WITHOUT `Retry-After`, because
+ * OpenLinker's deferral path reads that header, so the two are different
+ * measurements. `undefined` in the request body means "use the default 5";
+ * an explicit `null` means "send no header at all".
+ *
+ * Zero dependencies (node:http / node:crypto only), same posture as the
+ * Allegro stub next door.
+ */
+
+import http from 'node:http';
+import { randomUUID } from 'node:crypto';
+
+const CONFIG = {
+  port: Number.parseInt(process.env.PROXY_PORT || '8080', 10),
+  upstreamHost: process.env.PROXY_UPSTREAM_HOST || 'prestashop',
+  upstreamPort: Number.parseInt(process.env.PROXY_UPSTREAM_PORT || '80', 10),
+  // The Host header sent upstream. Defaults to the upstream host so the
+  // origin sees what it sees with no proxy in the path at all.
+  upstreamHostHeader: process.env.PROXY_UPSTREAM_HOST_HEADER || process.env.PROXY_UPSTREAM_HOST || 'prestashop',
+  gitSha: process.env.PROXY_GIT_SHA || 'unknown',
+};
+
+// What a `429` rule sends when the caller named no value. Declared once and
+// applied at rule-install time, never at send time.
+const DEFAULT_RETRY_AFTER_SECONDS = 5;
+
+const state = {
+  runId: process.env.PROXY_RUN_ID || randomUUID().slice(0, 8),
+  rule: null,
+  counters: {
+    total: 0,
+    proxied: 0,
+    faulted: 0,
+    upstreamError: 0,
+    byMode: {},
+    // Per path bucket, so a scenario can say "the cart calls succeeded and the
+    // importorder call failed" from the proxy's own numbers rather than from
+    // OpenLinker's logs. Bucketed rather than raw-pathed: PrestaShop
+    // webservice URLs carry ids and query strings, and an unbounded key space
+    // would grow without limit inside one window.
+    byBucket: {},
+  },
+};
+
+/**
+ * Which of PrestaShop's two request families a path belongs to, and which
+ * endpoint within it.
+ *
+ * OpenLinker reaches PrestaShop over two DIFFERENT surfaces, and the order
+ * create path uses both - which is what makes the partial-create fault
+ * #2978 asks for expressible at all:
+ *
+ *   /api/<resource>[/<id>]?ws_key=...     the webservice (cart, customer,
+ *                                          address, product reads)
+ *   /index.php?fc=module&module=openlinker&controller=<c>
+ *                                          the OL module's own front
+ *                                          controllers - `cartshipping` and
+ *                                          `importorder` (ADR-016)
+ *
+ * The front-controller path is `/index.php?...`, NOT `/module/...`, and it
+ * multiplexes on `controller=`, not on `action=`. Both details are read from
+ * `prestashop-openlinker-module.client.ts`'s own CARTSHIPPING_PATH /
+ * IMPORTORDER_PATH constants rather than guessed - getting either wrong
+ * buckets every module call as `other` and makes the partial-create fault
+ * silently unattributable.
+ *
+ * Bucketed rather than raw-pathed: webservice URLs carry ids and a ws_key
+ * query string, so an unbounded key space would grow without limit inside
+ * one window (and would put a credential in the counters).
+ */
+function bucketOf(path) {
+  const moduleMatch = /[?&]controller=([a-zA-Z0-9_-]+)/.exec(path);
+  if (path.includes('module=openlinker')) {
+    return moduleMatch ? `module:${moduleMatch[1]}` : 'module:unknown';
+  }
+  if (path.startsWith('/api/')) {
+    const seg = path.slice(5).split(/[/?]/)[0];
+    return `api:${seg || 'root'}`;
+  }
+  return 'other';
+}
+
+function bump(bucket, field) {
+  const b = (state.counters.byBucket[bucket] ??= { total: 0, proxied: 0, faulted: 0 });
+  b[field] += 1;
+}
+
+function sendJson(res, status, body) {
+  const payload = JSON.stringify(body);
+  res.writeHead(status, {
+    'Content-Type': 'application/json',
+    'Content-Length': Buffer.byteLength(payload),
+  });
+  res.end(payload);
+}
+
+async function readBody(req) {
+  const chunks = [];
+  for await (const chunk of req) chunks.push(chunk);
+  return Buffer.concat(chunks);
+}
+
+function ruleMatches(rule, req, path) {
+  if (!rule) return false;
+  if (rule.methods && !rule.methods.includes(req.method)) return false;
+  if (rule.pathIncludes && !path.includes(rule.pathIncludes)) return false;
+  // The coin flip is LAST, so a request excluded by path or method never
+  // consumes a draw - otherwise the delivered fraction would depend on how
+  // much unrelated traffic shared the window.
+  return Math.random() < (rule.fraction ?? 1);
+}
+
+/**
+ * Applies a matched rule. Returns true if the response is fully handled.
+ */
+function applyFault(rule, req, res, bucket) {
+  state.counters.faulted += 1;
+  state.counters.byMode[rule.mode] = (state.counters.byMode[rule.mode] || 0) + 1;
+  bump(bucket, 'faulted');
+
+  if (rule.mode === '500') {
+    // A shape PrestaShop itself produces: an HTML 500 from the PHP layer, not
+    // a JSON error. An adapter that only ever saw well-formed JSON errors is
+    // part of what this measures.
+    const body = '<!DOCTYPE html><html><head><title>500</title></head><body><h1>Internal server error</h1></body></html>';
+    res.writeHead(500, { 'Content-Type': 'text/html', 'Content-Length': Buffer.byteLength(body) });
+    res.end(body);
+    return true;
+  }
+
+  if (rule.mode === '429') {
+    const headers = { 'Content-Type': 'text/plain' };
+    // `null` is the ONLY value that suppresses the header, and the rule as
+    // stored already carries the resolved number for every other case (see
+    // the POST handler) - so what `GET /__fault` reports and what goes on
+    // the wire cannot disagree.
+    const ra = rule.retryAfterSeconds;
+    if (ra !== null && ra !== undefined) headers['Retry-After'] = String(ra);
+    const body = 'Too Many Requests';
+    headers['Content-Length'] = Buffer.byteLength(body);
+    res.writeHead(429, headers);
+    res.end(body);
+    return true;
+  }
+
+  if (rule.mode === 'hang') {
+    // Hold the connection open without answering. The socket is destroyed
+    // after hangMs so the proxy cannot leak sockets across a long window;
+    // hangMs must exceed the client's own timeout for this to measure a
+    // client-side timeout rather than a slow success.
+    const hangMs = rule.hangMs ?? 45000;
+    let settled = false;
+    req.on('close', () => {
+      settled = true;
+    });
+    setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      try {
+        res.destroy();
+      } catch {
+        /* the socket may already be gone */
+      }
+    }, hangMs);
+    return true;
+  }
+
+  if (rule.mode === 'reset') {
+    // A mid-flight connection drop, distinct from a hang: the client learns
+    // immediately rather than waiting out its timeout.
+    try {
+      req.socket.destroy();
+    } catch {
+      /* already gone */
+    }
+    return true;
+  }
+
+  return false;
+}
+
+function proxyRequest(req, res, bodyBuf, bucket) {
+  const headers = { ...req.headers, host: CONFIG.upstreamHostHeader };
+  // Content-Length is recomputed from the buffer we actually hold; a
+  // transfer-encoding the origin did not ask for would be a second difference.
+  delete headers['transfer-encoding'];
+  if (bodyBuf.length > 0) headers['content-length'] = String(bodyBuf.length);
+
+  const upstream = http.request(
+    {
+      host: CONFIG.upstreamHost,
+      port: CONFIG.upstreamPort,
+      method: req.method,
+      path: req.url,
+      headers,
+    },
+    (up) => {
+      res.writeHead(up.statusCode || 502, up.headers);
+      up.pipe(res);
+    },
+  );
+
+  upstream.on('error', (err) => {
+    state.counters.upstreamError += 1;
+    if (!res.headersSent) {
+      sendJson(res, 502, { error: 'ps-fault-proxy: upstream error', detail: String(err && err.message) });
+    } else {
+      try {
+        res.destroy();
+      } catch {
+        /* already gone */
+      }
+    }
+  });
+
+  state.counters.proxied += 1;
+  bump(bucket, 'proxied');
+  if (bodyBuf.length > 0) upstream.write(bodyBuf);
+  upstream.end();
+}
+
+const server = http.createServer(async (req, res) => {
+  const path = req.url || '/';
+
+  // ---- control surface, never proxied, never faulted -------------------
+  if (path.startsWith('/__fault')) {
+    if (req.method === 'GET' && path.startsWith('/__fault/health')) {
+      sendJson(res, 200, {
+        ok: true,
+        runId: state.runId,
+        gitSha: CONFIG.gitSha,
+        upstream: `http://${CONFIG.upstreamHost}:${CONFIG.upstreamPort}`,
+        upstreamHostHeader: CONFIG.upstreamHostHeader,
+      });
+      return;
+    }
+    if (req.method === 'GET' && path.startsWith('/__fault/stats')) {
+      sendJson(res, 200, { runId: state.runId, rule: state.rule, counters: state.counters });
+      return;
+    }
+    if (req.method === 'POST' && path.startsWith('/__fault/reset')) {
+      state.counters = { total: 0, proxied: 0, faulted: 0, upstreamError: 0, byMode: {}, byBucket: {} };
+      sendJson(res, 200, { reset: true, rule: state.rule });
+      return;
+    }
+    if (req.method === 'GET') {
+      sendJson(res, 200, { rule: state.rule });
+      return;
+    }
+    if (req.method === 'DELETE') {
+      state.rule = null;
+      sendJson(res, 200, { rule: null });
+      return;
+    }
+    if (req.method === 'POST') {
+      let body;
+      try {
+        body = JSON.parse((await readBody(req)).toString('utf8') || '{}');
+      } catch {
+        sendJson(res, 400, { error: 'invalid JSON body' });
+        return;
+      }
+      const modes = ['500', '429', 'hang', 'reset'];
+      if (!modes.includes(body.mode)) {
+        sendJson(res, 400, { error: `mode must be one of ${modes.join(', ')}` });
+        return;
+      }
+      const fraction = body.fraction === undefined ? 1 : Number(body.fraction);
+      if (!Number.isFinite(fraction) || fraction < 0 || fraction > 1) {
+        sendJson(res, 400, { error: 'fraction must be a number in [0,1]' });
+        return;
+      }
+      if (body.methods !== undefined && body.methods !== null && !Array.isArray(body.methods)) {
+        sendJson(res, 400, { error: 'methods must be an array of HTTP verbs, or null' });
+        return;
+      }
+      state.rule = {
+        mode: body.mode,
+        fraction,
+        pathIncludes: typeof body.pathIncludes === 'string' && body.pathIncludes ? body.pathIncludes : null,
+        methods: Array.isArray(body.methods) ? body.methods.map((m) => String(m).toUpperCase()) : null,
+        // Two states are STORED, not three: a number, or an explicit null
+        // meaning "send no header". An absent value is resolved to the
+        // default HERE rather than in applyFault, so the rule the control
+        // surface reports is byte-for-byte the rule that goes on the wire -
+        // the reported-equals-enforced rule (#2229). Resolving it at send
+        // time instead left `undefined` reaching applyFault's
+        // `ra !== undefined` test, which suppressed the header on every
+        // default 429 while `GET /__fault` and the manifest both claimed one
+        // was being sent. The proxy's own self-test found that, before any
+        // window was spent on it.
+        retryAfterSeconds:
+          body.retryAfterSeconds === null
+            ? null
+            : Number.isInteger(body.retryAfterSeconds)
+              ? body.retryAfterSeconds
+              : DEFAULT_RETRY_AFTER_SECONDS,
+        hangMs: Number.isInteger(body.hangMs) ? body.hangMs : undefined,
+      };
+      sendJson(res, 200, { rule: state.rule });
+      return;
+    }
+    sendJson(res, 405, { error: 'method not allowed on the control surface' });
+    return;
+  }
+
+  // ---- proxied traffic --------------------------------------------------
+  const bucket = bucketOf(path);
+  state.counters.total += 1;
+  bump(bucket, 'total');
+
+  // The body is buffered BEFORE the fault decision so that a faulted request
+  // has still been fully read off the wire. A client whose request body was
+  // never drained can observe a write error instead of the status we chose,
+  // which would make a 500 fault indistinguishable from a connection reset.
+  let bodyBuf;
+  try {
+    bodyBuf = await readBody(req);
+  } catch {
+    return;
+  }
+
+  if (ruleMatches(state.rule, req, path)) {
+    if (applyFault(state.rule, req, res, bucket)) return;
+  }
+
+  proxyRequest(req, res, bodyBuf, bucket);
+});
+
+// Long enough to outlast a `hang` fault plus the client's own timeout; the
+// node default of 0 (no timeout) would be fine too, but an explicit value
+// states that holding a socket open is intended here rather than accidental.
+server.headersTimeout = 0;
+server.requestTimeout = 0;
+server.keepAliveTimeout = 65000;
+
+const isMain = process.argv[1] && process.argv[1].endsWith('server.mjs');
+if (isMain) {
+  server.listen(CONFIG.port, () => {
+    process.stdout.write(
+      `${JSON.stringify({
+        ts: new Date().toISOString(),
+        event: 'listening',
+        runId: state.runId,
+        port: CONFIG.port,
+        upstream: `http://${CONFIG.upstreamHost}:${CONFIG.upstreamPort}`,
+      })}\n`,
+    );
+  });
+}
+
+export { server, CONFIG, state, bucketOf, ruleMatches };

--- a/perf/openlinker-throughput/stubs/ps-fault-proxy/test.mjs
+++ b/perf/openlinker-throughput/stubs/ps-fault-proxy/test.mjs
@@ -1,0 +1,279 @@
+/**
+ * Self-test for the PrestaShop fault-injection proxy (#2978).
+ *
+ * Runs entirely in-process against a throwaway upstream on an ephemeral port
+ * - it never touches the `lab` stand, so it can be run while a peer holds
+ * `guard_stand_exclusive`. That is the point: the fault injection this
+ * scenario depends on has to be provably correct BEFORE it is pointed at a
+ * measured window, or a window spent on a proxy bug is a window wasted.
+ *
+ *   node test.mjs
+ *
+ * Exits non-zero on the first failure and prints the assertion count, so a
+ * silently-empty run cannot pass (the #2673 shape - "not covered" and
+ * "covered and passing" must not read the same).
+ */
+
+import http from 'node:http';
+import { server, state, bucketOf, ruleMatches } from './server.mjs';
+
+let checks = 0;
+let failures = 0;
+
+function check(cond, label) {
+  checks += 1;
+  if (cond) {
+    process.stdout.write(`  ok   ${label}\n`);
+  } else {
+    failures += 1;
+    process.stdout.write(`  FAIL ${label}\n`);
+  }
+}
+
+function eq(actual, expected, label) {
+  check(
+    JSON.stringify(actual) === JSON.stringify(expected),
+    `${label} (expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)})`,
+  );
+}
+
+// --- a throwaway upstream ---------------------------------------------------
+const upstreamHits = [];
+const upstream = http.createServer(async (req, res) => {
+  const chunks = [];
+  for await (const c of req) chunks.push(c);
+  upstreamHits.push({
+    method: req.method,
+    url: req.url,
+    host: req.headers.host,
+    auth: req.headers.authorization || null,
+    body: Buffer.concat(chunks).toString('utf8'),
+  });
+  res.writeHead(200, { 'Content-Type': 'application/json', 'X-Upstream': 'yes' });
+  res.end(JSON.stringify({ upstream: true, url: req.url }));
+});
+
+function listen(s, port = 0) {
+  return new Promise((resolve) => s.listen(port, '127.0.0.1', () => resolve(s.address().port)));
+}
+
+function request(port, method, path, { body, timeoutMs = 5000, headers = {} } = {}) {
+  return new Promise((resolve) => {
+    const req = http.request({ host: '127.0.0.1', port, method, path, headers, timeout: timeoutMs }, (res) => {
+      const chunks = [];
+      res.on('data', (c) => chunks.push(c));
+      res.on('end', () =>
+        resolve({ status: res.statusCode, headers: res.headers, body: Buffer.concat(chunks).toString('utf8') }),
+      );
+    });
+    req.on('timeout', () => {
+      req.destroy();
+      resolve({ status: null, timedOut: true, headers: {}, body: '' });
+    });
+    req.on('error', (err) => resolve({ status: null, error: err.code || String(err.message), headers: {}, body: '' }));
+    if (body) req.write(body);
+    req.end();
+  });
+}
+
+async function ctl(port, method, path, body) {
+  const r = await request(port, method, path, {
+    body: body === undefined ? undefined : JSON.stringify(body),
+    headers: body === undefined ? {} : { 'Content-Type': 'application/json' },
+  });
+  return { status: r.status, json: r.body ? JSON.parse(r.body) : null };
+}
+
+async function main() {
+  const upstreamPort = await listen(upstream);
+  // The proxy reads CONFIG at import time, so the throwaway upstream's
+  // ephemeral port is injected by mutating the module's own exported CONFIG -
+  // the same in-process pattern the Allegro stub's test.mjs uses.
+  const { CONFIG } = await import('./server.mjs');
+  CONFIG.upstreamHost = '127.0.0.1';
+  CONFIG.upstreamPort = upstreamPort;
+  CONFIG.upstreamHostHeader = 'prestashop';
+  const proxyPort = await listen(server);
+
+  process.stdout.write('bucketOf\n');
+  eq(bucketOf('/api/carts?ws_key=X'), 'api:carts', 'webservice path buckets by resource');
+  eq(bucketOf('/api/orders/12'), 'api:orders', 'webservice path with an id buckets by resource');
+  // The two literal paths from prestashop-openlinker-module.client.ts's own
+  // IMPORTORDER_PATH / CARTSHIPPING_PATH constants, not a paraphrase of them.
+  eq(
+    bucketOf('/index.php?fc=module&module=openlinker&controller=importorder'),
+    'module:importorder',
+    'the real importorder front-controller path buckets as module:importorder',
+  );
+  eq(
+    bucketOf('/index.php?fc=module&module=openlinker&controller=cartshipping'),
+    'module:cartshipping',
+    'the real cartshipping front-controller path buckets as module:cartshipping',
+  );
+  eq(
+    bucketOf('/index.php?fc=module&module=openlinker'),
+    'module:unknown',
+    'a module path with no controller is named, not dropped',
+  );
+  eq(bucketOf('/robots.txt'), 'other', 'anything else buckets as other');
+
+  process.stdout.write('ruleMatches\n');
+  const req = { method: 'POST' };
+  eq(ruleMatches(null, req, '/api/carts'), false, 'no rule never matches');
+  eq(
+    ruleMatches({ mode: '500', fraction: 1, methods: ['GET'], pathIncludes: null }, req, '/api/carts'),
+    false,
+    'method filter excludes',
+  );
+  eq(
+    ruleMatches({ mode: '500', fraction: 1, methods: ['POST'], pathIncludes: null }, req, '/api/carts'),
+    true,
+    'method filter includes',
+  );
+  eq(
+    ruleMatches({ mode: '500', fraction: 1, methods: null, pathIncludes: 'importorder' }, req, '/api/carts'),
+    false,
+    'path filter excludes',
+  );
+  eq(
+    ruleMatches({ mode: '500', fraction: 0, methods: null, pathIncludes: null }, req, '/api/carts'),
+    false,
+    'fraction 0 never matches',
+  );
+  // A non-matching path must not consume a draw. Asserted by construction:
+  // with fraction 1 and a non-matching path the answer is false, which can
+  // only happen if the path test ran first.
+  eq(
+    ruleMatches({ mode: '500', fraction: 1, methods: null, pathIncludes: 'nope' }, req, '/api/carts'),
+    false,
+    'path test precedes the coin flip',
+  );
+
+  process.stdout.write('transparent proxying\n');
+  let r = await request(proxyPort, 'GET', '/api/carts?ws_key=SECRET', {
+    headers: { Authorization: 'Basic abc' },
+  });
+  eq(r.status, 200, 'a request with no rule reaches the upstream');
+  check(r.headers['x-upstream'] === 'yes', 'upstream response headers are preserved');
+  eq(upstreamHits.at(-1).host, 'prestashop', 'the Host header is rewritten to the upstream host');
+  eq(upstreamHits.at(-1).auth, 'Basic abc', 'the Authorization header is forwarded');
+  eq(upstreamHits.at(-1).url, '/api/carts?ws_key=SECRET', 'the query string is forwarded verbatim');
+
+  r = await request(proxyPort, 'POST', '/api/carts', { body: '<cart><id>1</id></cart>' });
+  eq(r.status, 200, 'a POST reaches the upstream');
+  eq(upstreamHits.at(-1).body, '<cart><id>1</id></cart>', 'the request body is forwarded byte for byte');
+
+  process.stdout.write('the 500 fault\n');
+  await ctl(proxyPort, 'POST', '/__fault', { mode: '500', fraction: 1, pathIncludes: 'controller=importorder' });
+  const before = upstreamHits.length;
+  r = await request(proxyPort, 'POST', '/index.php?fc=module&module=openlinker&controller=importorder');
+  eq(r.status, 500, 'a matching request is answered 500');
+  eq(upstreamHits.length, before, 'a faulted request never reaches the upstream');
+  r = await request(proxyPort, 'POST', '/api/carts');
+  eq(r.status, 200, 'a non-matching request still reaches the upstream');
+  check(upstreamHits.length === before + 1, 'the non-matching request did reach the upstream');
+
+  process.stdout.write('the 429 fault, both header variants\n');
+  const installed = await ctl(proxyPort, 'POST', '/__fault', { mode: '429', fraction: 1 });
+  // Reported === enforced: the rule the control surface (and therefore the
+  // manifest) reports must carry the resolved value, not an absent one that
+  // some later branch fills in.
+  eq(installed.json.rule.retryAfterSeconds, 5, 'an omitted retryAfterSeconds is RESOLVED into the stored rule');
+  r = await request(proxyPort, 'GET', '/api/orders');
+  eq(r.status, 429, 'default 429 is answered');
+  eq(r.headers['retry-after'], '5', 'a 429 with no explicit retryAfterSeconds carries the default header');
+  await ctl(proxyPort, 'POST', '/__fault', { mode: '429', fraction: 1, retryAfterSeconds: 17 });
+  r = await request(proxyPort, 'GET', '/api/orders');
+  eq(r.headers['retry-after'], '17', 'an explicit retryAfterSeconds is honoured');
+  await ctl(proxyPort, 'POST', '/__fault', { mode: '429', fraction: 1, retryAfterSeconds: null });
+  r = await request(proxyPort, 'GET', '/api/orders');
+  eq(r.status, 429, 'a 429 is still answered when the header is suppressed');
+  eq(r.headers['retry-after'], undefined, 'an explicit null retryAfterSeconds sends NO Retry-After header');
+
+  process.stdout.write('the hang fault\n');
+  await ctl(proxyPort, 'POST', '/__fault', { mode: 'hang', fraction: 1, hangMs: 3000 });
+  r = await request(proxyPort, 'GET', '/api/orders', { timeoutMs: 400 });
+  eq(r.timedOut, true, 'a hang fault does not answer inside the client timeout');
+
+  process.stdout.write('the reset fault\n');
+  await ctl(proxyPort, 'POST', '/__fault', { mode: 'reset', fraction: 1 });
+  r = await request(proxyPort, 'GET', '/api/orders', { timeoutMs: 2000 });
+  eq(r.status, null, 'a reset fault produces no status');
+  check(r.error === 'ECONNRESET' || r.error === 'ECONNABORTED', `a reset fault drops the connection (got ${r.error})`);
+
+  process.stdout.write('counters\n');
+  await ctl(proxyPort, 'POST', '/__fault/reset');
+  await ctl(proxyPort, 'POST', '/__fault', { mode: '500', fraction: 1, pathIncludes: 'controller=importorder' });
+  await request(proxyPort, 'POST', '/index.php?fc=module&module=openlinker&controller=importorder');
+  await request(proxyPort, 'POST', '/index.php?fc=module&module=openlinker&controller=cartshipping');
+  await request(proxyPort, 'GET', '/api/carts');
+  let stats = (await ctl(proxyPort, 'GET', '/__fault/stats')).json;
+  eq(stats.counters.total, 3, 'every proxied request is counted');
+  eq(stats.counters.faulted, 1, 'only the matching request is counted as faulted');
+  eq(stats.counters.proxied, 2, 'the other two reached the upstream');
+  eq(stats.counters.byBucket['module:importorder'].faulted, 1, 'the fault is attributed to its own bucket');
+  eq(
+    stats.counters.byBucket['module:cartshipping'].proxied,
+    1,
+    'a sibling front controller in the same module is untouched',
+  );
+  eq(stats.counters.byBucket['api:carts'].proxied, 1, 'webservice traffic is untouched');
+  // This is the partial-create shape #2978 asks for, asserted directly.
+  check(
+    stats.counters.byBucket['module:importorder'].faulted === 1 &&
+      (stats.counters.byBucket['api:carts'].faulted ?? 0) === 0,
+    'cart succeeds while importorder fails - the partial-create fault is expressible',
+  );
+
+  process.stdout.write('the control surface is never faulted\n');
+  await ctl(proxyPort, 'POST', '/__fault', { mode: '500', fraction: 1 });
+  const health = await ctl(proxyPort, 'GET', '/__fault/health');
+  eq(health.status, 200, 'health answers 200 under a fraction-1 blanket 500 rule');
+  const statsUnderFault = await ctl(proxyPort, 'GET', '/__fault/stats');
+  eq(statsUnderFault.status, 200, 'stats answers 200 under a fraction-1 blanket 500 rule');
+
+  process.stdout.write('rule validation\n');
+  eq((await ctl(proxyPort, 'POST', '/__fault', { mode: 'nonsense' })).status, 400, 'an unknown mode is refused');
+  eq((await ctl(proxyPort, 'POST', '/__fault', { mode: '500', fraction: 2 })).status, 400, 'fraction > 1 is refused');
+  eq(
+    (await ctl(proxyPort, 'POST', '/__fault', { mode: '500', methods: 'POST' })).status,
+    400,
+    'a non-array methods is refused',
+  );
+  eq((await ctl(proxyPort, 'DELETE', '/__fault')).json.rule, null, 'DELETE clears the rule');
+  r = await request(proxyPort, 'GET', '/api/carts');
+  eq(r.status, 200, 'traffic flows again once the rule is cleared');
+
+  process.stdout.write('fraction is honoured statistically\n');
+  await ctl(proxyPort, 'POST', '/__fault/reset');
+  await ctl(proxyPort, 'POST', '/__fault', { mode: '500', fraction: 0.5 });
+  for (let i = 0; i < 200; i += 1) await request(proxyPort, 'GET', '/api/carts');
+  stats = (await ctl(proxyPort, 'GET', '/__fault/stats')).json;
+  // A wide band on purpose: this asserts the coin flip is a coin flip, not
+  // that 200 draws land near the mean. 0.5 +/- 0.15 fails on roughly one run
+  // in 10^7 and catches "always" / "never" immediately.
+  check(
+    stats.counters.faulted > 70 && stats.counters.faulted < 130,
+    `fraction 0.5 over 200 requests faulted ${stats.counters.faulted} (expected 70..130)`,
+  );
+  eq(stats.counters.total, 200, 'every request in the fraction run was counted');
+  eq(
+    stats.counters.faulted + stats.counters.proxied,
+    200,
+    'faulted + proxied accounts for every request - none is lost from the ledger',
+  );
+
+  server.close();
+  upstream.close();
+  process.stdout.write(`\n${checks} checks, ${failures} failure(s)\n`);
+  if (checks < 49) {
+    process.stdout.write('FAIL: fewer checks ran than this suite declares - a silently-empty run must not pass\n');
+    process.exit(1);
+  }
+  process.exit(failures === 0 ? 0 : 1);
+}
+
+main().catch((err) => {
+  process.stdout.write(`FATAL ${err && err.stack}\n`);
+  process.exit(1);
+});

--- a/perf/openlinker-throughput/wait-peer-quiet.sh
+++ b/perf/openlinker-throughput/wait-peer-quiet.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+#
+# Waits until BOTH the stand lock is free AND no peer has enqueued anything on
+# the shared stand for a quiet period (#2978).
+#
+# The lock alone is not a sufficient signal, and this run learned that the
+# expensive way: a peer scenario wrote `inventory.propagateToMarketplaces`
+# fan-out children onto `perf-allegro-a` throughout an F10 window that was
+# holding `guard_stand_exclusive` at the time. Those children share the
+# `realtime` lane's per-scope slots with the order path being measured, so the
+# window was contaminated in a way no guard in lib.sh looks for - the lock
+# arbitrates scenarios that TAKE it, and cannot see one that does not.
+#
+# The quiet signal is therefore an absence of new rows, not an absence of a
+# lock holder.
+set -euo pipefail
+
+QUIET_MINUTES="${QUIET_MINUTES:-4}"
+POLL_SECS="${POLL_SECS:-30}"
+
+recent_peer_writes() {
+  docker exec -i lab-postgres psql -U postgres -d openlinker -qtAX \
+    -c "SELECT COUNT(*) FROM sync_jobs WHERE \"createdAt\" > NOW() - interval '${QUIET_MINUTES} minutes'" \
+    2>/dev/null | tr -d '[:space:]'
+}
+
+lock_holder() {
+  docker exec -i lab-redis redis-cli GET perf:stand:exclusive 2>/dev/null | tr -d '[:space:]'
+}
+
+while true; do
+  holder="$(lock_holder || printf '')"
+  writes="$(recent_peer_writes || printf 'unknown')"
+  if [ -z "$holder" ] && [ "$writes" = "0" ]; then
+    printf 'STAND QUIET at %s - lock free and no sync_jobs row created in the last %s minutes\n' \
+      "$(date -u +%H:%M:%SZ)" "$QUIET_MINUTES"
+    exit 0
+  fi
+  printf '  waiting: lock=[%s] rows_last_%smin=%s\n' "${holder:-free}" "$QUIET_MINUTES" "$writes"
+  sleep "$POLL_SECS"
+done

--- a/perf/openlinker-throughput/watch-peer-contamination.sh
+++ b/perf/openlinker-throughput/watch-peer-contamination.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# Watches for a peer writing onto the stand while F10 holds the lock (#2978).
+#
+# !! THIS DETECTOR IS KNOWN-WRONG AND IS NOT USED BY ANY SCENARIO. !!
+#
+# It is kept, labelled, rather than deleted, because the way it failed is
+# worth more than the check it was trying to make.
+#
+# It classifies every job row it did not personally mint as foreign. That is
+# wrong on a system whose entire job is to enqueue further work in response to
+# work: one order on the measured path produces roughly three more jobs -
+# `master.inventory.syncByExternalId` against the destination whose stock the
+# order consumed, then `inventory.propagateToMarketplaces`, then one
+# `marketplace.offerQuantity.update` per marketplace connection. Every one of
+# those carries an `inventory:`- or `order:`-prefixed key that this filter
+# calls somebody else's.
+#
+# Run against a completely clean stand it reported "PEER CONTAMINATION" within
+# ninety seconds, and an earlier window had already been thrown away on the
+# same misreading made by hand. A detector that cannot tell the system's own
+# consequences from a third party's writes will cry contamination on a healthy
+# run - and will be believed, unless somebody opens its output and traces one
+# of the rows back to the order that caused it.
+#
+# Anything reviving this needs an allow-list built from the CAUSAL keys the
+# handlers actually mint (see `inventory-propagate-to-marketplaces.handler.ts`
+# and the order-ingestion path), not from a prefix this script happens to use.
+#
+# This exists because it happened: a peer scenario enqueued
+# `inventory.propagateToMarketplaces` fan-out children onto the connection
+# under measurement, inside a held window, and was caught only by a "why is
+# this queue not draining" look at the job table. The stand lock arbitrates
+# scenarios that take it and is blind to one that does not, so the signal has
+# to be the rows themselves.
+#
+# Emits one line per detection and exits when the F10 scenario process is gone,
+# so it cannot outlive the run it is watching. It changes nothing - a window it
+# flags still has to be discarded by a human decision, because "was this window
+# contaminated" is not a question a watcher should answer by itself.
+set -euo pipefail
+
+WINDOW_MINUTES="${WINDOW_MINUTES:-2}"
+POLL_SECS="${POLL_SECS:-45}"
+
+# Keys this run mints itself. Anything else appearing on the stand during a
+# held window is somebody else's.
+OWN_PREFIXES="marketplace:%|f10:%"
+
+peer_rows() {
+  docker exec -i lab-postgres psql -U postgres -d openlinker -qtAX -c \
+    "SELECT COUNT(*) FROM sync_jobs
+     WHERE \"createdAt\" > NOW() - interval '${WINDOW_MINUTES} minutes'
+       AND \"idempotencyKey\" NOT LIKE 'marketplace:%'
+       AND \"idempotencyKey\" NOT LIKE 'f10:%'" 2>/dev/null | tr -d '[:space:]'
+}
+
+while true; do
+  if ! pgrep -f 'f10-dependency-failure.sh' >/dev/null 2>&1; then
+    printf 'F10 scenario process is gone - contamination watch ending at %s\n' "$(date -u +%H:%M:%SZ)"
+    exit 0
+  fi
+  n="$(peer_rows || printf '')"
+  case "${n:-}" in
+    ''|0) : ;;
+    *) printf 'PEER CONTAMINATION at %s: %s job row(s) not minted by this run were created on the stand in the last %s minutes\n' \
+         "$(date -u +%H:%M:%SZ)" "$n" "$WINDOW_MINUTES" ;;
+  esac
+  sleep "$POLL_SECS"
+done


### PR DESCRIPTION
Measures what OpenLinker does when a dependency misbehaves, under load. Every
other flow in the #2840 campaign ran against a stand where nothing ever failed.

**Twelve VALID windows.** One fault class (`I3`, worker SIGKILL) was not
exercised and is recorded as such with its reason rather than quietly dropped.
Full report: `perf/openlinker-throughput/results-F10-2026-09-08.md`.

## The three findings that carry it

**1. A Redis blip kills the API and it does not come back.** Stopping Redis for
twenty seconds kills the api process on an unhandled
`SocketClosedUnexpectedlyError` from the Redis client. It stays dead after
Redis returns healthy. **Reproduced exactly on two independent runs**; both
times `docker ps` read `lab-api Exited (1)` beside `lab-redis Up (healthy)`.
The worker survived - zero socket errors in its log - so this is specific to
the api process's client, not to the codebase's Redis usage.

The "does not come back" half is the **shipped default**, not a lab artefact:
no compose file in the repository gives `api` or `worker` a restart policy.
`docker-compose.yml` has zero `restart:` declarations, and the single one in
each of the demo and lab files is on `migrate`, a one-shot job where `'no'` is
correct. This needs no load, no scale and no unusual configuration.

**2. The job ledger reports total success over an order that never reached the
shop, and nothing retries it.** Under any destination fault every
`marketplace.order.sync` job reports `succeeded / ok / attempts 0 /
lastError NULL` while 2-5 of its orders are provably absent from the shop. The
report carries the rows: five stranded order ids, their `syncStatus` entries,
the five job rows joined on the idempotency key, and PrestaShop's own `ps_cart`
showing the cart OpenLinker's error message names existing with no order behind
it.

The parent/child objection is ruled out explicitly, because it would make this
a materially smaller defect: every job of every type on **every** connection in
the window - including the destination connection - is `succeeded`/`ok` with
zero attempts. There is no child; the create happens in process. And nothing
re-drives it: no scheduler task reads `syncStatus` at all, the retry service
has exactly one caller (an HTTP route), and a re-poll dedups away permanently
against the Postgres unique constraint on `sync_jobs.idempotencyKey`.

**The pair is the finding.** `claimedMissing` is 0 in every window - OpenLinker
never claimed an order the shop does not have - and that sits *beside* the
stranding rather than softening it. The system records the failure accurately,
surfaces it well to a human (a `Sync failed` badge with the raw error inline, a
clickable "Needs attention" KPI, three Retry buttons), and then never acts on
it, while the table a monitor would alert on stays green.

**3. Source faults recover; destination faults strand.** Four source faults,
four full recoveries (12/12 orders, zero orphaned carts). Four destination
faults, four sets of stranded orders under a green ledger. One clean line,
drawn along the direction of the write. `M3` is the instructive
counter-example: the source answers **HTTP 200** carrying `status: REJECTED`,
so the transport succeeds, and OpenLinker still treats it as a failure,
retries, and recovers on its own.

Smaller: `Retry-After` changes the *outcome*, not just the timing (12/12 with
the header, 9/12 without, same status and rate); a failed create leaves an
orphaned cart nothing cleans up, with the cart id sitting unused in
OpenLinker's own error string; and the detail page's "View failed orders" link
goes to a page that by construction excludes them.

## How the faults are injected

Two injectors, both **proven correct in isolation before any window was
spent** - 49 proxy checks and 27 stub tests, run in-process against a throwaway
upstream so they work while a peer holds the stand lock.

- `stubs/ps-fault-proxy` - a transparent reverse proxy in front of the **real**
  PrestaShop. A mock would change two variables at once; every unfaulted
  request reaches the same shop as in every other window of the campaign.
  Started as a plain `docker run`, so no existing container is recreated and
  `post_guard_containers_stable` keeps its meaning.
- the Allegro stub's fault surface, extended with per-endpoint targeting, a
  per-request fraction, and three modes chosen for *where* they fail:
  `malformed` (the parse), `truncated` (the transport), `reject-quantity`
  (neither - the transport succeeds).

Self-testing earned itself immediately: the proxy's own suite caught that a
default `429` sent no `Retry-After` at all while the control surface and the
manifest both claimed one was sent - which would have made the `D2a` and `D2b`
arms measure the same thing under two labels.

Every fault is **declared per window** in the manifest, the rule is read back
from the injector rather than echoed from what the script asked for, and the
**delivered** count is read back afterwards - so a rule that installed and
never matched cannot read like a system that absorbed the fault.

## Honesty notes

`run_post_guards` is deliberately not used wholesale: three of its members are
inverted by a fault window. Each guard runs individually and is routed to a
stand-invalidating list or an observation list; the two that do not run are
named with reasons. `drain_wait` was reordered to run *after* the settled
ledger read, because it marks leftover rows `dead` and would otherwise make a
row the harness killed indistinguishable from one the system dead-lettered.

Four windows were discarded and are kept under names that say why. **One
retraction is in the report rather than quietly corrected**: I stopped a window
on a diagnosis of peer contamination and was wrong - the rows were this run's
own downstream cascade. A second wrong reading, of an order as one the shop held
and OpenLinker did not know about, is also corrected in place: the identifier
mapping was written, so no duplicate exists and none was observed.

§ 8 carries nine things this did not establish.

Nothing found here is fixed. #2977 §2 refused a fix landing in the window that
scores it.

Closes #2978.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkKifZVwvZzHspxaQ7x396
