### PR TITLE
feat(inventory): locations CRUD UI — full operator-facing management for inventory_locations

### DIFF
--- a/apps/api/src/inventory/http/inventory-locations.controller.spec.ts
+++ b/apps/api/src/inventory/http/inventory-locations.controller.spec.ts
@@ -17,6 +17,7 @@ import {
   LocationInUseError,
   type ILocationService,
 } from '@openlinker/core/inventory';
+import { ROLE_PERMISSIONS, UserRoleValues } from '@openlinker/core/users';
 import { InventoryLocationsController } from './inventory-locations.controller';
 
 function makeLocation(
@@ -221,5 +222,19 @@ describe('InventoryLocationsController', () => {
       expect(result.created).toEqual([]);
       expect(result.existingCodes).toEqual(['MAIN']);
     });
+  });
+});
+
+describe('inventory-locations:write permission lockstep', () => {
+  it('should be granted to exactly the roles this controller @Roles(admin) on every write route', () => {
+    // `inventory-locations:write` is a display predicate only (no permission
+    // guard exists) - if this drifts from the controller's actual @Roles,
+    // either add a permission-based guard or revert the grant, the
+    // `shipments:write` / `automations:write` discipline.
+    const rolesWithPermission = UserRoleValues.filter((role) =>
+      ROLE_PERMISSIONS[role].includes('inventory-locations:write')
+    );
+
+    expect(rolesWithPermission).toEqual(['admin']);
   });
 });

--- a/apps/web/src/app/nav-registry.ts
+++ b/apps/web/src/app/nav-registry.ts
@@ -71,6 +71,11 @@ export const BASE_NAV_GROUPS: readonly NavRegistryGroup[] = [
     label: 'Platform',
     items: [
       { to: '/connections', label: 'Connections', countKey: 'connections' },
+      // Reads are `admin`/`operator`/`viewer` (InventoryLocationsController)
+      // - gated on `inventory:read` rather than `inventory-locations:write`,
+      // so a `packer` (which holds no permissions at all) is the only role
+      // that never sees the entry.
+      { to: '/inventory/locations', label: 'Inventory locations', requiresPermission: 'inventory:read' },
       { to: '/adapters', label: 'Adapters' },
       { to: '/settings', label: 'Settings' },
     ],

--- a/apps/web/src/app/nav-registry.ts
+++ b/apps/web/src/app/nav-registry.ts
@@ -71,11 +71,6 @@ export const BASE_NAV_GROUPS: readonly NavRegistryGroup[] = [
     label: 'Platform',
     items: [
       { to: '/connections', label: 'Connections', countKey: 'connections' },
-      // Reads are `admin`/`operator`/`viewer` (InventoryLocationsController)
-      // - gated on `inventory:read` rather than `inventory-locations:write`,
-      // so a `packer` (which holds no permissions at all) is the only role
-      // that never sees the entry.
-      { to: '/inventory/locations', label: 'Inventory locations', requiresPermission: 'inventory:read' },
       { to: '/adapters', label: 'Adapters' },
       { to: '/settings', label: 'Settings' },
     ],

--- a/apps/web/src/app/routes/inventory-locations.route.tsx
+++ b/apps/web/src/app/routes/inventory-locations.route.tsx
@@ -1,0 +1,13 @@
+import type { RouteObject } from 'react-router-dom';
+import type { RouteCrumbHandle } from '../nav-registry.types';
+
+export const inventoryLocationsRoute: RouteObject = {
+  path: 'inventory/locations',
+  handle: { crumb: { group: 'Platform', title: 'Inventory locations' } } satisfies RouteCrumbHandle,
+  lazy: async () => {
+    const { InventoryLocationsPage } = await import(
+      '../../pages/inventory/inventory-locations-page'
+    );
+    return { Component: InventoryLocationsPage };
+  },
+};

--- a/apps/web/src/app/routes/root.route.tsx
+++ b/apps/web/src/app/routes/root.route.tsx
@@ -24,6 +24,7 @@ import { cursorsRoute } from './cursors.route';
 import { customersRoute } from './customers.route';
 import { devUiRoute } from './dev-ui.route';
 import { insightsRoute } from './insights.route';
+import { inventoryLocationsRoute } from './inventory-locations.route';
 import { listingsRoute } from './listings.route';
 import { aiProviderSettingsRoute } from './ai-provider-settings.route';
 import { mcpTokensRoute } from './mcp-tokens.route';
@@ -71,6 +72,7 @@ export const coreChildren: RouteObject[] = [
   automationsRoute,
   invoicesRoute,
   connectionsRoute,
+  inventoryLocationsRoute,
   adaptersRoute,
   newConnectionRoute,
   advancedNewConnectionRoute,

--- a/apps/web/src/app/routes/route-lazy.test.ts
+++ b/apps/web/src/app/routes/route-lazy.test.ts
@@ -83,7 +83,7 @@ const lazyRoutes = collectLazyRoutes([
  *   - prompt-templates-legacy-redirects (inline `<Navigate>` element)
  *   - `/analytics` legacy alias (inline `<Navigate>` to `/`, #2740)
  */
-const EXPECTED_LAZY_ROUTE_COUNT = 63;
+const EXPECTED_LAZY_ROUTE_COUNT = 64;
 
 describe('route lazy contract', () => {
   it(`the registered route tree contains exactly ${EXPECTED_LAZY_ROUTE_COUNT} lazy routes`, () => {

--- a/apps/web/src/features/inventory/api/inventory-locations.types.ts
+++ b/apps/web/src/features/inventory/api/inventory-locations.types.ts
@@ -7,6 +7,16 @@
  * @module apps/web/src/features/inventory/api
  */
 
+/**
+ * `countryIso2` is normalised to uppercase in exactly one place — the API's
+ * own `ListLocationsQueryDto` does the same server-side, so this mirrors that
+ * rule rather than inventing a second one. #3135 review: was duplicated
+ * inline in `inventory.api.ts` and `location-dialog.schema.ts`.
+ */
+export function normalizeCountryIso2(value: string): string {
+  return value.toUpperCase();
+}
+
 /** What a location physically is (#2316). Operator-declared, never derived. */
 export const InventoryLocationKindValues = ['warehouse', 'store', 'third-party', 'virtual'] as const;
 export type InventoryLocationKind = (typeof InventoryLocationKindValues)[number];

--- a/apps/web/src/features/inventory/api/inventory-locations.types.ts
+++ b/apps/web/src/features/inventory/api/inventory-locations.types.ts
@@ -1,11 +1,50 @@
 /**
- * Inventory Location Types (frontend view of the #2313 / #2407 wire contract)
+ * Inventory Location Types (frontend view of the #2313 / #2316 / #2407 wire contract)
  *
  * The browser bundle cannot depend on `@openlinker/core` (#591), so these are
  * copies of the API's response shapes rather than imports.
  *
  * @module apps/web/src/features/inventory/api
  */
+
+/** What a location physically is (#2316). Operator-declared, never derived. */
+export const InventoryLocationKindValues = ['warehouse', 'store', 'third-party', 'virtual'] as const;
+export type InventoryLocationKind = (typeof InventoryLocationKindValues)[number];
+
+/**
+ * Whether the location participates in routing/availability today.
+ * `inactive` is a soft retirement, not a delete — see `deleteLocation`.
+ */
+export const InventoryLocationStatusValues = ['active', 'inactive'] as const;
+export type InventoryLocationStatus = (typeof InventoryLocationStatusValues)[number];
+
+/**
+ * The full row — mirrors `LocationResponseDto` field-for-field (#3064).
+ * `InventoryLocationSummary` below stays the minimal shape the #2407
+ * readiness/bootstrap surfaces already read; this is its superset, so an
+ * `InventoryLocation` satisfies every existing `InventoryLocationSummary`
+ * consumer without a second type walking the same fields.
+ */
+export interface InventoryLocation {
+  readonly id: string;
+  readonly code: string;
+  readonly name: string;
+  readonly kind: InventoryLocationKind;
+  /** Provenance only — whose sync may write positions here. Never authority (ADR-052). */
+  readonly ownerConnectionId: string | null;
+  /** Free-text operator reference. NOT an identifier mapping. */
+  readonly externalRef: string | null;
+  readonly status: InventoryLocationStatus;
+  /** ISO-3166-1 alpha-2. */
+  readonly countryIso2: string | null;
+  readonly postcode: string | null;
+  readonly latitude: number | null;
+  readonly longitude: number | null;
+  /** ISO-8601 */
+  readonly createdAt: string;
+  /** ISO-8601 */
+  readonly updatedAt: string;
+}
 
 export interface InventoryLocationSummary {
   readonly id: string;
@@ -14,12 +53,64 @@ export interface InventoryLocationSummary {
   readonly status: string;
 }
 
-/** The paged listing, of which only `total` is read by the readiness surface. */
+/** All optional and AND-combined; an absent field does not filter. */
+export interface InventoryLocationFilters {
+  kind?: InventoryLocationKind;
+  /** Omitted lists every status, including `inactive` — soft retirement stays visible. */
+  status?: InventoryLocationStatus;
+  /** ISO-3166-1 alpha-2. Matched case-insensitively (uppercased before the request). */
+  countryIso2?: string;
+  /** Case-insensitive prefix match on `code`. */
+  codePrefix?: string;
+}
+
+/**
+ * 1-based `page`/`limit`, unlike `InventoryPagination`'s `limit`/`offset` —
+ * the divergence mirrors `ListLocationsQueryDto`'s own docblock: this is the
+ * core `InventoryLocationPagination` contract, echoed verbatim.
+ */
+export interface InventoryLocationListPagination {
+  page?: number;
+  limit?: number;
+}
+
+/** The paged listing. Widened from summaries to full rows for #3064's `listLocations`. */
 export interface PaginatedInventoryLocations {
-  readonly items: readonly InventoryLocationSummary[];
+  readonly items: readonly InventoryLocation[];
   readonly total: number;
   readonly page: number;
   readonly limit: number;
+}
+
+/** Mirrors `CreateLocationDto` field-for-field (#3064). */
+export interface CreateInventoryLocationInput {
+  code: string;
+  name: string;
+  kind: InventoryLocationKind;
+  ownerConnectionId?: string | null;
+  externalRef?: string | null;
+  status?: InventoryLocationStatus;
+  countryIso2?: string | null;
+  postcode?: string | null;
+  latitude?: number | null;
+  longitude?: number | null;
+}
+
+/**
+ * Mirrors `UpdateLocationDto` field-for-field (#3064). Every field optional;
+ * an omitted field is left untouched, an explicit `null` clears a nullable
+ * column. `code` is deliberately absent — it is the row's natural key.
+ */
+export interface UpdateInventoryLocationInput {
+  name?: string;
+  kind?: InventoryLocationKind;
+  ownerConnectionId?: string | null;
+  externalRef?: string | null;
+  status?: InventoryLocationStatus;
+  countryIso2?: string | null;
+  postcode?: string | null;
+  latitude?: number | null;
+  longitude?: number | null;
 }
 
 /**

--- a/apps/web/src/features/inventory/api/inventory.api.test.ts
+++ b/apps/web/src/features/inventory/api/inventory.api.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Inventory API Client tests (#3064)
+ *
+ * Covers the four routes newly added to `InventoryApi` — `listLocations`,
+ * `getLocation`, `createLocation`, `updateLocation`, `deleteLocation`. The
+ * pre-existing `listActiveLocations` / `bootstrapLocations` probes are
+ * untouched and not re-tested here.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { createInventoryApi } from './inventory.api';
+import type { InventoryLocation } from './inventory-locations.types';
+
+function location(overrides: Partial<InventoryLocation> = {}): InventoryLocation {
+  return {
+    id: 'ol_location_1',
+    code: 'WH1',
+    name: 'Main warehouse',
+    kind: 'warehouse',
+    ownerConnectionId: null,
+    externalRef: null,
+    status: 'active',
+    countryIso2: null,
+    postcode: null,
+    latitude: null,
+    longitude: null,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('createInventoryApi.listLocations', () => {
+  it('should send no query string when nothing is filtered or paged', async () => {
+    const request = vi.fn().mockResolvedValue({ items: [], total: 0, page: 1, limit: 25 });
+
+    await createInventoryApi(request).listLocations();
+
+    expect(request).toHaveBeenCalledWith('/inventory/locations');
+  });
+
+  it('should forward every declared filter and pagination field', async () => {
+    const request = vi.fn().mockResolvedValue({ items: [], total: 0, page: 2, limit: 10 });
+
+    await createInventoryApi(request).listLocations(
+      { kind: 'warehouse', status: 'active', countryIso2: 'pl', codePrefix: 'WH' },
+      { page: 2, limit: 10 },
+    );
+
+    const [path] = request.mock.calls[0] as [string];
+    const query = new URLSearchParams(path.split('?')[1]);
+    expect(query.get('kind')).toBe('warehouse');
+    expect(query.get('status')).toBe('active');
+    expect(query.get('codePrefix')).toBe('WH');
+    expect(query.get('page')).toBe('2');
+    expect(query.get('limit')).toBe('10');
+  });
+
+  it('should uppercase countryIso2 before sending it', async () => {
+    const request = vi.fn().mockResolvedValue({ items: [], total: 0, page: 1, limit: 25 });
+
+    await createInventoryApi(request).listLocations({ countryIso2: 'pl' });
+
+    const [path] = request.mock.calls[0] as [string];
+    expect(new URLSearchParams(path.split('?')[1]).get('countryIso2')).toBe('PL');
+  });
+});
+
+describe('createInventoryApi.getLocation', () => {
+  it('should request the location by id', async () => {
+    const request = vi.fn().mockResolvedValue(location());
+
+    await createInventoryApi(request).getLocation('ol_location_1');
+
+    expect(request).toHaveBeenCalledWith('/inventory/locations/ol_location_1');
+  });
+});
+
+describe('createInventoryApi.createLocation', () => {
+  it('should POST the input as the JSON body', async () => {
+    const request = vi.fn().mockResolvedValue(location());
+    const input = { code: 'WH1', name: 'Main warehouse', kind: 'warehouse' as const };
+
+    await createInventoryApi(request).createLocation(input);
+
+    expect(request).toHaveBeenCalledWith('/inventory/locations', {
+      method: 'POST',
+      body: JSON.stringify(input),
+    });
+  });
+});
+
+describe('createInventoryApi.updateLocation', () => {
+  it('should PATCH the patch as the JSON body against the location id', async () => {
+    const request = vi.fn().mockResolvedValue(location({ name: 'Renamed' }));
+    const patch = { name: 'Renamed' };
+
+    await createInventoryApi(request).updateLocation('ol_location_1', patch);
+
+    expect(request).toHaveBeenCalledWith('/inventory/locations/ol_location_1', {
+      method: 'PATCH',
+      body: JSON.stringify(patch),
+    });
+  });
+
+  it('should serialize an explicit null as a clear, distinct from an omitted field', async () => {
+    const request = vi.fn().mockResolvedValue(location());
+
+    await createInventoryApi(request).updateLocation('ol_location_1', {
+      ownerConnectionId: null,
+    });
+
+    const [, init] = request.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string) as Record<string, unknown>;
+    expect(body).toEqual({ ownerConnectionId: null });
+    expect('name' in body).toBe(false);
+  });
+});
+
+describe('createInventoryApi.deleteLocation', () => {
+  it('should DELETE the location by id', async () => {
+    const request = vi.fn().mockResolvedValue(undefined);
+
+    await createInventoryApi(request).deleteLocation('ol_location_1');
+
+    expect(request).toHaveBeenCalledWith('/inventory/locations/ol_location_1', {
+      method: 'DELETE',
+    });
+  });
+});

--- a/apps/web/src/features/inventory/api/inventory.api.ts
+++ b/apps/web/src/features/inventory/api/inventory.api.ts
@@ -13,8 +13,13 @@ import type {
   InventoryAvailabilityResponse,
 } from './inventory.types';
 import type {
+  CreateInventoryLocationInput,
+  InventoryLocation,
+  InventoryLocationFilters,
+  InventoryLocationListPagination,
   LocationBootstrapResult,
   PaginatedInventoryLocations,
+  UpdateInventoryLocationInput,
 } from './inventory-locations.types';
 
 export interface InventoryApi {
@@ -36,6 +41,31 @@ export interface InventoryApi {
    * that already exists comes back in `existingCodes` untouched.
    */
   bootstrapLocations: () => Promise<LocationBootstrapResult>;
+  /**
+   * Full, filtered, paginated locations read (#2316 / #3064). Named
+   * `listLocations` rather than the plain `list` #3064 sketched — this
+   * interface already carries `list` for inventory *items*, and the two
+   * would collide — following the `listActiveLocations` /
+   * `bootstrapLocations` naming this file already established.
+   */
+  listLocations: (
+    filters?: InventoryLocationFilters,
+    pagination?: InventoryLocationListPagination,
+  ) => Promise<PaginatedInventoryLocations>;
+  /** GET /inventory/locations/:id (#2316 / #3064). */
+  getLocation: (id: string) => Promise<InventoryLocation>;
+  /** POST /inventory/locations (#2316 / #3064). */
+  createLocation: (input: CreateInventoryLocationInput) => Promise<InventoryLocation>;
+  /** PATCH /inventory/locations/:id (#2316 / #3064). `code` cannot be patched. */
+  updateLocation: (id: string, patch: UpdateInventoryLocationInput) => Promise<InventoryLocation>;
+  /**
+   * DELETE /inventory/locations/:id (#2316 / #3064). Refused with a 409 while
+   * any `inventory_items` row still references the location — callers should
+   * check `ApiError.isConflict()` and offer retire (`updateLocation(id, {
+   * status: 'inactive' })`) instead. That flow is #3068's; this method only
+   * issues the request.
+   */
+  deleteLocation: (id: string) => Promise<void>;
 }
 
 interface ApiRequest {
@@ -49,6 +79,25 @@ function buildQuery(filters?: InventoryFilters, pagination?: InventoryPagination
   if (filters?.locationId) params.set('locationId', filters.locationId);
   if (pagination?.limit !== undefined) params.set('limit', String(pagination.limit));
   if (pagination?.offset !== undefined) params.set('offset', String(pagination.offset));
+  const qs = params.toString();
+  return qs.length > 0 ? `?${qs}` : '';
+}
+
+// `countryIso2` is uppercased here to match `ListLocationsQueryDto`'s own
+// note that the controller uppercases it server-side too — sending it
+// pre-normalised keeps the request legible in devtools rather than relying
+// on the backend to silently correct a lowercase value.
+function buildLocationsQuery(
+  filters?: InventoryLocationFilters,
+  pagination?: InventoryLocationListPagination,
+): string {
+  const params = new URLSearchParams();
+  if (filters?.kind) params.set('kind', filters.kind);
+  if (filters?.status) params.set('status', filters.status);
+  if (filters?.countryIso2) params.set('countryIso2', filters.countryIso2.toUpperCase());
+  if (filters?.codePrefix) params.set('codePrefix', filters.codePrefix);
+  if (pagination?.page !== undefined) params.set('page', String(pagination.page));
+  if (pagination?.limit !== undefined) params.set('limit', String(pagination.limit));
   const qs = params.toString();
   return qs.length > 0 ? `?${qs}` : '';
 }
@@ -67,6 +116,29 @@ export function createInventoryApi(request: ApiRequest): InventoryApi {
     },
     bootstrapLocations(): Promise<LocationBootstrapResult> {
       return request<LocationBootstrapResult>('/inventory/locations/bootstrap', { method: 'POST' });
+    },
+    listLocations(filters, pagination): Promise<PaginatedInventoryLocations> {
+      return request<PaginatedInventoryLocations>(
+        `/inventory/locations${buildLocationsQuery(filters, pagination)}`,
+      );
+    },
+    getLocation(id): Promise<InventoryLocation> {
+      return request<InventoryLocation>(`/inventory/locations/${id}`);
+    },
+    createLocation(input): Promise<InventoryLocation> {
+      return request<InventoryLocation>('/inventory/locations', {
+        method: 'POST',
+        body: JSON.stringify(input),
+      });
+    },
+    updateLocation(id, patch): Promise<InventoryLocation> {
+      return request<InventoryLocation>(`/inventory/locations/${id}`, {
+        method: 'PATCH',
+        body: JSON.stringify(patch),
+      });
+    },
+    deleteLocation(id): Promise<void> {
+      return request<void>(`/inventory/locations/${id}`, { method: 'DELETE' });
     },
   };
 }

--- a/apps/web/src/features/inventory/api/inventory.api.ts
+++ b/apps/web/src/features/inventory/api/inventory.api.ts
@@ -12,6 +12,7 @@ import type {
   PaginatedInventory,
   InventoryAvailabilityResponse,
 } from './inventory.types';
+import { normalizeCountryIso2 } from './inventory-locations.types';
 import type {
   CreateInventoryLocationInput,
   InventoryLocation,
@@ -94,7 +95,7 @@ function buildLocationsQuery(
   const params = new URLSearchParams();
   if (filters?.kind) params.set('kind', filters.kind);
   if (filters?.status) params.set('status', filters.status);
-  if (filters?.countryIso2) params.set('countryIso2', filters.countryIso2.toUpperCase());
+  if (filters?.countryIso2) params.set('countryIso2', normalizeCountryIso2(filters.countryIso2));
   if (filters?.codePrefix) params.set('codePrefix', filters.codePrefix);
   if (pagination?.page !== undefined) params.set('page', String(pagination.page));
   if (pagination?.limit !== undefined) params.set('limit', String(pagination.limit));

--- a/apps/web/src/features/inventory/api/inventory.query-keys.ts
+++ b/apps/web/src/features/inventory/api/inventory.query-keys.ts
@@ -1,4 +1,5 @@
 import type { InventoryFilters, InventoryPagination } from './inventory.types';
+import type { InventoryLocationFilters, InventoryLocationListPagination } from './inventory-locations.types';
 
 export const inventoryQueryKeys = {
   all: ['inventory'] as const,
@@ -14,4 +15,16 @@ export const inventoryQueryKeys = {
   // but the hook never fires for empty input so it's never used.
   availability: (variantIds: readonly string[]) =>
     ['inventory', 'availability', [...variantIds].sort().join(',')] as const,
+  /**
+   * The shared prefix of every locations-registry key below (`activeLocations`
+   * included, since it shares the `['inventory', 'locations']` root) — the
+   * one key a create/update/delete mutation invalidates against (#3065), the
+   * `sales-document-rules` `all` shape applied to this sub-domain rather than
+   * the whole `inventory` root, which would also drop the unrelated stock
+   * list/detail/availability caches.
+   */
+  locationsAll: () => ['inventory', 'locations'] as const,
+  locations: (filters?: InventoryLocationFilters, pagination?: InventoryLocationListPagination) =>
+    ['inventory', 'locations', 'list', filters ?? {}, pagination ?? {}] as const,
+  locationDetail: (id: string) => ['inventory', 'locations', 'detail', id] as const,
 };

--- a/apps/web/src/features/inventory/components/inventory-locations-tile.tsx
+++ b/apps/web/src/features/inventory/components/inventory-locations-tile.tsx
@@ -1,0 +1,37 @@
+/**
+ * Inventory Locations Tile
+ *
+ * The `SettingsPage` entry point for `/inventory/locations` (#2316 /
+ * #3066) — a link-out card, not an inline configuration form, mirroring
+ * `WhoDecidesTile`'s shape rather than the admin-only settings forms
+ * (Currency, Mailer, MCP tokens, …).
+ *
+ * **Deliberately NOT admin-gated** — `InventoryLocationsController`'s reads
+ * are `@Roles('admin', 'operator', 'viewer')` and the sidebar nav entry is
+ * already gated on `inventory:read`, not on being an admin. Gating this tile
+ * to admin-only would make it LESS reachable than the nav item that already
+ * links to the same page, for no reason tied to what the page actually
+ * requires.
+ *
+ * @module apps/web/src/features/inventory/components
+ */
+import type { ReactElement } from 'react';
+import { Link } from 'react-router-dom';
+import { INVENTORY_LOCATIONS_TILE_COPY } from '../lib/inventory-locations-tile.copy';
+
+export function InventoryLocationsTile(): ReactElement {
+  return (
+    <article className="panel panel--dense">
+      <div className="panel__header">
+        <div>
+          <p className="eyebrow">{INVENTORY_LOCATIONS_TILE_COPY.eyebrow}</p>
+          <h3 className="section-title">{INVENTORY_LOCATIONS_TILE_COPY.title}</h3>
+        </div>
+      </div>
+      <p className="muted-text">{INVENTORY_LOCATIONS_TILE_COPY.description}</p>
+      <Link className="button button--secondary button--sm" to="/inventory/locations">
+        {INVENTORY_LOCATIONS_TILE_COPY.linkLabel}
+      </Link>
+    </article>
+  );
+}

--- a/apps/web/src/features/inventory/components/location-delete-dialog.test.tsx
+++ b/apps/web/src/features/inventory/components/location-delete-dialog.test.tsx
@@ -1,0 +1,154 @@
+import { cleanup, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders, createMockApiClient } from '../../../test/test-utils';
+import { ApiError } from '../../../shared/api/api-error';
+import { LocationDeleteDialog } from './location-delete-dialog';
+import type { InventoryLocation } from '../api/inventory-locations.types';
+
+const target: InventoryLocation = {
+  id: 'ol_location_1',
+  code: 'KRK-OVF',
+  name: 'Kraków — Overflow',
+  kind: 'warehouse',
+  ownerConnectionId: null,
+  externalRef: null,
+  status: 'active',
+  countryIso2: 'PL',
+  postcode: '30-001',
+  latitude: null,
+  longitude: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+describe('LocationDeleteDialog', () => {
+  afterEach(cleanup);
+
+  it('should render nothing (closed) when location is null', () => {
+    renderWithProviders(<LocationDeleteDialog location={null} onClose={() => undefined} />);
+
+    expect(screen.queryByText(/delete/i)).not.toBeInTheDocument();
+  });
+
+  it('should delete and close on success when nothing references the location', async () => {
+    const deleteLocation = vi.fn().mockResolvedValue(undefined);
+    const apiClient = createMockApiClient({ inventory: { deleteLocation } });
+    const onClose = vi.fn();
+    renderWithProviders(<LocationDeleteDialog location={target} onClose={onClose} />, { apiClient });
+
+    await screen.findByText('Delete "Kraków — Overflow"?');
+    await userEvent.click(screen.getByRole('button', { name: /^delete$/i }));
+
+    await waitFor(() => expect(deleteLocation).toHaveBeenCalledWith('ol_location_1'));
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it('should switch to the in-use explanation on a 409 and offer Retire instead', async () => {
+    const deleteLocation = vi
+      .fn()
+      .mockRejectedValue(
+        new ApiError('Inventory location ol_location_1 is referenced by 3 inventory position(s)', 409, {}),
+      );
+    const apiClient = createMockApiClient({ inventory: { deleteLocation } });
+    renderWithProviders(<LocationDeleteDialog location={target} onClose={() => undefined} />, { apiClient });
+
+    await screen.findByText('Delete "Kraków — Overflow"?');
+    await userEvent.click(screen.getByRole('button', { name: /^delete$/i }));
+
+    expect(await screen.findByText('Can\'t delete "Kraków — Overflow"')).toBeInTheDocument();
+    expect(screen.getByText('Stock positions still point here, so the delete was refused.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /retire instead/i })).toBeInTheDocument();
+    // A refused delete never renders the raw domain error as a second, generic alert.
+    expect(
+      screen.queryByText('Inventory location ol_location_1 is referenced by 3 inventory position(s)'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('should retire successfully from the in-use state and close', async () => {
+    const deleteLocation = vi
+      .fn()
+      .mockRejectedValue(new ApiError('Inventory location ol_location_1 is referenced by 3 inventory position(s)', 409, {}));
+    const updateLocation = vi.fn().mockResolvedValue({ ...target, status: 'inactive' });
+    const apiClient = createMockApiClient({ inventory: { deleteLocation, updateLocation } });
+    const onClose = vi.fn();
+    renderWithProviders(<LocationDeleteDialog location={target} onClose={onClose} />, { apiClient });
+
+    await screen.findByText('Delete "Kraków — Overflow"?');
+    await userEvent.click(screen.getByRole('button', { name: /^delete$/i }));
+    await screen.findByRole('button', { name: /retire instead/i });
+
+    await userEvent.click(screen.getByRole('button', { name: /retire instead/i }));
+
+    await waitFor(() =>
+      expect(updateLocation).toHaveBeenCalledWith('ol_location_1', { status: 'inactive' }),
+    );
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  // Tech-review finding: the `genericError` ternary — the component's only
+  // logic for surfacing a real infra/5xx failure — had zero coverage. Every
+  // prior test exercised either success or the mapped 409, never the branch
+  // this dialog falls back to for everything else.
+  it('shows a generic error alert on a non-conflict delete failure, and stays in the confirm phase', async () => {
+    const deleteLocation = vi.fn().mockRejectedValue(new ApiError('Internal server error', 500, {}));
+    const apiClient = createMockApiClient({ inventory: { deleteLocation } });
+    renderWithProviders(<LocationDeleteDialog location={target} onClose={() => undefined} />, { apiClient });
+
+    await screen.findByText('Delete "Kraków — Overflow"?');
+    await userEvent.click(screen.getByRole('button', { name: /^delete$/i }));
+
+    expect(await screen.findByText('Could not save the location')).toBeInTheDocument();
+    expect(screen.getByText('Internal server error')).toBeInTheDocument();
+    // A 5xx is not a mapped conflict, so the dialog must not silently switch
+    // to the retire flow — that would hide the real failure behind an
+    // unrelated affordance.
+    expect(screen.queryByRole('button', { name: /retire instead/i })).not.toBeInTheDocument();
+    expect(screen.getByText('Delete "Kraków — Overflow"?')).toBeInTheDocument();
+  });
+
+  it('shows a generic error alert when the retire (update) call itself fails from the in-use state', async () => {
+    const deleteLocation = vi
+      .fn()
+      .mockRejectedValue(new ApiError('Inventory location ol_location_1 is referenced by 3 inventory position(s)', 409, {}));
+    const updateLocation = vi.fn().mockRejectedValue(new ApiError('Internal server error', 500, {}));
+    const apiClient = createMockApiClient({ inventory: { deleteLocation, updateLocation } });
+    const onClose = vi.fn();
+    renderWithProviders(<LocationDeleteDialog location={target} onClose={onClose} />, { apiClient });
+
+    await screen.findByText('Delete "Kraków — Overflow"?');
+    await userEvent.click(screen.getByRole('button', { name: /^delete$/i }));
+    await screen.findByRole('button', { name: /retire instead/i });
+
+    await userEvent.click(screen.getByRole('button', { name: /retire instead/i }));
+
+    expect(await screen.findByText('Could not save the location')).toBeInTheDocument();
+    expect(screen.getByText('Internal server error')).toBeInTheDocument();
+    // The dialog stays open in the in-use phase so the operator can retry —
+    // a failed retire must not silently close the dialog or drop them back
+    // to the "Delete?" confirm they already got past.
+    expect(screen.getByRole('button', { name: /retire instead/i })).toBeInTheDocument();
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('should reset to the confirm phase when reopened for a different location', async () => {
+    const deleteLocation = vi
+      .fn()
+      .mockRejectedValue(new ApiError('Inventory location ol_location_1 is referenced by 3 inventory position(s)', 409, {}));
+    const apiClient = createMockApiClient({ inventory: { deleteLocation } });
+    const { rerender } = renderWithProviders(
+      <LocationDeleteDialog location={target} onClose={() => undefined} />,
+      { apiClient },
+    );
+
+    await screen.findByText('Delete "Kraków — Overflow"?');
+    await userEvent.click(screen.getByRole('button', { name: /^delete$/i }));
+    await screen.findByRole('button', { name: /retire instead/i });
+
+    const other: InventoryLocation = { ...target, id: 'ol_location_2', name: 'Gdańsk — Flagship store' };
+    rerender(<LocationDeleteDialog location={other} onClose={() => undefined} />);
+
+    expect(await screen.findByText('Delete "Gdańsk — Flagship store"?')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /retire instead/i })).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/features/inventory/components/location-delete-dialog.tsx
+++ b/apps/web/src/features/inventory/components/location-delete-dialog.tsx
@@ -1,0 +1,145 @@
+/**
+ * Location Delete Dialog (#2316 / #3068)
+ *
+ * `DELETE /inventory/locations/:id` is refused with a 409
+ * (`LocationInUseError`) while any `inventory_items` row still references the
+ * location — there is no cheap way to know this ahead of the attempt (the
+ * list read carries no such signal today), so this dialog always starts in
+ * `confirm` and only learns `in-use` from the failed delete itself, exactly
+ * the reviewed mockup's interaction:
+ * https://claude.ai/code/artifact/fbb5f9e1-52a3-4b7b-8136-ad59dcf4f318
+ *
+ * On `in-use` the SAME dialog swaps its body and its confirm action to
+ * "Retire instead" (`PATCH { status: 'inactive' }`) rather than closing and
+ * reopening a second dialog — the operator's next step is right there rather
+ * than requiring them to find a new control.
+ *
+ * @module apps/web/src/features/inventory/components
+ */
+import { useEffect, useState, type ReactElement } from 'react';
+import { Alert } from '../../../shared/ui/alert';
+import { ConfirmDialog } from '../../../shared/ui/confirm-dialog';
+import { useToast } from '../../../shared/ui/toast-provider';
+import { ApiError, isUnmappedApiError } from '../../../shared/api/api-error';
+import { useDeleteInventoryLocationMutation } from '../hooks/use-delete-inventory-location-mutation';
+import { useUpdateInventoryLocationMutation } from '../hooks/use-update-inventory-location-mutation';
+import type { InventoryLocation } from '../api/inventory-locations.types';
+
+interface LocationDeleteDialogProps {
+  location: InventoryLocation | null;
+  onClose: () => void;
+}
+
+export function LocationDeleteDialog({ location, onClose }: LocationDeleteDialogProps): ReactElement {
+  const { showToast } = useToast();
+  const [phase, setPhase] = useState<'confirm' | 'in-use'>('confirm');
+  const deleteMutation = useDeleteInventoryLocationMutation();
+  const retireMutation = useUpdateInventoryLocationMutation();
+
+  const { reset: resetDelete } = deleteMutation;
+  const { reset: resetRetire } = retireMutation;
+  const locationId = location?.id ?? null;
+  useEffect(() => {
+    if (locationId === null) return;
+    setPhase('confirm');
+    resetDelete();
+    resetRetire();
+    // Keyed on the id, not the `location` object's identity: unlike
+    // `LocationDialog`'s `target` (a fresh wrapper minted at open-time),
+    // `location` here is the row itself. A future caller that derives it
+    // reactively off refetched query data (`locations.find(...)`) would
+    // otherwise hand this effect a new-but-equal object on every refetch and
+    // silently reset an in-flight `in-use`/retire decision back to plain
+    // "Delete?" mid-flow. #3068 tech-review.
+  }, [locationId, resetDelete, resetRetire]);
+
+  async function handleDelete(): Promise<void> {
+    if (location === null) return;
+    try {
+      await deleteMutation.mutateAsync(location.id);
+      showToast({
+        tone: 'success',
+        title: `"${location.name}" deleted`,
+        description: 'No inventory position named it, so the row is gone rather than retired.',
+      });
+      onClose();
+    } catch (error) {
+      if (error instanceof ApiError && error.isConflict()) {
+        setPhase('in-use');
+        return;
+      }
+      // Surfaced via deleteMutation.error → the dialog body below.
+    }
+  }
+
+  async function handleRetire(): Promise<void> {
+    if (location === null) return;
+    try {
+      await retireMutation.mutateAsync({ id: location.id, patch: { status: 'inactive' } });
+      showToast({
+        tone: 'success',
+        title: `"${location.name}" retired`,
+        // Not "can be re-activated later" — nothing in the product exposes
+        // that yet (#3068 tech-review: `toUpdateInput` never sends `status`
+        // back to `'active'`, and the list renders no Reactivate action), so
+        // stating only what actually happened rather than a capability the
+        // UI doesn't offer.
+        description: 'Existing positions keep pointing at it.',
+      });
+      onClose();
+    } catch {
+      // Surfaced via retireMutation.error → the dialog body below.
+    }
+  }
+
+  const open = location !== null;
+  const isInUse = phase === 'in-use';
+  const genericError =
+    deleteMutation.error && isUnmappedApiError(deleteMutation.error, (e) => e.isConflict())
+      ? deleteMutation.error
+      : (retireMutation.error ?? null);
+
+  return (
+    <ConfirmDialog
+      open={open}
+      onOpenChange={(nextOpen) => { if (!nextOpen) onClose(); }}
+      title={isInUse ? `Can't delete "${location?.name ?? ''}"` : `Delete "${location?.name ?? ''}"?`}
+      description={
+        isInUse
+          ? 'Stock positions still point here, so the delete was refused.'
+          : "This can't be undone. If stock still points here, the delete will be refused instead."
+      }
+      body={
+        <>
+          {/* Distinct from `description` above on purpose — the description
+              says WHY delete was refused, this says what retiring actually
+              does, so the two don't restate the same fact (#3068
+              tech-review). No "can be re-activated later" — see the
+              matching note on the retire success toast. */}
+          {isInUse ? (
+            <Alert tone="warning" title="Retire instead">
+              Retiring keeps the row and its history intact — nothing is deleted.
+            </Alert>
+          ) : null}
+          {genericError ? (
+            <Alert tone="error" title="Could not save the location">
+              {genericError.message}
+            </Alert>
+          ) : null}
+        </>
+      }
+      // Retire is a corrective, non-destructive action — styling it danger-red
+      // like the delete it replaces would be the wrong severity signal.
+      tone={isInUse ? 'default' : 'danger'}
+      confirmLabel={isInUse ? 'Retire instead' : 'Delete'}
+      isConfirming={deleteMutation.isPending || retireMutation.isPending}
+      onConfirm={() => {
+        if (isInUse) {
+          void handleRetire();
+        } else {
+          void handleDelete();
+        }
+      }}
+    />
+  );
+}

--- a/apps/web/src/features/inventory/components/location-dialog.schema.ts
+++ b/apps/web/src/features/inventory/components/location-dialog.schema.ts
@@ -1,0 +1,114 @@
+/**
+ * Location dialog Zod schema (#2316 / #3067)
+ *
+ * Covers every `CreateLocationDto` field. Native form controls always bind
+ * strings, so the optional/nullable backend fields (`ownerConnectionId`,
+ * `externalRef`, `countryIso2`, `postcode`, `latitude`, `longitude`) are
+ * modelled as `''` meaning "not set" and mapped to `null` in `toCreateInput` /
+ * `toUpdateInput` — the `generate-label-form.schema.ts` precedent for an
+ * optional-amount field.
+ *
+ * `code` is validated here (create) but the dialog omits the field entirely
+ * on edit per the PATCH contract (`UpdateLocationDto` has no `code` — see its
+ * own docblock: renaming the natural key is not a patch-shaped operation).
+ *
+ * @module apps/web/src/features/inventory/components
+ */
+import { z } from 'zod';
+import type {
+  CreateInventoryLocationInput,
+  InventoryLocationKind,
+  UpdateInventoryLocationInput,
+} from '../api/inventory-locations.types';
+import { InventoryLocationKindValues, normalizeCountryIso2 } from '../api/inventory-locations.types';
+
+const latLngField = z.union([
+  z.literal(''),
+  z.coerce
+    .number()
+    // A non-numeric input coerces to `NaN`, which the plain min/max chain
+    // would then fail with a misleading "must be between -90 and 90" — this
+    // named check runs first so a non-number gets a message about being a
+    // number (tech-review finding).
+    .refine(Number.isFinite, 'Must be a number')
+    .refine((value) => value >= -90 && value <= 90, 'Must be between -90 and 90'),
+]);
+
+const lngField = z.union([
+  z.literal(''),
+  z.coerce
+    .number()
+    .refine(Number.isFinite, 'Must be a number')
+    .refine((value) => value >= -180 && value <= 180, 'Must be between -180 and 180'),
+]);
+
+export const locationDialogSchema = z.object({
+  code: z.string().trim().min(1, 'Code is required').max(64, 'Code must be 64 characters or fewer'),
+  name: z.string().trim().min(1, 'Name is required').max(255, 'Name must be 255 characters or fewer'),
+  kind: z.enum(InventoryLocationKindValues),
+  // '' = none. A real select value is a connection id, never validated as a
+  // UUID here — the backend's own @IsUUID / LocationOwnerConnectionNotFoundError
+  // (422) is the source of truth for whether it names a real connection.
+  ownerConnectionId: z.string(),
+  externalRef: z.string().trim().max(255, 'Must be 255 characters or fewer'),
+  countryIso2: z.union([
+    z.literal(''),
+    z.string().trim().length(2, 'Use a 2-letter country code (ISO-3166-1 alpha-2)'),
+  ]),
+  postcode: z.string().trim().max(16, 'Must be 16 characters or fewer'),
+  latitude: latLngField,
+  longitude: lngField,
+});
+
+// Two derived types (the `generate-label-form.schema.ts` shape): `Values` is
+// what RHF binds to, `Submission` is the resolved post-coercion shape the
+// submit handler sees (z.coerce turns the union's number branch into `number`).
+export type LocationDialogFormValues = z.input<typeof locationDialogSchema>;
+export type LocationDialogFormSubmission = z.output<typeof locationDialogSchema>;
+
+export const LOCATION_DIALOG_DEFAULT_VALUES: LocationDialogFormValues = {
+  code: '',
+  name: '',
+  kind: 'warehouse',
+  ownerConnectionId: '',
+  externalRef: '',
+  countryIso2: '',
+  postcode: '',
+  latitude: '',
+  longitude: '',
+};
+
+export const KIND_LABEL: Record<InventoryLocationKind, string> = {
+  warehouse: 'Warehouse',
+  store: 'Store',
+  'third-party': 'Third-party',
+  virtual: 'Virtual',
+};
+
+export function toCreateInput(values: LocationDialogFormSubmission): CreateInventoryLocationInput {
+  return {
+    code: values.code.toUpperCase(),
+    name: values.name,
+    kind: values.kind,
+    ownerConnectionId: values.ownerConnectionId === '' ? null : values.ownerConnectionId,
+    externalRef: values.externalRef === '' ? null : values.externalRef,
+    countryIso2: values.countryIso2 === '' ? null : normalizeCountryIso2(values.countryIso2),
+    postcode: values.postcode === '' ? null : values.postcode,
+    latitude: values.latitude === '' ? null : values.latitude,
+    longitude: values.longitude === '' ? null : values.longitude,
+  };
+}
+
+/** Same mapping, minus `code` — `UpdateLocationDto` does not accept it. */
+export function toUpdateInput(values: LocationDialogFormSubmission): UpdateInventoryLocationInput {
+  return {
+    name: values.name,
+    kind: values.kind,
+    ownerConnectionId: values.ownerConnectionId === '' ? null : values.ownerConnectionId,
+    externalRef: values.externalRef === '' ? null : values.externalRef,
+    countryIso2: values.countryIso2 === '' ? null : normalizeCountryIso2(values.countryIso2),
+    postcode: values.postcode === '' ? null : values.postcode,
+    latitude: values.latitude === '' ? null : values.latitude,
+    longitude: values.longitude === '' ? null : values.longitude,
+  };
+}

--- a/apps/web/src/features/inventory/components/location-dialog.schema.ts
+++ b/apps/web/src/features/inventory/components/location-dialog.schema.ts
@@ -18,9 +18,14 @@ import { z } from 'zod';
 import type {
   CreateInventoryLocationInput,
   InventoryLocationKind,
+  InventoryLocationStatus,
   UpdateInventoryLocationInput,
 } from '../api/inventory-locations.types';
-import { InventoryLocationKindValues, normalizeCountryIso2 } from '../api/inventory-locations.types';
+import {
+  InventoryLocationKindValues,
+  InventoryLocationStatusValues,
+  normalizeCountryIso2,
+} from '../api/inventory-locations.types';
 
 const latLngField = z.union([
   z.literal(''),
@@ -46,6 +51,11 @@ export const locationDialogSchema = z.object({
   code: z.string().trim().min(1, 'Code is required').max(64, 'Code must be 64 characters or fewer'),
   name: z.string().trim().min(1, 'Name is required').max(255, 'Name must be 255 characters or fewer'),
   kind: z.enum(InventoryLocationKindValues),
+  // Present in form state on both create and edit, but only ever RENDERED on
+  // edit (mockup: `locStatusRow` ships `hidden` and is revealed only by
+  // `openEdit`) — a freshly created location is always active, so the field
+  // stays at its default and `toCreateInput` never sends it.
+  status: z.enum(InventoryLocationStatusValues),
   // '' = none. A real select value is a connection id, never validated as a
   // UUID here — the backend's own @IsUUID / LocationOwnerConnectionNotFoundError
   // (422) is the source of truth for whether it names a real connection.
@@ -70,6 +80,7 @@ export const LOCATION_DIALOG_DEFAULT_VALUES: LocationDialogFormValues = {
   code: '',
   name: '',
   kind: 'warehouse',
+  status: 'active',
   ownerConnectionId: '',
   externalRef: '',
   countryIso2: '',
@@ -85,6 +96,15 @@ export const KIND_LABEL: Record<InventoryLocationKind, string> = {
   virtual: 'Virtual',
 };
 
+/** Mockup's `locStatus` `<select>` option labels — Edit-only field. */
+export const STATUS_OPTION_LABEL: Record<InventoryLocationStatus, string> = {
+  active: 'Active',
+  inactive: 'Retired',
+};
+
+// `status` is deliberately OMITTED — the field is invisible on create (the
+// mockup ships `locStatusRow` `hidden` there), so a freshly created location
+// is always the backend's own default, never a value this form asserted.
 export function toCreateInput(values: LocationDialogFormSubmission): CreateInventoryLocationInput {
   return {
     code: values.code.toUpperCase(),
@@ -104,6 +124,7 @@ export function toUpdateInput(values: LocationDialogFormSubmission): UpdateInven
   return {
     name: values.name,
     kind: values.kind,
+    status: values.status,
     ownerConnectionId: values.ownerConnectionId === '' ? null : values.ownerConnectionId,
     externalRef: values.externalRef === '' ? null : values.externalRef,
     countryIso2: values.countryIso2 === '' ? null : normalizeCountryIso2(values.countryIso2),

--- a/apps/web/src/features/inventory/components/location-dialog.test.tsx
+++ b/apps/web/src/features/inventory/components/location-dialog.test.tsx
@@ -1,0 +1,170 @@
+import { cleanup, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders, createMockApiClient, sampleConnection } from '../../../test/test-utils';
+import { ApiError } from '../../../shared/api/api-error';
+import { LocationDialog } from './location-dialog';
+import type { InventoryLocation } from '../api/inventory-locations.types';
+
+const editTarget: InventoryLocation = {
+  id: 'ol_location_1',
+  code: 'WH1',
+  name: 'Main warehouse',
+  kind: 'warehouse',
+  ownerConnectionId: null,
+  externalRef: null,
+  status: 'active',
+  countryIso2: null,
+  postcode: null,
+  latitude: null,
+  longitude: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+describe('LocationDialog', () => {
+  afterEach(cleanup);
+
+  it('should render the create form with a Code field and empty defaults', async () => {
+    renderWithProviders(<LocationDialog target={{ mode: 'create' }} onClose={() => undefined} />);
+
+    expect(await screen.findByText('Add location')).toBeInTheDocument();
+    expect(screen.getByLabelText('Code')).toHaveValue('');
+    expect(screen.getByLabelText('Name')).toHaveValue('');
+  });
+
+  it('should render the edit form pre-filled and without a Code field', async () => {
+    renderWithProviders(
+      <LocationDialog target={{ mode: 'edit', location: editTarget }} onClose={() => undefined} />,
+    );
+
+    expect(await screen.findByText('Edit "Main warehouse"')).toBeInTheDocument();
+    expect(screen.getByLabelText('Name')).toHaveValue('Main warehouse');
+    // UpdateLocationDto has no `code` — the edit form must not offer it.
+    expect(screen.queryByLabelText('Code')).not.toBeInTheDocument();
+  });
+
+  it('should show validation errors after an empty create submit', async () => {
+    renderWithProviders(<LocationDialog target={{ mode: 'create' }} onClose={() => undefined} />);
+    await screen.findByText('Add location');
+
+    await userEvent.click(screen.getByRole('button', { name: /save location/i }));
+
+    expect((await screen.findAllByText('Code is required')).length).toBeGreaterThan(0);
+    expect((await screen.findAllByText('Name is required')).length).toBeGreaterThan(0);
+  });
+
+  it('should create with the mapped input and close on success', async () => {
+    const createLocation = vi.fn().mockResolvedValue(editTarget);
+    const apiClient = createMockApiClient({
+      inventory: { createLocation },
+      connections: { list: vi.fn().mockResolvedValue([]) },
+    });
+    const onClose = vi.fn();
+    renderWithProviders(<LocationDialog target={{ mode: 'create' }} onClose={onClose} />, { apiClient });
+    await screen.findByText('Add location');
+
+    await userEvent.type(screen.getByLabelText('Code'), 'wh1');
+    await userEvent.type(screen.getByLabelText('Name'), 'Overflow');
+    await userEvent.click(screen.getByRole('button', { name: /save location/i }));
+
+    await waitFor(() =>
+      expect(createLocation).toHaveBeenCalledWith(
+        expect.objectContaining({ code: 'WH1', name: 'Overflow', kind: 'warehouse', ownerConnectionId: null }),
+      ),
+    );
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it('should map a 409 duplicate-code response to a field error and keep the dialog open', async () => {
+    const createLocation = vi
+      .fn()
+      .mockRejectedValue(new ApiError('Inventory location code already exists: WH1', 409, {}));
+    const apiClient = createMockApiClient({
+      inventory: { createLocation },
+      connections: { list: vi.fn().mockResolvedValue([]) },
+    });
+    const onClose = vi.fn();
+    renderWithProviders(<LocationDialog target={{ mode: 'create' }} onClose={onClose} />, { apiClient });
+    await screen.findByText('Add location');
+
+    await userEvent.type(screen.getByLabelText('Code'), 'WH1');
+    await userEvent.type(screen.getByLabelText('Name'), 'Overflow');
+    await userEvent.click(screen.getByRole('button', { name: /save location/i }));
+
+    expect(
+      (await screen.findAllByText('Inventory location code already exists: WH1')).length,
+    ).toBeGreaterThan(0);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('should update with the mapped patch, omitting code', async () => {
+    const updateLocation = vi.fn().mockResolvedValue(editTarget);
+    const apiClient = createMockApiClient({
+      inventory: { updateLocation },
+      connections: { list: vi.fn().mockResolvedValue([]) },
+    });
+    const onClose = vi.fn();
+    renderWithProviders(
+      <LocationDialog target={{ mode: 'edit', location: editTarget }} onClose={onClose} />,
+      { apiClient },
+    );
+    await screen.findByText('Edit "Main warehouse"');
+
+    await userEvent.clear(screen.getByLabelText('Name'));
+    await userEvent.type(screen.getByLabelText('Name'), 'Renamed warehouse');
+    await userEvent.click(screen.getByRole('button', { name: /save location/i }));
+
+    await waitFor(() =>
+      expect(updateLocation).toHaveBeenCalledWith(
+        'ol_location_1',
+        expect.objectContaining({ name: 'Renamed warehouse', kind: 'warehouse' }),
+      ),
+    );
+    const [, patch] = updateLocation.mock.calls[0] as [string, Record<string, unknown>];
+    expect('code' in patch).toBe(false);
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  // Tech-review finding: a disabled/needs_reauth connection "can't currently
+  // sync", so offering it as an owner under a field described as "whose
+  // sync may write stock here" is misleading.
+  it('excludes non-active connections from the owning-connection select', async () => {
+    const inactive = { ...sampleConnection, id: 'conn_inactive', name: 'Disabled store', status: 'disabled' as const };
+    const apiClient = createMockApiClient({
+      connections: { list: vi.fn().mockResolvedValue([sampleConnection, inactive]) },
+    });
+    renderWithProviders(<LocationDialog target={{ mode: 'create' }} onClose={() => undefined} />, { apiClient });
+    await screen.findByText('Add location');
+
+    const select = await screen.findByLabelText('Owning connection (optional)');
+    await waitFor(() => expect(select).toHaveTextContent(sampleConnection.name));
+    expect(select).not.toHaveTextContent('Disabled store');
+  });
+
+  // The row's CURRENT owner must survive even if it has since gone
+  // inactive - otherwise the select has no matching <option> for the
+  // loaded value and silently blanks it on open.
+  it('keeps the edited location\'s current owner in the select even when that connection is inactive', async () => {
+    const inactiveOwner = {
+      ...sampleConnection,
+      id: 'conn_inactive_owner',
+      name: 'Now-disabled owner',
+      status: 'disabled' as const,
+    };
+    const apiClient = createMockApiClient({
+      connections: { list: vi.fn().mockResolvedValue([inactiveOwner]) },
+    });
+    renderWithProviders(
+      <LocationDialog
+        target={{ mode: 'edit', location: { ...editTarget, ownerConnectionId: 'conn_inactive_owner' } }}
+        onClose={() => undefined}
+      />,
+      { apiClient },
+    );
+    await screen.findByText('Edit "Main warehouse"');
+
+    const select = await screen.findByLabelText('Owning connection (optional)');
+    await waitFor(() => expect(select).toHaveTextContent('Now-disabled owner'));
+  });
+});

--- a/apps/web/src/features/inventory/components/location-dialog.test.tsx
+++ b/apps/web/src/features/inventory/components/location-dialog.test.tsx
@@ -31,9 +31,13 @@ describe('LocationDialog', () => {
     expect(await screen.findByText('Add location')).toBeInTheDocument();
     expect(screen.getByLabelText('Code')).toHaveValue('');
     expect(screen.getByLabelText('Name')).toHaveValue('');
+    // Mockup: `locStatusRow` ships `hidden` and is only revealed by `openEdit`
+    // — a freshly created location is always active, so create offers no
+    // Status field to set.
+    expect(screen.queryByLabelText('Status')).not.toBeInTheDocument();
   });
 
-  it('should render the edit form pre-filled and without a Code field', async () => {
+  it('should render the edit form pre-filled and without a Code field, and show Status', async () => {
     renderWithProviders(
       <LocationDialog target={{ mode: 'edit', location: editTarget }} onClose={() => undefined} />,
     );
@@ -42,6 +46,19 @@ describe('LocationDialog', () => {
     expect(screen.getByLabelText('Name')).toHaveValue('Main warehouse');
     // UpdateLocationDto has no `code` — the edit form must not offer it.
     expect(screen.queryByLabelText('Code')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Status')).toHaveValue('active');
+  });
+
+  it('should pre-fill Status as Retired for a retired location', async () => {
+    renderWithProviders(
+      <LocationDialog
+        target={{ mode: 'edit', location: { ...editTarget, status: 'inactive' } }}
+        onClose={() => undefined}
+      />,
+    );
+
+    await screen.findByText('Edit "Main warehouse"');
+    expect(screen.getByLabelText('Status')).toHaveValue('inactive');
   });
 
   it('should show validation errors after an empty create submit', async () => {
@@ -124,6 +141,29 @@ describe('LocationDialog', () => {
     const [, patch] = updateLocation.mock.calls[0] as [string, Record<string, unknown>];
     expect('code' in patch).toBe(false);
     await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it('should send a changed Status in the update patch', async () => {
+    const updateLocation = vi.fn().mockResolvedValue({ ...editTarget, status: 'inactive' });
+    const apiClient = createMockApiClient({
+      inventory: { updateLocation },
+      connections: { list: vi.fn().mockResolvedValue([]) },
+    });
+    renderWithProviders(
+      <LocationDialog target={{ mode: 'edit', location: editTarget }} onClose={() => undefined} />,
+      { apiClient },
+    );
+    await screen.findByText('Edit "Main warehouse"');
+
+    await userEvent.selectOptions(screen.getByLabelText('Status'), 'inactive');
+    await userEvent.click(screen.getByRole('button', { name: /save location/i }));
+
+    await waitFor(() =>
+      expect(updateLocation).toHaveBeenCalledWith(
+        'ol_location_1',
+        expect.objectContaining({ status: 'inactive' }),
+      ),
+    );
   });
 
   // Tech-review finding: a disabled/needs_reauth connection "can't currently

--- a/apps/web/src/features/inventory/components/location-dialog.tsx
+++ b/apps/web/src/features/inventory/components/location-dialog.tsx
@@ -1,0 +1,277 @@
+/**
+ * Location Dialog — create/edit form for `inventory_locations` (#2316 / #3067)
+ *
+ * `target` follows the `AiProviderKeyDialog` shape: `null` closes the
+ * dialog; a value opens it, pinned to either a fresh create or one existing
+ * row. Switching `target` (e.g. clicking Edit on a different row while this
+ * dialog is already open) resets the form and any prior mutation error, so
+ * an operator editing several rows back-to-back never sees a stale value.
+ *
+ * `code` is rendered only on CREATE — `UpdateLocationDto` has no `code` field
+ * (it's the row's natural key), so the edit form must not offer to change it
+ * rather than silently dropping an edited value on submit.
+ *
+ * @module apps/web/src/features/inventory/components
+ */
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useEffect, useMemo, type ReactElement } from 'react';
+import { useForm } from 'react-hook-form';
+import { Alert } from '../../../shared/ui/alert';
+import { Button } from '../../../shared/ui/button';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogTitle,
+} from '../../../shared/ui/dialog';
+import { FormErrorSummary } from '../../../shared/ui/form-error-summary';
+import { FormField } from '../../../shared/ui/form-field';
+import { Input } from '../../../shared/ui/input';
+import { Select } from '../../../shared/ui/select';
+import { useToast } from '../../../shared/ui/toast-provider';
+import { usePlatforms } from '../../../shared/plugins';
+import { ApiError, isUnmappedApiError } from '../../../shared/api/api-error';
+import { resolvePlatformLabel } from '../../mappings';
+import { useConnectionsQuery } from '../../connections';
+import { useCreateInventoryLocationMutation } from '../hooks/use-create-inventory-location-mutation';
+import { useUpdateInventoryLocationMutation } from '../hooks/use-update-inventory-location-mutation';
+import type { InventoryLocation } from '../api/inventory-locations.types';
+import { InventoryLocationKindValues } from '../api/inventory-locations.types';
+import {
+  KIND_LABEL,
+  LOCATION_DIALOG_DEFAULT_VALUES,
+  locationDialogSchema,
+  toCreateInput,
+  toUpdateInput,
+  type LocationDialogFormSubmission,
+  type LocationDialogFormValues,
+} from './location-dialog.schema';
+
+export type LocationDialogTarget = { mode: 'create' } | { mode: 'edit'; location: InventoryLocation };
+
+interface LocationDialogProps {
+  target: LocationDialogTarget | null;
+  onClose: () => void;
+}
+
+function toFormValues(location: InventoryLocation): LocationDialogFormValues {
+  return {
+    code: location.code,
+    name: location.name,
+    kind: location.kind,
+    ownerConnectionId: location.ownerConnectionId ?? '',
+    externalRef: location.externalRef ?? '',
+    countryIso2: location.countryIso2 ?? '',
+    postcode: location.postcode ?? '',
+    latitude: location.latitude ?? '',
+    longitude: location.longitude ?? '',
+  };
+}
+
+export function LocationDialog({ target, onClose }: LocationDialogProps): ReactElement {
+  const { showToast } = useToast();
+  const platforms = usePlatforms();
+  const connectionsQuery = useConnectionsQuery();
+  const createMutation = useCreateInventoryLocationMutation();
+  const updateMutation = useUpdateInventoryLocationMutation();
+
+  const isEdit = target?.mode === 'edit';
+  const mutation = isEdit ? updateMutation : createMutation;
+
+  const form = useForm<LocationDialogFormValues, undefined, LocationDialogFormSubmission>({
+    defaultValues: LOCATION_DIALOG_DEFAULT_VALUES,
+    resolver: zodResolver(locationDialogSchema),
+  });
+
+  const { reset: resetForm } = form;
+  const { reset: resetCreate } = createMutation;
+  const { reset: resetUpdate } = updateMutation;
+  useEffect(() => {
+    if (target === null) return;
+    resetForm(target.mode === 'edit' ? toFormValues(target.location) : LOCATION_DIALOG_DEFAULT_VALUES);
+    resetCreate();
+    resetUpdate();
+    // `target` is a fresh object identity on every open (including a
+    // create-then-immediately-create-again click), so it — not its nested
+    // fields — is the right dependency for "the dialog just opened".
+  }, [target, resetForm, resetCreate, resetUpdate]);
+
+  // Active connections only — "whose sync may write stock here" (the
+  // field's own description) is misleading for a connection that currently
+  // can't sync (tech-review finding). The row's CURRENT owner, if any, is
+  // kept even when inactive so editing doesn't silently blank a value the
+  // select would otherwise have no matching <option> for.
+  const currentOwnerId = target?.mode === 'edit' ? target.location.ownerConnectionId : null;
+  const connectionOptions = useMemo(
+    () =>
+      (connectionsQuery.data ?? [])
+        .filter((connection) => connection.status === 'active' || connection.id === currentOwnerId)
+        .map((connection) => ({
+          id: connection.id,
+          label: `${resolvePlatformLabel(platforms, connection.platformType)} — ${connection.name}`,
+        })),
+    [connectionsQuery.data, platforms, currentOwnerId],
+  );
+
+  const onSubmit = form.handleSubmit(async (values) => {
+    try {
+      if (target?.mode === 'edit') {
+        await updateMutation.mutateAsync({ id: target.location.id, patch: toUpdateInput(values) });
+        showToast({ tone: 'success', title: 'Location updated', description: `"${values.name}" was saved.` });
+      } else {
+        await createMutation.mutateAsync(toCreateInput(values));
+        showToast({ tone: 'success', title: 'Location created', description: `"${values.name}" was added.` });
+      }
+      onClose();
+    } catch (error) {
+      if (error instanceof ApiError && error.isConflict()) {
+        // DuplicateLocationCodeError → 409. Only reachable on create — the
+        // edit form never sends `code`.
+        form.setError('code', { message: error.message });
+        return;
+      }
+      if (error instanceof ApiError && error.status === 422) {
+        // LocationOwnerConnectionNotFoundError → 422, in practice unreachable
+        // through the select (it's populated from real connections) but
+        // handled for a stale cache / direct-edit race.
+        form.setError('ownerConnectionId', { message: error.message });
+        return;
+      }
+      // Surfaced via mutation.error → <Alert> below.
+    }
+  });
+
+  const validationMessages = Object.values(form.formState.errors)
+    .map((entry) => entry?.message)
+    .filter((message): message is string => typeof message === 'string');
+  const showValidationSummary = form.formState.submitCount > 0 && validationMessages.length > 0;
+
+  const open = target !== null;
+  const title = isEdit ? `Edit "${target.location.name}"` : 'Add location';
+
+  return (
+    <Dialog open={open} onOpenChange={(nextOpen) => { if (!nextOpen) onClose(); }}>
+      <DialogContent>
+        <DialogTitle>{title}</DialogTitle>
+        <DialogDescription>
+          The warehouses, stores and third-party sites OpenLinker can source stock from.
+        </DialogDescription>
+
+        {mutation.error && isUnmappedApiError(mutation.error, (e) => e.isConflict() || e.status === 422) ? (
+          <Alert tone="error" title="Could not save the location">
+            {mutation.error.message}
+          </Alert>
+        ) : null}
+
+        <form onSubmit={(event) => { void onSubmit(event); }} noValidate>
+          {showValidationSummary ? <FormErrorSummary errors={validationMessages} /> : null}
+
+          <div className="form-field-row">
+            {isEdit ? null : (
+              <FormField
+                label="Code"
+                name="code"
+                error={form.formState.errors.code?.message}
+                description="Unique across the install. Normalised to uppercase on save."
+              >
+                <Input placeholder="WH1" maxLength={64} {...form.register('code')} />
+              </FormField>
+            )}
+            <FormField label="Name" name="name" error={form.formState.errors.name?.message}>
+              <Input placeholder="Main warehouse" maxLength={255} {...form.register('name')} />
+            </FormField>
+          </div>
+
+          <div className="form-field-row">
+            <FormField label="Kind" name="kind" error={form.formState.errors.kind?.message}>
+              <Select {...form.register('kind')}>
+                {InventoryLocationKindValues.map((kind) => (
+                  <option key={kind} value={kind}>
+                    {KIND_LABEL[kind]}
+                  </option>
+                ))}
+              </Select>
+            </FormField>
+            <FormField
+              label="Owning connection (optional)"
+              name="ownerConnectionId"
+              error={form.formState.errors.ownerConnectionId?.message}
+              description={
+                connectionsQuery.isError
+                  ? "Couldn't load connections — try again, or leave unset."
+                  : connectionsQuery.isLoading
+                    ? 'Loading connections…'
+                    : 'Whose sync may write stock here. Not authority over the location.'
+              }
+            >
+              <Select {...form.register('ownerConnectionId')}>
+                <option value="">— none —</option>
+                {connectionOptions.map((option) => (
+                  <option key={option.id} value={option.id}>
+                    {option.label}
+                  </option>
+                ))}
+              </Select>
+            </FormField>
+          </div>
+
+          <div className="form-field-row">
+            <FormField
+              label="Country (optional)"
+              name="countryIso2"
+              error={form.formState.errors.countryIso2?.message}
+            >
+              <Input placeholder="PL" maxLength={2} style={{ textTransform: 'uppercase' }} {...form.register('countryIso2')} />
+            </FormField>
+            <FormField
+              label="Postcode (optional)"
+              name="postcode"
+              error={form.formState.errors.postcode?.message}
+            >
+              <Input placeholder="00-001" maxLength={16} {...form.register('postcode')} />
+            </FormField>
+          </div>
+
+          <div className="form-field-row">
+            <FormField
+              label="Latitude (optional)"
+              name="latitude"
+              error={form.formState.errors.latitude?.message}
+            >
+              <Input type="number" step="0.0001" min={-90} max={90} {...form.register('latitude')} />
+            </FormField>
+            <FormField
+              label="Longitude (optional)"
+              name="longitude"
+              error={form.formState.errors.longitude?.message}
+            >
+              <Input type="number" step="0.0001" min={-180} max={180} {...form.register('longitude')} />
+            </FormField>
+          </div>
+
+          <FormField
+            label="Operator reference (optional)"
+            name="externalRef"
+            error={form.formState.errors.externalRef?.message}
+            description="Not an identifier mapping — nothing external reads this."
+          >
+            <Input placeholder="Free text — e.g. an internal warehouse code" maxLength={255} {...form.register('externalRef')} />
+          </FormField>
+
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button type="button" tone="ghost">
+                Cancel
+              </Button>
+            </DialogClose>
+            <Button type="submit" disabled={mutation.isPending}>
+              {mutation.isPending ? 'Saving…' : 'Save location'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/features/inventory/components/location-dialog.tsx
+++ b/apps/web/src/features/inventory/components/location-dialog.tsx
@@ -38,11 +38,12 @@ import { useConnectionsQuery } from '../../connections';
 import { useCreateInventoryLocationMutation } from '../hooks/use-create-inventory-location-mutation';
 import { useUpdateInventoryLocationMutation } from '../hooks/use-update-inventory-location-mutation';
 import type { InventoryLocation } from '../api/inventory-locations.types';
-import { InventoryLocationKindValues } from '../api/inventory-locations.types';
+import { InventoryLocationKindValues, InventoryLocationStatusValues } from '../api/inventory-locations.types';
 import {
   KIND_LABEL,
   LOCATION_DIALOG_DEFAULT_VALUES,
   locationDialogSchema,
+  STATUS_OPTION_LABEL,
   toCreateInput,
   toUpdateInput,
   type LocationDialogFormSubmission,
@@ -61,6 +62,7 @@ function toFormValues(location: InventoryLocation): LocationDialogFormValues {
     code: location.code,
     name: location.name,
     kind: location.kind,
+    status: location.status,
     ownerConnectionId: location.ownerConnectionId ?? '',
     externalRef: location.externalRef ?? '',
     countryIso2: location.countryIso2 ?? '',
@@ -216,6 +218,26 @@ export function LocationDialog({ target, onClose }: LocationDialogProps): ReactE
               </Select>
             </FormField>
           </div>
+
+          {isEdit ? (
+            <div className="form-field-row">
+              <FormField
+                label="Status"
+                name="status"
+                error={form.formState.errors.status?.message}
+                description="Retiring stops new stock from targeting it; existing history keeps pointing at the row. Flip back to Active to re-activate."
+              >
+                <Select {...form.register('status')}>
+                  {InventoryLocationStatusValues.map((status) => (
+                    <option key={status} value={status}>
+                      {STATUS_OPTION_LABEL[status]}
+                    </option>
+                  ))}
+                </Select>
+              </FormField>
+              <div />
+            </div>
+          ) : null}
 
           <div className="form-field-row">
             <FormField

--- a/apps/web/src/features/inventory/hooks/use-bootstrap-locations-mutation.ts
+++ b/apps/web/src/features/inventory/hooks/use-bootstrap-locations-mutation.ts
@@ -3,9 +3,15 @@
  *
  * Mints the first-run inventory location an operator was offered (#2407).
  *
- * Invalidates the active-location count on success, so the readiness surface
- * re-reads the fact rather than assuming the write moved it — the route is
- * idempotent and a re-run legitimately creates nothing.
+ * Invalidates `locationsAll()` on success — the same prefix the #3065 CRUD
+ * mutations use — rather than only `activeLocations()`. Narrower
+ * invalidation was correct while the only consumer was the connection-detail
+ * readiness panel (which reads only the active count), but the #3066
+ * locations list page reads `locations()` under the same prefix, and a
+ * bootstrap that invalidated just `activeLocations()` left that list stale
+ * until a full page reload — the click looked like it did nothing. The
+ * route is idempotent either way, so re-reading after a re-run that created
+ * nothing is still the correct, cheap thing to do.
  *
  * @module apps/web/src/features/inventory/hooks
  */
@@ -25,7 +31,7 @@ export function useBootstrapLocationsMutation(): UseMutationResult<
   return useMutation({
     mutationFn: () => apiClient.inventory.bootstrapLocations(),
     onSuccess: async () => {
-      await queryClient.invalidateQueries({ queryKey: inventoryQueryKeys.activeLocations() });
+      await queryClient.invalidateQueries({ queryKey: inventoryQueryKeys.locationsAll() });
     },
   });
 }

--- a/apps/web/src/features/inventory/hooks/use-create-inventory-location-mutation.ts
+++ b/apps/web/src/features/inventory/hooks/use-create-inventory-location-mutation.ts
@@ -1,0 +1,30 @@
+/**
+ * useCreateInventoryLocationMutation (#2316 / #3065)
+ *
+ * Invalidates `locationsAll()` rather than a single list key: the write can
+ * change what any filtered/paginated list returns and also the install-wide
+ * `activeLocations` count (a fresh location defaults to `active`), so every
+ * cache entry under the `['inventory', 'locations']` prefix has to move.
+ *
+ * @module apps/web/src/features/inventory/hooks
+ */
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query';
+import { inventoryQueryKeys } from '../api/inventory.query-keys';
+import type { CreateInventoryLocationInput, InventoryLocation } from '../api/inventory-locations.types';
+import { useApiClient } from '../../../app/api/api-client-provider';
+
+export function useCreateInventoryLocationMutation(): UseMutationResult<
+  InventoryLocation,
+  Error,
+  CreateInventoryLocationInput
+> {
+  const apiClient = useApiClient();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (input) => apiClient.inventory.createLocation(input),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: inventoryQueryKeys.locationsAll() });
+    },
+  });
+}

--- a/apps/web/src/features/inventory/hooks/use-delete-inventory-location-mutation.ts
+++ b/apps/web/src/features/inventory/hooks/use-delete-inventory-location-mutation.ts
@@ -1,0 +1,25 @@
+/**
+ * useDeleteInventoryLocationMutation (#2316 / #3065)
+ *
+ * The backend refuses with a 409 (`ApiError.isConflict()`) while any
+ * `inventory_items` row still references the location — that check and the
+ * "retire instead" recovery flow belong to the delete-confirm dialog (#3068),
+ * this hook only issues the request and reports the mutation's own error.
+ *
+ * @module apps/web/src/features/inventory/hooks
+ */
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query';
+import { inventoryQueryKeys } from '../api/inventory.query-keys';
+import { useApiClient } from '../../../app/api/api-client-provider';
+
+export function useDeleteInventoryLocationMutation(): UseMutationResult<void, Error, string> {
+  const apiClient = useApiClient();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => apiClient.inventory.deleteLocation(id),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: inventoryQueryKeys.locationsAll() });
+    },
+  });
+}

--- a/apps/web/src/features/inventory/hooks/use-inventory-location-mutations.test.tsx
+++ b/apps/web/src/features/inventory/hooks/use-inventory-location-mutations.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * Covers the invalidation behaviour shared by the three write hooks
+ * (create/update/delete): every one of them has to move BOTH a filtered list
+ * entry and the unrelated `activeLocations` count, which is why they all
+ * invalidate the `locationsAll()` prefix rather than their own narrow key —
+ * see the docblock on each hook. This test pins that prefix actually clears
+ * a real cached query, rather than asserting the mock was called with the
+ * right array (which would pass even if the prefix did not match anything).
+ */
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider, useQuery } from '@tanstack/react-query';
+import type { PropsWithChildren, ReactElement } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { ApiClientProvider } from '../../../app/api/api-client-provider';
+import { createMockApiClient } from '../../../test/test-utils';
+import { inventoryQueryKeys } from '../api/inventory.query-keys';
+import { useCreateInventoryLocationMutation } from './use-create-inventory-location-mutation';
+import { useUpdateInventoryLocationMutation } from './use-update-inventory-location-mutation';
+import { useDeleteInventoryLocationMutation } from './use-delete-inventory-location-mutation';
+import type { InventoryLocation } from '../api/inventory-locations.types';
+
+const row: InventoryLocation = {
+  id: 'ol_location_1',
+  code: 'WH1',
+  name: 'Main warehouse',
+  kind: 'warehouse',
+  ownerConnectionId: null,
+  externalRef: null,
+  status: 'active',
+  countryIso2: null,
+  postcode: null,
+  latitude: null,
+  longitude: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+function createWrapper(
+  apiClient: ReturnType<typeof createMockApiClient>,
+  queryClient: QueryClient,
+): ({ children }: PropsWithChildren) => ReactElement {
+  return function Wrapper({ children }: PropsWithChildren): ReactElement {
+    return (
+      <ApiClientProvider client={apiClient}>
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      </ApiClientProvider>
+    );
+  };
+}
+
+/** Renders both the mutation-under-test and a sibling read against every
+ * locations-registry key, so a real cache invalidation is observable. */
+function renderWithSiblingReads(
+  apiClient: ReturnType<typeof createMockApiClient>,
+  useMutationHook: () => { mutate: (input: never) => void },
+): {
+  activeCalls: () => number;
+  listCalls: () => number;
+  detailCalls: () => number;
+  mutate: (input: never) => void;
+} {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  const wrapper = createWrapper(apiClient, queryClient);
+
+  renderHook(
+    () => useQuery({ queryKey: inventoryQueryKeys.activeLocations(), queryFn: () => Promise.resolve(1) }),
+    { wrapper },
+  );
+  renderHook(
+    () =>
+      useQuery({
+        queryKey: inventoryQueryKeys.locations(),
+        queryFn: () => Promise.resolve({ items: [], total: 0, page: 1, limit: 25 }),
+      }),
+    { wrapper },
+  );
+  renderHook(
+    () =>
+      useQuery({
+        queryKey: inventoryQueryKeys.locationDetail('ol_location_1'),
+        queryFn: () => Promise.resolve(row),
+      }),
+    { wrapper },
+  );
+  const mutation = renderHook(() => useMutationHook(), { wrapper });
+
+  return {
+    activeCalls: () => queryClient.getQueryState(inventoryQueryKeys.activeLocations())?.dataUpdateCount ?? 0,
+    listCalls: () => queryClient.getQueryState(inventoryQueryKeys.locations())?.dataUpdateCount ?? 0,
+    detailCalls: () =>
+      queryClient.getQueryState(inventoryQueryKeys.locationDetail('ol_location_1'))?.dataUpdateCount ?? 0,
+    mutate: mutation.result.current.mutate,
+  };
+}
+
+describe('locations mutation invalidation', () => {
+  it('create should refresh the active-count, list and detail caches', async () => {
+    const createLocation = vi.fn().mockResolvedValue(row);
+    const apiClient = createMockApiClient({ inventory: { createLocation } });
+    const { activeCalls, listCalls, detailCalls, mutate } = renderWithSiblingReads(apiClient, () =>
+      useCreateInventoryLocationMutation(),
+    );
+
+    await waitFor(() => expect(activeCalls()).toBe(1));
+    await waitFor(() => expect(listCalls()).toBe(1));
+    await waitFor(() => expect(detailCalls()).toBe(1));
+
+    act(() => mutate({ code: 'WH2', name: 'Overflow', kind: 'warehouse' } as never));
+
+    await waitFor(() => expect(createLocation).toHaveBeenCalled());
+    await waitFor(() => expect(activeCalls()).toBe(2));
+    await waitFor(() => expect(listCalls()).toBe(2));
+    await waitFor(() => expect(detailCalls()).toBe(2));
+  });
+
+  it('update should refresh the active-count, list and detail caches', async () => {
+    const updateLocation = vi.fn().mockResolvedValue(row);
+    const apiClient = createMockApiClient({ inventory: { updateLocation } });
+    const { activeCalls, listCalls, detailCalls, mutate } = renderWithSiblingReads(apiClient, () =>
+      useUpdateInventoryLocationMutation(),
+    );
+
+    await waitFor(() => expect(activeCalls()).toBe(1));
+
+    act(() => mutate({ id: 'ol_location_1', patch: { status: 'inactive' } } as never));
+
+    await waitFor(() => expect(updateLocation).toHaveBeenCalledWith('ol_location_1', { status: 'inactive' }));
+    await waitFor(() => expect(activeCalls()).toBe(2));
+    await waitFor(() => expect(listCalls()).toBe(2));
+    await waitFor(() => expect(detailCalls()).toBe(2));
+  });
+
+  it('delete should refresh the active-count, list and detail caches', async () => {
+    const deleteLocation = vi.fn().mockResolvedValue(undefined);
+    const apiClient = createMockApiClient({ inventory: { deleteLocation } });
+    const { activeCalls, listCalls, detailCalls, mutate } = renderWithSiblingReads(apiClient, () =>
+      useDeleteInventoryLocationMutation(),
+    );
+
+    await waitFor(() => expect(activeCalls()).toBe(1));
+
+    act(() => mutate('ol_location_1' as never));
+
+    await waitFor(() => expect(deleteLocation).toHaveBeenCalledWith('ol_location_1'));
+    await waitFor(() => expect(activeCalls()).toBe(2));
+    await waitFor(() => expect(listCalls()).toBe(2));
+    await waitFor(() => expect(detailCalls()).toBe(2));
+  });
+});

--- a/apps/web/src/features/inventory/hooks/use-inventory-location-query.test.tsx
+++ b/apps/web/src/features/inventory/hooks/use-inventory-location-query.test.tsx
@@ -1,0 +1,73 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { PropsWithChildren, ReactElement } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { ApiClientProvider } from '../../../app/api/api-client-provider';
+import { createMockApiClient } from '../../../test/test-utils';
+import { useInventoryLocationQuery } from './use-inventory-location-query';
+import type { InventoryLocation } from '../api/inventory-locations.types';
+
+function createWrapper(
+  apiClient: ReturnType<typeof createMockApiClient>,
+): ({ children }: PropsWithChildren) => ReactElement {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: PropsWithChildren): ReactElement {
+    return (
+      <ApiClientProvider client={apiClient}>
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      </ApiClientProvider>
+    );
+  };
+}
+
+const row: InventoryLocation = {
+  id: 'ol_location_1',
+  code: 'WH1',
+  name: 'Main warehouse',
+  kind: 'warehouse',
+  ownerConnectionId: null,
+  externalRef: null,
+  status: 'active',
+  countryIso2: null,
+  postcode: null,
+  latitude: null,
+  longitude: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+describe('useInventoryLocationQuery', () => {
+  it('should fetch the location by id', async () => {
+    const getLocation = vi.fn().mockResolvedValue(row);
+    const apiClient = createMockApiClient({ inventory: { getLocation } });
+
+    const { result } = renderHook(() => useInventoryLocationQuery('ol_location_1'), {
+      wrapper: createWrapper(apiClient),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(getLocation).toHaveBeenCalledWith('ol_location_1');
+    expect(result.current.data).toEqual(row);
+  });
+
+  it('should not fetch when the id is empty', () => {
+    const getLocation = vi.fn().mockResolvedValue(row);
+    const apiClient = createMockApiClient({ inventory: { getLocation } });
+
+    renderHook(() => useInventoryLocationQuery(''), { wrapper: createWrapper(apiClient) });
+
+    expect(getLocation).not.toHaveBeenCalled();
+  });
+
+  it('should not fetch when the caller disables it', () => {
+    const getLocation = vi.fn().mockResolvedValue(row);
+    const apiClient = createMockApiClient({ inventory: { getLocation } });
+
+    renderHook(() => useInventoryLocationQuery('ol_location_1', { enabled: false }), {
+      wrapper: createWrapper(apiClient),
+    });
+
+    expect(getLocation).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/features/inventory/hooks/use-inventory-location-query.ts
+++ b/apps/web/src/features/inventory/hooks/use-inventory-location-query.ts
@@ -1,0 +1,29 @@
+/**
+ * useInventoryLocationQuery
+ *
+ * Single-location read by id (#2316 / #3065), for the edit dialog (#3067).
+ *
+ * `enabled` follows the `useConnectionQuery` shape: an empty id never fires
+ * (an unmounted-but-still-hooked edit dialog with no target selected), and a
+ * caller may additionally suppress the fetch — e.g. while a page-level list
+ * read already resolved the row and there is nothing left to ask for.
+ *
+ * @module apps/web/src/features/inventory/hooks
+ */
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { inventoryQueryKeys } from '../api/inventory.query-keys';
+import type { InventoryLocation } from '../api/inventory-locations.types';
+import { useApiClient } from '../../../app/api/api-client-provider';
+
+export function useInventoryLocationQuery(
+  id: string,
+  options?: { enabled?: boolean },
+): UseQueryResult<InventoryLocation> {
+  const apiClient = useApiClient();
+
+  return useQuery({
+    enabled: id.length > 0 && (options?.enabled ?? true),
+    queryKey: inventoryQueryKeys.locationDetail(id),
+    queryFn: () => apiClient.inventory.getLocation(id),
+  });
+}

--- a/apps/web/src/features/inventory/hooks/use-inventory-locations-query.test.tsx
+++ b/apps/web/src/features/inventory/hooks/use-inventory-locations-query.test.tsx
@@ -1,0 +1,61 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { PropsWithChildren, ReactElement } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { ApiClientProvider } from '../../../app/api/api-client-provider';
+import { createMockApiClient } from '../../../test/test-utils';
+import { useInventoryLocationsQuery } from './use-inventory-locations-query';
+import type { PaginatedInventoryLocations } from '../api/inventory-locations.types';
+
+function createWrapper(
+  apiClient: ReturnType<typeof createMockApiClient>,
+): ({ children }: PropsWithChildren) => ReactElement {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return function Wrapper({ children }: PropsWithChildren): ReactElement {
+    return (
+      <ApiClientProvider client={apiClient}>
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      </ApiClientProvider>
+    );
+  };
+}
+
+const page: PaginatedInventoryLocations = {
+  items: [],
+  total: 0,
+  page: 1,
+  limit: 25,
+};
+
+describe('useInventoryLocationsQuery', () => {
+  it('should forward filters and pagination to the api client', async () => {
+    const listLocations = vi.fn().mockResolvedValue(page);
+    const apiClient = createMockApiClient({ inventory: { listLocations } });
+
+    const { result } = renderHook(
+      () => useInventoryLocationsQuery({ kind: 'warehouse', status: 'active' }, { page: 2, limit: 10 }),
+      { wrapper: createWrapper(apiClient) },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(listLocations).toHaveBeenCalledWith(
+      { kind: 'warehouse', status: 'active' },
+      { page: 2, limit: 10 },
+    );
+    expect(result.current.data).toEqual(page);
+  });
+
+  it('should surface an error when the request rejects', async () => {
+    const apiClient = createMockApiClient({
+      inventory: { listLocations: vi.fn().mockRejectedValue(new Error('Network error')) },
+    });
+
+    const { result } = renderHook(() => useInventoryLocationsQuery(), {
+      wrapper: createWrapper(apiClient),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error?.message).toBe('Network error');
+  });
+});

--- a/apps/web/src/features/inventory/hooks/use-inventory-locations-query.ts
+++ b/apps/web/src/features/inventory/hooks/use-inventory-locations-query.ts
@@ -1,0 +1,29 @@
+/**
+ * useInventoryLocationsQuery
+ *
+ * Full, filtered, paginated read of `inventory_locations` (#2316 / #3065) —
+ * the list page's own query, distinct from `useActiveLocationCountQuery`'s
+ * install-wide `active`-only `total` probe.
+ *
+ * @module apps/web/src/features/inventory/hooks
+ */
+import { useQuery, type UseQueryResult } from '@tanstack/react-query';
+import { inventoryQueryKeys } from '../api/inventory.query-keys';
+import type {
+  InventoryLocationFilters,
+  InventoryLocationListPagination,
+  PaginatedInventoryLocations,
+} from '../api/inventory-locations.types';
+import { useApiClient } from '../../../app/api/api-client-provider';
+
+export function useInventoryLocationsQuery(
+  filters?: InventoryLocationFilters,
+  pagination?: InventoryLocationListPagination,
+): UseQueryResult<PaginatedInventoryLocations> {
+  const apiClient = useApiClient();
+
+  return useQuery({
+    queryKey: inventoryQueryKeys.locations(filters, pagination),
+    queryFn: () => apiClient.inventory.listLocations(filters, pagination),
+  });
+}

--- a/apps/web/src/features/inventory/hooks/use-update-inventory-location-mutation.ts
+++ b/apps/web/src/features/inventory/hooks/use-update-inventory-location-mutation.ts
@@ -1,0 +1,35 @@
+/**
+ * useUpdateInventoryLocationMutation (#2316 / #3065)
+ *
+ * Same `locationsAll()` invalidation reasoning as the create mutation — a
+ * patch can move `status` (so `activeLocations` may change) and any filtered
+ * list can gain or lose the row, so a narrower invalidation targeting only
+ * `locationDetail(id)` would leave stale list entries behind.
+ *
+ * @module apps/web/src/features/inventory/hooks
+ */
+import { useMutation, useQueryClient, type UseMutationResult } from '@tanstack/react-query';
+import { inventoryQueryKeys } from '../api/inventory.query-keys';
+import type { InventoryLocation, UpdateInventoryLocationInput } from '../api/inventory-locations.types';
+import { useApiClient } from '../../../app/api/api-client-provider';
+
+export interface UpdateInventoryLocationMutationInput {
+  id: string;
+  patch: UpdateInventoryLocationInput;
+}
+
+export function useUpdateInventoryLocationMutation(): UseMutationResult<
+  InventoryLocation,
+  Error,
+  UpdateInventoryLocationMutationInput
+> {
+  const apiClient = useApiClient();
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, patch }) => apiClient.inventory.updateLocation(id, patch),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: inventoryQueryKeys.locationsAll() });
+    },
+  });
+}

--- a/apps/web/src/features/inventory/index.ts
+++ b/apps/web/src/features/inventory/index.ts
@@ -24,10 +24,18 @@ export type {
 } from './api/inventory.types';
 
 export type {
+  CreateInventoryLocationInput,
+  InventoryLocation,
+  InventoryLocationFilters,
+  InventoryLocationKind,
+  InventoryLocationListPagination,
+  InventoryLocationStatus,
   InventoryLocationSummary,
   LocationBootstrapResult,
   PaginatedInventoryLocations,
+  UpdateInventoryLocationInput,
 } from './api/inventory-locations.types';
+export { InventoryLocationKindValues, InventoryLocationStatusValues } from './api/inventory-locations.types';
 
 // #2407 — consumed by the connection detail page's routing-readiness panel,
 // which lives in `features/connections` and so must reach these through the

--- a/apps/web/src/features/inventory/index.ts
+++ b/apps/web/src/features/inventory/index.ts
@@ -43,6 +43,24 @@ export { InventoryLocationKindValues, InventoryLocationStatusValues } from './ap
 export { useActiveLocationCountQuery } from './hooks/use-active-location-count-query';
 export { useBootstrapLocationsMutation } from './hooks/use-bootstrap-locations-mutation';
 
+// #2316 / #3065 — the full CRUD surface, consumed by the (upcoming) locations
+// list page in `pages/inventory/`, which is a page rather than a feature and
+// so must reach these through the barrel per the dependency rule.
+export { useInventoryLocationsQuery } from './hooks/use-inventory-locations-query';
+export { useInventoryLocationQuery } from './hooks/use-inventory-location-query';
+export { useCreateInventoryLocationMutation } from './hooks/use-create-inventory-location-mutation';
+export {
+  useUpdateInventoryLocationMutation,
+  type UpdateInventoryLocationMutationInput,
+} from './hooks/use-update-inventory-location-mutation';
+export { useDeleteInventoryLocationMutation } from './hooks/use-delete-inventory-location-mutation';
+
+// #3067 / #3068 — the create/edit and delete/retire dialogs, consumed by the
+// (upcoming) locations list page in `pages/inventory/`.
+export { LocationDialog, type LocationDialogTarget } from './components/location-dialog';
+export { LocationDeleteDialog } from './components/location-delete-dialog';
+export { KIND_LABEL } from './components/location-dialog.schema';
+
 export { useInventoryAvailabilityBatchQuery } from './hooks/use-inventory-availability-batch-query';
 // Query-key factory re-exported so the bulk wizard's chunked per-variant
 // availability fan-out (#1741) shares cache entries with the batch hook above.

--- a/apps/web/src/features/inventory/index.ts
+++ b/apps/web/src/features/inventory/index.ts
@@ -61,6 +61,10 @@ export { LocationDialog, type LocationDialogTarget } from './components/location
 export { LocationDeleteDialog } from './components/location-delete-dialog';
 export { KIND_LABEL } from './components/location-dialog.schema';
 
+// Consumed by `pages/settings/settings-page.tsx` — a link-out tile, not a
+// full settings section (#2316 / #3066 follow-up).
+export { InventoryLocationsTile } from './components/inventory-locations-tile';
+
 export { useInventoryAvailabilityBatchQuery } from './hooks/use-inventory-availability-batch-query';
 // Query-key factory re-exported so the bulk wizard's chunked per-variant
 // availability fan-out (#1741) shares cache entries with the batch hook above.

--- a/apps/web/src/features/inventory/lib/inventory-locations-tile.copy.ts
+++ b/apps/web/src/features/inventory/lib/inventory-locations-tile.copy.ts
@@ -1,0 +1,17 @@
+/**
+ * Inventory Locations Tile Copy
+ *
+ * Every operator-facing string for the `SettingsPage` entry point that links
+ * out to `/inventory/locations` — the `who-decides.copy.ts` placement
+ * precedent, one module per settings tile.
+ *
+ * @module apps/web/src/features/inventory/lib
+ */
+export const INVENTORY_LOCATIONS_TILE_COPY = {
+  eyebrow: 'Fulfilment routing',
+  title: 'Inventory locations',
+  description:
+    'The warehouses, stores and third-party sites OpenLinker can source stock from.',
+  linkLabel: 'Open',
+  chip: 'Inventory locations',
+};

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -2997,6 +2997,26 @@ a.delivery-rider-banner__button:focus-visible {
   cursor: pointer;
 }
 
+/* ── Row action button groups (#3066) — the `table-actions` class name was
+   already used on `users-page.tsx` / `invoices-list-page.tsx` /
+   `prompt-template-detail-page.tsx` with no rule backing it. */
+.table-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+/* ── Filter-bar inline checkbox toggle (#3066) — e.g. "show retired" ── */
+.toolbar__checkbox-label {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: 0.8125rem;
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+
 .data-table__action {
   color: var(--accent-primary);
   font-weight: 500;

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -3007,6 +3007,34 @@ a.delivery-rider-banner__button:focus-visible {
   flex-wrap: wrap;
 }
 
+/* ── Fixed-width status-toggle action (#3066 follow-up) — Retire/Reactivate
+   render the same slot with different label lengths ("Retire" vs
+   "Reactivate"); without a fixed width the table's auto column layout
+   re-sizes the whole actions column — and with it the whole table — every
+   time a row's status flips. `min-width` alone is not enough: `.button` is
+   `inline-flex` with content-driven width, so the wider "Reactivate" label
+   still grows past a mere floor. `width` fixes the box regardless of
+   content; `.button`'s own `justify-content: center` keeps the shorter
+   "Retire" label centered inside it rather than left-aligned. */
+.loc-status-action {
+  width: 90px;
+  flex-shrink: 0;
+}
+
+/* ── Fixed-width status badge, desktop table cell only (#3066 follow-up) —
+   the SAME auto-table-layout mechanism as `.loc-status-action` above: with
+   `table-layout: auto` (the default, and `.data-table` sets none), EVERY
+   column's width is recomputed from the widest cell across ALL rows, so
+   "Active" (6 chars) vs "Retired" (7 chars) alone reflows the whole table on
+   toggle even with the action button already fixed — verified in an
+   isolated repro against the real stylesheet before landing this. Not
+   applied to the mobile card `meta` badge, which isn't inside a `<table>`
+   and has no column-width coupling to fix. */
+.loc-status-badge {
+  justify-content: center;
+  width: 72px;
+}
+
 /* ── Filter-bar inline checkbox toggle (#3066) — e.g. "show retired" ── */
 .toolbar__checkbox-label {
   display: inline-flex;

--- a/apps/web/src/pages/inventory/inventory-locations-page.test.tsx
+++ b/apps/web/src/pages/inventory/inventory-locations-page.test.tsx
@@ -256,12 +256,13 @@ describe('InventoryLocationsPage', () => {
     expect(addManually.closest('.read-only-lock')).not.toBeNull();
   });
 
-  it('hides Edit/Delete row actions and Add location for a session with no write permission', async () => {
+  it('hides Edit/Retire/Delete row actions and Add location for a session with no write permission', async () => {
     const apiClient = createMockApiClient({ inventory: { listLocations: vi.fn().mockResolvedValue(page()) } });
     renderWithProviders(<InventoryLocationsPage />, { apiClient });
 
     await screen.findByText('Warsaw — Main warehouse');
     expect(screen.queryByRole('button', { name: 'Edit' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Retire' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Delete' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: '+ Add location' })).not.toBeInTheDocument();
   });
@@ -300,6 +301,34 @@ describe('InventoryLocationsPage', () => {
     await userEvent.click(await screen.findByRole('button', { name: 'Delete' }));
 
     expect(await screen.findByText('Delete "Warsaw — Main warehouse"?')).toBeInTheDocument();
+  });
+
+  // Mockup: https://claude.ai/code/artifact/fbb5f9e1-52a3-4b7b-8136-ad59dcf4f318
+  // renders a direct Retire/Reactivate row action per row (⏸/↻, toggling on
+  // status) rather than only surfacing Retire as a 409 fallback inside the
+  // Delete dialog — before this, status could only ever move active ->
+  // inactive via that fallback, and never the other way at all.
+  it('shows Retire for an active row and Reactivate for a retired row, for a session with write access', async () => {
+    const rows = [location, { ...location, id: 'ol_location_2', name: 'Kraków — Overflow', status: 'inactive' as const }];
+    const apiClient = createMockApiClient({ inventory: { listLocations: vi.fn().mockResolvedValue(page(rows)) } });
+    renderWithProviders(<InventoryLocationsPage />, {
+      apiClient,
+      sessionAdapter: createAuthenticatedSessionAdapter(),
+    });
+
+    await screen.findByText('Kraków — Overflow');
+    expect(screen.getAllByRole('button', { name: 'Retire' })).toHaveLength(1);
+    expect(screen.getAllByRole('button', { name: 'Reactivate' })).toHaveLength(1);
+  });
+
+  it('hides Retire and Reactivate for a session with no write permission', async () => {
+    const rows = [location, { ...location, id: 'ol_location_2', name: 'Kraków — Overflow', status: 'inactive' as const }];
+    const apiClient = createMockApiClient({ inventory: { listLocations: vi.fn().mockResolvedValue(page(rows)) } });
+    renderWithProviders(<InventoryLocationsPage />, { apiClient });
+
+    await screen.findByText('Kraków — Overflow');
+    expect(screen.queryByRole('button', { name: 'Retire' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Reactivate' })).not.toBeInTheDocument();
   });
 
   // #3070 — end-to-end round trips through the real mutation hooks' cache
@@ -377,6 +406,51 @@ describe('InventoryLocationsPage', () => {
       await userEvent.click(screen.getByRole('button', { name: /retire instead/i }));
 
       await waitFor(() => expect(screen.getByText('Retired')).toBeInTheDocument());
+      expect(listLocations).toHaveBeenCalledTimes(2);
+    });
+
+    it('retire: clicking Retire directly flips an active row to Retired with no confirm dialog', async () => {
+      const listLocations = vi
+        .fn()
+        .mockResolvedValueOnce(page([location]))
+        .mockResolvedValueOnce(page([{ ...location, status: 'inactive' }]));
+      const updateLocation = vi.fn().mockResolvedValue({ ...location, status: 'inactive' });
+      const apiClient = createMockApiClient({ inventory: { listLocations, updateLocation } });
+      renderWithProviders(<InventoryLocationsPage />, {
+        apiClient,
+        sessionAdapter: createAuthenticatedSessionAdapter(),
+      });
+
+      await screen.findByText('Active');
+      await userEvent.click(screen.getByRole('button', { name: 'Retire' }));
+
+      await waitFor(() =>
+        expect(updateLocation).toHaveBeenCalledWith('ol_location_1', { status: 'inactive' }),
+      );
+      await waitFor(() => expect(screen.getByText('Retired')).toBeInTheDocument());
+      expect(listLocations).toHaveBeenCalledTimes(2);
+    });
+
+    it('reactivate: clicking Reactivate flips a retired row back to Active with no confirm dialog', async () => {
+      const retired = { ...location, status: 'inactive' as const };
+      const listLocations = vi
+        .fn()
+        .mockResolvedValueOnce(page([retired]))
+        .mockResolvedValueOnce(page([location]));
+      const updateLocation = vi.fn().mockResolvedValue(location);
+      const apiClient = createMockApiClient({ inventory: { listLocations, updateLocation } });
+      renderWithProviders(<InventoryLocationsPage />, {
+        apiClient,
+        sessionAdapter: createAuthenticatedSessionAdapter(),
+      });
+
+      await screen.findByText('Retired');
+      await userEvent.click(screen.getByRole('button', { name: 'Reactivate' }));
+
+      await waitFor(() =>
+        expect(updateLocation).toHaveBeenCalledWith('ol_location_1', { status: 'active' }),
+      );
+      await waitFor(() => expect(screen.getByText('Active')).toBeInTheDocument());
       expect(listLocations).toHaveBeenCalledTimes(2);
     });
   });

--- a/apps/web/src/pages/inventory/inventory-locations-page.test.tsx
+++ b/apps/web/src/pages/inventory/inventory-locations-page.test.tsx
@@ -1,0 +1,383 @@
+import { cleanup, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  createAuthenticatedSessionAdapter,
+  createMockApiClient,
+  renderWithProviders,
+} from '../../test/test-utils';
+import { ApiError } from '../../shared/api/api-error';
+import { InventoryLocationsPage } from './inventory-locations-page';
+import type { InventoryLocation, PaginatedInventoryLocations } from '../../features/inventory';
+
+const location: InventoryLocation = {
+  id: 'ol_location_1',
+  code: 'MAIN',
+  name: 'Warsaw — Main warehouse',
+  kind: 'warehouse',
+  ownerConnectionId: null,
+  externalRef: null,
+  status: 'active',
+  countryIso2: 'PL',
+  postcode: '02-677',
+  latitude: null,
+  longitude: null,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+};
+
+function page(
+  items: InventoryLocation[] = [location],
+  overrides: Partial<Pick<PaginatedInventoryLocations, 'total' | 'page' | 'limit'>> = {},
+): PaginatedInventoryLocations {
+  return { items, total: items.length, page: 1, limit: 25, ...overrides };
+}
+
+describe('InventoryLocationsPage', () => {
+  afterEach(cleanup);
+
+  it('renders the page heading', () => {
+    const apiClient = createMockApiClient({ inventory: { listLocations: vi.fn().mockResolvedValue(page([])) } });
+    renderWithProviders(<InventoryLocationsPage />, { apiClient });
+    expect(screen.getByRole('heading', { name: 'Inventory locations' })).toBeInTheDocument();
+  });
+
+  it('renders the kind filter and a Show retired toggle, checked by default', async () => {
+    const apiClient = createMockApiClient({ inventory: { listLocations: vi.fn().mockResolvedValue(page()) } });
+    renderWithProviders(<InventoryLocationsPage />, { apiClient });
+
+    expect(await screen.findByRole('combobox', { name: 'Filter by kind' })).toBeInTheDocument();
+    const toggle = screen.getByRole('checkbox', { name: /show retired/i });
+    expect(toggle).toBeChecked();
+  });
+
+  it('displays locations returned by the API', async () => {
+    const apiClient = createMockApiClient({ inventory: { listLocations: vi.fn().mockResolvedValue(page()) } });
+    renderWithProviders(<InventoryLocationsPage />, { apiClient });
+
+    expect(await screen.findByText('Warsaw — Main warehouse')).toBeInTheDocument();
+  });
+
+  it('shows loading state while fetching', () => {
+    const apiClient = createMockApiClient({
+      inventory: { listLocations: vi.fn().mockReturnValue(new Promise(() => {})) },
+    });
+    renderWithProviders(<InventoryLocationsPage />, { apiClient });
+
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('shows an error state when the fetch fails', async () => {
+    const apiClient = createMockApiClient({
+      inventory: { listLocations: vi.fn().mockRejectedValue(new Error('Network error')) },
+    });
+    renderWithProviders(<InventoryLocationsPage />, { apiClient });
+
+    expect(await screen.findByRole('heading', { name: "Couldn't load locations" })).toBeInTheDocument();
+  });
+
+  it('shows the pre-bootstrap empty state with write access', async () => {
+    const apiClient = createMockApiClient({ inventory: { listLocations: vi.fn().mockResolvedValue(page([])) } });
+    renderWithProviders(<InventoryLocationsPage />, {
+      apiClient,
+      sessionAdapter: createAuthenticatedSessionAdapter(),
+    });
+
+    expect(await screen.findByRole('heading', { name: 'Routing has nowhere to source stock from' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Create first location' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '+ Add manually' })).toBeInTheDocument();
+  });
+
+  // Regression: useBootstrapLocationsMutation used to invalidate only
+  // activeLocations() (the #2407 readiness-panel key), so a successful
+  // bootstrap here left the list's own locations() query stale — the click
+  // visibly did nothing until a full page reload re-fetched it.
+  it('the newly-minted location appears without a page reload after Create first location', async () => {
+    const created = { ...location, id: 'ol_location_main' };
+    const listLocations = vi
+      .fn()
+      .mockResolvedValueOnce(page([]))
+      .mockResolvedValueOnce(page([created]));
+    const bootstrapLocations = vi
+      .fn()
+      .mockResolvedValue({ created: [created], existingCodes: [] });
+    const apiClient = createMockApiClient({ inventory: { listLocations, bootstrapLocations } });
+    renderWithProviders(<InventoryLocationsPage />, {
+      apiClient,
+      sessionAdapter: createAuthenticatedSessionAdapter(),
+    });
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Create first location' }));
+
+    expect(await screen.findByText('Warsaw — Main warehouse')).toBeInTheDocument();
+    expect(listLocations).toHaveBeenCalledTimes(2);
+  });
+
+  it('turning the Show retired toggle off filters to status=active', async () => {
+    const listLocations = vi.fn().mockResolvedValue(page());
+    const apiClient = createMockApiClient({ inventory: { listLocations } });
+    renderWithProviders(<InventoryLocationsPage />, { apiClient });
+
+    await screen.findByText('Warsaw — Main warehouse');
+    await userEvent.click(screen.getByRole('checkbox', { name: /show retired/i }));
+
+    await waitFor(() =>
+      expect(listLocations).toHaveBeenLastCalledWith(
+        expect.objectContaining({ status: 'active' }),
+        { page: 1, limit: 25 },
+      ),
+    );
+  });
+
+  it('changing the kind filter narrows the list query', async () => {
+    const listLocations = vi.fn().mockResolvedValue(page());
+    const apiClient = createMockApiClient({ inventory: { listLocations } });
+    renderWithProviders(<InventoryLocationsPage />, { apiClient });
+
+    await screen.findByText('Warsaw — Main warehouse');
+    await userEvent.selectOptions(screen.getByRole('combobox', { name: 'Filter by kind' }), 'warehouse');
+
+    await waitFor(() =>
+      expect(listLocations).toHaveBeenLastCalledWith(
+        expect.objectContaining({ kind: 'warehouse' }),
+        { page: 1, limit: 25 },
+      ),
+    );
+  });
+
+  // #3135 review — pagination was silently dropped: the query never received
+  // a `pagination` argument and `total` was never read anywhere on the page.
+  describe('pagination (tech-lead review fix)', () => {
+    it('does not render a pager when everything fits on one page', async () => {
+      const apiClient = createMockApiClient({
+        inventory: { listLocations: vi.fn().mockResolvedValue(page([location], { total: 1 })) },
+      });
+      renderWithProviders(<InventoryLocationsPage />, { apiClient });
+
+      await screen.findByText('Warsaw — Main warehouse');
+      expect(screen.queryByText(/page 1 of/i)).not.toBeInTheDocument();
+    });
+
+    it('renders the pager and disables Previous on the first page, when total exceeds one page', async () => {
+      const apiClient = createMockApiClient({
+        inventory: { listLocations: vi.fn().mockResolvedValue(page([location], { total: 30 })) },
+      });
+      renderWithProviders(<InventoryLocationsPage />, { apiClient });
+
+      await screen.findByText('Warsaw — Main warehouse');
+      expect(screen.getByText('Page 1 of 2 · 30 locations')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Previous' })).toBeDisabled();
+      expect(screen.getByRole('button', { name: 'Next' })).toBeEnabled();
+    });
+
+    it('clicking Next requests page 2 and enables Previous', async () => {
+      const listLocations = vi.fn().mockResolvedValue(page([location], { total: 30 }));
+      const apiClient = createMockApiClient({ inventory: { listLocations } });
+      renderWithProviders(<InventoryLocationsPage />, { apiClient });
+
+      await screen.findByText('Warsaw — Main warehouse');
+      await userEvent.click(screen.getByRole('button', { name: 'Next' }));
+
+      // `MemoryRouter` doesn't sync to `window.location`, so the URL isn't a
+      // reachable assertion here — the request args and the page's own
+      // rendered pager state are: both are downstream of the same
+      // `useSearchParams` change a real browser navigation would also drive.
+      await waitFor(() =>
+        expect(listLocations).toHaveBeenLastCalledWith(expect.anything(), { page: 2, limit: 25 }),
+      );
+      expect(await screen.findByText('Page 2 of 2 · 30 locations')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: 'Previous' })).toBeEnabled();
+    });
+
+    it('changing a filter lands back on page 1', async () => {
+      const listLocations = vi.fn().mockResolvedValue(page([location], { total: 30 }));
+      const apiClient = createMockApiClient({ inventory: { listLocations } });
+      renderWithProviders(<InventoryLocationsPage />, { apiClient, route: '/inventory/locations?page=2' });
+
+      await screen.findByText('Warsaw — Main warehouse');
+      await userEvent.selectOptions(screen.getByRole('combobox', { name: 'Filter by kind' }), 'warehouse');
+
+      await waitFor(() =>
+        expect(listLocations).toHaveBeenLastCalledWith(
+          expect.objectContaining({ kind: 'warehouse' }),
+          { page: 1, limit: 25 },
+        ),
+      );
+      expect(await screen.findByText('Page 1 of 2 · 30 locations')).toBeInTheDocument();
+    });
+
+    // Tech-review finding: an out-of-range page (emptied by a concurrent
+    // delete, or a hand-edited URL) used to render the pre-bootstrap "zero
+    // locations" empty state even though rows exist on another page.
+    it('shows a page-not-found empty state, not the bootstrap empty state, when the current page is empty but total > 0', async () => {
+      const listLocations = vi.fn().mockResolvedValue(page([], { total: 25, page: 3 }));
+      const apiClient = createMockApiClient({ inventory: { listLocations } });
+      renderWithProviders(<InventoryLocationsPage />, {
+        apiClient,
+        route: '/inventory/locations?page=3',
+        sessionAdapter: createAuthenticatedSessionAdapter(),
+      });
+
+      expect(await screen.findByText("This page doesn't exist anymore")).toBeInTheDocument();
+      expect(screen.getByText('There are 25 locations, but not on page 3.')).toBeInTheDocument();
+      expect(screen.queryByRole('heading', { name: 'Routing has nowhere to source stock from' })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: 'Create first location' })).not.toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('button', { name: 'Back to page 1' }));
+
+      await waitFor(() =>
+        expect(listLocations).toHaveBeenLastCalledWith(expect.anything(), { page: 1, limit: 25 }),
+      );
+    });
+  });
+
+  // #3135 review — the empty-state's "Create first location" / "+ Add
+  // manually" buttons used the same `disabled={write.demoReadOnly}`
+  // condition as every other write affordance on the page but skipped the
+  // `ReadOnlyLock` wrapper, so a demo viewer got disabled buttons with no
+  // explanatory tooltip there and there alone.
+  it('wraps the empty-state write buttons in ReadOnlyLock for a demo read-only viewer', async () => {
+    const viewerSession = createAuthenticatedSessionAdapter({
+      id: 'u2',
+      username: 'viewer',
+      email: null,
+      role: 'viewer',
+      permissions: ['inventory:read'],
+    });
+    const apiClient = createMockApiClient({
+      inventory: { listLocations: vi.fn().mockResolvedValue(page([], { total: 0 })) },
+      system: { getConfig: vi.fn().mockResolvedValue({ demoMode: true }) },
+    });
+    renderWithProviders(<InventoryLocationsPage />, { apiClient, sessionAdapter: viewerSession });
+
+    const createFirst = await screen.findByRole('button', { name: 'Create first location' });
+    const addManually = screen.getByRole('button', { name: '+ Add manually' });
+    expect(createFirst.closest('.read-only-lock')).not.toBeNull();
+    expect(addManually.closest('.read-only-lock')).not.toBeNull();
+  });
+
+  it('hides Edit/Delete row actions and Add location for a session with no write permission', async () => {
+    const apiClient = createMockApiClient({ inventory: { listLocations: vi.fn().mockResolvedValue(page()) } });
+    renderWithProviders(<InventoryLocationsPage />, { apiClient });
+
+    await screen.findByText('Warsaw — Main warehouse');
+    expect(screen.queryByRole('button', { name: 'Edit' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Delete' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: '+ Add location' })).not.toBeInTheDocument();
+  });
+
+  it('opens the create dialog from Add location, for a session with write access', async () => {
+    const apiClient = createMockApiClient({ inventory: { listLocations: vi.fn().mockResolvedValue(page()) } });
+    renderWithProviders(<InventoryLocationsPage />, {
+      apiClient,
+      sessionAdapter: createAuthenticatedSessionAdapter(),
+    });
+
+    await userEvent.click(await screen.findByRole('button', { name: '+ Add location' }));
+
+    expect(await screen.findByText('Add location')).toBeInTheDocument();
+  });
+
+  it('opens the edit dialog pre-filled from the row, for a session with write access', async () => {
+    const apiClient = createMockApiClient({ inventory: { listLocations: vi.fn().mockResolvedValue(page()) } });
+    renderWithProviders(<InventoryLocationsPage />, {
+      apiClient,
+      sessionAdapter: createAuthenticatedSessionAdapter(),
+    });
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Edit' }));
+
+    expect(await screen.findByText('Edit "Warsaw — Main warehouse"')).toBeInTheDocument();
+  });
+
+  it('opens the delete-confirm dialog from the row, for a session with write access', async () => {
+    const apiClient = createMockApiClient({ inventory: { listLocations: vi.fn().mockResolvedValue(page()) } });
+    renderWithProviders(<InventoryLocationsPage />, {
+      apiClient,
+      sessionAdapter: createAuthenticatedSessionAdapter(),
+    });
+
+    await userEvent.click(await screen.findByRole('button', { name: 'Delete' }));
+
+    expect(await screen.findByText('Delete "Warsaw — Main warehouse"?')).toBeInTheDocument();
+  });
+
+  // #3070 — end-to-end round trips through the real mutation hooks' cache
+  // invalidation, not just "the dialog opened": every hook/dialog test above
+  // stops at the request being made, so none of them prove the PAGE actually
+  // reflects a successful write.
+  describe('end-to-end CRUD round trips (#3070)', () => {
+    it('create: the new row appears in the table after a successful submit', async () => {
+      const created: InventoryLocation = { ...location, id: 'ol_location_2', code: 'WH2', name: 'Overflow' };
+      const listLocations = vi
+        .fn()
+        .mockResolvedValueOnce(page([location]))
+        .mockResolvedValueOnce(page([location, created]));
+      const createLocation = vi.fn().mockResolvedValue(created);
+      const apiClient = createMockApiClient({ inventory: { listLocations, createLocation } });
+      renderWithProviders(<InventoryLocationsPage />, {
+        apiClient,
+        sessionAdapter: createAuthenticatedSessionAdapter(),
+      });
+
+      await screen.findByText('Warsaw — Main warehouse');
+      await userEvent.click(screen.getByRole('button', { name: '+ Add location' }));
+      await screen.findByText('Add location');
+      await userEvent.type(screen.getByLabelText('Code'), 'WH2');
+      await userEvent.type(screen.getByLabelText('Name'), 'Overflow');
+      await userEvent.click(screen.getByRole('button', { name: /save location/i }));
+
+      expect(await screen.findByText('Overflow')).toBeInTheDocument();
+      expect(listLocations).toHaveBeenCalledTimes(2);
+    });
+
+    it('delete: the row is gone from the table after a successful delete', async () => {
+      const listLocations = vi
+        .fn()
+        .mockResolvedValueOnce(page([location]))
+        .mockResolvedValueOnce(page([]));
+      const deleteLocation = vi.fn().mockResolvedValue(undefined);
+      const apiClient = createMockApiClient({ inventory: { listLocations, deleteLocation } });
+      renderWithProviders(<InventoryLocationsPage />, {
+        apiClient,
+        sessionAdapter: createAuthenticatedSessionAdapter(),
+      });
+
+      await screen.findByText('Warsaw — Main warehouse');
+      await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+      await screen.findByText('Delete "Warsaw — Main warehouse"?');
+      await userEvent.click(screen.getByRole('button', { name: /^delete$/i }));
+
+      await waitFor(() => expect(screen.queryByText('Warsaw — Main warehouse')).not.toBeInTheDocument());
+      expect(listLocations).toHaveBeenCalledTimes(2);
+    });
+
+    it('retire: a 409-refused delete, retired instead, flips the row to Retired', async () => {
+      const listLocations = vi
+        .fn()
+        .mockResolvedValueOnce(page([location]))
+        .mockResolvedValueOnce(page([{ ...location, status: 'inactive' }]));
+      const deleteLocation = vi
+        .fn()
+        .mockRejectedValue(new ApiError('Inventory location ol_location_1 is referenced by 3 inventory position(s)', 409, {}));
+      const updateLocation = vi.fn().mockResolvedValue({ ...location, status: 'inactive' });
+      const apiClient = createMockApiClient({ inventory: { listLocations, deleteLocation, updateLocation } });
+      renderWithProviders(<InventoryLocationsPage />, {
+        apiClient,
+        sessionAdapter: createAuthenticatedSessionAdapter(),
+      });
+
+      await screen.findByText('Warsaw — Main warehouse');
+      expect(screen.getByText('Active')).toBeInTheDocument();
+
+      await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
+      await screen.findByText('Delete "Warsaw — Main warehouse"?');
+      await userEvent.click(screen.getByRole('button', { name: /^delete$/i }));
+      await screen.findByRole('button', { name: /retire instead/i });
+      await userEvent.click(screen.getByRole('button', { name: /retire instead/i }));
+
+      await waitFor(() => expect(screen.getByText('Retired')).toBeInTheDocument());
+      expect(listLocations).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/apps/web/src/pages/inventory/inventory-locations-page.tsx
+++ b/apps/web/src/pages/inventory/inventory-locations-page.tsx
@@ -344,6 +344,7 @@ export function InventoryLocationsPage(): ReactElement {
 
   return (
     <PageLayout
+      backTo={{ to: '/settings', label: 'Settings' }}
       eyebrow="Fulfilment routing"
       title="Inventory locations"
       description="The warehouses, stores and third-party sites OpenLinker can source stock from. A location isn't authority over stock — it's the place sourcing rules pick between. Delete is refused while any stock still points here; retire it instead."

--- a/apps/web/src/pages/inventory/inventory-locations-page.tsx
+++ b/apps/web/src/pages/inventory/inventory-locations-page.tsx
@@ -1,0 +1,396 @@
+/**
+ * Inventory Locations Page (#2316 / #3066)
+ *
+ * The warehouses, stores and third-party sites OpenLinker can source stock
+ * from — the operator-facing surface over `inventory_locations` (#2313), of
+ * which only the `?status=active&limit=1` probe and the bootstrap POST were
+ * previously reachable from the product (#3029/#3063).
+ *
+ * Follows the `connections-list-page.tsx` cockpit-list composition (filter
+ * bar → loading/error/empty → `DataTable`), with the CRUD dialogs mounted on
+ * this page rather than routed to separate pages — the `users-page.tsx`
+ * inline-dialog precedent, since a location is a small, flat record with no
+ * own detail page to justify.
+ *
+ * @module apps/web/src/pages/inventory
+ */
+import { useMemo, useState, type ReactElement } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { PageLayout } from '../../shared/ui/page-layout';
+import { DataTable, type DataTableColumn } from '../../shared/ui/data-table';
+import { DataTableSkeleton } from '../../shared/ui/data-table-skeleton';
+import { ErrorState, EmptyState } from '../../shared/ui/feedback-state';
+import { StatusBadge, type StatusBadgeTone } from '../../shared/ui/status-badge';
+import { Button } from '../../shared/ui/button';
+import { Select } from '../../shared/ui/select';
+import { EmptyValue } from '../../shared/ui/empty-value';
+import { ReadOnlyLock } from '../../shared/ui/read-only-lock';
+import { useWriteAccess } from '../../shared/auth/use-permission';
+import { DEMO_READ_ONLY_ACTION_MESSAGE } from '../../shared/config/demo-mode';
+import { useDemoMode } from '../../features/system';
+import { usePlatforms } from '../../shared/plugins';
+import { resolvePlatformLabel } from '../../features/mappings';
+import { ConnectionCell, useConnectionsQuery, type Connection } from '../../features/connections';
+import {
+  InventoryLocationKindValues,
+  KIND_LABEL,
+  LocationDialog,
+  LocationDeleteDialog,
+  useInventoryLocationsQuery,
+  useBootstrapLocationsMutation,
+  type InventoryLocation,
+  type InventoryLocationFilters,
+  type InventoryLocationKind,
+  type LocationDialogTarget,
+} from '../../features/inventory';
+
+const PAGE_SIZE = 25;
+
+function isKnownKind(value: string): value is InventoryLocationKind {
+  return (InventoryLocationKindValues as readonly string[]).includes(value);
+}
+
+function statusTone(status: InventoryLocation['status']): StatusBadgeTone {
+  return status === 'active' ? 'success' : 'neutral';
+}
+
+// #3135 review: the wire value `inactive` was rendered verbatim, while
+// every other badge surface in this app renders operator copy and the
+// "Show retired" toggle beside it already calls the same state "retired".
+const STATUS_LABEL: Record<InventoryLocation['status'], string> = {
+  active: 'Active',
+  inactive: 'Retired',
+};
+
+// Guards against a malformed `?page=abc` producing NaN, which would
+// otherwise be sent straight through to the API as the `page` filter
+// (the `users-page.tsx` `readPageParam` precedent, adapted to this
+// endpoint's 1-based paging).
+function readPageParam(raw: string | null): number {
+  const parsed = Number(raw ?? '1');
+  return Number.isFinite(parsed) && parsed >= 1 ? Math.trunc(parsed) : 1;
+}
+
+// The `users-page.tsx` pager, adapted to 1-based paging and a `total` that
+// arrives in the SAME response as the rows (#2316's `PaginatedInventoryLocations`
+// — no two-stage-total machinery needed here, unlike `products-list-page.tsx`).
+function renderPagination(page: number, setPage: (next: number) => void, total: number): ReactElement | null {
+  const pageCount = Math.max(1, Math.ceil(total / PAGE_SIZE));
+  if (pageCount <= 1) return null;
+  return (
+    <div className="pagination">
+      <span className="text-muted">
+        Page {page} of {pageCount} · {total} location{total === 1 ? '' : 's'}
+      </span>
+      <div className="pagination__actions">
+        <Button disabled={page <= 1} onClick={() => setPage(page - 1)}>
+          Previous
+        </Button>
+        <Button disabled={page >= pageCount} onClick={() => setPage(page + 1)}>
+          Next
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function InventoryLocationsPage(): ReactElement {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const demoMode = useDemoMode();
+  const platforms = usePlatforms();
+  const write = useWriteAccess('inventory-locations:write', demoMode);
+  const [dialogTarget, setDialogTarget] = useState<LocationDialogTarget | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<InventoryLocation | null>(null);
+
+  const kindParam = searchParams.get('kind') ?? '';
+  const kind = isKnownKind(kindParam) ? kindParam : undefined;
+  // Default true — soft retirement keeps a row visible by design (#2316), so
+  // the toggle narrows to active-only rather than the other way round.
+  const showRetired = searchParams.get('retired') !== '0';
+  const page = readPageParam(searchParams.get('page'));
+
+  const filters: InventoryLocationFilters = {
+    kind,
+    status: showRetired ? undefined : 'active',
+  };
+
+  const query = useInventoryLocationsQuery(filters, { page, limit: PAGE_SIZE });
+  const connectionsQuery = useConnectionsQuery();
+  const bootstrapMutation = useBootstrapLocationsMutation();
+
+  const connectionById = useMemo(() => {
+    const map = new Map<string, Connection>();
+    (connectionsQuery.data ?? []).forEach((c) => map.set(c.id, c));
+    return map;
+  }, [connectionsQuery.data]);
+
+  function handleFilterChange(key: string, value: string): void {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      if (value) {
+        next.set(key, value);
+      } else {
+        next.delete(key);
+      }
+      // A changed filter can shrink the result set out from under the
+      // current page, so land back on page 1 rather than risk a page
+      // number the new filter has no rows for.
+      next.delete('page');
+      return next;
+    });
+  }
+
+  function clearFilters(): void {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      next.delete('kind');
+      next.delete('retired');
+      next.delete('page');
+      return next;
+    });
+  }
+
+  function setPage(nextPage: number): void {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      if (nextPage <= 1) {
+        next.delete('page');
+      } else {
+        next.set('page', String(nextPage));
+      }
+      return next;
+    });
+  }
+
+  const filtersActive = Boolean(kind) || !showRetired;
+  // Distinct from `filtersActive`: an empty current page with a non-zero
+  // total means the PAGE is wrong, not the filters (e.g. page 2 emptied by
+  // a delete elsewhere, or a hand-edited `?page=99`). Rendering the
+  // pre-bootstrap "zero locations" empty state there would falsely tell the
+  // operator nothing exists (tech-review finding).
+  const pageOutOfRange = page > 1 && (query.data?.total ?? 0) > 0 && (query.data?.items.length ?? 0) === 0;
+
+  // No column declares `sortable`/`accessor`: `ListLocationsQueryDto` has no
+  // sort param (the backend always orders by `code`), and this list is
+  // paginated. `DataTable` falls back to CLIENT sort with neither `sort` nor
+  // `onSortChange` supplied, which would only reorder the visible page —
+  // page 2's "sorted" rows wouldn't compose with page 1's, so the table
+  // would look globally sorted while lying about it (tech-review finding).
+  const columns = useMemo<DataTableColumn<InventoryLocation>[]>(
+    () => [
+      {
+        id: 'location',
+        header: 'Location',
+        cell: (location) => (
+          <div className="data-table__stack">
+            <strong>{location.name}</strong>
+            <span className="muted-text mono-text">
+              {location.code}
+              {location.externalRef ? ` · ${location.externalRef}` : ''}
+            </span>
+          </div>
+        ),
+      },
+      {
+        id: 'kind',
+        header: 'Kind',
+        cell: (location) => KIND_LABEL[location.kind],
+      },
+      {
+        id: 'geo',
+        header: 'Country / postcode',
+        cell: (location): ReactElement => {
+          const geo = [location.countryIso2, location.postcode].filter(Boolean).join(' · ');
+          return geo ? <span className="mono-text">{geo}</span> : <EmptyValue label="No country/postcode" />;
+        },
+        hideBelow: 1024,
+      },
+      {
+        id: 'owner',
+        header: 'Owning connection',
+        cell: (location): ReactElement => {
+          if (!location.ownerConnectionId) {
+            return <EmptyValue label="No owning connection" />;
+          }
+          const connection = connectionById.get(location.ownerConnectionId) ?? null;
+          return (
+            <ConnectionCell
+              connectionId={location.ownerConnectionId}
+              connection={connection}
+              loading={connectionsQuery.isLoading}
+              adornment={
+                connection ? (
+                  <span className="channel-pill" data-channel={connection.platformType}>
+                    {resolvePlatformLabel(platforms, connection.platformType)}
+                  </span>
+                ) : null
+              }
+            />
+          );
+        },
+        hideBelow: 1024,
+      },
+      {
+        id: 'status',
+        header: 'Status',
+        cell: (location) => (
+          <StatusBadge tone={statusTone(location.status)}>{STATUS_LABEL[location.status]}</StatusBadge>
+        ),
+      },
+      {
+        id: 'actions',
+        header: '',
+        cell: (location) =>
+          write.visible ? (
+            <div className="table-actions">
+              <ReadOnlyLock active={write.demoReadOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
+                <Button
+                  className="button--sm"
+                  tone="secondary"
+                  disabled={write.demoReadOnly}
+                  onClick={() => setDialogTarget({ mode: 'edit', location })}
+                >
+                  Edit
+                </Button>
+              </ReadOnlyLock>
+              <ReadOnlyLock active={write.demoReadOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
+                <Button
+                  className="button--sm"
+                  tone="danger"
+                  disabled={write.demoReadOnly}
+                  onClick={() => setDeleteTarget(location)}
+                >
+                  Delete
+                </Button>
+              </ReadOnlyLock>
+            </div>
+          ) : null,
+      },
+    ],
+    [connectionById, connectionsQuery.isLoading, platforms, write.visible, write.demoReadOnly],
+  );
+
+  return (
+    <PageLayout
+      eyebrow="Fulfilment routing"
+      title="Inventory locations"
+      description="The warehouses, stores and third-party sites OpenLinker can source stock from. A location isn't authority over stock — it's the place sourcing rules pick between. Delete is refused while any stock still points here; retire it instead."
+      actions={
+        write.visible ? (
+          <ReadOnlyLock active={write.demoReadOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
+            <Button disabled={write.demoReadOnly} onClick={() => setDialogTarget({ mode: 'create' })}>
+              + Add location
+            </Button>
+          </ReadOnlyLock>
+        ) : null
+      }
+    >
+      <div className="toolbar">
+        <div className="toolbar__group">
+          <Select
+            aria-label="Filter by kind"
+            value={kind ?? ''}
+            onChange={(e) => { handleFilterChange('kind', e.target.value); }}
+          >
+            <option value="">All kinds</option>
+            {InventoryLocationKindValues.map((k) => (
+              <option key={k} value={k}>
+                {KIND_LABEL[k]}
+              </option>
+            ))}
+          </Select>
+          <label className="toolbar__checkbox-label">
+            <input
+              type="checkbox"
+              name="showRetired"
+              checked={showRetired}
+              onChange={(e) => { handleFilterChange('retired', e.target.checked ? '' : '0'); }}
+            />
+            Show retired
+          </label>
+        </div>
+      </div>
+
+      {query.isLoading ? (
+        <DataTableSkeleton columns={columns.length} rows={5} />
+      ) : query.error ? (
+        <ErrorState
+          title="Couldn't load locations"
+          message={query.error.message}
+          action={<Button onClick={() => { void query.refetch(); }}>Retry</Button>}
+        />
+      ) : (query.data?.items ?? []).length === 0 ? (
+        <EmptyState
+          title={
+            pageOutOfRange
+              ? "This page doesn't exist anymore"
+              : filtersActive
+                ? 'No locations match this filter'
+                : 'Routing has nowhere to source stock from'
+          }
+          message={
+            pageOutOfRange
+              ? `There are ${query.data?.total ?? 0} locations, but not on page ${page}.`
+              : filtersActive
+                ? 'No locations match the current filters.'
+                // #3135 review: routing is opt-in (#2407) and ConnectionService
+                // refuses the false->true transition while zero locations
+                // exist, so a zero-location install either has routing off
+                // (orders fulfil fine today) or could never have enabled it —
+                // "every order is unfulfillable" was false in both directions.
+                : "Fulfilment routing has nowhere to source stock from yet, so it can't be enabled for any connection. Mint the first location, or add your own — either way it still needs stock assigned before routing can succeed."
+          }
+          action={
+            pageOutOfRange ? (
+              <Button onClick={() => setPage(1)}>Back to page 1</Button>
+            ) : filtersActive ? (
+              <Button onClick={clearFilters}>Clear filters</Button>
+            ) : write.visible ? (
+              <div className="table-actions">
+                <ReadOnlyLock active={write.demoReadOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
+                  <Button
+                    disabled={write.demoReadOnly || bootstrapMutation.isPending}
+                    onClick={() => bootstrapMutation.mutate()}
+                  >
+                    Create first location
+                  </Button>
+                </ReadOnlyLock>
+                <ReadOnlyLock active={write.demoReadOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
+                  <Button
+                    tone="secondary"
+                    disabled={write.demoReadOnly}
+                    onClick={() => setDialogTarget({ mode: 'create' })}
+                  >
+                    + Add manually
+                  </Button>
+                </ReadOnlyLock>
+              </div>
+            ) : null
+          }
+        />
+      ) : (
+        <>
+          <DataTable
+            caption="Inventory locations"
+            columns={columns}
+            rowKey={(location) => location.id}
+            rows={[...(query.data?.items ?? [])]}
+            cardView={{
+              title: (location) => location.name,
+              subtitle: (location) => location.code,
+              meta: (location) => (
+                <StatusBadge tone={statusTone(location.status)} compact>
+                  {STATUS_LABEL[location.status]}
+                </StatusBadge>
+              ),
+            }}
+          />
+          {renderPagination(page, setPage, query.data?.total ?? 0)}
+        </>
+      )}
+
+      <LocationDialog target={dialogTarget} onClose={() => setDialogTarget(null)} />
+      <LocationDeleteDialog location={deleteTarget} onClose={() => setDeleteTarget(null)} />
+    </PageLayout>
+  );
+}

--- a/apps/web/src/pages/inventory/inventory-locations-page.tsx
+++ b/apps/web/src/pages/inventory/inventory-locations-page.tsx
@@ -25,6 +25,7 @@ import { Button } from '../../shared/ui/button';
 import { Select } from '../../shared/ui/select';
 import { EmptyValue } from '../../shared/ui/empty-value';
 import { ReadOnlyLock } from '../../shared/ui/read-only-lock';
+import { useToast } from '../../shared/ui/toast-provider';
 import { useWriteAccess } from '../../shared/auth/use-permission';
 import { DEMO_READ_ONLY_ACTION_MESSAGE } from '../../shared/config/demo-mode';
 import { useDemoMode } from '../../features/system';
@@ -38,6 +39,7 @@ import {
   LocationDeleteDialog,
   useInventoryLocationsQuery,
   useBootstrapLocationsMutation,
+  useUpdateInventoryLocationMutation,
   type InventoryLocation,
   type InventoryLocationFilters,
   type InventoryLocationKind,
@@ -98,6 +100,7 @@ export function InventoryLocationsPage(): ReactElement {
   const [searchParams, setSearchParams] = useSearchParams();
   const demoMode = useDemoMode();
   const platforms = usePlatforms();
+  const { showToast } = useToast();
   const write = useWriteAccess('inventory-locations:write', demoMode);
   const [dialogTarget, setDialogTarget] = useState<LocationDialogTarget | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<InventoryLocation | null>(null);
@@ -117,12 +120,48 @@ export function InventoryLocationsPage(): ReactElement {
   const query = useInventoryLocationsQuery(filters, { page, limit: PAGE_SIZE });
   const connectionsQuery = useConnectionsQuery();
   const bootstrapMutation = useBootstrapLocationsMutation();
+  const reactivateMutation = useUpdateInventoryLocationMutation();
+  const retireMutation = useUpdateInventoryLocationMutation();
 
   const connectionById = useMemo(() => {
     const map = new Map<string, Connection>();
     (connectionsQuery.data ?? []).forEach((c) => map.set(c.id, c));
     return map;
   }, [connectionsQuery.data]);
+
+  // Mirrors `users-page.tsx`'s handleReactivate — a direct, single-click
+  // action with no confirm dialog (the mockup's `reactivateLocation`):
+  // reactivating is reversible and non-destructive, unlike delete.
+  async function handleReactivate(location: InventoryLocation): Promise<void> {
+    try {
+      await reactivateMutation.mutateAsync({ id: location.id, patch: { status: 'active' } });
+      showToast({
+        tone: 'success',
+        title: `"${location.name}" reactivated`,
+        description: 'New stock can target it again.',
+      });
+    } catch {
+      showToast({ tone: 'error', title: 'Reactivation failed', description: 'Try again.' });
+    }
+  }
+
+  // Direct row-level counterpart to handleReactivate (the mockup's
+  // `retireLocation`) — no confirm dialog, because retiring never deletes
+  // anything and Reactivate undoes it in one click. The delete-confirm
+  // dialog's own "Retire instead" 409 fallback stays as a defensive path for
+  // an operator who reaches for Delete first; this is the direct one.
+  async function handleRetire(location: InventoryLocation): Promise<void> {
+    try {
+      await retireMutation.mutateAsync({ id: location.id, patch: { status: 'inactive' } });
+      showToast({
+        tone: 'success',
+        title: `"${location.name}" retired`,
+        description: 'Existing positions keep pointing at it.',
+      });
+    } catch {
+      showToast({ tone: 'error', title: 'Retire failed', description: 'Try again.' });
+    }
+  }
 
   function handleFilterChange(key: string, value: string): void {
     setSearchParams((prev) => {
@@ -234,7 +273,9 @@ export function InventoryLocationsPage(): ReactElement {
         id: 'status',
         header: 'Status',
         cell: (location) => (
-          <StatusBadge tone={statusTone(location.status)}>{STATUS_LABEL[location.status]}</StatusBadge>
+          <StatusBadge tone={statusTone(location.status)} className="loc-status-badge">
+            {STATUS_LABEL[location.status]}
+          </StatusBadge>
         ),
       },
       {
@@ -253,6 +294,29 @@ export function InventoryLocationsPage(): ReactElement {
                   Edit
                 </Button>
               </ReadOnlyLock>
+              {location.status === 'active' ? (
+                <ReadOnlyLock active={write.demoReadOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
+                  <Button
+                    className="button--sm loc-status-action"
+                    tone="secondary"
+                    disabled={write.demoReadOnly || retireMutation.isPending}
+                    onClick={() => { void handleRetire(location); }}
+                  >
+                    Retire
+                  </Button>
+                </ReadOnlyLock>
+              ) : (
+                <ReadOnlyLock active={write.demoReadOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
+                  <Button
+                    className="button--sm loc-status-action"
+                    tone="secondary"
+                    disabled={write.demoReadOnly || reactivateMutation.isPending}
+                    onClick={() => { void handleReactivate(location); }}
+                  >
+                    Reactivate
+                  </Button>
+                </ReadOnlyLock>
+              )}
               <ReadOnlyLock active={write.demoReadOnly} message={DEMO_READ_ONLY_ACTION_MESSAGE}>
                 <Button
                   className="button--sm"
@@ -267,7 +331,15 @@ export function InventoryLocationsPage(): ReactElement {
           ) : null,
       },
     ],
-    [connectionById, connectionsQuery.isLoading, platforms, write.visible, write.demoReadOnly],
+    [
+      connectionById,
+      connectionsQuery.isLoading,
+      platforms,
+      write.visible,
+      write.demoReadOnly,
+      reactivateMutation.isPending,
+      retireMutation.isPending,
+    ],
   );
 
   return (

--- a/apps/web/src/pages/settings/settings-page.test.tsx
+++ b/apps/web/src/pages/settings/settings-page.test.tsx
@@ -121,6 +121,34 @@ describe('SettingsPage', () => {
     ).toBeInTheDocument();
   });
 
+  /**
+   * Same deviation, same reason: `InventoryLocationsController`'s reads are
+   * `@Roles('admin', 'operator', 'viewer')` and the sidebar nav entry is
+   * already gated on `inventory:read`, not on being an admin — gating this
+   * link-out tile to admin-only would make it LESS reachable than the nav
+   * item pointing at the same page.
+   */
+  it('always renders the Inventory locations tile, including for a non-admin session', async () => {
+    renderWithProviders(<SettingsPage />, {
+      sessionAdapter: createAuthenticatedSessionAdapter({
+        id: 'user_4',
+        username: 'viewer',
+        email: 'viewer3@example.com',
+        role: 'viewer',
+        permissions: ['inventory:read'],
+        analyticsConsent: true,
+      }),
+    });
+
+    expect(await screen.findByText('viewer3@example.com')).toBeInTheDocument();
+    expect(
+      await screen.findByRole('heading', { name: 'Inventory locations' }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText('Inventory locations', { selector: '.toolbar-chip' }),
+    ).toBeInTheDocument();
+  });
+
   it('shows the PostHog tile for an admin session', async () => {
     renderWithProviders(<SettingsPage />, {
       sessionAdapter: createAuthenticatedSessionAdapter(),

--- a/apps/web/src/pages/settings/settings-page.tsx
+++ b/apps/web/src/pages/settings/settings-page.tsx
@@ -8,6 +8,7 @@ import { McpTokensTile } from '../../features/mcp-tokens/components/mcp-tokens-t
 import { SalesDocumentsTile } from '../../features/sales-documents';
 import { WhoDecidesTile } from '../../features/fulfillment-authority';
 import { SyncPacingTile } from '../../features/settings';
+import { InventoryLocationsTile } from '../../features/inventory';
 import { PageLayout } from '../../shared/ui/page-layout';
 
 export function SettingsPage(): ReactElement {
@@ -31,6 +32,8 @@ export function SettingsPage(): ReactElement {
           {/* Ungated, unlike its admin-gated neighbours — see `WhoDecidesTile`'s docblock. */}
           <span className="toolbar-chip">Who decides what</span>
           {isAdmin ? <span className="toolbar-chip">Sync pacing</span> : null}
+          {/* Ungated — see `InventoryLocationsTile`'s docblock. */}
+          <span className="toolbar-chip">Inventory locations</span>
           <span className="toolbar-chip">Upcoming</span>
         </div>
       }
@@ -114,6 +117,9 @@ export function SettingsPage(): ReactElement {
 
         {/* ── Sync pacing (admin-only, #2653) ───────────────────────── */}
         {isAdmin ? <SyncPacingTile /> : null}
+
+        {/* Deliberately NOT admin-gated — see `InventoryLocationsTile`'s docblock. */}
+        <InventoryLocationsTile />
 
         {/* ── Notifications (planned) ───────────────────────────────── */}
         <article className="panel panel--dense">

--- a/apps/web/src/shared/api/api-error.ts
+++ b/apps/web/src/shared/api/api-error.ts
@@ -55,3 +55,22 @@ export class ApiError extends Error {
     return new ApiError(`Request timed out: ${path}`, 0, { timeout: true, path });
   }
 }
+
+/**
+ * True when `error` is a mutation failure a caller has NOT already surfaced
+ * through its own recovery UI (a field error, a dedicated "in use" state) —
+ * so a generic "Could not save" alert is the only place it will be shown.
+ *
+ * `isMapped` names the caller's own recognised-and-handled statuses (e.g.
+ * `(e) => e.isConflict()`); anything else — a non-`ApiError`, or an `ApiError`
+ * `isMapped` doesn't recognise — is unmapped and must still reach the user
+ * somewhere, which is exactly what this predicate is for.
+ *
+ * Extracted after #3068 tech-review found `LocationDialog` and
+ * `LocationDeleteDialog` computing this same "is this the one I already
+ * handled" check inline, with the same shape and no shared source — a third
+ * mutation dialog would otherwise have copied it a third time.
+ */
+export function isUnmappedApiError(error: unknown, isMapped: (apiError: ApiError) => boolean): boolean {
+  return !(error instanceof ApiError && isMapped(error));
+}

--- a/apps/web/src/shared/auth/session.types.ts
+++ b/apps/web/src/shared/auth/session.types.ts
@@ -17,10 +17,6 @@ export const PermissionValues = [
   'products:write',
   'inventory:read',
   'inventory:write',
-  // DISPLAY-ONLY (#3066): gates the locations-list Add/Edit/Delete/Retire
-  // affordances. Deliberately not `inventory:write` — see that constant's
-  // docblock on the backend for why.
-  'inventory-locations:write',
   'listings:read',
   'listings:write',
   'users:read',
@@ -35,6 +31,10 @@ export const PermissionValues = [
   'content:write',
   'automations:read',
   'automations:write',
+  // DISPLAY-ONLY (#3066): gates the locations-list Add/Edit/Delete/Retire
+  // affordances. Deliberately not `inventory:write` — see that constant's
+  // docblock on the backend for why.
+  'inventory-locations:write',
   'analytics:write',
 ] as const;
 

--- a/apps/web/src/shared/auth/session.types.ts
+++ b/apps/web/src/shared/auth/session.types.ts
@@ -17,6 +17,10 @@ export const PermissionValues = [
   'products:write',
   'inventory:read',
   'inventory:write',
+  // DISPLAY-ONLY (#3066): gates the locations-list Add/Edit/Delete/Retire
+  // affordances. Deliberately not `inventory:write` — see that constant's
+  // docblock on the backend for why.
+  'inventory-locations:write',
   'listings:read',
   'listings:write',
   'users:read',

--- a/docs/plans/mockups/inventory-locations-3063.html
+++ b/docs/plans/mockups/inventory-locations-3063.html
@@ -1,0 +1,819 @@
+<title>Inventory Locations</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap">
+<style>
+:root, [data-theme='light'] {
+  --bg-canvas: oklch(99% 0.003 80); --bg-shell: oklch(97.5% 0.004 80);
+  --bg-surface: #ffffff; --bg-surface-elevated: oklch(99% 0.003 80);
+  --bg-surface-muted: oklch(96% 0.005 80); --bg-surface-hover: oklch(93% 0.006 80);
+  --bg-strong: oklch(93% 0.006 80);
+  --border-subtle: oklch(93.5% 0.006 80); --border-default: oklch(88% 0.008 80);
+  --border-strong: oklch(78% 0.010 80); --border-focus: oklch(68% 0.18 50);
+  --text-primary: oklch(20% 0.012 80); --text-secondary: oklch(38% 0.010 80);
+  --text-muted: oklch(52% 0.008 80); --text-disabled: oklch(70% 0.005 80);
+  --text-inverse: oklch(96% 0.005 80); --text-on-primary: oklch(18% 0.012 50);
+  --text-link: oklch(50% 0.14 250);
+  --accent-primary: oklch(68% 0.18 50); --accent-primary-hover: oklch(62% 0.19 50);
+  --accent-primary-active: oklch(56% 0.20 50); --accent-primary-soft: oklch(96% 0.04 60);
+  --accent-primary-border: oklch(85% 0.10 55); --accent-ring: oklch(68% 0.18 50 / 0.30);
+  --status-success: oklch(54% 0.14 150); --status-success-soft: oklch(96% 0.04 150);
+  --status-success-border: oklch(85% 0.08 150); --status-success-fg: oklch(36% 0.12 150);
+  --status-warning: oklch(72% 0.16 85); --status-warning-soft: oklch(96% 0.05 85);
+  --status-warning-border: oklch(85% 0.10 85); --status-warning-fg: oklch(42% 0.12 80);
+  --status-error: oklch(58% 0.20 25); --status-error-soft: oklch(96% 0.04 25);
+  --status-error-border: oklch(85% 0.10 25); --status-error-fg: oklch(42% 0.16 25);
+  --status-info: oklch(56% 0.14 245); --status-info-soft: oklch(96% 0.03 245);
+  --status-info-border: oklch(85% 0.08 245); --status-info-fg: oklch(40% 0.12 245);
+  --status-disabled: oklch(55% 0.008 80); --status-disabled-soft: oklch(95% 0.005 80);
+  --status-disabled-border: oklch(85% 0.008 80); --status-disabled-fg: oklch(38% 0.010 80);
+  --space-1:.25rem; --space-2:.5rem; --space-3:.75rem; --space-4:1rem; --space-5:1.5rem; --space-6:2rem;
+  --radius-xs:4px; --radius-sm:6px; --radius-md:8px; --radius-lg:10px; --radius-xl:14px; --radius-pill:9999px;
+  --shadow-xs: 0 1px 2px rgb(15 18 26 / 0.04);
+  --shadow-soft: 0 1px 2px rgb(15 18 26 / .04), 0 6px 16px rgb(15 18 26 / .06);
+  --shadow-inset-top: inset 0 1px 0 rgb(255 255 255 / .6);
+  --shadow-focus: 0 0 0 3px var(--accent-ring);
+  --shadow-overlay: 0 24px 48px rgb(15 18 26 / .16), 0 8px 16px rgb(15 18 26 / .08);
+  --overlay-scrim: rgb(15 18 26 / 0.55);
+  --duration-fast: 120ms; --ease-out: cubic-bezier(.16,1,.3,1);
+  --font-sans: 'IBM Plex Sans', ui-sans-serif, system-ui, sans-serif;
+  --font-mono: 'IBM Plex Mono', ui-monospace, SFMono-Regular, Menlo, monospace;
+  /* Channel brand hues (#1752) — identical in light/dark, brand identity not status */
+  --channel-prestashop: oklch(60% 0.18 250);
+  --channel-woocommerce: oklch(64% 0.16 150);
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme='light']) {
+    --bg-canvas: oklch(14% 0.005 270); --bg-shell: oklch(16% 0.006 270);
+    --bg-surface: oklch(19% 0.007 270); --bg-surface-elevated: oklch(22% 0.008 270);
+    --bg-surface-muted: oklch(24% 0.009 270); --bg-surface-hover: oklch(28% 0.010 270);
+    --bg-strong: oklch(28% 0.010 270);
+    --border-subtle: oklch(24% 0.010 270); --border-default: oklch(30% 0.012 270);
+    --border-strong: oklch(42% 0.014 270); --border-focus: oklch(72% 0.18 50);
+    --text-primary: oklch(96% 0.006 270); --text-secondary: oklch(78% 0.010 270);
+    --text-muted: oklch(60% 0.012 270); --text-disabled: oklch(42% 0.012 270);
+    --text-inverse: oklch(20% 0.012 80); --text-on-primary: oklch(16% 0.012 50);
+    --accent-primary: oklch(72% 0.18 50); --accent-primary-hover: oklch(78% 0.18 50);
+    --accent-primary-active: oklch(84% 0.16 50); --accent-primary-soft: oklch(28% 0.08 50);
+    --accent-primary-border: oklch(40% 0.14 55); --accent-ring: oklch(72% 0.18 50 / 0.40);
+    --status-success-soft: oklch(26% 0.06 150); --status-success-border: oklch(36% 0.10 150); --status-success-fg: oklch(86% 0.14 150);
+    --status-warning-soft: oklch(28% 0.07 85); --status-warning-border: oklch(38% 0.10 85); --status-warning-fg: oklch(88% 0.14 85);
+    --status-error-soft: oklch(28% 0.10 25); --status-error-border: oklch(40% 0.14 25); --status-error-fg: oklch(86% 0.14 25);
+    --status-info-soft: oklch(26% 0.06 245); --status-info-border: oklch(36% 0.10 245); --status-info-fg: oklch(86% 0.12 245);
+    --status-disabled-soft: oklch(24% 0.010 270); --status-disabled-border: oklch(34% 0.012 270); --status-disabled-fg: oklch(82% 0.010 270);
+    --shadow-soft: 0 1px 2px rgb(0 0 0 / .4), 0 8px 24px rgb(0 0 0 / .4);
+    --shadow-xs: 0 1px 2px rgb(0 0 0 / .4);
+    --shadow-inset-top: inset 0 1px 0 rgb(255 255 255 / .04);
+    --overlay-scrim: rgb(0 0 0 / 0.72);
+  }
+}
+:root[data-theme='dark'] {
+  --bg-canvas: oklch(14% 0.005 270); --bg-shell: oklch(16% 0.006 270);
+  --bg-surface: oklch(19% 0.007 270); --bg-surface-elevated: oklch(22% 0.008 270);
+  --bg-surface-muted: oklch(24% 0.009 270); --bg-surface-hover: oklch(28% 0.010 270);
+  --bg-strong: oklch(28% 0.010 270);
+  --border-subtle: oklch(24% 0.010 270); --border-default: oklch(30% 0.012 270);
+  --border-strong: oklch(42% 0.014 270); --border-focus: oklch(72% 0.18 50);
+  --text-primary: oklch(96% 0.006 270); --text-secondary: oklch(78% 0.010 270);
+  --text-muted: oklch(60% 0.012 270); --text-disabled: oklch(42% 0.012 270);
+  --text-inverse: oklch(20% 0.012 80); --text-on-primary: oklch(16% 0.012 50);
+  --accent-primary: oklch(72% 0.18 50); --accent-primary-hover: oklch(78% 0.18 50);
+  --accent-primary-active: oklch(84% 0.16 50); --accent-primary-soft: oklch(28% 0.08 50);
+  --accent-primary-border: oklch(40% 0.14 55); --accent-ring: oklch(72% 0.18 50 / 0.40);
+  --status-success-soft: oklch(26% 0.06 150); --status-success-border: oklch(36% 0.10 150); --status-success-fg: oklch(86% 0.14 150);
+  --status-warning-soft: oklch(28% 0.07 85); --status-warning-border: oklch(38% 0.10 85); --status-warning-fg: oklch(88% 0.14 85);
+  --status-error-soft: oklch(28% 0.10 25); --status-error-border: oklch(40% 0.14 25); --status-error-fg: oklch(86% 0.14 25);
+  --status-info-soft: oklch(26% 0.06 245); --status-info-border: oklch(36% 0.10 245); --status-info-fg: oklch(86% 0.12 245);
+  --status-disabled-soft: oklch(24% 0.010 270); --status-disabled-border: oklch(34% 0.012 270); --status-disabled-fg: oklch(82% 0.010 270);
+  --shadow-soft: 0 1px 2px rgb(0 0 0 / .4), 0 8px 24px rgb(0 0 0 / .4);
+  --shadow-xs: 0 1px 2px rgb(0 0 0 / .4);
+  --overlay-scrim: rgb(0 0 0 / 0.72);
+}
+* { box-sizing: border-box; }
+[hidden] { display: none !important; }
+body { margin:0; min-width:320px; background:var(--bg-canvas); color:var(--text-primary); font-family:var(--font-sans); font-size:.8125rem; line-height:1.5; }
+a { color: var(--accent-primary-hover); text-decoration: underline; text-underline-offset:.16em; }
+h1,h2,h3,p { margin:0; }
+button:focus-visible, a:focus-visible, input:focus-visible, select:focus-visible { outline:none; box-shadow:var(--shadow-focus); border-radius:var(--radius-sm); }
+
+.shell { min-height:100vh; display:grid; grid-template-columns:minmax(0,1fr); grid-template-rows:auto 1fr; }
+@media (min-width:1024px){ .shell{ grid-template-columns:240px minmax(0,1fr);} }
+.shell-sidebar{ display:none; }
+@media (min-width:1024px){ .shell-sidebar{ display:flex; flex-direction:column; background:var(--bg-shell); border-right:1px solid var(--border-subtle); padding:12px 0; position:sticky; top:0; height:100vh; } }
+.shell-brand{ display:flex; align-items:center; gap:8px; padding:4px 16px 16px; }
+.shell-brand__mark{ width:26px;height:26px;border-radius:6px;background:var(--accent-primary);display:grid;place-items:center;color:var(--text-on-primary);font-weight:700;font-size:13px; }
+.shell-brand__name{ font-weight:600; font-size:14px; letter-spacing:-.02em; }
+.shell-nav{ flex:1; overflow-y:auto; padding:0 12px; }
+.shell-nav__group{ margin-bottom:16px; }
+.shell-nav__label{ margin:0 0 4px; padding:0 8px; font-size:10px; font-weight:600; letter-spacing:.11em; text-transform:uppercase; color:var(--text-muted); }
+.shell-nav__list{ list-style:none; padding:0; margin:0; display:grid; gap:1px; }
+.shell-nav__link{ display:flex; align-items:center; padding:6px 8px; border-radius:6px; color:var(--text-secondary); font-size:13px; font-weight:500; text-decoration:none; }
+.shell-nav__link:hover{ background:var(--bg-surface-muted); color:var(--text-primary); }
+.shell-nav__link--active{ background:var(--bg-surface-muted); color:var(--text-primary); font-weight:600; box-shadow:inset 2px 0 0 var(--accent-primary); }
+.shell-topbar{ position:sticky; top:0; z-index:10; display:flex; align-items:center; gap:12px; height:52px; padding:0 16px; background:var(--bg-shell); border-bottom:1px solid var(--border-subtle); }
+.shell-crumbs{ font-size:13px; color:var(--text-secondary); }
+.shell-crumbs b{ color:var(--text-primary); font-weight:500; }
+.shell-main{ min-width:0; }
+.shell-content{ padding:20px 32px 48px; max-width:1180px; }
+
+.back-link{ display:inline-flex; align-items:center; gap:.375rem; font-size:.8125rem; color:var(--text-muted); text-decoration:none; margin-bottom:2px; }
+.back-link:hover{ color:var(--text-primary); }
+.eyebrow{ margin:0; font-size:.76rem; font-weight:700; letter-spacing:.08em; text-transform:uppercase; color:var(--accent-primary-hover); }
+.page-header{ display:grid; gap:.45rem; margin-bottom:20px; }
+.page-header__row{ display:flex; align-items:start; justify-content:space-between; gap:16px; flex-wrap:wrap; }
+.page-title{ font-size:1.75rem; font-weight:600; letter-spacing:-.02em; }
+.page-description{ color:var(--text-secondary); font-size:.875rem; max-width:64ch; }
+.page-header__actions{ display:flex; gap:8px; flex-shrink:0; }
+
+.button{ display:inline-flex; align-items:center; justify-content:center; gap:var(--space-2); border:1px solid var(--accent-primary-border); border-radius:var(--radius-md); padding:0 var(--space-4); height:2rem; background:var(--accent-primary); color:var(--text-on-primary); font-family:inherit; font-size:.8125rem; font-weight:500; cursor:pointer; text-decoration:none; white-space:nowrap; box-shadow:var(--shadow-xs), var(--shadow-inset-top); }
+.button:hover{ background:var(--accent-primary-hover); border-color:var(--accent-primary-hover); }
+.button--secondary{ border-color:var(--border-default); background:var(--bg-surface); color:var(--text-primary); }
+.button--secondary:hover{ background:var(--bg-surface-muted); border-color:var(--border-strong); }
+.button--ghost{ border-color:transparent; background:transparent; color:var(--text-secondary); box-shadow:none; }
+.button--ghost:hover{ background:var(--bg-surface-muted); color:var(--text-primary); }
+.button--danger{ border-color:color-mix(in oklab, var(--status-error) 80%, black); background:var(--status-error); color:#fff; }
+.button--danger:hover{ background:color-mix(in oklab, var(--status-error) 90%, black); }
+.button:disabled{ cursor:not-allowed; opacity:.5; box-shadow:none; }
+.button--sm{ height:1.75rem; padding:0 var(--space-3); font-size:.75rem; }
+.button--icon{ padding:0; width:2rem; }
+.button--icon.button--sm{ width:1.75rem; }
+
+.status-badge{ display:inline-flex; align-items:center; gap:var(--space-2); padding:2px var(--space-2); border:1px solid var(--status-disabled-border); border-radius:var(--radius-sm); background:var(--status-disabled-soft); color:var(--status-disabled-fg); font-family:var(--font-mono); font-size:.6875rem; font-weight:500; letter-spacing:.02em; text-transform:uppercase; white-space:nowrap; }
+.status-badge__dot{ width:.375rem; height:.375rem; border-radius:999px; background:currentColor; opacity:.75; }
+.status-badge--success{ border-color:var(--status-success-border); background:var(--status-success-soft); color:var(--status-success-fg); }
+.status-badge--warning{ border-color:var(--status-warning-border); background:var(--status-warning-soft); color:var(--status-warning-fg); }
+.status-badge--error{ border-color:var(--status-error-border); background:var(--status-error-soft); color:var(--status-error-fg); }
+.status-badge--neutral{ border-color:var(--status-disabled-border); background:var(--status-disabled-soft); color:var(--status-disabled-fg); }
+.status-badge--compact{ padding:1px var(--space-2); font-size:.625rem; }
+
+.chip{ display:inline-flex; align-items:center; gap:.25rem; height:1.375rem; padding:0 .5rem; border:1px solid var(--border-subtle); border-radius:var(--radius-pill); background:var(--bg-surface-muted); color:var(--text-secondary); font-size:.75rem; font-weight:500; cursor:pointer; }
+.chip.chip--active{ background:var(--accent-primary-soft); border-color:var(--accent-primary-border); color:var(--accent-primary-hover); font-weight:600; }
+
+.alert{ display:flex; gap:var(--space-3); padding:var(--space-3) var(--space-4); border-radius:var(--radius-lg); border:1px solid; margin-bottom:20px; align-items:flex-start; }
+.alert--info{ background:var(--status-info-soft); border-color:var(--status-info-border); color:var(--status-info-fg); }
+.alert--warning{ background:var(--status-warning-soft); border-color:var(--status-warning-border); color:var(--status-warning-fg); }
+.alert--error{ background:var(--status-error-soft); border-color:var(--status-error-border); color:var(--status-error-fg); }
+.alert__glyph{ flex-shrink:0; font-size:1rem; line-height:1.4; }
+.alert__content{ display:grid; gap:2px; }
+.alert__title{ font-weight:600; color:var(--text-primary); font-size:.8125rem; }
+.alert__description{ font-size:.8125rem; color:var(--text-secondary); }
+.alert__actions{ margin-left:auto; flex-shrink:0; align-self:center; display:flex; gap:8px; }
+
+.filter-bar{ display:flex; align-items:center; gap:8px; margin-bottom:14px; flex-wrap:wrap; }
+.filter-bar__group{ display:flex; gap:6px; align-items:center; }
+.filter-bar__label{ font-family:var(--font-mono); font-size:.6875rem; text-transform:uppercase; letter-spacing:.06em; color:var(--text-muted); margin-right:2px; }
+
+.data-table__container{ overflow-x:auto; border:1px solid var(--border-subtle); border-radius:var(--radius-lg); background:var(--bg-surface); box-shadow:var(--shadow-xs); }
+.data-table{ width:100%; border-collapse:collapse; font-size:.8125rem; }
+.data-table thead th{ padding:var(--space-3) var(--space-4); text-align:left; border-bottom:1px solid var(--border-subtle); color:var(--text-muted); font-family:var(--font-mono); font-size:.6875rem; font-weight:500; letter-spacing:.08em; text-transform:uppercase; background:var(--bg-shell); }
+.data-table tbody td{ padding:var(--space-3) var(--space-4); border-top:1px solid var(--border-subtle); vertical-align:top; }
+.data-table tbody tr:hover{ background:color-mix(in oklab, var(--bg-shell) 55%, transparent); }
+.data-table tbody tr.loc-row--inactive{ opacity:.62; }
+.data-table__empty-cell{ padding:var(--space-5) var(--space-3); color:var(--text-muted); text-align:center; }
+.mono{ font-family:var(--font-mono); font-size:.75rem; color:var(--text-secondary); }
+
+.loc-cell__name{ font-weight:600; color:var(--text-primary); }
+.loc-cell__code{ font-family:var(--font-mono); font-size:.6875rem; color:var(--text-muted); margin-top:2px; }
+.loc-positions-link{ font-family:var(--font-mono); color:var(--text-link); }
+.loc-kind-badge{ font-family:var(--font-mono); font-size:.625rem; text-transform:uppercase; letter-spacing:.06em; padding:1px 6px; border-radius:var(--radius-xs); background:var(--bg-surface-muted); color:var(--text-secondary); border:1px solid var(--border-subtle); }
+.loc-actions{ display:flex; gap:4px; justify-content:flex-end; }
+
+/* Owning-connection cell — same composition as the products-list Source
+   column: a channel-pill (platform identity) beside the connection name,
+   the whole thing a link to /connections/:id. */
+.channel-pill{ display:inline-flex; align-items:center; gap:var(--space-1); padding:2px var(--space-2); border:1px solid var(--border-subtle); border-radius:var(--radius-pill); background:var(--bg-surface-muted); color:var(--text-secondary); font-family:var(--font-mono); font-size:.6875rem; white-space:nowrap; flex-shrink:0; }
+.channel-pill::before{ content:''; width:6px; height:6px; border-radius:50%; background:var(--text-muted); flex-shrink:0; }
+.channel-pill[data-channel='prestashop']::before{ background:var(--channel-prestashop); }
+.channel-pill[data-channel='woocommerce']::before{ background:var(--channel-woocommerce); }
+.loc-owner-link{ display:inline-flex; align-items:center; gap:6px; min-width:0; max-width:100%; color:var(--text-primary); text-decoration:none; }
+.loc-owner-link:hover .loc-owner-link__name{ text-decoration:underline; }
+.loc-owner-link__name{ overflow:hidden; text-overflow:ellipsis; white-space:nowrap; font-weight:500; }
+
+.state-card{ border:1px solid var(--border-default); border-radius:var(--radius-lg); background:var(--bg-surface); box-shadow:var(--shadow-soft); padding:32px 28px; text-align:left; }
+.state-card--error{ border-color:var(--status-error-border); }
+.state-card__title{ font-size:1.0625rem; font-weight:600; margin-top:4px; }
+.state-card__message{ color:var(--text-secondary); font-size:.8125rem; margin-top:6px; max-width:56ch; }
+.state-card__actions{ margin-top:14px; display:flex; gap:8px; }
+.skeleton-line{ height:12px; border-radius:4px; background:linear-gradient(90deg, var(--bg-surface-muted) 25%, var(--bg-surface-hover) 37%, var(--bg-surface-muted) 63%); background-size:400% 100%; animation:skeleton 1.4s ease infinite; }
+@keyframes skeleton{ 0%{background-position:100% 50%;} 100%{background-position:0 50%;} }
+@media (prefers-reduced-motion:reduce){ .skeleton-line{ animation:none; } }
+
+.form-field{ display:grid; gap:var(--space-2); margin-bottom:var(--space-4); }
+.form-field__label{ font-size:.8125rem; font-weight:500; }
+.form-field__description{ margin:0; color:var(--text-muted); font-size:.75rem; }
+.form-field__error{ margin:0; color:var(--status-error-fg); font-size:.75rem; display:flex; gap:4px; align-items:center; }
+input[type=text],input[type=number],select{ width:100%; height:2rem; border:1px solid var(--border-default); border-radius:var(--radius-md); padding:0 var(--space-3); background:var(--bg-surface); color:var(--text-primary); font-family:inherit; font-size:.8125rem; }
+select{ padding-right:28px; background-image:linear-gradient(45deg,transparent 50%,var(--text-secondary) 50%),linear-gradient(135deg,var(--text-secondary) 50%,transparent 50%); background-position:calc(100% - 14px) calc(50% - 2px), calc(100% - 8px) calc(50% - 2px); background-size:5px 5px,5px 5px; background-repeat:no-repeat; appearance:none; }
+input[aria-invalid=true],select[aria-invalid=true]{ border-color:var(--status-error); }
+input:disabled{ background:var(--bg-surface-muted); color:var(--text-disabled); }
+input:read-only{ background:var(--bg-surface-muted); color:var(--text-secondary); cursor:not-allowed; }
+.form-field-row{ display:grid; grid-template-columns:1fr 1fr; gap:var(--space-3); }
+.form-field-row--3{ grid-template-columns:1fr 1fr 1fr; }
+@media (max-width:520px){ .form-field-row, .form-field-row--3{ grid-template-columns:1fr; } }
+
+.pagination{ display:flex; align-items:center; justify-content:space-between; gap:12px; margin-top:12px; font-size:.75rem; color:var(--text-muted); flex-wrap:wrap; }
+.pagination__nav{ display:flex; gap:6px; }
+
+.dialog-backdrop{ position:fixed; inset:0; display:none; place-items:center; padding:24px; background:var(--overlay-scrim); z-index:40; overflow-y:auto; }
+.dialog-backdrop.is-open{ display:grid; }
+.dialog{ width:min(100%, 30rem); border:1px solid var(--border-default); border-radius:var(--radius-xl); padding:20px; background:var(--bg-surface); box-shadow:var(--shadow-overlay); }
+.dialog__header{ display:flex; justify-content:space-between; align-items:start; margin-bottom:4px; }
+.dialog__title{ font-size:1.0625rem; font-weight:600; }
+.dialog__subtitle{ font-size:.75rem; color:var(--text-muted); margin-top:2px; }
+.dialog__close{ border:none; background:none; color:var(--text-muted); cursor:pointer; font-size:18px; line-height:1; padding:2px 4px; }
+.dialog__body{ margin:16px 0; }
+.dialog__actions{ display:flex; justify-content:flex-end; gap:8px; padding-top:12px; border-top:1px solid var(--border-subtle); }
+
+.demo-toolbar{ position:sticky; top:52px; z-index:9; display:flex; align-items:center; gap:10px; padding:10px 32px; background:var(--bg-surface-elevated); border-bottom:1px solid var(--border-subtle); flex-wrap:wrap; }
+.demo-toolbar__label{ font-family:var(--font-mono); font-size:.6875rem; text-transform:uppercase; letter-spacing:.08em; color:var(--text-muted); margin-right:4px; }
+.gallery-section{ margin-top:44px; padding-top:28px; border-top:1px dashed var(--border-strong); }
+.gallery-section__title{ font-size:1.0625rem; font-weight:600; margin-bottom:4px; }
+.gallery-section__desc{ font-size:.8125rem; color:var(--text-muted); margin-bottom:16px; max-width:68ch; }
+.gallery-grid{ display:grid; grid-template-columns:repeat(auto-fit, minmax(280px, 1fr)); gap:16px; }
+.gallery-card{ border:1px solid var(--border-default); border-radius:var(--radius-lg); background:var(--bg-surface); overflow:hidden; }
+.gallery-card__label{ font-family:var(--font-mono); font-size:.6875rem; text-transform:uppercase; letter-spacing:.06em; color:var(--text-muted); padding:8px 12px; border-bottom:1px solid var(--border-subtle); background:var(--bg-shell); }
+.gallery-card__body{ padding:16px; }
+.sr-only{ position:absolute; width:1px; height:1px; overflow:hidden; clip:rect(0,0,0,0); white-space:nowrap; }
+</style>
+
+<div class="shell">
+  <aside class="shell-sidebar">
+    <div class="shell-brand"><span class="shell-brand__mark">OL</span><span class="shell-brand__name">OpenLinker</span></div>
+    <nav class="shell-nav">
+      <div class="shell-nav__group">
+        <p class="shell-nav__label">Operations</p>
+        <ul class="shell-nav__list">
+          <li><a class="shell-nav__link" href="#">Analytics</a></li>
+          <li><a class="shell-nav__link" href="#">Orders</a></li>
+          <li><a class="shell-nav__link" href="#">Products</a></li>
+          <li><a class="shell-nav__link" href="#">Shipments</a></li>
+          <li><a class="shell-nav__link" href="#">Fulfilment</a></li>
+        </ul>
+      </div>
+      <div class="shell-nav__group">
+        <p class="shell-nav__label">Platform</p>
+        <ul class="shell-nav__list">
+          <li><a class="shell-nav__link" href="#">Connections</a></li>
+          <li><a class="shell-nav__link" href="#">Adapters</a></li>
+          <li><a class="shell-nav__link" href="#">Settings</a></li>
+        </ul>
+      </div>
+    </nav>
+  </aside>
+
+  <div class="shell-main">
+    <!-- No sidebar item points here — the only entry point is the "Inventory locations"
+         tile on /settings (mirroring WhoDecidesTile's shape), so nothing in the
+         Platform group is active and the crumb is 2-level: {group:'Platform',
+         title:'Inventory locations'}, unchanged from the sidebar-nav-item era. -->
+    <div class="shell-topbar"><div class="shell-crumbs">Platform / <b>Inventory locations</b></div></div>
+
+    <div class="demo-toolbar" role="group" aria-label="Mockup state switcher — not part of the product">
+      <span class="demo-toolbar__label">Mockup · view state</span>
+      <button class="chip chip--active" data-state="populated" onclick="setState('populated')">Populated (5 locations)</button>
+      <button class="chip" data-state="empty" onclick="setState('empty')">Empty (pre-bootstrap)</button>
+      <button class="chip" data-state="loading" onclick="setState('loading')">Loading</button>
+      <button class="chip" data-state="error" onclick="setState('error')">Error</button>
+      <span style="margin-left:auto; font-size:.6875rem; color:var(--text-muted); font-family:var(--font-mono);">try: filter by kind, edit, retire, delete a used location</span>
+    </div>
+    <div class="demo-toolbar" role="group" aria-label="Mockup role switcher — not part of the product" style="top:96px;">
+      <span class="demo-toolbar__label">Mockup · viewing as</span>
+      <button class="chip chip--active" data-role="admin" onclick="setRole('admin')">Admin</button>
+      <button class="chip" data-role="operator" onclick="setRole('operator')">Operator</button>
+      <button class="chip" data-role="viewer" onclick="setRole('viewer')">Viewer</button>
+      <span style="margin-left:auto; font-size:.6875rem; color:var(--text-muted); font-family:var(--font-mono);">writes are admin-only (LocationsController @Roles('admin')); operator/viewer get a read-only page</span>
+    </div>
+
+    <div class="shell-content">
+      <a class="back-link" href="#">&larr; Settings</a>
+      <header class="page-header">
+        <div class="page-header__row">
+          <div>
+            <p class="eyebrow">Inventory</p>
+            <h1 class="page-title">Inventory locations</h1>
+            <p class="page-description">The warehouses, stores and third-party sites OpenLinker can source stock from. A location isn't authority over stock — it's the place sourcing rules pick between. Delete is refused while any stock still points here; retire it instead.</p>
+          </div>
+          <div class="page-header__actions">
+            <button class="button button--sm" id="addLocationBtn" onclick="openCreate()">+ Add location</button>
+          </div>
+        </div>
+      </header>
+
+      <div id="alertSlot"></div>
+
+      <div class="filter-bar">
+        <div class="filter-bar__group">
+          <span class="filter-bar__label">Kind</span>
+          <button class="chip chip--active" data-kind="" onclick="setKindFilter('')">All</button>
+          <button class="chip" data-kind="warehouse" onclick="setKindFilter('warehouse')">Warehouse</button>
+          <button class="chip" data-kind="store" onclick="setKindFilter('store')">Store</button>
+          <button class="chip" data-kind="third-party" onclick="setKindFilter('third-party')">Third-party</button>
+          <button class="chip" data-kind="virtual" onclick="setKindFilter('virtual')">Virtual</button>
+        </div>
+        <div class="filter-bar__group">
+          <span class="filter-bar__label">Status</span>
+          <label style="display:flex; align-items:center; gap:5px; font-size:.75rem; color:var(--text-secondary); cursor:pointer;">
+            <input type="checkbox" id="showInactive" checked onchange="renderLocations()"> show retired
+          </label>
+        </div>
+      </div>
+
+      <section id="tableSection">
+        <div class="data-table__container">
+          <table class="data-table" aria-label="Inventory locations">
+            <thead>
+              <tr>
+                <th>Location</th>
+                <th style="width:130px;">Kind</th>
+                <th style="width:140px;">Country / postcode</th>
+                <th style="width:200px;">Owning connection</th>
+                <th style="width:100px;">Status</th>
+                <th style="width:128px;"><span class="sr-only">Actions</span></th>
+              </tr>
+            </thead>
+            <tbody id="locBody"></tbody>
+          </table>
+        </div>
+      </section>
+    </div>
+  </div>
+</div>
+
+<!-- ============================================================
+     CREATE / EDIT DIALOG
+     ============================================================ -->
+<div class="dialog-backdrop" id="locDialogBackdrop">
+  <div class="dialog" role="dialog" aria-modal="true" aria-labelledby="locDialogTitle">
+    <div class="dialog__header">
+      <div><h2 class="dialog__title" id="locDialogTitle">Add location</h2></div>
+      <button class="dialog__close" aria-label="Close" onclick="closeDialog('locDialogBackdrop')">&times;</button>
+    </div>
+    <div class="dialog__body">
+      <div class="form-field-row">
+        <div class="form-field">
+          <label class="form-field__label" for="locCode">Code</label>
+          <input type="text" id="locCode" placeholder="WH1" maxlength="64" />
+          <p class="form-field__description" id="locCodeHint">Unique across the install. Normalised to uppercase on save.</p>
+        </div>
+        <div class="form-field">
+          <label class="form-field__label" for="locName">Name</label>
+          <input type="text" id="locName" placeholder="Main warehouse" maxlength="255" />
+        </div>
+      </div>
+
+      <div class="form-field-row">
+        <div class="form-field">
+          <label class="form-field__label" for="locKind">Kind</label>
+          <select id="locKind">
+            <option value="warehouse">Warehouse</option>
+            <option value="store">Store</option>
+            <option value="third-party">Third-party</option>
+            <option value="virtual">Virtual</option>
+          </select>
+        </div>
+        <div class="form-field">
+          <label class="form-field__label" for="locOwner">Owning connection <span style="color:var(--text-muted); font-weight:400;">(optional)</span></label>
+          <select id="locOwner">
+            <option value="">— none —</option>
+            <option value="c1">PrestaShop — Main store</option>
+            <option value="c2">WooCommerce — EU store</option>
+          </select>
+          <p class="form-field__description">Whose sync may write stock here. Not authority over the location.</p>
+        </div>
+      </div>
+
+      <div class="form-field-row" id="locStatusRow" hidden>
+        <div class="form-field">
+          <label class="form-field__label" for="locStatus">Status</label>
+          <select id="locStatus">
+            <option value="active">Active</option>
+            <option value="inactive">Retired</option>
+          </select>
+          <p class="form-field__description">Retiring stops new stock from targeting it; existing history keeps pointing at the row. Flip back to Active to re-activate.</p>
+        </div>
+        <div></div>
+      </div>
+
+      <div class="form-field-row">
+        <div class="form-field">
+          <label class="form-field__label" for="locCountry">Country <span style="color:var(--text-muted); font-weight:400;">(optional)</span></label>
+          <input type="text" id="locCountry" placeholder="PL" maxlength="2" style="text-transform:uppercase;" />
+          <p class="form-field__error" id="locCountryError" hidden>✕ Exactly 2 letters (ISO 3166-1 alpha-2), or leave blank.</p>
+        </div>
+        <div class="form-field">
+          <label class="form-field__label" for="locPostcode">Postcode <span style="color:var(--text-muted); font-weight:400;">(optional)</span></label>
+          <input type="text" id="locPostcode" placeholder="00-001" maxlength="16" />
+        </div>
+      </div>
+
+      <div class="form-field-row">
+        <div class="form-field">
+          <label class="form-field__label" for="locLat">Latitude <span style="color:var(--text-muted); font-weight:400;">(optional)</span></label>
+          <input type="number" id="locLat" step="0.000001" min="-90" max="90" />
+        </div>
+        <div class="form-field">
+          <label class="form-field__label" for="locLng">Longitude <span style="color:var(--text-muted); font-weight:400;">(optional)</span></label>
+          <input type="number" id="locLng" step="0.000001" min="-180" max="180" />
+        </div>
+      </div>
+
+      <div class="form-field">
+        <label class="form-field__label" for="locExternalRef">Operator reference <span style="color:var(--text-muted); font-weight:400;">(optional)</span></label>
+        <input type="text" id="locExternalRef" placeholder="Free text — e.g. an internal warehouse code" maxlength="255" />
+        <p class="form-field__description">Not an identifier mapping — nothing external reads this.</p>
+      </div>
+
+      <div class="form-field" id="locErrorField" hidden>
+        <p class="form-field__error">✕ A location with code "WH1" already exists.</p>
+      </div>
+    </div>
+    <div class="dialog__actions">
+      <button class="button button--secondary" onclick="closeDialog('locDialogBackdrop')">Cancel</button>
+      <button class="button" onclick="saveLocation()">Save location</button>
+    </div>
+  </div>
+</div>
+
+<!-- ============================================================
+     RETIRE / DELETE
+     ============================================================ -->
+<div class="dialog-backdrop" id="deleteDialogBackdrop">
+  <div class="dialog" role="dialog" aria-modal="true" aria-labelledby="deleteDialogTitle">
+    <div class="dialog__header">
+      <div><h2 class="dialog__title" id="deleteDialogTitle">Delete this location?</h2></div>
+      <button class="dialog__close" aria-label="Close" onclick="closeDialog('deleteDialogBackdrop')">&times;</button>
+    </div>
+    <div class="dialog__body" id="deleteDialogBody">
+      <p style="font-size:.8125rem; color:var(--text-secondary);">This can't be undone. If stock still points here, the delete will be refused instead.</p>
+    </div>
+    <div class="dialog__actions">
+      <button class="button button--secondary" onclick="closeDialog('deleteDialogBackdrop')">Cancel</button>
+      <button class="button button--danger" onclick="confirmDelete()">Delete</button>
+    </div>
+  </div>
+</div>
+
+<!-- ============================================================
+     STATE GALLERY
+     ============================================================ -->
+<div class="shell-content" style="max-width:1180px; margin:0 auto; padding:0 32px 64px;">
+  <section class="gallery-section">
+    <h2 class="gallery-section__title">Component states, for review</h2>
+    <p class="gallery-section__desc">The toolbar above switches the live view through list / empty / loading / error. The two outcomes below only surface inside a real delete attempt, so they're pinned here for review.</p>
+    <div class="gallery-grid">
+      <div class="gallery-card">
+        <p class="gallery-card__label">Delete refused — location in use</p>
+        <div class="gallery-card__body">
+          <div class="alert alert--error" style="margin:0;">
+            <span class="alert__glyph">✕</span>
+            <div class="alert__content">
+              <p class="alert__title">Can't delete "Kraków — Overflow"</p>
+              <p class="alert__description">42 inventory positions still point here. Retire it instead — existing history keeps pointing at a row that exists, and it can be re-activated later.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="gallery-card">
+        <p class="gallery-card__label">Delete succeeded — no stock referenced it</p>
+        <div class="gallery-card__body">
+          <div class="alert alert--info" style="margin:0;">
+            <span class="alert__glyph">✓</span>
+            <div class="alert__content">
+              <p class="alert__title">"Wrocław — 3PL partner" deleted</p>
+              <p class="alert__description">No inventory position named it, so the row is gone rather than retired.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="gallery-card">
+        <p class="gallery-card__label">Bootstrap re-run — no-op</p>
+        <div class="gallery-card__body">
+          <div class="alert alert--info" style="margin:0;">
+            <span class="alert__glyph">ℹ</span>
+            <div class="alert__content">
+              <p class="alert__title">"MAIN" already exists</p>
+              <p class="alert__description">Nothing created. The install already has a first-run location — clicking again is safe and changes nothing.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div class="gallery-card">
+        <p class="gallery-card__label">Duplicate code on create</p>
+        <div class="gallery-card__body">
+          <div class="form-field" style="margin:0;">
+            <label class="form-field__label">Code</label>
+            <input type="text" value="WH1" aria-invalid="true" readonly />
+            <p class="form-field__error">✕ A location with code "WH1" already exists.</p>
+          </div>
+        </div>
+      </div>
+      <div class="gallery-card">
+        <p class="gallery-card__label">Entry point — the /settings tile (not part of this screen)</p>
+        <div class="gallery-card__body">
+          <div style="border:1px solid var(--border-default); border-radius:var(--radius-lg); background:var(--bg-surface); box-shadow:var(--shadow-xs); padding:16px; max-width:320px;">
+            <p class="eyebrow" style="margin-bottom:2px;">Fulfilment routing</p>
+            <h3 style="margin:0 0 8px; font-size:.9375rem; font-weight:600;">Inventory locations</h3>
+            <p style="margin:0 0 12px; font-size:.8125rem; color:var(--text-secondary);">The warehouses, stores and third-party sites OpenLinker can source stock from.</p>
+            <button class="button button--secondary button--sm" disabled>Open</button>
+          </div>
+          <p style="margin-top:10px; font-size:.75rem; color:var(--text-muted); max-width:56ch;">This is the only way in — there's no sidebar item for this screen, only a link-out card on <code>/settings</code> (mirroring the "Who decides what" tile's shape). Not admin-gated: the page's own reads are admin/operator/viewer, so the tile must be at least as reachable as the page it links to. The back-link above ("← Settings") and the two-level breadcrumb ("Platform / Inventory locations") both point back here.</p>
+        </div>
+      </div>
+    </div>
+  </section>
+</div>
+
+<script>
+const CONNECTIONS = {
+  c1: { platformType:'prestashop', platformLabel:'PrestaShop', name:'Main store' },
+  c2: { platformType:'woocommerce', platformLabel:'WooCommerce', name:'EU store' },
+};
+function connectionDisplayName(id){ const c = CONNECTIONS[id]; return c ? `${c.platformLabel} — ${c.name}` : id; }
+const KIND_LABEL = { warehouse:'Warehouse', store:'Store', 'third-party':'Third-party', virtual:'Virtual' };
+
+const LOCATIONS_SEED = [
+  { id:'l1', code:'MAIN', name:'Warsaw — Main warehouse', kind:'warehouse', status:'active', countryIso2:'PL', postcode:'02-677', latitude:52.2297, longitude:21.0122, ownerConnectionId:'c1', externalRef:null, positionCount:128 },
+  { id:'l2', code:'KRK-OVF', name:'Kraków — Overflow', kind:'warehouse', status:'active', countryIso2:'PL', postcode:'30-001', latitude:null, longitude:null, ownerConnectionId:null, externalRef:'internal ref 4471', positionCount:42 },
+  { id:'l3', code:'SHOP-01', name:'Gdańsk — Flagship store', kind:'store', status:'active', countryIso2:'PL', postcode:'80-001', latitude:null, longitude:null, ownerConnectionId:null, externalRef:null, positionCount:0 },
+  { id:'l4', code:'3PL-DE', name:'Berlin — 3PL partner', kind:'third-party', status:'active', countryIso2:'DE', postcode:'10115', latitude:52.5200, longitude:13.4050, ownerConnectionId:'c2', externalRef:null, positionCount:15 },
+  { id:'l5', code:'CONSIGN-01', name:'Consignment site — Silesia distributor', kind:'virtual', status:'inactive', countryIso2:'PL', postcode:null, latitude:null, longitude:null, ownerConnectionId:null, externalRef:null, positionCount:6 },
+];
+
+let locations = JSON.parse(JSON.stringify(LOCATIONS_SEED));
+let kindFilter = '';
+let editingId = null;
+let pendingDeleteId = null;
+// LocationsController: reads are @Roles('admin','operator','viewer'), writes @Roles('admin')
+// only — an operator/viewer can open this page but every mutating action must be disabled.
+let currentRole = 'admin';
+function canWrite(){ return currentRole === 'admin'; }
+function setRole(role) {
+  currentRole = role;
+  document.querySelectorAll('.demo-toolbar .chip[data-role]').forEach(c => c.classList.toggle('chip--active', c.dataset.role === role));
+  document.getElementById('addLocationBtn').disabled = !canWrite();
+  document.getElementById('addLocationBtn').title = canWrite() ? '' : "Requires the admin role — you're viewing read-only";
+  renderLocations();
+}
+// The list read is server-side paginated (ListLocationsQueryDto: page/limit); this mockup's
+// 5-row demo dataset fits on one page, so pagination is shown as a static affordance rather
+// than wired to real paging state. countryIso2 / codePrefix query filters are likewise a
+// scoped-out choice for this pass, not an oversight — Kind + status are the ones drawn.
+//
+// `positionCount` is drawn here as if the list read already exposed it, which today it does
+// not: LocationResponseDto/toDto carries no positions-count field, and the only place the
+// count exists server-side (countPositionsAtLocation) surfaces solely as free text inside
+// LocationInUseError's 409 message. Rendering "in use" without a number is what the pre-fix
+// version of this mockup did — reviewers flagged that an operator managing several locations
+// needs the count (both to gauge blast radius before retiring, and because right now the real
+// page has nowhere to get one without either a new bulk/per-id count endpoint or fragile
+// 409-message parsing). This is a backend-contract decision #3063's implementation needs to
+// make, not something this mockup can resolve on its own — flagging it here so it isn't lost.
+
+function escapeHtml(s){ return String(s).replace(/[&<>"']/g,(c)=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c])); }
+function writeDisabledAttrs(label, title) {
+  const disabled = !canWrite();
+  const t = disabled ? "Requires the admin role — you're viewing read-only" : (title || '');
+  return `<button class="button button--ghost button--icon button--sm" aria-label="${escapeHtml(label)}"${disabled ? ' disabled' : ''}${t ? ` title="${escapeHtml(t)}"` : ''}`;
+}
+
+function setKindFilter(kind) {
+  kindFilter = kind;
+  document.querySelectorAll('.filter-bar__group .chip[data-kind]').forEach(c => c.classList.toggle('chip--active', c.dataset.kind === kind));
+  renderLocations();
+}
+
+function renderLocations() {
+  const showInactive = document.getElementById('showInactive').checked;
+  const body = document.getElementById('locBody');
+  const visible = locations.filter(l => (!kindFilter || l.kind === kindFilter) && (showInactive || l.status === 'active'));
+  body.innerHTML = '';
+
+  if (visible.length === 0) {
+    body.innerHTML = `<tr><td colspan="6" class="data-table__empty-cell">No locations match this filter.</td></tr>`;
+    return;
+  }
+
+  visible.forEach(l => {
+    const tr = document.createElement('tr');
+    tr.className = l.status === 'inactive' ? 'loc-row--inactive' : '';
+    const geo = [l.countryIso2, l.postcode].filter(Boolean).join(' · ') || '—';
+    let owner = '<span style="color:var(--text-muted);">— none —</span>';
+    if (l.ownerConnectionId) {
+      const c = CONNECTIONS[l.ownerConnectionId];
+      owner = `<a href="#" class="loc-owner-link" title="Open connection ${escapeHtml(connectionDisplayName(l.ownerConnectionId))}" onclick="event.preventDefault();">
+        <span class="channel-pill" data-channel="${c.platformType}">${escapeHtml(c.platformLabel)}</span>
+        <span class="loc-owner-link__name">${escapeHtml(c.name)}</span>
+      </a>`;
+    }
+    const positions = l.positionCount > 0
+      ? `<a href="#" class="loc-positions-link" onclick="event.preventDefault(); alert('Would open /inventory filtered to this location.');">${l.positionCount} position${l.positionCount === 1 ? '' : 's'}</a>`
+      : '<span style="color:var(--text-muted);">no positions</span>';
+    tr.innerHTML = `
+      <td>
+        <div class="loc-cell__name">${escapeHtml(l.name)}</div>
+        <div class="loc-cell__code">${escapeHtml(l.code)}${l.externalRef ? ' · ' + escapeHtml(l.externalRef) : ''} · ${positions}</div>
+      </td>
+      <td><span class="loc-kind-badge">${KIND_LABEL[l.kind]}</span></td>
+      <td class="mono">${geo}</td>
+      <td style="font-size:.8125rem;">${owner}</td>
+      <td>${l.status === 'active'
+        ? '<span class="status-badge status-badge--success"><span class="status-badge__dot"></span>Active</span>'
+        : '<span class="status-badge status-badge--neutral"><span class="status-badge__dot"></span>Retired</span>'}</td>
+      <td>
+        <div class="loc-actions">
+          ${writeDisabledAttrs(`Edit ${escapeHtml(l.name)}`)} onclick="openEdit('${l.id}')">✎</button>
+          ${l.status === 'active'
+            ? `${writeDisabledAttrs(`Retire ${escapeHtml(l.name)}`, 'Retire')} onclick="retireLocation('${l.id}')">⏸</button>`
+            : `${writeDisabledAttrs(`Reactivate ${escapeHtml(l.name)}`, 'Reactivate')} onclick="reactivateLocation('${l.id}')">↻</button>`}
+          ${writeDisabledAttrs(`Delete ${escapeHtml(l.name)}`)} onclick="requestDelete('${l.id}')">🗑</button>
+        </div>
+      </td>
+    `;
+    body.appendChild(tr);
+  });
+}
+
+function setState(name) {
+  document.body.dataset.state = name;
+  document.querySelectorAll('.demo-toolbar .chip[data-state]').forEach(c => c.classList.toggle('chip--active', c.dataset.state === name));
+  const section = document.getElementById('tableSection');
+  document.getElementById('alertSlot').innerHTML = '';
+
+  if (name === 'populated') {
+    locations = JSON.parse(JSON.stringify(LOCATIONS_SEED));
+    section.innerHTML = `<div class="data-table__container">
+      <table class="data-table" aria-label="Inventory locations">
+        <thead><tr><th>Location</th><th style="width:130px;">Kind</th><th style="width:140px;">Country / postcode</th><th style="width:200px;">Owning connection</th><th style="width:100px;">Status</th><th style="width:128px;"><span class="sr-only">Actions</span></th></tr></thead>
+        <tbody id="locBody"></tbody>
+      </table></div>
+      <nav class="pagination" aria-label="Locations pagination">
+        <span>5 of 5 locations</span>
+        <div class="pagination__nav">
+          <button class="button button--secondary button--sm" disabled>&larr; Previous</button>
+          <button class="button button--secondary button--sm" disabled>Next &rarr;</button>
+        </div>
+      </nav>`;
+    renderLocations();
+    return;
+  }
+  if (name === 'empty') {
+    section.innerHTML = `<div class="state-card">
+      <p class="eyebrow">No locations yet</p>
+      <h3 class="state-card__title">Nothing here for sourcing rules to pick between</h3>
+      <p class="state-card__message">Fulfilment routing can't be turned on while a connection has zero locations, so if you're seeing this, routing here is either off or has never been configured — no orders are affected. Mint a starting location to unblock enabling it, or add your own.</p>
+      <div class="state-card__actions">
+        <button class="button button--sm" onclick="alert('Mints one MAIN warehouse location idempotently. Re-running it after this is a safe no-op. The minted row holds no stock of its own — it still needs stock assigned before routing can source from it.')">Create first location</button>
+        <button class="button button--secondary button--sm" onclick="openCreate()">+ Add manually</button>
+      </div>
+    </div>`;
+    return;
+  }
+  if (name === 'loading') {
+    section.innerHTML = `<div style="display:grid; gap:10px;">
+      <div class="skeleton-line" style="width:100%; height:44px; border-radius:10px;"></div>
+      <div class="skeleton-line" style="width:100%; height:44px; border-radius:10px;"></div>
+      <div class="skeleton-line" style="width:70%; height:44px; border-radius:10px;"></div>
+    </div>`;
+    return;
+  }
+  if (name === 'error') {
+    section.innerHTML = `<div class="state-card state-card--error">
+      <p class="eyebrow" style="color:var(--status-error-fg);">Error</p>
+      <h3 class="state-card__title">Couldn't load locations</h3>
+      <p class="state-card__message">The request failed: 500 Internal Server Error.</p>
+      <div class="state-card__actions"><button class="button button--secondary button--sm" onclick="setState('populated')">Retry</button></div>
+    </div>`;
+    return;
+  }
+}
+
+function openDialog(id){ document.getElementById(id).classList.add('is-open'); }
+function closeDialog(id){ document.getElementById(id).classList.remove('is-open'); }
+document.querySelectorAll('.dialog-backdrop').forEach(bd => bd.addEventListener('click', (e) => { if (e.target === bd) bd.classList.remove('is-open'); }));
+document.addEventListener('keydown', (e) => { if (e.key === 'Escape') document.querySelectorAll('.dialog-backdrop.is-open').forEach(bd => bd.classList.remove('is-open')); });
+
+function openCreate() {
+  editingId = null;
+  document.getElementById('locDialogTitle').textContent = 'Add location';
+  ['locCode','locName','locCountry','locPostcode','locLat','locLng','locExternalRef'].forEach(id => document.getElementById(id).value = '');
+  document.getElementById('locKind').value = 'warehouse';
+  document.getElementById('locOwner').value = '';
+  document.getElementById('locCode').readOnly = false;
+  document.getElementById('locCodeHint').textContent = 'Unique across the install. Normalised to uppercase on save.';
+  document.getElementById('locStatusRow').hidden = true;
+  document.getElementById('locErrorField').hidden = true;
+  document.getElementById('locCountryError').hidden = true;
+  openDialog('locDialogBackdrop');
+}
+function openEdit(id) {
+  const l = locations.find(x => x.id === id);
+  if (!l) return;
+  editingId = id;
+  document.getElementById('locDialogTitle').textContent = 'Edit location';
+  document.getElementById('locCode').value = l.code;
+  // code is deliberately absent from UpdateLocationDto — the natural key
+  // is not a patch-shaped field, so it renders read-only rather than editable.
+  document.getElementById('locCode').readOnly = true;
+  document.getElementById('locCodeHint').textContent = "Can't be changed after create.";
+  document.getElementById('locName').value = l.name;
+  document.getElementById('locKind').value = l.kind;
+  document.getElementById('locOwner').value = l.ownerConnectionId || '';
+  document.getElementById('locStatus').value = l.status;
+  document.getElementById('locStatusRow').hidden = false;
+  document.getElementById('locCountry').value = l.countryIso2 || '';
+  document.getElementById('locPostcode').value = l.postcode || '';
+  document.getElementById('locLat').value = l.latitude ?? '';
+  document.getElementById('locLng').value = l.longitude ?? '';
+  document.getElementById('locExternalRef').value = l.externalRef || '';
+  document.getElementById('locErrorField').hidden = true;
+  document.getElementById('locCountryError').hidden = true;
+  openDialog('locDialogBackdrop');
+}
+function saveLocation() {
+  const code = document.getElementById('locCode').value.trim().toUpperCase();
+  const dup = locations.find(l => l.code === code && l.id !== editingId);
+  if (dup) { document.getElementById('locErrorField').hidden = false; return; }
+  document.getElementById('locErrorField').hidden = true;
+
+  // Real DTO: @Length(2,2) — must be exactly 2 letters when present, never 1.
+  const countryRaw = document.getElementById('locCountry').value.trim();
+  if (countryRaw && countryRaw.length !== 2) {
+    document.getElementById('locCountryError').hidden = false;
+    return;
+  }
+  document.getElementById('locCountryError').hidden = true;
+
+  const lat = document.getElementById('locLat').value.trim();
+  const lng = document.getElementById('locLng').value.trim();
+  const payload = {
+    code, name: document.getElementById('locName').value.trim() || code,
+    kind: document.getElementById('locKind').value,
+    ownerConnectionId: document.getElementById('locOwner').value || null,
+    countryIso2: document.getElementById('locCountry').value.trim().toUpperCase() || null,
+    postcode: document.getElementById('locPostcode').value.trim() || null,
+    latitude: lat === '' ? null : Number(lat),
+    longitude: lng === '' ? null : Number(lng),
+    externalRef: document.getElementById('locExternalRef').value.trim() || null,
+  };
+  if (editingId) {
+    // code is intentionally excluded — PATCH never carries it, so an edit can't rename it.
+    const idx = locations.findIndex(l => l.id === editingId);
+    payload.status = document.getElementById('locStatus').value;
+    locations[idx] = { ...locations[idx], ...payload, code: locations[idx].code };
+  } else {
+    locations.push({ id:'l-' + Date.now(), status:'active', positionCount:0, ...payload });
+  }
+  renderLocations();
+  closeDialog('locDialogBackdrop');
+}
+
+function requestDelete(id) {
+  pendingDeleteId = id;
+  const l = locations.find(x => x.id === id);
+  document.getElementById('deleteDialogTitle').textContent = `Delete "${l.name}"?`;
+  const body = document.getElementById('deleteDialogBody');
+  if (l.positionCount > 0) {
+    body.innerHTML = `<div class="alert alert--warning" style="margin:0;">
+      <span class="alert__glyph">⚠</span>
+      <div class="alert__content">
+        <p class="alert__title">${l.positionCount} inventory position${l.positionCount === 1 ? '' : 's'} still point here</p>
+        <p class="alert__description">The delete will be refused. Retire the location instead — existing positions keep pointing at a row that exists.
+          <a href="#" onclick="event.preventDefault(); alert('Would open /inventory filtered to this location.');">View referencing positions</a></p>
+      </div>
+    </div>`;
+  } else {
+    body.innerHTML = `<p style="font-size:.8125rem; color:var(--text-secondary);">This can't be undone. No stock currently points here, so the delete will succeed.</p>`;
+  }
+  openDialog('deleteDialogBackdrop');
+}
+function confirmDelete() {
+  const l = locations.find(x => x.id === pendingDeleteId);
+  if (l && l.positionCount > 0) {
+    closeDialog('deleteDialogBackdrop');
+    document.getElementById('alertSlot').innerHTML = `<div class="alert alert--error">
+      <span class="alert__glyph">✕</span>
+      <div class="alert__content">
+        <p class="alert__title">Can't delete "${escapeHtml(l.name)}"</p>
+        <p class="alert__description">${l.positionCount} inventory position${l.positionCount === 1 ? '' : 's'} still point here. Retire it instead — existing history keeps pointing at a row that exists, and it can be re-activated later.</p>
+      </div>
+      <div class="alert__actions">
+        <button class="button button--sm button--secondary" onclick="retireLocation('${l.id}'); this.closest('.alert').remove();">Retire instead</button>
+      </div>
+    </div>`;
+    return;
+  }
+  locations = locations.filter(x => x.id !== pendingDeleteId);
+  renderLocations();
+  closeDialog('deleteDialogBackdrop');
+}
+function retireLocation(id) {
+  const l = locations.find(x => x.id === id);
+  if (l) l.status = 'inactive';
+  renderLocations();
+}
+function reactivateLocation(id) {
+  const l = locations.find(x => x.id === id);
+  if (l) l.status = 'active';
+  renderLocations();
+}
+
+setState('populated');
+</script>

--- a/libs/core/src/users/domain/types/role.types.ts
+++ b/libs/core/src/users/domain/types/role.types.ts
@@ -77,6 +77,16 @@ export const PermissionValues = [
   // own reasoning. Same discipline as `shipments:write` above.
   'automations:read',
   'automations:write',
+  // DISPLAY-ONLY (#3066): gates the FE's inventory-locations write
+  // affordances (Add/Edit/Delete/Retire on the locations list, #2316). It is
+  // deliberately NOT `inventory:write` — that permission is held by `operator`
+  // too, but `InventoryLocationsController`'s three write routes are
+  // `@Roles('admin')` only, so granting `inventory:write` here would show an
+  // operator an enabled button that then 403s. The roles holding this
+  // permission MUST stay identical to that controller's `@Roles` list (asserted
+  // in `inventory-locations.controller.spec.ts`), the `shipments:write` /
+  // `automations:write` discipline.
+  'inventory-locations:write',
   // DISPLAY-ONLY (#2473): gates the FE's analytics-settings write affordances
   // (tax-rate opt-in toggle, currency-recalculation trigger). It authorizes no
   // mutation — those endpoints are `@Roles('admin')`-gated directly and no


### PR DESCRIPTION
## Summary

`inventory_locations` (#2313/#2316) has had a complete CRUD API since #2316, but the frontend only ever called `listActiveLocations` (a degenerate `limit=1` probe) and `bootstrapLocations` — list, single-item read, create, update and delete were all unreachable from the product, reachable only via `curl`. This epic closes that gap.

Stacked sub-issues landed in this branch, each reviewed and CI-green individually:
- #3064 — extend `InventoryApi` with `listLocations` / `getLocation` / `createLocation` / `updateLocation` / `deleteLocation`
- #3065 — query hooks + filters (kind, status, codePrefix)
- #3067 — create/edit location dialog
- #3068 — delete confirm, including the 409 "location in use" case with a retire-instead fallback
- #3066 — list page with filter bar
- #3069 — nav entry (mounted as a Settings tile, per a later refinement on the branch)
- #3070 — CRUD tests

## What changed

- `apps/web/src/pages/inventory/inventory-locations-page.tsx` (+tests) — the operator-facing list/create/edit/delete/retire surface
- `apps/web/src/features/inventory/**` — API client methods, types, query/mutation hooks
- `apps/web/src/pages/settings/settings-page.tsx` — mount point (Settings tile, not a dedicated nav item)
- Minor shared-UI fixes surfaced along the way (`confirm-dialog.tsx`, `api-error.ts`, `session.types.ts`)

Built against the reviewed mockup: docs/plans/mockups/inventory-locations-3063.html (design issue #3113/#3120, Artifact: https://claude.ai/code/artifact/fbb5f9e1-52a3-4b7b-8136-ad59dcf4f318)

## Test plan
- [x] `pnpm --filter @openlinker/web type-check`
- [x] `eslint` on changed files
- [x] Unit tests for API client, hooks, and the list/create/edit/delete/retire flows (all green per individual sub-issue PRs #3131–#3137, all merged)
- [x] CI green on the final integration PR (#3131): type-check, lint, unit tests, integration tests, build, docker smoke — all SUCCESS

Closes #3063

🤖 Generated with [Claude Code](https://claude.com/claude-code)