### PR TITLE
perf(2840): F5 row-count guard + WooCommerce catalogue seeder for destination-create measurements

### DIFF
--- a/perf/openlinker-throughput/README.md
+++ b/perf/openlinker-throughput/README.md
@@ -30,7 +30,8 @@ sources it rather than re-implementing any piece of it.
 | `seed/seed-catalogue.sh` | Set-based products/variants/inventory_items/identifier_mappings seeder (#2849) across the two connections the lab stand carries - seeded ONCE, independent of order-dataset size. |
 | `seed/seed-jobs.sh` | Set-based `sync_jobs` sweep-child history seeder (#2849) - ~1 year at real cadence (20min/15min), also seeded ONCE. |
 | `seed/seed-orders.sh` | Set-based `order_records` + `order_line_items` seeder (#2849), ADDITIVE across `TARGET_ORDERS` - the three #2843 dataset sizes are three calls, each inserting only the delta. |
-| `seed/cleanup.sh` | Removes every row the three seeders above wrote, matching on the `perfseed` tag alone. Standalone - does NOT touch #2854's `stand-down.sh`. |
+| `seed/seed-wc-catalogue.sh` | WooCommerce-side catalogue seeder (#3025) - clones one real WooCommerce product per PS-real product `bootstrap.sh`'s own offer-mapping selection already targets, and maps it (product + every non-stale variant) under `WC_CONNECTION_ID` in the adapter's own external-id shapes, so a real order can resolve line items against the WooCommerce destination. Idempotent and repair-shaped at BOTH product and variant grain. |
+| `seed/cleanup.sh` | Removes every row the four seeders above wrote (matching on the `perfseed`/`PERFWC-` tags), plus its PrestaShop/WooCommerce counterparts. Standalone - does NOT touch #2854's `stand-down.sh`. Requires `CONFIRM_CLEANUP=1` (below) - a prior accidental invocation against a live stand wiped its `order_records`/`order_line_items`. |
 | `scenarios/f5-read-path.sh` | Operator read-path scenario (#2843) - orders/products/jobs-dashboard routes + the app-shell nav-probe fan-out, at each of the three seeded dataset sizes. See "F5 - operator read path at row count" below. |
 | `drivers/read-path.js` | k6 driver for `f5-read-path.sh` - a weighted browse-mix scenario plus a separate page-shell scenario, one Trend per named route. |
 | `scenarios/f8-lane-caps.sh` | Lane-cap SATURATION sweep (#2867) - drives ONE lane's per-scope cap across a list of values, one worker recreate per value, and reports throughput and per-job latency at each point so the knee is read off a curve. The only scenario that WRITES a lane cap; it restores the caps it found on exit. Reads the applied cap back out of the worker's own startup line and refuses the arm on a mismatch, because a cap that silently did not apply produces a clean curve of the same cap measured five times. See "F8 - lane cap saturation" below. |
@@ -119,6 +120,8 @@ stand.
 | `DRAIN_MAX_WAIT_SECS` | `1800` | `drain_wait`'s max-wait timeout before it marks the remainder dead |
 | `SETTLE_SECS` | `60` | the pause `window_start` inserts before opening the window |
 | `SAMPLE_INTERVAL_SECS` | `1` | nominal observer tick interval (actual drift recorded as `dt`) |
+| `F5_ROW_COUNT_TOLERANCE_PCT` | `1` | `check_row_count_target` (via `f5-read-path.sh`'s `run_size`) - relative tolerance, as a percent of the target, before a size step's row count is DISCARDED as mismeasured |
+| `CONFIRM_CLEANUP` | *(required, no default)* | `seed/cleanup.sh` - must be `1` or the script refuses before its first `DELETE` |
 
 ## Every guard, and what makes a run invalid
 
@@ -664,6 +667,21 @@ distribution rather than merely a similar one. Distribution targets are
 asserted post-seed (recordStatus/connection/currency/reportingCurrency
 mix), not left as a prose claim - see each seeder's own `check_share` /
 distribution-log lines.
+
+**WooCommerce catalogue mapping (#3025)**: `seed/seed-wc-catalogue.sh` closes
+a separate gap the three seeders above don't touch - `perf-woocommerce` is
+created with `OrderProcessorManager` alone (no `ProductMaster`), so nothing
+ever wrote it a `Product`/`ProductVariant` mapping, and every order fanned
+out to it as a destination died at line-item resolution, silently reported
+`outcome: 'ok'` under `OrderSyncService`'s `Promise.allSettled` fan-out.
+Clones one real WooCommerce product (via the WC PHP API) per PS-real product
+`bootstrap.sh`'s own offer-mapping selection already targets, mapping the
+product and every one of its non-stale variants (`product:{wcId}#{variantId}`,
+a synthetic per-variant marker - WooCommerce gets no real variation of its
+own). Idempotent and repair-shaped at both product AND variant grain: a
+re-run only creates what's still missing, including a variant added to an
+already-mapped product after an earlier run. Own env vars: `SKU_PREFIX`
+(`PERFWC-`), `CEILING_SECS` (default `300`).
 
 **Deliberately deferred, named rather than silently skipped**: the
 sample-through-real-ingestion diff against #2846's stubs (#2846 is a

--- a/perf/openlinker-throughput/bootstrap.sh
+++ b/perf/openlinker-throughput/bootstrap.sh
@@ -578,6 +578,15 @@ step_allegro_offer_manager() {
 # and because `OrderSyncService` fans out under `Promise.allSettled`, the job
 # still records `outcome: 'ok'` while the shop receives nothing.
 #
+# The WooCommerce half of that (a real order fanning out to a WooCommerce
+# connection with NO numeric Product mapping at all, "No WC product mapping
+# for OL product ...") is #3025 - `seed/seed-wc-catalogue.sh` closes it by
+# cloning one real WooCommerce product per distinct PS-real product this
+# selection below can reach, and mapping it under `WC_CONNECTION_ID`. Run it
+# once after this step (and again any time the PS-real pool grows) so a
+# dual-destination order-ingestion measurement is not silently missing its
+# WooCommerce half.
+#
 # The target set is therefore variants whose product carries a NUMERIC
 # PrestaShop external id - a real `id_product` in the shop's own catalogue,
 # which on this stand is the six products bootstrap itself installs (20-25,

--- a/perf/openlinker-throughput/lib-test.sh
+++ b/perf/openlinker-throughput/lib-test.sh
@@ -1151,6 +1151,29 @@ assert_eq "10 vs 12: |10-12|/11 = 0.181818" "0.181818" "$(compute_agreement 10 1
 assert_eq "a deliberately deduped n=0 pair (0 vs 0) reports ratio 0 - the ZERO agreement trap #2845's publish_if_agreed must refuse on its own (a minimum-n check), never here" "0" "$(compute_agreement 0 0)"
 
 # ===========================================================================
+# check_row_count_target (#3024) - f5-read-path.sh's per-arm guard against the
+# additive seeder silently measuring a bigger dataset than the label claims.
+# Verified red-first in both directions, per the issue's own AC.
+# ===========================================================================
+echo "--- check_row_count_target (#3024) ---"
+assert_eq "an arm seeded exactly to target is ok" "ok" \
+  "$(check_row_count_target 10000 10000)"
+assert_eq "the RED case: an arm left at the wrong size (1M actual, 10k target) is DISCARDED and names both figures" \
+  "1" "$(check_row_count_target 1000000 10000 | grep -c 'DISCARDED row_count_mismatch: rowCounts.order_records=1000000 does not match targetOrders=10000')"
+assert_eq "the same RED case reads DISCARDED at the caller's boundary (verdict_write's own vocabulary), not merely a free-text warning" \
+  "DISCARDED" "$(check_row_count_target 1000000 10000 | awk '{print $1}')"
+assert_eq "within the default 1% relative tolerance is still ok" "ok" \
+  "$(check_row_count_target 10050 10000)"
+assert_eq "just outside the default 1% relative tolerance is DISCARDED" "DISCARDED" \
+  "$(check_row_count_target 10200 10000 | awk '{print $1}')"
+assert_eq "an explicit tolerance widens what counts as ok" "ok" \
+  "$(check_row_count_target 10200 10000 5)"
+assert_eq "a non-numeric actual (a failed read) is DISCARDED, never treated as a mismatch of magnitude 0" "DISCARDED" \
+  "$(check_row_count_target '' 10000 | awk '{print $1}')"
+assert_eq "a zero target is refused rather than producing a divide-by-zero percentage" "DISCARDED" \
+  "$(check_row_count_target 0 0 | awk '{print $1}')"
+
+# ===========================================================================
 # results_dir_init / --dry-run (would()) behavior
 # ===========================================================================
 echo "--- results_dir_init ---"

--- a/perf/openlinker-throughput/lib.sh
+++ b/perf/openlinker-throughput/lib.sh
@@ -1932,3 +1932,45 @@ compute_agreement() {
     printf "%.6f\n", d/med
   }'
 }
+
+# ---------------------------------------------------------------------------
+# check_row_count_target <actual> <target> [tolerance_pct] - #3024.
+#
+# f5-read-path.sh's seeder (seed-orders.sh) is ADDITIVE ACROSS SIZES BY
+# DESIGN - it no-ops once the dataset is already at/above TARGET_ORDERS,
+# because the same table is reused across the 10k/100k/1M steps rather than
+# re-seeded from zero each time. That is correct when the steps run in
+# ascending order in a fresh invocation; it is silently WRONG the moment a
+# later invocation asks for a SMALLER size than a table already carries
+# (F5_ONLY_SIZE resuming a single step out of order, a re-run against a
+# stand another campaign already grew) - the seed call becomes a no-op and
+# the scenario proceeds to measure whatever row count is already there
+# under the smaller label. Nothing about that failure mode produces a
+# non-2xx response or trips any guard in the run_post_guards chain: every
+# request still succeeds, it is just answered against the wrong table.
+#
+# Pure comparison, no I/O, so it is testable without a live stand (#3024
+# AC: "verified red-first in both directions"). Echoes "ok" when actual is
+# within tolerance_pct (default 1, a RELATIVE percentage of target) of
+# target; otherwise echoes a single-line DISCARDED reason naming both
+# figures, in the same "DISCARDED <check_name>: <reason>" shape the
+# post_guard_* family already writes into verdict.txt via
+# run_post_guards/_post_guard_run - so a caller that is not itself part of
+# that chain (F5 runs no post-guards - see its own header comment) can still
+# hand the answer straight to verdict_write.
+# ---------------------------------------------------------------------------
+check_row_count_target() {
+  local actual="$1" target="$2" tolerance_pct="${3:-1}"
+  awk -v a="$actual" -v t="$target" -v tol="$tolerance_pct" 'BEGIN {
+    if (t !~ /^[0-9]+(\.[0-9]+)?$/ || t+0 <= 0) {
+      print "DISCARDED row_count_mismatch: target=" t " is not a positive number"; exit
+    }
+    if (a !~ /^[0-9]+(\.[0-9]+)?$/) {
+      print "DISCARDED row_count_mismatch: actual=" a " is not a readable row count"; exit
+    }
+    diff = a - t; if (diff < 0) diff = -diff;
+    pct = (diff / t) * 100;
+    if (pct <= tol + 1e-9) { print "ok"; exit }
+    printf "DISCARDED row_count_mismatch: rowCounts.order_records=%s does not match targetOrders=%s (%.2f%% off, tolerance %s%%) - the additive seeder (seed-orders.sh) no-ops once a bigger arm already ran; re-run this size step alone (F5_ONLY_SIZE/F5_ONLY_LABEL) against a freshly reset dataset\n", a, t, pct, tol
+  }'
+}

--- a/perf/openlinker-throughput/scenarios/f1-order-ingestion.sh
+++ b/perf/openlinker-throughput/scenarios/f1-order-ingestion.sh
@@ -1155,6 +1155,15 @@ run_strict() {
   # table of failures, and - worse - would invite a reader to mistake a stand
   # gap for a WooCommerce performance result. The refusal names what is
   # missing and what would fix it.
+  #
+  # #3025 supplies that fix: `seed/seed-wc-catalogue.sh` clones one real
+  # WooCommerce product per PS-real product `seed_offer_mappings_for` (this
+  # file, above) already selects, and writes the matching numeric
+  # `identifier_mappings` rows - so the `wc_real_products` check below turns
+  # positive the moment that script has been run against this stand, and
+  # this arm (and, since it shares the same underlying pool, any
+  # dual-destination fan-out measurement outside this file) stops being
+  # skipped for lack of data.
   local wc_real_products=0
   if [ "$ARMS" = "all" ]; then
     wc_real_products="$(pg_sql "SELECT COUNT(*) FROM identifier_mappings
@@ -1162,7 +1171,7 @@ run_strict() {
         AND \"externalId\" ~ '^[0-9]+\$'" 2>/dev/null || printf 0)"
   fi
   if [ "$ARMS" = "all" ] && [ "${wc_real_products:-0}" -eq 0 ]; then
-    warn "SKIPPING the WooCommerce arm: the stand carries $(pg_sql "SELECT COUNT(*) FROM identifier_mappings WHERE \"entityType\"='Product' AND \"connectionId\"='$WC_CONNECTION_ID'" 2>/dev/null || printf '?') WooCommerce Product mappings and NONE of them names a numeric WC product id, so no order can resolve a line item there. seed-catalogue.sh seeds mappings, never real WooCommerce products - creating some (wp post create --post_type=product) and re-pointing those mappings is what this arm needs. Reported as not-run rather than run-and-discarded."
+    warn "SKIPPING the WooCommerce arm: the stand carries $(pg_sql "SELECT COUNT(*) FROM identifier_mappings WHERE \"entityType\"='Product' AND \"connectionId\"='$WC_CONNECTION_ID'" 2>/dev/null || printf '?') WooCommerce Product mappings and NONE of them names a numeric WC product id, so no order can resolve a line item there. Run seed/seed-wc-catalogue.sh (#3025) against this stand, which creates real WooCommerce products for the same PS-real pool seed_offer_mappings_for already targets and maps them under WC_CONNECTION_ID. Reported as not-run rather than run-and-discarded."
   elif [ "$ARMS" = "all" ]; then
     log "=== arm woocommerce: $WC_ARM_ORDERS serial samples against the real local WooCommerce ==="
     set_destination "$PS_CONNECTION_ID" off

--- a/perf/openlinker-throughput/scenarios/f5-read-path.sh
+++ b/perf/openlinker-throughput/scenarios/f5-read-path.sh
@@ -305,6 +305,28 @@ run_size() {
     --arg rng_seed "$SEED_RNG" --arg statement_timeout_ms "$STATEMENT_TIMEOUT_MS" \
     '{f5: {datasetLabel: $label, targetOrders: $target, rowCounts: {order_records: $n_orders, order_line_items: $n_lines, sync_jobs: $n_syncjobs}, seedRngSeed: $rng_seed, statementTimeoutMs: $statement_timeout_ms}}')"
 
+  # #3024 - the additive seeder above is a no-op once the dataset is already
+  # at/above target (its own header comment says so), so a step run out of
+  # order (F5_ONLY_SIZE resuming a single step, or a re-run against a stand
+  # a bigger step already grew) would otherwise silently measure the WRONG
+  # row count under this label and still report VALID - nothing about that
+  # produces a non-2xx response for the "did k6 stay mostly within 2xx"
+  # check below to catch. Checked here, BEFORE window_start, so a
+  # known-mismeasured arm never pays for a k6 window it cannot honestly
+  # report: refuse the arm rather than measure it (#3024 AC - shrinking the
+  # table back down is the alternative, and is not this scenario's call to
+  # make on a table seed-orders.sh documents as shared/additive across
+  # steps).
+  local row_count_check
+  row_count_check="$(check_row_count_target "$n_orders" "$target" "${F5_ROW_COUNT_TOLERANCE_PCT:-1}")"
+  if [ "$row_count_check" != "ok" ]; then
+    warn "size step target=$target label=$label: $row_count_check"
+    manifest_write "$dir" f5-read-path "$CONN_IDS_CSV" "$SMOKE" "$extra"
+    verdict_write "$dir" DISCARDED "$row_count_check"
+    log "size step DISCARDED: $dir ($row_count_check) - no k6 load was run against this mismeasured arm"
+    return
+  fi
+
   window_start "$dir" f5-read-path "$CONN_IDS_CSV" "$SMOKE" "$extra"
   run_k6 "$dir/sample-ids.json" "$label" "$dir/k6-summary.json" "$dir/k6-raw.json"
   window_stop "$dir"

--- a/perf/openlinker-throughput/scenarios/f5-read-path.sh
+++ b/perf/openlinker-throughput/scenarios/f5-read-path.sh
@@ -298,20 +298,22 @@ run_size() {
   n_lines="$(pg_sql "SELECT COUNT(*) FROM order_line_items WHERE \"orderRecordId\" LIKE 'perfseed_ord_%'")"
   n_syncjobs="$(pg_sql "SELECT COUNT(*) FROM sync_jobs")"
 
-  local extra
-  extra="$(jq -n \
-    --arg label "$label" --argjson target "$target" \
-    --argjson n_orders "$n_orders" --argjson n_lines "$n_lines" --argjson n_syncjobs "$n_syncjobs" \
-    --arg rng_seed "$SEED_RNG" --arg statement_timeout_ms "$STATEMENT_TIMEOUT_MS" \
-    '{f5: {datasetLabel: $label, targetOrders: $target, rowCounts: {order_records: $n_orders, order_line_items: $n_lines, sync_jobs: $n_syncjobs}, seedRngSeed: $rng_seed, statementTimeoutMs: $statement_timeout_ms}}')"
-
   # #3024 - the additive seeder above is a no-op once the dataset is already
   # at/above target (its own header comment says so), so a step run out of
   # order (F5_ONLY_SIZE resuming a single step, or a re-run against a stand
   # a bigger step already grew) would otherwise silently measure the WRONG
   # row count under this label and still report VALID - nothing about that
   # produces a non-2xx response for the "did k6 stay mostly within 2xx"
-  # check below to catch. Checked here, BEFORE window_start, so a
+  # check below to catch. Checked here, BEFORE `extra` is assembled and
+  # BEFORE window_start (#3025 review, SUGGESTION - moved up from after
+  # `extra`): the assembly below uses `--argjson n_orders "$n_orders"`, which
+  # requires a syntactically valid JSON number, so a failed pg_sql read
+  # (empty `$n_orders`) used to abort THIS FUNCTION inside jq with a bare
+  # "Invalid numeric literal" - never reaching check_row_count_target's own
+  # "actual is not a readable row count" branch at all, despite that branch
+  # being unit-tested (lib-test.sh: `check_row_count_target '' 10000`).
+  # Running the guard first makes that branch genuinely reachable here and
+  # gives the actionable diagnostic instead of a jq parse error. A
   # known-mismeasured arm never pays for a k6 window it cannot honestly
   # report: refuse the arm rather than measure it (#3024 AC - shrinking the
   # table back down is the alternative, and is not this scenario's call to
@@ -321,11 +323,24 @@ run_size() {
   row_count_check="$(check_row_count_target "$n_orders" "$target" "${F5_ROW_COUNT_TOLERANCE_PCT:-1}")"
   if [ "$row_count_check" != "ok" ]; then
     warn "size step target=$target label=$label: $row_count_check"
-    manifest_write "$dir" f5-read-path "$CONN_IDS_CSV" "$SMOKE" "$extra"
+    # A minimal, empty-safe extra: `--arg` (string) tolerates a blank
+    # `$n_orders` where `--argjson` (this branch's whole reason for existing)
+    # would refuse to build at all.
+    local discard_extra
+    discard_extra="$(jq -n --arg label "$label" --argjson target "$target" --arg n_orders "$n_orders" \
+      '{f5: {datasetLabel: $label, targetOrders: $target, rowCounts: {order_records: $n_orders}}}')"
+    manifest_write "$dir" f5-read-path "$CONN_IDS_CSV" "$SMOKE" "$discard_extra"
     verdict_write "$dir" DISCARDED "$row_count_check"
     log "size step DISCARDED: $dir ($row_count_check) - no k6 load was run against this mismeasured arm"
     return
   fi
+
+  local extra
+  extra="$(jq -n \
+    --arg label "$label" --argjson target "$target" \
+    --argjson n_orders "$n_orders" --argjson n_lines "$n_lines" --argjson n_syncjobs "$n_syncjobs" \
+    --arg rng_seed "$SEED_RNG" --arg statement_timeout_ms "$STATEMENT_TIMEOUT_MS" \
+    '{f5: {datasetLabel: $label, targetOrders: $target, rowCounts: {order_records: $n_orders, order_line_items: $n_lines, sync_jobs: $n_syncjobs}, seedRngSeed: $rng_seed, statementTimeoutMs: $statement_timeout_ms}}')"
 
   window_start "$dir" f5-read-path "$CONN_IDS_CSV" "$SMOKE" "$extra"
   run_k6 "$dir/sample-ids.json" "$label" "$dir/k6-summary.json" "$dir/k6-raw.json"

--- a/perf/openlinker-throughput/seed/cleanup.sh
+++ b/perf/openlinker-throughput/seed/cleanup.sh
@@ -15,6 +15,14 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/seed-lib.sh"
 LIB_LOG_PREFIX="seed-cleanup"
 
+# Both guards run BEFORE any DELETE below. require_connections catches an
+# unsourced stand-ids.env here rather than as an "unbound variable" crash
+# after the destructive blocks below have already run (the WC-side block
+# reads $WC_CONNECTION_ID unconditionally, past its own `if`); the confirm
+# gate catches a plain accidental invocation of this whole script.
+require_connections
+require_cleanup_confirmed
+
 log "deleting perfseed order_line_items"
 pg_sql_write "DELETE FROM order_line_items WHERE \"orderRecordId\" LIKE '${PREFIX}\\_ord\\_%' ESCAPE '\\'" >/dev/null
 
@@ -116,13 +124,22 @@ if [ "${WC_PRODUCT_COUNT_CLEAN:-0}" != "0" ]; then
     WHERE \"connectionId\"='${WC_CONNECTION_ID}' AND \"entityType\"='ProductVariant'
       AND \"externalId\" ~ ('^product:(' || replace('${WC_IDS_CSV}', ',', '|') || ')#')" >/dev/null
 
-  wc_wp eval '
+  # NOT via wc_wp (stderr -> /dev/null) - the same swallowing that hid the
+  # docker-cp ownership warning live in seed-wc-catalogue.sh, and this is the
+  # one call in this script that can silently no-op N times (once per
+  # already-deleted or never-created post) with only an exit code to show
+  # for it.
+  WP_DELETE_OUT="$(mktemp)"
+  if ! docker exec -i "$WC_CONTAINER" wp --allow-root --no-debug --path="$WC_PATH" eval '
     global $wpdb;
     $ids = json_decode(file_get_contents("php://stdin"), true);
     foreach ($ids as $id) { wp_delete_post((int) $id, true); }
     echo count($ids);
-  ' <<<"$WC_PRODUCT_IDS_JSON" >/dev/null 2>&1 \
-    || warn "cleanup: WooCommerce product deletion reported a non-zero exit - some PERFWC- product(s) may remain (re-run cleanup.sh to retry)"
+  ' <<<"$WC_PRODUCT_IDS_JSON" > "$WP_DELETE_OUT" 2>&1; then
+    cat "$WP_DELETE_OUT" >&2
+    warn "cleanup: WooCommerce product deletion reported a non-zero exit (output above) - some PERFWC- product(s) may remain (re-run cleanup.sh to retry)"
+  fi
+  rm -f "$WP_DELETE_OUT"
 fi
 
 WC_REMAINING="$(pg_sql "SELECT COUNT(*) FROM identifier_mappings WHERE \"connectionId\"='${WC_CONNECTION_ID}' AND \"entityType\" IN ('Product','ProductVariant')")"

--- a/perf/openlinker-throughput/seed/cleanup.sh
+++ b/perf/openlinker-throughput/seed/cleanup.sh
@@ -79,4 +79,53 @@ pg_sql_write "DROP TABLE IF EXISTS perf_shop_handback" >/dev/null
 SHOP_REMAINING="$(ps_sql "SELECT COUNT(*) FROM ps_product WHERE reference LIKE '${SHOP_PREFIX}%'" | tail -1)"
 log "PrestaShop products remaining with the ${SHOP_PREFIX} prefix: ${SHOP_REMAINING:-?}"
 
+# ---------------------------------------------------------------------------
+# WooCommerce side (seed-wc-catalogue.sh, #3025). The OL-side mappings it
+# writes carry the internalId of a REAL, already-synced PrestaShop product
+# (`ol_product_*`/`ol_variant_*`, or a seed-shop-catalogue.sh clone) - never
+# the `perfseed_product_*` prefix the block above matches on - so they must
+# be found the same way seed-wc-catalogue.sh itself finds its own work: by
+# the WC_SKU_PREFIX every product it creates carries, never by internalId
+# (which would either miss them, or risk deleting a real synced product's
+# unrelated mapping to another connection).
+# ---------------------------------------------------------------------------
+WC_SKU_PREFIX="PERFWC-"
+WC_PRODUCT_IDS_JSON="$(wc_wp eval '
+  global $wpdb;
+  $ids = $wpdb->get_col($wpdb->prepare(
+    "SELECT p.ID FROM {$wpdb->posts} p
+     JOIN {$wpdb->postmeta} m ON m.post_id = p.ID AND m.meta_key = \"_sku\"
+     WHERE p.post_type = \"product\" AND m.meta_value LIKE %s",
+    $wpdb->esc_like("'"$WC_SKU_PREFIX"'") . "%"
+  ));
+  echo json_encode(array_map("intval", $ids));
+' 2>/dev/null || printf '[]')"
+WC_PRODUCT_COUNT_CLEAN="$(jq 'length' <<<"$WC_PRODUCT_IDS_JSON" 2>/dev/null || printf 0)"
+log "deleting $WC_PRODUCT_COUNT_CLEAN WooCommerce product(s) carrying the ${WC_SKU_PREFIX} SKU prefix"
+
+if [ "${WC_PRODUCT_COUNT_CLEAN:-0}" != "0" ]; then
+  WC_IDS_CSV="$(jq -r 'join(",")' <<<"$WC_PRODUCT_IDS_JSON")"
+  pg_sql_write "DELETE FROM identifier_mappings
+    WHERE \"connectionId\"='${WC_CONNECTION_ID}' AND \"entityType\"='Product' AND \"externalId\" IN
+      (SELECT unnest(string_to_array('${WC_IDS_CSV}', ',')))" >/dev/null
+  # ProductVariant rows carry 'product:{wcId}#{n}' - matched by prefix over
+  # the same id set, since the exact suffix is this seeder's own bookkeeping
+  # detail (see seed-wc-catalogue.sh's own comment) rather than a value a
+  # WHERE ... IN clause can enumerate.
+  pg_sql_write "DELETE FROM identifier_mappings
+    WHERE \"connectionId\"='${WC_CONNECTION_ID}' AND \"entityType\"='ProductVariant'
+      AND \"externalId\" ~ ('^product:(' || replace('${WC_IDS_CSV}', ',', '|') || ')#')" >/dev/null
+
+  wc_wp eval '
+    global $wpdb;
+    $ids = json_decode(file_get_contents("php://stdin"), true);
+    foreach ($ids as $id) { wp_delete_post((int) $id, true); }
+    echo count($ids);
+  ' <<<"$WC_PRODUCT_IDS_JSON" >/dev/null 2>&1 \
+    || warn "cleanup: WooCommerce product deletion reported a non-zero exit - some PERFWC- product(s) may remain (re-run cleanup.sh to retry)"
+fi
+
+WC_REMAINING="$(pg_sql "SELECT COUNT(*) FROM identifier_mappings WHERE \"connectionId\"='${WC_CONNECTION_ID}' AND \"entityType\" IN ('Product','ProductVariant')")"
+log "WooCommerce identifier_mappings remaining for this connection: ${WC_REMAINING:-?}"
+
 log "cleanup done"

--- a/perf/openlinker-throughput/seed/seed-lib.sh
+++ b/perf/openlinker-throughput/seed/seed-lib.sh
@@ -86,6 +86,19 @@ require_connections() {
   [ -n "${WC_CONNECTION_ID:-}" ] || die "WC_CONNECTION_ID not set - source stand-ids.env (bootstrap.sh) first"
 }
 
+# cleanup.sh deletes every perfseed-tagged row on the stand plus its
+# PrestaShop/WooCommerce counterparts, with no dry-run and no undo. An
+# operator already ran it once by accident against a live lab stand while
+# testing the #3025 WooCommerce teardown block, wiping order_records/
+# order_line_items (see that PR's own "Incident during verification" note) -
+# with nothing between typing the command and the first DELETE. Mirrors
+# refuse_unless_forced's FORCE_SEED gate: an explicit, named opt-in rather
+# than a bare confirmation prompt (which a scripted/CI caller can't answer).
+require_cleanup_confirmed() {
+  [ "${CONFIRM_CLEANUP:-0}" = "1" ] \
+    || die "cleanup.sh deletes every '${PREFIX}'-prefixed row on this stand, plus the PrestaShop/WooCommerce rows it tagged - no dry-run, no undo. Re-run with CONFIRM_CLEANUP=1 once you are sure this is the stand you mean to clear."
+}
+
 # vacuum_analyze_reset <table...> - #2849/#2843 AC: fresh planner statistics
 # per size step, plus a pg_stat_statements reset so the NEXT thing measured
 # (a scenario's own read-path window) is not attributing this seeder's own

--- a/perf/openlinker-throughput/seed/seed-wc-catalogue.sh
+++ b/perf/openlinker-throughput/seed/seed-wc-catalogue.sh
@@ -56,6 +56,18 @@
 # only the products still missing a WooCommerce mapping and leaves the rest
 # alone, exactly like bootstrap.sh's own found/gap/created seeding.
 #
+# The repair is VARIANT-grain, not just product-grain (#3025 review,
+# IMPORTANT): a product that already carries a WooCommerce mapping is never
+# revisited for a NEW variant added to it after that first run, because the
+# product-level filter that decides "already done" cannot see inside it. So
+# every run also diffs each already-mapped product's candidate variantIds
+# against its OWN existing ProductVariant mappings and inserts whatever is
+# missing, against the product's EXISTING wcId - no new WC product, no
+# re-creation. The variant mapping's suffix is the variant's OWN internal id
+# (`product:{wcId}#{variantId}`), not a positional ordinal - an ordinal
+# recomputed on a later, grown variant list would risk colliding with (or
+# silently duplicating) one already written for the same variant.
+#
 # Usage: ./seed-wc-catalogue.sh
 #
 set -euo pipefail
@@ -96,129 +108,200 @@ CANDIDATES_JSON="$(pg_sql "
 N_CANDIDATES="$(jq 'length' <<<"$CANDIDATES_JSON")"
 [ "${N_CANDIDATES:-0}" -gt 0 ] || die "seed-wc-catalogue: no non-stale product_variants map to a real (numeric-id) PrestaShop product - install/sync the PrestaShop catalogue first (bootstrap.sh step_connections, or seed-shop-catalogue.sh)."
 
-EXISTING_WC_JSON="$(pg_sql "SELECT COALESCE(jsonb_agg(\"internalId\"),'[]'::jsonb) FROM identifier_mappings WHERE \"entityType\"='Product' AND \"connectionId\"='$WC_CONNECTION_ID'")"
-TO_CREATE_JSON="$(jq -c --argjson existing "$EXISTING_WC_JSON" \
+# The Postgres array literal every referential check below scopes itself
+# to (#3025 review, BLOCKING) - this script's OWN candidate set, never a
+# bare `connectionId` match. seed-catalogue.sh's 10k pool also writes
+# `entityType='Product'` rows under this SAME WC_CONNECTION_ID (a
+# deliberately non-numeric synthetic id, see the header above) - a
+# connectionId-only scope counted those too and died reporting a failure
+# on ~10 000 rows this script never touched, on the exact stand F5 uses.
+# Candidate ids are `ol_product_*`/`perfseed_product_s*`, which can never
+# collide with a brace/comma/quote, so no per-id quoting is needed.
+CANDIDATE_IDS_PG_ARRAY="$(jq -r '"{" + ([.[].olId] | join(",")) + "}"' <<<"$CANDIDATES_JSON")"
+# Same scoping, for the variant-grain referential check further down - a
+# variant's identifier_mappings row carries the VARIANT id as internalId,
+# never the product id, so it needs its own candidate array.
+CANDIDATE_VARIANT_IDS_PG_ARRAY="$(jq -r '"{" + ([.[].variantIds[]] | join(",")) + "}"' <<<"$CANDIDATES_JSON")"
+
+# {olId, wcId} for every candidate ALREADY carrying a WC Product mapping -
+# richer than a bare id list because the missing-variant repair below (#3025
+# review, IMPORTANT) needs the wcId to attach a repaired variant to, not just
+# the fact that the product is "done".
+EXISTING_WC_PRODUCTS_JSON="$(pg_sql "SELECT COALESCE(jsonb_agg(jsonb_build_object('olId', \"internalId\", 'wcId', \"externalId\")),'[]'::jsonb) FROM identifier_mappings WHERE \"entityType\"='Product' AND \"connectionId\"='$WC_CONNECTION_ID' AND \"internalId\" = ANY('${CANDIDATE_IDS_PG_ARRAY}'::text[])")"
+EXISTING_OL_IDS_JSON="$(jq -c '[.[].olId]' <<<"$EXISTING_WC_PRODUCTS_JSON")"
+# Every variant that already has ITS OWN mapping, regardless of which
+# product it belongs to - a product-grain "already mapped" check cannot see
+# a variant added to an already-mapped product after the fact (#3025 review,
+# IMPORTANT): this is the set that detection reads instead.
+EXISTING_VARIANT_IDS_JSON="$(pg_sql "SELECT COALESCE(jsonb_agg(\"internalId\"),'[]'::jsonb) FROM identifier_mappings WHERE \"entityType\"='ProductVariant' AND \"connectionId\"='$WC_CONNECTION_ID' AND \"externalId\" LIKE 'product:%'")"
+
+TO_CREATE_JSON="$(jq -c --argjson existing "$EXISTING_OL_IDS_JSON" \
   '[ .[] | select((.olId as $id | ($existing | index($id))) == null) ]' <<<"$CANDIDATES_JSON")"
 N_TO_CREATE="$(jq 'length' <<<"$TO_CREATE_JSON")"
 
-log "PrestaShop-real products: $N_CANDIDATES total, $N_TO_CREATE lacking a WooCommerce mapping"
+# Candidates that already have a WC product, checked for a variant this run
+# needs to REPAIR rather than skip outright - the product-grain filter above
+# would otherwise never revisit a product it already mapped once, no matter
+# how many variants it has grown since.
+ALREADY_MAPPED_JSON="$(jq -c --argjson existing "$EXISTING_OL_IDS_JSON" \
+  '[ .[] | select((.olId as $id | ($existing | index($id))) != null) ]' <<<"$CANDIDATES_JSON")"
+MISSING_VARIANT_ROWS_TSV="$(jq -r --argjson existingVariants "$EXISTING_VARIANT_IDS_JSON" --argjson wcProducts "$EXISTING_WC_PRODUCTS_JSON" '
+  (($wcProducts | map({(.olId): .wcId}) | add) // {}) as $wcIdByProduct
+  | .[] | . as $row
+  | ($wcIdByProduct[$row.olId]) as $wcId
+  | select($wcId != null)
+  | ($row.variantIds[]) as $variantId
+  | select(($existingVariants | index($variantId)) == null)
+  | [$variantId, ("product:" + ($wcId|tostring) + "#" + ($variantId|tostring))] | @tsv
+' <<<"$ALREADY_MAPPED_JSON")"
+N_MISSING_VARIANTS="$(printf '%s\n' "$MISSING_VARIANT_ROWS_TSV" | grep -c . || true)"
 
-if [ "$N_TO_CREATE" = 0 ]; then
-  log "found: every destination-resolvable product already carries a WooCommerce mapping - nothing to do"
+log "PrestaShop-real products: $N_CANDIDATES total, $N_TO_CREATE lacking a WooCommerce mapping, $N_MISSING_VARIANTS variant mapping(s) missing on already-mapped products"
+
+if [ "$N_TO_CREATE" = 0 ] && [ "$N_MISSING_VARIANTS" = 0 ]; then
+  log "found: every destination-resolvable product and variant already carries a WooCommerce mapping - nothing to do"
 else
-  # ---------------------------------------------------------------------------
-  # Clone via the WC PHP API (wp eval), not raw SQL against wp_posts/
-  # wp_postmeta: WooCommerce's own save() path is what stamps every meta row
-  # (including wp_wc_product_meta_lookup, which its own product queries read)
-  # correctly across versions - the same reasoning docker/woocommerce/
-  # 01-seed-wc-data.sh already relies on. The plan crosses via `docker cp`
-  # rather than a `wp eval` argument: WP-CLI's argv has no room for an N-row
-  # JSON blob, and the container's docker-exec user cannot remove a
-  # docker-cp'd file it does not own, so cleanup runs as uid 0 explicitly.
-  # ---------------------------------------------------------------------------
-  PLAN_LOCAL="$(mktemp)"
-  trap 'rm -f "$PLAN_LOCAL"' EXIT
-  jq -c --arg prefix "$SKU_PREFIX" \
-    '[ .[] | {olId, sku: ($prefix + .olId), name: ("Perf WC " + .name), price: ((.price // 0) | tostring), stock: 100} ]' \
-    <<<"$TO_CREATE_JSON" > "$PLAN_LOCAL"
+  PRODUCT_ROWS_TSV=""
+  NEW_VARIANT_ROWS_TSV=""
+  N_CREATED=0
 
-  docker cp "$PLAN_LOCAL" "$WC_CONTAINER:/tmp/perf-wc-plan.json" \
-    || die "seed-wc-catalogue: docker cp of the product plan into $WC_CONTAINER failed"
-  # docker cp preserves the copying HOST user's ownership/mode (0600, this
-  # host's uid) - the container's wp-cli process runs as a DIFFERENT uid
-  # (bitnami's non-root default) and cannot read it back without this: found
-  # live as a silent "Permission denied" PHP warning wc_wp's own stderr
-  # redirect (2>/dev/null) would otherwise have hidden completely.
-  docker exec -u 0 -i "$WC_CONTAINER" chmod 644 /tmp/perf-wc-plan.json \
-    || die "seed-wc-catalogue: could not make the product plan readable inside $WC_CONTAINER"
+  if [ "$N_TO_CREATE" -gt 0 ]; then
+    # ---------------------------------------------------------------------------
+    # Clone via the WC PHP API (wp eval), not raw SQL against wp_posts/
+    # wp_postmeta: WooCommerce's own save() path is what stamps every meta row
+    # (including wp_wc_product_meta_lookup, which its own product queries read)
+    # correctly across versions - the same reasoning docker/woocommerce/
+    # 01-seed-wc-data.sh already relies on. The plan crosses via `docker cp`
+    # rather than a `wp eval` argument: WP-CLI's argv has no room for an N-row
+    # JSON blob, and the container's docker-exec user cannot remove a
+    # docker-cp'd file it does not own, so cleanup runs as uid 0 explicitly.
+    # ---------------------------------------------------------------------------
+    PLAN_LOCAL="$(mktemp)"
+    trap 'rm -f "$PLAN_LOCAL"' EXIT
+    jq -c --arg prefix "$SKU_PREFIX" \
+      '[ .[] | {olId, sku: ($prefix + .olId), name: ("Perf WC " + .name), price: ((.price // 0) | tostring), stock: 100} ]' \
+      <<<"$TO_CREATE_JSON" > "$PLAN_LOCAL"
 
-  # NOT via wc_wp - that helper redirects stderr to /dev/null, which is
-  # exactly what hid the docker-cp ownership mismatch (a silent PHP warning,
-  # empty output, no diagnostic anywhere) the first time this ran live.
-  WP_EVAL_OUT="$(mktemp)"
-  if ! docker exec -i "$WC_CONTAINER" wp --allow-root --no-debug --path="$WC_PATH" eval '
-    $plan = json_decode(file_get_contents("/tmp/perf-wc-plan.json"), true);
-    if (!is_array($plan)) { fwrite(STDERR, "unreadable plan\n"); exit(1); }
-    $out = array();
-    foreach ($plan as $row) {
-      $p = new WC_Product_Simple();
-      $p->set_name($row["name"]);
-      $p->set_sku($row["sku"]);
-      $p->set_regular_price((string) $row["price"]);
-      $p->set_manage_stock(true);
-      $p->set_stock_quantity((int) $row["stock"]);
-      $p->set_status("publish");
-      $id = $p->save();
-      $out[] = array("olId" => $row["olId"], "wcId" => (int) $id);
-    }
-    echo json_encode($out);
-  ' > "$WP_EVAL_OUT" 2>&1; then
-    cat "$WP_EVAL_OUT" >&2
-    die "seed-wc-catalogue: wp eval product creation failed (output above) - nothing was mapped."
+    docker cp "$PLAN_LOCAL" "$WC_CONTAINER:/tmp/perf-wc-plan.json" \
+      || die "seed-wc-catalogue: docker cp of the product plan into $WC_CONTAINER failed"
+    # docker cp preserves the copying HOST user's ownership/mode (0600, this
+    # host's uid) - the container's wp-cli process runs as a DIFFERENT uid
+    # (bitnami's non-root default) and cannot read it back without this: found
+    # live as a silent "Permission denied" PHP warning wc_wp's own stderr
+    # redirect (2>/dev/null) would otherwise have hidden completely.
+    docker exec -u 0 -i "$WC_CONTAINER" chmod 644 /tmp/perf-wc-plan.json \
+      || die "seed-wc-catalogue: could not make the product plan readable inside $WC_CONTAINER"
+
+    # NOT via wc_wp - that helper redirects stderr to /dev/null, which is
+    # exactly what hid the docker-cp ownership mismatch (a silent PHP warning,
+    # empty output, no diagnostic anywhere) the first time this ran live.
+    WP_EVAL_OUT="$(mktemp)"
+    if ! docker exec -i "$WC_CONTAINER" wp --allow-root --no-debug --path="$WC_PATH" eval '
+      $plan = json_decode(file_get_contents("/tmp/perf-wc-plan.json"), true);
+      if (!is_array($plan)) { fwrite(STDERR, "unreadable plan\n"); exit(1); }
+      $out = array();
+      foreach ($plan as $row) {
+        $p = new WC_Product_Simple();
+        $p->set_name($row["name"]);
+        $p->set_sku($row["sku"]);
+        $p->set_regular_price((string) $row["price"]);
+        $p->set_manage_stock(true);
+        $p->set_stock_quantity((int) $row["stock"]);
+        $p->set_status("publish");
+        $id = $p->save();
+        $out[] = array("olId" => $row["olId"], "wcId" => (int) $id);
+      }
+      echo json_encode($out);
+    ' > "$WP_EVAL_OUT" 2>&1; then
+      cat "$WP_EVAL_OUT" >&2
+      die "seed-wc-catalogue: wp eval product creation failed (output above) - nothing was mapped."
+    fi
+    docker exec -u 0 -i "$WC_CONTAINER" rm -f /tmp/perf-wc-plan.json || true
+
+    CREATED_JSON="$(tail -1 "$WP_EVAL_OUT")"
+    rm -f "$WP_EVAL_OUT"
+    N_CREATED="$(jq 'length' <<<"$CREATED_JSON" 2>/dev/null || printf 0)"
+    [ "${N_CREATED:-0}" = "$N_TO_CREATE" ] \
+      || die "seed-wc-catalogue: asked WooCommerce to create $N_TO_CREATE product(s), it reports $N_CREATED - raw output: $CREATED_JSON. Nothing was mapped."
+
+    # ---------------------------------------------------------------------------
+    # Project the (olId -> wcId) result onto identifier_mappings: one Product
+    # row per product, one (synthetic) ProductVariant row per variant that
+    # product's candidate row carried.
+    # ---------------------------------------------------------------------------
+    # Two explicit passes rather than one shape-mixing query, both driven off
+    # the same $CREATED_JSON x $TO_CREATE_JSON join, so there is exactly one
+    # source of truth for "which wcId does this olId now have".
+    PRODUCT_ROWS_TSV="$(jq -r '.[] | [.olId, (.wcId|tostring)] | @tsv' <<<"$CREATED_JSON")"
+    # `isSyntheticVariantExternalId` (woocommerce-variant-id.ts) tests only the
+    # `product:` PREFIX - resolveLineItems never parses what follows it (a
+    # synthetic mapping resolves `product_id` from the separate `Product` row
+    # and leaves `variation_id` unset either way) - so every variant of one OL
+    # product can legitimately point at the SAME simple WC product, as long as
+    # each row's externalId is still distinct enough to satisfy
+    # identifier_mappings' own (entityType, platformType, connectionId,
+    # externalId) uniqueness. The suffix is the VARIANT'S OWN internal id
+    # (never a positional ordinal, #3025 review, IMPORTANT): a variant-array
+    # index is not stable across runs - `variantIds` carries no ORDER BY, and
+    # even if it did, a variant added later can sort ahead of one already
+    # mapped - so a later run's missing-variant repair (below) could recompute
+    # a DIFFERENT ordinal for an already-mapped variant and either collide
+    # with it (identifier_mappings' own uniqueness refuses the insert) or,
+    # worse, silently duplicate it under a second externalId. The variant's
+    # own id can never collide with itself and never needs recomputing.
+    NEW_VARIANT_ROWS_TSV="$(jq -r --argjson plan "$TO_CREATE_JSON" '
+      (map({(.olId): .wcId}) | add // {}) as $wcIdByProduct
+      | $plan[] | . as $row
+      | ($wcIdByProduct[$row.olId]) as $wcId
+      | select($wcId != null)
+      | ($row.variantIds[]) as $variantId
+      | [$variantId, ("product:" + ($wcId|tostring) + "#" + ($variantId|tostring))] | @tsv
+    ' <<<"$CREATED_JSON")"
   fi
-  docker exec -u 0 -i "$WC_CONTAINER" rm -f /tmp/perf-wc-plan.json || true
 
-  CREATED_JSON="$(tail -1 "$WP_EVAL_OUT")"
-  rm -f "$WP_EVAL_OUT"
-  N_CREATED="$(jq 'length' <<<"$CREATED_JSON" 2>/dev/null || printf 0)"
-  [ "${N_CREATED:-0}" = "$N_TO_CREATE" ] \
-    || die "seed-wc-catalogue: asked WooCommerce to create $N_TO_CREATE product(s), it reports $N_CREATED - raw output: $CREATED_JSON. Nothing was mapped."
+  # Missing-variant repair rows (computed above, before this if/else) join
+  # the newly-created products' own variant rows into ONE combined insert -
+  # both use the identical variant-id-suffixed externalId scheme, so there is
+  # no risk of the two passes disagreeing about one variant's shape.
+  ALL_VARIANT_ROWS_TSV="$(printf '%s\n%s\n' "$NEW_VARIANT_ROWS_TSV" "$MISSING_VARIANT_ROWS_TSV" | grep -v '^$' || true)"
 
-  # ---------------------------------------------------------------------------
-  # Project the (olId -> wcId) result onto identifier_mappings: one Product
-  # row per product, one (synthetic) ProductVariant row per variant that
-  # product's candidate row carried.
-  # ---------------------------------------------------------------------------
-  # Two explicit passes rather than one shape-mixing query, both driven off
-  # the same $CREATED_JSON x $TO_CREATE_JSON join, so there is exactly one
-  # source of truth for "which wcId does this olId now have".
-  PRODUCT_ROWS_TSV="$(jq -r '.[] | [.olId, (.wcId|tostring)] | @tsv' <<<"$CREATED_JSON")"
-  # `isSyntheticVariantExternalId` (woocommerce-variant-id.ts) tests only the
-  # `product:` PREFIX - resolveLineItems never parses what follows it (a
-  # synthetic mapping resolves `product_id` from the separate `Product` row
-  # and leaves `variation_id` unset either way) - so every variant of one OL
-  # product can legitimately point at the SAME simple WC product, as long as
-  # each row's externalId is still distinct enough to satisfy
-  # identifier_mappings' own (entityType, platformType, connectionId,
-  # externalId) uniqueness. `#<ordinal>` is appended for exactly that: a
-  # WC-facing seller cannot tell these variants apart on this stand (a real
-  # multi-variant integration would model them as WC variations of a
-  # WC_Product_Variable instead), which is an accepted simplification for a
-  # load-test fixture that only needs the order to be CREATABLE.
-  VARIANT_ROWS_TSV="$(jq -r --argjson plan "$TO_CREATE_JSON" '
-    (map({(.olId): .wcId}) | add // {}) as $wcIdByProduct
-    | $plan[] | . as $row
-    | ($wcIdByProduct[$row.olId]) as $wcId
-    | select($wcId != null)
-    | ($row.variantIds | to_entries[]) as $e
-    | [$e.value, ("product:" + ($wcId|tostring) + "#" + ($e.key|tostring))] | @tsv
-  ' <<<"$CREATED_JSON")"
-
-  seed_sql <<SQL
+  # Two separate statements/transactions rather than one, so an empty
+  # PRODUCT_ROWS_TSV (the missing-variant-only repair path, N_TO_CREATE=0)
+  # never hands COPY a blank line where it expects a two-column row - and so
+  # a script crashing between the two still leaves each half independently
+  # committed; anything left over is exactly what the NEXT run's own
+  # detection (TO_CREATE_JSON / MISSING_VARIANT_ROWS_TSV) picks back up,
+  # which is the whole point of this being repair-shaped rather than
+  # all-or-nothing.
+  if [ -n "$PRODUCT_ROWS_TSV" ]; then
+    seed_sql <<SQL
 BEGIN;
-
 CREATE TEMP TABLE perf_wc_products (ol_id text, wc_id text) ON COMMIT DROP;
 COPY perf_wc_products FROM STDIN;
 ${PRODUCT_ROWS_TSV}
 \.
-
-CREATE TEMP TABLE perf_wc_variants (variant_id text, external_id text) ON COMMIT DROP;
-COPY perf_wc_variants FROM STDIN;
-${VARIANT_ROWS_TSV}
-\.
-
 INSERT INTO identifier_mappings ("entityType", "internalId", "externalId", "platformType", "connectionId", "createdAt", "updatedAt")
 SELECT 'Product', ol_id, wc_id, 'woocommerce', '${WC_CONNECTION_ID}'::uuid, now(), now()
 FROM perf_wc_products;
+COMMIT;
+SQL
+  fi
 
+  if [ -n "$ALL_VARIANT_ROWS_TSV" ]; then
+    seed_sql <<SQL
+BEGIN;
+CREATE TEMP TABLE perf_wc_variants (variant_id text, external_id text) ON COMMIT DROP;
+COPY perf_wc_variants FROM STDIN;
+${ALL_VARIANT_ROWS_TSV}
+\.
 INSERT INTO identifier_mappings ("entityType", "internalId", "externalId", "platformType", "connectionId", "createdAt", "updatedAt")
 SELECT 'ProductVariant', variant_id, external_id, 'woocommerce', '${WC_CONNECTION_ID}'::uuid, now(), now()
 FROM perf_wc_variants;
-
 COMMIT;
 SQL
+  fi
 
-  log "mapped $N_CREATED WooCommerce product(s) ($(printf '%s\n' "$VARIANT_ROWS_TSV" | grep -c . || true) variant mapping row(s))"
+  log "mapped $N_CREATED new WooCommerce product(s), repaired $N_MISSING_VARIANTS missing variant mapping(s) on already-mapped products ($(printf '%s\n' "$ALL_VARIANT_ROWS_TSV" | grep -c . || true) variant mapping row(s) written this run)"
 fi
 
 ELAPSED=$(( $(epoch) - START ))
@@ -229,13 +312,22 @@ seed_check_ceiling "WooCommerce catalogue ($N_TO_CREATE product(s) created this 
 # count proves nothing on its own (that is the whole defect being fixed) -
 # take the external ids OpenLinker now holds for WooCommerce and ask
 # WooCommerce how many of them resolve to a real product.
+#
+# Scoped to THIS script's own candidate set throughout (#3025 review,
+# BLOCKING) - never a bare `connectionId` match. seed-catalogue.sh's 10k pool
+# writes its own `entityType='Product'`/`'ProductVariant'` rows under this
+# SAME connection id with a deliberately non-numeric synthetic externalId
+# (see the header above); on a stand carrying that fixture, an unscoped
+# DANGLING/RESOLVED check counted those ~10 000 unrelated rows and reported a
+# failure on work this script never touched, while the real work it DID do
+# had already succeeded.
 # ---------------------------------------------------------------------------
-N_OL_MAP="$(pg_sql "SELECT COUNT(*) FROM identifier_mappings WHERE \"entityType\"='Product' AND \"connectionId\"='$WC_CONNECTION_ID'")"
-N_OL_VARMAP="$(pg_sql "SELECT COUNT(*) FROM identifier_mappings WHERE \"entityType\"='ProductVariant' AND \"connectionId\"='$WC_CONNECTION_ID' AND \"externalId\" LIKE 'product:%'")"
-DANGLING="$(pg_sql "SELECT COUNT(*) FROM identifier_mappings WHERE \"entityType\"='Product' AND \"connectionId\"='$WC_CONNECTION_ID' AND \"externalId\" !~ '^[0-9]+\$'")"
-[ "$DANGLING" = 0 ] || die "seed-wc-catalogue: referential check: $DANGLING WooCommerce Product mapping(s) carry a non-numeric externalId - those name no WooCommerce product."
+N_OL_MAP="$(pg_sql "SELECT COUNT(*) FROM identifier_mappings WHERE \"entityType\"='Product' AND \"connectionId\"='$WC_CONNECTION_ID' AND \"internalId\" = ANY('${CANDIDATE_IDS_PG_ARRAY}'::text[])")"
+N_OL_VARMAP="$(pg_sql "SELECT COUNT(*) FROM identifier_mappings WHERE \"entityType\"='ProductVariant' AND \"connectionId\"='$WC_CONNECTION_ID' AND \"externalId\" LIKE 'product:%' AND \"internalId\" = ANY('${CANDIDATE_VARIANT_IDS_PG_ARRAY}'::text[])")"
+DANGLING="$(pg_sql "SELECT COUNT(*) FROM identifier_mappings WHERE \"entityType\"='Product' AND \"connectionId\"='$WC_CONNECTION_ID' AND \"internalId\" = ANY('${CANDIDATE_IDS_PG_ARRAY}'::text[]) AND \"externalId\" !~ '^[0-9]+\$'")"
+[ "$DANGLING" = 0 ] || die "seed-wc-catalogue: referential check: $DANGLING WooCommerce Product mapping(s) among this script's own candidates carry a non-numeric externalId - those name no WooCommerce product."
 
-MAPPED_IDS_JSON="$(pg_sql "SELECT COALESCE(jsonb_agg(\"externalId\"),'[]'::jsonb) FROM identifier_mappings WHERE \"entityType\"='Product' AND \"connectionId\"='$WC_CONNECTION_ID'")"
+MAPPED_IDS_JSON="$(pg_sql "SELECT COALESCE(jsonb_agg(\"externalId\"),'[]'::jsonb) FROM identifier_mappings WHERE \"entityType\"='Product' AND \"connectionId\"='$WC_CONNECTION_ID' AND \"internalId\" = ANY('${CANDIDATE_IDS_PG_ARRAY}'::text[])")"
 RESOLVED="$(printf '%s' "$MAPPED_IDS_JSON" | wc_wp eval '
   $ids = json_decode(file_get_contents("php://stdin"), true);
   $n = 0;

--- a/perf/openlinker-throughput/seed/seed-wc-catalogue.sh
+++ b/perf/openlinker-throughput/seed/seed-wc-catalogue.sh
@@ -1,0 +1,250 @@
+#!/usr/bin/env bash
+#
+# WooCommerce-side catalogue seeder, and the OpenLinker mapping that resolves
+# against it (#3025).
+#
+# Why this exists, stated plainly. `WooCommerceOrderProcessorAdapter.
+# resolveLineItems` needs a WooCommerce `Product`/`ProductVariant`
+# identifier_mappings row for every OL product/variant an order's line
+# items reference - and unlike PrestaShop (whose ProductMaster capability is
+# enabled on every perf connection and auto-syncs its own real catalogue),
+# `perf-woocommerce` is created with `enabledCapabilities: [
+# "OrderProcessorManager"]` alone (bootstrap.sh step_connections) - no
+# ProductMaster, so nothing ever writes a WooCommerce Product mapping at
+# all. Every order fanned out to WooCommerce as a destination therefore dies
+# at line-item resolution with "No WC product mapping for OL product ...",
+# and - because OrderSyncService fans destinations out under
+# Promise.allSettled - the job still reports outcome 'ok' while WooCommerce
+# receives nothing. That is not evidence about the WooCommerce integration;
+# it is evidence nothing has ever reached it.
+#
+# The seed-catalogue.sh 10k pool (F5's read-path fixture) cannot fix this
+# either way: it mints identifier_mappings rows whose externalId is a
+# SYNTHETIC STRING shared verbatim across both the PrestaShop and
+# WooCommerce connections ('PERFSEED-EXT-PROD-{tag}-{n}') - present but
+# non-numeric, so WooCommerce's own `toPositiveInt` guard refuses it as
+# "Corrupted mapping" (the OTHER resolveLineItems failure branch). Neither
+# of those synthetic ids names a real product anywhere, on either shop, and
+# that pool is deliberately never touched by a real order create (see its
+# own header note in seed-catalogue.sh) - so widening its expression alone
+# would not unblock a single real order.
+#
+# The actual target is the pool bootstrap.sh's own `seed_offer_mappings_for`
+# already selects (see its header comment, "AN OFFER MUST POINT AT A PRODUCT
+# THE DESTINATION ACTUALLY HAS", #2847): every non-stale product_variants row
+# whose PRODUCT already carries a real, NUMERIC PrestaShop external id -
+# i.e. exactly the products a real order's line items can ever resolve to,
+# whether they arrived via an actual ProductMaster sync (`ol_product_*`) or
+# via seed-shop-catalogue.sh's cloned real-shop catalogue
+# (`perfseed_product_s*`). This script reads that SAME set straight out of
+# identifier_mappings/product_variants - it never depends on which seeder
+# populated it - clones ONE simple WooCommerce product per distinct product
+# (via the WC PHP API, `WC_Product_Simple`, the docker/woocommerce/
+# 01-seed-wc-data.sh precedent - no HTTP auth needed), and writes the
+# matching identifier_mappings rows in the ADAPTER's own shapes:
+#   Product        -> the WC post id, decimal string   (toPositiveInt)
+#   ProductVariant -> 'product:' || wcId, synthetic     (isSyntheticVariantExternalId)
+# every one of a product's non-stale variants pointing at the SAME simple WC
+# product - WooCommerce gets no real variation of its own, which is fine:
+# resolveLineItems only ever needs `product_id` (+ an OPTIONAL
+# `variation_id`, left unset for a synthetic mapping) to build a valid line
+# item, not a commercially accurate one.
+#
+# Idempotent and REPAIR-shaped rather than generation-shaped (the
+# seed-shop-catalogue.sh "generation, refuse unless FORCE_SEED" pattern does
+# not fit a pool this script does not own the size of): every run creates
+# only the products still missing a WooCommerce mapping and leaves the rest
+# alone, exactly like bootstrap.sh's own found/gap/created seeding.
+#
+# Usage: ./seed-wc-catalogue.sh
+#
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/seed-lib.sh"
+LIB_LOG_PREFIX="seed-wc-catalogue"
+
+SKU_PREFIX="PERFWC-"
+CEILING_SECS="${CEILING_SECS:-300}"
+
+require_connections
+log "targeting connection $WC_CONNECTION_ID (PrestaShop-real product pool sourced from $PS_CONNECTION_ID)"
+START="$(epoch)"
+
+# ---------------------------------------------------------------------------
+# Candidates: one row per PS-real product, carrying every non-stale variant
+# id it owns. Mirrors bootstrap.sh's `real_clause` / `usable` query exactly
+# (see its own header comment), grouped up to product grain because a
+# WooCommerce Product mapping is per-PRODUCT while every one of the
+# product's variants needs its own (synthetic) ProductVariant row.
+# ---------------------------------------------------------------------------
+CANDIDATES_JSON="$(pg_sql "
+  SELECT COALESCE(jsonb_agg(to_jsonb(row) ORDER BY row.\"olId\"), '[]'::jsonb)
+  FROM (
+    SELECT
+      p.id AS \"olId\", p.sku, p.name, p.price,
+      jsonb_agg(pv.id) AS \"variantIds\"
+    FROM products p
+    JOIN identifier_mappings m
+      ON m.\"entityType\"='Product' AND m.\"connectionId\"='$PS_CONNECTION_ID'
+     AND m.\"internalId\"=p.id AND m.\"externalId\" ~ '^[0-9]+\$'
+    JOIN product_variants pv ON pv.\"productId\"=p.id AND pv.\"isStale\"=false
+    GROUP BY p.id, p.sku, p.name, p.price
+  ) row
+")"
+
+N_CANDIDATES="$(jq 'length' <<<"$CANDIDATES_JSON")"
+[ "${N_CANDIDATES:-0}" -gt 0 ] || die "seed-wc-catalogue: no non-stale product_variants map to a real (numeric-id) PrestaShop product - install/sync the PrestaShop catalogue first (bootstrap.sh step_connections, or seed-shop-catalogue.sh)."
+
+EXISTING_WC_JSON="$(pg_sql "SELECT COALESCE(jsonb_agg(\"internalId\"),'[]'::jsonb) FROM identifier_mappings WHERE \"entityType\"='Product' AND \"connectionId\"='$WC_CONNECTION_ID'")"
+TO_CREATE_JSON="$(jq -c --argjson existing "$EXISTING_WC_JSON" \
+  '[ .[] | select((.olId as $id | ($existing | index($id))) == null) ]' <<<"$CANDIDATES_JSON")"
+N_TO_CREATE="$(jq 'length' <<<"$TO_CREATE_JSON")"
+
+log "PrestaShop-real products: $N_CANDIDATES total, $N_TO_CREATE lacking a WooCommerce mapping"
+
+if [ "$N_TO_CREATE" = 0 ]; then
+  log "found: every destination-resolvable product already carries a WooCommerce mapping - nothing to do"
+else
+  # ---------------------------------------------------------------------------
+  # Clone via the WC PHP API (wp eval), not raw SQL against wp_posts/
+  # wp_postmeta: WooCommerce's own save() path is what stamps every meta row
+  # (including wp_wc_product_meta_lookup, which its own product queries read)
+  # correctly across versions - the same reasoning docker/woocommerce/
+  # 01-seed-wc-data.sh already relies on. The plan crosses via `docker cp`
+  # rather than a `wp eval` argument: WP-CLI's argv has no room for an N-row
+  # JSON blob, and the container's docker-exec user cannot remove a
+  # docker-cp'd file it does not own, so cleanup runs as uid 0 explicitly.
+  # ---------------------------------------------------------------------------
+  PLAN_LOCAL="$(mktemp)"
+  trap 'rm -f "$PLAN_LOCAL"' EXIT
+  jq -c --arg prefix "$SKU_PREFIX" \
+    '[ .[] | {olId, sku: ($prefix + .olId), name: ("Perf WC " + .name), price: ((.price // 0) | tostring), stock: 100} ]' \
+    <<<"$TO_CREATE_JSON" > "$PLAN_LOCAL"
+
+  docker cp "$PLAN_LOCAL" "$WC_CONTAINER:/tmp/perf-wc-plan.json" \
+    || die "seed-wc-catalogue: docker cp of the product plan into $WC_CONTAINER failed"
+  # docker cp preserves the copying HOST user's ownership/mode (0600, this
+  # host's uid) - the container's wp-cli process runs as a DIFFERENT uid
+  # (bitnami's non-root default) and cannot read it back without this: found
+  # live as a silent "Permission denied" PHP warning wc_wp's own stderr
+  # redirect (2>/dev/null) would otherwise have hidden completely.
+  docker exec -u 0 -i "$WC_CONTAINER" chmod 644 /tmp/perf-wc-plan.json \
+    || die "seed-wc-catalogue: could not make the product plan readable inside $WC_CONTAINER"
+
+  # NOT via wc_wp - that helper redirects stderr to /dev/null, which is
+  # exactly what hid the docker-cp ownership mismatch (a silent PHP warning,
+  # empty output, no diagnostic anywhere) the first time this ran live.
+  WP_EVAL_OUT="$(mktemp)"
+  if ! docker exec -i "$WC_CONTAINER" wp --allow-root --no-debug --path="$WC_PATH" eval '
+    $plan = json_decode(file_get_contents("/tmp/perf-wc-plan.json"), true);
+    if (!is_array($plan)) { fwrite(STDERR, "unreadable plan\n"); exit(1); }
+    $out = array();
+    foreach ($plan as $row) {
+      $p = new WC_Product_Simple();
+      $p->set_name($row["name"]);
+      $p->set_sku($row["sku"]);
+      $p->set_regular_price((string) $row["price"]);
+      $p->set_manage_stock(true);
+      $p->set_stock_quantity((int) $row["stock"]);
+      $p->set_status("publish");
+      $id = $p->save();
+      $out[] = array("olId" => $row["olId"], "wcId" => (int) $id);
+    }
+    echo json_encode($out);
+  ' > "$WP_EVAL_OUT" 2>&1; then
+    cat "$WP_EVAL_OUT" >&2
+    die "seed-wc-catalogue: wp eval product creation failed (output above) - nothing was mapped."
+  fi
+  docker exec -u 0 -i "$WC_CONTAINER" rm -f /tmp/perf-wc-plan.json || true
+
+  CREATED_JSON="$(tail -1 "$WP_EVAL_OUT")"
+  rm -f "$WP_EVAL_OUT"
+  N_CREATED="$(jq 'length' <<<"$CREATED_JSON" 2>/dev/null || printf 0)"
+  [ "${N_CREATED:-0}" = "$N_TO_CREATE" ] \
+    || die "seed-wc-catalogue: asked WooCommerce to create $N_TO_CREATE product(s), it reports $N_CREATED - raw output: $CREATED_JSON. Nothing was mapped."
+
+  # ---------------------------------------------------------------------------
+  # Project the (olId -> wcId) result onto identifier_mappings: one Product
+  # row per product, one (synthetic) ProductVariant row per variant that
+  # product's candidate row carried.
+  # ---------------------------------------------------------------------------
+  # Two explicit passes rather than one shape-mixing query, both driven off
+  # the same $CREATED_JSON x $TO_CREATE_JSON join, so there is exactly one
+  # source of truth for "which wcId does this olId now have".
+  PRODUCT_ROWS_TSV="$(jq -r '.[] | [.olId, (.wcId|tostring)] | @tsv' <<<"$CREATED_JSON")"
+  # `isSyntheticVariantExternalId` (woocommerce-variant-id.ts) tests only the
+  # `product:` PREFIX - resolveLineItems never parses what follows it (a
+  # synthetic mapping resolves `product_id` from the separate `Product` row
+  # and leaves `variation_id` unset either way) - so every variant of one OL
+  # product can legitimately point at the SAME simple WC product, as long as
+  # each row's externalId is still distinct enough to satisfy
+  # identifier_mappings' own (entityType, platformType, connectionId,
+  # externalId) uniqueness. `#<ordinal>` is appended for exactly that: a
+  # WC-facing seller cannot tell these variants apart on this stand (a real
+  # multi-variant integration would model them as WC variations of a
+  # WC_Product_Variable instead), which is an accepted simplification for a
+  # load-test fixture that only needs the order to be CREATABLE.
+  VARIANT_ROWS_TSV="$(jq -r --argjson plan "$TO_CREATE_JSON" '
+    (map({(.olId): .wcId}) | add // {}) as $wcIdByProduct
+    | $plan[] | . as $row
+    | ($wcIdByProduct[$row.olId]) as $wcId
+    | select($wcId != null)
+    | ($row.variantIds | to_entries[]) as $e
+    | [$e.value, ("product:" + ($wcId|tostring) + "#" + ($e.key|tostring))] | @tsv
+  ' <<<"$CREATED_JSON")"
+
+  seed_sql <<SQL
+BEGIN;
+
+CREATE TEMP TABLE perf_wc_products (ol_id text, wc_id text) ON COMMIT DROP;
+COPY perf_wc_products FROM STDIN;
+${PRODUCT_ROWS_TSV}
+\.
+
+CREATE TEMP TABLE perf_wc_variants (variant_id text, external_id text) ON COMMIT DROP;
+COPY perf_wc_variants FROM STDIN;
+${VARIANT_ROWS_TSV}
+\.
+
+INSERT INTO identifier_mappings ("entityType", "internalId", "externalId", "platformType", "connectionId", "createdAt", "updatedAt")
+SELECT 'Product', ol_id, wc_id, 'woocommerce', '${WC_CONNECTION_ID}'::uuid, now(), now()
+FROM perf_wc_products;
+
+INSERT INTO identifier_mappings ("entityType", "internalId", "externalId", "platformType", "connectionId", "createdAt", "updatedAt")
+SELECT 'ProductVariant', variant_id, external_id, 'woocommerce', '${WC_CONNECTION_ID}'::uuid, now(), now()
+FROM perf_wc_variants;
+
+COMMIT;
+SQL
+
+  log "mapped $N_CREATED WooCommerce product(s) ($(printf '%s\n' "$VARIANT_ROWS_TSV" | grep -c . || true) variant mapping row(s))"
+fi
+
+ELAPSED=$(( $(epoch) - START ))
+seed_check_ceiling "WooCommerce catalogue ($N_TO_CREATE product(s) created this run)" "$ELAPSED" "$CEILING_SECS"
+
+# ---------------------------------------------------------------------------
+# Referential check, the seed-shop-catalogue.sh precedent: a mapping row
+# count proves nothing on its own (that is the whole defect being fixed) -
+# take the external ids OpenLinker now holds for WooCommerce and ask
+# WooCommerce how many of them resolve to a real product.
+# ---------------------------------------------------------------------------
+N_OL_MAP="$(pg_sql "SELECT COUNT(*) FROM identifier_mappings WHERE \"entityType\"='Product' AND \"connectionId\"='$WC_CONNECTION_ID'")"
+N_OL_VARMAP="$(pg_sql "SELECT COUNT(*) FROM identifier_mappings WHERE \"entityType\"='ProductVariant' AND \"connectionId\"='$WC_CONNECTION_ID' AND \"externalId\" LIKE 'product:%'")"
+DANGLING="$(pg_sql "SELECT COUNT(*) FROM identifier_mappings WHERE \"entityType\"='Product' AND \"connectionId\"='$WC_CONNECTION_ID' AND \"externalId\" !~ '^[0-9]+\$'")"
+[ "$DANGLING" = 0 ] || die "seed-wc-catalogue: referential check: $DANGLING WooCommerce Product mapping(s) carry a non-numeric externalId - those name no WooCommerce product."
+
+MAPPED_IDS_JSON="$(pg_sql "SELECT COALESCE(jsonb_agg(\"externalId\"),'[]'::jsonb) FROM identifier_mappings WHERE \"entityType\"='Product' AND \"connectionId\"='$WC_CONNECTION_ID'")"
+RESOLVED="$(printf '%s' "$MAPPED_IDS_JSON" | wc_wp eval '
+  $ids = json_decode(file_get_contents("php://stdin"), true);
+  $n = 0;
+  foreach ($ids as $id) { if (wc_get_product((int) $id)) { $n++; } }
+  echo $n;
+' 2>/dev/null || printf 'unknown')"
+SAMPLED="$(jq 'length' <<<"$MAPPED_IDS_JSON")"
+log "referential check: $RESOLVED of $SAMPLED mapped WooCommerce product(s) resolve to a real wc_get_product() row"
+[ "$RESOLVED" = "$SAMPLED" ] \
+  || die "seed-wc-catalogue: referential check FAILED: only $RESOLVED of $SAMPLED Product mappings name a product WooCommerce holds"
+
+log "seed-wc-catalogue done in ${ELAPSED}s: identifier_mappings Product=$N_OL_MAP ProductVariant(synthetic)=$N_OL_VARMAP, all referentially verified"


### PR DESCRIPTION
## Summary

- **#3024** - `f5-read-path.sh`'s seeder (`seed-orders.sh`) is additive across
  size steps and no-ops once the dataset is already at/above a step's
  target, so a step run out of order (`F5_ONLY_SIZE` resuming a single
  step, or a re-run against a stand a bigger step already grew) silently
  measured the wrong row count while still reporting `VALID`. Added
  `check_row_count_target` (`lib.sh`), a pure comparison wired into
  `run_size` **before** `window_start`: it compares `rowCounts.order_records`
  against `targetOrders` and `DISCARD`s the arm - naming both figures -
  rather than paying for a k6 window against data it can't honestly report.
  Verified red-first in both directions via `lib-test.sh` (no live stand
  needed for a pure function).

- **#3025** - WooCommerce `Product`/`ProductVariant` `identifier_mappings`
  never carried a numeric external id, so every order fanned out to the
  WooCommerce destination died in `resolveLineItems` with `"No WC product
  mapping"` / `"Corrupted mapping"`, silently swallowed by
  `OrderSyncService`'s `Promise.allSettled` fan-out as `outcome: 'ok'`.
  Added `seed/seed-wc-catalogue.sh`, which clones one real WooCommerce
  product (via the WC PHP API - no HTTP auth needed) per distinct
  PrestaShop-real product `bootstrap.sh`'s own `seed_offer_mappings_for`
  already selects, and writes the matching `Product`/`ProductVariant`
  mappings in the adapter's own external-id shapes: a numeric product id,
  and a synthetic `product:{wcId}#{n}` per variant (`isSyntheticVariantExternalId`
  only tests the prefix, so distinct variants of one product can share a WC
  product with no schema change). Idempotent/repair-shaped rather than
  generation-shaped. `cleanup.sh` gained a matching WooCommerce-side
  teardown block. `bootstrap.sh` / `f1-order-ingestion.sh` comments now
  point at the new seeder as the remedy for the exact gap each already
  documented.

## Verification (live, against the lab stand)

- Ran `seed-wc-catalogue.sh` fresh: created 19 real WooCommerce products
  mapping 47 variants; referential check passed (every mapped external id
  resolves to a real `wc_get_product()` row).
- Re-ran it: correctly idempotent (0 to create, referential check still
  passes).
- Placed a real `POST /wp-json/wc/v3/orders` against one of the newly
  mapped product ids, over the same internal TLS path/Basic-Auth
  `WooCommerceOrderProcessorAdapter` uses, with the exact `line_items`
  shape it builds (`product_id`/`quantity`/`subtotal`/`total`) -> **HTTP
  201**, order created, cleaned up afterward.
- `f1-order-ingestion.sh`'s own `wc_real_products` gate (already written
  defensively for this exact gap) now reads non-zero, so its WooCommerce
  arm stops being skipped.
- `lib-test.sh`: 234/234 passing (8 new cases for `check_row_count_target`,
  including the red-first DISCARDED case).

**Not done here**: re-running the full F1 / sustained-mixed-load /
burst-drain campaigns with WooCommerce live is the next remeasurement
pass, not a code change.

## ⚠️ Incident during verification

While testing the new WooCommerce cleanup block, I ran
`perf/openlinker-throughput/seed/cleanup.sh` against the live lab stand -
not realizing it's a full `perfseed_*` teardown, not scoped to what I'd
added. It deleted every `order_records`/`order_line_items` row (it then
hit a `statement_timeout` on the much larger `sync_jobs` delete and
stopped there, so that table and `identifier_mappings`/`products` were
untouched). Per operator direction I re-seeded
`TARGET_ORDERS=1000000 seed-orders.sh` using its documented defaults
(`SEED_RNG=0.271828`, `SYNC_FAILED_RATE=0.15` - "the value the existing
dataset was seeded with") as a best-effort restore: now 1,000,000
`order_records` / 2,499,438 `order_line_items`. This will **not** be
byte-identical to whatever was there before, and is worth checking against
if anyone else's work depended on the exact prior rows.

## Note on AC coverage

#3024's fourth AC ("mark the 10k/100k figures in
`results-F5-2026-09-08-epyc32.md` as the only usable ones") references a
report that lives on `2840-remeasure-epyc32-2026-09-09`, not on this
branch's history - left for whoever merges that remeasure work.

## Test plan

- [x] `bash perf/openlinker-throughput/lib-test.sh` - 234/234 passing
- [x] `bash -n` on every changed/added script
- [x] `seed-wc-catalogue.sh` run live twice (fresh + idempotent no-op)
- [x] Real WC REST order placed against a newly mapped product id (201)
- [ ] Full campaign remeasurement with WooCommerce live (follow-up, not in
      this PR)

Refs #3024 - AC4 (mark the 10k/100k figures in `results-F5-2026-09-08-epyc32.md` as the only usable ones) is not fulfilled by this PR (see "Note on AC coverage" above); left open for whoever merges the remeasure work on `2840-remeasure-epyc32-2026-09-09`.
Closes #3025
