### PR TITLE
test(integration): reset the harness around every int-spec, not per file

### DIFF
--- a/apps/api/test/integration/harness-isolation.int-spec.ts
+++ b/apps/api/test/integration/harness-isolation.int-spec.ts
@@ -1,0 +1,73 @@
+/**
+ * Global harness isolation - regression guard (#2986)
+ *
+ * `setup-each.ts` registers a `beforeEach` + `afterEach` reset for every
+ * int-spec through `setupFilesAfterEnv`. That registration is one line in
+ * `apps/api/test/jest-integration.cjs`: delete it and nothing fails, nothing
+ * warns, and the suite goes back to 118 specs whose first assertion reads
+ * whatever the previous file left behind. That is the shape of defect the fix
+ * exists to remove, so it needs an assertion that goes red when the wiring
+ * goes away.
+ *
+ * ## How it works
+ *
+ * This file deliberately registers NO reset of its own - that absence is the
+ * test. The first case leaves a row behind on purpose; the second asserts it
+ * is gone. Only the global hook can have removed it.
+ *
+ * ## What it proves, and what it does not
+ *
+ * Proves: the harness really is reset BETWEEN the test cases of a spec that
+ * resets nothing itself, i.e. `setup-each.ts` is registered and running.
+ *
+ * Does not prove: which of the two hooks did it (indistinguishable from
+ * inside one file), nor that the previous FILE's rows were cleared - that
+ * would need a fixture spanning two files, which Jest's default ordering on
+ * this config does not guarantee, and an order-dependent guard against an
+ * order-dependence bug is not a guard.
+ *
+ * Counts are taken RELATIVE to a baseline rather than against a literal zero.
+ * A literal zero would additionally assert that booting `AppModule` seeds no
+ * connection row - true today, but a claim this file has no business making,
+ * and one that would turn an unrelated change into a mystifying failure here.
+ * `oms-connection-never-seeded.int-spec.ts` owns the never-seeded question.
+ *
+ * @module apps/api/test/integration
+ */
+import { getTestHarness, IntegrationTestHarness, teardownTestHarness } from './setup';
+import { createTestConnection } from './helpers/test-connection.helper';
+import { countConnections } from './helpers/test-database.helper';
+
+describe('Global integration-harness isolation (#2986)', () => {
+  let harness: IntegrationTestHarness;
+  let baseline = -1;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  // NO beforeEach/afterEach reset here, on purpose. See the docblock.
+
+  it('should record a row that this file never cleans up', async () => {
+    const dataSource = harness.getDataSource();
+
+    baseline = await countConnections(dataSource);
+    await createTestConnection(dataSource, { name: 'harness-isolation probe' });
+
+    // Non-vacuity for the next case: without this, "the row is gone" would be
+    // trivially true for a row that was never written.
+    expect(await countConnections(dataSource)).toBe(baseline + 1);
+  });
+
+  it('should not see the row the previous case left, because the harness was reset', async () => {
+    // Guard against a reordering that would make this case run first and pass
+    // for the wrong reason - an unset baseline is not a clean database.
+    expect(baseline).toBeGreaterThanOrEqual(0);
+
+    expect(await countConnections(harness.getDataSource())).toBe(baseline);
+  });
+});

--- a/apps/api/test/integration/setup-each.ts
+++ b/apps/api/test/integration/setup-each.ts
@@ -1,0 +1,109 @@
+/**
+ * Per-test isolation for API integration tests (#2986)
+ *
+ * Registers a root-level `beforeEach` + `afterEach` calling
+ * `resetTestHarness()` for EVERY int-spec. Wired in through
+ * `setupFilesAfterEnv` in `apps/api/test/jest-integration.cjs`, so it applies
+ * by omission rather than by each new spec's author remembering to call it.
+ *
+ * ## What was wrong
+ *
+ * Of the 127 int-specs in this directory before this change, 118 reset in
+ * `afterEach` ONLY and six reset nowhere at all (`api-versioning`,
+ * `automation-dispatch-gate`, `bootstrap-admin-disabled`,
+ * `fulfillment-work-migration-parity`, `listings-offer-status-snapshot`,
+ * `oms-connection-never-seeded`).
+ *
+ * An `afterEach`-only reset is a courtesy to the NEXT file; it is not
+ * isolation for THIS one. A file's first test case reads whatever the previous
+ * file left behind, and this config runs `maxWorkers: 1` against one shared
+ * Postgres and declares no `testSequencer`, so which file that is can change
+ * between runs. PR #2957 measured the consequence rather than theorising it:
+ * 41 assertions in `paginated-total-split.int-spec.ts` were passing only
+ * because of accidental row state left by whichever spec ran immediately
+ * before it. They were not true in isolation.
+ *
+ * ## Why both halves
+ *
+ * `beforeEach` is the load-bearing one: it is what makes a spec's assertions
+ * true in isolation whatever ran before it, and it is the only half that
+ * protects a spec reading a table it never writes. `bootstrap-admin-disabled`
+ * asserts zero `admin` users, so a neighbour's leaked login row fails it for a
+ * reason that has nothing to do with what it tests.
+ *
+ * `afterEach` preserves the invariant this suite already relies on - every
+ * file leaves the database clean - so that a spec which ever has cause to opt
+ * OUT of the `beforeEach` still cannot poison its neighbours, and so a run
+ * inspected afterwards is not showing the last file's leftovers.
+ *
+ * ## Why here rather than in `setup.ts`
+ *
+ * Two reasons. `setup.ts` is an ordinary module, and calling Jest globals at
+ * its top level would make it unimportable from any realm where `beforeEach`
+ * is undefined - this config has two such realms already (`globalSetup` /
+ * `globalTeardown`), and `teardown.ts` carries a standing rule about what it
+ * may import from there, for its own separate reason. More importantly, hooks
+ * placed in `setup.ts` would reach only the specs that happen to import it,
+ * which is the same "remember to wire it up" failure one level down.
+ * `setupFilesAfterEnv` is Jest's own mechanism for a hook that cannot be
+ * skipped by omission, and `apps/worker/jest.config.js` already uses it.
+ *
+ * The import below is deliberately static rather than a lazy `import()`:
+ * `module: Node16` does not reliably downlevel a dynamic import to `require`,
+ * and every int-spec already imports this module at its own top level, so
+ * requiring it here resolves the SAME singleton from the same per-file module
+ * registry and changes no evaluation order that matters (the harness applies
+ * its `env` block lazily inside `setup()`, not at construction).
+ *
+ * ## Cost
+ *
+ * Read off `truncateTables` in `libs/test-kit/src/harness.ts` rather than
+ * guessed: it probes first (one `UNION ALL ... WHERE EXISTS` round-trip) and
+ * issues `TRUNCATE` only for tables that actually hold a row, so a reset
+ * immediately following another one costs ONE round-trip and truncates
+ * nothing. `resetTestHarness()` is additionally a no-op when the harness was
+ * never booted. The added cost is therefore at most two probe round-trips per
+ * test case (1010 cases at the time of the audit) and never an extra
+ * `TRUNCATE`.
+ *
+ * ## The opt-out audit (#2986's second ask): nobody needs one
+ *
+ * - NO int-spec seeds database rows in `beforeAll` - checked across all 127,
+ *   twice, the second time with a wide net that also catches HTTP seeding and
+ *   helpers whose names do not contain "seed". So the global `beforeEach`
+ *   cannot destroy a suite-scoped fixture. The only `beforeAll` bodies that
+ *   touch the database at all are the two migration-chain specs'
+ *   `DROP`/`CREATE DATABASE`, and two specs that register an in-memory
+ *   adapter, neither of which a `TRUNCATE` can reach.
+ * - `fulfillment-work-migration-parity` and `oms-connection-never-seeded`
+ *   build the real migration chain in a SECOND database and assert against
+ *   that database plus `information_schema` / `pg_catalog`. Truncation cannot
+ *   cross a database boundary in Postgres and changes no catalogue row, so the
+ *   reset is invisible to every assertion they make. Note the corollary: if
+ *   either were ever "simplified" to query the harness DataSource instead,
+ *   this reset would make its zero-row assertion trivially true, which is the
+ *   "check that cannot fail" both of those docblocks exist to warn about.
+ * - No `afterEach` or `afterAll` hook anywhere in the suite reads or asserts
+ *   database state, so the added `afterEach` cannot pull state out from under
+ *   a teardown hook.
+ *
+ * The six files are deliberately left unedited: adding six calls to a function
+ * the global hook already calls would reinstate the per-file remembering this
+ * exists to remove.
+ *
+ * @see harness-isolation.int-spec.ts - the regression guard that fails if this
+ *   file stops being registered.
+ * @module apps/api/test/integration
+ */
+import { resetTestHarness } from './setup';
+
+// Both hooks are the same idempotent call, so their order relative to a spec's
+// own hooks does not matter - only that one of them runs before the first
+// assertion of every test.
+beforeEach(async () => {
+  await resetTestHarness();
+});
+
+afterEach(async () => {
+  await resetTestHarness();
+});

--- a/apps/api/test/jest-integration.cjs
+++ b/apps/api/test/jest-integration.cjs
@@ -39,6 +39,14 @@ module.exports = {
   // libs/test-kit/src/harness.ts's `IntegrationTestHarnessImpl.teardown()`
   // comment, which explicitly relies on this global hook to do it (#1285).
   globalTeardown: '<rootDir>/test/integration/teardown.ts',
+  // Reset the shared harness around EVERY test case of EVERY int-spec, so a
+  // spec is isolated by omission rather than by its author remembering to call
+  // resetTestHarness(). 118 of the 127 specs here reset in `afterEach` only and
+  // six reset nowhere, which left a file's first assertion reading whatever the
+  // previous file happened to leave behind - measured, not theorised (#2986,
+  // PR #2957). The rationale, the cost and the opt-out audit live in
+  // setup-each.ts.
+  setupFilesAfterEnv: ['<rootDir>/test/integration/setup-each.ts'],
   moduleNameMapper: {
     '^@openlinker/api/(.*)$': path.resolve(__dirname, '../src/$1'),
     '^@openlinker/core$': path.resolve(__dirname, '../../../libs/core/src/index.ts'),

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -1397,3 +1397,36 @@ child rather than trusting the assignment.
 `lib.sh` that declares `${VAR:-...}` defaults at top level.
 
 **Source**: #2840 (weak-shop rate-limit gate).
+
+## An `afterEach`-only harness reset is not isolation - the next file inherits your rows
+
+**Context**: #2986. `apps/api/test/integration` holds 127 int-specs sharing ONE Testcontainers
+Postgres at `maxWorkers: 1`. 118 of them called `resetTestHarness()` in `afterEach` only; six
+(`api-versioning`, `automation-dispatch-gate`, `bootstrap-admin-disabled`,
+`fulfillment-work-migration-parity`, `listings-offer-status-snapshot`,
+`oms-connection-never-seeded`) called it nowhere.
+
+**Problem**: an `afterEach` reset is a courtesy to the NEXT file, not isolation for the current
+one. A spec's FIRST test case reads whatever the previous file left behind, and this config
+declares no `testSequencer`, so which file that is is not stable between runs. PR #2957 measured
+the consequence: 41 assertions in `paginated-total-split.int-spec.ts` were green only because of a
+neighbour's rows, and were false in isolation. The failure mode is the worst available - the suite
+is green and the thing that is wrong is what "green" means, so nothing prompts anyone to look.
+
+**Rule**: put isolation in a `beforeEach`, because that is the only hook that makes a spec's
+assertions true independently of what ran before it. Register it ONCE in a `setupFilesAfterEnv`
+module so it cannot be skipped by omission; a per-file call depends on each new author remembering,
+which is the mechanism that produced the six. Keep an `afterEach` as well, so a spec that ever opts
+out of the `beforeEach` still cannot poison its neighbours. Cost is not a reason to skip either
+half: `truncateTables` probes for dirty tables first and issues no `TRUNCATE` at all when there are
+none, so a redundant reset costs one round-trip. Before making such a reset unconditional, check
+for suite-scoped fixtures seeded in `beforeAll` - a global `beforeEach` destroys those - and check
+that no teardown hook reads database state.
+
+**Applies to**: `apps/api/test/integration/**`, wired in `apps/api/test/jest-integration.cjs` via
+`setup-each.ts` and guarded by `harness-isolation.int-spec.ts`. **Not yet fixed for
+`apps/worker/test/integration/**`**, which has the same gap in five boot specs
+(`invoicing-auto-issue-boot`, `automation-emission-boot`, `automation-dispatch-boot`,
+`fulfillment-no-injection-boot`, `oms-module-boot`) and likewise declares no `setupFilesAfterEnv`.
+
+**Source**: #2986; reported in PR #2957 review rounds 5/6.


### PR DESCRIPTION
## Not run - read this first

**The integration suite has NOT been executed.** A performance measurement held this machine's
stand, so Docker and Testcontainers were unavailable, and `pnpm lint` / `pnpm type-check` were out
for the same CPU reason. The change was written and verified by reading.

That matters more than usual here, because **neither local gate would have covered these files
anyway**: `apps/api` scopes `lint` to `eslint "src/**/*.ts"` and `type-check` to
`tsconfig.type-check.json`, which lists `"exclude": ["node_modules", "dist", "test"]`. The only
gate that type-checks `apps/api/test/**` is ts-jest at integration-run time.

**Before this leaves draft, run:**

```bash
pnpm --filter @openlinker/api test:integration   # the only gate for these files
pnpm lint && pnpm type-check                     # check:invariants touches the config I edited
```

And **expect a possible failure in a file this PR did not touch.** Removing inherited rows is the
point of the change, so any spec that was green only because of a neighbour's rows now goes red.
Such a failure is a pre-existing false assertion this change surfaced - the same class #2957 found
in `paginated-total-split.int-spec.ts` - not a regression introduced here. Aggregate/count-shaped
specs are the plausible set.

## What was wrong

Of the 127 int-specs in `apps/api/test/integration`, **118 reset the shared harness in `afterEach`
only** and **six reset nowhere at all**. The issue's framing ("most call it in `beforeEach`") is
inverted: `beforeEach` is the rare case here (6 files), and `afterEach`-only is the house
convention.

An `afterEach` reset is a courtesy to the NEXT file; it is not isolation for the current one. A
spec's FIRST test case reads whatever the previous file left behind, and that is order-dependent by
construction: this config runs `maxWorkers: 1` against one shared Postgres and declares no
`testSequencer`, so which file ran before is not stable between runs. PR #2957 measured the
consequence - 41 assertions were green only because of a neighbour's rows and were false in
isolation. The failure mode is the worst available: the suite is green, and the thing that is wrong
is what "green" means.

## The shape chosen, and why

A dedicated `setupFilesAfterEnv` module (`apps/api/test/integration/setup-each.ts`) registering a
root-level `beforeEach` **and** `afterEach` that call `resetTestHarness()`, wired in from
`apps/api/test/jest-integration.cjs`.

**Not hooks in `setup.ts`**, which the issue offered as the first option, for two reasons. `setup.ts`
is an ordinary module, so calling Jest globals at its top level makes it unimportable from any realm
where `beforeEach` is undefined - and this config already has two such realms (`globalSetup` /
`globalTeardown`). More importantly, hooks there reach only the specs that happen to *import* it,
which is the same "remember to wire it up" failure one level down. `setupFilesAfterEnv` is Jest's
mechanism for a hook that cannot be skipped by omission, which is exactly the "isolated by default"
property the issue asks for. `apps/worker/jest.config.js` already uses it, so it is not a new
mechanism in this repo.

**Both halves, not just `beforeEach`.** `beforeEach` is load-bearing: it is the only hook that makes
a spec true independently of what ran before, and the only one that protects a spec reading a table
it never writes - `bootstrap-admin-disabled` asserts zero `admin` users, so a neighbour's leaked
login row fails it for a reason unrelated to what it tests. `afterEach` preserves the invariant the
suite already relies on (every file leaves the database clean), so a spec that ever opts out of the
`beforeEach` still cannot poison its neighbours.

**The import is static, not a lazy `import()`.** `module: Node16` does not reliably downlevel a
dynamic import to `require`, and every int-spec already imports `./setup` at its own top level, so a
static require resolves the SAME singleton from the same per-file module registry. Checked: the
harness applies its `env` block lazily inside `setup()` rather than at construction, so no
evaluation order that matters changes.

## The two second-database files: no opt-out needed

Both were read in full. Neither needs to opt out, and neither is harmed.

`fulfillment-work-migration-parity.int-spec.ts` uses the harness DataSource for exactly two things:
server-level DDL (`DROP`/`CREATE DATABASE`) and catalogue reads against `information_schema.columns`,
`pg_indexes` and `pg_constraint`. Its only row writes (the CASCADE case) go into the `migrated`
database and are deleted in the same test. `TRUNCATE` changes no catalogue row and cannot cross a
database boundary in Postgres, so the reset is invisible to every assertion it makes.

`oms-connection-never-seeded.int-spec.ts` is the same shape: all four cases count rows in the
`migrated` database. One corollary is worth recording rather than discovering later - if either file
were ever "simplified" to query the harness DataSource instead, this reset would make its zero-row
assertion trivially true, which is precisely the "check that cannot fail" both docblocks exist to
warn about. That note is in `setup-each.ts`.

## The seed-then-truncate hazard: audited, and it does not exist here

A global `beforeEach` destroys any fixture seeded in `beforeAll`. Every `beforeAll` body in all 127
specs was extracted by paren-matching and inspected twice - the second pass with a deliberately wide
net that also catches HTTP seeding (`.post(`), `create*`, `persist`, `register`, and helpers whose
names contain no "seed".

**No int-spec seeds database rows in `beforeAll`.** Every file that seeds does so per-test. The only
`beforeAll` bodies that touch the database at all are the two migration-chain specs' DDL above; two
more (`publish-quantity-parity`, `resolve-category-stream`) register an in-memory adapter, which is
process state a `TRUNCATE` cannot reach.

Also checked, for the `afterEach` half: **no `afterEach` or `afterAll` hook anywhere in the suite
reads or asserts database state**, so the added reset cannot pull state out from under a teardown
hook.

## Runtime cost

Read off `truncateTables` in `libs/test-kit/src/harness.ts` rather than guessed. It probes first
(one `UNION ALL ... WHERE EXISTS` round-trip) and issues `TRUNCATE` only for tables that actually
hold a row, and `resetTestHarness()` is a no-op when the harness was never booted. So a reset
immediately following another one costs **one round-trip and truncates nothing** - the added cost is
at most two probe round-trips per test case (1010 cases at audit time) and never an extra `TRUNCATE`.

Estimated at roughly 10-20 s on a ~35-minute suite (under 1%), most of it the one extra AppModule
boot the new guard spec costs. **Estimated, not measured** - it needs the run above. If the owner
would rather not pay even that, dropping the `afterEach` half halves the probe cost and still fixes
the reported defect; the `beforeEach` is the half that must stay.

## Verification, and its limits

The wiring is one line in a config file: delete it and nothing fails and nothing warns. So
`harness-isolation.int-spec.ts` is the regression guard - it registers **no** reset of its own (that
absence is the test), leaves a row behind in one case, and asserts it is gone in the next. Only the
global hook can have removed it, so removing the registration turns it red.

Counts there are relative to a baseline rather than against a literal zero: a literal zero would
additionally assert that booting `AppModule` seeds no connection row, which is true today but a
claim that file has no business making and one that would turn an unrelated change into a mystifying
failure. What the guard does **not** prove is stated in its own docblock - which of the two hooks
did the reset (indistinguishable from inside one file), and that the previous *file's* rows were
cleared (that needs a two-file fixture, and an order-dependent guard against an order-dependence bug
is not a guard).

## Found but deliberately not fixed

`apps/worker/test/integration` has the same gap: 5 of its 26 int-specs never reset
(`invoicing-auto-issue-boot`, `automation-emission-boot`, `automation-dispatch-boot`,
`fulfillment-no-injection-boot`, `oms-module-boot`), and its `jest-integration.cjs` likewise declares
no `setupFilesAfterEnv`. Left out of scope: the issue names the api suite, the worker harness has its
own truncate list and stream/Redis per-file behaviour that this PR did not audit, and doubling the
unverified surface on a PR that could not be executed is the wrong trade. Recorded in
`docs/lessons.md` under **Applies to** so it is not lost. Happy to open a follow-up issue on request.

Note also that `paginated-total-split.int-spec.ts` - the file the evidence comes from - does not
exist on `perf-programme-2840`; it arrives with PR #2957. This change is independent of it and
benefits it on merge.

Closes #2986

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkKifZVwvZzHspxaQ7x396
