### PR TITLE
feat(orders): admin+env-gated test seam to stamp taxRateEra=pre-rollout

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -632,7 +632,9 @@ OL_PII_HASH_SALT=your-org-level-salt-change-in-production
 # install reach analytics/order states no real ingestion flow can ever produce
 # (e.g. POST /orders/:id/test-fixtures/mark-pre-rollout-era). Each such endpoint
 # is ALSO @Roles('admin') — this env var is the SECOND gate, so a real
-# production admin cannot silently corrupt real order data by mistake.
+# production admin cannot silently corrupt real order data by mistake. A THIRD,
+# fail-closed check refuses unconditionally under NODE_ENV=production, so a
+# copy-pasted .env carrying this var into production is still caught.
 #
 # DEV/TEST-ONLY. Defaults OFF. NEVER set this to true in a production `.env`.
 # OL_ALLOW_TEST_FIXTURES=false

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -625,3 +625,15 @@ OL_PII_HASH_SALT=your-org-level-salt-change-in-production
 # to the default rather than throwing.
 # Default 3.
 # OL_WAYBILL_RELAY_FAILURE_ALERT_THRESHOLD=3
+
+# --- Test fixtures: admin+env-gated seams (#2855) ----------------------------
+#
+# Gates a narrow set of write endpoints that exist ONLY to let a non-production
+# install reach analytics/order states no real ingestion flow can ever produce
+# (e.g. POST /orders/:id/test-fixtures/mark-pre-rollout-era). Each such endpoint
+# is ALSO @Roles('admin') — this env var is the SECOND gate, so a real
+# production admin cannot silently corrupt real order data by mistake.
+#
+# DEV/TEST-ONLY. Defaults OFF. NEVER set this to true in a production `.env`.
+# OL_ALLOW_TEST_FIXTURES=false
+

--- a/apps/api/src/auth/route-authorization-coverage.spec.ts
+++ b/apps/api/src/auth/route-authorization-coverage.spec.ts
@@ -105,11 +105,25 @@ const CLASS_LEVEL_PUBLIC_CONTROLLERS = [
   'WebhookController',
 ] as const;
 
+/**
+ * A route path segment that marks a TEST-FIXTURE seam — a write that exists
+ * only to reach a state no real flow can produce, and that must never run
+ * against real data. See the `test-fixture route` describe block below.
+ */
+const TEST_FIXTURE_PATH_SEGMENT = 'test-fixtures';
+
+/** The in-process gate every test-fixture route must reach before doing work. */
+const TEST_FIXTURE_GATE_CALL = 'assertTestFixturesAllowed(';
+
 interface DiscoveredRoute {
   readonly file: string;
   readonly controller: string;
   readonly handler: string;
   readonly verb: string;
+  /** `@Controller(...)` prefix segments followed by the handler's own path segments. */
+  readonly pathSegments: readonly string[];
+  /** The RESOLVED role list (handler's, else the class's), `[]` when neither. */
+  readonly roles: readonly string[];
   readonly isPublic: boolean;
   readonly hasRoles: boolean;
   readonly hasAnyRole: boolean;
@@ -182,11 +196,27 @@ function collectRoutes(file: string): DiscoveredRoute[] {
       const hasRoles = handlerDeclares ? handlerHasRoles : classHasRoles;
       const hasAnyRole = handlerDeclares ? handlerAnyRole : classAnyRole;
 
+      // `@Controller(['a', 'b'])` and `@Post(['x', 'y'])` are both legal, so
+      // the metadata may be an array. Flattening rather than `String(...)`-ing
+      // it keeps a multi-path route's segments separable instead of glueing
+      // them with a comma — which would make a `test-fixtures` segment
+      // unmatchable on exactly the shape most likely to hide one.
+      const toSegments = (raw: unknown): string[] =>
+        (Array.isArray(raw) ? raw : [raw])
+          .flatMap((part) => String(part ?? '').split('/'))
+          .filter((part) => part.length > 0);
+      const resolvedRoles = (handlerDeclares ? handlerRoles : classRoles) ?? [];
+
       routes.push({
         file: file.replace(`${SRC_ROOT}/`, ''),
         controller: name,
         handler,
         verb: RequestMethod[verb],
+        pathSegments: [
+          ...toSegments(Reflect.getMetadata(PATH_METADATA, cls)),
+          ...toSegments(Reflect.getMetadata(PATH_METADATA, fn)),
+        ],
+        roles: resolvedRoles.map((role) => String(role)),
         isPublic: classPublic || Reflect.getMetadata(IS_PUBLIC_KEY, fn) === true,
         hasRoles,
         hasAnyRole,
@@ -206,6 +236,36 @@ const allRoutes = [...routesByFile.values()].flat();
 
 function describeRoute(r: DiscoveredRoute): string {
   return `${r.file} :: ${r.controller}.${r.handler} (${r.verb})`;
+}
+
+/**
+ * The source text of one handler's body, by brace-matching from its
+ * declaration. Reflection cannot answer "does this handler call X" — the
+ * decorator metadata says nothing about the body — so the only way to assert
+ * the in-process gate is reached is to read it.
+ *
+ * Returns `null` when the declaration is not found, which the caller must
+ * treat as a FAILURE rather than as "no gate needed": a silent `null` here is
+ * exactly the vacuity the file header's five guards exist to prevent.
+ */
+function extractHandlerBody(fileSource: string, handler: string): string | null {
+  // Bounded by INDENTATION, not by brace counting. Prettier (`tabWidth: 2`)
+  // puts every class member at two spaces and every statement inside one at
+  // four or more, so `\n  }` is unambiguously the member's own closing brace.
+  //
+  // Brace counting was tried and rejected: it needs string and comment
+  // literals masked out first, and masking single quotes without also
+  // handling backticks pairs an apostrophe inside a template literal with a
+  // real string quote and blanks whole methods. That failed OPEN — the slice
+  // ran past the member and could find the gate call in the next one. This
+  // cannot: the slice never crosses `\n  }`.
+  const declaration = new RegExp(`\\n  (?:async )?${handler}\\s*\\(`).exec(fileSource);
+  if (declaration === null) return null;
+
+  const end = fileSource.indexOf('\n  }', declaration.index);
+  if (end === -1) return null;
+
+  return fileSource.slice(declaration.index, end + '\n  }'.length);
 }
 
 describe('Route-authorization coverage invariant (#2079)', () => {
@@ -374,6 +434,114 @@ describe('Route-authorization coverage invariant (#2079)', () => {
       expect(route?.isPublic).toBe(true);
       expect(route?.hasRoles).toBe(false);
       expect(route?.hasAnyRole).toBe(false);
+    });
+  });
+
+  /**
+   * Test-fixture routes (#3127 review)
+   *
+   * A separate invariant sharing this file's discovery machinery, because a
+   * second walk of `apps/api` would be a second set that could silently stop
+   * agreeing with this one.
+   *
+   * `OrderTestFixtureService.assertTestFixturesAllowed()` is a METHOD the
+   * controller must remember to call — precisely the "applies by remembering
+   * rather than by omission" shape #2999 exists to remove one directory over.
+   * The route that exists today calls it correctly, so both gates hold. What
+   * fails silently is the NEXT `test-fixtures/*` route: `@Roles('admin')`
+   * alone leaves it live in production, and nothing else in the build objects
+   * — lint passes, type-check passes, and the coverage invariant above is
+   * satisfied by the audience decorator without ever asking whether the gate
+   * was reached.
+   *
+   * So the two halves are asserted here, over EVERY discovered route whose
+   * path carries a `test-fixtures` segment:
+   *
+   *   1. it is `@Roles('admin')` exactly — never `@Public()`, never
+   *      `@AnyRole()`, never a wider or different role set;
+   *   2. its body reaches `assertTestFixturesAllowed(`.
+   *
+   * Non-vacuity, matching the file header's discipline: a filter that matches
+   * nothing reads green, so the count is asserted first. If the seam is ever
+   * removed, DELETE this block — do not let it pass over an empty set.
+   *
+   * The path segment is the discriminator rather than a decorator, because a
+   * decorator is one more thing to remember and this check must fire on a
+   * route whose author forgot everything except the URL they chose.
+   */
+  describe('test-fixture routes are admin-gated AND reach the in-process gate (#3127 review)', () => {
+    const fixtureRoutes = allRoutes.filter((r) =>
+      r.pathSegments.includes(TEST_FIXTURE_PATH_SEGMENT)
+    );
+
+    it('discovers at least one test-fixture route (non-vacuity)', () => {
+      expect(fixtureRoutes.length).toBeGreaterThan(0);
+    });
+
+    it('every test-fixture route is @Roles(admin) exactly', () => {
+      const offenders = fixtureRoutes
+        .filter(
+          (r) =>
+            r.isPublic ||
+            r.hasAnyRole ||
+            r.roles.length !== 1 ||
+            r.roles[0] !== 'admin'
+        )
+        .map((r) => `${describeRoute(r)} → roles=[${r.roles.join(', ')}] public=${r.isPublic}`);
+
+      expect(offenders).toEqual([]);
+    });
+
+    it('every test-fixture route reaches assertTestFixturesAllowed()', () => {
+      const offenders: string[] = [];
+
+      for (const route of fixtureRoutes) {
+        const source = readFileSync(join(SRC_ROOT, route.file), 'utf8');
+        const body = extractHandlerBody(source, route.handler);
+
+        // A body we could not locate is an offender, not a pass. Reporting it
+        // as "no gate needed" is how this check would quietly stop checking.
+        if (body === null) {
+          offenders.push(`${describeRoute(route)} → handler body not found`);
+          continue;
+        }
+        if (!body.includes(TEST_FIXTURE_GATE_CALL)) {
+          offenders.push(`${describeRoute(route)} → does not call ${TEST_FIXTURE_GATE_CALL})`);
+        }
+      }
+
+      expect(offenders).toEqual([]);
+    });
+
+    it('the body extractor can fail, so a missing gate is really detected', () => {
+      // Guard on the guard: `extractHandlerBody` returning a body that happens
+      // to contain the call for unrelated reasons would make the assertion
+      // above green forever. Feed it a handler that provably lacks the call,
+      // and one that does not exist at all.
+      const source = readFileSync(join(SRC_ROOT, 'auth/auth.controller.ts'), 'utf8');
+      const body = extractHandlerBody(source, 'login');
+
+      expect(body).not.toBeNull();
+      expect(body).toContain('validateUser');
+      expect(body).not.toContain(TEST_FIXTURE_GATE_CALL);
+      expect(extractHandlerBody(source, 'noSuchHandlerExists')).toBeNull();
+    });
+
+    it('resolves a body for EVERY discovered route, so the indentation assumption is checked', () => {
+      // `extractHandlerBody` bounds the slice on `\n  }`, which is only the
+      // member's closing brace while every class member sits at two spaces.
+      // That is Prettier's doing, not a language rule — so it is asserted
+      // rather than assumed. If a formatting change ever breaks it, this goes
+      // red here instead of silently turning the gate check above into a
+      // "handler body not found" that someone deletes.
+      const unresolved = allRoutes
+        .filter((route) => {
+          const source = readFileSync(join(SRC_ROOT, route.file), 'utf8');
+          return extractHandlerBody(source, route.handler) === null;
+        })
+        .map(describeRoute);
+
+      expect(unresolved).toEqual([]);
     });
   });
 });

--- a/apps/api/src/orders/http/dto/mark-pre-rollout-era-response.dto.ts
+++ b/apps/api/src/orders/http/dto/mark-pre-rollout-era-response.dto.ts
@@ -1,0 +1,17 @@
+/**
+ * Mark Pre-Rollout Era Response DTO
+ *
+ * Response shape for `POST /orders/:internalOrderId/test-fixtures/mark-pre-rollout-era` (#2855).
+ *
+ * @module apps/api/src/orders/http/dto
+ */
+import { ApiProperty } from '@nestjs/swagger';
+
+export class MarkPreRolloutEraResponseDto {
+  @ApiProperty({
+    description:
+      'true if this call changed the row; false if it already carried taxRateEra=\'pre-rollout\'',
+    example: true,
+  })
+  applied!: boolean;
+}

--- a/apps/api/src/orders/http/orders.controller.spec.ts
+++ b/apps/api/src/orders/http/orders.controller.spec.ts
@@ -17,6 +17,7 @@ import {
   ORDER_DESTINATION_RETRY_SERVICE_TOKEN,
   ORDER_RECORD_SERVICE_TOKEN,
   SALES_DOCUMENT_VIEW_SERVICE_TOKEN,
+  ORDER_TEST_FIXTURE_SERVICE_TOKEN,
   OrderRecord,
   OrderRecordNotFoundException,
   OrderDestinationNotFoundException,
@@ -27,6 +28,7 @@ import {
   OrderAlreadyOnHoldError,
   HoldAlreadyReleasedError,
   HoldReleaseNoteRequiredError,
+  TestFixturesDisabledException,
 } from '@openlinker/core/orders';
 import type {
   OrderRecordRepositoryPort,
@@ -36,6 +38,7 @@ import type {
   IOrderProvisioningResumeService,
   OrderHold,
   ISalesDocumentViewService,
+  IOrderTestFixtureService,
 } from '@openlinker/core/orders';
 import type { SalesDocumentView } from '@openlinker/core/sales-documents';
 import { INVOICE_SERVICE_TOKEN } from '@openlinker/core/invoicing';
@@ -62,6 +65,7 @@ describe('OrdersController', () => {
   let holdService: jest.Mocked<IOrderHoldService>;
   let provisioningResume: jest.Mocked<IOrderProvisioningResumeService>;
   let salesDocumentView: jest.Mocked<ISalesDocumentViewService>;
+  let testFixtureService: jest.Mocked<IOrderTestFixtureService>;
 
   const mockOrder = new OrderRecord(
     'ol_order_001',
@@ -127,6 +131,7 @@ describe('OrdersController', () => {
       findCurrencyMismatchOrderRefsAfter: jest.fn(),
       clearFxStampForRestatement: jest.fn(),
       countRemainingCurrencyMismatch: jest.fn(),
+      stampPreRolloutEraForTesting: jest.fn(),
     };
 
     const mockOrderRecordService = {
@@ -197,6 +202,9 @@ describe('OrdersController', () => {
       getForOrders: jest.fn().mockResolvedValue(new Map()),
       getForOrder: jest.fn().mockResolvedValue(null),
     };
+    const mockTestFixtureService: jest.Mocked<IOrderTestFixtureService> = {
+      markPreRolloutEraForTesting: jest.fn().mockResolvedValue(true),
+    };
 
     const module: TestingModule = await Test.createTestingModule({
       controllers: [OrdersController],
@@ -241,6 +249,10 @@ describe('OrdersController', () => {
           provide: SALES_DOCUMENT_VIEW_SERVICE_TOKEN,
           useValue: mockSalesDocumentView,
         },
+        {
+          provide: ORDER_TEST_FIXTURE_SERVICE_TOKEN,
+          useValue: mockTestFixtureService,
+        },
       ],
     }).compile();
 
@@ -254,6 +266,7 @@ describe('OrdersController', () => {
     holdService = module.get(ORDER_HOLD_SERVICE_TOKEN);
     provisioningResume = module.get(ORDER_PROVISIONING_RESUME_SERVICE_TOKEN);
     salesDocumentView = module.get(SALES_DOCUMENT_VIEW_SERVICE_TOKEN);
+    testFixtureService = module.get(ORDER_TEST_FIXTURE_SERVICE_TOKEN);
   });
 
   describe('listOrders', () => {
@@ -1511,4 +1524,42 @@ describe('OrdersController', () => {
     });
   });
 
+  describe('markPreRolloutEra (#2855, TEST-FIXTURE-ONLY)', () => {
+    it('404s without calling the service when the order does not exist', async () => {
+      repository.findById.mockResolvedValue(null);
+
+      await expect(controller.markPreRolloutEra('ol_order_missing')).rejects.toBeInstanceOf(
+        NotFoundException
+      );
+      expect(testFixtureService.markPreRolloutEraForTesting).not.toHaveBeenCalled();
+    });
+
+    it('returns { applied } from the service when the order exists', async () => {
+      repository.findById.mockResolvedValue(mockOrder);
+      testFixtureService.markPreRolloutEraForTesting.mockResolvedValue(true);
+
+      await expect(controller.markPreRolloutEra('ol_order_001')).resolves.toEqual({
+        applied: true,
+      });
+      expect(testFixtureService.markPreRolloutEraForTesting).toHaveBeenCalledWith('ol_order_001');
+    });
+
+    it('maps TestFixturesDisabledException to a 403 with a machine-readable code', async () => {
+      repository.findById.mockResolvedValue(mockOrder);
+      testFixtureService.markPreRolloutEraForTesting.mockRejectedValue(
+        new TestFixturesDisabledException()
+      );
+
+      await expect(controller.markPreRolloutEra('ol_order_001')).rejects.toMatchObject({
+        response: expect.objectContaining({ error: 'TEST_FIXTURES_DISABLED' }),
+      });
+    });
+
+    it('re-throws an unmodelled error rather than swallowing it', async () => {
+      repository.findById.mockResolvedValue(mockOrder);
+      testFixtureService.markPreRolloutEraForTesting.mockRejectedValue(new Error('boom'));
+
+      await expect(controller.markPreRolloutEra('ol_order_001')).rejects.toThrow('boom');
+    });
+  });
 });

--- a/apps/api/src/orders/http/orders.controller.spec.ts
+++ b/apps/api/src/orders/http/orders.controller.spec.ts
@@ -204,6 +204,7 @@ describe('OrdersController', () => {
     };
     const mockTestFixtureService: jest.Mocked<IOrderTestFixtureService> = {
       markPreRolloutEraForTesting: jest.fn().mockResolvedValue(true),
+      assertTestFixturesAllowed: jest.fn(),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -1525,23 +1526,40 @@ describe('OrdersController', () => {
   });
 
   describe('markPreRolloutEra (#2855, TEST-FIXTURE-ONLY)', () => {
-    it('404s without calling the service when the order does not exist', async () => {
-      repository.findById.mockResolvedValue(null);
+    const USER = { id: 'user-1', username: 'op', role: 'admin' } as never;
 
-      await expect(controller.markPreRolloutEra('ol_order_missing')).rejects.toBeInstanceOf(
-        NotFoundException
-      );
+    it('checks the env gate BEFORE reading the order, and refuses fast when closed', async () => {
+      testFixtureService.assertTestFixturesAllowed.mockImplementation(() => {
+        throw new TestFixturesDisabledException();
+      });
+
+      await expect(controller.markPreRolloutEra('ol_order_001', USER)).rejects.toMatchObject({
+        response: expect.objectContaining({ error: 'TEST_FIXTURES_DISABLED' }),
+      });
+      expect(repository.findById).not.toHaveBeenCalled();
       expect(testFixtureService.markPreRolloutEraForTesting).not.toHaveBeenCalled();
     });
 
-    it('returns { applied } from the service when the order exists', async () => {
+    it('404s without calling the service when the order does not exist', async () => {
+      repository.findById.mockResolvedValue(null);
+
+      await expect(
+        controller.markPreRolloutEra('ol_order_missing', USER)
+      ).rejects.toBeInstanceOf(NotFoundException);
+      expect(testFixtureService.markPreRolloutEraForTesting).not.toHaveBeenCalled();
+    });
+
+    it('returns { applied } from the service when the order exists, threading the actor', async () => {
       repository.findById.mockResolvedValue(mockOrder);
       testFixtureService.markPreRolloutEraForTesting.mockResolvedValue(true);
 
-      await expect(controller.markPreRolloutEra('ol_order_001')).resolves.toEqual({
+      await expect(controller.markPreRolloutEra('ol_order_001', USER)).resolves.toEqual({
         applied: true,
       });
-      expect(testFixtureService.markPreRolloutEraForTesting).toHaveBeenCalledWith('ol_order_001');
+      expect(testFixtureService.markPreRolloutEraForTesting).toHaveBeenCalledWith(
+        'ol_order_001',
+        'user-1'
+      );
     });
 
     it('maps TestFixturesDisabledException to a 403 with a machine-readable code', async () => {
@@ -1550,7 +1568,7 @@ describe('OrdersController', () => {
         new TestFixturesDisabledException()
       );
 
-      await expect(controller.markPreRolloutEra('ol_order_001')).rejects.toMatchObject({
+      await expect(controller.markPreRolloutEra('ol_order_001', USER)).rejects.toMatchObject({
         response: expect.objectContaining({ error: 'TEST_FIXTURES_DISABLED' }),
       });
     });
@@ -1559,7 +1577,7 @@ describe('OrdersController', () => {
       repository.findById.mockResolvedValue(mockOrder);
       testFixtureService.markPreRolloutEraForTesting.mockRejectedValue(new Error('boom'));
 
-      await expect(controller.markPreRolloutEra('ol_order_001')).rejects.toThrow('boom');
+      await expect(controller.markPreRolloutEra('ol_order_001', USER)).rejects.toThrow('boom');
     });
   });
 });

--- a/apps/api/src/orders/http/orders.controller.ts
+++ b/apps/api/src/orders/http/orders.controller.ts
@@ -81,7 +81,10 @@ import {
   HoldReleaseNotPermittedError,
   deriveSlaState,
   IOrderHoldService,
-  IOrderProvisioningResumeService} from '@openlinker/core/orders';
+  IOrderProvisioningResumeService,
+  ORDER_TEST_FIXTURE_SERVICE_TOKEN,
+  IOrderTestFixtureService,
+  TestFixturesDisabledException} from '@openlinker/core/orders';
 import type {
   OrderRecord,
   OrderRecordFilters,
@@ -135,6 +138,7 @@ import type { SyncAttemptResponseDto } from './dto/sync-attempt-response.dto';
 import { PaginatedOrdersResponseDto } from './dto/paginated-orders-response.dto';
 import { RetryOrderDestinationResponseDto } from './dto/retry-order-destination-response.dto';
 import { PlaceOrderHoldRequestDto } from './dto/place-order-hold-request.dto';
+import { MarkPreRolloutEraResponseDto } from './dto/mark-pre-rollout-era-response.dto';
 import { ReleaseOrderHoldRequestDto } from './dto/release-order-hold-request.dto';
 import type {
   OrderHoldDto,
@@ -258,7 +262,10 @@ export class OrdersController {
     @Inject(ORDER_PROVISIONING_RESUME_SERVICE_TOKEN)
     private readonly provisioningResume: IOrderProvisioningResumeService,
     @Inject(SALES_DOCUMENT_VIEW_SERVICE_TOKEN)
-    private readonly salesDocumentView: ISalesDocumentViewService
+    private readonly salesDocumentView: ISalesDocumentViewService,
+    // #2855 — test-fixture-only writes, never called against real order data.
+    @Inject(ORDER_TEST_FIXTURE_SERVICE_TOKEN)
+    private readonly testFixtureService: IOrderTestFixtureService
   ) {}
 
   @Roles('admin', 'operator', 'viewer')
@@ -897,6 +904,46 @@ export class OrdersController {
       hold: this.toHoldDto(released),
       provisioningResume: this.toProvisioningResumeDto(resume),
     };
+  }
+
+  @Roles('admin')
+  @Post(':internalOrderId/test-fixtures/mark-pre-rollout-era')
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'TEST-FIXTURE-ONLY: stamp taxRateEra=pre-rollout on an order',
+    description:
+      'Exists ONLY to let a non-production install reach the tax-a / tax-c analytics coverage ' +
+      'states (#2482) with a fresh, flow-seeded order — no real ingestion path ever writes ' +
+      'taxRateEra (it was set exactly once, by a historical backfill migration), so those states ' +
+      'are otherwise unreachable. Double-gated: @Roles(admin) here, plus OL_ALLOW_TEST_FIXTURES ' +
+      'must be true in the process env. MUST NEVER be called against real order data — it silently ' +
+      'excludes the order from Net Sales figures via the pre-rollout tax-rate-era rule.',
+  })
+  @ApiResponse({ status: 200, description: 'Stamp applied (or already present)', type: MarkPreRolloutEraResponseDto })
+  @ApiResponse({ status: 403, description: 'Insufficient permissions, or TEST_FIXTURES_DISABLED' })
+  @ApiResponse({ status: 404, description: 'Order not found' })
+  async markPreRolloutEra(
+    @Param('internalOrderId') internalOrderId: string
+  ): Promise<MarkPreRolloutEraResponseDto> {
+    // Refuse before any side effect, same ordering rationale as `placeHold`.
+    const order = await this.orderRecordRepository.findById(internalOrderId);
+    if (!order) {
+      throw new NotFoundException(`Order not found: ${internalOrderId}`);
+    }
+
+    try {
+      const applied = await this.testFixtureService.markPreRolloutEraForTesting(internalOrderId);
+      return { applied };
+    } catch (error) {
+      if (error instanceof TestFixturesDisabledException) {
+        throw new ForbiddenException({
+          statusCode: HttpStatus.FORBIDDEN,
+          error: 'TEST_FIXTURES_DISABLED',
+          message: error.message,
+        });
+      }
+      throw error;
+    }
   }
 
   /** TypeORM may hand back a string for a timestamptz; `toDto` guards the same way. */

--- a/apps/api/src/orders/http/orders.controller.ts
+++ b/apps/api/src/orders/http/orders.controller.ts
@@ -56,7 +56,13 @@ import {
   Inject,
   ParseUUIDPipe,
 } from '@nestjs/common';
-import { ApiBearerAuth, ApiTags, ApiOperation, ApiResponse } from '@nestjs/swagger';
+import {
+  ApiBearerAuth,
+  ApiExcludeEndpoint,
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+} from '@nestjs/swagger';
 import { Roles } from '../../auth/decorators/roles.decorator';
 import { CurrentUser } from '../../auth/decorators/current-user.decorator';
 import { AuthenticatedUser } from '../../auth/auth.types';
@@ -909,6 +915,14 @@ export class OrdersController {
   @Roles('admin')
   @Post(':internalOrderId/test-fixtures/mark-pre-rollout-era')
   @HttpCode(HttpStatus.OK)
+  // Kept out of the published OpenAPI document (#3127 review). The route is
+  // inert on any production install — it refuses unconditionally under
+  // NODE_ENV=production — so advertising a "MUST NEVER be called against real
+  // order data" endpoint that always 403s there is disclosure with no reader
+  // it could serve. The @ApiOperation below is retained deliberately: it is
+  // the description a developer reads in source, and it comes back the moment
+  // this line is removed for a local Swagger run.
+  @ApiExcludeEndpoint()
   @ApiOperation({
     summary: 'TEST-FIXTURE-ONLY: stamp taxRateEra=pre-rollout on an order',
     description:

--- a/apps/api/src/orders/http/orders.controller.ts
+++ b/apps/api/src/orders/http/orders.controller.ts
@@ -915,24 +915,45 @@ export class OrdersController {
       'Exists ONLY to let a non-production install reach the tax-a / tax-c analytics coverage ' +
       'states (#2482) with a fresh, flow-seeded order — no real ingestion path ever writes ' +
       'taxRateEra (it was set exactly once, by a historical backfill migration), so those states ' +
-      'are otherwise unreachable. Double-gated: @Roles(admin) here, plus OL_ALLOW_TEST_FIXTURES ' +
-      'must be true in the process env. MUST NEVER be called against real order data — it silently ' +
-      'excludes the order from Net Sales figures via the pre-rollout tax-rate-era rule.',
+      'are otherwise unreachable. Triple-gated: @Roles(admin) here, OL_ALLOW_TEST_FIXTURES must ' +
+      'be true in the process env, and NODE_ENV must not be production (refused unconditionally, ' +
+      'even with the env var set). The acting admin is recorded in the audit log. MUST NEVER be ' +
+      'called against real order data — it silently excludes the order from Net Sales figures via ' +
+      'the pre-rollout tax-rate-era rule.',
   })
   @ApiResponse({ status: 200, description: 'Stamp applied (or already present)', type: MarkPreRolloutEraResponseDto })
   @ApiResponse({ status: 403, description: 'Insufficient permissions, or TEST_FIXTURES_DISABLED' })
   @ApiResponse({ status: 404, description: 'Order not found' })
   async markPreRolloutEra(
-    @Param('internalOrderId') internalOrderId: string
+    @Param('internalOrderId') internalOrderId: string,
+    @CurrentUser() user: AuthenticatedUser
   ): Promise<MarkPreRolloutEraResponseDto> {
-    // Refuse before any side effect, same ordering rationale as `placeHold`.
+    // The feature-flag gate is checked BEFORE the DB pre-read: on a production
+    // deployment (the default — the flag defaults off) this route is entirely
+    // inert, and it should cost no read before that is established.
+    try {
+      this.testFixtureService.assertTestFixturesAllowed();
+    } catch (error) {
+      if (error instanceof TestFixturesDisabledException) {
+        throw new ForbiddenException({
+          statusCode: HttpStatus.FORBIDDEN,
+          error: 'TEST_FIXTURES_DISABLED',
+          message: error.message,
+        });
+      }
+      throw error;
+    }
+
     const order = await this.orderRecordRepository.findById(internalOrderId);
     if (!order) {
       throw new NotFoundException(`Order not found: ${internalOrderId}`);
     }
 
     try {
-      const applied = await this.testFixtureService.markPreRolloutEraForTesting(internalOrderId);
+      const applied = await this.testFixtureService.markPreRolloutEraForTesting(
+        internalOrderId,
+        user.id
+      );
       return { applied };
     } catch (error) {
       if (error instanceof TestFixturesDisabledException) {

--- a/apps/api/test/integration/orders/order-test-fixtures-api.int-spec.ts
+++ b/apps/api/test/integration/orders/order-test-fixtures-api.int-spec.ts
@@ -1,0 +1,159 @@
+/**
+ * Order Test Fixtures API Integration Test (#2855)
+ *
+ * `POST /orders/:internalOrderId/test-fixtures/mark-pre-rollout-era` is the
+ * narrow, double(+env-gated-triple)-gated seam that stamps
+ * `taxRateEra = 'pre-rollout'` so a non-production install can reach the
+ * `tax-a` / `tax-c` analytics coverage states with a fresh, flow-seeded order.
+ *
+ * What only an int-spec can prove here:
+ *
+ * 1. **The guarded `UPDATE ... WHERE "taxRateEra" IS DISTINCT FROM 'pre-rollout'`
+ *    is really idempotent against real Postgres** — a unit-mocked repository
+ *    cannot show the second call returns `applied: false` against a row the
+ *    first call actually changed.
+ * 2. **`NODE_ENV=production` refuses even with the env var set**, over the
+ *    real HTTP -> guard pipeline (`RolesGuard`, `JwtAuthGuard`) rather than a
+ *    hand-constructed service.
+ * 3. **The env gate is checked BEFORE the order lookup** — a request for an
+ *    order that does not exist still answers 403 (not 404) when the gate is
+ *    closed, which only the real controller wiring proves.
+ *
+ * @module apps/api/test/integration/orders
+ */
+import {
+  ORDER_RECORD_SERVICE_TOKEN,
+  type IOrderRecordService,
+  type Order,
+} from '@openlinker/core/orders';
+import {
+  getTestHarness,
+  resetTestHarness,
+  teardownTestHarness,
+  type IntegrationTestHarness,
+} from '../setup';
+import { createTestConnection } from '../helpers/test-connection.helper';
+import { loginAsAdmin } from '../helpers/test-auth.helper';
+
+const ORDER_ID = 'ol_order_test_fixtures_api';
+
+function makeOrder(id: string, orderNumber: string): Order {
+  return {
+    id,
+    orderNumber,
+    status: 'pending',
+    items: [
+      {
+        id: 'l1',
+        productId: 'ol_product_1',
+        variantId: 'ol_variant_1',
+        quantity: 1,
+        price: 10,
+        sku: 'SKU-1',
+      },
+    ],
+    totals: { subtotal: 10, tax: 0, shipping: 0, total: 10, currency: 'PLN' },
+    createdAt: new Date('2026-08-01T00:00:00Z'),
+    updatedAt: new Date('2026-08-01T00:00:00Z'),
+  } as Order;
+}
+
+describe('Order test-fixtures API (#2855)', () => {
+  let harness: IntegrationTestHarness;
+  let token: string;
+  const previousAllowTestFixtures = process.env.OL_ALLOW_TEST_FIXTURES;
+  const previousNodeEnv = process.env.NODE_ENV;
+
+  beforeAll(async () => {
+    harness = await getTestHarness();
+  });
+
+  beforeEach(async () => {
+    // Once per TEST — mirrors order-holds-api.int-spec.ts's rationale: a
+    // second `loginAsAdmin` call inside one test violates the users unique
+    // constraint, and `resetTestHarness` truncates `users` between tests.
+    token = await loginAsAdmin(harness.getHttp(), harness.getDataSource());
+
+    const records = harness
+      .getApp()
+      .get<IOrderRecordService>(ORDER_RECORD_SERVICE_TOKEN, { strict: false });
+
+    const source = await createTestConnection(harness.getDataSource(), {
+      platformType: 'allegro',
+      name: 'Allegro source',
+      adapterKey: 'allegro.test.unused',
+    });
+
+    await records.persistOrder(makeOrder(ORDER_ID, 'ORD-TEST-FIXTURES-1'), source.id, 'evt-1');
+  });
+
+  afterEach(async () => {
+    if (previousAllowTestFixtures === undefined) {
+      delete process.env.OL_ALLOW_TEST_FIXTURES;
+    } else {
+      process.env.OL_ALLOW_TEST_FIXTURES = previousAllowTestFixtures;
+    }
+    if (previousNodeEnv === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = previousNodeEnv;
+    }
+    await resetTestHarness();
+  });
+
+  afterAll(async () => {
+    await teardownTestHarness();
+  });
+
+  const auth = () => ({ Authorization: `Bearer ${token}` });
+
+  const markPreRolloutEra = (orderId: string) =>
+    harness
+      .getHttp()
+      .post(`/v1/orders/${orderId}/test-fixtures/mark-pre-rollout-era`)
+      .set(auth())
+      .send({});
+
+  it('should answer 403 TEST_FIXTURES_DISABLED when the env var is unset', async () => {
+    delete process.env.OL_ALLOW_TEST_FIXTURES;
+
+    const res = await markPreRolloutEra(ORDER_ID).expect(403);
+
+    expect(res.body.error).toBe('TEST_FIXTURES_DISABLED');
+  });
+
+  it('should answer 403 BEFORE looking up the order when the gate is closed', async () => {
+    delete process.env.OL_ALLOW_TEST_FIXTURES;
+
+    // An order id that does not exist — a 404 here would mean the lookup ran
+    // ahead of the (cheaper, side-effect-free) gate check.
+    const res = await markPreRolloutEra('ol_order_does_not_exist').expect(403);
+
+    expect(res.body.error).toBe('TEST_FIXTURES_DISABLED');
+  });
+
+  it('should stamp the order idempotently when the env var is true', async () => {
+    process.env.OL_ALLOW_TEST_FIXTURES = 'true';
+
+    const first = await markPreRolloutEra(ORDER_ID).expect(200);
+    expect(first.body.applied).toBe(true);
+
+    const second = await markPreRolloutEra(ORDER_ID).expect(200);
+    expect(second.body.applied).toBe(false);
+  });
+
+  it('should answer 403 under NODE_ENV=production even with the env var set', async () => {
+    process.env.OL_ALLOW_TEST_FIXTURES = 'true';
+    process.env.NODE_ENV = 'production';
+
+    const res = await markPreRolloutEra(ORDER_ID).expect(403);
+
+    expect(res.body.error).toBe('TEST_FIXTURES_DISABLED');
+  });
+
+  it('should answer 404 for an order that does not exist when the gate is open', async () => {
+    process.env.OL_ALLOW_TEST_FIXTURES = 'true';
+
+    await markPreRolloutEra('ol_order_does_not_exist').expect(404);
+  });
+});

--- a/docs/plans/implementation-plan-orders-mark-pre-rollout-era-test-fixture.md
+++ b/docs/plans/implementation-plan-orders-mark-pre-rollout-era-test-fixture.md
@@ -1,0 +1,119 @@
+# Implementation Plan — admin+env-gated test seam to stamp `taxRateEra='pre-rollout'` (#2855)
+
+## 1. Task
+
+`order_records.taxRateEra = 'pre-rollout'` is written exactly once, ever, by a historical
+migration — no ingestion path can ever produce it for a fresh order, making the `tax-a` /
+`tax-c` analytics coverage states structurally unreachable by any flow-driven E2E seed. Add a
+narrow, double-gated (role `admin` + env `OL_ALLOW_TEST_FIXTURES`) write seam to stamp it on
+demand. CORE (orders context) + Interface layer. Non-goal: wiring #2482's E2E spec to call it —
+out of scope for this issue's own acceptance criteria items 1-3; item 4 (E2E wiring) is deferred
+to whichever E2E work item actually touches that spec.
+
+## 2. Research
+
+- `OrderRecordRepository.clearFxStampForRestatement` (`order-record.repository.ts:957`) is the
+  exact shape to mirror: a single conditional `UPDATE ... WHERE` via query builder, `affected > 0`
+  as the `boolean` answer, idempotent (re-running when already in the target state is a no-op
+  reporting `false`).
+- `OrdersController.placeHold` / `.releaseHold` (`orders.controller.ts:772` / `:836`) is the HTTP
+  shape: `@Roles('admin')`, `@CurrentUser()` never trusted from the body, a pre-read for 404,
+  domain exceptions mapped to specific HTTP status via `catch`.
+- `ReportingCurrencySettingsService` (`libs/core/src/currency/application/services/reporting-currency-settings.service.ts`)
+  shows the established convention for reading an `OL_*` boolean env var inside `libs/core` via
+  `ConfigService.get<string>(name, 'false').trim().toLowerCase() === 'true'` (`@nestjs/config`
+  already used inside `libs/core`, e.g. `currency`, `operational-settings`).
+- No dedicated interface file exists for `OrderHoldService` at the same level as `OrderRecordService`
+  — interfaces for small services live in `libs/core/src/orders/application/interfaces/*.service.interface.ts`
+  (e.g. `order-hold.service.interface.ts`). No existing service is a clean fit for this seam (per
+  the issue's own note) — a small dedicated `OrderTestFixtureService` is added.
+- `orders.tokens.ts` / `orders.module.ts` show the DI-token + module-wiring convention (Symbol
+  token per service, `useExisting` binding, service class + token both exported).
+- No existing precedent for `OL_ALLOW_TEST_FIXTURES` anywhere in the repo — this issue introduces
+  it, matching the issue's own assumption.
+
+## 3. Design
+
+- **Domain exception**: `TestFixturesDisabledException` in
+  `libs/core/src/orders/domain/exceptions/test-fixtures-disabled.exception.ts` — thrown when the
+  env gate is off. A distinct, named exception (not a generic `Error`) so the controller can map
+  it deterministically, matching `OrderAlreadyOnHoldError` / `OrderHoldContendedError`'s pattern.
+- **Repository** (`order-record.repository.ts` + `order-record-repository.port.ts`):
+  `stampPreRolloutEraForTesting(internalOrderId: string): Promise<boolean>` —
+  `UPDATE order_records SET "taxRateEra" = 'pre-rollout' WHERE "internalOrderId" = :id AND
+  "taxRateEra" IS DISTINCT FROM 'pre-rollout'`, `affected > 0` as the answer. No role/env
+  awareness at this layer — the repository is a dumb, narrow conditional writer, same as its
+  precedent; the gates live in the service.
+- **Service**: `OrderTestFixtureService implements IOrderTestFixtureService` —
+  `markPreRolloutEraForTesting(internalOrderId: string): Promise<boolean>`. Reads
+  `OL_ALLOW_TEST_FIXTURES` via `ConfigService`; throws `TestFixturesDisabledException` when not
+  `'true'`. Calls the repository method; logs at `warn` on a successful (non-throwing) call,
+  regardless of whether the write was actually applied (an idempotent no-repeat call is still a
+  fixture action worth an audit trail).
+- **Controller**: `POST /orders/:internalOrderId/test-fixtures/mark-pre-rollout-era`,
+  `@Roles('admin')`. Pre-reads the order via the repository (already injected in
+  `OrdersController`) for a 404 when it doesn't exist — same ordering rationale as `placeHold`
+  (refuse before any side effect). Catches `TestFixturesDisabledException` → maps to 403
+  Forbidden with a machine-readable body (`{ statusCode: 403, error: 'TEST_FIXTURES_DISABLED',
+  message }`), matching the `ConflictException({ statusCode, error, message })` shape
+  `placeHold`/`releaseHold` already use for their own domain exceptions. Returns
+  `{ applied: boolean }` — `true` if the row was changed by this call, `false` if it already
+  carried `'pre-rollout'` (idempotent, matches the repository's own semantics).
+- **`.env.example`**: document `OL_ALLOW_TEST_FIXTURES` under a new commented block, default
+  off, explicitly dev/test-only.
+
+## 4. Steps
+
+1. `libs/core/src/orders/domain/exceptions/test-fixtures-disabled.exception.ts` (new) —
+   `TestFixturesDisabledException extends Error`.
+2. `libs/core/src/orders/domain/ports/order-record-repository.port.ts` — add
+   `stampPreRolloutEraForTesting(internalOrderId: string): Promise<boolean>;` to the port,
+   documented with the same rationale style as `clearFxStampForRestatement`.
+3. `libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts` —
+   implement the method per the design above.
+4. `libs/core/src/orders/application/interfaces/order-test-fixture.service.interface.ts` (new) —
+   `IOrderTestFixtureService { markPreRolloutEraForTesting(internalOrderId: string): Promise<boolean>; }`.
+5. `libs/core/src/orders/application/services/order-test-fixture.service.ts` (new) —
+   `OrderTestFixtureService implements IOrderTestFixtureService`, per design.
+6. `libs/core/src/orders/orders.tokens.ts` — add `ORDER_TEST_FIXTURE_SERVICE_TOKEN = Symbol('IOrderTestFixtureService')`.
+7. `libs/core/src/orders/orders.module.ts` — register `OrderTestFixtureService` as a provider,
+   bind the token, export both (mirrors every other service in the file).
+8. `libs/core/src/orders/index.ts` — export `IOrderTestFixtureService` type and
+   `TestFixturesDisabledException` from the top-level barrel (cross-context-safe symbol shapes:
+   `I*Service`, `*Exception`) so `apps/api` can import them; token comes via the tokens sub-barrel
+   already re-exported.
+9. `apps/api/src/orders/http/orders.controller.ts` — inject
+   `@Inject(ORDER_TEST_FIXTURE_SERVICE_TOKEN) private readonly testFixtureService:
+   IOrderTestFixtureService`, add the new endpoint per design (with `@ApiOperation` /
+   `@ApiResponse` docs matching `placeHold`'s density, explicitly warning this must never be
+   called against real order data).
+10. `apps/api/.env.example` — document `OL_ALLOW_TEST_FIXTURES` (default off, dev/test-only,
+    commented out).
+11. Tests:
+    - `order-record.repository.spec.ts` — unit test for `stampPreRolloutEraForTesting` (guarded
+      UPDATE, idempotent no-op).
+    - `order-test-fixture.service.spec.ts` (new) — throws when env gate off; calls repository and
+      logs when on; returns the repository's boolean.
+    - `orders.controller.spec.ts` — 404 for unknown order, 403 for `TestFixturesDisabledException`,
+      200 with `{ applied }` on success.
+
+## 5. Validate
+
+- CORE ↔ Interface boundary respected: repository/service/exception in `libs/core`, controller
+  wiring in `apps/api`, no CORE dependency on NestJS beyond the already-established `@nestjs/common`
+  + `@nestjs/config` usage.
+- Naming: `*.exception.ts`, `*.service.interface.ts`, `*.service.ts`, Symbol token
+  `{CONTEXT}_{INTERFACE}_TOKEN` — all match `docs/engineering-standards.md`.
+- Security: double-gated (role + env), narrow to one column/one value, never settable via request
+  body, audit-logged at `warn`. `.env.example` keeps the gate default-off and documented as
+  dev/test-only, so it can never silently ship enabled.
+- No migration needed — `taxRateEra` column already exists.
+
+## Result
+
+Implemented as designed. Quality gate: `pnpm --filter @openlinker/core lint` (0 errors),
+`pnpm --filter @openlinker/core type-check` (clean), `pnpm --filter @openlinker/api lint`
+(0 errors), `pnpm --filter @openlinker/api type-check` (clean), `pnpm check:invariants`
+(exit 0 — cross-context imports and service-interface conformance both explicitly confirmed
+for the new files). Unit tests not run locally per project convention (weak laptop); the
+pre-commit hook's `smart-test` run below is the verification.

--- a/libs/core/src/orders/application/interfaces/order-test-fixture.service.interface.ts
+++ b/libs/core/src/orders/application/interfaces/order-test-fixture.service.interface.ts
@@ -5,8 +5,9 @@
  * reach analytics states no real ingestion flow can ever produce (e.g.
  * `taxRateEra = 'pre-rollout'`, written exactly once, by a historical
  * backfill migration). Never called against real order data — see
- * {@link IOrderTestFixtureService.markPreRolloutEraForTesting} for the double
- * gate (`@Roles('admin')` on the HTTP layer + `OL_ALLOW_TEST_FIXTURES` here).
+ * {@link IOrderTestFixtureService.markPreRolloutEraForTesting} for the triple
+ * gate (`@Roles('admin')` on the HTTP layer + `OL_ALLOW_TEST_FIXTURES` +
+ * `NODE_ENV !== 'production'` here).
  *
  * @module libs/core/src/orders/application/interfaces
  * @see {@link OrderTestFixtureService} for the implementation
@@ -22,10 +23,25 @@ export interface IOrderTestFixtureService {
    * defaults OFF and must never be set in a production `.env`. This is the
    * SECOND gate alongside the HTTP layer's `@Roles('admin')`: role alone would
    * let a real production admin silently corrupt a real order's Net Sales
-   * eligibility by mistake.
+   * eligibility by mistake. A THIRD, fail-closed check refuses unconditionally
+   * under `NODE_ENV=production` — the `credentials-resolver.service.ts` §709
+   * precedent — so a deploy that accidentally carries the env var set is still
+   * caught rather than trusting the var alone.
+   *
+   * `actorUserId` is recorded in the warn-level audit log line — never the
+   * env var alone, and never omitted — matching `placeHold`/`releaseHold` in
+   * the same controller: an endpoint whose own docblock says "MUST NEVER be
+   * called against real order data" must record WHO invoked it.
    *
    * Returns `true` if the row was changed by this call, `false` if it already
    * carried `'pre-rollout'` (idempotent — a repeated call is a no-op).
    */
-  markPreRolloutEraForTesting(internalOrderId: string): Promise<boolean>;
+  markPreRolloutEraForTesting(internalOrderId: string, actorUserId: string): Promise<boolean>;
+
+  /**
+   * The gate alone, with no side effect — lets a caller fail fast (and avoid
+   * an unnecessary DB read) before it looks up anything else. Throws the same
+   * `TestFixturesDisabledException` `markPreRolloutEraForTesting` would.
+   */
+  assertTestFixturesAllowed(): void;
 }

--- a/libs/core/src/orders/application/interfaces/order-test-fixture.service.interface.ts
+++ b/libs/core/src/orders/application/interfaces/order-test-fixture.service.interface.ts
@@ -1,0 +1,31 @@
+/**
+ * Order Test Fixture Service Interface (#2855)
+ *
+ * A narrow seam of writes that exist ONLY to let a non-production install
+ * reach analytics states no real ingestion flow can ever produce (e.g.
+ * `taxRateEra = 'pre-rollout'`, written exactly once, by a historical
+ * backfill migration). Never called against real order data — see
+ * {@link IOrderTestFixtureService.markPreRolloutEraForTesting} for the double
+ * gate (`@Roles('admin')` on the HTTP layer + `OL_ALLOW_TEST_FIXTURES` here).
+ *
+ * @module libs/core/src/orders/application/interfaces
+ * @see {@link OrderTestFixtureService} for the implementation
+ */
+export interface IOrderTestFixtureService {
+  /**
+   * Stamps `taxRateEra = 'pre-rollout'` on one order so the `tax-a` / `tax-c`
+   * analytics coverage states (#2482) become reachable with a fresh,
+   * flow-seeded order in a non-production install.
+   *
+   * Refuses (throws `TestFixturesDisabledException`) unless
+   * `OL_ALLOW_TEST_FIXTURES=true` is set in the process env — the env var
+   * defaults OFF and must never be set in a production `.env`. This is the
+   * SECOND gate alongside the HTTP layer's `@Roles('admin')`: role alone would
+   * let a real production admin silently corrupt a real order's Net Sales
+   * eligibility by mistake.
+   *
+   * Returns `true` if the row was changed by this call, `false` if it already
+   * carried `'pre-rollout'` (idempotent — a repeated call is a no-op).
+   */
+  markPreRolloutEraForTesting(internalOrderId: string): Promise<boolean>;
+}

--- a/libs/core/src/orders/application/interfaces/order-test-fixture.service.interface.ts
+++ b/libs/core/src/orders/application/interfaces/order-test-fixture.service.interface.ts
@@ -33,6 +33,20 @@ export interface IOrderTestFixtureService {
    * the same controller: an endpoint whose own docblock says "MUST NEVER be
    * called against real order data" must record WHO invoked it.
    *
+   * **Why a log line and not a ledger row, when #2468 needed one.** The
+   * comparison is the obvious one to make and the answer is deliberate rather
+   * than an oversight: #2468 justified the single exception to FX-stamp
+   * immutability with a persisted `analytics_remediation_runs` row because
+   * that write moves a financial figure of record, and a figure that moves
+   * with no traceable cause is what ADR-040 forbids. This write moves the
+   * same KIND of figure — a pre-rollout stamp silently drops the order out of
+   * Net Sales — but it is structurally impossible where a figure of record
+   * exists: the `NODE_ENV === 'production'` gate is unconditional and is
+   * checked first, so there is no production install in which this row can be
+   * written and therefore no audit trail for a production reader to need. The
+   * log line exists for the developer standing in front of the seeded stand,
+   * which is the only place it can run.
+   *
    * Returns `true` if the row was changed by this call, `false` if it already
    * carried `'pre-rollout'` (idempotent — a repeated call is a no-op).
    */

--- a/libs/core/src/orders/application/services/__tests__/order-test-fixture.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-test-fixture.service.spec.ts
@@ -56,7 +56,7 @@ describe('OrderTestFixtureService', () => {
 
     it.each([
       ['a number', 1],
-      ['a boolean', true],
+      ['the boolean false', false],
       ['an object', { enabled: true }],
       ['undefined', undefined],
       ['null', null],
@@ -77,6 +77,23 @@ describe('OrderTestFixtureService', () => {
         expect(repository.stampPreRolloutEraForTesting).not.toHaveBeenCalled();
       }
     );
+
+    it('opens the gate for the boolean true, which is the one non-string that means "enabled"', async () => {
+      // The deliberate asymmetry with the case above, and the reason the
+      // coercion is `String(...)` rather than a `typeof raw === 'string'`
+      // rejection: a `load:` factory returning a real boolean `true` is an
+      // operator saying the fixtures are on, and refusing it would be fail-
+      // closed in the pedantic sense while doing nothing for safety — the
+      // NODE_ENV gate above it is what keeps this unreachable in production.
+      // Asserted so the behaviour is a decision rather than a side effect of
+      // how `String` happens to render a boolean.
+      configService.get.mockReturnValue(true);
+      const service = buildService();
+
+      await expect(service.markPreRolloutEraForTesting('ol_order_a', 'ol_user_a')).resolves.toBe(
+        true
+      );
+    });
 
     it('is case/whitespace tolerant on the gate value', async () => {
       configService.get.mockReturnValue('  TRUE  ');

--- a/libs/core/src/orders/application/services/__tests__/order-test-fixture.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-test-fixture.service.spec.ts
@@ -1,0 +1,80 @@
+/**
+ * Order Test Fixture Service Tests
+ *
+ * @module libs/core/src/orders/application/services/__tests__
+ */
+import type { ConfigService } from '@nestjs/config';
+import { Logger } from '@openlinker/shared/logging';
+import { TestFixturesDisabledException } from '../../../domain/exceptions/test-fixtures-disabled.exception';
+import type { OrderRecordRepositoryPort } from '../../../domain/ports/order-record-repository.port';
+import { OrderTestFixtureService } from '../order-test-fixture.service';
+
+describe('OrderTestFixtureService', () => {
+  let repository: jest.Mocked<Pick<OrderRecordRepositoryPort, 'stampPreRolloutEraForTesting'>>;
+  let configService: jest.Mocked<ConfigService>;
+  let warn: jest.SpyInstance;
+
+  function buildService(): OrderTestFixtureService {
+    return new OrderTestFixtureService(
+      repository as unknown as OrderRecordRepositoryPort,
+      configService
+    );
+  }
+
+  beforeEach(() => {
+    repository = { stampPreRolloutEraForTesting: jest.fn().mockResolvedValue(true) };
+    configService = { get: jest.fn().mockReturnValue('false') } as unknown as jest.Mocked<
+      ConfigService
+    >;
+    warn = jest.spyOn(Logger.prototype, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warn.mockRestore();
+  });
+
+  describe('markPreRolloutEraForTesting', () => {
+    it('refuses with TestFixturesDisabledException when OL_ALLOW_TEST_FIXTURES is not set', async () => {
+      const service = buildService();
+
+      await expect(service.markPreRolloutEraForTesting('ol_order_a')).rejects.toBeInstanceOf(
+        TestFixturesDisabledException
+      );
+      expect(repository.stampPreRolloutEraForTesting).not.toHaveBeenCalled();
+    });
+
+    it("refuses when OL_ALLOW_TEST_FIXTURES is set to a non-'true' value", async () => {
+      configService.get.mockReturnValue('1');
+      const service = buildService();
+
+      await expect(service.markPreRolloutEraForTesting('ol_order_a')).rejects.toBeInstanceOf(
+        TestFixturesDisabledException
+      );
+    });
+
+    it('is case/whitespace tolerant on the gate value', async () => {
+      configService.get.mockReturnValue('  TRUE  ');
+      const service = buildService();
+
+      await expect(service.markPreRolloutEraForTesting('ol_order_a')).resolves.toBe(true);
+    });
+
+    it('calls the repository and returns its answer when the gate is open', async () => {
+      configService.get.mockReturnValue('true');
+      repository.stampPreRolloutEraForTesting.mockResolvedValue(false);
+      const service = buildService();
+
+      await expect(service.markPreRolloutEraForTesting('ol_order_a')).resolves.toBe(false);
+      expect(repository.stampPreRolloutEraForTesting).toHaveBeenCalledWith('ol_order_a');
+    });
+
+    it('logs at warn on a successful (non-throwing) call — an audit trail for a fixture action', async () => {
+      configService.get.mockReturnValue('true');
+      const service = buildService();
+
+      await service.markPreRolloutEraForTesting('ol_order_a');
+
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('ol_order_a'));
+    });
+  });
+});

--- a/libs/core/src/orders/application/services/__tests__/order-test-fixture.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-test-fixture.service.spec.ts
@@ -54,6 +54,30 @@ describe('OrderTestFixtureService', () => {
       ).rejects.toBeInstanceOf(TestFixturesDisabledException);
     });
 
+    it.each([
+      ['a number', 1],
+      ['a boolean', true],
+      ['an object', { enabled: true }],
+      ['undefined', undefined],
+      ['null', null],
+    ])(
+      'refuses with the MODELLED 403 rather than a 500 when the config value is %s (#3127 review)',
+      async (_label, raw) => {
+        // `configService.get<string>()` is a type assertion, not a guarantee —
+        // ConfigService also resolves from `load:` factories, which are not
+        // type-constrained. A bare `raw.trim()` would throw a TypeError and
+        // turn the documented TestFixturesDisabledException (403) into a 500.
+        // Fail-closed either way, but the response must stay the documented one.
+        configService.get.mockReturnValue(raw);
+        const service = buildService();
+
+        await expect(
+          service.markPreRolloutEraForTesting('ol_order_a', 'ol_user_a')
+        ).rejects.toBeInstanceOf(TestFixturesDisabledException);
+        expect(repository.stampPreRolloutEraForTesting).not.toHaveBeenCalled();
+      }
+    );
+
     it('is case/whitespace tolerant on the gate value', async () => {
       configService.get.mockReturnValue('  TRUE  ');
       const service = buildService();

--- a/libs/core/src/orders/application/services/__tests__/order-test-fixture.service.spec.ts
+++ b/libs/core/src/orders/application/services/__tests__/order-test-fixture.service.spec.ts
@@ -13,6 +13,7 @@ describe('OrderTestFixtureService', () => {
   let repository: jest.Mocked<Pick<OrderRecordRepositoryPort, 'stampPreRolloutEraForTesting'>>;
   let configService: jest.Mocked<ConfigService>;
   let warn: jest.SpyInstance;
+  const originalNodeEnv = process.env.NODE_ENV;
 
   function buildService(): OrderTestFixtureService {
     return new OrderTestFixtureService(
@@ -31,15 +32,16 @@ describe('OrderTestFixtureService', () => {
 
   afterEach(() => {
     warn.mockRestore();
+    process.env.NODE_ENV = originalNodeEnv;
   });
 
   describe('markPreRolloutEraForTesting', () => {
     it('refuses with TestFixturesDisabledException when OL_ALLOW_TEST_FIXTURES is not set', async () => {
       const service = buildService();
 
-      await expect(service.markPreRolloutEraForTesting('ol_order_a')).rejects.toBeInstanceOf(
-        TestFixturesDisabledException
-      );
+      await expect(
+        service.markPreRolloutEraForTesting('ol_order_a', 'ol_user_a')
+      ).rejects.toBeInstanceOf(TestFixturesDisabledException);
       expect(repository.stampPreRolloutEraForTesting).not.toHaveBeenCalled();
     });
 
@@ -47,16 +49,18 @@ describe('OrderTestFixtureService', () => {
       configService.get.mockReturnValue('1');
       const service = buildService();
 
-      await expect(service.markPreRolloutEraForTesting('ol_order_a')).rejects.toBeInstanceOf(
-        TestFixturesDisabledException
-      );
+      await expect(
+        service.markPreRolloutEraForTesting('ol_order_a', 'ol_user_a')
+      ).rejects.toBeInstanceOf(TestFixturesDisabledException);
     });
 
     it('is case/whitespace tolerant on the gate value', async () => {
       configService.get.mockReturnValue('  TRUE  ');
       const service = buildService();
 
-      await expect(service.markPreRolloutEraForTesting('ol_order_a')).resolves.toBe(true);
+      await expect(
+        service.markPreRolloutEraForTesting('ol_order_a', 'ol_user_a')
+      ).resolves.toBe(true);
     });
 
     it('calls the repository and returns its answer when the gate is open', async () => {
@@ -64,17 +68,48 @@ describe('OrderTestFixtureService', () => {
       repository.stampPreRolloutEraForTesting.mockResolvedValue(false);
       const service = buildService();
 
-      await expect(service.markPreRolloutEraForTesting('ol_order_a')).resolves.toBe(false);
+      await expect(
+        service.markPreRolloutEraForTesting('ol_order_a', 'ol_user_a')
+      ).resolves.toBe(false);
       expect(repository.stampPreRolloutEraForTesting).toHaveBeenCalledWith('ol_order_a');
     });
 
-    it('logs at warn on a successful (non-throwing) call — an audit trail for a fixture action', async () => {
+    it('logs at warn on a successful (non-throwing) call — an audit trail for a fixture action, including the actor', async () => {
       configService.get.mockReturnValue('true');
       const service = buildService();
 
-      await service.markPreRolloutEraForTesting('ol_order_a');
+      await service.markPreRolloutEraForTesting('ol_order_a', 'ol_user_a');
 
-      expect(warn).toHaveBeenCalledWith(expect.stringContaining('ol_order_a'));
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('ol_order_a')
+      );
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('ol_user_a'));
+    });
+
+    it('refuses under NODE_ENV=production even when OL_ALLOW_TEST_FIXTURES is true', async () => {
+      configService.get.mockReturnValue('true');
+      process.env.NODE_ENV = 'production';
+      const service = buildService();
+
+      await expect(
+        service.markPreRolloutEraForTesting('ol_order_a', 'ol_user_a')
+      ).rejects.toBeInstanceOf(TestFixturesDisabledException);
+      expect(repository.stampPreRolloutEraForTesting).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('assertTestFixturesAllowed', () => {
+    it('throws without touching the repository when the gate is closed', () => {
+      const service = buildService();
+
+      expect(() => service.assertTestFixturesAllowed()).toThrow(TestFixturesDisabledException);
+    });
+
+    it('does not throw when the gate is open', () => {
+      configService.get.mockReturnValue('true');
+      const service = buildService();
+
+      expect(() => service.assertTestFixturesAllowed()).not.toThrow();
     });
   });
 });

--- a/libs/core/src/orders/application/services/order-test-fixture.service.ts
+++ b/libs/core/src/orders/application/services/order-test-fixture.service.ts
@@ -1,0 +1,47 @@
+/**
+ * Order Test Fixture Service
+ *
+ * Implements {@link IOrderTestFixtureService} — the narrow, double-gated
+ * (role + env) write seam for analytics states no real ingestion flow can
+ * ever produce (#2855).
+ *
+ * @module libs/core/src/orders/application/services
+ * @implements {IOrderTestFixtureService}
+ */
+import { Inject, Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { Logger } from '@openlinker/shared/logging';
+import type { IOrderTestFixtureService } from '../interfaces/order-test-fixture.service.interface';
+import { OrderRecordRepositoryPort } from '../../domain/ports/order-record-repository.port';
+import { TestFixturesDisabledException } from '../../domain/exceptions/test-fixtures-disabled.exception';
+import { ORDER_RECORD_REPOSITORY_TOKEN } from '../../orders.tokens';
+
+const ALLOW_TEST_FIXTURES_ENV_VAR = 'OL_ALLOW_TEST_FIXTURES';
+
+@Injectable()
+export class OrderTestFixtureService implements IOrderTestFixtureService {
+  private readonly logger = new Logger(OrderTestFixtureService.name);
+
+  constructor(
+    @Inject(ORDER_RECORD_REPOSITORY_TOKEN)
+    private readonly orderRecordRepository: OrderRecordRepositoryPort,
+    private readonly configService: ConfigService
+  ) {}
+
+  async markPreRolloutEraForTesting(internalOrderId: string): Promise<boolean> {
+    this.assertTestFixturesAllowed();
+
+    const applied = await this.orderRecordRepository.stampPreRolloutEraForTesting(internalOrderId);
+    this.logger.warn(
+      `Test fixture: stamped taxRateEra='pre-rollout' on order ${internalOrderId} (applied=${applied})`
+    );
+    return applied;
+  }
+
+  private assertTestFixturesAllowed(): void {
+    const raw = this.configService.get<string>(ALLOW_TEST_FIXTURES_ENV_VAR, 'false');
+    if (raw.trim().toLowerCase() !== 'true') {
+      throw new TestFixturesDisabledException();
+    }
+  }
+}

--- a/libs/core/src/orders/application/services/order-test-fixture.service.ts
+++ b/libs/core/src/orders/application/services/order-test-fixture.service.ts
@@ -51,7 +51,11 @@ export class OrderTestFixtureService implements IOrderTestFixtureService {
       throw new TestFixturesDisabledException();
     }
 
-    const raw = this.configService.get<string>(ALLOW_TEST_FIXTURES_ENV_VAR, 'false');
+    // `get<string>` is a type ASSERTION, not a guarantee: ConfigService also
+    // resolves from `load:` factories, which are not type-constrained, so a
+    // non-string value would make a bare `raw.trim()` throw and turn the
+    // modelled 403 into a 500. Coercing keeps the refusal the documented one.
+    const raw = String(this.configService.get(ALLOW_TEST_FIXTURES_ENV_VAR) ?? 'false');
     if (raw.trim().toLowerCase() !== 'true') {
       throw new TestFixturesDisabledException();
     }

--- a/libs/core/src/orders/application/services/order-test-fixture.service.ts
+++ b/libs/core/src/orders/application/services/order-test-fixture.service.ts
@@ -1,9 +1,9 @@
 /**
  * Order Test Fixture Service
  *
- * Implements {@link IOrderTestFixtureService} — the narrow, double-gated
- * (role + env) write seam for analytics states no real ingestion flow can
- * ever produce (#2855).
+ * Implements {@link IOrderTestFixtureService} — the narrow, triple-gated
+ * (role + env + NODE_ENV) write seam for analytics states no real ingestion
+ * flow can ever produce (#2855).
  *
  * @module libs/core/src/orders/application/services
  * @implements {IOrderTestFixtureService}
@@ -28,17 +28,29 @@ export class OrderTestFixtureService implements IOrderTestFixtureService {
     private readonly configService: ConfigService
   ) {}
 
-  async markPreRolloutEraForTesting(internalOrderId: string): Promise<boolean> {
+  async markPreRolloutEraForTesting(
+    internalOrderId: string,
+    actorUserId: string
+  ): Promise<boolean> {
     this.assertTestFixturesAllowed();
 
     const applied = await this.orderRecordRepository.stampPreRolloutEraForTesting(internalOrderId);
     this.logger.warn(
-      `Test fixture: stamped taxRateEra='pre-rollout' on order ${internalOrderId} (applied=${applied})`
+      `Test fixture: stamped taxRateEra='pre-rollout' on order ${internalOrderId} ` +
+        `(applied=${applied}, actor=${actorUserId})`
     );
     return applied;
   }
 
-  private assertTestFixturesAllowed(): void {
+  assertTestFixturesAllowed(): void {
+    // Fail-closed under NODE_ENV=production regardless of the env var, mirroring
+    // credentials-resolver.service.ts's dev/test-only gate (#709) — a copy-pasted
+    // .env that carries OL_ALLOW_TEST_FIXTURES=true into production must not be
+    // the only thing standing between a real order and this write.
+    if (process.env.NODE_ENV === 'production') {
+      throw new TestFixturesDisabledException();
+    }
+
     const raw = this.configService.get<string>(ALLOW_TEST_FIXTURES_ENV_VAR, 'false');
     if (raw.trim().toLowerCase() !== 'true') {
       throw new TestFixturesDisabledException();

--- a/libs/core/src/orders/application/services/order-test-fixture.service.ts
+++ b/libs/core/src/orders/application/services/order-test-fixture.service.ts
@@ -55,6 +55,12 @@ export class OrderTestFixtureService implements IOrderTestFixtureService {
     // resolves from `load:` factories, which are not type-constrained, so a
     // non-string value would make a bare `raw.trim()` throw and turn the
     // modelled 403 into a 500. Coercing keeps the refusal the documented one.
+    //
+    // One value coerces the other way and it is intended: a real boolean
+    // `true` renders as `'true'` and OPENS the gate, because a factory
+    // returning it is an operator saying the fixtures are on. Refusing it
+    // would be fail-closed in the pedantic sense only — the unconditional
+    // NODE_ENV check above is what makes this unreachable in production.
     const raw = String(this.configService.get(ALLOW_TEST_FIXTURES_ENV_VAR) ?? 'false');
     if (raw.trim().toLowerCase() !== 'true') {
       throw new TestFixturesDisabledException();

--- a/libs/core/src/orders/domain/exceptions/test-fixtures-disabled.exception.ts
+++ b/libs/core/src/orders/domain/exceptions/test-fixtures-disabled.exception.ts
@@ -1,0 +1,25 @@
+/**
+ * Test Fixtures Disabled Exception (#2855)
+ *
+ * Raised by `OrderTestFixtureService` when a test-fixture-only write is
+ * attempted but `OL_ALLOW_TEST_FIXTURES` is not `'true'` in the process env.
+ * This is the SECOND gate alongside `@Roles('admin')` on the HTTP layer — role
+ * alone would let a real production admin silently corrupt a real order's
+ * Net Sales eligibility by mistake. The env var defaults OFF and must never
+ * be set in a production `.env`.
+ *
+ * @module libs/core/src/orders/domain/exceptions
+ */
+export class TestFixturesDisabledException extends Error {
+  constructor() {
+    super(
+      'Test fixtures are disabled — set OL_ALLOW_TEST_FIXTURES=true in a non-production ' +
+        'environment to enable this endpoint.'
+    );
+    this.name = 'TestFixturesDisabledException';
+
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, TestFixturesDisabledException);
+    }
+  }
+}

--- a/libs/core/src/orders/domain/ports/order-record-repository.port.ts
+++ b/libs/core/src/orders/domain/ports/order-record-repository.port.ts
@@ -892,6 +892,25 @@ export interface OrderRecordRepositoryPort {
   clearFxStampForRestatement(internalOrderId: string): Promise<boolean>;
 
   /**
+   * TEST-FIXTURE-ONLY (#2855). Stamps `taxRateEra = 'pre-rollout'` on one
+   * order so a non-production install can reach the `tax-a` / `tax-c`
+   * analytics coverage states with a fresh, flow-seeded order — no ingestion
+   * path writes this column going forward (it was set exactly once, by a
+   * historical backfill migration), so without this seam those states are
+   * structurally unreachable by any real order.
+   *
+   * Guarded on `"taxRateEra" IS DISTINCT FROM 'pre-rollout'`, the same
+   * idempotency shape {@link clearFxStampForRestatement} uses: a row already
+   * in the target state matches nothing and reports `false`, so a repeated
+   * call is a no-op rather than a second, redundant write.
+   *
+   * Deliberately NOT role/env-aware — this is a dumb, narrow conditional
+   * writer, same as its precedent. The `@Roles('admin')` + `OL_ALLOW_TEST_FIXTURES`
+   * double gate lives in `OrderTestFixtureService`, one layer up.
+   */
+  stampPreRolloutEraForTesting(internalOrderId: string): Promise<boolean>;
+
+  /**
    * The mismatched population still remaining in `filters`' scope,
    * partitioned by whether the FX pipeline already reached a terminal answer
    * (#2468) — what a restatement run's completion poll reads to decide

--- a/libs/core/src/orders/index.ts
+++ b/libs/core/src/orders/index.ts
@@ -313,6 +313,7 @@ export type {
   TaxRateBackfillPageResult,
 } from './application/services/tax-rate-backfill.service.interface';
 export type { ITaxCoverageDetectionService } from './application/services/tax-coverage-detection.service.interface';
+export type { IOrderTestFixtureService } from './application/interfaces/order-test-fixture.service.interface';
 export type { IDisplayCurrencyConversionService } from './application/interfaces/display-currency-conversion.service.interface';
 export * from './orders.tokens';
 
@@ -386,6 +387,7 @@ export type {
   ReleaseOrderHoldInput,
 } from './domain/types/order-hold.types';
 export { OrderAlreadyOnHoldError } from './domain/exceptions/order-already-on-hold.error';
+export { TestFixturesDisabledException } from './domain/exceptions/test-fixtures-disabled.exception';
 export { OrderHoldContendedError } from './domain/exceptions/order-hold-contended.error';
 export { HoldAlreadyReleasedError } from './domain/exceptions/hold-already-released.error';
 export { OrderHoldNotFoundError } from './domain/exceptions/order-hold-not-found.error';

--- a/libs/core/src/orders/infrastructure/persistence/repositories/__tests__/order-record.repository.spec.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/__tests__/order-record.repository.spec.ts
@@ -1265,6 +1265,40 @@ describe('OrderRecordRepository', () => {
     });
   });
 
+  describe('stampPreRolloutEraForTesting (#2855, TEST-FIXTURE-ONLY)', () => {
+    const mockUpdateQueryBuilder = (affected: number) => {
+      const chain = {
+        update: jest.fn().mockReturnThis(),
+        set: jest.fn().mockReturnThis(),
+        where: jest.fn().mockReturnThis(),
+        andWhere: jest.fn().mockReturnThis(),
+        execute: jest.fn().mockResolvedValue({ affected }),
+      };
+      (ormRepository.createQueryBuilder as jest.Mock).mockReturnValue(chain);
+      return chain;
+    };
+
+    it("stamps taxRateEra='pre-rollout' guarded on the row not already carrying it", async () => {
+      const chain = mockUpdateQueryBuilder(1);
+
+      await expect(repository.stampPreRolloutEraForTesting('ol_order_a')).resolves.toBe(true);
+
+      expect(chain.set).toHaveBeenCalledWith({ taxRateEra: 'pre-rollout' });
+      expect(chain.where).toHaveBeenCalledWith(expect.stringContaining('"internalOrderId"'), {
+        internalOrderId: 'ol_order_a',
+      });
+      expect(chain.andWhere).toHaveBeenCalledWith(
+        expect.stringContaining('"taxRateEra" IS DISTINCT FROM \'pre-rollout\'')
+      );
+    });
+
+    it('reports false when the row already carries pre-rollout, so a repeated call is idempotent', async () => {
+      mockUpdateQueryBuilder(0);
+
+      await expect(repository.stampPreRolloutEraForTesting('ol_order_a')).resolves.toBe(false);
+    });
+  });
+
   describe('findNetExcludedOrderCandidates (#2465)', () => {
     const baseFilters = {
       from: new Date('2026-08-01T00:00:00.000Z'),

--- a/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
+++ b/libs/core/src/orders/infrastructure/persistence/repositories/order-record.repository.ts
@@ -974,6 +974,18 @@ export class OrderRecordRepository implements OrderRecordRepositoryPort {
     return (result.affected ?? 0) > 0;
   }
 
+  /** See the port's JSDoc — TEST-FIXTURE-ONLY (#2855). */
+  async stampPreRolloutEraForTesting(internalOrderId: string): Promise<boolean> {
+    const result = await this.repository
+      .createQueryBuilder()
+      .update(OrderRecordOrmEntity)
+      .set({ taxRateEra: 'pre-rollout' })
+      .where('"internalOrderId" = :internalOrderId', { internalOrderId })
+      .andWhere('"taxRateEra" IS DISTINCT FROM \'pre-rollout\'')
+      .execute();
+    return (result.affected ?? 0) > 0;
+  }
+
   /**
    * Remaining mismatched population in scope, split by terminal marker
    * (#2468) — see the port's JSDoc for why the marker is the only evidence

--- a/libs/core/src/orders/orders.module.ts
+++ b/libs/core/src/orders/orders.module.ts
@@ -7,6 +7,7 @@
  * @module libs/core/src/orders
  */
 import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { OrderSyncService } from './application/services/order-sync.service';
 import { OrderIngestionService } from './application/services/order-ingestion.service';
@@ -28,6 +29,7 @@ import { RefundRecordRepository } from './infrastructure/persistence/repositorie
 import { RefundRecordOrmEntity } from './infrastructure/persistence/entities/refund-record.orm-entity';
 import { OrderLineItemOrmEntity } from './infrastructure/persistence/entities/order-line-item.orm-entity';
 import { TaxRateBackfillService } from './application/services/tax-rate-backfill.service';
+import { OrderTestFixtureService } from './application/services/order-test-fixture.service';
 import { TaxCoverageDetectionService } from './application/services/tax-coverage-detection.service';
 import { DisplayCurrencyConversionService } from './application/services/display-currency-conversion.service';
 import {
@@ -46,6 +48,7 @@ import {
   ORDER_FX_READ_SERVICE_TOKEN,
   ORDER_LINE_ITEM_REPOSITORY_TOKEN,
   TAX_RATE_BACKFILL_SERVICE_TOKEN,
+  ORDER_TEST_FIXTURE_SERVICE_TOKEN,
   FULFILLMENT_DISPATCH_RELAY_SERVICE_TOKEN,
   SALES_DOCUMENT_VIEW_SERVICE_TOKEN,
   TAX_COVERAGE_DETECTION_SERVICE_TOKEN,
@@ -81,6 +84,7 @@ export { ORDER_SYNC_SERVICE_TOKEN } from './orders.tokens';
 
 @Module({
   imports: [
+    ConfigModule, // Required for OrderTestFixtureService's OL_ALLOW_TEST_FIXTURES read (#2855)
     TypeOrmModule.forFeature([OrderRecordOrmEntity, RefundRecordOrmEntity, OrderLineItemOrmEntity]),
     IntegrationsModule, // Required for INTEGRATIONS_SERVICE_TOKEN and ADAPTER_FACTORY_RESOLVER_TOKEN
     IdentifierMappingModule, // Required for IDENTIFIER_MAPPING_SERVICE_TOKEN
@@ -141,6 +145,7 @@ export { ORDER_SYNC_SERVICE_TOKEN } from './orders.tokens';
     RefundRecordRepository,
     OrderLineItemRepository,
     TaxRateBackfillService,
+    OrderTestFixtureService,
     TaxCoverageDetectionService,
     DisplayCurrencyConversionService,
     // Then provide token bindings using useExisting
@@ -213,6 +218,10 @@ export { ORDER_SYNC_SERVICE_TOKEN } from './orders.tokens';
       useExisting: TaxRateBackfillService,
     },
     {
+      provide: ORDER_TEST_FIXTURE_SERVICE_TOKEN,
+      useExisting: OrderTestFixtureService,
+    },
+    {
       provide: SALES_DOCUMENT_VIEW_SERVICE_TOKEN,
       useExisting: SalesDocumentViewService,
     },
@@ -245,6 +254,9 @@ export { ORDER_SYNC_SERVICE_TOKEN } from './orders.tokens';
     // Exported so the worker's `orders.taxRate.backfill` handler can inject
     // the backfill seam (#2440).
     TAX_RATE_BACKFILL_SERVICE_TOKEN,
+    // Exported so the API's orders controller can inject the test-fixture
+    // seam (#2855).
+    ORDER_TEST_FIXTURE_SERVICE_TOKEN,
     // Re-exported so a consumer of `OrdersModule` reaches the hold repository
     // without also importing `OrderHoldsModule` (#2338). It is the MODULE that
     // is re-exported, not the token: Nest refuses to export a provider it does

--- a/libs/core/src/orders/orders.tokens.ts
+++ b/libs/core/src/orders/orders.tokens.ts
@@ -31,6 +31,8 @@ export const ORDER_REFUND_SERVICE_TOKEN = Symbol('IOrderRefundService');
 export const ORDER_LINE_ITEM_REPOSITORY_TOKEN = Symbol('OrderLineItemRepositoryPort');
 // Tax-rate backfill sweep for pre-#2245 lines (#2440).
 export const TAX_RATE_BACKFILL_SERVICE_TOKEN = Symbol('ITaxRateBackfillService');
+// Test-fixture-only writes unreachable via any real ingestion flow (#2855).
+export const ORDER_TEST_FIXTURE_SERVICE_TOKEN = Symbol('IOrderTestFixtureService');
 
 
 


### PR DESCRIPTION
## Summary
- Adds a narrow, double-gated write seam (`@Roles('admin')` + `OL_ALLOW_TEST_FIXTURES` env var) to stamp `order_records.taxRateEra = 'pre-rollout'` on an order: `POST /orders/:internalOrderId/test-fixtures/mark-pre-rollout-era`.
- `taxRateEra = 'pre-rollout'` is written exactly once, ever, by a historical migration — no real ingestion flow can produce it, so the `tax-a`/`tax-c` analytics coverage states (#2482) are otherwise structurally unreachable by a fresh, flow-seeded order in a non-production install.
- Repository method is a single conditional `UPDATE ... WHERE "taxRateEra" IS DISTINCT FROM 'pre-rollout'` (idempotent), mirroring `clearFxStampForRestatement`'s shape.
- The env var defaults off and is documented dev/test-only in `apps/api/.env.example`.

## Test plan
- [x] `pnpm --filter @openlinker/core lint` / `type-check` — clean
- [x] `pnpm --filter @openlinker/api lint` / `type-check` — clean
- [x] `pnpm check:invariants` — clean (cross-context imports + service-interface conformance)
- [x] New unit tests: repository (guarded UPDATE + idempotency), service (env gate on/off, case/whitespace tolerance, logging), controller (404 / 403 / 200 / rethrow-unmodelled)
- [ ] Full local `pnpm test` not run (laptop cannot run the monorepo's full suite locally — see plan doc's Result section)

Closes #2855

🤖 Generated with [Claude Code](https://claude.com/claude-code)