### PR TITLE
docs(perf): withdraw F5's sub-linear scaling conclusion, and say why rows/day is declined

### DIFF
--- a/perf/openlinker-throughput/results-F5-2026-09-06.md
+++ b/perf/openlinker-throughput/results-F5-2026-09-06.md
@@ -3,6 +3,43 @@
 _Built on #2849's set-based seeders (this same pass - no OL-side seeder existed in the tree
 before this campaign). Stand: `lab` (docker-compose.lab.yml, #2854)._
 
+> ## Correction, 2026-09-07 - the sub-linear scaling conclusion is withdrawn
+>
+> **Withdrawn as a conclusion, not as a measurement.** The section "The projection did
+> NOT hold" below reports that the 100k -> 1M step (10x the rows) cost only **3.6x** the
+> time on the needs-attention `COUNT` (39.64 -> 141.89 ms). **That measurement stands and
+> is not edited below.** What is withdrawn is reading it as the shape of the curve, which
+> this report's own framing invites and which has since been quoted that way.
+>
+> **What superseded it.** `results-reseed-2026-09-07.md` § 0 (Correction 1) and § 3.5 add
+> a fourth point at 2M rows, on the same table and the same predicate:
+> **1M -> 2M, 2x the rows, 148.55 -> 273.18 ms - 1.84x.** The unfiltered `COUNT` on the
+> same table behaves identically (36.25 -> 64.61 ms, **1.78x**), and the route follows
+> (`orders_list_needs_attention` 164.18 -> 286.15 ms). Fitting a power law to this
+> report's own 3.6x-for-10x gives an exponent of 0.55, predicting `2^0.55 = 1.47x` for a
+> doubling; the measured figure is 1.84x, low by about 25%.
+>
+> **The boundary, stated precisely.** Sub-linear scaling held over the **10k to 1M** range
+> this report measured. It does **not** hold **past 1M**, where the measured step is
+> **1.84x for 2x the rows**. The `Parallel Seq Scan` this report diagnoses was already in
+> use at 1M, so there was no further plan change left to absorb the growth - the sub-linear
+> step was a **transition between two regimes, not a property of the curve**.
+> **Anyone sizing hardware past 1M orders should assume linear.**
+>
+> **What this correction does not touch.** The COUNT-vs-page mechanism, the parallel-plan
+> diagnosis at 1M, and every per-route figure below all stand. The reseed pass separately
+> re-tested this report's headline - "the page is fast, and the total is slow" - at a
+> realistic 0.591% needs-attention share (against this seed's 27.7%) and it **SURVIVED**
+> (that report's § 3.3).
+>
+> **A second, separate correction to this report exists and is not the subject of this
+> one.** `results-reseed-2026-09-07.md` § 0 (Correction 2) / § 3.4 narrows this report's
+> *"`order_detail` and `product_detail` are flat across three orders of magnitude"* to
+> ORDER growth only: grow the catalogue instead and `product_detail` moves 2.60x,
+> `products_list` 3.80x, while `order_detail` stays flat (1.04) and the claim holds for it.
+> Recorded here so a reader of this file knows both corrections exist; it is not applied
+> in place below.
+
 ## Conditions - read this before reading any number below
 
 This is **not** a publishable industry figure and must not be read as one, and it is a
@@ -66,9 +103,18 @@ needs an exact number - a question this report is not positioned to answer.
 
 ## The projection did NOT hold, and that is the more interesting result
 
+> **SCOPED, 2026-09-07.** Everything in this section is the original 2026-09-06 text and
+> its figures stand as measurements of the **10k to 1M** range. The *conclusion* - that
+> the read path scales sub-linearly - is **withdrawn**: it does not hold past 1M, where
+> the measured step is 1.84x for 2x the rows. See the correction at the top of this
+> report, and `results-reseed-2026-09-07.md` § 0 / § 3.5.
+
 Naive linear extrapolation from the 100k figure (39.64 ms x 10) predicts **~396 ms** at 1M.
 The **measured** figure is **141.9 ms** - about 2.8x faster than the linear projection, and the
-100k->1M step (10x the rows) cost only 3.6x the time instead of ~10x.
+100k->1M step (10x the rows) cost only 3.6x the time instead of ~10x. **This 3.6x is true of
+the 10k-1M range and must not be read as the curve**: at 1M -> 2M the measured step is **1.84x
+for 2x the rows** (`results-reseed-2026-09-07.md` § 3.5), so past 1M the honest assumption is
+linear. See the correction at the top of this report.
 
 The mechanism is visible directly, captured live via `EXPLAIN (ANALYZE, BUFFERS)` against the
 real 1M-row table and the real predicate:
@@ -201,10 +247,20 @@ together occupy 2,334 MB at 1,000,000 orders (`pg_total_relation_size`, includes
 **~2.4 KB/order**. This is almost certainly a FLOOR for a real deployment: the seeded
 `orderSnapshot` is a minimal synthetic document (`totals`, one `shippingAddress` field, an
 `items` array of placeholder objects); a real order snapshot carries the full buyer address,
-payment details and richer line items, and would be larger per row. No arrival-rate assumption
-is stated because none was set for this scenario (row count and arrival rate are independent
-axes per #2849's own design; this pass exercises dataset-size only), so no "days until 1M" figure
-is derived from it - stating one would need an assumed arrival rate this report never fixed.
+payment details and richer line items, and would be larger per row.
+
+**Rows per day is deliberately NOT reported, and the decline is the answer rather than a gap.**
+#2843's criterion 14 asks for bytes per order **and** rows per day, *each qualified by an assumed
+arrival rate*. Bytes per order is measured above. Rows per day is not, because **no arrival rate
+was set for this scenario** - row count and arrival rate are independent axes by #2849's own
+design, and this pass exercises dataset-size only. The criterion asked for the qualifier, so the
+qualifier's absence is the honest answer to it: an arrival rate invented here would be a number
+with no measurement behind it, and a "days until 1M" figure derived from it would travel and get
+quoted exactly as this report's own 3.6x did (see the correction at the top). Nothing further
+needs measuring to get it - fix an arrival rate in a scenario that actually drives one, and rows
+per day is that rate multiplied by this dataset's **~3.5 rows per order** (1 `order_records` row
+plus ~2.5 `order_line_items` rows, from the table above), with the ~2.4 KB/order figure giving
+bytes per day on the same multiplication.
 
 ## The api's own statement_timeout guard broke the seeder, and the fix generalises
 
@@ -275,6 +331,8 @@ every step.
   the 100k-row state of `order_records` no longer exists to `EXPLAIN` directly once the dataset
   grew to 1M within this campaign; the sub-linear 100k->1M ratio is established from
   `pg_stat_statements` timing and a live 1M-scale `EXPLAIN`, not from a 100k-scale `EXPLAIN`.
+  (The sub-linear ratio itself is withdrawn as a *conclusion* about the curve - it holds for
+  10k-1M and not past 1M. See the correction at the top of this report.)
 - **Whether the parallel-scan self-healing observed at 1M holds under real production
   concurrency**, where `max_parallel_workers_per_gather` is shared across every concurrently
   running query, not just this scenario's own `browse_mix` traffic.
@@ -287,7 +345,9 @@ every step.
   confirmed every CHECK constraint held in the real migration-built schema (no insert failed).
 - **A production arrival-rate-derived "days until 1M orders" figure.** Row count and arrival
   rate are independent axes by design (#2849); no arrival rate was fixed for this scenario, so
-  none is derived here.
+  none is derived here. This is a **deliberate decline against #2843's criterion 14, not an
+  oversight** - the criterion asked for the arrival-rate qualifier, and inventing one to produce
+  a figure is the failure mode, not the fix. See "Bytes per order" above.
 - **Whether the api and the seed path sharing one Postgres role is a lab-stand artifact or a
   real production topology.** This report fixed the resulting failure at the harness level
   (a session-scoped override); whether a real deployment's migration/admin role is genuinely


### PR DESCRIPTION
Docs-only. One file: `perf/openlinker-throughput/results-F5-2026-09-06.md`.

## The defect

F5 published, as its own second-most-prominent result, that 10x the rows cost only **3.6x** the time on the needs-attention `COUNT`, framed as sub-linear scaling:

> Naive linear extrapolation from the 100k figure (39.64 ms x 10) predicts **~396 ms** at 1M. The **measured** figure is **141.9 ms** - about 2.8x faster than the linear projection, and the 100k->1M step (10x the rows) cost only 3.6x the time instead of ~10x.

A later report on this same branch, `results-reseed-2026-09-07.md` § 0 (Correction 1), invalidates that as a conclusion:

> **It described a boundary, and the boundary has been crossed.** A fourth point at 2M rows: [...] **1M -> 2M (this pass)** | **2x** | 148.55 -> 273.18 ms | **1.84x**
>
> **Anyone sizing hardware past 1M orders should assume linear.**

F5 carried no pointer to it. Grepping F5 for `reseed`, `supersede`, `correction`, `withdraw` or `09-07` returned **0 hits**; it now returns 18. So a reader opening F5 today was told the read path scales sub-linearly, which the same branch has since measured to be false past 1M, and could size hardware on it.

This is the campaign's recurring failure shape: not missing engineering, but a published number that was never corrected after a later measurement invalidated it. #2933 and #2931 block on the same shape one flow over.

## What changed

**The 3.6x figure is not deleted and not rewritten.** It was measured, and it is true of the range it covered. It is withdrawn explicitly *as a conclusion about the curve*, with the superseding figure named beside it and the original number left visible in all five places it appears - so a reader who saw it quoted elsewhere can find out what happened to it. A quietly edited number is worse than a wrong one, because nobody can tell it moved.

House style follows **F7** (`results-F7-2026-09-06.md`), the campaign's own best example of doing this correctly: a masthead correction block plus an in-place pointer at the figure. The pointer lands in four places, not only the masthead, because a reader lands on the table and not on the top of the file:

1. **Masthead correction block** - withdraws the conclusion, names what superseded it, states the boundary. It also cross-references the reseed pass's **second** correction to this same file (F5's *"`product_detail` is flat"* is scoped to ORDER growth only, § 0 Correction 2 / § 3.4), so a reader of this file knows both exist. That one is *not* applied in place - out of scope here, flagged rather than silently left.
2. **A `SCOPED` blockquote directly under "The projection did NOT hold"** - the section holding the figure, so it is hit before the number.
3. **An inline clause on the 3.6x sentence itself**, naming the 1.84x-for-2x step.
4. **A parenthetical on the third restatement**, in "What this did not establish".

**The boundary is stated as a range on both sides**, not as "F5 was wrong": sub-linear scaling held over the measured **10k to 1M** range, and does **not** hold **past 1M**, where the measured step is 1.84x for 2x the rows. The `Parallel Seq Scan` F5 diagnoses was already in use at 1M, so there was no further plan change left to absorb the growth - a transition between two regimes, not a property of the curve.

**What survives is stated too**, so the correction does not over-reach: the COUNT-vs-page mechanism, the parallel-plan diagnosis at 1M, and every per-route figure all stand - and the reseed pass separately re-tested F5's actual headline (*"the page is fast, and the total is slow"*) at a realistic 0.591% needs-attention share against this seed's 27.7%, where it **survived** (§ 3.3).

## Second, smaller item

#2843's criterion 14 asks for bytes per order **and** rows per day, each qualified by an assumed arrival rate. Bytes per order is measured (~2.4 KB/order). Rows per day was declined in one trailing clause that read as an omission. The reasoning is now explicit as a deliberate decision: the criterion asked for the qualifier, no arrival rate was set for this scenario (row count and arrival rate are independent axes by #2849's design), and an arrival rate invented here would be a number with no measurement behind it - which would travel and get quoted exactly as the 3.6x did.

**No arrival rate is invented.** The arithmetic that would produce the figure from an externally-fixed rate is named instead: ~3.5 rows per order (1 `order_records` row plus ~2.5 `order_line_items`, from F5's own row-count table). The matching bullet in "What this did not establish" now labels it a deliberate decline rather than an oversight.

## #2843 stays open, and why

**This does not close #2843.** Two of its criteria remain partial:

- the **100k chosen plan was never captured**, and under the campaign's additive-sizing contract that dataset state no longer exists to `EXPLAIN` - F5 says so itself in "What this did not establish";
- the catalogue-side ILIKE / trigram sites (`offer_mappings`, `destination_categories`) were never seeded and so never measured.

Marking the issue done off the back of a documentation fix would be the same defect one level up: a status that no longer matches what was measured.

## Verification

No build, test, lint or docker command was run - a measurement is live on this machine's stand, and this change is markdown only, touching no invariant-script input. Checks done: both quoted figures read directly out of both reports and confirmed verbatim; the detection grep goes 0 -> 18 hits; `3.6x` still present in 5 places; zero em-dashes; commit is GPG-signed (`G`) and carries `Signed-off-by`.

Closes nothing. Contributes to #2843, epic #2840.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkKifZVwvZzHspxaQ7x396
