### PR TITLE
perf(3004): close the silent-loss detector's remaining fail-open, and give F10 its results

### DIFF
--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -643,7 +643,11 @@ The unit test covering it passed, and that is the part worth remembering: it con
 
 **Both are the same underlying error: trusting a signal that is CORRELATED with the fact rather than CONSTITUTIVE of it.** That is the test to apply to a new check - not "could this be wrong?" but "is this the fact, or something that usually accompanies it?" A correlated signal fails silently and in both directions, which is why every one of the nine produced a confident answer and none of them errored.
 
-**A worked counter-example from the same branch, because the rule is not "distrust everything".** `post_guard_containers_stable` (#2852) asks whether every measured container's `.State.StartedAt` at `window_stop` equals the baseline captured at `window_start`. `StartedAt` **is** the fact - it changes on exactly the events that invalidate a window - so the guard caught an operator restarting `lab-api` mid-window, named the container and both timestamps, and discarded the arm. Constitutive signals do not need vigilance; that is the point of preferring them.
+**A worked counter-example from the same branch - CORRECTED (#3004), and the correction is the more useful half.** `post_guard_containers_stable` (#2852) asks whether every measured container's `.State.StartedAt` at `window_stop` equals the baseline captured at `window_start`. This entry used to say `StartedAt` **is** the fact, and offered it as the case where a probe needs no vigilance. **That is wrong, and it was wrong in the worst place** - the paragraph telling readers when they may relax.
+
+`StartedAt` is constitutive of **container restart** and is a *proxy* for **process liveness**, which is what a measurement window actually depends on. A parallel campaign observed the guard certify a window `VALID` while the api process had been **dead for three hours**: the process crashed in place, the container never restarted, and `StartedAt` never moved. The guard was answering the question it asks, correctly, and that question was not the one being relied on.
+
+So the real lesson is sharper than "prefer constitutive signals": **a signal is constitutive OF SOMETHING, and you have to name what.** `StartedAt` genuinely catches the recreate it was built for (it caught an operator restarting `lab-api` mid-window, named the container and both timestamps, and discarded the arm) and cannot catch a crash in place. Liveness needs a liveness probe - a request the process must answer, or a log line it must still be emitting - not an attribute of the box it runs in. Ask "what exactly would still be true if this signal were unchanged?" before treating any reading as needing no vigilance.
 
 **The generalisation the five instances support**: a guard's or probe's output must be verified in **both** directions. The ledger already covers a check that cannot report a FAILURE; instances (1) and (4) are a check that cannot stop reporting a **PASS**, and (2) is a *calculation* that cannot report "I have no data". A false pass sends someone to rebuild what was already correct or to hunt a stall that never happened; a false fail hides a real defect. Both are silent, and both are indistinguishable from the truth at the call site.
 
@@ -1592,3 +1596,92 @@ branches differ in what they carry.
 
 **Source**: #3009. Sibling entry: `docker logs --since "@<epoch>"` above - both are "a tool
 answered confidently about something it could not see".
+
+---
+
+## A fake that answers ONE value for every query cannot prove a predicate is scoped - key the fake on the SQL
+
+**Context**: `post_guard_destination_creates` counted an order that failed on ANY destination while
+its message promised "the declared destination". It shipped with two green assertions beside it for
+a whole campaign, and was repaired twice independently (#2985 and #3004) once the data was looked
+at.
+
+**Problem**: the assertions used the shared `FAKE_PG[count]`, a single number the fake returns for
+every query containing `COUNT(*)`. Both arms therefore read the SAME value, so a scoped predicate
+and an unscoped one are indistinguishable to the test - `FAKE_PG[count]=1` makes the correct and
+the broken implementation produce byte-identical output. The tests were not weak about the defect,
+they were structurally incapable of seeing it, while the guard flagged 650 of 652 ingested orders
+against a true count of 1.
+
+**Rule**: when a test must prove a query has a particular SHAPE, capture the emitted SQL and assert
+on it **per arm** - a whole-capture assertion that the destination appears SOMEWHERE is satisfied
+by the other arm on its own. Assert the specific message, never a word both arms share
+(`"DISCARDED"` passes for either). Then prove it: apply the mutation, watch the assertion go red,
+restore. Note `case` patterns are POSITIONAL - `*a*b*` requires `a` before `b`, so an arm that
+matches nothing looks exactly like an arm whose key holds the same number.
+
+**Applies to**: `perf/openlinker-throughput/lib-test.sh`, and any test double standing in for a
+database, HTTP client or CLI whose SHAPE the code under test is responsible for.
+
+**Source**: #2985, #3004.
+
+---
+
+## A read that folds stderr into stdout returns its ERROR as a VALUE - coerce before you compare or compute
+
+**Context**: `ps_sql` and `pg_sql` both end `|| true` and fold stderr into stdout, so a database
+failure is not an exit code any caller can test. F10's ground-truth silent-loss detector did
+`claimed_missing=$(( claimed_total - ${present:-0} ))` straight on that value, and
+`post_guard_destination_creates` did `[ "${failed:-0}" -gt 0 ]` on it.
+
+**Problem**: three different wrong answers, none of which errors. An empty read makes the
+subtraction report **every claimed order as missing** - the scenario's headline finding, red, for a
+hiccup. An error string makes `$(( ))` abort the run mid-window under `set -u`. And in a GUARD,
+`[ "ERROR ..." -gt 0 ]` is "integer expression expected", which under `set -e` aborts the caller
+and without it **falls through to `ok` and certifies a window nobody measured** - a fail-open
+sitting inside the fix for a different fail-open.
+
+**Rule**: coerce every count read from one of these helpers through `as_count` (`lib.sh`) before
+comparing or computing with it, and treat the empty answer as *not established* rather than as
+zero: a detector reports that it could not read, a guard DISCARDS. Carry the distinction into the
+artefact too - F10's ledger now emits `groundTruth.readable`, because
+`claimedButAbsentFromPsOrders: 0` from a failed read must not be quotable as a measured zero.
+
+**Applies to**: `perf/openlinker-throughput/**`, any caller of `ps_sql` / `pg_sql`.
+
+**Source**: #3004.
+
+---
+
+## Command substitution is a SUBSHELL - a function that reports by setting a global reports nothing through `$( )`
+
+**Context**: `f10-dependency-failure.sh` called `drain_result="$(drain_wait "$CONN_IDS")"`, where
+`drain_wait` reports which rows it killed by setting the globals `DRAIN_DEAD_IDS` /
+`DRAIN_DEFERRED_SEEN` / `DRAIN_REQUEUED_SEEN`.
+
+**Problem**: `$( )` forks, so every assignment inside it died with the subshell and
+`rowsTheHARNESSMarkedDeadDuringCleanup` was always `""` however many rows were killed. That is not
+cosmetic: F10 reads its ledgers BEFORE cleanup precisely so the harness cannot forge a finding, and
+this field was the only record that the cleanup killed anything. The one contamination the ordering
+was designed to keep visible was invisible, silently. The same shape bit a test recorder that
+appended captured SQL to a bash array from inside `pg_sql`.
+
+**Rule**: a function that communicates by side effect must be called WITHOUT command substitution -
+redirect its stdout to a file and read the file back. Check a helper's docblock for "sets X as a
+side effect" before reaching for `$( )`. Redirect **stdout only** unless you mean to swallow
+`warn`, which writes to stderr. For a recorder, use a file rather than an array whenever the thing
+being recorded is written from inside a substitution.
+
+**A related one from the same change, because it is the same silence.** A `case` dispatch with no
+`*)` arm reports nothing about an input it does not handle: a new fault id was added to the
+catalogue and to two other `case` statements but not to the one that reads the injector's delivery
+count back, so it ran a full 90 s measurement window whose manifest recorded `"delivered": {}` -
+the exact artefact that exists to tell "the rule installed and never matched" from "the system
+absorbed the fault". **A dispatch that cannot report an unhandled input is indistinguishable from
+one that handled it.** Give every dispatch over an open set a `*)` arm that warns and writes its
+own ignorance into the artefact.
+
+**Applies to**: `perf/openlinker-throughput/**`, and any bash calling a helper documented as
+setting globals.
+
+**Source**: #3004.

--- a/perf/openlinker-throughput/lib-test.sh
+++ b/perf/openlinker-throughput/lib-test.sh
@@ -516,10 +516,19 @@ FAKE_PG[count]=0
 # --- the destination predicate (#2840) -------------------------------------
 # Asserted in BOTH directions, and on the emitted SQL rather than on a
 # return value, because a fake answering 0 passes whatever the predicate says.
-# Three windows shipped a `failed` count that EXCEEDED the population it
-# described (2967 vs 2961 twice, 1798 vs 1792 once) because the arm carried no
-# destination predicate while its message said "the declared destination".
-# Scoped, arm A's real answer was 1 - the stranded order its report is about.
+# CORRECTED (#3004). This comment used to say three windows shipped a `failed`
+# count that EXCEEDED the population it described (2967 vs 2961, 1798 vs 1792).
+# That does not reproduce: re-measured against the same persisted rows the arms
+# read 650 of 652, 2967 of 2967 and 1792 of 1792 - equal to their source's
+# ingested count, never above it. The earlier figures compared the guard
+# against a differently-measured population, and the argument is withdrawn.
+# The true statement needs no arithmetic impossibility and is stronger: scoped
+# to the declared destination those same windows answer 1, 2 and 0. A guard
+# whose whole purpose is to isolate ONE class of failure was flagging
+# essentially the entire ingested population, so its output carried no
+# information at all - a signal that fires on everything is indistinguishable
+# from one that fires on nothing. Arm A's true 1 is the stranded order its
+# report is about, and at 650 it was invisible.
 # A guard that cannot refuse is worse than the unfiltered one, so the FIRE
 # direction is asserted first.
 # Captured to a FILE, not a variable: the guard calls pg_sql inside a command
@@ -582,9 +591,56 @@ case "$PG_CAPTURED" in
   *) assert_eq "unscoped guard emits no destination predicate" "absent" "absent" ;;
 esac
 
+# 6. The refusal NAMES the destination, not just its role (#3004). A stand
+#    carries five connections and four of them can also fail, so "the declared
+#    destination" alone sends its reader back to the scenario source.
+FAKE_PG[count]=1
+assert_contains "the refusal names the destination connection id" \
+  "$(post_guard_destination_creates '2026-01-01T00:00:00Z' 'dest-1')" "dest-1"
+
+# 7. An UNREADABLE count must DISCARD, never certify (#3004). pg_sql folds
+#    stderr into stdout and ends `|| true`, so a database failure is the VALUE.
+#    `[ "$x" -gt 0 ]` on a word is "integer expression expected" - under
+#    `set -e` that aborts the caller, and without it falls through to `ok` and
+#    certifies a window nobody measured. Asserted through the real code path by
+#    making pg_sql answer what a broken pg_sql answers.
+eval "$_pg_sql_real"
+_pg_sql_scoped="$(declare -f pg_sql)"
+pg_sql() { printf 'ERROR:  relation "order_records" does not exist\n'; }
+_unreadable="$(post_guard_destination_creates '2026-01-01T00:00:00Z' 'dest-1')"
+assert_contains "an unreadable count DISCARDS rather than certifying" \
+  "$_unreadable" "DISCARDED"
+assert_contains "and says the window was not measured, not that it passed" \
+  "$_unreadable" "could not be read"
+eval "$_pg_sql_scoped"
+
 eval "$_pg_sql_real"
 rm -f "$PG_CAPTURE_FILE"
 FAKE_PG[count]=0
+
+# --- as_count (#3004) ------------------------------------------------------
+# The coercion the guard above and F10's ground-truth detector both depend on.
+# Both failure modes are asserted as ARITHMETIC, because "it would have lied"
+# and "it would have died" are the claims, not the coercion.
+echo "--- as_count (#3004) ---"
+assert_eq "a plain count passes through" "12" "$(as_count 12)"
+assert_eq "zero is an ANSWER and must survive" "0" "$(as_count 0)"
+assert_eq "an empty read is not an answer" "" "$(as_count '')"
+assert_eq "a MySQL error string is not an answer" "" "$(as_count 'ERROR1054at')"
+assert_eq "a negative is not a count" "" "$(as_count '-1')"
+assert_eq "a decimal is not a count" "" "$(as_count '1.5')"
+assert_eq "a signed positive is not a count" "" "$(as_count '+3')"
+assert_eq "an embedded space is not a count" "" "$(as_count '1 2')"
+# Failure mode 1 - THE FABRICATED FINDING. present="" and claimed=3 made
+# claimed_missing 3: F10's headline silent-loss number, red, for a hiccup.
+_claimed=3; _present="$(as_count '')"
+assert_eq "an unreadable shop read is refused, not turned into 3 missing orders" \
+  "unreadable" "$( [ -z "$_present" ] && echo unreadable || echo "$(( _claimed - _present ))" )"
+# Failure mode 2 - THE MID-WINDOW ABORT.
+assert_dies "arithmetic on an unguarded error string aborts" \
+  bash -c 'set -euo pipefail; present="ERROR1054at"; echo $(( 3 - present ))'
+assert_ok "the guarded form survives the same input" \
+  bash -c 'set -euo pipefail; p="$(printf "")"; [ -z "$p" ] && exit 0; echo $(( 3 - p ))'
 
 echo "--- reset_between_repeats SCAN loop (#2847) ---"
 # This function shipped with NO CALLER in any scenario, so its SCAN loop had

--- a/perf/openlinker-throughput/lib.sh
+++ b/perf/openlinker-throughput/lib.sh
@@ -200,6 +200,34 @@ ps_sql() {
     mysql -uroot -N -B "$PS_DB" -e "$1" 2>&1 | grep -v '^mysql: \[Warning\]' || true
 }
 
+# as_count <value> - echoes <value> when it is a non-negative integer, and
+# NOTHING otherwise, so a caller can tell "the read answered 0" from "the read
+# did not answer" (#3004).
+#
+# Both `ps_sql` above and `pg_sql` fold stderr into stdout and end `|| true`,
+# so a database failure is not an exit code a caller can test - it arrives as
+# the VALUE. A caller that then does arithmetic or a numeric comparison on it
+# gets one of two wrong answers:
+#
+#   present=""            -> $(( claimed - 0 ))       -> a FABRICATED finding
+#   present="ERROR 1054"  -> arithmetic on a word     -> the run dies mid-window
+#
+# and for a GUARD the second form is worse than it looks: `[ "$n" -gt 0 ]` on a
+# non-numeric value is "integer expression expected", which under `set -e`
+# aborts the caller and without it falls through to the else branch and
+# CERTIFIES a window nobody measured.
+#
+# The rule this encodes is the campaign's own: a probe that cannot identify
+# its subject must report that it could not, never a number that looks like an
+# answer. Deliberately rejects a leading `+`/`-`, whitespace, decimals and the
+# empty string - every one of those is a read that did not return a count.
+as_count() {
+  case "${1:-}" in
+    ''|*[!0-9]*) printf '' ;;
+    *) printf '%s' "$1" ;;
+  esac
+}
+
 ps_sql_write() {
   ps_mysql_pwd
   docker exec -i -e MYSQL_PWD="$PS_MYSQL_PWD" "$PS_MYSQL_CONTAINER" \
@@ -1320,7 +1348,12 @@ post_guard_requeues() {
 post_guard_destination_creates() {
   local window_start_iso="$1" destination_conn_id="${2:-}" failed missing scope
   if [ -n "$destination_conn_id" ]; then
-    scope="the declared destination"
+    # Name the destination, not just its role (#3004). "the declared
+    # destination" is true of whichever connection the scenario passed, and a
+    # refusal that does not say WHICH sends its reader back to the scenario
+    # source to find out - on a stand carrying five connections, four of which
+    # can also fail.
+    scope="the declared destination $destination_conn_id"
     failed="$(pg_sql "SELECT COUNT(*) FROM order_records
       WHERE \"createdAt\">='$window_start_iso'
         AND EXISTS (SELECT 1 FROM jsonb_array_elements(\"syncStatus\") e
@@ -1339,8 +1372,21 @@ post_guard_destination_creates() {
         AND EXISTS (SELECT 1 FROM jsonb_array_elements(\"syncStatus\") e WHERE e->>'status'='failed')")"
     missing=0
   fi
-  if [ "${failed:-0}" -gt 0 ] || [ "${missing:-0}" -gt 0 ]; then
-    echo "DISCARDED post_guard_destination_creates: $failed order(s) carry a failed syncStatus entry on $scope, $missing lack syncedAt on $scope"
+  # FAIL CLOSED when the count could not be read (#3004). `pg_sql` folds stderr
+  # into stdout and ends `|| true`, so a database failure arrives as the VALUE
+  # of `failed`/`missing`, and `[ "$x" -gt 0 ]` on a non-numeric value is
+  # "integer expression expected" - which under `set -e` aborts the caller, and
+  # without it falls through to `ok` and CERTIFIES a window nobody measured.
+  # A guard that could not read cannot certify, and must say which arm.
+  local failed_n missing_n
+  failed_n="$(as_count "$failed")"
+  missing_n="$(as_count "$missing")"
+  if [ -z "$failed_n" ] || [ -z "$missing_n" ]; then
+    echo "DISCARDED post_guard_destination_creates: the count could not be read (failed=[${failed:0:60}] missing=[${missing:0:60}]) - this window was NOT measured for a swallowed per-destination failure"
+    return 0
+  fi
+  if [ "$failed_n" -gt 0 ] || [ "$missing_n" -gt 0 ]; then
+    echo "DISCARDED post_guard_destination_creates: $failed_n order(s) carry a failed syncStatus entry on $scope, $missing_n lack syncedAt on $scope"
   else
     echo "ok"
   fi

--- a/perf/openlinker-throughput/results-F10-2026-09-08.md
+++ b/perf/openlinker-throughput/results-F10-2026-09-08.md
@@ -2,9 +2,11 @@
 
 _Run 2026-09-08 on the `lab` stand. Scenario `scenarios/f10-dependency-failure.sh` (#2978, epic #2840)._
 
-> **STATUS: METHOD AND CONDITIONS ONLY.** The measurement sections below are
-> not yet filled. Nothing in this file may be quoted as a result until this
-> banner is gone.
+> **STATUS: COMPLETE.** § 6 is filled from two runs - `f10-final-2026-09-08`
+> (#2978, twelve windows) and `f10-3004-2026-09-08` (#3004, the two windows
+> that run did not deliver). Every figure carries its `n`, its detector and its
+> window. § 6.0 states what the `VALID` verdicts on the twelve #2978 windows do
+> and do not certify; read it before quoting any of them.
 
 ---
 
@@ -77,7 +79,16 @@ _(Filled from the run's own manifests - see § 8.)_
 - **Peer activity**: see § 2.1. Two windows were **discarded** before the
   measured run began, one of them because a peer wrote into this run's own
   connection while this run held the stand lock.
-- **Image**: TBD (`guard_build` records the image commit, not `HEAD`).
+- **Image**: for the #3004 windows,
+  `629921c5fe000f24dd66a02836a52a32ac58d877`, read from the running
+  containers' `org.opencontainers.image.revision` label. **For the twelve
+  #2978 windows the image commit is not recoverable**: `manifest.json` records
+  `gitSha` (the *checkout* at run time, `8c1c0bbe7ee52cf8683cf2a888c926457626ef7a`)
+  and the Postgres and Redis image digests, but no OL image revision, and the
+  containers have since been rebuilt. `guard_build` compared the trees at run
+  time and passed; nothing persisted what it compared them against. Stated
+  rather than back-filled from today's label, which would be a different
+  build's number written into an older run's conditions.
 - **Destination**: the **real local PrestaShop**, reached through the
   fault-injection proxy. Never a mock - see § 3.
 - **Source**: the Allegro upstream stub (#2856/#2935) at
@@ -321,6 +332,7 @@ Every fault class #2978 names, and where it is exercised.
 | `M2` | the source returns a malformed payload | allegro-stub | `malformed`, endpoint `checkout`, fraction 0.5 | order ingestion |
 | `M2t` | the source returns a truncated payload | allegro-stub | `truncated`, endpoint `events`, fraction 0.5 | order ingestion |
 | `M3` | the source rejects the offer-quantity write | allegro-stub | `reject-quantity` | `marketplace.offerQuantity.update` |
+| `M4` | **(added by #3004)** the source returns an HTTP error status | allegro-stub | `503`, endpoint `checkout`, fraction 0.5, `Retry-After: 5` | order ingestion |
 | `I1` | Redis becomes slow (a blocked client, not an outage) | `CLIENT PAUSE` | 3 000 ms every 6 s | order ingestion |
 | `I2` | Redis drops entirely mid-window | `docker stop` / `start` | at t+35 s, back 20 s later | order ingestion |
 | `I3` | the worker is killed mid-job | `docker kill -s KILL` / `start` | at t+35 s, back 10 s later | order ingestion |
@@ -340,8 +352,482 @@ Two notes on the choice of rule:
 
 ## 6. Results
 
-_TBD._
+All figures below are **measured** unless labelled otherwise. Two runs feed
+this section and they are never mixed:
 
+- **`f10-final-2026-09-08`** (#2978) - twelve windows, `windowSecs=90`,
+  `WINDOW_BACKLOG=12`. Every fault in the catalogue except `I3`, which
+  produced **no artefacts at all**.
+- **`f10-3004-2026-09-08`** (#3004) - the two windows that run did not
+  deliver: `I3`, and the new `M4` (§ 5).
+
+### 6.0 The verdicts these figures travel with
+
+Eleven of the twelve `f10-final` windows carry `verdict.txt` reading
+`status=VALID` and `I3` carries no verdict file. **That `VALID` is weaker than
+it looks and is not quoted as a clean bill of health**, for a reason this
+campaign has already recorded: those verdict files contain `status=` and
+`generatedAt=` and *nothing else*, so a `VALID` written by a run cannot be told
+apart from a `VALID` written before a guard existed (#3009, which adds
+`guard=<name>:<ok|failed>` lines for exactly this). Read instead the per-window
+`fault-observations.txt`, which does name what fired:
+
+| window | observations that read DISCARDED |
+|---|---|
+| baseline | `post_guard_limiter_degraded` (5 lines) |
+| D1 | `post_guard_destination_creates` (2/2), `post_guard_limiter_degraded` (3) |
+| D2a | - none - |
+| D2b | `post_guard_destination_creates` (3/3), `post_guard_limiter_degraded` (2) |
+| D3 | `post_guard_destination_creates` (1/1), `post_guard_limiter_degraded` (1) |
+| D4 | `post_guard_destination_creates` (5/5), `post_guard_limiter_degraded` (2) |
+| M1 | `post_guard_limiter_degraded` (1) |
+| M2 | `post_guard_limiter_degraded` (8) |
+| M2t | `post_guard_limiter_degraded` (10) |
+| M3 | `post_guard_attempts` (12 jobs with attempts>1), `post_guard_limiter_degraded` (3) |
+| I1 | `post_guard_limiter_degraded` (3) |
+| I2 | `post_guard_containers_stable` (EXPECTED-BY-FAULT), `post_guard_destination_creates` (0/2), `post_guard_limiter_degraded` (4) |
+
+`post_guard_limiter_degraded` fires in eleven of twelve windows. That is the
+#2984 shared-Redis defect, which was **fixed after this run** (the mixed-load
+re-run measured it at 1 454 -> 0), so it is a dated property of the build these
+windows ran on, not a fault of the measurement. It is disclosed rather than
+waved away: every figure here was taken on a build whose outbound limiter was
+degrading.
+
+### 6.1 The question, answered
+
+> **is the order LOST, RETRIED, or SILENTLY MARKED DONE?**
+
+**There are two distinct silent-loss shapes and only one of them occurs.**
+They are reported separately because merging them would have hidden the one
+that does.
+
+**Shape A - OpenLinker claims `synced` for an order the shop has no row for.**
+This is the scenario's own ground-truth detector (§ 1), and it is the only
+reading in the campaign whose witness is not OpenLinker.
+
+> **0 events out of 109 claimed-synced entries**, across the twelve
+> `f10-final` windows. **[measured]**
+
+That is a **measured zero, not an absence of evidence**: the detector was
+demonstrated able to fire before the run (three genuinely-claimed ids answered
+3 present / 0 missing, and the same query with one id replaced by a fabricated
+`999999` answered 2 present / **1 missing**), and it returned a non-zero
+denominator in eleven of the twelve windows, so it was looking. By the rule of
+three the 95% upper bound at n=109 is **2.75%** **[derived]**.
+
+**That upper bound EXCLUDES #2978's published 17-42% estimate for this shape,
+and this is the campaign's first measured refutation of a figure it had already
+published.** It does not exclude the sustained window's 0.24%. The refutation
+is only worth stating because of the demonstration above: a zero from a
+detector nobody has watched go red is worth nothing, and this campaign has
+eleven recorded reasons to insist on that (§ 6.7).
+
+**Shape B - the job ledger reports success over an order that failed at the
+destination, and nothing will ever retry it.** This is F10-1, and it is the
+shape `post_guard_destination_creates` exists to see.
+
+> **11 events out of 60 orders offered across the five destination-fault
+> windows = 18.3%.** **[measured]**
+> **0 events out of 36 offered across the three marketplace order-path windows,
+> and 0 out of 24 offered across the two infrastructure windows** - though
+> `I2` ingested only 2 of its 12, so its share of that zero rests on n=2
+> (§ 6.4). **[measured]**
+
+Every one of the 11 carries `marketplace.order.sync` at
+`status=succeeded outcome=ok`, and **zero** queued or running jobs. The order is
+LOST at the shop and SILENTLY MARKED DONE in OpenLinker at the same time; those
+are not alternatives here, they are the same event read from two tables.
+
+### 6.2 Per fault class
+
+`stranded` = an order whose `syncStatus` carries `failed` for the declared
+PrestaShop destination while its `marketplace.order.sync` row reads
+`succeeded`/`ok` with nothing queued or running. `offered` is the window's own
+fixed batch (`WINDOW_BACKLOG`), which is the quantity the scenario controls.
+
+**`faults delivered` is read back from the injector, not assumed.** A rule that
+installed and never matched must not read the same as a system that absorbed
+the fault, and one window here is close to that line: `M2` delivered a single
+malformed response, so its `0 stranded` is a much weaker statement than
+`M2t`'s or `M1`'s.
+
+| id | fault shape | faults delivered | offered | stranded | rate | ps_orders created | verdict of the class |
+|---|---|---|---|---|---|---|---|
+| `baseline` | none | 0 of 55 (transparent proxy) | 12 | **0** | 0% | 12 of 12 | reference |
+| `D1` | **HTTP error response** (500, 0.3) | 12 of 49 | 12 | **2** | 16.7% | 10 of 12 | LOST + silently done |
+| `D2a` | **HTTP error response** (429 **with** `Retry-After`) | 10 of 24 | 12 | **0** | 0% | 12 of 12 | RETRIED, recovered |
+| `D2b` | **HTTP error response** (429 **without** `Retry-After`) | 24 of 45 | 12 | **3** | 25.0% | 9 of 12 | LOST + silently done |
+| `D3` | **connection timeout** (hang 45 s past the client's 30 s abort) | 4 of 21 | 12 | **1** | 8.3% | 11 of 12 | LOST + silently done |
+| `D4` | **HTTP error response** (500 on `importorder`, fraction 1) | 4 of 52 | 12 | **5** | 41.7% | 7 of 12 | LOST + silently done |
+| `M1` | **connection timeout** (source, hydration) | 6 of 15 | 12 | **0** | 0% | 12 of 12 | RETRIED, recovered |
+| `M2` | 2xx, unparseable body | **1 of 16** | 12 | **0** | 0% | 12 of 12 | see the note above |
+| `M2t` | 2xx, truncated body (premature close) | 3 of 19 | 12 | **0** | 0% | 12 of 12 | RETRIED, recovered |
+| `M3` | 2xx, business rejection (quantity write) | 24 of 24 | n/a - quantity path, no orders | - | - | - | see § 6.4 |
+| `I1` | Redis slow (`CLIENT PAUSE` 3 s / 6 s) | container action | 12 | **0** | 0% | 12 of 12 | RETRIED, recovered |
+| `I2` | Redis dropped 20 s mid-window | container action | 12 | **0** | 0% | 1 of 2 ingested | see § 6.4 |
+
+The delivery counter is read PER INJECTOR, and that matters for anyone
+re-deriving these numbers: the proxy reports `delivered.proxyCounters.faulted`,
+the stub reports `delivered.stubFaultsApplied`, and an infrastructure fault
+reports neither by design. A single recursive scan for a key named `faulted`
+reads **0** for every stub and infrastructure window and double-counts the
+proxy ones - which is what the first pass over these artefacts did, and it
+looked exactly like six windows whose fault never landed.
+
+### 6.3 The two fault shapes behave differently, and the difference is not the shape
+
+Stated separately, as the issue requires:
+
+| shape | windows | offered | stranded | rate |
+|---|---|---|---|---|
+| **HTTP error response**, destination | D1 + D2a + D2b + D4 | 48 | 10 | **20.8%** |
+| **connection timeout**, destination | D3 | 12 | 1 | **8.3%** |
+| **connection timeout**, source | M1 | 12 | 0 | **0%** |
+| **2xx that is nonetheless wrong**, source | M2 + M2t | 24 | 0 | **0%** |
+
+**The dominant variable is not error-response versus timeout - it is which
+side of OpenLinker the fault is on.** Every stranded order in this run came
+from a *destination* fault; not one came from a *source* fault, under either
+shape. That is a mechanism, not a coincidence: a source failure happens before
+`persistOrder`, so the job fails honestly and the retry ladder re-drives it,
+whereas a destination failure happens inside
+`OrderSyncService.dispatchToDestinations`, where `Promise.allSettled` swallows
+it and the job still returns `ok`.
+
+**This contradicts the expectation the run was commissioned under, and the
+expectation was not the scenario's - it was the brief's.** The two shapes were
+required to be measured and reported separately on the stated reasoning that
+*the retry classifier may treat an error response differently from a timeout*.
+Measured, the classifier is **not** where the variance is: on the source side
+both shapes strand 0, and on the destination side a timeout (`D3`, 8.3%) sits
+inside the spread of the error responses (`D1` 16.7%, `D2a` 0%, `D2b` 25.0%,
+`D4` 41.7%) rather than apart from them. Keeping the shapes separate was still
+the right instruction - it is what makes this statement possible instead of
+assumed - but the hypothesis behind it is not supported. Recorded here rather
+than dropped, because a brief whose prediction failed is the kind of thing a
+report quietly stops mentioning.
+
+**`Retry-After` does NOT explain the D2a/D2b gap, and the ledger says so
+directly.** The obvious reading of D2a 0 versus D2b 3 - same status, same
+fraction, differing only by the header - is that OpenLinker honours
+`Retry-After`. **It does not.** Read from these windows' own
+`ledger-after-recovery.json`, every destination arm records
+`deferred_rows: 0` and `deferred_ms_total: 0` on `marketplace.order.sync`,
+**including D2a**, which sends `Retry-After: 5` on half its responses. A
+honoured `Retry-After` produces a deferral; zero deferrals in the arm that
+sends it means the header was ignored. `attempts_max` is likewise `0` in all
+five arms - the jobs did not retry at all, they succeeded.
+
+So the 0-versus-3 difference is not the header. It is most likely delivery
+volume or chance: the two windows did not deliver the same number of faults
+(D2a 10 of 24 proxied requests, D2b 24 of 45), because a fraction is drawn per
+request. **This corrects F10-2 as stated** - the header changes neither the
+timing nor, on this evidence, the outcome; what F10-2 observed was two windows
+that differed in more than the header. A fixed-count injector would separate
+them, and neither injector has one.
+
+An independent campaign on different hardware (`-epyc32` artefacts) reached the
+same conclusion by the same reading: `Retry-After` ignored outright, with
+`deferredTotalMs` at 0 even in the arm that sends it.
+
+The n behind each of these is 12-48 orders. **A 0% cell means "no event in 12
+offered orders", which is consistent with any true rate below ~22%** (rule of
+three at n=12) **[derived]** - it is not a demonstration that the class is
+safe. § 8 says so again where it belongs.
+
+### 6.4 Two classes whose result is about the harness, not the system
+
+- **`M3`** delivered 24 of 24 injected rejections on the quantity endpoint, so
+  the fault landed - but the class runs the quantity-write path, ingests no
+  orders, and its ledger records `attempts>1` on 12 jobs. It answers "does a
+  rejected quantity write retry" (**it does**) and says nothing about order
+  loss. It is not counted in any rate above.
+- **`I2`** ingested 2 orders against 12 offered, because stopping Redis for
+  20 s stopped the pump as well as the worker. Its 0 stranded therefore rests
+  on n=2 and is reported as such rather than as a clean pass. Its
+  `post_guard_destination_creates` line reads `0/2`, and § 6.5 explains why the
+  repaired guard now reads `0/0` there.
+
+### 6.5 Three independent reads agree on the same 11 orders
+
+The stranded count is not one query's opinion. Three readings, taken from
+different places, agree window by window:
+
+| window | `entriesFailed` after recovery (ledger JSON) | stranded (live job-ledger join) | 12 - `psOrdersCreated` (the shop's own table) |
+|---|---|---|---|
+| D1 | 2 | 2 | 2 |
+| D2b | 3 | 3 | 3 |
+| D3 | 1 | 1 | 1 |
+| D4 | 5 | 5 | 5 |
+| all others | 0 | 0 | 0 |
+
+The third column is the important one: it is counted at PrestaShop, so it does
+not share a failure mode with the first two.
+
+**A fourth reading, from a different machine and a different injector.** A
+parallel campaign (`-epyc32` artefacts) ran five destination-failure arms on
+other hardware with its own fault injection and reached the same finding
+independently: `succeeded` / `ok` on **every** job, `attempts` **0**
+everywhere, and **36 of 131 orders still lacking a destination `syncedAt` two
+and a half hours after the faults were lifted** - so not a timing artefact of a
+240 s observation window. Its `D4` equivalent (cart succeeds, `importorder`
+fails) lost **12 of 12**, against 5 of 12 here.
+
+Their 36/131 (**27.5%**) and this run's 11/60 (**18.3%**) are the same defect
+measured twice, on different hardware, with different injectors, at different
+scales. Neither figure is quoted as the other's confirmation of a *rate* - the
+arms are not matched and their D4 is twice as severe as ours - but the
+mechanism is now observed by two independent instruments, which is a much
+stronger claim than either run could make alone.
+
+**And the repaired `post_guard_destination_creates` (#3004) reproduces the
+numbers these windows recorded at the time** - 2/2, 3/3, 1/1, 5/5 on the four
+windows where it fired, and `0/0` on the seven where it reported `ok`. It
+differs on exactly one reading in twelve windows: **I2, recorded `0/2`,
+repaired `0/0`**, and it differs in the direction the repair's own docblock
+predicts. Those 2 orders have an EMPTY `syncStatus` - Redis was down, so they
+were never dispatched to any destination - and the repaired `missing` arm
+deliberately excludes orders the destination was never attempted on. They
+remain visible as `destinationFanOut.ordersWithNoSyncStatus: 2`; they are not
+lost from the record, they have stopped being attributed to a destination that
+never saw them.
+
+**Why the defect the repair fixes is invisible in this scenario.** F10 disables
+the WooCommerce `OrderProcessorManager` for the whole run, precisely so an
+unrelated second-destination failure cannot be attributed to the injected
+fault. That workaround is what made the unscoped `failed` arm harmless here -
+and it is a held-variable change the mixed-load run explicitly refused to make,
+which is why the same guard over-reported 650 against a true 1 there. The
+repair removes the need for the workaround rather than the workaround removing
+the need for the repair.
+
+**A correction to how that defect was argued, because the argument was
+weaker than the fact.** It was first stated as *"a count exceeding its own
+population can only come from an unscoped predicate"*, on figures of 2 967
+against 2 961 and 1 798 against 1 792. **That does not reproduce.** Re-measured
+against the same persisted rows, arms B and C read **2 967 of 2 967** and
+**1 792 of 1 792** - equal to their source's ingested count, never exceeding
+it; the small gap came from comparing the guard against a differently-measured
+population figure rather than against the table.
+
+The real statement needs no arithmetic impossibility and is stronger: scoped
+correctly, the three arms answer **1, 2 and 0** against unscoped **650, 2 967
+and 1 792**. A guard whose entire purpose is to isolate one class of failure
+was flagging **essentially the whole ingested population**, so its output
+carried no information at all - a signal that fires on everything is
+indistinguishable from a signal that fires on nothing.
+
+### 6.6 The two windows added by #3004
+
+Run `f10-3004-2026-09-08`, image revision
+`629921c5fe000f24dd66a02836a52a32ac58d877`. These are the **first windows to
+run against the repaired `post_guard_destination_creates`**, so their
+`fault-observations.txt` carries the scoped predicate's answers.
+
+| | `M4` @stop | `M4` @recovery | `I3` @stop | `I3` @recovery |
+|---|---|---|---|---|
+| faults delivered | 9 of 27 | - | container action | - |
+| order_records created | 8 | **12** | 9 | **12** |
+| `ps_orders` created | 7 | **12** | 5 | **10** (12 after the drain) |
+| claimed synced to PrestaShop | 7 | 12 | 5 | 10 |
+| **claimed but absent from `ps_orders`** | **0** | **0** | **0** | **0** |
+| ground truth readable | yes | yes | yes | yes |
+| stranded (Shape B) | - | **0** | - | **0** |
+
+**`M4` - the source returns 503 with `Retry-After` during hydration.** The
+marketplace-side HTTP-error-response shape, which did not exist in the #2978
+catalogue (§ 9). `verdict.txt` = `VALID`, **every observation reads `ok`**
+including the repaired destination guard, **9 faults delivered across 27 source
+requests**, recovered unattended in **60 s**, nothing queued or running when
+the observation ended. **0 stranded of 12 offered.**
+
+So a source that answers an error *status* behaves exactly like a source that
+times out (`M1`) and exactly like one that returns an unparseable body (`M2`):
+the job fails honestly, the ladder re-drives it, every order arrives. The
+error-response / timeout distinction that matters on the destination side
+(§ 6.3) **does not change the outcome on the source side**, in 12 orders.
+
+**This window was run twice, and the second run is the one quoted.** The first
+recorded `"delivered": {}` - `M4` had been added to the catalogue, to
+`fault_class` and to `install_fault`, but not to the `case` that reads the
+delivery count back, and that `case` had no `*)` arm to say so. A window whose
+fault delivery is unrecorded cannot be quoted, because "the rule installed and
+never matched" and "the system absorbed the fault" are then the same artefact.
+Both the missing arm and the missing default are fixed (§ 6.7), and the re-run
+records 9 of 27.
+
+**The re-run reproduces the first window to the order, and that is what makes
+the source-side statement a claim rather than a reading.** 12 ingested, 12 at
+the shop, 12 claimed synced, **0 claimed-but-absent**, twice, on the same build,
+from two independently launched windows. This campaign has spent enough
+instruments to have learned that **a single window is a hypothesis**; two
+agreeing windows is the cheapest thing that makes "a source fault strands
+nothing" worth stating at all. It is worth more than the delivery count the
+re-run was launched for.
+
+**It had to be run against the build the other thirteen windows used.** After
+this branch rebased onto the epic tip, `guard_build` **refused** it: eleven
+merged PRs had changed `apps/api`, so the working tree no longer matched the
+running image. Rebuilding would have measured `M4` against a build no other
+window in this report shares. It was instead run from a detached worktree at
+the image's own commit, carrying only this branch's `perf/` changes -
+`guard_build ok (image sha=629921c5f..., tree HEAD=4ff884d8e..., product paths
+identical)`.
+
+**So: every window in this report is pinned to image `629921c5f`, and the set
+is COMPLETE AS IT STANDS.** That is a statement about the shape of this
+evidence, not a caveat about its quality - the fourteen windows are internally
+comparable and jointly answer the question the scenario was built for. The epic
+tip no longer contains that build, so this matrix is **not a base for
+extension**: the next measurement of these flows is a re-baseline on the merged
+tip, one tree and one image, rather than another window appended here. That
+re-baseline is already the decided next step, and it inherits the repaired
+`post_guard_destination_creates` - several windows in this campaign were
+discarded *solely* by the unscoped predicate, so whether they now pass is its
+headline either way.
+
+**`I3` - the worker is SIGKILLed mid-job.** The window the #2978 run produced
+no artefacts for at all.
+
+The worker was killed 35 s into the window and started 10 s later; it
+re-announced its runner loop immediately (`runner lines 1 -> 2`, 0 s). Twelve
+orders had order_records after recovery and **ten reached the shop**.
+
+**Two `marketplace.order.sync` jobs did not finish, and they are the finding.**
+Read live from `sync_jobs` while the recovery observation was still running,
+both sat at:
+
+```
+jobType=marketplace.order.sync  status=running  attempts=0
+lockedAt=<set>  lockedBy=worker-7f3200901f5e-1788908644062  lastError=-
+```
+
+`lockedBy` names a worker instance that no longer exists. A SIGKILL therefore
+leaves a job **claimed by a dead holder**, with `attempts=0` and no error - not
+failed, not queued, and no process working on it.
+
+**But this is NOT the silent-success shape**, and the distinction is the whole
+point of separating the two: the row says `running`, which is true and is
+visible. Shape B is `succeeded`/`ok` over a failure, and `I3` produced **0** of
+those. `I3` fails *honestly*.
+
+**And it is a live instance of the repaired guard's stated weakening.** Read
+from the database at 23:22:01Z, `I3`'s window holds 12 ingested orders, **0**
+with a `failed` entry on the declared destination, 10 `synced`, and **2 with no
+`syncStatus` array at all** - the two whose jobs are stuck, so the destination
+fan-out never ran for them. The repaired `missing` arm only counts orders the
+destination was actually attempted on, so **it does not see these two**, which
+is exactly the trade the repair documents. They are not lost from the record:
+they appear as `destinationFanOut.ordersWithNoSyncStatus: 2` in the same
+ledger. The check that would catch them - "an order was ingested and dispatched
+NOWHERE" - is a different question and belongs in its own guard, which is why
+it was deliberately not smuggled into this one.
+
+**The window cannot show whether those two recover - but the drain that
+followed it did, and they did.** `StuckJobRecoveryService`
+(`apps/worker/src/maintenance/`) releases them by a conditional UPDATE on a
+stale `lockedAt`, with `STUCK_JOB_TIMEOUT_MINUTES = 15` swept every
+`STUCK_JOB_RECOVERY_INTERVAL_MS = 5 min`. F10's recovery observation is
+`RECOVERY_WAIT_SECS = 240` - **four minutes** - so `I3` reports
+`recoveredWithoutAHumanAfterSecs: null` **by construction**, whatever the
+system does. That is a harness limitation, not a system finding (§ 8).
+
+What settles it is `drain_wait`, which is not bounded by that four minutes:
+
+- the two jobs' `lockedAt` stamps were `23:12:59Z` and `23:13:10Z`;
+- the live `queued`/`running` count for the source connection fell **2 -> 0 at
+  23:30:06Z**, i.e. **~17 minutes** after the kill, inside the predicted 15-20;
+- `drain_wait` then reported `inflight=0 deferred=0 quiet=6 waited=645s` and
+  the run's own summary recorded `dead: 0` - **nothing was killed by the
+  harness**;
+- re-read afterwards, `I3`'s window holds **12 ingested, 12 `synced` on the
+  declared destination, 0 with an empty `syncStatus`**.
+
+So `I3` is **RETRIED and fully recovered, measured** - all 12 orders reached
+the shop, about seventeen minutes late, with no operator action. The
+ledger-after-recovery figures above (10 of 12) are a snapshot taken at t+240 s
+while two jobs were still held, not the end state, and are left as recorded
+rather than back-edited.
+### 6.7 Two more instruments that could report their own read failure as a finding - and the count is now the finding
+
+Both were found by *running* this scenario rather than by reading it, both are
+in the detector path this issue is about, and both are the campaign's standing
+mechanism: **a probe that trusts a signal correlated with the fact instead of
+one constitutive of it.** They are recorded here with the same weight as the
+guard repair, because either could have produced a confident wrong headline.
+
+**(1) The ground-truth detector could fabricate the number it exists to
+produce.** `ps_sql` folds stderr into stdout and ends `|| true`, so a MySQL
+failure is not an exit code a caller can test - it arrives as the *value*. The
+detector then did:
+
+```sh
+present="$(ps_sql "SELECT COUNT(DISTINCT id_order) ... IN ($claimed_ids)")"
+claimed_missing=$(( claimed_total - ${present:-0} ))
+```
+
+- `present=""` gives `claimed_missing = claimed_total`, i.e. **every claimed
+  order reported as absent from the shop** - the scenario's headline silent-loss
+  finding, red, for a hiccup;
+- `present="ERROR 1054 ..."` is arithmetic on a word, which under `set -u`
+  **kills the run mid-window**.
+
+`claimed_ids` is interpolated raw and `externalOrderId` is a jsonb *string*, so
+one non-numeric destination id is enough to reach the second. Both are now
+refused by a shared `as_count` (`lib.sh`), and the ledger carries
+`groundTruth.readable` so that a `claimedButAbsentFromPsOrders: 0` from a read
+that failed cannot be quoted as a measured zero. The same coercion is applied
+to the `ps_orders` / `ps_cart` deltas, whose unguarded `:-0` would have reported
+*the shop created nothing* - which is the orphaned-cart signal, inverted.
+
+**(2) `rowsTheHARNESSMarkedDeadDuringCleanup` was always the empty string.**
+`drain_wait` reports which rows it killed by setting globals
+(`DRAIN_DEAD_IDS`, `DRAIN_DEFERRED_SEEN`, `DRAIN_REQUEUED_SEEN`), and it was
+called as `drain_result="$(drain_wait "$CONN_IDS")"` - a command substitution,
+which is a **subshell**, so every one of those assignments died with it. This
+is not cosmetic: § 4 reads the ledgers *before* cleanup precisely so the
+harness cannot forge a finding, and this field was the only record that the
+cleanup killed anything at all. The one contamination the ordering was designed
+to keep visible was invisible, silently, and nothing failed or warned.
+
+**(3) A `case` with no `*)` arm ran a full window and said nothing about it.**
+`M4` was added to the catalogue, to `fault_class` and to `install_fault`, but
+not to the `case` that reads the delivery count back from the injector. It fell
+through to the initialiser and its manifest recorded `"delivered": {}` - which
+is the purest form of this family, because the artefact that exists to
+distinguish *the rule installed and never matched* from *the system absorbed
+the fault* recorded neither. The re-run with the arm in place reports
+`stubFaultsApplied: 9` across 27 source requests. The general rule:
+**a dispatch that cannot report an unhandled input is indistinguishable from
+one that handled it**, so the `case` now has a `*)` arm that warns and writes
+`unrecorded: true` into the manifest.
+
+**The count is now itself a finding.** These are the tenth, eleventh and
+twelfth instruments in this campaign to return a confident wrong answer with
+nothing erroring, joining a guard reading logs in a time format that matched nothing, a
+saturation guard that did not exist, three samplers that could not tell their
+own run from a sibling's, a `pkill` that matched and killed its own shell, a
+guard reading a log file when the lock was the authority, and a ramp-averaged
+rate quoted as a plateau rate. Eleven instances across one harness is no longer
+a run of bad luck; it is a property of how the harness was built - **probes were
+written to read whatever was convenient to read, and the question of whether
+that thing IS the fact was asked afterwards, if at all.**
+
+**And the campaign's standing counter-example has now failed too, which
+sharpens the rule rather than abolishing it.** `post_guard_containers_stable`
+was held up as the probe needing no vigilance, because a container's
+`StartedAt` *is* the fact rather than a proxy for it. A parallel campaign has
+since seen it certify a window `VALID` while the api process had been **dead
+for three hours**: the process crashed in place, the container never restarted,
+and `StartedAt` never moved. It is constitutive of **container restart** and a
+proxy for **process liveness** - and liveness is what a window depends on.
+
+The rule that survives is therefore narrower and more useful than "prefer
+constitutive signals": **a signal is constitutive OF SOMETHING, and you have to
+name what.** Then ask what would still be true if it were unchanged. For
+`StartedAt` the answer is "the process may be dead", and that is the whole
+defect. `docs/lessons.md` is corrected in this change.
 ---
 
 ## 7. Findings
@@ -539,11 +1025,100 @@ no page passes it.
 
 ## 8. What this did not establish
 
-_TBD. This section is mandatory and must not be empty._
+**The n is small, and every rate above should be read against it.** Each window
+offers 12 orders. A `0` in a per-class cell is consistent with any true rate
+below **~22%** (rule of three at n=12) **[derived]**, so "0 stranded" for a
+class means *no event was observed in twelve orders*, never *this class is
+safe*. The one figure with a usable denominator is Shape A's 0/109.
+
+**Two windows barely got their fault.** `M2` delivered **1** malformed response
+in 16 requests and `M2t` delivered 3 in 19, because a fraction is drawn per
+request and the source is called far fewer times per order than the
+destination. Their `0 stranded` is a statement about a system that met the
+fault once or three times, not one that survived a sustained one. A fixed-count
+injector - "deliver exactly N" rather than "fault a fraction" - would remove
+this whole class of caveat, and does not exist in either injector.
+
+**Shape A's zero is bounded, not proved.** 0 of 109 puts the 95% upper bound at
+2.75% **[derived]**. That excludes #2978's 17-42% estimate *for this shape* and
+does **not** exclude the sustained window's 0.24%. Distinguishing 0% from 0.2%
+needs roughly 1 500 claimed-synced entries, which at this scenario's window
+shape is about 125 windows.
+
+**The two rate estimates the issue quotes are not comparable to each other, and
+this run resolves only one of them.** #2978's 17-42% was Shape B under fault;
+the sustained window's 0.24% was measured over a window with no injected fault
+at all. This run's 18.3% Shape B rate under destination faults is consistent
+with the first; nothing here re-measures the second.
+
+**The recovery observation is shorter than one of the recovery mechanisms it
+observes, so `I3` can never report recovery *in its ledger*.**
+`RECOVERY_WAIT_SECS = 240` (four minutes); `StuckJobRecoveryService`'s
+stale-lock threshold is `STUCK_JOB_TIMEOUT_MINUTES = 15`, swept every five, so
+a job orphaned by a SIGKILLed worker is released 15-20 minutes after the kill
+and `I3`'s `recoveredWithoutAHumanAfterSecs: null` is a **property of the
+stopwatch, not of the system**. The recovery itself *was* observed here, but
+outside the ledger - during `drain_wait`, at ~17 minutes, ending 12 of 12 at
+the shop (§ 6.6). Any future `I3` window that wants its own ledger to carry
+that must set `RECOVERY_WAIT_SECS` above 1 200; as it stands the artefact and
+the finding disagree, and the artefact is the one that is wrong.
+
+**No figure here is a throughput or latency measurement**, and none should be
+quoted as one. Every window is a fixed 12-order batch against a deliberately
+faulted dependency, on a build whose outbound Redis limiter was degrading in
+eleven of twelve windows (§ 6.0). The campaign's throughput numbers come from
+the mixed-load and F1 runs, not from here.
+
+**`PERF_MAX_ATTEMPTS=3` against a shipped default of 10.** Every "did it
+retry" reading is against that cap. Whether an order that exhausted 3 attempts
+would have recovered at 10 is **not established** - and note the cap cannot
+explain a stranded order, because a stranded order consumed *zero* attempts:
+the job never failed.
+
+**Why an order is stranded is not established here, only that it is.** The
+mechanism named in § 6.3 - `Promise.allSettled` in
+`OrderSyncService.dispatchToDestinations` swallowing a per-destination
+rejection while the job returns `ok` - is read off the code and corroborated by
+the shape of the data. This run did not instrument that call site, so the
+attribution is **[derived]**, not measured.
+
+**Whether the 11 stranded orders would ever be recovered by anything is not
+established.** What is measured is that at the moment of reading, nothing was
+queued or running for them. A later catalogue sweep, a re-poll of the source,
+or an operator action might still create them; no such recovery was observed
+inside the 240 s recovery window, and none is scheduled by any code path this
+run exercised.
+
+**The `I3` and `M4` windows are single windows each**, run under #3004 rather
+than alongside the other twelve, on a different day and a different build. They
+are reported separately in § 6 and are not folded into the twelve-window
+totals.
+
+**`post_guard_limiter_degraded` fired in eleven of twelve `f10-final`
+windows.** The defect it names was fixed after that run (#2984). Whether any
+figure here would move on the fixed build is **not established** - the obvious
+candidate is D2b, where the limiter and the missing `Retry-After` both bear on
+the same retry decision.
+
+**Nothing here measures a destination other than PrestaShop.** F10 disables the
+WooCommerce `OrderProcessorManager` for the whole run (§ 6.5), so a two-
+destination fan-out under fault - which is the shape the mixed-load arms run
+and where the guard defect actually bit - is not exercised by this scenario at
+all.
 
 ---
 
 ## 9. Fault classes not exercised, and why
 
-_TBD. A class that could not be exercised is recorded here with its reason,
-never quietly dropped._
+A class that could not be exercised is recorded here with its reason, never
+quietly dropped.
+
+| class | status | reason |
+|---|---|---|
+| `I3` - the worker is killed mid-job | **exercised under #3004**, not under #2978 | The `f10-final-2026-09-08` run produced an `I3` directory containing **no files at all** - no manifest, no ledger, no verdict. Nothing in that run's logs records why. It was re-run as its own window under #3004 rather than left as a hole; see § 6.6. Its *recovery* half remains unexercised, and for a structural reason rather than an oversight: the observation window is 240 s and the mechanism takes 15-20 min (§ 8). |
+| `M4` - the source returns an HTTP error status | **added by #3004** | Did not exist in the #2978 catalogue. Every marketplace window there was a connection timeout (`M1`) or a 2xx that was nonetheless wrong (`M2` unparseable, `M2t` truncated, `M3` a business rejection), so the marketplace side had **no error-status window** while the destination side had four. The retry classifier reads a status, so that is a real gap rather than a naming one. |
+| the stub's `429` mode | **not exercised** | `M4` uses `503`. The stub always emits `Retry-After` on both `429` and `503` and offers no way to suppress it, so a marketplace `429` would differ from `M4` only in the number - it could not reproduce the `D2a`/`D2b` with/without-header contrast, which is the comparison that made the destination-side 429 pair worth running as two windows. |
+| a source `Retry-After`-suppressed error | **cannot be exercised** | The stub hard-codes `retryAfterSeconds ?? 5` on every `429`/`503` (`stubs/allegro/server.mjs`). Suppressing it needs a stub change, not a rule change. Recorded so the asymmetry with `D2a`/`D2b` is visible rather than inferred. |
+| a fault on a SECOND destination while the first succeeds | **not exercised** | F10 disables the WooCommerce destination for the whole run so that a failed `syncStatus` entry can be attributed to the injected fault. The multi-destination shape is exercised by the mixed-load arms instead, and it is where the `post_guard_destination_creates` defect this issue repairs actually bit. |
+| Postgres slow or dropped | **not exercised** | Not in the #2978 catalogue. Dropping the database drops OpenLinker's own bookkeeping as well as its work, so "was the order lost" has no witness inside OpenLinker to answer it; the shop-side ground truth would survive, but nothing would be left to compare it against. Recorded as a gap, not as a decision that it does not matter. |
+| a fault during the *source* poll rather than hydration | **partially exercised** | `M2t` faults the `events` endpoint, which is the feed read. `M1`/`M2`/`M4` fault `checkout` (hydration) only, deliberately: a tenant-wide fault stops the feed being read at all, so no order is hydrated and the window measures nothing about hydration. |

--- a/perf/openlinker-throughput/scenarios/f10-dependency-failure.sh
+++ b/perf/openlinker-throughput/scenarios/f10-dependency-failure.sh
@@ -256,7 +256,7 @@ QUANTITY_JOBS="${QUANTITY_JOBS:-12}"
 # is built - so what the manifest records and what the injector was told
 # cannot come from two different expressions.
 # ---------------------------------------------------------------------------
-ALL_FAULTS="baseline D1 D2a D2b D3 D4 M1 M2 M2t M3 I1 I2 I3"
+ALL_FAULTS="baseline D1 D2a D2b D3 D4 M1 M2 M2t M3 M4 I1 I2 I3"
 
 fault_class() {
   case "$1" in
@@ -270,6 +270,7 @@ fault_class() {
     M2)  printf 'marketplace: the source returns a malformed payload' ;;
     M2t) printf 'marketplace: the source returns a truncated payload' ;;
     M3)  printf 'marketplace: the source rejects the offer-quantity write' ;;
+    M4)  printf 'marketplace: the source returns 503 WITH Retry-After during hydration' ;;
     I1)  printf 'infrastructure: Redis becomes slow (a blocked client, not an outage)' ;;
     I2)  printf 'infrastructure: Redis drops entirely mid-window' ;;
     I3)  printf 'infrastructure: the worker is killed mid-job' ;;
@@ -721,6 +722,31 @@ install_fault() {
       jq -n --argjson r "$(stub_fault_set '{"mode":"reject-quantity","endpoints":["quantity"]}')" \
         '{injected:true, injector:"allegro-stub", rule:$r.fault}'
       ;;
+    M4)
+      # THE MARKETPLACE-SIDE HTTP-ERROR-RESPONSE SHAPE, and the reason this id
+      # exists (#3004). Before it, every marketplace window was either a
+      # connection timeout (M1) or a 2xx that was nonetheless wrong (M2
+      # unparseable, M2t truncated, M3 a business rejection). None of them is
+      # an error STATUS, and the retry classifier reads a status - so "the
+      # source failed" was measured in one shape only while the destination
+      # side had both (D1/D2 error responses, D3 hang). A matrix that covers
+      # one shape on one side and calls the axis covered is the merge this
+      # scenario exists to avoid.
+      #
+      # `checkout` only, for M1's reason: a tenant-wide fault stops the FEED
+      # being read too, so nothing is ever hydrated and the window measures
+      # nothing about hydration.
+      #
+      # Fraction 0.5 rather than 1: a source that fails everything is an
+      # outage, and the interesting question is the PARTIAL order - the same
+      # reasoning § 5 records for D1/D2a/D2b/D3.
+      #
+      # NOTE the stub always emits Retry-After on 429/503 and offers no way to
+      # suppress it, so the with/without-header comparison D2a/D2b makes is a
+      # PrestaShop-side experiment only and is not reproducible here.
+      jq -n --argjson r "$(stub_fault_set '{"mode":"503","endpoints":["checkout"],"fraction":0.5,"retryAfterSeconds":5}')" \
+        '{injected:true, injector:"allegro-stub", rule:$r.fault}'
+      ;;
     I1)
       # CLIENT PAUSE, not DEBUG SLEEP: DEBUG is disabled by default on Redis
       # 7+ (verified refused on this stand). PAUSE stalls command processing
@@ -936,13 +962,25 @@ enqueue_quantity_jobs() {
 
 # ps_max_ids - PrestaShop's own highest order and cart ids, so the window's
 # creates can be counted without trusting a clock shared across two engines.
-ps_max_order_id() { ps_sql "SELECT COALESCE(MAX(id_order),0) FROM ps_orders" | tr -d '[:space:]'; }
-ps_max_cart_id()  { ps_sql "SELECT COALESCE(MAX(id_cart),0)  FROM ps_cart"   | tr -d '[:space:]'; }
+# Both are coerced through as_count (lib.sh) for the reason recorded there:
+# ps_sql folds stderr into stdout and ends `|| true`, so a MySQL failure is a
+# VALUE, not an exit code, and these two feed ARITHMETIC. Unguarded, an error
+# string kills the run in `$(( ))` and an empty read silently reports that the
+# shop created nothing - which is the orphaned-cart signal, inverted (#3004).
+# An unreadable end of the pair is left EMPTY rather than defaulted to 0, so
+# the delta below is suppressed instead of fabricated.
+ps_max_order_id() { as_count "$(ps_sql "SELECT COALESCE(MAX(id_order),0) FROM ps_orders" 2>/dev/null | tr -d '[:space:]' || printf '')"; }
+ps_max_cart_id()  { as_count "$(ps_sql "SELECT COALESCE(MAX(id_cart),0)  FROM ps_cart"   2>/dev/null | tr -d '[:space:]' || printf '')"; }
 
 read_ledger() {
   local dir="$1" ws_iso="$2" ps_order_before="$3" ps_cart_before="$4" load="$5"
   local jobs_json orders_json ss_json claimed_total claimed_missing
   local ps_order_after ps_cart_after
+  # 1 until a read proves otherwise. `claimedButAbsentFromPsOrders: 0` means
+  # two completely different things depending on this flag - "we checked and
+  # nothing was missing" or "we could not check" - and a reader that cannot
+  # tell them apart will quote a measured zero it never measured (#3004).
+  local claimed_gt_readable=1
 
   ps_order_after="$(ps_max_order_id)"
   ps_cart_after="$(ps_max_cart_id)"
@@ -1027,9 +1065,39 @@ read_ledger() {
       # `grep -c` under `pipefail` returns 1 when it matches nothing, which
       # would abort the run on a legitimately empty set - hence `|| true`
       # above, and hence reading the count rather than testing the exit code.
-      local present
-      present="$(ps_sql "SELECT COUNT(DISTINCT id_order) FROM ps_orders WHERE id_order IN ($claimed_ids)" | tr -d '[:space:]')"
-      claimed_missing=$(( ${claimed_total:-0} - ${present:-0} ))
+      # The shop read must be NUMERIC or the detector reports its own read
+      # failure as the finding it exists to detect (#3004). `ps_sql` folds
+      # stderr into stdout and ends `|| true` (lib.sh), so a MySQL failure
+      # arrives as the VALUE of `present`, and this line is arithmetic:
+      #   - empty      -> claimed_missing = claimed_total - 0 = claimed_total,
+      #                   i.e. a FABRICATED silent-loss finding, red for a
+      #                   hiccup, and it would be the scenario's headline;
+      #   - error text -> arithmetic on a non-numeric token under `set -u`
+      #                   kills the run mid-window.
+      # `claimed_ids` is interpolated raw and `externalOrderId` is a jsonb
+      # STRING, so one non-numeric destination id is enough to produce that.
+      # A detector that cannot read its witness must say so, not answer.
+      local present present_raw
+      present_raw="$(ps_sql "SELECT COUNT(DISTINCT id_order) FROM ps_orders WHERE id_order IN ($claimed_ids)" 2>/dev/null | tr -d '[:space:]' || printf '')"
+      present="$(as_count "$present_raw")"
+      if [ -z "$present" ]; then
+        claimed_total=0
+        claimed_missing=0
+        claimed_gt_readable=0
+        log "  WARNING ground truth UNREADABLE: the ps_orders read answered [${present_raw:0:120}] - reported as not established, NOT as missing orders"
+      else
+        claimed_missing=$(( ${claimed_total:-0} - present ))
+      fi
+      # A negative difference means the shop holds MORE distinct ids than
+      # OpenLinker claimed, which cannot happen for an `IN` list built from
+      # those same claims - so it is a defect in this reading, never a
+      # finding, and is surfaced rather than published as a negative count.
+      if [ "${claimed_missing:-0}" -lt 0 ]; then
+        log "  WARNING ground truth INCOHERENT: claimed=$claimed_total present=$present - reported as not established"
+        claimed_total=0
+        claimed_missing=0
+        claimed_gt_readable=0
+      fi
     else
       claimed_total=0
       claimed_missing=0
@@ -1041,6 +1109,26 @@ read_ledger() {
     claimed_missing=0
   fi
 
+  # The shop deltas are emitted as JSON `null` when either end of the pair was
+  # unreadable, never as a fabricated 0 (#3004). A 0 here IS the orphaned-cart
+  # signal's denominator, so defaulting an unreadable read to 0 would report
+  # "the shop created nothing" - a finding - for a MySQL hiccup.
+  local ps_orders_created ps_carts_created
+  if [ -n "${ps_order_after:-}" ] && [ -n "${ps_order_before:-}" ]; then
+    ps_orders_created=$(( ps_order_after - ps_order_before ))
+  else
+    ps_orders_created=null
+    claimed_gt_readable=0
+    log "  WARNING ps_orders delta UNREADABLE (before=[${ps_order_before:-}] after=[${ps_order_after:-}]) - emitted as null"
+  fi
+  if [ -n "${ps_cart_after:-}" ] && [ -n "${ps_cart_before:-}" ]; then
+    ps_carts_created=$(( ps_cart_after - ps_cart_before ))
+  else
+    ps_carts_created=null
+    claimed_gt_readable=0
+    log "  WARNING ps_cart delta UNREADABLE (before=[${ps_cart_before:-}] after=[${ps_cart_after:-}]) - emitted as null"
+  fi
+
   jq -n \
     --argjson jobs "$jobs_json" \
     --argjson errors "$errors_json" \
@@ -1048,8 +1136,9 @@ read_ledger() {
     --argjson syncStatus "$ss_json" \
     --argjson claimedSynced "${claimed_total:-0}" \
     --argjson claimedMissingAtDestination "${claimed_missing:-0}" \
-    --argjson psOrdersCreated "$(( ${ps_order_after:-0} - ${ps_order_before:-0} ))" \
-    --argjson psCartsCreated "$(( ${ps_cart_after:-0} - ${ps_cart_before:-0} ))" \
+    --argjson groundTruthReadable "${claimed_gt_readable:-1}" \
+    --argjson psOrdersCreated "$ps_orders_created" \
+    --argjson psCartsCreated "$ps_carts_created" \
     '{
       syncJobs: $jobs,
       lastErrors: $errors,
@@ -1060,10 +1149,11 @@ read_ledger() {
         psCartsCreated: $psCartsCreated,
         claimedSyncedToPrestashop: $claimedSynced,
         claimedButAbsentFromPsOrders: $claimedMissingAtDestination,
-        note: "claimedButAbsentFromPsOrders > 0 is a success report over a failure: OpenLinker recorded syncStatus.status=synced with an externalOrderId that names no row in the shop.\nA nonzero psCartsCreated alongside a zero psOrdersCreated is an orphaned cart - work done at the destination that produced no order."
+        readable: $groundTruthReadable,
+        note: "claimedButAbsentFromPsOrders > 0 is a success report over a failure: OpenLinker recorded syncStatus.status=synced with an externalOrderId that names no row in the shop.\nA nonzero psCartsCreated alongside a zero psOrdersCreated is an orphaned cart - work done at the destination that produced no order.\nreadable=0 means the shop could NOT be read for this window: claimedSyncedToPrestashop and claimedButAbsentFromPsOrders are then BOTH zero because nothing was established, NOT because nothing was missing. A zero from this detector may only be quoted as a measured zero when readable=1."
       }
     }' > "$dir/ledger.json"
-  log "  ledger: $(jq -c '{orders:.orderRecords.created, psOrders:.groundTruth.psOrdersCreated, psCarts:.groundTruth.psCartsCreated, claimedSynced:.groundTruth.claimedSyncedToPrestashop, claimedMissing:.groundTruth.claimedButAbsentFromPsOrders}' "$dir/ledger.json")"
+  log "  ledger: $(jq -c '{orders:.orderRecords.created, psOrders:.groundTruth.psOrdersCreated, psCarts:.groundTruth.psCartsCreated, claimedSynced:.groundTruth.claimedSyncedToPrestashop, claimedMissing:.groundTruth.claimedButAbsentFromPsOrders, gtReadable:.groundTruth.readable}' "$dir/ledger.json")"
 }
 
 # ===========================================================================
@@ -1261,9 +1351,19 @@ run_fault() {
   local delivered='{}'
   case "$id" in
     D1|D2a|D2b|D3|D4) delivered="$(pfp_stats | jq -c '{proxyCounters: .counters}')" ;;
-    M1|M2|M2t|M3)     delivered="$(stub_stats | jq -c '{stubFaultsApplied: .faultsApplied, stubRequestCounts: .requestCounts}')" ;;
+    M1|M2|M2t|M3|M4)  delivered="$(stub_stats | jq -c '{stubFaultsApplied: .faultsApplied, stubRequestCounts: .requestCounts}')" ;;
     baseline)         delivered="$(pfp_stats | jq -c '{proxyCounters: .counters}')" ;;
     I1|I2|I3)         delivered="$(jq -n '{note:"an infrastructure fault has no per-request delivery count; its delivery is the container action itself, recorded in faultInjection.rule"}')" ;;
+    *)
+      # A fault id in ALL_FAULTS with no arm here records NO delivery and,
+      # before #3004, said nothing about it. M4 was added to the catalogue, to
+      # fault_class and to install_fault, ran a full 90 s window, and its
+      # manifest read `"delivered": {}` - which is indistinguishable from a
+      # rule that installed and never matched. That is the distinction the
+      # comment above exists to preserve, so the silence is now loud.
+      delivered="$(jq -n --arg id "$id" '{unrecorded:true, error:("no delivery read-back is defined for fault id " + $id + " - add an arm to the case in run_fault")}')"
+      warn "no delivery read-back is defined for fault id $id - its manifest will say so, and this window must NOT be quoted as a result"
+      ;;
   esac
   jq --argjson d "$delivered" '.faultInjection = (.faultInjection + {delivered: $d})' "$dir/manifest.json" > "$dir/manifest.json.tmp"
   mv "$dir/manifest.json.tmp" "$dir/manifest.json"
@@ -1306,9 +1406,27 @@ run_fault() {
   read_ledger "$dir" "$ws_iso" "$ps_order_before" "$ps_cart_before" "$load"
   mv "$dir/ledger.json" "$dir/ledger-after-recovery.json"
 
-  local drain_result
-  drain_result="$(drain_wait "$CONN_IDS" || true)"
+  # `drain_wait` reports its kills by SIDE EFFECT - it sets DRAIN_DEAD_IDS,
+  # DRAIN_DEFERRED_SEEN and DRAIN_REQUEUED_SEEN as globals (lib.sh). Running
+  # it inside `$( )` puts every one of those assignments in a SUBSHELL, which
+  # exits before the parent reads them, so `rowsTheHARNESSMarkedDeadDuringCleanup`
+  # was ALWAYS the empty string however many rows were killed (#3004).
+  #
+  # That is not a cosmetic loss. The ledgers above are deliberately read
+  # BEFORE this line so the harness's own cleanup cannot forge a finding, and
+  # this field is the only record that the cleanup killed anything at all - so
+  # the one contamination the ordering was designed to keep visible was
+  # invisible. Redirecting stdout to a file keeps the function in THIS shell.
+  # stdout only, NOT `2>&1`: `log` writes to stdout and `warn` to stderr, so
+  # capturing both would swallow drain_wait's own live warnings (its
+  # "marked dead" line among them) which streamed to the console before.
+  local drain_result drain_out
+  drain_out="$(mktemp)"
+  drain_wait "$CONN_IDS" > "$drain_out" || true
+  drain_result="$(cat "$drain_out")"
+  rm -f "$drain_out"
   log "  drain_wait (cleanup for the next window, AFTER the ledger was read): $drain_result"
+  [ -n "${DRAIN_DEAD_IDS:-}" ] && log "  drain_wait marked row(s) dead during cleanup: $DRAIN_DEAD_IDS"
 
   jq -n --arg d "$drain_result" --argjson w "$waited" \
     --arg r "${recovered_at:-never}" --argjson still "${still:-0}" \


### PR DESCRIPTION
Closes #3004.

**The predicates this issue asked for arrived independently in #2985 while this
branch was being built.** Commit `ff2e00b9f` landed both scoped arms, character
-identical to what was written here from the same evidence, with per-arm
SQL-shape assertions and its own mutation testing. That is recorded rather than
hidden: two people reaching the same SQL from the same measurement is worth
knowing. This branch is rebased onto that work and keeps only what is additive
to it.

## 1. What is additive to #2985

**A fail-open in the merged guard, which is the same defect class it was fixing.**
`[ "${failed:-0}" -gt 0 ]` runs on a raw `pg_sql` value, and `pg_sql` folds
stderr into stdout and ends `|| true` - so a database failure arrives as the
*value*. `[ "ERROR: ..." -gt 0 ]` is "integer expression expected", which under
`set -e` aborts the caller and **without it falls through to `ok` and certifies
a window nobody measured**. Both counts are now coerced through a new
`as_count` and an unreadable count DISCARDS, naming which arm could not be
read. Proved by mutation: reverting it makes the guard answer `ok` to a
database error.

**The refusal names the destination.** `scope` was the constant string "the
declared destination"; on a stand carrying five connections, four of which can
also fail, that sends its reader back to the scenario source. It now carries
the connection id.

**Their test comment carried the retracted framing, in the worst place for it.**
It said three windows shipped a `failed` count that *exceeded* the population
it described. Re-measured against the same persisted rows, the arms read **650
of 652, 2 967 of 2 967 and 1 792 of 1 792** - equal, never exceeding; the
earlier figures compared the guard against a differently-measured population.
The true statement is stronger and needs no arithmetic impossibility: scoped,
those windows answer **1, 2 and 0**, so a guard built to isolate one class of
failure was flagging essentially the entire ingested population, and a signal
that fires on everything is indistinguishable from one that fires on nothing.

**Two more detectors of the same family, found by running F10 rather than
reading it.**

- The **ground-truth detector could fabricate its own headline**:
  `claimed_missing = claimed_total - ${present:-0}` reports *every* claimed
  order as absent from the shop when the shop read comes back empty, and dies
  mid-window on an error string. Now coerced, and the ledger carries
  `groundTruth.readable` so a zero from a failed read is not quotable as a
  measured zero. The `ps_orders`/`ps_cart` deltas had the same exposure and
  emit `null` rather than a fabricated `0`.
- **`rowsTheHARNESSMarkedDeadDuringCleanup` was always empty.** `drain_wait`
  reports its kills by setting globals and was called inside `$( )`, a
  subshell. F10 reads its ledgers *before* cleanup precisely so the harness
  cannot forge a finding, and this was the only record that cleanup killed
  anything.

**A new `M4` fault class** - the source returns an HTTP error status - because
every marketplace window was a timeout or a 2xx that was nonetheless wrong, so
the source side had no error-status arm while the destination side had four.
Adding it exposed a second gap: the delivery read-back `case` had no `*)` arm,
so `M4` ran a full window with `"delivered": {}` and nothing said so. Both
fixed.

**`docs/lessons.md`**: three new entries, and a **correction** to the standing
`StartedAt` counter-example. It claimed `StartedAt` *is* the fact and offered
itself as the case needing no vigilance; a parallel campaign has since seen
`post_guard_containers_stable` certify a window `VALID` while the api process
had been dead for three hours - it crashed in place, so the container never
restarted. `StartedAt` is constitutive of *container restart* and a proxy for
*process liveness*. The rule that survives is narrower and more useful: a
signal is constitutive **of something**, and you have to name what.

## 2. F10 has results

The #2978 run had in fact been executed - twelve of thirteen windows carry
artefacts. What was missing was the tabulation, plus `I3` (no artefacts at all)
and any marketplace error-status window; both were run here, on the same
product build as the other twelve (`guard_build ok, product paths identical`).

- **Shape A** - OpenLinker claims `synced` for an order the shop has no row
  for: **0 of 109 claimed-synced entries**. A *measured* zero: the detector was
  demonstrated able to fire, and returned a non-zero denominator in eleven of
  twelve windows. 95% upper bound **2.75%**, which **excludes #2978's published
  17-42%** - the campaign's first measured refutation of a figure it had
  already published.
- **Shape B** - the job ledger reports success over an order that failed at the
  destination, nothing queued to retry it: **11 of 60 offered across the five
  destination-fault windows = 18.3%**, and **0 of 36** across the marketplace
  order-path windows.

Three independent reads agree on the same 11 orders, the third counted at
PrestaShop so it shares no failure mode with the first two. A **fourth**, from
a parallel campaign on different hardware with a different injector, reports
36 of 131 orders still lacking a destination `syncedAt` two and a half hours
after its faults were lifted, and 12 of 12 lost in its `D4` equivalent.

**Two expectations in the brief turned out wrong, and both are recorded:**

- **The fault *shape* is not the variable; the *side* is.** Every stranded
  order came from a destination fault, none from a source fault under either
  shape. The two shapes were kept separate on the reasoning that the retry
  classifier treats them differently - the measurement says the classifier is
  not where the variance is.
- **`Retry-After` is ignored.** The obvious reading of `D2a` 0 versus `D2b` 3
  is that the header is honoured. These windows' own ledgers record
  `deferred_rows: 0` and `deferred_ms_total: 0` on every destination arm
  *including* `D2a`, which sends it. This corrects F10-2 as stated; the
  0-versus-3 gap is delivery volume or chance (10 of 24 faults against 24 of
  45). The parallel campaign reached the same conclusion independently.

`I3` recovery is now **measured, not derived**: the two jobs orphaned by the
SIGKILL cleared 2 -> 0 at `23:30:06Z`, about **17 minutes** after their
`lockedAt` stamps, with `dead: 0`, and the window's 12 orders all reached the
shop. F10's own 240 s observation is structurally too short to see it (§ 8).

## Gate

`bash -n` clean on all three scripts; `lib-test.sh` **226 passed / 0 failed**
(212 at the rebased base, +14); `pnpm check:invariants` exit 0. Five mutations
applied and each watched go red, including one proving the fail-open would
certify an unreadable window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
