### PR TITLE
feat(inventory): nav entry for Inventory locations

### DIFF
--- a/apps/web/src/app/nav-registry.ts
+++ b/apps/web/src/app/nav-registry.ts
@@ -71,6 +71,11 @@ export const BASE_NAV_GROUPS: readonly NavRegistryGroup[] = [
     label: 'Platform',
     items: [
       { to: '/connections', label: 'Connections', countKey: 'connections' },
+      // Reads are `admin`/`operator`/`viewer` (InventoryLocationsController)
+      // - gated on `inventory:read` rather than `inventory-locations:write`,
+      // so a `packer` (which holds no permissions at all) is the only role
+      // that never sees the entry.
+      { to: '/inventory/locations', label: 'Inventory locations', requiresPermission: 'inventory:read' },
       { to: '/adapters', label: 'Adapters' },
       { to: '/settings', label: 'Settings' },
     ],

--- a/apps/web/src/app/routes/inventory-locations.route.tsx
+++ b/apps/web/src/app/routes/inventory-locations.route.tsx
@@ -1,0 +1,13 @@
+import type { RouteObject } from 'react-router-dom';
+import type { RouteCrumbHandle } from '../nav-registry.types';
+
+export const inventoryLocationsRoute: RouteObject = {
+  path: 'inventory/locations',
+  handle: { crumb: { group: 'Platform', title: 'Inventory locations' } } satisfies RouteCrumbHandle,
+  lazy: async () => {
+    const { InventoryLocationsPage } = await import(
+      '../../pages/inventory/inventory-locations-page'
+    );
+    return { Component: InventoryLocationsPage };
+  },
+};

--- a/apps/web/src/app/routes/root.route.tsx
+++ b/apps/web/src/app/routes/root.route.tsx
@@ -24,6 +24,7 @@ import { cursorsRoute } from './cursors.route';
 import { customersRoute } from './customers.route';
 import { devUiRoute } from './dev-ui.route';
 import { insightsRoute } from './insights.route';
+import { inventoryLocationsRoute } from './inventory-locations.route';
 import { listingsRoute } from './listings.route';
 import { aiProviderSettingsRoute } from './ai-provider-settings.route';
 import { mcpTokensRoute } from './mcp-tokens.route';
@@ -71,6 +72,7 @@ export const coreChildren: RouteObject[] = [
   automationsRoute,
   invoicesRoute,
   connectionsRoute,
+  inventoryLocationsRoute,
   adaptersRoute,
   newConnectionRoute,
   advancedNewConnectionRoute,

--- a/apps/web/src/app/routes/route-lazy.test.ts
+++ b/apps/web/src/app/routes/route-lazy.test.ts
@@ -83,7 +83,7 @@ const lazyRoutes = collectLazyRoutes([
  *   - prompt-templates-legacy-redirects (inline `<Navigate>` element)
  *   - `/analytics` legacy alias (inline `<Navigate>` to `/`, #2740)
  */
-const EXPECTED_LAZY_ROUTE_COUNT = 63;
+const EXPECTED_LAZY_ROUTE_COUNT = 64;
 
 describe('route lazy contract', () => {
   it(`the registered route tree contains exactly ${EXPECTED_LAZY_ROUTE_COUNT} lazy routes`, () => {

--- a/apps/web/src/pages/inventory/inventory-locations-page.test.tsx
+++ b/apps/web/src/pages/inventory/inventory-locations-page.test.tsx
@@ -6,6 +6,7 @@ import {
   createMockApiClient,
   renderWithProviders,
 } from '../../test/test-utils';
+import { ApiError } from '../../shared/api/api-error';
 import { InventoryLocationsPage } from './inventory-locations-page';
 import type { InventoryLocation, PaginatedInventoryLocations } from '../../features/inventory';
 
@@ -160,5 +161,84 @@ describe('InventoryLocationsPage', () => {
     await userEvent.click(await screen.findByRole('button', { name: 'Delete' }));
 
     expect(await screen.findByText('Delete "Warsaw — Main warehouse"?')).toBeInTheDocument();
+  });
+
+  // #3070 — end-to-end round trips through the real mutation hooks' cache
+  // invalidation, not just "the dialog opened": every hook/dialog test above
+  // stops at the request being made, so none of them prove the PAGE actually
+  // reflects a successful write.
+  describe('end-to-end CRUD round trips (#3070)', () => {
+    it('create: the new row appears in the table after a successful submit', async () => {
+      const created: InventoryLocation = { ...location, id: 'ol_location_2', code: 'WH2', name: 'Overflow' };
+      const listLocations = vi
+        .fn()
+        .mockResolvedValueOnce(page([location]))
+        .mockResolvedValueOnce(page([location, created]));
+      const createLocation = vi.fn().mockResolvedValue(created);
+      const apiClient = createMockApiClient({ inventory: { listLocations, createLocation } });
+      renderWithProviders(<InventoryLocationsPage />, {
+        apiClient,
+        sessionAdapter: createAuthenticatedSessionAdapter(),
+      });
+
+      await screen.findByText('Warsaw — Main warehouse');
+      await userEvent.click(screen.getByRole('button', { name: '+ Add location' }));
+      await screen.findByText('Add location');
+      await userEvent.type(screen.getByLabelText('Code'), 'WH2');
+      await userEvent.type(screen.getByLabelText('Name'), 'Overflow');
+      await userEvent.click(screen.getByRole('button', { name: /save location/i }));
+
+      expect(await screen.findByText('Overflow')).toBeInTheDocument();
+      expect(listLocations).toHaveBeenCalledTimes(2);
+    });
+
+    it('delete: the row is gone from the table after a successful delete', async () => {
+      const listLocations = vi
+        .fn()
+        .mockResolvedValueOnce(page([location]))
+        .mockResolvedValueOnce(page([]));
+      const deleteLocation = vi.fn().mockResolvedValue(undefined);
+      const apiClient = createMockApiClient({ inventory: { listLocations, deleteLocation } });
+      renderWithProviders(<InventoryLocationsPage />, {
+        apiClient,
+        sessionAdapter: createAuthenticatedSessionAdapter(),
+      });
+
+      await screen.findByText('Warsaw — Main warehouse');
+      await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+      await screen.findByText('Delete "Warsaw — Main warehouse"?');
+      await userEvent.click(screen.getByRole('button', { name: /^delete$/i }));
+
+      await waitFor(() => expect(screen.queryByText('Warsaw — Main warehouse')).not.toBeInTheDocument());
+      expect(listLocations).toHaveBeenCalledTimes(2);
+    });
+
+    it('retire: a 409-refused delete, retired instead, flips the row to Retired', async () => {
+      const listLocations = vi
+        .fn()
+        .mockResolvedValueOnce(page([location]))
+        .mockResolvedValueOnce(page([{ ...location, status: 'inactive' }]));
+      const deleteLocation = vi
+        .fn()
+        .mockRejectedValue(new ApiError('Inventory location ol_location_1 is referenced by 3 inventory position(s)', 409, {}));
+      const updateLocation = vi.fn().mockResolvedValue({ ...location, status: 'inactive' });
+      const apiClient = createMockApiClient({ inventory: { listLocations, deleteLocation, updateLocation } });
+      renderWithProviders(<InventoryLocationsPage />, {
+        apiClient,
+        sessionAdapter: createAuthenticatedSessionAdapter(),
+      });
+
+      await screen.findByText('Warsaw — Main warehouse');
+      expect(screen.getByText('active')).toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+      await screen.findByText('Delete "Warsaw — Main warehouse"?');
+      await userEvent.click(screen.getByRole('button', { name: /^delete$/i }));
+      await screen.findByRole('button', { name: /retire instead/i });
+      await userEvent.click(screen.getByRole('button', { name: /retire instead/i }));
+
+      await waitFor(() => expect(screen.getByText('inactive')).toBeInTheDocument());
+      expect(listLocations).toHaveBeenCalledTimes(2);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Adds `inventory-locations.route.tsx` (path `inventory/locations`, lazy-loaded, `Platform` breadcrumb group) and registers it in `root.route.tsx`
- Adds the sidebar entry under **Platform**, right after Connections, gated on `inventory:read` rather than `inventory-locations:write` — the page's reads are `admin`/`operator`/`viewer` (`InventoryLocationsController`), so gating on the write permission would hide the entry from `operator` and `viewer`, who can read the page fine. `packer` (which holds no permissions at all) is the only role that never sees it.
- Bumps `route-lazy.test.ts`'s exact lazy-route-count contract (63 → 64)

Stacked on #3066 (#3135). Base branch is `3066-locations-list-page`.

Closes #3069.

## Test plan
- [x] `pnpm --filter @openlinker/web type-check`
- [x] `eslint` on changed files
- [x] `route-lazy.test.ts` + `route-handle.test.ts` + `nav-registry.test.ts` — 130/130 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
