### PR TITLE
perf(3046): F16 shop-publish scenario

### DIFF
--- a/docker-compose.lab.yml
+++ b/docker-compose.lab.yml
@@ -178,6 +178,19 @@ services:
   prestashop:
     image: prestashop/prestashop:9.0.2-2.0-classic-8.4
     container_name: lab-prestashop
+    # `prestashop.lab` network alias (#3046) - WordPress's own
+    # `wp_http_validate_url()` refuses to fetch a remote image (or any
+    # remote URL) from a bare, dot-less hostname ("A valid URL was not
+    # provided", found live the first time a shop-publish scenario tried to
+    # attach a PrestaShop-hosted product image to a WooCommerce product).
+    # The bare `prestashop` alias below is UNCHANGED and still resolves -
+    # every already-measured scenario's connections keep working unmodified -
+    # this only ADDS a second, dotted name for `PS_INTERNAL_URL` to prefer
+    # going forward.
+    networks:
+      default:
+        aliases:
+          - prestashop.lab
     environment:
       PS_DOMAIN: 'localhost:${PRESTASHOP_HOST_PORT:-19080}'
       PS_FOLDER_ADMIN: admin

--- a/perf/openlinker-throughput/bootstrap.sh
+++ b/perf/openlinker-throughput/bootstrap.sh
@@ -40,7 +40,15 @@ LIB_LOG_PREFIX="bootstrap"
 source "$SCRIPT_DIR/lib.sh"
 
 # Internal hostnames as seen from the api/worker containers on the compose network.
-PS_INTERNAL_URL="${PS_INTERNAL_URL:-http://prestashop}"
+# PS_INTERNAL_URL uses the DOTTED `prestashop.lab` alias (#3046), not the bare
+# `prestashop` service name - WordPress's wp_http_validate_url() refuses to
+# fetch a remote image (or any URL) from a dot-less host, so a shop-publish
+# scenario attaching a PrestaShop-hosted image to a WooCommerce product would
+# fail every item with woocommerce_product_image_upload_error against the
+# bare name. The bare name still resolves (docker-compose.lab.yml's alias is
+# additive), so an operator overriding this var to the old value loses only
+# the image-attach path, not connectivity.
+PS_INTERNAL_URL="${PS_INTERNAL_URL:-http://prestashop.lab}"
 WC_INTERNAL_URL="${WC_INTERNAL_URL:-https://wc-tls}"
 ALLEGRO_STUB_URL="${ALLEGRO_STUB_URL:-http://allegro-stub:8080}"
 
@@ -338,6 +346,41 @@ step_tax_group() {
 # cleartext allows OAuth 1.0a only - query-string and Basic both require
 # is_ssl() - which is why the stand fronts it with the wc-tls proxy (#2854).
 # ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Step 3b - lab-only WordPress mu-plugins (#2854, #3046).
+#
+# NOT bind-mounted (docker-compose.lab.yml's own comment on the woocommerce
+# service explains why: bind-mounting under wp-content/ before the Bitnami
+# entrypoint's first boot makes it take the "restore" branch against an
+# empty volume and fail with "wp-config.php not found", verified live) - so
+# they are docker-cp'd in after the container is healthy instead. Idempotent:
+# a re-run just overwrites the same file with itself.
+#
+#   force-https.php             - makes WP's is_ssl() true behind the wc-tls
+#                                  TLS-terminating proxy (#2854).
+#   allow-internal-image-fetch.php - disables wp_http_validate_url()'s
+#                                  private-IP block (#3046) so the shop-
+#                                  publish image-upload path can fetch a
+#                                  product image from a Docker-internal host.
+# ---------------------------------------------------------------------------
+step_woocommerce_mu_plugins() {
+  log "--- WooCommerce mu-plugins ---"
+  local src_dir="$SCRIPT_DIR/stand/wc-mu-plugins" f name
+  [ -d "$src_dir" ] || { warn "no $src_dir - skipping mu-plugin sync"; return 0; }
+  if [ "$VERIFY_ONLY" = 1 ]; then
+    gap "mu-plugin sync only verified by re-running (docker cp has no dry-run probe worth trusting)"
+    return 0
+  fi
+  would "docker cp every *.php in $src_dir into $WC_CONTAINER:/opt/bitnami/wordpress/wp-content/mu-plugins/" && return 0
+  docker exec "$WC_CONTAINER" mkdir -p /opt/bitnami/wordpress/wp-content/mu-plugins
+  for f in "$src_dir"/*.php; do
+    [ -f "$f" ] || continue
+    name="$(basename "$f")"
+    docker cp "$f" "$WC_CONTAINER:/opt/bitnami/wordpress/wp-content/mu-plugins/$name"
+  done
+  created "mu-plugins synced ($(ls "$src_dir"/*.php 2>/dev/null | wc -l | tr -d ' ') file(s))"
+}
+
 step_woocommerce() {
   log "--- WooCommerce REST key ---"
   local existing
@@ -461,10 +504,16 @@ JSON
   # on CREATE directly; `ensure_woocommerce_publish_capabilities` below is the
   # idempotent PATCH half for a connection created by an earlier bootstrap run
   # (the `ensure_offer_manager` shape, generalised).
+  #
+  # `config.masterCatalogConnectionId` is likewise required for ProductPublisher
+  # to do anything at all - found live (#3046): a shop-publish submit with it
+  # absent fails every item with MASTER_CATALOG_NOT_CONFIGURED, since the
+  # publish builder has no master to read name/description/price from. Points
+  # at perf-prestashop, created immediately above.
   ol_ensure_connection WC_CONN_ID 'perf-woocommerce' "$(cat <<JSON
 {"name":"perf-woocommerce","platformType":"woocommerce",
  "enabledCapabilities":["OrderProcessorManager","ProductPublisher","CategoryProvisioner"],
- "config":{"siteUrl":"$WC_INTERNAL_URL"},
+ "config":{"siteUrl":"$WC_INTERNAL_URL","masterCatalogConnectionId":"${PS_CONN_ID:-}"},
  "credentials":{"consumerKey":"${WC_CK:-}","consumerSecret":"${WC_CS:-}"}}
 JSON
 )"
@@ -691,6 +740,53 @@ ensure_capabilities_present() {
 step_woocommerce_publish_capabilities() {
   log "--- WooCommerce ProductPublisher/CategoryProvisioner capability ---"
   ensure_capabilities_present "${WC_CONN_ID:-}" 'perf-woocommerce' ProductPublisher CategoryProvisioner
+  ensure_woocommerce_master_catalog
+  ensure_prestashop_shop_url_alias
+}
+
+# Idempotent ps_shop_url row for the PS_INTERNAL_URL hostname (#3046).
+#
+# PrestaShop's webservice dispatcher redirects a single-resource GET
+# (`/api/products/25`) to the shop's CANONICAL registered domain
+# (`ps_shop_url.main=1`, PS_DOMAIN's `localhost:19080`) whenever the
+# request's Host header doesn't match ANY registered ps_shop_url.domain row -
+# even with valid Basic Auth. List-style queries (`?filter[...]`) do NOT
+# trigger this (verified live). `PS_INTERNAL_URL` (the dotted `prestashop.lab`
+# alias WordPress's own dot-less-host check requires, see the comment above
+# its declaration) is never registered by the image's own install - only
+# PS_DOMAIN's value is - so every single-resource read the WooCommerce
+# publish path makes (`getProduct`) 301-redirected to `localhost:19080`,
+# which no in-network container can reach. Registering it as an ADDITIONAL
+# (main=0) domain fixes the redirect without touching the canonical one.
+ensure_prestashop_shop_url_alias() {
+  local host existing
+  host="$(printf '%s' "$PS_INTERNAL_URL" | sed -E 's#^[a-z]+://##; s#/.*$##; s#:[0-9]+$##')"
+  [ -n "$host" ] || { warn "could not parse a hostname out of PS_INTERNAL_URL=$PS_INTERNAL_URL - skipping ps_shop_url alias check"; return 0; }
+  existing="$(ps_sql "SELECT COUNT(*) FROM ps_shop_url WHERE domain='$host' OR domain_ssl='$host'")"
+  if [ "${existing:-0}" -gt 0 ]; then found "ps_shop_url row for '$host' (webservice single-resource reads resolve without a redirect)"; return 0; fi
+  if [ "$VERIFY_ONLY" = 1 ]; then gap "no ps_shop_url row for '$host' - single-resource webservice GETs (e.g. /api/products/:id) 301-redirect to the canonical shop domain"; return 0; fi
+  would "register ps_shop_url domain='$host' (main=0, active=1) for shop 1" && return 0
+  ps_sql_write "INSERT INTO ps_shop_url (id_shop, domain, domain_ssl, physical_uri, virtual_uri, main, active) VALUES (1, '$host', '$host', '/', '', 0, 1)"
+  created "ps_shop_url alias registered for '$host'"
+}
+
+# Idempotent PATCH half for config.masterCatalogConnectionId (#3046), for a
+# perf-woocommerce created by an earlier bootstrap run that predates this
+# key. `ConnectionRepository.update` REPLACES `config` wholesale (never a
+# deep merge), so this reads the CURRENT config back and merges client-side -
+# a bare `{config: {masterCatalogConnectionId: ...}}` patch would silently
+# wipe `siteUrl`. Never overwrites an operator-set value that differs from
+# perf-prestashop's id - only fills the gap when the key is absent.
+ensure_woocommerce_master_catalog() {
+  local conn_id="${WC_CONN_ID:-}" current_config current
+  [ -n "$conn_id" ] || { warn "no connection id for perf-woocommerce - skipping masterCatalogConnectionId check"; return 0; }
+  current_config="$(ol_api GET "/v1/connections/$conn_id" | jq -c '.config // {}')"
+  current="$(printf '%s' "$current_config" | jq -r '.masterCatalogConnectionId // empty')"
+  if [ -n "$current" ]; then found "masterCatalogConnectionId on perf-woocommerce ($current)"; return 0; fi
+  if [ "$VERIFY_ONLY" = 1 ]; then gap "perf-woocommerce has no config.masterCatalogConnectionId"; return 0; fi
+  would "set config.masterCatalogConnectionId=${PS_CONN_ID:-} on perf-woocommerce" && return 0
+  ol_api PATCH "/v1/connections/$conn_id" "$(jq -cn --argjson cfg "$current_config" --arg ps "${PS_CONN_ID:-}" '{config: ($cfg + {masterCatalogConnectionId: $ps})}')" >/dev/null
+  created "masterCatalogConnectionId set on perf-woocommerce (${PS_CONN_ID:-})"
 }
 
 # ---------------------------------------------------------------------------
@@ -940,6 +1036,7 @@ main() {
   step_module
   step_webservice
   step_tax_group
+  step_woocommerce_mu_plugins
   step_woocommerce
   step_connections
   # After step_connections (the connection must exist to be patched) and

--- a/perf/openlinker-throughput/results/f16-shop-publish/smoke/manifest.json
+++ b/perf/openlinker-throughput/results/f16-shop-publish/smoke/manifest.json
@@ -1,0 +1,178 @@
+{
+  "scenario": "f16-shop-publish",
+  "generatedAt": "2026-09-10T00:31:38Z",
+  "gitSha": "unknown",
+  "connectionIds": "'5f368651-83bc-4a95-bdf4-71050129e6ab'",
+  "quick": true,
+  "runnerState": "enabled",
+  "laneCaps": "realtime=4/2 bulk=12/8 fiscal=2/1 fan-out=8/4",
+  "workerReplicas": 1,
+  "workerContainers": "lab-worker-1",
+  "laneCapEnforcement": "per-process - the laneCaps above bound ONE worker process, so effective deployment concurrency is laneCaps x workerReplicas (ADR-050 amendment #2594 / #2302)",
+  "pool": {
+    "maxConnections": "unknown",
+    "olDbPoolMax": "unknown",
+    "processCount": "unknown",
+    "budget": "unknown"
+  },
+  "schedulerCadenceRow": {},
+  "olLogBodyMaxBytes": "unknown",
+  "syncJobsRowsAtStart": 16,
+  "syncJobsRowsAtEnd": 17,
+  "environment": {
+    "postgres": {
+      "shared_buffers": "128MB",
+      "work_mem": "4MB",
+      "shared_preload_libraries": "pg_stat_statements,auto_explain",
+      "installed_extensions": "pg_trgm",
+      "nonDefaultSettings": {
+        "roleConfig": {},
+        "databaseRoleConfig": [],
+        "liveSettingsSourceNotDefault": {
+          "lc_time": {
+            "source": "configuration file",
+            "setting": "en_US.utf8"
+          },
+          "TimeZone": {
+            "source": "configuration file",
+            "setting": "UTC"
+          },
+          "hba_file": {
+            "source": "override",
+            "setting": "/var/lib/postgresql/data/pg_hba.conf"
+          },
+          "DateStyle": {
+            "source": "configuration file",
+            "setting": "ISO, MDY"
+          },
+          "ident_file": {
+            "source": "override",
+            "setting": "/var/lib/postgresql/data/pg_ident.conf"
+          },
+          "lc_numeric": {
+            "source": "configuration file",
+            "setting": "en_US.utf8"
+          },
+          "config_file": {
+            "source": "override",
+            "setting": "/var/lib/postgresql/data/postgresql.conf"
+          },
+          "lc_messages": {
+            "source": "configuration file",
+            "setting": "en_US.utf8"
+          },
+          "lc_monetary": {
+            "source": "configuration file",
+            "setting": "en_US.utf8"
+          },
+          "log_timezone": {
+            "source": "configuration file",
+            "setting": "UTC"
+          },
+          "max_wal_size": {
+            "source": "configuration file",
+            "setting": "1024"
+          },
+          "min_wal_size": {
+            "source": "configuration file",
+            "setting": "80"
+          },
+          "data_directory": {
+            "source": "override",
+            "setting": "/var/lib/postgresql/data"
+          },
+          "shared_buffers": {
+            "source": "configuration file",
+            "setting": "16384"
+          },
+          "max_connections": {
+            "source": "command line",
+            "setting": "200"
+          },
+          "application_name": {
+            "source": "client",
+            "setting": "psql"
+          },
+          "listen_addresses": {
+            "source": "configuration file",
+            "setting": "*"
+          },
+          "statement_timeout": {
+            "source": "command line",
+            "setting": "30000"
+          },
+          "transaction_isolation": {
+            "source": "override",
+            "setting": "read committed"
+          },
+          "transaction_read_only": {
+            "source": "override",
+            "setting": "off"
+          },
+          "pg_stat_statements.max": {
+            "source": "command line",
+            "setting": "10000"
+          },
+          "transaction_deferrable": {
+            "source": "override",
+            "setting": "off"
+          },
+          "auto_explain.log_analyze": {
+            "source": "command line",
+            "setting": "on"
+          },
+          "auto_explain.log_buffers": {
+            "source": "command line",
+            "setting": "on"
+          },
+          "pg_stat_statements.track": {
+            "source": "command line",
+            "setting": "all"
+          },
+          "shared_preload_libraries": {
+            "source": "command line",
+            "setting": "pg_stat_statements,auto_explain"
+          },
+          "default_text_search_config": {
+            "source": "configuration file",
+            "setting": "pg_catalog.english"
+          },
+          "dynamic_shared_memory_type": {
+            "source": "configuration file",
+            "setting": "posix"
+          },
+          "auto_explain.log_min_duration": {
+            "source": "command line",
+            "setting": "2000"
+          }
+        }
+      }
+    },
+    "node_version": "v22.23.1",
+    "postgres_image_digest": "sha256:1bea307dfb3ee30541a7acf7de14b58bcd6948da98e5d31a04c627c4d35ec64b",
+    "redis_image_digest": "sha256:7ebbc18dec8fe54c06b66eb496df0094a2412445e510789b5fcdda3a7085469c",
+    "redis_used_memory_bytes": "1829408",
+    "host": {
+      "cpu_count": "22",
+      "ram": "15729MB",
+      "load_average": "0.27, 0.31, 0.27"
+    }
+  },
+  "containerLimits": [
+    {
+      "container": "lab-api",
+      "cpu_nanocpus": "none",
+      "memory_bytes": "none"
+    },
+    {
+      "container": "lab-worker-1",
+      "cpu_nanocpus": "none",
+      "memory_bytes": "none"
+    }
+  ],
+  "excludedPgStatStatementsQueries": [
+    "GET /v1/connections/:id/sync-status (7-day connection-sync-status aggregate over sync_jobs) - issued by sample_queue itself, see README"
+  ],
+  "destinationConnectionId": "5f368651-83bc-4a95-bdf4-71050129e6ab",
+  "destinationCapabilities": "ProductPublisher,CategoryProvisioner"
+}

--- a/perf/openlinker-throughput/results/f16-shop-publish/strict/manifest.json
+++ b/perf/openlinker-throughput/results/f16-shop-publish/strict/manifest.json
@@ -1,0 +1,178 @@
+{
+  "scenario": "f16-shop-publish",
+  "generatedAt": "2026-09-10T00:37:08Z",
+  "gitSha": "unknown",
+  "connectionIds": "'5f368651-83bc-4a95-bdf4-71050129e6ab'",
+  "quick": false,
+  "runnerState": "enabled",
+  "laneCaps": "realtime=4/2 bulk=12/8 fiscal=2/1 fan-out=8/4",
+  "workerReplicas": 1,
+  "workerContainers": "lab-worker-1",
+  "laneCapEnforcement": "per-process - the laneCaps above bound ONE worker process, so effective deployment concurrency is laneCaps x workerReplicas (ADR-050 amendment #2594 / #2302)",
+  "pool": {
+    "maxConnections": "unknown",
+    "olDbPoolMax": "unknown",
+    "processCount": "unknown",
+    "budget": "unknown"
+  },
+  "schedulerCadenceRow": {},
+  "olLogBodyMaxBytes": "unknown",
+  "syncJobsRowsAtStart": 33,
+  "syncJobsRowsAtEnd": 49,
+  "environment": {
+    "postgres": {
+      "shared_buffers": "128MB",
+      "work_mem": "4MB",
+      "shared_preload_libraries": "pg_stat_statements,auto_explain",
+      "installed_extensions": "pg_trgm",
+      "nonDefaultSettings": {
+        "roleConfig": {},
+        "databaseRoleConfig": [],
+        "liveSettingsSourceNotDefault": {
+          "lc_time": {
+            "source": "configuration file",
+            "setting": "en_US.utf8"
+          },
+          "TimeZone": {
+            "source": "configuration file",
+            "setting": "UTC"
+          },
+          "hba_file": {
+            "source": "override",
+            "setting": "/var/lib/postgresql/data/pg_hba.conf"
+          },
+          "DateStyle": {
+            "source": "configuration file",
+            "setting": "ISO, MDY"
+          },
+          "ident_file": {
+            "source": "override",
+            "setting": "/var/lib/postgresql/data/pg_ident.conf"
+          },
+          "lc_numeric": {
+            "source": "configuration file",
+            "setting": "en_US.utf8"
+          },
+          "config_file": {
+            "source": "override",
+            "setting": "/var/lib/postgresql/data/postgresql.conf"
+          },
+          "lc_messages": {
+            "source": "configuration file",
+            "setting": "en_US.utf8"
+          },
+          "lc_monetary": {
+            "source": "configuration file",
+            "setting": "en_US.utf8"
+          },
+          "log_timezone": {
+            "source": "configuration file",
+            "setting": "UTC"
+          },
+          "max_wal_size": {
+            "source": "configuration file",
+            "setting": "1024"
+          },
+          "min_wal_size": {
+            "source": "configuration file",
+            "setting": "80"
+          },
+          "data_directory": {
+            "source": "override",
+            "setting": "/var/lib/postgresql/data"
+          },
+          "shared_buffers": {
+            "source": "configuration file",
+            "setting": "16384"
+          },
+          "max_connections": {
+            "source": "command line",
+            "setting": "200"
+          },
+          "application_name": {
+            "source": "client",
+            "setting": "psql"
+          },
+          "listen_addresses": {
+            "source": "configuration file",
+            "setting": "*"
+          },
+          "statement_timeout": {
+            "source": "command line",
+            "setting": "30000"
+          },
+          "transaction_isolation": {
+            "source": "override",
+            "setting": "read committed"
+          },
+          "transaction_read_only": {
+            "source": "override",
+            "setting": "off"
+          },
+          "pg_stat_statements.max": {
+            "source": "command line",
+            "setting": "10000"
+          },
+          "transaction_deferrable": {
+            "source": "override",
+            "setting": "off"
+          },
+          "auto_explain.log_analyze": {
+            "source": "command line",
+            "setting": "on"
+          },
+          "auto_explain.log_buffers": {
+            "source": "command line",
+            "setting": "on"
+          },
+          "pg_stat_statements.track": {
+            "source": "command line",
+            "setting": "all"
+          },
+          "shared_preload_libraries": {
+            "source": "command line",
+            "setting": "pg_stat_statements,auto_explain"
+          },
+          "default_text_search_config": {
+            "source": "configuration file",
+            "setting": "pg_catalog.english"
+          },
+          "dynamic_shared_memory_type": {
+            "source": "configuration file",
+            "setting": "posix"
+          },
+          "auto_explain.log_min_duration": {
+            "source": "command line",
+            "setting": "2000"
+          }
+        }
+      }
+    },
+    "node_version": "v22.23.1",
+    "postgres_image_digest": "sha256:1bea307dfb3ee30541a7acf7de14b58bcd6948da98e5d31a04c627c4d35ec64b",
+    "redis_image_digest": "sha256:7ebbc18dec8fe54c06b66eb496df0094a2412445e510789b5fcdda3a7085469c",
+    "redis_used_memory_bytes": "1846568",
+    "host": {
+      "cpu_count": "22",
+      "ram": "15729MB",
+      "load_average": "0.40, 0.45, 0.34"
+    }
+  },
+  "containerLimits": [
+    {
+      "container": "lab-api",
+      "cpu_nanocpus": "none",
+      "memory_bytes": "none"
+    },
+    {
+      "container": "lab-worker-1",
+      "cpu_nanocpus": "none",
+      "memory_bytes": "none"
+    }
+  ],
+  "excludedPgStatStatementsQueries": [
+    "GET /v1/connections/:id/sync-status (7-day connection-sync-status aggregate over sync_jobs) - issued by sample_queue itself, see README"
+  ],
+  "destinationConnectionId": "5f368651-83bc-4a95-bdf4-71050129e6ab",
+  "destinationCapabilities": "ProductPublisher,CategoryProvisioner"
+}

--- a/perf/openlinker-throughput/results/f16-shop-publish/strict/verdict.txt
+++ b/perf/openlinker-throughput/results/f16-shop-publish/strict/verdict.txt
@@ -1,0 +1,2 @@
+status=VALID
+generatedAt=2026-09-10T00:38:47Z

--- a/perf/openlinker-throughput/scenarios/f16-shop-publish.sh
+++ b/perf/openlinker-throughput/scenarios/f16-shop-publish.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+#
+# F16 - shop publishing under load: ProductPublisher and CategoryProvisioner
+# (#3046, epic #2840).
+#
+# Measures the bulk shop-publish path (`POST /listings/bulk-shop-publish`)
+# against the real WooCommerce connection (#3043 provisioned it with
+# ProductPublisher + CategoryProvisioner), split the way #3046's own AC
+# requires: simple products and variable products are DIFFERENT units of
+# work (a variable product is one parent PLUS N variations, #1836) and must
+# never be averaged into one figure.
+#
+# Sources lib.sh (#2841) for every guard/manifest/verdict primitive - this
+# scenario owns nothing that library already owns.
+#
+# Four arms:
+#   A. simple-product publish  - N single-variant products
+#   B. variable-product publish - all sibling variants of N multi-variant
+#      products, submitted together (one parent + N variations each)
+#   C. partial-submit failure - a batch mixing real variant ids with one
+#      syntactically-valid-but-nonexistent id, to exercise #1845's
+#      totalCount reconciliation rather than assert it from the code
+#   D. AI-description arm - arm A resubmitted with generateDescription:true,
+#      reported SEPARATELY (never blended into the baseline)
+#
+# This stand's catalogue is small (11 real variants across 6 products, from
+# the OL PrestaShop module's own fixture seed) - too small for a k6 load
+# ladder to mean anything, so this scenario is a plain curl/bash driver
+# measuring real request latency and batch-completion time, not a
+# sustained-rate test. What it measures is real: real HTTP calls through
+# the real WooCommerce adapter, honestly reported at the scale the stand
+# actually has.
+#
+# Usage: ./f16-shop-publish.sh [--smoke]
+#   (default)  all four arms, a dated report under results/
+#   --smoke    arm A only, against one variant - proves the moving parts
+#
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_LOG_PREFIX="f16"
+# shellcheck disable=SC1091
+source "$SCRIPT_DIR/../lib.sh"
+SEED_DIR="$SCRIPT_DIR/../seed"
+# shellcheck disable=SC1091
+source "$SEED_DIR/seed-lib.sh"
+
+SMOKE=0
+[ "${1:-}" = "--smoke" ] && SMOKE=1
+
+require_connections
+[ -n "${WC_CONNECTION_ID:-}" ] || die "WC_CONNECTION_ID not set - run bootstrap.sh first"
+
+# The real fixture catalogue this stand carries (#3043's own module fixture
+# seed - not a #2849 set-based seeder, since the whole point of this
+# scenario is CREATING listings, not reading a pre-seeded history). Hardcoded
+# rather than queried, because `product_variants` on this stand also carries
+# stale rows from earlier reinstalls with NO live PrestaShop counterpart
+# (found live while building this scenario) - querying broadly would risk
+# publishing against a variant id the shop can no longer resolve. These six
+# products/eleven variants were confirmed live, right now, against the
+# CURRENT PrestaShop catalogue (`ps_product` ids 20-25) via
+# `GET /v1/products/:id/variants`.
+SIMPLE_VARIANTS=(
+  "ol_variant_83688137e69c47a38c9e07dac10a3acc"  # product 25, 1 variant
+  "ol_variant_9d0d33c14811489abf1880ab9c80d556"  # product 20, 1 variant
+  "ol_variant_de295062e5eb4c39af8047619843173a"  # product 21, 1 variant
+)
+# Three variable products, siblings grouped - each inner array is ONE
+# product's full variant set (#1836: one parent + N variations per submit).
+VARIABLE_PRODUCT_1=("ol_variant_b763c95fcae6447db922c0c42b402200" "ol_variant_d96340f70b8846d2ab0d7461325dd491" "ol_variant_68ecd29073eb48b7a91e3e00b05e12f2")
+VARIABLE_PRODUCT_2=("ol_variant_0b98ee6308b94a1c80984a3742f38381" "ol_variant_007fea1a00734960b2abe98ec83fff69" "ol_variant_715cdfcd6e3c4f1ba0e954f2e4cbfd9e")
+VARIABLE_PRODUCT_3=("ol_variant_dc6f93952048463295df861910892beb" "ol_variant_9953be66e18643ecba2f62f0ec1cff08")
+
+ol_login
+
+RESULTS_DIR="$(results_dir_init f16-shop-publish "$([ "$SMOKE" = 1 ] && echo smoke || echo strict)")"
+
+guard_stand_exclusive f16-shop-publish
+guard_scheduler_off
+guard_runner_state enabled
+
+CONN_IDS_CSV="'$WC_CONNECTION_ID'"
+window_start "$RESULTS_DIR" f16-shop-publish "$CONN_IDS_CSV" "$SMOKE" \
+  "$(jq -n --arg wc "$WC_CONNECTION_ID" '{destinationConnectionId: $wc, destinationCapabilities: "ProductPublisher,CategoryProvisioner"}')"
+
+# ---------------------------------------------------------------------------
+# submit_batch <items_json> <status> [generateDescription]
+# Submits, polls the batch to a terminal status (with a bounded wait), and
+# echoes "elapsedMs terminalStatus totalCount succeededCount failedCount".
+# ---------------------------------------------------------------------------
+POLL_MAX_WAIT_SECS="${POLL_MAX_WAIT_SECS:-120}"
+
+submit_batch() {
+  local items_json="$1" status="$2" gen_desc="${3:-false}" body resp batch_id t_start t_elapsed
+  body="$(jq -n --arg conn "$WC_CONNECTION_ID" --argjson items "$items_json" --arg status "$status" --argjson gen "$gen_desc" \
+    '{connectionId: $conn, items: $items, status: $status, generateDescription: $gen}')"
+  t_start="$(epoch)"
+  resp="$(ol_api POST /v1/listings/bulk-shop-publish "$body")"
+  batch_id="$(printf '%s' "$resp" | json_field batchId)"
+  [ -n "$batch_id" ] || die "submit_batch: no batchId in response: $resp"
+
+  local waited=0 poll batch_status total succ fail
+  while :; do
+    poll="$(ol_api GET "/v1/listings/bulk-shop-publish/$batch_id")"
+    batch_status="$(printf '%s' "$poll" | json_field status)"
+    case "$batch_status" in
+      completed|partially-failed|failed) break ;;
+    esac
+    waited=$((waited + 2))
+    [ "$waited" -lt "$POLL_MAX_WAIT_SECS" ] || die "submit_batch: batch $batch_id did not terminalise within ${POLL_MAX_WAIT_SECS}s (last status=$batch_status)"
+    sleep 2
+  done
+  t_elapsed="$(( $(epoch) - t_start ))"
+  total="$(printf '%s' "$poll" | jq -r '.totalCount')"
+  succ="$(printf '%s' "$poll" | jq -r '.succeededCount')"
+  fail="$(printf '%s' "$poll" | jq -r '.failedCount')"
+  # >&2, not stdout: submit_batch's return value is the single printf line
+  # below, captured via $(...) by every caller. lib.sh's log() writes to
+  # stdout (by design, for direct-run visibility) - if this diagnostic line
+  # shared that stream, every caller's `result="$(submit_batch ...)"` would
+  # capture BOTH lines, and arm C's `read -r ... <<< "$result"` word-splits
+  # across the embedded newline too, misassigning every field (found live:
+  # c_total ended up holding the batch id instead of "2").
+  log "batch $batch_id: status=$batch_status total=$total succeeded=$succ failed=$fail elapsed=${t_elapsed}s" >&2
+  printf '%s %s %s %s %s %s\n' "$t_elapsed" "$batch_status" "$total" "$succ" "$fail" "$batch_id"
+}
+
+ARM_RESULTS_FILE="$RESULTS_DIR/arm-results.txt"
+: > "$ARM_RESULTS_FILE"
+
+if [ "$SMOKE" = 1 ]; then
+  log "--- smoke: arm A only, one simple variant ---"
+  items="$(jq -n --arg v "${SIMPLE_VARIANTS[0]}" '[{internalVariantId: $v, stock: 5}]')"
+  result="$(submit_batch "$items" published false)"
+  printf 'smoke %s\n' "$result" >> "$ARM_RESULTS_FILE"
+else
+  log "--- arm A: simple-product publish (${#SIMPLE_VARIANTS[@]} products) ---"
+  items="$(printf '%s\n' "${SIMPLE_VARIANTS[@]}" | jq -R '{internalVariantId: ., stock: 5}' | jq -s '.')"
+  result="$(submit_batch "$items" published false)"
+  printf 'armA-simple %s\n' "$result" >> "$ARM_RESULTS_FILE"
+
+  log "--- arm B: variable-product publish (3 products, $(( ${#VARIABLE_PRODUCT_1[@]} + ${#VARIABLE_PRODUCT_2[@]} + ${#VARIABLE_PRODUCT_3[@]} )) variants total) ---"
+  items="$(printf '%s\n' "${VARIABLE_PRODUCT_1[@]}" "${VARIABLE_PRODUCT_2[@]}" "${VARIABLE_PRODUCT_3[@]}" | jq -R '{internalVariantId: ., stock: 3}' | jq -s '.')"
+  result="$(submit_batch "$items" published false)"
+  printf 'armB-variable %s\n' "$result" >> "$ARM_RESULTS_FILE"
+
+  # --- arm C: partial-submit failure ------------------------------------
+  # One real variant + one syntactically-valid, non-existent one
+  # (VARIANT_ID_PATTERN-shaped so it passes DTO validation and reaches the
+  # service, where resolution fails per-item - #1845's partial-submit
+  # atomicity is exactly "totalCount reconciles down, no batch left running
+  # forever", never "the whole request 400s").
+  log "--- arm C: partial-submit failure (1 real + 1 nonexistent variant) ---"
+  items="$(jq -n --arg v1 "${SIMPLE_VARIANTS[1]}" \
+    '[{internalVariantId: $v1, stock: 5}, {internalVariantId: "ol_variant_deadbeefdeadbeefdeadbeefdeadbeef", stock: 5}]')"
+  result="$(submit_batch "$items" published false)"
+  read -r c_elapsed c_status c_total c_succ c_fail c_batch_id <<< "$result"
+  printf 'armC-partial-failure %s\n' "$result" >> "$ARM_RESULTS_FILE"
+  # VALID direction: the reconciliation must show 2 total, exactly one
+  # success, exactly one failure - never "completed" (that would mean the
+  # bad row was silently dropped rather than counted as failed) and never
+  # left "running" (a stranded batch, the defect #1845 fixed).
+  ARM_C_OK=1
+  if [ "$c_total" != "2" ] || [ "$c_succ" != "1" ] || [ "$c_fail" != "1" ] || [ "$c_status" != "partially-failed" ]; then
+    ARM_C_OK=0
+    warn "arm C DISCARDED: expected total=2 succeeded=1 failed=1 status=partially-failed, got total=$c_total succeeded=$c_succ failed=$c_fail status=$c_status"
+  else
+    log "arm C VALID: partial-submit reconciliation correct (batch $c_batch_id: total=2, succeeded=1, failed=1, status=partially-failed)"
+  fi
+
+  # --- arm D: AI-description, reported separately -----------------------
+  log "--- arm D: AI-description arm (arm A resubmitted, generateDescription=true) ---"
+  items="$(printf '%s\n' "${SIMPLE_VARIANTS[@]}" | jq -R '{internalVariantId: ., stock: 5}' | jq -s '.')"
+  result="$(submit_batch "$items" published true)"
+  printf 'armD-ai-description %s\n' "$result" >> "$ARM_RESULTS_FILE"
+fi
+
+window_stop "$RESULTS_DIR"
+
+# ---------------------------------------------------------------------------
+# Verdict - no k6 involved, so run_post_guards' k6-specific arguments do not
+# apply here. This scenario's own correctness check (arm C) IS the guard
+# that matters: a partial-submit batch that reconciles wrong or never
+# terminalises is exactly the "stranded batch" defect #1845 fixed, and the
+# one thing this scenario would be worthless without checking.
+# ---------------------------------------------------------------------------
+if [ "$SMOKE" = 1 ]; then
+  log "smoke run - no verdict written (never produces a measurement, per this scenario's own header)"
+elif [ "${ARM_C_OK:-0}" = "1" ]; then
+  verdict_write "$RESULTS_DIR" VALID
+else
+  verdict_write "$RESULTS_DIR" DISCARDED "arm-c-partial-submit-reconciliation-wrong"
+fi
+
+log "results: $RESULTS_DIR"
+cat "$ARM_RESULTS_FILE"

--- a/perf/openlinker-throughput/stand/wc-mu-plugins/allow-internal-image-fetch.php
+++ b/perf/openlinker-throughput/stand/wc-mu-plugins/allow-internal-image-fetch.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Lab-stand-only mu-plugin (#3046).
+ *
+ * WordPress core's wp_http_validate_url() (wp-includes/http.php) refuses to
+ * fetch a remote URL whose host resolves to an RFC1918 private address
+ * UNLESS that host matches the site's own `home` option, or the
+ * `http_request_host_is_external` filter says otherwise. The shop-publish
+ * image-upload path (WooCommerce's `WC_REST_Products_Controller` ->
+ * `media_handle_sideload` -> `download_url` -> `wp_safe_remote_get`) always
+ * goes through this "safe" variant, so it always hits the check.
+ *
+ * On this lab stand every product-master host (`prestashop.lab`) resolves to
+ * a container IP inside Docker's default 172.16.0.0/12 bridge range - which
+ * is exactly one of the four ranges this check treats as "local, reject
+ * unless explicitly allowed" (confirmed live: `prestashop.lab` -> 172.22.x.x,
+ * second octet 22 falls inside [16,31]). Renaming the host to carry a dot
+ * (#3046's `prestashop.lab` alias) fixed WordPress's SEPARATE dot-less-host
+ * rejection, but this is a second, independent check in the same function -
+ * the two must not be confused as one fix.
+ *
+ * Lab-only: bind-mounted only into docker-compose.lab.yml's woocommerce
+ * service, never into the dev/demo stacks - a real production WooCommerce
+ * install should never disable this check wholesale.
+ */
+add_filter('http_request_host_is_external', '__return_true');


### PR DESCRIPTION
## Summary
- Adds `scenarios/f16-shop-publish.sh` (#3046, epic #2840): measures `POST /listings/bulk-shop-publish` against the real WooCommerce connection provisioned by #3043 — simple products (arm A), variable products (arm B, one parent + N variations per #1836), partial-submit reconciliation (arm C, #1845's own correctness guard), and an AI-description arm (arm D). No k6 — the stand's fixture catalogue (11 variants) is too small for a load ladder to mean anything; this is a plain curl/bash driver against the real adapter.
- Fixes three genuine, previously-undiscovered environment gaps found while getting a real product to publish end-to-end, each now an idempotent `bootstrap.sh` step:
  - `perf-woocommerce` had no `config.masterCatalogConnectionId` → `ensure_woocommerce_master_catalog()`.
  - WordPress's `wp_http_validate_url()` has two independent checks that both reject a PrestaShop-hosted product image URL: a dot-less-hostname refusal (fixed with a dotted `prestashop.lab` network alias, additive — the bare `prestashop` alias is untouched) and a separate RFC1918-private-address refusal (fixed with a lab-only mu-plugin, `stand/wc-mu-plugins/allow-internal-image-fetch.php`, docker-cp'd in by a new `step_woocommerce_mu_plugins` bootstrap step).
  - Switching to `prestashop.lab` then tripped a third, unrelated defect: PrestaShop's webservice dispatcher 301-redirects a single-resource GET to the shop's canonical registered domain unless the request's Host is itself registered → `ensure_prestashop_shop_url_alias()`.
- Fixes a real scenario bug: `submit_batch`'s progress log line shared stdout with its `$(...)` return value, so arm C's `read` on the multi-line capture misassigned every field and reported `DISCARDED` even when the batch reconciled correctly. Sent that log line to stderr.

## Verified both directions (per campaign rule)
- **DISCARDED**: arm C, before the log-stream fix — `arm-c-partial-submit-reconciliation-wrong`, against a real batch that had actually reconciled correctly (total=2, succeeded=1, failed=1, status=partially-failed). The DISCARDED verdict was a scenario-script bug, not a false claim about the destination.
- **VALID**: arm C, after the fix — same real batch shape (total=2, succeeded=1, failed=1, status=partially-failed), correctly read as VALID.

## Test plan
- [x] `lib-test.sh`: 259/259 passed, no regressions.
- [x] `scenarios/f16-shop-publish.sh --smoke` — real end-to-end publish (image upload + product data read) succeeds.
- [x] `scenarios/f16-shop-publish.sh` (full, 4 arms) — arm C verdict VALID.
- [x] Re-ran `bootstrap.sh` a second time — all three new idempotent steps report `FOUND`, not `CREATED`.

## Known limitation
Re-running the strict (non-smoke) scenario against an already-published catalogue causes arm B's variable-product siblings to hit `product_invalid_sku` on WooCommerce (duplicate SKU from the prior run's own variations). The scenario is not idempotent across repeated runs without a WooCommerce catalogue reset — out of scope for this issue, and orthogonal to arm C's own correctness guard, which is what the verdict is keyed on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QAgEHPJjSBLpeQv8LPdiQr