### PR TITLE
feat(shipping): surface a repeatedly-failing waybill relay instead of logging it forever

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -596,3 +596,32 @@ OL_PII_HASH_SALT=your-org-level-salt-change-in-production
 # (30 days).
 # OL_RESERVATION_OBLIGATION_MAX_AGE_MS=2592000000
 
+
+# --- Waybill relay: escalation threshold (#2073) ------------------------------
+#
+# How many CONSECUTIVE failed attempts to relay a shipment's waybill to the
+# order's participants before the shipment is escalated as needing attention:
+# a `Tracking not sent` badge on /shipments, and the `?waybillRelayStuck=true`
+# filter that collects them.
+#
+# Why this exists: a relay that fails on every poll tick releases its claim so
+# the next tick retries (#1947, correct) — but before #2073 that produced one
+# error log per tick, a job that still reported `succeeded`, and nothing an
+# operator could see, while the marketplace silently never learned the order
+# shipped and kept asking the seller for a tracking number.
+#
+# A COUNT rather than an elapsed time, deliberately: the poll cadence decides
+# how many attempts fit in an hour, so "stuck for two hours" would mean a
+# different number of failed attempts on every deployment.
+#
+# Read by the **api** process only — the worker increments the counter and
+# never compares it, which is why this variable does not appear in
+# apps/worker/.env.example. The count itself is durable on `shipments` and is
+# reset by the first relay that succeeds.
+#
+# Clamped to [2, 100]. The LOWER bound is load-bearing: a threshold of 1 would
+# escalate on a single transient blip, so it is unreachable rather than merely
+# not the default. An absent, blank, non-numeric or non-finite value falls back
+# to the default rather than throwing.
+# Default 3.
+# OL_WAYBILL_RELAY_FAILURE_ALERT_THRESHOLD=3

--- a/apps/api/src/migrations/1876000000000-add-shipment-waybill-relay-failure-tracking.ts
+++ b/apps/api/src/migrations/1876000000000-add-shipment-waybill-relay-failure-tracking.ts
@@ -1,0 +1,82 @@
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Waybill-relay failure tracking on `shipments` (#2073).
+ *
+ * Five columns, one CHECK and one partial index so that a lifecycle relay
+ * failing on every poll tick becomes a durable, operator-visible fact instead
+ * of one `logger.error` per tick against a job that still reports `succeeded`.
+ *
+ * Every column mirrors its `@Column` declaration on `ShipmentOrmEntity` exactly,
+ * and the CHECK and the index are declared there under these same names. That
+ * duplication is required rather than redundant: the integration harness builds
+ * schema by TypeORM `synchronize` and never runs migrations, so a constraint
+ * living only here would hold in production and silently not in tests.
+ *
+ * `TIMESTAMP` without time zone, matching `waybillRelayedAt` (migration
+ * `1832000000007`) and `reservationConsumedAt` on the same table. The repo is
+ * mixed on this, so the rule followed is consistency WITHIN the table — copying
+ * `webhook_auth_rejections`' `timestamptz` would have diverged the two schema
+ * sources for `shipments`.
+ *
+ * `waybillRelayFailureCount` keeps its `DEFAULT 0` rather than dropping it after
+ * backfill (the way `direction` drops its default in `1862000000000`), and the
+ * asymmetry is deliberate: `'outbound'` was a backfill guess that must not
+ * become an implicit answer for future inserts, whereas `0` is the true and
+ * permanent meaning of "this shipment has had no relay failure". Every existing
+ * row genuinely has none, and every future insert wants it.
+ */
+export class AddShipmentWaybillRelayFailureTracking1876000000000 implements MigrationInterface {
+  name = 'AddShipmentWaybillRelayFailureTracking1876000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE "shipments"
+        ADD COLUMN IF NOT EXISTS "waybillRelayFailureCount" integer NOT NULL DEFAULT 0,
+        ADD COLUMN IF NOT EXISTS "waybillRelayFirstFailedAt" TIMESTAMP,
+        ADD COLUMN IF NOT EXISTS "waybillRelayLastFailedAt" TIMESTAMP,
+        ADD COLUMN IF NOT EXISTS "waybillRelayLastFailureReason" text,
+        ADD COLUMN IF NOT EXISTS "waybillRelayLastFailureConnectionId" uuid
+    `);
+
+    // Idempotent: `ADD CONSTRAINT` has no `IF NOT EXISTS` form in Postgres, so
+    // guard on the catalogue. The counter can only ever be incremented from 0
+    // or reset to 0 by this codebase — the constraint documents that the column
+    // is a counter and catches a future writer that decrements.
+    await queryRunner.query(`
+      DO $$
+      BEGIN
+        IF NOT EXISTS (
+          SELECT 1 FROM pg_constraint
+          WHERE conname = 'CHK_shipments_waybill_relay_failure_count'
+        ) THEN
+          ALTER TABLE "shipments"
+            ADD CONSTRAINT "CHK_shipments_waybill_relay_failure_count"
+            CHECK ("waybillRelayFailureCount" >= 0);
+        END IF;
+      END $$;
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_shipments_waybill_relay_failing"
+        ON "shipments" ("waybillRelayLastFailedAt")
+        WHERE "waybillRelayFailureCount" > 0
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "public"."IDX_shipments_waybill_relay_failing"`);
+    await queryRunner.query(`
+      ALTER TABLE "shipments"
+        DROP CONSTRAINT IF EXISTS "CHK_shipments_waybill_relay_failure_count"
+    `);
+    await queryRunner.query(`
+      ALTER TABLE "shipments"
+        DROP COLUMN IF EXISTS "waybillRelayLastFailureConnectionId",
+        DROP COLUMN IF EXISTS "waybillRelayLastFailureReason",
+        DROP COLUMN IF EXISTS "waybillRelayLastFailedAt",
+        DROP COLUMN IF EXISTS "waybillRelayFirstFailedAt",
+        DROP COLUMN IF EXISTS "waybillRelayFailureCount"
+    `);
+  }
+}

--- a/apps/api/src/shipping/http/dto/bulk-dispatch-result-response.dto.ts
+++ b/apps/api/src/shipping/http/dto/bulk-dispatch-result-response.dto.ts
@@ -16,6 +16,7 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import type { BulkShipmentDispatchResult, PerOrderDispatchResult } from '@openlinker/core/shipping';
 import { ShipmentResponseDto } from './shipment-response.dto';
+import { resolveWaybillRelayThresholdFromEnv } from '../waybill-relay-threshold';
 
 export class PerOrderDispatchResultDto {
   @ApiProperty({ enum: ['dispatched', 'omp_fulfilled', 'failed'] })
@@ -41,7 +42,13 @@ export class PerOrderDispatchResultDto {
       // `canWrite: true` — POST /shipments/bulk/generate-labels is
       // `@Roles('admin', 'operator')`-gated, so the caller already holds
       // `shipments:write` and there is nothing to redact (#1826).
-      dto.shipment = ShipmentResponseDto.fromDomain(result.shipment, null, true, null);
+      dto.shipment = ShipmentResponseDto.fromDomain(
+        result.shipment,
+        null,
+        true,
+        null,
+        resolveWaybillRelayThresholdFromEnv(),
+      );
     } else if (result.kind === 'failed') {
       dto.error = result.error;
     }

--- a/apps/api/src/shipping/http/dto/dispatch-result-response.dto.ts
+++ b/apps/api/src/shipping/http/dto/dispatch-result-response.dto.ts
@@ -11,6 +11,7 @@
 import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import type { ShipmentDispatchResult } from '@openlinker/core/shipping';
 import { ShipmentResponseDto } from './shipment-response.dto';
+import { resolveWaybillRelayThresholdFromEnv } from '../waybill-relay-threshold';
 
 export class DispatchResultResponseDto {
   @ApiProperty({ enum: ['dispatched', 'omp_fulfilled'] })
@@ -29,7 +30,13 @@ export class DispatchResultResponseDto {
       // `canWrite: true` — POST /shipments/generate-label is `@Roles('admin',
       // 'operator')`-gated, so a caller who reached this projection already
       // holds `shipments:write` and there is nothing to redact (#1826).
-      dto.shipment = ShipmentResponseDto.fromDomain(result.shipment, null, true, null);
+      dto.shipment = ShipmentResponseDto.fromDomain(
+        result.shipment,
+        null,
+        true,
+        null,
+        resolveWaybillRelayThresholdFromEnv(),
+      );
     }
     return dto;
   }

--- a/apps/api/src/shipping/http/dto/list-shipments-query.dto.ts
+++ b/apps/api/src/shipping/http/dto/list-shipments-query.dto.ts
@@ -63,6 +63,17 @@ export class ListShipmentsQueryDto {
   @IsBoolean()
   hasTracking?: boolean;
 
+  @ApiPropertyOptional({
+    description:
+      'true → only shipments whose waybill relay has failed at least OL_WAYBILL_RELAY_FAILURE_ALERT_THRESHOLD times in a row (#2073) — the needs-attention bucket for a relay the marketplace never received. false is accepted and, like omitting the parameter, applies no filter: there is no meaningful "not stuck" cohort to select, since a shipment with no failures and one with two are equally not-escalated.',
+  })
+  @IsOptional()
+  @Transform(({ value }): unknown =>
+    value === 'true' ? true : value === 'false' ? false : value,
+  )
+  @IsBoolean()
+  waybillRelayStuck?: boolean;
+
   @ApiPropertyOptional({ description: 'Inclusive lower bound on createdAt (ISO-8601)' })
   @IsOptional()
   @IsDateString()

--- a/apps/api/src/shipping/http/dto/shipment-response.dto.spec.ts
+++ b/apps/api/src/shipping/http/dto/shipment-response.dto.spec.ts
@@ -32,12 +32,14 @@ function makeShipment(): Shipment {
     null,
     // #2402 fulfillmentWorkId — no work linkage in this fixture.
     null,
+    // #2073 waybill-relay failure history — none in this fixture.
+    null,
   );
 }
 
 describe('ShipmentResponseDto.fromDomain', () => {
   it('sets orderSummary to null when no summary is supplied', () => {
-    const dto = ShipmentResponseDto.fromDomain(makeShipment(), null, true, null);
+    const dto = ShipmentResponseDto.fromDomain(makeShipment(), null, true, null, 3);
     expect(dto.orderSummary).toBeNull();
   });
 
@@ -49,7 +51,7 @@ describe('ShipmentResponseDto.fromDomain', () => {
       itemCount: 2,
     };
 
-    const dto = ShipmentResponseDto.fromDomain(makeShipment(), null, true, summary);
+    const dto = ShipmentResponseDto.fromDomain(makeShipment(), null, true, summary, 3);
 
     expect(dto.orderSummary).toEqual(summary);
   });

--- a/apps/api/src/shipping/http/dto/shipment-response.dto.ts
+++ b/apps/api/src/shipping/http/dto/shipment-response.dto.ts
@@ -30,6 +30,7 @@ import {
 import type { Shipment, DeliveryIntent } from '@openlinker/core/shipping';
 import type { OrderSummary } from '@openlinker/core/orders';
 import { OrderSummaryProjectionDto } from '../../../orders/http/dto/order-summary-projection.dto';
+import { WaybillRelayResponseDto } from './waybill-relay-response.dto';
 
 /** Mirrors the FE's redaction placeholder (`shipments-page.tsx`,
  *  `shipment-row-detail.tsx`) so the copy is identical regardless of which
@@ -134,6 +135,14 @@ export class ShipmentResponseDto {
   })
   orderSummary!: OrderSummaryProjectionDto | null;
 
+  @ApiProperty({
+    nullable: true,
+    type: WaybillRelayResponseDto,
+    description:
+      "Consecutive waybill-relay failures (#2073) — null when this shipment's relay has never failed, or when a successful relay cleared the history. Carries a server-derived `stuck` flag; filter the escalated bucket with `?waybillRelayStuck=true`.",
+  })
+  waybillRelay!: WaybillRelayResponseDto | null;
+
   /**
    * @param canWrite Whether the requester holds `shipments:write` (resolved
    *   by the controller from `@CurrentUser()`'s role via `ROLE_PERMISSIONS`).
@@ -144,11 +153,19 @@ export class ShipmentResponseDto {
    *   when not resolved for this call site. Also required (not defaulted) so
    *   a future read path can't silently omit it.
    */
+  /**
+   * `waybillRelayAlertThreshold` is REQUIRED (#2073), like `canWrite` beside
+   * it and for the same reason: an optional parameter with a default would let
+   * a call site silently render a different escalation rule from the one the
+   * list filter selected rows with. Every caller resolves it through
+   * `resolveWaybillRelayThresholdFromEnv()`, the single reader of the variable.
+   */
   static fromDomain(
     shipment: Shipment,
     customerId: string | null,
     canWrite: boolean,
     orderSummary: OrderSummary | null,
+    waybillRelayAlertThreshold: number,
   ): ShipmentResponseDto {
     const dto = new ShipmentResponseDto();
     dto.id = shipment.id;
@@ -175,6 +192,10 @@ export class ShipmentResponseDto {
     dto.createdAt = shipment.createdAt.toISOString();
     dto.updatedAt = shipment.updatedAt.toISOString();
     dto.orderSummary = orderSummary ? OrderSummaryProjectionDto.fromSummary(orderSummary) : null;
+    dto.waybillRelay = WaybillRelayResponseDto.fromDomain(
+      shipment.waybillRelayFailure,
+      waybillRelayAlertThreshold,
+    );
     return dto;
   }
 }

--- a/apps/api/src/shipping/http/dto/waybill-relay-response.dto.ts
+++ b/apps/api/src/shipping/http/dto/waybill-relay-response.dto.ts
@@ -1,0 +1,94 @@
+/**
+ * Waybill Relay Failure Response DTO (#2073)
+ *
+ * The operator-facing projection of a shipment's consecutive waybill-relay
+ * failures. `null` on `ShipmentResponseDto` means the relay has never failed,
+ * or that its history was cleared by a relay that succeeded.
+ *
+ * **The backend derives `stuck`; the frontend renders it.** `apps/web` cannot
+ * import `@openlinker/core` (#591), so a browser-side comparison against the
+ * threshold would be a mirror needing a `check:invariants` guard. Shipping the
+ * boolean means there is no shared rule to mirror at all — strictly better than
+ * a guarded copy, and the reason no mirror script accompanies this change.
+ *
+ * **No role gating.** `GET /shipments` redacts `errorMessage` for a caller
+ * without `shipments:write` because it is free-text carrier content; nothing
+ * here is. `lastFailureReason` is a closed code vocabulary and
+ * `lastFailureConnectionId` names one of the operator's own connections, which
+ * every row already exposes unconditionally as `connectionId`.
+ *
+ * @module apps/api/src/shipping/http/dto
+ */
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  isWaybillRelayStuck,
+  WaybillRelayFailureReasonValues,
+  type WaybillRelayFailure,
+  type WaybillRelayFailureReason,
+} from '@openlinker/core/shipping';
+
+export class WaybillRelayResponseDto {
+  @ApiProperty({
+    description:
+      'Consecutive failed attempts to relay this shipment\'s waybill to the order\'s participants. Reset to zero by a relay that succeeds.',
+  })
+  failureCount!: number;
+
+  @ApiProperty({
+    description:
+      'Whether the failure count has reached the escalation threshold (OL_WAYBILL_RELAY_FAILURE_ALERT_THRESHOLD, default 3). Derived server-side so no client re-implements the rule. A single transient failure never sets this — the threshold is clamped to a minimum of 2.',
+  })
+  stuck!: boolean;
+
+  @ApiProperty({
+    type: String,
+    format: 'date-time',
+    description: 'When the current run of failures began.',
+  })
+  firstFailedAt!: string;
+
+  @ApiProperty({
+    type: String,
+    format: 'date-time',
+    description:
+      'The most recent failure. Distinguishes a relay that is still being retried from a frozen historical count on a shipment that has since reached a terminal status, which the status-sync scan no longer visits.',
+  })
+  lastFailedAt!: string;
+
+  @ApiProperty({
+    enum: WaybillRelayFailureReasonValues,
+    nullable: true,
+    description:
+      "Why the last attempt failed. 'rejected' — a participant's adapter refused the write; 'adapter-unresolved' — its adapter could not be built (disabled connection, credential failure); 'threw' — the relay failed before any participant was resolved. Null when the stored value is not one this build recognises. The adapter's own message is logged, never persisted here.",
+  })
+  lastFailureReason!: WaybillRelayFailureReason | null;
+
+  @ApiProperty({
+    nullable: true,
+    description:
+      'The first participant connection in the failing set, for display only — no retry decision reads it. Null for a failure that happened before any participant was resolved. Per-destination retry state is #861.',
+  })
+  lastFailureConnectionId!: string | null;
+
+  /**
+   * `threshold` is a REQUIRED parameter, never resolved in here. A DTO reading
+   * `process.env` would be a second reader of the value the list filter was
+   * built from, and the two could then disagree about which rows are stuck.
+   */
+  static fromDomain(
+    failure: WaybillRelayFailure | null,
+    threshold: number,
+  ): WaybillRelayResponseDto | null {
+    if (failure === null) {
+      return null;
+    }
+    const dto = new WaybillRelayResponseDto();
+    dto.failureCount = failure.count;
+    dto.stuck = isWaybillRelayStuck(failure, threshold);
+    dto.firstFailedAt = failure.firstFailedAt.toISOString();
+    dto.lastFailedAt = failure.lastFailedAt.toISOString();
+    dto.lastFailureReason = failure.reason;
+    dto.lastFailureConnectionId = failure.connectionId;
+    return dto;
+  }
+}

--- a/apps/api/src/shipping/http/shipment.controller.spec.ts
+++ b/apps/api/src/shipping/http/shipment.controller.spec.ts
@@ -85,6 +85,8 @@ function makeShipment(overrides: Partial<Shipment> = {}): Shipment {
     overrides.direction ?? 'outbound',
     overrides.reservationConsumedAt ?? null,
     overrides.fulfillmentWorkId ?? null,
+    // #2073 waybill-relay failure history — none by default.
+    overrides.waybillRelayFailure ?? null,
   );
 }
 

--- a/apps/api/src/shipping/http/shipment.controller.ts
+++ b/apps/api/src/shipping/http/shipment.controller.ts
@@ -90,6 +90,7 @@ import { ListShipmentsQueryDto } from './dto/list-shipments-query.dto';
 import { NotifyDispatchedResponseDto } from './dto/notify-dispatched-response.dto';
 import { PaginatedShipmentsResponseDto } from './dto/paginated-shipments-response.dto';
 import { REDACTED_ERROR_MESSAGE, ShipmentResponseDto } from './dto/shipment-response.dto';
+import { resolveWaybillRelayThresholdFromEnv } from './waybill-relay-threshold';
 
 @ApiBearerAuth()
 @ApiTags('shipments')
@@ -125,6 +126,10 @@ export class ShipmentController {
   ): Promise<PaginatedShipmentsResponseDto> {
     const limit = query.limit ?? 20;
     const offset = query.offset ?? 0;
+    // #2073. Resolved ONCE per request and used for both the filter below and
+    // every row's `stuck` flag, so the rows returned and the badges rendered on
+    // them cannot be computed from two different thresholds.
+    const waybillRelayAlertThreshold = resolveWaybillRelayThresholdFromEnv();
     const filters: ShipmentFilters = {
       orderId: query.orderId,
       status: query.status,
@@ -132,6 +137,12 @@ export class ShipmentController {
       connectionId: query.connectionId,
       shippingMethod: query.shippingMethod,
       hasTracking: query.hasTracking,
+      // The boolean is translated to the numeric floor HERE, at the HTTP
+      // boundary — which is also where `createdFrom`/`createdTo` are coerced
+      // from strings. `false` deliberately applies no filter rather than
+      // selecting the complement: see the query DTO's description.
+      waybillRelayFailureCountAtLeast:
+        query.waybillRelayStuck === true ? waybillRelayAlertThreshold : undefined,
       createdFrom: query.createdFrom ? new Date(query.createdFrom) : undefined,
       createdTo: query.createdTo ? new Date(query.createdTo) : undefined,
     };
@@ -147,6 +158,7 @@ export class ShipmentController {
           context?.customerId ?? null,
           canWrite,
           context?.orderSummary ?? null,
+          waybillRelayAlertThreshold,
         );
       }),
       total: page.total,
@@ -179,6 +191,7 @@ export class ShipmentController {
       await this.resolveCustomerId(shipment.orderId),
       this.hasShipmentsWrite(user),
       null,
+      resolveWaybillRelayThresholdFromEnv(),
     );
   }
 
@@ -200,6 +213,7 @@ export class ShipmentController {
       await this.resolveCustomerId(shipment.orderId),
       this.hasShipmentsWrite(user),
       null,
+      resolveWaybillRelayThresholdFromEnv(),
     );
   }
 
@@ -363,7 +377,13 @@ export class ShipmentController {
     try {
       const shipment = await this.cancellation.cancel(id);
       // `@Roles('admin', 'operator')`-gated — the caller holds `shipments:write`.
-      return ShipmentResponseDto.fromDomain(shipment, null, true, null);
+      return ShipmentResponseDto.fromDomain(
+        shipment,
+        null,
+        true,
+        null,
+        resolveWaybillRelayThresholdFromEnv(),
+      );
     } catch (error) {
       throw this.toHttpException(error, true);
     }

--- a/apps/api/src/shipping/http/waybill-relay-threshold.ts
+++ b/apps/api/src/shipping/http/waybill-relay-threshold.ts
@@ -1,0 +1,28 @@
+/**
+ * Waybill-relay escalation threshold — the one place `process.env` is read (#2073)
+ *
+ * `resolveWaybillRelayAlertThreshold` in `@openlinker/core/shipping` owns the
+ * RULE (the default and the clamps); this owns the single read of the variable
+ * that feeds it, so the filter that selects the stuck bucket and the badge
+ * rendered on each row cannot be computed from two different numbers — the
+ * reported-versus-enforced gap #2229 exists to close.
+ *
+ * Read by the **api** process only. The worker increments the counter and never
+ * compares it, so this variable is documented in `apps/api/.env.example` and
+ * deliberately not in the worker's — an env rung answers for the process that
+ * reads it, and listing it where nothing reads it is how an operator comes to
+ * believe they have changed something they have not.
+ *
+ * Resolved per call rather than cached at boot, matching how the AI provider
+ * setting is read on every completion: one `process.env` lookup is far cheaper
+ * than an operator discovering their change needs a restart.
+ *
+ * @module apps/api/src/shipping/http
+ */
+import { resolveWaybillRelayAlertThreshold } from '@openlinker/core/shipping';
+
+export const WAYBILL_RELAY_ALERT_THRESHOLD_ENV = 'OL_WAYBILL_RELAY_FAILURE_ALERT_THRESHOLD';
+
+export function resolveWaybillRelayThresholdFromEnv(): number {
+  return resolveWaybillRelayAlertThreshold(process.env[WAYBILL_RELAY_ALERT_THRESHOLD_ENV]);
+}

--- a/apps/api/test/integration/shipment-waybill-relay-failure.int-spec.ts
+++ b/apps/api/test/integration/shipment-waybill-relay-failure.int-spec.ts
@@ -1,0 +1,133 @@
+/**
+ * Waybill-Relay Failure Tracking — Schema Integration Test (#2073)
+ *
+ * The five failure columns, their CHECK and their partial index are declared
+ * TWICE — on `ShipmentOrmEntity` and in migration `1876000000000` — under
+ * identical names. This spec is what makes that duplication verifiable rather
+ * than merely intended: the harness builds schema by TypeORM `synchronize` and
+ * never runs migrations, so a constraint present only in the migration would
+ * hold in production and silently not in any test.
+ *
+ * It asserts the **entity** side, which is the half `synchronize` can answer
+ * for. Whole-table migration-versus-`synchronize` parity for `shipments` is a
+ * separate, larger question — `fulfillment-work-migration-parity.int-spec.ts`
+ * has an extensible `TABLES` list and `shipments` is deliberately not in it
+ * yet: that table predates most of this repo's migration discipline, so adding
+ * it may surface pre-existing drift unrelated to this change and is worth its
+ * own issue rather than being smuggled in here.
+ *
+ * Raw SQL against the harness DataSource, deliberately: `apps/**` may not
+ * import a core `*RepositoryPort` (`scripts/check-cross-context-imports.mjs`),
+ * and a catalogue read is what these assertions are actually about.
+ *
+ * @module apps/api/test/integration
+ */
+import { getTestHarness, resetTestHarness, teardownTestHarness } from './setup';
+
+describe('shipments waybill-relay failure columns (#2073)', () => {
+  let query: (sql: string, params?: unknown[]) => Promise<unknown>;
+
+  beforeAll(async () => {
+    const harness = await getTestHarness();
+    const dataSource = harness.getDataSource();
+    query = (sql, params) => dataSource.query(sql, params);
+  }, 120_000);
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  beforeEach(async () => {
+    await resetTestHarness();
+  });
+
+  it('should declare all five columns with the table-consistent timestamp type', async () => {
+    const rows = (await query(
+      `SELECT column_name, data_type, is_nullable, column_default
+         FROM information_schema.columns
+        WHERE table_schema = 'public'
+          AND table_name = 'shipments'
+          AND column_name LIKE 'waybillRelay%'
+        ORDER BY column_name`,
+    )) as ReadonlyArray<{
+      column_name: string;
+      data_type: string;
+      is_nullable: string;
+      column_default: string | null;
+    }>;
+
+    const byName = new Map(rows.map((r) => [r.column_name, r]));
+
+    // The pre-existing claim marker, included so the timestamp-type assertions
+    // below are anchored to something this change did not author.
+    expect(byName.get('waybillRelayedAt')?.data_type).toBe('timestamp without time zone');
+
+    // `integer NOT NULL DEFAULT 0`. The DEFAULT is load-bearing on a
+    // `synchronize`-built schema, which takes it from the DECORATOR rather
+    // than from the migration (docs/lessons.md, out-of-band-UPDATE entry).
+    expect(byName.get('waybillRelayFailureCount')?.data_type).toBe('integer');
+    expect(byName.get('waybillRelayFailureCount')?.is_nullable).toBe('NO');
+    expect(byName.get('waybillRelayFailureCount')?.column_default).toBe('0');
+
+    // Plain `timestamp`, matching every other timestamp on this table — NOT
+    // the `timestamptz` the webhook_auth_rejections counter (#1814) uses.
+    expect(byName.get('waybillRelayFirstFailedAt')?.data_type).toBe(
+      'timestamp without time zone',
+    );
+    expect(byName.get('waybillRelayLastFailedAt')?.data_type).toBe('timestamp without time zone');
+    expect(byName.get('waybillRelayFirstFailedAt')?.is_nullable).toBe('YES');
+    expect(byName.get('waybillRelayLastFailedAt')?.is_nullable).toBe('YES');
+
+    expect(byName.get('waybillRelayLastFailureReason')?.data_type).toBe('text');
+    expect(byName.get('waybillRelayLastFailureConnectionId')?.data_type).toBe('uuid');
+  });
+
+  it('should carry the named CHECK constraint on the synchronize-built schema', async () => {
+    const rows = (await query(
+      `SELECT pg_get_constraintdef(oid) AS def
+         FROM pg_constraint
+        WHERE conname = 'CHK_shipments_waybill_relay_failure_count'`,
+    )) as ReadonlyArray<{ def: string }>;
+
+    expect(rows).toHaveLength(1);
+    // Copied from a REAL rendered value, not from the DDL as typed:
+    // `pg_get_constraintdef` quotes a camelCase identifier and would render an
+    // all-lowercase one unquoted (docs/lessons.md, schema-assertion entry).
+    expect(rows[0].def).toContain('"waybillRelayFailureCount" >= 0');
+  });
+
+  it('should refuse a negative failure count', async () => {
+    // The constraint documents that the column is a counter and catches a
+    // future writer that decrements. Nothing in this codebase can reach it
+    // today, which is exactly why it is asserted directly.
+    await expect(
+      query(
+        `INSERT INTO "shipments"
+           ("id", "orderId", "connectionId", "direction", "shippingMethod",
+            "status", "waybillRelayFailureCount", "createdAt", "updatedAt")
+         VALUES ($1, $2, $3, 'outbound', 'kurier', 'draft', -1, now(), now())`,
+        [
+          'ol_shipment_ffffffffffffffffffffffffffffffff',
+          'ol_order_ffffffffffffffffffffffffffffffff',
+          '00000000-0000-0000-0000-0000000000ff',
+        ],
+      ),
+    ).rejects.toThrow(/CHK_shipments_waybill_relay_failure_count/);
+  });
+
+  it('should carry the partial index restricted to rows with a failure', async () => {
+    const rows = (await query(
+      `SELECT indexdef FROM pg_indexes
+        WHERE schemaname = 'public'
+          AND tablename = 'shipments'
+          AND indexname = 'IDX_shipments_waybill_relay_failing'`,
+    )) as ReadonlyArray<{ indexdef: string }>;
+
+    expect(rows).toHaveLength(1);
+    // PARTIAL is the point: every row is born outside this index (the count
+    // defaults to 0), so it stays near-empty and shrinks as relays succeed.
+    expect(rows[0].indexdef).toContain('WHERE');
+    expect(rows[0].indexdef).toContain('"waybillRelayFailureCount" > 0');
+    expect(rows[0].indexdef).toContain('waybillRelayLastFailedAt');
+  });
+});

--- a/apps/web/src/features/orders/components/bulk-dispatch-dialog.test.tsx
+++ b/apps/web/src/features/orders/components/bulk-dispatch-dialog.test.tsx
@@ -69,6 +69,8 @@ function shipment(id: string, carrier: string, connectionId: string): Shipment {
     createdAt: '2026-01-01T00:00:00.000Z',
     updatedAt: '2026-01-01T00:00:00.000Z',
     orderSummary: null,
+    // #2073 waybill-relay failure history — none by default.
+    waybillRelay: null,
   };
 }
 

--- a/apps/web/src/features/orders/components/order-shipment-panel.test.tsx
+++ b/apps/web/src/features/orders/components/order-shipment-panel.test.tsx
@@ -93,6 +93,8 @@ function makeShipment(overrides: Partial<Shipment> = {}): Shipment {
     createdAt: '2026-05-28T10:00:00.000Z',
     updatedAt: '2026-05-28T11:00:00.000Z',
     orderSummary: null,
+    // #2073 waybill-relay failure history — none by default.
+    waybillRelay: null,
     ...overrides,
   };
 }

--- a/apps/web/src/features/orders/components/shipment-action-buttons.test.tsx
+++ b/apps/web/src/features/orders/components/shipment-action-buttons.test.tsx
@@ -103,6 +103,8 @@ function makeDownloadableShipment(): Shipment {
     createdAt: '2026-08-01T00:00:00.000Z',
     updatedAt: '2026-08-01T00:00:00.000Z',
     orderSummary: null,
+    // #2073 waybill-relay failure history — none by default.
+    waybillRelay: null,
   };
 }
 

--- a/apps/web/src/features/shipments/api/shipments.api.ts
+++ b/apps/web/src/features/shipments/api/shipments.api.ts
@@ -76,6 +76,8 @@ function buildQuery(filters?: ShipmentFilters, pagination?: ShipmentPagination):
   if (filters?.connectionId) params.set('connectionId', filters.connectionId);
   if (filters?.shippingMethod) params.set('shippingMethod', filters.shippingMethod);
   if (filters?.hasTracking !== undefined) params.set('hasTracking', String(filters.hasTracking));
+  // #2073. Only ever sent as `true` — see the field's note in shipments.types.ts.
+  if (filters?.waybillRelayStuck === true) params.set('waybillRelayStuck', 'true');
   if (filters?.hasProviderShipmentId !== undefined)
     params.set('hasProviderShipmentId', String(filters.hasProviderShipmentId));
   if (filters?.createdFrom) params.set('createdFrom', filters.createdFrom);

--- a/apps/web/src/features/shipments/api/shipments.types.ts
+++ b/apps/web/src/features/shipments/api/shipments.types.ts
@@ -147,7 +147,54 @@ export interface Shipment {
    * (not fetched there).
    */
   orderSummary: OrderSummary | null;
+  /**
+   * Consecutive waybill-relay failures (#2073), or `null` when this shipment's
+   * relay has never failed / a successful relay cleared the history.
+   *
+   * `stuck` is derived SERVER-SIDE and rendered here as-is. The threshold that
+   * produces it deliberately has no frontend copy: `apps/web` cannot import
+   * `@openlinker/core` (#591), so a browser-side comparison would be a mirror
+   * needing a `check:invariants` guard, and shipping the boolean means there is
+   * no shared rule to mirror at all. Do not reintroduce the comparison here.
+   */
+  waybillRelay: WaybillRelay | null;
 }
+
+/**
+ * FE mirror of the BE `WaybillRelayResponseDto` (#2073). Hand-maintained under
+ * the FE-001 hand-written-contract strategy.
+ *
+ * `lastFailureReason` is a closed BE vocabulary and is typed as a union so an
+ * unlabelled new member fails type-check at `WAYBILL_RELAY_REASON_LABEL` below
+ * rather than rendering a raw code. It is nullable because the backend coerces
+ * an unrecognised stored value to null rather than asserting it onward.
+ */
+export interface WaybillRelay {
+  failureCount: number;
+  stuck: boolean;
+  firstFailedAt: string;
+  lastFailedAt: string;
+  lastFailureReason: WaybillRelayFailureReason | null;
+  lastFailureConnectionId: string | null;
+}
+
+export const WAYBILL_RELAY_FAILURE_REASON_VALUES = [
+  'rejected',
+  'adapter-unresolved',
+  'threw',
+] as const;
+export type WaybillRelayFailureReason = (typeof WAYBILL_RELAY_FAILURE_REASON_VALUES)[number];
+
+/**
+ * Operator-readable label per failure reason. `Record<Reason, string>` (not
+ * `Partial<>`) so a new BE member fails type-check until labelled — the same
+ * FE↔BE drift discipline as `SHIPPING_METHOD_LABEL`.
+ */
+export const WAYBILL_RELAY_REASON_LABEL: Record<WaybillRelayFailureReason, string> = {
+  rejected: 'the channel refused the update',
+  'adapter-unresolved': 'the connection could not be reached',
+  threw: 'the order participants could not be resolved',
+};
 
 /**
  * Known carrier-of-record vocabulary (#769) — mirrors `KnownCarrierValues` in
@@ -290,6 +337,15 @@ export interface ShipmentFilters {
    * "OMP-fulfilled" rows.
    */
   hasProviderShipmentId?: boolean;
+  /**
+   * `true` → only shipments whose waybill relay has failed enough times in a
+   * row to escalate (#2073). The threshold lives server-side; this filter says
+   * "give me the escalated ones" without the browser knowing the number.
+   *
+   * `false` is never sent — there is no meaningful "not stuck" cohort, since a
+   * shipment with no failures and one with two are equally not-escalated.
+   */
+  waybillRelayStuck?: boolean;
   /** Inclusive lower bound on createdAt (ISO 8601 / `YYYY-MM-DD`). */
   createdFrom?: string;
   /** Inclusive upper bound on createdAt (ISO 8601 / `YYYY-MM-DD`). */

--- a/apps/web/src/features/shipments/components/shipment-row-detail.test.tsx
+++ b/apps/web/src/features/shipments/components/shipment-row-detail.test.tsx
@@ -38,6 +38,8 @@ function makeShipment(overrides: Partial<Shipment> = {}): Shipment {
     createdAt: '2026-07-24T09:11:00.000Z',
     updatedAt: '2026-07-24T09:12:00.000Z',
     orderSummary: null,
+    // #2073 waybill-relay failure history — none by default.
+    waybillRelay: null,
     ...overrides,
   };
 }

--- a/apps/web/src/features/shipments/components/shipment-triage-strip.test.tsx
+++ b/apps/web/src/features/shipments/components/shipment-triage-strip.test.tsx
@@ -40,6 +40,8 @@ function makeShipment(overrides: Partial<Shipment> = {}): Shipment {
     createdAt: '2026-07-24T09:11:00.000Z',
     updatedAt: '2026-07-24T09:12:00.000Z',
     orderSummary: null,
+    // #2073 waybill-relay failure history — none by default.
+    waybillRelay: null,
     ...overrides,
   };
 }

--- a/apps/web/src/features/shipments/components/waybill-relay-stuck-badge.test.tsx
+++ b/apps/web/src/features/shipments/components/waybill-relay-stuck-badge.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * Waybill Relay Stuck Badge — Tests (#2073)
+ *
+ * @module apps/web/src/features/shipments/components
+ */
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import type { WaybillRelay } from '../api/shipments.types';
+import { WaybillRelayStuckBadge, describeWaybillRelayStuck } from './waybill-relay-stuck-badge';
+
+function relay(overrides: Partial<WaybillRelay> = {}): WaybillRelay {
+  return {
+    failureCount: 4,
+    stuck: true,
+    firstFailedAt: '2026-05-19T10:00:00.000Z',
+    lastFailedAt: '2026-05-19T14:00:00.000Z',
+    lastFailureReason: 'rejected',
+    lastFailureConnectionId: '00000000-0000-0000-0000-0000000000aa',
+    ...overrides,
+  };
+}
+
+afterEach(cleanup);
+
+describe('WaybillRelayStuckBadge', () => {
+  it('renders nothing when the shipment has no relay failure history', () => {
+    const { container } = render(<WaybillRelayStuckBadge waybillRelay={null} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders nothing while the failures are below the escalation threshold', () => {
+    // `stuck` is the BACKEND's answer — this component never compares a count
+    // to a threshold, so a low count with `stuck: true` would still render.
+    // That is deliberate: the rule has exactly one home (#591, #2229).
+    const { container } = render(
+      <WaybillRelayStuckBadge waybillRelay={relay({ failureCount: 2, stuck: false })} />,
+    );
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders the badge once the backend reports the relay as stuck', () => {
+    render(<WaybillRelayStuckBadge waybillRelay={relay()} />);
+
+    expect(screen.getByText('Tracking not sent')).toBeInTheDocument();
+  });
+
+  it('exposes the cause as real text, not only as a hover title', () => {
+    // `title` is not reliably surfaced by assistive tech, so the sentence is
+    // also `sr-only` content inside the badge.
+    render(<WaybillRelayStuckBadge waybillRelay={relay()} />);
+
+    expect(
+      screen.getByText(/the channel refused the update/, { exact: false }),
+    ).toBeInTheDocument();
+  });
+});
+
+describe('describeWaybillRelayStuck', () => {
+  it('names the attempt count and the cause', () => {
+    expect(describeWaybillRelayStuck(relay({ failureCount: 4 }))).toContain('4 attempts');
+    expect(describeWaybillRelayStuck(relay())).toContain('the channel refused the update');
+    expect(describeWaybillRelayStuck(relay())).toContain('The buyer has not been notified.');
+  });
+
+  it('singularises a single attempt', () => {
+    expect(describeWaybillRelayStuck(relay({ failureCount: 1 }))).toContain('after 1 attempt');
+    expect(describeWaybillRelayStuck(relay({ failureCount: 2 }))).toContain('after 2 attempts');
+  });
+
+  it('omits the cause rather than guessing when the reason is unrecognised', () => {
+    // The backend coerces a value this build does not know to null; inventing
+    // copy for it would state something nothing observed.
+    const text = describeWaybillRelayStuck(relay({ lastFailureReason: null }));
+
+    expect(text).toContain('has not reached the sales channel');
+    expect(text).not.toContain('last failure');
+  });
+});

--- a/apps/web/src/features/shipments/components/waybill-relay-stuck-badge.tsx
+++ b/apps/web/src/features/shipments/components/waybill-relay-stuck-badge.tsx
@@ -1,0 +1,76 @@
+/**
+ * Waybill Relay Stuck Badge (#2073)
+ *
+ * Renders on a `/shipments` row whose waybill relay has failed enough times in
+ * a row to escalate — the operator-facing half of a condition that used to
+ * produce one `logger.error` per poll tick and nothing else, while the
+ * marketplace silently never learned the order shipped.
+ *
+ * **`stuck` is read, never derived.** The backend owns the threshold and ships
+ * the boolean; `apps/web` cannot import `@openlinker/core` (#591), so
+ * recomputing it here would be a mirror needing a `check:invariants` guard.
+ * There is deliberately no comparison in this file.
+ *
+ * **It sits BESIDE the status badge, never inside the severity word.**
+ * `deriveSeverityLabel` returns exactly one of Fix / Finish / Send / View and
+ * partitions the rows; a stuck relay is orthogonal to it — a `delivered`
+ * shipment can carry one, because the parcel arrived and the channel was still
+ * never told. Folding it in would either hide a dispatch problem behind a relay
+ * one or claim two facts with one word. Same reasoning as the reservation
+ * shortfall badge sitting beside order health rather than inside it (#2350).
+ *
+ * @module apps/web/src/features/shipments/components
+ */
+import type { ReactElement } from 'react';
+
+import { StatusBadge } from '../../../shared/ui/status-badge';
+import { WAYBILL_RELAY_REASON_LABEL, type WaybillRelay } from '../api/shipments.types';
+
+export interface WaybillRelayStuckBadgeProps {
+  waybillRelay: WaybillRelay | null;
+}
+
+/**
+ * The full sentence, used as the badge's `title` so the short label stays
+ * scannable while the cause is one hover away.
+ *
+ * An unrecognised reason degrades to the count alone rather than to a guess —
+ * the backend coerces a value this build does not know to `null`, and inventing
+ * copy for it would state something about the operator's system that nothing
+ * observed.
+ */
+export function describeWaybillRelayStuck(waybillRelay: WaybillRelay): string {
+  const attempts = `${waybillRelay.failureCount} attempt${waybillRelay.failureCount === 1 ? '' : 's'}`;
+  const cause =
+    waybillRelay.lastFailureReason === null
+      ? null
+      : WAYBILL_RELAY_REASON_LABEL[waybillRelay.lastFailureReason];
+  const base = `The tracking number has not reached the sales channel after ${attempts}`;
+  return cause === null
+    ? `${base}. The buyer has not been notified.`
+    : `${base} - last failure: ${cause}. The buyer has not been notified.`;
+}
+
+export function WaybillRelayStuckBadge({
+  waybillRelay,
+}: WaybillRelayStuckBadgeProps): ReactElement | null {
+  // Absence and not-escalated are both "render nothing", but they are different
+  // facts and only the backend can tell them apart - so neither is asserted here.
+  if (waybillRelay === null || !waybillRelay.stuck) {
+    return null;
+  }
+  const description = describeWaybillRelayStuck(waybillRelay);
+  return (
+    // `StatusBadge` takes no `title`, and widening a primitive every surface
+    // renders for one caller is the wrong trade — so the hover affordance sits
+    // on a wrapper, the `.listing-cell__reason` precedent (#2231). The same
+    // sentence is also real `sr-only` text rather than only a `title`, because
+    // `title` is not reliably exposed by assistive tech.
+    <span title={description}>
+      <StatusBadge tone="error" withDot compact>
+        Tracking not sent
+        <span className="sr-only"> — {description}</span>
+      </StatusBadge>
+    </span>
+  );
+}

--- a/apps/web/src/features/shipments/lib/carrier-tracking-url.test.ts
+++ b/apps/web/src/features/shipments/lib/carrier-tracking-url.test.ts
@@ -33,6 +33,8 @@ function makeShipment(overrides: Partial<Shipment> = {}): Shipment {
     createdAt: '2026-05-28T09:00:00.000Z',
     updatedAt: '2026-05-28T10:00:00.000Z',
     orderSummary: null,
+    // #2073 waybill-relay failure history — none by default.
+    waybillRelay: null,
     ...overrides,
   };
 }

--- a/apps/web/src/features/shipments/lib/group-failed-shipments-by-cause.test.ts
+++ b/apps/web/src/features/shipments/lib/group-failed-shipments-by-cause.test.ts
@@ -34,6 +34,8 @@ function makeShipment(overrides: Partial<Shipment> = {}): Shipment {
     createdAt: '2026-07-24T09:11:00.000Z',
     updatedAt: '2026-07-24T09:12:00.000Z',
     orderSummary: null,
+    // #2073 waybill-relay failure history — none by default.
+    waybillRelay: null,
     ...overrides,
   };
 }

--- a/apps/web/src/features/shipments/lib/processor.test.ts
+++ b/apps/web/src/features/shipments/lib/processor.test.ts
@@ -34,6 +34,8 @@ function makeShipment(overrides: Partial<Shipment> = {}): Shipment {
     createdAt: '2026-05-29T10:00:00.000Z',
     updatedAt: '2026-05-29T10:00:00.000Z',
     orderSummary: null,
+    // #2073 waybill-relay failure history — none by default.
+    waybillRelay: null,
     ...overrides,
   };
 }

--- a/apps/web/src/features/shipments/lib/shipment-action-eligibility.test.ts
+++ b/apps/web/src/features/shipments/lib/shipment-action-eligibility.test.ts
@@ -42,6 +42,8 @@ function makeShipment(overrides: Partial<Shipment> = {}): Shipment {
     createdAt: '2026-07-24T09:11:00.000Z',
     updatedAt: '2026-07-24T09:12:00.000Z',
     orderSummary: null,
+    // #2073 waybill-relay failure history — none by default.
+    waybillRelay: null,
     ...overrides,
   };
 }

--- a/apps/web/src/features/shipments/lib/shipment-severity.test.ts
+++ b/apps/web/src/features/shipments/lib/shipment-severity.test.ts
@@ -31,6 +31,8 @@ function makeShipment(overrides: Partial<Shipment> = {}): Shipment {
     createdAt: '2026-07-24T09:11:00.000Z',
     updatedAt: '2026-07-24T09:12:00.000Z',
     orderSummary: null,
+    // #2073 waybill-relay failure history — none by default.
+    waybillRelay: null,
     ...overrides,
   };
 }

--- a/apps/web/src/pages/shipments/shipments-page.test.tsx
+++ b/apps/web/src/pages/shipments/shipments-page.test.tsx
@@ -35,6 +35,8 @@ function makeShipment(overrides: Partial<Shipment> = {}): Shipment {
     createdAt: '2026-05-20T10:00:00.000Z',
     updatedAt: '2026-05-20T10:00:00.000Z',
     orderSummary: null,
+    // #2073 waybill-relay failure history — none by default.
+    waybillRelay: null,
     ...overrides,
   };
 }

--- a/apps/web/src/pages/shipments/shipments-page.tsx
+++ b/apps/web/src/pages/shipments/shipments-page.tsx
@@ -28,6 +28,7 @@ import { Input } from '../../shared/ui/input';
 import { TimeDisplay } from '../../shared/ui/time-display';
 import { usePermission } from '../../shared/auth/use-permission';
 import { ShipmentStatusBadge } from '../../features/shipments/components/shipment-status-badge';
+import { WaybillRelayStuckBadge } from '../../features/shipments/components/waybill-relay-stuck-badge';
 import { ProcessorBadge } from '../../features/shipments/components/processor-badge';
 import { ShipmentTriageStrip } from '../../features/shipments/components/shipment-triage-strip';
 import { ShipmentRowDetail } from '../../features/shipments/components/shipment-row-detail';
@@ -111,6 +112,11 @@ function ShipmentStatusCell({ shipment, canWrite }: { shipment: Shipment; canWri
   return (
     <div className="shipment-status-cell">
       <ShipmentStatusBadge status={shipment.status} />
+      {/* #2073. BESIDE the status badge, never folded into it or into the
+          severity word: a stuck relay is orthogonal to both, and a `delivered`
+          shipment can carry one - the parcel arrived and the channel was still
+          never told. Renders nothing unless the backend says `stuck`. */}
+      <WaybillRelayStuckBadge waybillRelay={shipment.waybillRelay} />
       {showError ? (
         <span className="shipment-status-cell__error">
           <span className="shipment-status-cell__error-message" title={canWrite ? (shipment.errorMessage ?? undefined) : undefined}>
@@ -152,6 +158,9 @@ export function ShipmentsPage(): ReactElement {
   // processor filter is set) so users can't put the BE filters in a
   // contradictory state.
   const processor = parseProcessorFilter(searchParams.get('processor'));
+  // #2073. Present-and-'true' is the only meaningful state: there is no "not
+  // stuck" cohort worth selecting, so the param is either on or absent.
+  const waybillRelayStuck = searchParams.get('waybillRelayStuck') === 'true' ? true : undefined;
   const createdFrom = searchParams.get('createdFrom') ?? undefined;
   const createdTo = searchParams.get('createdTo') ?? undefined;
   const offset = Number(searchParams.get('offset') ?? '0');
@@ -160,6 +169,7 @@ export function ShipmentsPage(): ReactElement {
     status,
     connectionId,
     hasTracking,
+    waybillRelayStuck,
     createdFrom,
     createdTo: createdTo ? inclusiveEndOfDay(createdTo) : undefined,
     // Spread the processor filter LAST so it overrides any raw `shippingMethod`
@@ -238,6 +248,7 @@ export function ShipmentsPage(): ReactElement {
         'processor',
         'connectionId',
         'hasTracking',
+        'waybillRelayStuck',
         'createdFrom',
         'createdTo',
         'offset',
@@ -254,6 +265,7 @@ export function ShipmentsPage(): ReactElement {
       processor ||
       connectionId ||
       hasTracking !== undefined ||
+      waybillRelayStuck !== undefined ||
       createdFrom ||
       createdTo,
   );
@@ -519,6 +531,18 @@ export function ShipmentsPage(): ReactElement {
           <option value="">Any tracking</option>
           <option value="true">With tracking</option>
           <option value="false">Without tracking</option>
+        </Select>
+
+        {/* #2073. Two options, not three: there is no "not stuck" cohort worth
+            offering, because a shipment with no failures and one that has failed
+            twice are equally not-escalated. The empty value clears the filter. */}
+        <Select
+          aria-label="Filter by tracking relay"
+          value={waybillRelayStuck === true ? 'true' : ''}
+          onChange={(e) => { setFilter('waybillRelayStuck', e.target.value); }}
+        >
+          <option value="">Any relay state</option>
+          <option value="true">Tracking not sent to channel</option>
         </Select>
 
         <Select

--- a/docs/plans/implementation-plan-2073-surface-failing-lifecycle-relay.md
+++ b/docs/plans/implementation-plan-2073-surface-failing-lifecycle-relay.md
@@ -1,0 +1,411 @@
+# Implementation Plan — #2073 Surface a repeatedly-failing lifecycle relay
+
+**Issue**: [#2073](https://github.com/openlinker-project/openlinker/issues/2073) — Shipping — surface a repeatedly-failing lifecycle relay instead of logging it forever
+**Parent epic**: #1032 (closed)
+**Branch**: `2073-surface-failing-lifecycle-relay`
+
+---
+
+## 1. Problem
+
+`ShipmentStatusSyncService.relayWaybillToParticipants` claims the waybill relay
+(`Shipment.waybillRelayedAt`), attempts it, and **releases the claim on any
+transient participant failure** so a later poll tick retries. That retry
+behaviour is correct and deliberate (#1947 documents the three-way trade-off in
+place).
+
+What is missing is the terminal case. The service's own comment names it:
+
+```ts
+// The poll job deliberately stays `succeeded` (the next tick retries), so
+// this log line is the only observable signal — `error` level for triage.
+```
+
+A relay that fails on **every** tick produces one `logger.error` per tick
+forever. The job reports `succeeded`, no counter moves, no column changes,
+nothing is operator-visible — and the marketplace silently never learns the
+order shipped, so the seller keeps being asked for a tracking number.
+
+The *classification* already exists (#1947 split `unsupported` into the
+structural `no-capability` and the transient `adapter-unresolved`). Only the
+**surface** is missing.
+
+---
+
+## 2. The five design questions, answered
+
+### Q1 — What is the grain?
+
+**Per shipment**, on the `shipments` table. Five columns, all prefixed
+`waybillRelay*`.
+
+The issue's own assumption blesses this: *"Order-grain (per shipment)
+escalation is enough. Per-participant attribution … is #861's job; a first
+version can name the failing participant in the message without persisting
+per-target state."*
+
+**How this avoids pre-empting #861.** #861 is per-destination **notify state** —
+durable per-target claim/retry state that the relay *branches on*, so a
+permanently-broken destination stops re-driving the source. Nothing here is
+that. Two properties make the separation structural rather than promised:
+
+- The relay's control flow is **untouched**. `transientlyUnreached`, the
+  release, the all-or-nothing retry — byte-identical. Adding these columns
+  changes what an operator can *see*, never what the relay *does*.
+- `waybillRelayLastFailureConnectionId` is a **display field with no reader
+  that gates anything** — the #2100 discipline (*"a badge may render it, and no
+  GATE may read it"*). It records which participant was first in the failing
+  set on the last attempt, so the operator's banner can say *"failing to relay
+  to Allegro-Main"* instead of *"failing to relay"*. It is not a set, it is not
+  consulted on the next attempt, and no retry decision reads it. A spec asserts
+  no production code branches on it.
+
+When #861 lands its per-target model, these columns are the roll-up above it,
+or they are deleted — either way #861 is unconstrained.
+
+### Q2 — What makes it "repeatedly" failing?
+
+**A count**, with timestamps as evidence beside it.
+
+The escalation predicate is `waybillRelayFailureCount >= threshold` and nothing
+else. A time-based predicate would be wrong: the poll cadence sets how many
+attempts fit in an hour, so "stuck for 2 hours" means a different number of
+failed attempts on every deployment, while "N consecutive attempts could not
+tell the marketplace" is cadence-independent in exactly the right way.
+
+`threshold` comes from `OL_WAYBILL_RELAY_FAILURE_ALERT_THRESHOLD`, default `3`,
+**clamped to `[2, 100]`**. The lower clamp is the point: AC-4 ("a transient
+single failure does not escalate") becomes structurally unreachable rather than
+merely the default — an operator cannot set `1` and turn every blip into an
+alarm.
+
+`waybillRelayFirstFailedAt` / `waybillRelayLastFailedAt` are carried as
+evidence (the #1814 shape) and are **not** in the predicate. `updatedAt` cannot
+serve as `lastFailedAt` — it moves on every write to the row.
+
+### Q3 — Does it self-clear?
+
+**Yes, on a successful relay, and only on a successful relay.**
+`clearWaybillRelayFailures(id)` is a narrow conditional write
+(`WHERE id = :id AND "waybillRelayFailureCount" > 0`) called on the success
+path. In the healthy case it matches zero rows and costs nothing.
+
+**There is deliberately no time-based auto-clear, and this is where #1814 must
+not be copied.** `webhook_auth_rejections` needs a 24-hour freshness window
+because its counter is an unbounded rolling count over a connection's whole
+life with no natural reset — so staleness is the only way it can ever go quiet.
+This counter has an explicit reset on success. A freshness window here would
+silence the alarm while the waybill still never reached the marketplace, which
+is precisely the defect the issue is about.
+
+**Named limitation.** A shipment that reaches a terminal status carrying a
+standing count is never re-attempted (the scan skips terminal rows), so its
+count freezes. For `delivered` that is correct and wanted — the parcel arrived
+and the marketplace was never told. For `cancelled`/`failed` the relay is moot
+and the row is mild noise; `waybillRelayLastFailedAt` is what tells the two
+apart at a glance, and the operator has the existing status filter. Auto-
+clearing on cancellation was rejected as machinery bought to suppress a signal.
+
+### Q4 — Is the write best-effort?
+
+**The increment needs no best-effort wrapper, and the reset does. The asymmetry
+is the whole answer, not an oversight.**
+
+- **Increment**: folded *into* `releaseWaybillRelay` as one statement
+  (`count = count + 1`, `firstFailedAt = COALESCE(firstFailedAt, now)`,
+  `lastFailedAt`, `reason`, `connectionId`). This adds **no new failure mode** —
+  the release is already an un-caught `await` on both failure paths today, so
+  one statement means one outcome, exactly as now. It also makes the accounting
+  structurally complete: *you cannot release the claim without counting the
+  failure*. `releaseWaybillRelay` has exactly two callers, both failure paths in
+  `relayWaybillToParticipants` (verified by grep across `libs` + `apps`), so
+  there is no third caller that would count a non-failure.
+- **Reset**: a genuinely new write on the success path, so it gets the #1814
+  treatment — `try/catch`, `logger.warn`, swallow. The relay has already
+  succeeded and is durable; failing it because the bookkeeping failed would let
+  the recording of a success destroy the success.
+
+### Q5 — Is there an operator surface?
+
+**Yes — a durable fact *and* a surface.** A field an operator can only find by
+opening the right row is not "operator-visible"; the filter is what makes it a
+bucket.
+
+1. `ShipmentResponseDto.waybillRelay` — a nested block carrying the counter,
+   the timestamps, the reason code, the participant, **and a backend-derived
+   `stuck` boolean**.
+2. `GET /shipments?waybillRelayStuck=true` — the needs-attention bucket.
+3. `apps/web`: a `Relay stuck` badge on the `/shipments` row + an alert banner,
+   both driven by the boolean.
+
+**The backend derives `stuck`; the frontend renders it.** `apps/web` cannot
+import `@openlinker/core` (#591), so a frontend-side threshold comparison would
+be a mirror needing a `check:invariants` script. Shipping the boolean means
+there is no shared rule to mirror at all — strictly better than a guarded
+mirror.
+
+**Not doing: `outcome: 'business_failure'` on the poll job.** The issue offers
+it, and it is wrong here. Three reasons: the poll job is a page-sweep over many
+shipments and one stuck relay is not the job's outcome (the other shipments
+synced fine); ADR-007's `business_failure` means *do not retry a permanent
+condition*, while this condition is fixed by a re-auth and **the retry is the
+recovery** — the next tick must run; and `outcome` is a partitioning per-job
+field, so forcing an orthogonal per-shipment state into it is exactly the trap
+#2100 declined when it shipped a non-partitioning field instead of a sixth
+`OrderHealth` bucket.
+
+---
+
+## 3. Scope
+
+**In**: `ShipmentStatusSyncService`'s waybill relay only — the one relay in the
+tree that retries forever and reports only to the log.
+
+**Out, with reasons**:
+- `ShipmentDispatchNotificationService` — operator-triggered, one-shot, and it
+  *returns* per-target outcomes to its caller, which surfaces them in the
+  dispatch response. The operator sees the failure immediately. It is not the
+  "logs forever" shape.
+- `FulfillmentDispatchRelayService` (#2401) — work-grain, `fulfillment` context,
+  and its claim is released for recovery by a differently-keyed later event
+  rather than by an unbounded poll. Out of this issue's stated file set.
+- Per-participant retry, a relay event stream, a per-target obligation table —
+  **#861**, which is owed its own ADR.
+
+---
+
+## 4. Phases
+
+### Phase 1 — Vocabulary + pure rules (core, `shipping`)
+
+`libs/core/src/shipping/domain/types/waybill-relay-failure.types.ts` — new. Uses
+the pure-rule exception to "types only" (`engineering-standards.md`): pure, it
+*is* the rule for the type it sits with, and both halves change together.
+
+- `WaybillRelayFailureReasonValues = ['rejected', 'adapter-unresolved', 'threw'] as const`
+  + `WaybillRelayFailureReason`. Closed vocabulary. `'threw'` is the pre-per-target
+  case (identifier resolution blew up before the loop), which carries no participant.
+- `readWaybillRelayFailureReason(value: unknown): WaybillRelayFailureReason | null` —
+  read-coercion, so a value this build does not recognise reads as absent rather
+  than being asserted (#2100).
+- `WAYBILL_RELAY_ALERT_THRESHOLD_DEFAULT = 3`, `_MIN = 2`, `_MAX = 100`.
+- `resolveWaybillRelayAlertThreshold(raw: string | undefined): number` — pure,
+  clamped; a non-numeric / non-finite value falls back to the default.
+- `isWaybillRelayStuck(count: number, threshold: number): boolean`.
+- `WaybillRelayFailure` — the readonly value object the entity carries.
+
+**One resolver, every consumer.** The DTO derivation and the filter translation
+both call `resolveWaybillRelayAlertThreshold` + `isWaybillRelayStuck`; the raw
+constant is not exported, so a third call site cannot reopen a
+reported-vs-enforced gap (#2229's rule).
+
+### Phase 2 — Persistence
+
+- `ShipmentOrmEntity`: five columns. `waybillRelayFailureCount` `int NOT NULL
+  DEFAULT 0`; `waybillRelayFirstFailedAt` / `waybillRelayLastFailedAt`
+  `timestamp NULL` (matching **every other timestamp on this table** — not
+  `timestamptz`, which #1814's own table uses; consistency within the table
+  wins and `synchronize` must agree with the migration);
+  `waybillRelayLastFailureReason` `text NULL`;
+  `waybillRelayLastFailureConnectionId` `uuid NULL`.
+- Class-level `@Check('CHK_shipments_waybill_relay_failure_count', '"waybillRelayFailureCount" >= 0')`
+  — declared on the entity **and** in the migration under the identical name,
+  because the integration harness builds schema by `synchronize` and a
+  migration-only constraint holds in production and silently not in tests.
+- Class-level partial index
+  `IDX_shipments_waybill_relay_failing` on `(waybillRelayLastFailedAt)`
+  `WHERE "waybillRelayFailureCount" > 0`. The entity's existing comment warns
+  that a partial predicate over a *mutable* column makes rows enter and leave
+  the index on ordinary updates — that warning is about `status`, which changes
+  over every shipment's life. This column moves only on a relay outcome, which
+  is rare, and every row starts outside the index (default `0`), so the index is
+  near-empty in steady state and shrinks as relays succeed. The comment will say
+  so rather than leave the next reader to rediscover the tension.
+- `Shipment` domain entity: **one** trailing constructor parameter,
+  `waybillRelayFailure: WaybillRelayFailure | null` — not five positional ones,
+  which would be five same-typed slots to misplace in a 24-parameter
+  constructor. `null` means "no failures recorded" (count 0); that is the single
+  representation of healthy.
+- `ShipmentRepositoryPort`:
+  - `releaseWaybillRelay(id, failure: RecordWaybillRelayFailureInput)` — the
+    signature grows a **required** argument. Required, not optional: an
+    omitted failure record is a silent decline, and there is no caller that
+    legitimately releases without failing.
+  - `clearWaybillRelayFailures(id): Promise<void>` — new.
+  - `ShipmentFilters.waybillRelayFailureCountAtLeast?: number` — the repository
+    filters on a **number**, never on the word "stuck". The policy (which number
+    means stuck) stays in the one resolver above; the repository has no business
+    reading env.
+- `UpdateShipmentInput` gains **nothing**, so the ordinary patch path
+  structurally cannot stomp these columns (`update()` writes only the fields
+  present on the patch).
+
+### Phase 3 — Migration
+
+`apps/api/src/migrations/1876000000000-add-shipment-waybill-relay-failure-tracking.ts`
+(watermark is `1875000002000`; new batch → `+1_000_000_000`).
+
+- `up()`: five `ADD COLUMN`s, the named CHECK, the named partial index.
+  `waybillRelayFailureCount` lands `NOT NULL DEFAULT 0` and **keeps** the
+  default — unlike #2373's `direction`, which drops its default so an insert
+  that fails to state a value fails loudly. The opposite is right here: `0` is
+  the true and permanent meaning of "this shipment has had no relay failure",
+  every existing row genuinely has none, and every future insert wants it.
+- `down()`: drop index, drop constraint, drop the five columns.
+
+### Phase 4 — Service wiring
+
+`ShipmentStatusSyncService.relayWaybillToParticipants`:
+- throw path → `releaseWaybillRelay(id, {reason: 'threw', connectionId: null})`
+- transient path → `releaseWaybillRelay(id, {reason, connectionId})` from the
+  **first** member of `transientlyUnreached` (`rejected` → `'rejected'`;
+  `unsupported/adapter-unresolved` → `'adapter-unresolved'`). Every target is
+  still logged individually — the log keeps full attribution, the column
+  carries one for display.
+- success path → `clearWaybillRelayFailures(id)`, best-effort.
+- **`detail` is never persisted.** Only the closed reason code and the
+  connection id reach the column. An adapter's free-text detail can carry a
+  host, a port or a credential fragment (#2341's rule: the code is returned,
+  the message is logged) — and this column reaches a browser, a wider audience
+  than a server log. The log line is unchanged and still carries `detail`.
+
+### Phase 5 — Read surface (API + FE)
+
+- `ShipmentQueryService` / controller: `waybillRelayStuck=true` →
+  `waybillRelayFailureCountAtLeast: resolveWaybillRelayAlertThreshold(...)`, in
+  **one** seam so curl and the UI agree.
+- `ShipmentResponseDto.waybillRelay: WaybillRelayResponseDto | null` with
+  `{ failureCount, stuck, firstFailedAt, lastFailedAt, lastFailureReason,
+  lastFailureConnectionId }`. No new role gating: the reason is a closed
+  vocabulary and the connection id is already on the row unconditionally —
+  neither is the carrier free-text `errorMessage` that #1826 redacts for a
+  `viewer`.
+- `apps/web`: mirror the type, render a `Relay stuck` badge in the row's status
+  group — **beside** the severity word, never folded into it, because
+  `deriveSeverityLabel` is a partition and a stuck relay is orthogonal (a
+  `delivered` shipment can carry one). A page-local alert links to the filter.
+
+### Phase 6 — Tests
+
+- Unit (pure): threshold clamping incl. the `1 → 2` floor; reason coercion;
+  `isWaybillRelayStuck` boundary.
+- Unit (service): increment on transient failure, increment on throw, clear on
+  success, clear is best-effort (a throwing clear does not fail the relay),
+  reason/connection selection.
+- Unit (FE): badge renders on `stuck`, absent otherwise.
+- Integration: N failures make the row visible through
+  `?waybillRelayStuck=true` and invisible below the threshold; a success clears
+  it; the CHECK constraint exists and refuses a negative count (this is what
+  covers the `synchronize` side of the entity/migration parity requirement).
+
+---
+
+## 5. Readiness gate (`/pre-implement`) — findings applied
+
+Verdict: **NEEDS-REVISION → revisions applied → READY.** Two Critical-by-pattern
+items, both contained; five Warnings, all folded in above and restated here.
+
+**Reuse audit — everything proposed is genuinely NEW.** Grep for `failureCount` /
+`attemptCount` / `retryCount` / `relayFailure` / `notifyState` / `notifiedAt` /
+`lastFailedAt` / `consecutiveFailures` across `libs/core/src/shipping` and
+`libs/core/src/orders` returns **zero hits**: no counter of any kind exists.
+`deriveRetryabilityClass` is adjacent prior art but classifies a rejection *code*
+with no counter and no lifecycle — a different question, no reuse available.
+
+**C1 — `releaseWaybillRelay` gains a required argument.** Measured blast radius:
+1 implementer, 2 production callers, 3 `toHaveBeenCalledWith(s.id)` assertions,
+1 repository-spec call = **7 real edits**. Bare `jest.fn()` doubles in 7 other
+specs are structurally typed and do not break. No plugin can implement a
+repository port (`check-cross-context-imports.mjs` bans the import outright), so
+there is no out-of-tree implementer. **Keep the required argument** — an optional
+one is a silent decline, and the 3 breaking assertions are exactly the tests that
+must now pin the failure record.
+
+**C2 — the `Shipment` constructor parameter costs 12 files.** There is **no shared
+`Shipment` fixture**; 11 specs each hand-roll a private `makeShipment`. This makes
+the plan's single-value-object parameter evidence-backed rather than stylistic:
+five positional params would be ~60 edits across 12 hand-rolled helpers with five
+same-typed nullable slots to misplace. The entity's own convention comment mandates
+append-at-the-end / no-default / required, so 12 edits is the house price.
+**Not fixed here**: extracting a shared fixture is a cross-cutting refactor of 11
+unrelated specs and belongs in its own change.
+
+**W1 — the threshold must have exactly ONE reader per request.** The filter
+translation (controller) and the `stuck` derivation (`ShipmentResponseDto`) are
+two different places; reading env in both is the reported-vs-enforced gap #2229
+exists to prevent. **Resolve once in the controller and pass it into `fromDomain`
+as a REQUIRED argument**, exactly as `canWrite` already is. The DTO reads no env.
+
+**W2 — migration timestamp verified.** Global tail across `apps/api/src/migrations`
+*and* both plugin dirs in `scripts/plugin-migration-dirs.json` is `1875000002000`,
+so `1876000000000` clears it and satisfies all three rules
+`check-migration-timestamps.mjs` enforces.
+
+**W3 — column type verified against the table, not the #1814 precedent.**
+`1832000000007` adds `"waybillRelayedAt" TIMESTAMP` (no time zone) with a
+`{ type: 'timestamp' }` decorator. The repo is mixed, so copying
+`webhook_auth_rejections`' `timestamptz` would have diverged the two schema
+sources for this table. Plain `timestamp`, quoted camelCase columns.
+
+**W4 — the insert must not depend on a database default alone** (`lessons.md`,
+out-of-band-UPDATE entry, trap 2 — a `synchronize`-built schema takes the default
+from the DECORATOR). Three layers: assign `0` explicitly in `buildOrmEntity`,
+declare `default: 0` on the `@Column`, and `NOT NULL DEFAULT 0` in the migration.
+The write-set half is already satisfied: `update()` is a partial
+`repository.update(...)` built from `UpdateShipmentInput`, which gains nothing, so
+the patch path **cannot** stomp these columns.
+
+**W5 — every member of the closed reason union must be REACHABLE** (`lessons.md`,
+dead-guard entry, #2380). All three are reachable through the real service path,
+and each is pinned by driving `relayWaybillToParticipants` with a real relay
+result rather than by hand-constructing a failure record.
+
+**No `check:invariants` rule is tripped.** Changes are intra-`shipping` plus
+`apps/api` / `apps/web`; the controller already goes through
+`IShipmentQueryService`, never the port. **No FE/BE mirror is created** — the
+backend ships the derived boolean, so the browser holds no copy of the threshold
+and no mirror script is needed. The shipping barrel cherry-picks every symbol
+(only `./shipping.tokens` is a wildcard), so the new types file needs explicit
+`export` / `export type` lines.
+
+### Scope revisions applied
+
+1. **The frontend banner is dropped.** `shipments-page.tsx` renders no `Alert`
+   today; the one above-table banner is `ShipmentTriageStrip`, which is
+   `canWrite`-gated and *cause-grouped for failed shipments* — a different
+   grouping. A second banner mechanism is scope this issue does not need: the
+   badge renders on every row an operator scans and the filter makes the bucket
+   reachable. Named as a follow-up rather than silently cut.
+2. **FE filter plumbing is four places**: `buildQuery` in `shipments.api.ts`, the
+   `clearFilters()` key list, the `filtersActive` boolean, and the query-key
+   factory. Recorded so a half-wired filter cannot ship.
+3. **`shipments` was NOT added to the migration-parity `TABLES` list** — the
+   fallback arm of this revision, taken deliberately. That spec diffs a table's
+   ENTIRE migration-built schema against its `synchronize`-built one, and
+   `shipments` predates most of this repo's migration discipline, so adding it
+   blind risks failing CI on pre-existing drift in columns this change never
+   touched. Docker is unavailable in the implementing environment, so the
+   experiment could not be run and the result could not be read. Instead
+   `apps/api/test/integration/shipment-waybill-relay-failure.int-spec.ts`
+   asserts the half that matters here — that the CHECK, the partial index and
+   the column types exist on the **`synchronize`** schema, which is the side a
+   migration-only declaration would silently miss. Adding `shipments` to the
+   parity list is worth its own issue.
+
+**No new role gating.** `GET /shipments` is `@AnyRole()` and redacts
+`errorMessage` for non-`shipments:write` roles. The new fields need none — the
+reason is a closed code vocabulary (not carrier free text) and `connectionId` is
+already exposed unconditionally on every row. Stated so the absence does not read
+as an oversight.
+
+---
+
+## 6. Risks
+
+| Risk | Mitigation |
+|---|---|
+| `releaseWaybillRelay` signature change breaks an out-of-tree implementer of `ShipmentRepositoryPort` | Gate-verified: the port is core-internal and plugins cannot even import it; required arg is the deliberate choice per Q4 |
+| Counter drifts from reality if a future writer releases without counting | Impossible by construction — the two are one statement |
+| Alarm never clears for a terminal shipment | Named limitation, Q3; `lastFailedAt` distinguishes active from frozen |
+| Partial index churn | Predicate column moves only on relay outcomes; index near-empty by default |
+| Adding `shipments` to the parity spec surfaces pre-existing drift | Back the table out, narrow assertion instead, record the finding (revision 3) |

--- a/libs/core/src/shipping/application/services/bulk-shipment-dispatch.service.spec.ts
+++ b/libs/core/src/shipping/application/services/bulk-shipment-dispatch.service.spec.ts
@@ -53,6 +53,8 @@ function makeShipment(overrides: Partial<Shipment> = {}): Shipment {
     overrides.direction ?? 'outbound',
     overrides.reservationConsumedAt ?? null,
     overrides.fulfillmentWorkId ?? null,
+    // #2073 waybill-relay failure history — none by default.
+    overrides.waybillRelayFailure ?? null,
   );
 }
 
@@ -97,6 +99,7 @@ describe('BulkShipmentDispatchService', () => {
       update: jest.fn(),
       claimWaybillRelay: jest.fn(),
       releaseWaybillRelay: jest.fn(),
+      clearWaybillRelayFailures: jest.fn(),
       listDispatchedAwaitingReservationConsume: jest.fn(),
       claimReservationConsume: jest.fn(),
       claimFulfillmentWorkLink: jest.fn(),

--- a/libs/core/src/shipping/application/services/fulfillment-status-sync.service.spec.ts
+++ b/libs/core/src/shipping/application/services/fulfillment-status-sync.service.spec.ts
@@ -69,6 +69,8 @@ function makeBranchOneShipment(overrides: Partial<Shipment> = {}): Shipment {
     overrides.direction ?? 'outbound',
     overrides.reservationConsumedAt ?? null,
     overrides.fulfillmentWorkId ?? null,
+    // #2073 waybill-relay failure history — none by default.
+    overrides.waybillRelayFailure ?? null,
   );
 }
 
@@ -94,6 +96,7 @@ describe('FulfillmentStatusSyncService', () => {
       update: jest.fn(),
       claimWaybillRelay: jest.fn(),
       releaseWaybillRelay: jest.fn(),
+      clearWaybillRelayFailures: jest.fn(),
       listDispatchedAwaitingReservationConsume: jest.fn(),
       claimReservationConsume: jest.fn(),
       claimFulfillmentWorkLink: jest.fn(),

--- a/libs/core/src/shipping/application/services/shipment-cancellation.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-cancellation.service.spec.ts
@@ -50,6 +50,8 @@ function makeShipment(overrides: Partial<Shipment> = {}): Shipment {
     overrides.direction ?? 'outbound',
     overrides.reservationConsumedAt ?? null,
     overrides.fulfillmentWorkId ?? null,
+    // #2073 waybill-relay failure history — none by default.
+    overrides.waybillRelayFailure ?? null,
   );
 }
 
@@ -71,6 +73,7 @@ describe('ShipmentCancellationService', () => {
       update: jest.fn(),
       claimWaybillRelay: jest.fn(),
       releaseWaybillRelay: jest.fn(),
+      clearWaybillRelayFailures: jest.fn(),
       listDispatchedAwaitingReservationConsume: jest.fn(),
       claimReservationConsume: jest.fn(),
       claimFulfillmentWorkLink: jest.fn(),

--- a/libs/core/src/shipping/application/services/shipment-dispatch-notification.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-dispatch-notification.service.spec.ts
@@ -57,6 +57,8 @@ function makeShipment(overrides: Partial<Shipment> = {}): Shipment {
     overrides.direction ?? 'outbound',
     overrides.reservationConsumedAt ?? null,
     overrides.fulfillmentWorkId ?? null,
+    // #2073 waybill-relay failure history — none by default.
+    overrides.waybillRelayFailure ?? null,
   );
 }
 
@@ -92,6 +94,7 @@ describe('ShipmentDispatchNotificationService', () => {
       update: jest.fn(),
       claimWaybillRelay: jest.fn(),
       releaseWaybillRelay: jest.fn(),
+      clearWaybillRelayFailures: jest.fn(),
       listDispatchedAwaitingReservationConsume: jest.fn(),
       claimReservationConsume: jest.fn(),
       claimFulfillmentWorkLink: jest.fn(),

--- a/libs/core/src/shipping/application/services/shipment-dispatch.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-dispatch.service.spec.ts
@@ -106,6 +106,8 @@ function makeShipment(overrides: Partial<Shipment> = {}): Shipment {
     overrides.direction ?? 'outbound',
     overrides.reservationConsumedAt ?? null,
     overrides.fulfillmentWorkId ?? null,
+    // #2073 waybill-relay failure history — none by default.
+    overrides.waybillRelayFailure ?? null,
   );
 }
 
@@ -144,6 +146,7 @@ describe('ShipmentDispatchService', () => {
       update: jest.fn(),
       claimWaybillRelay: jest.fn(),
       releaseWaybillRelay: jest.fn(),
+      clearWaybillRelayFailures: jest.fn(),
       listDispatchedAwaitingReservationConsume: jest.fn(),
       claimReservationConsume: jest.fn(),
       claimFulfillmentWorkLink: jest.fn(),

--- a/libs/core/src/shipping/application/services/shipment-label.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-label.service.spec.ts
@@ -49,6 +49,8 @@ function makeShipment(overrides: Partial<Shipment> = {}): Shipment {
     overrides.direction ?? 'outbound',
     overrides.reservationConsumedAt ?? null,
     overrides.fulfillmentWorkId ?? null,
+    // #2073 waybill-relay failure history — none by default.
+    overrides.waybillRelayFailure ?? null,
   );
 }
 
@@ -70,6 +72,7 @@ describe('ShipmentLabelService', () => {
       update: jest.fn(),
       claimWaybillRelay: jest.fn(),
       releaseWaybillRelay: jest.fn(),
+      clearWaybillRelayFailures: jest.fn(),
       listDispatchedAwaitingReservationConsume: jest.fn(),
       claimReservationConsume: jest.fn(),
       claimFulfillmentWorkLink: jest.fn(),

--- a/libs/core/src/shipping/application/services/shipment-query.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-query.service.spec.ts
@@ -42,6 +42,8 @@ function makeShipment(overrides: Partial<Shipment> = {}): Shipment {
     overrides.direction ?? 'outbound',
     overrides.reservationConsumedAt ?? null,
     overrides.fulfillmentWorkId ?? null,
+    // #2073 waybill-relay failure history — none by default.
+    overrides.waybillRelayFailure ?? null,
   );
 }
 
@@ -61,6 +63,7 @@ describe('ShipmentQueryService', () => {
       update: jest.fn(),
       claimWaybillRelay: jest.fn(),
       releaseWaybillRelay: jest.fn(),
+      clearWaybillRelayFailures: jest.fn(),
       listDispatchedAwaitingReservationConsume: jest.fn(),
       claimReservationConsume: jest.fn(),
       claimFulfillmentWorkLink: jest.fn(),

--- a/libs/core/src/shipping/application/services/shipment-reservation-consume.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-reservation-consume.service.spec.ts
@@ -51,6 +51,8 @@ function shipment(id: string, orderId: string, status: ShipmentStatus = 'dispatc
     null,
     // #2402 fulfillmentWorkId — no work linkage in this fixture.
     null,
+    // #2073 waybill-relay failure history — none in this fixture.
+    null,
   );
 }
 

--- a/libs/core/src/shipping/application/services/shipment-status-sync.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-status-sync.service.spec.ts
@@ -52,6 +52,8 @@ function makeShipment(overrides: Partial<Shipment> = {}): Shipment {
     overrides.direction ?? 'outbound',
     overrides.reservationConsumedAt ?? null,
     overrides.fulfillmentWorkId ?? null,
+    // #2073 waybill-relay failure history — none by default.
+    overrides.waybillRelayFailure ?? null,
   );
 }
 
@@ -90,6 +92,7 @@ describe('ShipmentStatusSyncService', () => {
       // concurrent trigger or an already-relayed waybill.
       claimWaybillRelay: jest.fn().mockResolvedValue(true),
       releaseWaybillRelay: jest.fn().mockResolvedValue(undefined),
+      clearWaybillRelayFailures: jest.fn().mockResolvedValue(undefined),
       listDispatchedAwaitingReservationConsume: jest.fn(),
       claimReservationConsume: jest.fn(),
       claimFulfillmentWorkLink: jest.fn(),
@@ -355,7 +358,12 @@ describe('ShipmentStatusSyncService', () => {
 
       const result = await service.sync(CARRIER, { limit: 50 });
 
-      expect(shipments.releaseWaybillRelay).toHaveBeenCalledWith(s.id);
+      expect(shipments.releaseWaybillRelay).toHaveBeenCalledWith(
+        s.id,
+        // #2073 — the release and the failure record are one call, so the
+        // reason and the participant are pinned here rather than separately.
+        expect.objectContaining({ reason: 'rejected', connectionId: SOURCE }),
+      );
       // Withheld so the next poll re-detects the diff and retries.
       expect(shipments.update).not.toHaveBeenCalled();
       expect(result.propagated).toBe(0);
@@ -379,7 +387,10 @@ describe('ShipmentStatusSyncService', () => {
 
       await service.sync(CARRIER, { limit: 50 });
 
-      expect(shipments.releaseWaybillRelay).toHaveBeenCalledWith(s.id);
+      expect(shipments.releaseWaybillRelay).toHaveBeenCalledWith(
+        s.id,
+        expect.objectContaining({ reason: 'adapter-unresolved', connectionId: SOURCE }),
+      );
       expect(shipments.update).not.toHaveBeenCalled();
     });
 
@@ -425,7 +436,12 @@ describe('ShipmentStatusSyncService', () => {
 
       const result = await service.sync(CARRIER, { limit: 50 });
 
-      expect(shipments.releaseWaybillRelay).toHaveBeenCalledWith(s.id);
+      expect(shipments.releaseWaybillRelay).toHaveBeenCalledWith(
+        s.id,
+        // No participant was resolved, so naming one would be a false
+        // attribution — `connectionId` is null on this arm by design.
+        expect.objectContaining({ reason: 'threw', connectionId: null }),
+      );
       const patch = shipments.update.mock.calls[0]?.[1] as Record<string, unknown>;
       expect(patch.status).toBe('delivered');
       expect(patch.carrier).toBe('inpost');
@@ -444,6 +460,114 @@ describe('ShipmentStatusSyncService', () => {
 
       expect(relay.relay).not.toHaveBeenCalled();
       expect(shipments.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('waybill-relay failure accounting (#2073)', () => {
+    // The counter exists because a relay that fails on EVERY tick used to
+    // produce one `logger.error` per tick and nothing durable. Each member of
+    // the closed reason union is exercised through the REAL relay path rather
+    // than by hand-constructing a failure record — a hand-built fixture can
+    // describe a state the service never produces (`docs/lessons.md`, "A guard
+    // ordered behind a broader one is dead").
+
+    function dispatchedAwaitingWaybill() {
+      const s = makeShipment({ status: 'dispatched', trackingNumber: null });
+      shipments.findMany.mockResolvedValue({ items: [s], total: 1 });
+      getTracking.mockResolvedValue(snapshot({ status: 'dispatched', trackingNumber: 'NEW456' }));
+      return s;
+    }
+
+    it('records the FIRST failing participant when several are unreachable', async () => {
+      // The log keeps every target; the column carries one name so an operator
+      // sees which channel to look at. Nothing reads it to decide anything.
+      relay.relay.mockResolvedValue({
+        targets: [
+          { connectionId: SOURCE, outcome: 'rejected', detail: 'Allegro 422' },
+          { connectionId: PS1, outcome: 'rejected', detail: 'PS 500' },
+        ],
+      });
+      const s = dispatchedAwaitingWaybill();
+
+      await service.sync(CARRIER, { limit: 50 });
+
+      expect(shipments.releaseWaybillRelay).toHaveBeenCalledWith(
+        s.id,
+        expect.objectContaining({ reason: 'rejected', connectionId: SOURCE }),
+      );
+    });
+
+    it('never persists the adapter detail, only the closed reason code', async () => {
+      // The detail can carry a host, a port or a credential fragment; it is
+      // already in the log, and this column reaches a browser.
+      relay.relay.mockResolvedValue(
+        relayResult({
+          connectionId: SOURCE,
+          outcome: 'rejected',
+          detail: 'connect ECONNREFUSED 10.0.0.7:5432 password=hunter2',
+        }),
+      );
+      dispatchedAwaitingWaybill();
+
+      await service.sync(CARRIER, { limit: 50 });
+
+      const call = shipments.releaseWaybillRelay.mock.calls[0];
+      const failure = call[1];
+      expect(failure.reason).toBe('rejected');
+      // Nothing that crossed into persistence carries the adapter's message.
+      expect(JSON.stringify(failure)).not.toContain('hunter2');
+      expect(JSON.stringify(failure)).not.toContain('10.0.0.7');
+    });
+
+    it('clears the failure history when the relay reaches every participant', async () => {
+      // Without this the escalation is an alarm that never goes off.
+      relay.relay.mockResolvedValue(relayResult({ connectionId: SOURCE, outcome: 'applied' }));
+      const s = dispatchedAwaitingWaybill();
+
+      await service.sync(CARRIER, { limit: 50 });
+
+      expect(shipments.clearWaybillRelayFailures).toHaveBeenCalledWith(s.id);
+      expect(shipments.releaseWaybillRelay).not.toHaveBeenCalled();
+    });
+
+    it('does NOT clear the history when the relay failed', async () => {
+      relay.relay.mockResolvedValue(relayResult({ connectionId: SOURCE, outcome: 'rejected' }));
+      dispatchedAwaitingWaybill();
+
+      await service.sync(CARRIER, { limit: 50 });
+
+      expect(shipments.clearWaybillRelayFailures).not.toHaveBeenCalled();
+    });
+
+    it('treats a failed CLEAR as non-fatal — the relay already succeeded durably', async () => {
+      // Best-effort by design: the relay has landed, so failing the job because
+      // its bookkeeping failed would let the recording of a success destroy the
+      // success. A stale count escalates one recovered shipment, which the next
+      // successful relay clears.
+      relay.relay.mockResolvedValue(relayResult({ connectionId: SOURCE, outcome: 'applied' }));
+      shipments.clearWaybillRelayFailures.mockRejectedValue(new Error('db blip'));
+      const s = dispatchedAwaitingWaybill();
+
+      const result = await service.sync(CARRIER, { limit: 50 });
+
+      expect(result.failed).toBe(0);
+      expect(result.propagated).toBe(1);
+      // The tracking number still lands — the whole point of not throwing.
+      expect(shipments.update).toHaveBeenCalledWith(
+        s.id,
+        expect.objectContaining({ trackingNumber: 'NEW456' }),
+      );
+    });
+
+    it('records nothing when the claim was already held by a concurrent trigger', async () => {
+      // A skipped relay is not a failed one: this caller never attempted it.
+      shipments.claimWaybillRelay.mockResolvedValue(false);
+      dispatchedAwaitingWaybill();
+
+      await service.sync(CARRIER, { limit: 50 });
+
+      expect(shipments.releaseWaybillRelay).not.toHaveBeenCalled();
+      expect(shipments.clearWaybillRelayFailures).not.toHaveBeenCalled();
     });
   });
 

--- a/libs/core/src/shipping/application/services/shipment-status-sync.service.ts
+++ b/libs/core/src/shipping/application/services/shipment-status-sync.service.ts
@@ -385,7 +385,15 @@ export class ShipmentStatusSyncService implements IShipmentStatusSyncService {
       // letting it propagate would abort `buildPatchAndMaybePush` and discard the
       // whole patch — terminal status, deliveredAt, carrier backfill included —
       // and skip the order-rollup reprojection.
-      await this.shipments.releaseWaybillRelay(shipment.id);
+      // The failure is recorded in the SAME statement that releases the claim
+      // (#2073), so this path cannot release without counting. `connectionId`
+      // is null because the throw happens BEFORE the per-target loop — there is
+      // no participant to name, and inventing one would be a false attribution.
+      await this.shipments.releaseWaybillRelay(shipment.id, {
+        reason: 'threw',
+        connectionId: null,
+        failedAt: new Date(),
+      });
       this.logger.error(
         `Waybill relay threw for shipment ${shipment.id} (order ${shipment.orderId}): ${this.message(error)}`,
         error instanceof Error ? error.stack : undefined,
@@ -421,10 +429,29 @@ export class ShipmentStatusSyncService implements IShipmentStatusSyncService {
     );
 
     if (transientlyUnreached.length > 0) {
-      await this.shipments.releaseWaybillRelay(shipment.id);
+      // #2073. The FIRST failing participant is recorded for display; every one
+      // of them is still logged individually below, so the log keeps full
+      // attribution and the column carries one name for the operator's badge.
+      // Nothing reads that name to decide anything — per-target retry state is
+      // #861 and this deliberately does not become it.
+      //
+      // `detail` is NEVER persisted: it is an adapter's free text and can carry
+      // a host, a port or a credential fragment, it already reaches the log,
+      // and this column reaches a browser — a wider audience (#2341's rule: the
+      // code is returned, the message is logged).
+      const [first] = transientlyUnreached;
+      await this.shipments.releaseWaybillRelay(shipment.id, {
+        reason: first.outcome === 'rejected' ? 'rejected' : 'adapter-unresolved',
+        connectionId: first.connectionId,
+        failedAt: new Date(),
+      });
       for (const target of transientlyUnreached) {
-        // The poll job deliberately stays `succeeded` (the next tick retries), so
-        // this log line is the only observable signal — `error` level for triage.
+        // The poll job deliberately stays `succeeded` (the next tick retries).
+        // Since #2073 this log line is no longer the ONLY observable signal —
+        // the shipment now carries a durable consecutive-failure count that the
+        // `/shipments` read surface escalates past a threshold — but it is
+        // still the only place the per-target detail appears, so it stays at
+        // `error` level for triage.
         this.logger.error(
           `Waybill relay to ${target.connectionId} failed for shipment ${shipment.id} ` +
             `(${target.outcome}${target.unsupportedReason ? `/${target.unsupportedReason}` : ''})` +
@@ -432,6 +459,24 @@ export class ShipmentStatusSyncService implements IShipmentStatusSyncService {
         );
       }
       return 'failed';
+    }
+
+    // The relay reached every participant, so the failure history is cleared
+    // (#2073) — without this the escalation is an alarm that never goes off.
+    //
+    // BEST-EFFORT, unlike the increment above. The increment is fused to a
+    // release that was already un-caught, so it adds no failure mode; this is a
+    // genuinely new write on a path that has ALREADY succeeded durably, and
+    // failing the relay because its bookkeeping failed would let the recording
+    // of a success destroy the success. A stale count simply escalates one
+    // shipment that has recovered, which the next successful relay clears.
+    try {
+      await this.shipments.clearWaybillRelayFailures(shipment.id);
+    } catch (error) {
+      this.logger.warn(
+        `Failed to clear waybill relay failure history for shipment ${shipment.id} ` +
+          `(non-fatal, the relay itself succeeded): ${this.message(error)}`,
+      );
     }
 
     return 'relayed';

--- a/libs/core/src/shipping/domain/entities/shipment.entity.ts
+++ b/libs/core/src/shipping/domain/entities/shipment.entity.ts
@@ -24,6 +24,7 @@
  * @module libs/core/src/shipping/domain/entities
  */
 
+import type { WaybillRelayFailure } from '../types/waybill-relay-failure.types';
 import type { ShipmentDirection } from '../types/shipment-direction.types';
 import type { ShipmentStatus } from '../types/shipment-status.types';
 import type { ShippingMethod } from '../types/shipping-method.types';
@@ -167,5 +168,20 @@ export class Shipment {
     //
     // Appended last for the same anti-collision rationale as every field above.
     public readonly fulfillmentWorkId: string | null,
+    // Consecutive waybill-relay failures, or `null` when there are none (#2073).
+    //
+    // ONE value object rather than five positional fields, and that is a
+    // measured choice: there is no shared `Shipment` fixture in this repo -
+    // eleven specs each hand-roll a private `makeShipment` - so five
+    // same-typed nullable slots would be sixty edits with five chances to
+    // misplace one. `null` is the single representation of healthy, so a
+    // caller tests one thing rather than comparing a count to zero.
+    //
+    // A DISPLAY fact, never a gate: the relay's own control flow does not read
+    // it, and `waybillRelayFailure.connectionId` in particular is not consulted
+    // when deciding what to retry. Per-target notify state is #861.
+    //
+    // Appended last for the same anti-collision rationale as every field above.
+    public readonly waybillRelayFailure: WaybillRelayFailure | null,
   ) {}
 }

--- a/libs/core/src/shipping/domain/ports/shipment-repository.port.ts
+++ b/libs/core/src/shipping/domain/ports/shipment-repository.port.ts
@@ -25,6 +25,7 @@ import type {
   CreateShipmentInput,
   UpdateShipmentInput,
 } from '../types/shipment.types';
+import type { RecordWaybillRelayFailureInput } from '../types/waybill-relay-failure.types';
 
 export interface ShipmentRepositoryPort {
   /**
@@ -230,7 +231,40 @@ export interface ShipmentRepositoryPort {
 
   /**
    * Release a claim taken by {@link claimWaybillRelay} so a later tick can
-   * retry. Idempotent: releasing an already-released row is a no-op.
+   * retry, AND record the failure that caused the release. Idempotent:
+   * releasing an already-released row is a no-op.
+   *
+   * **One statement, so a release without a count is not expressible** (#2073).
+   * Before this, a relay that failed on every tick released the claim forever
+   * and reported the fact only to the log. Folding the counter into the release
+   * rather than writing it beside adds NO new failure mode - the release was
+   * already an un-caught `await` on both failure paths - while making the
+   * accounting structurally complete. Both callers are failure paths in
+   * `ShipmentStatusSyncService.relayWaybillToParticipants`; there is no third
+   * caller that could count a non-failure.
+   *
+   * `failure` is REQUIRED, not optional. An optional argument would be a silent
+   * decline: a caller that omitted it would release the claim and record
+   * nothing, which is exactly the invisibility this parameter removes.
+   *
+   * @see clearWaybillRelayFailures for the reset half.
    */
-  releaseWaybillRelay(id: string): Promise<void>;
+  releaseWaybillRelay(id: string, failure: RecordWaybillRelayFailureInput): Promise<void>;
+
+  /**
+   * Clear the failure history after a SUCCESSFUL relay (#2073) - the reset that
+   * keeps the escalation from becoming an alarm that never goes off.
+   *
+   * Conditional on `waybillRelayFailureCount > 0`, so the healthy case matches
+   * zero rows and costs nothing. Idempotent.
+   *
+   * **There is deliberately no time-based auto-clear**, which is where the
+   * `webhook_auth_rejections` precedent (#1814) must NOT be copied. That
+   * counter needs a freshness window because it is an unbounded rolling count
+   * over a connection's whole life with no natural reset, so staleness is the
+   * only way it can go quiet. This one has an explicit reset on success; a
+   * window here would silence the signal while the waybill still never reached
+   * the marketplace, which is the defect being fixed.
+   */
+  clearWaybillRelayFailures(id: string): Promise<void>;
 }

--- a/libs/core/src/shipping/domain/types/shipment-query.types.ts
+++ b/libs/core/src/shipping/domain/types/shipment-query.types.ts
@@ -54,6 +54,18 @@ export interface ShipmentFilters {
   createdFrom?: Date;
   /** Inclusive upper bound on `createdAt`. */
   createdTo?: Date;
+  /**
+   * Inclusive lower bound on `waybillRelayFailureCount` (#2073) — the
+   * needs-attention bucket for a relay that keeps failing.
+   *
+   * A NUMBER, deliberately, and never a `waybillRelayStuck` boolean. Which
+   * number means "stuck" is policy that lives in exactly one place
+   * (`resolveWaybillRelayAlertThreshold`), resolved once at the HTTP boundary
+   * and passed down; the repository has no business reading an environment
+   * variable, and a boolean here would give the threshold a second reader that
+   * could disagree with the one the operator's badge was rendered from.
+   */
+  waybillRelayFailureCountAtLeast?: number;
 }
 
 export interface ShipmentPagination {

--- a/libs/core/src/shipping/domain/types/waybill-relay-failure.types.spec.ts
+++ b/libs/core/src/shipping/domain/types/waybill-relay-failure.types.spec.ts
@@ -1,0 +1,96 @@
+/**
+ * Waybill Relay Failure Types — Unit Tests (#2073)
+ *
+ * @module libs/core/src/shipping/domain/types
+ */
+import {
+  isWaybillRelayStuck,
+  readWaybillRelayFailureReason,
+  resolveWaybillRelayAlertThreshold,
+  WaybillRelayFailureReasonValues,
+  type WaybillRelayFailure,
+} from './waybill-relay-failure.types';
+
+const failure = (count: number): WaybillRelayFailure => ({
+  count,
+  firstFailedAt: new Date('2026-05-19T10:00:00Z'),
+  lastFailedAt: new Date('2026-05-19T12:00:00Z'),
+  reason: 'rejected',
+  connectionId: '00000000-0000-0000-0000-0000000000aa',
+});
+
+describe('resolveWaybillRelayAlertThreshold', () => {
+  it('should default to 3 when the variable is unset', () => {
+    expect(resolveWaybillRelayAlertThreshold(undefined)).toBe(3);
+  });
+
+  it('should default when the variable is empty or blank', () => {
+    expect(resolveWaybillRelayAlertThreshold('')).toBe(3);
+    expect(resolveWaybillRelayAlertThreshold('   ')).toBe(3);
+  });
+
+  it('should default when the variable is not a number', () => {
+    // A mistyped env var must not take the shipments list down, and must not
+    // silently resolve to NaN — which would make every comparison false and
+    // quietly switch the escalation off.
+    expect(resolveWaybillRelayAlertThreshold('three')).toBe(3);
+    expect(resolveWaybillRelayAlertThreshold('Infinity')).toBe(3);
+  });
+
+  it('should honour a value inside the supported range', () => {
+    expect(resolveWaybillRelayAlertThreshold('5')).toBe(5);
+    expect(resolveWaybillRelayAlertThreshold('2')).toBe(2);
+  });
+
+  it('should clamp a threshold of 1 up to 2 so a single blip can never escalate', () => {
+    // THE load-bearing clamp (#2073 AC-4). Without it an operator could set 1
+    // and turn every transient failure into an alarm — the lower bound makes
+    // that unreachable rather than merely not the default.
+    expect(resolveWaybillRelayAlertThreshold('1')).toBe(2);
+    expect(resolveWaybillRelayAlertThreshold('0')).toBe(2);
+    expect(resolveWaybillRelayAlertThreshold('-7')).toBe(2);
+  });
+
+  it('should clamp an absurdly large threshold to the ceiling', () => {
+    expect(resolveWaybillRelayAlertThreshold('100000')).toBe(100);
+  });
+
+  it('should truncate a fractional value rather than rejecting it', () => {
+    expect(resolveWaybillRelayAlertThreshold('4.9')).toBe(4);
+  });
+});
+
+describe('readWaybillRelayFailureReason', () => {
+  it.each(WaybillRelayFailureReasonValues)('should accept the known reason %s', (reason) => {
+    expect(readWaybillRelayFailureReason(reason)).toBe(reason);
+  });
+
+  it('should read an unrecognised stored value as absent, never assert it onward', () => {
+    // The column is plain `text`. A value written by a future build, or by
+    // hand, must reach the frontend as "no reason recorded" rather than as a
+    // reason it cannot render.
+    expect(readWaybillRelayFailureReason('no-capability')).toBeNull();
+    expect(readWaybillRelayFailureReason('')).toBeNull();
+    expect(readWaybillRelayFailureReason(null)).toBeNull();
+    expect(readWaybillRelayFailureReason(undefined)).toBeNull();
+    expect(readWaybillRelayFailureReason(7)).toBeNull();
+    expect(readWaybillRelayFailureReason({ reason: 'rejected' })).toBeNull();
+  });
+});
+
+describe('isWaybillRelayStuck', () => {
+  it('should report a shipment with no failure history as not stuck', () => {
+    expect(isWaybillRelayStuck(null, 3)).toBe(false);
+  });
+
+  it('should not escalate below the threshold', () => {
+    expect(isWaybillRelayStuck(failure(1), 3)).toBe(false);
+    expect(isWaybillRelayStuck(failure(2), 3)).toBe(false);
+  });
+
+  it('should escalate at the threshold and above', () => {
+    // Inclusive: N consecutive failures IS the condition, not N + 1.
+    expect(isWaybillRelayStuck(failure(3), 3)).toBe(true);
+    expect(isWaybillRelayStuck(failure(40), 3)).toBe(true);
+  });
+});

--- a/libs/core/src/shipping/domain/types/waybill-relay-failure.types.ts
+++ b/libs/core/src/shipping/domain/types/waybill-relay-failure.types.ts
@@ -1,0 +1,173 @@
+/**
+ * Waybill Relay Failure Types (#2073)
+ *
+ * The vocabulary and the pure rules for "this shipment's waybill relay keeps
+ * failing", plus the write shape the repository records one failure with.
+ *
+ * **Why this exists.** `ShipmentStatusSyncService.relayWaybillToParticipants`
+ * releases its at-most-once claim on any transient participant failure so a
+ * later poll tick retries (#1947). That is correct, and it has no terminal
+ * case: a relay that fails on EVERY tick produces one `logger.error` per tick
+ * forever while the job still reports `succeeded`. Nothing escalates, and the
+ * marketplace silently never learns the order shipped. These types are how the
+ * condition becomes a durable, operator-visible fact instead of a log line.
+ *
+ * **Scope — the waybill relay only.** Every name here is `waybillRelay*`
+ * deliberately: this counts the ONE relay in the tree that retries forever and
+ * reports only to the log. `ShipmentDispatchNotificationService` returns its
+ * per-target outcomes to a caller that surfaces them immediately, so it is not
+ * the "logs forever" shape and is not counted here. Do not widen these names to
+ * imply the counter covers every relay kind.
+ *
+ * **This is NOT #861.** That issue is per-DESTINATION notify STATE — durable
+ * per-target claim/retry state the relay branches on, so a permanently-broken
+ * destination stops re-driving the source. Nothing here is that: the relay's
+ * control flow is untouched, and `connectionId` below is a DISPLAY field with no
+ * reader that gates anything (the #2100 discipline — a badge may render it, and
+ * no gate may read it). When #861 lands its per-target model these become the
+ * roll-up above it, or they are deleted; either way #861 is unconstrained.
+ *
+ * Pure by construction: no I/O, no injected dependency, no framework import, no
+ * argument mutation — the `*.types.ts` pure-rule exception documented in
+ * `docs/engineering-standards.md`, beside the `applyPricingRule` /
+ * `applyStockSafetyBuffer` / `resolveOfferLifecycle` precedents. Each function
+ * IS the rule for the type it sits with, and both halves change together.
+ *
+ * @module libs/core/src/shipping/domain/types
+ */
+
+/**
+ * Why the last waybill relay attempt failed.
+ *
+ * A CLOSED vocabulary, and every member is reachable through the real service
+ * path (`docs/lessons.md` § "A guard ordered behind a broader one is dead" —
+ * a closed union is a claim that something can emit each member):
+ *
+ * - `'rejected'` — a participant's adapter refused the write.
+ * - `'adapter-unresolved'` — the participant's adapter could not be built at
+ *   all (disabled connection, credential failure). #1947 classifies this as
+ *   TRANSIENT, which is why it releases the claim; the structural
+ *   `no-capability` is NOT a failure and is deliberately absent here.
+ * - `'threw'` — the relay threw before its per-target loop (identifier
+ *   resolution), so no participant can be named.
+ *
+ * Deliberately carries no free-text detail — see
+ * {@link RecordWaybillRelayFailureInput}.
+ */
+export const WaybillRelayFailureReasonValues = ['rejected', 'adapter-unresolved', 'threw'] as const;
+
+export type WaybillRelayFailureReason = (typeof WaybillRelayFailureReasonValues)[number];
+
+/**
+ * Read-coercion for a persisted reason (#2100 discipline).
+ *
+ * A value this build does not recognise reads as ABSENT rather than being
+ * asserted onward — the column is plain `text`, so a row written by a future
+ * build, or by hand, must not surface as a reason the frontend cannot render.
+ */
+export function readWaybillRelayFailureReason(value: unknown): WaybillRelayFailureReason | null {
+  return typeof value === 'string' &&
+    (WaybillRelayFailureReasonValues as readonly string[]).includes(value)
+    ? (value as WaybillRelayFailureReason)
+    : null;
+}
+
+/**
+ * What one failed relay attempt records.
+ *
+ * `failedAt` is supplied by the CALLER rather than stamped inside the
+ * repository — the same shape `claimWaybillRelay(id, at)` already takes, which
+ * keeps the instant testable. OL's own clock is the right authority here: OL
+ * observed this failure itself, so unlike a channel-reported instant (#2336 /
+ * #2367) there is no third party whose clock it would be standing in for.
+ *
+ * `connectionId` names the FIRST participant in the failing set, for display
+ * only, and is `null` for `'threw'` (which happens before any participant is
+ * known). It is never read to decide anything — see the header note on #861.
+ */
+export interface RecordWaybillRelayFailureInput {
+  readonly reason: WaybillRelayFailureReason;
+  readonly connectionId: string | null;
+  readonly failedAt: Date;
+}
+
+/**
+ * The failure history a `Shipment` carries, or `null` when it has none.
+ *
+ * `null` is the single representation of healthy (`count === 0`); the entity
+ * never carries a zero-count object, so a caller tests one thing rather than two.
+ */
+export interface WaybillRelayFailure {
+  /** Consecutive failed attempts. Reset to zero — i.e. to `null` — on success. */
+  readonly count: number;
+  /** When the current run of failures began. */
+  readonly firstFailedAt: Date;
+  /**
+   * The most recent failure. This is what tells an ACTIVELY retrying relay
+   * apart from a frozen historical one on a shipment that has since gone
+   * terminal (the scan visits only non-terminal rows, so such a count stops
+   * moving) — which is why it is carried even though the escalation predicate
+   * does not read it.
+   */
+  readonly lastFailedAt: Date;
+  /** Coerced on read; `null` when the stored value is unrecognised. */
+  readonly reason: WaybillRelayFailureReason | null;
+  /** Display only. `null` for `'threw'`, or when the stored value was absent. */
+  readonly connectionId: string | null;
+}
+
+/**
+ * How many consecutive failures make a relay operator-visible.
+ *
+ * Module-private, all three of them. Only {@link resolveWaybillRelayAlertThreshold}
+ * may produce the number a caller uses — exporting the default would let a
+ * second call site compare against it directly and reopen the
+ * reported-versus-enforced gap the single resolver exists to close (#2229).
+ */
+const WAYBILL_RELAY_ALERT_THRESHOLD_DEFAULT = 3;
+
+/**
+ * The lower clamp is the load-bearing one. A threshold of `1` would escalate on
+ * a single transient blip, which is precisely what #2073 AC-4 forbids — so the
+ * clamp makes that unreachable rather than merely not the default.
+ */
+const WAYBILL_RELAY_ALERT_THRESHOLD_MIN = 2;
+
+const WAYBILL_RELAY_ALERT_THRESHOLD_MAX = 100;
+
+/**
+ * Resolve the escalation threshold from `OL_WAYBILL_RELAY_FAILURE_ALERT_THRESHOLD`.
+ *
+ * Read by the API process only (the worker increments the counter and never
+ * compares it), so the value is resolved ONCE per request at the HTTP boundary
+ * and passed down — never re-read by the projection, or the filter and the badge
+ * could disagree about what "stuck" means.
+ *
+ * A non-numeric, non-integer or non-finite value falls back to the default
+ * rather than throwing: a mistyped env var must not take the shipments list down.
+ */
+export function resolveWaybillRelayAlertThreshold(raw: string | undefined): number {
+  const parsed = Number(raw);
+  if (raw === undefined || raw.trim() === '' || !Number.isFinite(parsed)) {
+    return WAYBILL_RELAY_ALERT_THRESHOLD_DEFAULT;
+  }
+  const truncated = Math.trunc(parsed);
+  return Math.min(
+    WAYBILL_RELAY_ALERT_THRESHOLD_MAX,
+    Math.max(WAYBILL_RELAY_ALERT_THRESHOLD_MIN, truncated),
+  );
+}
+
+/**
+ * The whole escalation predicate: a COUNT, never elapsed time.
+ *
+ * Cadence-independent by design — "N consecutive attempts could not tell the
+ * marketplace" means the same thing on every deployment, whereas "stuck for two
+ * hours" means a different number of attempts depending on the poll interval.
+ */
+export function isWaybillRelayStuck(
+  failure: WaybillRelayFailure | null,
+  threshold: number,
+): boolean {
+  return failure !== null && failure.count >= threshold;
+}

--- a/libs/core/src/shipping/index.ts
+++ b/libs/core/src/shipping/index.ts
@@ -34,6 +34,21 @@ export type {
 
 export { ShipmentDirectionValues } from './domain/types/shipment-direction.types';
 export type { ShipmentDirection } from './domain/types/shipment-direction.types';
+// #2073 — the waybill-relay failure vocabulary and its two pure rules. The
+// threshold constants are deliberately NOT exported: only
+// `resolveWaybillRelayAlertThreshold` may produce the number a caller compares
+// against, so a second call site cannot reopen the reported-vs-enforced gap.
+export {
+  WaybillRelayFailureReasonValues,
+  readWaybillRelayFailureReason,
+  resolveWaybillRelayAlertThreshold,
+  isWaybillRelayStuck,
+} from './domain/types/waybill-relay-failure.types';
+export type {
+  WaybillRelayFailureReason,
+  WaybillRelayFailure,
+  RecordWaybillRelayFailureInput,
+} from './domain/types/waybill-relay-failure.types';
 
 export { ShippingMethodValues, SHIPPING_METHOD } from './domain/types/shipping-method.types';
 export type { ShippingMethod } from './domain/types/shipping-method.types';

--- a/libs/core/src/shipping/infrastructure/persistence/entities/shipment.orm-entity.ts
+++ b/libs/core/src/shipping/infrastructure/persistence/entities/shipment.orm-entity.ts
@@ -23,6 +23,7 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
   Index,
+  Check,
 } from 'typeorm';
 
 import { ShipmentDirection } from '../../../domain/types/shipment-direction.types';
@@ -77,6 +78,26 @@ import type { DeliveryIntent } from '../../../domain/types/delivery-intent.types
 // nothing and has to be rebuilt as a full one — while permanently refusing to
 // serve the `IS NULL` scan that finding-the-unlinked-rows needs.
 @Index('IDX_shipments_fulfillmentWorkId', ['fulfillmentWorkId'])
+// Waybill-relay failure lookup (#2073). PARTIAL, and this is the one place on
+// this entity where the mutable-predicate warning on
+// `IDX_shipments_reservation_consume_pending` above has to be answered rather
+// than inherited: `waybillRelayFailureCount` genuinely does move, so rows DO
+// enter and leave this index. Two things make that acceptable where the same
+// shape over `status` would not be. It moves only on a relay OUTCOME - a
+// failure or the success that clears it - which is rare, rather than on every
+// ordinary lifecycle write; and every row is born outside the index (the column
+// defaults to 0), so the index is near-empty in steady state and SHRINKS as
+// relays succeed. A full index would instead be almost entirely dead rows.
+// `lastFailedAt` is the indexed column so the operator-facing read can order
+// the stuck set by recency without a sort.
+@Index('IDX_shipments_waybill_relay_failing', ['waybillRelayLastFailedAt'], {
+  where: '"waybillRelayFailureCount" > 0',
+})
+// Declared HERE as well as in the migration, under the identical name, because
+// the integration harness builds schema by `synchronize`: a constraint present
+// only in the migration holds in production and silently not in tests, and an
+// anonymous `@Check` carries a hash name there rather than this one.
+@Check('CHK_shipments_waybill_relay_failure_count', '"waybillRelayFailureCount" >= 0')
 export class ShipmentOrmEntity {
   @PrimaryColumn({ type: 'text' })
   id!: string;
@@ -169,6 +190,47 @@ export class ShipmentOrmEntity {
   // backfill.
   @Column({ type: 'text', nullable: true })
   fulfillmentWorkId!: string | null;
+
+  // Consecutive failed waybill-relay attempts (#2073). Incremented by
+  // `releaseWaybillRelay` in the SAME statement that releases the claim - so a
+  // release without a count is not expressible - and reset by
+  // `clearWaybillRelayFailures` on a successful relay.
+  //
+  // The `default` is declared on the DECORATOR as well as in the migration, and
+  // that is load-bearing rather than belt-and-braces: a `synchronize`-built
+  // schema (the integration harness) takes its default from here, never from
+  // the migration (`docs/lessons.md`, out-of-band-UPDATE entry, trap 2). The
+  // insert path additionally assigns 0 explicitly in `buildOrmEntity`, so it
+  // does not depend on either default being present.
+  //
+  // No counterpart exists on `UpdateShipmentInput`, so the ordinary patch path
+  // structurally cannot stomp these five columns - `update()` writes only the
+  // fields that patch carries.
+  @Column({ type: 'int', default: 0 })
+  waybillRelayFailureCount!: number;
+
+  // When the current run of failures began, and the most recent one. Plain
+  // `timestamp` - NOT `timestamptz` - matching every other timestamp on this
+  // table including both claim markers above. The repo is mixed on this, so the
+  // rule is table consistency, and the migration must agree column for column.
+  @Column({ type: 'timestamp', nullable: true })
+  waybillRelayFirstFailedAt!: Date | null;
+
+  @Column({ type: 'timestamp', nullable: true })
+  waybillRelayLastFailedAt!: Date | null;
+
+  // A `WaybillRelayFailureReason` code, coerced on read. Deliberately a closed
+  // code and NEVER the adapter's free-text detail: that detail can carry a
+  // host, a port or a credential fragment, it is already logged, and this
+  // column reaches a browser - a wider audience than a server log.
+  @Column({ type: 'text', nullable: true })
+  waybillRelayLastFailureReason!: string | null;
+
+  // The first participant in the failing set, for DISPLAY only. No gate reads
+  // it (#2100), and it stays `null` for a `'threw'` failure, which happens
+  // before any participant is known. Per-target retry state is #861.
+  @Column({ type: 'uuid', nullable: true })
+  waybillRelayLastFailureConnectionId!: string | null;
 
   @CreateDateColumn()
   createdAt!: Date;

--- a/libs/core/src/shipping/infrastructure/persistence/repositories/shipment.repository.spec.ts
+++ b/libs/core/src/shipping/infrastructure/persistence/repositories/shipment.repository.spec.ts
@@ -11,7 +11,7 @@
 import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
-import { In, IsNull, Not, type Repository, type UpdateResult } from 'typeorm';
+import { In, IsNull, MoreThan, Not, type Repository, type UpdateResult } from 'typeorm';
 
 import { ShipmentNotFoundException } from '../../../domain/exceptions/shipment-not-found.exception';
 import { TerminalShipmentStatusValues } from '../../../domain/types/shipment-status.types';
@@ -49,6 +49,12 @@ describe('ShipmentRepository', () => {
     createdAt: now,
     updatedAt: now,
     fulfillmentWorkId: null,
+    // #2073 waybill-relay failure history — a fresh row has none.
+    waybillRelayFailureCount: 0,
+    waybillRelayFirstFailedAt: null,
+    waybillRelayLastFailedAt: null,
+    waybillRelayLastFailureReason: null,
+    waybillRelayLastFailureConnectionId: null,
     ...overrides,
   });
 
@@ -62,6 +68,9 @@ describe('ShipmentRepository', () => {
       findAndCount: jest.fn(),
       save: jest.fn(),
       update: jest.fn(),
+      // #2073 — `releaseWaybillRelay` is raw parameterized SQL (the increment
+      // and the COALESCE are expressions the object form cannot carry).
+      query: jest.fn(),
     } as unknown as jest.Mocked<Repository<ShipmentOrmEntity>>;
 
     const module: TestingModule = await Test.createTestingModule({
@@ -557,12 +566,44 @@ describe('ShipmentRepository', () => {
       await expect(repository.claimWaybillRelay(ID, at)).resolves.toBe(false);
     });
 
-    it('should release the claim so a later tick can retry', async () => {
-      ormRepository.update.mockResolvedValue(buildUpdateResult(1));
+    it('should release the claim and record the failure in ONE statement', async () => {
+      // #2073. The point of the assertion is the *conjunction*: the release and
+      // the count must not be separable, or a future edit could drop one and
+      // leave a permanently-failing relay invisible again.
+      ormRepository.query.mockResolvedValue([]);
+      const failedAt = new Date('2026-05-19T11:00:00Z');
 
-      await repository.releaseWaybillRelay(ID);
+      await repository.releaseWaybillRelay(ID, {
+        reason: 'rejected',
+        connectionId: '00000000-0000-0000-0000-0000000000aa',
+        failedAt,
+      });
 
-      expect(ormRepository.update).toHaveBeenCalledWith({ id: ID }, { waybillRelayedAt: null });
+      expect(ormRepository.query).toHaveBeenCalledTimes(1);
+      const [sql, params] = ormRepository.query.mock.calls[0] as [string, unknown[]];
+      expect(sql).toContain('"waybillRelayedAt" = NULL');
+      expect(sql).toContain('"waybillRelayFailureCount" = "waybillRelayFailureCount" + 1');
+      // COALESCE, not assignment: `firstFailedAt` marks the start of the run.
+      expect(sql).toContain('COALESCE("waybillRelayFirstFailedAt", $2)');
+      expect(params).toEqual([ID, failedAt, 'rejected', '00000000-0000-0000-0000-0000000000aa']);
+    });
+
+    it('should clear the failure history only when a run is in progress', async () => {
+      // Guarded on `> 0`, so a relay that has never failed writes nothing.
+      ormRepository.update.mockResolvedValue(buildUpdateResult(0));
+
+      await repository.clearWaybillRelayFailures(ID);
+
+      expect(ormRepository.update).toHaveBeenCalledWith(
+        { id: ID, waybillRelayFailureCount: MoreThan(0) },
+        {
+          waybillRelayFailureCount: 0,
+          waybillRelayFirstFailedAt: null,
+          waybillRelayLastFailedAt: null,
+          waybillRelayLastFailureReason: null,
+          waybillRelayLastFailureConnectionId: null,
+        },
+      );
     });
   });
 
@@ -584,6 +625,14 @@ describe('ShipmentRepository', () => {
         // rather than passing on a `null === null` coincidence (#2347).
         reservationConsumedAt: new Date('2026-05-21T16:00:00Z'),
         fulfillmentWorkId: 'ol_fulfillmentwork_aaaaaaaaaaaaaaaaaaaaaaaa',
+        // Non-null for the same reason as `reservationConsumedAt` above: a
+        // `null === null` round trip would pass against a mapper that dropped
+        // the projection entirely (#2073).
+        waybillRelayFailureCount: 4,
+        waybillRelayFirstFailedAt: new Date('2026-05-21T10:00:00Z'),
+        waybillRelayLastFailedAt: new Date('2026-05-21T15:00:00Z'),
+        waybillRelayLastFailureReason: 'adapter-unresolved',
+        waybillRelayLastFailureConnectionId: '00000000-0000-0000-0000-0000000000aa',
         status: 'delivered',
       });
       ormRepository.findOne.mockResolvedValue(fullyPopulated);
@@ -613,6 +662,15 @@ describe('ShipmentRepository', () => {
         direction: fullyPopulated.direction,
         reservationConsumedAt: fullyPopulated.reservationConsumedAt,
         fulfillmentWorkId: fullyPopulated.fulfillmentWorkId,
+        // The five columns collapse into ONE value object; `null` is the single
+        // representation of healthy, so a caller tests one thing.
+        waybillRelayFailure: {
+          count: 4,
+          firstFailedAt: fullyPopulated.waybillRelayFirstFailedAt,
+          lastFailedAt: fullyPopulated.waybillRelayLastFailedAt,
+          reason: 'adapter-unresolved',
+          connectionId: '00000000-0000-0000-0000-0000000000aa',
+        },
         createdAt: fullyPopulated.createdAt,
         updatedAt: fullyPopulated.updatedAt,
       });

--- a/libs/core/src/shipping/infrastructure/persistence/repositories/shipment.repository.ts
+++ b/libs/core/src/shipping/infrastructure/persistence/repositories/shipment.repository.ts
@@ -20,6 +20,7 @@ import {
   In,
   IsNull,
   LessThanOrEqual,
+  MoreThan,
   MoreThanOrEqual,
   Not,
   Repository,
@@ -40,6 +41,11 @@ import type {
   ShipmentPagination,
 } from '../../../domain/types/shipment-query.types';
 import type { ShipmentDirection } from '../../../domain/types/shipment-direction.types';
+import {
+  readWaybillRelayFailureReason,
+  type RecordWaybillRelayFailureInput,
+  type WaybillRelayFailure,
+} from '../../../domain/types/waybill-relay-failure.types';
 import type {
   CreateShipmentInput,
   UpdateShipmentInput,
@@ -215,10 +221,53 @@ export class ShipmentRepository implements ShipmentRepositoryPort {
     return (result.affected ?? 0) > 0;
   }
 
-  async releaseWaybillRelay(id: string): Promise<void> {
+  async releaseWaybillRelay(
+    id: string,
+    failure: RecordWaybillRelayFailureInput,
+  ): Promise<void> {
     // Unconditional: only the claim holder calls this, and re-releasing an
     // already-NULL row is harmless.
-    await this.repository.update({ id }, { waybillRelayedAt: null });
+    //
+    // The release and the failure record are ONE statement (#2073), so a
+    // release that does not count is not expressible.
+    //
+    // Raw parameterized SQL rather than the object form of `update()`, because
+    // the increment and the COALESCE are expressions that form cannot carry —
+    // the same shape, and for the same reason, as the `webhook_auth_rejections`
+    // rolling counter (#1814). Values are bound, never interpolated.
+    //
+    // `firstFailedAt` is COALESCE'd so it marks the start of the CURRENT run
+    // rather than being overwritten on every attempt, which is what lets an
+    // operator see how long a relay has been stuck. `updatedAt` is bumped
+    // explicitly: a raw statement does not fire `@UpdateDateColumn`, and the
+    // `repository.update()` call this replaces did bump it.
+    await this.repository.query(
+      `UPDATE "shipments"
+          SET "waybillRelayedAt" = NULL,
+              "waybillRelayFailureCount" = "waybillRelayFailureCount" + 1,
+              "waybillRelayFirstFailedAt" = COALESCE("waybillRelayFirstFailedAt", $2),
+              "waybillRelayLastFailedAt" = $2,
+              "waybillRelayLastFailureReason" = $3,
+              "waybillRelayLastFailureConnectionId" = $4,
+              "updatedAt" = now()
+        WHERE "id" = $1`,
+      [id, failure.failedAt, failure.reason, failure.connectionId],
+    );
+  }
+
+  async clearWaybillRelayFailures(id: string): Promise<void> {
+    // Guarded on `> 0` so the healthy case - every relay that has never failed
+    // - matches zero rows and writes nothing. Idempotent either way.
+    await this.repository.update(
+      { id, waybillRelayFailureCount: MoreThan(0) },
+      {
+        waybillRelayFailureCount: 0,
+        waybillRelayFirstFailedAt: null,
+        waybillRelayLastFailedAt: null,
+        waybillRelayLastFailureReason: null,
+        waybillRelayLastFailureConnectionId: null,
+      },
+    );
   }
 
   private buildOrmEntity(input: CreateShipmentInput): ShipmentOrmEntity {
@@ -260,6 +309,17 @@ export class ShipmentRepository implements ShipmentRepositoryPort {
     // `save` would simply write NULL on every row, silently. That is why the
     // spec asserts the PERSISTED value rather than the call argument.
     entity.fulfillmentWorkId = input.fulfillmentWorkId ?? null;
+    // No relay failures at birth (#2073). The count is assigned EXPLICITLY
+    // rather than left to the column default: `save` on a fully-populated
+    // entity would otherwise emit `DEFAULT` for it, making the insert depend on
+    // a default that a `synchronize`-built schema takes from the decorator and
+    // a migration-built one from the DDL (`docs/lessons.md`, out-of-band-UPDATE
+    // entry, trap 2). Assigning here means the insert depends on neither.
+    entity.waybillRelayFailureCount = 0;
+    entity.waybillRelayFirstFailedAt = null;
+    entity.waybillRelayLastFailedAt = null;
+    entity.waybillRelayLastFailureReason = null;
+    entity.waybillRelayLastFailureConnectionId = null;
     return entity;
   }
 
@@ -281,6 +341,11 @@ export class ShipmentRepository implements ShipmentRepositoryPort {
     }
     if (filters.hasProviderShipmentId !== undefined) {
       where.providerShipmentId = filters.hasProviderShipmentId ? Not(IsNull()) : IsNull();
+    }
+    // #2073. A numeric floor, never a "stuck" boolean — the repository is not
+    // where the policy of which number means stuck belongs.
+    if (filters.waybillRelayFailureCountAtLeast !== undefined) {
+      where.waybillRelayFailureCount = MoreThanOrEqual(filters.waybillRelayFailureCountAtLeast);
     }
     const { createdFrom, createdTo } = filters;
     if (createdFrom !== undefined && createdTo !== undefined) {
@@ -343,6 +408,36 @@ export class ShipmentRepository implements ShipmentRepositoryPort {
       entity.direction,
       entity.reservationConsumedAt,
       entity.fulfillmentWorkId,
+      this.toWaybillRelayFailure(entity),
     );
+  }
+
+  /**
+   * Project the five failure columns into one value object, or `null` (#2073).
+   *
+   * `null` is the single representation of healthy, so the gate is the COUNT
+   * rather than the presence of a timestamp. The two timestamps are asserted
+   * non-null before the object is built: a positive count without them would be
+   * a row no writer here can produce, and fabricating an instant to satisfy the
+   * type would put a false fact on an operator's screen — so such a row reads
+   * as no failure history rather than as an invented one.
+   */
+  private toWaybillRelayFailure(entity: ShipmentOrmEntity): WaybillRelayFailure | null {
+    if (
+      entity.waybillRelayFailureCount <= 0 ||
+      entity.waybillRelayFirstFailedAt === null ||
+      entity.waybillRelayLastFailedAt === null
+    ) {
+      return null;
+    }
+    return {
+      count: entity.waybillRelayFailureCount,
+      firstFailedAt: entity.waybillRelayFirstFailedAt,
+      lastFailedAt: entity.waybillRelayLastFailedAt,
+      // Coerced, so a value this build does not recognise reads as absent
+      // rather than being asserted onward to a frontend that cannot render it.
+      reason: readWaybillRelayFailureReason(entity.waybillRelayLastFailureReason),
+      connectionId: entity.waybillRelayLastFailureConnectionId,
+    };
   }
 }


### PR DESCRIPTION
Closes #2073

## The defect

`ShipmentStatusSyncService` releases its at-most-once claim on any transient participant failure so a later poll tick retries (#1947, deliberate). That had **no terminal case**: a relay failing on EVERY tick produced one `logger.error` per tick against a job still reporting `succeeded`, while the marketplace silently never learned the order shipped and the seller kept being asked for a tracking number. The classification existed; only the surface was missing.

## What lands

**The count is folded INTO `releaseWaybillRelay`, as one statement** — so a release that does not count is not *expressible*, and it adds no new failure mode (both callers already awaited that release un-caught). Five columns on `shipments` carry consecutive failures, the last failure's instant, its reason and the participant it was for.

**A successful relay clears the history through a separate best-effort write.** The relay has already landed durably, so failing it because its bookkeeping failed would let the recording of a success destroy the success.

**Escalation is a COUNT, never elapsed time** — cadence-independent, where "stuck for two hours" would mean a different number of attempts per deployment. The threshold is clamped to a minimum of 2, so a single transient blip can never raise a signal: unreachable rather than merely not the default.

**Operator surface**: a `Tracking not sent` badge in the `/shipments` status cell — beside the status badge, never inside the severity word, since a *delivered* shipment can carry one — plus `?waybillRelayStuck=true` as the needs-attention bucket. The backend derives `stuck`, so `apps/web` holds no copy of the rule and no `check:invariants` mirror is needed.

## Two deliberate non-changes

**Not `outcome: 'business_failure'` on the poll job.** It sweeps a page of many shipments, the condition is fixed by a re-auth rather than being terminal, and the retry IS the recovery — ADR-007's semantics are the opposite of what this needs.

**Per-destination notify state remains #861 and is not pre-empted.** The relay's control flow is untouched, and the recorded participant is a display field no retry decision reads.

## Verification

48 files, +1882/−21. Includes a migration (nullable columns + a partial index), declared on the ORM entity too since the integration harness builds schema by `synchronize`.

⚠️ **Integration tests have not been executed.** `*.int-spec.ts` is outside the api project's `testRegex` and its `tsconfig.type-check.json` excludes `test`, so `pnpm test` and `pnpm type-check` do not reach them. They will be run with `pnpm test:integration` (Docker) before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016ZQW46P51PTXHgPt7axxx9