### PR TITLE
feat(infakt): add per-connection defaultSaleType for non-PL invoice issuance, with a diagnosis hint for the missing-config case

### DIFF
--- a/apps/web/src/features/invoicing/api/invoicing.types.ts
+++ b/apps/web/src/features/invoicing/api/invoicing.types.ts
@@ -41,6 +41,9 @@ export type FailureMode = (typeof FailureModeValues)[number];
 export const FailureCodeValues = [
   'buyer-tax-id-invalid',
   'invalid-currency',
+  // A missing per-connection sale classification (goods vs. services) — a
+  // one-field config gap, not an order-data problem (#3031).
+  'sale-classification-required',
   'provider-rejected',
   'transport-timeout',
   'provider-error',

--- a/apps/web/src/features/invoicing/lib/derive-invoice-display.ts
+++ b/apps/web/src/features/invoicing/lib/derive-invoice-display.ts
@@ -70,6 +70,8 @@ const FAILURE_CODE_FALLBACK: Record<FailureCode, string> = {
     'The provider rejected the buyer’s tax ID. Check the tax ID on the order’s customer, then retry. Nothing was issued.',
   'invalid-currency':
     'The document’s settlement currency is missing, malformed, or not accepted for this document. Fix the currency on the source order, then retry. Nothing was issued.',
+  'sale-classification-required':
+    'This connection needs a sale classification (goods vs. services) configured before it can issue invoices. Set it in the connection’s configuration, then retry. Nothing was issued.',
   'provider-rejected':
     'The provider rejected the document. Check the order’s data, then retry. Nothing was issued.',
   'transport-timeout':

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -1226,3 +1226,38 @@ where an adjacent context already owns similar vocabulary (`routing`, `fulfillme
 
 **Source**: #2953 (caught by `/pre-implement` before implementation; both collisions were in the
 first draft of the plan).
+
+---
+
+## Format only the touched files with the workspace's own pinned prettier binary — never `npx prettier`
+
+**Context**: #3031 touched ten files. A convenience pass over all of them with `npx prettier
+--write` (intending to just clean up the new hunks) reformatted every one **in full** — hundreds of
+unrelated lines, stripping trailing commas from every multi-line call/array/constructor across
+files nobody was asked to touch.
+
+**Problem**: `npx prettier` resolves (and may fetch) a prettier build outside this pnpm workspace's
+`node_modules`, so it does not reliably pick up the repo's pinned `prettier@3.2.5` or apply
+`.prettierrc` (`trailingComma: "es5"`) the way the workspace's own tooling does. The result reads
+like an intentional whole-file reformat and is easy to miss in a large diff — `git diff --stat`
+before-and-after is the tell (a 12-line intended change became 700+ lines across 5 files). Re-running
+the SAME command with the LOCAL binary (`node_modules/.bin/prettier` / `pnpm exec prettier`)
+reproduced the identical mass-reformat, which ruled out a version mismatch and confirmed the
+project's own quality gate (`pnpm lint` → `.eslintrc.js`'s `extends: ['prettier']` is
+`eslint-config-prettier`, which only *disables* conflicting stylistic ESLint rules — it does **not**
+run `eslint-plugin-prettier`) never enforces prettier formatting as a lint error, and CI has no
+separate `format:check` step either. So running prettier at all here bought nothing the gate needed
+and cost a large, unreviewable diff.
+
+**Rule**: don't run prettier as a formatting pass on a diff unless the task is specifically a
+formatting task. When touching a handful of files, format by hand to match the surrounding style
+(the existing lines are the spec) and verify with `git diff --stat` that only the intended lines
+changed. If prettier must run, target the exact files with the local pinned binary
+(`node_modules/.bin/prettier --config .prettierrc --write <files>`), never `npx prettier`, and
+`git diff --stat` immediately after to catch a whole-file reformat before it's mixed into a commit.
+
+**Applies to**: any edit to existing `*.ts`/`*.tsx` files in this repo, especially a small,
+surgical change to a large pre-existing file.
+
+**Source**: #3031 (caught before commit by comparing `git diff --stat` line counts against the
+size of the intended change).

--- a/libs/core/src/invoicing/application/services/invoice.service.spec.ts
+++ b/libs/core/src/invoicing/application/services/invoice.service.spec.ts
@@ -600,6 +600,34 @@ describe('InvoiceService', () => {
       );
     });
 
+    it("(d5b) failureCode: a 'rejected' throwable naming a missing sale classification maps to 'sale-classification-required' (#3031)", async () => {
+      repo.findByIdempotencyKey.mockResolvedValue(null);
+      repo.create.mockResolvedValue(makeRecord({ id: 'rec-1', status: 'pending' }));
+      // Structural `reason` field — mirrors how an adapter recognises its own
+      // provider's "you must configure this" 422 shape and re-throws with a
+      // reason matching SALE_CLASSIFICATION_REJECTION_MARKERS (#3031, inFakt's
+      // `errors.sale_type` detection), rather than propagating the provider's
+      // raw (possibly buyer-PII-echoing) message.
+      const rejection = Object.assign(new Error('rejected'), {
+        failureMode: 'rejected' as const,
+        reason: 'Infakt requires a sale classification to be configured for this connection',
+      });
+      adapter.issueInvoice.mockRejectedValue(rejection);
+      repo.updateOutcome.mockResolvedValue(makeRecord({ id: 'rec-1', status: 'failed' }));
+
+      await expect(service.issueInvoice(makeCmd())).rejects.toBe(rejection);
+      expect(repo.updateOutcome).toHaveBeenCalledWith(
+        'rec-1',
+        expect.objectContaining({
+          status: 'failed',
+          failureMode: 'rejected',
+          failureCode: 'sale-classification-required',
+          failureReason:
+            "This connection requires a sale classification (goods vs. services) to be configured before it can issue invoices. Set the connection's `defaultSaleType` and re-issue.",
+        }),
+      );
+    });
+
     it("(d5) failureCode: a tax-id rejection that also mentions a currency stays 'buyer-tax-id-invalid'", async () => {
       repo.findByIdempotencyKey.mockResolvedValue(null);
       repo.create.mockResolvedValue(makeRecord({ id: 'rec-1', status: 'pending' }));

--- a/libs/core/src/invoicing/application/services/invoice.service.ts
+++ b/libs/core/src/invoicing/application/services/invoice.service.ts
@@ -68,7 +68,10 @@ import { MissingTaxRateException } from '../../domain/exceptions/missing-tax-rat
 import { CapabilityNotSupportedException } from '@openlinker/core/integrations';
 // Published so an adapter spec can pin its own pre-call refusal message against
 // the very markers this service matches on (#2103 review) — see the constant's doc.
-import { CURRENCY_REJECTION_MARKERS } from '../../domain/types/invoicing.types';
+import {
+  CURRENCY_REJECTION_MARKERS,
+  SALE_CLASSIFICATION_REJECTION_MARKERS,
+} from '../../domain/types/invoicing.types';
 import type {
   CorrectionLine,
   GetInvoiceByOrderQuery,
@@ -982,6 +985,9 @@ export class InvoiceService implements IInvoiceService {
     if (CURRENCY_REJECTION_MARKERS.some((marker) => haystack.includes(marker))) {
       return 'invalid-currency';
     }
+    if (SALE_CLASSIFICATION_REJECTION_MARKERS.some((marker) => haystack.includes(marker))) {
+      return 'sale-classification-required';
+    }
     return 'provider-rejected';
   }
 
@@ -1001,6 +1007,11 @@ export class InvoiceService implements IInvoiceService {
       // route here, which is why it names the condition rather than the actor.
       'invalid-currency':
         'The settlement currency is missing, malformed, or not accepted for this document. Fix the currency on the order and re-issue.',
+      // Names the connection config field an operator can actually set — the
+      // generic 'provider-rejected' copy gives no clue this is a one-field
+      // config gap rather than a per-order problem (#3031).
+      'sale-classification-required':
+        "This connection requires a sale classification (goods vs. services) to be configured before it can issue invoices. Set the connection's `defaultSaleType` and re-issue.",
       'provider-rejected': 'The invoicing provider rejected the request.',
       'transport-timeout':
         'The invoicing request timed out; the document may or may not have been created.',

--- a/libs/core/src/invoicing/application/services/invoice.service.ts
+++ b/libs/core/src/invoicing/application/services/invoice.service.ts
@@ -950,8 +950,10 @@ export class InvoiceService implements IInvoiceService {
    * throwable's `reason`/message — never value-importing an adapter error class.
    *
    *   - `rejected` (TERMINAL): a tax-identifier rejection → `buyer-tax-id-invalid`;
-   *     a settlement-currency rejection → `invalid-currency` (both operator-
-   *     fixable on the source order); anything else → `provider-rejected`.
+   *     a settlement-currency rejection → `invalid-currency`; a missing
+   *     sale-classification rejection → `sale-classification-required` (all
+   *     three operator-fixable on the source order / connection config);
+   *     anything else → `provider-rejected`.
    *   - `in-doubt` (transient/indeterminate transport): `transport-timeout`.
    *
    * Tax id is checked first purely for determinism — a message naming both is

--- a/libs/core/src/invoicing/domain/types/invoicing.types.spec.ts
+++ b/libs/core/src/invoicing/domain/types/invoicing.types.spec.ts
@@ -42,6 +42,7 @@ describe('invoicing.types', () => {
     expect([...InvoiceFailureCodeValues]).toEqual([
       'buyer-tax-id-invalid',
       'invalid-currency',
+      'sale-classification-required',
       'provider-rejected',
       'transport-timeout',
       'provider-error',

--- a/libs/core/src/invoicing/domain/types/invoicing.types.ts
+++ b/libs/core/src/invoicing/domain/types/invoicing.types.ts
@@ -87,6 +87,18 @@ export type InvoiceFailureMode = (typeof InvoiceFailureModeValues)[number];
  *     accurately, since the provider did reject it. Operator-fixable on the
  *     source order either way. Currency and ISO 4217 are country-agnostic
  *     vocabulary, so this stays ADR-026-clean.
+ *   - `sale-classification-required`: a TERMINAL `rejected` failure caused by a
+ *     missing per-connection sale classification (goods vs. services) — a
+ *     required-but-unconfigured PLUGIN SETTING, not an order-data problem
+ *     (#3031). Unlike `invalid-currency` this genuinely IS a provider-side
+ *     rejection (the adapter has no signal to refuse the call pre-emptively —
+ *     #2177/#2995 deliberately did not add a goods/service field to
+ *     `InvoiceLine`), so it can only be detected reactively, by an adapter
+ *     recognising its own provider's shape for "you must configure this" and
+ *     re-throwing with a `reason` one of {@link SALE_CLASSIFICATION_REJECTION_MARKERS}
+ *     matches. The operator-fixable remedy is a one-field connection config
+ *     change, which is why this must not collapse into `provider-rejected` —
+ *     that copy gives no clue there is a config knob to set at all.
  *   - `provider-rejected`: any other TERMINAL `rejected` failure (safe to
  *     re-attempt once the underlying input is corrected).
  *   - `transport-timeout`: an `in-doubt` transport failure — the document MAY
@@ -97,6 +109,7 @@ export type InvoiceFailureMode = (typeof InvoiceFailureModeValues)[number];
 export const InvoiceFailureCodeValues = [
   'buyer-tax-id-invalid',
   'invalid-currency',
+  'sale-classification-required',
   'provider-rejected',
   'transport-timeout',
   'provider-error',
@@ -129,6 +142,34 @@ export const CURRENCY_REJECTION_MARKERS = [
   'currency is required',
   'currency code',
 ] as const;
+
+/**
+ * Substrings (case-insensitive) that mark a `rejected` failure as a missing
+ * per-connection sale-classification (goods vs. services) setting, so
+ * `classifyFailureCode` can resolve `sale-classification-required` instead of
+ * the generic `provider-rejected` (#3031, follow-up to #2177/#2995).
+ *
+ * Unlike the currency markers this is a genuine POST-CALL provider rejection —
+ * core cannot know ahead of time whether the buyer's country needs the field,
+ * and #2995 deliberately declined to add a goods/service signal to
+ * `InvoiceLine` (a national VAT-classification concept ADR-026 keeps out of
+ * `libs/core`). An adapter that recognises its own provider's "you must
+ * configure a sale classification" response re-throws with a `reason`
+ * matching one of these markers instead of propagating the provider's raw
+ * (possibly buyer-PII-echoing) message.
+ *
+ * PUBLISHED for the same reason {@link CURRENCY_REJECTION_MARKERS} is: both
+ * ends of the structural read live in this repo (the reason text an adapter
+ * throws is OL-authored, never a verbatim provider string), so an adapter
+ * spec can assert its own message still matches one of these markers and a
+ * reword breaks the build rather than silently degrading the operator's
+ * failure reason. Neutral vocabulary only — "sale classification" names no
+ * country or tax system (ADR-026); it deliberately avoids inFakt's own wire
+ * field name (`sale_type`) so the marker itself never leaks one provider's
+ * naming into a cross-provider vocabulary, even though inFakt is the only
+ * shipped adapter that triggers it today.
+ */
+export const SALE_CLASSIFICATION_REJECTION_MARKERS = ['sale classification'] as const;
 
 /**
  * Neutral Continuous-Transaction-Controls clearance lifecycle. The adapter maps

--- a/libs/integrations/infakt/README.md
+++ b/libs/integrations/infakt/README.md
@@ -47,7 +47,8 @@ Authentication uses a **static API key** (no OAuth).
     "id": "12345",
     "accountNumber": "PL00 0000 0000 0000 0000 0000 0000",
     "bankName": "mBank"
-  }
+  },
+  "defaultSaleType": "service"
 }
 ```
 
@@ -61,6 +62,8 @@ missing suffix onto the override automatically, but the corrected example
 above should be preferred over relying on that normalization.
 `defaultPaymentMethod` and `bankAccount` are optional (see #1309/#1310 below) -
 omit both to fall back to `cash` with no stamped account.
+`defaultSaleType` is optional (see #2177 below) - omit it to leave `sale_type`
+off the payload entirely, matching pre-#2177 behavior.
 
 ## Notable implementation details
 
@@ -109,6 +112,22 @@ omit both to fall back to `cash` with no stamped account.
   picker; the picked account is snapshotted into `config.bankAccount` and pushed back
   as the inFakt default via `BankAccountDefaultSetter.setDefaultBankAccount()`.
   `transfer` invoices carry the snapshot's `bank_account` / `bank_name` fields.
+- **Per-connection sale type for non-PL clients** (#2177): `config.defaultSaleType`
+  (`goods | service`) is stamped as `sale_type` on every issued invoice/correction
+  when configured. inFakt silently defaults `sale_type` for a PL-country client, so
+  issuance without this field has always worked for PL buyers; for any other
+  country inFakt rejects the request with 422
+  (`{"errors":{"sale_type":["Proszę określić rodzaj sprzedaży."]}}`) unless it is
+  present. There is **no safe universal default** — the field is left unset unless
+  the operator configures it, and unset means `sale_type` is omitted from the
+  payload entirely (PL issuance keeps working; non-PL issuance still 422s exactly
+  as before, unchanged). Only `'service'` is confirmed against inFakt's sandbox
+  (exact lowercase match); the correct value for a physical-goods sale (`'goods'`
+  here is the placement, not a confirmed value) was **not** found and needs
+  confirming separately by an operator with a physical-goods catalog. Picking the
+  wrong value misstates the invoice's VAT sale-type classification, so this is an
+  explicit, compliance-sensitive operator opt-in — OL cannot infer goods vs.
+  services from a possibly-mixed catalog.
 - **Rendered-PDF download** (#1321): `RegulatoryDocumentReader.getRegulatoryDocument
   (record, 'rendered')` fetches the invoice PDF as rendered by inFakt - this backs
   the **Download PDF** button on the accepted invoice detail page.

--- a/libs/integrations/infakt/README.md
+++ b/libs/integrations/infakt/README.md
@@ -63,7 +63,16 @@ above should be preferred over relying on that normalization.
 `defaultPaymentMethod` and `bankAccount` are optional (see #1309/#1310 below) -
 omit both to fall back to `cash` with no stamped account.
 `defaultSaleType` is optional (see #2177 below) - omit it to leave `sale_type`
-off the payload entirely, matching pre-#2177 behavior.
+off the payload entirely, matching pre-#2177 behavior. **Set through the raw
+config JSON editor only** — deliberately not surfaced by either the setup
+wizard or the structured edit-form section, unlike `defaultPaymentMethod`
+right above it. Two reasons, both intentional (#2995 review): the field's
+only confirmed value today is `'service'` (see below), so a `<select>` with
+one usable option buys little discoverability over the raw-JSON path; and the
+value is compliance-sensitive per-catalog VAT classification, which is not a
+knob to expose broadly until there's a real goods/services choice to offer.
+Revisit once a confirmed `'goods'` value lands (see the follow-up referenced
+below).
 
 ## Notable implementation details
 
@@ -113,21 +122,28 @@ off the payload entirely, matching pre-#2177 behavior.
   as the inFakt default via `BankAccountDefaultSetter.setDefaultBankAccount()`.
   `transfer` invoices carry the snapshot's `bank_account` / `bank_name` fields.
 - **Per-connection sale type for non-PL clients** (#2177): `config.defaultSaleType`
-  (`goods | service`) is stamped as `sale_type` on every issued invoice/correction
-  when configured. inFakt silently defaults `sale_type` for a PL-country client, so
-  issuance without this field has always worked for PL buyers; for any other
-  country inFakt rejects the request with 422
+  (today only `'service'` — see below) is stamped as `sale_type` on every issued
+  invoice/correction when configured. inFakt silently defaults `sale_type` for a
+  PL-country client, so issuance without this field has always worked for PL
+  buyers; for any other country inFakt rejects the request with 422
   (`{"errors":{"sale_type":["Proszę określić rodzaj sprzedaży."]}}`) unless it is
   present. There is **no safe universal default** — the field is left unset unless
   the operator configures it, and unset means `sale_type` is omitted from the
   payload entirely (PL issuance keeps working; non-PL issuance still 422s exactly
-  as before, unchanged). Only `'service'` is confirmed against inFakt's sandbox
-  (exact lowercase match); the correct value for a physical-goods sale (`'goods'`
-  here is the placement, not a confirmed value) was **not** found and needs
-  confirming separately by an operator with a physical-goods catalog. Picking the
-  wrong value misstates the invoice's VAT sale-type classification, so this is an
-  explicit, compliance-sensitive operator opt-in — OL cannot infer goods vs.
-  services from a possibly-mixed catalog.
+  as before, unchanged). Picking the wrong value misstates the invoice's VAT
+  sale-type classification, so this is an explicit, compliance-sensitive operator
+  opt-in — OL cannot infer goods vs. services from a possibly-mixed catalog.
+  Only `'service'` is confirmed against inFakt's sandbox (exact lowercase match).
+  Several other spellings — `goods`, `product`, `towar`, `usluga`, `mixed`, case
+  variants — were all live-tested and **rejected**, including `'goods'` itself;
+  the correct value for a physical-goods sale was not found. `InfaktSaleTypeValues`
+  therefore lists `'service'` alone (#2995 review) — a placeholder `'goods'` value
+  would pass the save-time shape gate and then 422 at issuance, converting the
+  guard into a trap for exactly the operator this fix is meant to help. Finding
+  the real goods-sale value (and, separately, detecting `errors.sale_type` in a
+  422 body to give an un-configured connection a specific hint instead of the
+  generic "The invoicing provider rejected the request.") is tracked as a
+  follow-up: #3031.
 - **Rendered-PDF download** (#1321): `RegulatoryDocumentReader.getRegulatoryDocument
   (record, 'rendered')` fetches the invoice PDF as rendered by inFakt - this backs
   the **Download PDF** button on the accepted invoice detail page.

--- a/libs/integrations/infakt/README.md
+++ b/libs/integrations/infakt/README.md
@@ -133,6 +133,13 @@ below).
   as before, unchanged). Picking the wrong value misstates the invoice's VAT
   sale-type classification, so this is an explicit, compliance-sensitive operator
   opt-in — OL cannot infer goods vs. services from a possibly-mixed catalog.
+  Setting it is a connection-wide toggle, not a per-catalog signal: a connection
+  that sells both goods and services to PL clients while also needing
+  `defaultSaleType: 'service'` set to unblock a single non-PL service client will
+  have that value stamped on **every** issued PL invoice too, overriding inFakt's
+  own server-side inference (which may have correctly inferred `goods` for those
+  PL sales). Deliberate given there is no per-catalog signal to route on — but
+  worth knowing before enabling it on a mixed catalog.
   Only `'service'` is confirmed against inFakt's sandbox (exact lowercase match).
   Several other spellings — `goods`, `product`, `towar`, `usluga`, `mixed`, case
   variants — were all live-tested and **rejected**, including `'goods'` itself;
@@ -140,8 +147,9 @@ below).
   therefore lists `'service'` alone (#2995 review) — a placeholder `'goods'` value
   would pass the save-time shape gate and then 422 at issuance, converting the
   guard into a trap for exactly the operator this fix is meant to help. **Finding
-  the confirmed goods-sale value remains open** — tracked as #3031, unresolved
-  pending live sandbox access; do not guess it in, per the rule above.
+  the confirmed goods-sale value remains open and untracked** — #3031 (below)
+  turned out to be the diagnosis-hint work, not this; do not guess the value in,
+  per the rule above, until it is confirmed against a live sandbox.
 - **Missing-`sale_type` diagnosis hint** (#3031): `issueInvoice` detects Infakt's
   field-level validation shape for the 422 above —
   `{"errors":{"sale_type":[...]}}`, checked structurally (key presence only,

--- a/libs/integrations/infakt/README.md
+++ b/libs/integrations/infakt/README.md
@@ -139,11 +139,25 @@ below).
   the correct value for a physical-goods sale was not found. `InfaktSaleTypeValues`
   therefore lists `'service'` alone (#2995 review) — a placeholder `'goods'` value
   would pass the save-time shape gate and then 422 at issuance, converting the
-  guard into a trap for exactly the operator this fix is meant to help. Finding
-  the real goods-sale value (and, separately, detecting `errors.sale_type` in a
-  422 body to give an un-configured connection a specific hint instead of the
-  generic "The invoicing provider rejected the request.") is tracked as a
-  follow-up: #3031.
+  guard into a trap for exactly the operator this fix is meant to help. **Finding
+  the confirmed goods-sale value remains open** — tracked as #3031, unresolved
+  pending live sandbox access; do not guess it in, per the rule above.
+- **Missing-`sale_type` diagnosis hint** (#3031): `issueInvoice` detects Infakt's
+  field-level validation shape for the 422 above —
+  `{"errors":{"sale_type":[...]}}`, checked structurally (key presence only,
+  never the Polish message text or the array's contents, so a locale change
+  can't silently break it) — and re-throws with a `reason` matching core's
+  published `SALE_CLASSIFICATION_REJECTION_MARKERS`
+  (`@openlinker/core/invoicing`). `InvoiceService.classifyFailureCode` (#1200/W1)
+  routes that to the `sale-classification-required` failure code instead of the
+  generic `provider-rejected`, so a non-PL connection with no `defaultSaleType`
+  configured gets an operator-facing hint naming the config field to set, rather
+  than the uninformative "The invoicing provider rejected the request." Only the
+  direct `invoices.json` create path can carry this shape — a correction's
+  failure surfaces through the async task's `{processing_code,
+  processing_description}` envelope (#1763), which carries no field-level
+  `errors` object at all, so the same detection cannot apply to
+  `issueCorrection`.
 - **Rendered-PDF download** (#1321): `RegulatoryDocumentReader.getRegulatoryDocument
   (record, 'rendered')` fetches the invoice PDF as rendered by inFakt - this backs
   the **Download PDF** button on the accepted invoice detail page.

--- a/libs/integrations/infakt/src/domain/exceptions/infakt-api.error.ts
+++ b/libs/integrations/infakt/src/domain/exceptions/infakt-api.error.ts
@@ -27,6 +27,18 @@ export class InfaktApiError extends Error {
     message: string,
     public readonly statusCode: number,
     public readonly responseBody: unknown,
+    /**
+     * Operator-readable rejection reason, read STRUCTURALLY (duck-typed) by
+     * core's `InvoiceService.classifyFailureCode` (#1200/W1) — mirrors
+     * `SubiektInvoiceRejectedError.reason`. Optional and OL-authored: `message`
+     * deliberately never echoes the raw provider response body (it can carry
+     * buyer PII), so `reason` is the one place an adapter may recognise a
+     * SPECIFIC rejection shape (e.g. a missing `errors.sale_type`, #3031) and
+     * hand core a PII-free phrase it can match against a published marker
+     * list to derive a more actionable `InvoiceFailureCode` than the generic
+     * `provider-rejected`.
+     */
+    public readonly reason?: string,
   ) {
     super(message);
     this.name = 'InfaktApiError';

--- a/libs/integrations/infakt/src/domain/types/infakt-connection.types.ts
+++ b/libs/integrations/infakt/src/domain/types/infakt-connection.types.ts
@@ -34,13 +34,16 @@ export type InfaktPaymentMethod = (typeof InfaktPaymentMethodValues)[number];
  *
  * Only `'service'` is CONFIRMED against inFakt's sandbox (live-tested,
  * exact-lowercase match) — several other spellings (`goods`, `product`,
- * `towar`, `usluga`, `mixed`, case variants) were all rejected. The correct
- * value for a physical-goods sale was NOT found in that pass; `'goods'` is
- * included here as the documented placement for whichever value an operator
- * with a physical-goods catalog confirms works for their account — it is
- * NOT independently verified.
+ * `towar`, `usluga`, `mixed`, case variants) were all rejected, including
+ * `'goods'` itself. The correct value for a physical-goods sale was NOT found
+ * in that pass, and is deliberately NOT listed here (#2995 review): this
+ * union is closed and validated at save time, so a placeholder value an
+ * operator could select would pass that gate and then 422 at issuance —
+ * converting the very guard meant to catch a malformed shape into a trap.
+ * Add the second member (with its own confirmed test coverage) once the real
+ * goods value is found — tracked as a follow-up, see the plugin README.
  */
-export const InfaktSaleTypeValues = ['goods', 'service'] as const;
+export const InfaktSaleTypeValues = ['service'] as const;
 export type InfaktSaleType = (typeof InfaktSaleTypeValues)[number];
 
 /**
@@ -110,6 +113,11 @@ export interface InfaktConnectionConfig {
    * sale misstates that classification on a real fiscal document — this is an
    * explicit operator opt-in for their own catalog composition, never an
    * inference OL can make from a possibly-mixed catalog.
+   *
+   * Deliberately reachable only through the raw config JSON editor, unlike
+   * {@link InfaktConnectionConfig.defaultPaymentMethod} (#2995 review) — see
+   * the plugin README for why a structured `<select>` isn't worth adding
+   * while the field carries a single confirmed option.
    */
   defaultSaleType?: InfaktSaleType;
 }

--- a/libs/integrations/infakt/src/domain/types/infakt-connection.types.ts
+++ b/libs/integrations/infakt/src/domain/types/infakt-connection.types.ts
@@ -25,6 +25,25 @@ export const InfaktPaymentMethodValues = ['cash', 'transfer'] as const;
 export type InfaktPaymentMethod = (typeof InfaktPaymentMethodValues)[number];
 
 /**
+ * Sale-type values inFakt requires on `POST invoices.json` for a non-PL client
+ * (#2177). inFakt silently defaults `sale_type` for a PL-country client, so
+ * issuance to a PL buyer worked without it; for any other country inFakt
+ * rejects the request with 422
+ * (`{"errors":{"sale_type":["Proszę określić rodzaj sprzedaży."]}}`) unless
+ * the field is present.
+ *
+ * Only `'service'` is CONFIRMED against inFakt's sandbox (live-tested,
+ * exact-lowercase match) — several other spellings (`goods`, `product`,
+ * `towar`, `usluga`, `mixed`, case variants) were all rejected. The correct
+ * value for a physical-goods sale was NOT found in that pass; `'goods'` is
+ * included here as the documented placement for whichever value an operator
+ * with a physical-goods catalog confirms works for their account — it is
+ * NOT independently verified.
+ */
+export const InfaktSaleTypeValues = ['goods', 'service'] as const;
+export type InfaktSaleType = (typeof InfaktSaleTypeValues)[number];
+
+/**
  * inFakt API environment (#2174). The neutral choice the FE create wizard and
  * edit form persist on `connection.config.environment`; the adapter factory
  * and connection tester map it to the concrete API base URL via
@@ -75,4 +94,22 @@ export interface InfaktConnectionConfig {
    * and Infakt is left to reject the invoice as documented in #1303.
    */
   bankAccount?: InfaktBankAccountConfig;
+  /**
+   * Sale-type sent on EVERY issued invoice/correction (#2177) — applied
+   * uniformly, not only for non-PL clients, to match how `defaultPaymentMethod`
+   * always applies rather than branching on the buyer's country.
+   *
+   * There is NO safe universal default: a PL client works today because inFakt
+   * silently defaults `sale_type` server-side, and this field defaults to
+   * leaving `sale_type` OFF the payload entirely when unset — PL issuance keeps
+   * working exactly as before, and non-PL issuance keeps 422ing exactly as
+   * before, until the operator configures this explicitly.
+   *
+   * Compliance caveat: the value asserts the invoice's VAT sale-type
+   * classification (goods vs. services). Configuring the wrong one for a given
+   * sale misstates that classification on a real fiscal document — this is an
+   * explicit operator opt-in for their own catalog composition, never an
+   * inference OL can make from a possibly-mixed catalog.
+   */
+  defaultSaleType?: InfaktSaleType;
 }

--- a/libs/integrations/infakt/src/domain/types/infakt.types.ts
+++ b/libs/integrations/infakt/src/domain/types/infakt.types.ts
@@ -7,6 +7,7 @@
  *
  * @module libs/integrations/infakt/src/domain/types
  */
+import type { InfaktSaleType } from './infakt-connection.types';
 
 /** Infakt KSeF status values as returned in `ksef_data.status`. */
 export const InfaktKsefStatusValues = [
@@ -246,9 +247,11 @@ export interface InfaktInvoiceRequest {
      * inFakt's sale-type classification (#2177) — required by inFakt for a
      * non-PL client, silently defaulted for a PL one. Sent only when the
      * connection has `defaultSaleType` configured; see
-     * `InfaktConnectionConfig.defaultSaleType`.
+     * `InfaktConnectionConfig.defaultSaleType`. Narrowed to the same closed
+     * union as the config field (#2995 review) — nothing here may stamp an
+     * unvalidated string onto a fiscal payload.
      */
-    sale_type?: string;
+    sale_type?: InfaktSaleType;
     external_id?: string;
   };
 }
@@ -307,9 +310,10 @@ export interface InfaktCorrectiveInvoiceRequest {
     /**
      * inFakt's sale-type classification (#2177) — see the matching field on
      * {@link InfaktInvoiceRequest}. A correction should not disagree with the
-     * original invoice's sale classification.
+     * original invoice's sale classification. Narrowed to the same closed
+     * union (#2995 review).
      */
-    sale_type?: string;
+    sale_type?: InfaktSaleType;
     corrected_invoice_number: string | null;
     corrected_invoice_date: string;
     corrected_invoice_uuid: string;

--- a/libs/integrations/infakt/src/domain/types/infakt.types.ts
+++ b/libs/integrations/infakt/src/domain/types/infakt.types.ts
@@ -242,6 +242,13 @@ export interface InfaktInvoiceRequest {
     services: InfaktInvoiceServiceRequest[];
     bank_account?: string;
     bank_name?: string;
+    /**
+     * inFakt's sale-type classification (#2177) — required by inFakt for a
+     * non-PL client, silently defaulted for a PL one. Sent only when the
+     * connection has `defaultSaleType` configured; see
+     * `InfaktConnectionConfig.defaultSaleType`.
+     */
+    sale_type?: string;
     external_id?: string;
   };
 }
@@ -297,6 +304,12 @@ export interface InfaktCorrectiveInvoiceRequest {
     client_id: number | null;
     bank_account?: string;
     bank_name?: string;
+    /**
+     * inFakt's sale-type classification (#2177) — see the matching field on
+     * {@link InfaktInvoiceRequest}. A correction should not disagree with the
+     * original invoice's sale classification.
+     */
+    sale_type?: string;
     corrected_invoice_number: string | null;
     corrected_invoice_date: string;
     corrected_invoice_uuid: string;

--- a/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-connection-config-shape-validator.adapter.spec.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-connection-config-shape-validator.adapter.spec.ts
@@ -120,12 +120,9 @@ describe('InfaktConnectionConfigShapeValidatorAdapter', () => {
       await expect(validator.validate({})).resolves.toBeUndefined();
     });
 
-    it.each(['goods', 'service'])(
-      'should resolve when defaultSaleType is %s',
-      async (defaultSaleType) => {
-        await expect(validator.validate({ defaultSaleType })).resolves.toBeUndefined();
-      },
-    );
+    it.each(['service'])('should resolve when defaultSaleType is %s', async (defaultSaleType) => {
+      await expect(validator.validate({ defaultSaleType })).resolves.toBeUndefined();
+    });
 
     it('should resolve when defaultSaleType is null', async () => {
       await expect(validator.validate({ defaultSaleType: null })).resolves.toBeUndefined();
@@ -136,9 +133,18 @@ describe('InfaktConnectionConfigShapeValidatorAdapter', () => {
         validator.validate({ defaultSaleType: 'towar' }),
       ).rejects.toMatchObject({
         pluginName: 'Infakt',
-        errors: [
-          { path: 'defaultSaleType', message: expect.stringContaining('goods, service') },
-        ],
+        errors: [{ path: 'defaultSaleType', message: expect.stringContaining('service') }],
+      });
+    });
+
+    // #2995 review: 'goods' is a CONFIRMED-REJECTED inFakt value (#2177), not
+    // merely an unconfirmed one — it must be refused at save time exactly
+    // like any other unsupported string, never accepted as a placeholder for
+    // a still-unknown correct value.
+    it('should reject when defaultSaleType is the confirmed-rejected value "goods"', async () => {
+      await expect(validator.validate({ defaultSaleType: 'goods' })).rejects.toMatchObject({
+        pluginName: 'Infakt',
+        errors: [{ path: 'defaultSaleType', message: expect.stringContaining('service') }],
       });
     });
 

--- a/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-connection-config-shape-validator.adapter.spec.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-connection-config-shape-validator.adapter.spec.ts
@@ -115,6 +115,40 @@ describe('InfaktConnectionConfigShapeValidatorAdapter', () => {
     );
   });
 
+  describe('defaultSaleType (#2177)', () => {
+    it('should resolve when defaultSaleType is absent', async () => {
+      await expect(validator.validate({})).resolves.toBeUndefined();
+    });
+
+    it.each(['goods', 'service'])(
+      'should resolve when defaultSaleType is %s',
+      async (defaultSaleType) => {
+        await expect(validator.validate({ defaultSaleType })).resolves.toBeUndefined();
+      },
+    );
+
+    it('should resolve when defaultSaleType is null', async () => {
+      await expect(validator.validate({ defaultSaleType: null })).resolves.toBeUndefined();
+    });
+
+    it('should reject when defaultSaleType is not a supported value', async () => {
+      await expect(
+        validator.validate({ defaultSaleType: 'towar' }),
+      ).rejects.toMatchObject({
+        pluginName: 'Infakt',
+        errors: [
+          { path: 'defaultSaleType', message: expect.stringContaining('goods, service') },
+        ],
+      });
+    });
+
+    it('should reject when defaultSaleType is not a string', async () => {
+      await expect(validator.validate({ defaultSaleType: 123 })).rejects.toBeInstanceOf(
+        InvalidConnectionConfigException,
+      );
+    });
+  });
+
   describe('environment (#2174)', () => {
     it('should resolve when environment is absent', async () => {
       await expect(validator.validate({})).resolves.toBeUndefined();

--- a/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-invoicing.adapter.spec.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-invoicing.adapter.spec.ts
@@ -22,6 +22,7 @@ import type { LoggerPort } from '@openlinker/shared/logging';
 import {
   BuyerProfile,
   CURRENCY_REJECTION_MARKERS,
+  SALE_CLASSIFICATION_REJECTION_MARKERS,
   FractionalTaxRateNotationError,
   MissingTaxRateException,
   InvoiceRecord,
@@ -1884,6 +1885,76 @@ describe('InfaktInvoicingAdapter', () => {
       const invoiceCall = http.calls.find((c) => c.method === 'POST' && c.path === 'invoices.json');
       expect(invoiceCall?.body).toMatchObject({
         invoice: expect.objectContaining({ sale_type: 'service' }),
+      });
+    });
+
+    // #3031: detect Infakt's `errors.sale_type` 422 shape and surface a
+    // specific, actionable hint instead of the generic provider-rejected
+    // failure — for the connection that never configured `defaultSaleType`
+    // and whose buyer requires the field (the exact opaque-422 case #2177
+    // originally reported).
+    describe('missing-sale_type 422 detection (#3031)', () => {
+      it('should re-throw with a reason core routes to sale-classification-required for the errors.sale_type shape', async () => {
+        seedIssueFixtures();
+        // Live-verified body shape (#2177): a Rails-style field-level
+        // validation error, not the async task's {processing_code, ...}
+        // envelope — this shape is only reachable on the direct
+        // `invoices.json` POST issueInvoice makes.
+        http.seedError(
+          'POST',
+          'invoices.json',
+          new InfaktApiError('Infakt API POST invoices.json failed with status 422', 422, {
+            errors: { sale_type: ['Proszę określić rodzaj sprzedaży.'] },
+          }),
+        );
+
+        const error = await adapter
+          .issueInvoice(nonPlInvoiceCmd)
+          .then(() => null)
+          .catch((e: unknown) => e as InfaktApiError);
+
+        expect(error).toBeInstanceOf(InfaktApiError);
+        expect(error).toMatchObject({ statusCode: 422, failureMode: 'rejected' });
+        // Asserted against the published marker list rather than a copied
+        // string (the #2103 `invalid-currency` precedent) — a reword on
+        // either side breaks the build instead of silently losing the
+        // routing to the specific failure code.
+        const haystack = (error?.reason ?? '').toLowerCase();
+        expect(
+          SALE_CLASSIFICATION_REJECTION_MARKERS.some((marker: string) =>
+            haystack.includes(marker),
+          ),
+        ).toBe(true);
+      });
+
+      it('should propagate an unrelated 422 unchanged (no reason stamped)', async () => {
+        seedIssueFixtures();
+        const original = new InfaktApiError(
+          'Infakt API POST invoices.json failed with status 422',
+          422,
+          { errors: { client_id: ['jest wymagane'] } },
+        );
+        http.seedError('POST', 'invoices.json', original);
+
+        const error = await adapter
+          .issueInvoice(nonPlInvoiceCmd)
+          .then(() => null)
+          .catch((e: unknown) => e as InfaktApiError);
+
+        expect(error).toBe(original);
+        expect(error?.reason).toBeUndefined();
+      });
+
+      it('should propagate a 422 with a non-object body unchanged (defensive)', async () => {
+        seedIssueFixtures();
+        const original = new InfaktApiError(
+          'Infakt API POST invoices.json returned non-JSON (422)',
+          422,
+          'not json',
+        );
+        http.seedError('POST', 'invoices.json', original);
+
+        await expect(adapter.issueInvoice(nonPlInvoiceCmd)).rejects.toBe(original);
       });
     });
 

--- a/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-invoicing.adapter.spec.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-invoicing.adapter.spec.ts
@@ -62,7 +62,9 @@ function listResponse<T>(entities: T[]): InfaktListResponse<T> {
   return { entities, metainfo: { ...CLIENTS_CAPTURE.metainfo, total_count: entities.length } };
 }
 
-function buyer(overrides: Partial<{ nip: string | null; email: string | null }> = {}): BuyerProfile {
+function buyer(
+  overrides: Partial<{ nip: string | null; email: string | null; countryIso2: string }> = {},
+): BuyerProfile {
   return new BuyerProfile(
     'Acme Sp. z o.o.',
     overrides.nip === undefined || overrides.nip === null
@@ -73,7 +75,7 @@ function buyer(overrides: Partial<{ nip: string | null; email: string | null }> 
       line2: null,
       city: 'Warszawa',
       postalCode: '00-001',
-      countryIso2: 'PL',
+      countryIso2: overrides.countryIso2 ?? 'PL',
     },
     overrides.nip ? 'company' : 'private',
     overrides.email ?? null,
@@ -1800,6 +1802,15 @@ describe('InfaktInvoicingAdapter', () => {
       lines: [{ name: 'Widget', quantity: 1, unitPriceGross: 123, taxRate: '23' }],
       idempotencyKey: 'idem-1',
     };
+    // AC-3 (#2177): the entire subject of the issue is a non-PL buyer — every
+    // other case in this describe block uses the PL-hardcoded `buyer()`
+    // default, which asserts nothing about the reported bug (a PL client
+    // 422s neither with nor without `sale_type`, since inFakt defaults it
+    // server-side there). This is the first case to actually exercise it.
+    const nonPlInvoiceCmd: IssueInvoiceCommand = {
+      ...invoiceCmd,
+      buyer: buyer({ nip: '1234567890', countryIso2: 'DE' }),
+    };
     const correctionCmd: IssueCorrectionCommand = {
       connectionId: 'conn-1',
       orderId: 'order-1',
@@ -1846,7 +1857,7 @@ describe('InfaktInvoicingAdapter', () => {
       expect('sale_type' in body.invoice).toBe(false);
     });
 
-    it.each(['goods', 'service'] as const)(
+    it.each(['service'] as const)(
       'should send sale_type: %s on issueInvoice when defaultSaleType is configured',
       async (saleType) => {
         const configured = new InfaktInvoicingAdapter('conn-1', http, logger, {
@@ -1862,6 +1873,20 @@ describe('InfaktInvoicingAdapter', () => {
       },
     );
 
+    it('should succeed for a non-PL client once defaultSaleType is configured (AC-3, #2177)', async () => {
+      const configured = new InfaktInvoicingAdapter('conn-1', http, logger, {
+        defaultSaleType: 'service',
+      });
+      seedIssueFixtures();
+
+      await configured.issueInvoice(nonPlInvoiceCmd);
+
+      const invoiceCall = http.calls.find((c) => c.method === 'POST' && c.path === 'invoices.json');
+      expect(invoiceCall?.body).toMatchObject({
+        invoice: expect.objectContaining({ sale_type: 'service' }),
+      });
+    });
+
     it('should NOT include sale_type on issueCorrection when the connection has no defaultSaleType configured (regression guard)', async () => {
       seedCorrectionFixtures();
       await adapter.issueCorrection(correctionCmd);
@@ -1873,7 +1898,7 @@ describe('InfaktInvoicingAdapter', () => {
       expect('sale_type' in body.corrective_invoice).toBe(false);
     });
 
-    it.each(['goods', 'service'] as const)(
+    it.each(['service'] as const)(
       'should send sale_type: %s on issueCorrection when defaultSaleType is configured',
       async (saleType) => {
         const configured = new InfaktInvoicingAdapter('conn-1', http, logger, {

--- a/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-invoicing.adapter.spec.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-invoicing.adapter.spec.ts
@@ -1791,6 +1791,107 @@ describe('InfaktInvoicingAdapter', () => {
     });
   });
 
+  describe('sale_type (#2177)', () => {
+    const invoiceCmd: IssueInvoiceCommand = {
+      connectionId: 'conn-1',
+      orderId: 'order-1',
+      buyer: buyer({ nip: '1234567890' }),
+      currency: 'PLN',
+      lines: [{ name: 'Widget', quantity: 1, unitPriceGross: 123, taxRate: '23' }],
+      idempotencyKey: 'idem-1',
+    };
+    const correctionCmd: IssueCorrectionCommand = {
+      connectionId: 'conn-1',
+      orderId: 'order-1',
+      originalProviderInvoiceId: 'inv-uuid-1',
+      reason: 'Zwrot towaru',
+      lines: [{ originalLineNumber: 1, newQuantity: 0 }],
+      idempotencyKey: 'idem-corr-1',
+    };
+
+    function seedIssueFixtures(): void {
+      http.seed<InfaktListResponse<InfaktClient>>('GET', 'clients.json', listResponse([]));
+      http.seed('POST', 'clients.json', {
+        id: 1,
+        uuid: 'client-uuid-1',
+        name: 'Acme',
+        nip: '1234567890',
+        email: null,
+        city: null,
+        street: null,
+        post_code: null,
+        country: null,
+      });
+      http.seed('POST', 'invoices.json', invoiceFixture());
+      http.seed('POST', 'invoices/inv-uuid-1/send_to_ksef.json', ksefResponseFixture());
+    }
+
+    function seedCorrectionFixtures(): void {
+      http.seed('GET', 'invoices/inv-uuid-1.json', invoiceFixture());
+      http.seed('POST', 'async/corrective_invoices.json', asyncTaskFixture());
+      http.seed(
+        'GET',
+        'corrective_invoices/corr-uuid-1.json',
+        invoiceFixture({ uuid: 'corr-uuid-1', kind: 'correction' }),
+      );
+      http.seed('POST', 'corrective_invoices/corr-uuid-1/send_to_ksef.json', ksefResponseFixture());
+    }
+
+    it('should NOT include sale_type on issueInvoice when the connection has no defaultSaleType configured (regression guard)', async () => {
+      seedIssueFixtures();
+      await adapter.issueInvoice(invoiceCmd);
+
+      const invoiceCall = http.calls.find((c) => c.method === 'POST' && c.path === 'invoices.json');
+      const body = invoiceCall?.body as { invoice: Record<string, unknown> };
+      expect('sale_type' in body.invoice).toBe(false);
+    });
+
+    it.each(['goods', 'service'] as const)(
+      'should send sale_type: %s on issueInvoice when defaultSaleType is configured',
+      async (saleType) => {
+        const configured = new InfaktInvoicingAdapter('conn-1', http, logger, {
+          defaultSaleType: saleType,
+        });
+        seedIssueFixtures();
+        await configured.issueInvoice(invoiceCmd);
+
+        const invoiceCall = http.calls.find((c) => c.method === 'POST' && c.path === 'invoices.json');
+        expect(invoiceCall?.body).toMatchObject({
+          invoice: expect.objectContaining({ sale_type: saleType }),
+        });
+      },
+    );
+
+    it('should NOT include sale_type on issueCorrection when the connection has no defaultSaleType configured (regression guard)', async () => {
+      seedCorrectionFixtures();
+      await adapter.issueCorrection(correctionCmd);
+
+      const invoiceCall = http.calls.find(
+        (c) => c.method === 'POST' && c.path === 'async/corrective_invoices.json',
+      );
+      const body = invoiceCall?.body as { corrective_invoice: Record<string, unknown> };
+      expect('sale_type' in body.corrective_invoice).toBe(false);
+    });
+
+    it.each(['goods', 'service'] as const)(
+      'should send sale_type: %s on issueCorrection when defaultSaleType is configured',
+      async (saleType) => {
+        const configured = new InfaktInvoicingAdapter('conn-1', http, logger, {
+          defaultSaleType: saleType,
+        });
+        seedCorrectionFixtures();
+        await configured.issueCorrection(correctionCmd);
+
+        const invoiceCall = http.calls.find(
+          (c) => c.method === 'POST' && c.path === 'async/corrective_invoices.json',
+        );
+        expect(invoiceCall?.body).toMatchObject({
+          corrective_invoice: expect.objectContaining({ sale_type: saleType }),
+        });
+      },
+    );
+  });
+
   describe('bank accounts (#1303 follow-up)', () => {
     // Seeded from the real `GET /bank_accounts.json` capture, so the mapping is
     // asserted against the envelope inFakt actually emits (#1926).

--- a/libs/integrations/infakt/src/infrastructure/adapters/infakt-connection-config-shape-validator.adapter.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/infakt-connection-config-shape-validator.adapter.ts
@@ -14,7 +14,8 @@
  * number) plus non-empty `accountNumber` and `bankName` strings — the
  * adapter stamps the latter two straight onto `'transfer'` invoices, so a
  * malformed shape must fail fast at save time (400) rather than surface as
- * an opaque inFakt 422 at issuance. Registered against
+ * an opaque inFakt 422 at issuance; an optional `defaultSaleType` (#2177)
+ * that, when present, must be one of `InfaktSaleTypeValues`. Registered against
  * `ConnectionConfigShapeValidatorRegistryService` at `infakt.accounting.v1`;
  * `ConnectionService` maps the thrown exception to a 400 at the API boundary.
  *
@@ -34,6 +35,7 @@ import { isAllowedInfaktBaseUrl } from '../../domain/policies/infakt-base-url.po
 import {
   InfaktEnvironmentValues,
   InfaktPaymentMethodValues,
+  InfaktSaleTypeValues,
 } from '../../domain/types/infakt-connection.types';
 
 export class InfaktConnectionConfigShapeValidatorAdapter
@@ -70,6 +72,18 @@ export class InfaktConnectionConfigShapeValidatorAdapter
       issues.push({
         path: 'defaultPaymentMethod',
         message: `must be one of: ${InfaktPaymentMethodValues.join(', ')}`,
+      });
+    }
+
+    const defaultSaleType = config.defaultSaleType;
+    if (
+      defaultSaleType !== undefined &&
+      defaultSaleType !== null &&
+      !InfaktSaleTypeValues.includes(defaultSaleType as (typeof InfaktSaleTypeValues)[number])
+    ) {
+      issues.push({
+        path: 'defaultSaleType',
+        message: `must be one of: ${InfaktSaleTypeValues.join(', ')}`,
       });
     }
 

--- a/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
@@ -146,6 +146,46 @@ function toInfaktCurrency(currency: string | null | undefined, context: string):
 }
 
 /**
+ * The `reason` this adapter stamps on the re-thrown `InfaktApiError` when it
+ * recognises the `errors.sale_type` 422 shape (#3031). Matches one of core's
+ * published `SALE_CLASSIFICATION_REJECTION_MARKERS`
+ * (`@openlinker/core/invoicing`) by construction — spec-asserted below, so a
+ * reword on either side breaks the build rather than silently losing the
+ * routing to the specific `sale-classification-required` failure code.
+ */
+const SALE_TYPE_HINT_REASON =
+  'Infakt requires a sale classification to be configured for this connection';
+
+/**
+ * Detects Infakt's field-level validation shape for a missing/required
+ * `sale_type` on `POST invoices.json` — `{"errors":{"sale_type":[...]}}`,
+ * live-verified against the sandbox for a non-PL buyer with no
+ * `defaultSaleType` configured (#3031, #2177 review).
+ *
+ * Structural only: checks that `errors.sale_type` is PRESENT, never the array
+ * contents (Infakt's message text is Polish and locale-dependent, so matching
+ * on it would silently stop working under a locale change) and never the
+ * emptiness of the array (a present-but-empty array would still be Infakt
+ * naming the field as the cause). Any other 422 shape — a different field, a
+ * non-object body, no `errors` key — reports `false` so it keeps propagating
+ * as the generic provider rejection it is.
+ */
+function isMissingSaleTypeRejection(error: unknown): error is InfaktApiError {
+  if (!(error instanceof InfaktApiError) || error.statusCode !== 422) {
+    return false;
+  }
+  const body = error.responseBody;
+  if (typeof body !== 'object' || body === null) {
+    return false;
+  }
+  const errors = (body as { errors?: unknown }).errors;
+  if (typeof errors !== 'object' || errors === null) {
+    return false;
+  }
+  return 'sale_type' in errors;
+}
+
+/**
  * Maps Infakt ksef_data.status → neutral RegulatoryStatus.
  *
  * `success` is the TERMINAL accepted state — it must map to `accepted`, not
@@ -625,9 +665,10 @@ export class InfaktInvoicingAdapter
     };
 
     // InfaktApiError carries the neutral `failureMode` discriminator core's
-    // InvoiceService reads structurally (#1200) — propagate as-is rather
-    // than wrapping into a plain Error, which would erase that signal.
-    const invoice = await this.http.post<InfaktInvoice>('invoices.json', payload);
+    // InvoiceService reads structurally (#1200) — propagate as-is, EXCEPT for
+    // the specific `errors.sale_type` 422 shape (#3031), which is re-thrown
+    // with a `reason` core can route to a more actionable failure code.
+    const invoice = await this.postInvoiceWithSaleTypeHint(payload);
 
     this.logger.log(`Infakt invoice created: ${invoice.uuid} (${invoice.number ?? 'draft'})`);
 
@@ -685,6 +726,43 @@ export class InfaktInvoicingAdapter
     // leave the record disagreeing with the document by a grosz here and there,
     // with no way for a reader to tell which is right.
     return { record, documentLines: toDocumentLineAmounts(invoice.services) };
+  }
+
+  /**
+   * Wraps the `invoices.json` create call to detect Infakt's field-level
+   * validation shape for a missing `sale_type` (#3031) —
+   * `{"errors":{"sale_type":["Proszę określić rodzaj sprzedaży."]}}`, live-
+   * verified against the sandbox for a non-PL buyer with no `defaultSaleType`
+   * configured — and re-throw with a `reason` core's `InvoiceService` can
+   * route to the specific `sale-classification-required` failure code instead
+   * of the generic `provider-rejected` (#2177 review).
+   *
+   * Only the DIRECT `invoices.json` POST goes through this: a correction's
+   * failure surfaces through `awaitCorrectionTask`'s async-task envelope
+   * (`{processing_code, processing_description}`, live-verified #1763), which
+   * carries no field-level `errors` object at all — there is no
+   * `errors.sale_type` shape for a correction to be detected against.
+   *
+   * `isMissingSaleTypeRejection` reads only the STRUCTURE of the parsed body
+   * (key presence), never its text — the Polish message it carries is not
+   * matched against, since a locale change would silently stop the detection.
+   */
+  private async postInvoiceWithSaleTypeHint(
+    payload: InfaktInvoiceRequest,
+  ): Promise<InfaktInvoice> {
+    try {
+      return await this.http.post<InfaktInvoice>('invoices.json', payload);
+    } catch (err) {
+      if (isMissingSaleTypeRejection(err)) {
+        throw new InfaktApiError(
+          err.message,
+          err.statusCode,
+          err.responseBody,
+          SALE_TYPE_HINT_REASON,
+        );
+      }
+      throw err;
+    }
   }
 
   async getInvoice(query: GetInvoiceQuery): Promise<InvoiceRecord | null> {

--- a/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
@@ -1066,6 +1066,12 @@ export class InfaktInvoicingAdapter
         // Per-connection setting (#2177) — see `this.saleType` doc. A
         // correction should not disagree with the original invoice's sale
         // classification, so the same conditional-spread pattern applies.
+        // NOTE (shared with bankAccountFields() above): this reads the LIVE
+        // connection config, not a snapshot of what was stamped on the
+        // original invoice — if an operator changes `defaultSaleType` between
+        // issuing and correcting, the correction can disagree with the
+        // original after all. Pre-existing adapter precedent, not a
+        // regression introduced here (#2995 review).
         ...(this.saleType ? { sale_type: this.saleType } : {}),
         corrected_invoice_number: original.number,
         corrected_invoice_date: original.invoice_date ?? new Date().toISOString().slice(0, 10),

--- a/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
@@ -468,6 +468,15 @@ export class InfaktInvoicingAdapter
    */
   private readonly bankAccount: InfaktConnectionConfig['bankAccount'];
 
+  /**
+   * Sale-type sent on every issued invoice/correction (#2177) — see
+   * `InfaktConnectionConfig.defaultSaleType`. Stays `undefined` unless the
+   * operator explicitly configured it; there is NO fallback here, since a
+   * silently-guessed sale type would misstate the invoice's VAT
+   * classification for a real fiscal document.
+   */
+  private readonly saleType: InfaktConnectionConfig['defaultSaleType'];
+
   constructor(
     private readonly connectionId: string,
     private readonly http: IInfaktHttpClient,
@@ -476,6 +485,7 @@ export class InfaktInvoicingAdapter
   ) {
     this.paymentMethod = config.defaultPaymentMethod ?? 'cash';
     this.bankAccount = config.bankAccount;
+    this.saleType = config.defaultSaleType;
   }
 
   /**
@@ -605,6 +615,11 @@ export class InfaktInvoicingAdapter
         client_id: clientId,
         services,
         ...this.bankAccountFields(),
+        // Per-connection setting (#2177) — see `this.saleType` doc. Omitted
+        // entirely when unconfigured so a PL client keeps relying on inFakt's
+        // own silent default and a non-PL client keeps 422ing exactly as
+        // before, unchanged from pre-#2177 behaviour.
+        ...(this.saleType ? { sale_type: this.saleType } : {}),
         ...(idempotencyKey ? { external_id: idempotencyKey } : {}),
       },
     };
@@ -970,6 +985,10 @@ export class InfaktInvoicingAdapter
         // upsertCustomer round-trip is needed for a correction.
         client_id: original.client_id,
         ...this.bankAccountFields(),
+        // Per-connection setting (#2177) — see `this.saleType` doc. A
+        // correction should not disagree with the original invoice's sale
+        // classification, so the same conditional-spread pattern applies.
+        ...(this.saleType ? { sale_type: this.saleType } : {}),
         corrected_invoice_number: original.number,
         corrected_invoice_date: original.invoice_date ?? new Date().toISOString().slice(0, 10),
         // Documented alongside corrected_invoice_number/_date as a third,


### PR DESCRIPTION
## Summary

- `InfaktInvoicingAdapter.issueInvoice` never sends `sale_type` on `POST invoices.json`. inFakt silently defaults this for a PL-country client, so PL issuance has always worked — but for any other country inFakt rejects the request with HTTP 422 (`{"errors":{"sale_type":["Proszę określić rodzaj sprzedaży."]}}`).
- Adds a per-connection opt-in `defaultSaleType` config field, mirroring the existing `defaultPaymentMethod` pattern: `InfaktConnectionConfig.defaultSaleType`, wired into the adapter constructor (`this.saleType`), stamped conditionally on both `issueInvoice`'s and `issueCorrection`'s payloads, and validated in `InfaktConnectionConfigShapeValidatorAdapter`. Reachable through the raw config JSON editor only (see below for why).
- **No silent default is introduced.** The field stays `undefined` unless the operator explicitly configures it, and the adapter omits `sale_type` from the payload entirely when unset — so a PL client keeps working exactly as before, and a non-PL client keeps 422ing exactly as before, until the operator opts in. This is deliberate: there is no safe universal default across a possibly-mixed (goods + services) catalog, and guessing wrong misstates the invoice's VAT sale-type classification on a real fiscal document.
- **Also folds in the 422-diagnosis-hint half of the follow-up (#3031, via PR #3129, merged into this branch).** `issueInvoice` now structurally detects inFakt's `{"errors":{"sale_type":[...]}}` 422 shape (key presence only, never the Polish message text) and routes it through a new `sale-classification-required` `InvoiceFailureCode` — so a non-PL connection with no `defaultSaleType` configured now gets an operator-facing hint naming `defaultSaleType` as the field to set, instead of the generic "The invoicing provider rejected the request."

## Design decision (already resolved with the maintainer before implementation)

Per-connection default setting, following the `defaultPaymentMethod` pattern — no new upstream domain field on `InvoiceLine`/`IssueInvoiceCommand` (there is genuinely no goods/service signal anywhere in the product/order domain today, and adding one is out of scope for this fix).

## Review round (piotrswierzy) — addressed

- **`InfaktSaleTypeValues` narrowed to `['service']` only.** `'goods'` was a *confirmed-rejected* inFakt value, not merely unconfirmed — leaving it selectable let it pass OL's save-time shape gate and then 422 at issuance, turning the guard into a trap for exactly the operator this fix is meant to help. Filed [#3031](https://github.com/openlinker-project/openlinker/issues/3031) to track finding the real goods-sale value (and, separately, detecting `errors.sale_type` in a 422 body to give an un-configured connection a specific hint instead of the generic provider-rejected message) — the diagnosis-hint half of that follow-up is now merged into this PR (see above); the goods-sale value itself remains unconfirmed (see Known residual gap below).
- **`sale_type` narrowed from `string` to `InfaktSaleType`** on both `InfaktInvoiceRequest` and `InfaktCorrectiveInvoiceRequest`, matching the config field.
- **Added a non-PL fixture and an issuance test that actually exercises the reported bug.** Every prior case used the PL-hardcoded `buyer()` default, which asserts nothing about a non-PL client (a PL client 422s neither with nor without `sale_type`).
- **Documented, in the README and the config field's docblock, why `defaultSaleType` is deliberately raw-JSON-only** rather than a structured `<select>` beside `defaultPaymentMethod` — the field currently carries a single confirmed option, and it's compliance-sensitive per-catalog VAT classification.
- Updated `InfaktConnectionConfigShapeValidatorAdapter` tests to assert `'goods'` is *rejected* at save time (it previously asserted the opposite).
- Merged `main` into the branch (previously behind).
- **Merged #3129 (closing #3031's diagnosis-hint half) into this branch** — see the "Also folds in" bullet above.

## Known residual gap — NOT resolved by this PR

The correct `sale_type` value for a physical-goods sale was not found in the live reproduction pass and is **not** shipped as a selectable option (see above). Non-PL issuance for a goods-classified sale still 422s, unchanged from before this PR, but now surfaces the specific `sale-classification-required` hint instead of a generic rejection; non-PL issuance for a service-classified sale now succeeds once the operator sets `defaultSaleType: "service"`.

Closes #2177 for the confirmed `'service'` case (the fix this issue asked for: a config-driven `sale_type`, validated, with no unsafe default) and closes #3031 for the diagnosis-hint case. The goods-value gap itself remains genuinely unconfirmed — no sandbox access was available to positively verify a value, and guessing one in would recreate the exact trap this PR closed for `'service'`. A future follow-up should file a fresh issue once the correct value is confirmed.

## Test plan

- [x] `pnpm lint` — passed (exit 0, repo-wide)
- [x] `pnpm type-check` — passed (exit 0, repo-wide, including `libs/integrations/infakt`)
- [x] Scoped + full package unit tests — executed locally (`libs/integrations/infakt`, all suites green, including the review-round additions: the `'goods'`-rejection save-time test, the non-PL-buyer issuance test covering AC-3, and #3129's 422-shape-detection + failure-code classification tests). `pnpm smart-test --no-integration` (the repo's pre-commit hook) also ran and passed against each diff.
