### PR TITLE
perf(worker): give the job intake loop its own Redis client, unconditionally

### DIFF
--- a/apps/worker/src/sync/__tests__/job-intake.consumer.spec.ts
+++ b/apps/worker/src/sync/__tests__/job-intake.consumer.spec.ts
@@ -18,6 +18,8 @@ import type { SyncJobRequest } from '@openlinker/core/sync';
 import { JobTypeValues } from '@openlinker/core/sync';
 import { SyncJobEntity as SyncJob } from '@openlinker/core/sync';
 import { randomUUID } from 'crypto';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import { JOB_INTAKE_REDIS_CLIENT_TOKEN } from '../sync-worker.tokens';
 
 describe('JobIntakeConsumer', () => {
@@ -32,6 +34,9 @@ describe('JobIntakeConsumer', () => {
       xGroupCreate: jest.fn(),
       xReadGroup: jest.fn(),
       xAck: jest.fn(),
+      // The client is the consumer's own dedicated connection (#2840), so
+      // `onModuleDestroy` quits it - without this the teardown below throws.
+      quit: jest.fn(),
     } as unknown as jest.Mocked<RedisClientType>;
 
     // Mock repository
@@ -45,10 +50,11 @@ describe('JobIntakeConsumer', () => {
         JobIntakeConsumer,
         {
           // The consumer injects its own token rather than `'REDIS_CLIENT'`
-          // (#2840) - in production that token resolves to the shared client
-          // unless `OL_JOB_INTAKE_DEDICATED_REDIS=true`. Which client backs it
-          // is `SyncWorkerModule`'s decision, not this unit's, so the unit
-          // test supplies the token directly.
+          // (#2840) - in production that token is always a dedicated
+          // connection, never the shared client the outbound rate limiter is
+          // built on. Constructing it is `SyncWorkerModule`'s job, not this
+          // unit's, so the unit test supplies the token directly; the
+          // "no configuration shares it" half is asserted below.
           provide: JOB_INTAKE_REDIS_CLIENT_TOKEN,
           useValue: mockRedisClient,
         },
@@ -776,6 +782,41 @@ describe('JobIntakeConsumer', () => {
       await expect(
         runRecovery({ kind: 'entry', id: '1-0', fields: { jobType: 'a' }, deliveryCount: 1 })
       ).rejects.toThrow('Socket closed');
+    });
+  });
+
+  describe('dedicated Redis client (#2840)', () => {
+    it('should quit its own client on shutdown', async () => {
+      // The client is this consumer's alone, so releasing it is this
+      // consumer's job - the `MasterDeletionToJobHandler` precedent. If the
+      // token ever resolved to the shared client again this would close the
+      // connection the rate limiter and every other worker consumer use.
+      await consumer.onModuleDestroy();
+
+      expect(redisClient.quit).toHaveBeenCalled();
+    });
+
+    it('should leave no configuration that shares the rate limiter client', () => {
+      // Textual, and deliberately so: which client backs the token is decided
+      // by a `useFactory` in `SyncWorkerModule`, and importing that module to
+      // call the factory would pull in the whole handler graph. What must hold
+      // is a property of the source - the factory reads no flag and injects no
+      // shared client - so the source is what is read. Comment lines are
+      // stripped first, because the comment legitimately NAMES the retired
+      // seam while explaining why it is gone.
+      const source = readFileSync(join(__dirname, '..', 'sync-worker.module.ts'), 'utf8')
+        .split('\n')
+        .filter((line) => !line.trim().startsWith('//'))
+        .join('\n');
+
+      expect(source).toContain('provide: JOB_INTAKE_REDIS_CLIENT_TOKEN');
+      // No flag: there is no env var that can put the intake loop back on the
+      // shared client.
+      expect(source).not.toContain('OL_JOB_INTAKE_DEDICATED_REDIS');
+      // No shared client reaches the factory at all, so it cannot return one.
+      expect(source).not.toContain("'REDIS_CLIENT'");
+      // And it really does build one of its own.
+      expect(source).toContain('createClient(');
     });
   });
 });

--- a/apps/worker/src/sync/job-intake.consumer.ts
+++ b/apps/worker/src/sync/job-intake.consumer.ts
@@ -59,10 +59,11 @@ export class JobIntakeConsumer implements OnModuleInit, OnModuleDestroy {
 
   constructor(
     // NOT `'REDIS_CLIENT'` directly (#2840). This loop blocks on `xReadGroup`
-    // with `BLOCK: 5000`, and the shared client is also the outbound rate
-    // limiter's — see the provider in `sync-worker.module.ts`. The token
-    // resolves to the shared client by default, so this is a seam, not a
-    // behaviour change.
+    // with `BLOCK: 5000`, a blocked client serves no other commands, and the
+    // shared client is also the outbound rate limiter's - so the token is
+    // always a dedicated connection. The mechanism and the measurement are in
+    // the provider in `sync-worker.module.ts`; because the connection is this
+    // consumer's alone, `onModuleDestroy` quits it.
     @Inject(JOB_INTAKE_REDIS_CLIENT_TOKEN)
     private readonly redisClient: RedisClientType,
     @Inject(SYNC_JOB_REPOSITORY_TOKEN)
@@ -93,6 +94,11 @@ export class JobIntakeConsumer implements OnModuleInit, OnModuleDestroy {
 
   async onModuleDestroy(): Promise<void> {
     await this.stopConsumptionLoop();
+    // The client is this consumer's own dedicated connection (#2840), so it is
+    // this consumer's to release - the `MasterDeletionToJobHandler` precedent,
+    // and the same ordering: stop the loop first, then quit, or the quit races
+    // an in-flight blocking read.
+    await this.redisClient.quit();
   }
 
   /**

--- a/apps/worker/src/sync/sync-worker.module.ts
+++ b/apps/worker/src/sync/sync-worker.module.ts
@@ -109,53 +109,57 @@ import { JOB_INTAKE_REDIS_CLIENT_TOKEN } from './sync-worker.tokens';
   ],
   providers: [
     {
-      // The client `JobIntakeConsumer` blocks on, and the ONE reason it is a
-      // provider rather than a plain `@Inject('REDIS_CLIENT')`.
+      // The client `JobIntakeConsumer` blocks on - a DEDICATED connection of
+      // its own, never the worker's shared `'REDIS_CLIENT'`, and the ONE
+      // reason this is a provider rather than a plain
+      // `@Inject('REDIS_CLIENT')`.
       //
-      // `JobIntakeConsumer` runs `xReadGroup` with `BLOCK: 5000` in a loop
-      // (`job-intake.consumer.ts`), and Redis serves no further commands from
-      // a client that is parked in a blocking read. The worker's shared
+      // Mechanism. `JobIntakeConsumer` runs `xReadGroup` with `BLOCK: 5000`
+      // in a loop (`job-intake.consumer.ts`), and Redis serves no further
+      // commands from a connection parked in a blocking read. The shared
       // `'REDIS_CLIENT'` is also what `RateLimitModule` builds the outbound
-      // rate limiter's registry on (`libs/plugin-sdk/src/rate-limit.module.ts`
-      // — `inject: ['REDIS_CLIENT']`), so a pace `EVAL` issued while an intake
-      // block is in flight waits out the block's residual: up to 5 s, against
-      // the limiter's own 1000 ms timeout. Past that the limiter logs
-      // "falling back to per-process in-memory limiting" and stops being the
-      // thing it was configured to be.
+      // rate limiter's registry on
+      // (`libs/plugin-sdk/src/rate-limit.module.ts:70` -
+      // `inject: ['REDIS_CLIENT']`), so on the shared client a pace `EVAL`
+      // issued while an intake block is in flight waits out that block's
+      // residual: up to 5 s, against the limiter's own 1000 ms timeout. Past
+      // it the limiter logs "falling back to per-process in-memory limiting"
+      // and stops being the thing it was configured to be.
       //
-      // `EventsConsumerModule` already gives its own stream consumer a
-      // dedicated client for exactly this reason, and says so in its comment;
-      // the limiter never got the same treatment. This provider is what makes
-      // that hypothesis MEASURABLE rather than argued: the flag defaults to
-      // the shipped behaviour, so an unset stand is byte-identical to its
-      // pre-change self, and one env var switches the single variable under
-      // test without a second image.
+      // Measured, not argued (#2840). The controlled A/B in
+      // `perf/openlinker-throughput/results-limiter-ab-2026-09-07.md`: 226
+      // orders/h on the shared client, 225 with the destination rate limit
+      // raised tenfold and nothing else changed - so the destination budget
+      // was never the bind - and 333 with this dedicated client and no
+      // setting change at all, i.e. +47%. Degradation lines ran 34 to 58 per
+      // window on the shared client and 0 in all six dedicated-client
+      // windows, and the limiter went from reaching about 70% of its own
+      // allowance to saturating it exactly. `results-retest-2026-09-07.md`
+      // re-measured it on a quiet machine (207.3 -> 333) and found the fix
+      // removes most of the run-to-run variance too;
+      // `results-F10-2026-09-08.md` shows the degradation firing about five
+      // times in a clean 300 s baseline with Redis untouched, so it needs
+      // neither load nor a fault to appear.
       //
-      // The flag is a measurement seam, not the intended end state. If a
-      // dedicated client is shown to remove the degradation, the follow-up is
-      // to make it unconditional and delete the flag — evidence first, in that
-      // order.
+      // `EventsConsumerModule`
+      // (`apps/worker/src/events/events-consumer.module.ts:23-26`)
+      // established this remedy: it gives its own stream consumer a dedicated
+      // client and says why. This provider extends it to the one blocking
+      // consumer that missed it. The cost is one extra Redis connection per
+      // worker process, resolved from exactly the same config keys as the
+      // shared client, so the two can never end up pointed at different Redis
+      // instances.
       //
-      // No shutdown quit, matching the `EventsConsumerModule` precedent: a
-      // plain object provider carries no lifecycle hook, and the cost is one
-      // Redis connection per worker process, released when the process exits.
+      // There is deliberately no shared-client branch and no env flag. The
+      // measurement seam (`OL_JOB_INTAKE_DEDICATED_REDIS`) existed only until
+      // the evidence above landed, and a dead alternative left behind is a
+      // thing the next reader restores "to be safe". Lifecycle follows the
+      // same precedent: this provider carries no hook, and
+      // `JobIntakeConsumer` quits the client in its own `onModuleDestroy`,
+      // exactly as `MasterDeletionToJobHandler` does.
       provide: JOB_INTAKE_REDIS_CLIENT_TOKEN,
-      useFactory: async (
-        configService: ConfigService,
-        sharedClient: RedisClientType
-      ): Promise<RedisClientType> => {
+      useFactory: async (configService: ConfigService): Promise<RedisClientType> => {
         const logger = new Logger('JobIntakeRedisClient');
-        const dedicated =
-          configService.get<string>('OL_JOB_INTAKE_DEDICATED_REDIS', 'false') === 'true';
-        if (!dedicated) {
-          // Logged on BOTH branches, and asserted on by the harness. A
-          // configuration that silently did not apply is the worst failure a
-          // measurement can have (#2229's reported-versus-enforced rule), and
-          // an env var read from outside the container is a request, not a
-          // reading.
-          logger.log('Job intake Redis client: SHARED (OL_JOB_INTAKE_DEDICATED_REDIS is not true)');
-          return sharedClient;
-        }
         const client = createClient({
           socket: {
             host: configService.get<string>('REDIS_HOST', 'localhost'),
@@ -167,16 +171,22 @@ import { JOB_INTAKE_REDIS_CLIENT_TOKEN } from './sync-worker.tokens';
         try {
           await client.connect();
         } catch (error) {
+          // Throws rather than silently falling back to the shared client: a
+          // fallback would reintroduce the degradation this provider exists to
+          // remove, and it would do so invisibly.
           throw new Error(
             `SyncWorkerModule: Failed to connect JOB_INTAKE_REDIS_CLIENT: ${error instanceof Error ? error.message : String(error)}`
           );
         }
+        // Which client backs the intake loop is worth one line at boot - a
+        // configuration you cannot read back is a request, not a reading
+        // (#2229).
         logger.log(
-          'Job intake Redis client: DEDICATED (OL_JOB_INTAKE_DEDICATED_REDIS=true) - the shared client is left free for the outbound rate limiter'
+          'Job intake Redis client: DEDICATED - the shared client is left free for the outbound rate limiter (#2840)'
         );
         return client as RedisClientType;
       },
-      inject: [ConfigService, 'REDIS_CLIENT'],
+      inject: [ConfigService],
     },
     JobIntakeConsumer,
     SyncJobRunner,
@@ -237,4 +247,3 @@ import { JOB_INTAKE_REDIS_CLIENT_TOKEN } from './sync-worker.tokens';
   ],
 })
 export class SyncWorkerModule {}
-

--- a/apps/worker/src/sync/sync-worker.tokens.ts
+++ b/apps/worker/src/sync/sync-worker.tokens.ts
@@ -7,9 +7,10 @@
 /**
  * The Redis client `JobIntakeConsumer` blocks on.
  *
- * Resolves to the worker's shared `'REDIS_CLIENT'` unless
- * `OL_JOB_INTAKE_DEDICATED_REDIS=true`, in which case it is a dedicated
- * connection of its own — see the provider in `sync-worker.module.ts` for why
- * that distinction is measurable rather than cosmetic.
+ * Always a dedicated connection of its own, never the worker's shared
+ * `'REDIS_CLIENT'` - a client parked in a blocking `xReadGroup` serves no
+ * other commands, and the shared one is the outbound rate limiter's. See the
+ * provider in `sync-worker.module.ts` for the mechanism and the measurement
+ * (#2840). There is no configuration that shares it.
  */
 export const JOB_INTAKE_REDIS_CLIENT_TOKEN = Symbol('JOB_INTAKE_REDIS_CLIENT');

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -1240,13 +1240,15 @@ refused a correctly-configured arm on their very first real run.
 
 **Problem**: two different mechanisms, one shape.
 
-1. *A token matched inside an identifier's own name.* The worker logs
+1. *A token matched inside an identifier's own name.* The worker logged
    `Job intake Redis client: SHARED (OL_JOB_INTAKE_DEDICATED_REDIS is not true)`, and the guard
    parsed it with `grep -oE 'SHARED|DEDICATED' | tail -1`. The alternation matches `SHARED` and
    then the `DEDICATED` inside the variable's own name, so `tail -1` returned `DEDICATED` and the
    guard refused the SHARED baseline with "asked for false but the worker reports DEDICATED"
    while `printenv` in the same message read `false`. The self-contradiction in its own error
-   text is what gave it away.
+   text is what gave it away. (Past tense: the A/B answered, the dedicated client became
+   unconditional and `OL_JOB_INTAKE_DEDICATED_REDIS` was deleted, so neither that log line nor
+   that env var exists any more - the lesson is about the parse, not the flag.)
 2. *Two JSON objects compared as strings.* `set_rate_limit` PATCHed
    `{requestsPerMinute:60, maxConcurrent:4}` and compared the read-back against
    `jq -nc '{requestsPerMinute:$r, maxConcurrent:$c}'`. `jq -c` preserves insertion order and the


### PR DESCRIPTION
The job intake loop gets its own Redis client, always. `OL_JOB_INTAKE_DEDICATED_REDIS` is deleted - the flag and the shared-client branch together.

## Why

`JobIntakeConsumer` blocks on `xReadGroup` with `BLOCK: 5000` in a loop, and a Redis connection parked in a blocking read serves no other commands. The worker's shared `'REDIS_CLIENT'` is also what `RateLimitModule` builds the outbound rate limiter's registry on (`libs/plugin-sdk/src/rate-limit.module.ts:70`, `inject: ['REDIS_CLIENT']`), so a pace `EVAL` queued behind an in-flight intake block waited out that block's residual - up to 5 s, against the limiter's own 1000 ms timeout. Past it the limiter logs *"falling back to per-process in-memory limiting"* and stops being the thing it was configured to be.

`apps/worker/src/events/events-consumer.module.ts:23-26` already carries a comment describing this exact hazard and gives its own stream consumer a dedicated client. This extends that established remedy to the one blocking consumer that missed it.

## The evidence

#2840 built the flag as a measurement seam and said in the same comment that the follow-up, if the evidence landed, was to make it unconditional and delete it. It landed, four independent ways.

| Report | Finding |
|---|---|
| `perf/openlinker-throughput/results-limiter-ab-2026-09-07.md` | Controlled A/B: **226** orders/h shipped, **225** with the destination rate limit raised tenfold and nothing else changed, **333** with the dedicated client and no setting change at all. Degradation lines 34 to 58 per window on the shared client, **0** in all six dedicated-client windows. The limiter went from reaching about 70% of its own allowance to saturating it exactly (60.0 req/min). |
| `perf/openlinker-throughput/results-retest-2026-09-07.md` | Re-measured on a quiet machine: **207.3 -> 333**, spread falling from 6.3% to **1.0%**, so the fix removes most of the run-to-run variance too. The quiet machine made the shared-client arm *slower*, which retires "the host was busy" as the explanation. |
| `perf/openlinker-throughput/results-F10-2026-09-08.md` | The degradation fires about **five times in a clean 300 s baseline** with Redis untouched - it needs neither load nor a fault. |
| `perf/openlinker-throughput/results-weak-shop-2026-09-07.md` | Raising the destination rate limit fivefold bought **nothing** under full mixed load. |

**Provisional, from a run still open at the time of writing**: under full co-tenancy - the sweeps and 30 crons competing - a 300 req/min destination limit measured about **205** orders/h against **207**/h for the isolated path at 60. A fourth line pointing at this limiter rather than the destination budget, cited as provisional because that run has not closed.

**The figure for this change is +47%** (226 to 333, and 207.3 to 333 on the quiet machine). The 10.8x in the A/B is with the destination limit *also* raised - a different configuration, and conflating the two would overstate this PR.

No `defaultRateLimit` value is touched. #2982 measured PrestaShop's 300 and deliberately left WooCommerce and Subiekt at an unmeasured 60; this change is orthogonal.

## A real behaviour change hiding inside "make it default"

The old provider comment said *"No shutdown quit, matching the `EventsConsumerModule` precedent"* - and that misread the precedent it cited. The sibling module's provider carries no hook, but its **handler** does: `MasterDeletionToJobHandler.onModuleDestroy` calls `stopConsumptionLoop()` and then `this.redisClient.quit()`.

The omission was nonetheless correct *under the flag*, for a reason the comment did not give: on the shared branch the token resolved to `'REDIS_CLIENT'`, so a quit would have closed the connection the rate limiter and every other worker consumer use. Unconditionally dedicated, the quit is both safe and required - the connection is this consumer's alone and nothing else would release it. So `JobIntakeConsumer.onModuleDestroy` now quits it, in the same order as the sibling (stop the loop first, or the quit races an in-flight blocking read). This should not travel silently.

## Known consequence, needs an owner

**`perf/openlinker-throughput/scenarios/limiter-ab.sh` can no longer run, and this PR deliberately does not fix it.**

Its Arm D flips `OL_JOB_INTAKE_DEDICATED_REDIS`, and `assert_intake_client` reads the value back from `printenv` inside the container plus the worker's own boot log (the #2229 reported-versus-enforced rule). With the flag gone, `printenv` answers `<unset>` and the worker always logs `DEDICATED`, so that guard will **refuse every arm** - including the ones that are correctly configured. Somebody will hit this.

It is left alone for two reasons: a multi-hour measurement is in flight and that script may be the one executing, and the scenario has already answered the question it was built for. Retiring it, or just its Arm D and the assertion, needs a quiet machine. Nine references to the flag remain in `perf/` - that script plus the three results reports, which are historical records and must not be rewritten.

## Tests

Two new cases under `dedicated Redis client (#2840)` in `job-intake.consumer.spec.ts`:

- the consumer quits its own client on shutdown;
- no configuration shares the rate limiter's client. This one reads `sync-worker.module.ts`, strips `//` lines (the comment legitimately *names* the retired flag while explaining that it is gone) and asserts the factory reads no flag, injects no `'REDIS_CLIENT'`, and does call `createClient(`.

The second assertion is **textual, and its docblock says so with the reason**: which client backs the token is decided by a `useFactory`, and importing `SyncWorkerModule` to call it would pull in the whole handler graph. It was proved able to fail in both directions - against `HEAD` it reports `{flag: true, shared: true}`, against this change `{flag: false, shared: false}`. `quit: jest.fn()` was added to the mock; without it the existing teardown throws.

## Gate

- Scoped `jest` on `apps/worker/src/sync/__tests__/job-intake.consumer.spec.ts`: **32/32 pass**. `pnpm test` was not run.
- `pnpm type-check`: **exit 0**.
- ESLint on all four changed source files: **exit 0**. Prettier: clean (it also stripped one pre-existing trailing blank line from `sync-worker.module.ts` - that file already failed `prettier --check` at `HEAD` for it alone).
- `pnpm check:invariants` and `pnpm -r lint`: every check passed locally up to `check-bundle-budgets`, which fails on `vite build` because this worktree has no installed `node_modules`. Environmental, and the diff touches zero frontend files; `pnpm install` was declined so as not to load the host mid-measurement. **Unverified here - CI settles them.**

No stand was touched: no builds, no container commands, no scenario runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkKifZVwvZzHspxaQ7x396
