### PR TITLE
fix(orders): persist a durable early-cancellation signal (#2069)

### DIFF
--- a/apps/api/src/migrations/1878000000000-create-order-cancellation-signals.ts
+++ b/apps/api/src/migrations/1878000000000-create-order-cancellation-signals.ts
@@ -1,0 +1,72 @@
+/**
+ * Create Order Cancellation Signals Migration (#2069)
+ *
+ * Creates `order_cancellation_signals` — a durable trace that a source
+ * cancellation arrived for an order OpenLinker has not yet ingested.
+ *
+ * Before this, `OrderIngestionService.handleSourceCancellation` had nowhere
+ * to write when `IIdentifierMappingService.getInternalId` resolved no
+ * mapping: `OrderRecordRepository.markCancelled` is a bare
+ * `UPDATE ... WHERE "internalOrderId" = $2` with no insert fallback, so a
+ * cancel racing ahead of the order's own create/sync job was silently
+ * dropped and the later create provisioned the order as active at every
+ * destination. Minting an internal id via `getOrCreateInternalId` from the
+ * cancellation path to give `markCancelled` something to hit was rejected —
+ * it would create a phantom, operator-visible order with no real data yet,
+ * exactly the shape #2328 rejected for returns attribution.
+ *
+ * The signal is keyed on `(sourceConnectionId, externalOrderId)` instead —
+ * the one durable identity that exists before ingestion — and is consumed
+ * (atomically, `DELETE ... RETURNING`) by
+ * `OrderRecordService.persistIncomingSnapshot` the moment the order is
+ * genuinely first ingested, applying it through the existing first-write-wins
+ * `markCancelled` pipeline (#1984) that `OrderSyncService`'s `#2284`
+ * `cancelledAt IS NULL` provisioning guard already reads.
+ *
+ * There is deliberately **no FK** to `order_records` — the `order_holds` /
+ * `order_changes` / `refund_records` precedent of an indexed reference by
+ * value; here there is nothing yet to reference at all. Nothing cascades
+ * into this table, so `apps/api/test/integration/setup.ts` truncates it
+ * explicitly.
+ *
+ * The unique index name matches `OrderCancellationSignalOrmEntity`'s
+ * class-level `@Index` declaration exactly, because the integration harness
+ * builds its schema by `synchronize` rather than by migration (the
+ * `order_holds` precedent) — an unnamed index there would hash-name
+ * differently and the two schemas would diverge on the very constraint the
+ * repository's first-write-wins guarantee (`ON CONFLICT DO NOTHING`) depends
+ * on.
+ *
+ * @module apps/api/src/migrations
+ */
+import type { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class CreateOrderCancellationSignals1878000000000 implements MigrationInterface {
+  name = 'CreateOrderCancellationSignals1878000000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // `id` defaults to uuid_generate_v4() — the same guard 1846/1847/1850 use.
+    await queryRunner.query(`CREATE EXTENSION IF NOT EXISTS "uuid-ossp"`);
+
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "order_cancellation_signals" (
+        "id" uuid NOT NULL DEFAULT uuid_generate_v4(),
+        "sourceConnectionId" uuid NOT NULL,
+        "externalOrderId" text NOT NULL,
+        "cancelledAt" TIMESTAMP WITH TIME ZONE NOT NULL,
+        "createdAt" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_order_cancellation_signals" PRIMARY KEY ("id")
+      )
+    `);
+
+    await queryRunner.query(`
+      CREATE UNIQUE INDEX IF NOT EXISTS "UQ_order_cancellation_signals_source_external"
+        ON "order_cancellation_signals" ("sourceConnectionId", "externalOrderId")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "UQ_order_cancellation_signals_source_external"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "order_cancellation_signals"`);
+  }
+}

--- a/apps/api/src/migrations/1879000000000-create-order-cancellation-signals.ts
+++ b/apps/api/src/migrations/1879000000000-create-order-cancellation-signals.ts
@@ -41,8 +41,8 @@
  */
 import type { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class CreateOrderCancellationSignals1878000000000 implements MigrationInterface {
-  name = 'CreateOrderCancellationSignals1878000000000';
+export class CreateOrderCancellationSignals1879000000000 implements MigrationInterface {
+  name = 'CreateOrderCancellationSignals1879000000000';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
     // `id` defaults to uuid_generate_v4() — the same guard 1846/1847/1850 use.

--- a/apps/api/src/orders/http/refunds.controller.spec.ts
+++ b/apps/api/src/orders/http/refunds.controller.spec.ts
@@ -44,6 +44,7 @@ describe('RefundsController', () => {
       findByIds: jest.fn(),
       updateFulfillmentState: jest.fn(),
       markCancelled: jest.fn(),
+      recordEarlyCancellationSignal: jest.fn(),
       markSalesDocumentBlock: jest.fn(),
       markFulfillmentBlock: jest.fn(),
       getEarliestOrderDateByConnection: jest.fn(),

--- a/apps/api/src/shipping/http/shipment.controller.spec.ts
+++ b/apps/api/src/shipping/http/shipment.controller.spec.ts
@@ -137,6 +137,7 @@ describe('ShipmentController', () => {
       markItemResolutionFailure: jest.fn(),
       getFailedSyncValueSummary: jest.fn(),
       markCancelled: jest.fn(),
+      recordEarlyCancellationSignal: jest.fn(),
       markSalesDocumentBlock: jest.fn(),
       markFulfillmentBlock: jest.fn(),
       markPacked: jest.fn(),

--- a/apps/api/test/integration/orders/order-early-cancellation-signal.int-spec.ts
+++ b/apps/api/test/integration/orders/order-early-cancellation-signal.int-spec.ts
@@ -234,6 +234,33 @@ describe('Order early-cancellation signal (#2069)', () => {
       where: { sourceConnectionId: sourceConnection.id, externalOrderId },
     });
     expect(signalAfterSync).toBeNull();
+
+    // Act 3: a THIRD poll, after the signal has already been consumed and the
+    // source's order resource is still lagging (`incoming.status: 'pending'`
+    // from `makeIncomingOrder`, unchanged). `persistIncomingSnapshot` no longer
+    // has a signal to consume, so `snapshotRecord.cancelledAt` alone would read
+    // `null` here (`upsert()`'s `fromRawRow` excludes `cancelledAt` from its
+    // write set on this non-writing path) — this is the exact regression the
+    // #2069 re-review found: without the `existing.cancelledAt` fallback in
+    // `OrderIngestionService`, this poll would silently re-provision an order
+    // OL already recorded as cancelled.
+    const thirdPoll = await ingestion.syncOrderFromSource(
+      sourceConnection.id,
+      externalOrderId,
+      'create-evt-2'
+    );
+
+    expect(thirdPoll).toHaveLength(1);
+    expect(thirdPoll[0].status).toBe('skipped_cancelled');
+    expect(createOrderCalls).toHaveLength(0);
+
+    const recordAfterThirdPoll = await recordRepo.findOne({
+      where: { internalOrderId: mappingAfterSync!.internalId },
+    });
+    expect(recordAfterThirdPoll!.cancelledAt).not.toBeNull();
+    expect(recordAfterThirdPoll!.cancelledAt!.getTime()).toBe(
+      signalAfterCancel!.cancelledAt.getTime()
+    );
   });
 
   // #2069 review — the exact race the signal exists for: the source's order
@@ -322,6 +349,13 @@ describe('Order early-cancellation signal (#2069)', () => {
       where: { sourceConnectionId: sourceConnection.id, externalOrderId },
     });
     expect(signalAfterFirst).not.toBeNull();
+
+    // Force the two calls' `new Date()` stamps onto DISTINCT milliseconds —
+    // without this, two `ingestion.syncOrderFromSource` calls back-to-back can
+    // land in the same millisecond, and the equality assertion below would
+    // pass trivially (by timestamp coincidence) even against a `DO UPDATE`
+    // that overwrote the row with the second cancel's instant.
+    await new Promise((resolve) => setTimeout(resolve, 5));
 
     // A second, later-arriving cancel event for the SAME
     // (sourceConnectionId, externalOrderId) — e.g. a duplicate delivery or a

--- a/apps/api/test/integration/orders/order-early-cancellation-signal.int-spec.ts
+++ b/apps/api/test/integration/orders/order-early-cancellation-signal.int-spec.ts
@@ -169,12 +169,14 @@ describe('Order early-cancellation signal (#2069)', () => {
 
     // Act 1: the cancel event arrives before the order has ever been
     // ingested — no identifier mapping exists yet.
+    const beforeCancel = new Date();
     const cancelResult = await ingestion.syncOrderFromSource(
       sourceConnection.id,
       externalOrderId,
       'cancel-evt-1',
       'cancelled'
     );
+    const afterCancel = new Date();
     expect(cancelResult).toEqual([]);
 
     const mappingAfterCancel = await mappingRepo.findOne({
@@ -190,6 +192,13 @@ describe('Order early-cancellation signal (#2069)', () => {
       where: { sourceConnectionId: sourceConnection.id, externalOrderId },
     });
     expect(signalAfterCancel).not.toBeNull();
+    // The signal carries the instant the cancel-handling branch stamped
+    // (`new Date()` at the time of the call), not a sentinel — pin the value
+    // rather than only its non-nullness.
+    expect(signalAfterCancel!.cancelledAt.getTime()).toBeGreaterThanOrEqual(
+      beforeCancel.getTime()
+    );
+    expect(signalAfterCancel!.cancelledAt.getTime()).toBeLessThanOrEqual(afterCancel.getTime());
 
     // Act 2: the create/sync job now runs — the ordinary path, no eventType.
     const syncResult = await ingestion.syncOrderFromSource(
@@ -214,13 +223,30 @@ describe('Order early-cancellation signal (#2069)', () => {
     const record = await recordRepo.findOne({
       where: { internalOrderId: mappingAfterSync!.internalId },
     });
+    // Pin the VALUE, not just non-nullness: `cancelledAt` must be the
+    // signal's own consumed instant (`earlySignalAt`), never `now` at
+    // ingestion time — proving `consume()`'s returned timestamp actually
+    // reached `markCancelled` rather than merely triggering it.
     expect(record!.cancelledAt).not.toBeNull();
+    expect(record!.cancelledAt.getTime()).toBe(signalAfterCancel!.cancelledAt.getTime());
 
     const signalAfterSync = await signalRepo.findOne({
       where: { sourceConnectionId: sourceConnection.id, externalOrderId },
     });
     expect(signalAfterSync).toBeNull();
   });
+
+  // #2069 review — the exact race the signal exists for: the source's order
+  // RESOURCE still reports its pre-cancel status when the sync job's
+  // `getOrder` runs (the event journal that produced the signal leads the
+  // resource), so a downstream gate keyed on `incoming.status`/`order.status`
+  // alone must not be trusted once the signal is consumed. Pinned at the unit
+  // level in `order-ingestion.service.spec.ts` ("should not reserve, and
+  // should enqueue stock-restore, when the incoming status still lags a
+  // consumed early-cancellation signal") against `reservationService` and
+  // `jobQueue` mocks — this harness's real Redis-stream job queue and
+  // `IReservationService` binding are not wired to observe those effects
+  // directly here.
 
   it('normal ordering unchanged: create arrives first, no prior cancel — destination order IS created', async () => {
     const dataSource = harness.getDataSource();
@@ -260,5 +286,62 @@ describe('Order early-cancellation signal (#2069)', () => {
       where: { sourceConnectionId: sourceConnection.id, externalOrderId },
     });
     expect(signalRow).toBeNull();
+  });
+
+  // #2069 review — `ON CONFLICT DO NOTHING` is the port's stated first-write-
+  // wins guarantee, but nothing previously called `record()` twice for the
+  // same key against real Postgres: the unit spec mocks `Repository.query`
+  // to resolve, which asserts nothing about the conflict clause and would
+  // pass identically against a plain `INSERT`.
+  it('first-write-wins: two cancel events for the same order keep the EARLIER cancelledAt', async () => {
+    const dataSource = harness.getDataSource();
+    const signalRepo = dataSource.getRepository(OrderCancellationSignalOrmEntity);
+    const externalOrderId = 'early-cancel-repeat-1';
+    const sourceAdapterKey = registerSourceStub(
+      harness,
+      externalOrderId,
+      makeIncomingOrder(externalOrderId)
+    );
+
+    const sourceConnection = await createTestConnection(dataSource, {
+      platformType: 'allegro',
+      name: 'Allegro source',
+      adapterKey: sourceAdapterKey,
+      enabledCapabilities: ['OrderSource'],
+    });
+
+    const firstCancel = await ingestion.syncOrderFromSource(
+      sourceConnection.id,
+      externalOrderId,
+      'cancel-evt-1',
+      'cancelled'
+    );
+    expect(firstCancel).toEqual([]);
+
+    const signalAfterFirst = await signalRepo.findOne({
+      where: { sourceConnectionId: sourceConnection.id, externalOrderId },
+    });
+    expect(signalAfterFirst).not.toBeNull();
+
+    // A second, later-arriving cancel event for the SAME
+    // (sourceConnectionId, externalOrderId) — e.g. a duplicate delivery or a
+    // reconciliation poll re-observing the cancel. `ON CONFLICT DO NOTHING`
+    // must leave the row — and its earlier `cancelledAt` — untouched.
+    const secondCancel = await ingestion.syncOrderFromSource(
+      sourceConnection.id,
+      externalOrderId,
+      'cancel-evt-2',
+      'cancelled'
+    );
+    expect(secondCancel).toEqual([]);
+
+    const signalAfterSecond = await signalRepo.findOne({
+      where: { sourceConnectionId: sourceConnection.id, externalOrderId },
+    });
+    expect(signalAfterSecond).not.toBeNull();
+    expect(signalAfterSecond!.id).toBe(signalAfterFirst!.id);
+    expect(signalAfterSecond!.cancelledAt.getTime()).toBe(
+      signalAfterFirst!.cancelledAt.getTime()
+    );
   });
 });

--- a/apps/api/test/integration/orders/order-early-cancellation-signal.int-spec.ts
+++ b/apps/api/test/integration/orders/order-early-cancellation-signal.int-spec.ts
@@ -228,7 +228,7 @@ describe('Order early-cancellation signal (#2069)', () => {
     // ingestion time — proving `consume()`'s returned timestamp actually
     // reached `markCancelled` rather than merely triggering it.
     expect(record!.cancelledAt).not.toBeNull();
-    expect(record!.cancelledAt.getTime()).toBe(signalAfterCancel!.cancelledAt.getTime());
+    expect(record!.cancelledAt!.getTime()).toBe(signalAfterCancel!.cancelledAt.getTime());
 
     const signalAfterSync = await signalRepo.findOne({
       where: { sourceConnectionId: sourceConnection.id, externalOrderId },

--- a/apps/api/test/integration/orders/order-early-cancellation-signal.int-spec.ts
+++ b/apps/api/test/integration/orders/order-early-cancellation-signal.int-spec.ts
@@ -158,11 +158,13 @@ describe('Order early-cancellation signal (#2069)', () => {
       platformType: 'allegro',
       name: 'Allegro source',
       adapterKey: sourceAdapterKey,
+      enabledCapabilities: ['OrderSource'],
     });
     await createTestConnection(dataSource, {
       platformType: DEST_PLATFORM_TYPE,
       name: 'Destination',
       adapterKey: DEST_ADAPTER_KEY,
+      enabledCapabilities: ['OrderProcessorManager'],
     });
 
     // Act 1: the cancel event arrives before the order has ever been
@@ -235,11 +237,13 @@ describe('Order early-cancellation signal (#2069)', () => {
       platformType: 'allegro',
       name: 'Allegro source',
       adapterKey: sourceAdapterKey,
+      enabledCapabilities: ['OrderSource'],
     });
     await createTestConnection(dataSource, {
       platformType: DEST_PLATFORM_TYPE,
       name: 'Destination',
       adapterKey: DEST_ADAPTER_KEY,
+      enabledCapabilities: ['OrderProcessorManager'],
     });
 
     const syncResult = await ingestion.syncOrderFromSource(

--- a/apps/api/test/integration/orders/order-early-cancellation-signal.int-spec.ts
+++ b/apps/api/test/integration/orders/order-early-cancellation-signal.int-spec.ts
@@ -1,0 +1,260 @@
+/**
+ * Order Early-Cancellation Signal Int-Spec (#2069)
+ *
+ * Exercises the cancel-before-create race against the real Postgres harness:
+ * a source cancellation event that arrives before OpenLinker has ever
+ * ingested the order must leave a durable trace, so the later create/sync
+ * job observes it and skips destination provisioning
+ * (`OrderSyncService`'s `#2284` `cancelledAt IS NULL` guard) instead of
+ * provisioning the order as active.
+ *
+ * Registers minimal inline `OrderSourcePort` / `OrderProcessorManagerPort`
+ * stubs via the same `AdapterRegistryService` + `AdapterFactoryResolverService`
+ * seam real integrations use — mirroring `allegro-test-source-stub.helper.ts`
+ * and `fulfillment-relay-test-stubs.helper.ts`'s `destStub` shape (minus the
+ * sub-capability the latter needs and this spec doesn't). Both stubs are
+ * registered per-test, keyed by the test's own `externalOrderId`, so two
+ * tests in this file never collide on `AdapterRegistryService`'s
+ * one-registration-per-key rule.
+ *
+ * @module apps/api/test/integration/orders
+ */
+import {
+  ADAPTER_FACTORY_RESOLVER_TOKEN,
+  ADAPTER_REGISTRY_TOKEN,
+  AdapterFactoryResolverService,
+  AdapterRegistryPort,
+} from '@openlinker/core/integrations';
+import {
+  ORDER_INGESTION_SERVICE_TOKEN,
+  type IOrderIngestionService,
+  type IncomingOrder,
+  type OrderCreate,
+  type OrderProcessorManagerPort,
+  type OrderRef,
+  type OrderSourcePort,
+} from '@openlinker/core/orders';
+import {
+  OrderCancellationSignalOrmEntity,
+  OrderRecordOrmEntity,
+} from '@openlinker/core/orders/orm-entities';
+import { IdentifierMappingOrmEntity } from '@openlinker/core/identifier-mapping/orm-entities';
+import {
+  getTestHarness,
+  resetTestHarness,
+  teardownTestHarness,
+  type IntegrationTestHarness,
+} from '../setup';
+import { createTestConnection } from '../helpers/test-connection.helper';
+
+const DEST_ADAPTER_KEY = 'test.orderprocessor.earlycancel.v1';
+const DEST_PLATFORM_TYPE = 'prestashop';
+
+function makeIncomingOrder(externalOrderId: string): IncomingOrder {
+  return {
+    externalOrderId,
+    orderNumber: `ORD-${externalOrderId}`,
+    status: 'pending',
+    items: [],
+    totals: { subtotal: 10, tax: 0, shipping: 0, total: 10, currency: 'PLN' },
+    createdAt: '2026-08-01T00:00:00.000Z',
+    updatedAt: '2026-08-01T00:00:00.000Z',
+  };
+}
+
+/** Registers a per-test `OrderSourcePort` stub returning a fixed IncomingOrder. */
+function registerSourceStub(
+  harness: IntegrationTestHarness,
+  externalOrderId: string,
+  incoming: IncomingOrder
+): string {
+  const adapterKey = `test.ordersource.earlycancel.${externalOrderId}`;
+  const adapterRegistry = harness.getApp().get<AdapterRegistryPort>(ADAPTER_REGISTRY_TOKEN);
+  const factoryResolver = harness
+    .getApp()
+    .get<AdapterFactoryResolverService>(ADAPTER_FACTORY_RESOLVER_TOKEN);
+
+  const stub: OrderSourcePort = {
+    listOrderFeed: () => Promise.resolve({ items: [], nextCursor: null }),
+    getOrder: () => Promise.resolve(incoming),
+  };
+
+  adapterRegistry.register({
+    adapterKey,
+    platformType: 'allegro',
+    supportedCapabilities: ['OrderSource'],
+    displayName: `Early-cancel test source (${externalOrderId})`,
+    version: '0.0.0-test',
+    isDefault: false,
+  });
+  factoryResolver.registerFactory(adapterKey, {
+    createCapabilityAdapter: <T>(): Promise<T> => Promise.resolve(stub as unknown as T),
+  });
+
+  return adapterKey;
+}
+
+describe('Order early-cancellation signal (#2069)', () => {
+  let harness: IntegrationTestHarness;
+  let ingestion: IOrderIngestionService;
+  let createOrderCalls: OrderCreate[];
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+    ingestion = harness.getApp().get<IOrderIngestionService>(ORDER_INGESTION_SERVICE_TOKEN);
+
+    const adapterRegistry = harness.getApp().get<AdapterRegistryPort>(ADAPTER_REGISTRY_TOKEN);
+    const factoryResolver = harness
+      .getApp()
+      .get<AdapterFactoryResolverService>(ADAPTER_FACTORY_RESOLVER_TOKEN);
+
+    createOrderCalls = [];
+    const destStub: OrderProcessorManagerPort = {
+      createOrder(command: OrderCreate): Promise<OrderRef> {
+        createOrderCalls.push(command);
+        return Promise.resolve({ orderId: 'dest-order-1' });
+      },
+    };
+
+    adapterRegistry.register({
+      adapterKey: DEST_ADAPTER_KEY,
+      platformType: DEST_PLATFORM_TYPE,
+      supportedCapabilities: ['OrderProcessorManager'],
+      displayName: 'Early-cancel test destination',
+      version: '0.0.0-test',
+      isDefault: false,
+    });
+    factoryResolver.registerFactory(DEST_ADAPTER_KEY, {
+      createCapabilityAdapter: <T>(): Promise<T> => Promise.resolve(destStub as unknown as T),
+    });
+  });
+
+  beforeEach(() => {
+    createOrderCalls.length = 0;
+  });
+
+  afterEach(async () => {
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  it('cancel arrives first, then the sync job runs: no destination order is created', async () => {
+    const dataSource = harness.getDataSource();
+    const signalRepo = dataSource.getRepository(OrderCancellationSignalOrmEntity);
+    const recordRepo = dataSource.getRepository(OrderRecordOrmEntity);
+    const mappingRepo = dataSource.getRepository(IdentifierMappingOrmEntity);
+
+    const externalOrderId = 'early-cancel-race-1';
+    const sourceAdapterKey = registerSourceStub(
+      harness,
+      externalOrderId,
+      makeIncomingOrder(externalOrderId)
+    );
+
+    const sourceConnection = await createTestConnection(dataSource, {
+      platformType: 'allegro',
+      name: 'Allegro source',
+      adapterKey: sourceAdapterKey,
+    });
+    await createTestConnection(dataSource, {
+      platformType: DEST_PLATFORM_TYPE,
+      name: 'Destination',
+      adapterKey: DEST_ADAPTER_KEY,
+    });
+
+    // Act 1: the cancel event arrives before the order has ever been
+    // ingested — no identifier mapping exists yet.
+    const cancelResult = await ingestion.syncOrderFromSource(
+      sourceConnection.id,
+      externalOrderId,
+      'cancel-evt-1',
+      'cancelled'
+    );
+    expect(cancelResult).toEqual([]);
+
+    const mappingAfterCancel = await mappingRepo.findOne({
+      where: {
+        entityType: 'Order',
+        externalId: externalOrderId,
+        connectionId: sourceConnection.id,
+      },
+    });
+    expect(mappingAfterCancel).toBeNull();
+
+    const signalAfterCancel = await signalRepo.findOne({
+      where: { sourceConnectionId: sourceConnection.id, externalOrderId },
+    });
+    expect(signalAfterCancel).not.toBeNull();
+
+    // Act 2: the create/sync job now runs — the ordinary path, no eventType.
+    const syncResult = await ingestion.syncOrderFromSource(
+      sourceConnection.id,
+      externalOrderId,
+      'create-evt-1'
+    );
+
+    expect(syncResult).toHaveLength(1);
+    expect(syncResult[0].status).toBe('skipped_cancelled');
+    expect(createOrderCalls).toHaveLength(0);
+
+    const mappingAfterSync = await mappingRepo.findOne({
+      where: {
+        entityType: 'Order',
+        externalId: externalOrderId,
+        connectionId: sourceConnection.id,
+      },
+    });
+    expect(mappingAfterSync).not.toBeNull();
+
+    const record = await recordRepo.findOne({
+      where: { internalOrderId: mappingAfterSync!.internalId },
+    });
+    expect(record!.cancelledAt).not.toBeNull();
+
+    const signalAfterSync = await signalRepo.findOne({
+      where: { sourceConnectionId: sourceConnection.id, externalOrderId },
+    });
+    expect(signalAfterSync).toBeNull();
+  });
+
+  it('normal ordering unchanged: create arrives first, no prior cancel — destination order IS created', async () => {
+    const dataSource = harness.getDataSource();
+    const signalRepo = dataSource.getRepository(OrderCancellationSignalOrmEntity);
+
+    const externalOrderId = 'no-early-cancel-1';
+    const sourceAdapterKey = registerSourceStub(
+      harness,
+      externalOrderId,
+      makeIncomingOrder(externalOrderId)
+    );
+
+    const sourceConnection = await createTestConnection(dataSource, {
+      platformType: 'allegro',
+      name: 'Allegro source',
+      adapterKey: sourceAdapterKey,
+    });
+    await createTestConnection(dataSource, {
+      platformType: DEST_PLATFORM_TYPE,
+      name: 'Destination',
+      adapterKey: DEST_ADAPTER_KEY,
+    });
+
+    const syncResult = await ingestion.syncOrderFromSource(
+      sourceConnection.id,
+      externalOrderId,
+      'create-evt-1'
+    );
+
+    expect(syncResult).toHaveLength(1);
+    expect(syncResult[0].status).toBe('success');
+    expect(createOrderCalls).toHaveLength(1);
+
+    const signalRow = await signalRepo.findOne({
+      where: { sourceConnectionId: sourceConnection.id, externalOrderId },
+    });
+    expect(signalRow).toBeNull();
+  });
+});

--- a/apps/api/test/integration/setup.ts
+++ b/apps/api/test/integration/setup.ts
@@ -174,6 +174,14 @@ const harness = createIntegrationTestHarness({
     // because the unique index is partial on OPEN rows, that leak surfaces as a
     // spurious `OrderAlreadyOnHoldError` in an unrelated spec.
     'order_holds',
+    // order_cancellation_signals (#2069) — a durable trace that a source
+    // cancellation arrived for an order OL has not yet ingested. No FK to
+    // order_records (the order_holds precedent of an indexed reference by
+    // value — here there is nothing yet to reference at all), so nothing
+    // cascades in and `truncateTables`' CASCADE walk would never reach it.
+    // Truncate explicitly or a signal from one case still holds the
+    // (sourceConnectionId, externalOrderId) slot in the next.
+    'order_cancellation_signals',
     // automation_* (#2358) — the OMS automation v1 storage. NOTHING here
     // carries an FK: not runs/firings -> automation_rules (a deleted rule must
     // neither destroy its history nor be blocked by it), and not subjectId ->

--- a/docs/plans/implementation-plan-order-early-cancellation-signal.md
+++ b/docs/plans/implementation-plan-order-early-cancellation-signal.md
@@ -1,7 +1,7 @@
 # Implementation Plan: Durable Early-Cancellation Signal (#2069)
 
 **Date**: 2026-09-09
-**Status**: Draft
+**Status**: Implemented
 **Estimated Effort**: 0.75–1.5 days
 
 ---

--- a/docs/plans/implementation-plan-order-early-cancellation-signal.md
+++ b/docs/plans/implementation-plan-order-early-cancellation-signal.md
@@ -1,0 +1,862 @@
+# Implementation Plan: Durable Early-Cancellation Signal (#2069)
+
+**Date**: 2026-09-09
+**Status**: Draft
+**Estimated Effort**: 0.75–1.5 days
+
+---
+
+## 1. Task Summary
+
+**Objective**: Close the remaining half of #2069 — a source cancellation event
+that arrives **before** OpenLinker has ever ingested the order must leave a
+durable trace, so that the later create/sync job (which today provisions the
+order as *active* at every destination) can observe the cancellation and skip
+destination provisioning instead.
+
+**Context**: `OrderIngestionService.handleSourceCancellation` resolves the
+order's internal id via `IIdentifierMappingService.getInternalId`. When the
+mapping does not exist yet (the order is genuinely unknown to OL), the method
+logs a warning and returns `[]` — **nothing is written anywhere**. The later
+create job then calls `getOrCreateInternalId`, persists a fresh
+`order_records` row with `cancelledAt = null`, and `OrderSyncService.syncOrder`
+(the `#2284` guard, already shipped) sees no cancellation and provisions the
+order at every destination. The operator ends up with a live, shippable order
+the buyer already cancelled.
+
+Half of this issue shipped as **#2284**: `OrderSyncService.syncOrder` already
+consults `record.cancelledAt` before provisioning and returns a distinct
+terminal `'skipped_cancelled'` result per destination when it is set. That
+half needs **no changes** — it is the consumer the new write feeds into.
+
+This plan implements the remaining half only: **the durable write for an
+early/unknown-order cancellation**, keyed on `(sourceConnectionId,
+externalOrderId)` since no internal order id exists yet to write against.
+
+**Explicitly rejected alternative** (per the issue's own analysis, and
+reiterated in the retitling comment): minting an internal id via
+`getOrCreateInternalId` from the cancellation path. That would create a real
+`identifier_mappings` row — and, to hold `cancelledAt`, a stub `order_records`
+row — for an order OL has never actually ingested, i.e. a phantom order
+visible in the operator's order list before any real order data exists. This
+is exactly the shape #2328 rejected for returns attribution ("point every
+downstream trigger at a phantom").
+
+**Classification**: CORE (Application + Infrastructure + Domain layers,
+`libs/core/src/orders/`). One new database migration. No Interface-layer
+(controller/DTO) or Integration-layer (adapter) changes; no new capability
+port; no plugin-contract change.
+
+---
+
+## 2. Scope & Non-Goals
+
+### In Scope
+- A new durable "early cancellation signal" record, keyed on
+  `(sourceConnectionId, externalOrderId)`, written when
+  `handleSourceCancellation` cannot resolve an internal order id.
+- Consuming that signal the moment the order is genuinely first (or later)
+  ingested, and applying it via the existing, already-tested
+  `markCancelled`/`recordCancellationIfNeeded` machinery so `#2284`'s
+  provisioning guard sees it.
+- Updating the two stale code comments the issue names (AC5, AC6).
+- Unit tests (`order-ingestion.service.spec.ts`, `order-record.service.spec.ts`,
+  a new repository spec) and an integration test exercising the full
+  cancel-before-create race against real Postgres.
+
+### Out of Scope
+- Any change to `OrderSyncService`'s provisioning guard — it is already
+  correct (#2284) and untouched by this plan.
+- A lock or other mechanism to close the *microsecond*-scale TOCTOU race
+  between `handleSourceCancellation`'s `getInternalId` read and the create
+  job's `getOrCreateInternalId` write (see § 8 Risks — this residual is
+  self-healing on the very next poll/webhook for that order, unlike today's
+  bug, which never self-heals).
+- A scheduled cleanup sweep for orphaned signal rows (an order that is
+  cancelled before ingestion and then genuinely never re-synced again). The
+  expected volume is bounded by how often this race fires at all, which is
+  already the rare case the issue exists to close; see § 8.
+- The `marketplace.offer.stockRestore` early-fire hook. It is gated on
+  `incoming.status === 'cancelled'` and is **not** fired by the known-order
+  `handleSourceCancellation` path either (verified — that method never
+  enqueues it), so leaving it untouched keeps the new path symmetric with the
+  existing one rather than introducing new behavior nothing asked for.
+- Editing historical implementation-plan documents
+  (`docs/plans/implementation-plan-1158-order-status-writeback-relay.md` etc.)
+  that describe the residual as it stood at the time — those are point-in-time
+  records, not living documentation. Only the *code comments* the issue names
+  (AC5, AC6) are updated.
+- An ADR. This is a single-bounded-context bug fix that reuses an
+  already-established pattern in this exact context — a small,
+  indexed-reference-by-value side table with no FK to its subject
+  (`order_holds`, `order_changes`, `refund_records` all precede it) — and
+  introduces no new capability port, no cross-context edge, and no
+  plugin-contract change. It does not cross the bar in
+  `docs/architecture/adrs/README.md § When to write an ADR`, and the issue
+  itself does not ask for one.
+
+### Constraints
+- Must not regress the normal (create-then-cancel) ordering, already covered
+  by `#1984`/`#2284`'s existing tests.
+- Must not touch `persistOrder`'s signature or call sites — see § 4 for why
+  the fix is fully contained in `persistIncomingSnapshot`, which always runs
+  first and unconditionally on every non-cancel-event ingestion call.
+- Follows the migration-timestamp convention in `docs/migrations.md`: the next
+  free synthetic timestamp after the current tail
+  (`1877000000000-add-fulfillment-progress-claims-shipped-index.ts`, core) and
+  `1869000000200-create-oms-routing-rules.ts` (the only plugin migration dir
+  ahead of core) is **`1878000000000`**.
+
+---
+
+## 3. Architecture Mapping
+
+**Target Layer**: CORE (`libs/core/src/orders/`) — domain port + type,
+infrastructure ORM entity + repository, application service wiring. Plus one
+migration in `apps/api/src/migrations/`.
+
+**Capabilities Involved**: None new. No `OrderSourcePort` /
+`OrderProcessorManagerPort` change. The fix sits entirely in ingestion
+orchestration and persistence, below any capability port.
+
+**Existing Services Reused**:
+- `IIdentifierMappingService.getInternalId` (unchanged — still the read that
+  decides which branch `handleSourceCancellation` takes).
+- `IOrderRecordService.markCancelled` / the private `recordCancellationIfNeeded`
+  helper and its first-write-wins, refresh-once-after-both-writers plumbing
+  (`#1984`, `#2125`) — reused verbatim, not reimplemented.
+- `OrderSyncService`'s `#2284` `cancelledAt IS NULL` provisioning guard —
+  unchanged; it is what makes the new write actually matter.
+
+**New Components Required**:
+- `OrderCancellationSignalRepositoryPort` (domain port) — `record()` +
+  `consume()`.
+- `OrderCancellationSignalOrmEntity` (`order_cancellation_signals` table).
+- `OrderCancellationSignalRepository` (infrastructure implementation).
+- `ORDER_CANCELLATION_SIGNAL_REPOSITORY_TOKEN` in `orders.tokens.ts`.
+- One new method on `IOrderRecordService` /  `OrderRecordService`:
+  `recordEarlyCancellationSignal(sourceConnectionId, externalOrderId,
+  cancelledAt)`.
+- One migration creating the table.
+
+**Core vs Integration Justification**: This is pure order-ingestion
+orchestration and persistence — no external system is involved beyond the
+ones already touched by `handleSourceCancellation` and `syncOrderFromSource`.
+It belongs in `libs/core/src/orders/`, the same context that already owns
+`order_records`, `order_holds`, and `order_changes`.
+
+---
+
+## 4. Internal Research — How The Fix Fits The Existing Flow
+
+### 4.1 The two cancellation-observation paths (`#1984`)
+
+`OrderRecordService` already has two ways a cancellation reaches
+`order_records.cancelledAt`, both funneling through the same private
+`recordCancellationIfNeeded(internalOrderId, isCancelled, cancelledAt)` →
+`repository.markCancelled` (atomic, `COALESCE`-based, first-write-wins):
+
+1. **`persistIncomingSnapshot`** (called at Step 2 of
+   `OrderIngestionService.syncOrderFromSource`, *before* item resolution,
+   *unconditionally* on every non-cancel-event call) — fires when the fetched
+   `incoming.status === 'cancelled'`.
+2. **`persistOrder`** (Step 5, only reached once item resolution succeeds) —
+   fires on the same condition, off the built `Order.status`.
+3. **`handleSourceCancellation`** itself, for the *already-known* order case
+   — calls `markCancelled` directly with `new Date()`.
+
+`persistOrder`'s own `upsertWithLineItems()` call **excludes** `cancelledAt`
+from its column list (already asserted by
+`order-record.repository.spec.ts:1824` — "should NOT include cancelledAt in
+the upsert statement"), so whatever `persistIncomingSnapshot` wrote at Step 2
+survives Step 5 untouched. Combined with the fact that `persistIncomingSnapshot`
+is the **only** caller-side entry point that runs before `persistOrder` in
+every `syncOrderFromSource` invocation (verified: `persistOrder` has exactly
+one caller in the whole tree, `syncOrderFromSource`, always preceded by
+`persistIncomingSnapshot` in the same call), **the entire fix can live inside
+`persistIncomingSnapshot` alone** — no change to `persistOrder`'s signature or
+body, no new parameter threading through `OrderIngestionService`.
+
+### 4.2 Why a new keyed record, not a phantom order
+
+`handleSourceCancellation`'s unknown-order branch has no internal id to write
+`markCancelled` against — `OrderRecordRepository.markCancelled` is a bare
+`UPDATE ... WHERE "internalOrderId" = $2` with **no insert fallback** (it is
+explicitly documented as "No-op ... when the order row doesn't exist yet").
+Minting an id via `getOrCreateInternalId` to make that `UPDATE` land would (a)
+create a real `identifier_mappings` row for an order with no data yet, and
+(b) still need a stub `order_records` INSERT to have any row for the `UPDATE`
+to hit, i.e. an operator-visible phantom order — which is precisely what the
+issue's own analysis and the retitling comment reject, citing #2328's
+"point every downstream trigger at a phantom" rule for returns.
+
+The new record is instead keyed on `(sourceConnectionId, externalOrderId)` —
+the one piece of durable identity that exists before ingestion. It carries no
+FK to `order_records` (there is nothing to reference), mirroring the
+`order_holds` / `order_changes` / `refund_records` "indexed reference by
+value" precedent in this exact context.
+
+### 4.3 Consumption timing and the self-healing property
+
+`consume()` must run **after** the order-record row for `internalOrderId`
+already exists (i.e. after `repository.upsert(orderRecord)` inside
+`persistIncomingSnapshot`), for the same reason `recordCancellationIfNeeded`
+is already placed there: if `consume()` ran first and then the `upsert()`
+failed, a retry of the whole ingestion attempt would find the signal already
+deleted and lose the fact permanently. Placed **after** the upsert (exactly
+where `recordCancellationIfNeeded` already sits), a failure in `consume()`
+itself leaves the signal row untouched (a `DELETE` that throws commits
+nothing), so a retry — or the next ordinary poll/webhook for that order,
+since `consume()` runs unconditionally on **every** `persistIncomingSnapshot`
+call, not just the first — picks it up. This is a materially different
+failure mode from today's bug: today's gap **never** self-heals; the narrow
+TOCTOU window this design leaves open (see § 8) self-heals on the very next
+sync for that order.
+
+### 4.4 Destination-echo guard does not need to be duplicated
+
+`handleSourceCancellation`'s *known*-order branch already applies the ADR-017
+destination-echo guard (skip when `existing.sourceConnectionId !==
+connectionId`). The new unknown-order branch does not need an equivalent
+check: a destination can only "echo" a cancellation for an order it has
+itself been told to create, which requires OL to have already written an
+`identifier_mappings` row for `(Order, itsExternalId, itsConnectionId)` →
+the same internal id. If that mapping exists, `getInternalId` returns
+non-null and the call routes into the *known*-order branch (where the guard
+already applies) instead of the new one. The unknown-order branch is
+reachable only for a genuine, first-ever cancellation signal for that
+`(connectionId, externalOrderId)` pair.
+
+---
+
+## 5. Questions & Assumptions
+
+### Open Questions
+None — the design question the issue itself left open ("what does the early
+cancel write against?") is answered in § 4.2/4.3 above.
+
+### Assumptions
+- The destination create path (`OrderSyncService.syncOrder`, gated by
+  `#2284`) is the only provisioning path that needs the guard, as the issue's
+  own "Assumptions" section states. Verified: `OrderProvisioningResumeService`
+  and `OrderDestinationRetryService` both re-enqueue the *same*
+  `marketplace.order.sync` job type, which re-enters
+  `OrderIngestionService.syncOrderFromSource` → `OrderSyncService.syncOrder`,
+  so they inherit the guard for free and need no separate check.
+- A signal row surviving indefinitely (an order cancelled before ingestion
+  that is then never synced again by that source) is an acceptable residual —
+  see § 8. No TTL/cleanup sweep is added in this plan.
+- `IncomingOrder.status` is a raw, source-native string (not the neutral
+  `OrderStatus` union); the fix does not need to interpret it, only compare
+  it to `'cancelled'`, exactly as the two existing call sites already do.
+
+### Documentation Gaps
+None found — `docs/architecture-overview.md § Order Lifecycle` /
+`§ Orders` and the two relevant code files carry enough detail to design and
+test this without further clarification.
+
+---
+
+## 6. Proposed Implementation Plan
+
+### Phase 1 — Domain port, ORM entity, repository, migration
+
+**Goal**: Introduce the new durable signal, following the `order_holds`
+precedent exactly (small side table, no FK, `IF [NOT] EXISTS` migration).
+
+**Steps**:
+
+1. **Domain port**
+   - **File**: `libs/core/src/orders/domain/ports/order-cancellation-signal-repository.port.ts`
+   - **Action**: Define
+     ```ts
+     export interface OrderCancellationSignalRepositoryPort {
+       /**
+        * Durably record that a cancellation arrived for an order OL has not
+        * yet ingested (#2069). Keyed on (sourceConnectionId, externalOrderId)
+        * — no internal id exists yet, and minting one would point every
+        * downstream trigger at a phantom order (the #2328 lesson).
+        * First-write-wins: ON CONFLICT DO NOTHING, so a redelivered cancel
+        * event never disturbs an already-recorded signal.
+        */
+       record(
+         sourceConnectionId: string,
+         externalOrderId: string,
+         cancelledAt: Date
+       ): Promise<void>;
+
+       /**
+        * Atomically read-and-clear the signal for
+        * (sourceConnectionId, externalOrderId), if one exists — one
+        * DELETE ... RETURNING statement, so two concurrent ingestion
+        * attempts for the same external order can never both apply it and
+        * the signal is applied at most once. Runs unconditionally on every
+        * `persistIncomingSnapshot` call (not only the first), which is what
+        * makes it self-healing against the narrow write/consume race
+        * described in the repository's own doc comment.
+        */
+       consume(
+         sourceConnectionId: string,
+         externalOrderId: string
+       ): Promise<Date | null>;
+     }
+     ```
+   - **Acceptance**: File compiles; no domain-entity class needed (matches
+     the `ConnectionCursorRepositoryPort` minimalism — this is a plain fact,
+     not an aggregate with behavior, per ADR-011).
+
+2. **ORM entity**
+   - **File**: `libs/core/src/orders/infrastructure/persistence/entities/order-cancellation-signal.orm-entity.ts`
+   - **Action**:
+     ```ts
+     @Entity('order_cancellation_signals')
+     @Index(['sourceConnectionId', 'externalOrderId'], { unique: true })
+     export class OrderCancellationSignalOrmEntity {
+       @PrimaryColumn('uuid', { default: () => 'uuid_generate_v4()' })
+       id!: string;
+
+       @Column({ type: 'uuid' })
+       sourceConnectionId!: string;
+
+       @Column({ type: 'varchar' })
+       externalOrderId!: string;
+
+       @Column({ type: 'timestamptz' })
+       cancelledAt!: Date;
+
+       @CreateDateColumn()
+       createdAt!: Date;
+     }
+     ```
+   - **Acceptance**: `synchronize`-built test schema (integration harness)
+     and the migration (Step 4) produce an identical shape — no drift, since
+     neither is asserted against the other automatically here (unlike
+     `fulfillment_works`, this table is small enough that a dedicated parity
+     spec is not warranted; the existing int-spec in Phase 4 exercises the
+     real column names end to end).
+
+3. **Repository implementation**
+   - **File**: `libs/core/src/orders/infrastructure/persistence/repositories/order-cancellation-signal.repository.ts`
+   - **Action**: TypeORM `Repository<OrderCancellationSignalOrmEntity>`
+     injected via `@InjectRepository`. `record()` issues
+     `INSERT INTO "order_cancellation_signals" ("sourceConnectionId",
+     "externalOrderId", "cancelledAt") VALUES ($1, $2, $3)
+     ON CONFLICT ("sourceConnectionId", "externalOrderId") DO NOTHING`
+     (raw parameterized query, matching `markCancelled`'s own idiom — no
+     domain-entity round trip needed for a fire-and-forget write).
+     `consume()` issues
+     `DELETE FROM "order_cancellation_signals" WHERE "sourceConnectionId" =
+     $1 AND "externalOrderId" = $2 RETURNING "cancelledAt"`, returning
+     `rows[0]?.cancelledAt ?? null`.
+   - **Acceptance**: Repository unit spec
+     (`order-cancellation-signal.repository.spec.ts`) asserts the exact SQL
+     text and parameter order for both methods, mirroring
+     `order-record.repository.spec.ts`'s `markCancelled` test style (assert
+     on the mocked `Repository.query` call args).
+
+4. **Migration**
+   - **File**: `apps/api/src/migrations/1878000000000-create-order-cancellation-signals.ts`
+   - **Action**: `CREATE TABLE IF NOT EXISTS "order_cancellation_signals"`
+     with columns `id uuid NOT NULL DEFAULT uuid_generate_v4()`,
+     `"sourceConnectionId" uuid NOT NULL`, `"externalOrderId" text NOT NULL`,
+     `"cancelledAt" TIMESTAMP WITH TIME ZONE NOT NULL`, `"createdAt" TIMESTAMP
+     WITH TIME ZONE NOT NULL DEFAULT now()`, `CONSTRAINT
+     "PK_order_cancellation_signals" PRIMARY KEY ("id")`, plus
+     `CREATE UNIQUE INDEX IF NOT EXISTS
+     "UQ_order_cancellation_signals_source_external" ON
+     "order_cancellation_signals" ("sourceConnectionId", "externalOrderId")`.
+     `down()` drops the index then the table. `CREATE EXTENSION IF NOT
+     EXISTS "uuid-ossp"` guard reused (matches `1850000000008`).
+   - **Acceptance**: `pnpm --filter @openlinker/api migration:show` lists it;
+     `scripts/check-migration-timestamps.mjs` (part of `pnpm lint`) passes —
+     `1878000000000` is strictly greater than every timestamp already on
+     `main` (core tail `1877000000000`, plugin tail
+     `1869000000200`/`1850000000000`).
+
+5. **Wire into `OrdersModule`**
+   - **File**: `libs/core/src/orders/orders.module.ts`
+   - **Action**: Add `OrderCancellationSignalOrmEntity` to
+     `TypeOrmModule.forFeature([...])`; add
+     `OrderCancellationSignalRepository` to `providers`; add the token
+     binding `{ provide: ORDER_CANCELLATION_SIGNAL_REPOSITORY_TOKEN,
+     useExisting: OrderCancellationSignalRepository }`.
+   - **File**: `libs/core/src/orders/orders.tokens.ts`
+   - **Action**: Add `export const ORDER_CANCELLATION_SIGNAL_REPOSITORY_TOKEN
+     = Symbol('OrderCancellationSignalRepositoryPort');` beside the other
+     small-table tokens (`ORDER_HOLD_REPOSITORY_TOKEN` etc.).
+   - **File**: `libs/core/src/orders/orm-entities.ts`
+   - **Action**: Add
+     `export { OrderCancellationSignalOrmEntity } from
+     './infrastructure/persistence/entities/order-cancellation-signal.orm-entity';`
+     with a comment naming the Phase 4 int-spec as the consumer (matches the
+     existing convention for every other entry in this file).
+   - **Acceptance**: `pnpm --filter @openlinker/api type-check` (or the
+     equivalent workspace build) passes; the app boots (an existing
+     app-boot int-spec exercises the module graph).
+
+### Phase 2 — `OrderRecordService`: record + consume
+
+**Goal**: Give `OrderIngestionService` a place to record the signal, and make
+`persistIncomingSnapshot` apply it transparently through the existing
+first-write-wins machinery.
+
+**Steps**:
+
+6. **Interface method**
+   - **File**: `libs/core/src/orders/application/interfaces/order-record.service.interface.ts`
+   - **Action**: Add, beside `markCancelled`'s doc block:
+     ```ts
+     /**
+      * Durably record that a cancellation arrived for an order OL has not
+      * yet ingested (#2069). Called by
+      * `OrderIngestionService.handleSourceCancellation` when
+      * `getInternalId` resolves nothing. Keyed on
+      * (sourceConnectionId, externalOrderId) — see
+      * `OrderCancellationSignalRepositoryPort` for why no internal id is
+      * minted here. Consumed by `persistIncomingSnapshot` the moment the
+      * order is genuinely ingested; first-write-wins, so a redelivered
+      * cancel event is a harmless no-op.
+      */
+     recordEarlyCancellationSignal(
+       sourceConnectionId: string,
+       externalOrderId: string,
+       cancelledAt: Date
+     ): Promise<void>;
+     ```
+   - **Acceptance**: Type-checks against the new implementation in Step 7.
+
+7. **Implementation**
+   - **File**: `libs/core/src/orders/application/services/order-record.service.ts`
+   - **Action**:
+     - Add a 6th constructor parameter:
+       `@Inject(ORDER_CANCELLATION_SIGNAL_REPOSITORY_TOKEN) private readonly
+       cancellationSignalRepository: OrderCancellationSignalRepositoryPort`.
+     - Implement `recordEarlyCancellationSignal` as a direct pass-through to
+       `this.cancellationSignalRepository.record(...)`.
+     - In `persistIncomingSnapshot`, immediately **after** `const saved =
+       await this.repository.upsert(orderRecord);` and the existing
+       `warnOnAttributionDivergence` call, add:
+       ```ts
+       const earlySignalAt = await this.cancellationSignalRepository.consume(
+         sourceConnectionId,
+         incoming.externalOrderId
+       );
+       const cancellationWrote = await this.recordCancellationIfNeeded(
+         internalOrderId,
+         incoming.status === 'cancelled' || earlySignalAt !== null,
+         earlySignalAt ?? now
+       );
+       ```
+       replacing the existing `recordCancellationIfNeeded(internalOrderId,
+       incoming.status === 'cancelled', now)` call one-for-one. **No other
+       line in `persistIncomingSnapshot` changes.**
+   - **Acceptance**:
+     - `incoming.status !== 'cancelled'` and no signal present →
+       `cancellationWrote === false`, no `markCancelled` call, no behavior
+       change (regression guard).
+     - `incoming.status !== 'cancelled'` and a signal is present →
+       `markCancelled(internalOrderId, earlySignalAt)` is called with the
+       *signal's* instant, not `now`.
+     - `incoming.status === 'cancelled'` (existing case, no signal present)
+       → unchanged: `markCancelled(internalOrderId, now)`.
+
+8. **Do not touch `persistOrder`**
+   - **Action**: No change. Documented in § 4.1/4.3 above: `persistOrder`'s
+     `upsertWithLineItems()` excludes `cancelledAt` from its column list, so
+     the value `persistIncomingSnapshot` wrote at Step 2 of
+     `syncOrderFromSource` survives Step 5 untouched, and `persistOrder` is
+     never called without `persistIncomingSnapshot` having already run in
+     the same request.
+   - **Acceptance**: Existing `persistOrder`-focused tests in
+     `order-record.service.spec.ts` (the `cancellation recorded via
+     markCancelled` describe block) pass unmodified.
+
+### Phase 3 — `OrderIngestionService.handleSourceCancellation`
+
+**Goal**: Replace the silent no-op with a durable write; update the two
+stale comments the issue names.
+
+**Steps**:
+
+9. **Write the signal on the unknown-order branch**
+   - **File**: `libs/core/src/orders/application/services/order-ingestion.service.ts`
+   - **Action**: Replace
+     ```ts
+     if (!internalOrderId) {
+       this.logger.warn(
+         `Cancellation for unknown order: external ${externalOrderId} on connection ${connectionId} ` +
+           `has no internal mapping — nothing to cancel`
+       );
+       return [];
+     }
+     ```
+     with
+     ```ts
+     if (!internalOrderId) {
+       // #2069: a cancel for an order OL has not yet ingested must still
+       // leave a durable trace, or the later create provisions the order as
+       // active at every destination. No internal id exists yet, and
+       // minting one via getOrCreateInternalId would point every downstream
+       // trigger at a phantom order before any real order data arrives (the
+       // #2328 lesson for returns attribution) — so the signal is keyed on
+       // (sourceConnectionId, externalOrderId) instead, and consumed by
+       // OrderRecordService.persistIncomingSnapshot the moment the order is
+       // genuinely first ingested. Left unguarded (not try/caught): the only
+       // action on this branch is the write, so a DB failure should retry
+       // the job rather than be silently swallowed.
+       await this.orderRecordService.recordEarlyCancellationSignal(
+         connectionId,
+         externalOrderId,
+         new Date()
+       );
+       this.logger.warn(
+         `Cancellation for unknown order: external ${externalOrderId} on connection ${connectionId} ` +
+           `has no internal mapping yet — recorded as a pending cancellation signal so the later ` +
+           `create is not provisioned active`
+       );
+       return [];
+     }
+     ```
+   - **Acceptance**: The unit test at line ~1725 of
+     `order-ingestion.service.spec.ts` ("does NOT mark the record cancelled
+     when the order was never ingested") is updated (Step 12) to assert
+     `recordEarlyCancellationSignal` **is** called, while `markCancelled`
+     remains **not** called (order_records still doesn't exist).
+
+10. **Update the JSDoc atop `handleSourceCancellation`**
+    - **File**: same file, the method's own doc comment (currently states
+      "Resolves the existing internal order; if unknown (never ingested)
+      there is nothing to cancel").
+    - **Action**: Amend to state the unknown-order branch now durably
+      records a signal instead of doing nothing, referencing #2069.
+
+11. **Amend the stale `#1160` "Known residual" comment (AC6)**
+    - **File**: same file, near the end of `handleSourceCancellation` (the
+      block starting `// Known residual (#1160): a cancel that arrives
+      *before* the order's create/sync job has run finds no targets here...`).
+    - **Action**: Replace with a note that #2069 closes this residual: the
+      unknown-order branch now records a durable signal (Step 9) that
+      `persistIncomingSnapshot` consumes (Step 7), and `#2284`'s
+      `cancelledAt IS NULL` provisioning guard is what then withholds
+      destination creation — so the deferred monotonic/relay-log machinery
+      this comment originally pointed at was never needed, exactly as the
+      issue's own analysis concluded. State explicitly that the comment is
+      corrected rather than merely removed, so a future reader does not
+      wonder whether the residual was silently dropped.
+
+### Phase 4 — Comment update on the ORM entity (AC5)
+
+**Steps**:
+
+12. **File**: `libs/core/src/orders/infrastructure/persistence/entities/order-record.orm-entity.ts`
+    - **Action**: Update the `cancelledAt` column's doc comment (currently
+      "Indexed for the future exclusion predicate (#1987/#1988: `WHERE
+      "cancelledAt" IS NULL`)") to state the predicate has shipped
+      (`OrderSyncService.syncOrder`, #2284), and that #2069 closed the
+      remaining gap by giving a not-yet-ingested order's cancellation a
+      durable home too (`OrderCancellationSignalRepositoryPort`, consumed by
+      `OrderRecordService.persistIncomingSnapshot`).
+
+### Phase 5 — Tests
+
+**Steps**:
+
+13. **Unit — `order-ingestion.service.spec.ts`**
+    - Update the existing test "does NOT mark the record cancelled when the
+      order was never ingested" (line ~1725) to also assert
+      `orderRecordService.recordEarlyCancellationSignal` was called with
+      `(connectionId, externalOrderId, expect.any(Date))`, while
+      `markCancelled` remains uncalled.
+    - Add a new test asserting a thrown error from
+      `recordEarlyCancellationSignal` **propagates** (is not swallowed),
+      unlike the known-order branch's `markCancelled` call — mirroring the
+      contrast documented in Step 9's inline comment.
+    - Add `recordEarlyCancellationSignal: jest.fn().mockResolvedValue(undefined)`
+      to the `orderRecordService` mock object in `beforeEach`.
+
+14. **Unit — `order-record.service.spec.ts`**
+    - Add `record: jest.fn()` / `consume: jest.fn().mockResolvedValue(null)`
+      to a new `cancellationSignalRepository` mock, injected as the service's
+      6th constructor argument in the module-building `beforeEach`.
+    - New `describe('recordEarlyCancellationSignal (#2069)', ...)`:
+      asserts pass-through to `cancellationSignalRepository.record`.
+    - Extend the existing `persistIncomingSnapshot` cancellation tests (or
+      add a sibling `describe`) with:
+      - `consume` resolves a `Date` and `incoming.status !== 'cancelled'` →
+        `markCancelled` is called with **that** date, not `now`.
+      - `consume` resolves `null` and `incoming.status !== 'cancelled'` →
+        `markCancelled` is not called (regression guard, matches current
+        behavior byte-for-byte).
+      - `consume` resolves a `Date` **and** `incoming.status === 'cancelled'`
+        → `markCancelled` is still called exactly once (no double-write),
+        with `cancelledAt` preferring the signal's instant over `now`.
+
+15. **Unit — `order-cancellation-signal.repository.spec.ts`** (new file)
+    - Mirrors `order-record.repository.spec.ts`'s `markCancelled` describe
+      block: assert the exact `INSERT ... ON CONFLICT DO NOTHING` and
+      `DELETE ... RETURNING` statements and parameter order against a mocked
+      `Repository.query`.
+
+16. **Integration — new file**
+    `apps/api/test/integration/orders/order-early-cancellation-signal.int-spec.ts`
+    - Reuses `installAllegroTestSourceStub(harness)`
+      (`apps/api/test/integration/helpers/allegro-test-source-stub.helper.ts`)
+      for the source side.
+    - Registers one minimal inline destination stub via
+      `ADAPTER_REGISTRY_TOKEN` + `ADAPTER_FACTORY_RESOLVER_TOKEN`
+      implementing `OrderProcessorManagerPort`, whose `createOrder` is a
+      `jest.fn()` resolving `{ orderId: 'dest-1' }` — mirrors the `destStub`
+      shape in `fulfillment-relay-test-stubs.helper.ts` (minus the
+      `FulfillmentStatusReader` sub-capability, which this test doesn't
+      need).
+    - **Test A — cancel arrives first, then the sync job runs**:
+      1. Create the Allegro source connection and the destination connection
+         (`OrderProcessorManager`-capable).
+      2. Call `ingestion.syncOrderFromSource(sourceConnectionId,
+         externalOrderId, 'cancel-evt-1', 'cancelled')`. Assert: result is
+         `[]`; no `identifier_mappings` row exists for `(Order,
+         externalOrderId, sourceConnectionId)`; a row exists in
+         `order_cancellation_signals` for `(sourceConnectionId,
+         externalOrderId)`.
+      3. `stub.setNextIncomingOrder({ externalOrderId, status: 'pending',
+         items: [], totals: {...}, createdAt, updatedAt })` (a non-cancelled
+         order — `status: 'pending'` mirrors `OrderStatusValues`' first
+         member and needs no status-mapping configuration to validate).
+      4. Call `ingestion.syncOrderFromSource(sourceConnectionId,
+         externalOrderId, 'create-evt-1')` (no `eventType` — the ordinary
+         create path). Assert: the returned `OrderSyncResult[]` contains
+         exactly one entry with `status: 'skipped_cancelled'`; the
+         destination stub's `createOrder` was **never** called; the
+         `order_records` row for the resolved internal id has a non-null
+         `cancelledAt`; the `order_cancellation_signals` row is now gone
+         (consumed).
+    - **Test B — normal ordering unchanged (regression guard)**: same setup,
+      but call `syncOrderFromSource` with the create event **first** (no
+      prior cancel), non-cancelled `IncomingOrder`. Assert: `createOrder`
+      **was** called exactly once; the returned result has
+      `status: 'success'`; `order_cancellation_signals` has no row for this
+      pair (nothing was ever written).
+    - **File**: `apps/api/test/integration/setup.ts`
+    - **Action**: Add `'order_cancellation_signals'` to `tablesToTruncate`
+      (per `docs/testing-guide.md`, a table must be listed there to be
+      cleaned between tests even though the probe skips empty tables cheaply).
+
+---
+
+## 7. Alternatives Considered
+
+### Alternative 1: Mint the internal id in `handleSourceCancellation` via `getOrCreateInternalId`
+- **Description**: On the unknown-order branch, call
+  `getOrCreateInternalId` to mint the mapping, then insert a minimal stub
+  `order_records` row (or extend `markCancelled` to `INSERT ... ON CONFLICT`)
+  so `cancelledAt` has somewhere to live.
+- **Why Rejected**: Creates a phantom, operator-visible order with no real
+  order data before any create ever runs — a stub row would need to satisfy
+  every `NOT NULL` column on `order_records` (`orderSnapshot`,
+  `recordStatus`, etc.) with placeholder values, and would show up in
+  `/orders` and every list/aggregate read that scans the table. This is
+  exactly the failure mode #2328 named and rejected for returns attribution.
+- **Trade-offs**: Would avoid a new table, but at the cost of a much larger,
+  riskier blast radius (every reader of `order_records` now has to reason
+  about a possible phantom row) for no benefit over the keyed-signal design.
+
+### Alternative 2: Reuse the existing `connection_cursors` key-value table
+- **Description**: Store the signal as a `connection_cursors` row keyed
+  `(connectionId, cursorKey='order.earlyCancel:{externalOrderId}')`, value =
+  ISO cancellation instant.
+- **Why Rejected**: `connection_cursors` is documented and consumed
+  throughout the codebase as adapter *sync-position* state ("watermarks"),
+  not per-entity facts. Overloading it would (a) mix an unrelated concern
+  into a table whose every other consumer assumes "cursor" semantics
+  (`findMostRecentUpdate`, `advanceIfGreater`'s monotonic-string precondition
+  do not apply here), and (b) require an unbounded number of rows — one per
+  ever-cancelled-before-ingestion order — accumulating in a table sized and
+  reasoned about as "one row per (connection, cursor kind)" today.
+- **Trade-offs**: Saves a migration and a new port/repository, at the cost of
+  conflating two genuinely different concepts and complicating every future
+  reader of `connection_cursors`.
+
+### Alternative 3: Add a lock around `getOrCreateInternalId` + signal consumption to close the TOCTOU race entirely
+- **Description**: Take a per-`(connectionId, externalOrderId)` lock (the
+  `SyncLockPort` already used elsewhere in this file) around the
+  read-mapping / consume-signal sequence, so the microsecond race described
+  in § 8 cannot occur at all.
+- **Why Rejected**: The issue's own review comment explicitly found that the
+  "deferred monotonic / relay-log machinery" originally invoked to justify
+  leaving this open was unnecessary — the fix is "one durable write". Adding
+  a new per-order lock for a race window this narrow, on a hot path
+  (`syncOrderFromSource` runs on every order poll/webhook), is
+  disproportionate to the residual risk it closes, and the residual it
+  leaves is materially better than today's bug (self-healing on the next
+  poll/webhook, vs. never).
+- **Trade-offs**: Would fully close a race that today is unbounded, at the
+  cost of new lock contention and complexity on the ingestion hot path. Left
+  as a documented, accepted residual (§ 8) rather than implemented.
+
+---
+
+## 8. Validation & Risks
+
+### Architecture Compliance
+- ✅ Hexagonal layering: new port in `domain/ports/`, ORM entity + repository
+  in `infrastructure/persistence/`, orchestration in `application/services/`.
+- ✅ Domain layer has no framework dependency (the port interface imports
+  nothing from `@nestjs/*` or `typeorm`).
+- ✅ Repository ports pattern: `OrderRecordService` depends on
+  `OrderCancellationSignalRepositoryPort` via a Symbol token, never the
+  concrete `OrderCancellationSignalRepository` class.
+- ✅ Cross-context dependency rule: no new `@openlinker/core/<ctx>` import in
+  either direction; everything is intra-`orders`.
+
+### Naming Conventions
+- ✅ `*.port.ts` / `{Capability}Port` naming for the new interface.
+- ✅ `*.orm-entity.ts` for the TypeORM entity; `*.repository.ts` for the
+  implementation.
+- ✅ Token naming `ORDER_CANCELLATION_SIGNAL_REPOSITORY_TOKEN` matches the
+  `{CONTEXT}_{INTERFACE}_TOKEN` convention and the Symbol description
+  matches the interface name.
+
+### Existing Patterns
+- ✅ Mirrors `order_holds` (small side table, no FK, `IF [NOT] EXISTS`
+  migration, `synchronize`-parity via a plain integration test rather than a
+  dedicated schema-parity spec since the table has three real columns).
+- ✅ Mirrors `IdentifierMappingRepository.insertMapping` /
+  `OrderHoldRepository`'s `ON CONFLICT DO NOTHING` idiom for first-write-wins
+  inserts.
+- ✅ Reuses the exact `recordCancellationIfNeeded` → `markCancelled` pipeline
+  #1984/#2125 already built and tested, rather than duplicating a second
+  cancellation-write code path.
+
+### Risks
+
+- **Residual TOCTOU race** (documented, accepted, out of scope — § 6/7 Alt.
+  3): if `handleSourceCancellation`'s `getInternalId` read and the create
+  job's `getOrCreateInternalId`/`consume()` sequence interleave at
+  microsecond granularity such that `consume()` runs *before* `record()`
+  commits, the order is ingested with `cancelledAt = null` and the orphaned
+  signal row sits unconsumed. **Mitigation**: this is self-healing — `consume()`
+  runs unconditionally on **every** subsequent `persistIncomingSnapshot` call
+  for that order (every later poll/webhook), so the very next sync for that
+  order applies the signal. The only unrecoverable case is an order that
+  genuinely receives no further sync of any kind after this exact race — a
+  materially narrower failure mode than today's bug, which never recovers.
+- **Orphaned signal rows for orders that are never (re-)ingested**: if a
+  cancellation signal is written and the order is truly never synced again
+  by that source (rare — most sources either poll or receive further
+  webhooks), the row is never consumed. Given the row is tiny (three
+  columns, one per rare race occurrence) and this class of "small,
+  never-swept side table" already exists elsewhere in the codebase
+  (`automation_trigger_firings` is deliberately never pruned per-key), this
+  is accepted without a cleanup sweep. If volume ever becomes a concern, a
+  scheduled sweep mirroring `DemoAccountCleanupService`'s retention pattern
+  is the natural follow-up — explicitly flagged as a **future** issue, not
+  part of this plan.
+- **External-id reuse after a long gap**: an extremely rare compounding
+  scenario (the early-cancel race fires, the signal is never consumed, *and*
+  the source later reuses the same `externalOrderId` string for an unrelated
+  order on the same connection) could apply a stale cancellation to the
+  wrong order. This requires two independently rare events to compound and
+  is not addressed here; documented for awareness only.
+
+### Edge Cases
+- **Redelivered cancel event for an unknown order** (at-least-once delivery,
+  platform-wide invariant): `record()`'s `ON CONFLICT DO NOTHING` makes a
+  second `handleSourceCancellation` call for the same
+  `(connectionId, externalOrderId)` a no-op — matches `markCancelled`'s own
+  first-write-wins semantics.
+- **Order later resolves as a destination-echo**: cannot happen for the
+  unknown-order branch — see § 4.4.
+- **`incoming.status === 'cancelled'` AND a signal exists simultaneously**:
+  handled by the single `recordCancellationIfNeeded` call — the signal's
+  instant is preferred (it is the more authoritative, dedicated cancel-event
+  timestamp) and `markCancelled`'s own `COALESCE` guarantees exactly one
+  write regardless of which condition true first.
+
+### Backward Compatibility
+- ✅ No breaking change. New table, new port, one new interface method, one
+  new branch in an existing private method. Every existing caller of
+  `persistIncomingSnapshot`/`persistOrder`/`handleSourceCancellation` is
+  unaffected when no signal exists (the overwhelming majority of calls),
+  verified by the explicit regression-guard tests in Steps 13/14/16-B.
+- No data migration needed — the new table starts empty; there is nothing to
+  backfill.
+
+---
+
+## 9. Testing Strategy & Acceptance Criteria
+
+### Unit Tests
+- `libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts`
+  — updated + new cases per Step 13.
+- `libs/core/src/orders/application/services/__tests__/order-record.service.spec.ts`
+  — new cases per Step 14.
+- `libs/core/src/orders/infrastructure/persistence/repositories/__tests__/order-cancellation-signal.repository.spec.ts`
+  — new file per Step 15.
+
+### Integration Tests
+- `apps/api/test/integration/orders/order-early-cancellation-signal.int-spec.ts`
+  — new file per Step 16, against the real Postgres Testcontainer harness.
+
+### Mocking Strategy
+- Unit tests mock `OrderCancellationSignalRepositoryPort` and
+  `IOrderRecordService` exactly as the existing surrounding tests already
+  mock their neighbors (`markCancelled`, `getOrderRecord`, etc.) — no new
+  mocking pattern introduced.
+- The integration test mocks only the two external-boundary ports
+  (`OrderSourcePort`, `OrderProcessorManagerPort`) via the established
+  `AdapterRegistryService` + `AdapterFactoryResolverService` test seam; every
+  core layer (identifier mapping, order records, the new signal table) runs
+  for real against Postgres.
+
+### Acceptance Criteria (mapped 1:1 to the issue's remaining checklist)
+- [ ] A cancel for a not-yet-ingested order persists something the later
+      create can observe — `OrderCancellationSignalRepositoryPort.record`,
+      wired into `handleSourceCancellation`'s unknown-order branch (Step 9).
+- [ ] Integration test: cancel first, then sync — assert no destination
+      order is created (Step 16, Test A).
+- [ ] Integration test: normal ordering unchanged (Step 16, Test B).
+- [ ] The `#1987/#1988: future exclusion predicate` comment on the ORM
+      entity is updated (Step 12).
+- [ ] The `#1160` residual comment is removed or amended (Step 11 — amended,
+      with the reasoning for why the previously-invoked machinery was never
+      needed, per the issue's own retitling comment).
+
+---
+
+## 10. Alignment Checklist
+
+- [x] Follows hexagonal architecture
+- [x] Respects CORE vs Integration boundaries (no integration-layer change)
+- [x] Uses existing patterns (`order_holds`-shaped side table,
+      `ON CONFLICT DO NOTHING` idiom, existing `markCancelled` pipeline —
+      no unnecessary new abstraction)
+- [x] Idempotency considered (`record()` first-write-wins;
+      `consume()` at-most-once via `DELETE ... RETURNING`;
+      `markCancelled` already first-write-wins)
+- [x] Event-driven patterns used where applicable (webhook = trigger, poll =
+      reconciliation backstop — the self-healing property in § 4.3 relies on
+      exactly this existing pattern)
+- [x] Rate limits & retries addressed (n/a — no external call added; the one
+      new write is left unguarded specifically so a DB failure retries the
+      job, per Step 9's reasoning)
+- [x] Error handling comprehensive (see § 8 Risks + Edge Cases)
+- [x] Testing strategy complete (§ 9)
+- [x] Naming conventions followed (§ 8)
+- [x] File structure matches standards (§ 6)
+- [x] Plan is execution-ready
+- [x] Plan is saved as markdown file
+
+---
+
+## Related Documentation
+
+- [Architecture Overview](../architecture-overview.md) — § Orders,
+  § Cross-context dependencies in core
+- [Engineering Standards](../engineering-standards.md) — Repository Ports
+  Pattern, Symbol DI Token Re-export Convention
+- [Database Migrations Guide](../migrations.md) — timestamp convention
+- [Testing Guide](../testing-guide.md) — Testcontainers harness,
+  `tablesToTruncate`
+- Prior plan: `implementation-plan-order-cancellation-record-state.md`
+  (#1984 — the machinery this plan builds on)
+- GitHub issue: [#2069](https://github.com/openlinker-project/openlinker/issues/2069)

--- a/libs/core/src/orders/application/interfaces/order-record.service.interface.ts
+++ b/libs/core/src/orders/application/interfaces/order-record.service.interface.ts
@@ -238,6 +238,29 @@ export interface IOrderRecordService {
   markCancelled(internalOrderId: string, cancelledAt: Date): Promise<void>;
 
   /**
+   * Durably record that a cancellation arrived for an order OL has not yet
+   * ingested (#2069). Called by
+   * `OrderIngestionService.handleSourceCancellation` when
+   * `IIdentifierMappingService.getInternalId` resolves nothing — there is no
+   * internal order id yet for `markCancelled` to hit, so the signal is keyed
+   * on `(sourceConnectionId, externalOrderId)` instead. See
+   * `OrderCancellationSignalRepositoryPort` for why no internal id is minted
+   * here (minting one would point every downstream trigger at a phantom
+   * order — the #2328 lesson for returns attribution).
+   *
+   * Consumed by `persistIncomingSnapshot` the moment the order is genuinely
+   * first (or later) ingested, and applied through the same first-write-wins
+   * `markCancelled` pipeline this cancellation-observation path already uses.
+   * First-write-wins here too: a redelivered cancel event is a harmless
+   * no-op.
+   */
+  recordEarlyCancellationSignal(
+    sourceConnectionId: string,
+    externalOrderId: string,
+    cancelledAt: Date
+  ): Promise<void>;
+
+  /**
    * Record — or clear — why OpenLinker issued no fiscal document for this order
    * (#2100, ADR-041 decision 11: a block is never log-only).
    *

--- a/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
@@ -147,6 +147,7 @@ describe('OrderIngestionService', () => {
       findByIds: jest.fn(),
       markItemResolutionFailure: jest.fn().mockResolvedValue(undefined),
       markCancelled: jest.fn().mockResolvedValue(undefined),
+      recordEarlyCancellationSignal: jest.fn().mockResolvedValue(undefined),
       markSalesDocumentBlock: jest.fn().mockResolvedValue(undefined),
       markFulfillmentBlock: jest.fn().mockResolvedValue(undefined),
       recordAmendment: jest.fn().mockResolvedValue(undefined),
@@ -1724,12 +1725,35 @@ describe('OrderIngestionService', () => {
       expect(markCancelledOrder).toBeLessThan(relayOrder);
     });
 
-    it('does NOT mark the record cancelled when the order was never ingested (no internal mapping)', async () => {
+    it('does NOT mark the record cancelled when the order was never ingested (no internal mapping) — instead records a durable early-cancellation signal (#2069)', async () => {
       identifierMapping.getInternalId.mockResolvedValue(null);
 
-      await service.syncOrderFromSource(connectionId, externalOrderId, 'evt-1', 'cancelled');
+      const result = await service.syncOrderFromSource(
+        connectionId,
+        externalOrderId,
+        'evt-1',
+        'cancelled'
+      );
 
+      expect(result).toEqual([]);
       expect(orderRecordService.markCancelled).not.toHaveBeenCalled();
+      expect(orderRecordService.recordEarlyCancellationSignal).toHaveBeenCalledWith(
+        connectionId,
+        externalOrderId,
+        expect.any(Date)
+      );
+      expect(orderLifecycleRelay.relay).not.toHaveBeenCalled();
+    });
+
+    it('propagates a failure recording the early-cancellation signal (#2069) — unlike the known-order branch, there is no relay to protect', async () => {
+      identifierMapping.getInternalId.mockResolvedValue(null);
+      orderRecordService.recordEarlyCancellationSignal.mockRejectedValueOnce(
+        new Error('db unavailable')
+      );
+
+      await expect(
+        service.syncOrderFromSource(connectionId, externalOrderId, 'evt-1', 'cancelled')
+      ).rejects.toThrow('db unavailable');
     });
 
     it('does NOT mark the record cancelled on a destination-echo cancel', async () => {

--- a/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
@@ -140,7 +140,11 @@ describe('OrderIngestionService', () => {
 
     orderRecordService = {
       persistOrder: jest.fn().mockResolvedValue({}),
-      persistIncomingSnapshot: jest.fn().mockResolvedValue({}),
+      // `cancelledAt: null` by default so a mock that doesn't override this
+      // return value isn't mistaken for an early-cancellation signal (#2069) —
+      // an omitted field would read as `undefined`, which the service treats
+      // as "no signal" via `!= null`, but making it explicit here pins that.
+      persistIncomingSnapshot: jest.fn().mockResolvedValue({ cancelledAt: null }),
       updateSyncStatus: jest.fn().mockResolvedValue(undefined),
       getOrderRecord: jest.fn(),
       findMany: jest.fn(),
@@ -428,6 +432,28 @@ describe('OrderIngestionService', () => {
       await service.syncOrderFromSource(connectionId, externalOrderId);
 
       expect(reservationService.reserveForOrder).not.toHaveBeenCalled();
+    });
+
+    // #2069 review — the exact race the early-cancellation signal exists for:
+    // the source's order RESOURCE still reports the pre-cancel status when
+    // `getOrder` runs (the event journal that produced the signal leads the
+    // resource), so `incoming.status` alone must not be trusted once
+    // `persistIncomingSnapshot` reports a consumed signal via `cancelledAt`.
+    it('should not reserve, and should enqueue stock-restore, when the incoming status still lags a consumed early-cancellation signal', async () => {
+      orderSource.getOrder.mockResolvedValue(reservableIncoming); // status still 'BOUGHT'
+      orderRecordService.persistIncomingSnapshot.mockResolvedValue({
+        cancelledAt: new Date('2026-08-01T10:00:00.000Z'),
+      } as unknown as OrderRecord);
+
+      await service.syncOrderFromSource(connectionId, externalOrderId);
+
+      expect(reservationService.reserveForOrder).not.toHaveBeenCalled();
+      expect(jobQueue.enqueue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'marketplace.offer.stockRestore',
+          payload: expect.objectContaining({ internalOrderId: 'ol_order_res' }),
+        })
+      );
     });
   });
 

--- a/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-ingestion.service.spec.ts
@@ -455,6 +455,34 @@ describe('OrderIngestionService', () => {
         })
       );
     });
+
+    // #2069 re-review — the residue found in the fix above: on the poll AFTER
+    // the one that consumed the signal, `persistIncomingSnapshot` no longer
+    // has anything to consume, so it returns `upsert()`'s own return value
+    // (`fromRawRow` resets every column outside its write set, and
+    // `cancelledAt` is deliberately outside it) — `cancelledAt: null` here,
+    // even though the row IS cancelled. Without also reading the
+    // pre-persist `existing` record loaded via `getOrderRecord`, this poll
+    // would silently regress to the original defect.
+    it('should not reserve, and should enqueue stock-restore, on a poll AFTER the signal was already consumed', async () => {
+      orderSource.getOrder.mockResolvedValue(reservableIncoming); // status still 'BOUGHT'
+      orderRecordService.getOrderRecord.mockResolvedValue({
+        cancelledAt: new Date('2026-08-01T10:00:00.000Z'),
+      } as unknown as OrderRecord);
+      orderRecordService.persistIncomingSnapshot.mockResolvedValue({
+        cancelledAt: null,
+      } as unknown as OrderRecord);
+
+      await service.syncOrderFromSource(connectionId, externalOrderId);
+
+      expect(reservationService.reserveForOrder).not.toHaveBeenCalled();
+      expect(jobQueue.enqueue).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'marketplace.offer.stockRestore',
+          payload: expect.objectContaining({ internalOrderId: 'ol_order_res' }),
+        })
+      );
+    });
   });
 
   describe('auto-issue trigger (OL #1120)', () => {

--- a/libs/core/src/orders/application/services/__tests__/order-record.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-record.service.spec.ts
@@ -10,6 +10,7 @@ import type { TestingModule } from '@nestjs/testing';
 import { Test } from '@nestjs/testing';
 import { OrderRecordService } from '../order-record.service';
 import type { OrderRecordRepositoryPort } from '../../../domain/ports/order-record-repository.port';
+import type { OrderCancellationSignalRepositoryPort } from '../../../domain/ports/order-cancellation-signal-repository.port';
 import type { OrderLineItemRepositoryPort } from '../../../domain/ports/order-line-item-repository.port';
 import type { OrderSyncStatus } from '../../../domain/entities/order-record.entity';
 import { OrderRecord } from '../../../domain/entities/order-record.entity';
@@ -41,6 +42,7 @@ describe('OrderRecordService', () => {
   let fxStamp: jest.Mocked<IOrderFxStampService>;
   let lineItemRepository: jest.Mocked<OrderLineItemRepositoryPort>;
   let reportingCurrencySettings: jest.Mocked<IReportingCurrencySettingsService>;
+  let cancellationSignalRepository: jest.Mocked<OrderCancellationSignalRepositoryPort>;
 
   const originalEnv = process.env.OL_STORE_PII;
   const originalPiiHashSalt = process.env.OL_PII_HASH_SALT;
@@ -97,6 +99,14 @@ describe('OrderRecordService', () => {
       setReportingCurrency: jest.fn(),
       listSelectableCurrencies: jest.fn(),
     } as unknown as jest.Mocked<IReportingCurrencySettingsService>;
+
+    // #2069 — defaults to "no signal" so every pre-existing cancellation
+    // assertion (`incoming.status === 'cancelled'`) keeps its original
+    // meaning unless a test opts into a signal being present.
+    cancellationSignalRepository = {
+      record: jest.fn().mockResolvedValue(undefined),
+      consume: jest.fn().mockResolvedValue(null),
+    } as unknown as jest.Mocked<OrderCancellationSignalRepositoryPort>;
 
     const module: TestingModule = await Test.createTestingModule({
       providers: [
@@ -218,7 +228,14 @@ describe('OrderRecordService', () => {
   describe('persistOrder - PII enabled', () => {
     beforeEach(() => {
       process.env.OL_STORE_PII = 'true';
-      service = new OrderRecordService(repository, fxStamp, lineItemRepository, reportingCurrencySettings, automationEmission);
+      service = new OrderRecordService(
+        repository,
+        fxStamp,
+        lineItemRepository,
+        reportingCurrencySettings,
+        automationEmission,
+        cancellationSignalRepository
+      );
     });
 
     it('should persist order with all PII fields when PII storage is enabled', async () => {
@@ -578,7 +595,14 @@ describe('OrderRecordService', () => {
   describe('persistOrder - PII disabled', () => {
     beforeEach(() => {
       process.env.OL_STORE_PII = 'false';
-      service = new OrderRecordService(repository, fxStamp, lineItemRepository, reportingCurrencySettings, automationEmission);
+      service = new OrderRecordService(
+        repository,
+        fxStamp,
+        lineItemRepository,
+        reportingCurrencySettings,
+        automationEmission,
+        cancellationSignalRepository
+      );
     });
 
     it('should store no buyer tax id at all when PII storage is disabled (#2599)', async () => {
@@ -710,7 +734,14 @@ describe('OrderRecordService', () => {
   describe('persistOrder — cancellation recorded via markCancelled (#1984)', () => {
     beforeEach(() => {
       process.env.OL_STORE_PII = 'true';
-      service = new OrderRecordService(repository, fxStamp, lineItemRepository, reportingCurrencySettings, automationEmission);
+      service = new OrderRecordService(
+        repository,
+        fxStamp,
+        lineItemRepository,
+        reportingCurrencySettings,
+        automationEmission,
+        cancellationSignalRepository
+      );
     });
 
     it('never constructs the OrderRecord passed to upsertWithLineItems() with a non-null cancelledAt, even for a cancelled order', async () => {
@@ -781,7 +812,14 @@ describe('OrderRecordService', () => {
   describe('persistOrder - fulfillment rollup left to updateFulfillmentState (#2101)', () => {
     beforeEach(() => {
       process.env.OL_STORE_PII = 'true';
-      service = new OrderRecordService(repository, fxStamp, lineItemRepository, reportingCurrencySettings, automationEmission);
+      service = new OrderRecordService(
+        repository,
+        fxStamp,
+        lineItemRepository,
+        reportingCurrencySettings,
+        automationEmission,
+        cancellationSignalRepository
+      );
     });
 
     it('never constructs the OrderRecord passed to upsertWithLineItems() with a fulfillment state', async () => {
@@ -802,7 +840,14 @@ describe('OrderRecordService', () => {
   describe('persist paths - destination sync state left to updateSyncStatus (#2140)', () => {
     beforeEach(() => {
       process.env.OL_STORE_PII = 'true';
-      service = new OrderRecordService(repository, fxStamp, lineItemRepository, reportingCurrencySettings, automationEmission);
+      service = new OrderRecordService(
+        repository,
+        fxStamp,
+        lineItemRepository,
+        reportingCurrencySettings,
+        automationEmission,
+        cancellationSignalRepository
+      );
     });
 
     it('never constructs the OrderRecord passed to upsertWithLineItems() with sync state', async () => {
@@ -840,7 +885,14 @@ describe('OrderRecordService', () => {
   describe('persistIncomingSnapshot', () => {
     beforeEach(() => {
       process.env.OL_STORE_PII = 'true';
-      service = new OrderRecordService(repository, fxStamp, lineItemRepository, reportingCurrencySettings, automationEmission);
+      service = new OrderRecordService(
+        repository,
+        fxStamp,
+        lineItemRepository,
+        reportingCurrencySettings,
+        automationEmission,
+        cancellationSignalRepository
+      );
     });
 
     it('should persist incoming snapshot with awaiting_mapping status', async () => {
@@ -904,7 +956,14 @@ describe('OrderRecordService', () => {
 
     it('should sanitize addresses in snapshot when PII is disabled', async () => {
       process.env.OL_STORE_PII = 'false';
-      service = new OrderRecordService(repository, fxStamp, lineItemRepository, reportingCurrencySettings, automationEmission);
+      service = new OrderRecordService(
+        repository,
+        fxStamp,
+        lineItemRepository,
+        reportingCurrencySettings,
+        automationEmission,
+        cancellationSignalRepository
+      );
 
       const incoming = createMockIncomingOrder();
       const expectedRecord = new OrderRecord(
@@ -979,7 +1038,14 @@ describe('OrderRecordService', () => {
 
     it('should omit customerEmail from the snapshot under hash-only PII mode (#948)', async () => {
       process.env.OL_STORE_PII = 'false';
-      service = new OrderRecordService(repository, fxStamp, lineItemRepository, reportingCurrencySettings, automationEmission);
+      service = new OrderRecordService(
+        repository,
+        fxStamp,
+        lineItemRepository,
+        reportingCurrencySettings,
+        automationEmission,
+        cancellationSignalRepository
+      );
 
       const incoming = createMockIncomingOrder();
       repository.upsert.mockResolvedValue({} as OrderRecord);
@@ -1030,7 +1096,14 @@ describe('OrderRecordService', () => {
   describe('persistIncomingSnapshot — cancellation recorded via markCancelled (#1984)', () => {
     beforeEach(() => {
       process.env.OL_STORE_PII = 'true';
-      service = new OrderRecordService(repository, fxStamp, lineItemRepository, reportingCurrencySettings, automationEmission);
+      service = new OrderRecordService(
+        repository,
+        fxStamp,
+        lineItemRepository,
+        reportingCurrencySettings,
+        automationEmission,
+        cancellationSignalRepository
+      );
     });
 
     it('never constructs the OrderRecord passed to upsert() with a non-null cancelledAt, even for a cancelled order', async () => {
@@ -1067,6 +1140,109 @@ describe('OrderRecordService', () => {
       await service.persistIncomingSnapshot(incoming, 'ol_order_abc', null, 'conn-123', null);
 
       expect(repository.markCancelled).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('persistIncomingSnapshot — consuming the early-cancellation signal (#2069)', () => {
+    beforeEach(() => {
+      process.env.OL_STORE_PII = 'true';
+      service = new OrderRecordService(
+        repository,
+        fxStamp,
+        lineItemRepository,
+        reportingCurrencySettings,
+        automationEmission,
+        cancellationSignalRepository
+      );
+    });
+
+    it('consumes the signal keyed on (sourceConnectionId, incoming.externalOrderId)', async () => {
+      const incoming = createMockIncomingOrder();
+      incoming.status = 'pending';
+      repository.upsert.mockResolvedValue({} as OrderRecord);
+      cancellationSignalRepository.consume.mockResolvedValue(null);
+
+      await service.persistIncomingSnapshot(incoming, 'ol_order_abc', null, 'conn-123', null);
+
+      expect(cancellationSignalRepository.consume).toHaveBeenCalledWith(
+        'conn-123',
+        incoming.externalOrderId
+      );
+    });
+
+    it('marks the order cancelled with the SIGNAL instant (not now) when a signal exists and the incoming order is not itself reported cancelled', async () => {
+      const incoming = createMockIncomingOrder();
+      incoming.status = 'pending';
+      const signalCancelledAt = new Date('2026-08-01T10:00:00.000Z');
+      repository.upsert.mockResolvedValue({} as OrderRecord);
+      repository.findById.mockResolvedValue({} as OrderRecord);
+      cancellationSignalRepository.consume.mockResolvedValue(signalCancelledAt);
+
+      await service.persistIncomingSnapshot(incoming, 'ol_order_abc', null, 'conn-123', null);
+
+      expect(repository.markCancelled).toHaveBeenCalledWith('ol_order_abc', signalCancelledAt);
+    });
+
+    it('does not call markCancelled when no signal exists and the order is not cancelled (regression guard, byte-for-byte pre-#2069 behavior)', async () => {
+      const incoming = createMockIncomingOrder();
+      incoming.status = 'pending';
+      repository.upsert.mockResolvedValue({} as OrderRecord);
+      cancellationSignalRepository.consume.mockResolvedValue(null);
+
+      await service.persistIncomingSnapshot(incoming, 'ol_order_abc', null, 'conn-123', null);
+
+      expect(repository.markCancelled).not.toHaveBeenCalled();
+    });
+
+    it('calls markCancelled exactly once — never twice — when a signal exists AND incoming.status is already cancelled, preferring the signal instant', async () => {
+      const incoming = createMockIncomingOrder();
+      incoming.status = 'cancelled';
+      const signalCancelledAt = new Date('2026-08-01T10:00:00.000Z');
+      repository.upsert.mockResolvedValue({} as OrderRecord);
+      repository.findById.mockResolvedValue({} as OrderRecord);
+      cancellationSignalRepository.consume.mockResolvedValue(signalCancelledAt);
+
+      await service.persistIncomingSnapshot(incoming, 'ol_order_abc', null, 'conn-123', null);
+
+      expect(repository.markCancelled).toHaveBeenCalledTimes(1);
+      expect(repository.markCancelled).toHaveBeenCalledWith('ol_order_abc', signalCancelledAt);
+    });
+
+    it('runs consume() AFTER the snapshot upsert, so a failed upsert never consumes the signal', async () => {
+      const incoming = createMockIncomingOrder();
+      incoming.status = 'pending';
+      repository.upsert.mockRejectedValue(new Error('db unavailable'));
+
+      await expect(
+        service.persistIncomingSnapshot(incoming, 'ol_order_abc', null, 'conn-123', null)
+      ).rejects.toThrow('db unavailable');
+
+      expect(cancellationSignalRepository.consume).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('recordEarlyCancellationSignal (#2069)', () => {
+    beforeEach(() => {
+      service = new OrderRecordService(
+        repository,
+        fxStamp,
+        lineItemRepository,
+        reportingCurrencySettings,
+        automationEmission,
+        cancellationSignalRepository
+      );
+    });
+
+    it('delegates to the repository verbatim', async () => {
+      const cancelledAt = new Date('2026-08-01T10:00:00.000Z');
+
+      await service.recordEarlyCancellationSignal('conn-123', 'ext-order-1', cancelledAt);
+
+      expect(cancellationSignalRepository.record).toHaveBeenCalledWith(
+        'conn-123',
+        'ext-order-1',
+        cancelledAt
+      );
     });
   });
 

--- a/libs/core/src/orders/application/services/__tests__/order-record.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-record.service.spec.ts
@@ -25,6 +25,7 @@ import {
   ORDER_FX_STAMP_SERVICE_TOKEN,
   ORDER_LINE_ITEM_REPOSITORY_TOKEN,
   ORDER_RECORD_REPOSITORY_TOKEN,
+  ORDER_CANCELLATION_SIGNAL_REPOSITORY_TOKEN,
 } from '../../../orders.tokens';
 
 describe('OrderRecordService', () => {
@@ -130,6 +131,10 @@ describe('OrderRecordService', () => {
         {
           provide: REPORTING_CURRENCY_SETTINGS_SERVICE_TOKEN,
           useValue: reportingCurrencySettings,
+        },
+        {
+          provide: ORDER_CANCELLATION_SIGNAL_REPOSITORY_TOKEN,
+          useValue: cancellationSignalRepository,
         },
       ],
     }).compile();

--- a/libs/core/src/orders/application/services/order-ingestion.service.ts
+++ b/libs/core/src/orders/application/services/order-ingestion.service.ts
@@ -1213,14 +1213,19 @@ export class OrderIngestionService implements IOrderIngestionService {
 
   /**
    * Inbound source cancellation → destination(s) via the lifecycle relay (#1158).
-   * Resolves the existing internal order; if unknown (never ingested) there is
-   * nothing to cancel. Applies the same destination-echo guard as ingestion
-   * (ADR-017) so a re-read of an order OL itself created elsewhere doesn't
-   * propagate a spurious cancel. Also durably records the cancellation on the
-   * order record itself via `markCancelled` (#1984), best-effort and before
-   * the relay call — see the inline comment at the call site for why a DB
-   * failure there must never block the relay. Returns an empty result set —
-   * a cancel is not an order-create, so there are no OrderSyncResults to report.
+   * Resolves the existing internal order; if unknown (never ingested), there is
+   * no `order_records` row to mark cancelled yet — instead, a durable
+   * `(sourceConnectionId, externalOrderId)`-keyed signal is recorded (#2069)
+   * so the later create/sync job can observe the cancellation and skip
+   * destination provisioning (`OrderSyncService`'s `#2284` guard) instead of
+   * provisioning the order as active. Applies the same destination-echo guard
+   * as ingestion (ADR-017) so a re-read of an order OL itself created
+   * elsewhere doesn't propagate a spurious cancel. Also durably records the
+   * cancellation on the order record itself via `markCancelled` (#1984),
+   * best-effort and before the relay call — see the inline comment at the
+   * call site for why a DB failure there must never block the relay. Returns
+   * an empty result set — a cancel is not an order-create, so there are no
+   * OrderSyncResults to report.
    */
   private async handleSourceCancellation(
     connectionId: string,
@@ -1232,9 +1237,28 @@ export class OrderIngestionService implements IOrderIngestionService {
       connectionId
     );
     if (!internalOrderId) {
+      // #2069: a cancel for an order OL has not yet ingested must still leave
+      // a durable trace, or the later create provisions the order as active
+      // at every destination. No internal id exists yet, and minting one via
+      // getOrCreateInternalId would point every downstream trigger at a
+      // phantom order before any real order data arrives (the #2328 lesson
+      // for returns attribution) — so the signal is keyed on
+      // (sourceConnectionId, externalOrderId) instead, and consumed by
+      // OrderRecordService.persistIncomingSnapshot the moment the order is
+      // genuinely first ingested. Left unguarded (not try/caught): the only
+      // action on this branch is the write, so a DB failure here should
+      // retry the job rather than be silently swallowed — unlike the
+      // known-order branch below, where a relay to already-resolved
+      // destinations must proceed regardless.
+      await this.orderRecordService.recordEarlyCancellationSignal(
+        connectionId,
+        externalOrderId,
+        new Date()
+      );
       this.logger.warn(
         `Cancellation for unknown order: external ${externalOrderId} on connection ${connectionId} ` +
-          `has no internal mapping — nothing to cancel`
+          `has no internal mapping yet — recorded as a pending cancellation signal so the later ` +
+          `create is not provisioned active`
       );
       return [];
     }
@@ -1283,11 +1307,20 @@ export class OrderIngestionService implements IOrderIngestionService {
     // Surface any non-`applied` target (e.g. a destination that already shipped,
     // so the cancel was rejected) at warn — the cancel is never silently dropped.
     //
-    // Known residual (#1160): a cancel that arrives *before* the order's
-    // create/sync job has run finds no targets here, and the later create then
-    // provisions the order as active. Fully closing that out-of-order race needs
-    // the deferred monotonic / relay-log machinery (ADR-027 guardrails) tracked
-    // with the bidirectional slices — out of scope for this unidirectional slice.
+    // Formerly a known residual (#1160): a cancel that arrives *before* the
+    // order's create/sync job has run finds no relay targets here (there is
+    // no order yet to relay to), and the comment used to say closing that
+    // race needed the deferred monotonic / relay-log machinery (ADR-027
+    // guardrails). #2069's own analysis found that claim false — a per-target
+    // relay-obligation table cannot fix a cancel with zero resolved targets,
+    // because a sweep re-drives writes that were attempted and failed, and
+    // this one was never attemptable. The fix needed only a durable write:
+    // the unknown-order branch above now records a `(sourceConnectionId,
+    // externalOrderId)`-keyed signal, `OrderRecordService
+    // .persistIncomingSnapshot` consumes it the moment the order is
+    // genuinely ingested, and `OrderSyncService`'s `#2284`
+    // `cancelledAt IS NULL` guard is what then withholds destination
+    // creation. No relay-log machinery was ever needed.
     if (result.targets.some((t) => t.outcome !== 'applied')) {
       this.logger.warn(message);
     } else {

--- a/libs/core/src/orders/application/services/order-ingestion.service.ts
+++ b/libs/core/src/orders/application/services/order-ingestion.service.ts
@@ -401,13 +401,27 @@ export class OrderIngestionService implements IOrderIngestionService {
     );
 
     // Step 2: persist raw snapshot immediately — operator can see the order even if item resolution fails
-    await this.orderRecordService.persistIncomingSnapshot(
+    const snapshotRecord = await this.orderRecordService.persistIncomingSnapshot(
       incoming,
       internalOrderId,
       internalCustomerId ?? null,
       connectionId,
       sourceEventId ?? null
     );
+
+    // #2069: `persistIncomingSnapshot` may have consumed an early-cancellation
+    // signal recorded before this order was ever ingested — the exact race this
+    // fix exists to close is one where the source's order RESOURCE still
+    // reports the pre-cancel status here (the event journal that produced the
+    // signal leads the resource read), so `incoming.status` alone is not a
+    // reliable "is this order cancelled" answer once a signal exists. Every
+    // downstream gate that used to test `incoming.status`/`order.status` alone
+    // must also honour this, or OL reserves inventory and skips the stock
+    // restore for an order it already knows is dead (#2628's shape: a
+    // permanent ATP subtraction naming a cancelled order). `cancelledAt`, once
+    // written, is never cleared on this path, so capturing it here is valid
+    // for every gate below.
+    const cancelledFromEarlySignal = snapshotRecord.cancelledAt != null;
 
     // Early-fire cancellation hook (#1146): enqueue the stock-restore job
     // immediately after the raw snapshot is persisted and BEFORE item resolution
@@ -420,7 +434,7 @@ export class OrderIngestionService implements IOrderIngestionService {
     // will carry variantIds; if items never resolve, OfferStockRestoreService
     // will no-op (no variantIds in the raw snapshot) and the job stays visible
     // in the dead-letter queue for operator inspection.
-    if (incoming.status === 'cancelled' && priorStatus !== 'cancelled') {
+    if ((incoming.status === 'cancelled' || cancelledFromEarlySignal) && priorStatus !== 'cancelled') {
       try {
         await this.jobQueue.enqueue({
           type: 'marketplace.offer.stockRestore',
@@ -522,8 +536,10 @@ export class OrderIngestionService implements IOrderIngestionService {
     );
 
     // #2344: record OL's own advisory holds. Placed after `persistOrder` so the
-    // order row exists, and before destination provisioning.
-    await this.reserveOrderInventory(order, connectionId);
+    // order row exists, and before destination provisioning. `cancelledFromEarlySignal`
+    // (#2069) is threaded through so an order already known-cancelled via the
+    // signal is never held, even while `order.status` still lags.
+    await this.reserveOrderInventory(order, connectionId, cancelledFromEarlySignal);
 
     // Cancellation-observe hook (#1146): on the `→ cancelled` transition, enqueue
     // a marketplace.offer.stockRestore job so the destination marketplace's
@@ -532,8 +548,9 @@ export class OrderIngestionService implements IOrderIngestionService {
     // 'cancelled') so a re-poll within the watermark window doesn't re-fire;
     // the dedupeKey makes any re-enqueue safe. Marketplace-agnostic — the worker
     // handler narrows the source connection's adapter to OfferStockRestorer and
-    // no-ops if the capability is absent.
-    if (order.status === 'cancelled' && priorStatus !== 'cancelled') {
+    // no-ops if the capability is absent. `cancelledFromEarlySignal` (#2069)
+    // covers the race where `order.status` still lags the signal.
+    if ((order.status === 'cancelled' || cancelledFromEarlySignal) && priorStatus !== 'cancelled') {
       try {
         await this.jobQueue.enqueue({
           type: 'marketplace.offer.stockRestore',
@@ -1250,6 +1267,15 @@ export class OrderIngestionService implements IOrderIngestionService {
       // retry the job rather than be silently swallowed — unlike the
       // known-order branch below, where a relay to already-resolved
       // destinations must proceed regardless.
+      //
+      // Sits above the ADR-017 destination-echo guard further down (which
+      // needs an existing record to compare `sourceConnectionId` against): a
+      // cancel arriving on a *destination* connection whose `Order` mapping
+      // is not yet written records a signal keyed to that destination
+      // connection's id — permanently unconsumable, since the echo guard
+      // would early-return before `persistIncomingSnapshot` ever runs for
+      // that connection. Narrow and self-limiting (the signal never affects
+      // provisioning, it just sits there), not worth a second lookup here.
       await this.orderRecordService.recordEarlyCancellationSignal(
         connectionId,
         externalOrderId,
@@ -1553,8 +1579,20 @@ export class OrderIngestionService implements IOrderIngestionService {
    * would burn the whole retry ladder against a condition retrying cannot change.
    * Surfacing a shortfall as a named fact ON the order is #2349's work; until
    * then the signal is this error-level log.
+   *
+   * `alreadyCancelled` (#2069) covers the race where an early-cancellation
+   * signal was already consumed onto this order's `cancelledAt` while
+   * `order.status` — built from the same source read that raced the signal —
+   * still reports the pre-cancel status. Holding stock for an order OL already
+   * knows is dead would be a hold nothing then releases (#2346's expiry sweep
+   * does not release while `UnavailableOrderHoldReader` is bound), so this must
+   * be checked independently of `order.status`.
    */
-  private async reserveOrderInventory(order: Order, connectionId: string): Promise<void> {
+  private async reserveOrderInventory(
+    order: Order,
+    connectionId: string,
+    alreadyCancelled = false
+  ): Promise<void> {
     try {
       // A kill switch, default ON (#2344 review). The ledger is additive and
       // nothing subtracts from it until #2345, but this is new unconditional
@@ -1566,7 +1604,7 @@ export class OrderIngestionService implements IOrderIngestionService {
       if (!getEnvBoolean('OL_RESERVATIONS_ENABLED', true)) return;
 
       // Holding stock for an order that arrived already dead is pure noise.
-      if (order.status === 'cancelled') return;
+      if (order.status === 'cancelled' || alreadyCancelled) return;
 
       const lines: ReserveOrderLineInput[] = order.items
         .filter((item) => Boolean(item.productId) && item.quantity > 0)

--- a/libs/core/src/orders/application/services/order-ingestion.service.ts
+++ b/libs/core/src/orders/application/services/order-ingestion.service.ts
@@ -421,7 +421,20 @@ export class OrderIngestionService implements IOrderIngestionService {
     // permanent ATP subtraction naming a cancelled order). `cancelledAt`, once
     // written, is never cleared on this path, so capturing it here is valid
     // for every gate below.
-    const cancelledFromEarlySignal = snapshotRecord.cancelledAt != null;
+    //
+    // `snapshotRecord.cancelledAt` alone is NOT enough: `persistIncomingSnapshot`
+    // only returns a freshly-`findById`'d record when IT wrote the cancellation
+    // on THIS call (`cancellationWrote`); on every other invocation it returns
+    // `upsert()`'s own return value, whose `fromRawRow(row, writeSet)` resets
+    // every column outside the write set — and `cancelledAt` is deliberately
+    // outside it (#2100) — so `cancelledAt` reads back as `null` there even
+    // though the row itself is cancelled. Without the `existing` fallback, the
+    // very NEXT poll after the one that consumed the signal (source still
+    // lagging, signal already deleted) would silently regress to the original
+    // defect: advisory holds reserved, no stock-restore enqueued, for an order
+    // OL already recorded as cancelled.
+    const cancelledFromEarlySignal =
+      snapshotRecord.cancelledAt != null || existing?.cancelledAt != null;
 
     // Early-fire cancellation hook (#1146): enqueue the stock-restore job
     // immediately after the raw snapshot is persisted and BEFORE item resolution

--- a/libs/core/src/orders/application/services/order-record-packed.service.spec.ts
+++ b/libs/core/src/orders/application/services/order-record-packed.service.spec.ts
@@ -15,6 +15,7 @@ import type { IOrderFxStampService } from '../interfaces/order-fx-stamp.service.
 import type { OrderLineItemRepositoryPort } from '../../domain/ports/order-line-item-repository.port';
 import type { IReportingCurrencySettingsService } from '@openlinker/core/currency';
 import type { IAutomationTriggerEmissionService } from '@openlinker/core/automation';
+import type { OrderCancellationSignalRepositoryPort } from '../../domain/ports/order-cancellation-signal-repository.port';
 
 const ORDER_ID = 'ol_order_packed_001';
 
@@ -80,13 +81,18 @@ describe('OrderRecordService — packed fact (#2287)', () => {
         evaluatedRuleCount: 0,
       }),
     } as unknown as IAutomationTriggerEmissionService;
+    // #2069 collaborator: this suite exercises only the packed-fact path,
+    // which never touches the early-cancellation signal, so an inert stub
+    // keeps the constructor honest without implying participation.
+    const cancellationSignalRepository = {} as unknown as OrderCancellationSignalRepositoryPort;
 
     service = new OrderRecordService(
       repository as unknown as OrderRecordRepositoryPort,
       fxStamp,
       lineItemRepository,
       reportingCurrencySettings,
-      automationEmission
+      automationEmission,
+      cancellationSignalRepository
     );
   });
 

--- a/libs/core/src/orders/application/services/order-record-packed.service.spec.ts
+++ b/libs/core/src/orders/application/services/order-record-packed.service.spec.ts
@@ -84,7 +84,10 @@ describe('OrderRecordService — packed fact (#2287)', () => {
     // #2069 collaborator: this suite exercises only the packed-fact path,
     // which never touches the early-cancellation signal, so an inert stub
     // keeps the constructor honest without implying participation.
-    const cancellationSignalRepository = {} as unknown as OrderCancellationSignalRepositoryPort;
+    const cancellationSignalRepository: jest.Mocked<OrderCancellationSignalRepositoryPort> = {
+      record: jest.fn(),
+      consume: jest.fn().mockResolvedValue(null),
+    };
 
     service = new OrderRecordService(
       repository as unknown as OrderRecordRepositoryPort,

--- a/libs/core/src/orders/application/services/order-record.service.ts
+++ b/libs/core/src/orders/application/services/order-record.service.ts
@@ -16,6 +16,7 @@ import {
 } from '../../domain/types/buyer-tax-id.types';
 import { OrderRecordRepositoryPort } from '../../domain/ports/order-record-repository.port';
 import { OrderLineItemRepositoryPort } from '../../domain/ports/order-line-item-repository.port';
+import { OrderCancellationSignalRepositoryPort } from '../../domain/ports/order-cancellation-signal-repository.port';
 import { OrderRecord } from '../../domain/entities/order-record.entity';
 import type { OrderSyncStatus, SyncAttempt } from '../../domain/types/order-sync.types';
 import type { IOrderRecordService } from '../interfaces/order-record.service.interface';
@@ -59,6 +60,7 @@ import {
   ORDER_FX_STAMP_SERVICE_TOKEN,
   ORDER_LINE_ITEM_REPOSITORY_TOKEN,
   ORDER_RECORD_REPOSITORY_TOKEN,
+  ORDER_CANCELLATION_SIGNAL_REPOSITORY_TOKEN,
 } from '../../orders.tokens';
 import { deriveOrderAnalyticsScalars, deriveOrderLineItems } from '../../domain/order-analytics-projection';
 import { buildOrderAutomationFacts } from '../../domain/order-automation-facts-projection';
@@ -94,7 +96,9 @@ export class OrderRecordService implements IOrderRecordService {
     @Inject(REPORTING_CURRENCY_SETTINGS_SERVICE_TOKEN)
     private readonly reportingCurrencySettings: IReportingCurrencySettingsService,
     @Inject(AUTOMATION_TRIGGER_EMISSION_SERVICE_TOKEN)
-    private readonly automationEmission: IAutomationTriggerEmissionService
+    private readonly automationEmission: IAutomationTriggerEmissionService,
+    @Inject(ORDER_CANCELLATION_SIGNAL_REPOSITORY_TOKEN)
+    private readonly cancellationSignalRepository: OrderCancellationSignalRepositoryPort
   ) {}
 
   /**
@@ -441,10 +445,25 @@ export class OrderRecordService implements IOrderRecordService {
     // stamping here would be work repeated moments later for the overwhelming
     // majority of orders. An order that never leaves `awaiting_mapping` still
     // carries `totals` in this snapshot and is picked up by the reconcile sweep.
+    //
+    // Consume the early-cancellation signal (#2069) HERE, after the row above
+    // is durably persisted, never before: a failure here leaves the signal
+    // row untouched (a DELETE that throws commits nothing), so a retry — or
+    // simply the next ordinary poll/webhook for this order, since this call
+    // runs unconditionally on every invocation, not only the first — picks it
+    // up again. Consuming before the upsert would risk losing the signal
+    // forever if the upsert itself then failed. `persistOrder` never needs
+    // the same check: its own `upsertWithLineItems()` excludes `cancelledAt`
+    // from its column list, so whatever this write sets here survives it
+    // untouched.
+    const earlySignalAt = await this.cancellationSignalRepository.consume(
+      sourceConnectionId,
+      incoming.externalOrderId
+    );
     const cancellationWrote = await this.recordCancellationIfNeeded(
       internalOrderId,
-      incoming.status === 'cancelled',
-      now
+      incoming.status === 'cancelled' || earlySignalAt !== null,
+      earlySignalAt ?? now
     );
 
     return cancellationWrote ? (await this.repository.findById(internalOrderId)) ?? saved : saved;
@@ -680,6 +699,18 @@ export class OrderRecordService implements IOrderRecordService {
    */
   async markCancelled(internalOrderId: string, cancelledAt: Date): Promise<void> {
     await this.repository.markCancelled(internalOrderId, cancelledAt);
+  }
+
+  async recordEarlyCancellationSignal(
+    sourceConnectionId: string,
+    externalOrderId: string,
+    cancelledAt: Date
+  ): Promise<void> {
+    await this.cancellationSignalRepository.record(
+      sourceConnectionId,
+      externalOrderId,
+      cancelledAt
+    );
   }
 
   async getSalesAndChannelAnalytics(

--- a/libs/core/src/orders/domain/ports/order-cancellation-signal-repository.port.ts
+++ b/libs/core/src/orders/domain/ports/order-cancellation-signal-repository.port.ts
@@ -43,6 +43,17 @@ export interface OrderCancellationSignalRepositoryPort {
    * interleave: a signal that misses this call's `consume()` is picked up by
    * the very next poll/webhook for the same order, rather than lost forever.
    *
+   * That unconditionality has a real, accepted cost: an extra `DELETE`
+   * statement on every order ingestion — `persistIncomingSnapshot` runs on
+   * what `OrderIngestionService.reserveOrderInventory`'s own kill-switch
+   * comment calls "the hottest path in the system". Short-circuiting on a
+   * cheap read first (e.g. an existence check) was rejected — it would
+   * forfeit the atomicity of the read-and-clear and reopen the very race this
+   * method exists to close. A zero-row `DELETE` against a two-column unique
+   * index is cheap; there is no escape hatch here (unlike the reservation
+   * kill switch) because the write is unconditional by design, not optional
+   * work.
+   *
    * @returns the recorded cancellation instant, or `null` when no signal
    *   exists for this pair.
    */

--- a/libs/core/src/orders/domain/ports/order-cancellation-signal-repository.port.ts
+++ b/libs/core/src/orders/domain/ports/order-cancellation-signal-repository.port.ts
@@ -1,0 +1,50 @@
+/**
+ * Order Cancellation Signal Repository Port (#2069)
+ *
+ * Defines the contract for durably recording a source cancellation that
+ * arrived for an order OpenLinker has not yet ingested. `OrderRecordRepository
+ * .markCancelled` is a bare `UPDATE ... WHERE "internalOrderId" = $2` with no
+ * insert fallback, so it has nothing to write against when no internal order
+ * id exists yet — and minting one via `getOrCreateInternalId` from the
+ * cancellation path would point every downstream trigger at a phantom order
+ * before any real order data arrives (the #2328 lesson for returns
+ * attribution). The signal is keyed instead on the one durable identity that
+ * exists before ingestion: `(sourceConnectionId, externalOrderId)`.
+ *
+ * No FK to `order_records` — the `order_holds` / `order_changes` /
+ * `refund_records` precedent of an indexed reference by value, since there is
+ * nothing yet to reference.
+ *
+ * @module libs/core/src/orders/domain/ports
+ * @see {@link OrderCancellationSignalRepository} for the TypeORM implementation
+ */
+export interface OrderCancellationSignalRepositoryPort {
+  /**
+   * Durably record that a cancellation arrived for an order OL has not yet
+   * ingested. Called by `OrderIngestionService.handleSourceCancellation` when
+   * `IIdentifierMappingService.getInternalId` resolves nothing.
+   *
+   * First-write-wins: `ON CONFLICT DO NOTHING` against the unique
+   * `(sourceConnectionId, externalOrderId)` index, so a redelivered cancel
+   * event (at-least-once delivery is a platform-wide invariant) is a harmless
+   * no-op rather than a second row or an error.
+   */
+  record(sourceConnectionId: string, externalOrderId: string, cancelledAt: Date): Promise<void>;
+
+  /**
+   * Atomically read-and-clear the signal for `(sourceConnectionId,
+   * externalOrderId)`, if one exists — one `DELETE ... RETURNING` statement,
+   * so two concurrent ingestion attempts for the same external order can
+   * never both apply it and the signal is applied at most once.
+   *
+   * Called unconditionally by `OrderRecordService.persistIncomingSnapshot` on
+   * EVERY call, not only the first — which is what makes the design
+   * self-healing against the narrow race where `record()` and `consume()`
+   * interleave: a signal that misses this call's `consume()` is picked up by
+   * the very next poll/webhook for the same order, rather than lost forever.
+   *
+   * @returns the recorded cancellation instant, or `null` when no signal
+   *   exists for this pair.
+   */
+  consume(sourceConnectionId: string, externalOrderId: string): Promise<Date | null>;
+}

--- a/libs/core/src/orders/infrastructure/persistence/entities/order-cancellation-signal.orm-entity.ts
+++ b/libs/core/src/orders/infrastructure/persistence/entities/order-cancellation-signal.orm-entity.ts
@@ -1,0 +1,46 @@
+/**
+ * Order Cancellation Signal ORM Entity (#2069)
+ *
+ * TypeORM entity for `order_cancellation_signals` — a durable trace that a
+ * source cancellation arrived for an order OpenLinker has not yet ingested.
+ * See {@link OrderCancellationSignalRepositoryPort} for why this table exists
+ * and why it is keyed on `(sourceConnectionId, externalOrderId)` rather than
+ * an internal order id.
+ *
+ * No FK to `order_records` — the `order_holds` / `order_changes` /
+ * `refund_records` precedent of an indexed reference by value, avoiding
+ * cross-table lock coupling and, here, referencing a row that may not exist
+ * yet at all. `apps/api/test/integration/setup.ts` lists this table in
+ * `tablesToTruncate` explicitly: nothing cascades into it.
+ *
+ * The unique index is declared at class level with the SAME NAME the
+ * migration uses (`UQ_order_cancellation_signals_source_external`) — the
+ * integration harness builds its schema by `synchronize`, not by migration,
+ * so an unnamed decorator would produce a hash name there and the two schemas
+ * would diverge on exactly the constraint the port's first-write-wins
+ * guarantee relies on (the `order_holds` / `ReturnLineOrmEntity` precedent).
+ *
+ * @module libs/core/src/orders/infrastructure/persistence/entities
+ */
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity('order_cancellation_signals')
+@Index('UQ_order_cancellation_signals_source_external', ['sourceConnectionId', 'externalOrderId'], {
+  unique: true,
+})
+export class OrderCancellationSignalOrmEntity {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @Column({ type: 'uuid' })
+  sourceConnectionId!: string;
+
+  @Column({ type: 'varchar' })
+  externalOrderId!: string;
+
+  @Column({ type: 'timestamptz' })
+  cancelledAt!: Date;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+}

--- a/libs/core/src/orders/infrastructure/persistence/entities/order-cancellation-signal.orm-entity.ts
+++ b/libs/core/src/orders/infrastructure/persistence/entities/order-cancellation-signal.orm-entity.ts
@@ -35,7 +35,7 @@ export class OrderCancellationSignalOrmEntity {
   @Column({ type: 'uuid' })
   sourceConnectionId!: string;
 
-  @Column({ type: 'varchar' })
+  @Column({ type: 'text' })
   externalOrderId!: string;
 
   @Column({ type: 'timestamptz' })

--- a/libs/core/src/orders/infrastructure/persistence/entities/order-cancellation-signal.orm-entity.ts
+++ b/libs/core/src/orders/infrastructure/persistence/entities/order-cancellation-signal.orm-entity.ts
@@ -41,6 +41,6 @@ export class OrderCancellationSignalOrmEntity {
   @Column({ type: 'timestamptz' })
   cancelledAt!: Date;
 
-  @CreateDateColumn()
+  @CreateDateColumn({ type: 'timestamptz' })
   createdAt!: Date;
 }

--- a/libs/core/src/orders/infrastructure/persistence/entities/order-record.orm-entity.ts
+++ b/libs/core/src/orders/infrastructure/persistence/entities/order-record.orm-entity.ts
@@ -114,7 +114,16 @@ export class OrderRecordOrmEntity {
    * Instant the source reported this order cancelled (#1984). `null` = never
    * cancelled (or a historical row the backfill migration could not derive a
    * proxy timestamp for). Independent of `recordStatus`. Indexed for the
-   * future exclusion predicate (#1987/#1988: `WHERE "cancelledAt" IS NULL`).
+   * exclusion predicate `WHERE "cancelledAt" IS NULL`, which
+   * `OrderSyncService.syncOrder` applies before destination provisioning
+   * (#2284) — no longer future. #2069 closed the remaining gap: a
+   * cancellation that arrives before the order is ever ingested has no row
+   * here yet to write against, so it is recorded as a durable signal keyed
+   * on `(sourceConnectionId, externalOrderId)` instead
+   * (`OrderCancellationSignalRepositoryPort`), consumed by
+   * `OrderRecordService.persistIncomingSnapshot` the moment this row is
+   * first created — so a not-yet-ingested order's later create still sees
+   * this column set before `OrderSyncService` ever reads it.
    */
   @Column({ type: 'timestamptz', nullable: true })
   @Index()

--- a/libs/core/src/orders/infrastructure/persistence/repositories/__tests__/order-cancellation-signal.repository.spec.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/__tests__/order-cancellation-signal.repository.spec.ts
@@ -1,0 +1,83 @@
+/**
+ * Order Cancellation Signal Repository Unit Tests (#2069)
+ *
+ * Asserts the exact SQL text and parameter order both methods issue against
+ * a mocked `Repository.query` — mirrors
+ * `OrderRecordRepository.markCancelled`'s own test style. The database-level
+ * guarantee (the unique index, first-write-wins) is asserted against real
+ * Postgres in
+ * `apps/api/test/integration/orders/order-early-cancellation-signal.int-spec.ts`.
+ *
+ * @module libs/core/src/orders/infrastructure/persistence/repositories/__tests__
+ */
+import type { Repository } from 'typeorm';
+import { OrderCancellationSignalRepository } from '../order-cancellation-signal.repository';
+import type { OrderCancellationSignalOrmEntity } from '../../entities/order-cancellation-signal.orm-entity';
+
+describe('OrderCancellationSignalRepository', () => {
+  let repository: OrderCancellationSignalRepository;
+  let ormRepository: jest.Mocked<Pick<Repository<OrderCancellationSignalOrmEntity>, 'query'>>;
+
+  beforeEach(() => {
+    ormRepository = {
+      query: jest.fn(),
+    };
+
+    repository = new OrderCancellationSignalRepository(
+      ormRepository as unknown as Repository<OrderCancellationSignalOrmEntity>
+    );
+  });
+
+  describe('record', () => {
+    it('should issue an ON CONFLICT DO NOTHING insert with the given values', async () => {
+      (ormRepository.query as jest.Mock).mockResolvedValue([]);
+      const cancelledAt = new Date('2026-08-11T09:00:00Z');
+
+      await repository.record('conn-1', 'ext-order-1', cancelledAt);
+
+      expect(ormRepository.query).toHaveBeenCalledWith(
+        expect.stringContaining('ON CONFLICT ("sourceConnectionId", "externalOrderId") DO NOTHING'),
+        ['conn-1', 'ext-order-1', cancelledAt]
+      );
+      expect(ormRepository.query).toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO "order_cancellation_signals"'),
+        expect.anything()
+      );
+    });
+
+    it('should not throw when a redelivered cancel event collides with an existing signal', async () => {
+      (ormRepository.query as jest.Mock).mockResolvedValue([]);
+
+      await expect(
+        repository.record('conn-1', 'ext-order-1', new Date())
+      ).resolves.toBeUndefined();
+    });
+  });
+
+  describe('consume', () => {
+    it('should issue a DELETE ... RETURNING and return the recorded instant when a signal exists', async () => {
+      const cancelledAt = new Date('2026-08-11T09:00:00Z');
+      (ormRepository.query as jest.Mock).mockResolvedValue([{ cancelledAt }]);
+
+      const result = await repository.consume('conn-1', 'ext-order-1');
+
+      expect(result).toEqual(cancelledAt);
+      expect(ormRepository.query).toHaveBeenCalledWith(
+        expect.stringContaining('DELETE FROM "order_cancellation_signals"'),
+        ['conn-1', 'ext-order-1']
+      );
+      expect(ormRepository.query).toHaveBeenCalledWith(
+        expect.stringContaining('RETURNING "cancelledAt"'),
+        expect.anything()
+      );
+    });
+
+    it('should return null when no signal exists for the pair', async () => {
+      (ormRepository.query as jest.Mock).mockResolvedValue([]);
+
+      const result = await repository.consume('conn-1', 'ext-order-1');
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/libs/core/src/orders/infrastructure/persistence/repositories/__tests__/order-cancellation-signal.repository.spec.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/__tests__/order-cancellation-signal.repository.spec.ts
@@ -1,11 +1,19 @@
 /**
  * Order Cancellation Signal Repository Unit Tests (#2069)
  *
- * Asserts the exact SQL text and parameter order both methods issue against
- * a mocked `Repository.query` — mirrors
- * `OrderRecordRepository.markCancelled`'s own test style. The database-level
- * guarantee (the unique index, first-write-wins) is asserted against real
- * Postgres in
+ * `record()` asserts the exact `INSERT ... ON CONFLICT DO NOTHING` statement
+ * against a mocked `Repository.query` — mirrors
+ * `OrderRecordRepository.markCancelled`'s own test style.
+ *
+ * `consume()` asserts against a mocked QueryBuilder chain instead, matching
+ * `OrderHoldRepository.releaseHeld`'s test style — deliberately NOT
+ * `Repository.query`, because a raw `DELETE ... RETURNING` through that path
+ * returns `[rows, rowCount]`, not `rows` directly, and a mock built the naive
+ * way would have hidden exactly the bug (#2069, found only by a real Postgres
+ * round-trip) that `consume()` no longer has.
+ *
+ * The database-level guarantee (the unique index, first-write-wins) is
+ * asserted against real Postgres in
  * `apps/api/test/integration/orders/order-early-cancellation-signal.int-spec.ts`.
  *
  * @module libs/core/src/orders/infrastructure/persistence/repositories/__tests__
@@ -14,13 +22,36 @@ import type { Repository } from 'typeorm';
 import { OrderCancellationSignalRepository } from '../order-cancellation-signal.repository';
 import type { OrderCancellationSignalOrmEntity } from '../../entities/order-cancellation-signal.orm-entity';
 
+/** A chainable QueryBuilder stub whose `execute` resolves the given raw rows. */
+interface StubDeleteBuilder {
+  delete: jest.Mock;
+  from: jest.Mock;
+  where: jest.Mock;
+  returning: jest.Mock;
+  execute: jest.Mock;
+}
+
+const stubDeleteBuilder = (raw: Array<{ cancelledAt: Date }>): StubDeleteBuilder => {
+  const builder: StubDeleteBuilder = {
+    delete: jest.fn(() => builder),
+    from: jest.fn(() => builder),
+    where: jest.fn(() => builder),
+    returning: jest.fn(() => builder),
+    execute: jest.fn().mockResolvedValue({ raw, affected: raw.length }),
+  };
+  return builder;
+};
+
 describe('OrderCancellationSignalRepository', () => {
   let repository: OrderCancellationSignalRepository;
-  let ormRepository: jest.Mocked<Pick<Repository<OrderCancellationSignalOrmEntity>, 'query'>>;
+  let ormRepository: jest.Mocked<
+    Pick<Repository<OrderCancellationSignalOrmEntity>, 'query' | 'createQueryBuilder'>
+  >;
 
   beforeEach(() => {
     ormRepository = {
       query: jest.fn(),
+      createQueryBuilder: jest.fn(),
     };
 
     repository = new OrderCancellationSignalRepository(
@@ -55,29 +86,43 @@ describe('OrderCancellationSignalRepository', () => {
   });
 
   describe('consume', () => {
-    it('should issue a DELETE ... RETURNING and return the recorded instant when a signal exists', async () => {
+    it('should return the recorded instant when a signal exists, reading it off result.raw (not query()\'s [rows, rowCount] tuple)', async () => {
       const cancelledAt = new Date('2026-08-11T09:00:00Z');
-      (ormRepository.query as jest.Mock).mockResolvedValue([{ cancelledAt }]);
+      const builder = stubDeleteBuilder([{ cancelledAt }]);
+      ormRepository.createQueryBuilder.mockReturnValue(builder as never);
 
       const result = await repository.consume('conn-1', 'ext-order-1');
 
       expect(result).toEqual(cancelledAt);
-      expect(ormRepository.query).toHaveBeenCalledWith(
-        expect.stringContaining('DELETE FROM "order_cancellation_signals"'),
-        ['conn-1', 'ext-order-1']
+      expect(builder.delete).toHaveBeenCalled();
+      expect(builder.from).toHaveBeenCalledWith(expect.anything());
+      expect(builder.where).toHaveBeenCalledWith(
+        expect.stringContaining('"sourceConnectionId" = :sourceConnectionId'),
+        { sourceConnectionId: 'conn-1', externalOrderId: 'ext-order-1' }
       );
-      expect(ormRepository.query).toHaveBeenCalledWith(
-        expect.stringContaining('RETURNING "cancelledAt"'),
-        expect.anything()
-      );
+      expect(builder.returning).toHaveBeenCalledWith('"cancelledAt"');
     });
 
     it('should return null when no signal exists for the pair', async () => {
-      (ormRepository.query as jest.Mock).mockResolvedValue([]);
+      const builder = stubDeleteBuilder([]);
+      ormRepository.createQueryBuilder.mockReturnValue(builder as never);
 
       const result = await repository.consume('conn-1', 'ext-order-1');
 
       expect(result).toBeNull();
+    });
+
+    // Regression guard for #2069's actual bug: a naive mock of
+    // `Repository.query` resolving `[{cancelledAt}]` directly would pass even
+    // though `consume()` no longer calls `query()` at all — this asserts the
+    // QueryBuilder path is what's actually exercised.
+    it('should never call the raw Repository.query for the delete', async () => {
+      const builder = stubDeleteBuilder([{ cancelledAt: new Date() }]);
+      ormRepository.createQueryBuilder.mockReturnValue(builder as never);
+
+      await repository.consume('conn-1', 'ext-order-1');
+
+      expect(ormRepository.query).not.toHaveBeenCalled();
     });
   });
 });

--- a/libs/core/src/orders/infrastructure/persistence/repositories/order-cancellation-signal.repository.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/order-cancellation-signal.repository.ts
@@ -1,0 +1,48 @@
+/**
+ * Order Cancellation Signal Repository (#2069)
+ *
+ * TypeORM implementation of `OrderCancellationSignalRepositoryPort`. Both
+ * methods are single raw statements — the same idiom
+ * `OrderRecordRepository.markCancelled` already uses — because TypeORM's
+ * `Repository` entity API cannot express `ON CONFLICT DO NOTHING` with no
+ * conflict action, or a `DELETE ... RETURNING`, without dropping to raw SQL.
+ *
+ * @module libs/core/src/orders/infrastructure/persistence/repositories
+ * @implements {OrderCancellationSignalRepositoryPort}
+ */
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import type { OrderCancellationSignalRepositoryPort } from '../../../domain/ports/order-cancellation-signal-repository.port';
+import { OrderCancellationSignalOrmEntity } from '../entities/order-cancellation-signal.orm-entity';
+
+@Injectable()
+export class OrderCancellationSignalRepository implements OrderCancellationSignalRepositoryPort {
+  constructor(
+    @InjectRepository(OrderCancellationSignalOrmEntity)
+    private readonly repository: Repository<OrderCancellationSignalOrmEntity>
+  ) {}
+
+  async record(
+    sourceConnectionId: string,
+    externalOrderId: string,
+    cancelledAt: Date
+  ): Promise<void> {
+    await this.repository.query(
+      `INSERT INTO "order_cancellation_signals" ("sourceConnectionId", "externalOrderId", "cancelledAt")
+       VALUES ($1, $2, $3)
+       ON CONFLICT ("sourceConnectionId", "externalOrderId") DO NOTHING`,
+      [sourceConnectionId, externalOrderId, cancelledAt]
+    );
+  }
+
+  async consume(sourceConnectionId: string, externalOrderId: string): Promise<Date | null> {
+    const rows = (await this.repository.query(
+      `DELETE FROM "order_cancellation_signals"
+       WHERE "sourceConnectionId" = $1 AND "externalOrderId" = $2
+       RETURNING "cancelledAt"`,
+      [sourceConnectionId, externalOrderId]
+    )) as Array<{ cancelledAt: Date }>;
+    return rows[0]?.cancelledAt ?? null;
+  }
+}

--- a/libs/core/src/orders/infrastructure/persistence/repositories/order-cancellation-signal.repository.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/order-cancellation-signal.repository.ts
@@ -1,11 +1,25 @@
 /**
  * Order Cancellation Signal Repository (#2069)
  *
- * TypeORM implementation of `OrderCancellationSignalRepositoryPort`. Both
- * methods are single raw statements — the same idiom
+ * TypeORM implementation of `OrderCancellationSignalRepositoryPort`.
+ *
+ * `record()` is a single raw statement — the same idiom
  * `OrderRecordRepository.markCancelled` already uses — because TypeORM's
  * `Repository` entity API cannot express `ON CONFLICT DO NOTHING` with no
- * conflict action, or a `DELETE ... RETURNING`, without dropping to raw SQL.
+ * conflict action without dropping to raw SQL.
+ *
+ * `consume()` deliberately goes through the QueryBuilder rather than
+ * `Repository.query()`, even though both can express `DELETE ... RETURNING`.
+ * TypeORM's raw driver-level `query()` special-cases `DELETE`/`UPDATE`: it
+ * wraps the result as `[rows, rowCount]` instead of returning `rows` directly
+ * (see `PostgresQueryRunner.query`'s `switch (raw.command)` branch) — a
+ * caller expecting a plain rows array silently reads `rows[0]` as the WHOLE
+ * `[rows, rowCount]` tuple and gets `undefined` for every field, with no
+ * error anywhere. `DeleteQueryBuilder.execute()` normalizes this itself
+ * (`DeleteResult.raw = queryResult.records`), matching every other
+ * write-with-`RETURNING` in this codebase (`OrderHoldRepository.releaseHeld`,
+ * `InvoiceRecordRepository`, `PromptTemplateRepository`, …) — none of which
+ * uses raw `.query()` for exactly this reason.
  *
  * @module libs/core/src/orders/infrastructure/persistence/repositories
  * @implements {OrderCancellationSignalRepositoryPort}
@@ -37,12 +51,18 @@ export class OrderCancellationSignalRepository implements OrderCancellationSigna
   }
 
   async consume(sourceConnectionId: string, externalOrderId: string): Promise<Date | null> {
-    const rows = (await this.repository.query(
-      `DELETE FROM "order_cancellation_signals"
-       WHERE "sourceConnectionId" = $1 AND "externalOrderId" = $2
-       RETURNING "cancelledAt"`,
-      [sourceConnectionId, externalOrderId]
-    )) as Array<{ cancelledAt: Date }>;
+    const result = await this.repository
+      .createQueryBuilder()
+      .delete()
+      .from(OrderCancellationSignalOrmEntity)
+      .where('"sourceConnectionId" = :sourceConnectionId AND "externalOrderId" = :externalOrderId', {
+        sourceConnectionId,
+        externalOrderId,
+      })
+      .returning('"cancelledAt"')
+      .execute();
+
+    const rows = result.raw as Array<{ cancelledAt: Date }>;
     return rows[0]?.cancelledAt ?? null;
   }
 }

--- a/libs/core/src/orders/orders.module.ts
+++ b/libs/core/src/orders/orders.module.ts
@@ -27,6 +27,8 @@ import { OrderRefundService } from './application/services/order-refund.service'
 import { RefundRecordRepository } from './infrastructure/persistence/repositories/refund-record.repository';
 import { RefundRecordOrmEntity } from './infrastructure/persistence/entities/refund-record.orm-entity';
 import { OrderLineItemOrmEntity } from './infrastructure/persistence/entities/order-line-item.orm-entity';
+import { OrderCancellationSignalRepository } from './infrastructure/persistence/repositories/order-cancellation-signal.repository';
+import { OrderCancellationSignalOrmEntity } from './infrastructure/persistence/entities/order-cancellation-signal.orm-entity';
 import { TaxRateBackfillService } from './application/services/tax-rate-backfill.service';
 import { TaxCoverageDetectionService } from './application/services/tax-coverage-detection.service';
 import { DisplayCurrencyConversionService } from './application/services/display-currency-conversion.service';
@@ -50,6 +52,7 @@ import {
   SALES_DOCUMENT_VIEW_SERVICE_TOKEN,
   TAX_COVERAGE_DETECTION_SERVICE_TOKEN,
   DISPLAY_CURRENCY_CONVERSION_SERVICE_TOKEN,
+  ORDER_CANCELLATION_SIGNAL_REPOSITORY_TOKEN,
 } from './orders.tokens';
 import { OrderHoldsModule } from './order-holds.module';
 import { IntegrationsModule } from '@openlinker/core/integrations';
@@ -81,7 +84,12 @@ export { ORDER_SYNC_SERVICE_TOKEN } from './orders.tokens';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([OrderRecordOrmEntity, RefundRecordOrmEntity, OrderLineItemOrmEntity]),
+    TypeOrmModule.forFeature([
+      OrderRecordOrmEntity,
+      RefundRecordOrmEntity,
+      OrderLineItemOrmEntity,
+      OrderCancellationSignalOrmEntity,
+    ]),
     IntegrationsModule, // Required for INTEGRATIONS_SERVICE_TOKEN and ADAPTER_FACTORY_RESOLVER_TOKEN
     IdentifierMappingModule, // Required for IDENTIFIER_MAPPING_SERVICE_TOKEN
     SyncModule, // Required for cursor repository, job queue, and locks
@@ -143,6 +151,7 @@ export { ORDER_SYNC_SERVICE_TOKEN } from './orders.tokens';
     TaxRateBackfillService,
     TaxCoverageDetectionService,
     DisplayCurrencyConversionService,
+    OrderCancellationSignalRepository,
     // Then provide token bindings using useExisting
     {
       provide: ORDER_SYNC_SERVICE_TOKEN,
@@ -195,6 +204,10 @@ export { ORDER_SYNC_SERVICE_TOKEN } from './orders.tokens';
     {
       provide: ORDER_REFUND_RECORD_REPOSITORY_TOKEN,
       useExisting: RefundRecordRepository,
+    },
+    {
+      provide: ORDER_CANCELLATION_SIGNAL_REPOSITORY_TOKEN,
+      useExisting: OrderCancellationSignalRepository,
     },
     {
       provide: ORDER_REFUND_SERVICE_TOKEN,

--- a/libs/core/src/orders/orders.tokens.ts
+++ b/libs/core/src/orders/orders.tokens.ts
@@ -31,6 +31,12 @@ export const ORDER_REFUND_SERVICE_TOKEN = Symbol('IOrderRefundService');
 export const ORDER_LINE_ITEM_REPOSITORY_TOKEN = Symbol('OrderLineItemRepositoryPort');
 // Tax-rate backfill sweep for pre-#2245 lines (#2440).
 export const TAX_RATE_BACKFILL_SERVICE_TOKEN = Symbol('ITaxRateBackfillService');
+// Durable early-cancellation signal for an order OL has not yet ingested
+// (#2069). Keyed on (sourceConnectionId, externalOrderId) — see
+// OrderCancellationSignalRepositoryPort for why no internal id exists yet.
+export const ORDER_CANCELLATION_SIGNAL_REPOSITORY_TOKEN = Symbol(
+  'OrderCancellationSignalRepositoryPort'
+);
 
 
 

--- a/libs/core/src/orders/orm-entities.ts
+++ b/libs/core/src/orders/orm-entities.ts
@@ -16,3 +16,6 @@ export { OrderChangeOrmEntity } from './infrastructure/persistence/entities/orde
 // Consumer: apps/api/test/integration/orders/top-products-ranking.int-spec.ts (#1988) —
 // direct fixture seeding of order_line_items alongside order_records.
 export { OrderLineItemOrmEntity } from './infrastructure/persistence/entities/order-line-item.orm-entity';
+// Consumer: apps/api/test/integration/orders/order-early-cancellation-signal.int-spec.ts (#2069) —
+// asserts the signal row is written and consumed against the real table.
+export { OrderCancellationSignalOrmEntity } from './infrastructure/persistence/entities/order-cancellation-signal.orm-entity';

--- a/libs/core/src/shipping/application/services/fulfillment-status-sync.service.spec.ts
+++ b/libs/core/src/shipping/application/services/fulfillment-status-sync.service.spec.ts
@@ -114,6 +114,7 @@ describe('FulfillmentStatusSyncService', () => {
       markItemResolutionFailure: jest.fn(),
       getFailedSyncValueSummary: jest.fn(),
       markCancelled: jest.fn(),
+      recordEarlyCancellationSignal: jest.fn(),
       markSalesDocumentBlock: jest.fn(),
       markFulfillmentBlock: jest.fn(),
       markPacked: jest.fn(),

--- a/libs/core/src/shipping/application/services/shipment-dispatch-notification.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-dispatch-notification.service.spec.ts
@@ -111,6 +111,7 @@ describe('ShipmentDispatchNotificationService', () => {
       markItemResolutionFailure: jest.fn(),
       getFailedSyncValueSummary: jest.fn(),
       markCancelled: jest.fn(),
+      recordEarlyCancellationSignal: jest.fn(),
       markSalesDocumentBlock: jest.fn(),
       markFulfillmentBlock: jest.fn(),
       markPacked: jest.fn(),

--- a/libs/core/src/shipping/application/services/shipment-dispatch.service.spec.ts
+++ b/libs/core/src/shipping/application/services/shipment-dispatch.service.spec.ts
@@ -182,6 +182,7 @@ describe('ShipmentDispatchService', () => {
       markItemResolutionFailure: jest.fn(),
       getFailedSyncValueSummary: jest.fn(),
       markCancelled: jest.fn(),
+      recordEarlyCancellationSignal: jest.fn(),
       markSalesDocumentBlock: jest.fn(),
       markFulfillmentBlock: jest.fn(),
       markPacked: jest.fn(),


### PR DESCRIPTION
## Summary
- A source cancellation arriving before OL had ever ingested the order was silently dropped: `handleSourceCancellation` found no internal mapping and returned, so the later create/sync job provisioned the order as active at every destination.
- Adds a durable `order_cancellation_signals` table keyed on `(sourceConnectionId, externalOrderId)` — the one identity that exists before ingestion — rather than minting a phantom internal id (the #2328 lesson for returns attribution).
- `handleSourceCancellation` records the signal when the order is unknown; `OrderRecordService.persistIncomingSnapshot` consumes it atomically (`DELETE ... RETURNING`) the moment the order is genuinely ingested, feeding it through the existing first-write-wins `markCancelled` pipeline (#1984) — so `OrderSyncService`'s already-shipped `cancelledAt IS NULL` provisioning guard (#2284) sees it and skips destination creation.
- Updates the stale `#1160` residual comment and the `#1987/#1988` "future predicate" comment on the ORM entity to reflect the shipped state.

## Acceptance criteria (from #2069)
- [x] A cancel for a not-yet-ingested order persists something the later create can observe
- [x] Integration test: cancel first, then sync — assert no destination order is created
- [x] Integration test: normal ordering unchanged
- [x] `#1987/#1988` future-predicate comment updated
- [x] `#1160` residual comment amended (explaining why the relay-log machinery was never needed)

## Test plan
- [x] `pnpm type-check` — full workspace, green
- [x] `pnpm lint` — full workspace, green (0 errors; pre-existing warnings only)
- [x] New unit tests: `order-cancellation-signal.repository.spec.ts`, extended `order-ingestion.service.spec.ts` / `order-record.service.spec.ts`
- [x] New integration test: `order-early-cancellation-signal.int-spec.ts` (cancel-before-create + normal-ordering regression)
- [ ] `pnpm test` / `pnpm test:integration` — not run in this session (Docker-gated); please run in CI before merge

Closes #2069

🤖 Generated with [Claude Code](https://claude.com/claude-code)