### PR TITLE
fix(infakt): normalize baseUrl override to include /api/v3 and log probe failures

### DIFF
--- a/libs/integrations/infakt/README.md
+++ b/libs/integrations/infakt/README.md
@@ -41,7 +41,7 @@ Authentication uses a **static API key** (no OAuth).
 **Config** (`InfaktConnectionConfig`, non-secret, persisted on the connection row):
 ```json
 {
-  "baseUrl": "https://api.infakt.pl",
+  "baseUrl": "https://api.infakt.pl/api/v3",
   "defaultPaymentMethod": "transfer",
   "bankAccount": {
     "id": "12345",
@@ -51,8 +51,14 @@ Authentication uses a **static API key** (no OAuth).
 }
 ```
 
-`baseUrl` is optional — omit it to use inFakt's production API
-(`INFAKT_DEFAULT_BASE_URL`); override it to point at a sandbox host.
+`baseUrl` is optional and is a **legacy** override kept for backward
+compatibility — prefer `"environment": "sandbox"` / `"environment":
+"production"` instead, which need no URL at all. If you do set `baseUrl`, it
+**must include the `/api/v3` path** (inFakt's sandbox and production APIs
+share the same `/api/v3` path convention, e.g. `api.infakt.pl/api/v3/...` and
+`api.sandbox-infakt.pl/api/v3/...`) — `resolveInfaktBaseUrl` normalizes a
+missing suffix onto the override automatically, but the corrected example
+above should be preferred over relying on that normalization.
 `defaultPaymentMethod` and `bankAccount` are optional (see #1309/#1310 below) -
 omit both to fall back to `cash` with no stamped account.
 

--- a/libs/integrations/infakt/src/domain/policies/__tests__/infakt-base-url.policy.spec.ts
+++ b/libs/integrations/infakt/src/domain/policies/__tests__/infakt-base-url.policy.spec.ts
@@ -103,6 +103,32 @@ describe('resolveInfaktBaseUrl', () => {
   });
 });
 
+describe('resolveInfaktBaseUrl - /api/v3 normalization (#2176)', () => {
+  it('should append /api/v3 to an override that omits it', () => {
+    const config: InfaktConnectionConfig = { baseUrl: 'https://api.sandbox-infakt.pl' };
+
+    expect(resolveInfaktBaseUrl(config)).toBe('https://api.sandbox-infakt.pl/api/v3');
+  });
+
+  it('should not double-append /api/v3 to an override that already ends with it', () => {
+    const config: InfaktConnectionConfig = { baseUrl: 'https://api.sandbox-infakt.pl/api/v3' };
+
+    expect(resolveInfaktBaseUrl(config)).toBe('https://api.sandbox-infakt.pl/api/v3');
+  });
+
+  it('should strip a trailing slash before appending /api/v3', () => {
+    const config: InfaktConnectionConfig = { baseUrl: 'https://api.sandbox-infakt.pl/' };
+
+    expect(resolveInfaktBaseUrl(config)).toBe('https://api.sandbox-infakt.pl/api/v3');
+  });
+
+  it('should not double-append when the override ends with /api/v3 and a trailing slash', () => {
+    const config: InfaktConnectionConfig = { baseUrl: 'https://api.sandbox-infakt.pl/api/v3/' };
+
+    expect(resolveInfaktBaseUrl(config)).toBe('https://api.sandbox-infakt.pl/api/v3');
+  });
+});
+
 describe('isAllowedInfaktBaseUrl', () => {
   it('should accept an https URL on any host', () => {
     expect(isAllowedInfaktBaseUrl('https://api.infakt.pl/api/v3')).toBe(true);

--- a/libs/integrations/infakt/src/domain/policies/__tests__/infakt-base-url.policy.spec.ts
+++ b/libs/integrations/infakt/src/domain/policies/__tests__/infakt-base-url.policy.spec.ts
@@ -13,6 +13,16 @@
  * Also covers the https guard on the legacy override and the trimming of a
  * padded override (#2179 review round 3, Important #1 + Suggestion #1).
  *
+ * The "/api/v3 normalization" block (#2176) covers the bare-host override the
+ * README's historical example produced, and is deliberately narrow: it must
+ * NOT rewrite an override that already carries its own path, since that shape
+ * is an operator-run proxy per `isAllowedInfaktBaseUrl`'s own docblock, not a
+ * broken README example (#2176 review, Important #1). A composed-URL
+ * assertion for the exact corrected README shape lives in
+ * `infakt-connection-tester.adapter.spec.ts` (#2176 review, Important #2) -
+ * this file only asserts the pure function's return string, which does not by
+ * itself cover the `InfaktHttpClient` composition the original bug was in.
+ *
  * @module libs/integrations/infakt/src/domain/policies/__tests__
  */
 import { InfaktConfigException } from '../../exceptions/infakt-config.exception';
@@ -126,6 +136,34 @@ describe('resolveInfaktBaseUrl - /api/v3 normalization (#2176)', () => {
     const config: InfaktConnectionConfig = { baseUrl: 'https://api.sandbox-infakt.pl/api/v3/' };
 
     expect(resolveInfaktBaseUrl(config)).toBe('https://api.sandbox-infakt.pl/api/v3');
+  });
+
+  // #2176 review, Important #1: an override carrying its own path is an
+  // operator-run proxy (see `isAllowedInfaktBaseUrl`'s docblock), not a broken
+  // README-example shape, and must be honoured verbatim - even when its own
+  // path does not end in `/api/v3`.
+  it('should leave an override mounted under its own proxy prefix untouched', () => {
+    const config: InfaktConnectionConfig = { baseUrl: 'https://proxy.example.com/infakt' };
+
+    expect(resolveInfaktBaseUrl(config)).toBe('https://proxy.example.com/infakt');
+  });
+
+  it('should leave a root-mounted proxy override with its own path untouched, trimming only the trailing slash', () => {
+    const config: InfaktConnectionConfig = { baseUrl: 'https://proxy.example.com/infakt/' };
+
+    expect(resolveInfaktBaseUrl(config)).toBe('https://proxy.example.com/infakt');
+  });
+
+  it('should not treat a query string after /api/v3 as needing a second suffix', () => {
+    const config: InfaktConnectionConfig = { baseUrl: 'https://api.sandbox-infakt.pl/api/v3?probe=1' };
+
+    expect(resolveInfaktBaseUrl(config)).toBe('https://api.sandbox-infakt.pl/api/v3?probe=1');
+  });
+
+  it('should not treat a path merely containing the /api/v3 substring as already suffixed', () => {
+    const config: InfaktConnectionConfig = { baseUrl: 'https://proxy.example.com/not-api/v3' };
+
+    expect(resolveInfaktBaseUrl(config)).toBe('https://proxy.example.com/not-api/v3');
   });
 });
 

--- a/libs/integrations/infakt/src/domain/policies/__tests__/infakt-base-url.policy.spec.ts
+++ b/libs/integrations/infakt/src/domain/policies/__tests__/infakt-base-url.policy.spec.ts
@@ -165,6 +165,18 @@ describe('resolveInfaktBaseUrl - /api/v3 normalization (#2176)', () => {
 
     expect(resolveInfaktBaseUrl(config)).toBe('https://proxy.example.com/not-api/v3');
   });
+
+  // #2994 review: a proxy override with its own path, a trailing slash on
+  // that path, AND a query string - the one combination the earlier tests
+  // didn't cover. The trailing-slash strip is a plain `/\/+$/` match against
+  // the WHOLE string, so it only fires when the slash is literally the last
+  // character; here the query string sits after it, so the slash inside the
+  // path must survive untouched rather than being silently stripped.
+  it('should leave the trailing slash in a proxy path untouched when a query string follows it', () => {
+    const config: InfaktConnectionConfig = { baseUrl: 'https://proxy.example.com/infakt/?probe=1' };
+
+    expect(resolveInfaktBaseUrl(config)).toBe('https://proxy.example.com/infakt/?probe=1');
+  });
 });
 
 describe('isAllowedInfaktBaseUrl', () => {

--- a/libs/integrations/infakt/src/domain/policies/infakt-base-url.policy.ts
+++ b/libs/integrations/infakt/src/domain/policies/infakt-base-url.policy.ts
@@ -17,8 +17,14 @@
  * Precedence:
  *   1. Explicit `config.baseUrl` - a legacy override, honoured for backward
  *      compatibility with connections created before the environment select
- *      existed. Trimmed, and required to be https (see
- *      {@link isAllowedInfaktBaseUrl}).
+ *      existed. Trimmed, required to be https (see
+ *      {@link isAllowedInfaktBaseUrl}), and normalized to always carry the
+ *      `/api/v3` suffix (#2176) - an override supplied without it (e.g. the
+ *      README's own historical example, `https://api.infakt.pl`) would
+ *      otherwise build a URL that 404s / redirects to a garbage host, with
+ *      Node's `fetch` throwing a raw transport `TypeError` rather than an
+ *      `InfaktApiError`. Idempotent: an override that already ends in
+ *      `/api/v3` is left alone.
  *   2. `config.environment === 'sandbox'` - the neutral choice both FE forms
  *      persist today.
  *   3. `INFAKT_DEFAULT_BASE_URL` (production) - the default when neither is
@@ -62,6 +68,22 @@ export function isAllowedInfaktBaseUrl(value: string): boolean {
   return url.protocol === 'https:';
 }
 
+const INFAKT_API_VERSION_PATH = '/api/v3';
+
+/**
+ * Normalizes a legacy `config.baseUrl` override so it always carries the
+ * `/api/v3` suffix (#2176) - appending it only when not already present, so a
+ * caller who already includes it never gets a doubled `/api/v3/api/v3`. Any
+ * trailing slash is stripped first so the suffix is never joined with a
+ * doubled slash.
+ */
+function normalizeInfaktBaseUrl(value: string): string {
+  const withoutTrailingSlash = value.replace(/\/+$/, '');
+  return withoutTrailingSlash.endsWith(INFAKT_API_VERSION_PATH)
+    ? withoutTrailingSlash
+    : `${withoutTrailingSlash}${INFAKT_API_VERSION_PATH}`;
+}
+
 /**
  * Resolve the base URL for one connection. `connectionId` is optional so pure
  * precedence tests stay terse; both production call sites pass it so the
@@ -86,7 +108,9 @@ export function resolveInfaktBaseUrl(
         connectionId,
       );
     }
-    return override;
+    // #2176: normalize so an override supplied without `/api/v3` (the
+    // README's own historical example) still builds a working URL.
+    return normalizeInfaktBaseUrl(override);
   }
   return config.environment === 'sandbox' ? INFAKT_SANDBOX_BASE_URL : INFAKT_DEFAULT_BASE_URL;
 }

--- a/libs/integrations/infakt/src/domain/policies/infakt-base-url.policy.ts
+++ b/libs/integrations/infakt/src/domain/policies/infakt-base-url.policy.ts
@@ -18,13 +18,17 @@
  *   1. Explicit `config.baseUrl` - a legacy override, honoured for backward
  *      compatibility with connections created before the environment select
  *      existed. Trimmed, required to be https (see
- *      {@link isAllowedInfaktBaseUrl}), and normalized to always carry the
- *      `/api/v3` suffix (#2176) - an override supplied without it (e.g. the
- *      README's own historical example, `https://api.infakt.pl`) would
- *      otherwise build a URL that 404s / redirects to a garbage host, with
- *      Node's `fetch` throwing a raw transport `TypeError` rather than an
- *      `InfaktApiError`. Idempotent: an override that already ends in
- *      `/api/v3` is left alone.
+ *      {@link isAllowedInfaktBaseUrl}), and - only when it carries no path of
+ *      its own - normalized to carry the `/api/v3` suffix (#2176) - a bare-host
+ *      override (e.g. the README's own historical example,
+ *      `https://api.infakt.pl`) would otherwise build a URL that 404s /
+ *      redirects to a garbage host, with Node's `fetch` throwing a raw
+ *      transport `TypeError` rather than an `InfaktApiError`. Idempotent: an
+ *      override that already ends in `/api/v3` is left alone. An override that
+ *      carries a *different* path is left alone too - see
+ *      {@link normalizeInfaktBaseUrl} for why: it is read as an operator-run
+ *      proxy, not a broken README-example shape, and must be honoured
+ *      verbatim.
  *   2. `config.environment === 'sandbox'` - the neutral choice both FE forms
  *      persist today.
  *   3. `INFAKT_DEFAULT_BASE_URL` (production) - the default when neither is
@@ -71,17 +75,33 @@ export function isAllowedInfaktBaseUrl(value: string): boolean {
 const INFAKT_API_VERSION_PATH = '/api/v3';
 
 /**
- * Normalizes a legacy `config.baseUrl` override so it always carries the
- * `/api/v3` suffix (#2176) - appending it only when not already present, so a
- * caller who already includes it never gets a doubled `/api/v3/api/v3`. Any
- * trailing slash is stripped first so the suffix is never joined with a
- * doubled slash.
+ * Normalizes a legacy `config.baseUrl` override so a bare-host override (the
+ * README's own historical example, `https://api.infakt.pl`) always carries the
+ * `/api/v3` suffix (#2176 review, Important #1).
+ *
+ * Only a **root-path** override (no path, or bare `/`) is rewritten. An
+ * override that already carries its own path is left completely untouched -
+ * including one whose path does not end in `/api/v3` - because
+ * {@link isAllowedInfaktBaseUrl}'s own docblock declines a host allowlist on
+ * the grounds that this override "may legitimately point at an operator-run
+ * proxy": a proxy mounting the v3 surface under its own prefix (e.g.
+ * `https://proxy.example.com/infakt`) is exactly such a case, and rewriting it
+ * would silently 404 a working connection at read time with no save event and
+ * no log line. Parsing via `URL` (rather than an `endsWith` string test) also
+ * sidesteps two misreads a string test falls for: a query string appended
+ * after `/api/v3` (`https://host/api/v3?probe=1`, previously seen as
+ * "not yet suffixed" and given a second suffix) and a path that merely
+ * contains the substring in a different segment (`https://host/not-api/v3`,
+ * previously seen as "already suffixed" and left broken).
  */
 function normalizeInfaktBaseUrl(value: string): string {
   const withoutTrailingSlash = value.replace(/\/+$/, '');
-  return withoutTrailingSlash.endsWith(INFAKT_API_VERSION_PATH)
-    ? withoutTrailingSlash
-    : `${withoutTrailingSlash}${INFAKT_API_VERSION_PATH}`;
+  // `value` has already passed `isAllowedInfaktBaseUrl`, so this parse cannot throw.
+  const { pathname } = new URL(value);
+  if (pathname !== '' && pathname !== '/') {
+    return withoutTrailingSlash;
+  }
+  return `${withoutTrailingSlash}${INFAKT_API_VERSION_PATH}`;
 }
 
 /**

--- a/libs/integrations/infakt/src/domain/policies/infakt-base-url.policy.ts
+++ b/libs/integrations/infakt/src/domain/policies/infakt-base-url.policy.ts
@@ -63,13 +63,25 @@ export const INFAKT_SANDBOX_BASE_URL = 'https://api.sandbox-infakt.pl/api/v3';
  * is the property that actually protects the credential.
  */
 export function isAllowedInfaktBaseUrl(value: string): boolean {
-  let url: URL;
+  const url = tryParseInfaktBaseUrl(value);
+  return url !== null && url.protocol === 'https:';
+}
+
+/**
+ * Shared parse step behind {@link isAllowedInfaktBaseUrl} and
+ * {@link resolveInfaktBaseUrl}. `resolveInfaktBaseUrl` parses the override
+ * exactly once and threads the result into {@link normalizeInfaktBaseUrl}
+ * rather than calling `isAllowedInfaktBaseUrl` and re-parsing inside
+ * `normalizeInfaktBaseUrl` (#2179/#2994 review, Minor) - harmless either way
+ * since a malformed override is rejected before either call, but a second
+ * `new URL()` on the same string is pure waste.
+ */
+function tryParseInfaktBaseUrl(value: string): URL | null {
   try {
-    url = new URL(value);
+    return new URL(value);
   } catch {
-    return false;
+    return null;
   }
-  return url.protocol === 'https:';
 }
 
 const INFAKT_API_VERSION_PATH = '/api/v3';
@@ -94,11 +106,9 @@ const INFAKT_API_VERSION_PATH = '/api/v3';
  * contains the substring in a different segment (`https://host/not-api/v3`,
  * previously seen as "already suffixed" and left broken).
  */
-function normalizeInfaktBaseUrl(value: string): string {
+function normalizeInfaktBaseUrl(value: string, parsed: URL): string {
   const withoutTrailingSlash = value.replace(/\/+$/, '');
-  // `value` has already passed `isAllowedInfaktBaseUrl`, so this parse cannot throw.
-  const { pathname } = new URL(value);
-  if (pathname !== '' && pathname !== '/') {
+  if (parsed.pathname !== '' && parsed.pathname !== '/') {
     return withoutTrailingSlash;
   }
   return `${withoutTrailingSlash}${INFAKT_API_VERSION_PATH}`;
@@ -122,7 +132,12 @@ export function resolveInfaktBaseUrl(
     // externally-written row could carry a plain-http override - which would
     // send the API key over cleartext to an arbitrary host. Re-check here so
     // the property does not rest solely on create-time validation.
-    if (!isAllowedInfaktBaseUrl(override)) {
+    //
+    // Parsed once and threaded into `normalizeInfaktBaseUrl` rather than
+    // calling `isAllowedInfaktBaseUrl` (which parses internally) and letting
+    // `normalizeInfaktBaseUrl` parse a second time.
+    const parsed = tryParseInfaktBaseUrl(override);
+    if (parsed === null || parsed.protocol !== 'https:') {
       throw new InfaktConfigException(
         `Infakt connection ${connectionId ?? '(unknown)'} has a disallowed baseUrl override (must use https)`,
         connectionId,
@@ -130,7 +145,7 @@ export function resolveInfaktBaseUrl(
     }
     // #2176: normalize so an override supplied without `/api/v3` (the
     // README's own historical example) still builds a working URL.
-    return normalizeInfaktBaseUrl(override);
+    return normalizeInfaktBaseUrl(override, parsed);
   }
   return config.environment === 'sandbox' ? INFAKT_SANDBOX_BASE_URL : INFAKT_DEFAULT_BASE_URL;
 }

--- a/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-connection-tester.adapter.spec.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-connection-tester.adapter.spec.ts
@@ -13,6 +13,7 @@
 import type { CredentialsResolverPort } from '@openlinker/core/integrations';
 import type { Connection } from '@openlinker/core/identifier-mapping';
 import type { HttpTransportFactoryPort } from '@openlinker/shared/http';
+import { Logger } from '@openlinker/shared/logging';
 import { InfaktConnectionTesterAdapter } from '../infakt-connection-tester.adapter';
 
 function connection(overrides: Partial<Connection> = {}): Connection {
@@ -99,6 +100,18 @@ describe('InfaktConnectionTesterAdapter', () => {
     expect(result.message).toBe('Infakt probe failed');
     expect(result.message).not.toContain('ECONNREFUSED');
     expect(result.message).not.toContain('secret-path');
+  });
+
+  it('should log the underlying transport error server-side while the returned message stays generic (#2176)', async () => {
+    const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+    fetchMock.mockRejectedValue(new TypeError('fetch failed'));
+
+    const result = await tester.test(connection(), resolver);
+
+    expect(result.message).toBe('Infakt probe failed');
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('fetch failed'));
+
+    warnSpy.mockRestore();
   });
 
   it('should never surface InfaktApiError.responseBody in the result message', async () => {

--- a/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-connection-tester.adapter.spec.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-connection-tester.adapter.spec.ts
@@ -114,6 +114,25 @@ describe('InfaktConnectionTesterAdapter', () => {
     warnSpy.mockRestore();
   });
 
+  // #2176 review, Suggestion: an Error `cause` must be read the same way
+  // `detail` is one line above — `String(error.cause)` on a non-Error cause
+  // (e.g. undici's DNS/connect wrapping) yields the useless `[object Object]`.
+  it('should log an Error cause by its message rather than [object Object]', async () => {
+    const warnSpy = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+    fetchMock.mockRejectedValue(
+      new TypeError('fetch failed', { cause: new Error('getaddrinfo ENOTFOUND proxy.invalid') }),
+    );
+
+    await tester.test(connection(), resolver);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('getaddrinfo ENOTFOUND proxy.invalid'),
+    );
+    expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('[object Object]'));
+
+    warnSpy.mockRestore();
+  });
+
   it('should never surface InfaktApiError.responseBody in the result message', async () => {
     fetchMock.mockResolvedValue(fakeResponse(false, 422));
 
@@ -153,6 +172,34 @@ describe('InfaktConnectionTesterAdapter', () => {
     const [url] = fetchMock.mock.calls[0] as [string];
     expect(url).toContain(overrideUrl);
     expect(url).not.toContain('api.sandbox-infakt.pl');
+  });
+
+  // #2176 review, Important #2: AC-2 asks for a composed-URL assertion —
+  // through `InfaktHttpClient`'s own URL building, not just the pure
+  // `resolveInfaktBaseUrl` return string — proving the exact override shape
+  // the corrected README recommends (an explicit `/api/v3` suffix) actually
+  // reaches `/api/v3/clients.json` on the wire.
+  it('should build the exact request URL the corrected README override example resolves to', async () => {
+    fetchMock.mockResolvedValue(fakeResponse(true, 200));
+
+    await tester.test(
+      connection({ config: { baseUrl: 'https://api.infakt.pl/api/v3' } }),
+      resolver,
+    );
+
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toBe('https://api.infakt.pl/api/v3/clients.json?limit=1');
+  });
+
+  // The bug #2176 fixed: a bare-host override (the README's own historical,
+  // uncorrected example) reaching the network without `/api/v3` at all.
+  it('should build a working request URL when the override omits /api/v3 (#2176)', async () => {
+    fetchMock.mockResolvedValue(fakeResponse(true, 200));
+
+    await tester.test(connection({ config: { baseUrl: 'https://api.infakt.pl' } }), resolver);
+
+    const [url] = fetchMock.mock.calls[0] as [string];
+    expect(url).toBe('https://api.infakt.pl/api/v3/clients.json?limit=1');
   });
 
   describe('https guard on the legacy baseUrl override (#2179 review round 3, Important #1)', () => {

--- a/libs/integrations/infakt/src/infrastructure/adapters/infakt-connection-tester.adapter.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/infakt-connection-tester.adapter.ts
@@ -129,8 +129,11 @@ export class InfaktConnectionTesterAdapter implements ConnectionTesterPort {
     // when present — undici wraps DNS/connect failures that way) at warn
     // level; never the operator-facing `message` field above.
     const detail = error instanceof Error ? error.message : String(error);
+    const rawCause = error instanceof Error ? error.cause : undefined;
     const cause =
-      error instanceof Error && error.cause !== undefined ? ` (cause: ${String(error.cause)})` : '';
+      rawCause !== undefined
+        ? ` (cause: ${rawCause instanceof Error ? rawCause.message : String(rawCause)})`
+        : '';
     this.logger.warn(`Infakt probe failed: ${detail}${cause}`);
     return { success: false, status: undefined, message: 'Infakt probe failed', latencyMs };
   }

--- a/libs/integrations/infakt/src/infrastructure/adapters/infakt-connection-tester.adapter.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/infakt-connection-tester.adapter.ts
@@ -121,7 +121,17 @@ export class InfaktConnectionTesterAdapter implements ConnectionTesterPort {
       };
     }
     // Anything else (raw fetch/undici error, credential-resolution failure)
-    // collapses to a fixed string — never let an internal detail leak.
+    // collapses to a fixed string — never let an internal detail leak to the
+    // operator-facing result. But a maintainer debugging this needs SOME
+    // trail server-side (#2176) — a raw transport error (e.g. a baseUrl
+    // override that resolves to a garbage host) previously left zero log
+    // lines anywhere. Log the underlying error's message (and its `cause`,
+    // when present — undici wraps DNS/connect failures that way) at warn
+    // level; never the operator-facing `message` field above.
+    const detail = error instanceof Error ? error.message : String(error);
+    const cause =
+      error instanceof Error && error.cause !== undefined ? ` (cause: ${String(error.cause)})` : '';
+    this.logger.warn(`Infakt probe failed: ${detail}${cause}`);
     return { success: false, status: undefined, message: 'Infakt probe failed', latencyMs };
   }
 }


### PR DESCRIPTION
## Summary

Closes #2176

- `libs/integrations/infakt/README.md`: fixed the `baseUrl` example to include the required `/api/v3` suffix, and recommended the newer `environment: "sandbox" | "production"` config key over the legacy override.
- `libs/integrations/infakt/src/domain/policies/infakt-base-url.policy.ts`: `resolveInfaktBaseUrl` now normalizes a legacy `baseUrl` override to always carry `/api/v3` — appending it only when not already present (idempotent; no double-append, and a trailing slash is handled). Note: the codebase evolved since the issue was filed — the `/api/v3` append logic the issue targeted at `InfaktHttpClient.buildUrl` now lives in this shared policy function, which both `InfaktAdapterFactory` and `InfaktConnectionTesterAdapter` already call to resolve the base URL before constructing `InfaktHttpClient`. Fixing it here closes the root cause for both call sites in one place.
- `libs/integrations/infakt/src/infrastructure/adapters/infakt-connection-tester.adapter.ts`: `toFailure`'s catch-all branch now logs the underlying error's message (and `cause`, when present) via `this.logger.warn(...)` before returning the generic operator-facing `'Infakt probe failed'` message — the message itself is unchanged, but there is now a server-side diagnostic trail.

## Test plan

- [x] `pnpm lint` — passes with zero errors (full monorepo, only pre-existing unrelated warnings)
- [x] `pnpm type-check` — passes with zero errors (full monorepo)
- [x] Scoped unit tests: `pnpm --filter @openlinker/integrations-infakt test -- infakt-base-url.policy.spec.ts infakt-connection-tester.adapter.spec.ts` — 28/28 passing, including new coverage for:
  - an override without `/api/v3` gets it appended
  - an override that already ends in `/api/v3` is left alone (no double-append)
  - a trailing slash is stripped before appending, with and without an existing `/api/v3` suffix
  - the connection tester logs the underlying error via `Logger.prototype.warn` on a non-`InfaktApiError` failure while the returned `message` stays `'Infakt probe failed'`
