### PR TITLE
fix(infakt): detect the errors.sale_type 422 shape and surface a config hint

### DIFF
--- a/apps/web/src/features/invoicing/api/invoicing.types.ts
+++ b/apps/web/src/features/invoicing/api/invoicing.types.ts
@@ -41,6 +41,9 @@ export type FailureMode = (typeof FailureModeValues)[number];
 export const FailureCodeValues = [
   'buyer-tax-id-invalid',
   'invalid-currency',
+  // A missing per-connection sale classification (goods vs. services) — a
+  // one-field config gap, not an order-data problem (#3031).
+  'sale-classification-required',
   'provider-rejected',
   'transport-timeout',
   'provider-error',

--- a/apps/web/src/features/invoicing/lib/derive-invoice-display.ts
+++ b/apps/web/src/features/invoicing/lib/derive-invoice-display.ts
@@ -70,6 +70,8 @@ const FAILURE_CODE_FALLBACK: Record<FailureCode, string> = {
     'The provider rejected the buyer’s tax ID. Check the tax ID on the order’s customer, then retry. Nothing was issued.',
   'invalid-currency':
     'The document’s settlement currency is missing, malformed, or not accepted for this document. Fix the currency on the source order, then retry. Nothing was issued.',
+  'sale-classification-required':
+    'This connection needs a sale classification (goods vs. services) configured before it can issue invoices. Set it in the connection’s configuration, then retry. Nothing was issued.',
   'provider-rejected':
     'The provider rejected the document. Check the order’s data, then retry. Nothing was issued.',
   'transport-timeout':

--- a/docs/lessons.md
+++ b/docs/lessons.md
@@ -1226,3 +1226,38 @@ where an adjacent context already owns similar vocabulary (`routing`, `fulfillme
 
 **Source**: #2953 (caught by `/pre-implement` before implementation; both collisions were in the
 first draft of the plan).
+
+---
+
+## Format only the touched files with the workspace's own pinned prettier binary — never `npx prettier`
+
+**Context**: #3031 touched ten files. A convenience pass over all of them with `npx prettier
+--write` (intending to just clean up the new hunks) reformatted every one **in full** — hundreds of
+unrelated lines, stripping trailing commas from every multi-line call/array/constructor across
+files nobody was asked to touch.
+
+**Problem**: `npx prettier` resolves (and may fetch) a prettier build outside this pnpm workspace's
+`node_modules`, so it does not reliably pick up the repo's pinned `prettier@3.2.5` or apply
+`.prettierrc` (`trailingComma: "es5"`) the way the workspace's own tooling does. The result reads
+like an intentional whole-file reformat and is easy to miss in a large diff — `git diff --stat`
+before-and-after is the tell (a 12-line intended change became 700+ lines across 5 files). Re-running
+the SAME command with the LOCAL binary (`node_modules/.bin/prettier` / `pnpm exec prettier`)
+reproduced the identical mass-reformat, which ruled out a version mismatch and confirmed the
+project's own quality gate (`pnpm lint` → `.eslintrc.js`'s `extends: ['prettier']` is
+`eslint-config-prettier`, which only *disables* conflicting stylistic ESLint rules — it does **not**
+run `eslint-plugin-prettier`) never enforces prettier formatting as a lint error, and CI has no
+separate `format:check` step either. So running prettier at all here bought nothing the gate needed
+and cost a large, unreviewable diff.
+
+**Rule**: don't run prettier as a formatting pass on a diff unless the task is specifically a
+formatting task. When touching a handful of files, format by hand to match the surrounding style
+(the existing lines are the spec) and verify with `git diff --stat` that only the intended lines
+changed. If prettier must run, target the exact files with the local pinned binary
+(`node_modules/.bin/prettier --config .prettierrc --write <files>`), never `npx prettier`, and
+`git diff --stat` immediately after to catch a whole-file reformat before it's mixed into a commit.
+
+**Applies to**: any edit to existing `*.ts`/`*.tsx` files in this repo, especially a small,
+surgical change to a large pre-existing file.
+
+**Source**: #3031 (caught before commit by comparing `git diff --stat` line counts against the
+size of the intended change).

--- a/libs/core/src/invoicing/application/services/invoice.service.spec.ts
+++ b/libs/core/src/invoicing/application/services/invoice.service.spec.ts
@@ -600,6 +600,34 @@ describe('InvoiceService', () => {
       );
     });
 
+    it("(d5b) failureCode: a 'rejected' throwable naming a missing sale classification maps to 'sale-classification-required' (#3031)", async () => {
+      repo.findByIdempotencyKey.mockResolvedValue(null);
+      repo.create.mockResolvedValue(makeRecord({ id: 'rec-1', status: 'pending' }));
+      // Structural `reason` field — mirrors how an adapter recognises its own
+      // provider's "you must configure this" 422 shape and re-throws with a
+      // reason matching SALE_CLASSIFICATION_REJECTION_MARKERS (#3031, inFakt's
+      // `errors.sale_type` detection), rather than propagating the provider's
+      // raw (possibly buyer-PII-echoing) message.
+      const rejection = Object.assign(new Error('rejected'), {
+        failureMode: 'rejected' as const,
+        reason: 'Infakt requires a sale classification to be configured for this connection',
+      });
+      adapter.issueInvoice.mockRejectedValue(rejection);
+      repo.updateOutcome.mockResolvedValue(makeRecord({ id: 'rec-1', status: 'failed' }));
+
+      await expect(service.issueInvoice(makeCmd())).rejects.toBe(rejection);
+      expect(repo.updateOutcome).toHaveBeenCalledWith(
+        'rec-1',
+        expect.objectContaining({
+          status: 'failed',
+          failureMode: 'rejected',
+          failureCode: 'sale-classification-required',
+          failureReason:
+            "This connection requires a sale classification (goods vs. services) to be configured before it can issue invoices. Set the connection's `defaultSaleType` and re-issue.",
+        }),
+      );
+    });
+
     it("(d5) failureCode: a tax-id rejection that also mentions a currency stays 'buyer-tax-id-invalid'", async () => {
       repo.findByIdempotencyKey.mockResolvedValue(null);
       repo.create.mockResolvedValue(makeRecord({ id: 'rec-1', status: 'pending' }));

--- a/libs/core/src/invoicing/application/services/invoice.service.ts
+++ b/libs/core/src/invoicing/application/services/invoice.service.ts
@@ -68,7 +68,10 @@ import { MissingTaxRateException } from '../../domain/exceptions/missing-tax-rat
 import { CapabilityNotSupportedException } from '@openlinker/core/integrations';
 // Published so an adapter spec can pin its own pre-call refusal message against
 // the very markers this service matches on (#2103 review) — see the constant's doc.
-import { CURRENCY_REJECTION_MARKERS } from '../../domain/types/invoicing.types';
+import {
+  CURRENCY_REJECTION_MARKERS,
+  SALE_CLASSIFICATION_REJECTION_MARKERS,
+} from '../../domain/types/invoicing.types';
 import type {
   CorrectionLine,
   GetInvoiceByOrderQuery,
@@ -982,6 +985,9 @@ export class InvoiceService implements IInvoiceService {
     if (CURRENCY_REJECTION_MARKERS.some((marker) => haystack.includes(marker))) {
       return 'invalid-currency';
     }
+    if (SALE_CLASSIFICATION_REJECTION_MARKERS.some((marker) => haystack.includes(marker))) {
+      return 'sale-classification-required';
+    }
     return 'provider-rejected';
   }
 
@@ -1001,6 +1007,11 @@ export class InvoiceService implements IInvoiceService {
       // route here, which is why it names the condition rather than the actor.
       'invalid-currency':
         'The settlement currency is missing, malformed, or not accepted for this document. Fix the currency on the order and re-issue.',
+      // Names the connection config field an operator can actually set — the
+      // generic 'provider-rejected' copy gives no clue this is a one-field
+      // config gap rather than a per-order problem (#3031).
+      'sale-classification-required':
+        "This connection requires a sale classification (goods vs. services) to be configured before it can issue invoices. Set the connection's `defaultSaleType` and re-issue.",
       'provider-rejected': 'The invoicing provider rejected the request.',
       'transport-timeout':
         'The invoicing request timed out; the document may or may not have been created.',

--- a/libs/core/src/invoicing/domain/types/invoicing.types.spec.ts
+++ b/libs/core/src/invoicing/domain/types/invoicing.types.spec.ts
@@ -42,6 +42,7 @@ describe('invoicing.types', () => {
     expect([...InvoiceFailureCodeValues]).toEqual([
       'buyer-tax-id-invalid',
       'invalid-currency',
+      'sale-classification-required',
       'provider-rejected',
       'transport-timeout',
       'provider-error',

--- a/libs/core/src/invoicing/domain/types/invoicing.types.ts
+++ b/libs/core/src/invoicing/domain/types/invoicing.types.ts
@@ -87,6 +87,18 @@ export type InvoiceFailureMode = (typeof InvoiceFailureModeValues)[number];
  *     accurately, since the provider did reject it. Operator-fixable on the
  *     source order either way. Currency and ISO 4217 are country-agnostic
  *     vocabulary, so this stays ADR-026-clean.
+ *   - `sale-classification-required`: a TERMINAL `rejected` failure caused by a
+ *     missing per-connection sale classification (goods vs. services) — a
+ *     required-but-unconfigured PLUGIN SETTING, not an order-data problem
+ *     (#3031). Unlike `invalid-currency` this genuinely IS a provider-side
+ *     rejection (the adapter has no signal to refuse the call pre-emptively —
+ *     #2177/#2995 deliberately did not add a goods/service field to
+ *     `InvoiceLine`), so it can only be detected reactively, by an adapter
+ *     recognising its own provider's shape for "you must configure this" and
+ *     re-throwing with a `reason` one of {@link SALE_CLASSIFICATION_REJECTION_MARKERS}
+ *     matches. The operator-fixable remedy is a one-field connection config
+ *     change, which is why this must not collapse into `provider-rejected` —
+ *     that copy gives no clue there is a config knob to set at all.
  *   - `provider-rejected`: any other TERMINAL `rejected` failure (safe to
  *     re-attempt once the underlying input is corrected).
  *   - `transport-timeout`: an `in-doubt` transport failure — the document MAY
@@ -97,6 +109,7 @@ export type InvoiceFailureMode = (typeof InvoiceFailureModeValues)[number];
 export const InvoiceFailureCodeValues = [
   'buyer-tax-id-invalid',
   'invalid-currency',
+  'sale-classification-required',
   'provider-rejected',
   'transport-timeout',
   'provider-error',
@@ -129,6 +142,34 @@ export const CURRENCY_REJECTION_MARKERS = [
   'currency is required',
   'currency code',
 ] as const;
+
+/**
+ * Substrings (case-insensitive) that mark a `rejected` failure as a missing
+ * per-connection sale-classification (goods vs. services) setting, so
+ * `classifyFailureCode` can resolve `sale-classification-required` instead of
+ * the generic `provider-rejected` (#3031, follow-up to #2177/#2995).
+ *
+ * Unlike the currency markers this is a genuine POST-CALL provider rejection —
+ * core cannot know ahead of time whether the buyer's country needs the field,
+ * and #2995 deliberately declined to add a goods/service signal to
+ * `InvoiceLine` (a national VAT-classification concept ADR-026 keeps out of
+ * `libs/core`). An adapter that recognises its own provider's "you must
+ * configure a sale classification" response re-throws with a `reason`
+ * matching one of these markers instead of propagating the provider's raw
+ * (possibly buyer-PII-echoing) message.
+ *
+ * PUBLISHED for the same reason {@link CURRENCY_REJECTION_MARKERS} is: both
+ * ends of the structural read live in this repo (the reason text an adapter
+ * throws is OL-authored, never a verbatim provider string), so an adapter
+ * spec can assert its own message still matches one of these markers and a
+ * reword breaks the build rather than silently degrading the operator's
+ * failure reason. Neutral vocabulary only — "sale classification" names no
+ * country or tax system (ADR-026); it deliberately avoids inFakt's own wire
+ * field name (`sale_type`) so the marker itself never leaks one provider's
+ * naming into a cross-provider vocabulary, even though inFakt is the only
+ * shipped adapter that triggers it today.
+ */
+export const SALE_CLASSIFICATION_REJECTION_MARKERS = ['sale classification'] as const;
 
 /**
  * Neutral Continuous-Transaction-Controls clearance lifecycle. The adapter maps

--- a/libs/integrations/infakt/README.md
+++ b/libs/integrations/infakt/README.md
@@ -133,11 +133,25 @@ below).
   the correct value for a physical-goods sale was not found. `InfaktSaleTypeValues`
   therefore lists `'service'` alone (#2995 review) — a placeholder `'goods'` value
   would pass the save-time shape gate and then 422 at issuance, converting the
-  guard into a trap for exactly the operator this fix is meant to help. Finding
-  the real goods-sale value (and, separately, detecting `errors.sale_type` in a
-  422 body to give an un-configured connection a specific hint instead of the
-  generic "The invoicing provider rejected the request.") is tracked as a
-  follow-up: #3031.
+  guard into a trap for exactly the operator this fix is meant to help. **Finding
+  the confirmed goods-sale value remains open** — tracked as #3031, unresolved
+  pending live sandbox access; do not guess it in, per the rule above.
+- **Missing-`sale_type` diagnosis hint** (#3031): `issueInvoice` detects Infakt's
+  field-level validation shape for the 422 above —
+  `{"errors":{"sale_type":[...]}}`, checked structurally (key presence only,
+  never the Polish message text or the array's contents, so a locale change
+  can't silently break it) — and re-throws with a `reason` matching core's
+  published `SALE_CLASSIFICATION_REJECTION_MARKERS`
+  (`@openlinker/core/invoicing`). `InvoiceService.classifyFailureCode` (#1200/W1)
+  routes that to the `sale-classification-required` failure code instead of the
+  generic `provider-rejected`, so a non-PL connection with no `defaultSaleType`
+  configured gets an operator-facing hint naming the config field to set, rather
+  than the uninformative "The invoicing provider rejected the request." Only the
+  direct `invoices.json` create path can carry this shape — a correction's
+  failure surfaces through the async task's `{processing_code,
+  processing_description}` envelope (#1763), which carries no field-level
+  `errors` object at all, so the same detection cannot apply to
+  `issueCorrection`.
 - **Rendered-PDF download** (#1321): `RegulatoryDocumentReader.getRegulatoryDocument
   (record, 'rendered')` fetches the invoice PDF as rendered by inFakt - this backs
   the **Download PDF** button on the accepted invoice detail page.

--- a/libs/integrations/infakt/src/domain/exceptions/infakt-api.error.ts
+++ b/libs/integrations/infakt/src/domain/exceptions/infakt-api.error.ts
@@ -27,6 +27,18 @@ export class InfaktApiError extends Error {
     message: string,
     public readonly statusCode: number,
     public readonly responseBody: unknown,
+    /**
+     * Operator-readable rejection reason, read STRUCTURALLY (duck-typed) by
+     * core's `InvoiceService.classifyFailureCode` (#1200/W1) — mirrors
+     * `SubiektInvoiceRejectedError.reason`. Optional and OL-authored: `message`
+     * deliberately never echoes the raw provider response body (it can carry
+     * buyer PII), so `reason` is the one place an adapter may recognise a
+     * SPECIFIC rejection shape (e.g. a missing `errors.sale_type`, #3031) and
+     * hand core a PII-free phrase it can match against a published marker
+     * list to derive a more actionable `InvoiceFailureCode` than the generic
+     * `provider-rejected`.
+     */
+    public readonly reason?: string,
   ) {
     super(message);
     this.name = 'InfaktApiError';

--- a/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-invoicing.adapter.spec.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/__tests__/infakt-invoicing.adapter.spec.ts
@@ -22,6 +22,7 @@ import type { LoggerPort } from '@openlinker/shared/logging';
 import {
   BuyerProfile,
   CURRENCY_REJECTION_MARKERS,
+  SALE_CLASSIFICATION_REJECTION_MARKERS,
   FractionalTaxRateNotationError,
   MissingTaxRateException,
   InvoiceRecord,
@@ -1884,6 +1885,76 @@ describe('InfaktInvoicingAdapter', () => {
       const invoiceCall = http.calls.find((c) => c.method === 'POST' && c.path === 'invoices.json');
       expect(invoiceCall?.body).toMatchObject({
         invoice: expect.objectContaining({ sale_type: 'service' }),
+      });
+    });
+
+    // #3031: detect Infakt's `errors.sale_type` 422 shape and surface a
+    // specific, actionable hint instead of the generic provider-rejected
+    // failure — for the connection that never configured `defaultSaleType`
+    // and whose buyer requires the field (the exact opaque-422 case #2177
+    // originally reported).
+    describe('missing-sale_type 422 detection (#3031)', () => {
+      it('should re-throw with a reason core routes to sale-classification-required for the errors.sale_type shape', async () => {
+        seedIssueFixtures();
+        // Live-verified body shape (#2177): a Rails-style field-level
+        // validation error, not the async task's {processing_code, ...}
+        // envelope — this shape is only reachable on the direct
+        // `invoices.json` POST issueInvoice makes.
+        http.seedError(
+          'POST',
+          'invoices.json',
+          new InfaktApiError('Infakt API POST invoices.json failed with status 422', 422, {
+            errors: { sale_type: ['Proszę określić rodzaj sprzedaży.'] },
+          }),
+        );
+
+        const error = await adapter
+          .issueInvoice(nonPlInvoiceCmd)
+          .then(() => null)
+          .catch((e: unknown) => e as InfaktApiError);
+
+        expect(error).toBeInstanceOf(InfaktApiError);
+        expect(error).toMatchObject({ statusCode: 422, failureMode: 'rejected' });
+        // Asserted against the published marker list rather than a copied
+        // string (the #2103 `invalid-currency` precedent) — a reword on
+        // either side breaks the build instead of silently losing the
+        // routing to the specific failure code.
+        const haystack = (error?.reason ?? '').toLowerCase();
+        expect(
+          SALE_CLASSIFICATION_REJECTION_MARKERS.some((marker: string) =>
+            haystack.includes(marker),
+          ),
+        ).toBe(true);
+      });
+
+      it('should propagate an unrelated 422 unchanged (no reason stamped)', async () => {
+        seedIssueFixtures();
+        const original = new InfaktApiError(
+          'Infakt API POST invoices.json failed with status 422',
+          422,
+          { errors: { client_id: ['jest wymagane'] } },
+        );
+        http.seedError('POST', 'invoices.json', original);
+
+        const error = await adapter
+          .issueInvoice(nonPlInvoiceCmd)
+          .then(() => null)
+          .catch((e: unknown) => e as InfaktApiError);
+
+        expect(error).toBe(original);
+        expect(error?.reason).toBeUndefined();
+      });
+
+      it('should propagate a 422 with a non-object body unchanged (defensive)', async () => {
+        seedIssueFixtures();
+        const original = new InfaktApiError(
+          'Infakt API POST invoices.json returned non-JSON (422)',
+          422,
+          'not json',
+        );
+        http.seedError('POST', 'invoices.json', original);
+
+        await expect(adapter.issueInvoice(nonPlInvoiceCmd)).rejects.toBe(original);
       });
     });
 

--- a/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
+++ b/libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts
@@ -146,6 +146,46 @@ function toInfaktCurrency(currency: string | null | undefined, context: string):
 }
 
 /**
+ * The `reason` this adapter stamps on the re-thrown `InfaktApiError` when it
+ * recognises the `errors.sale_type` 422 shape (#3031). Matches one of core's
+ * published `SALE_CLASSIFICATION_REJECTION_MARKERS`
+ * (`@openlinker/core/invoicing`) by construction — spec-asserted below, so a
+ * reword on either side breaks the build rather than silently losing the
+ * routing to the specific `sale-classification-required` failure code.
+ */
+const SALE_TYPE_HINT_REASON =
+  'Infakt requires a sale classification to be configured for this connection';
+
+/**
+ * Detects Infakt's field-level validation shape for a missing/required
+ * `sale_type` on `POST invoices.json` — `{"errors":{"sale_type":[...]}}`,
+ * live-verified against the sandbox for a non-PL buyer with no
+ * `defaultSaleType` configured (#3031, #2177 review).
+ *
+ * Structural only: checks that `errors.sale_type` is PRESENT, never the array
+ * contents (Infakt's message text is Polish and locale-dependent, so matching
+ * on it would silently stop working under a locale change) and never the
+ * emptiness of the array (a present-but-empty array would still be Infakt
+ * naming the field as the cause). Any other 422 shape — a different field, a
+ * non-object body, no `errors` key — reports `false` so it keeps propagating
+ * as the generic provider rejection it is.
+ */
+function isMissingSaleTypeRejection(error: unknown): error is InfaktApiError {
+  if (!(error instanceof InfaktApiError) || error.statusCode !== 422) {
+    return false;
+  }
+  const body = error.responseBody;
+  if (typeof body !== 'object' || body === null) {
+    return false;
+  }
+  const errors = (body as { errors?: unknown }).errors;
+  if (typeof errors !== 'object' || errors === null) {
+    return false;
+  }
+  return 'sale_type' in errors;
+}
+
+/**
  * Maps Infakt ksef_data.status → neutral RegulatoryStatus.
  *
  * `success` is the TERMINAL accepted state — it must map to `accepted`, not
@@ -625,9 +665,10 @@ export class InfaktInvoicingAdapter
     };
 
     // InfaktApiError carries the neutral `failureMode` discriminator core's
-    // InvoiceService reads structurally (#1200) — propagate as-is rather
-    // than wrapping into a plain Error, which would erase that signal.
-    const invoice = await this.http.post<InfaktInvoice>('invoices.json', payload);
+    // InvoiceService reads structurally (#1200) — propagate as-is, EXCEPT for
+    // the specific `errors.sale_type` 422 shape (#3031), which is re-thrown
+    // with a `reason` core can route to a more actionable failure code.
+    const invoice = await this.postInvoiceWithSaleTypeHint(payload);
 
     this.logger.log(`Infakt invoice created: ${invoice.uuid} (${invoice.number ?? 'draft'})`);
 
@@ -685,6 +726,43 @@ export class InfaktInvoicingAdapter
     // leave the record disagreeing with the document by a grosz here and there,
     // with no way for a reader to tell which is right.
     return { record, documentLines: toDocumentLineAmounts(invoice.services) };
+  }
+
+  /**
+   * Wraps the `invoices.json` create call to detect Infakt's field-level
+   * validation shape for a missing `sale_type` (#3031) —
+   * `{"errors":{"sale_type":["Proszę określić rodzaj sprzedaży."]}}`, live-
+   * verified against the sandbox for a non-PL buyer with no `defaultSaleType`
+   * configured — and re-throw with a `reason` core's `InvoiceService` can
+   * route to the specific `sale-classification-required` failure code instead
+   * of the generic `provider-rejected` (#2177 review).
+   *
+   * Only the DIRECT `invoices.json` POST goes through this: a correction's
+   * failure surfaces through `awaitCorrectionTask`'s async-task envelope
+   * (`{processing_code, processing_description}`, live-verified #1763), which
+   * carries no field-level `errors` object at all — there is no
+   * `errors.sale_type` shape for a correction to be detected against.
+   *
+   * `isMissingSaleTypeRejection` reads only the STRUCTURE of the parsed body
+   * (key presence), never its text — the Polish message it carries is not
+   * matched against, since a locale change would silently stop the detection.
+   */
+  private async postInvoiceWithSaleTypeHint(
+    payload: InfaktInvoiceRequest,
+  ): Promise<InfaktInvoice> {
+    try {
+      return await this.http.post<InfaktInvoice>('invoices.json', payload);
+    } catch (err) {
+      if (isMissingSaleTypeRejection(err)) {
+        throw new InfaktApiError(
+          err.message,
+          err.statusCode,
+          err.responseBody,
+          SALE_TYPE_HINT_REASON,
+        );
+      }
+      throw err;
+    }
   }
 
   async getInvoice(query: GetInvoiceQuery): Promise<InvoiceRecord | null> {


### PR DESCRIPTION
## Summary

Follow-up to #2177 / PR #2995's review round. Two independent gaps were left open there:

1. **inFakt's confirmed `sale_type` value for a physical-goods sale — still NOT resolved.** No sandbox access is available in this environment to positively confirm it, and per the standing rule from the #2995 review (a placeholder value would pass OL's save-time shape gate and then 422 at issuance, turning the guard into a trap), I have **not** guessed a value in. `InfaktSaleTypeValues` stays `['service']`. This half of #3031 remains open, documented as such in the plugin README, and needs a human with live inFakt sandbox access.
2. **Missing-`sale_type` diagnosis hint — shipped.** `InfaktInvoicingAdapter.issueInvoice` now detects inFakt's field-level validation shape for the 422 this bug is about — `{"errors":{"sale_type":[...]}}` — and re-throws with a `reason` that routes through a new, published `SALE_CLASSIFICATION_REJECTION_MARKERS` marker list (the `CURRENCY_REJECTION_MARKERS` / #2103 precedent) to a new closed `InvoiceFailureCode` member, `sale-classification-required`. A non-PL connection with no `defaultSaleType` configured now gets an operator-facing hint naming the config field to set, instead of the generic "The invoicing provider rejected the request."

## What changed

- `libs/integrations/infakt/src/domain/exceptions/infakt-api.error.ts` — `InfaktApiError` gains an optional `reason` (mirrors `SubiektInvoiceRejectedError.reason`), the one PII-free channel an adapter can use to hand core a specific rejection cause without echoing the provider's raw response body.
- `libs/integrations/infakt/src/infrastructure/adapters/infakt-invoicing.adapter.ts` — `issueInvoice`'s `invoices.json` POST is wrapped by a new `postInvoiceWithSaleTypeHint`, which structurally detects `errors.sale_type` presence (never the Polish message text, so a locale change can't silently break it) and re-throws with a matching `reason`. Scoped to the direct create call only — a correction's failure surfaces through the async task's `{processing_code, processing_description}` envelope, which carries no field-level `errors` object at all, so the same detection is documented as inapplicable there.
- `libs/core/src/invoicing/domain/types/invoicing.types.ts` — new `SALE_CLASSIFICATION_REJECTION_MARKERS` (published, same rationale as `CURRENCY_REJECTION_MARKERS`) and a new `InvoiceFailureCode` member, `sale-classification-required`.
- `libs/core/src/invoicing/application/services/invoice.service.ts` — `classifyFailureCode` routes a matching `reason` to the new code; `deriveFailureReason` gets the new code's fixed, PII-free, operator-facing copy (names `defaultSaleType` as the field to set).
- `apps/web/src/features/invoicing/api/invoicing.types.ts` + `.../lib/derive-invoice-display.ts` — FE mirror of the new failure code and its localized fallback copy, so the reg-card copy and the Retry-safety gate agree (the code's `failureMode` is `rejected`, so Retry is already correctly offered by the existing `failureMode`-only gate; only the copy needed the new entry).
- Test coverage mirroring the existing `'service'`-case pattern: a core `invoice.service.spec.ts` case for the new failure-code classification, and three adapter-spec cases (positive detection, an unrelated 422 left unchanged, and a non-object body handled defensively) plus the `InvoiceFailureCodeValues` array assertion update.
- `libs/integrations/infakt/README.md` — documents the shipped hint and restates that the goods-value confirmation remains open.
- `docs/lessons.md` — a lesson from this session: don't run `npx prettier` (or even the local pinned binary) as a casual formatting pass on a diff — it reformatted whole files far beyond the intended hunks before being caught and reverted.

## Acceptance criteria

- [ ] ~~`InfaktSaleTypeValues` gains a confirmed second member for physical-goods sales~~ — **not done, deliberately.** No live sandbox access in this environment to positively confirm the value; guessing would recreate the exact trap #2995's review closed. Left open, documented, needs a human with sandbox access.
- [ ] ~~New value has test coverage mirroring the existing `'service'` cases in both spec files~~ — N/A while the value above is unconfirmed (nothing to add test coverage for).
- [x] A 422 response body carrying `errors.sale_type` surfaces a specific, actionable hint instead of the generic provider-rejected message.
- [x] Tests added for the non-trivial logic (adapter detection + core classification/copy).
- [x] No architecture boundary violations (CORE ↔ Integration) — the adapter never reads a new core symbol beyond the published `SALE_CLASSIFICATION_REJECTION_MARKERS` constant off the top-level `@openlinker/core/invoicing` barrel (the same seam `CURRENCY_REJECTION_MARKERS` already uses); the reason text stays PII-free and adapter-authored.

## Test plan

- [x] `pnpm lint` (full repo, chained `check:invariants`) — see run output below
- [x] `pnpm type-check` (full repo) — passed, exit 0
- [ ] `pnpm test` — **not run**, per project convention (local machine too weak; the repo's pre-commit hook runs `pnpm smart-test --no-integration` on the affected packages instead)

## Notes for the reviewer

- This branch is stacked on `2177-infakt-sale-type-422` (PR #2995, still open) rather than bare `main`, because part 2 genuinely builds on that PR's `InfaktSaleTypeValues` / `defaultSaleType` / `InfaktApiError` groundwork, which is not yet on `main`. The diff against `main` therefore includes #2995's commits until that PR merges; the diff against `2177-infakt-sale-type-422` is the ten-file, ~270-line change described above.

Addresses #3031

🤖 Generated with [Claude Code](https://claude.com/claude-code)
