### PR TITLE
test(inventory): locations CRUD tests

### DIFF
--- a/apps/web/src/pages/inventory/inventory-locations-page.test.tsx
+++ b/apps/web/src/pages/inventory/inventory-locations-page.test.tsx
@@ -6,6 +6,7 @@ import {
   createMockApiClient,
   renderWithProviders,
 } from '../../test/test-utils';
+import { ApiError } from '../../shared/api/api-error';
 import { InventoryLocationsPage } from './inventory-locations-page';
 import type { InventoryLocation, PaginatedInventoryLocations } from '../../features/inventory';
 
@@ -160,5 +161,84 @@ describe('InventoryLocationsPage', () => {
     await userEvent.click(await screen.findByRole('button', { name: 'Delete' }));
 
     expect(await screen.findByText('Delete "Warsaw — Main warehouse"?')).toBeInTheDocument();
+  });
+
+  // #3070 — end-to-end round trips through the real mutation hooks' cache
+  // invalidation, not just "the dialog opened": every hook/dialog test above
+  // stops at the request being made, so none of them prove the PAGE actually
+  // reflects a successful write.
+  describe('end-to-end CRUD round trips (#3070)', () => {
+    it('create: the new row appears in the table after a successful submit', async () => {
+      const created: InventoryLocation = { ...location, id: 'ol_location_2', code: 'WH2', name: 'Overflow' };
+      const listLocations = vi
+        .fn()
+        .mockResolvedValueOnce(page([location]))
+        .mockResolvedValueOnce(page([location, created]));
+      const createLocation = vi.fn().mockResolvedValue(created);
+      const apiClient = createMockApiClient({ inventory: { listLocations, createLocation } });
+      renderWithProviders(<InventoryLocationsPage />, {
+        apiClient,
+        sessionAdapter: createAuthenticatedSessionAdapter(),
+      });
+
+      await screen.findByText('Warsaw — Main warehouse');
+      await userEvent.click(screen.getByRole('button', { name: '+ Add location' }));
+      await screen.findByText('Add location');
+      await userEvent.type(screen.getByLabelText('Code'), 'WH2');
+      await userEvent.type(screen.getByLabelText('Name'), 'Overflow');
+      await userEvent.click(screen.getByRole('button', { name: /save location/i }));
+
+      expect(await screen.findByText('Overflow')).toBeInTheDocument();
+      expect(listLocations).toHaveBeenCalledTimes(2);
+    });
+
+    it('delete: the row is gone from the table after a successful delete', async () => {
+      const listLocations = vi
+        .fn()
+        .mockResolvedValueOnce(page([location]))
+        .mockResolvedValueOnce(page([]));
+      const deleteLocation = vi.fn().mockResolvedValue(undefined);
+      const apiClient = createMockApiClient({ inventory: { listLocations, deleteLocation } });
+      renderWithProviders(<InventoryLocationsPage />, {
+        apiClient,
+        sessionAdapter: createAuthenticatedSessionAdapter(),
+      });
+
+      await screen.findByText('Warsaw — Main warehouse');
+      await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+      await screen.findByText('Delete "Warsaw — Main warehouse"?');
+      await userEvent.click(screen.getByRole('button', { name: /^delete$/i }));
+
+      await waitFor(() => expect(screen.queryByText('Warsaw — Main warehouse')).not.toBeInTheDocument());
+      expect(listLocations).toHaveBeenCalledTimes(2);
+    });
+
+    it('retire: a 409-refused delete, retired instead, flips the row to Retired', async () => {
+      const listLocations = vi
+        .fn()
+        .mockResolvedValueOnce(page([location]))
+        .mockResolvedValueOnce(page([{ ...location, status: 'inactive' }]));
+      const deleteLocation = vi
+        .fn()
+        .mockRejectedValue(new ApiError('Inventory location ol_location_1 is referenced by 3 inventory position(s)', 409, {}));
+      const updateLocation = vi.fn().mockResolvedValue({ ...location, status: 'inactive' });
+      const apiClient = createMockApiClient({ inventory: { listLocations, deleteLocation, updateLocation } });
+      renderWithProviders(<InventoryLocationsPage />, {
+        apiClient,
+        sessionAdapter: createAuthenticatedSessionAdapter(),
+      });
+
+      await screen.findByText('Warsaw — Main warehouse');
+      expect(screen.getByText('active')).toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+      await screen.findByText('Delete "Warsaw — Main warehouse"?');
+      await userEvent.click(screen.getByRole('button', { name: /^delete$/i }));
+      await screen.findByRole('button', { name: /retire instead/i });
+      await userEvent.click(screen.getByRole('button', { name: /retire instead/i }));
+
+      await waitFor(() => expect(screen.getByText('inactive')).toBeInTheDocument());
+      expect(listLocations).toHaveBeenCalledTimes(2);
+    });
   });
 });


### PR DESCRIPTION
## Summary
Every prior sub-issue (#3064–#3069) already carries colocated unit/component tests for its own layer — the API client, the query/mutation hooks (incl. a dedicated cache-invalidation test), the create/edit dialog (incl. validation and the 409 duplicate-code mapping), the delete/retire dialog (incl. the 409-in-use branch), and the list page's filters/states/write-gating. None of them proves the **page** actually reflects a successful write, since each stops at "the request was made" or "the dialog opened".

- Adds three end-to-end round-trip tests to `inventory-locations-page.test.tsx`:
  - **create** — the new row appears in the table after submit
  - **delete** — the row disappears after confirm
  - **retire** — a 409-refused delete followed by "Retire instead" flips the row's status badge from Active to Retired

Each drives the real mutation hooks' cache invalidation via a second `listLocations` response (`mockResolvedValueOnce` × 2), rather than asserting a mocked table update — so a regression in `inventoryQueryKeys.locationsAll()` invalidation (see #3065's PR) would be caught here even though it isn't touched by this diff.

Stacked on #3069 (#3136). Base branch is `3069-locations-nav-route`.

Closes #3070, the **last** sub-issue of #3063.

## Test plan
- [x] `pnpm --filter @openlinker/web type-check`
- [x] `eslint` on changed files
- [x] `inventory-locations-page.test.tsx`: 15/15 green (12 existing + 3 new)
- [x] Full `features/inventory` + `pages/inventory` suite: 45/45 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)
