### PR TITLE
feat(inventory): locations list page with filter bar

### DIFF
--- a/apps/api/src/inventory/http/inventory-locations.controller.spec.ts
+++ b/apps/api/src/inventory/http/inventory-locations.controller.spec.ts
@@ -17,6 +17,7 @@ import {
   LocationInUseError,
   type ILocationService,
 } from '@openlinker/core/inventory';
+import { ROLE_PERMISSIONS, UserRoleValues } from '@openlinker/core/users';
 import { InventoryLocationsController } from './inventory-locations.controller';
 
 function makeLocation(
@@ -221,5 +222,19 @@ describe('InventoryLocationsController', () => {
       expect(result.created).toEqual([]);
       expect(result.existingCodes).toEqual(['MAIN']);
     });
+  });
+});
+
+describe('inventory-locations:write permission lockstep', () => {
+  it('should be granted to exactly the roles this controller @Roles(admin) on every write route', () => {
+    // `inventory-locations:write` is a display predicate only (no permission
+    // guard exists) - if this drifts from the controller's actual @Roles,
+    // either add a permission-based guard or revert the grant, the
+    // `shipments:write` / `automations:write` discipline.
+    const rolesWithPermission = UserRoleValues.filter((role) =>
+      ROLE_PERMISSIONS[role].includes('inventory-locations:write')
+    );
+
+    expect(rolesWithPermission).toEqual(['admin']);
   });
 });

--- a/apps/web/src/app/nav-registry.ts
+++ b/apps/web/src/app/nav-registry.ts
@@ -71,6 +71,11 @@ export const BASE_NAV_GROUPS: readonly NavRegistryGroup[] = [
     label: 'Platform',
     items: [
       { to: '/connections', label: 'Connections', countKey: 'connections' },
+      // Reads are `admin`/`operator`/`viewer` (InventoryLocationsController)
+      // - gated on `inventory:read` rather than `inventory-locations:write`,
+      // so a `packer` (which holds no permissions at all) is the only role
+      // that never sees the entry.
+      { to: '/inventory/locations', label: 'Inventory locations', requiresPermission: 'inventory:read' },
       { to: '/adapters', label: 'Adapters' },
       { to: '/settings', label: 'Settings' },
     ],

--- a/apps/web/src/app/routes/inventory-locations.route.tsx
+++ b/apps/web/src/app/routes/inventory-locations.route.tsx
@@ -1,0 +1,13 @@
+import type { RouteObject } from 'react-router-dom';
+import type { RouteCrumbHandle } from '../nav-registry.types';
+
+export const inventoryLocationsRoute: RouteObject = {
+  path: 'inventory/locations',
+  handle: { crumb: { group: 'Platform', title: 'Inventory locations' } } satisfies RouteCrumbHandle,
+  lazy: async () => {
+    const { InventoryLocationsPage } = await import(
+      '../../pages/inventory/inventory-locations-page'
+    );
+    return { Component: InventoryLocationsPage };
+  },
+};

--- a/apps/web/src/app/routes/root.route.tsx
+++ b/apps/web/src/app/routes/root.route.tsx
@@ -24,6 +24,7 @@ import { cursorsRoute } from './cursors.route';
 import { customersRoute } from './customers.route';
 import { devUiRoute } from './dev-ui.route';
 import { insightsRoute } from './insights.route';
+import { inventoryLocationsRoute } from './inventory-locations.route';
 import { listingsRoute } from './listings.route';
 import { aiProviderSettingsRoute } from './ai-provider-settings.route';
 import { mcpTokensRoute } from './mcp-tokens.route';
@@ -71,6 +72,7 @@ export const coreChildren: RouteObject[] = [
   automationsRoute,
   invoicesRoute,
   connectionsRoute,
+  inventoryLocationsRoute,
   adaptersRoute,
   newConnectionRoute,
   advancedNewConnectionRoute,

--- a/apps/web/src/app/routes/route-lazy.test.ts
+++ b/apps/web/src/app/routes/route-lazy.test.ts
@@ -83,7 +83,7 @@ const lazyRoutes = collectLazyRoutes([
  *   - prompt-templates-legacy-redirects (inline `<Navigate>` element)
  *   - `/analytics` legacy alias (inline `<Navigate>` to `/`, #2740)
  */
-const EXPECTED_LAZY_ROUTE_COUNT = 63;
+const EXPECTED_LAZY_ROUTE_COUNT = 64;
 
 describe('route lazy contract', () => {
   it(`the registered route tree contains exactly ${EXPECTED_LAZY_ROUTE_COUNT} lazy routes`, () => {

--- a/apps/web/src/features/inventory/api/inventory-locations.types.ts
+++ b/apps/web/src/features/inventory/api/inventory-locations.types.ts
@@ -7,6 +7,16 @@
  * @module apps/web/src/features/inventory/api
  */
 
+/**
+ * `countryIso2` is normalised to uppercase in exactly one place — the API's
+ * own `ListLocationsQueryDto` does the same server-side, so this mirrors that
+ * rule rather than inventing a second one. #3135 review: was duplicated
+ * inline in `inventory.api.ts` and `location-dialog.schema.ts`.
+ */
+export function normalizeCountryIso2(value: string): string {
+  return value.toUpperCase();
+}
+
 /** What a location physically is (#2316). Operator-declared, never derived. */
 export const InventoryLocationKindValues = ['warehouse', 'store', 'third-party', 'virtual'] as const;
 export type InventoryLocationKind = (typeof InventoryLocationKindValues)[number];

--- a/apps/web/src/features/inventory/api/inventory.api.ts
+++ b/apps/web/src/features/inventory/api/inventory.api.ts
@@ -12,6 +12,7 @@ import type {
   PaginatedInventory,
   InventoryAvailabilityResponse,
 } from './inventory.types';
+import { normalizeCountryIso2 } from './inventory-locations.types';
 import type {
   CreateInventoryLocationInput,
   InventoryLocation,
@@ -94,7 +95,7 @@ function buildLocationsQuery(
   const params = new URLSearchParams();
   if (filters?.kind) params.set('kind', filters.kind);
   if (filters?.status) params.set('status', filters.status);
-  if (filters?.countryIso2) params.set('countryIso2', filters.countryIso2.toUpperCase());
+  if (filters?.countryIso2) params.set('countryIso2', normalizeCountryIso2(filters.countryIso2));
   if (filters?.codePrefix) params.set('codePrefix', filters.codePrefix);
   if (pagination?.page !== undefined) params.set('page', String(pagination.page));
   if (pagination?.limit !== undefined) params.set('limit', String(pagination.limit));

--- a/apps/web/src/features/inventory/components/location-delete-dialog.test.tsx
+++ b/apps/web/src/features/inventory/components/location-delete-dialog.test.tsx
@@ -57,7 +57,7 @@ describe('LocationDeleteDialog', () => {
     await userEvent.click(screen.getByRole('button', { name: /^delete$/i }));
 
     expect(await screen.findByText('Can\'t delete "Kraków — Overflow"')).toBeInTheDocument();
-    expect(screen.getByText('Stock still points here')).toBeInTheDocument();
+    expect(screen.getByText('Stock positions still point here.')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: /retire instead/i })).toBeInTheDocument();
     // A refused delete never renders the raw domain error as a second, generic alert.
     expect(

--- a/apps/web/src/features/inventory/components/location-delete-dialog.tsx
+++ b/apps/web/src/features/inventory/components/location-delete-dialog.tsx
@@ -93,15 +93,14 @@ export function LocationDeleteDialog({ location, onClose }: LocationDeleteDialog
       title={isInUse ? `Can't delete "${location?.name ?? ''}"` : `Delete "${location?.name ?? ''}"?`}
       description={
         isInUse
-          ? "Stock positions still point here. Retire it instead — existing history keeps pointing at a row that exists, and it can be re-activated later."
+          ? 'Stock positions still point here.'
           : "This can't be undone. If stock still points here, the delete will be refused instead."
       }
       body={
         <>
           {isInUse ? (
-            <Alert tone="warning" title="Stock still points here">
-              The delete was refused. Retire the location instead — existing positions keep pointing at a
-              row that exists.
+            <Alert tone="warning" title="Retire instead">
+              Existing history keeps pointing at a row that exists, and it can be re-activated later.
             </Alert>
           ) : null}
           {genericError ? (

--- a/apps/web/src/features/inventory/components/location-dialog.schema.ts
+++ b/apps/web/src/features/inventory/components/location-dialog.schema.ts
@@ -20,7 +20,7 @@ import type {
   InventoryLocationKind,
   UpdateInventoryLocationInput,
 } from '../api/inventory-locations.types';
-import { InventoryLocationKindValues } from '../api/inventory-locations.types';
+import { InventoryLocationKindValues, normalizeCountryIso2 } from '../api/inventory-locations.types';
 
 const latLngField = z.union([
   z.literal(''),
@@ -82,7 +82,7 @@ export function toCreateInput(values: LocationDialogFormSubmission): CreateInven
     kind: values.kind,
     ownerConnectionId: values.ownerConnectionId === '' ? null : values.ownerConnectionId,
     externalRef: values.externalRef === '' ? null : values.externalRef,
-    countryIso2: values.countryIso2 === '' ? null : values.countryIso2.toUpperCase(),
+    countryIso2: values.countryIso2 === '' ? null : normalizeCountryIso2(values.countryIso2),
     postcode: values.postcode === '' ? null : values.postcode,
     latitude: values.latitude === '' ? null : values.latitude,
     longitude: values.longitude === '' ? null : values.longitude,
@@ -96,7 +96,7 @@ export function toUpdateInput(values: LocationDialogFormSubmission): UpdateInven
     kind: values.kind,
     ownerConnectionId: values.ownerConnectionId === '' ? null : values.ownerConnectionId,
     externalRef: values.externalRef === '' ? null : values.externalRef,
-    countryIso2: values.countryIso2 === '' ? null : values.countryIso2.toUpperCase(),
+    countryIso2: values.countryIso2 === '' ? null : normalizeCountryIso2(values.countryIso2),
     postcode: values.postcode === '' ? null : values.postcode,
     latitude: values.latitude === '' ? null : values.latitude,
     longitude: values.longitude === '' ? null : values.longitude,

--- a/apps/web/src/features/inventory/components/location-dialog.test.tsx
+++ b/apps/web/src/features/inventory/components/location-dialog.test.tsx
@@ -1,7 +1,7 @@
 import { cleanup, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { renderWithProviders, createMockApiClient } from '../../../test/test-utils';
+import { renderWithProviders, createMockApiClient, sampleConnection } from '../../../test/test-utils';
 import { ApiError } from '../../../shared/api/api-error';
 import { LocationDialog } from './location-dialog';
 import type { InventoryLocation } from '../api/inventory-locations.types';
@@ -124,5 +124,47 @@ describe('LocationDialog', () => {
     const [, patch] = updateLocation.mock.calls[0] as [string, Record<string, unknown>];
     expect('code' in patch).toBe(false);
     await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  // Tech-review finding: a disabled/needs_reauth connection "can't currently
+  // sync", so offering it as an owner under a field described as "whose
+  // sync may write stock here" is misleading.
+  it('excludes non-active connections from the owning-connection select', async () => {
+    const inactive = { ...sampleConnection, id: 'conn_inactive', name: 'Disabled store', status: 'disabled' as const };
+    const apiClient = createMockApiClient({
+      connections: { list: vi.fn().mockResolvedValue([sampleConnection, inactive]) },
+    });
+    renderWithProviders(<LocationDialog target={{ mode: 'create' }} onClose={() => undefined} />, { apiClient });
+    await screen.findByText('Add location');
+
+    const select = await screen.findByLabelText('Owning connection (optional)');
+    await waitFor(() => expect(select).toHaveTextContent(sampleConnection.name));
+    expect(select).not.toHaveTextContent('Disabled store');
+  });
+
+  // The row's CURRENT owner must survive even if it has since gone
+  // inactive - otherwise the select has no matching <option> for the
+  // loaded value and silently blanks it on open.
+  it('keeps the edited location\'s current owner in the select even when that connection is inactive', async () => {
+    const inactiveOwner = {
+      ...sampleConnection,
+      id: 'conn_inactive_owner',
+      name: 'Now-disabled owner',
+      status: 'disabled' as const,
+    };
+    const apiClient = createMockApiClient({
+      connections: { list: vi.fn().mockResolvedValue([inactiveOwner]) },
+    });
+    renderWithProviders(
+      <LocationDialog
+        target={{ mode: 'edit', location: { ...editTarget, ownerConnectionId: 'conn_inactive_owner' } }}
+        onClose={() => undefined}
+      />,
+      { apiClient },
+    );
+    await screen.findByText('Edit "Main warehouse"');
+
+    const select = await screen.findByLabelText('Owning connection (optional)');
+    await waitFor(() => expect(select).toHaveTextContent('Now-disabled owner'));
   });
 });

--- a/apps/web/src/features/inventory/components/location-dialog.tsx
+++ b/apps/web/src/features/inventory/components/location-dialog.tsx
@@ -98,13 +98,21 @@ export function LocationDialog({ target, onClose }: LocationDialogProps): ReactE
     // fields — is the right dependency for "the dialog just opened".
   }, [target, resetForm, resetCreate, resetUpdate]);
 
+  // Active connections only — "whose sync may write stock here" (the
+  // field's own description) is misleading for a connection that currently
+  // can't sync (tech-review finding). The row's CURRENT owner, if any, is
+  // kept even when inactive so editing doesn't silently blank a value the
+  // select would otherwise have no matching <option> for.
+  const currentOwnerId = target?.mode === 'edit' ? target.location.ownerConnectionId : null;
   const connectionOptions = useMemo(
     () =>
-      (connectionsQuery.data ?? []).map((connection) => ({
-        id: connection.id,
-        label: `${resolvePlatformLabel(platforms, connection.platformType)} — ${connection.name}`,
-      })),
-    [connectionsQuery.data, platforms],
+      (connectionsQuery.data ?? [])
+        .filter((connection) => connection.status === 'active' || connection.id === currentOwnerId)
+        .map((connection) => ({
+          id: connection.id,
+          label: `${resolvePlatformLabel(platforms, connection.platformType)} — ${connection.name}`,
+        })),
+    [connectionsQuery.data, platforms, currentOwnerId],
   );
 
   const onSubmit = form.handleSubmit(async (values) => {

--- a/apps/web/src/features/inventory/hooks/use-bootstrap-locations-mutation.ts
+++ b/apps/web/src/features/inventory/hooks/use-bootstrap-locations-mutation.ts
@@ -3,9 +3,15 @@
  *
  * Mints the first-run inventory location an operator was offered (#2407).
  *
- * Invalidates the active-location count on success, so the readiness surface
- * re-reads the fact rather than assuming the write moved it — the route is
- * idempotent and a re-run legitimately creates nothing.
+ * Invalidates `locationsAll()` on success — the same prefix the #3065 CRUD
+ * mutations use — rather than only `activeLocations()`. Narrower
+ * invalidation was correct while the only consumer was the connection-detail
+ * readiness panel (which reads only the active count), but the #3066
+ * locations list page reads `locations()` under the same prefix, and a
+ * bootstrap that invalidated just `activeLocations()` left that list stale
+ * until a full page reload — the click looked like it did nothing. The
+ * route is idempotent either way, so re-reading after a re-run that created
+ * nothing is still the correct, cheap thing to do.
  *
  * @module apps/web/src/features/inventory/hooks
  */
@@ -25,7 +31,7 @@ export function useBootstrapLocationsMutation(): UseMutationResult<
   return useMutation({
     mutationFn: () => apiClient.inventory.bootstrapLocations(),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: inventoryQueryKeys.activeLocations() });
+      await queryClient.invalidateQueries({ queryKey: inventoryQueryKeys.locationsAll() });
     },
   });
 }

--- a/apps/web/src/features/inventory/index.ts
+++ b/apps/web/src/features/inventory/index.ts
@@ -59,6 +59,7 @@ export { useDeleteInventoryLocationMutation } from './hooks/use-delete-inventory
 // (upcoming) locations list page in `pages/inventory/`.
 export { LocationDialog, type LocationDialogTarget } from './components/location-dialog';
 export { LocationDeleteDialog } from './components/location-delete-dialog';
+export { KIND_LABEL } from './components/location-dialog.schema';
 
 export { useInventoryAvailabilityBatchQuery } from './hooks/use-inventory-availability-batch-query';
 // Query-key factory re-exported so the bulk wizard's chunked per-variant

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2997,6 +2997,26 @@ a.delivery-rider-banner__button:focus-visible {
   cursor: pointer;
 }
 
+/* ── Row action button groups (#3066) — the `table-actions` class name was
+   already used on `users-page.tsx` / `invoices-list-page.tsx` /
+   `prompt-template-detail-page.tsx` with no rule backing it. */
+.table-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+/* ── Filter-bar inline checkbox toggle (#3066) — e.g. "show retired" ── */
+.toolbar__checkbox-label {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
 .data-table__action {
   color: var(--accent-primary);
   font-weight: 500;

--- a/apps/web/src/pages/inventory/inventory-locations-page.test.tsx
+++ b/apps/web/src/pages/inventory/inventory-locations-page.test.tsx
@@ -88,6 +88,31 @@ describe('InventoryLocationsPage', () => {
     expect(screen.getByRole('button', { name: '+ Add manually' })).toBeInTheDocument();
   });
 
+  // Regression: useBootstrapLocationsMutation used to invalidate only
+  // activeLocations() (the #2407 readiness-panel key), so a successful
+  // bootstrap here left the list's own locations() query stale — the click
+  // visibly did nothing until a full page reload re-fetched it.
+  it('the newly-minted location appears without a page reload after Create first location', async () => {
+    const created = { ...location, id: 'ol_location_main' };
+    const listLocations = vi
+      .fn()
+      .mockResolvedValueOnce(page([]))
+      .mockResolvedValueOnce(page([created]));
+    const bootstrapLocations = vi
+      .fn()
+      .mockResolvedValue({ created: [created], existingCodes: [] });
+    const apiClient = createMockApiClient({ inventory: { listLocations, bootstrapLocations } });
+    renderWithProviders(<InventoryLocationsPage />, {
+      apiClient,
+      sessionAdapter: createAuthenticatedSessionAdapter(),
+    });
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Create first location' }));
+
+    expect(await screen.findByText('Warsaw — Main warehouse')).toBeInTheDocument();
+    expect(listLocations).toHaveBeenCalledTimes(2);
+  });
+
   it('turning the Show retired toggle off filters to status=active', async () => {
     const listLocations = vi.fn().mockResolvedValue(page());
     const apiClient = createMockApiClient({ inventory: { listLocations } });

--- a/apps/web/src/pages/inventory/inventory-locations-page.test.tsx
+++ b/apps/web/src/pages/inventory/inventory-locations-page.test.tsx
@@ -205,6 +205,30 @@ describe('InventoryLocationsPage', () => {
       );
       expect(await screen.findByText('Page 1 of 2 · 30 locations')).toBeInTheDocument();
     });
+
+    // Tech-review finding: an out-of-range page (emptied by a concurrent
+    // delete, or a hand-edited URL) used to render the pre-bootstrap "zero
+    // locations" empty state even though rows exist on another page.
+    it('shows a page-not-found empty state, not the bootstrap empty state, when the current page is empty but total > 0', async () => {
+      const listLocations = vi.fn().mockResolvedValue(page([], { total: 25, page: 3 }));
+      const apiClient = createMockApiClient({ inventory: { listLocations } });
+      renderWithProviders(<InventoryLocationsPage />, {
+        apiClient,
+        route: '/inventory/locations?page=3',
+        sessionAdapter: createAuthenticatedSessionAdapter(),
+      });
+
+      expect(await screen.findByText("This page doesn't exist anymore")).toBeInTheDocument();
+      expect(screen.getByText('There are 25 locations, but not on page 3.')).toBeInTheDocument();
+      expect(screen.queryByRole('heading', { name: 'Routing has nowhere to source stock from' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Create first location' })).not.toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('button', { name: 'Back to page 1' }));
+
+      await waitFor(() =>
+        expect(listLocations).toHaveBeenLastCalledWith(expect.anything(), { page: 1, limit: 25 }),
+      );
+    });
   });
 
   // #3135 review — the empty-state's "Create first location" / "+ Add
@@ -344,7 +368,7 @@ describe('InventoryLocationsPage', () => {
       });
 
       await screen.findByText('Warsaw — Main warehouse');
-      expect(screen.getByText('active')).toBeInTheDocument();
+      expect(screen.getByText('Active')).toBeInTheDocument();
 
       await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
       await screen.findByText('Delete "Warsaw — Main warehouse"?');
@@ -352,7 +376,7 @@ describe('InventoryLocationsPage', () => {
       await screen.findByRole('button', { name: /retire instead/i });
       await userEvent.click(screen.getByRole('button', { name: /retire instead/i }));
 
-      await waitFor(() => expect(screen.getByText('inactive')).toBeInTheDocument());
+      await waitFor(() => expect(screen.getByText('Retired')).toBeInTheDocument());
       expect(listLocations).toHaveBeenCalledTimes(2);
     });
   });

--- a/apps/web/src/pages/inventory/inventory-locations-page.test.tsx
+++ b/apps/web/src/pages/inventory/inventory-locations-page.test.tsx
@@ -6,6 +6,7 @@ import {
   createMockApiClient,
   renderWithProviders,
 } from '../../test/test-utils';
+import { ApiError } from '../../shared/api/api-error';
 import { InventoryLocationsPage } from './inventory-locations-page';
 import type { InventoryLocation, PaginatedInventoryLocations } from '../../features/inventory';
 
@@ -160,5 +161,84 @@ describe('InventoryLocationsPage', () => {
     await userEvent.click(await screen.findByRole('button', { name: 'Delete' }));
 
     expect(await screen.findByText('Delete "Warsaw — Main warehouse"?')).toBeInTheDocument();
+  });
+
+  // #3070 — end-to-end round trips through the real mutation hooks' cache
+  // invalidation, not just "the dialog opened": every hook/dialog test above
+  // stops at the request being made, so none of them prove the PAGE actually
+  // reflects a successful write.
+  describe('end-to-end CRUD round trips (#3070)', () => {
+    it('create: the new row appears in the table after a successful submit', async () => {
+      const created: InventoryLocation = { ...location, id: 'ol_location_2', code: 'WH2', name: 'Overflow' };
+      const listLocations = vi
+        .fn()
+        .mockResolvedValueOnce(page([location]))
+        .mockResolvedValueOnce(page([location, created]));
+      const createLocation = vi.fn().mockResolvedValue(created);
+      const apiClient = createMockApiClient({ inventory: { listLocations, createLocation } });
+      renderWithProviders(<InventoryLocationsPage />, {
+        apiClient,
+        sessionAdapter: createAuthenticatedSessionAdapter(),
+      });
+
+      await screen.findByText('Warsaw — Main warehouse');
+      await userEvent.click(screen.getByRole('button', { name: '+ Add location' }));
+      await screen.findByText('Add location');
+      await userEvent.type(screen.getByLabelText('Code'), 'WH2');
+      await userEvent.type(screen.getByLabelText('Name'), 'Overflow');
+      await userEvent.click(screen.getByRole('button', { name: /save location/i }));
+
+      expect(await screen.findByText('Overflow')).toBeInTheDocument();
+      expect(listLocations).toHaveBeenCalledTimes(2);
+    });
+
+    it('delete: the row is gone from the table after a successful delete', async () => {
+      const listLocations = vi
+        .fn()
+        .mockResolvedValueOnce(page([location]))
+        .mockResolvedValueOnce(page([]));
+      const deleteLocation = vi.fn().mockResolvedValue(undefined);
+      const apiClient = createMockApiClient({ inventory: { listLocations, deleteLocation } });
+      renderWithProviders(<InventoryLocationsPage />, {
+        apiClient,
+        sessionAdapter: createAuthenticatedSessionAdapter(),
+      });
+
+      await screen.findByText('Warsaw — Main warehouse');
+      await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+      await screen.findByText('Delete "Warsaw — Main warehouse"?');
+      await userEvent.click(screen.getByRole('button', { name: /^delete$/i }));
+
+      await waitFor(() => expect(screen.queryByText('Warsaw — Main warehouse')).not.toBeInTheDocument());
+      expect(listLocations).toHaveBeenCalledTimes(2);
+    });
+
+    it('retire: a 409-refused delete, retired instead, flips the row to Retired', async () => {
+      const listLocations = vi
+        .fn()
+        .mockResolvedValueOnce(page([location]))
+        .mockResolvedValueOnce(page([{ ...location, status: 'inactive' }]));
+      const deleteLocation = vi
+        .fn()
+        .mockRejectedValue(new ApiError('Inventory location ol_location_1 is referenced by 3 inventory position(s)', 409, {}));
+      const updateLocation = vi.fn().mockResolvedValue({ ...location, status: 'inactive' });
+      const apiClient = createMockApiClient({ inventory: { listLocations, deleteLocation, updateLocation } });
+      renderWithProviders(<InventoryLocationsPage />, {
+        apiClient,
+        sessionAdapter: createAuthenticatedSessionAdapter(),
+      });
+
+      await screen.findByText('Warsaw — Main warehouse');
+      expect(screen.getByText('active')).toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+      await screen.findByText('Delete "Warsaw — Main warehouse"?');
+      await userEvent.click(screen.getByRole('button', { name: /^delete$/i }));
+      await screen.findByRole('button', { name: /retire instead/i });
+      await userEvent.click(screen.getByRole('button', { name: /retire instead/i }));
+
+      await waitFor(() => expect(screen.getByText('inactive')).toBeInTheDocument());
+      expect(listLocations).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/apps/web/src/pages/inventory/inventory-locations-page.test.tsx
+++ b/apps/web/src/pages/inventory/inventory-locations-page.test.tsx
@@ -26,8 +26,11 @@ const location: InventoryLocation = {
   updatedAt: '2026-01-01T00:00:00.000Z',
 };
 
-function page(items: InventoryLocation[] = [location]): PaginatedInventoryLocations {
-  return { items, total: items.length, page: 1, limit: 25 };
+function page(
+  items: InventoryLocation[] = [location],
+  overrides: Partial<Pick<PaginatedInventoryLocations, 'total' | 'page' | 'limit'>> = {},
+): PaginatedInventoryLocations {
+  return { items, total: items.length, page: 1, limit: 25, ...overrides };
 }
 
 describe('InventoryLocationsPage', () => {
@@ -96,7 +99,7 @@ describe('InventoryLocationsPage', () => {
     await waitFor(() =>
       expect(listLocations).toHaveBeenLastCalledWith(
         expect.objectContaining({ status: 'active' }),
-        undefined,
+        { page: 1, limit: 25 },
       ),
     );
   });
@@ -112,9 +115,96 @@ describe('InventoryLocationsPage', () => {
     await waitFor(() =>
       expect(listLocations).toHaveBeenLastCalledWith(
         expect.objectContaining({ kind: 'warehouse' }),
-        undefined,
+        { page: 1, limit: 25 },
       ),
     );
+  });
+
+  // #3135 review — pagination was silently dropped: the query never received
+  // a `pagination` argument and `total` was never read anywhere on the page.
+  describe('pagination (tech-lead review fix)', () => {
+    it('does not render a pager when everything fits on one page', async () => {
+      const apiClient = createMockApiClient({
+        inventory: { listLocations: vi.fn().mockResolvedValue(page([location], { total: 1 })) },
+      });
+      renderWithProviders(<InventoryLocationsPage />, { apiClient });
+
+      await screen.findByText('Warsaw — Main warehouse');
+      expect(screen.queryByText(/page 1 of/i)).not.toBeInTheDocument();
+    });
+
+    it('renders the pager and disables Previous on the first page, when total exceeds one page', async () => {
+      const apiClient = createMockApiClient({
+        inventory: { listLocations: vi.fn().mockResolvedValue(page([location], { total: 30 })) },
+      });
+      renderWithProviders(<InventoryLocationsPage />, { apiClient });
+
+      await screen.findByText('Warsaw — Main warehouse');
+      expect(screen.getByText('Page 1 of 2 · 30 locations')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Previous' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Next' })).toBeEnabled();
+    });
+
+    it('clicking Next requests page 2 and enables Previous', async () => {
+      const listLocations = vi.fn().mockResolvedValue(page([location], { total: 30 }));
+      const apiClient = createMockApiClient({ inventory: { listLocations } });
+      renderWithProviders(<InventoryLocationsPage />, { apiClient });
+
+      await screen.findByText('Warsaw — Main warehouse');
+      await userEvent.click(screen.getByRole('button', { name: 'Next' }));
+
+      // `MemoryRouter` doesn't sync to `window.location`, so the URL isn't a
+      // reachable assertion here — the request args and the page's own
+      // rendered pager state are: both are downstream of the same
+      // `useSearchParams` change a real browser navigation would also drive.
+      await waitFor(() =>
+        expect(listLocations).toHaveBeenLastCalledWith(expect.anything(), { page: 2, limit: 25 }),
+      );
+      expect(await screen.findByText('Page 2 of 2 · 30 locations')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Previous' })).toBeEnabled();
+    });
+
+    it('changing a filter lands back on page 1', async () => {
+      const listLocations = vi.fn().mockResolvedValue(page([location], { total: 30 }));
+      const apiClient = createMockApiClient({ inventory: { listLocations } });
+      renderWithProviders(<InventoryLocationsPage />, { apiClient, route: '/inventory/locations?page=2' });
+
+      await screen.findByText('Warsaw — Main warehouse');
+      await userEvent.selectOptions(screen.getByRole('combobox', { name: 'Filter by kind' }), 'warehouse');
+
+      await waitFor(() =>
+        expect(listLocations).toHaveBeenLastCalledWith(
+          expect.objectContaining({ kind: 'warehouse' }),
+          { page: 1, limit: 25 },
+        ),
+      );
+      expect(await screen.findByText('Page 1 of 2 · 30 locations')).toBeInTheDocument();
+    });
+  });
+
+  // #3135 review — the empty-state's "Create first location" / "+ Add
+  // manually" buttons used the same `disabled={write.demoReadOnly}`
+  // condition as every other write affordance on the page but skipped the
+  // `ReadOnlyLock` wrapper, so a demo viewer got disabled buttons with no
+  // explanatory tooltip there and there alone.
+  it('wraps the empty-state write buttons in ReadOnlyLock for a demo read-only viewer', async () => {
+    const viewerSession = createAuthenticatedSessionAdapter({
+      id: 'u2',
+      username: 'viewer',
+      email: null,
+      role: 'viewer',
+      permissions: ['inventory:read'],
+    });
+    const apiClient = createMockApiClient({
+      inventory: { listLocations: vi.fn().mockResolvedValue(page([], { total: 0 })) },
+      system: { getConfig: vi.fn().mockResolvedValue({ demoMode: true }) },
+    });
+    renderWithProviders(<InventoryLocationsPage />, { apiClient, sessionAdapter: viewerSession });
+
+    const createFirst = await screen.findByRole('button', { name: 'Create first location' });
+    const addManually = screen.getByRole('button', { name: '+ Add manually' });
+    expect(createFirst.closest('.read-only-lock')).not.toBeNull();
+    expect(addManually.closest('.read-only-lock')).not.toBeNull();
   });
 
   it('hides Edit/Delete row actions and Add location for a session with no write permission', async () => {

--- a/apps/web/src/pages/inventory/inventory-locations-page.test.tsx
+++ b/apps/web/src/pages/inventory/inventory-locations-page.test.tsx
@@ -1,0 +1,164 @@
+import { cleanup, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  createAuthenticatedSessionAdapter,
+  createMockApiClient,
+  renderWithProviders,
+} from '../../test/test-utils';
+import { InventoryLocationsPage } from './inventory-locations-page';
+import type { InventoryLocation, PaginatedInventoryLocations } from '../../features/inventory';
+
+const location: InventoryLocation = {
+  id: 'ol_location_1',
+  code: 'MAIN',
+  name: 'Warsaw — Main warehouse',
+  kind: 'warehouse',
+  ownerConnectionId: null,
+  externalRef: null,
+  status: 'active',
+  countryIso2: 'PL',
+  postcode: '02-677',
+  latitude: null,
+  longitude: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+function page(items: InventoryLocation[] = [location]): PaginatedInventoryLocations {
+  return { items, total: items.length, page: 1, limit: 25 };
+}
+
+describe('InventoryLocationsPage', () => {
+  afterEach(cleanup);
+
+  it('renders the page heading', () => {
+    const apiClient = createMockApiClient({ inventory: { listLocations: vi.fn().mockResolvedValue(page([])) } });
+    renderWithProviders(<InventoryLocationsPage />, { apiClient });
+    expect(screen.getByRole('heading', { name: 'Inventory locations' })).toBeInTheDocument();
+  });
+
+  it('renders the kind filter and a Show retired toggle, checked by default', async () => {
+    const apiClient = createMockApiClient({ inventory: { listLocations: vi.fn().mockResolvedValue(page()) } });
+    renderWithProviders(<InventoryLocationsPage />, { apiClient });
+
+    expect(await screen.findByRole('combobox', { name: 'Filter by kind' })).toBeInTheDocument();
+    const toggle = screen.getByRole('checkbox', { name: /show retired/i });
+    expect(toggle).toBeChecked();
+  });
+
+  it('displays locations returned by the API', async () => {
+    const apiClient = createMockApiClient({ inventory: { listLocations: vi.fn().mockResolvedValue(page()) } });
+    renderWithProviders(<InventoryLocationsPage />, { apiClient });
+
+    expect(await screen.findByText('Warsaw — Main warehouse')).toBeInTheDocument();
+  });
+
+  it('shows loading state while fetching', () => {
+    const apiClient = createMockApiClient({
+      inventory: { listLocations: vi.fn().mockReturnValue(new Promise(() => {})) },
+    });
+    renderWithProviders(<InventoryLocationsPage />, { apiClient });
+
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('shows an error state when the fetch fails', async () => {
+    const apiClient = createMockApiClient({
+      inventory: { listLocations: vi.fn().mockRejectedValue(new Error('Network error')) },
+    });
+    renderWithProviders(<InventoryLocationsPage />, { apiClient });
+
+    expect(await screen.findByRole('heading', { name: "Couldn't load locations" })).toBeInTheDocument();
+  });
+
+  it('shows the pre-bootstrap empty state with write access', async () => {
+    const apiClient = createMockApiClient({ inventory: { listLocations: vi.fn().mockResolvedValue(page([])) } });
+    renderWithProviders(<InventoryLocationsPage />, {
+      apiClient,
+      sessionAdapter: createAuthenticatedSessionAdapter(),
+    });
+
+    expect(await screen.findByRole('heading', { name: 'Routing has nowhere to source stock from' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Create first location' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '+ Add manually' })).toBeInTheDocument();
+  });
+
+  it('turning the Show retired toggle off filters to status=active', async () => {
+    const listLocations = vi.fn().mockResolvedValue(page());
+    const apiClient = createMockApiClient({ inventory: { listLocations } });
+    renderWithProviders(<InventoryLocationsPage />, { apiClient });
+
+    await screen.findByText('Warsaw — Main warehouse');
+    await userEvent.click(screen.getByRole('checkbox', { name: /show retired/i }));
+
+    await waitFor(() =>
+      expect(listLocations).toHaveBeenLastCalledWith(
+        expect.objectContaining({ status: 'active' }),
+        undefined,
+      ),
+    );
+  });
+
+  it('changing the kind filter narrows the list query', async () => {
+    const listLocations = vi.fn().mockResolvedValue(page());
+    const apiClient = createMockApiClient({ inventory: { listLocations } });
+    renderWithProviders(<InventoryLocationsPage />, { apiClient });
+
+    await screen.findByText('Warsaw — Main warehouse');
+    await userEvent.selectOptions(screen.getByRole('combobox', { name: 'Filter by kind' }), 'warehouse');
+
+    await waitFor(() =>
+      expect(listLocations).toHaveBeenLastCalledWith(
+        expect.objectContaining({ kind: 'warehouse' }),
+        undefined,
+      ),
+    );
+  });
+
+  it('hides Edit/Delete row actions and Add location for a session with no write permission', async () => {
+    const apiClient = createMockApiClient({ inventory: { listLocations: vi.fn().mockResolvedValue(page()) } });
+    renderWithProviders(<InventoryLocationsPage />, { apiClient });
+
+    await screen.findByText('Warsaw — Main warehouse');
+    expect(screen.queryByRole('button', { name: 'Edit' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Delete' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '+ Add location' })).not.toBeInTheDocument();
+  });
+
+  it('opens the create dialog from Add location, for a session with write access', async () => {
+    const apiClient = createMockApiClient({ inventory: { listLocations: vi.fn().mockResolvedValue(page()) } });
+    renderWithProviders(<InventoryLocationsPage />, {
+      apiClient,
+      sessionAdapter: createAuthenticatedSessionAdapter(),
+    });
+
+    await userEvent.click(await screen.findByRole('button', { name: '+ Add location' }));
+
+    expect(await screen.findByText('Add location')).toBeInTheDocument();
+  });
+
+  it('opens the edit dialog pre-filled from the row, for a session with write access', async () => {
+    const apiClient = createMockApiClient({ inventory: { listLocations: vi.fn().mockResolvedValue(page()) } });
+    renderWithProviders(<InventoryLocationsPage />, {
+      apiClient,
+      sessionAdapter: createAuthenticatedSessionAdapter(),
+    });
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Edit' }));
+
+    expect(await screen.findByText('Edit "Warsaw — Main warehouse"')).toBeInTheDocument();
+  });
+
+  it('opens the delete-confirm dialog from the row, for a session with write access', async () => {
+    const apiClient = createMockApiClient({ inventory: { listLocations: vi.fn().mockResolvedValue(page()) } });
+    renderWithProviders(<InventoryLocationsPage />, {
+      apiClient,
+      sessionAdapter: createAuthenticatedSessionAdapter(),
+    });
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Delete' }));
+
+    expect(await screen.findByText('Delete "Warsaw — Main warehouse"?')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/pages/inventory/inventory-locations-page.tsx
+++ b/apps/web/src/pages/inventory/inventory-locations-page.tsx
@@ -1,0 +1,307 @@
+/**
+ * Inventory Locations Page (#2316 / #3066)
+ *
+ * The warehouses, stores and third-party sites OpenLinker can source stock
+ * from — the operator-facing surface over `inventory_locations` (#2313), of
+ * which only the `?status=active&limit=1` probe and the bootstrap POST were
+ * previously reachable from the product (#3029/#3063).
+ *
+ * Follows the `connections-list-page.tsx` cockpit-list composition (filter
+ * bar → loading/error/empty → `DataTable`), with the CRUD dialogs mounted on
+ * this page rather than routed to separate pages — the `users-page.tsx`
+ * inline-dialog precedent, since a location is a small, flat record with no
+ * own detail page to justify.
+ *
+ * @module apps/web/src/pages/inventory
+ */
+import { useMemo, useState, type ReactElement } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { PageLayout } from '../../shared/ui/page-layout';
+import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
+import { DataTableSkeleton } from '../../shared/ui/data-table-skeleton';
+import { ErrorState, EmptyState } from '../../shared/ui/feedback-state';
+import { StatusBadge, type StatusBadgeTone } from '../../shared/ui/status-badge';
+import { Button } from '../../shared/ui/button';
+import { Select } from '../../shared/ui/select';
+import { EmptyValue } from '../../shared/ui/empty-value';
+import { ReadOnlyLock } from '../../shared/ui/read-only-lock';
+import { useWriteAccess } from '../../shared/auth/use-permission';
+import { DEMO_READ_ONLY_ACTION_MESSAGE } from '../../shared/config/demo-mode';
+import { useDemoMode } from '../../features/system';
+import { usePlatforms } from '../../shared/plugins';
+import { resolvePlatformLabel } from '../../features/mappings';
+import { ConnectionCell, useConnectionsQuery, type Connection } from '../../features/connections';
+import {
+  InventoryLocationKindValues,
+  KIND_LABEL,
+  LocationDialog,
+  LocationDeleteDialog,
+  useInventoryLocationsQuery,
+  useBootstrapLocationsMutation,
+  type InventoryLocation,
+  type InventoryLocationFilters,
+  type InventoryLocationKind,
+  type LocationDialogTarget,
+} from '../../features/inventory';
+
+function isKnownKind(value: string): value is InventoryLocationKind {
+  return (InventoryLocationKindValues as readonly string[]).includes(value);
+}
+
+function statusTone(status: InventoryLocation['status']): StatusBadgeTone {
+  return status === 'active' ? 'success' : 'neutral';
+}
+
+export function InventoryLocationsPage(): ReactElement {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const demoMode = useDemoMode();
+  const platforms = usePlatforms();
+  const write = useWriteAccess('inventory-locations:write', demoMode);
+  const [dialogTarget, setDialogTarget] = useState<LocationDialogTarget | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<InventoryLocation | null>(null);
+
+  const kindParam = searchParams.get('kind') ?? '';
+  const kind = isKnownKind(kindParam) ? kindParam : undefined;
+  // Default true — soft retirement keeps a row visible by design (#2316), so
+  // the toggle narrows to active-only rather than the other way round.
+  const showRetired = searchParams.get('retired') !== '0';
+
+  const filters: InventoryLocationFilters = {
+    kind,
+    status: showRetired ? undefined : 'active',
+  };
+
+  const query = useInventoryLocationsQuery(filters);
+  const connectionsQuery = useConnectionsQuery();
+  const bootstrapMutation = useBootstrapLocationsMutation();
+
+  const connectionById = useMemo(() => {
+    const map = new Map<string, Connection>();
+    (connectionsQuery.data ?? []).forEach((c) => map.set(c.id, c));
+    return map;
+  }, [connectionsQuery.data]);
+
+  function handleFilterChange(key: string, value: string): void {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      if (value) {
+        next.set(key, value);
+      } else {
+        next.delete(key);
+      }
+      return next;
+    });
+  }
+
+  function clearFilters(): void {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      next.delete('kind');
+      next.delete('retired');
+      return next;
+    });
+  }
+
+  const filtersActive = Boolean(kind) || !showRetired;
+
+  const columns = useMemo<DataTableColumn<InventoryLocation>[]>(
+    () => [
+      {
+        id: 'location',
+        header: 'Location',
+        cell: (location) => (
+          <div className="data-table__stack">
+            <strong>{location.name}</strong>
+            <span className="muted-text mono-text">
+              {location.code}
+              {location.externalRef ? ` · ${location.externalRef}` : ''}
+            </span>
+          </div>
+        ),
+        accessor: (location) => location.name,
+        sortable: true,
+      },
+      {
+        id: 'kind',
+        header: 'Kind',
+        cell: (location) => KIND_LABEL[location.kind],
+        accessor: (location) => location.kind,
+        sortable: true,
+      },
+      {
+        id: 'geo',
+        header: 'Country / postcode',
+        cell: (location): ReactElement => {
+          const geo = [location.countryIso2, location.postcode].filter(Boolean).join(' · ');
+          return geo ? <span className="mono-text">{geo}</span> : <EmptyValue label="No location set" />;
+        },
+        hideBelow: 1024,
+      },
+      {
+        id: 'owner',
+        header: 'Owning connection',
+        cell: (location): ReactElement => {
+          if (!location.ownerConnectionId) {
+            return <EmptyValue label="No owning connection" />;
+          }
+          const connection = connectionById.get(location.ownerConnectionId) ?? null;
+          return (
+            <ConnectionCell
+              connectionId={location.ownerConnectionId}
+              connection={connection}
+              loading={connectionsQuery.isLoading}
+              adornment={
+                connection ? (
+                  <span className="channel-pill" data-channel={connection.platformType}>
+                    {resolvePlatformLabel(platforms, connection.platformType)}
+                  </span>
+                ) : null
+              }
+            />
+          );
+        },
+        hideBelow: 1024,
+      },
+      {
+        id: 'status',
+        header: 'Status',
+        cell: (location) => (
+          <StatusBadge tone={statusTone(location.status)}>{location.status}</StatusBadge>
+        ),
+        accessor: (location) => location.status,
+        sortable: true,
+      },
+      {
+        id: 'actions',
+        header: '',
+        cell: (location) =>
+          write.visible ? (
+            <div className="table-actions">
+              <ReadOnlyLock active={write.demoReadOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
+                <Button
+                  className="button--sm"
+                  tone="secondary"
+                  disabled={write.demoReadOnly}
+                  onClick={() => setDialogTarget({ mode: 'edit', location })}
+                >
+                  Edit
+                </Button>
+              </ReadOnlyLock>
+              <ReadOnlyLock active={write.demoReadOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
+                <Button
+                  className="button--sm"
+                  tone="danger"
+                  disabled={write.demoReadOnly}
+                  onClick={() => setDeleteTarget(location)}
+                >
+                  Delete
+                </Button>
+              </ReadOnlyLock>
+            </div>
+          ) : null,
+      },
+    ],
+    [connectionById, connectionsQuery.isLoading, platforms, write.visible, write.demoReadOnly],
+  );
+
+  return (
+    <PageLayout
+      eyebrow="Fulfilment routing"
+      title="Inventory locations"
+      description="The warehouses, stores and third-party sites OpenLinker can source stock from. A location isn't authority over stock — it's the place sourcing rules pick between. Delete is refused while any stock still points here; retire it instead."
+      actions={
+        write.visible ? (
+          <ReadOnlyLock active={write.demoReadOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
+            <Button disabled={write.demoReadOnly} onClick={() => setDialogTarget({ mode: 'create' })}>
+              + Add location
+            </Button>
+          </ReadOnlyLock>
+        ) : null
+      }
+    >
+      <div className="toolbar">
+        <div className="toolbar__group">
+          <Select
+            aria-label="Filter by kind"
+            value={kind ?? ''}
+            onChange={(e) => { handleFilterChange('kind', e.target.value); }}
+          >
+            <option value="">All kinds</option>
+            {InventoryLocationKindValues.map((k) => (
+              <option key={k} value={k}>
+                {KIND_LABEL[k]}
+              </option>
+            ))}
+          </Select>
+          <label className="toolbar__checkbox-label">
+            <input
+              type="checkbox"
+              checked={showRetired}
+              onChange={(e) => { handleFilterChange('retired', e.target.checked ? '' : '0'); }}
+            />
+            Show retired
+          </label>
+        </div>
+      </div>
+
+      {query.isLoading ? (
+        <DataTableSkeleton columns={columns.length} rows={5} />
+      ) : query.error ? (
+        <ErrorState
+          title="Couldn't load locations"
+          message={query.error.message}
+          action={<Button onClick={() => { void query.refetch(); }}>Retry</Button>}
+        />
+      ) : (query.data?.items ?? []).length === 0 ? (
+        <EmptyState
+          title={filtersActive ? 'No locations match this filter' : 'Routing has nowhere to source stock from'}
+          message={
+            filtersActive
+              ? 'No locations match the current filters.'
+              : 'Zero locations exist — every order is currently unfulfillable. Mint the first one, or add your own.'
+          }
+          action={
+            filtersActive ? (
+              <Button onClick={clearFilters}>Clear filters</Button>
+            ) : write.visible ? (
+              <div className="table-actions">
+                <Button
+                  disabled={write.demoReadOnly || bootstrapMutation.isPending}
+                  onClick={() => bootstrapMutation.mutate()}
+                >
+                  Create first location
+                </Button>
+                <Button
+                  tone="secondary"
+                  disabled={write.demoReadOnly}
+                  onClick={() => setDialogTarget({ mode: 'create' })}
+                >
+                  + Add manually
+                </Button>
+              </div>
+            ) : null
+          }
+        />
+      ) : (
+        <DataTable
+          caption="Inventory locations"
+          columns={columns}
+          rowKey={(location) => location.id}
+          rows={[...(query.data?.items ?? [])]}
+          cardView={{
+            title: (location) => location.name,
+            subtitle: (location) => location.code,
+            meta: (location) => (
+              <StatusBadge tone={statusTone(location.status)} compact>
+                {location.status}
+              </StatusBadge>
+            ),
+          }}
+        />
+      )}
+
+      <LocationDialog target={dialogTarget} onClose={() => setDialogTarget(null)} />
+      <LocationDeleteDialog location={deleteTarget} onClose={() => setDeleteTarget(null)} />
+    </PageLayout>
+  );
+}

--- a/apps/web/src/pages/inventory/inventory-locations-page.tsx
+++ b/apps/web/src/pages/inventory/inventory-locations-page.tsx
@@ -54,6 +54,14 @@ function statusTone(status: InventoryLocation['status']): StatusBadgeTone {
   return status === 'active' ? 'success' : 'neutral';
 }
 
+// #3135 review: the wire value `inactive` was rendered verbatim, while
+// every other badge surface in this app renders operator copy and the
+// "Show retired" toggle beside it already calls the same state "retired".
+const STATUS_LABEL: Record<InventoryLocation['status'], string> = {
+  active: 'Active',
+  inactive: 'Retired',
+};
+
 // Guards against a malformed `?page=abc` producing NaN, which would
 // otherwise be sent straight through to the API as the `page` filter
 // (the `users-page.tsx` `readPageParam` precedent, adapted to this
@@ -155,7 +163,19 @@ export function InventoryLocationsPage(): ReactElement {
   }
 
   const filtersActive = Boolean(kind) || !showRetired;
+  // Distinct from `filtersActive`: an empty current page with a non-zero
+  // total means the PAGE is wrong, not the filters (e.g. page 2 emptied by
+  // a delete elsewhere, or a hand-edited `?page=99`). Rendering the
+  // pre-bootstrap "zero locations" empty state there would falsely tell the
+  // operator nothing exists (tech-review finding).
+  const pageOutOfRange = page > 1 && (query.data?.total ?? 0) > 0 && (query.data?.items.length ?? 0) === 0;
 
+  // No column declares `sortable`/`accessor`: `ListLocationsQueryDto` has no
+  // sort param (the backend always orders by `code`), and this list is
+  // paginated. `DataTable` falls back to CLIENT sort with neither `sort` nor
+  // `onSortChange` supplied, which would only reorder the visible page —
+  // page 2's "sorted" rows wouldn't compose with page 1's, so the table
+  // would look globally sorted while lying about it (tech-review finding).
   const columns = useMemo<DataTableColumn<InventoryLocation>[]>(
     () => [
       {
@@ -170,22 +190,18 @@ export function InventoryLocationsPage(): ReactElement {
             </span>
           </div>
         ),
-        accessor: (location) => location.name,
-        sortable: true,
       },
       {
         id: 'kind',
         header: 'Kind',
         cell: (location) => KIND_LABEL[location.kind],
-        accessor: (location) => location.kind,
-        sortable: true,
       },
       {
         id: 'geo',
         header: 'Country / postcode',
         cell: (location): ReactElement => {
           const geo = [location.countryIso2, location.postcode].filter(Boolean).join(' · ');
-          return geo ? <span className="mono-text">{geo}</span> : <EmptyValue label="No location set" />;
+          return geo ? <span className="mono-text">{geo}</span> : <EmptyValue label="No country/postcode" />;
         },
         hideBelow: 1024,
       },
@@ -218,10 +234,8 @@ export function InventoryLocationsPage(): ReactElement {
         id: 'status',
         header: 'Status',
         cell: (location) => (
-          <StatusBadge tone={statusTone(location.status)}>{location.status}</StatusBadge>
+          <StatusBadge tone={statusTone(location.status)}>{STATUS_LABEL[location.status]}</StatusBadge>
         ),
-        accessor: (location) => location.status,
-        sortable: true,
       },
       {
         id: 'actions',
@@ -307,14 +321,29 @@ export function InventoryLocationsPage(): ReactElement {
         />
       ) : (query.data?.items ?? []).length === 0 ? (
         <EmptyState
-          title={filtersActive ? 'No locations match this filter' : 'Routing has nowhere to source stock from'}
+          title={
+            pageOutOfRange
+              ? "This page doesn't exist anymore"
+              : filtersActive
+                ? 'No locations match this filter'
+                : 'Routing has nowhere to source stock from'
+          }
           message={
-            filtersActive
-              ? 'No locations match the current filters.'
-              : 'Zero locations exist — every order is currently unfulfillable. Mint the first one, or add your own.'
+            pageOutOfRange
+              ? `There are ${query.data?.total ?? 0} locations, but not on page ${page}.`
+              : filtersActive
+                ? 'No locations match the current filters.'
+                // #3135 review: routing is opt-in (#2407) and ConnectionService
+                // refuses the false->true transition while zero locations
+                // exist, so a zero-location install either has routing off
+                // (orders fulfil fine today) or could never have enabled it —
+                // "every order is unfulfillable" was false in both directions.
+                : "Fulfilment routing has nowhere to source stock from yet, so it can't be enabled for any connection. Mint the first location, or add your own — either way it still needs stock assigned before routing can succeed."
           }
           action={
-            filtersActive ? (
+            pageOutOfRange ? (
+              <Button onClick={() => setPage(1)}>Back to page 1</Button>
+            ) : filtersActive ? (
               <Button onClick={clearFilters}>Clear filters</Button>
             ) : write.visible ? (
               <div className="table-actions">
@@ -351,7 +380,7 @@ export function InventoryLocationsPage(): ReactElement {
               subtitle: (location) => location.code,
               meta: (location) => (
                 <StatusBadge tone={statusTone(location.status)} compact>
-                  {location.status}
+                  {STATUS_LABEL[location.status]}
                 </StatusBadge>
               ),
             }}

--- a/apps/web/src/pages/inventory/inventory-locations-page.tsx
+++ b/apps/web/src/pages/inventory/inventory-locations-page.tsx
@@ -236,6 +236,7 @@ export function InventoryLocationsPage(): ReactElement {
           <label className="toolbar__checkbox-label">
             <input
               type="checkbox"
+              name="showRetired"
               checked={showRetired}
               onChange={(e) => { handleFilterChange('retired', e.target.checked ? '' : '0'); }}
             />

--- a/apps/web/src/pages/inventory/inventory-locations-page.tsx
+++ b/apps/web/src/pages/inventory/inventory-locations-page.tsx
@@ -44,12 +44,46 @@ import {
   type LocationDialogTarget,
 } from '../../features/inventory';
 
+const PAGE_SIZE = 25;
+
 function isKnownKind(value: string): value is InventoryLocationKind {
   return (InventoryLocationKindValues as readonly string[]).includes(value);
 }
 
 function statusTone(status: InventoryLocation['status']): StatusBadgeTone {
   return status === 'active' ? 'success' : 'neutral';
+}
+
+// Guards against a malformed `?page=abc` producing NaN, which would
+// otherwise be sent straight through to the API as the `page` filter
+// (the `users-page.tsx` `readPageParam` precedent, adapted to this
+// endpoint's 1-based paging).
+function readPageParam(raw: string | null): number {
+  const parsed = Number(raw ?? '1');
+  return Number.isFinite(parsed) && parsed >= 1 ? Math.trunc(parsed) : 1;
+}
+
+// The `users-page.tsx` pager, adapted to 1-based paging and a `total` that
+// arrives in the SAME response as the rows (#2316's `PaginatedInventoryLocations`
+// — no two-stage-total machinery needed here, unlike `products-list-page.tsx`).
+function renderPagination(page: number, setPage: (next: number) => void, total: number): ReactElement | null {
+  const pageCount = Math.max(1, Math.ceil(total / PAGE_SIZE));
+  if (pageCount <= 1) return null;
+  return (
+    <div className="pagination">
+      <span className="text-muted">
+        Page {page} of {pageCount} · {total} location{total === 1 ? '' : 's'}
+      </span>
+      <div className="pagination__actions">
+        <Button disabled={page <= 1} onClick={() => setPage(page - 1)}>
+          Previous
+        </Button>
+        <Button disabled={page >= pageCount} onClick={() => setPage(page + 1)}>
+          Next
+        </Button>
+      </div>
+    </div>
+  );
 }
 
 export function InventoryLocationsPage(): ReactElement {
@@ -65,13 +99,14 @@ export function InventoryLocationsPage(): ReactElement {
   // Default true — soft retirement keeps a row visible by design (#2316), so
   // the toggle narrows to active-only rather than the other way round.
   const showRetired = searchParams.get('retired') !== '0';
+  const page = readPageParam(searchParams.get('page'));
 
   const filters: InventoryLocationFilters = {
     kind,
     status: showRetired ? undefined : 'active',
   };
 
-  const query = useInventoryLocationsQuery(filters);
+  const query = useInventoryLocationsQuery(filters, { page, limit: PAGE_SIZE });
   const connectionsQuery = useConnectionsQuery();
   const bootstrapMutation = useBootstrapLocationsMutation();
 
@@ -89,6 +124,10 @@ export function InventoryLocationsPage(): ReactElement {
       } else {
         next.delete(key);
       }
+      // A changed filter can shrink the result set out from under the
+      // current page, so land back on page 1 rather than risk a page
+      // number the new filter has no rows for.
+      next.delete('page');
       return next;
     });
   }
@@ -98,6 +137,19 @@ export function InventoryLocationsPage(): ReactElement {
       const next = new URLSearchParams(prev);
       next.delete('kind');
       next.delete('retired');
+      next.delete('page');
+      return next;
+    });
+  }
+
+  function setPage(nextPage: number): void {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      if (nextPage <= 1) {
+        next.delete('page');
+      } else {
+        next.set('page', String(nextPage));
+      }
       return next;
     });
   }
@@ -266,39 +318,46 @@ export function InventoryLocationsPage(): ReactElement {
               <Button onClick={clearFilters}>Clear filters</Button>
             ) : write.visible ? (
               <div className="table-actions">
-                <Button
-                  disabled={write.demoReadOnly || bootstrapMutation.isPending}
-                  onClick={() => bootstrapMutation.mutate()}
-                >
-                  Create first location
-                </Button>
-                <Button
-                  tone="secondary"
-                  disabled={write.demoReadOnly}
-                  onClick={() => setDialogTarget({ mode: 'create' })}
-                >
-                  + Add manually
-                </Button>
+                <ReadOnlyLock active={write.demoReadOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
+                  <Button
+                    disabled={write.demoReadOnly || bootstrapMutation.isPending}
+                    onClick={() => bootstrapMutation.mutate()}
+                  >
+                    Create first location
+                  </Button>
+                </ReadOnlyLock>
+                <ReadOnlyLock active={write.demoReadOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
+                  <Button
+                    tone="secondary"
+                    disabled={write.demoReadOnly}
+                    onClick={() => setDialogTarget({ mode: 'create' })}
+                  >
+                    + Add manually
+                  </Button>
+                </ReadOnlyLock>
               </div>
             ) : null
           }
         />
       ) : (
-        <DataTable
-          caption="Inventory locations"
-          columns={columns}
-          rowKey={(location) => location.id}
-          rows={[...(query.data?.items ?? [])]}
-          cardView={{
-            title: (location) => location.name,
-            subtitle: (location) => location.code,
-            meta: (location) => (
-              <StatusBadge tone={statusTone(location.status)} compact>
-                {location.status}
-              </StatusBadge>
-            ),
-          }}
-        />
+        <>
+          <DataTable
+            caption="Inventory locations"
+            columns={columns}
+            rowKey={(location) => location.id}
+            rows={[...(query.data?.items ?? [])]}
+            cardView={{
+              title: (location) => location.name,
+              subtitle: (location) => location.code,
+              meta: (location) => (
+                <StatusBadge tone={statusTone(location.status)} compact>
+                  {location.status}
+                </StatusBadge>
+              ),
+            }}
+          />
+          {renderPagination(page, setPage, query.data?.total ?? 0)}
+        </>
       )}
 
       <LocationDialog target={dialogTarget} onClose={() => setDialogTarget(null)} />

--- a/apps/web/src/shared/auth/session.types.ts
+++ b/apps/web/src/shared/auth/session.types.ts
@@ -17,6 +17,10 @@ export const PermissionValues = [
   'products:write',
   'inventory:read',
   'inventory:write',
+  // DISPLAY-ONLY (#3066): gates the locations-list Add/Edit/Delete/Retire
+  // affordances. Deliberately not `inventory:write` — see that constant's
+  // docblock on the backend for why.
+  'inventory-locations:write',
   'listings:read',
   'listings:write',
   'users:read',

--- a/libs/core/src/users/domain/types/role.types.ts
+++ b/libs/core/src/users/domain/types/role.types.ts
@@ -77,6 +77,16 @@ export const PermissionValues = [
   // own reasoning. Same discipline as `shipments:write` above.
   'automations:read',
   'automations:write',
+  // DISPLAY-ONLY (#3066): gates the FE's inventory-locations write
+  // affordances (Add/Edit/Delete/Retire on the locations list, #2316). It is
+  // deliberately NOT `inventory:write` — that permission is held by `operator`
+  // too, but `InventoryLocationsController`'s three write routes are
+  // `@Roles('admin')` only, so granting `inventory:write` here would show an
+  // operator an enabled button that then 403s. The roles holding this
+  // permission MUST stay identical to that controller's `@Roles` list (asserted
+  // in `inventory-locations.controller.spec.ts`), the `shipments:write` /
+  // `automations:write` discipline.
+  'inventory-locations:write',
   // DISPLAY-ONLY (#2473): gates the FE's analytics-settings write affordances
   // (tax-rate opt-in toggle, currency-recalculation trigger). It authorizes no
   // mutation — those endpoints are `@Roles('admin')`-gated directly and no


### PR DESCRIPTION
## Summary
- Adds `InventoryLocationsPage`: `DataTable` (code+name, kind, country/postcode, owning connection, status, actions), a kind filter `Select` and a "Show retired" toggle defaulting **ON** (soft retirement keeps a row visible by design, #2316), loading/error/empty states following the `connections-list-page.tsx` cockpit-list composition
- The owning-connection cell reuses `ConnectionCell` with a channel-pill adornment — the same composition `products-list-page.tsx` already uses for a connection's platform identity
- Wires in the #3067/#3068 dialogs (`LocationDialog`, `LocationDeleteDialog`) for Add/Edit/Delete/Retire
- Adds a dedicated `inventory-locations:write` permission (backend + frontend) rather than reusing the existing `inventory:write` — that one is also held by `operator`, but `InventoryLocationsController`'s three write routes are `@Roles('admin')` only, so granting `inventory:write` here would show an operator an enabled button that then 403s. A controller spec asserts the permission is held by exactly `['admin']`, the `shipments:write`/`automations:write` discipline already established in this codebase.
- Two small reusable CSS additions: `.table-actions` (already referenced by three existing pages with no rule backing it — this fixes that gap for all of them) and `.toolbar__checkbox-label`

Based on the reviewed `inventory-locations` mockup: https://claude.ai/code/artifact/fbb5f9e1-52a3-4b7b-8136-ad59dcf4f318

Stacked on #3068 (#3134), whose dialogs this page mounts. Base branch is `3068-location-delete-dialog`.

Closes #3066.

## Test plan
- [x] `pnpm --filter @openlinker/web type-check`
- [x] `pnpm --filter @openlinker/api type-check`, `pnpm --filter @openlinker/core type-check`
- [x] `eslint` on changed files
- [x] Backend: `inventory-locations.controller.spec.ts` (13/13, including the new permission-lockstep test) + `role.types.spec.ts` (20/20, no drift) + `use-permission.test.ts` (12/12, no drift)
- [x] Frontend: 12 new page tests (heading, filters, data display, loading/error/empty states incl. pre-bootstrap empty state, toggle→query mapping, kind-filter→query mapping, write-gating hidden without permission, Add/Edit/Delete opening the right dialogs) — all green
- [x] Full `features/inventory` + `pages/inventory` suite: 42/42 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
