### PR TITLE
perf(2979): F11 concurrent multi-channel harness (Allegro + PrestaShop-source)

### DIFF
--- a/perf/openlinker-throughput/drivers/ps-order-source.sh
+++ b/perf/openlinker-throughput/drivers/ps-order-source.sh
@@ -91,10 +91,20 @@ PSO_CURSOR_KEY="${PSO_CURSOR_KEY:-prestashop.orders.dateUpd}"
 # request body on a write, only `Output-Format: JSON` on the RESPONSE of a
 # GET (verified against this repo's own webservice client,
 # prestashop-webservice.client.ts:380/573-576, which sends
-# `Content-Type: application/xml` on every write and only asks for
-# `Output-Format: JSON` on GET). Dies on a non-2xx with the body printed -
-# PrestaShop's validation errors are the whole point of using the webservice
-# over raw SQL, so swallowing them here would throw away the one advantage.
+# `Content-Type: application/xml` on every write and forces
+# `Output-Format: XML` on the RESPONSE of a write - the reference client
+# deliberately never asks the live shop for a JSON response on POST/PUT, so
+# this driver cannot assume one either).
+#
+# Belt-and-braces on the response format: we ASK for JSON on every call
+# (`output_format=JSON` query param + `Output-Format: JSON` header - both
+# are documented PrestaShop webservice overrides, sent together in case one
+# shop configuration honours only one of the two), but callers must not
+# assume the ask was honoured - see pso_extract_id below, which falls back
+# to parsing the PrestaShop XML envelope when jq finds no JSON. Dies on a
+# non-2xx with the body printed - PrestaShop's validation errors are the
+# whole point of using the webservice over raw SQL, so swallowing them here
+# would throw away the one advantage.
 # ---------------------------------------------------------------------------
 pso_ws_curl() {
   local method="$1" path="$2" body="${3:-}" sep resp status resp_body
@@ -103,10 +113,11 @@ pso_ws_curl() {
   if [ -n "$body" ]; then
     resp="$(curl -sS -w '\n%{http_code}' -X "$method" \
       "$PSO_BASE_URL$path${sep}ws_key=$PSO_WS_KEY&output_format=JSON" \
-      -H 'Content-Type: application/xml' -d "$body")"
+      -H 'Content-Type: application/xml' -H 'Output-Format: JSON' -d "$body")"
   else
     resp="$(curl -sS -w '\n%{http_code}' -X "$method" \
-      "$PSO_BASE_URL$path${sep}ws_key=$PSO_WS_KEY&output_format=JSON")"
+      "$PSO_BASE_URL$path${sep}ws_key=$PSO_WS_KEY&output_format=JSON" \
+      -H 'Output-Format: JSON')"
   fi
   status="$(printf '%s' "$resp" | tail -n1)"
   resp_body="$(printf '%s' "$resp" | sed '$d')"
@@ -115,6 +126,31 @@ pso_ws_curl() {
     *) die "pso_ws_curl: $method $path -> HTTP $status
 $resp_body" ;;
   esac
+}
+
+# ---------------------------------------------------------------------------
+# pso_extract_id <response> <resource-key> - reads the newly-created
+# resource's id out of a pso_ws_curl POST response, whichever wire format
+# the shop actually answered with.
+#
+# jq first (the JSON we asked for); on empty/invalid JSON, fall back to
+# PrestaShop's XML envelope (`<resource><id>N</id>...`, sometimes
+# CDATA-wrapped: `<id><![CDATA[5]]></id>`) via a plain grep/sed extraction -
+# deliberately not a real XML parser, since the only thing this driver reads
+# out of a create response is one integer id. This is what makes
+# pso_ws_curl's belt-and-braces JSON request safe to have been ignored by
+# the shop: every caller (pso_ensure_customer, pso_push_one_order) goes
+# through this rather than assuming `jq -r '.foo.id'` alone.
+# ---------------------------------------------------------------------------
+pso_extract_id() {
+  local resp="$1" key="$2" id
+  id="$(printf '%s' "$resp" | jq -r ".${key}.id // empty" 2>/dev/null || true)"
+  if [ -z "$id" ] || [ "$id" = "null" ]; then
+    id="$(printf '%s' "$resp" | grep -oP '(?<=<id>).*?(?=</id>)' | head -n1)"
+    id="${id#*CDATA[}"
+    id="${id%\]\]*}"
+  fi
+  printf '%s' "$id"
 }
 
 # ---------------------------------------------------------------------------
@@ -190,7 +226,7 @@ pso_ensure_customer() {
     <optin>0</optin>
   </customer>
 </prestashop>")"
-    PSO_CUSTOMER_ID="$(printf '%s' "$resp" | jq -r '.customer.id // empty')"
+    PSO_CUSTOMER_ID="$(pso_extract_id "$resp" customer)"
     [ -n "$PSO_CUSTOMER_ID" ] || die "pso_ensure_customer: create returned no id. Response: $resp"
   fi
 
@@ -211,7 +247,7 @@ pso_ensure_customer() {
     <postcode>00-001</postcode>
   </address>
 </prestashop>")"
-    PSO_ADDRESS_ID="$(printf '%s' "$resp" | jq -r '.address.id // empty')"
+    PSO_ADDRESS_ID="$(pso_extract_id "$resp" address)"
     [ -n "$PSO_ADDRESS_ID" ] || die "pso_ensure_customer: address create returned no id. Response: $resp"
   fi
   log "pso_ensure_customer: customer=$PSO_CUSTOMER_ID address=$PSO_ADDRESS_ID"
@@ -255,7 +291,7 @@ pso_push_one_order() {
     </associations>
   </cart>
 </prestashop>")"
-  cart_id="$(printf '%s' "$resp" | jq -r '.cart.id // empty')"
+  cart_id="$(pso_extract_id "$resp" cart)"
   [ -n "$cart_id" ] || die "pso_push_one_order: cart create returned no id. Response: $resp"
 
   total_excl="$PSO_PRODUCT_PRICE"
@@ -311,7 +347,7 @@ pso_push_one_order() {
     </associations>
   </order>
 </prestashop>")"
-  order_id="$(printf '%s' "$resp" | jq -r '.order.id // empty')"
+  order_id="$(pso_extract_id "$resp" order)"
   [ -n "$order_id" ] || die "pso_push_one_order: order create returned no id. Response: $resp"
   printf '%s' "$order_id"
 }

--- a/perf/openlinker-throughput/drivers/ps-order-source.sh
+++ b/perf/openlinker-throughput/drivers/ps-order-source.sh
@@ -110,14 +110,22 @@ pso_ws_curl() {
   local method="$1" path="$2" body="${3:-}" sep resp status resp_body
   [ -n "$PSO_WS_KEY" ] || die "pso_ws_curl: PSO_WS_KEY is not set - export PS_WS_KEY from stand-ids.env"
   case "$path" in *\?*) sep='&' ;; *) sep='?' ;; esac
+  # -H 'Host: prestashop' works around a canonical-domain redirect: the shop's
+  # ps_shop_url.domain is the docker-network alias "prestashop" (reachable
+  # in-network with no mismatch), but this driver runs on the host and hits
+  # the published port as 127.0.0.1:19080 - curl then sends that as the Host
+  # header, PrestaShop's Dispatcher sees a mismatch against ps_shop_url and
+  # answers 302 to http://prestashop/?..., which this driver can't follow
+  # (it isn't resolvable from the host). Verified manually: identical request
+  # plus this header returns 200 JSON instead of 302.
   if [ -n "$body" ]; then
     resp="$(curl -sS -w '\n%{http_code}' -X "$method" \
       "$PSO_BASE_URL$path${sep}ws_key=$PSO_WS_KEY&output_format=JSON" \
-      -H 'Content-Type: application/xml' -H 'Output-Format: JSON' -d "$body")"
+      -H 'Content-Type: application/xml' -H 'Output-Format: JSON' -H 'Host: prestashop' -d "$body")"
   else
     resp="$(curl -sS -w '\n%{http_code}' -X "$method" \
       "$PSO_BASE_URL$path${sep}ws_key=$PSO_WS_KEY&output_format=JSON" \
-      -H 'Output-Format: JSON')"
+      -H 'Output-Format: JSON' -H 'Host: prestashop')"
   fi
   status="$(printf '%s' "$resp" | tail -n1)"
   resp_body="$(printf '%s' "$resp" | sed '$d')"
@@ -219,7 +227,7 @@ pso_ensure_customer() {
   <customer>
     <passwd>Perf-Source-1234</passwd>
     <lastname>Source</lastname>
-    <firstname>Perf${tag^}</firstname>
+    <firstname>Perf</firstname>
     <email>${email}</email>
     <active>1</active>
     <newsletter>0</newsletter>
@@ -241,7 +249,7 @@ pso_ensure_customer() {
     <id_country>${PSO_COUNTRY_ID}</id_country>
     <alias>perf-source-${tag}</alias>
     <lastname>Source</lastname>
-    <firstname>Perf${tag^}</firstname>
+    <firstname>Perf</firstname>
     <address1>1 Perf Source Street</address1>
     <city>Warsaw</city>
     <postcode>00-001</postcode>

--- a/perf/openlinker-throughput/drivers/ps-order-source.sh
+++ b/perf/openlinker-throughput/drivers/ps-order-source.sh
@@ -1,0 +1,358 @@
+#!/usr/bin/env bash
+#
+# F11 driver library (#2979, epic #2840) - PrestaShop-as-order-SOURCE
+# primitives, for the second channel of the concurrent multi-channel scenario.
+#
+# Sourced by scenarios/f11-concurrent-multichannel.sh, never run standalone.
+# Requires lib.sh already sourced (ps_sql/ps_sql_write/log/warn/die).
+#
+# ---------------------------------------------------------------------------
+# WHY THIS EXISTS, AND WHY IT IS NOT ORDER-FEED.SH POINTED AT A SECOND STUB
+# ---------------------------------------------------------------------------
+# Every prior order-arrival driver on this stand (order-feed.sh for Allegro,
+# make-8line-order.sh / run-a4-ingest.sh for PrestaShop) pushes an order into
+# something OL reads FROM one direction only: a stub marketplace, or OL's own
+# order_records as the DESTINATION side of a create. None of them makes
+# PrestaShop itself the SOURCE - a genuine native order sitting in ps_orders
+# that OL's PrestashopOrderSourceAdapter discovers on its own, the same way a
+# real customer's checkout would produce one.
+#
+# #2979 needs a second real PLATFORM channel, not a second Allegro tenant (see
+# the F11 scenario's own header for why two same-platform connections would
+# answer a narrower question). PrestaShop is the only second OrderSourcePort
+# implementer already provisioned on this stand with a working webservice key
+# and real seeded catalogue (WooCommerce's catalogue is not yet seeded,
+# #3024/#3025 in flight; Erli has no stub and its base-URL policy refuses one,
+# #2865 decision doc) - so PrestaShop-as-source is the only channel-2 that
+# does not require new infrastructure this issue would have to build first.
+#
+# ---------------------------------------------------------------------------
+# WEBSERVICE, NOT RAW SQL, NOT A BROWSER CHECKOUT
+# ---------------------------------------------------------------------------
+# Three ways exist to make a native order appear in PrestaShop. Raw INSERT
+# into ps_orders/ps_order_detail/ps_customer/ps_address/ps_cart is the
+# lowest-level and the riskiest: a subtly wrong row shape either fails
+# silently (an order OL's adapter cannot parse, which reads as "ingestion
+# broken" when the fault is the seed) or writes something structurally
+# invalid into a shop OTHER scenarios' guards also read from (ps_orders
+# COUNT is ground truth for run-a4-ingest.sh and f10-dependency-failure.sh).
+# A full browser-driven checkout (cart -> address -> carrier -> payment
+# module -> validateOrder) is the most realistic but needs Selenium/Playwright
+# machinery this repo's perf stand does not carry anywhere.
+#
+# The webservice sits between the two: it is PrestaShop's own supported write
+# API (customer -> address -> cart -> order, bootstrap.sh already grants full
+# CRUD on every resource this needs - "orders order_details customers
+# addresses countries currencies carts ... carriers order_carriers
+# order_states"), and unlike a raw INSERT a malformed request comes back as
+# an explicit 400 naming the missing/invalid field rather than a row that
+# quietly fails to parse. It is also the same shape OpenLinker's own
+# `PrestashopOrderProcessorAdapter` docblock warns AGAINST for OL's outbound
+# writes ("bypasses validateOrder and drops the carrier" - #503/#898) - but
+# that warning is about FIDELITY to what a specific-priced OL order must
+# reproduce exactly. Here the order is native to begin with; the webservice
+# write IS the "real" order, the same way an admin creating an order by hand
+# in the back office is real.
+#
+# ---------------------------------------------------------------------------
+# WHY THE REQUIRED-FIELD LIST BELOW IS AN EDUCATED STARTING POINT, NOT A
+# VERIFIED ONE - AND WHAT TO DO WHEN IT IS WRONG
+# ---------------------------------------------------------------------------
+# PrestaShop's webservice does not recompute an Order's totals server-side the
+# way checkout's PaymentModule::validateOrder does - it persists what it is
+# given. Getting a numeric field wrong (a missing total_* column, a stale
+# reference to a deleted carrier) does not corrupt anything: PrestaShop's
+# webservice validates required fields before writing and answers a 400
+# naming the field. `pso_push_orders` is written to surface that response
+# body verbatim rather than swallow it, specifically so the ONE validation
+# call #2979's process asks for produces an actionable error rather than a
+# silent failure - this has NOT been exercised against a live shop, and the
+# field list is expected to need at least one iteration.
+#
+set -euo pipefail
+
+# The shop's own base URL as seen from the HOST (curl runs here, same
+# host-vs-network-namespace split as order-feed.sh's OF_STUB_URL) - port
+# 19080, docker-compose.lab.yml's PRESTASHOP_HOST_PORT default.
+PSO_BASE_URL="${PSO_BASE_URL:-http://127.0.0.1:19080}"
+PSO_WS_KEY="${PSO_WS_KEY:-${PS_WS_KEY:-}}"
+
+# The cursor key PrestaShop's OrderSourcePort uses for its date_upd-watermark
+# reconciliation poll (`prestashop-orders-poll` task /
+# prestashop-order-source.adapter.ts). Restated, not invented, for the same
+# reason order-feed.sh restates OF_CURSOR_KEY: a driver that guessed at this
+# would silently measure a cursor the adapter never reads.
+PSO_CURSOR_KEY="${PSO_CURSOR_KEY:-prestashop.orders.dateUpd}"
+
+# ---------------------------------------------------------------------------
+# pso_ws_curl <method> <path-with-query> [xml-body]
+#
+# POST/PUT bodies are XML - PrestaShop's webservice does not accept a JSON
+# request body on a write, only `Output-Format: JSON` on the RESPONSE of a
+# GET (verified against this repo's own webservice client,
+# prestashop-webservice.client.ts:380/573-576, which sends
+# `Content-Type: application/xml` on every write and only asks for
+# `Output-Format: JSON` on GET). Dies on a non-2xx with the body printed -
+# PrestaShop's validation errors are the whole point of using the webservice
+# over raw SQL, so swallowing them here would throw away the one advantage.
+# ---------------------------------------------------------------------------
+pso_ws_curl() {
+  local method="$1" path="$2" body="${3:-}" sep resp status resp_body
+  [ -n "$PSO_WS_KEY" ] || die "pso_ws_curl: PSO_WS_KEY is not set - export PS_WS_KEY from stand-ids.env"
+  case "$path" in *\?*) sep='&' ;; *) sep='?' ;; esac
+  if [ -n "$body" ]; then
+    resp="$(curl -sS -w '\n%{http_code}' -X "$method" \
+      "$PSO_BASE_URL$path${sep}ws_key=$PSO_WS_KEY&output_format=JSON" \
+      -H 'Content-Type: application/xml' -d "$body")"
+  else
+    resp="$(curl -sS -w '\n%{http_code}' -X "$method" \
+      "$PSO_BASE_URL$path${sep}ws_key=$PSO_WS_KEY&output_format=JSON")"
+  fi
+  status="$(printf '%s' "$resp" | tail -n1)"
+  resp_body="$(printf '%s' "$resp" | sed '$d')"
+  case "$status" in
+    2*) printf '%s' "$resp_body" ;;
+    *) die "pso_ws_curl: $method $path -> HTTP $status
+$resp_body" ;;
+  esac
+}
+
+# ---------------------------------------------------------------------------
+# pso_resolve_refs - reads the reference ids this channel needs off the LIVE
+# shop, once per scenario run, and exports them as PSO_* globals. Every read
+# is a plain SELECT against ps_sql (read-only, no guard_stand_exclusive
+# needed for a read alone - only the WRITES this file makes are stand
+# mutations).
+#
+# Refuses (via `die`) rather than guessing when a reference is absent: an
+# invented carrier/currency/state id would either 400 at the webservice (the
+# same failure surfaced later and more confusingly) or - worse - silently
+# resolve to SOME other row on a shop whose ids happen to collide.
+# ---------------------------------------------------------------------------
+pso_resolve_refs() {
+  PSO_CURRENCY_ID="$(as_count "$(ps_sql "SELECT id_currency FROM ps_currency WHERE active=1 ORDER BY id_currency LIMIT 1" 2>/dev/null | tr -d '[:space:]')")"
+  [ -n "$PSO_CURRENCY_ID" ] || die "pso_resolve_refs: no active currency on the shop"
+
+  PSO_COUNTRY_ID="$(as_count "$(ps_sql "SELECT id_country FROM ps_country WHERE iso_code='PL' LIMIT 1" 2>/dev/null | tr -d '[:space:]')")"
+  [ -n "$PSO_COUNTRY_ID" ] || PSO_COUNTRY_ID="$(as_count "$(ps_sql "SELECT id_country FROM ps_country WHERE active=1 ORDER BY id_country LIMIT 1" 2>/dev/null | tr -d '[:space:]')")"
+  [ -n "$PSO_COUNTRY_ID" ] || die "pso_resolve_refs: no usable country on the shop"
+
+  PSO_CARRIER_ID="$(as_count "$(ps_sql "SELECT id_carrier FROM ps_carrier WHERE deleted=0 AND active=1 ORDER BY id_carrier LIMIT 1" 2>/dev/null | tr -d '[:space:]')")"
+  [ -n "$PSO_CARRIER_ID" ] || die "pso_resolve_refs: no active, non-deleted carrier on the shop"
+
+  # A paid state (paid=1) so the order round-trips through the
+  # PrestashopOrderSourceAdapter's cancelled-detection read as a live order
+  # (prestashop-order-source.adapter.ts:500, statusOf on current_state), not
+  # as something OL might read as already-terminal.
+  PSO_ORDER_STATE_ID="$(as_count "$(ps_sql "SELECT id_order_state FROM ps_order_state WHERE paid=1 ORDER BY id_order_state LIMIT 1" 2>/dev/null | tr -d '[:space:]')")"
+  [ -n "$PSO_ORDER_STATE_ID" ] || die "pso_resolve_refs: no paid=1 order state on the shop"
+
+  # The seeded PERFBASE catalogue (seed-catalogue.sh), the same population
+  # make-8line-order.sh draws from - already tax-grouped by bootstrap.sh's
+  # step_tax_group, so its price/tax fields are internally consistent.
+  PSO_PRODUCT_ID="$(as_count "$(ps_sql "SELECT id_product FROM ps_product WHERE reference LIKE 'PERFBASE-%' AND active=1 ORDER BY id_product LIMIT 1" 2>/dev/null | tr -d '[:space:]')")"
+  [ -n "$PSO_PRODUCT_ID" ] || die "pso_resolve_refs: no active PERFBASE product on the shop - run seed-catalogue.sh first"
+  PSO_PRODUCT_PRICE="$(ps_sql "SELECT price FROM ps_product WHERE id_product=$PSO_PRODUCT_ID" 2>/dev/null | tr -d '[:space:]')"
+  [ -n "$PSO_PRODUCT_PRICE" ] || die "pso_resolve_refs: product $PSO_PRODUCT_ID has no price"
+  # 0 = the simple-product convention for a cart row with no combination.
+  PSO_PRODUCT_ATTR_ID="$(as_count "$(ps_sql "SELECT id_product_attribute FROM ps_product_attribute WHERE id_product=$PSO_PRODUCT_ID ORDER BY id_product_attribute LIMIT 1" 2>/dev/null | tr -d '[:space:]')")"
+  [ -n "$PSO_PRODUCT_ATTR_ID" ] || PSO_PRODUCT_ATTR_ID=0
+
+  log "pso_resolve_refs: currency=$PSO_CURRENCY_ID country=$PSO_COUNTRY_ID carrier=$PSO_CARRIER_ID state=$PSO_ORDER_STATE_ID product=$PSO_PRODUCT_ID(attr=$PSO_PRODUCT_ATTR_ID, price=$PSO_PRODUCT_PRICE)"
+}
+
+# ---------------------------------------------------------------------------
+# pso_ensure_customer <tag> - get-or-create ONE reusable customer+address for
+# this channel, mirroring make-8line-order.sh's "reuse the customer of an
+# order that already synced" reasoning: fewer moving parts pushing N orders
+# than minting N customers, and it is the customer/address pair, not the
+# order, whose identity this channel needs to be stable across the run.
+#
+# Idempotent by email: a re-run of the scenario against a stand that already
+# has this channel's customer reuses it rather than accumulating duplicates
+# (bootstrap.sh's own found/created convention).
+# ---------------------------------------------------------------------------
+pso_ensure_customer() {
+  local tag="${1:-f11}" email="perf-source-${1:-f11}@example.invalid" existing
+  existing="$(as_count "$(ps_sql "SELECT id_customer FROM ps_customer WHERE email='$email' LIMIT 1" 2>/dev/null | tr -d '[:space:]')")"
+  if [ -n "$existing" ]; then
+    PSO_CUSTOMER_ID="$existing"
+  else
+    local resp
+    resp="$(pso_ws_curl POST '/api/customers' "<prestashop xmlns=\"http://www.prestashop.com/xml/xsd\">
+  <customer>
+    <passwd>Perf-Source-1234</passwd>
+    <lastname>Source</lastname>
+    <firstname>Perf${tag^}</firstname>
+    <email>${email}</email>
+    <active>1</active>
+    <newsletter>0</newsletter>
+    <optin>0</optin>
+  </customer>
+</prestashop>")"
+    PSO_CUSTOMER_ID="$(printf '%s' "$resp" | jq -r '.customer.id // empty')"
+    [ -n "$PSO_CUSTOMER_ID" ] || die "pso_ensure_customer: create returned no id. Response: $resp"
+  fi
+
+  existing="$(as_count "$(ps_sql "SELECT id_address FROM ps_address WHERE id_customer=$PSO_CUSTOMER_ID AND deleted=0 LIMIT 1" 2>/dev/null | tr -d '[:space:]')")"
+  if [ -n "$existing" ]; then
+    PSO_ADDRESS_ID="$existing"
+  else
+    local resp
+    resp="$(pso_ws_curl POST '/api/addresses' "<prestashop xmlns=\"http://www.prestashop.com/xml/xsd\">
+  <address>
+    <id_customer>${PSO_CUSTOMER_ID}</id_customer>
+    <id_country>${PSO_COUNTRY_ID}</id_country>
+    <alias>perf-source-${tag}</alias>
+    <lastname>Source</lastname>
+    <firstname>Perf${tag^}</firstname>
+    <address1>1 Perf Source Street</address1>
+    <city>Warsaw</city>
+    <postcode>00-001</postcode>
+  </address>
+</prestashop>")"
+    PSO_ADDRESS_ID="$(printf '%s' "$resp" | jq -r '.address.id // empty')"
+    [ -n "$PSO_ADDRESS_ID" ] || die "pso_ensure_customer: address create returned no id. Response: $resp"
+  fi
+  log "pso_ensure_customer: customer=$PSO_CUSTOMER_ID address=$PSO_ADDRESS_ID"
+}
+
+# ---------------------------------------------------------------------------
+# pso_push_one_order - creates ONE cart, then ONE order against it, and
+# echoes the new order's id_order. A fresh cart per order (rather than one
+# shared cart) because PrestaShop's own admin UI treats a cart as
+# order-scoped once validated; sharing one across N webservice orders is an
+# untested shape this driver has no reason to reach for when a fresh cart
+# costs one extra request.
+#
+# `total_products` / `total_paid*` are a computed APPROXIMATION
+# (price x quantity, x1.23 for the tax-inclusive figures) rather than a true
+# tax computation - deliberate, since this channel exists to exercise
+# OL's INGESTION read path, not to reproduce PrestaShop's own tax engine.
+# See the file header for what to do if the webservice rejects these.
+# ---------------------------------------------------------------------------
+pso_push_one_order() {
+  local reference_tag="${1:-f11}" resp cart_id order_id total_excl total_incl
+  resp="$(pso_ws_curl POST '/api/carts' "<prestashop xmlns=\"http://www.prestashop.com/xml/xsd\">
+  <cart>
+    <id_currency>${PSO_CURRENCY_ID}</id_currency>
+    <id_lang>1</id_lang>
+    <id_address_delivery>${PSO_ADDRESS_ID}</id_address_delivery>
+    <id_address_invoice>${PSO_ADDRESS_ID}</id_address_invoice>
+    <id_customer>${PSO_CUSTOMER_ID}</id_customer>
+    <id_carrier>${PSO_CARRIER_ID}</id_carrier>
+    <recyclable>0</recyclable>
+    <gift>0</gift>
+    <associations>
+      <cart_rows>
+        <cart_row>
+          <id_product>${PSO_PRODUCT_ID}</id_product>
+          <id_product_attribute>${PSO_PRODUCT_ATTR_ID}</id_product_attribute>
+          <id_address_delivery>${PSO_ADDRESS_ID}</id_address_delivery>
+          <quantity>1</quantity>
+        </cart_row>
+      </cart_rows>
+    </associations>
+  </cart>
+</prestashop>")"
+  cart_id="$(printf '%s' "$resp" | jq -r '.cart.id // empty')"
+  [ -n "$cart_id" ] || die "pso_push_one_order: cart create returned no id. Response: $resp"
+
+  total_excl="$PSO_PRODUCT_PRICE"
+  total_incl="$(awk -v p="$PSO_PRODUCT_PRICE" 'BEGIN{printf "%.2f", p*1.23}')"
+
+  resp="$(pso_ws_curl POST '/api/orders' "<prestashop xmlns=\"http://www.prestashop.com/xml/xsd\">
+  <order>
+    <id_address_delivery>${PSO_ADDRESS_ID}</id_address_delivery>
+    <id_address_invoice>${PSO_ADDRESS_ID}</id_address_invoice>
+    <id_cart>${cart_id}</id_cart>
+    <id_currency>${PSO_CURRENCY_ID}</id_currency>
+    <id_lang>1</id_lang>
+    <id_customer>${PSO_CUSTOMER_ID}</id_customer>
+    <id_carrier>${PSO_CARRIER_ID}</id_carrier>
+    <current_state>${PSO_ORDER_STATE_ID}</current_state>
+    <module>ps_wirepayment</module>
+    <invoice_number>0</invoice_number>
+    <delivery_number>0</delivery_number>
+    <valid>1</valid>
+    <payment>Bank wire (perf source)</payment>
+    <recyclable>0</recyclable>
+    <gift>0</gift>
+    <total_discounts>0</total_discounts>
+    <total_discounts_tax_incl>0</total_discounts_tax_incl>
+    <total_discounts_tax_excl>0</total_discounts_tax_excl>
+    <total_paid>${total_incl}</total_paid>
+    <total_paid_tax_incl>${total_incl}</total_paid_tax_incl>
+    <total_paid_tax_excl>${total_excl}</total_paid_tax_excl>
+    <total_paid_real>${total_incl}</total_paid_real>
+    <total_products>${total_excl}</total_products>
+    <total_products_wt>${total_incl}</total_products_wt>
+    <total_shipping>0</total_shipping>
+    <total_shipping_tax_incl>0</total_shipping_tax_incl>
+    <total_shipping_tax_excl>0</total_shipping_tax_excl>
+    <carrier_tax_rate>0</carrier_tax_rate>
+    <total_wrapping>0</total_wrapping>
+    <total_wrapping_tax_incl>0</total_wrapping_tax_incl>
+    <total_wrapping_tax_excl>0</total_wrapping_tax_excl>
+    <round_mode>0</round_mode>
+    <round_type>0</round_type>
+    <conversion_rate>1</conversion_rate>
+    <associations>
+      <order_rows>
+        <order_row>
+          <product_id>${PSO_PRODUCT_ID}</product_id>
+          <product_attribute_id>${PSO_PRODUCT_ATTR_ID}</product_attribute_id>
+          <product_quantity>1</product_quantity>
+          <product_price>${total_excl}</product_price>
+          <unit_price_tax_incl>${total_incl}</unit_price_tax_incl>
+          <unit_price_tax_excl>${total_excl}</unit_price_tax_excl>
+        </order_row>
+      </order_rows>
+    </associations>
+  </order>
+</prestashop>")"
+  order_id="$(printf '%s' "$resp" | jq -r '.order.id // empty')"
+  [ -n "$order_id" ] || die "pso_push_one_order: order create returned no id. Response: $resp"
+  printf '%s' "$order_id"
+}
+
+# pso_push_orders <count> [tag] - loop wrapper, echoes the count actually
+# created (a create failure dies the whole scenario via pso_ws_curl/die -
+# there is deliberately no partial-success tolerance here, unlike
+# of_push_orders' single bulk request: each order is its own multi-step
+# webservice sequence and a partial failure midway (order created, its cart
+# reused by nothing) is not a state worth limping past silently).
+pso_push_orders() {
+  local count="$1" tag="${2:-f11}" i=0 ids=()
+  while [ "$i" -lt "$count" ]; do
+    ids+=("$(pso_push_one_order "$tag")")
+    i=$((i + 1))
+  done
+  log "pso_push_orders: created ${#ids[@]} order(s): ${ids[*]}"
+  printf '%s' "${#ids[@]}"
+}
+
+# pso_orders_count - COUNT(*) on ps_orders, the same ground-truth read
+# run-a4-ingest.sh / f10-dependency-failure.sh already use.
+pso_orders_count() {
+  as_count "$(ps_sql "SELECT COUNT(*) FROM ps_orders" 2>/dev/null | tr -d '[:space:]')"
+}
+
+# pso_enqueue_poll <connection_id> <tag> - enqueue one
+# marketplace.orders.poll-shaped job for the PrestaShop source connection,
+# mirroring of_enqueue_poll's reasoning: the scheduler stays off for the same
+# co-tenancy-control reason, so the harness drives the poll cadence itself.
+# The job type and payload shape are the shop-side counterpart
+# (`prestashop-orders-poll` task / OrderSourcePort.listOrderFeed reading the
+# date_upd watermark) - restated from the adapter/task rather than invented.
+# The real scheduler task's default (prestashop-scheduler-tasks.ts:65),
+# restated rather than invented for the same reason OF_POLL_LIMIT is.
+PSO_POLL_LIMIT="${PSO_POLL_LIMIT:-100}"
+
+pso_enqueue_poll() {
+  local conn="$1" tag="${2:-f11}" key
+  key="prestashop:$conn:orders:poll:$tag:$(date +%s%3N)"
+  enqueue_perf_job 'marketplace.orders.poll' "$conn" \
+    "{\"schemaVersion\":1,\"cursorKey\":\"$PSO_CURSOR_KEY\",\"limit\":$PSO_POLL_LIMIT}" "$key" >/dev/null
+  printf '%s' "$key"
+}

--- a/perf/openlinker-throughput/lib-test.sh
+++ b/perf/openlinker-throughput/lib-test.sh
@@ -1560,6 +1560,26 @@ if [ -f "$PSO_DRIVER" ]; then
     "$PSO_SRC" 'HTTP $status'
   assert_contains "ps-order-source resolves reference ids from the LIVE shop, never guesses" \
     "$PSO_SRC" 'pso_resolve_refs'
+
+  # pso_extract_id is the belt-and-braces reader for a create response: the
+  # reference webservice client (prestashop-webservice.client.ts:576) forces
+  # Output-Format: XML on every POST/PUT response regardless of what we ask
+  # for, so a driver that only ever ran `jq -r '.foo.id'` against a live
+  # shop would die on every single create with "returned no id" even though
+  # the create succeeded. Both wire shapes must resolve to the same id.
+  PSO_EXTRACT_RESULT="$(
+    # shellcheck source=/dev/null
+    source "$PSO_DRIVER" 2>/dev/null
+    JSON_RESP='{"customer":{"id":"5"}}'
+    XML_RESP='<?xml version="1.0" encoding="UTF-8"?><prestashop xmlns="http://www.prestashop.com/xml/xsd"><customer><id><![CDATA[5]]></id></customer></prestashop>'
+    XML_RESP_PLAIN='<?xml version="1.0" encoding="UTF-8"?><prestashop><order><id>9</id></order></prestashop>'
+    got_json="$(pso_extract_id "$JSON_RESP" customer)"
+    got_xml_cdata="$(pso_extract_id "$XML_RESP" customer)"
+    got_xml_plain="$(pso_extract_id "$XML_RESP_PLAIN" order)"
+    printf '%s|%s|%s' "$got_json" "$got_xml_cdata" "$got_xml_plain"
+  )"
+  assert_eq "pso_extract_id reads the id whether the shop answers JSON or XML" \
+    "5|5|9" "$PSO_EXTRACT_RESULT"
 else
   FAIL=$((FAIL + 1)); FAILURES+=("ps-order-source.sh not found at $PSO_DRIVER")
 fi

--- a/perf/openlinker-throughput/lib-test.sh
+++ b/perf/openlinker-throughput/lib-test.sh
@@ -1481,6 +1481,91 @@ fi
 
 # ---------------------------------------------------------------------------
 echo
+echo "--- classify_channel_contention (#2979 F11) ---"
+# VALID pass: a mild drop under the default 20% threshold reads held.
+assert_eq "5% drop under threshold reads held" "held" "$(classify_channel_contention 100 95 20)"
+# DISCARDED case: a drop AT the threshold reads starved (>= is the boundary).
+assert_eq "20% drop at threshold reads starved" "starved" "$(classify_channel_contention 100 80 20)"
+assert_eq "50% drop well past threshold reads starved" "starved" "$(classify_channel_contention 200 100 20)"
+# Concurrent faster than solo is not evidence of anything wrong.
+assert_eq "concurrent rate exceeding solo reads held" "held" "$(classify_channel_contention 100 120 20)"
+assert_eq "concurrent rate equal to solo reads held" "held" "$(classify_channel_contention 100 100 20)"
+# unknown is a THIRD answer, never silently "held" - #2979's own framing.
+assert_eq "zero solo rate is unknown, never held" "unknown" "$(classify_channel_contention 0 50 20)"
+assert_eq "non-numeric solo rate is unknown" "unknown" "$(classify_channel_contention abc 50 20)"
+assert_eq "non-numeric concurrent rate is unknown" "unknown" "$(classify_channel_contention 100 xyz 20)"
+assert_eq "empty solo rate is unknown" "unknown" "$(classify_channel_contention '' 50 20)"
+assert_eq "non-numeric threshold is unknown rather than a silent default" "unknown" "$(classify_channel_contention 100 50 abc)"
+# threshold defaults to 20 when omitted.
+assert_eq "omitted threshold defaults to 20" "starved" "$(classify_channel_contention 100 79)"
+assert_eq "omitted threshold, just under 20% drop reads held" "held" "$(classify_channel_contention 100 81)"
+
+# ---------------------------------------------------------------------------
+echo
+echo "--- f11-concurrent-multichannel.sh source-level guards (#2979) ---"
+F11_SCENARIO="$SCRIPT_DIR/scenarios/f11-concurrent-multichannel.sh"
+if [ -f "$F11_SCENARIO" ]; then
+  F11_SRC="$(cat "$F11_SCENARIO")"
+  assert_contains "f11 claims the stand lock before any state mutation" \
+    "$F11_SRC" 'guard_stand_exclusive'
+  # The self-referential-loop guard: the PrestaShop DESTINATION connection's
+  # OrderProcessorManager must be disabled for the whole run, or a
+  # PrestaShop-sourced order would destine back into the SAME physical shop
+  # it came from and get re-ingested as a "new" source order next poll -
+  # an unbounded feedback loop against a container other agents may share.
+  assert_contains "f11 disables the PrestaShop destination's OrderProcessorManager for the run" \
+    "$F11_SRC" 'OrderProcessorManager'
+  assert_contains "f11 states the self-referential-loop hazard explicitly" \
+    "$F11_SRC" 'feedback loop'
+  # Cleanup discipline mirroring F1's own lesson: a single EXIT trap, since a
+  # second `trap ... EXIT` after guard_stand_exclusive's REPLACES it.
+  assert_contains "f11 releases the stand lock from its own on-exit handler" \
+    "$F11_SRC" 'release_stand_exclusive'
+  # Both single-channel baselines must be re-taken in the SAME run, not
+  # quoted from a prior report (#2979's own acceptance criterion).
+  assert_contains "f11 runs an Allegro-only baseline window in this session" \
+    "$F11_SRC" 'baseline'
+  assert_contains "f11 samples per-channel queue depth into separate directories" \
+    "$F11_SRC" 'sampler_start'
+  assert_contains "f11 classifies starvation via the shared lib.sh function" \
+    "$F11_SRC" 'classify_channel_contention'
+  # The scope-cut this scenario documents must be visible in the script
+  # itself, not only in the PR description - a reader six months from now
+  # opens the file, not the review thread.
+  assert_contains "f11 names the fallback from 3 platforms to 2, with reason" \
+    "$F11_SRC" 'two-channel'
+  assert_contains "f11 states why Erli is out of scope (no stub, base-URL policy)" \
+    "$F11_SRC" 'erli.pl'
+else
+  FAIL=$((FAIL + 1)); FAILURES+=("f11-concurrent-multichannel.sh not found at $F11_SCENARIO")
+fi
+
+# ---------------------------------------------------------------------------
+echo
+echo "--- ps-order-source.sh source-level guards (#2979) ---"
+PSO_DRIVER="$SCRIPT_DIR/drivers/ps-order-source.sh"
+if [ -f "$PSO_DRIVER" ]; then
+  PSO_SRC="$(cat "$PSO_DRIVER")"
+  # POST bodies to the PrestaShop webservice MUST be XML - the webservice
+  # client this repo already ships (prestashop-webservice.client.ts) never
+  # accepts a JSON request body, only JSON on GET responses via
+  # Output-Format. A JSON POST body would 400 on every single call.
+  assert_contains "ps-order-source POSTs application/xml, never JSON, to the webservice" \
+    "$PSO_SRC" "Content-Type: application/xml"
+  # A non-2xx must surface PrestaShop's own validation error rather than
+  # being swallowed - this is the whole reason the webservice route was
+  # chosen over raw SQL (#2979 review: a wrong field is now an explicit 400
+  # naming the field, not a silently invalid row).
+  assert_contains "ps-order-source surfaces the webservice's error body on failure" \
+    "$PSO_SRC" 'HTTP $status'
+  assert_contains "ps-order-source resolves reference ids from the LIVE shop, never guesses" \
+    "$PSO_SRC" 'pso_resolve_refs'
+else
+  FAIL=$((FAIL + 1)); FAILURES+=("ps-order-source.sh not found at $PSO_DRIVER")
+fi
+
+# ---------------------------------------------------------------------------
+echo
 echo "=== $PASS passed, $FAIL failed ==="
 if [ "$FAIL" -gt 0 ]; then
   printf 'FAILURES:\n'

--- a/perf/openlinker-throughput/lib.sh
+++ b/perf/openlinker-throughput/lib.sh
@@ -1932,3 +1932,39 @@ compute_agreement() {
     printf "%.6f\n", d/med
   }'
 }
+
+# ---------------------------------------------------------------------------
+# classify_channel_contention <solo_rate> <concurrent_rate> <threshold_pct>
+# (#2979, F11 - concurrent multi-channel load)
+#
+# Echoes "starved" when a channel's throughput running CONCURRENTLY with
+# another has dropped by threshold_pct or more against that same channel's
+# own SOLO baseline; "held" when it has not (including when it is faster
+# concurrently than solo, which happens and is not itself evidence of
+# anything wrong); "unknown" when either rate cannot be read as a
+# non-negative number.
+#
+# "unknown" is a THIRD answer, not a fallback to "held" - #2979's own framing
+# is "an aggregate that holds while one channel gets nothing is the failure
+# that matters", and a starvation check that reads a bad or missing number as
+# "held" would silently manufacture exactly that false reassurance. A caller
+# must treat "unknown" as "starvation was not established either way", never
+# as a passing result.
+#
+# threshold_pct defaults to 20: run-to-run variance on a shared contended
+# stand is real (see MOVED_THRESHOLD_PCT's 15% in f1-order-ingestion.sh for
+# the same reasoning applied to a different question), and 20% is
+# deliberately wider than that variance so an ordinary noisy run does not
+# read as starvation on its own.
+# ---------------------------------------------------------------------------
+classify_channel_contention() {
+  local solo="$1" concurrent="$2" threshold="${3:-20}"
+  case "$solo" in ''|*[!0-9.]*) printf 'unknown'; return 0 ;; esac
+  case "$concurrent" in ''|*[!0-9.]*) printf 'unknown'; return 0 ;; esac
+  case "$threshold" in ''|*[!0-9.]*) printf 'unknown'; return 0 ;; esac
+  awk -v s="$solo" -v c="$concurrent" -v t="$threshold" 'BEGIN {
+    if (s <= 0) { print "unknown"; exit }
+    drop = (s - c) / s * 100
+    if (drop >= t) print "starved"; else print "held"
+  }'
+}

--- a/perf/openlinker-throughput/run-smoke.sh
+++ b/perf/openlinker-throughput/run-smoke.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+set -a
+# shellcheck disable=SC1091
+. ./stand-ids.env
+set +a
+export PS_WS_KEY="$PS_WEBSERVICE_KEY"
+export OL_API_URL="${OL_API_URL:-http://127.0.0.1:19000}"
+exec ./scenarios/f11-concurrent-multichannel.sh --smoke

--- a/perf/openlinker-throughput/scenarios/f11-concurrent-multichannel.sh
+++ b/perf/openlinker-throughput/scenarios/f11-concurrent-multichannel.sh
@@ -1,0 +1,508 @@
+#!/usr/bin/env bash
+#
+# F11 - concurrent multi-channel load (#2979, epic #2840).
+#
+# Every measurement in #2840 up to this issue drove ONE channel at a time.
+# That is not a small simplification: the outbound rate limiter keys its
+# pacing bucket on connectionId ALONE (http-transport-factory.ts:150), the
+# realtime lane's per-scope cap of 2 was measured with one channel (#2975),
+# and #2977's replica-scaling correction was likewise taken on one channel.
+# This scenario drives TWO real channels simultaneously through the same
+# worker/Redis/Postgres-pool infrastructure and reports whether the
+# aggregate scales, holds or collapses; whether either channel is starved;
+# which resource binds first, with evidence; and whether the per-connection
+# rate limit still holds per connection when two connections pace through
+# the same Redis at once.
+#
+# ---------------------------------------------------------------------------
+# SCOPE CUT #1 - TWO channels, not three, and why (stated here, not only in
+# the PR, because a reader six months from now opens this file, not the
+# review thread)
+# ---------------------------------------------------------------------------
+# The issue names Allegro + Erli + WooCommerce as the three intended
+# channels. Neither Erli nor WooCommerce is reachable on this stand today:
+#
+#  - Erli: no stub exists anywhere in this repository, and building one was
+#    explicitly evaluated and REJECTED for this same epic
+#    (docs' decision-erli-inbox-cliff-2026-09-05.md, #2865) - Erli's own
+#    base-URL policy (erli-base-url.policy.ts) hard-refuses any host that is
+#    not a real https://*.erli.pl or *.erli.dev, so it cannot even be
+#    pointed at a local stub without DNS tricks a perf harness has no
+#    business attempting. Real Erli needs the vendor's own sandbox
+#    agreement, which is out of scope for this issue.
+#  - WooCommerce: perf/openlinker-throughput/seed/seed-shop-catalogue.sh is
+#    PrestaShop-only today (no WooCommerce seeding code exists on
+#    perf-programme-2840). The branch doing that work
+#    (3024-3025-f5-seeding-and-wc-mappings) has no PR yet and is still in
+#    flight, so a WooCommerce arm would measure an empty catalogue.
+#
+# So this is a two-channel arm, reported as exactly that, never dressed up
+# as "three channels, one degraded".
+#
+# ---------------------------------------------------------------------------
+# SCOPE CUT #2 - WHAT the second channel is, and why NOT two Allegro
+# connections
+# ---------------------------------------------------------------------------
+# The cheapest, zero-new-risk way to get "two connections contending for one
+# worker" is two Allegro connections on the stub's existing multi-tenant
+# support. That was considered and rejected: it answers a narrower question
+# than #2979 asks. Two same-platform connections can only ever exercise
+# connection-SCOPING (Redis key isolation, per-scope lane slots) - it cannot
+# surface anything platform-adapter-SHAPED, which is exactly what the
+# issue's "Why" section is worried about (a platform-specific batching/
+# caching quirk interacting badly with a second tenant of the SAME platform
+# vs. a structurally different adapter). Reported as "two channels" while
+# secretly meaning "two connections of one platform" would also be exactly
+# the kind of silent scope-narrowing this programme's own conventions exist
+# to prevent (see results/README's "a report that cannot be reproduced from
+# its own recipe is a claim, not a measurement").
+#
+# So channel 2 here is PrestaShop acting as its own order SOURCE - a
+# genuine, structurally different `OrderSourcePort` implementation
+# (webhook + date_upd-watermark poll reconciliation) from Allegro's
+# event-journal stub. Channel 2's orders are minted via PrestaShop's own
+# WEBSERVICE API (drivers/ps-order-source.sh) - customer -> address ->
+# cart -> order - rather than raw SQL (too easy to write a row OL's adapter
+# cannot parse, or corrupt a shop other scenarios also read from) or a full
+# browser checkout (no Selenium/Playwright machinery on this stand). A
+# webservice write that gets a required field wrong answers an explicit 400
+# naming the field - safer feedback than either extreme, and stated in the
+# driver's own header as needing live iteration to finish getting right.
+#
+# ---------------------------------------------------------------------------
+# THE SELF-REFERENTIAL LOOP THIS SCENARIO IS DESIGNED TO AVOID
+# ---------------------------------------------------------------------------
+# PrestaShop-as-source (a NEW connection, PS_SOURCE_CONNECTION_ID) and
+# PrestaShop-as-destination (the EXISTING perf-prestashop connection,
+# PS_CONNECTION_ID) point at the SAME physical shop. If the destination
+# connection's OrderProcessorManager stayed enabled, a channel-2 order would
+# get written BACK into the very shop it was read from, as a genuinely new
+# native order - which the source connection would then discover on its
+# NEXT poll and destine again, forever: an uncontrolled feedback loop
+# amplifying against a MySQL container three other agents may be sharing
+# right now. There is no per-source destination-routing mechanism in this
+# codebase to prevent it structurally (no fulfilment router is configured
+# on this stand), so this scenario prevents it the same way F1 already
+# prevents its own single-destination bias: by disabling the PrestaShop
+# destination connection's `OrderProcessorManager` capability for the
+# WHOLE run (both baselines and the concurrent window), leaving Allegro's
+# and channel 2's orders to destine to WooCommerce alone - a different
+# physical system, so no loop is possible.
+#
+# The cost, stated rather than hidden: this makes the re-taken Allegro
+# baseline (Allegro -> WooCommerce) methodologically DIFFERENT from #2977's
+# original Allegro -> PrestaShop baseline. The two numbers are not directly
+# comparable; what IS comparable, and what this scenario exists to produce,
+# is solo-vs-concurrent WITHIN this one session, on one consistent
+# destination.
+#
+# ---------------------------------------------------------------------------
+# WHAT THIS SCENARIO DOES NOT MEASURE
+# ---------------------------------------------------------------------------
+# The full order-ingest-to-destination-creation latency chain (F1's t0..t6)
+# is NOT reproduced here - this is a throughput/contention scenario, not a
+# latency-hop reconstruction, and F1 already owns that question for the
+# single-channel case. What is measured is: order arrival -> order_records
+# persisted (ingestion throughput), per channel and combined, plus the
+# post-window guards/manifest evidence for naming what bound first.
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+LIB_LOG_PREFIX="f11"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/../lib.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/../drivers/order-feed.sh"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/../drivers/ps-order-source.sh"
+
+# ---------------------------------------------------------------------------
+# Configuration (env-overridable, same convention as f1/lib.sh)
+# ---------------------------------------------------------------------------
+SOURCE_TENANT="${SOURCE_TENANT:-perf-f11-allegro}"
+PSO_TAG="${PSO_TAG:-f11}"
+
+# Each arm's backlog must outlast its window at the highest offered rate, or
+# post_guard_feed_starved (Allegro side) / a starved PrestaShop-source count
+# discards the run - see f1's identical reasoning. Kept modest by default
+# because channel 2's backlog costs one full webservice round-trip PER
+# order (no bulk-push primitive exists for a native PrestaShop order).
+THROUGHPUT_BACKLOG="${THROUGHPUT_BACKLOG:-150}"
+THROUGHPUT_WINDOW_SECS="${THROUGHPUT_WINDOW_SECS:-300}"
+POLL_CADENCE_SECS="${POLL_CADENCE_SECS:-10}"
+
+# The starvation threshold classify_channel_contention (lib.sh) applies: a
+# concurrent-vs-solo throughput drop of this % or more reads "starved".
+STARVATION_THRESHOLD_PCT="${STARVATION_THRESHOLD_PCT:-20}"
+
+MODE="strict"
+for arg in "$@"; do
+  case "$arg" in
+    --smoke) MODE="smoke" ;;
+    -h|--help)
+      cat <<'USAGE'
+Usage: f11-concurrent-multichannel.sh [--smoke]
+
+  (no flag)   strict measurement - both solo baselines (re-taken in THIS
+              session), then the concurrent window, with per-channel and
+              aggregate reporting, starvation classification, and a dated
+              report under results/.
+  --smoke     driver self-test only: resolves PrestaShop reference ids,
+              pushes ONE PrestaShop-source order end to end, prints the
+              result. No window, no manifest, no verdict. This is the
+              validation step the setup process requires BEFORE any shared
+              stand time is requested for the real windows - it still needs
+              guard_stand_exclusive, because pushing one real order into a
+              shared PrestaShop container is itself a stand mutation.
+USAGE
+      exit 0
+      ;;
+    *) die "unknown argument: $arg (use --smoke, --help, or nothing)" ;;
+  esac
+done
+
+require_tools docker jq curl awk
+
+[ -n "${ALLEGRO_A_CONNECTION_ID:-}" ] || die "ALLEGRO_A_CONNECTION_ID is not set - source stand-ids.env (bootstrap.sh) or export it by hand"
+[ -n "${PS_CONNECTION_ID:-}" ] || die "PS_CONNECTION_ID is not set - source stand-ids.env"
+[ -n "${WC_CONNECTION_ID:-}" ] || die "WC_CONNECTION_ID is not set - source stand-ids.env"
+ALLEGRO_SOURCE_CONNECTION_ID="${SOURCE_CONNECTION_ID:-$ALLEGRO_A_CONNECTION_ID}"
+
+# ===========================================================================
+# guard_stand_exclusive FIRST, before ANY state mutation - this scenario
+# creates a new connection, disables the shared PrestaShop destination's
+# capability, and pushes real orders into a shared shop. A peer racing any
+# of that invalidates both runs (#2842/#2848's own lesson).
+# ===========================================================================
+guard_stand_exclusive "f11-concurrent-multichannel"
+
+ol_login
+
+connection_json() { ol_api GET "/v1/connections/$1"; }
+
+# ---------------------------------------------------------------------------
+# Posture capture, for the single EXIT trap (bash has ONE trap slot -
+# guard_stand_exclusive already claimed it, so f11_on_exit below calls
+# release_stand_exclusive itself at the end, exactly as f1 does).
+# ---------------------------------------------------------------------------
+ORIGINAL_PS_CAPS="$(connection_json "$PS_CONNECTION_ID" | jq -c '.enabledCapabilities // []')"
+ORIGINAL_PS_CONFIG="$(connection_json "$PS_CONNECTION_ID" | jq -c '.config // {}')"
+log "posture at start: perf-prestashop caps=$ORIGINAL_PS_CAPS"
+
+CONNECTIONS_TOUCHED=0
+PS_SOURCE_CONNECTION_ID=""
+RESULTS_DIR_MADE=""
+
+restore_curl() {
+  local method="$1" path="$2" body="${3:-}"
+  [ -n "${RESTORE_TOKEN:-}" ] || return 0
+  curl -sS -o /dev/null -X "$method" "$OL_API_URL$path" \
+    -H "Authorization: Bearer $RESTORE_TOKEN" -H 'Content-Type: application/json' \
+    ${body:+-d "$body"} 2>/dev/null || true
+}
+
+f11_on_exit() {
+  local rc=$?
+  # Stop every sampler this run may have started, whatever the exit path.
+  for d in "$RESULTS_DIR_ALLEGRO_SOLO" "$RESULTS_DIR_PS_SOLO" "$RESULTS_DIR_CONCURRENT_A" "$RESULTS_DIR_CONCURRENT_B" "$RESULTS_DIR_CONCURRENT_AGG"; do
+    [ -n "${d:-}" ] && sampler_stop "$d" 2>/dev/null || true
+  done
+
+  if [ "$CONNECTIONS_TOUCHED" = "0" ]; then
+    log "nothing was changed on the stand - no restore needed"
+    release_stand_exclusive
+    return $rc
+  fi
+
+  log "restoring stand posture"
+  RESTORE_TOKEN="$(curl -sS -X POST "$OL_API_URL/v1/auth/login" -H 'Content-Type: application/json' \
+    -d "{\"username\":\"$OL_ADMIN_USER\",\"password\":\"$OL_ADMIN_PASSWORD\"}" 2>/dev/null \
+    | jq -r '.access_token // .accessToken // empty' 2>/dev/null || printf '')"
+  [ -n "$RESTORE_TOKEN" ] || warn "could not log in to restore perf-prestashop's capabilities - it is left with OrderProcessorManager disabled"
+
+  # Restore the shared destination connection to exactly what it was.
+  restore_curl PATCH "/v1/connections/$PS_CONNECTION_ID" \
+    "$(jq -n --argjson c "$ORIGINAL_PS_CAPS" --argjson g "$ORIGINAL_PS_CONFIG" '{enabledCapabilities:$c, config:$g}' 2>/dev/null || printf '')"
+
+  # The new PrestaShop-source connection did not exist before this run.
+  # There is no DELETE /v1/connections/:id endpoint in this codebase
+  # (connection.controller.ts has GET/POST/PATCH only), so full removal is
+  # not available - disabling it is the closest available "leave it as I
+  # found it" (a disabled, inert connection rather than a live one still
+  # polling a shop it should not be). Recorded as an accepted residual
+  # state rather than a silent gap.
+  if [ -n "$PS_SOURCE_CONNECTION_ID" ]; then
+    restore_curl PATCH "/v1/connections/$PS_SOURCE_CONNECTION_ID/disable" ""
+    log "perf-prestashop-source ($PS_SOURCE_CONNECTION_ID) disabled - no DELETE endpoint exists to remove it outright"
+  fi
+
+  release_stand_exclusive
+  return $rc
+}
+trap f11_on_exit EXIT
+
+# set_destination <connection_id> <on|off> - identical reasoning to f1's own
+# helper: toggles the capability rather than `status`, because a status
+# flip into `active` fires the taxonomy-sync bootstrap (#2084/#2085) this
+# run does not want to add noise from.
+set_destination() {
+  local conn="$1" state="$2" caps
+  caps="$(connection_json "$conn" | jq -c '.enabledCapabilities // []')"
+  if [ "$state" = "on" ]; then
+    caps="$(printf '%s' "$caps" | jq -c '. + ["OrderProcessorManager"] | unique')"
+  else
+    caps="$(printf '%s' "$caps" | jq -c 'map(select(. != "OrderProcessorManager"))')"
+  fi
+  CONNECTIONS_TOUCHED=1
+  ol_api PATCH "/v1/connections/$conn" "$(jq -n --argjson c "$caps" '{enabledCapabilities:$c}')" >/dev/null
+  log "set_destination $conn -> $state (caps now $caps)"
+}
+
+# ---------------------------------------------------------------------------
+# f11_ensure_source_connection - get-or-create the NEW PrestaShop-as-source
+# connection. Idempotent by name, the bootstrap.sh convention
+# (ol_connection_id_by_name / ol_ensure_connection), reimplemented locally
+# because those helpers live in bootstrap.sh, a setup script this scenario
+# does not want to re-run wholesale.
+#
+# ONLY OrderSource is enabled - no ProductMaster/InventoryMaster/
+# OrderProcessorManager - so this connection can never itself become a
+# destination and cannot collide with perf-prestashop's own master-sync
+# claims (#1904's rival-claimant guard governs ProductMaster/InventoryMaster
+# collisions, which this sidesteps by not claiming either).
+# ---------------------------------------------------------------------------
+f11_ensure_source_connection() {
+  local name="perf-prestashop-source" existing
+  existing="$(ol_api GET "/v1/connections" | jq -r --arg n "$name" \
+    'if type=="array" then . else (.items // []) end | map(select(.name==$n)) | .[0].id // empty')"
+  if [ -n "$existing" ]; then
+    log "found connection '$name' ($existing)"
+    printf '%s' "$existing"
+    return 0
+  fi
+  local base_url
+  base_url="$(connection_json "$PS_CONNECTION_ID" | jq -r '.config.baseUrl // empty')"
+  [ -n "$base_url" ] || die "f11_ensure_source_connection: perf-prestashop has no config.baseUrl to copy"
+  local ws_key="${PS_WS_KEY:-${PS_WEBSERVICE_KEY:-}}"
+  [ -n "$ws_key" ] || die "f11_ensure_source_connection: no PrestaShop webservice key available (PS_WS_KEY/PS_WEBSERVICE_KEY) - source stand-ids.env"
+  CONNECTIONS_TOUCHED=1
+  local id
+  id="$(ol_api POST /v1/connections "$(jq -n --arg u "$base_url" --arg k "$ws_key" \
+    '{name:"perf-prestashop-source", platformType:"prestashop",
+      enabledCapabilities:["OrderSource"],
+      config:{baseUrl:$u, shopId:1},
+      credentials:{webserviceApiKey:$k}}')" | jq -r '.id // empty')"
+  [ -n "$id" ] || die "f11_ensure_source_connection: connection create returned no id"
+  log "created connection 'perf-prestashop-source' ($id)"
+  printf '%s' "$id"
+}
+
+# ===========================================================================
+# --smoke: driver self-test, no window, no manifest. This is the ONE
+# validation call the setup process requires before requesting a shared
+# stand window - and it still mutates the stand (a real order lands in
+# ps_orders), so it runs behind guard_stand_exclusive above like everything
+# else in this file, not as an exception to it.
+# ===========================================================================
+if [ "$MODE" = "smoke" ]; then
+  log "=== smoke: resolving PrestaShop reference ids ==="
+  pso_resolve_refs
+  pso_ensure_customer "$PSO_TAG"
+  log "=== smoke: pushing ONE PrestaShop-source order ==="
+  order_id="$(pso_push_one_order "$PSO_TAG")"
+  log "smoke ok: created native PrestaShop order id=$order_id"
+  log "ps_orders count is now $(pso_orders_count)"
+  exit 0
+fi
+
+# ===========================================================================
+# Strict mode from here: create the second connection, disable the shared
+# destination for the self-loop reason above, then run the three windows.
+# ===========================================================================
+PS_SOURCE_CONNECTION_ID="$(f11_ensure_source_connection)"
+pso_resolve_refs
+pso_ensure_customer "$PSO_TAG"
+
+set_destination "$PS_CONNECTION_ID" off
+
+CONN_IDS_ALL="'$ALLEGRO_SOURCE_CONNECTION_ID','$PS_SOURCE_CONNECTION_ID'"
+
+guard_queue_empty "$CONN_IDS_ALL"
+guard_scheduler_off
+guard_demo_mode_off
+guard_connection_budget
+guard_pool_recorded
+guard_build
+guard_runner_state enabled
+guard_log_level
+guard_perf_max_attempts
+
+snapshot_jobs_before "$CONN_IDS_ALL"
+RUN_LABEL="run$(date +%s)"
+RESULTS_DIR_ALLEGRO_SOLO="$(results_dir_init f11-concurrent-multichannel "$RUN_LABEL-solo-allegro")"
+RESULTS_DIR_PS_SOLO="$(results_dir_init f11-concurrent-multichannel "$RUN_LABEL-solo-prestashop")"
+RESULTS_DIR_CONCURRENT_A="$(results_dir_init f11-concurrent-multichannel "$RUN_LABEL-concurrent-allegro")"
+RESULTS_DIR_CONCURRENT_B="$(results_dir_init f11-concurrent-multichannel "$RUN_LABEL-concurrent-prestashop")"
+RESULTS_DIR_CONCURRENT_AGG="$(results_dir_init f11-concurrent-multichannel "$RUN_LABEL-concurrent-aggregate")"
+RESULTS_DIR_MADE=1
+
+# ---------------------------------------------------------------------------
+# f11_orders_ingested_since <sourceConnectionId> <since_iso> - the
+# THROUGHPUT figure both baselines and the concurrent arm read: order_records
+# rows attributed to this SOURCE connection, created in the window. This is
+# ingestion throughput (arrival -> order_records persisted), deliberately
+# NOT full ingest-to-destination-creation - see the file header's "what this
+# does not measure".
+# ---------------------------------------------------------------------------
+f11_orders_ingested_since() {
+  local conn="$1" since_iso="$2"
+  as_count "$(pg_sql "SELECT COUNT(*) FROM order_records WHERE \"sourceConnectionId\"='$conn' AND \"createdAt\">='$since_iso'" 2>/dev/null | tr -d '[:space:]')"
+}
+
+# ===========================================================================
+# ARM 1 - Allegro solo baseline (RE-TAKEN in this session, not quoted from
+# #2977 - and methodologically Allegro->WooCommerce here, not
+# Allegro->PrestaShop, per the self-loop scope cut above).
+# ===========================================================================
+log "=== ARM 1: Allegro solo baseline ==="
+of_new_run "f11-a1-$(date +%s)" >/dev/null
+of_push_orders "$SOURCE_TENANT" "$THROUGHPUT_BACKLOG" 1 1 >/dev/null
+window_start "$RESULTS_DIR_ALLEGRO_SOLO" f11-concurrent-multichannel "$CONN_IDS_ALL" 0 \
+  '{"arm":"solo-allegro","destination":"woocommerce-only","arrivalRatePerSec":null}'
+sampler_start "$RESULTS_DIR_ALLEGRO_SOLO" "'$ALLEGRO_SOURCE_CONNECTION_ID'"
+ARM1_START_ISO="$(iso_now)"
+t_end=$(( $(epoch) + THROUGHPUT_WINDOW_SECS ))
+while [ "$(epoch)" -lt "$t_end" ]; do
+  of_enqueue_poll "$ALLEGRO_SOURCE_CONNECTION_ID" "f11-a1" >/dev/null
+  sleep "$POLL_CADENCE_SECS"
+done
+sampler_stop "$RESULTS_DIR_ALLEGRO_SOLO"
+window_stop "$RESULTS_DIR_ALLEGRO_SOLO"
+manifest_set_sync_jobs_end "$RESULTS_DIR_ALLEGRO_SOLO"
+ARM1_COUNT="$(f11_orders_ingested_since "$ALLEGRO_SOURCE_CONNECTION_ID" "$ARM1_START_ISO")"
+ARM1_RATE_PER_HOUR="$(awk -v n="$ARM1_COUNT" -v s="$THROUGHPUT_WINDOW_SECS" 'BEGIN{printf "%.2f", n*3600/s}')"
+log "ARM1 (Allegro solo): $ARM1_COUNT orders in ${THROUGHPUT_WINDOW_SECS}s = $ARM1_RATE_PER_HOUR/h"
+run_post_guards "$RESULTS_DIR_ALLEGRO_SOLO" "'$ALLEGRO_SOURCE_CONNECTION_ID'" "$ARM1_START_ISO" \
+  "$(date -d "$ARM1_START_ISO" +%s 2>/dev/null || date -j -f '%Y-%m-%dT%H:%M:%SZ' "$ARM1_START_ISO" +%s)" "$(epoch)"
+
+reset_between_repeats "'$ALLEGRO_SOURCE_CONNECTION_ID'" "'allegro.orders.lastEventId'"
+
+# ===========================================================================
+# ARM 2 - PrestaShop-source solo baseline.
+# ===========================================================================
+log "=== ARM 2: PrestaShop-source solo baseline ==="
+window_start "$RESULTS_DIR_PS_SOLO" f11-concurrent-multichannel "'$PS_SOURCE_CONNECTION_ID'" 0 \
+  '{"arm":"solo-prestashop-source","destination":"woocommerce-only"}'
+sampler_start "$RESULTS_DIR_PS_SOLO" "'$PS_SOURCE_CONNECTION_ID'"
+ARM2_START_ISO="$(iso_now)"
+pso_push_orders "$THROUGHPUT_BACKLOG" "f11-a2" >/dev/null
+t_end=$(( $(epoch) + THROUGHPUT_WINDOW_SECS ))
+while [ "$(epoch)" -lt "$t_end" ]; do
+  pso_enqueue_poll "$PS_SOURCE_CONNECTION_ID" "f11-a2" >/dev/null
+  sleep "$POLL_CADENCE_SECS"
+done
+sampler_stop "$RESULTS_DIR_PS_SOLO"
+window_stop "$RESULTS_DIR_PS_SOLO"
+manifest_set_sync_jobs_end "$RESULTS_DIR_PS_SOLO"
+ARM2_COUNT="$(f11_orders_ingested_since "$PS_SOURCE_CONNECTION_ID" "$ARM2_START_ISO")"
+ARM2_RATE_PER_HOUR="$(awk -v n="$ARM2_COUNT" -v s="$THROUGHPUT_WINDOW_SECS" 'BEGIN{printf "%.2f", n*3600/s}')"
+log "ARM2 (PrestaShop-source solo): $ARM2_COUNT orders in ${THROUGHPUT_WINDOW_SECS}s = $ARM2_RATE_PER_HOUR/h"
+run_post_guards "$RESULTS_DIR_PS_SOLO" "'$PS_SOURCE_CONNECTION_ID'" "$ARM2_START_ISO" \
+  "$(date -d "$ARM2_START_ISO" +%s 2>/dev/null || date -j -f '%Y-%m-%dT%H:%M:%SZ' "$ARM2_START_ISO" +%s)" "$(epoch)"
+
+reset_between_repeats "'$PS_SOURCE_CONNECTION_ID'" "'prestashop.orders.dateUpd'"
+
+# ===========================================================================
+# ARM 3 - CONCURRENT window. Both channels driven at once. Three samplers
+# (Allegro-only, PrestaShop-source-only, combined) into three directories -
+# sample_queue (lib.sh) already accepts an arbitrary conn_ids filter, so no
+# lib.sh change was needed to get per-channel breakdown: three calls to the
+# SAME function, pointed at three scopes.
+# ===========================================================================
+log "=== ARM 3: CONCURRENT (Allegro + PrestaShop-source) ==="
+of_new_run "f11-a3-$(date +%s)" >/dev/null
+of_push_orders "$SOURCE_TENANT" "$THROUGHPUT_BACKLOG" 1 1 >/dev/null
+pso_push_orders "$THROUGHPUT_BACKLOG" "f11-a3" >/dev/null
+window_start "$RESULTS_DIR_CONCURRENT_AGG" f11-concurrent-multichannel "$CONN_IDS_ALL" 0 \
+  '{"arm":"concurrent","destination":"woocommerce-only","channels":["allegro","prestashop-source"]}'
+sampler_start "$RESULTS_DIR_CONCURRENT_A" "'$ALLEGRO_SOURCE_CONNECTION_ID'"
+sampler_start "$RESULTS_DIR_CONCURRENT_B" "'$PS_SOURCE_CONNECTION_ID'"
+sampler_start "$RESULTS_DIR_CONCURRENT_AGG" "$CONN_IDS_ALL"
+ARM3_START_ISO="$(iso_now)"
+t_end=$(( $(epoch) + THROUGHPUT_WINDOW_SECS ))
+while [ "$(epoch)" -lt "$t_end" ]; do
+  of_enqueue_poll "$ALLEGRO_SOURCE_CONNECTION_ID" "f11-a3" >/dev/null
+  pso_enqueue_poll "$PS_SOURCE_CONNECTION_ID" "f11-a3" >/dev/null
+  sleep "$POLL_CADENCE_SECS"
+done
+sampler_stop "$RESULTS_DIR_CONCURRENT_A"
+sampler_stop "$RESULTS_DIR_CONCURRENT_B"
+sampler_stop "$RESULTS_DIR_CONCURRENT_AGG"
+window_stop "$RESULTS_DIR_CONCURRENT_AGG"
+manifest_set_sync_jobs_end "$RESULTS_DIR_CONCURRENT_AGG"
+
+ARM3_ALLEGRO_COUNT="$(f11_orders_ingested_since "$ALLEGRO_SOURCE_CONNECTION_ID" "$ARM3_START_ISO")"
+ARM3_PS_COUNT="$(f11_orders_ingested_since "$PS_SOURCE_CONNECTION_ID" "$ARM3_START_ISO")"
+ARM3_ALLEGRO_RATE="$(awk -v n="$ARM3_ALLEGRO_COUNT" -v s="$THROUGHPUT_WINDOW_SECS" 'BEGIN{printf "%.2f", n*3600/s}')"
+ARM3_PS_RATE="$(awk -v n="$ARM3_PS_COUNT" -v s="$THROUGHPUT_WINDOW_SECS" 'BEGIN{printf "%.2f", n*3600/s}')"
+ARM3_AGG_RATE="$(awk -v a="$ARM3_ALLEGRO_RATE" -v b="$ARM3_PS_RATE" 'BEGIN{printf "%.2f", a+b}')"
+log "ARM3 concurrent: allegro=$ARM3_ALLEGRO_COUNT ($ARM3_ALLEGRO_RATE/h) prestashop-source=$ARM3_PS_COUNT ($ARM3_PS_RATE/h) aggregate=$ARM3_AGG_RATE/h"
+
+run_post_guards "$RESULTS_DIR_CONCURRENT_AGG" "$CONN_IDS_ALL" "$ARM3_START_ISO" \
+  "$(date -d "$ARM3_START_ISO" +%s 2>/dev/null || date -j -f '%Y-%m-%dT%H:%M:%SZ' "$ARM3_START_ISO" +%s)" "$(epoch)"
+
+# ===========================================================================
+# STARVATION CLASSIFICATION - the check the issue itself names as the one
+# that matters most ("an aggregate that holds while one channel gets
+# nothing is the failure"). classify_channel_contention (lib.sh, #2979)
+# reads unparseable/zero rates as "unknown", never as a silent "held".
+# ===========================================================================
+ALLEGRO_VERDICT="$(classify_channel_contention "$ARM1_RATE_PER_HOUR" "$ARM3_ALLEGRO_RATE" "$STARVATION_THRESHOLD_PCT")"
+PS_VERDICT="$(classify_channel_contention "$ARM2_RATE_PER_HOUR" "$ARM3_PS_RATE" "$STARVATION_THRESHOLD_PCT")"
+log "starvation check: allegro solo=$ARM1_RATE_PER_HOUR/h concurrent=$ARM3_ALLEGRO_RATE/h -> $ALLEGRO_VERDICT"
+log "starvation check: prestashop-source solo=$ARM2_RATE_PER_HOUR/h concurrent=$ARM3_PS_RATE/h -> $PS_VERDICT"
+
+# ---------------------------------------------------------------------------
+# BINDING-CONSTRAINT EVIDENCE - read straight off the manifest/timeseries
+# this run already wrote, never inferred from the throughput number alone
+# (#2979's own acceptance criterion). Peak per-connection `running`
+# sync_jobs count during the concurrent window, against the documented
+# realtime lane caps (total=4, perScope=2, sync-job.runner.ts) - if BOTH
+# channels are simultaneously pegged at perScope while the lane total is
+# saturated, that is direct evidence the LANE, not either destination's
+# rate limit, is what a third channel would queue behind.
+# ---------------------------------------------------------------------------
+f11_peak_running() {
+  local conn="$1"
+  as_count "$(pg_sql "SELECT MAX(c) FROM (SELECT COUNT(*) c FROM sync_jobs WHERE \"connectionId\"='$conn' AND status='running' GROUP BY \"lockedAt\") x" 2>/dev/null | tr -d '[:space:]')"
+}
+PEAK_RUNNING_ALLEGRO="$(f11_peak_running "$ALLEGRO_SOURCE_CONNECTION_ID")"
+PEAK_RUNNING_PS="$(f11_peak_running "$PS_SOURCE_CONNECTION_ID")"
+LIMITER_DEGRADED_LOGGED="unknown"
+if grep -q 'rate_limiter_degraded_entered' "$RESULTS_DIR_CONCURRENT_AGG"/*.log 2>/dev/null; then
+  LIMITER_DEGRADED_LOGGED="yes"
+else
+  LIMITER_DEGRADED_LOGGED="no (or logs unavailable to this scan)"
+fi
+log "binding-constraint evidence: peak running (allegro)=${PEAK_RUNNING_ALLEGRO:-unknown} (prestashop-source)=${PEAK_RUNNING_PS:-unknown}; realtime lane caps total=4 perScope=2; limiter-degraded log seen=$LIMITER_DEGRADED_LOGGED"
+
+jq -n \
+  --arg allegroSolo "$ARM1_RATE_PER_HOUR" --arg psSolo "$ARM2_RATE_PER_HOUR" \
+  --arg allegroConcurrent "$ARM3_ALLEGRO_RATE" --arg psConcurrent "$ARM3_PS_RATE" \
+  --arg aggregateConcurrent "$ARM3_AGG_RATE" \
+  --arg allegroVerdict "$ALLEGRO_VERDICT" --arg psVerdict "$PS_VERDICT" \
+  --arg peakRunningAllegro "${PEAK_RUNNING_ALLEGRO:-unknown}" --arg peakRunningPs "${PEAK_RUNNING_PS:-unknown}" \
+  --arg limiterDegraded "$LIMITER_DEGRADED_LOGGED" \
+  '{
+    labelled: "measured",
+    scopeCut: "two channels (Allegro stub + PrestaShop-as-source), not three - Erli/WooCommerce unreachable on this stand, see file header",
+    baselines: {allegroSoloPerHour: $allegroSolo, prestashopSourceSoloPerHour: $psSolo},
+    concurrent: {allegroPerHour: $allegroConcurrent, prestashopSourcePerHour: $psConcurrent, aggregatePerHour: $aggregateConcurrent},
+    starvation: {allegro: $allegroVerdict, prestashopSource: $psVerdict, thresholdPct: '"$STARVATION_THRESHOLD_PCT"'},
+    bindingConstraintEvidence: {peakRunningAllegro: $peakRunningAllegro, peakRunningPrestashopSource: $peakRunningPs, realtimeLaneCaps: "total=4 perScope=2 (sync-job.runner.ts)", limiterDegradedLogSeen: $limiterDegraded}
+  }' > "$RESULTS_DIR_CONCURRENT_AGG/f11-summary.json"
+log "wrote $RESULTS_DIR_CONCURRENT_AGG/f11-summary.json"
+
+log "=== F11 done. See $RESULTS_DIR_CONCURRENT_AGG for the aggregate window and its two per-channel siblings. ==="

--- a/perf/openlinker-throughput/scenarios/f11-concurrent-multichannel.sh
+++ b/perf/openlinker-throughput/scenarios/f11-concurrent-multichannel.sh
@@ -194,6 +194,18 @@ log "posture at start: perf-prestashop caps=$ORIGINAL_PS_CAPS"
 CONNECTIONS_TOUCHED=0
 PS_SOURCE_CONNECTION_ID=""
 RESULTS_DIR_MADE=""
+# Declared here (empty) rather than only in strict mode below, so the EXIT
+# trap's `${d:-}` loop never hits an unbound-variable error under `set -u`
+# when MODE=smoke (or any early-die path) exits before strict mode assigns
+# these - an unbound var inside the trap aborts the trap itself, which means
+# release_stand_exclusive() never runs and the stand lock leaks permanently.
+# Found the hard way: a --smoke run that died in pso_resolve_refs left
+# perf:stand:exclusive stuck under a since-dead PID.
+RESULTS_DIR_ALLEGRO_SOLO=""
+RESULTS_DIR_PS_SOLO=""
+RESULTS_DIR_CONCURRENT_A=""
+RESULTS_DIR_CONCURRENT_B=""
+RESULTS_DIR_CONCURRENT_AGG=""
 
 restore_curl() {
   local method="$1" path="$2" body="${3:-}"


### PR DESCRIPTION
Part of #2840. Harness for F11 (concurrent multi-channel: Allegro order source + PrestaShop order source running concurrently) — scenario script, driver fixes (a Host-header workaround for the PrestaShop webservice redirect, and an Output-Format/exit-trap robustness fix under `set -u`), and a smoke-test launcher.

No VALID/DISCARDED verdict yet — the actual measurement run is being finished on a different machine. Merging the harness code now so that machine can pull it directly instead of re-deriving the fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)