### PR TITLE
perf(2840): sustained mixed load - 200 orders/h, slot-bound at 2, nothing accumulates

### DIFF
--- a/docker-compose.lab.yml
+++ b/docker-compose.lab.yml
@@ -487,6 +487,25 @@ services:
       # file deliberately does not carry.
       OL_WORKER_ROLE: '${OL_WORKER_ROLE:-}'
       WORKER_RUNNER_ENABLED: '${WORKER_RUNNER_ENABLED:-false}'
+      # The job-intake Redis client (#2983). `sync-worker.module.ts` still
+      # defaults this to `'false'`, i.e. the intake consumer shares the
+      # worker's one Redis client with the rate limiter's registry - and
+      # `JobIntakeConsumer` blocks on `xReadGroup` with `BLOCK: 5000` on that
+      # shared client, so a limiter `EVAL` can wait out up to 5s against its
+      # own 1s budget and fall back to per-process pacing. `results-retest-
+      # 2026-09-07.md` measured 40-49 fallback episodes per 300s window with
+      # the default and 0 with `true`, at 10.8x the order throughput.
+      #
+      # Passed through for the same reason the lane caps below are, and it is
+      # the same trap: compose substitutes `${VAR}` only for keys the service
+      # itself lists, so exporting this around `docker compose up` - or
+      # writing it into .env.lab - changed NOTHING before this line existed.
+      # Do not trust it either; read the worker's own
+      # `Job intake Redis client: SHARED|DEDICATED` startup line back.
+      #
+      # Empty is the default and means UNSET, so an untouched stand is
+      # byte-identical to its pre-#2983 self.
+      OL_JOB_INTAKE_DEDICATED_REDIS: '${OL_JOB_INTAKE_DEDICATED_REDIS:-}'
       # Lane caps (ADR-050 decisions 2/6, #2867). Passed through so a scenario
       # can SWEEP a cap - which is the only way to measure one, and was not
       # possible before: compose substitutes `${VAR}` only for keys the service

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -1451,3 +1451,39 @@ either - read the source that owns it.
 `docs/architecture/adrs/**`, and PR or issue commentary that says a prior claim is unsupported.
 
 **Source**: #2983 (epic #2840, sustained mixed load).
+
+---
+
+## A liveness check keyed on a process NAME matches a peer's process - bound a sampler by its window, or by the PID it was started against
+
+**Context**: a mid-run side sampler added to the #2983 mixed-load window, writing container
+cgroup RSS into that run's results directory every 60 s. Its stop condition was
+`ps aux | grep '[s]ustained-mixed-load'` - the scenario's own name - on the reasoning that the
+sampler must not outlive the window it describes.
+
+**Problem**: a peer agent in another worktree then ran **the same scenario**, the grep matched
+*their* process, and the sampler kept appending to this run's results for **3.5 hours past
+`window_stop`**. The first analysis ran minutes after the window closed and therefore picked up
+post-window rows taken while the worker was being recreated by the teardown - which is where an
+anomalous `min 75.1 MB` came from. Restricting to in-window samples moved the fitted memory slopes
+materially (the worker's from +0.67 to +1.85 MB/h) and forced a published correction. Nothing
+warned: the CSV grew monotonically and every row was individually valid. On a host where several
+agents share one stand and routinely run each other's scenarios, a name is not an identity.
+
+**Rule**: a sampler's lifetime must be tied to the thing it measures, not to a process pattern.
+Prefer an explicit bound - a sample count, or the window's own end instant passed in - so the
+series cannot extend past the window even if the sampler is never signalled. Where liveness is
+genuinely needed, key it on the **PID** the sampler was started against (`kill -0 "$pid"`), never
+on a name a peer can also be running. Whatever the bound, **stamp the window's start and end into
+the results directory** so a later reader can restrict the series without having to reconstruct
+it. The two samplers `lib.sh` owns were never exposed to this: `sampler_stop` and its scenario
+counterpart both `kill` a recorded PID.
+
+Corollary for the analysis, not just the collection: when a series can outlive its window, an
+analysis run "just after the window closed" is not the same as one restricted to the window. Apply
+the time restriction explicitly rather than relying on when the analysis happened to run.
+
+**Applies to**: `perf/openlinker-throughput/**` samplers and any ad-hoc background collector
+writing into a measurement's results directory on a shared host.
+
+**Source**: #2983 (sustained mixed load, epic #2840).

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -1041,6 +1041,24 @@ media queries evaluate against, which at a boundary inverts the reading.
 
 **Source**: #2405 (the parity spec from #2392 is now load-bearing for a second issue).
 
+## Before trusting a detector's NEGATIVES, feed it a known positive and watch it fire
+
+**Context**: `post_guard_limiter_degraded` (`perf/openlinker-throughput/lib.sh`) greps the worker log for the Redis rate-limiter's degraded-mode message, and its `ok` is written into `verdict.txt` for every scenario it runs against. It carried `docker logs --since "@$epoch"` from the day it was written.
+
+**Problem**: on Docker 29.5.2 the `@epoch` form is **accepted without error and matches nothing** — the same window returns 180 lines with a bare epoch, an RFC3339 timestamp or a relative `25m`, and 0 with `@`. So the guard answered `ok` on every scenario in the #2840 campaign **while being structurally unable to see a single degraded-limiter line, whatever the limiter did**. Fixed in `b12d4b272` (PR #2969); the verdict timestamps then split the campaign cleanly either side of it — F2 (09-05 23:53), F3 (09-05 23:23–09-06 00:30), F5 (09-06 09:23) and the #2943 read-path report all pre-date the fix, so **their `VALID` does not include "the limiter was not degraded"**, while all four F1 runs (09-07 02:01 onward) post-date it and are `DISCARDED` on exactly this guard.
+
+Two things make this worse than *a test passing for a reason it does not claim* (the seeder and migration entries above, and the red-first rule immediately preceding). First, a weak negative is still evidence; **this was no evidence at all**, dressed as a passing check. Second, a guard's answer is *recorded into every verdict it touches*, so one blind detector **retroactively weakened every prior `VALID` in the campaign** — the damage is not scoped to the run that introduced it.
+
+And note that **red-first does not catch this class**. Breaking the limiter deliberately would not have made the guard fire, because the guard could not see the log line under any condition. Nor can a stub-based unit test: a fake that returns lines regardless of the window passes however the window is spelled, which is precisely how the defect survived review. The fix's own test therefore asserts on the **arguments the guard hands `docker`** (a bare epoch, and no `@`) rather than on a count.
+
+**Rule**: a detector whose value is its negative — a guard, a post-guard, an absence assertion, a "no errors in the log" check — must be exercised against a **known positive** before any of its negatives is believed. Emit one real instance of the thing it looks for (a throwaway container printing the matched line, a deliberately injected failure) and confirm it reports; then confirm the window *before* that instance still reports clean, or the check is matching everything rather than the right thing. Where the detector shells out to an external tool, assert the **arguments** as well as the outcome, because a stub cannot distinguish a correct invocation from a malformed one. Red-first proves an assertion can fail *on bad input*; this proves the instrument can *see at all*.
+
+**Corollary, and it is what saved the published figures**: a contaminated guard does **not** automatically invalidate the measurements it accompanied. Each has to be re-argued on the mechanism, one at a time. The four figures now in the client-facing document were re-argued and are immune, each for its own reason: the **webhook-accept** arms ran with `runnerState=disabled`, so no job executed and the outbound limiter was never consulted; the **read-path** and **#2943** figures are pure HTTP reads that never touch the outbound limiter, and #2943 is additionally an in-run A/B on one dataset and one binary; and **F2** ran a single worker replica, where the per-process fallback equals the configured rate, so degradation cannot have inflated the figure — any Redis timeout on that path makes it *worse*, which is the conservative direction. What is not available is the blanket claim "the guard passed, so the limiter was fine".
+
+**Applies to**: `perf/openlinker-throughput/lib.sh` post-guards and `lib-test.sh`; any absence-shaped assertion, and any check that shells out to `docker logs`, `grep`, `journalctl` or similar to look for something.
+
+**Source**: #2851 (F4, where the guard was fixed), #2969 (the fix), #2840 (the campaign whose verdicts it retroactively qualified).
+
 ## A manifest that advertises no capabilities stamps an EMPTY `enabledCapabilities`, permanently
 
 **Context**: #2405 shipped the OL-OMS manifest with `supportedCapabilities: []`, following the Erli #980 precedent that a capability name enters the manifest together with the adapter that delivers it.

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -1395,3 +1395,41 @@ child rather than trusting the assignment.
 `lib.sh` that declares `${VAR:-...}` defaults at top level.
 
 **Source**: #2840 (weak-shop rate-limit gate).
+
+---
+
+## Verify a claim against the source that would carry it - a grep that came back empty is not evidence
+
+**Context**: a mixed-workload perf run (#2983, epic #2840) was commissioned with the framing
+that such a run is "the only run whose orders/hour figure an operator can apply to their own
+Tuesday", attributed to the epic. Before building on that framing I checked it, grepping all six
+`perf/openlinker-throughput/*.md` campaign documents for `mixed`, `soak`, `sustained`, `for
+hours`, `co-tenan`, `steady-state`, `queue depth` and `drain rate`. Two hits, neither relevant.
+I published a correction withdrawing the attribution.
+
+**Problem**: the sentence exists, verbatim, in **GitHub issue #2840's body** - a source I never
+searched. `gh issue view 2840` returns it at line 120, together with two obligations I had also
+therefore missed: that the run's composition is *"sweep crons ticking, plus an order ramp, plus
+stock churn"*, and that it must be *"flagged in its manifest as one inside which attribution is
+impossible"*. The grep was accurate; the inference from it was not. **An epic is an issue, and an
+issue's framing lives in its body** - so six repo files not containing a sentence says nothing
+about whether the epic said it. The withdrawal was more confidently wrong than the claim it
+corrected, because it was dressed as a verification.
+
+Note the mirror error this campaign has made repeatedly in the other direction: believing a
+figure because a PR comment or an earlier agent's paraphrase asserted it (ADR-050's `2.77x`
+attribution, F7's `32x` growth ratio, #2590's p95 ratios - all withdrawn). Both failures share
+one root: treating a *convenient* source as authoritative instead of the *owning* one.
+
+**Rule**: before asserting that a claim is unsupported, enumerate where it *would* live and check
+each - for a programme claim that means the epic and child issue bodies (`gh issue view N`), the
+ADRs, and the repo docs, not whichever of those is already open. State the scope actually
+searched, so a reader can see what was not. Silence from one source is grounds for widening the
+search, never for a withdrawal; a withdrawal needs positive evidence that the owning source does
+not carry it. This cuts both ways: an assertion in a comment is not evidence a figure is real
+either - read the source that owns it.
+
+**Applies to**: any correction, withdrawal or provenance claim in `perf/**/results-*.md`,
+`docs/architecture/adrs/**`, and PR or issue commentary that says a prior claim is unsupported.
+
+**Source**: #2983 (epic #2840, sustained mixed load).

--- a/perf/openlinker-throughput/drivers/mixed-summarize.sh
+++ b/perf/openlinker-throughput/drivers/mixed-summarize.sh
@@ -61,6 +61,17 @@ PG_USER="${PG_USER:-postgres}"
 # sourcing lib.sh here would install a second one in the child.
 pg() { docker exec -i "$PG_CONTAINER" psql -U "$PG_USER" -d "$PG_DB" -tA -c "$1"; }
 
+# Same, but tab-separated columns instead of one hand-concatenated string.
+#
+# Concatenating inside the SELECT list looked tidier and is wrong the moment a
+# GROUP BY is involved: `SELECT a || COUNT(*) ... GROUP BY 1` groups by the
+# whole expression, which now contains an aggregate, and Postgres refuses with
+# "aggregate functions are not allowed in GROUP BY". Found by running this
+# summarizer against a synthetic results directory before a four-hour window
+# depended on it - the failure would otherwise have surfaced after the
+# measurement, with the CSVs intact but the report step broken.
+pgcols() { docker exec -i "$PG_CONTAINER" psql -U "$PG_USER" -d "$PG_DB" -tA -F$'\t' -c "$1"; }
+
 hr() { printf '%s\n' '---------------------------------------------------------------------------'; }
 
 # Column indices, resolved from the header by NAME rather than hardcoded, so a
@@ -238,9 +249,9 @@ tail -1 "$SUPP" | sed -n 's/.*,"{\(.*\)}"$/{\1}/p' | sed 's/""/"/g' \
 hr
 echo "6. JOBS CREATED IN THE WINDOW, BY TYPE AND TERMINAL STATE  [measured]"
 hr
-pg "SELECT \"jobType\" || E'\t' || status || E'\t' || COALESCE(outcome,'-') || E'\t' || COUNT(*)
+pgcols "SELECT \"jobType\", status, COALESCE(outcome,'-'), COUNT(*)
     FROM sync_jobs WHERE \"createdAt\" >= '$WS_ISO'
-    GROUP BY 1,2,3 ORDER BY COUNT(*) DESC LIMIT 40" \
+    GROUP BY 1,2,3 ORDER BY 4 DESC LIMIT 40" \
   | awk -F'\t' '{printf "     %-44s %-10s %-16s %s\n", $1, $2, $3, $4}'
 
 # --- 7. Destination outcome ----------------------------------------------
@@ -276,13 +287,13 @@ echo "   non-null sample size is printed beside each row: the column is null on"
 echo "   every row predating its migration and is reset on every enqueue, so"
 echo "   counting nulls as zero would understate every duration (#2611)."
 hr
-pg "SELECT \"jobType\" || E'\t' || COUNT(*) || E'\t' ||
-      COALESCE(ROUND(percentile_cont(0.5) WITHIN GROUP (ORDER BY \"lastAttemptDurationMs\"))::text,'-') || E'\t' ||
-      COALESCE(ROUND(percentile_cont(0.95) WITHIN GROUP (ORDER BY \"lastAttemptDurationMs\"))::text,'-') || E'\t' ||
+pgcols "SELECT \"jobType\", COUNT(*),
+      COALESCE(ROUND(percentile_cont(0.5) WITHIN GROUP (ORDER BY \"lastAttemptDurationMs\"))::text,'-'),
+      COALESCE(ROUND(percentile_cont(0.95) WITHIN GROUP (ORDER BY \"lastAttemptDurationMs\"))::text,'-'),
       COALESCE(MAX(\"lastAttemptDurationMs\")::text,'-')
     FROM sync_jobs
     WHERE \"createdAt\" >= '$WS_ISO' AND \"lastAttemptDurationMs\" IS NOT NULL
-    GROUP BY 1 ORDER BY COUNT(*) DESC LIMIT 20" \
+    GROUP BY 1 ORDER BY 2 DESC LIMIT 20" \
   | awk -F'\t' 'BEGIN {printf "     %-44s %6s %8s %8s %8s\n", "jobType", "n", "p50ms", "p95ms", "maxms"}
                {printf "     %-44s %6s %8s %8s %8s\n", $1, $2, $3, $4, $5}'
 
@@ -290,20 +301,25 @@ pg "SELECT \"jobType\" || E'\t' || COUNT(*) || E'\t' ||
 hr
 echo "9. RETRIES AND DEFERRALS FOR WINDOW JOBS  [measured]"
 hr
-pg "SELECT 'jobs with attempts>1' || E'\t' || COUNT(*) FROM sync_jobs
-      WHERE \"createdAt\" >= '$WS_ISO' AND attempts > 1
-    UNION ALL
-    SELECT 'jobs with deferredTotalMs>0' || E'\t' || COUNT(*) FROM sync_jobs
-      WHERE \"createdAt\" >= '$WS_ISO' AND \"deferredTotalMs\" > 0
-    UNION ALL
-    SELECT 'max attempts seen' || E'\t' || COALESCE(MAX(attempts)::text,'-') FROM sync_jobs
-      WHERE \"createdAt\" >= '$WS_ISO'
-    UNION ALL
-    SELECT 'max deferredTotalMs seen' || E'\t' || COALESCE(MAX(\"deferredTotalMs\")::text,'-') FROM sync_jobs
-      WHERE \"createdAt\" >= '$WS_ISO'
-    UNION ALL
-    SELECT 'dead jobs' || E'\t' || COUNT(*) FROM sync_jobs
-      WHERE \"createdAt\" >= '$WS_ISO' AND status='dead'" \
+# Explicitly ORDERed. A bare UNION ALL has no defined row order, and it came
+# back shuffled on the dry run - harmless for a labelled list, but a report
+# whose rows move between runs is one a reader cannot diff.
+pgcols "SELECT label, value FROM (
+      SELECT 1 AS o, 'jobs with attempts>1' AS label, COUNT(*)::text AS value FROM sync_jobs
+        WHERE \"createdAt\" >= '$WS_ISO' AND attempts > 1
+      UNION ALL
+      SELECT 2, 'max attempts seen', COALESCE(MAX(attempts)::text,'-') FROM sync_jobs
+        WHERE \"createdAt\" >= '$WS_ISO'
+      UNION ALL
+      SELECT 3, 'jobs with deferredTotalMs>0', COUNT(*)::text FROM sync_jobs
+        WHERE \"createdAt\" >= '$WS_ISO' AND \"deferredTotalMs\" > 0
+      UNION ALL
+      SELECT 4, 'max deferredTotalMs seen', COALESCE(MAX(\"deferredTotalMs\")::text,'-') FROM sync_jobs
+        WHERE \"createdAt\" >= '$WS_ISO'
+      UNION ALL
+      SELECT 5, 'dead jobs', COUNT(*)::text FROM sync_jobs
+        WHERE \"createdAt\" >= '$WS_ISO' AND status='dead'
+    ) t ORDER BY o" \
   | awk -F'\t' '{printf "     %-32s %s\n", $1, $2}'
 
 # --- 10. Database growth --------------------------------------------------

--- a/perf/openlinker-throughput/drivers/mixed-summarize.sh
+++ b/perf/openlinker-throughput/drivers/mixed-summarize.sh
@@ -221,6 +221,13 @@ echo "   Each line is an EPISODE, not a call: the fallback message is logged on"
 echo "   the transition into degraded mode and then at most once per 30s"
 echo "   (DEGRADED_LOG_INTERVAL_MS). The number of individual calls that fell"
 echo "   back is NOT established by this figure."
+echo
+echo "   The AUTHORITATIVE total for the window is post_guard_limiter_degraded's,"
+echo "   in verdict.txt: it reads the whole window in one grep. The sum below is"
+echo "   a sum of per-interval counts, kept because it is the only thing that"
+echo "   shows the SHAPE over time - whether episodes cluster at boot and early"
+echo "   load, as F7 found, or accumulate. The two can differ by a line landing"
+echo "   on an interval boundary; quote the verdict's figure as the total."
 hr
 awk -F, -v cd="$C_DEG" -v ce="$C_ELAPSED" '
   NR>1 && $cd >= 0 { n++; t+=$cd; if ($cd>mx) mx=$cd; e=$ce }

--- a/perf/openlinker-throughput/drivers/mixed-summarize.sh
+++ b/perf/openlinker-throughput/drivers/mixed-summarize.sh
@@ -1,0 +1,325 @@
+#!/usr/bin/env bash
+#
+# Summarizer for scenarios/sustained-mixed-load.sh (#2983, epic #2840).
+#
+# Reads the two CSVs the scenario wrote and prints the figures a soak is
+# commissioned to produce: the queue-depth curve and whether it converged,
+# memory and Postgres backends over time, the achieved order rate per phase,
+# and the observed-vs-extrapolated limiter degradation.
+#
+# ---------------------------------------------------------------------------
+# WHY THIS IS A SEPARATE SCRIPT, AND WHY IT IS SHELL
+# ---------------------------------------------------------------------------
+# It runs AFTER the window, so its own cost cannot contaminate a measurement,
+# and being separate means a run whose numbers need re-reading does not have
+# to be repeated - the CSVs are the record. Shell + awk rather than python
+# because it reads two flat CSVs by column and needs no JSON parsing of the
+# quoted blobs; #2930 records python's `csv.DictReader` silently truncating
+# this file's `docker_stats_json` column at its first internal comma, and the
+# safest response is not to parse that column here at all. Memory is read
+# from `docker stats` at the point of use instead.
+#
+# ---------------------------------------------------------------------------
+# THE ONE JUDGEMENT THIS SCRIPT MAKES, AND ITS LIMIT
+# ---------------------------------------------------------------------------
+# "Did the queue converge?" is answered from a least-squares slope over the
+# LAST THIRD of the samples, not from the endpoints. An endpoint comparison
+# cannot tell a plateau from a peak, and the last third is where a plateau
+# would be if there were one.
+#
+# The verdict has exactly three values and the third is the honest one:
+#
+#   converging   slope is negative beyond noise - the queue is draining
+#   plateau      |slope| is inside the noise band - depth is bounded
+#   growing      slope is positive beyond noise - unbounded at this rate
+#
+# It NEVER reports a steady state from a rising curve. The commissioning task
+# names this as the specific dishonesty a long run must avoid: if the queue
+# was still growing when the window closed, the run ended before it
+# converged, and the last sample is not an equilibrium.
+#
+# Usage: mixed-summarize.sh <results_dir> <window_start_iso> <src_conn> <dst_conn> <pushed_total>
+#
+set -euo pipefail
+
+DIR="${1:?results dir required}"
+WS_ISO="${2:?window start iso required}"
+SRC_CONN="${3:?source connection id required}"
+DST_CONN="${4:?destination connection id required}"
+PUSHED="${5:-0}"
+
+SUPP="$DIR/mixed-timeseries.csv"
+PUSHES="$DIR/pushes.csv"
+[ -f "$SUPP" ] || { echo "mixed-summarize: $SUPP not found"; exit 1; }
+
+PG_CONTAINER="${PG_CONTAINER:-lab-postgres}"
+PG_DB="${PG_DB:-openlinker}"
+PG_USER="${PG_USER:-postgres}"
+
+# Local copy rather than sourcing lib.sh: this script is run as a child of the
+# scenario, which already holds the stand lock and has an EXIT trap installed -
+# sourcing lib.sh here would install a second one in the child.
+pg() { docker exec -i "$PG_CONTAINER" psql -U "$PG_USER" -d "$PG_DB" -tA -c "$1"; }
+
+hr() { printf '%s\n' '---------------------------------------------------------------------------'; }
+
+# Column indices, resolved from the header by NAME rather than hardcoded, so a
+# column added to the scenario's CSV cannot silently shift every figure here.
+col() {
+  awk -F, -v want="$1" 'NR==1 {for(i=1;i<=NF;i++) if ($i==want) {print i; exit}}' "$SUPP"
+}
+C_ELAPSED="$(col elapsed)"
+C_PHASE="$(col phase)"
+C_QDUE="$(col g_queued_due)"
+C_QDEF="$(col g_queued_deferred)"
+C_RUN="$(col g_running)"
+C_DEAD="$(col g_dead)"
+C_OSQ="$(col ord_sync_queued)"
+C_OSS="$(col ord_sync_succeeded)"
+C_ING="$(col orders_ingested)"
+C_BE="$(col pg_backends)"
+C_BEA="$(col pg_backends_active)"
+C_MAXC="$(col pg_max_conn)"
+C_DEG="$(col limiter_degraded_delta)"
+for v in C_ELAPSED C_PHASE C_QDUE C_QDEF C_RUN C_DEAD C_OSQ C_OSS C_ING C_BE C_BEA C_MAXC C_DEG; do
+  [ -n "${!v}" ] || { echo "mixed-summarize: could not resolve column for $v from $SUPP header"; exit 1; }
+done
+
+NSAMPLES="$(awk 'NR>1' "$SUPP" | wc -l | tr -d ' ')"
+ELAPSED="$(awk -F, -v c="$C_ELAPSED" 'NR>1 {v=$c} END {print v+0}' "$SUPP")"
+
+echo
+hr
+echo "SUSTAINED MIXED LOAD - summary"
+hr
+printf 'window start (UTC)      %s\n' "$WS_ISO"
+printf 'window length           %ss (%.2f h)\n' "$ELAPSED" "$(awk -v e="$ELAPSED" 'BEGIN{printf "%.2f", e/3600}')"
+printf 'samples                 %s\n' "$NSAMPLES"
+printf 'orders pushed to stub   %s\n' "$PUSHED"
+
+# --- 1. Queue depth curve -------------------------------------------------
+hr
+echo "1. QUEUE DEPTH (install-wide, all connections; DUE rows only)"
+echo "   A 'queued' row whose nextRunAt is in the future is backing off on its"
+echo "   own schedule and is not queue depth - it is reported separately."
+hr
+# The curve rule lives in ONE place - drivers/queue-curve.awk - and is
+# exercised by drivers/queue-curve-test.sh against three synthetic curves
+# whose right answers are known by construction. An inline copy here is
+# exactly the shape `perf/prestashop-baseline` grew seven times, one of them
+# wrong in a way nobody noticed until a results file reported the wrong
+# offset (lib.sh's own header records it).
+CURVE_AWK="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/queue-curve.awk"
+[ -f "$CURVE_AWK" ] || { echo "mixed-summarize: $CURVE_AWK not found"; exit 1; }
+CURVE="$(awk -F, -v ce="$C_ELAPSED" -v cq="$C_QDUE" -f "$CURVE_AWK" "$SUPP")"
+cv() { awk -F= -v k="$1" '$1==k {print $2; exit}' <<< "$CURVE"; }
+
+CV_VERDICT="$(cv verdict)"
+printf '   samples used / dropped         : %s / %s\n' "$(cv n)" "$(cv dropped)"
+if [ "$CV_VERDICT" = "insufficient-samples" ]; then
+  printf '   verdict                        : INSUFFICIENT SAMPLES (floor %s)\n' "$(cv min_samples)"
+else
+  printf '   depth first / min / max / last : %s / %s / %s / %s\n' "$(cv first)" "$(cv min)" "$(cv max)" "$(cv last)"
+  printf '   deferred (backing off) at end  : %s\n' \
+    "$(awk -F, -v c="$C_QDEF" 'END{print $c}' "$SUPP")"
+  printf '   running at end                 : %s\n' \
+    "$(awk -F, -v c="$C_RUN" 'END{print $c}' "$SUPP")"
+  printf '   overall slope                  : %s jobs/h (least squares)\n' "$(cv overall_slope_per_h)"
+  printf '   last-third slope               : %s jobs/h (n=%s over %ss)\n' \
+    "$(cv tail_slope_per_h)" "$(cv tail_n)" "$(cv tail_span_s)"
+  printf '   noise band (+/-)               : %s jobs/h (sd=%s)\n' "$(cv noise_band_per_h)" "$(cv tail_sd)"
+  case "$CV_VERDICT" in
+    growing)
+      echo "   verdict                        : GROWING - unbounded at this offered rate"
+      echo "   NOTE: the window ENDED BEFORE THE QUEUE CONVERGED. The last sample"
+      echo "         is not an equilibrium and must not be quoted as one." ;;
+    converging) echo "   verdict                        : CONVERGING - draining" ;;
+    plateau)    echo "   verdict                        : PLATEAU - bounded at this offered rate" ;;
+    *)          printf '   verdict                        : UNRECOGNISED [%s]\n' "$CV_VERDICT" ;;
+  esac
+fi
+
+echo
+echo "   curve (every ~10th sample): elapsed_s  due  deferred  running"
+awk -F, -v ce="$C_ELAPSED" -v cq="$C_QDUE" -v cd="$C_QDEF" -v cr="$C_RUN" '
+  NR>1 { n++; if (n % 10 == 1) printf "     %8d %6d %9d %8d\n", $ce, $cq, $cd, $cr }' "$SUPP"
+
+# --- 2. Order throughput --------------------------------------------------
+hr
+echo "2. ORDER THROUGHPUT"
+echo "   'ingested'  = order_records rows created in the window for the source"
+echo "   'completed' = marketplace.order.sync jobs that reached status=succeeded"
+hr
+awk -F, -v ce="$C_ELAPSED" -v ci="$C_ING" -v cs="$C_OSS" -v cp="$C_PHASE" '
+  NR>1 && $ci >= 0 {
+    if (!seen) { e0=$ce; i0=$ci; s0=$cs; seen=1 }
+    e1=$ce; i1=$ci; s1=$cs;
+    # Per-phase first/last so a fault window can be reported separately.
+    if (!(($cp) in pf)) { pf[$cp]=$ce; pi[$cp]=$ci; ps[$cp]=$cs }
+    pl[$cp]=$ce; pil[$cp]=$ci; psl[$cp]=$cs;
+  }
+  END {
+    if (!seen) { print "   no samples"; exit }
+    dur = e1-e0; if (dur<=0) dur=1;
+    printf "   whole window : ingested %d, completed %d over %ds\n", i1-i0, s1-s0, dur;
+    printf "                  = %.1f orders/h ingested, %.1f orders/h completed  [measured]\n", (i1-i0)*3600/dur, (s1-s0)*3600/dur;
+    print  "";
+    print  "   by phase:";
+    for (p in pf) {
+      d = pl[p]-pf[p]; if (d<=0) continue;
+      printf "     %-10s %5ds  ingested %5d (%7.1f/h)  completed %5d (%7.1f/h)\n", \
+        p, d, pil[p]-pi[p], (pil[p]-pi[p])*3600/d, psl[p]-ps[p], (psl[p]-ps[p])*3600/d;
+    }
+  }' "$SUPP"
+
+# --- 3. Memory and connections --------------------------------------------
+hr
+echo "3. POSTGRES BACKENDS AND MEMORY"
+hr
+awk -F, -v cb="$C_BE" -v ca="$C_BEA" -v cm="$C_MAXC" '
+  NR>1 && $cb >= 0 {
+    n++; if (n==1 || $cb>bmax) bmax=$cb; if (n==1 || $cb<bmin) bmin=$cb; bs+=$cb;
+    if (n==1 || $ca>amax) amax=$ca; as+=$ca; mx=$cm; last=$cb;
+  }
+  END {
+    if (!n) { print "   no samples"; exit }
+    printf "   backends  min %d  mean %.1f  max %d  last %d   (max_connections %s)\n", bmin, bs/n, bmax, last, mx;
+    printf "   active    mean %.1f  max %d\n", as/n, amax;
+    if (mx+0 > 0) printf "   peak utilisation %.1f%% of max_connections\n", bmax*100/mx;
+  }' "$SUPP"
+
+echo
+echo "   container memory, first and last sample (from the stored docker stats blob):"
+for pos in first last; do
+  if [ "$pos" = first ]; then row="$(awk 'NR==2' "$SUPP")"; else row="$(tail -1 "$SUPP")"; fi
+  # The blob is the second-to-last RFC4180-quoted field. Pulled out with sed
+  # rather than a CSV parser for the reason in this script's header.
+  blob="$(printf '%s' "$row" | sed -n 's/.*,"\(\[.*\]\)","{.*/\1/p' | sed 's/""/"/g')"
+  if [ -n "$blob" ]; then
+    printf '     %-5s ' "$pos"
+    printf '%s' "$blob" | jq -r '[.[] | select(.name|test("lab-(api|worker|postgres|redis|prestashop)")) | "\(.name)=\(.mem|split(" / ")[0])"] | join("  ")' 2>/dev/null || echo "(unparseable)"
+  else
+    printf '     %-5s (blob not found in row)\n' "$pos"
+  fi
+done
+
+# --- 4. Limiter degradation ------------------------------------------------
+hr
+echo "4. LIMITER DEGRADATION"
+echo "   Each line is an EPISODE, not a call: the fallback message is logged on"
+echo "   the transition into degraded mode and then at most once per 30s"
+echo "   (DEGRADED_LOG_INTERVAL_MS). The number of individual calls that fell"
+echo "   back is NOT established by this figure."
+hr
+awk -F, -v cd="$C_DEG" -v ce="$C_ELAPSED" '
+  NR>1 && $cd >= 0 { n++; t+=$cd; if ($cd>mx) mx=$cd; e=$ce }
+  END {
+    if (!n) { print "   no samples"; exit }
+    dur = (e>0) ? e : 1;
+    printf "   observed total          : %d episode(s) over %ds  [measured]\n", t, dur;
+    printf "   observed rate           : %.1f episodes/h\n", t*3600/dur;
+    printf "   busiest sample interval : %d episode(s)\n", mx;
+    print  "";
+    printf "   For comparison, extrapolating the retest campaign 300s arm-A figure\n";
+    printf "   (40-49 episodes per 300s window, MEASURED 2026-09-07) to this\n";
+    printf "   window length predicts %.0f-%.0f episodes  [extrapolated].\n", 40*dur/300, 49*dur/300;
+    printf "   Observed / low-end extrapolation = %.2fx.\n", (40*dur/300>0) ? t/(40*dur/300) : 0;
+  }' "$SUPP"
+
+# --- 5. Where the queue went ----------------------------------------------
+hr
+echo "5. WHAT THE QUEUE WAS MADE OF (last sample)"
+hr
+tail -1 "$SUPP" | sed -n 's/.*,"{\(.*\)}"$/{\1}/p' | sed 's/""/"/g' \
+  | jq -r 'to_entries | sort_by(-.value) | .[] | "     \(.value)\t\(.key)"' 2>/dev/null \
+  || echo "     (unparseable)"
+
+# --- 6. Terminal job outcomes ---------------------------------------------
+hr
+echo "6. JOBS CREATED IN THE WINDOW, BY TYPE AND TERMINAL STATE  [measured]"
+hr
+pg "SELECT \"jobType\" || E'\t' || status || E'\t' || COALESCE(outcome,'-') || E'\t' || COUNT(*)
+    FROM sync_jobs WHERE \"createdAt\" >= '$WS_ISO'
+    GROUP BY 1,2,3 ORDER BY COUNT(*) DESC LIMIT 40" \
+  | awk -F'\t' '{printf "     %-44s %-10s %-16s %s\n", $1, $2, $3, $4}'
+
+# --- 7. Destination outcome ----------------------------------------------
+hr
+echo "7. DESTINATION CREATES FOR ORDERS INGESTED IN THE WINDOW  [measured]"
+echo "   This is the one syncStatus containment read in the whole run - F5"
+echo "   measured it at ~142ms and ~540MB of buffer traffic per execution at"
+echo "   1M rows, so it is computed once here rather than sampled."
+hr
+pg "SELECT
+      COUNT(*)::text || E'\t' || 'ingested'
+    FROM order_records WHERE \"createdAt\" >= '$WS_ISO' AND \"sourceConnectionId\" = '$SRC_CONN'
+    UNION ALL
+    SELECT COUNT(*)::text || E'\t' || 'with syncedAt on the destination'
+    FROM order_records WHERE \"createdAt\" >= '$WS_ISO' AND \"sourceConnectionId\" = '$SRC_CONN'
+      AND EXISTS (SELECT 1 FROM jsonb_array_elements(\"syncStatus\") e
+                  WHERE e->>'destinationConnectionId' = '$DST_CONN' AND e->>'syncedAt' IS NOT NULL)
+    UNION ALL
+    SELECT COUNT(*)::text || E'\t' || 'carrying a FAILED syncStatus entry'
+    FROM order_records WHERE \"createdAt\" >= '$WS_ISO' AND \"sourceConnectionId\" = '$SRC_CONN'
+      AND EXISTS (SELECT 1 FROM jsonb_array_elements(\"syncStatus\") e WHERE e->>'status' = 'failed')
+    UNION ALL
+    SELECT COUNT(*)::text || E'\t' || 'with NO syncStatus entry at all'
+    FROM order_records WHERE \"createdAt\" >= '$WS_ISO' AND \"sourceConnectionId\" = '$SRC_CONN'
+      AND (\"syncStatus\" IS NULL OR jsonb_array_length(\"syncStatus\") = 0)" \
+  | awk -F'\t' '{printf "     %8s  %s\n", $1, $2}'
+
+# --- 8. Per-attempt duration ---------------------------------------------
+hr
+echo "8. PER-ATTEMPT DURATION, sync_jobs.lastAttemptDurationMs  [measured]"
+echo "   Real precision, not the ~1Hz sampler floor. NULL is EXCLUDED and the"
+echo "   non-null sample size is printed beside each row: the column is null on"
+echo "   every row predating its migration and is reset on every enqueue, so"
+echo "   counting nulls as zero would understate every duration (#2611)."
+hr
+pg "SELECT \"jobType\" || E'\t' || COUNT(*) || E'\t' ||
+      COALESCE(ROUND(percentile_cont(0.5) WITHIN GROUP (ORDER BY \"lastAttemptDurationMs\"))::text,'-') || E'\t' ||
+      COALESCE(ROUND(percentile_cont(0.95) WITHIN GROUP (ORDER BY \"lastAttemptDurationMs\"))::text,'-') || E'\t' ||
+      COALESCE(MAX(\"lastAttemptDurationMs\")::text,'-')
+    FROM sync_jobs
+    WHERE \"createdAt\" >= '$WS_ISO' AND \"lastAttemptDurationMs\" IS NOT NULL
+    GROUP BY 1 ORDER BY COUNT(*) DESC LIMIT 20" \
+  | awk -F'\t' 'BEGIN {printf "     %-44s %6s %8s %8s %8s\n", "jobType", "n", "p50ms", "p95ms", "maxms"}
+               {printf "     %-44s %6s %8s %8s %8s\n", $1, $2, $3, $4, $5}'
+
+# --- 9. Attempts / deferrals ----------------------------------------------
+hr
+echo "9. RETRIES AND DEFERRALS FOR WINDOW JOBS  [measured]"
+hr
+pg "SELECT 'jobs with attempts>1' || E'\t' || COUNT(*) FROM sync_jobs
+      WHERE \"createdAt\" >= '$WS_ISO' AND attempts > 1
+    UNION ALL
+    SELECT 'jobs with deferredTotalMs>0' || E'\t' || COUNT(*) FROM sync_jobs
+      WHERE \"createdAt\" >= '$WS_ISO' AND \"deferredTotalMs\" > 0
+    UNION ALL
+    SELECT 'max attempts seen' || E'\t' || COALESCE(MAX(attempts)::text,'-') FROM sync_jobs
+      WHERE \"createdAt\" >= '$WS_ISO'
+    UNION ALL
+    SELECT 'max deferredTotalMs seen' || E'\t' || COALESCE(MAX(\"deferredTotalMs\")::text,'-') FROM sync_jobs
+      WHERE \"createdAt\" >= '$WS_ISO'
+    UNION ALL
+    SELECT 'dead jobs' || E'\t' || COUNT(*) FROM sync_jobs
+      WHERE \"createdAt\" >= '$WS_ISO' AND status='dead'" \
+  | awk -F'\t' '{printf "     %-32s %s\n", $1, $2}'
+
+# --- 10. Database growth --------------------------------------------------
+hr
+echo "10. DATABASE SIZE  [measured]"
+hr
+if [ -f "$DIR/timeseries.csv" ]; then
+  awk -F, 'NR==2 {a=$7} END {b=$7} END {
+    printf "     first sample %.1f MB, last sample %.1f MB, delta %+.1f MB\n", a/1048576, b/1048576, (b-a)/1048576 }' \
+    "$DIR/timeseries.csv"
+else
+  echo "     (lib.sh timeseries.csv absent)"
+fi
+
+hr
+echo "Pushes log:      $PUSHES"
+echo "Queue timeseries: $SUPP"
+echo "lib timeseries:   $DIR/timeseries.csv"
+hr

--- a/perf/openlinker-throughput/drivers/queue-curve-test.sh
+++ b/perf/openlinker-throughput/drivers/queue-curve-test.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+#
+# Tests for drivers/queue-curve.awk (#2983).
+#
+# The point of this file is anti-vacuity, in the sense this campaign's own
+# guards use the word: a convergence verdict that CANNOT return `growing`
+# reads exactly like a healthy system, and a plateau band wide enough to
+# swallow any slope makes every run look bounded. So each verdict is proved
+# reachable against a curve whose right answer is known by construction, and
+# the flattering answers are proved NOT to be returned for the others.
+#
+#   bash drivers/queue-curve-test.sh
+#
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AWK_PROG="$DIR/queue-curve.awk"
+[ -f "$AWK_PROG" ] || { echo "queue-curve.awk not found beside this test"; exit 1; }
+
+PASS=0
+FAIL=0
+FAILURES=()
+
+# Column layout matches the scenario's own CSV closely enough to be
+# meaningful: elapsed in column 1, depth in column 2, plus a third column so a
+# trailing field cannot be silently read as the depth.
+synth() {
+  # synth <out> <start> <step_per_sample> <n> [jitter_amplitude]
+  local out="$1" start="$2" step="$3" count="$4" jit="${5:-0}"
+  printf 'elapsed,depth,other\n' > "$out"
+  awk -v s="$start" -v st="$step" -v n="$count" -v j="$jit" 'BEGIN {
+    srand(7);
+    for (i = 0; i < n; i++) {
+      d = s + st * i;
+      if (j > 0) d += (int(rand() * (2 * j + 1)) - j);
+      if (d < 0) d = 0;
+      printf "%d,%d,x\n", i * 30, d;
+    }
+  }' >> "$out"
+}
+
+run_curve() {
+  awk -F, -v ce=1 -v cq=2 -f "$AWK_PROG" "$1"
+}
+
+field() {
+  awk -F= -v k="$2" '$1 == k { print $2; exit }' <<< "$1"
+}
+
+check() {
+  local name="$1" want="$2" got="$3"
+  if [ "$want" = "$got" ]; then
+    PASS=$((PASS + 1))
+  else
+    FAIL=$((FAIL + 1))
+    FAILURES+=("$name: expected [$want] got [$got]")
+  fi
+}
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+echo "--- the three verdicts are each reachable ---"
+
+# A queue growing by 2 jobs per 30s sample = 240 jobs/h, unmistakable.
+synth "$TMP/grow.csv" 0 2 200
+OUT="$(run_curve "$TMP/grow.csv")"
+check "a monotonically rising curve is GROWING" growing "$(field "$OUT" verdict)"
+check "and its tail slope is positive" 1 "$(awk -v v="$(field "$OUT" tail_slope_per_h)" 'BEGIN{print (v>0)?1:0}')"
+
+# A flat queue with +/-3 jobs of jitter. This is the assertion that stops the
+# band being cosmetic: without a noise band the sign of the tail slope here is
+# a coin toss.
+synth "$TMP/flat.csv" 500 0 200 3
+OUT="$(run_curve "$TMP/flat.csv")"
+check "a flat curve with jitter is PLATEAU" plateau "$(field "$OUT" verdict)"
+
+# A draining queue.
+synth "$TMP/drain.csv" 5000 -2 200
+OUT="$(run_curve "$TMP/drain.csv")"
+check "a falling curve is CONVERGING" converging "$(field "$OUT" verdict)"
+check "and its tail slope is negative" 1 "$(awk -v v="$(field "$OUT" tail_slope_per_h)" 'BEGIN{print (v<0)?1:0}')"
+
+echo "--- a peak that flattens is not reported as still growing ---"
+# Rises hard for the first half, then flat. An OVERALL slope would call this
+# growing for ever; the last third is what makes it a plateau. This is the
+# "endpoint comparison cannot tell a plateau from a peak" case in the awk
+# program's own header, proved rather than asserted.
+{
+  printf 'elapsed,depth,other\n'
+  awk 'BEGIN { for (i = 0; i < 90; i++) printf "%d,%d,x\n", i*30, i*10 }'
+  awk 'BEGIN { for (i = 90; i < 180; i++) printf "%d,%d,x\n", i*30, 890 }'
+} > "$TMP/peak.csv"
+OUT="$(run_curve "$TMP/peak.csv")"
+check "a curve that rose and then flattened is PLATEAU" plateau "$(field "$OUT" verdict)"
+check "even though its overall slope is clearly positive" 1 \
+  "$(awk -v v="$(field "$OUT" overall_slope_per_h)" 'BEGIN{print (v>100)?1:0}')"
+
+echo "--- a still-rising tail is never softened to plateau ---"
+# The inverse of the case above, and the one that matters: flat for the first
+# half, rising at the end. Reporting this as a plateau would publish the
+# endpoint of an unconverged run as an equilibrium.
+{
+  printf 'elapsed,depth,other\n'
+  awk 'BEGIN { for (i = 0; i < 90; i++) printf "%d,%d,x\n", i*30, 100 }'
+  awk 'BEGIN { for (i = 90; i < 180; i++) printf "%d,%d,x\n", i*30, 100 + (i-90)*5 }'
+} > "$TMP/late.csv"
+OUT="$(run_curve "$TMP/late.csv")"
+check "a curve rising only at the end is GROWING" growing "$(field "$OUT" verdict)"
+
+echo "--- failed samples are dropped, never read as zero ---"
+# The sampler writes -1 when a query failed. Reading those as 0 would drag a
+# rising curve toward the flattering answer, so they must be dropped and
+# COUNTED.
+{
+  printf 'elapsed,depth,other\n'
+  awk 'BEGIN { for (i = 0; i < 200; i++) printf "%d,%d,x\n", i*30, (i%20==0) ? -1 : 1000 + i*2 }'
+} > "$TMP/neg.csv"
+OUT="$(run_curve "$TMP/neg.csv")"
+check "negative depths are dropped" 10 "$(field "$OUT" dropped)"
+check "and the surviving samples still read GROWING" growing "$(field "$OUT" verdict)"
+check "n counts only the surviving samples" 190 "$(field "$OUT" n)"
+
+echo "--- too little data refuses rather than guessing ---"
+{
+  printf 'elapsed,depth,other\n'
+  printf '0,5,x\n30,9,x\n'
+} > "$TMP/tiny.csv"
+OUT="$(run_curve "$TMP/tiny.csv")"
+check "two samples cannot describe a curve" insufficient-samples "$(field "$OUT" verdict)"
+
+# Eleven samples is one below the floor: a rising curve this short must be
+# refused rather than labelled, because its tail would be three points and the
+# noise band would come from three samples. This is the assertion that keeps
+# MIN_SAMPLES from being lowered back to the n>=4 the first draft used.
+{
+  printf 'elapsed,depth,other\n'
+  awk 'BEGIN { for (i = 0; i < 11; i++) printf "%d,%d,x\n", i*30, 10+i*5 }'
+} > "$TMP/eleven.csv"
+OUT="$(run_curve "$TMP/eleven.csv")"
+check "eleven samples is below the floor and is refused" insufficient-samples "$(field "$OUT" verdict)"
+check "and the refusal names the floor it applied" 12 "$(field "$OUT" min_samples)"
+
+# Twelve is the floor exactly, and must produce a verdict rather than refusing -
+# a floor that is never cleared is a floor that disables the instrument.
+{
+  printf 'elapsed,depth,other\n'
+  awk 'BEGIN { for (i = 0; i < 12; i++) printf "%d,%d,x\n", i*30, 10+i*5 }'
+} > "$TMP/twelve.csv"
+OUT="$(run_curve "$TMP/twelve.csv")"
+check "twelve samples clears the floor" growing "$(field "$OUT" verdict)"
+
+echo "--- a header-only file does not crash ---"
+printf 'elapsed,depth,other\n' > "$TMP/empty.csv"
+OUT="$(run_curve "$TMP/empty.csv")"
+check "an empty body reports zero samples" 0 "$(field "$OUT" n)"
+check "and refuses a verdict" insufficient-samples "$(field "$OUT" verdict)"
+
+echo
+if [ "$FAIL" -eq 0 ]; then
+  printf '=== %d passed, 0 failed ===\n' "$PASS"
+  exit 0
+fi
+printf '=== %d passed, %d failed ===\n' "$PASS" "$FAIL"
+printf 'FAILURES:\n'
+for f in "${FAILURES[@]}"; do printf '  - %s\n' "$f"; done
+exit 1

--- a/perf/openlinker-throughput/drivers/queue-curve.awk
+++ b/perf/openlinker-throughput/drivers/queue-curve.awk
@@ -1,0 +1,110 @@
+# Queue-depth curve analysis for the sustained mixed-load soak (#2983).
+#
+# Reads a CSV on stdin and prints one `key=value` line per figure. Kept as its
+# own program, rather than inline in mixed-summarize.sh, for one reason: it is
+# the only place in this scenario that makes a JUDGEMENT rather than reporting
+# a number, and the commissioning task names the specific dishonesty it must
+# avoid - "reporting an endpoint as if it were a steady state". A judgement
+# that cannot be tested against a known-growing curve is a judgement nobody
+# should believe, and `queue-curve-test.sh` feeds it three synthetic curves
+# whose right answers are known by construction.
+#
+# Required variables (-v):
+#   ce  1-based column index of the elapsed-seconds field
+#   cq  1-based column index of the queue-depth field
+# Optional:
+#   skip  number of leading data rows to ignore (default 0)
+#
+# Input contract: row 1 is a header and is skipped. A row whose depth field is
+# negative is DROPPED, not read as zero - the sampler writes -1 when a query
+# failed, and averaging a failed sample in as 0 would drag a rising curve
+# toward "plateau", i.e. toward the flattering answer.
+#
+# ---------------------------------------------------------------------------
+# WHY THE LAST THIRD, AND WHY A NOISE BAND
+# ---------------------------------------------------------------------------
+# An endpoint comparison (last minus first) cannot tell a plateau from a peak,
+# and an overall slope over a curve that rose and then flattened reports the
+# rise for ever. The last third is where a plateau would be if there were one.
+#
+# The noise band is one sample-to-sample standard deviation of that last
+# third, converted to a per-hour slope over the sub-window it spans. Without
+# it, a curve jittering by a few jobs around a flat mean would be labelled
+# `growing` or `converging` at random depending on which sample happened to be
+# last. `plateau` is therefore the answer only when the slope is INSIDE the
+# band - it is a claim about being unable to distinguish the slope from
+# jitter, not a claim that the slope is zero.
+#
+# The three verdicts are exhaustive and there is deliberately no fourth
+# "steady state" value: `plateau` is as strong a claim as this instrument can
+# support, and `growing` carries an explicit note that the window ended before
+# the queue converged.
+# The minimum surviving-sample count a verdict may be computed from.
+#
+# 12 rather than 4, and the reason is the TAIL rather than the whole curve:
+# the verdict is a slope over the last third compared against that third's own
+# standard deviation, so the floor has to leave the tail with enough points
+# for an sd to mean anything. At n=12 the tail is 4 points; below that the
+# band is computed from two or three samples and would label a curve on the
+# strength of essentially nothing.
+#
+# A real window is nowhere near this bound - the scenario samples every 30s,
+# so four hours is ~480 samples. The floor exists so a truncated or
+# interrupted run REFUSES rather than publishing a confident verdict from a
+# handful of rows, which is the same failure `post_guard_feed_starved` refuses
+# for offered load.
+BEGIN { n = 0; nskipped = 0; ndropped = 0; MIN_SAMPLES = 12 }
+
+NR == 1 { next }
+
+{
+  if (skip > 0 && nskipped < skip) { nskipped++; next }
+  if ($cq + 0 < 0) { ndropped++; next }
+  n++
+  e[n] = $ce + 0
+  q[n] = $cq + 0
+  if (n == 1) { mn = q[n]; mx = q[n]; first = q[n] }
+  if (q[n] < mn) mn = q[n]
+  if (q[n] > mx) mx = q[n]
+  last = q[n]
+  sx += e[n]; sy += q[n]; sxx += e[n] * e[n]; sxy += e[n] * q[n]
+}
+
+END {
+  printf "n=%d\n", n
+  printf "dropped=%d\n", ndropped
+  if (n < MIN_SAMPLES) {
+    printf "min_samples=%d\n", MIN_SAMPLES
+    print "verdict=insufficient-samples"
+    exit 0
+  }
+  printf "first=%d\nmin=%d\nmax=%d\nlast=%d\n", first, mn, mx, last
+
+  denom = n * sxx - sx * sx
+  if (denom != 0) printf "overall_slope_per_h=%.1f\n", (n * sxy - sx * sy) / denom * 3600
+  else print "overall_slope_per_h=nan"
+
+  lo = int(n * 2 / 3); if (lo < 1) lo = 1
+  m = 0; tx = 0; ty = 0; txx = 0; txy = 0
+  for (i = lo; i <= n; i++) { m++; tx += e[i]; ty += q[i]; txx += e[i] * e[i]; txy += e[i] * q[i] }
+  tdenom = m * txx - tx * tx
+  if (m < 3 || tdenom == 0) {
+    printf "tail_n=%d\n", m
+    print "verdict=insufficient-samples"
+    exit 0
+  }
+  ts = (m * txy - tx * ty) / tdenom * 3600
+
+  mean = ty / m; ss = 0
+  for (i = lo; i <= n; i++) ss += (q[i] - mean) * (q[i] - mean)
+  sd = (m > 1) ? sqrt(ss / (m - 1)) : 0
+  span = e[n] - e[lo]; if (span <= 0) span = 1
+  band = sd / span * 3600
+
+  printf "tail_n=%d\ntail_span_s=%d\ntail_mean=%.1f\ntail_sd=%.1f\n", m, span, mean, sd
+  printf "tail_slope_per_h=%.1f\nnoise_band_per_h=%.1f\n", ts, band
+
+  if (ts > band)       print "verdict=growing"
+  else if (ts < -band) print "verdict=converging"
+  else                 print "verdict=plateau"
+}

--- a/perf/openlinker-throughput/lib-test.sh
+++ b/perf/openlinker-throughput/lib-test.sh
@@ -624,7 +624,19 @@ echo "--- run_post_guards threads the feed guard through ---"
 # is the failure mode the k6-summary argument already has a warning about in
 # run_post_guards' own docblock. These two assertions pin both directions.
 FAKE_PG[count]=0
+WORKER_CONTAINERS="lab-worker"
 RPG_DIR="$(mktemp -d)"
+# window_start would have captured this baseline; a test calling
+# run_post_guards directly must establish it too, or
+# post_guard_containers_stable correctly refuses to certify a window it has no
+# "before" reading for - and the VALID assertion below then fails for a reason
+# that has nothing to do with the feed argument it is about. That is exactly
+# how this assertion shipped failing: the sibling block under
+# "run_post_guards wiring" below carries this same line and this one did not,
+# so the first of these two assertions has never passed. The missing-baseline
+# refusal itself is covered separately, under
+# "post_guard_containers_stable", so seeding it here hides nothing.
+capture_container_starts "$RPG_DIR"
 run_post_guards "$RPG_DIR" "'c1'" '2026-01-01T00:00:00Z' 0 9999999999 '' '' '' '' >/dev/null 2>&1 || true
 assert_eq "omitting the feed argument leaves the verdict VALID (not applicable)" \
   "VALID" "$(verdict_read "$RPG_DIR" | head -1)"

--- a/perf/openlinker-throughput/results-sustained-mixed-load-2026-09-08.md
+++ b/perf/openlinker-throughput/results-sustained-mixed-load-2026-09-08.md
@@ -16,6 +16,42 @@ hourly cron, nine `master.product.syncAll` ticks, twelve
 `master.inventory.syncAll` ticks, ~180 order polls and ~360 samples. It is
 stated here rather than implied, and § 6 says what a longer window would add.
 
+> ## Correction, 2026-09-08 - the memory figures published in the first
+> ## revision of this report were contaminated, and are restated in § 4
+>
+> **Withdrawn.** The RSS slopes and endpoints in the first revision:
+> `lab-worker-1` +0.67 MB/h, first 133.1 -> last 133.6, min 75.1;
+> `lab-api` −1.46 MB/h; `lab-postgres` −1.71 MB/h; `lab-redis` +0.70 MB/h;
+> Postgres page cache "1 574 -> 1 502 MB". All n=134/135.
+>
+> **Why.** The side sampler added mid-window (§ 2.4.1) decided when to stop
+> with `ps aux | grep '[s]ustained-mixed-load'` - the scenario's own *name*.
+> A **peer agent in another worktree then ran the same scenario**, that grep
+> matched their process, and the sampler kept appending to this run's results
+> directory for **3.5 hours past window close**. The first analysis was run
+> minutes after the window closed and so picked up a handful of post-window
+> rows, taken while the worker was being recreated by the teardown - which is
+> where the anomalous `min 75.1 MB` came from.
+>
+> **What replaced it.** § 4's table, recomputed over the **131 samples with
+> `ts <= 08:54:04Z`**. The slopes move materially - the worker's nearly
+> triples, from +0.67 to +1.85 MB/h - so this is a real correction and not a
+> rounding one.
+>
+> **What did NOT change: the conclusion.** Nothing accumulates. On the
+> corrected series the worker *ends 16.9 MB lower than it starts* inside a
+> 45 MB band, which is a stronger reading of "no leak" than the original
+> figures gave. What weakens is the *sensitivity*: the floor below which a
+> leak would be invisible rises from ~1 MB/h to ~2 MB/h.
+>
+> **Nothing else in this report draws on that file.** The throughput,
+> concurrency, queue-curve, degradation and fault findings come from
+> `sync_jobs`, `order_records` and `mixed-timeseries.csv`, all of which stop
+> at `window_stop` by construction. The raw CSV is deliberately **not**
+> trimmed - editing collected data is worse than documenting its boundary -
+> so a reader re-running the analysis must apply the same `ts` restriction.
+> The process lesson is at § 7 item 8.
+
 ## This is the run the epic named and never got
 
 The framing is **#2840's own**, in the epic issue body:
@@ -79,7 +115,7 @@ Window **10 783 s = 3.00 h**, 319 samples, 10 800 orders offered. **Verdict:
 | **What binds it?** | The `realtime` **per-scope cap of 2**, proven twice (§ 3.3). `2 slots / 31.44 s mean service = 229 orders/h` ceiling; the recovery phase reached 99.3% of it | measured + derived |
 | **Was the destination rate limit binding?** | **No.** At ~11 req/order and 200 orders/h that is ~37 req/min against the 300/min the manifest now ships - ~12% utilisation | derived |
 | **Does the queue converge?** | **No - it grows without bound at this offered rate**, +4 298 jobs/h over the last third against a ±1 259 noise band. But this is a property of the OFFERED LOAD, not a capacity result - see § 0.2 | measured |
-| **Does anything accumulate over hours?** | **No.** Worker RSS +0.67 MB/h inside a 75-143 MB oscillation band; api and Postgres RSS slopes negative; Postgres page cache plateaued at ~1.5 GB; backends peaked at 46 of 200; database +29.8 MB | measured |
+| **Does anything accumulate over hours?** | **No.** Worker RSS *ends 16.9 MB lower than it starts* inside a 98-143 MB band (fitted slope +1.85 MB/h = 9% of the band); api and Postgres slopes negative; Postgres page cache plateaued (+2%); backends peaked at 46 of 200; database +29.8 MB. A leak slower than ~2 MB/h is not distinguishable here | measured |
 | **How many limiter-degradation episodes does 3 h carry, vs the 300 s extrapolation?** | **1 454** against a predicted 1 438-1 761. **The 300 s figure extrapolates linearly - 1.01x the low end.** Degradation is a steady ~8/min, it does not accumulate | measured vs extrapolated |
 | **Does a destination fault strand orders at volume the way it does at 12?** | **The mechanism reproduced; the rate did not scale.** 1 of 413 (0.24%) against #2978's 17-42%. Stranding scales with orders IN FLIGHT, which the lane cap bounds - not with queue depth (§ 3.4) | measured |
 | Did the sweeps actually run inside the window? | **Yes** - 9 `master.product.syncAll`, 45 `syncBatch`, 300 `syncFromSweep`, 12 `master.inventory.syncAll`, 3 `master.product.reconcile`, matching their crons exactly (§ 3.1) | measured |
@@ -795,28 +831,35 @@ the `requeueWithoutPenalty` path (#2613) never fired.
 
 The question a 300-second window structurally cannot answer.
 
-**Memory (cgroup `total_rss`, n=134 samples over ~2 h 14 m - see § 2.4.1 for
-why `docker stats` cannot answer this and why the series starts late):**
+**Memory (cgroup `total_rss`, n=131 samples over ~2 h 13 m, restricted to
+samples inside the window - see § 2.4.1 for why `docker stats` cannot answer
+this and why the series starts late, and the correction block at the top of
+this report for why the restriction is necessary):**
 
 | container | first | last | min | max | mean | slope |
 |---|---|---|---|---|---|---|
-| `lab-worker-1` | 133.1 | 133.6 | 75.1 | 143.3 | 114.5 | **+0.67 MB/h** |
-| `lab-api` | 126.3 | 109.9 | 109.9 | 126.4 | 125.7 | −1.46 MB/h |
-| `lab-postgres` | 77.1 | 1.1 | 1.0 | 77.1 | 13.7 | −1.71 MB/h |
-| `lab-redis` | 45.5 | 41.8 | 41.8 | 51.8 | 47.7 | +0.70 MB/h |
+| `lab-worker-1` | 133.1 | **116.2** | 98.4 | 143.3 | 114.9 | **+1.85 MB/h** |
+| `lab-api` | 126.3 | 121.8 | 121.8 | 126.4 | 126.0 | −0.75 MB/h |
+| `lab-postgres` | 77.1 | 9.5 | 3.0 | 77.1 | 14.1 | −0.78 MB/h |
+| `lab-redis` | 45.5 | 45.2 | 44.9 | 51.8 | 47.8 | +1.12 MB/h |
 
-The worker's +0.67 MB/h is **inside its own 68 MB oscillation band** and its
-first and last samples are 0.5 MB apart, so it is not distinguishable from
-sawtooth GC behaviour. Two of the four slopes are negative. **No leak is
-detectable over three hours** - and the honest bound on that claim is that a
-leak slower than ~1 MB/h would be invisible here; ruling one out needs a
-24-hour window.
+**No leak is detectable over three hours**, and the worker's row is worth
+reading carefully rather than from its slope alone. The fitted slope is
+**+1.85 MB/h**, but the container **ended 16.9 MB LOWER than it started**
+(133.1 -> 116.2) inside a **45 MB oscillation band**. A positive slope fitted
+across a sawtooth whose endpoints fall is a property of where the samples
+landed, not a trend: +1.85 MB/h over the 2.18 h series is ~4 MB, i.e. **9% of
+the band**. Two of the four slopes are negative outright.
+
+The honest bound on the claim: a leak slower than **~2 MB/h** is not
+distinguishable from this oscillation, so this window cannot rule one out.
+Doing that needs a 24-hour run.
 
 Postgres page cache **plateaued** rather than growing: 1 574 MB at the first
-RSS sample and 1 502 MB at the last. It filled during the first ~48 minutes as
-the sweeps first touched the 2M-row table and then stopped, which is what
-confirms the § 2.4.1 reading that the earlier 7.7x `docker stats` rise was
-cache fill and not growth.
+RSS sample and 1 608 MB at the last - **+34 MB, or +2%, over 2 h 13 m**. It
+filled during the first ~48 minutes as the sweeps first touched the 2M-row
+table and then essentially stopped, which is what confirms the § 2.4.1 reading
+that the earlier 7.7x `docker stats` rise was cache fill and not growth.
 
 **Postgres connections:** mean 11, **max 46**, last 9, against
 `max_connections = 200` - a **23% peak**. The budget guard's arithmetic
@@ -960,7 +1003,20 @@ Three things it does support, none of which is a config change:
    the PrestaShop webservice key and reseeded offer mappings - i.e. changed
    the thing under measurement - so the scenario resolves connection ids from
    the database by name instead, which is what bootstrap itself keys on.
-7. **`lib-test.sh` shipped with a permanently-failing assertion** (165 passed
+8. **A sampler that decides when to stop by grepping for a process NAME will
+   outlive its own window on a shared host.** The mid-window RSS sampler used
+   `ps aux | grep '[s]ustained-mixed-load'`; a peer agent in another worktree
+   ran the same scenario, the grep matched *their* process, and it kept
+   appending to this run's results directory for 3.5 hours after
+   `window_stop`. That is how contaminated figures reached the first revision
+   of this report (see the correction block at the top). Two things would have
+   prevented it, and a future side sampler should do both: **bound it by the
+   window** rather than by liveness (pass `window_stop` in, or a sample count),
+   and if liveness is used at all, key it on the **PID** the sampler was
+   started against, never on a name any peer can also be running. The
+   scenario's own two samplers were never exposed to this - `sampler_stop` and
+   `mixed_supp_sampler_stop` both `kill` a recorded PID.
+9. **`lib-test.sh` shipped with a permanently-failing assertion** (165 passed
    / 1 failed at the start of this session). "Omitting the feed argument
    leaves the verdict VALID" called `run_post_guards` against a fresh temp
    directory, so `post_guard_containers_stable` correctly refused a window it

--- a/perf/openlinker-throughput/results-sustained-mixed-load-2026-09-08.md
+++ b/perf/openlinker-throughput/results-sustained-mixed-load-2026-09-08.md
@@ -188,6 +188,69 @@ names as unmeasured: `order-fx-stamp-sweep`, `orders-tax-rate-backfill` and
 `master-product-reconcile` (which enumerates OL's own product mappings against
 a 50 006-product catalogue).
 
+### 1.4 Two contaminants this window carries that F1 controlled for
+
+Both were found by querying the window mid-run rather than by planning for
+them, and both are stated here because a reader comparing this run's
+orders/hour against F1's needs them.
+
+**(a) The destination fan-out has two members and one of them always fails.**
+Measured over the window's own orders:
+
+| destination | status | entries |
+|---|---|---|
+| `perf-woocommerce` | **failed** | 414 |
+| `perf-prestashop` | synced | 413 |
+| `perf-prestashop` | failed | 1 |
+
+Every order fails WooCommerce with
+`No WC product mapping for OL product ol_product_…`. That is the stand
+limitation the campaign already records - the 10 000 seeded WC `Product`
+mappings name no numeric WooCommerce product id, and
+`WooCommerceOrderProcessorAdapter.resolveLineItems` needs one. **F1 disabled
+WooCommerce before its windows precisely so the fan-out had one member**; this
+run did not, so:
+
+* `post_guard_destination_creates` fires on 414 failed entries for a reason
+  that has nothing to do with mixed load. The health signal is the PrestaShop
+  row: **413 synced against 1 failed**, i.e. the destination create succeeds
+  on essentially every first attempt.
+* the WooCommerce failure is a **local mapping lookup, not an HTTP call**, so
+  it consumes no destination budget and fails fast. Its cost to the order rate
+  is therefore small - but it is not zero and **this run did not measure it**,
+  so the orders/hour figure below should be read as a floor with respect to
+  this contaminant.
+* `syncStatus[].syncedAt` is stamped inside a `Promise.allSettled` over every
+  destination and so records whichever finished last. F1 removed that bias
+  structurally; this run inherits it. It affects any `syncedAt`-derived
+  timing, which is why the throughput figure here is taken from
+  **`marketplace.order.sync` job terminal state** instead.
+
+**(b) 328 jobs died on stub endpoints that do not exist.** Turning the crons on
+reached Allegro endpoints no previous window in this campaign called, and the
+stub does not implement them:
+
+| job type | dead | attempts | error |
+|---|---|---|---|
+| `marketplace.offer.updateFields` | 328 | **0** | `Allegro API error (404): .../sale/product-offers/perf-allegro-a-offer-100` |
+| `marketplace.offers.sync` | 8 | **0** | `Allegro API error (404): .../sale/offer-events?limit=100` |
+| `destination.taxonomy.sync` | 2 | **0** | — |
+
+`attempts = 0` on all of them, so they were classified non-retryable and
+killed on the first pass rather than burning a ladder - **correct behaviour**,
+since a 404 is deterministic. This is a **harness coverage gap, not a product
+defect**: `ol-perf:allegro-stub` implements the order-feed endpoints F1 needed
+and not the offer-management ones `allegro-offers-sync`,
+`allegro-offer-status-sync` and the field-update path call.
+
+What it does to the figures: those jobs are load - they cost claim cycles and
+stub requests - but they consume no PrestaShop budget, so the order path's
+rate limit is untouched. And their contribution to queue **depth** is
+negligible: 50 `marketplace.offer.updateFields` rows were queued against a due
+queue of ~8 000, i.e. **0.6%**, so the divergence finding does not rest on
+them. Extending the stub is the honest fix and belongs to whoever next runs
+this scenario.
+
 ## 2. Method
 
 ### 2.0 The closest call in this campaign: a log reader that inverted its own answer
@@ -305,6 +368,37 @@ They are not folded into `sample_queue` because that would change the header
 `f1-summarize.py` and `f2-summarize.py` already parse, for one scenario's
 benefit.
 
+#### 2.4.1 `docker stats` cannot answer the memory question, and a side sampler was added mid-run
+
+Both samplers take memory from `docker stats`, and **on this host that number
+includes the cgroup's page cache**, which for a database container is most of
+it. Measured directly at t+2645s:
+
+| `lab-postgres` | value |
+|---|---|
+| `docker stats` MemUsage | **1.412 GiB** |
+| cgroup `total_rss` (anonymous) | **17.4 MiB** |
+| cgroup `total_cache` (file-backed) | **1.53 GiB** |
+| of which `total_active_file` | 1.26 GiB |
+
+So the 7.7x rise from 188 MiB looks like a leak and is not one: it is the
+kernel caching database file pages as the hourly sweeps scan a 2 003 176-row
+`order_records` (F5 measured that heap at ~613 MB) and a 50 006-product
+catalogue. It is reclaimable, and the container carries no memory limit
+(`HostConfig.Memory = 0`), so it is bounded by host pressure rather than by a
+cap. `shared_buffers` is only 160 MiB, which is what rules out shared memory
+as the explanation.
+
+**The general point: `docker stats` MemUsage is the wrong instrument for
+detecting a leak in any container that reads files, and this campaign's
+samplers use it.** A `rss-timeseries.csv` reading cgroup `total_rss` and
+`total_cache` per container was therefore started **mid-window, at ~t+2 900s**,
+and covers only the last ~2 h 10 m of the 3-hour window. That late start is a
+limitation of this run, not of the instrument: the first 48 minutes have
+`docker stats` figures only, and for `lab-postgres` those cannot be read as
+memory growth. The scenario should sample cgroup RSS from `window_start` in
+future runs.
+
 ### 2.5 The convergence verdict, and the dishonesty it exists to avoid
 
 `drivers/queue-curve.awk` fits a least-squares slope over the **last third**
@@ -390,7 +484,103 @@ per-jobType queue breakdown is a *depth* attribution and must not be read as a
 
 ## 3. Results
 
-TBD
+### 3.4 The destination fault: stranding scales with CONCURRENCY, not with queue depth
+
+This is the question #2978 left open. It found that a destination fault
+stranded **2-5 orders per window at 12 orders in flight**, with jobs reporting
+`succeeded` and never retrying, and could not say what happens at volume.
+
+**The mechanism reproduced exactly. The rate did not scale.**
+
+`docker pause lab-prestashop` at t+6601s, `docker unpause` at t+6901s -
+exactly 300 s, with ~8 000 jobs queued and 4-8 running.
+
+**What the fault did to throughput** (samples, `measured`):
+
+| t+ | phase | due | running | ingested | completed |
+|---|---|---|---|---|---|
+| 6574 | steady | 7 835 | 4 | 403 | 353 |
+| 6608 | **fault** | 7 896 | 4 | 405 | 355 |
+| 6745 | fault | 8 016 | 6 | 406 | 356 |
+| 6883 | fault | 8 140 | 8 | 406 | 356 |
+| 6918 | recovery | 8 196 | 5 | 407 | 357 |
+
+Order processing **stopped almost completely** for the fault's duration - 1
+order ingested and 1 completed across 275 s of samples - while `running` rose
+from 4 to 8 as jobs sat on the client's 30 s timeout. Arrivals continued, so
+the queue kept growing at its usual rate. Throughput resumed immediately on
+unpause. Nothing needed operator intervention.
+
+**What it stranded: exactly one order, permanently and silently.**
+
+`ol_order_535e48890c8b42fea3353ccf3828586f`, created 07:44:14 - 19 seconds
+before the pause, so it was mid-dispatch when the shop went away. Its
+`syncStatus`:
+
+```json
+[ { "destinationConnectionId": "…prestashop", "status": "failed",
+    "error": "Request timeout after 30000ms: http://prestashop/api/carriers?display=full&…" },
+  { "destinationConnectionId": "…woocommerce", "status": "failed",
+    "error": "No WC product mapping for OL product perfseed_product_s200063…" } ]
+```
+
+And its job:
+
+```
+status=succeeded  outcome=ok  attempts=0  lastError=-  lastAttemptDurationMs=137792
+```
+
+**The job reports success, with no error, having reached no destination.**
+`attempts=0` and an empty `lastError` mean nothing failed as far as the runner
+is concerned; `dispatchToDestinations`' `Promise.allSettled` swallowed both
+per-destination failures (`order-sync.service.ts`). The order's `updatedAt`
+has not moved in the 13+ minutes since, and **nothing will ever retry it** -
+there is no reconcile sweep for a per-destination dispatch failure. This is
+precisely the defect `post_guard_destination_creates`' docblock calls itself
+*"the only guard that can see"*, observed in the wild rather than reasoned
+about.
+
+**The scaling answer:**
+
+| run | orders in flight | offered | stranded | rate |
+|---|---|---|---|---|
+| #2978 | ~12 | 12 orders | 2-5 | **17-42%** |
+| this run | 4-8 running, ~8 000 queued | 413 ingested | **1** | **0.24%** |
+
+So stranding scales with the number of orders **in the destination-dispatch
+step at the instant the destination fails** - which ADR-050's `realtime`
+per-scope cap of 2 bounds - and **not** with queue depth or offered volume. A
+deeper queue does not widen the exposure window; it lengthens the tail of work
+that will be dispatched *after* the destination returns, and that work is
+unaffected.
+
+Three consequences, and the third is the one that matters:
+
+1. **A 300 s outage costs ~300 s of throughput and no operator action.** The
+   retry ladder absorbed 305 order-sync jobs whose attempt landed in the fault
+   window - they were requeued, not failed - and no `marketplace.order.sync`
+   job died in the whole window (`dead = 0`).
+2. **The absolute stranded count does not grow with volume**, which is the
+   reassuring half and is why #2978's 17-42% must not be extrapolated to a
+   busy install.
+3. **But every stranded order is permanent, and 0.24% of a real order book is
+   not a rounding error.** At the ~210 orders/h this window sustained, one
+   300 s destination hiccup per day silently loses an order roughly every four
+   days, with the job log reading clean. The fix is not more retries - it is
+   that a swallowed per-destination failure must leave something for a sweep to
+   find, which no code path currently does.
+
+**One caveat that bounds this finding, stated because it is easy to miss.**
+`docker pause` produces a **timeout-shaped** fault: the connection is
+accepted and never answered, and the client aborts at 30 s
+(`prestashop-webservice.client.ts:109`). A timeout is classified retryable,
+which is why 305 jobs were requeued. #2978 used a fault **proxy**
+(`ol-perf:ps-fault-proxy` is still on this host), which can return HTTP error
+*responses* - and an error response may be classified differently by the
+per-plugin retry classifier. **This run therefore says nothing about the
+error-response-shaped fault #2978 measured**; it measures the timeout-shaped
+one and finds the same swallowing mechanism at the end of it. Whether an
+error-response fault strands more is unmeasured here.
 
 ## 4. Recommendation
 

--- a/perf/openlinker-throughput/results-sustained-mixed-load-2026-09-08.md
+++ b/perf/openlinker-throughput/results-sustained-mixed-load-2026-09-08.md
@@ -1,0 +1,538 @@
+# What does a Tuesday look like? Orders, catalogue sweeps and crons together, for hours
+
+> **DRAFT - the window is still running.** Every `TBD` below is a figure this
+> run has not produced yet. Nothing in this file may be quoted until this
+> banner is gone.
+
+**Run**: `results/sustained-mixed-load/run1788846800`, window opened
+2026-09-08T05:54 UTC. **One continuous measurement window, 3 hours.**
+**Scenario**: `scenarios/sustained-mixed-load.sh`.
+**Image**: `fabab189eda90f7a09bbe64301449b092b00d5ff`, rebuilt for this run
+(see § 1.1), `guard_build ok`. Verdict: TBD.
+
+**Why three hours and not four.** The window length was cut from the planned
+four hours because rebuilding the two application images (§ 1.1) took ~40
+minutes of session budget. Three hours still covers three firings of every
+hourly cron, nine `master.product.syncAll` ticks, twelve
+`master.inventory.syncAll` ticks, ~180 order polls and ~360 samples. It is
+stated here rather than implied, and § 6 says what a longer window would add.
+
+## This is the run the epic named and never got
+
+The framing is **#2840's own**, in the epic issue body:
+
+> Flows are **serial on one stand**. [...] Two consequences follow rather than
+> being optional: every non-mixed figure carries the idle-stand label above,
+> and **one explicitly non-isolating mixed-workload run** (sweep crons
+> ticking, plus an order ramp, plus stock churn) is added to #2845 **in week
+> 3, once #2847 and #2848 exist** [...], flagged in its manifest as one
+> inside which attribution is impossible. **It is the only run whose
+> orders/hour figure an operator can apply to their own Tuesday.** Note also
+> that serialising flows does not separate F1 from F2:
+> `marketplace.orders.poll` and `inventory.propagateToMarketplaces` are both
+> registered on `fan-out` [...] alongside all three master sweep parents, so
+> each flow must record whether the sweeps ran inside its window.
+>
+> — `gh issue view 2840`, issue body
+
+So this window is not an extra; it is the one deliverable #2840 specified for
+week 3 and never produced. Three obligations come with that sentence, and this
+report is answerable for all three:
+
+1. **The composition is specified**: sweep crons ticking, an order ramp, *and
+   stock churn*. This run has the first two. **It has no stock churn** - see
+   § 6, where that is named as a departure with an owner, not glossed.
+2. **The manifest must be flagged as one inside which attribution is
+   impossible.** § 2.8 states where that flag is and is not.
+3. **Every flow must record whether the sweeps ran inside its window.** § 1.3
+   records the whole resolved cron inventory, and § 3 reports which of them
+   actually fired.
+
+> ### A methodology note, because the withdrawal was published before this
+>
+> An earlier draft of this report **withdrew** the sentence above, on the
+> grounds that it does not appear in any of the six `perf/openlinker-throughput`
+> campaign documents. That grep was accurate and the conclusion drawn from it
+> was wrong: the epic is a GitHub issue, and an issue's framing lives in its
+> body, which was never searched. **Six files not containing a sentence is not
+> evidence the epic never said it.** Verifying a claim means reading the source
+> that would carry it, not reading a different source and concluding from
+> silence. Recorded in `docs/lessons.md`, because this campaign has repeatedly
+> made the mirror mistake - believing a figure because a comment asserted it -
+> and both errors have the same root.
+
+What the campaign *documents* add, and which still holds, is the surrounding
+context: `campaign-2026-09-06.md` § 7 lists *"Any ceiling ... every figure
+here is a floor"*, *"Cross-lane starvation. ADR-050's lane model is not
+validated by any run here"* and *"Read-path cost at a large history of the
+OTHER tables"*; and `results-retest-2026-09-07.md` § 5.3 calls the
+lane-starvation window *"the natural next window"*. This run is that window,
+widened to the composition #2840 asked for.
+
+## 0. The answers, in one page
+
+| Question | Answer | Label |
+|---|---|---|
+| Does the queue converge under sustained mixed load at shipped defaults? | TBD | TBD |
+| What order rate survives competing catalogue sweeps? | TBD | TBD |
+| Does anything accumulate over hours - memory, Postgres backends, DB size? | TBD | TBD |
+| How many limiter-degradation episodes does an hours-long window really carry, against the 300 s extrapolation? | TBD | TBD |
+| Does a destination fault strand orders at volume the way it does at 12? | TBD | TBD |
+
+> Every figure is labelled **measured**, **derived** or **extrapolated**.
+> § 6 "What this did not establish" is not optional reading.
+
+## 1. Conditions
+
+### 1.1 The stand had to be repaired and rebuilt before it could be measured
+
+Two things were wrong with the stand as found, and both are findings rather
+than housekeeping.
+
+**`lab-api` was dead.** It read `Exited (1)` - killed by a peer's Redis-outage
+test roughly two hours earlier and never restarted, because **no service in
+`docker-compose.lab.yml` declares a restart policy** (`api` carries none;
+`migrate` carries an explicit `restart: 'no'`). Nothing in the harness noticed:
+`guard_stand_exclusive` arbitrates scenarios, `post_guard_containers_stable`
+compares `.State.StartedAt` **within** a window, and neither answers "is the
+stand actually up" before one opens. A scenario would have died at its first
+`ol_api` call with a connection error rather than a diagnosis.
+
+**Both application images predated the change this run is about - and that is
+a finding, not setup friction.** They carried
+`org.opencontainers.image.revision = 8c1c0bbe`, while the tree has moved past
+it under `libs/`: #2982 raised PrestaShop's manifest `defaultRateLimit` from
+60 to **300 req/min** (`prestashop-plugin.ts:125`).
+
+So a run at "shipped defaults" against those images would have been pacing the
+destination at **60 req/min while its report claimed 300** - and since the
+governing arithmetic is
+`orders/hour = requestsPerMinute / requests-per-order x 60`, the headline
+figure would have been wrong by a factor of five with every guard green.
+`guard_build`'s tree comparison refused them, and it was right to: the mistake
+it prevents here is not a stale binary in the abstract, it is publishing a
+number under the wrong headline condition. **That guard has now refused three
+agents across this campaign and been correct every time**, which is worth
+stating because a guard that only ever refuses is easy to start working
+around.
+
+The rebuild cost ~40 minutes of session budget, which is the whole reason this
+window is 3 hours rather than 4. That trade is stated rather than hidden.
+
+`ol-perf:api` and `ol-perf:worker` were therefore rebuilt from this branch's
+HEAD with `--build-arg OL_GIT_SHA=$(git rev-parse HEAD)`, and `lab-api` and the
+worker recreated onto them.
+
+### 1.2 Dataset and posture
+
+| Axis | Value | How it was read |
+|---|---|---|
+| Stand | `lab`, compose project `lab` | container labels |
+| PrestaShop catalogue | 50 006 products, all active | `ps_product` |
+| OpenLinker catalogue | 60 006 products, 111 678 variants | `products` / `product_variants` |
+| `order_records` at window start | 2 003 176 | `COUNT(*)` |
+| `sync_jobs` at window start | 140 718 rows, **0** queued or running | `COUNT(*)`, `guard_queue_empty` |
+| Allegro offer mappings (`perf-allegro-a`) | 200 | `identifier_mappings` |
+| Active connections | 5 (PrestaShop, two Allegro, PrestaShop webhook-ingress, WooCommerce) | `connections` |
+| Worker replicas | 1 | compose service label, discovered |
+| Runner | **enabled** | `guard_runner_state enabled` |
+| **Scheduler** | **ENABLED** - the departure this run exists to make | recorded, not guarded |
+| Scheduler tasks registered | **30** (full inventory in § 1.3) | worker's own `Registered scheduler task:` lines |
+| Lane caps | `realtime=4/2 bulk=12/8 fiscal=2/1 fan-out=8/4` | worker's own startup line |
+| Job intake Redis client | **SHARED** (`OL_JOB_INTAKE_DEDICATED_REDIS` unset) | worker's own startup line |
+| Stub | `ol-perf:allegro-stub-2978`, latency `eventsMs 276` / `checkoutMs 1106` | `/__stub/config` |
+| Destination `config.rateLimit` | override removed, so the manifest's 300/4 applies | `connections.config` |
+| `operational_settings` cadence row | `{}` (empty - no row) | `scheduler_cadence_row` |
+| `max_connections` / `OL_DB_POOL_MAX` | 200 / 40, budget 80 | `guard_connection_budget` |
+| `OL_LOG_BODY_MAX_BYTES` | 8192 | `guard_log_level` |
+| `OL_DEMO_MODE` | false | `guard_demo_mode_off` |
+| Host | 28 cores, 15 GiB, 847 GB free | `free`, `df` |
+
+The stand carried an explicit `{maxConcurrent: 4, requestsPerMinute: 60}` on
+the destination connection, left behind by the weak-shop ramp (#2982's own
+measurement). That is **not** the shipped default any more, and a
+connection-level override beats the manifest, so the override was removed for
+this window and restored afterwards. Removing the key rather than writing
+`300` is the truer reading of "shipped defaults": it is the state a connection
+an operator never touched is in.
+
+The stub's pinned upstream latencies are **identical to F1's** (`eventsMs`
+276, `checkoutMs` 1106 - the #2861 Allegro sandbox p50s), so the order-path
+figures here are comparable with that report's despite the stub image having
+been built by a peer campaign. Its `gitSha` reads `2978-f10`, which is
+recorded rather than glossed: the image is not from this branch.
+
+### 1.3 What "unfiltered crons" actually resolved to
+
+Thirty tasks, read back out of the worker's own log rather than inferred from
+the code. This is the co-tenancy every previous window in this campaign
+switched off:
+
+| Cron | Task | Job type |
+|---|---|---|
+| `*/1` | allegro-orders-poll | `marketplace.orders.poll` |
+| `*/2` | allegro-quantity-ack-reconcile | `marketplace.offerQuantity.reconcile` |
+| `*/5` | inventory-provenance-backfill | `inventory.provenance.backfill` |
+| `*/5` | erli-orders-poll, woocommerce-orders-poll | `marketplace.orders.poll` |
+| `*/10` | prestashop-orders-poll, reservation-consume-sweep | `marketplace.orders.poll`, `inventory.reservations.consume` |
+| `*/15` | **master-inventory-sync**, automation-deadline-sweep, prestashop-fulfillment-status-sync, allegro-shipment-status-sync | `master.inventory.syncAll`, … |
+| **`*/20`** | **master-product-sync**, reservation-shortfall-sweep, pending-recovery | `master.product.syncAll`, … |
+| `*/30` | allegro-offers-sync, returns-orphan-reconcile, regulatory-status-reconcile, inpost/dpd-shipment-status-sync | … |
+| hourly | **master-product-reconcile** (`0`), reservation-expiry-sweep (`15`), stale-offer-pause-sweep (`17`), **order-fx-stamp-sweep** (`23`), destination-taxonomy-sync (`23`), **orders-tax-rate-backfill** (`37`), order-hold-reconcile (`0`), allegro/erli-offer-status-sync (`0`), woocommerce-product-status-sync (`0`) | … |
+| daily | pickup-point-refresh (`0 3`) | `shipping.pickupPoint.refreshFrequent` |
+
+Three of the hourly ones are worth calling out because they sweep the
+**2 003 176-row** `order_records` history this stand carries, which is the
+"read-path cost at a large history of the OTHER tables" the campaign doc § 7
+names as unmeasured: `order-fx-stamp-sweep`, `orders-tax-rate-backfill` and
+`master-product-reconcile` (which enumerates OL's own product mappings against
+a 50 006-product catalogue).
+
+## 2. Method
+
+### 2.0 The closest call in this campaign: a log reader that inverted its own answer
+
+Before any method: the single most consequential configuration fact in this
+programme was very nearly recorded backwards, and the mechanism generalises to
+every value any scenario reads out of a log.
+
+`sync-worker.module.ts` logs on both branches, precisely so a harness can
+assert which one it took:
+
+```
+Job intake Redis client: SHARED (OL_JOB_INTAKE_DEDICATED_REDIS is not true)
+Job intake Redis client: DEDICATED (OL_JOB_INTAKE_DEDICATED_REDIS=true) - ...
+```
+
+This scenario's reader was `case "$line" in *DEDICATED*) ... ;; *SHARED*)`.
+**The SHARED message contains the string `DEDICATED`, inside the variable's
+own name**, so the `*DEDICATED*` arm matched first and the scenario recorded
+`DEDICATED` for a worker that had logged `SHARED`.
+
+Why it matters more than an ordinary bug: `results-retest-2026-09-07.md`
+measured **207 orders/h** on the shared client against **2 233** on the
+dedicated one - **10.8x**, the largest single effect in the campaign. A report
+claiming the fixed configuration while running the broken one would have been
+wrong by an order of magnitude *about its own premise*, with a manifest
+asserting the wrong value, and **nothing in the numbers would have looked
+odd** - a mixed-load run is expected to be slower than an isolated one, so
+~200 orders/h under a "DEDICATED" label reads as co-tenancy cost rather than
+as a misread condition. It was caught only because a five-minute smoke run was
+executed and its output read line by line against `docker logs`.
+
+The reader now takes **the one token immediately after the colon** and nothing
+else, and anything it does not recognise reads `unknown` rather than
+defaulting. The general rule this is the strongest evidence yet for, and which
+#2229 states for reported-versus-enforced generally: **substring-matching a
+log line is not reading a value.** Extract the field, then test it against the
+closed set of values it may hold.
+
+The same class of defect, found in the same smoke run, is at § 7 item 3
+(the scheduler-task count read six seconds before the singleton lease was
+acquired, recording 0 while 30 were registered).
+
+### 2.1 The one guard this scenario inverts, and the authority for doing so
+
+`guard_scheduler_off` is deliberately **not called**. Its own docblock
+authorises the departure - *"a scenario that wants it on should not call this
+guard at all and should instead record its posture via manifest_set
+directly"* - and the scenario records three things in its place: the posture,
+the full set of scheduler tasks read back out of the worker's own
+`Registered scheduler task:` lines, and the `operational_settings` cadence
+row, which overrides `cronEnvVar`/`defaultCron` and is invisible to an
+env-var-only reading.
+
+Nothing else is waived. `guard_queue_empty`, `guard_build`,
+`guard_connection_budget`, `guard_pool_recorded`, `guard_log_level`,
+`guard_demo_mode_off` and `guard_runner_state` all ran.
+
+`PERF_MAX_ATTEMPTS` is **not** applied, and that is a choice rather than an
+omission: the jobs in this window are minted by the real scheduler, not by
+`enqueue_perf_job`, so they carry the `sync_jobs` entity default of 10
+attempts with backoff - which is what a deployment carries.
+
+### 2.2 The arrival rate is chosen to saturate
+
+Under a standing backlog, achieved throughput **is** the service rate. That
+single number is both the "orders/hour under mixed load" figure and the
+convergence threshold, since an offered rate below it converges and above it
+diverges - so one saturating rate answers both questions from one continuous
+window, instead of from a step ladder whose segments each carry their own
+settle and their own noise.
+
+The rate has to clear the plausible ceiling. The governing arithmetic
+`results-retest-2026-09-07.md` establishes is
+`orders/hour ceiling = requestsPerMinute / requests-per-order x 60`; at 300
+req/min and the measured ~11 requests per order that is **~1 636 orders/h**
+[derived]. The run offers **60 orders/min = 3 600/h**, about 2.2x clear of it.
+
+It is deliberately not higher. The Allegro poll takes up to 100 events per
+tick (`limit: 100`, hardcoded), so an arrival rate under 100/min keeps the
+stub's own backlog near zero and moves the whole backlog into `sync_jobs`,
+where it is observable. A rate above 100/min would bank an unobserved backlog
+inside the stub's memory instead - less useful, and a real OOM risk over
+hours.
+
+### 2.3 The sampler is slowed down, on purpose
+
+`SAMPLE_INTERVAL_SECS` defaults to **1** in `lib.sh`, which is right for a
+300-second window and wrong for a four-hour one: `sample_queue` shells out to
+`docker stats --no-stream` on every tick, and at 1 Hz over four hours that is
+~14 400 invocations of a command that takes on the order of a second. That is
+a material, self-inflicted load on the thing being measured. Both samplers ran
+at **30 s**, and the figure is stated here so the sampling cost is a condition
+rather than a hidden one.
+
+### 2.4 What the supplementary sampler adds
+
+`sample_queue` records the queue scoped to the scenario's connection ids plus
+`pg_database_size` and a `docker stats` blob. A soak needs four things it does
+not carry, so a second CSV (`mixed-timeseries.csv`) carries them:
+
+* **an install-wide queue count.** The all-zero system connection id owns
+  `marketplace.offer.pauseStale` jobs and is in no scenario's id list, so a
+  scoped count under-reports the install's real depth - which is the headline.
+* **Postgres backends** against `max_connections`.
+* **a per-jobType breakdown** of what the queue is made of.
+* **an incremental limiter-degradation count.** Sampled per interval, never
+  window-to-date: a cumulative grep re-reads the whole log every tick, which
+  is O(n^2) over a four-hour log. Both `docker logs` bounds are **bare**
+  epochs - the `@epoch` form is accepted and matches nothing on Docker 29.5.2
+  (#2851), the bug that silenced this exact measurement across the whole
+  campaign.
+
+They are not folded into `sample_queue` because that would change the header
+`f1-summarize.py` and `f2-summarize.py` already parse, for one scenario's
+benefit.
+
+### 2.5 The convergence verdict, and the dishonesty it exists to avoid
+
+`drivers/queue-curve.awk` fits a least-squares slope over the **last third**
+of the samples and compares it against that third's own standard deviation,
+expressed as a per-hour slope over the sub-window it spans.
+
+* An endpoint comparison cannot tell a plateau from a peak. The last third is
+  where a plateau would be if there were one.
+* Without the noise band, a curve jittering by a few jobs around a flat mean
+  would be labelled `growing` or `converging` at random depending on which
+  sample happened to be last. `plateau` therefore means *the slope is not
+  distinguishable from jitter*, not *the slope is zero*.
+* There are exactly three verdicts and **no fourth "steady state" value**. A
+  `growing` verdict carries an explicit note that the window ended before the
+  queue converged, and that the last sample is not an equilibrium. That is the
+  specific dishonesty a long run has to avoid.
+* A sample the harness could not read is written `-1` and is **dropped and
+  counted**, never averaged in as zero - which would drag a rising curve
+  toward the flattering answer.
+* Below 12 surviving samples it **refuses** rather than labelling, because the
+  tail would then be three points and the band would come from three samples.
+
+`drivers/queue-curve-test.sh` (17 assertions) proves each verdict reachable
+against synthetic curves whose right answers are known by construction,
+including the two inverse cases that matter: a curve that rose and then
+flattened must read `plateau` despite a clearly positive overall slope, and a
+curve flat until the end must read `growing` rather than being softened.
+
+### 2.6 The destination fault
+
+`docker pause lab-prestashop` at T+9 000 s for 300 s, then unpause.
+
+`pause` rather than `stop` for two reasons: it leaves `.State.StartedAt`
+untouched, so `post_guard_containers_stable` still means what it means; and it
+produces the shape #2978 measured at 12 orders - a destination that accepts
+the connection and never answers - rather than a connection refusal. The
+PrestaShop client's own timeout is **30 s**
+(`prestashop-webservice.client.ts:109`), so a 300 s pause is roughly ten
+attempt-cycles deep rather than a single hang.
+
+### 2.7 Which post-guards fire by construction
+
+A saturating multi-hour window at shipped defaults trips several guards
+structurally. Each was still run, because the count is the finding.
+
+| Post-guard | Why it fires here | What to read instead |
+|---|---|---|
+| `post_guard_limiter_degraded` | The shared intake client is still the default (`sync-worker.module.ts:149`), and the retest measured 40-49 episodes per 300 s window | the episode count and its rate, § 5 |
+| `post_guard_destination_creates` | No in-flight allowance, no upper time bound - any window ending with work in flight fires it | the **failed** count, not the missing one |
+| `post_guard_attempts` | Any window long enough to contain one retry | § 5 retries table |
+| `post_guard_deferrals` | Any window long enough to contain one rate-limit deferral | § 5 retries table |
+
+**The verdict is expected to read `DISCARDED`, and a reader must not take that
+as "the run failed".** § 3.0 draws the may-travel line explicitly, the way
+F7 § 8 does.
+
+### 2.8 Attribution is impossible inside this window, and where that is recorded
+
+#2840 requires this run to be *"flagged in its manifest as one inside which
+attribution is impossible"*. Being precise about where that flag is:
+
+* The manifest **does** record every fact a reader needs to reach that
+  conclusion: `schedulerPosture: "ON (guard_scheduler_off deliberately not
+  called)"`, the 30 registered tasks with their crons, `ordersPerMin`, the
+  destination rate limit in force, and `jobIntakeRedisClient`.
+* It does **not** carry a single boolean saying so in as many words. The
+  requirement was read out of the epic body *after* this window had already
+  opened, and `manifest.json` is written before the window by construction.
+  **Editing a manifest after its window is exactly the kind of retrofit that
+  makes a results directory untrustworthy**, so it was not edited; the field
+  is added to the scenario for subsequent runs instead.
+
+The substance of the flag, stated here where a reader will meet it: **no
+figure in § 3 may be attributed to any single flow.** Thirty crons, an order
+ramp and the sweeps share one worker process, one connection pool, one Redis
+limiter and - for PrestaShop - one rate-limit budget. When the order rate
+comes out below F1's isolated figure, this run cannot say how much of the
+difference is the catalogue sweeps, how much is the twenty-seven other tasks,
+and how much is the hourly sweeps over a 2M-row `order_records`. That is not a
+shortcoming of the instrument; it is the definition of the window. The
+per-jobType queue breakdown is a *depth* attribution and must not be read as a
+*cost* one.
+
+## 3. Results
+
+TBD
+
+## 4. Recommendation
+
+TBD
+
+## 5. Accumulation
+
+TBD
+
+## 6. What this did NOT establish
+
+* **Stock churn - a departure from the composition #2840 specified.** The
+  epic asks for *"sweep crons ticking, plus an order ramp, plus stock
+  churn"*. This window has the crons and the order ramp; it drives no
+  deliberate stock churn at the master. The driver exists
+  (`drivers/stock-control.sh`, F2's) and was not wired in, because the
+  requirement was read out of the epic body after the window had already
+  opened, and adding a third load source mid-window would have made the two
+  halves incomparable - the one thing a single continuous window must not do.
+  What the run *does* carry is the **incidental** stock path: every ingested
+  order fires `master.inventory.syncByExternalId` and then
+  `inventory.propagateToMarketplaces`, both visible in § 3's job table, so the
+  `fan-out` lane is genuinely exercised. What is missing is
+  operator-originated churn independent of the order rate. **Owner: a second
+  run of this scenario with the F2 driver attached**; it is the one remaining
+  gap between this window and the composition #2840 named.
+* **A second arm.** The retest's recommended fix
+  (`OL_JOB_INTAKE_DEDICATED_REDIS=true`) was **not** run under mixed load. The
+  passthrough it needs now exists in `docker-compose.lab.yml` - before this
+  change compose forwarded nothing, so writing the variable into `.env.lab`
+  had no effect at all - but the arm itself is unrun, so **nothing here says
+  what the fix does to a mixed workload.** Everything below is the shipped
+  default, i.e. the SHARED intake client. Owner: a repeat of this scenario
+  with that variable exported and the worker's own `DEDICATED` line asserted.
+* **Any ceiling.** Same limitation the campaign doc § 7 states for every other
+  flow: this window was driven to saturation on a contended developer
+  workstation, not to failure on representative hardware. The figures are
+  floors.
+* **Whether the shop degrades under mixed load.** No shop-latency probe rode
+  this window. `results-weak-shop-2026-09-07.md` measured PrestaShop's own
+  response time under a *synthetic* offered rate and found it free to ~6.5
+  req/s; whether a real mixed workload plus catalogue sweeps moves that is not
+  measured here, and adding a probe would have put its own requests inside the
+  connection's rate-limit budget on a run that is deliberately saturating it.
+* **Which of the thirty crons costs what.** The run measures the aggregate. It
+  does not attribute queue depth or destination requests to individual tasks,
+  because nothing in the tree exports per-task cost - the metrics exporter
+  (#2850) does not exist, which `results-retest-2026-09-07.md` § 9 calls
+  the biggest single gap in this campaign's ability to answer "slots or the
+  loop?". The per-jobType queue breakdown in § 3 is the closest available
+  substitute and it is a *depth* attribution, not a *cost* one.
+* **Multi-replica behaviour.** One worker replica. ADR-050's slot accounting
+  is per process, so nothing here transfers to a scaled deployment except by
+  the 1.50x the retest measured for the order path alone.
+* **Lane starvation as F7 frames it.** This run creates the co-tenancy F7 was
+  built to probe, but it carries no claim-latency probes, so it cannot say
+  whether a `realtime` job waited behind `bulk`. It measures the *aggregate*
+  consequence of the mixture, not the isolation property.
+* **Whether the queue would have converged later.** See the verdict rule in
+  § 2.5 - if § 3 reports `growing`, the honest statement is that the window
+  ended first, and no extrapolation of a growth slope to an eventual plateau
+  is offered.
+
+## 7. What fought this run
+
+1. **`lab-api` was dead on arrival, and nothing in the harness could have
+   said so.** No compose service declares a restart policy, so a peer's
+   Redis-outage test killed it two hours earlier and it stayed down.
+   `guard_stand_exclusive` arbitrates scenarios; `post_guard_containers_stable`
+   compares `.State.StartedAt` *within* a window. Neither answers "is the
+   stand up" before one opens. A scenario would have died at its first
+   `ol_api` call with a connection error rather than a diagnosis. **A
+   `guard_stand_healthy` that pings the api and asserts every measured
+   container is `running` would have turned ten minutes of confusion into one
+   line**, and is the cheapest harness addition this run suggests.
+2. **The images predated the change the run is about**, and rebuilding them
+   cost roughly 40 minutes of session budget - which is why the window is 3
+   hours rather than 4. That is `guard_build` working, not fighting: without
+   it the run would have measured PrestaShop's *old* 60 req/min manifest
+   default while its own report claimed 300.
+3. **Two of the scenario's own log readers were wrong, and the smoke run is
+   the only reason the report does not carry their answers.** The intake-client
+   reader matched `*DEDICATED*` against a line reading
+   `SHARED (OL_JOB_INTAKE_DEDICATED_REDIS is not true)` and so inverted the
+   single most consequential configuration fact in this campaign. The
+   scheduler-task reader ran six seconds before `SingletonRoleLease` acquired
+   `singleton:scheduler` and recorded "0 task(s)" while thirty were
+   registered. Both are now fixed, the second by waiting and then **refusing**
+   a run with no registered tasks - a mixed run whose scheduler registered
+   nothing is an order-only run wearing the wrong label. Neither was visible
+   by reading the code.
+4. **The degradation sampler measured points in the window rather than the
+   window.** It read the clock *after* each sample and used that as the next
+   interval's lower bound, so each sample's own duration (seconds - several
+   Postgres counts plus a `docker stats`) fell outside every interval. Caught
+   by disagreement: the sampler totalled 19 episodes where
+   `post_guard_limiter_degraded`'s single whole-window grep found 25.
+   Intervals now tile.
+5. **The summarizer's two `GROUP BY` queries were invalid**, and would have
+   failed *after* the measurement with the CSVs intact. Concatenating columns
+   in the SELECT list puts an aggregate inside the GROUP BY expression;
+   Postgres refuses. Found by running the summarizer against a synthetic
+   results directory before the window opened, which is the only reason it was
+   found before rather than after.
+6. **`stand-ids.env` did not exist.** `bootstrap.sh` deletes it on any run
+   that found a gap and it is gitignored, so a stand bootstrapped from another
+   worktree may simply not have one. Re-running bootstrap would have rotated
+   the PrestaShop webservice key and reseeded offer mappings - i.e. changed
+   the thing under measurement - so the scenario resolves connection ids from
+   the database by name instead, which is what bootstrap itself keys on.
+7. **`lib-test.sh` shipped with a permanently-failing assertion** (165 passed
+   / 1 failed at the start of this session). "Omitting the feed argument
+   leaves the verdict VALID" called `run_post_guards` against a fresh temp
+   directory, so `post_guard_containers_stable` correctly refused a window it
+   had no baseline for and the verdict came back DISCARDED for an unrelated
+   reason. The sibling block forty lines below already seeds that baseline
+   with a comment explaining why. Fixed; 166 / 0.
+
+## 8. Reproducing it
+
+```bash
+export PS_CONTAINER=lab-prestashop PS_MYSQL_CONTAINER=lab-mysql \
+       WC_CONTAINER=lab-woocommerce PG_CONTAINER=lab-postgres \
+       REDIS_CONTAINER=lab-redis OL_API_CONTAINER=lab-api \
+       OL_API_URL=http://127.0.0.1:19000 OL_ADMIN_USER=admin OL_ADMIN_PASSWORD=admin
+unset WORKER_CONTAINERS
+
+export OL_STAND_LOCK_TTL_SECS=21600
+export SETTLE_SECS=60
+export MIXED_DURATION_SECS=14400
+export MIXED_ORDERS_PER_MIN=60
+export MIXED_SAMPLE_INTERVAL_SECS=30
+export MIXED_FAULT_AT_SECS=9000
+export MIXED_FAULT_SECS=300
+
+bash scenarios/sustained-mixed-load.sh
+```
+
+The images must carry the working tree's revision or `guard_build` refuses:
+
+```bash
+docker build --target production --build-arg OL_GIT_SHA=$(git rev-parse HEAD) -t ol-perf:api .
+docker build --target worker     --build-arg OL_GIT_SHA=$(git rev-parse HEAD) -t ol-perf:worker .
+docker compose -f docker-compose.lab.yml --env-file <stand>/.env.lab -p lab up -d --no-deps api worker
+```

--- a/perf/openlinker-throughput/results-sustained-mixed-load-2026-09-08.md
+++ b/perf/openlinker-throughput/results-sustained-mixed-load-2026-09-08.md
@@ -1,14 +1,13 @@
 # What does a Tuesday look like? Orders, catalogue sweeps and crons together, for hours
 
-> **DRAFT - the window is still running.** Every `TBD` below is a figure this
-> run has not produced yet. Nothing in this file may be quoted until this
-> banner is gone.
-
-**Run**: `results/sustained-mixed-load/run1788846800`, window opened
-2026-09-08T05:54 UTC. **One continuous measurement window, 3 hours.**
+**Run**: `results/sustained-mixed-load/run1788846800`,
+2026-09-08T05:54:21Z - 08:54:04Z. **One continuous measurement window,
+10 783 s = 3.00 h, 319 samples.**
 **Scenario**: `scenarios/sustained-mixed-load.sh`.
 **Image**: `fabab189eda90f7a09bbe64301449b092b00d5ff`, rebuilt for this run
-(see § 1.1), `guard_build ok`. Verdict: TBD.
+(see § 1.1), `guard_build ok`.
+**Verdict: `DISCARDED`** on three guards - **read § 0.1 before quoting any
+figure.**
 
 **Why three hours and not four.** The window length was cut from the planned
 four hours because rebuilding the two application images (§ 1.1) took ~40
@@ -71,16 +70,82 @@ widened to the composition #2840 asked for.
 
 ## 0. The answers, in one page
 
+Window **10 783 s = 3.00 h**, 319 samples, 10 800 orders offered. **Verdict:
+`DISCARDED`** - see § 0.1, which must be read before any figure is quoted.
+
 | Question | Answer | Label |
 |---|---|---|
-| Does the queue converge under sustained mixed load at shipped defaults? | TBD | TBD |
-| What order rate survives competing catalogue sweeps? | TBD | TBD |
-| Does anything accumulate over hours - memory, Postgres backends, DB size? | TBD | TBD |
-| How many limiter-degradation episodes does an hours-long window really carry, against the 300 s extrapolation? | TBD | TBD |
-| Does a destination fault strand orders at volume the way it does at 12? | TBD | TBD |
+| **What order rate survives competing catalogue sweeps and 30 crons?** | **200.6 orders/h** completed over the whole window (193.3/h steady, 227.3/h recovery) | measured |
+| **What binds it?** | The `realtime` **per-scope cap of 2**, proven twice (§ 3.3). `2 slots / 31.44 s mean service = 229 orders/h` ceiling; the recovery phase reached 99.3% of it | measured + derived |
+| **Was the destination rate limit binding?** | **No.** At ~11 req/order and 200 orders/h that is ~37 req/min against the 300/min the manifest now ships - ~12% utilisation | derived |
+| **Does the queue converge?** | **No - it grows without bound at this offered rate**, +4 298 jobs/h over the last third against a ±1 259 noise band. But this is a property of the OFFERED LOAD, not a capacity result - see § 0.2 | measured |
+| **Does anything accumulate over hours?** | **No.** Worker RSS +0.67 MB/h inside a 75-143 MB oscillation band; api and Postgres RSS slopes negative; Postgres page cache plateaued at ~1.5 GB; backends peaked at 46 of 200; database +29.8 MB | measured |
+| **How many limiter-degradation episodes does 3 h carry, vs the 300 s extrapolation?** | **1 454** against a predicted 1 438-1 761. **The 300 s figure extrapolates linearly - 1.01x the low end.** Degradation is a steady ~8/min, it does not accumulate | measured vs extrapolated |
+| **Does a destination fault strand orders at volume the way it does at 12?** | **The mechanism reproduced; the rate did not scale.** 1 of 413 (0.24%) against #2978's 17-42%. Stranding scales with orders IN FLIGHT, which the lane cap bounds - not with queue depth (§ 3.4) | measured |
+| Did the sweeps actually run inside the window? | **Yes** - 9 `master.product.syncAll`, 45 `syncBatch`, 300 `syncFromSweep`, 12 `master.inventory.syncAll`, 3 `master.product.reconcile`, matching their crons exactly (§ 3.1) | measured |
+| What did a second arm with `OL_JOB_INTAKE_DEDICATED_REDIS=true` show? | **Not run** - § 6 | not measured |
 
 > Every figure is labelled **measured**, **derived** or **extrapolated**.
 > § 6 "What this did not establish" is not optional reading.
+
+### 0.1 This window is `DISCARDED` by the harness's own rule, and must not be presented as a clean capacity measurement
+
+`verdict.txt` reads `DISCARDED`, on three guards:
+
+| Guard | Count | Structural? |
+|---|---|---|
+| `post_guard_limiter_degraded` | **1 454** degraded-mode lines | yes - shipped default is the SHARED intake client |
+| `post_guard_destination_creates` | 650 orders with a failed `syncStatus` entry, 729 lacking `syncedAt` | yes - § 1.4(a) two-member fan-out, and no in-flight allowance |
+| `post_guard_attempts` | 474 jobs with `attempts > 1` | yes - any 3-hour window contains retries |
+
+**The limiter count is the one that matters, and it is not waived.** 1 454 is
+non-zero, the guard's rule is that non-zero discards, and this report does not
+relabel it, exempt it, or argue it away. **This is therefore not a clean
+capacity measurement.**
+
+What the window *is* legitimate evidence for, stated so the distinction is not
+lost:
+
+1. **A `before` figure for the intake-client A/B.** This is the baseline arm -
+   shipped defaults, SHARED intake client (read back from the worker's own log,
+   § 2.0), which is precisely the configuration the degradation comes from. A
+   baseline that the harness rejects *for carrying the very defect the fix
+   removes* is still the right before-figure for that fix, provided it is
+   labelled as one. It is not a general-purpose capacity number.
+2. **The concurrency finding (§ 3.3), which does not depend on the limiter at
+   all.** The bind is the lane's per-scope cap of 2, established from job
+   timestamps by two independent methods. And the direction of the
+   contamination is knowable: a degraded limiter falls back to per-process
+   pacing, and at **one replica per-process pacing equals the configured
+   rate**, so degradation cannot have *inflated* the throughput - each
+   fallback adds latency to a limiter call, which raises mean service time and
+   *lowers* the derived ceiling. The capacity figure is therefore a
+   conservative lower bound with respect to this defect. That is an argument
+   about the mechanism, not a waiver of the guard.
+3. **The fault-stranding result (§ 3.4)**, which is a claim about a code path -
+   `Promise.allSettled` swallowing a per-destination failure - and is
+   established by one order's own persisted rows, not by a rate.
+
+### 0.2 `verdict = growing` is a property of the OFFERED LOAD, not a capacity result
+
+Stated explicitly because `+4 298 jobs/h` is the kind of number a later reader
+will quote as though it measured the system:
+
+The scenario **deliberately offers 60 orders/min = 3 600 orders/h** in order to
+saturate (§ 2.2), against a drain of ~200 orders/h. The queue therefore *must*
+grow at roughly `3 600 - 200 = 3 400` order-syncs/h plus whatever the 30 crons
+contribute, and the measured +4 298 jobs/h is that arithmetic, observed.
+
+**It is not a defect, not a capacity figure, and not a statement about
+OpenLinker.** It is what saturation looks like, and saturation is the method:
+under a standing backlog the achieved throughput *is* the service rate, which
+is why the 200.6 orders/h above is the capacity answer and the growth rate is
+merely the confirmation that the offered rate exceeded it.
+
+The actionable form of the same observation is the **threshold**: at shipped
+defaults, with the sweeps and crons running, **an install offered more than
+~200 orders/h will accumulate queue without bound.** Offered less, it
+converges. That is the number an operator can act on; `+4 298 jobs/h` is not.
 
 ## 1. Conditions
 
@@ -484,6 +549,122 @@ per-jobType queue breakdown is a *depth* attribution and must not be read as a
 
 ## 3. Results
 
+Five readings, in order of how much they matter.
+
+### 3.1 The sweeps and crons genuinely ran - the co-tenancy is real
+
+#2840 requires each flow to record whether the sweeps ran inside its window.
+They did, and the counts match the crons exactly, which is the check that the
+scheduler was not merely enabled but firing:
+
+| job type | succeeded | expected from its cron over 3 h |
+|---|---|---|
+| `master.product.syncAll` | **9** | `*/20` -> 9 |
+| `master.product.syncBatch` | 45 | 5 batch children per tick x 9 |
+| `master.product.syncFromSweep` | 300 | per-product children |
+| `master.inventory.syncAll` | **12** | `*/15` -> 12 |
+| `master.inventory.syncBatch` | 12 | |
+| `master.product.reconcile` | **3** | hourly -> 3 |
+| `marketplace.orders.poll` | 378 | `*/1` allegro x2 + `*/5` wc/erli + `*/10` ps |
+| `orders.taxRate.backfill` | 9 | hourly x 3 `OrderSource` connections |
+| `marketplace.order.fxStampSweep` | 9 | hourly x 3 |
+| `inventory.propagateToMarketplaces` | 327 | per-order cascade |
+| `automation.trigger.deadlineSweep` | 36 | `*/15` x 3 |
+
+The two hourly sweeps over the 2 003 176-row `order_records` history
+(`orders.taxRate.backfill`, `marketplace.order.fxStampSweep`) both completed
+every tick, at p50 9.6 s and 9.8 s per attempt - so the "read-path cost at a
+large history of the OTHER tables" the campaign doc § 7 names as unmeasured is,
+for these two sweeps at this row count, **not a problem**.
+
+**One thing the crons did that nothing had measured before.**
+`marketplace.fulfillment.statusSync` on the destination connection took a
+**p50 of 474 s** per run - just under 8 minutes - and runs every 15 minutes, a
+**~53% duty cycle** holding one slot continuously for more than half the
+window. Its sibling on `perf-webhook-ingress` took p50 9.8 s, so the cost is
+specific to the connection with the 50 006-product catalogue. It registers in
+the **`bulk`** lane (`handler-registration.service.ts:282`), so it competes
+with the catalogue-sweep children rather than with the order path - which is
+why it does not appear in the capacity model below, and why it is worth a look
+by whoever owns #834.
+
+### 3.2 The capacity answer: 200.6 orders/h
+
+`marketplace.order.sync` jobs reaching `status = 'succeeded'`, which is the
+job-terminal measure rather than a `syncedAt`-derived one (§ 1.4(a) explains
+why):
+
+| phase | duration | completed | orders/h |
+|---|---|---|---|
+| steady | 6 574 s | 353 | **193.3** |
+| fault | 275 s | 1 | 13.1 |
+| recovery | 3 865 s | 244 | **227.3** |
+| **whole window** | **10 783 s** | **601** | **200.6** |
+
+Ingestion ran slightly ahead at 217.3 orders/h (651 rows), because an
+`order_records` row is written before the destination create and a job that
+fails the create and retries has already written one.
+
+**Context, with the comparison stated carefully.** The retest campaign measured
+**207 orders/h** for the *isolated* order path, same SHARED intake client, with
+the destination limited to 60 req/min. This window measured **200.6 orders/h**
+with the destination at 300 req/min *and* the full cron co-tenancy. Two changes
+moved in opposite directions at once and **this run cannot separate them** -
+that is exactly what § 2.8's attribution flag means. What can be said is the
+conjunction: **raising the destination limit 5x did not buy enough to offset
+the co-tenancy**, and § 3.3 explains why raising it could not have helped much
+in the first place.
+
+### 3.3 What binds: the realtime per-scope cap of 2, confirmed twice
+
+Not assumed from the config. Two independent measurements over the steady
+phase, both from job timestamps at real precision rather than the sampler's
+30 s floor:
+
+**(a) Little's law**, `L = lambda x W`:
+
+| term | value |
+|---|---|
+| n (succeeded order.sync, steady) | 405 |
+| span | 6 560.8 s |
+| lambda | 0.061 73 /s |
+| W (mean `lastAttemptDurationMs`) | 31.44 s (p50 30.31 s) |
+| **L** | **1.941** |
+
+**(b) Direct interval overlap.** Each succeeded job's execution interval is
+`[updatedAt - lastAttemptDurationMs, updatedAt]`; counting intervals spanning a
+probe instant *is* the concurrency there. 105 probes at 60 s spacing:
+
+| statistic | value |
+|---|---|
+| mean | 1.95 |
+| p50 / p90 | 2 / 2 |
+| **max** | **2** |
+| probes at concurrency >= 2 | 95.2% |
+| probes above 2 | **0** |
+
+Distribution: concurrency 1 at 5 probes, **concurrency 2 at 100 probes**, never
+3. The cap is binding, hard, essentially all of the time.
+
+**The capacity model that follows**, and it closes:
+
+```
+ceiling = perScope_cap / mean_service_time
+        = 2 / 31.44 s
+        = 0.0636 /s = 229 orders/h        [derived]
+```
+
+The recovery phase measured **227.3 orders/h**, i.e. **99.3% of that ceiling**.
+So the order path is slot-bound, not budget-bound: at ~11 requests per order
+and 200 orders/h the destination sees ~37 req/min against the 300/min the
+manifest now ships - about **12% utilisation** [derived; the per-order request
+count is the retest's measurement, not re-measured here].
+
+Both figures are **lower bounds on true occupancy**, for a reason worth
+stating: `lastAttemptDurationMs` records the last attempt only and is reset on
+every enqueue (#2611), so a job that retried contributes only its final
+attempt while its earlier attempts also held a slot.
+
 ### 3.4 The destination fault: stranding scales with CONCURRENCY, not with queue depth
 
 This is the question #2978 left open. It found that a destination fault
@@ -582,13 +763,101 @@ error-response-shaped fault #2978 measured**; it measures the timeout-shaped
 one and finds the same swallowing mechanism at the end of it. Whether an
 error-response fault strands more is unmeasured here.
 
-## 4. Recommendation
+### 3.5 The queue curve
 
-TBD
+| statistic | value |
+|---|---|
+| samples used / dropped | 319 / 0 |
+| depth first / min / max / last | 58 / 56 / **12 832** / 12 832 |
+| deferred (backing off) at end | 184 |
+| overall slope | +4 180.6 jobs/h |
+| **last-third slope** | **+4 298.0 jobs/h** (n=108 over 3 727 s) |
+| noise band | ±1 259.3 jobs/h (sd 1 303.8) |
+| **verdict** | **`growing`** - 3.4x the band |
 
-## 5. Accumulation
+The overall slope (+4 181/h) and the last-third slope (+4 298/h) agree within
+3%, so the divergence is **linear** - the apparent deceleration in the first
+half hour was the crons' initial burst clearing on top of a constant floor, not
+the queue approaching a plateau. **The window ended before the queue converged,
+and it was never going to at this offered rate**; the last sample is not an
+equilibrium. § 0.2 states why this is a property of the offered load.
 
-TBD
+At the end, 11 926 of the 12 832 due rows (93%) were `marketplace.order.sync`.
+The three job types that died on missing stub endpoints (§ 1.4(b)) contributed
+41 queued rows, **0.3%**, so the finding does not rest on them.
+
+**One incidental figure worth recording:** `deferredTotalMs > 0` on **zero**
+jobs, despite 1 454 limiter degradations. Degradation and penalty-free
+deferral are different mechanisms and this window exercised only the first;
+the `requeueWithoutPenalty` path (#2613) never fired.
+
+## 4. Accumulation over hours: nothing does
+
+The question a 300-second window structurally cannot answer.
+
+**Memory (cgroup `total_rss`, n=134 samples over ~2 h 14 m - see § 2.4.1 for
+why `docker stats` cannot answer this and why the series starts late):**
+
+| container | first | last | min | max | mean | slope |
+|---|---|---|---|---|---|---|
+| `lab-worker-1` | 133.1 | 133.6 | 75.1 | 143.3 | 114.5 | **+0.67 MB/h** |
+| `lab-api` | 126.3 | 109.9 | 109.9 | 126.4 | 125.7 | −1.46 MB/h |
+| `lab-postgres` | 77.1 | 1.1 | 1.0 | 77.1 | 13.7 | −1.71 MB/h |
+| `lab-redis` | 45.5 | 41.8 | 41.8 | 51.8 | 47.7 | +0.70 MB/h |
+
+The worker's +0.67 MB/h is **inside its own 68 MB oscillation band** and its
+first and last samples are 0.5 MB apart, so it is not distinguishable from
+sawtooth GC behaviour. Two of the four slopes are negative. **No leak is
+detectable over three hours** - and the honest bound on that claim is that a
+leak slower than ~1 MB/h would be invisible here; ruling one out needs a
+24-hour window.
+
+Postgres page cache **plateaued** rather than growing: 1 574 MB at the first
+RSS sample and 1 502 MB at the last. It filled during the first ~48 minutes as
+the sweeps first touched the 2M-row table and then stopped, which is what
+confirms the § 2.4.1 reading that the earlier 7.7x `docker stats` rise was
+cache fill and not growth.
+
+**Postgres connections:** mean 11, **max 46**, last 9, against
+`max_connections = 200` - a **23% peak**. The budget guard's arithmetic
+(`OL_DB_POOL_MAX 40 x 2 processes = 80`) held with a wide margin, and the peak
+of 46 exceeding the 40-per-process pool is the api and worker pools summing,
+exactly as expected.
+
+**Database size:** 4 817.7 MB -> 4 847.5 MB, **+29.8 MB** over three hours,
+against 651 ingested orders and ~14 000 `sync_jobs` rows. Nothing here suggests
+a storage problem at this rate.
+
+**Retries:** 474 jobs reached `attempts > 1`, max 9 - so one job came within a
+single attempt of the entity default of 10 and `dead` - and 352 jobs died, all
+of them on the stub 404s of § 1.4(b). **No `marketplace.order.sync` job died
+at all.**
+
+## 5. Recommendation
+
+**None is owed by this run**, and saying so is the honest answer rather than a
+gap. This is the baseline arm of an A/B whose second arm has not been run
+(§ 6), and its verdict is `DISCARDED` for carrying the very defect the fix
+addresses (§ 0.1). A recommendation drawn from one contaminated arm is exactly
+what `results-retest-2026-09-07.md` had to withdraw when it corrected ADR-050's
+`2.77x` attribution.
+
+Three things it does support, none of which is a config change:
+
+1. **The order path is slot-bound at the `realtime` per-scope cap, not
+   budget-bound.** §3.3 shows the destination at ~12% of its rate-limit
+   budget while concurrency sat at the cap 95% of the time. This is
+   corroborating evidence for a finding the campaign already holds and
+   deliberately declines to act on: the prior campaign's arm ED raised
+   `realtime` 4/2 -> 16/16 and throughput **fell 12.5%**, and F7 measured a
+   5-6x execution-time penalty under destination contention. **Raising the cap
+   is not the indicated fix and this run does not recommend it.**
+2. **`marketplace.fulfillment.statusSync` deserves a look** (§ 3.1): p50 474 s
+   per run every 15 minutes on a 50 006-product catalogue is a ~53% duty cycle
+   on one `bulk` slot. Whether that is inherent or accidental is unmeasured.
+3. **A swallowed per-destination failure needs to leave a trace a sweep can
+   find** (§ 3.4). That is a product gap, not a tuning one, and this run is
+   the second independent observation of it.
 
 ## 6. What this did NOT establish
 

--- a/perf/openlinker-throughput/scenarios/sustained-mixed-load.sh
+++ b/perf/openlinker-throughput/scenarios/sustained-mixed-load.sh
@@ -584,8 +584,7 @@ mixed_supp_header() {
 # than several of the flows under measurement. It is computed once, at the
 # end, in the summary.
 mixed_supp_sample() {
-  local csv="$1" ws_epoch="$2" ws_iso="$3" prev_epoch="$4" now phase
-  now="$(epoch)"
+  local csv="$1" ws_epoch="$2" ws_iso="$3" prev_epoch="$4" now="$5" phase
   phase="$(cat "$MIXED_PHASE_FILE" 2>/dev/null || printf 'unknown')"
 
   local gq gd gr gdead
@@ -653,10 +652,21 @@ mixed_supp_sampler_start() {
   mixed_phase_set "starting"
   mixed_supp_header "$MIXED_SUPP_CSV"
   (
-    local prev="$ws_epoch"
+    # `now` is computed HERE and handed to the sample, then becomes the next
+    # interval's lower bound. Reading the clock again AFTER the sample returns
+    # leaves the sample's own duration uncovered by any interval - and a
+    # sample takes seconds (several Postgres counts plus a `docker stats`),
+    # so at a 15s interval roughly a third of the window went uncounted.
+    #
+    # Measured on this scenario's first smoke run: the sampler totalled 19
+    # limiter-degradation episodes over a window in which
+    # `post_guard_limiter_degraded`, reading the whole window in one grep,
+    # found 25. The intervals must TILE the window, not sample points in it.
+    local prev="$ws_epoch" now
     while :; do
-      mixed_supp_sample "$MIXED_SUPP_CSV" "$ws_epoch" "$ws_iso" "$prev" || true
-      prev="$(epoch)"
+      now="$(epoch)"
+      mixed_supp_sample "$MIXED_SUPP_CSV" "$ws_epoch" "$ws_iso" "$prev" "$now" || true
+      prev="$now"
       sleep "$MIXED_SAMPLE_INTERVAL_SECS"
     done
   ) &

--- a/perf/openlinker-throughput/scenarios/sustained-mixed-load.sh
+++ b/perf/openlinker-throughput/scenarios/sustained-mixed-load.sh
@@ -320,31 +320,21 @@ log "posture at scenario start: WORKER_RUNNER_ENABLED=$ORIGINAL_RUNNER_ENABLED O
 MIXED_SAMPLER_PID=""
 MIXED_FAULT_ACTIVE=0
 
-# One combined EXIT handler. `trap ... EXIT` is a SINGLE slot in bash, not a
-# stack, so a second `trap ... EXIT` would REPLACE guard_stand_exclusive's own
-# release and leave the stand locked for the full TTL after any `die` - the
-# bug f7-lane-starvation.sh documents having been caught. INT/TERM are trapped
-# explicitly as well: a default-disposition SIGTERM does not run an EXIT trap,
-# and a four-hour run is exactly the kind a human interrupts.
-mixed_on_exit() {
-  local rc=$?
-  set +e
-  mixed_supp_sampler_stop
-  # Unpause before anything else - a paused destination makes every restore
-  # step below hang on a shop call it does not need to make.
-  if [ "$MIXED_FAULT_ACTIVE" = "1" ]; then
-    warn "unpausing $PS_CONTAINER (fault injection was still active at exit)"
-    docker unpause "$PS_CONTAINER" >/dev/null 2>&1 || true
-    MIXED_FAULT_ACTIVE=0
-  fi
-  mixed_restore_dest_rate_limit
-  mixed_restore_worker_posture
-  release_stand_exclusive
-  return $rc
+# ---------------------------------------------------------------------------
+# Every restore step is defined BEFORE the trap that calls them, and that
+# ordering is load-bearing rather than tidy: bash resolves a function name at
+# CALL time, so a `die` between installing the trap and executing a later
+# definition would run an EXIT handler whose body does not exist yet. On a
+# four-hour run the handler is the only thing that hands the stand back, so it
+# must be complete from the moment it is armed.
+# ---------------------------------------------------------------------------
+mixed_supp_sampler_stop() {
+  [ -n "$MIXED_SAMPLER_PID" ] || return 0
+  kill "$MIXED_SAMPLER_PID" >/dev/null 2>&1 || true
+  wait "$MIXED_SAMPLER_PID" 2>/dev/null || true
+  MIXED_SAMPLER_PID=""
+  log "supplementary sampler stopped"
 }
-trap mixed_on_exit EXIT
-trap 'exit 130' INT
-trap 'exit 143' TERM
 
 mixed_restore_dest_rate_limit() {
   local current
@@ -428,6 +418,44 @@ mixed_set_worker_posture() {
     done
   done
 }
+
+# ---------------------------------------------------------------------------
+# ARM THE TEARDOWN. Placed here, immediately after the last function it calls,
+# for the reason stated above the restore helpers: bash resolves a function
+# name at call time, so a trap armed earlier would run a handler whose body
+# had not been executed yet.
+#
+# `trap ... EXIT` is a SINGLE slot in bash, not a stack, so this REPLACES
+# guard_stand_exclusive's own `trap release_stand_exclusive EXIT` - which is
+# why the release is the last thing this handler does. Getting that wrong
+# leaves the stand locked for the whole TTL after any `die`, the bug
+# f7-lane-starvation.sh documents having been caught.
+#
+# INT and TERM are trapped explicitly as well: a default-disposition SIGTERM
+# does NOT run an EXIT trap, and a four-hour window is exactly the kind of run
+# a human interrupts. Both re-enter through `exit`, so the EXIT handler is
+# what actually performs the restore, once, from one place.
+# ---------------------------------------------------------------------------
+mixed_on_exit() {
+  local rc=$?
+  set +e
+  mixed_supp_sampler_stop
+  # Unpause FIRST - a paused destination makes several of the restore steps
+  # below wait on a shop call they do not need to make.
+  if [ "$MIXED_FAULT_ACTIVE" = "1" ]; then
+    warn "unpausing $PS_CONTAINER (fault injection was still active at exit)"
+    docker unpause "$PS_CONTAINER" >/dev/null 2>&1 || true
+    MIXED_FAULT_ACTIVE=0
+  fi
+  mixed_restore_dest_rate_limit
+  mixed_restore_worker_posture
+  release_stand_exclusive
+  return $rc
+}
+trap mixed_on_exit EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+log "teardown armed (restores runner/scheduler posture, destination rate limit, stand lock)"
 
 # ---------------------------------------------------------------------------
 # Which scheduler tasks did the worker ACTUALLY register? Read out of the
@@ -573,13 +601,8 @@ mixed_supp_sampler_start() {
   log "supplementary sampler started (pid=$MIXED_SAMPLER_PID, interval=${MIXED_SAMPLE_INTERVAL_SECS}s) -> $MIXED_SUPP_CSV"
 }
 
-mixed_supp_sampler_stop() {
-  [ -n "$MIXED_SAMPLER_PID" ] || return 0
-  kill "$MIXED_SAMPLER_PID" >/dev/null 2>&1 || true
-  wait "$MIXED_SAMPLER_PID" 2>/dev/null || true
-  MIXED_SAMPLER_PID=""
-  log "supplementary sampler stopped"
-}
+# (mixed_supp_sampler_stop is defined above, beside the other teardown steps,
+# because the EXIT trap calls it.)
 
 # ===========================================================================
 # Pre-flight
@@ -601,6 +624,18 @@ log "operational_settings cadence row: ${MANIFEST_SCHEDULER_CADENCE_ROW:-<none>}
 # blind offers no load and would report the harness rather than the system.
 of_health >/dev/null || die "the Allegro stub did not answer /__stub/health - bring up lab-allegro-stub"
 log "stub health ok"
+
+# The stub's own RUNNING configuration, read from the stub rather than
+# restated from docker-compose.lab.yml - which is the whole point of that
+# endpoint. It matters more here than in a single-flow scenario: the pinned
+# upstream latencies (`GET /order/events`, `GET /order/checkout-forms/{id}`)
+# are a direct multiplier on order throughput, the stub image on this stand
+# was built by a peer campaign rather than from this branch, and a figure
+# taken against a differently-configured stub is not comparable with F1's.
+MIXED_STUB_CONFIG="$(of_config)"
+MIXED_STUB_IMAGE="$(docker inspect lab-allegro-stub --format '{{.Config.Image}}' 2>/dev/null || printf 'unknown')"
+log "stub image: $MIXED_STUB_IMAGE"
+log "stub config: $MIXED_STUB_CONFIG"
 
 # ===========================================================================
 # Arrange
@@ -674,8 +709,12 @@ MIXED_EXTRA="$(jq -n \
   --arg taskCount "$MIXED_TASK_COUNT" \
   --arg cadence "${MANIFEST_SCHEDULER_CADENCE_ROW:-}" \
   --arg intake "$MIXED_INTAKE_CLIENT" \
+  --arg stubImage "$MIXED_STUB_IMAGE" \
+  --argjson stubConfig "$MIXED_STUB_CONFIG" \
   '{
      jobIntakeRedisClient: $intake,
+     stubImage: $stubImage,
+     stubConfig: $stubConfig,
      scenarioKind: "sustained-mixed-load",
      schedulerPosture: "ON (guard_scheduler_off deliberately not called)",
      runnerPosture: "enabled",

--- a/perf/openlinker-throughput/scenarios/sustained-mixed-load.sh
+++ b/perf/openlinker-throughput/scenarios/sustained-mixed-load.sh
@@ -787,6 +787,17 @@ MIXED_EXTRA="$(jq -n \
   --arg stubImage "$MIXED_STUB_IMAGE" \
   --argjson stubConfig "$MIXED_STUB_CONFIG" \
   '{
+     # #2840 requires this run to be "flagged in its manifest as one inside
+     # which attribution is impossible", and this is that flag. It is a
+     # statement about the WINDOW, not a warning about the harness: thirty
+     # crons, an order ramp and the master sweeps share one worker process,
+     # one connection pool, one Redis limiter and one destination rate-limit
+     # budget, so no figure this window produces can be attributed to any
+     # single flow. A per-jobType queue breakdown is a DEPTH attribution and
+     # must not be read as a COST one.
+     attributionImpossible: true,
+     attributionImpossibleReason:
+       "scheduler ON with 30 registered tasks plus a saturating order ramp against one worker process, one pool, one limiter and one destination budget (#2840: an explicitly non-isolating mixed-workload run)",
      jobIntakeRedisClient: $intake,
      stubImage: $stubImage,
      stubConfig: $stubConfig,

--- a/perf/openlinker-throughput/scenarios/sustained-mixed-load.sh
+++ b/perf/openlinker-throughput/scenarios/sustained-mixed-load.sh
@@ -470,9 +470,57 @@ log "teardown armed (restores runner/scheduler posture, destination rate limit, 
 mixed_registered_tasks() {
   local w out=""
   for w in $WORKER_CONTAINERS; do
-    out="$out$(docker logs "$w" 2>&1 | grep -F 'Registered scheduler task:' | sed 's/.*Registered scheduler task: //' | sort -u || true)"$'\n'
+    # `sed 's/\x1b\[[0-9;]*m//g'` strips the Nest logger's ANSI colour codes,
+    # which wrap the message on both sides - harmless for the `grep -F` that
+    # finds the line, fatal for the trailing `)[39m` that would otherwise end
+    # up inside every recorded task description.
+    out="$out$(docker logs "$w" 2>&1 \
+      | grep -F 'Registered scheduler task:' \
+      | sed 's/\x1b\[[0-9;]*m//g' \
+      | sed 's/.*Registered scheduler task: //' | sort -u || true)"$'\n'
   done
   printf '%s' "$out" | sed '/^$/d' | sort -u
+}
+
+# ---------------------------------------------------------------------------
+# Wait for the scheduler to actually REGISTER, then refuse a run where it did
+# not. Both halves are load-bearing and the first smoke run of this scenario
+# is why they exist.
+#
+# The wait: the scheduler is a fleet singleton behind a Redis lease
+# (`SchedulerLeaseCoordinator`, #2279), so registration happens only after
+# `SingletonRoleLease` acquires `singleton:scheduler` - measured at ~5s after
+# boot on this stand, and up to a full lease TTL (`OL_SCHEDULER_LEASE_TTL_MS`,
+# default 60s) if a previous holder died without releasing. The runner's own
+# `Starting sync job runner loop` line lands well before that, so a scenario
+# that reads the log as soon as `guard_runner_state` passes reads it too
+# early. That is exactly what happened: 27 tasks were registered and the
+# scenario recorded "0 task(s)".
+#
+# The refusal: a mixed-workload run whose scheduler registered nothing is not
+# a mixed-workload run - it is an order-only run wearing the wrong label, and
+# every co-tenancy figure it produced would be a statement about a condition
+# that never existed. Recording 0 and continuing is the reported-versus-
+# enforced gap this harness exists to close.
+# ---------------------------------------------------------------------------
+mixed_wait_for_scheduler() {
+  local tries=0 n tasks
+  while :; do
+    tasks="$(mixed_registered_tasks)"
+    n="$(printf '%s\n' "$tasks" | sed '/^$/d' | wc -l | tr -d ' ')"
+    [ "${n:-0}" -eq 0 ] || { printf '%s' "$tasks"; return 0; }
+    tries=$((tries + 1))
+    if [ "$tries" -ge 30 ]; then
+      die "mixed_wait_for_scheduler: no 'Registered scheduler task:' line appeared on [$WORKER_CONTAINERS] within 150s of the recreate.
+  This scenario's entire premise is that the scheduler is ON, so a run with
+  zero registered tasks must abort rather than measure an order-only window
+  and label it mixed. Check that OL_SCHEDULER_ENABLED=true really reached the
+  container (docker exec $WORKER_CONTAINERS printenv OL_SCHEDULER_ENABLED) and
+  that the singleton lease is free:
+    docker exec -i $REDIS_CONTAINER redis-cli GET singleton:scheduler"
+    fi
+    sleep 5
+  done
 }
 
 # SHARED or DEDICATED, read from the worker's own startup line
@@ -481,16 +529,32 @@ mixed_registered_tasks() {
 # the difference between 207 and 2 233 orders/h in the retest campaign. The
 # module logs on BOTH branches precisely so a harness can assert it.
 #
+# THE VALUE IS THE TOKEN IMMEDIATELY AFTER THE COLON, and nothing else.
+# Substring-matching the line is wrong in a way that inverts the answer: the
+# SHARED message reads
+#   "Job intake Redis client: SHARED (OL_JOB_INTAKE_DEDICATED_REDIS is not true)"
+# which CONTAINS the string `DEDICATED` inside the variable's own name. A
+# `case "$line" in *DEDICATED*)` test therefore reports DEDICATED for a
+# worker that logged SHARED - caught on this scenario's first smoke run,
+# where the log said SHARED and the scenario recorded DEDICATED. Publishing
+# that would have inverted the single most consequential configuration fact
+# in this campaign.
+#
 # `unknown` is reported rather than defaulted: a worker that printed neither
 # line is a worker whose intake wiring this run cannot describe, and guessing
 # `SHARED` would put an unverified condition into the manifest.
 mixed_intake_client() {
-  local w line answer="unknown"
+  local w tok answer="unknown"
   for w in $WORKER_CONTAINERS; do
-    line="$(docker logs "$w" 2>&1 | grep -F 'Job intake Redis client:' | tail -1 || true)"
-    case "$line" in
-      *DEDICATED*) answer="DEDICATED" ;;
-      *SHARED*)    answer="SHARED" ;;
+    # ANSI-stripped first (the Nest logger colours the message), then the one
+    # word following the colon.
+    tok="$(docker logs "$w" 2>&1 \
+      | grep -F 'Job intake Redis client:' \
+      | sed 's/\x1b\[[0-9;]*m//g' \
+      | sed -n 's/.*Job intake Redis client: \([A-Z]*\).*/\1/p' \
+      | tail -1 || true)"
+    case "$tok" in
+      DEDICATED|SHARED) answer="$tok" ;;
     esac
   done
   printf '%s' "$answer"
@@ -681,7 +745,8 @@ MIXED_INTAKE_CLIENT="$(mixed_intake_client)"
 log "job intake Redis client: $MIXED_INTAKE_CLIENT (env OL_JOB_INTAKE_DEDICATED_REDIS=$(docker exec "$(printf '%s' "$WORKER_CONTAINERS" | awk '{print $1}')" printenv OL_JOB_INTAKE_DEDICATED_REDIS 2>/dev/null || printf '<unset>'))"
 [ "$MIXED_INTAKE_CLIENT" != "unknown" ] || warn "could not read the worker's 'Job intake Redis client:' line - the manifest will say unknown rather than guess"
 
-MIXED_TASKS="$(mixed_registered_tasks)"
+log "waiting for the scheduler singleton to acquire its lease and register"
+MIXED_TASKS="$(mixed_wait_for_scheduler)"
 MIXED_TASK_COUNT="$(printf '%s\n' "$MIXED_TASKS" | sed '/^$/d' | wc -l | tr -d ' ')"
 log "scheduler registered $MIXED_TASK_COUNT task(s)"
 printf '%s\n' "$MIXED_TASKS" | sed 's/^/    /'

--- a/perf/openlinker-throughput/scenarios/sustained-mixed-load.sh
+++ b/perf/openlinker-throughput/scenarios/sustained-mixed-load.sh
@@ -1,0 +1,834 @@
+#!/usr/bin/env bash
+#
+# Sustained mixed load - orders, catalogue sweeps and crons together, for
+# hours (#2983, epic #2840).
+#
+# ---------------------------------------------------------------------------
+# WHY THIS SCENARIO EXISTS, AND WHY IT BREAKS THE HARNESS'S OWN PRECONDITIONS
+# ---------------------------------------------------------------------------
+# Every flow measured so far drove exactly ONE thing, in a 300-second window,
+# with the scheduler OFF. That is the right way to measure a hop and the wrong
+# way to answer "what does a Tuesday look like". Two properties of a real
+# install are missing from every figure in this tree:
+#
+#   CO-TENANCY   F1's own header states it: "Turning the scheduler on instead
+#                would have fired every other default-on task with it,
+#                including the PrestaShop master sweeps whose parents share
+#                the `fan-out` lane with `marketplace.orders.poll` itself" -
+#                and calls that co-tenancy "the exact contaminant #2847 names
+#                to control for". Controlling for it was correct for F1. It
+#                also means nothing in this campaign has ever measured it.
+#
+#   DURATION     `results-weak-shop-2026-09-07.md` § 3.3 is the only
+#                accumulation-detection design in the tree, and its sentence
+#                generalises: "A 60 s step cannot see an accumulating problem,
+#                and the condition this whole question is about is
+#                accumulating by nature." A leak, an unbounded queue and a
+#                connection-pool creep are all invisible in 300 seconds.
+#
+# So this scenario deliberately runs WITH the scheduler on and WITHOUT
+# `guard_scheduler_off`, which is the one guard whose contract it inverts.
+# `guard_scheduler_off`'s own docblock authorises that: "a scenario that wants
+# it on should not call this guard at all and should instead record its posture
+# via manifest_set directly". This script records the posture, the whole
+# resolved task inventory, and every cadence it could read.
+#
+# A NOTE ON PROVENANCE, because it is easy to get wrong when quoting this run:
+# the commissioning task described a mixed-workload run as "the only run whose
+# orders/hour figure an operator can apply to their own Tuesday". That framing
+# is the TASK's, not a quotation from `campaign-2026-09-06.md`. What the
+# campaign doc actually says, in § 7, is narrower and should be quoted instead:
+# "Any ceiling. No flow was driven to failure on hardware that could be
+# described as representative. Every figure here is a floor." and
+# "Cross-lane starvation. ADR-050's lane model is not validated by any run
+# here." `results-retest-2026-09-07.md` § 5.3 names the lane-starvation window
+# as "the natural next window". This run is that window widened, not a
+# requirement the campaign doc set.
+#
+# ---------------------------------------------------------------------------
+# WHAT IS DRIVEN, AND WHAT DRIVES ITSELF
+# ---------------------------------------------------------------------------
+#   1. ORDERS      pushed into the Allegro stub at a fixed arrival rate. The
+#                  harness does NOT enqueue the poll - the real
+#                  `allegro-orders-poll` cron does, at its shipped `*/1`
+#                  cadence. That is the whole point: F1 owned the poll cadence
+#                  and said so; here the poll wait is a REAL figure for the
+#                  first time in this campaign.
+#   2. SWEEPS      `master.product.syncAll` (*/20) and
+#                  `master.inventory.syncAll` (*/15) against a 50 006-product
+#                  PrestaShop, fired by the scheduler, unassisted.
+#   3. EVERYTHING  every other default-on task the scheduler resolves for the
+#      ELSE        stand's five connections, unfiltered. Disabling the
+#                  inconvenient ones would reproduce the isolation this run
+#                  exists to remove.
+#
+# ---------------------------------------------------------------------------
+# THE ARRIVAL RATE IS CHOSEN TO SATURATE, AND THAT IS A METHOD CHOICE
+# ---------------------------------------------------------------------------
+# Under a standing backlog, achieved throughput IS the service rate - which is
+# both the "orders/hour under mixed load" figure and the convergence
+# threshold, since an offered rate below it converges and above it diverges.
+# One saturating rate therefore answers both questions, and answers them from
+# a single continuous window rather than from a step ladder whose segments
+# each carry their own settle and their own noise.
+#
+# The rate must be above the plausible ceiling to guarantee saturation. The
+# governing arithmetic `results-retest-2026-09-07.md` establishes is
+# `orders/hour ceiling = requestsPerMinute / requests-per-order x 60`; at the
+# newly-shipped PrestaShop default of 300 req/min (prestashop-plugin.ts:125)
+# and the measured ~11 requests/order that is ~1 636 orders/h. The default
+# below is 60 orders/min = 3 600/h, which clears it about 2.2x.
+#
+# It is DELIBERATELY not higher. The Allegro poll takes up to 100 events per
+# tick, so an arrival rate under 100/min keeps the stub's own backlog near
+# zero and moves the whole backlog into `sync_jobs`, where it is observable;
+# a rate above 100/min would bank an unobserved backlog inside the stub's
+# memory instead, which is both less useful and a real OOM risk over hours.
+#
+# ---------------------------------------------------------------------------
+# WHICH POST-GUARDS WILL FIRE BY CONSTRUCTION, AND WHY THEY ARE STILL RUN
+# ---------------------------------------------------------------------------
+# A saturating multi-hour window at shipped defaults trips several guards
+# structurally. Each one is still run, because the COUNT is the finding:
+#
+#   post_guard_limiter_degraded    Fires with near-certainty. The shared
+#     intake-client defect (`OL_JOB_INTAKE_DEDICATED_REDIS` still defaults
+#     `'false'` - sync-worker.module.ts:149) produced 40-49 fallback lines per
+#     300 s arm A window in the retest. Extrapolating that to hours is one of
+#     the questions this run was commissioned to check, so the guard's DISCARD
+#     is the expected answer and not a reason to change configuration.
+#   post_guard_destination_creates  Fires on any window that ends with work in
+#     flight; it has no in-flight allowance and no upper time bound. The
+#     health signal inside its message is the `failed` count, not the
+#     `missing` one (retest § 3).
+#   post_guard_attempts / post_guard_deferrals  Fire on any run long enough to
+#     contain a retry or a rate-limit deferral. `PERF_MAX_ATTEMPTS` is
+#     deliberately NOT applied here: the jobs are minted by the real
+#     scheduler, not by `enqueue_perf_job`, so they carry the entity default
+#     of 10 attempts - which is what a deployment carries.
+#
+# The verdict this scenario writes is therefore expected to read DISCARDED,
+# and `verdict.txt` will name each reason. A reader must not take that as
+# "the run failed"; § "Which figures may travel" in the report draws the line
+# explicitly, the way F7 § 8 does.
+#
+# ---------------------------------------------------------------------------
+# THE SAMPLER IS SLOWED DOWN ON PURPOSE
+# ---------------------------------------------------------------------------
+# `SAMPLE_INTERVAL_SECS` defaults to 1 in lib.sh, which is right for a
+# 300-second window and wrong for a four-hour one: `sample_queue` shells out to
+# `docker stats --no-stream` on every tick, and at 1 Hz over four hours that is
+# ~14 400 invocations of a command that takes on the order of a second - a
+# material, self-inflicted load on the very thing being measured. This
+# scenario raises the interval (see MIXED_SAMPLE_INTERVAL_SECS below) and
+# records what it used, so the sampling cost is a stated condition rather than
+# a hidden one.
+#
+# ---------------------------------------------------------------------------
+# WHAT THE SUPPLEMENTARY SAMPLER ADDS, AND WHY IT IS NOT IN lib.sh
+# ---------------------------------------------------------------------------
+# `sample_queue` records the queue scoped to the scenario's connection ids
+# plus `pg_database_size` and a `docker stats` blob. A soak needs four things
+# it does not carry: an INSTALL-WIDE queue count (the all-zero system
+# connection id owns `marketplace.offer.pauseStale` jobs and is in no
+# scenario's id list), the Postgres backend count against `max_connections`,
+# a per-jobType breakdown of what the queue is actually made of, and an
+# INCREMENTAL limiter-degradation count.
+#
+# Those go into a second CSV rather than into `sample_queue`, because changing
+# that function's header would change the file every existing consumer parses
+# (`drivers/f1-summarize.py`, `drivers/f2-summarize.py`) for the benefit of one
+# scenario. The cost is two sampler loops; the alternative is a schema change
+# under four shipped scenarios.
+#
+# The degradation count is sampled as a PER-INTERVAL delta, never as a
+# window-to-date grep. A cumulative grep re-reads the whole log on every tick,
+# which is O(n^2) over a four-hour log, and `results-retest-2026-09-07.md`
+# records that a degradation count cannot be re-derived after the fact anyway.
+# Both `docker logs` bounds are BARE epochs - the `@epoch` form is accepted
+# and matches nothing on Docker 29.5.2 (#2851), which is the bug that silenced
+# this exact measurement across the whole campaign.
+#
+# ---------------------------------------------------------------------------
+# USAGE
+# ---------------------------------------------------------------------------
+#   export PS_CONTAINER=lab-prestashop PS_MYSQL_CONTAINER=lab-mysql \
+#          PG_CONTAINER=lab-postgres REDIS_CONTAINER=lab-redis \
+#          OL_API_CONTAINER=lab-api OL_API_URL=http://127.0.0.1:19000 \
+#          OL_ADMIN_USER=admin OL_ADMIN_PASSWORD=admin
+#   export OL_STAND_LOCK_TTL_SECS=21600          # MUST cover the whole run
+#   bash scenarios/sustained-mixed-load.sh
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib.sh
+source "$SCRIPT_DIR/../lib.sh"
+# shellcheck source=../drivers/order-feed.sh
+source "$SCRIPT_DIR/../drivers/order-feed.sh"
+
+LIB_LOG_PREFIX="mixed"
+
+require_tools docker jq curl awk
+
+# ---------------------------------------------------------------------------
+# Knobs. Every one is named `MIXED_*` rather than reusing a lib.sh name -
+# `results-retest-2026-09-07.md` records a scenario-local `X="${X:-10}"`
+# written AFTER sourcing lib.sh silently losing to the library's own
+# `X="${X:-60}"`, so the script said 10 and did 60. A distinct name cannot
+# lose that way.
+# ---------------------------------------------------------------------------
+
+# Total measured window, seconds. 4 hours by default: long enough for four
+# firings of every hourly cron, twelve catalogue-sweep ticks, sixteen
+# inventory-sweep ticks and ~240 order polls.
+MIXED_DURATION_SECS="${MIXED_DURATION_SECS:-14400}"
+
+# Orders pushed into the stub per minute. See "THE ARRIVAL RATE" above.
+MIXED_ORDERS_PER_MIN="${MIXED_ORDERS_PER_MIN:-60}"
+
+# Sampling cadence for BOTH samplers. See "THE SAMPLER IS SLOWED DOWN".
+MIXED_SAMPLE_INTERVAL_SECS="${MIXED_SAMPLE_INTERVAL_SECS:-30}"
+
+# Destination fault injection. `docker pause` on the shop, at
+# MIXED_FAULT_AT_SECS into the window, for MIXED_FAULT_SECS. Set
+# MIXED_FAULT_AT_SECS to 0 to skip it entirely.
+#
+# `pause` rather than `stop`: it leaves `.State.StartedAt` untouched, so
+# `post_guard_containers_stable` still means what it means, and it produces
+# the shape #2978 measured at 12 orders - a destination that accepts the TCP
+# connection and never answers - rather than a connection refusal.
+MIXED_FAULT_AT_SECS="${MIXED_FAULT_AT_SECS:-9000}"
+MIXED_FAULT_SECS="${MIXED_FAULT_SECS:-300}"
+
+# Restore the destination's `config.rateLimit` to the shipped default (i.e.
+# remove the connection-level override so the plugin manifest's own
+# `defaultRateLimit` applies). The stand currently carries an explicit
+# `{maxConcurrent: 4, requestsPerMinute: 60}` left behind by the weak-shop
+# ramp, which is NOT the shipped default any more - #2982 moved the manifest
+# to 300/4. A run that claims "shipped defaults" must not inherit that.
+MIXED_RESET_DEST_RATE_LIMIT="${MIXED_RESET_DEST_RATE_LIMIT:-1}"
+
+# The stub tenant and its OpenLinker connection.
+MIXED_TENANT="${MIXED_TENANT:-perf-allegro-a}"
+
+# ---------------------------------------------------------------------------
+# The stand lock, claimed BEFORE any arrange step (the F1 rule): this script
+# rewrites the destination's rate limit and recreates the worker, and both are
+# changes a peer scenario would silently measure.
+#
+# The TTL is the one knob a multi-hour run MUST set. The lock carries no
+# heartbeat, so a TTL shorter than the window would expire mid-run and let a
+# peer take a stand that is under load.
+# ---------------------------------------------------------------------------
+MIXED_MIN_LOCK_TTL=$(( MIXED_DURATION_SECS + SETTLE_SECS + 1800 ))
+[ "$STAND_LOCK_TTL_SECS" -ge "$MIXED_MIN_LOCK_TTL" ] || die \
+"the stand lock TTL (${STAND_LOCK_TTL_SECS}s) is shorter than this run needs (${MIXED_MIN_LOCK_TTL}s
+  = ${MIXED_DURATION_SECS}s window + ${SETTLE_SECS}s settle + 1800s for arrange/teardown).
+  The lock has no heartbeat, so it would expire mid-window and hand a loaded
+  stand to a peer. Re-run with:
+    export OL_STAND_LOCK_TTL_SECS=$(( MIXED_MIN_LOCK_TTL + 1800 ))"
+
+guard_stand_exclusive "sustained-mixed-load"
+
+# ---------------------------------------------------------------------------
+# Connection ids.
+#
+# `stand-ids.env` is absent on this stand (bootstrap.sh deletes it on any run
+# that found a gap, and it is gitignored, so a stand bootstrapped from another
+# worktree may simply not have one). Rather than re-running bootstrap - which
+# rotates the PrestaShop webservice key and reseeds offer mappings, i.e.
+# changes the thing under measurement - the ids are resolved from the database
+# by NAME, which is what bootstrap itself keys on.
+#
+# Resolved rather than hardcoded so this script survives a reseed, and each
+# one is asserted non-empty: an empty id silently widens every `IN (...)`
+# predicate below to `IN ('')`, which matches nothing and would report a
+# perfectly busy queue as empty.
+# ---------------------------------------------------------------------------
+conn_id_by_name() {
+  local name="$1" id
+  id="$(pg_sql "SELECT id FROM connections WHERE name='$name' LIMIT 1")"
+  [ -n "$id" ] || die "conn_id_by_name: no connection named '$name' on this stand - run bootstrap.sh, or set the id explicitly"
+  printf '%s' "$id"
+}
+
+PS_CONNECTION_ID="${PS_CONNECTION_ID:-$(conn_id_by_name perf-prestashop)}"
+ALLEGRO_A_CONNECTION_ID="${ALLEGRO_A_CONNECTION_ID:-$(conn_id_by_name "$MIXED_TENANT")}"
+
+# EVERY active connection, not just the two this script drives. With the
+# scheduler on, the resolver fires each capability task for every active
+# connection that carries the capability, so a queue scoped to two ids would
+# under-report the install's real depth - which is the headline figure.
+ALL_CONN_IDS_CSV="$(pg_sql "SELECT string_agg(quote_literal(id), ',' ORDER BY \"createdAt\") FROM connections WHERE status='active'")"
+[ -n "$ALL_CONN_IDS_CSV" ] || die "no active connections on this stand"
+CONN_IDS="$ALL_CONN_IDS_CSV"
+log "connections under measurement: $CONN_IDS"
+log "orders source: $MIXED_TENANT ($ALLEGRO_A_CONNECTION_ID); destination: perf-prestashop ($PS_CONNECTION_ID)"
+
+# ---------------------------------------------------------------------------
+# Which compose file and env file is the RUNNING stand using? Resolved from
+# the container's own labels, verbatim from f7-lane-starvation.sh - on a
+# multi-worktree checkout the stand is routinely brought up from a DIFFERENT
+# worktree, and a hardcoded `$SCRIPT_DIR/../../../.env.lab` does not exist
+# there. Verified again on this host: the `lab` project's working_dir points
+# at a sibling agent worktree.
+# ---------------------------------------------------------------------------
+_compose_label() {
+  local w
+  w="$(discover_worker_containers | awk '{print $1}')"
+  [ -n "$w" ] || return 0
+  docker inspect --format "{{index .Config.Labels \"$1\"}}" "$w" 2>/dev/null || true
+}
+LAB_ENV_FILE="${LAB_ENV_FILE:-$(_compose_label com.docker.compose.project.environment_file)}"
+[ -n "$LAB_ENV_FILE" ] || LAB_ENV_FILE="$SCRIPT_DIR/../../../.env.lab"
+LAB_COMPOSE_FILE="${LAB_COMPOSE_FILE:-$(_compose_label com.docker.compose.project.config_files)}"
+[ -n "$LAB_COMPOSE_FILE" ] || LAB_COMPOSE_FILE="$SCRIPT_DIR/../../../docker-compose.lab.yml"
+case "$LAB_COMPOSE_FILE" in
+  *,*) die "LAB_COMPOSE_FILE resolved to a multi-file compose project [$LAB_COMPOSE_FILE] - set LAB_COMPOSE_FILE explicitly to the file carrying the 'worker' service" ;;
+esac
+[ -f "$LAB_ENV_FILE" ] || die "LAB_ENV_FILE [$LAB_ENV_FILE] not found - set it to the .env.lab the running stand was created from"
+log "stand config: compose=$LAB_COMPOSE_FILE env=$LAB_ENV_FILE project=$LAB_COMPOSE_PROJECT"
+
+# ---------------------------------------------------------------------------
+# Capture, then restore, everything this run changes. Read from the RUNNING
+# replica first and fall back to the env file (the F7/F4 pattern); an
+# unreadable value is fatal rather than guessed, because the whole point is to
+# hand the stand back in the posture it was found in.
+# ---------------------------------------------------------------------------
+_read_worker_env() {
+  local key="$1" w val
+  w="$(discover_worker_containers | awk '{print $1}')"
+  if [ -n "$w" ]; then
+    val="$(docker exec "$w" printenv "$key" 2>/dev/null || printf '')"
+    [ -z "$val" ] || { printf '%s' "$val"; return 0; }
+  fi
+  val="$(awk -F= -v k="^$key=" '$0 ~ k {print $2; exit}' "$LAB_ENV_FILE" 2>/dev/null || printf '')"
+  [ -n "$val" ] || die "_read_worker_env: could not read $key from any running worker replica [$(discover_worker_containers)] or from $LAB_ENV_FILE - refusing to guess a posture this run must restore"
+  printf '%s' "$val"
+}
+
+ORIGINAL_RUNNER_ENABLED="$(_read_worker_env WORKER_RUNNER_ENABLED)"
+ORIGINAL_SCHEDULER_ENABLED="$(_read_worker_env OL_SCHEDULER_ENABLED)"
+# `config->'rateLimit'` as text, or the literal string `null` when the key is
+# absent. Kept as raw JSON so the restore is byte-exact - reconstructing it
+# from parsed fields would silently normalise `{"maxConcurrent": 4}` key order
+# and drop any field this script does not know about.
+ORIGINAL_DEST_RATE_LIMIT="$(pg_sql "SELECT COALESCE(config->'rateLimit', 'null'::jsonb)::text FROM connections WHERE id='$PS_CONNECTION_ID'")"
+log "posture at scenario start: WORKER_RUNNER_ENABLED=$ORIGINAL_RUNNER_ENABLED OL_SCHEDULER_ENABLED=$ORIGINAL_SCHEDULER_ENABLED destRateLimit=$ORIGINAL_DEST_RATE_LIMIT"
+
+MIXED_SAMPLER_PID=""
+MIXED_FAULT_ACTIVE=0
+
+# One combined EXIT handler. `trap ... EXIT` is a SINGLE slot in bash, not a
+# stack, so a second `trap ... EXIT` would REPLACE guard_stand_exclusive's own
+# release and leave the stand locked for the full TTL after any `die` - the
+# bug f7-lane-starvation.sh documents having been caught. INT/TERM are trapped
+# explicitly as well: a default-disposition SIGTERM does not run an EXIT trap,
+# and a four-hour run is exactly the kind a human interrupts.
+mixed_on_exit() {
+  local rc=$?
+  set +e
+  mixed_supp_sampler_stop
+  # Unpause before anything else - a paused destination makes every restore
+  # step below hang on a shop call it does not need to make.
+  if [ "$MIXED_FAULT_ACTIVE" = "1" ]; then
+    warn "unpausing $PS_CONTAINER (fault injection was still active at exit)"
+    docker unpause "$PS_CONTAINER" >/dev/null 2>&1 || true
+    MIXED_FAULT_ACTIVE=0
+  fi
+  mixed_restore_dest_rate_limit
+  mixed_restore_worker_posture
+  release_stand_exclusive
+  return $rc
+}
+trap mixed_on_exit EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+mixed_restore_dest_rate_limit() {
+  local current
+  current="$(pg_sql "SELECT COALESCE(config->'rateLimit', 'null'::jsonb)::text FROM connections WHERE id='$PS_CONNECTION_ID'" 2>/dev/null || printf '')"
+  [ -n "$current" ] || { warn "restore: could not read the destination's current rateLimit - leaving it as-is"; return 0; }
+  [ "$current" != "$ORIGINAL_DEST_RATE_LIMIT" ] || return 0
+  log "restoring destination config.rateLimit to $ORIGINAL_DEST_RATE_LIMIT (was $current)"
+  if [ "$ORIGINAL_DEST_RATE_LIMIT" = "null" ]; then
+    pg_sql_write "UPDATE connections SET config = config - 'rateLimit' WHERE id='$PS_CONNECTION_ID'" >/dev/null
+  else
+    pg_sql_write "UPDATE connections SET config = jsonb_set(config, '{rateLimit}', '$ORIGINAL_DEST_RATE_LIMIT'::jsonb) WHERE id='$PS_CONNECTION_ID'" >/dev/null
+  fi
+}
+
+mixed_restore_worker_posture() {
+  local cur_runner cur_sched
+  cur_runner="$(_read_worker_env WORKER_RUNNER_ENABLED 2>/dev/null || printf '')"
+  cur_sched="$(_read_worker_env OL_SCHEDULER_ENABLED 2>/dev/null || printf '')"
+  if [ -z "$cur_runner" ] || [ -z "$cur_sched" ]; then
+    warn "restore: could not read the current worker posture - leaving the stand as-is"
+    return 0
+  fi
+  if [ "$cur_runner" = "$ORIGINAL_RUNNER_ENABLED" ] && [ "$cur_sched" = "$ORIGINAL_SCHEDULER_ENABLED" ]; then
+    return 0
+  fi
+  log "restoring WORKER_RUNNER_ENABLED=$ORIGINAL_RUNNER_ENABLED OL_SCHEDULER_ENABLED=$ORIGINAL_SCHEDULER_ENABLED (were $cur_runner / $cur_sched)"
+  mixed_set_worker_posture "$ORIGINAL_RUNNER_ENABLED" "$ORIGINAL_SCHEDULER_ENABLED" skip-wait
+}
+
+# ---------------------------------------------------------------------------
+# mixed_set_worker_posture <runner:true|false> <scheduler:true|false> [skip-wait]
+#
+# Flips both keys in .env.lab and recreates ONLY the `worker` service.
+# `-p lab` is REQUIRED: the worker service carries no `container_name` since
+# #2851, so without an explicit project name compose derives one from the
+# directory and brings up a SECOND, parallel worker against this same
+# database. `--no-deps` plus an explicit service name bounds the blast radius
+# to `worker` even though this run holds the stand lock.
+# ---------------------------------------------------------------------------
+mixed_set_env_key() {
+  local key="$1" want="$2" env_file="$LAB_ENV_FILE"
+  # `grep -q` on a plain FILE argument is safe. The SIGPIPE/pipefail trap
+  # docs/lessons.md records applies only when grep terminates a PIPE.
+  if grep -q "^$key=" "$env_file"; then
+    sed -i "s/^$key=.*/$key=$want/" "$env_file"
+  else
+    printf '%s=%s\n' "$key" "$want" >> "$env_file"
+  fi
+}
+
+mixed_set_worker_posture() {
+  local runner="$1" sched="$2" mode="${3:-wait}"
+  mixed_set_env_key WORKER_RUNNER_ENABLED "$runner"
+  mixed_set_env_key OL_SCHEDULER_ENABLED "$sched"
+  ( cd "$(dirname "$LAB_COMPOSE_FILE")" \
+    && docker compose -f "$LAB_COMPOSE_FILE" --env-file "$LAB_ENV_FILE" -p "$LAB_COMPOSE_PROJECT" \
+         up -d --no-deps worker >/dev/null )
+  sleep 5
+  # The recreate mints a NEW container, so lib.sh's memoised list is stale.
+  WORKER_CONTAINERS=""
+  WORKER_CONTAINERS_RESOLVED=0
+  _ensure_worker_containers
+  [ "$mode" = "wait" ] || return 0
+  [ "$runner" = "true" ] || return 0
+
+  # Wait for the runner's own startup line. `grep -c`, never `grep -q`:
+  # `grep -q` exits at its first match, closing the pipe while `docker logs`
+  # is still writing, so `docker logs` dies of SIGPIPE (141) and
+  # `set -o pipefail` reports the pipeline FAILED even though the line
+  # matched. It is length-dependent, so it passes while the log is short and
+  # starts failing once the worker has been up a while (#2851).
+  local w tries hits
+  for w in $WORKER_CONTAINERS; do
+    tries=0
+    while :; do
+      hits="$(docker logs "$w" 2>&1 | grep -c -F 'Starting sync job runner loop' || true)"
+      [ "${hits:-0}" -eq 0 ] || break
+      tries=$((tries + 1))
+      [ "$tries" -lt 24 ] || die "mixed_set_worker_posture: $w never printed 'Starting sync job runner loop' within 120s of the recreate"
+      sleep 5
+    done
+  done
+}
+
+# ---------------------------------------------------------------------------
+# Which scheduler tasks did the worker ACTUALLY register? Read out of the
+# worker's own startup log, never inferred from the code, for the same reason
+# f8-lane-caps.sh reads its lane caps back rather than trusting `printenv`:
+# compose forwards an env-file key only if the service's own `environment:`
+# block names it, so a cadence "set" in .env.lab may change nothing at all.
+#
+# One line per registered task, and this is the run's own record of what
+# "unfiltered crons" resolved to on this stand.
+# ---------------------------------------------------------------------------
+mixed_registered_tasks() {
+  local w out=""
+  for w in $WORKER_CONTAINERS; do
+    out="$out$(docker logs "$w" 2>&1 | grep -F 'Registered scheduler task:' | sed 's/.*Registered scheduler task: //' | sort -u || true)"$'\n'
+  done
+  printf '%s' "$out" | sed '/^$/d' | sort -u
+}
+
+# SHARED or DEDICATED, read from the worker's own startup line
+# (sync-worker.module.ts:156 / :175) and never from `printenv` - an env var
+# read from outside the container is a request, not a reading, and this one is
+# the difference between 207 and 2 233 orders/h in the retest campaign. The
+# module logs on BOTH branches precisely so a harness can assert it.
+#
+# `unknown` is reported rather than defaulted: a worker that printed neither
+# line is a worker whose intake wiring this run cannot describe, and guessing
+# `SHARED` would put an unverified condition into the manifest.
+mixed_intake_client() {
+  local w line answer="unknown"
+  for w in $WORKER_CONTAINERS; do
+    line="$(docker logs "$w" 2>&1 | grep -F 'Job intake Redis client:' | tail -1 || true)"
+    case "$line" in
+      *DEDICATED*) answer="DEDICATED" ;;
+      *SHARED*)    answer="SHARED" ;;
+    esac
+  done
+  printf '%s' "$answer"
+}
+
+# ===========================================================================
+# Supplementary sampler - see the header block for why this is not in lib.sh.
+# ===========================================================================
+MIXED_SUPP_CSV=""
+MIXED_PHASE_FILE=""
+
+mixed_phase_set() {
+  [ -n "$MIXED_PHASE_FILE" ] || return 0
+  printf '%s' "$1" > "$MIXED_PHASE_FILE"
+}
+
+mixed_supp_header() {
+  printf 'ts,epoch,elapsed,phase,g_queued_due,g_queued_deferred,g_running,g_dead,ord_sync_queued,ord_sync_succeeded,ord_sync_dead,orders_ingested,pg_backends,pg_backends_active,pg_max_conn,limiter_degraded_delta,stub_backlog,mem_json,queue_by_type_json\n' > "$1"
+}
+
+# One sample. Every query is chosen to be servable by an existing index:
+# `sync_jobs` by (status, nextRunAt) / (connectionId, jobType, status,
+# updatedAt), `order_records` by IDX_order_records_createdAt. The
+# `syncStatus @> ...` containment count is DELIBERATELY absent - F5 measured
+# it at 141.9 ms and ~540 MB of buffer traffic per execution at 1M rows, so
+# sampling it every 30 s for four hours would be a self-inflicted load larger
+# than several of the flows under measurement. It is computed once, at the
+# end, in the summary.
+mixed_supp_sample() {
+  local csv="$1" ws_epoch="$2" ws_iso="$3" prev_epoch="$4" now phase
+  now="$(epoch)"
+  phase="$(cat "$MIXED_PHASE_FILE" 2>/dev/null || printf 'unknown')"
+
+  local gq gd gr gdead
+  gq="$(pg_sql "SELECT COUNT(*) FROM sync_jobs WHERE status='queued' AND \"nextRunAt\"<=NOW()" 2>/dev/null || printf -1)"
+  gd="$(pg_sql "SELECT COUNT(*) FROM sync_jobs WHERE status='queued' AND \"nextRunAt\">NOW()" 2>/dev/null || printf -1)"
+  gr="$(pg_sql "SELECT COUNT(*) FROM sync_jobs WHERE status='running'" 2>/dev/null || printf -1)"
+  gdead="$(pg_sql "SELECT COUNT(*) FROM sync_jobs WHERE status='dead' AND \"createdAt\">='$ws_iso'" 2>/dev/null || printf -1)"
+
+  local osq oss osd
+  osq="$(pg_sql "SELECT COUNT(*) FROM sync_jobs WHERE \"jobType\"='marketplace.order.sync' AND status='queued' AND \"createdAt\">='$ws_iso'" 2>/dev/null || printf -1)"
+  oss="$(pg_sql "SELECT COUNT(*) FROM sync_jobs WHERE \"jobType\"='marketplace.order.sync' AND status='succeeded' AND \"createdAt\">='$ws_iso'" 2>/dev/null || printf -1)"
+  osd="$(pg_sql "SELECT COUNT(*) FROM sync_jobs WHERE \"jobType\"='marketplace.order.sync' AND status='dead' AND \"createdAt\">='$ws_iso'" 2>/dev/null || printf -1)"
+
+  local ing
+  ing="$(pg_sql "SELECT COUNT(*) FROM order_records WHERE \"createdAt\">='$ws_iso' AND \"sourceConnectionId\"='$ALLEGRO_A_CONNECTION_ID'" 2>/dev/null || printf -1)"
+
+  local be bea mx
+  be="$(pg_sql "SELECT COUNT(*) FROM pg_stat_activity" 2>/dev/null || printf -1)"
+  bea="$(pg_sql "SELECT COUNT(*) FROM pg_stat_activity WHERE state='active'" 2>/dev/null || printf -1)"
+  mx="$(pg_sql "SHOW max_connections" 2>/dev/null || printf -1)"
+
+  # Degradation lines inside THIS interval only. Both bounds are BARE epochs:
+  # `--since "@$epoch"` is accepted and matches nothing (#2851). `grep -c`
+  # reads to EOF, so there is no SIGPIPE hazard here.
+  local deg=0 w hit
+  for w in $WORKER_CONTAINERS; do
+    hit="$(docker logs --since "$prev_epoch" --until "$now" "$w" 2>&1 \
+      | grep -c -F 'falling back to per-process in-memory limiting' || true)"
+    deg=$((deg + ${hit:-0}))
+  done
+
+  local backlog
+  backlog="$(of_backlog "$MIXED_TENANT" "$ALLEGRO_A_CONNECTION_ID" 2>/dev/null || printf 'unknown')"
+
+  # Memory from the host's own cgroup view via `docker stats`. One invocation
+  # per sample, at the slowed cadence - see the header note.
+  local mem
+  mem="$(docker stats --no-stream --format '{"name":"{{.Name}}","mem":"{{.MemUsage}}","cpu":"{{.CPUPerc}}"}' 2>/dev/null | jq -cs '.' || printf '[]')"
+
+  # What the queue is MADE of. Bounded to the ten deepest types so one
+  # pathological type cannot make the CSV row unbounded.
+  local bytype
+  bytype="$(pg_sql "SELECT COALESCE(jsonb_object_agg(t.\"jobType\", t.n)::text,'{}') FROM (
+      SELECT \"jobType\", COUNT(*) AS n FROM sync_jobs
+      WHERE status='queued' GROUP BY \"jobType\" ORDER BY n DESC LIMIT 10) t" 2>/dev/null || printf '{}')"
+
+  # Both JSON columns are RFC4180-quoted (wrapped in a literal `"..."` pair
+  # with internal `"` doubled). #2930 records a naive reader silently
+  # comma-splitting an unquoted JSON column into extra fields instead of
+  # erroring - the internal escaping was right and the outer quote pair was
+  # the missing half.
+  printf '%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s,"%s","%s"\n' \
+    "$(iso_now)" "$now" "$((now - ws_epoch))" "$phase" \
+    "$gq" "$gd" "$gr" "$gdead" \
+    "$osq" "$oss" "$osd" "$ing" \
+    "$be" "$bea" "$mx" "$deg" "$backlog" \
+    "$(printf '%s' "$mem" | sed 's/"/""/g')" \
+    "$(printf '%s' "$bytype" | sed 's/"/""/g')" >> "$csv"
+}
+
+mixed_supp_sampler_start() {
+  local dir="$1" ws_epoch="$2" ws_iso="$3"
+  MIXED_SUPP_CSV="$dir/mixed-timeseries.csv"
+  MIXED_PHASE_FILE="$dir/.phase"
+  mixed_phase_set "starting"
+  mixed_supp_header "$MIXED_SUPP_CSV"
+  (
+    local prev="$ws_epoch"
+    while :; do
+      mixed_supp_sample "$MIXED_SUPP_CSV" "$ws_epoch" "$ws_iso" "$prev" || true
+      prev="$(epoch)"
+      sleep "$MIXED_SAMPLE_INTERVAL_SECS"
+    done
+  ) &
+  MIXED_SAMPLER_PID=$!
+  echo "$MIXED_SAMPLER_PID" > "$dir/.mixed-sampler.pid"
+  log "supplementary sampler started (pid=$MIXED_SAMPLER_PID, interval=${MIXED_SAMPLE_INTERVAL_SECS}s) -> $MIXED_SUPP_CSV"
+}
+
+mixed_supp_sampler_stop() {
+  [ -n "$MIXED_SAMPLER_PID" ] || return 0
+  kill "$MIXED_SAMPLER_PID" >/dev/null 2>&1 || true
+  wait "$MIXED_SAMPLER_PID" 2>/dev/null || true
+  MIXED_SAMPLER_PID=""
+  log "supplementary sampler stopped"
+}
+
+# ===========================================================================
+# Pre-flight
+# ===========================================================================
+log "=== pre-flight ==="
+guard_demo_mode_off
+guard_log_level
+guard_build
+guard_connection_budget
+guard_pool_recorded
+guard_queue_empty "$CONN_IDS"
+# guard_scheduler_off is DELIBERATELY NOT CALLED - see the header. Its cadence
+# half is still recorded, because an operational_settings row overrides
+# cronEnvVar/defaultCron and is invisible to an env-var-only reading.
+MANIFEST_SCHEDULER_CADENCE_ROW="$(scheduler_cadence_row)"
+log "operational_settings cadence row: ${MANIFEST_SCHEDULER_CADENCE_ROW:-<none>}"
+
+# The stub must be reachable and must be able to mint. A run whose upstream is
+# blind offers no load and would report the harness rather than the system.
+of_health >/dev/null || die "the Allegro stub did not answer /__stub/health - bring up lab-allegro-stub"
+log "stub health ok"
+
+# ===========================================================================
+# Arrange
+# ===========================================================================
+log "=== arrange ==="
+
+if [ "$MIXED_RESET_DEST_RATE_LIMIT" = "1" ]; then
+  if [ "$ORIGINAL_DEST_RATE_LIMIT" = "null" ]; then
+    log "destination carries no config.rateLimit override - the manifest default already applies"
+  else
+    log "removing the destination's config.rateLimit override ($ORIGINAL_DEST_RATE_LIMIT) so the plugin manifest default applies"
+    pg_sql_write "UPDATE connections SET config = config - 'rateLimit' WHERE id='$PS_CONNECTION_ID'" >/dev/null
+  fi
+fi
+MIXED_DEST_RATE_LIMIT_IN_WINDOW="$(pg_sql "SELECT COALESCE(config->'rateLimit', 'null'::jsonb)::text FROM connections WHERE id='$PS_CONNECTION_ID'")"
+log "destination config.rateLimit for this window: $MIXED_DEST_RATE_LIMIT_IN_WINDOW (null => plugin manifest defaultRateLimit)"
+
+# A fresh stub run, and the matching cursor reset. Both halves are required
+# and neither is optional housekeeping: the child job's dedupe key is
+# `marketplace:{connectionId}:order:{eventKey}` with a 7-day TTL and
+# `eventKey` is the stub's own event id, so repeating inside that window
+# without a new run id re-mints keys the previous run already reserved and
+# every enqueue silently no-ops. And OpenLinker's persisted
+# `allegro.orders.lastEventId` still names the PREVIOUS run's sequence, which
+# compares meaninglessly against a restarted one.
+MIXED_RUN_ID="mixed-$(epoch)"
+of_new_run "$MIXED_RUN_ID" >/dev/null
+log "stub run id: $MIXED_RUN_ID"
+reset_between_repeats "'$ALLEGRO_A_CONNECTION_ID'" "'$OF_CURSOR_KEY'"
+
+# Prime the feed so the first poll tick has something to take, then bring the
+# worker up with BOTH the runner and the scheduler on.
+MIXED_PRIME_ORDERS="${MIXED_PRIME_ORDERS:-$MIXED_ORDERS_PER_MIN}"
+log "priming the stub with $MIXED_PRIME_ORDERS order(s)"
+of_push_orders "$MIXED_TENANT" "$MIXED_PRIME_ORDERS" >/dev/null
+
+log "flipping the worker to runner=true scheduler=true"
+mixed_set_worker_posture true true
+guard_runner_state enabled
+log "lane caps in force: ${MANIFEST_LANE_CAPS:-<unread>}"
+
+MIXED_INTAKE_CLIENT="$(mixed_intake_client)"
+log "job intake Redis client: $MIXED_INTAKE_CLIENT (env OL_JOB_INTAKE_DEDICATED_REDIS=$(docker exec "$(printf '%s' "$WORKER_CONTAINERS" | awk '{print $1}')" printenv OL_JOB_INTAKE_DEDICATED_REDIS 2>/dev/null || printf '<unset>'))"
+[ "$MIXED_INTAKE_CLIENT" != "unknown" ] || warn "could not read the worker's 'Job intake Redis client:' line - the manifest will say unknown rather than guess"
+
+MIXED_TASKS="$(mixed_registered_tasks)"
+MIXED_TASK_COUNT="$(printf '%s\n' "$MIXED_TASKS" | sed '/^$/d' | wc -l | tr -d ' ')"
+log "scheduler registered $MIXED_TASK_COUNT task(s)"
+printf '%s\n' "$MIXED_TASKS" | sed 's/^/    /'
+
+snapshot_jobs_before "$CONN_IDS"
+
+# ===========================================================================
+# Window
+# ===========================================================================
+RESULTS_DIR="$(results_dir_init sustained-mixed-load "run$(epoch)")"
+
+MIXED_EXTRA="$(jq -n \
+  --arg dur "$MIXED_DURATION_SECS" \
+  --arg opm "$MIXED_ORDERS_PER_MIN" \
+  --arg si "$MIXED_SAMPLE_INTERVAL_SECS" \
+  --arg rl "$MIXED_DEST_RATE_LIMIT_IN_WINDOW" \
+  --arg rl0 "$ORIGINAL_DEST_RATE_LIMIT" \
+  --arg runid "$MIXED_RUN_ID" \
+  --arg tenant "$MIXED_TENANT" \
+  --arg src "$ALLEGRO_A_CONNECTION_ID" \
+  --arg dst "$PS_CONNECTION_ID" \
+  --arg faultAt "$MIXED_FAULT_AT_SECS" \
+  --arg faultFor "$MIXED_FAULT_SECS" \
+  --arg tasks "$MIXED_TASKS" \
+  --arg taskCount "$MIXED_TASK_COUNT" \
+  --arg cadence "${MANIFEST_SCHEDULER_CADENCE_ROW:-}" \
+  --arg intake "$MIXED_INTAKE_CLIENT" \
+  '{
+     jobIntakeRedisClient: $intake,
+     scenarioKind: "sustained-mixed-load",
+     schedulerPosture: "ON (guard_scheduler_off deliberately not called)",
+     runnerPosture: "enabled",
+     durationSecs: ($dur|tonumber),
+     ordersPerMin: ($opm|tonumber),
+     sampleIntervalSecs: ($si|tonumber),
+     destRateLimitInWindow: $rl,
+     destRateLimitBeforeRun: $rl0,
+     stubRunId: $runid,
+     stubTenant: $tenant,
+     sourceConnectionId: $src,
+     destinationConnectionId: $dst,
+     faultInjectAtSecs: ($faultAt|tonumber),
+     faultInjectForSecs: ($faultFor|tonumber),
+     registeredSchedulerTaskCount: ($taskCount|tonumber),
+     registeredSchedulerTasks: ($tasks | split("\n") | map(select(length>0))),
+     operationalSettingsCadenceRow: $cadence
+   }')"
+
+# lib.sh's own sampler runs at the slowed cadence too - see the header note on
+# why 1 Hz is wrong for a four-hour window.
+SAMPLE_INTERVAL_SECS="$MIXED_SAMPLE_INTERVAL_SECS"
+
+window_start "$RESULTS_DIR" sustained-mixed-load "$CONN_IDS" 0 "$MIXED_EXTRA"
+WS_ISO="$(date -u -d "@$WINDOW_START_EPOCH" +%Y-%m-%dT%H:%M:%SZ)"
+mixed_supp_sampler_start "$RESULTS_DIR" "$WINDOW_START_EPOCH" "$WS_ISO"
+
+# The arrival-rate driver. Pushes in one-minute ticks so the rate is a rate
+# and not a burst, and records what it actually pushed - `of_push_orders`
+# reports the stub's own minted count rather than echoing the request back, so
+# a stub that quietly minted fewer is visible here rather than assumed away.
+MIXED_PUSH_LOG="$RESULTS_DIR/pushes.csv"
+printf 'ts,epoch,elapsed,phase,asked,minted,total\n' > "$MIXED_PUSH_LOG"
+MIXED_PUSHED_TOTAL=0
+
+mixed_push_tick() {
+  local phase="$1" asked="$MIXED_ORDERS_PER_MIN" minted now
+  minted="$(of_push_orders "$MIXED_TENANT" "$asked" 2>/dev/null || printf 0)"
+  MIXED_PUSHED_TOTAL=$((MIXED_PUSHED_TOTAL + ${minted:-0}))
+  now="$(epoch)"
+  printf '%s,%s,%s,%s,%s,%s,%s\n' \
+    "$(iso_now)" "$now" "$((now - WINDOW_START_EPOCH))" "$phase" \
+    "$asked" "${minted:-0}" "$MIXED_PUSHED_TOTAL" >> "$MIXED_PUSH_LOG"
+}
+
+# MIN_AVAILABLE_WORK for post_guard_feed_starved. The number that guard wants
+# is upstream supply PLUS the due queue, never the upstream backlog alone -
+# on this run the backlog lives in `sync_jobs` by design (the poll drains the
+# stub within a tick or two), so a stub-only reading would report a starved
+# feed on a run carrying thousands of queued children.
+MIXED_MIN_AVAILABLE_WORK=""
+
+mixed_track_available_work() {
+  local backlog due total
+  backlog="$(of_backlog "$MIXED_TENANT" "$ALLEGRO_A_CONNECTION_ID" 2>/dev/null || printf 'unknown')"
+  due="$(pg_sql "SELECT COUNT(*) FROM sync_jobs WHERE status IN ('queued','running') AND \"nextRunAt\"<=NOW()" 2>/dev/null || printf 0)"
+  case "$backlog" in
+    ''|*[!0-9]*) total="${due:-0}" ;;   # unknown upstream -> count the queue only
+    *)           total=$(( backlog + ${due:-0} )) ;;
+  esac
+  if [ -z "$MIXED_MIN_AVAILABLE_WORK" ] || [ "$total" -lt "$MIXED_MIN_AVAILABLE_WORK" ]; then
+    MIXED_MIN_AVAILABLE_WORK="$total"
+  fi
+}
+
+log "=== window open: ${MIXED_DURATION_SECS}s, ${MIXED_ORDERS_PER_MIN} orders/min offered ==="
+mixed_phase_set "steady"
+
+MIXED_TICK=0
+while :; do
+  MIXED_ELAPSED=$(( $(epoch) - WINDOW_START_EPOCH ))
+  [ "$MIXED_ELAPSED" -lt "$MIXED_DURATION_SECS" ] || break
+
+  # Fault window. Entered and left by elapsed time so a slow tick cannot skip
+  # it, and the phase label is what lets the report separate the pre-fault
+  # throughput from the recovery.
+  if [ "$MIXED_FAULT_AT_SECS" -gt 0 ]; then
+    if [ "$MIXED_FAULT_ACTIVE" = "0" ] \
+       && [ "$MIXED_ELAPSED" -ge "$MIXED_FAULT_AT_SECS" ] \
+       && [ "$MIXED_ELAPSED" -lt $(( MIXED_FAULT_AT_SECS + MIXED_FAULT_SECS )) ]; then
+      log "injecting destination fault: docker pause $PS_CONTAINER (elapsed ${MIXED_ELAPSED}s)"
+      docker pause "$PS_CONTAINER" >/dev/null
+      MIXED_FAULT_ACTIVE=1
+      mixed_phase_set "fault"
+    elif [ "$MIXED_FAULT_ACTIVE" = "1" ] \
+       && [ "$MIXED_ELAPSED" -ge $(( MIXED_FAULT_AT_SECS + MIXED_FAULT_SECS )) ]; then
+      log "clearing destination fault: docker unpause $PS_CONTAINER (elapsed ${MIXED_ELAPSED}s)"
+      docker unpause "$PS_CONTAINER" >/dev/null
+      MIXED_FAULT_ACTIVE=0
+      mixed_phase_set "recovery"
+    fi
+  fi
+
+  mixed_push_tick "$(cat "$MIXED_PHASE_FILE" 2>/dev/null || printf 'steady')"
+  mixed_track_available_work
+
+  MIXED_TICK=$((MIXED_TICK + 1))
+  if [ $(( MIXED_TICK % 10 )) -eq 0 ]; then
+    log "t+${MIXED_ELAPSED}s phase=$(cat "$MIXED_PHASE_FILE" 2>/dev/null) pushed=$MIXED_PUSHED_TOTAL minAvailableWork=${MIXED_MIN_AVAILABLE_WORK:-?}"
+  fi
+
+  # One push per minute. `sleep` is computed against the wall clock rather
+  # than a fixed 60 so a slow tick (a paused destination makes several of the
+  # queries above wait) does not let the arrival rate drift downward
+  # unnoticed - the offered rate is an independent variable and must stay one.
+  MIXED_NEXT=$(( WINDOW_START_EPOCH + MIXED_TICK * 60 ))
+  MIXED_SLEEP=$(( MIXED_NEXT - $(epoch) ))
+  if [ "$MIXED_SLEEP" -gt 0 ]; then
+    sleep "$MIXED_SLEEP"
+  else
+    warn "push tick $MIXED_TICK ran $(( -MIXED_SLEEP ))s late - the offered rate is drifting below ${MIXED_ORDERS_PER_MIN}/min"
+  fi
+done
+
+if [ "$MIXED_FAULT_ACTIVE" = "1" ]; then
+  log "clearing destination fault at window close"
+  docker unpause "$PS_CONTAINER" >/dev/null
+  MIXED_FAULT_ACTIVE=0
+fi
+
+mixed_phase_set "closing"
+mixed_supp_sampler_stop
+window_stop "$RESULTS_DIR"
+log "=== window closed after $(( WINDOW_STOP_EPOCH - WINDOW_START_EPOCH ))s, pushed $MIXED_PUSHED_TOTAL order(s) ==="
+
+# ===========================================================================
+# Post-guards and summary
+# ===========================================================================
+run_post_guards "$RESULTS_DIR" "$CONN_IDS" "$WS_ISO" \
+  "$WINDOW_START_EPOCH" "$WINDOW_STOP_EPOCH" "$PS_CONNECTION_ID" "" "" \
+  "$MIXED_MIN_AVAILABLE_WORK"
+
+log "=== summary ==="
+bash "$SCRIPT_DIR/../drivers/mixed-summarize.sh" "$RESULTS_DIR" \
+  "$WS_ISO" "$ALLEGRO_A_CONNECTION_ID" "$PS_CONNECTION_ID" "$MIXED_PUSHED_TOTAL" \
+  | tee "$RESULTS_DIR/summary.txt"
+
+# ---------------------------------------------------------------------------
+# Hand the stand back. The runner goes off FIRST so nothing is mid-flight
+# while the backlog is purged, and only then are this window's own leftovers
+# removed - `guard_queue_empty` is the next scenario's first pre-flight check,
+# and a saturating run leaves thousands of rows behind by construction.
+#
+# Rows are deleted rather than marked `dead`: a `dead` row is an operator-
+# facing failure record, and these jobs did not fail - they were never
+# reached. Bounded to rows created inside this window so nothing predating the
+# run is touched.
+# ---------------------------------------------------------------------------
+log "=== teardown ==="
+mixed_set_worker_posture "$ORIGINAL_RUNNER_ENABLED" "$ORIGINAL_SCHEDULER_ENABLED" skip-wait
+MIXED_PURGED="$(pg_sql "WITH d AS (DELETE FROM sync_jobs WHERE \"createdAt\">='$WS_ISO' AND status IN ('queued','running') RETURNING 1) SELECT COUNT(*) FROM d")"
+log "purged ${MIXED_PURGED:-0} unreached sync_jobs row(s) created inside the window"
+mixed_restore_dest_rate_limit
+
+log "results: $RESULTS_DIR"
+verdict_read "$RESULTS_DIR" | sed 's/^/    /'


### PR DESCRIPTION
The run #2840 specified for week 3 and never produced: **one continuous 3-hour window with the scheduler ON**, 30 registered crons, the master sweeps ticking against a 50 006-product catalogue, and a saturating order ramp — all on one worker process. 10 783 s, 319 samples, 10 800 orders offered.

Every prior flow in this campaign drove exactly one thing, for 300 seconds, with the scheduler off. This is the first window in the tree that measures the co-tenancy F1's own header names as "the exact contaminant #2847 names to control for", and the first that runs long enough for accumulation to be visible.

**Report: `perf/openlinker-throughput/results-sustained-mixed-load-2026-09-08.md`.**

## Read § 0.1 first — the verdict is `DISCARDED` and is not waived

| Guard | Count |
|---|---|
| `post_guard_limiter_degraded` | **1 454** degraded-mode lines |
| `post_guard_destination_creates` | 650 orders with a failed `syncStatus` entry |
| `post_guard_attempts` | 474 jobs past one attempt |

This is **not a clean capacity measurement**, and the report says so rather than relabelling anything. What it *is* legitimate evidence for is stated explicitly: a **before-figure for the intake-client A/B** (this is the baseline arm — SHARED client, read back from the worker's own log), the concurrency finding (which never touches the limiter), and the stranding result (a claim about a code path, from one order's persisted rows).

The contamination direction is knowable: at one replica, per-process fallback pacing *equals* the configured rate, so degradation can only *lower* the derived ceiling, never inflate it. The capacity figure is a conservative lower bound with respect to this defect.

## The capacity answer, and what binds it

**200.6 orders/h** completed over the whole window (193.3/h steady, 227.3/h recovery).

What binds it is now measured rather than assumed — the `realtime` **per-scope cap of 2**, confirmed twice from job timestamps at real precision:

| method | result |
|---|---|
| Little's law `L = λW` | 0.061 73/s × 31.44 s = **1.941** |
| Interval overlap, 105 probes | mean 1.95, p50 2, **max 2**, 100 of 105 probes at exactly 2, **none above** |

The model closes: `2 slots / 31.44 s = 229 orders/h`, and the recovery phase measured **227.3 — 99.3% of that ceiling**.

So the order path is **slot-bound, not budget-bound**: at ~11 req/order the destination sees ~37 req/min against the 300/min the manifest now ships, ~12% utilisation. That is why raising PrestaShop's limit 5× did not offset the co-tenancy — and it corroborates a finding the campaign already holds and deliberately declines to act on (arm ED raised `realtime` 4/2 → 16/16 and throughput *fell* 12.5%). **This run does not recommend raising the cap.**

## `verdict = growing` is a property of the offered load, not a capacity result

Stated in its own section because `+4 298 jobs/h` is exactly the number a later reader will quote as though it measured the system. The scenario offers 3 600 orders/h *in order to* saturate; the queue must therefore grow at roughly `3 600 − 200` plus the crons' own children, and the measured slope is that arithmetic observed.

The actionable form is the **threshold**: at shipped defaults with the sweeps running, an install offered more than **~200 orders/h** accumulates queue without bound. The window ended before convergence and was never going to converge at this rate — the summarizer says so unprompted, and there is no fourth "steady state" verdict for it to hide behind.

## Nothing accumulates over three hours

| container | RSS first → last | band | slope |
|---|---|---|---|
| worker | 133.1 → **116.2** MB | 98–143 | **+1.85 MB/h** |
| api | 126.3 → 121.8 MB | 122–126 | −0.75 MB/h |
| postgres | 77.1 → 9.5 MB | 3–77 | −0.78 MB/h |
| redis | 45.5 → 45.2 MB | 45–52 | +1.12 MB/h |

The worker **ends 16.9 MB lower than it starts** inside a 45 MB band, so its positive fitted slope (~9% of the band) is where the samples landed, not a trend. Postgres page cache **plateaued** (+2% over 2 h 13 m). Backends peaked at 46 of 200 (23%). Database +29.8 MB. Honest bound: a leak slower than **~2 MB/h** is not distinguishable here and needs 24 hours to rule out.

> **These figures are a published correction.** The first revision of the report quoted +0.67 MB/h for the worker, and those numbers were contaminated: the mid-window side sampler stopped on `ps aux | grep '[s]ustained-mixed-load'` — the scenario's own *name* — so when a **peer agent in another worktree ran the same scenario**, the grep matched their process and it kept appending to this run's results for 3.5 h past `window_stop`. Recomputing over the 131 in-window samples moved the slopes materially. **The conclusion did not change** (nothing accumulates); the *sensitivity* did. The report carries a correction block, § 7 item 8 carries the process finding, and `docs/lessons.md` carries the rule: bind a sampler by its window, or by the PID it was started against — on a shared host a process name is not an identity. Nothing else in the report draws on that file; every other figure comes from sources that stop at `window_stop` by construction.

**`docker stats` cannot answer this question, and both of this campaign's samplers use it.** `lab-postgres` read 1.412 GiB in `docker stats` while its cgroup `total_rss` was 17.4 MiB and `total_cache` 1.53 GiB — the number includes page cache. A side sampler reading cgroup RSS was added mid-window and its late start is recorded as a limitation.

## The limiter-degradation extrapolation held almost exactly

**1 454** episodes measured against **1 438–1 761** predicted by scaling the retest's 40–49 per 300 s — **1.01× the low end**. Degradation is a steady ~8/min; it does not accumulate or worsen with queue depth.

Incidentally: `deferredTotalMs > 0` on **zero** jobs. Despite 1 454 degradations the penalty-free deferral path never fired — degradation and deferral are different mechanisms.

## The destination fault: the mechanism reproduced, the rate did not scale

| run | in flight | offered | stranded | rate |
|---|---|---|---|---|
| #2978 | ~12 | 12 | 2–5 | **17–42%** |
| this run | 4–8 running, ~8 000 queued | 413 | **1** | **0.24%** |

The one stranded order's job reads `status=succeeded outcome=ok attempts=0 lastError=-` while its `syncStatus` carries `failed` for both destinations — `Promise.allSettled` swallowed both, and nothing will ever retry it. **Stranding scales with orders in the dispatch step at the instant the destination fails**, which the lane cap bounds — not with queue depth. So #2978's percentage must not be extrapolated to a busy install; but every stranded order is permanent, and the fix is not more retries, it is that a swallowed per-destination failure must leave something a sweep can find.

**Caveat:** `docker pause` produces a *timeout*-shaped fault (retryable — hence 305 jobs requeued, zero dead). #2978 used a fault proxy returning HTTP error *responses*, which the retry classifier may treat differently. This run says nothing about that shape.

## Two things only the crons could surface

- **`marketplace.fulfillment.statusSync`** on the 50 006-product connection: **p50 474 s** per run, every 15 minutes — a ~53% duty cycle on one `bulk` slot, against 9.8 s for its sibling on the small connection. Worth a look by whoever owns #834.
- The two hourly sweeps over the **2 003 176-row** `order_records` history both completed every tick at p50 ~10 s, so the campaign doc's "read-path cost at a large history of the OTHER tables" is, for those two at this row count, **not** a problem.

## Instrument, and the five defects it had before it ran

`scenarios/sustained-mixed-load.sh` is the first scenario that deliberately does **not** call `guard_scheduler_off` — that guard's own docblock authorises the departure, and the scenario records the posture, all 30 resolved tasks read back from the worker's log, and the `operational_settings` cadence row in its place. The manifest carries #2840's required `attributionImpossible` flag with its reason.

`drivers/queue-curve.awk` owns the one judgement the run makes, with 17 assertions proving each verdict reachable against synthetic curves — including the two inverse cases that matter (a curve that rose then flattened must read `plateau`; a curve flat until the end must read `growing`).

Five defects were caught by *exercising* the instrument, not by reading it:

1. **The intake-client reader inverted its answer** — `*DEDICATED*` matched inside `SHARED (OL_JOB_INTAKE_DEDICATED_REDIS is not true)`. That is a value the retest measured at 10.8× (207 vs 2 233 orders/h), and nothing in the numbers would have looked odd, because a mixed run is *expected* to be slower.
2. **The scheduler-task reader ran 6 s early**, recording "0 tasks" while 30 were registered. It now waits and **refuses** a run with none — a mixed run whose scheduler registered nothing is an order-only run wearing the wrong label.
3. **The degradation sampler measured points, not the window** — 19 against the post-guard's 25. Intervals now tile.
4. **Two summarizer `GROUP BY` queries were invalid SQL**, and would have failed *after* the measurement.
5. **`lib-test.sh` shipped with a permanently-failing assertion** (165/1 → **166/0**).

Also: `docker-compose.lab.yml` now forwards `OL_JOB_INTAKE_DEDICATED_REDIS`, which compose previously substituted for nothing — the same trap #2867 fixed for the lane caps, on the one variable worth 10.8×. And `docs/lessons.md` gains two entries: *verify a claim against the source that would carry it* (I withdrew #2840's own sentence on the strength of six repo files' silence; it is in the issue body), and *before trusting a detector's negatives, feed it a known positive* (the coordinator's audit of `post_guard_limiter_degraded`).

## Stand

Repaired and rebuilt before measuring, both of which are findings in § 1.1: `lab-api` was `Exited (1)` with **no compose service declaring a restart policy**, and both images predated #2982 so they carried PrestaShop's **old 60 req/min** default — a "shipped defaults" run against them would have been wrong by a factor of five with every guard green. `guard_build` refused them, correctly.

Handed back in the posture found: worker `runner=false scheduler=false`, 0 queued jobs, rate-limit override restored, lock released, PrestaShop unpaused. The worker was SIGTERM'd by something ~40 s after my lock released and was restarted.

## Gate

`bash -n` clean on all four scripts; `lib-test.sh` **166/0**; `queue-curve-test.sh` **17/0**. `pnpm check:invariants` passes every check through `check-bundle-budgets --self-check` (3/3) and then fails on `check-bundle-budgets` itself with `Command "vite" not found` — **this worktree has no `node_modules`**. The diff is one compose YAML, two markdown files, four shell scripts and one awk file, with zero TypeScript and nothing under `apps/web`, so a frontend bundle budget cannot be affected by it.

## Not established

No second arm with `OL_JOB_INTAKE_DEDICATED_REDIS=true`; no stock churn (a departure from the composition #2840 specifies — F2's driver exists and is unwired); no shop-latency probe; no per-cron cost attribution; one replica only; no claim-latency probes, so this does not answer F7's isolation question. § 6 carries each with an owner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkKifZVwvZzHspxaQ7x396
